### PR TITLE
Configure API base URL for production environment

### DIFF
--- a/apps/ui/src/app/chat/page.tsx
+++ b/apps/ui/src/app/chat/page.tsx
@@ -11,8 +11,7 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import Link from "next/link";
-
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:9000";
+import { getApiBaseUrl } from "@/lib/api/client";
 
 interface ChatMessage {
   id: string;
@@ -81,7 +80,7 @@ export default function ChatPage() {
         params.set("thread_id", threadId);
       }
 
-      const url = `${API_BASE}/v1/ag-ui?${params}`;
+      const url = `${getApiBaseUrl()}/v1/ag-ui?${params}`;
 
       // Send request with messages
       const response = await fetch(url, {

--- a/apps/ui/src/lib/api/client.ts
+++ b/apps/ui/src/lib/api/client.ts
@@ -1,5 +1,10 @@
+// API base URL configuration:
+// - In production: defaults to "/api" (same-origin, requires reverse proxy)
+// - In development: defaults to "http://localhost:9000"
+// - Can be overridden via NEXT_PUBLIC_API_BASE_URL environment variable
 const API_BASE =
-  process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:9000";
+  process.env.NEXT_PUBLIC_API_BASE_URL ||
+  (process.env.NODE_ENV === "production" ? "/api" : "http://localhost:9000");
 
 export class ApiError extends Error {
   constructor(


### PR DESCRIPTION
## Summary

Updates the UI to automatically use relative `/api` path in production builds, enabling same-origin API hosting behind a reverse proxy. Local development continues to use `localhost:9000`.

## Changes

- **Auto-detect production**: UI now checks `NODE_ENV` to determine API base URL
- **Centralized config**: Refactored chat page to use `getApiBaseUrl()` instead of duplicating the constant
