### PR TITLE
Publish Docker images to GitHub Registry

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,66 @@
+name: Docker Publish
+
+on:
+  push:
+    branches: [main, 'claude/**']
+
+env:
+  REGISTRY: ghcr.io
+  # Repository name for image naming
+  IMAGE_BASE: ghcr.io/${{ github.repository_owner }}
+
+jobs:
+  build-and-push:
+    name: Build & Push (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: api
+            dockerfile: docker/Dockerfile.unified
+            image_name: everruns-api
+          - target: worker
+            dockerfile: docker/Dockerfile.unified
+            image_name: everruns-worker
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_BASE }}/${{ matrix.image_name }}
+          tags: |
+            # On main: tag as 'latest' and with short SHA
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=sha,prefix=,format=short
+            # Also add full SHA for traceability
+            type=sha,prefix=,format=long
+
+      - name: Build and push ${{ matrix.target }}
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          target: ${{ matrix.target }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=docker-${{ matrix.target }}
+          cache-to: type=gha,mode=max,scope=docker-${{ matrix.target }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,9 @@ name: Docker Publish
 
 on:
   push:
-    branches: [main, 'claude/**']
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 env:
   REGISTRY: ghcr.io
@@ -41,17 +43,28 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Determine SHA
+        id: sha
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+            echo "sha_short=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
+          else
+            echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+            echo "sha_short=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
+          fi
+
       - name: Extract metadata for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE_BASE }}/${{ matrix.image_name }}
           tags: |
-            # On main: tag as 'latest' and with short SHA
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-            type=sha,prefix=,format=short
-            # Also add full SHA for traceability
-            type=sha,prefix=,format=long
+            # On main push: tag as 'latest'
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+            # Always tag with short and full SHA
+            type=raw,value=${{ steps.sha.outputs.sha_short }}
+            type=raw,value=${{ steps.sha.outputs.sha }}
 
       - name: Build and push ${{ matrix.target }}
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Summary

- Add Docker image publishing workflow to GitHub Container Registry (ghcr.io)
- Publish `everruns-api` and `everruns-worker` images to `ghcr.io/everruns/`
- On PR: tag with commit SHA (short + full) for testing deployments
- On main: additionally tag as `latest` for production use

## Test plan

- [ ] Verify workflow runs on this PR and publishes images with SHA tags
- [ ] Check images appear in GitHub Packages: `ghcr.io/everruns/everruns-api` and `ghcr.io/everruns/everruns-worker`
- [ ] After merge, verify `latest` tag is applied