### PR TITLE
Add abstraction layer for LLM providers

### DIFF
--- a/apps/ui/src/app/agents/[agentId]/edit/page.tsx
+++ b/apps/ui/src/app/agents/[agentId]/edit/page.tsx
@@ -169,7 +169,7 @@ export default function EditAgentPage() {
                 <Label htmlFor="status">Status</Label>
                 <Select
                   value={formData.status}
-                  onValueChange={(value: AgentStatus) => setFormData({ ...formData, status: value })}
+                  onValueChange={(value) => setFormData({ ...formData, status: value as AgentStatus })}
                 >
                   <SelectTrigger>
                     <SelectValue placeholder="Select status" />

--- a/apps/ui/src/app/agents/[agentId]/edit/page.tsx
+++ b/apps/ui/src/app/agents/[agentId]/edit/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { useAgent, useUpdateAgent } from "@/hooks/use-agents";
@@ -29,12 +29,14 @@ export default function EditAgentPage() {
   const { data: agent, isLoading, error } = useAgent(agentId);
   const updateAgent = useUpdateAgent(agentId);
 
-  const [formData, setFormData] = useState({
-    name: "",
-    description: "",
-    default_model_id: "",
-    status: "active" as AgentStatus,
-  });
+  const initialFormData = useMemo(() => ({
+    name: agent?.name || "",
+    description: agent?.description || "",
+    default_model_id: agent?.default_model_id || "",
+    status: (agent?.status || "active") as AgentStatus,
+  }), [agent]);
+
+  const [formData, setFormData] = useState(initialFormData);
 
   // Sync form data when agent loads - valid pattern for external data sync
   useEffect(() => {
@@ -72,13 +74,13 @@ export default function EditAgentPage() {
         <div className="p-6 max-w-2xl">
           <Card>
             <CardHeader>
-              <Skeleton className="h-6 w-32" />
+              <Skeleton className="h-8 w-48" />
               <Skeleton className="h-4 w-64" />
             </CardHeader>
-            <CardContent className="space-y-6">
-              {[...Array(4)].map((_, i) => (
-                <Skeleton key={i} className="h-10 w-full" />
-              ))}
+            <CardContent className="space-y-4">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-20 w-full" />
+              <Skeleton className="h-10 w-full" />
             </CardContent>
           </Card>
         </div>
@@ -90,7 +92,7 @@ export default function EditAgentPage() {
     return (
       <>
         <Header
-          title="Agent Not Found"
+          title="Edit Agent"
           action={
             <Link href="/agents">
               <Button variant="ghost">
@@ -148,16 +150,17 @@ export default function EditAgentPage() {
                   id="description"
                   value={formData.description}
                   onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                  rows={3}
+                  placeholder="Optional description for your agent"
                 />
               </div>
 
               <div className="space-y-2">
-                <Label htmlFor="model">Default Model</Label>
+                <Label htmlFor="model">Model ID</Label>
                 <Input
                   id="model"
                   value={formData.default_model_id}
                   onChange={(e) => setFormData({ ...formData, default_model_id: e.target.value })}
+                  placeholder="gpt-4"
                   required
                 />
               </div>
@@ -166,12 +169,10 @@ export default function EditAgentPage() {
                 <Label htmlFor="status">Status</Label>
                 <Select
                   value={formData.status}
-                  onValueChange={(value) =>
-                    setFormData({ ...formData, status: value as AgentStatus })
-                  }
+                  onValueChange={(value: AgentStatus) => setFormData({ ...formData, status: value })}
                 >
                   <SelectTrigger>
-                    <SelectValue />
+                    <SelectValue placeholder="Select status" />
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="active">Active</SelectItem>
@@ -180,13 +181,7 @@ export default function EditAgentPage() {
                 </Select>
               </div>
 
-              {updateAgent.error && (
-                <div className="bg-destructive/10 text-destructive p-3 rounded-lg text-sm">
-                  Failed to update agent: {updateAgent.error.message}
-                </div>
-              )}
-
-              <div className="flex gap-3">
+              <div className="flex gap-2">
                 <Button type="submit" disabled={updateAgent.isPending}>
                   {updateAgent.isPending && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
                   Save Changes

--- a/apps/ui/src/app/runs/page.tsx
+++ b/apps/ui/src/app/runs/page.tsx
@@ -46,12 +46,12 @@ export default function RunsPage() {
     return new Date(dateStr).toLocaleString();
   };
 
-  // Calculate duration - uses Date.now() for running tasks to show live duration
+  // Calculate duration - shows "running..." for in-progress runs
   const formatDuration = (startedAt: string | null, finishedAt: string | null) => {
     if (!startedAt) return "-";
+    if (!finishedAt) return "running...";
     const start = new Date(startedAt).getTime();
-    // eslint-disable-next-line react-hooks/purity
-    const end = finishedAt ? new Date(finishedAt).getTime() : Date.now();
+    const end = new Date(finishedAt).getTime();
     const seconds = Math.floor((end - start) / 1000);
 
     if (seconds < 60) return `${seconds}s`;

--- a/apps/ui/src/app/settings/page.tsx
+++ b/apps/ui/src/app/settings/page.tsx
@@ -28,7 +28,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from "@/components/ui/dialog";
 import {
   useLlmProviders,
@@ -46,7 +45,6 @@ import {
   Key,
   Star,
   Cpu,
-  Edit,
 } from "lucide-react";
 import type {
   LlmProvider,

--- a/apps/ui/src/app/settings/page.tsx
+++ b/apps/ui/src/app/settings/page.tsx
@@ -1,0 +1,655 @@
+"use client";
+
+import { useState } from "react";
+import { Header } from "@/components/layout/header";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  useLlmProviders,
+  useLlmModels,
+  useCreateLlmProvider,
+  useUpdateLlmProvider,
+  useDeleteLlmProvider,
+  useCreateLlmModel,
+  useDeleteLlmModel,
+} from "@/hooks/use-llm-providers";
+import {
+  Plus,
+  Server,
+  Trash2,
+  Key,
+  Star,
+  Cpu,
+  Edit,
+} from "lucide-react";
+import type {
+  LlmProvider,
+  LlmModelWithProvider,
+  LlmProviderType,
+  CreateLlmProviderRequest,
+  CreateLlmModelRequest,
+} from "@/lib/api/types";
+
+const PROVIDER_TYPES: { value: LlmProviderType; label: string }[] = [
+  { value: "openai", label: "OpenAI" },
+  { value: "anthropic", label: "Anthropic" },
+  { value: "azure_openai", label: "Azure OpenAI" },
+  { value: "ollama", label: "Ollama" },
+  { value: "custom", label: "Custom" },
+];
+
+function ProviderCard({
+  provider,
+  onDelete,
+  onSetApiKey,
+}: {
+  provider: LlmProvider;
+  onDelete: (id: string) => void;
+  onSetApiKey: (provider: LlmProvider) => void;
+}) {
+  const providerLabel =
+    PROVIDER_TYPES.find((t) => t.value === provider.provider_type)?.label ||
+    provider.provider_type;
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between space-y-0">
+        <div className="flex items-center gap-3">
+          <div className="p-2 bg-primary/10 rounded-lg">
+            <Server className="h-5 w-5 text-primary" />
+          </div>
+          <div>
+            <CardTitle className="text-lg flex items-center gap-2">
+              {provider.name}
+              {provider.is_default && (
+                <Star className="h-4 w-4 text-yellow-500 fill-yellow-500" />
+              )}
+            </CardTitle>
+            <CardDescription className="text-sm">{providerLabel}</CardDescription>
+          </div>
+        </div>
+        <Badge
+          variant="outline"
+          className={
+            provider.status === "active"
+              ? "bg-green-100 text-green-800"
+              : "bg-gray-100 text-gray-800"
+          }
+        >
+          {provider.status}
+        </Badge>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-2 text-sm">
+          {provider.base_url && (
+            <p className="text-muted-foreground truncate">
+              URL: {provider.base_url}
+            </p>
+          )}
+          <div className="flex items-center gap-2">
+            <Key className="h-4 w-4 text-muted-foreground" />
+            <span className="text-muted-foreground">
+              API Key: {provider.api_key_set ? "Configured" : "Not set"}
+            </span>
+          </div>
+        </div>
+        <div className="flex items-center justify-end gap-2 mt-4">
+          <Button variant="outline" size="sm" onClick={() => onSetApiKey(provider)}>
+            <Key className="h-4 w-4 mr-1" />
+            {provider.api_key_set ? "Update Key" : "Set Key"}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-destructive"
+            onClick={() => onDelete(provider.id)}
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ModelRow({
+  model,
+  onDelete,
+}: {
+  model: LlmModelWithProvider;
+  onDelete: (id: string) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between p-3 border rounded-lg">
+      <div className="flex items-center gap-3">
+        <Cpu className="h-5 w-5 text-muted-foreground" />
+        <div>
+          <div className="font-medium flex items-center gap-2">
+            {model.display_name}
+            {model.is_default && (
+              <Star className="h-3 w-3 text-yellow-500 fill-yellow-500" />
+            )}
+          </div>
+          <div className="text-sm text-muted-foreground">
+            {model.model_id} - {model.provider_name}
+          </div>
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        {model.capabilities.length > 0 && (
+          <div className="flex gap-1">
+            {model.capabilities.slice(0, 2).map((cap) => (
+              <Badge key={cap} variant="secondary" className="text-xs">
+                {cap}
+              </Badge>
+            ))}
+            {model.capabilities.length > 2 && (
+              <Badge variant="secondary" className="text-xs">
+                +{model.capabilities.length - 2}
+              </Badge>
+            )}
+          </div>
+        )}
+        <Badge
+          variant="outline"
+          className={
+            model.status === "active"
+              ? "bg-green-100 text-green-800"
+              : "bg-gray-100 text-gray-800"
+          }
+        >
+          {model.status}
+        </Badge>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-destructive"
+          onClick={() => onDelete(model.id)}
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function AddProviderDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [name, setName] = useState("");
+  const [providerType, setProviderType] = useState<LlmProviderType>("openai");
+  const [baseUrl, setBaseUrl] = useState("");
+  const [apiKey, setApiKey] = useState("");
+  const [isDefault, setIsDefault] = useState(false);
+
+  const createProvider = useCreateLlmProvider();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const data: CreateLlmProviderRequest = {
+      name,
+      provider_type: providerType,
+      base_url: baseUrl || undefined,
+      api_key: apiKey || undefined,
+      is_default: isDefault,
+    };
+    await createProvider.mutateAsync(data);
+    onOpenChange(false);
+    setName("");
+    setProviderType("openai");
+    setBaseUrl("");
+    setApiKey("");
+    setIsDefault(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add LLM Provider</DialogTitle>
+          <DialogDescription>
+            Configure a new LLM provider for your agents to use.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="name">Name</Label>
+            <Input
+              id="name"
+              value={name}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setName(e.target.value)}
+              placeholder="My OpenAI Provider"
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="provider-type">Provider Type</Label>
+            <Select value={providerType} onValueChange={(v) => setProviderType(v as LlmProviderType)}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Select provider type" />
+              </SelectTrigger>
+              <SelectContent>
+                {PROVIDER_TYPES.map((type) => (
+                  <SelectItem key={type.value} value={type.value}>
+                    {type.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="base-url">Base URL (optional)</Label>
+            <Input
+              id="base-url"
+              value={baseUrl}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setBaseUrl(e.target.value)}
+              placeholder="https://api.openai.com/v1"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="api-key">API Key (optional)</Label>
+            <Input
+              id="api-key"
+              type="password"
+              value={apiKey}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setApiKey(e.target.value)}
+              placeholder="sk-..."
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="is-default"
+              checked={isDefault}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setIsDefault(e.target.checked)}
+              className="h-4 w-4"
+            />
+            <Label htmlFor="is-default">Set as default provider</Label>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={createProvider.isPending || !name}>
+              {createProvider.isPending ? "Creating..." : "Create Provider"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function SetApiKeyDialog({
+  provider,
+  open,
+  onOpenChange,
+}: {
+  provider: LlmProvider | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [apiKey, setApiKey] = useState("");
+  const updateProvider = useUpdateLlmProvider(provider?.id || "");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!provider) return;
+    await updateProvider.mutateAsync({ api_key: apiKey });
+    onOpenChange(false);
+    setApiKey("");
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {provider?.api_key_set ? "Update" : "Set"} API Key
+          </DialogTitle>
+          <DialogDescription>
+            {provider?.api_key_set
+              ? "Enter a new API key to replace the existing one."
+              : "Enter the API key for this provider."}
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="new-api-key">API Key</Label>
+            <Input
+              id="new-api-key"
+              type="password"
+              value={apiKey}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setApiKey(e.target.value)}
+              placeholder="sk-..."
+              required
+            />
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={updateProvider.isPending || !apiKey}>
+              {updateProvider.isPending ? "Saving..." : "Save API Key"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function AddModelDialog({
+  providers,
+  open,
+  onOpenChange,
+}: {
+  providers: LlmProvider[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [providerId, setProviderId] = useState("");
+  const [modelId, setModelId] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [contextWindow, setContextWindow] = useState("");
+  const [isDefault, setIsDefault] = useState(false);
+
+  const createModel = useCreateLlmModel(providerId);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const data: CreateLlmModelRequest = {
+      model_id: modelId,
+      display_name: displayName,
+      context_window: contextWindow ? parseInt(contextWindow) : undefined,
+      is_default: isDefault,
+    };
+    await createModel.mutateAsync(data);
+    onOpenChange(false);
+    setProviderId("");
+    setModelId("");
+    setDisplayName("");
+    setContextWindow("");
+    setIsDefault(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add Model</DialogTitle>
+          <DialogDescription>
+            Add a new model to an existing provider.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="provider">Provider</Label>
+            <Select value={providerId} onValueChange={setProviderId}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Select provider" />
+              </SelectTrigger>
+              <SelectContent>
+                {providers.map((p) => (
+                  <SelectItem key={p.id} value={p.id}>
+                    {p.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="model-id">Model ID</Label>
+            <Input
+              id="model-id"
+              value={modelId}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setModelId(e.target.value)}
+              placeholder="gpt-4o"
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="display-name">Display Name</Label>
+            <Input
+              id="display-name"
+              value={displayName}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setDisplayName(e.target.value)}
+              placeholder="GPT-4o"
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="context-window">Context Window (optional)</Label>
+            <Input
+              id="context-window"
+              type="number"
+              value={contextWindow}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setContextWindow(e.target.value)}
+              placeholder="128000"
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="model-is-default"
+              checked={isDefault}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setIsDefault(e.target.checked)}
+              className="h-4 w-4"
+            />
+            <Label htmlFor="model-is-default">Set as default for this provider</Label>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={createModel.isPending || !providerId || !modelId || !displayName}
+            >
+              {createModel.isPending ? "Creating..." : "Create Model"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ProviderCardSkeleton() {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between space-y-0">
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-9 w-9 rounded-lg" />
+          <div className="space-y-2">
+            <Skeleton className="h-5 w-32" />
+            <Skeleton className="h-4 w-24" />
+          </div>
+        </div>
+        <Skeleton className="h-5 w-16" />
+      </CardHeader>
+      <CardContent>
+        <Skeleton className="h-4 w-full mb-4" />
+        <Skeleton className="h-8 w-24 ml-auto" />
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function SettingsPage() {
+  const { data: providers = [], isLoading: providersLoading, error: providersError } = useLlmProviders();
+  const { data: models = [], isLoading: modelsLoading, error: modelsError } = useLlmModels();
+  const deleteProvider = useDeleteLlmProvider();
+  const deleteModel = useDeleteLlmModel();
+
+  const [addProviderOpen, setAddProviderOpen] = useState(false);
+  const [addModelOpen, setAddModelOpen] = useState(false);
+  const [apiKeyProvider, setApiKeyProvider] = useState<LlmProvider | null>(null);
+
+  const handleDeleteProvider = async (id: string) => {
+    if (confirm("Are you sure you want to delete this provider? All associated models will also be deleted.")) {
+      await deleteProvider.mutateAsync(id);
+    }
+  };
+
+  const handleDeleteModel = async (id: string) => {
+    if (confirm("Are you sure you want to delete this model?")) {
+      await deleteModel.mutateAsync(id);
+    }
+  };
+
+  return (
+    <>
+      <Header title="Settings" />
+      <div className="p-6 space-y-8">
+        {/* LLM Providers Section */}
+        <section>
+          <div className="flex items-center justify-between mb-4">
+            <div>
+              <h2 className="text-xl font-semibold">LLM Providers</h2>
+              <p className="text-sm text-muted-foreground">
+                Configure the LLM providers that your agents can use.
+              </p>
+            </div>
+            <Button onClick={() => setAddProviderOpen(true)}>
+              <Plus className="h-4 w-4 mr-2" />
+              Add Provider
+            </Button>
+          </div>
+
+          {providersError && (
+            <div className="bg-destructive/10 text-destructive p-4 rounded-lg mb-4">
+              Failed to load providers: {providersError.message}
+            </div>
+          )}
+
+          {providersLoading ? (
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {[...Array(3)].map((_, i) => (
+                <ProviderCardSkeleton key={i} />
+              ))}
+            </div>
+          ) : providers.length === 0 ? (
+            <Card className="p-8 text-center">
+              <Server className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+              <h3 className="text-lg font-medium mb-2">No providers configured</h3>
+              <p className="text-muted-foreground mb-4">
+                Add an LLM provider to start using AI models with your agents.
+              </p>
+              <Button onClick={() => setAddProviderOpen(true)}>
+                <Plus className="h-4 w-4 mr-2" />
+                Add Provider
+              </Button>
+            </Card>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {providers.map((provider) => (
+                <ProviderCard
+                  key={provider.id}
+                  provider={provider}
+                  onDelete={handleDeleteProvider}
+                  onSetApiKey={setApiKeyProvider}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* LLM Models Section */}
+        <section>
+          <div className="flex items-center justify-between mb-4">
+            <div>
+              <h2 className="text-xl font-semibold">Models</h2>
+              <p className="text-sm text-muted-foreground">
+                Manage the models available from your configured providers.
+              </p>
+            </div>
+            <Button onClick={() => setAddModelOpen(true)} disabled={providers.length === 0}>
+              <Plus className="h-4 w-4 mr-2" />
+              Add Model
+            </Button>
+          </div>
+
+          {modelsError && (
+            <div className="bg-destructive/10 text-destructive p-4 rounded-lg mb-4">
+              Failed to load models: {modelsError.message}
+            </div>
+          )}
+
+          {modelsLoading ? (
+            <div className="space-y-2">
+              {[...Array(3)].map((_, i) => (
+                <Skeleton key={i} className="h-16 w-full" />
+              ))}
+            </div>
+          ) : models.length === 0 ? (
+            <Card className="p-8 text-center">
+              <Cpu className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+              <h3 className="text-lg font-medium mb-2">No models configured</h3>
+              <p className="text-muted-foreground mb-4">
+                {providers.length === 0
+                  ? "Add a provider first, then add models to it."
+                  : "Add models to your providers to use them with agents."}
+              </p>
+              {providers.length > 0 && (
+                <Button onClick={() => setAddModelOpen(true)}>
+                  <Plus className="h-4 w-4 mr-2" />
+                  Add Model
+                </Button>
+              )}
+            </Card>
+          ) : (
+            <div className="space-y-2">
+              {models.map((model) => (
+                <ModelRow key={model.id} model={model} onDelete={handleDeleteModel} />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+
+      {/* Dialogs */}
+      <AddProviderDialog open={addProviderOpen} onOpenChange={setAddProviderOpen} />
+      <SetApiKeyDialog
+        provider={apiKeyProvider}
+        open={apiKeyProvider !== null}
+        onOpenChange={(open) => !open && setApiKeyProvider(null)}
+      />
+      <AddModelDialog
+        providers={providers}
+        open={addModelOpen}
+        onOpenChange={setAddModelOpen}
+      />
+    </>
+  );
+}

--- a/apps/ui/src/app/settings/page.tsx
+++ b/apps/ui/src/app/settings/page.tsx
@@ -417,7 +417,11 @@ function AddModelDialog({
             <Label htmlFor="provider">Provider</Label>
             <Select value={providerId} onValueChange={setProviderId}>
               <SelectTrigger className="w-full">
-                <SelectValue placeholder="Select provider" />
+                <span className={!providerId ? "text-muted-foreground" : ""}>
+                  {providerId
+                    ? providers.find((p) => p.id === providerId)?.name
+                    : "Select provider"}
+                </span>
               </SelectTrigger>
               <SelectContent>
                 {providers.map((p) => (

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -9,6 +9,7 @@ import {
   Bot,
   Play,
   MessageSquare,
+  Settings,
 } from "lucide-react";
 
 const navigation = [
@@ -16,6 +17,7 @@ const navigation = [
   { name: "Agents", href: "/agents", icon: Bot },
   { name: "Runs", href: "/runs", icon: Play },
   { name: "Chat", href: "/chat", icon: MessageSquare },
+  { name: "Settings", href: "/settings", icon: Settings },
 ];
 
 export function Sidebar() {

--- a/apps/ui/src/hooks/index.ts
+++ b/apps/ui/src/hooks/index.ts
@@ -2,3 +2,4 @@ export * from "./use-agents";
 export * from "./use-runs";
 export * from "./use-threads";
 export * from "./use-sse-events";
+export * from "./use-llm-providers";

--- a/apps/ui/src/hooks/use-llm-providers.ts
+++ b/apps/ui/src/hooks/use-llm-providers.ts
@@ -1,0 +1,129 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  getLlmProviders,
+  getLlmProvider,
+  createLlmProvider,
+  updateLlmProvider,
+  deleteLlmProvider,
+  getLlmModels,
+  getLlmProviderModels,
+  getLlmModel,
+  createLlmModel,
+  updateLlmModel,
+  deleteLlmModel,
+} from "@/lib/api/llm-providers";
+import type {
+  CreateLlmProviderRequest,
+  UpdateLlmProviderRequest,
+  CreateLlmModelRequest,
+  UpdateLlmModelRequest,
+} from "@/lib/api/types";
+
+// Provider hooks
+export function useLlmProviders() {
+  return useQuery({
+    queryKey: ["llm-providers"],
+    queryFn: getLlmProviders,
+    staleTime: 30000,
+  });
+}
+
+export function useLlmProvider(providerId: string) {
+  return useQuery({
+    queryKey: ["llm-providers", providerId],
+    queryFn: () => getLlmProvider(providerId),
+    enabled: !!providerId,
+  });
+}
+
+export function useCreateLlmProvider() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateLlmProviderRequest) => createLlmProvider(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["llm-providers"] });
+    },
+  });
+}
+
+export function useUpdateLlmProvider(providerId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: UpdateLlmProviderRequest) =>
+      updateLlmProvider(providerId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["llm-providers"] });
+      queryClient.invalidateQueries({ queryKey: ["llm-providers", providerId] });
+    },
+  });
+}
+
+export function useDeleteLlmProvider() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (providerId: string) => deleteLlmProvider(providerId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["llm-providers"] });
+      queryClient.invalidateQueries({ queryKey: ["llm-models"] });
+    },
+  });
+}
+
+// Model hooks
+export function useLlmModels() {
+  return useQuery({
+    queryKey: ["llm-models"],
+    queryFn: getLlmModels,
+    staleTime: 30000,
+  });
+}
+
+export function useLlmProviderModels(providerId: string) {
+  return useQuery({
+    queryKey: ["llm-providers", providerId, "models"],
+    queryFn: () => getLlmProviderModels(providerId),
+    enabled: !!providerId,
+  });
+}
+
+export function useLlmModel(modelId: string) {
+  return useQuery({
+    queryKey: ["llm-models", modelId],
+    queryFn: () => getLlmModel(modelId),
+    enabled: !!modelId,
+  });
+}
+
+export function useCreateLlmModel(providerId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateLlmModelRequest) => createLlmModel(providerId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["llm-models"] });
+      queryClient.invalidateQueries({ queryKey: ["llm-providers", providerId, "models"] });
+    },
+  });
+}
+
+export function useUpdateLlmModel(modelId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: UpdateLlmModelRequest) => updateLlmModel(modelId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["llm-models"] });
+    },
+  });
+}
+
+export function useDeleteLlmModel() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (modelId: string) => deleteLlmModel(modelId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["llm-models"] });
+      queryClient.invalidateQueries({ queryKey: ["llm-providers"] });
+    },
+  });
+}

--- a/apps/ui/src/lib/api/index.ts
+++ b/apps/ui/src/lib/api/index.ts
@@ -3,3 +3,4 @@ export * from "./client";
 export * from "./agents";
 export * from "./threads";
 export * from "./runs";
+export * from "./llm-providers";

--- a/apps/ui/src/lib/api/llm-providers.ts
+++ b/apps/ui/src/lib/api/llm-providers.ts
@@ -1,0 +1,85 @@
+import { apiClient } from "./client";
+import type {
+  LlmProvider,
+  LlmModel,
+  LlmModelWithProvider,
+  CreateLlmProviderRequest,
+  UpdateLlmProviderRequest,
+  CreateLlmModelRequest,
+  UpdateLlmModelRequest,
+} from "./types";
+
+// Provider CRUD
+export async function getLlmProviders(): Promise<LlmProvider[]> {
+  return apiClient<LlmProvider[]>("/v1/llm-providers");
+}
+
+export async function getLlmProvider(providerId: string): Promise<LlmProvider> {
+  return apiClient<LlmProvider>(`/v1/llm-providers/${providerId}`);
+}
+
+export async function createLlmProvider(
+  data: CreateLlmProviderRequest
+): Promise<LlmProvider> {
+  return apiClient<LlmProvider>("/v1/llm-providers", {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+export async function updateLlmProvider(
+  providerId: string,
+  data: UpdateLlmProviderRequest
+): Promise<LlmProvider> {
+  return apiClient<LlmProvider>(`/v1/llm-providers/${providerId}`, {
+    method: "PATCH",
+    body: JSON.stringify(data),
+  });
+}
+
+export async function deleteLlmProvider(providerId: string): Promise<void> {
+  await apiClient(`/v1/llm-providers/${providerId}`, {
+    method: "DELETE",
+  });
+}
+
+// Model CRUD
+export async function getLlmModels(): Promise<LlmModelWithProvider[]> {
+  return apiClient<LlmModelWithProvider[]>("/v1/llm-models");
+}
+
+export async function getLlmProviderModels(
+  providerId: string
+): Promise<LlmModel[]> {
+  return apiClient<LlmModel[]>(`/v1/llm-providers/${providerId}/models`);
+}
+
+export async function getLlmModel(modelId: string): Promise<LlmModel> {
+  return apiClient<LlmModel>(`/v1/llm-models/${modelId}`);
+}
+
+export async function createLlmModel(
+  providerId: string,
+  data: CreateLlmModelRequest
+): Promise<LlmModel> {
+  return apiClient<LlmModel>(`/v1/llm-providers/${providerId}/models`, {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+export async function updateLlmModel(
+  modelId: string,
+  data: UpdateLlmModelRequest
+): Promise<LlmModel> {
+  return apiClient<LlmModel>(`/v1/llm-models/${modelId}`, {
+    method: "PATCH",
+    body: JSON.stringify(data),
+  });
+}
+
+export async function deleteLlmModel(modelId: string): Promise<void> {
+  await apiClient(`/v1/llm-models/${modelId}`, {
+    method: "DELETE",
+  });
+}

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -172,3 +172,78 @@ export interface HealthResponse {
   status: string;
   version: string;
 }
+
+// LLM Provider types
+export type LlmProviderType =
+  | "openai"
+  | "anthropic"
+  | "azure_openai"
+  | "ollama"
+  | "custom";
+
+export type LlmProviderStatus = "active" | "disabled";
+export type LlmModelStatus = "active" | "disabled";
+
+export interface LlmProvider {
+  id: string;
+  name: string;
+  provider_type: LlmProviderType;
+  base_url?: string;
+  api_key_set: boolean;
+  is_default: boolean;
+  status: LlmProviderStatus;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface LlmModel {
+  id: string;
+  provider_id: string;
+  model_id: string;
+  display_name: string;
+  capabilities: string[];
+  context_window?: number;
+  is_default: boolean;
+  status: LlmModelStatus;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface LlmModelWithProvider extends LlmModel {
+  provider_name: string;
+  provider_type: LlmProviderType;
+}
+
+export interface CreateLlmProviderRequest {
+  name: string;
+  provider_type: LlmProviderType;
+  base_url?: string;
+  api_key?: string;
+  is_default?: boolean;
+}
+
+export interface UpdateLlmProviderRequest {
+  name?: string;
+  provider_type?: LlmProviderType;
+  base_url?: string;
+  api_key?: string;
+  is_default?: boolean;
+  status?: LlmProviderStatus;
+}
+
+export interface CreateLlmModelRequest {
+  model_id: string;
+  display_name: string;
+  capabilities?: string[];
+  context_window?: number;
+  is_default?: boolean;
+}
+
+export interface UpdateLlmModelRequest {
+  model_id?: string;
+  display_name?: string;
+  capabilities?: string[];
+  context_window?: number;
+  is_default?: boolean;
+  status?: LlmModelStatus;
+}

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -151,10 +151,8 @@ export interface UpdateAgentRequest {
   status?: AgentStatus;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface CreateThreadRequest {
-  // Empty for now - will be extended with metadata, etc.
-}
+// Empty request body - threads are created without parameters
+export type CreateThreadRequest = Record<string, never>;
 
 export interface CreateMessageRequest {
   role: string;

--- a/crates/everruns-api/src/llm_models.rs
+++ b/crates/everruns-api/src/llm_models.rs
@@ -1,0 +1,336 @@
+// LLM Model API endpoints
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    routing::{delete, get, patch, post},
+    Json, Router,
+};
+use everruns_contracts::{LlmModel, LlmModelStatus, LlmModelWithProvider, LlmProviderType};
+use everruns_storage::{
+    models::{CreateLlmModel, UpdateLlmModel},
+    Database,
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub db: Arc<Database>,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct CreateLlmModelRequest {
+    pub model_id: String,
+    pub display_name: String,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_window: Option<i32>,
+    #[serde(default)]
+    pub is_default: bool,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct UpdateLlmModelRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_window: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_default: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<LlmModelStatus>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ErrorResponse {
+    error: String,
+}
+
+fn row_to_model(row: &everruns_storage::models::LlmModelRow) -> LlmModel {
+    let capabilities: Vec<String> =
+        serde_json::from_value(row.capabilities.clone()).unwrap_or_default();
+    LlmModel {
+        id: row.id,
+        provider_id: row.provider_id,
+        model_id: row.model_id.clone(),
+        display_name: row.display_name.clone(),
+        capabilities,
+        context_window: row.context_window,
+        is_default: row.is_default,
+        status: match row.status.as_str() {
+            "active" => LlmModelStatus::Active,
+            _ => LlmModelStatus::Disabled,
+        },
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+    }
+}
+
+fn row_to_model_with_provider(
+    row: &everruns_storage::models::LlmModelWithProviderRow,
+) -> LlmModelWithProvider {
+    let capabilities: Vec<String> =
+        serde_json::from_value(row.capabilities.clone()).unwrap_or_default();
+    LlmModelWithProvider {
+        id: row.id,
+        provider_id: row.provider_id,
+        model_id: row.model_id.clone(),
+        display_name: row.display_name.clone(),
+        capabilities,
+        context_window: row.context_window,
+        is_default: row.is_default,
+        status: match row.status.as_str() {
+            "active" => LlmModelStatus::Active,
+            _ => LlmModelStatus::Disabled,
+        },
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+        provider_name: row.provider_name.clone(),
+        provider_type: row.provider_type.parse().unwrap_or(LlmProviderType::Custom),
+    }
+}
+
+/// Create a new model for a provider
+#[utoipa::path(
+    post,
+    path = "/v1/llm-providers/{provider_id}/models",
+    params(
+        ("provider_id" = Uuid, Path, description = "Provider ID")
+    ),
+    request_body = CreateLlmModelRequest,
+    responses(
+        (status = 201, description = "Model created", body = LlmModel),
+        (status = 400, description = "Invalid request"),
+        (status = 500, description = "Internal error")
+    ),
+    tag = "llm-models"
+)]
+pub async fn create_model(
+    State(state): State<AppState>,
+    Path(provider_id): Path<Uuid>,
+    Json(req): Json<CreateLlmModelRequest>,
+) -> Result<(StatusCode, Json<LlmModel>), (StatusCode, Json<ErrorResponse>)> {
+    let input = CreateLlmModel {
+        provider_id,
+        model_id: req.model_id,
+        display_name: req.display_name,
+        capabilities: req.capabilities,
+        context_window: req.context_window,
+        is_default: req.is_default,
+    };
+
+    let row = state.db.create_llm_model(input).await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+    })?;
+
+    Ok((StatusCode::CREATED, Json(row_to_model(&row))))
+}
+
+/// List models for a specific provider
+#[utoipa::path(
+    get,
+    path = "/v1/llm-providers/{provider_id}/models",
+    params(
+        ("provider_id" = Uuid, Path, description = "Provider ID")
+    ),
+    responses(
+        (status = 200, description = "List of models", body = Vec<LlmModel>)
+    ),
+    tag = "llm-models"
+)]
+pub async fn list_provider_models(
+    State(state): State<AppState>,
+    Path(provider_id): Path<Uuid>,
+) -> Result<Json<Vec<LlmModel>>, (StatusCode, Json<ErrorResponse>)> {
+    let rows = state
+        .db
+        .list_llm_models_for_provider(provider_id)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+        })?;
+
+    Ok(Json(rows.iter().map(row_to_model).collect()))
+}
+
+/// List all models across all providers
+#[utoipa::path(
+    get,
+    path = "/v1/llm-models",
+    responses(
+        (status = 200, description = "List of all models", body = Vec<LlmModelWithProvider>)
+    ),
+    tag = "llm-models"
+)]
+pub async fn list_all_models(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<LlmModelWithProvider>>, (StatusCode, Json<ErrorResponse>)> {
+    let rows = state.db.list_all_llm_models().await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+    })?;
+
+    Ok(Json(rows.iter().map(row_to_model_with_provider).collect()))
+}
+
+/// Get a specific model
+#[utoipa::path(
+    get,
+    path = "/v1/llm-models/{id}",
+    params(
+        ("id" = Uuid, Path, description = "Model ID")
+    ),
+    responses(
+        (status = 200, description = "Model found", body = LlmModel),
+        (status = 404, description = "Model not found")
+    ),
+    tag = "llm-models"
+)]
+pub async fn get_model(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<LlmModel>, (StatusCode, Json<ErrorResponse>)> {
+    let row = state.db.get_llm_model(id).await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+    })?;
+
+    match row {
+        Some(r) => Ok(Json(row_to_model(&r))),
+        None => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: "Model not found".to_string(),
+            }),
+        )),
+    }
+}
+
+/// Update a model
+#[utoipa::path(
+    patch,
+    path = "/v1/llm-models/{id}",
+    params(
+        ("id" = Uuid, Path, description = "Model ID")
+    ),
+    request_body = UpdateLlmModelRequest,
+    responses(
+        (status = 200, description = "Model updated", body = LlmModel),
+        (status = 404, description = "Model not found")
+    ),
+    tag = "llm-models"
+)]
+pub async fn update_model(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    Json(req): Json<UpdateLlmModelRequest>,
+) -> Result<Json<LlmModel>, (StatusCode, Json<ErrorResponse>)> {
+    let input = UpdateLlmModel {
+        model_id: req.model_id,
+        display_name: req.display_name,
+        capabilities: req.capabilities,
+        context_window: req.context_window,
+        is_default: req.is_default,
+        status: req.status.map(|s| match s {
+            LlmModelStatus::Active => "active".to_string(),
+            LlmModelStatus::Disabled => "disabled".to_string(),
+        }),
+    };
+
+    let row = state.db.update_llm_model(id, input).await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+    })?;
+
+    match row {
+        Some(r) => Ok(Json(row_to_model(&r))),
+        None => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: "Model not found".to_string(),
+            }),
+        )),
+    }
+}
+
+/// Delete a model
+#[utoipa::path(
+    delete,
+    path = "/v1/llm-models/{id}",
+    params(
+        ("id" = Uuid, Path, description = "Model ID")
+    ),
+    responses(
+        (status = 204, description = "Model deleted"),
+        (status = 404, description = "Model not found")
+    ),
+    tag = "llm-models"
+)]
+pub async fn delete_model(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let deleted = state.db.delete_llm_model(id).await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+    })?;
+
+    if deleted {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: "Model not found".to_string(),
+            }),
+        ))
+    }
+}
+
+pub fn routes(state: AppState) -> Router {
+    Router::new()
+        .route("/v1/llm-providers/{provider_id}/models", post(create_model))
+        .route(
+            "/v1/llm-providers/{provider_id}/models",
+            get(list_provider_models),
+        )
+        .route("/v1/llm-models", get(list_all_models))
+        .route("/v1/llm-models/{id}", get(get_model))
+        .route("/v1/llm-models/{id}", patch(update_model))
+        .route("/v1/llm-models/{id}", delete(delete_model))
+        .with_state(state)
+}

