### PR TITLE
Remove temporal feature flag completely

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,6 @@ OPENAI_API_KEY=sk-s....
 AGENT_RUNNER_MODE=in-process
 
 # Temporal Configuration (only used when AGENT_RUNNER_MODE=temporal)
-# Note: Requires compiling with --features temporal
 TEMPORAL_ADDRESS=localhost:7233
 TEMPORAL_NAMESPACE=default
 TEMPORAL_TASK_QUEUE=everruns-agent-runs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,8 +172,8 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Install jq and protobuf compiler
+        run: sudo apt-get update && sudo apt-get install -y jq protobuf-compiler
 
       - name: Cache cargo
         uses: actions/cache@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 utoipa = { version = "5.2", features = ["axum_extras", "chrono", "uuid"] }
 utoipa-swagger-ui = { version = "8.0", features = ["axum"] }
 
-# Temporal SDK (feature-gated, used when AGENT_RUNNER_MODE=temporal)
+# Temporal SDK (used when AGENT_RUNNER_MODE=temporal)
 temporal-sdk-core = "0.1.0-alpha.1"
 temporal-sdk-core-protos = "0.1.0-alpha.1"
 prost = "0.13"

--- a/crates/everruns-api/Cargo.toml
+++ b/crates/everruns-api/Cargo.toml
@@ -4,10 +4,6 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
-[features]
-default = []
-temporal = ["everruns-worker/temporal"]
-
 [dependencies]
 axum.workspace = true
 axum-extra.workspace = true

--- a/crates/everruns-api/Dockerfile
+++ b/crates/everruns-api/Dockerfile
@@ -12,6 +12,8 @@ RUN apt-get update && apt-get install -y \
     protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 
+RUN rustup component add rustfmt
+
 RUN cargo install cargo-chef --locked
 
 WORKDIR /app

--- a/crates/everruns-api/Dockerfile
+++ b/crates/everruns-api/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y \
     pkg-config \
     libssl-dev \
     curl \
+    protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 
 RUN cargo install cargo-chef --locked

--- a/crates/everruns-worker/Cargo.toml
+++ b/crates/everruns-worker/Cargo.toml
@@ -4,18 +4,6 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
-[features]
-default = []
-# Temporal feature flag - when enabled, uses Temporal SDK for durable workflow execution
-# with true Temporal server integration (workflow/activity polling)
-temporal = [
-    "dep:temporal-sdk-core",
-    "dep:temporal-sdk-core-protos",
-    "dep:prost",
-    "dep:prost-types",
-    "dep:tonic",
-]
-
 [dependencies]
 tokio.workspace = true
 serde.workspace = true
@@ -39,9 +27,9 @@ sha2 = "0.10"
 hex = "0.4"
 url = "2.5"
 
-# Temporal SDK dependencies (optional, feature-gated)
-temporal-sdk-core = { workspace = true, optional = true }
-temporal-sdk-core-protos = { workspace = true, optional = true }
-prost = { workspace = true, optional = true }
-prost-types = { workspace = true, optional = true }
-tonic = { version = "0.12", optional = true }
+# Temporal SDK dependencies
+temporal-sdk-core.workspace = true
+temporal-sdk-core-protos.workspace = true
+prost.workspace = true
+prost-types.workspace = true
+tonic = "0.12"

--- a/crates/everruns-worker/Dockerfile
+++ b/crates/everruns-worker/Dockerfile
@@ -12,6 +12,8 @@ RUN apt-get update && apt-get install -y \
     protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 
+RUN rustup component add rustfmt
+
 RUN cargo install cargo-chef --locked
 
 WORKDIR /app

--- a/crates/everruns-worker/Dockerfile
+++ b/crates/everruns-worker/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y \
     pkg-config \
     libssl-dev \
     curl \
+    protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 
 RUN cargo install cargo-chef --locked

--- a/crates/everruns-worker/src/lib.rs
+++ b/crates/everruns-worker/src/lib.rs
@@ -6,8 +6,6 @@ pub mod runner_inprocess;
 pub mod tools;
 pub mod workflows;
 
-// Temporal-specific module (feature-gated)
-#[cfg(feature = "temporal")]
 pub mod temporal;
 
 // Re-export main types

--- a/crates/everruns-worker/src/main.rs
+++ b/crates/everruns-worker/src/main.rs
@@ -29,33 +29,22 @@ async fn main() -> Result<()> {
         }
         RunnerMode::Temporal => {
             // Temporal mode: Worker with step checkpointing for durability
-            #[cfg(feature = "temporal")]
-            {
-                let database_url = std::env::var("DATABASE_URL")
-                    .expect("DATABASE_URL environment variable required");
+            let database_url =
+                std::env::var("DATABASE_URL").expect("DATABASE_URL environment variable required");
 
-                // Initialize database connection for Temporal worker
-                let db = Database::from_url(&database_url).await?;
-                tracing::info!("Database connection established");
+            // Initialize database connection for Temporal worker
+            let db = Database::from_url(&database_url).await?;
+            tracing::info!("Database connection established");
 
-                tracing::info!(
-                    address = %config.temporal_address(),
-                    namespace = %config.temporal_namespace(),
-                    task_queue = %config.temporal_task_queue(),
-                    "Starting Temporal worker with checkpointing"
-                );
+            tracing::info!(
+                address = %config.temporal_address(),
+                namespace = %config.temporal_namespace(),
+                task_queue = %config.temporal_task_queue(),
+                "Starting Temporal worker with checkpointing"
+            );
 
-                // Run the temporal worker (keeps running until shutdown)
-                everruns_worker::temporal::run_temporal_worker(&config, db).await?;
-            }
-
-            #[cfg(not(feature = "temporal"))]
-            {
-                anyhow::bail!(
-                    "Temporal mode requested but 'temporal' feature is not enabled. \
-                    Compile with: cargo build --features temporal"
-                );
-            }
+            // Run the temporal worker (keeps running until shutdown)
+            everruns_worker::temporal::run_temporal_worker(&config, db).await?;
         }
     }
 

