### PR TITLE
Move UI development server to port 9100

### DIFF
--- a/.claude/skills/smoke-tests/SKILL.md
+++ b/.claude/skills/smoke-tests/SKILL.md
@@ -618,7 +618,7 @@ cd apps/ui && npm run dev
 Expected output:
 ```
 ▲ Next.js 16.x
-- Local: http://localhost:3000
+- Local: http://localhost:9100
 ```
 
 ### Verify UI Pages
@@ -627,15 +627,15 @@ With API running, open in browser:
 
 | Page | URL | Expected |
 |------|-----|----------|
-| Dashboard | http://localhost:3000/dashboard | Stats, recent runs, agents list |
-| Agents | http://localhost:3000/agents | Agent cards grid |
-| Create Agent | http://localhost:3000/agents/new | Form to create agent |
-| Runs | http://localhost:3000/runs | Run table with filters |
-| Chat | http://localhost:3000/chat | Agent selector, chat interface |
+| Dashboard | http://localhost:9100/dashboard | Stats, recent runs, agents list |
+| Agents | http://localhost:9100/agents | Agent cards grid |
+| Create Agent | http://localhost:9100/agents/new | Form to create agent |
+| Runs | http://localhost:9100/runs | Run table with filters |
+| Chat | http://localhost:9100/chat | Agent selector, chat interface |
 
 ### End-to-End UI Test
 
-1. Open http://localhost:3000
+1. Open http://localhost:9100
 2. Navigate to Agents → Create new agent
 3. Fill in name, select model, click Create
 4. Click "New Version" → Add system prompt → Create

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ cargo run --example create_agent
 
 **Manual testing**:
 - API docs: http://localhost:9000/swagger-ui/
-- UI: http://localhost:3000
+- UI: http://localhost:9100
 - Health check: `curl http://localhost:9000/health`
 
 ### Cloud Agent testing (no Docker)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Everruns is a service that runs AI agents in the most reliable way possible. Eac
 ```
 
 Services available at:
-- **UI**: http://localhost:3000
+- **UI**: http://localhost:9100
 - **API**: http://localhost:9000
 - **API Docs**: http://localhost:9000/swagger-ui/
 - **Temporal UI**: http://localhost:8080
@@ -62,14 +62,14 @@ Services available at:
 
 ### Create an Agent
 
-1. Open http://localhost:3000/agents
+1. Open http://localhost:9100/agents
 2. Click "New Agent"
 3. Enter name and select model (e.g., `gpt-5.1`)
 4. Create a version with a system prompt
 
 ### Chat with an Agent
 
-1. Open http://localhost:3000/chat
+1. Open http://localhost:9100/chat
 2. Select your agent
 3. Send a message and watch the response stream
 

--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -27,9 +27,9 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 USER nextjs
 
-EXPOSE 3000
+EXPOSE 9100
 
-ENV PORT=3000
+ENV PORT=9100
 ENV HOSTNAME="0.0.0.0"
 
 CMD ["node", "server.js"]

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -14,7 +14,7 @@ pnpm dev
 bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:9100](http://localhost:9100) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --port 9100",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",

--- a/harness/docker-compose.yml
+++ b/harness/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - temporal
     environment:
       - TEMPORAL_ADDRESS=temporal:7233
-      - TEMPORAL_CORS_ORIGINS=http://localhost:3000
+      - TEMPORAL_CORS_ORIGINS=http://localhost:9100
     ports:
       - "8080:8080"
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -157,7 +157,7 @@ case "$command" in
     echo ""
     echo "   🌐 API:         http://localhost:9000"
     echo "   📖 API Docs:    http://localhost:9000/swagger-ui/"
-    echo "   🖥️  UI:          http://localhost:3000"
+    echo "   🖥️  UI:          http://localhost:9100"
     echo "   ⏱️  Temporal UI: http://localhost:8080"
     echo ""
     echo "💡 To stop all services: ./scripts/dev.sh stop-all"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -5,10 +5,10 @@ set -euo pipefail
 # Usage: ./scripts/test-api.sh [--with-ui]
 #
 # Options:
-#   --with-ui    Also test the UI at localhost:3000
+#   --with-ui    Also test the UI at localhost:9100
 
 API_URL="http://localhost:9000"
-UI_URL="http://localhost:3000"
+UI_URL="http://localhost:9100"
 TEST_UI=false
 
 # Parse arguments


### PR DESCRIPTION
Update all references to use port 9100 for local UI development:
- package.json dev script with --port flag
- Dockerfile EXPOSE and ENV PORT
- docker-compose.yml CORS origin
- smoke-test.sh and dev.sh scripts
- Documentation files (README.md, AGENTS.md, SKILL.md)