--- a/crates/everruns-api/src/llm_models.rs
+++ b/crates/everruns-api/src/llm_models.rs
@@ -3,7 +3,7 @@
 use axum::{
     extract::{Path, State},
     http::StatusCode,
-    routing::{delete, get, patch, post},
+    routing::{get, post},
     Json, Router,
 };
 use everruns_contracts::{LlmModel, LlmModelStatus, LlmModelWithProvider, LlmProviderType};
@@ -323,14 +323,14 @@ pub async fn delete_model(
 
 pub fn routes(state: AppState) -> Router {
     Router::new()
-        .route("/v1/llm-providers/{provider_id}/models", post(create_model))
         .route(
             "/v1/llm-providers/{provider_id}/models",
-            get(list_provider_models),
+            post(create_model).get(list_provider_models),
         )
         .route("/v1/llm-models", get(list_all_models))
-        .route("/v1/llm-models/{id}", get(get_model))
-        .route("/v1/llm-models/{id}", patch(update_model))
-        .route("/v1/llm-models/{id}", delete(delete_model))
+        .route(
+            "/v1/llm-models/{id}",
+            get(get_model).patch(update_model).delete(delete_model),
+        )
         .with_state(state)
 }

--- a/crates/everruns-api/src/llm_models.rs
+++ b/crates/everruns-api/src/llm_models.rs
@@ -324,12 +324,12 @@ pub async fn delete_model(
 pub fn routes(state: AppState) -> Router {
     Router::new()
         .route(
-            "/v1/llm-providers/{provider_id}/models",
+            "/v1/llm-providers/:provider_id/models",
             post(create_model).get(list_provider_models),
         )
         .route("/v1/llm-models", get(list_all_models))
         .route(
-            "/v1/llm-models/{id}",
+            "/v1/llm-models/:id",
             get(get_model).patch(update_model).delete(delete_model),
         )
         .with_state(state)

--- a/crates/everruns-api/src/llm_providers.rs
+++ b/crates/everruns-api/src/llm_providers.rs
@@ -1,0 +1,315 @@
+// LLM Provider API endpoints
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    routing::{delete, get, patch, post},
+    Json, Router,
+};
+use everruns_contracts::{LlmProvider, LlmProviderStatus, LlmProviderType};
+use everruns_storage::{
+    models::{CreateLlmProvider, UpdateLlmProvider},
+    Database, EncryptionService,
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub db: Arc<Database>,
+    pub encryption: Option<Arc<EncryptionService>>,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct CreateLlmProviderRequest {
+    pub name: String,
+    pub provider_type: LlmProviderType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_key: Option<String>,
+    #[serde(default)]
+    pub is_default: bool,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct UpdateLlmProviderRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider_type: Option<LlmProviderType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_default: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<LlmProviderStatus>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ErrorResponse {
+    error: String,
+}
+
+fn row_to_provider(row: &everruns_storage::models::LlmProviderRow) -> LlmProvider {
+    LlmProvider {
+        id: row.id,
+        name: row.name.clone(),
+        provider_type: row.provider_type.parse().unwrap_or(LlmProviderType::Custom),
+        base_url: row.base_url.clone(),
+        api_key_set: row.api_key_set,
+        is_default: row.is_default,
+        status: match row.status.as_str() {
+            "active" => LlmProviderStatus::Active,
+            _ => LlmProviderStatus::Disabled,
+        },
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+    }
+}
+
+/// Create a new LLM provider
+#[utoipa::path(
+    post,
+    path = "/v1/llm-providers",
+    request_body = CreateLlmProviderRequest,
+    responses(
+        (status = 201, description = "Provider created", body = LlmProvider),
+        (status = 400, description = "Invalid request"),
+        (status = 500, description = "Internal error")
+    ),
+    tag = "llm-providers"
+)]
+pub async fn create_provider(
+    State(state): State<AppState>,
+    Json(req): Json<CreateLlmProviderRequest>,
+) -> Result<(StatusCode, Json<LlmProvider>), (StatusCode, Json<ErrorResponse>)> {
+    // Encrypt API key if provided and encryption is available
+    let api_key_encrypted = if let Some(api_key) = &req.api_key {
+        if let Some(encryption) = &state.encryption {
+            Some(encryption.encrypt_string(api_key).map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: format!("Failed to encrypt API key: {}", e),
+                    }),
+                )
+            })?)
+        } else {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: "Encryption not configured. Cannot store API key.".to_string(),
+                }),
+            ));
+        }
+    } else {
+        None
+    };
+
+    let input = CreateLlmProvider {
+        name: req.name,
+        provider_type: req.provider_type.to_string(),
+        base_url: req.base_url,
+        api_key_encrypted,
+        is_default: req.is_default,
+    };
+
+    let row = state.db.create_llm_provider(input).await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+    })?;
+
+    Ok((StatusCode::CREATED, Json(row_to_provider(&row))))
+}
+
+/// List all LLM providers
+#[utoipa::path(
+    get,
+    path = "/v1/llm-providers",
+    responses(
+        (status = 200, description = "List of providers", body = Vec<LlmProvider>)
+    ),
+    tag = "llm-providers"
+)]
+pub async fn list_providers(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<LlmProvider>>, (StatusCode, Json<ErrorResponse>)> {
+    let rows = state.db.list_llm_providers().await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+    })?;
+
+    Ok(Json(rows.iter().map(row_to_provider).collect()))
+}
+
+/// Get a specific LLM provider
+#[utoipa::path(
+    get,
+    path = "/v1/llm-providers/{id}",
+    params(
+        ("id" = Uuid, Path, description = "Provider ID")
+    ),
+    responses(
+        (status = 200, description = "Provider found", body = LlmProvider),
+        (status = 404, description = "Provider not found")
+    ),
+    tag = "llm-providers"
+)]
+pub async fn get_provider(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<LlmProvider>, (StatusCode, Json<ErrorResponse>)> {
+    let row = state.db.get_llm_provider(id).await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+    })?;
+
+    match row {
+        Some(r) => Ok(Json(row_to_provider(&r))),
+        None => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: "Provider not found".to_string(),
+            }),
+        )),
+    }
+}
+
+/// Update an LLM provider
+#[utoipa::path(
+    patch,
+    path = "/v1/llm-providers/{id}",
+    params(
+        ("id" = Uuid, Path, description = "Provider ID")
+    ),
+    request_body = UpdateLlmProviderRequest,
+    responses(
+        (status = 200, description = "Provider updated", body = LlmProvider),
+        (status = 404, description = "Provider not found")
+    ),
+    tag = "llm-providers"
+)]
+pub async fn update_provider(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    Json(req): Json<UpdateLlmProviderRequest>,
+) -> Result<Json<LlmProvider>, (StatusCode, Json<ErrorResponse>)> {
+    // Encrypt API key if provided
+    let api_key_encrypted = if let Some(api_key) = &req.api_key {
+        if let Some(encryption) = &state.encryption {
+            Some(encryption.encrypt_string(api_key).map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: format!("Failed to encrypt API key: {}", e),
+                    }),
+                )
+            })?)
+        } else {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: "Encryption not configured. Cannot store API key.".to_string(),
+                }),
+            ));
+        }
+    } else {
+        None
+    };
+
+    let input = UpdateLlmProvider {
+        name: req.name,
+        provider_type: req.provider_type.map(|t| t.to_string()),
+        base_url: req.base_url,
+        api_key_encrypted,
+        is_default: req.is_default,
+        status: req.status.map(|s| match s {
+            LlmProviderStatus::Active => "active".to_string(),
+            LlmProviderStatus::Disabled => "disabled".to_string(),
+        }),
+    };
+
+    let row = state.db.update_llm_provider(id, input).await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+    })?;
+
+    match row {
+        Some(r) => Ok(Json(row_to_provider(&r))),
+        None => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: "Provider not found".to_string(),
+            }),
+        )),
+    }
+}
+
+/// Delete an LLM provider
+#[utoipa::path(
+    delete,
+    path = "/v1/llm-providers/{id}",
+    params(
+        ("id" = Uuid, Path, description = "Provider ID")
+    ),
+    responses(
+        (status = 204, description = "Provider deleted"),
+        (status = 404, description = "Provider not found")
+    ),
+    tag = "llm-providers"
+)]
+pub async fn delete_provider(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let deleted = state.db.delete_llm_provider(id).await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+    })?;
+
+    if deleted {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: "Provider not found".to_string(),
+            }),
+        ))
+    }
+}
+
+pub fn routes(state: AppState) -> Router {
+    Router::new()
+        .route("/v1/llm-providers", post(create_provider))
+        .route("/v1/llm-providers", get(list_providers))
+        .route("/v1/llm-providers/{id}", get(get_provider))
+        .route("/v1/llm-providers/{id}", patch(update_provider))
+        .route("/v1/llm-providers/{id}", delete(delete_provider))
+        .with_state(state)
+}