--- a/crates/everruns-worker/src/runner.rs
+++ b/crates/everruns-worker/src/runner.rs
@@ -108,19 +108,8 @@ pub async fn create_runner(
                 "Creating Temporal agent runner"
             );
 
-            #[cfg(feature = "temporal")]
-            {
-                let runner = crate::temporal::TemporalRunner::new(config.clone(), db).await?;
-                Ok(Arc::new(runner))
-            }
-
-            #[cfg(not(feature = "temporal"))]
-            {
-                anyhow::bail!(
-                    "Temporal runner requested but 'temporal' feature is not enabled. \
-                    Compile with: cargo build --features temporal"
-                )
-            }
+            let runner = crate::temporal::TemporalRunner::new(config.clone(), db).await?;
+            Ok(Arc::new(runner))
         }
     }
 }

--- a/docker/Dockerfile.unified
+++ b/docker/Dockerfile.unified
@@ -19,6 +19,8 @@ RUN apt-get update && apt-get install -y \
     protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 
+RUN rustup component add rustfmt
+
 RUN cargo install cargo-chef --locked
 
 WORKDIR /app

--- a/docker/Dockerfile.unified
+++ b/docker/Dockerfile.unified
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
     pkg-config \
     libssl-dev \
     curl \
+    protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 
 RUN cargo install cargo-chef --locked

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -75,12 +75,12 @@ case "$command" in
 
   api)
     echo "🌐 Starting API server (Temporal mode)..."
-    AGENT_RUNNER_MODE=temporal cargo run -p everruns-api --features temporal
+    AGENT_RUNNER_MODE=temporal cargo run -p everruns-api
     ;;
 
   worker)
     echo "⚙️  Starting worker (Temporal mode)..."
-    AGENT_RUNNER_MODE=temporal cargo run -p everruns-worker --features temporal
+    AGENT_RUNNER_MODE=temporal cargo run -p everruns-worker
     ;;
 
   ui)
@@ -129,9 +129,9 @@ case "$command" in
     sqlx migrate run --source crates/everruns-storage/migrations
     echo "   ✅ Migrations complete"
 
-    # Start API in background (with temporal feature and mode enabled)
+    # Start API in background (Temporal mode)
     echo "4️⃣  Starting API server (Temporal mode)..."
-    AGENT_RUNNER_MODE=temporal cargo run -p everruns-api --features temporal &
+    AGENT_RUNNER_MODE=temporal cargo run -p everruns-api &
     API_PID=$!
     sleep 3
 
@@ -142,9 +142,9 @@ case "$command" in
       echo "   ⚠️  API may still be starting..."
     fi
 
-    # Start Worker in background (with temporal feature and mode enabled)
+    # Start Worker in background (Temporal mode)
     echo "5️⃣  Starting Temporal worker..."
-    AGENT_RUNNER_MODE=temporal cargo run -p everruns-worker --features temporal &
+    AGENT_RUNNER_MODE=temporal cargo run -p everruns-worker &
     WORKER_PID=$!
     sleep 2
     echo "   ✅ Worker is starting (PID: $WORKER_PID)"

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -27,7 +27,7 @@ Everruns is a durable AI agent execution platform built on Rust and Temporal. It
 1. **Runner Abstraction**: `AgentRunner` trait provides pluggable execution backends
 2. **Execution Modes**:
    - **In-Process** (`AGENT_RUNNER_MODE=inprocess`): Workflows run as tokio tasks in API process. Good for development.
-   - **Temporal** (`AGENT_RUNNER_MODE=temporal`): True Temporal workflow execution with separate worker process. Required feature: `--features temporal`
+   - **Temporal** (`AGENT_RUNNER_MODE=temporal`): True Temporal workflow execution with separate worker process
 3. **Workflow Isolation**: Temporal concepts (workflow IDs, task queues) never exposed in public API
 4. **Event Streaming**: AG-UI protocol over SSE for real-time event delivery via database-backed events
 

--- a/specs/temporal-integration.md
+++ b/specs/temporal-integration.md
@@ -130,30 +130,10 @@ TEMPORAL_NAMESPACE=default          # Temporal namespace
 TEMPORAL_TASK_QUEUE=everruns-agent-runs  # Task queue name
 ```
 
-## Feature Gating
-
-Temporal integration is behind a feature flag:
-
-```toml
-# Cargo.toml
-[features]
-temporal = [
-    "dep:temporal-sdk-core",
-    "dep:temporal-sdk-core-protos",
-    ...
-]
-```
-
-Build with temporal support:
-```bash
-cargo build --features temporal
-```
-
 ## In-Process Mode (Default)
 
 When `AGENT_RUNNER_MODE=inprocess` (default), execution happens in the API process:
 
-- No Temporal dependency required
 - Workflows are tokio tasks
 - Same activity logic reused
 - Good for development and single-process deployment


### PR DESCRIPTION
Temporal SDK is now always compiled in rather than being behind a feature flag. This simplifies the build process and eliminates the need for --features temporal in all commands.

Changes:
- Remove [features] section from everruns-worker/Cargo.toml
- Remove temporal feature from everruns-api/Cargo.toml
- Remove #[cfg(feature = "temporal")] attributes from source files
- Update dev.sh to remove --features temporal from cargo commands
- Update documentation (.env.example, specs) to remove feature references