--- a/crates/everruns-api/src/llm_providers.rs
+++ b/crates/everruns-api/src/llm_providers.rs
@@ -311,7 +311,7 @@ pub fn routes(state: AppState) -> Router {
             post(create_provider).get(list_providers),
         )
         .route(
-            "/v1/llm-providers/{id}",
+            "/v1/llm-providers/:id",
             get(get_provider).patch(update_provider).delete(delete_provider),
         )
         .with_state(state)

--- a/crates/everruns-api/src/llm_providers.rs
+++ b/crates/everruns-api/src/llm_providers.rs
@@ -312,7 +312,9 @@ pub fn routes(state: AppState) -> Router {
         )
         .route(
             "/v1/llm-providers/:id",
-            get(get_provider).patch(update_provider).delete(delete_provider),
+            get(get_provider)
+                .patch(update_provider)
+                .delete(delete_provider),
         )
         .with_state(state)
 }

--- a/crates/everruns-api/src/llm_providers.rs
+++ b/crates/everruns-api/src/llm_providers.rs
@@ -3,7 +3,7 @@
 use axum::{
     extract::{Path, State},
     http::StatusCode,
-    routing::{delete, get, patch, post},
+    routing::{get, post},
     Json, Router,
 };
 use everruns_contracts::{LlmProvider, LlmProviderStatus, LlmProviderType};
@@ -306,10 +306,13 @@ pub async fn delete_provider(
 
 pub fn routes(state: AppState) -> Router {
     Router::new()
-        .route("/v1/llm-providers", post(create_provider))
-        .route("/v1/llm-providers", get(list_providers))
-        .route("/v1/llm-providers/{id}", get(get_provider))
-        .route("/v1/llm-providers/{id}", patch(update_provider))
-        .route("/v1/llm-providers/{id}", delete(delete_provider))
+        .route(
+            "/v1/llm-providers",
+            post(create_provider).get(list_providers),
+        )
+        .route(
+            "/v1/llm-providers/{id}",
+            get(get_provider).patch(update_provider).delete(delete_provider),
+        )
         .with_state(state)
 }

--- a/crates/everruns-api/src/main.rs
+++ b/crates/everruns-api/src/main.rs
@@ -202,14 +202,17 @@ async fn main() -> Result<()> {
     };
 
     // Build router
+    // Note: llm_models routes must be merged BEFORE llm_providers
+    // because /v1/llm-providers/{provider_id}/models is more specific
+    // than /v1/llm-providers/{id}
     let app = Router::new()
         .route("/health", get(health).with_state(health_state))
         .merge(agents::routes(agents_state))
         .merge(threads::routes(threads_state))
         .merge(runs::routes(runs_state))
         .merge(agui::routes(agui_state))
-        .merge(llm_providers::routes(llm_providers_state))
         .merge(llm_models::routes(llm_models_state))
+        .merge(llm_providers::routes(llm_providers_state))
         .merge(SwaggerUi::new("/swagger-ui").url("/api-doc/openapi.json", ApiDoc::openapi()))
         .layer(
             CorsLayer::new()

--- a/crates/everruns-api/tests/integration_test.rs
+++ b/crates/everruns-api/tests/integration_test.rs
@@ -1,7 +1,7 @@
 // Integration tests for Everruns API
 // Run with: cargo test --test integration_test
 
-use everruns_contracts::{Agent, AgentStatus, Message, Run, Thread};
+use everruns_contracts::{Agent, AgentStatus, Message, Run, Thread, LlmProvider, LlmModel};
 use serde_json::json;
 
 const API_BASE_URL: &str = "http://localhost:9000";
@@ -220,4 +220,205 @@ async fn test_openapi_spec() {
     let spec: serde_json::Value = response.json().await.expect("Failed to parse spec");
     println!("✅ OpenAPI spec title: {}", spec["info"]["title"]);
     assert_eq!(spec["info"]["title"], "Everruns API");
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_llm_provider_and_model_workflow() {
+    let client = reqwest::Client::new();
+
+    println!("🧪 Testing LLM Provider and Model workflow...");
+
+    // Step 1: Create an LLM provider
+    println!("\n📝 Step 1: Creating LLM provider...");
+    let create_provider_response = client
+        .post(format!("{}/v1/llm-providers", API_BASE_URL))
+        .json(&json!({
+            "name": "Test OpenAI Provider",
+            "provider_type": "openai",
+            "base_url": "https://api.openai.com/v1",
+            "is_default": true
+        }))
+        .send()
+        .await
+        .expect("Failed to create LLM provider");
+
+    println!(
+        "Create provider response status: {}",
+        create_provider_response.status()
+    );
+    let response_text = create_provider_response
+        .text()
+        .await
+        .expect("Failed to get response text");
+    println!("Create provider response body: {}", response_text);
+
+    let provider: LlmProvider =
+        serde_json::from_str(&response_text).expect("Failed to parse provider response");
+
+    println!("✅ Created provider: {} ({})", provider.name, provider.id);
+    assert_eq!(provider.name, "Test OpenAI Provider");
+
+    // Step 2: List providers
+    println!("\n📋 Step 2: Listing providers...");
+    let list_response = client
+        .get(format!("{}/v1/llm-providers", API_BASE_URL))
+        .send()
+        .await
+        .expect("Failed to list providers");
+
+    assert_eq!(list_response.status(), 200);
+    let providers: Vec<LlmProvider> = list_response
+        .json()
+        .await
+        .expect("Failed to parse providers");
+    println!("✅ Found {} provider(s)", providers.len());
+    assert!(!providers.is_empty());
+
+    // Step 3: Get provider by ID
+    println!("\n🔍 Step 3: Getting provider by ID...");
+    let get_response = client
+        .get(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
+        .send()
+        .await
+        .expect("Failed to get provider");
+
+    assert_eq!(get_response.status(), 200);
+    let fetched_provider: LlmProvider = get_response
+        .json()
+        .await
+        .expect("Failed to parse provider");
+    println!("✅ Fetched provider: {}", fetched_provider.name);
+    assert_eq!(fetched_provider.id, provider.id);
+
+    // Step 4: Create a model for the provider
+    println!("\n🤖 Step 4: Creating model for provider...");
+    let model_url = format!(
+        "{}/v1/llm-providers/{}/models",
+        API_BASE_URL, provider.id
+    );
+    println!("POST {}", model_url);
+
+    let create_model_response = client
+        .post(&model_url)
+        .json(&json!({
+            "model_id": "gpt-4o",
+            "display_name": "GPT-4o",
+            "capabilities": ["chat", "vision"],
+            "context_window": 128000,
+            "is_default": true
+        }))
+        .send()
+        .await
+        .expect("Failed to create model");
+
+    let model_status = create_model_response.status();
+    println!("Create model response status: {}", model_status);
+
+    let model_response_text = create_model_response
+        .text()
+        .await
+        .expect("Failed to get model response text");
+    println!("Create model response body: {}", model_response_text);
+
+    assert_eq!(
+        model_status, 201,
+        "Expected 201 Created for model creation, got {}. Response: {}",
+        model_status, model_response_text
+    );
+
+    let model: LlmModel =
+        serde_json::from_str(&model_response_text).expect("Failed to parse model response");
+
+    println!("✅ Created model: {} ({})", model.display_name, model.id);
+    assert_eq!(model.model_id, "gpt-4o");
+    assert_eq!(model.display_name, "GPT-4o");
+
+    // Step 5: List models for provider
+    println!("\n📋 Step 5: Listing models for provider...");
+    let list_models_response = client
+        .get(format!(
+            "{}/v1/llm-providers/{}/models",
+            API_BASE_URL, provider.id
+        ))
+        .send()
+        .await
+        .expect("Failed to list models for provider");
+
+    assert_eq!(list_models_response.status(), 200);
+    let provider_models: Vec<LlmModel> = list_models_response
+        .json()
+        .await
+        .expect("Failed to parse provider models");
+    println!("✅ Found {} model(s) for provider", provider_models.len());
+    assert!(!provider_models.is_empty());
+
+    // Step 6: List all models
+    println!("\n📋 Step 6: Listing all models...");
+    let all_models_response = client
+        .get(format!("{}/v1/llm-models", API_BASE_URL))
+        .send()
+        .await
+        .expect("Failed to list all models");
+
+    assert_eq!(all_models_response.status(), 200);
+
+    // Step 7: Get model by ID
+    println!("\n🔍 Step 7: Getting model by ID...");
+    let get_model_response = client
+        .get(format!("{}/v1/llm-models/{}", API_BASE_URL, model.id))
+        .send()
+        .await
+        .expect("Failed to get model");
+
+    assert_eq!(get_model_response.status(), 200);
+    let fetched_model: LlmModel = get_model_response
+        .json()
+        .await
+        .expect("Failed to parse model");
+    println!("✅ Fetched model: {}", fetched_model.display_name);
+    assert_eq!(fetched_model.id, model.id);
+
+    // Step 8: Update model
+    println!("\n✏️  Step 8: Updating model...");
+    let update_model_response = client
+        .patch(format!("{}/v1/llm-models/{}", API_BASE_URL, model.id))
+        .json(&json!({
+            "display_name": "GPT-4o (Updated)"
+        }))
+        .send()
+        .await
+        .expect("Failed to update model");
+
+    assert_eq!(update_model_response.status(), 200);
+    let updated_model: LlmModel = update_model_response
+        .json()
+        .await
+        .expect("Failed to parse updated model");
+    println!("✅ Updated model: {}", updated_model.display_name);
+    assert_eq!(updated_model.display_name, "GPT-4o (Updated)");
+
+    // Step 9: Delete model
+    println!("\n🗑️  Step 9: Deleting model...");
+    let delete_model_response = client
+        .delete(format!("{}/v1/llm-models/{}", API_BASE_URL, model.id))
+        .send()
+        .await
+        .expect("Failed to delete model");
+
+    assert_eq!(delete_model_response.status(), 204);
+    println!("✅ Deleted model");
+
+    // Step 10: Delete provider
+    println!("\n🗑️  Step 10: Deleting provider...");
+    let delete_provider_response = client
+        .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
+        .send()
+        .await
+        .expect("Failed to delete provider");
+
+    assert_eq!(delete_provider_response.status(), 204);
+    println!("✅ Deleted provider");
+
+    println!("\n🎉 All LLM provider and model tests passed!");
 }

--- a/crates/everruns-api/tests/integration_test.rs
+++ b/crates/everruns-api/tests/integration_test.rs
@@ -1,7 +1,7 @@
 // Integration tests for Everruns API
 // Run with: cargo test --test integration_test
 
-use everruns_contracts::{Agent, AgentStatus, Message, Run, Thread, LlmProvider, LlmModel};
+use everruns_contracts::{Agent, AgentStatus, LlmModel, LlmProvider, Message, Run, Thread};
 use serde_json::json;
 
 const API_BASE_URL: &str = "http://localhost:9000";
@@ -284,19 +284,14 @@ async fn test_llm_provider_and_model_workflow() {
         .expect("Failed to get provider");
 
     assert_eq!(get_response.status(), 200);
-    let fetched_provider: LlmProvider = get_response
-        .json()
-        .await
-        .expect("Failed to parse provider");
+    let fetched_provider: LlmProvider =
+        get_response.json().await.expect("Failed to parse provider");
     println!("✅ Fetched provider: {}", fetched_provider.name);
     assert_eq!(fetched_provider.id, provider.id);
 
     // Step 4: Create a model for the provider
     println!("\n🤖 Step 4: Creating model for provider...");
-    let model_url = format!(
-        "{}/v1/llm-providers/{}/models",
-        API_BASE_URL, provider.id
-    );
+    let model_url = format!("{}/v1/llm-providers/{}/models", API_BASE_URL, provider.id);
     println!("POST {}", model_url);
 
     let create_model_response = client

--- a/crates/everruns-contracts/src/lib.rs
+++ b/crates/everruns-contracts/src/lib.rs
@@ -3,10 +3,12 @@
 
 pub mod agents;
 pub mod events;
+pub mod llm;
 pub mod resources;
 pub mod tools;
 
 pub use agents::*;
 pub use events::*;
+pub use llm::*;
 pub use resources::*;
 pub use tools::*;

--- a/crates/everruns-contracts/src/llm.rs
+++ b/crates/everruns-contracts/src/llm.rs
@@ -1,0 +1,107 @@
+// LLM Provider and Model public DTOs
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum LlmProviderType {
+    Openai,
+    Anthropic,
+    AzureOpenai,
+    Ollama,
+    Custom,
+}
+
+impl std::fmt::Display for LlmProviderType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LlmProviderType::Openai => write!(f, "openai"),
+            LlmProviderType::Anthropic => write!(f, "anthropic"),
+            LlmProviderType::AzureOpenai => write!(f, "azure_openai"),
+            LlmProviderType::Ollama => write!(f, "ollama"),
+            LlmProviderType::Custom => write!(f, "custom"),
+        }
+    }
+}
+
+impl std::str::FromStr for LlmProviderType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "openai" => Ok(LlmProviderType::Openai),
+            "anthropic" => Ok(LlmProviderType::Anthropic),
+            "azure_openai" => Ok(LlmProviderType::AzureOpenai),
+            "ollama" => Ok(LlmProviderType::Ollama),
+            "custom" => Ok(LlmProviderType::Custom),
+            _ => Err(format!("Unknown provider type: {}", s)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum LlmProviderStatus {
+    Active,
+    Disabled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum LlmModelStatus {
+    Active,
+    Disabled,
+}
+
+/// LLM Provider (API keys never exposed)
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct LlmProvider {
+    pub id: Uuid,
+    pub name: String,
+    pub provider_type: LlmProviderType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_url: Option<String>,
+    /// Whether an API key is configured (key is never returned)
+    pub api_key_set: bool,
+    pub is_default: bool,
+    pub status: LlmProviderStatus,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// LLM Model
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct LlmModel {
+    pub id: Uuid,
+    pub provider_id: Uuid,
+    pub model_id: String,
+    pub display_name: String,
+    pub capabilities: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_window: Option<i32>,
+    pub is_default: bool,
+    pub status: LlmModelStatus,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// LLM Model with provider info
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct LlmModelWithProvider {
+    pub id: Uuid,
+    pub provider_id: Uuid,
+    pub model_id: String,
+    pub display_name: String,
+    pub capabilities: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_window: Option<i32>,
+    pub is_default: bool,
+    pub status: LlmModelStatus,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub provider_name: String,
+    pub provider_type: LlmProviderType,
+}

--- a/crates/everruns-storage/Cargo.toml
+++ b/crates/everruns-storage/Cargo.toml
@@ -18,4 +18,9 @@ rand.workspace = true
 base64.workspace = true
 tracing.workspace = true
 
+# Encryption
+aes-gcm = "0.10"
+base64 = "0.22"
+rand = "0.8"
+
 everruns-contracts = { path = "../everruns-contracts" }

--- a/crates/everruns-storage/Cargo.toml
+++ b/crates/everruns-storage/Cargo.toml
@@ -18,9 +18,4 @@ rand.workspace = true
 base64.workspace = true
 tracing.workspace = true
 
-# Encryption
-aes-gcm = "0.10"
-base64 = "0.22"
-rand = "0.8"
-
 everruns-contracts = { path = "../everruns-contracts" }

--- a/crates/everruns-storage/migrations/002_llm_providers.sql
+++ b/crates/everruns-storage/migrations/002_llm_providers.sql
@@ -1,0 +1,51 @@
+-- LLM Providers and Models
+-- Decision: API keys encrypted with AES-256-GCM, key from SECRETS_ENCRYPTION_KEY env var
+-- Decision: api_key_set flag indicates if key is configured (key never exposed in API)
+
+-- LLM Providers table
+CREATE TABLE llm_providers (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    name TEXT NOT NULL,
+    provider_type TEXT NOT NULL CHECK (provider_type IN ('openai', 'anthropic', 'azure_openai', 'ollama', 'custom')),
+    base_url TEXT,
+    -- Encrypted API key (AES-256-GCM): 12-byte nonce || ciphertext || 16-byte tag
+    api_key_encrypted BYTEA,
+    api_key_set BOOLEAN NOT NULL DEFAULT FALSE,
+    is_default BOOLEAN NOT NULL DEFAULT FALSE,
+    status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'disabled')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_llm_providers_status ON llm_providers(status);
+CREATE INDEX idx_llm_providers_provider_type ON llm_providers(provider_type);
+-- Ensure only one default provider
+CREATE UNIQUE INDEX idx_llm_providers_default ON llm_providers(is_default) WHERE is_default = TRUE;
+
+-- LLM Models table
+CREATE TABLE llm_models (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    provider_id UUID NOT NULL REFERENCES llm_providers(id) ON DELETE CASCADE,
+    model_id TEXT NOT NULL,
+    display_name TEXT NOT NULL,
+    capabilities JSONB NOT NULL DEFAULT '[]'::jsonb,
+    context_window INTEGER,
+    is_default BOOLEAN NOT NULL DEFAULT FALSE,
+    status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'disabled')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_llm_models_provider_id ON llm_models(provider_id);
+CREATE INDEX idx_llm_models_status ON llm_models(status);
+-- Unique model_id per provider
+CREATE UNIQUE INDEX idx_llm_models_provider_model ON llm_models(provider_id, model_id);
+-- Ensure only one default model per provider
+CREATE UNIQUE INDEX idx_llm_models_provider_default ON llm_models(provider_id, is_default) WHERE is_default = TRUE;
+
+-- Apply updated_at trigger
+CREATE TRIGGER update_llm_providers_updated_at BEFORE UPDATE ON llm_providers
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_llm_models_updated_at BEFORE UPDATE ON llm_models
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/crates/everruns-storage/src/encryption.rs
+++ b/crates/everruns-storage/src/encryption.rs
@@ -324,13 +324,12 @@ pub struct EncryptedColumn {
 /// - `reencrypt-secrets` CLI tool for key rotation
 /// - Tests to ensure all encrypted columns are properly registered
 pub const ENCRYPTED_COLUMNS: &[EncryptedColumn] = &[
-    // Add encrypted columns here as they're created.
-    // Example:
-    // EncryptedColumn {
-    //     table: "llm_providers",
-    //     column: "api_key_encrypted",
-    //     id_column: "id",
-    // },
+    // LLM Provider API keys are encrypted at rest
+    EncryptedColumn {
+        table: "llm_providers",
+        column: "api_key_encrypted",
+        id_column: "id",
+    },
 ];
 
 #[cfg(test)]

--- a/crates/everruns-storage/src/models.rs
+++ b/crates/everruns-storage/src/models.rs
@@ -159,3 +159,89 @@ pub struct CreateRunEvent {
     pub event_type: String,
     pub event_data: serde_json::Value,
 }
+
+// LLM Provider types
+
+#[derive(Debug, Clone, FromRow)]
+pub struct LlmProviderRow {
+    pub id: Uuid,
+    pub name: String,
+    pub provider_type: String,
+    pub base_url: Option<String>,
+    pub api_key_encrypted: Option<Vec<u8>>,
+    pub api_key_set: bool,
+    pub is_default: bool,
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, FromRow)]
+pub struct LlmModelRow {
+    pub id: Uuid,
+    pub provider_id: Uuid,
+    pub model_id: String,
+    pub display_name: String,
+    pub capabilities: sqlx::types::JsonValue,
+    pub context_window: Option<i32>,
+    pub is_default: bool,
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Model with provider info joined
+#[derive(Debug, Clone, FromRow)]
+pub struct LlmModelWithProviderRow {
+    pub id: Uuid,
+    pub provider_id: Uuid,
+    pub model_id: String,
+    pub display_name: String,
+    pub capabilities: sqlx::types::JsonValue,
+    pub context_window: Option<i32>,
+    pub is_default: bool,
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub provider_name: String,
+    pub provider_type: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateLlmProvider {
+    pub name: String,
+    pub provider_type: String,
+    pub base_url: Option<String>,
+    pub api_key_encrypted: Option<Vec<u8>>,
+    pub is_default: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct UpdateLlmProvider {
+    pub name: Option<String>,
+    pub provider_type: Option<String>,
+    pub base_url: Option<String>,
+    pub api_key_encrypted: Option<Vec<u8>>,
+    pub is_default: Option<bool>,
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateLlmModel {
+    pub provider_id: Uuid,
+    pub model_id: String,
+    pub display_name: String,
+    pub capabilities: Vec<String>,
+    pub context_window: Option<i32>,
+    pub is_default: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct UpdateLlmModel {
+    pub model_id: Option<String>,
+    pub display_name: Option<String>,
+    pub capabilities: Option<Vec<String>>,
+    pub context_window: Option<i32>,
+    pub is_default: Option<bool>,
+    pub status: Option<String>,
+}

--- a/crates/everruns-storage/src/repositories.rs
+++ b/crates/everruns-storage/src/repositories.rs
@@ -337,4 +337,261 @@ impl Database {
 
         Ok(rows)
     }
+
+    // LLM Providers
+
+    pub async fn create_llm_provider(&self, input: CreateLlmProvider) -> Result<LlmProviderRow> {
+        let api_key_set = input.api_key_encrypted.is_some();
+
+        let row = sqlx::query_as::<_, LlmProviderRow>(
+            r#"
+            INSERT INTO llm_providers (name, provider_type, base_url, api_key_encrypted, api_key_set, is_default)
+            VALUES ($1, $2, $3, $4, $5, $6)
+            RETURNING id, name, provider_type, base_url, api_key_encrypted, api_key_set, is_default, status, created_at, updated_at
+            "#,
+        )
+        .bind(&input.name)
+        .bind(&input.provider_type)
+        .bind(&input.base_url)
+        .bind(&input.api_key_encrypted)
+        .bind(api_key_set)
+        .bind(input.is_default)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    pub async fn get_llm_provider(&self, id: Uuid) -> Result<Option<LlmProviderRow>> {
+        let row = sqlx::query_as::<_, LlmProviderRow>(
+            r#"
+            SELECT id, name, provider_type, base_url, api_key_encrypted, api_key_set, is_default, status, created_at, updated_at
+            FROM llm_providers
+            WHERE id = $1
+            "#,
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    pub async fn list_llm_providers(&self) -> Result<Vec<LlmProviderRow>> {
+        let rows = sqlx::query_as::<_, LlmProviderRow>(
+            r#"
+            SELECT id, name, provider_type, base_url, api_key_encrypted, api_key_set, is_default, status, created_at, updated_at
+            FROM llm_providers
+            ORDER BY created_at DESC
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+
+    pub async fn update_llm_provider(
+        &self,
+        id: Uuid,
+        input: UpdateLlmProvider,
+    ) -> Result<Option<LlmProviderRow>> {
+        // If updating api_key, also update api_key_set
+        let api_key_set = input.api_key_encrypted.as_ref().map(|_| true);
+
+        let row = sqlx::query_as::<_, LlmProviderRow>(
+            r#"
+            UPDATE llm_providers
+            SET
+                name = COALESCE($2, name),
+                provider_type = COALESCE($3, provider_type),
+                base_url = COALESCE($4, base_url),
+                api_key_encrypted = COALESCE($5, api_key_encrypted),
+                api_key_set = COALESCE($6, api_key_set),
+                is_default = COALESCE($7, is_default),
+                status = COALESCE($8, status),
+                updated_at = NOW()
+            WHERE id = $1
+            RETURNING id, name, provider_type, base_url, api_key_encrypted, api_key_set, is_default, status, created_at, updated_at
+            "#,
+        )
+        .bind(id)
+        .bind(&input.name)
+        .bind(&input.provider_type)
+        .bind(&input.base_url)
+        .bind(&input.api_key_encrypted)
+        .bind(api_key_set)
+        .bind(input.is_default)
+        .bind(&input.status)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    pub async fn delete_llm_provider(&self, id: Uuid) -> Result<bool> {
+        let result = sqlx::query("DELETE FROM llm_providers WHERE id = $1")
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    pub async fn get_default_llm_provider(&self) -> Result<Option<LlmProviderRow>> {
+        let row = sqlx::query_as::<_, LlmProviderRow>(
+            r#"
+            SELECT id, name, provider_type, base_url, api_key_encrypted, api_key_set, is_default, status, created_at, updated_at
+            FROM llm_providers
+            WHERE is_default = TRUE AND status = 'active'
+            "#,
+        )
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    // LLM Models
+
+    pub async fn create_llm_model(&self, input: CreateLlmModel) -> Result<LlmModelRow> {
+        let capabilities_json = serde_json::to_value(&input.capabilities)?;
+
+        let row = sqlx::query_as::<_, LlmModelRow>(
+            r#"
+            INSERT INTO llm_models (provider_id, model_id, display_name, capabilities, context_window, is_default)
+            VALUES ($1, $2, $3, $4, $5, $6)
+            RETURNING id, provider_id, model_id, display_name, capabilities, context_window, is_default, status, created_at, updated_at
+            "#,
+        )
+        .bind(input.provider_id)
+        .bind(&input.model_id)
+        .bind(&input.display_name)
+        .bind(&capabilities_json)
+        .bind(input.context_window)
+        .bind(input.is_default)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    pub async fn get_llm_model(&self, id: Uuid) -> Result<Option<LlmModelRow>> {
+        let row = sqlx::query_as::<_, LlmModelRow>(
+            r#"
+            SELECT id, provider_id, model_id, display_name, capabilities, context_window, is_default, status, created_at, updated_at
+            FROM llm_models
+            WHERE id = $1
+            "#,
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    pub async fn list_llm_models_for_provider(
+        &self,
+        provider_id: Uuid,
+    ) -> Result<Vec<LlmModelRow>> {
+        let rows = sqlx::query_as::<_, LlmModelRow>(
+            r#"
+            SELECT id, provider_id, model_id, display_name, capabilities, context_window, is_default, status, created_at, updated_at
+            FROM llm_models
+            WHERE provider_id = $1
+            ORDER BY display_name ASC
+            "#,
+        )
+        .bind(provider_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+
+    pub async fn list_all_llm_models(&self) -> Result<Vec<LlmModelWithProviderRow>> {
+        let rows = sqlx::query_as::<_, LlmModelWithProviderRow>(
+            r#"
+            SELECT m.id, m.provider_id, m.model_id, m.display_name, m.capabilities, m.context_window, m.is_default, m.status, m.created_at, m.updated_at,
+                   p.name as provider_name, p.provider_type
+            FROM llm_models m
+            JOIN llm_providers p ON m.provider_id = p.id
+            WHERE m.status = 'active' AND p.status = 'active'
+            ORDER BY p.name ASC, m.display_name ASC
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+
+    pub async fn update_llm_model(
+        &self,
+        id: Uuid,
+        input: UpdateLlmModel,
+    ) -> Result<Option<LlmModelRow>> {
+        let capabilities_json = input
+            .capabilities
+            .map(|c| serde_json::to_value(&c))
+            .transpose()?;
+
+        let row = sqlx::query_as::<_, LlmModelRow>(
+            r#"
+            UPDATE llm_models
+            SET
+                model_id = COALESCE($2, model_id),
+                display_name = COALESCE($3, display_name),
+                capabilities = COALESCE($4, capabilities),
+                context_window = COALESCE($5, context_window),
+                is_default = COALESCE($6, is_default),
+                status = COALESCE($7, status),
+                updated_at = NOW()
+            WHERE id = $1
+            RETURNING id, provider_id, model_id, display_name, capabilities, context_window, is_default, status, created_at, updated_at
+            "#,
+        )
+        .bind(id)
+        .bind(&input.model_id)
+        .bind(&input.display_name)
+        .bind(&capabilities_json)
+        .bind(input.context_window)
+        .bind(input.is_default)
+        .bind(&input.status)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    pub async fn delete_llm_model(&self, id: Uuid) -> Result<bool> {
+        let result = sqlx::query("DELETE FROM llm_models WHERE id = $1")
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Get model by model_id string (for resolving agent model references)
+    pub async fn get_llm_model_by_model_id(
+        &self,
+        model_id: &str,
+    ) -> Result<Option<LlmModelWithProviderRow>> {
+        let row = sqlx::query_as::<_, LlmModelWithProviderRow>(
+            r#"
+            SELECT m.id, m.provider_id, m.model_id, m.display_name, m.capabilities, m.context_window, m.is_default, m.status, m.created_at, m.updated_at,
+                   p.name as provider_name, p.provider_type
+            FROM llm_models m
+            JOIN llm_providers p ON m.provider_id = p.id
+            WHERE m.model_id = $1 AND m.status = 'active' AND p.status = 'active'
+            "#,
+        )
+        .bind(model_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
 }


### PR DESCRIPTION
## Summary

Add LLM Provider abstraction to support multiple AI providers (OpenAI, Anthropic, Azure, Ollama, custom) with encrypted API key storage and a Settings UI for management.

### Key Features

- **Multi-provider support**: Configure multiple LLM providers with different types
- **Encrypted API key storage**: API keys are encrypted at rest using the envelope encryption system
- **Write-only secrets**: API keys are never returned in API responses, only a `api_key_set` boolean flag
- **Settings UI**: New `/settings` page for managing providers and models via the web interface
- **Full CRUD API**: RESTful endpoints for providers and models
