### PR TITLE
Build Agent Loop abstraction with streaming support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-agent-loop"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -816,6 +816,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "eventsource-stream",
+ "everruns-agent-loop",
  "everruns-contracts",
  "everruns-storage",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,6 +730,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "everruns-agent-loop"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "everruns-contracts",
+ "futures",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "tracing-subscriber 0.3.22",
+ "uuid 1.19.0",
+]
+
+[[package]]
 name = "everruns-api"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/everruns-worker",
     "crates/everruns-contracts",
     "crates/everruns-storage",
+    "crates/everruns-agent-loop",
 ]
 
 [workspace.package]
@@ -44,6 +45,9 @@ chrono = { version = "0.4", features = ["serde"] }
 # Error handling
 anyhow = "1.0"
 thiserror = "2.0"
+
+# Async traits
+async-trait = "0.1"
 
 # Environment
 dotenvy = "0.15"

--- a/apps/ui/src/app/settings/page.tsx
+++ b/apps/ui/src/app/settings/page.tsx
@@ -436,7 +436,7 @@ function AddModelDialog({
               id="model-id"
               value={modelId}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => setModelId(e.target.value)}
-              placeholder="gpt-4o"
+              placeholder="gpt-5.2"
               required
             />
           </div>

--- a/crates/everruns-agent-loop/Cargo.toml
+++ b/crates/everruns-agent-loop/Cargo.toml
@@ -1,0 +1,45 @@
+# Agent Loop Abstraction
+# Decision: Keep the loop logic DB-agnostic via traits (EventEmitter, MessageStore, ToolExecutor)
+# Decision: Use async_trait for trait definitions to support async operations
+# Decision: Re-export AG-UI events from everruns-contracts for consistency
+
+[package]
+name = "everruns-agent-loop"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Agentic loop abstraction for Everruns - DB-agnostic, streamable, decomposable"
+
+[dependencies]
+# Core dependencies
+anyhow.workspace = true
+thiserror.workspace = true
+async-trait.workspace = true
+
+# Async runtime
+tokio = { workspace = true, features = ["sync"] }
+tokio-stream.workspace = true
+futures.workspace = true
+
+# Serialization
+serde.workspace = true
+serde_json.workspace = true
+
+# UUID and time
+uuid.workspace = true
+chrono.workspace = true
+
+# Tracing
+tracing.workspace = true
+
+# Internal dependencies
+everruns-contracts = { path = "../everruns-contracts" }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full", "test-util"] }
+tracing-subscriber.workspace = true
+
+[[example]]
+name = "simple_loop"
+path = "examples/simple_loop.rs"

--- a/crates/everruns-agent-loop/Cargo.toml
+++ b/crates/everruns-agent-loop/Cargo.toml
@@ -41,5 +41,5 @@ tokio = { workspace = true, features = ["full", "test-util"] }
 tracing-subscriber.workspace = true
 
 [[example]]
-name = "simple_loop"
-path = "examples/simple_loop.rs"
+name = "mock_demo"
+path = "examples/mock_demo.rs"

--- a/crates/everruns-agent-loop/examples/mock_demo.rs
+++ b/crates/everruns-agent-loop/examples/mock_demo.rs
@@ -1,9 +1,9 @@
-//! Simple Agent Loop Example
+//! Mock Demo - Agent Loop with Mocked LLM Provider
 //!
-//! This example demonstrates how to use the everruns-agent-loop crate
-//! with in-memory implementations for a standalone agent execution.
+//! This example demonstrates the agent loop using mocked components,
+//! perfect for testing and demos without needing an API key.
 //!
-//! Run with: cargo run --example simple_loop -p everruns-agent-loop
+//! Run with: cargo run --example mock_demo -p everruns-agent-loop
 
 use everruns_agent_loop::{
     config::AgentConfig,
@@ -20,7 +20,8 @@ async fn main() -> anyhow::Result<()> {
         .with_max_level(tracing::Level::INFO)
         .init();
 
-    println!("=== Simple Agent Loop Example ===\n");
+    println!("=== Agent Loop Mock Demo ===");
+    println!("(No API key required - using mocked responses)\n");
 
     // Example 1: Basic conversation
     basic_conversation().await?;
@@ -28,7 +29,7 @@ async fn main() -> anyhow::Result<()> {
     // Example 2: Conversation with tool calls
     conversation_with_tools().await?;
 
-    println!("\n=== All examples completed! ===");
+    println!("\n=== Demo completed! ===");
     Ok(())
 }
 

--- a/crates/everruns-agent-loop/examples/simple_loop.rs
+++ b/crates/everruns-agent-loop/examples/simple_loop.rs
@@ -39,7 +39,7 @@ async fn basic_conversation() -> anyhow::Result<()> {
     // Create agent configuration
     let config = AgentConfig::new(
         "You are a helpful assistant that provides concise answers.",
-        "gpt-4o",
+        "gpt-5.2",
     );
 
     // Create mock LLM provider with predefined response
@@ -90,7 +90,7 @@ async fn conversation_with_tools() -> anyhow::Result<()> {
     // Create agent configuration with a tool
     let config = AgentConfig::new(
         "You are a helpful assistant with access to a weather tool.",
-        "gpt-4o",
+        "gpt-5.2",
     )
     .with_tools(vec![everruns_agent_loop::ToolDefinition::Builtin(
         everruns_contracts::tools::BuiltinTool {

--- a/crates/everruns-agent-loop/examples/simple_loop.rs
+++ b/crates/everruns-agent-loop/examples/simple_loop.rs
@@ -1,0 +1,193 @@
+//! Simple Agent Loop Example
+//!
+//! This example demonstrates how to use the everruns-agent-loop crate
+//! with in-memory implementations for a standalone agent execution.
+//!
+//! Run with: cargo run --example simple_loop -p everruns-agent-loop
+
+use everruns_agent_loop::{
+    config::AgentConfig,
+    memory::{InMemoryAgentLoopBuilder, InMemoryMessageStore, MockLlmProvider, MockLlmResponse},
+    message::ConversationMessage,
+    ToolCall,
+};
+use uuid::Uuid;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Set up logging
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .init();
+
+    println!("=== Simple Agent Loop Example ===\n");
+
+    // Example 1: Basic conversation
+    basic_conversation().await?;
+
+    // Example 2: Conversation with tool calls
+    conversation_with_tools().await?;
+
+    println!("\n=== All examples completed! ===");
+    Ok(())
+}
+
+/// Example 1: Basic conversation without tools
+async fn basic_conversation() -> anyhow::Result<()> {
+    println!("--- Example 1: Basic Conversation ---\n");
+
+    // Create agent configuration
+    let config = AgentConfig::new(
+        "You are a helpful assistant that provides concise answers.",
+        "gpt-4o",
+    );
+
+    // Create mock LLM provider with predefined response
+    let llm_provider = MockLlmProvider::new();
+    llm_provider
+        .add_response(MockLlmResponse::text(
+            "Hello! I'm your AI assistant. How can I help you today?",
+        ))
+        .await;
+
+    // Create message store and seed with user message
+    let message_store = InMemoryMessageStore::new();
+    let session_id = Uuid::now_v7();
+    message_store
+        .seed(
+            session_id,
+            vec![ConversationMessage::user("Hello, who are you?")],
+        )
+        .await;
+
+    // Build the agent loop
+    let (agent_loop, event_emitter, _, _, _) = InMemoryAgentLoopBuilder::new(config)
+        .llm_provider(llm_provider)
+        .message_store(message_store)
+        .build_with_refs();
+
+    // Run the loop
+    let result = agent_loop.run(session_id).await?;
+
+    // Print results
+    println!("Session ID: {}", result.session_id);
+    println!("Iterations: {}", result.iterations);
+    println!(
+        "Final response: {}",
+        result.final_response.unwrap_or_default()
+    );
+    println!("Total messages: {}", result.messages.len());
+    println!("Events emitted: {}", event_emitter.count().await);
+
+    println!();
+    Ok(())
+}
+
+/// Example 2: Conversation with tool calls
+async fn conversation_with_tools() -> anyhow::Result<()> {
+    println!("--- Example 2: Conversation with Tools ---\n");
+
+    // Create agent configuration with a tool
+    let config = AgentConfig::new(
+        "You are a helpful assistant with access to a weather tool.",
+        "gpt-4o",
+    )
+    .with_tools(vec![everruns_agent_loop::ToolDefinition::Builtin(
+        everruns_contracts::tools::BuiltinTool {
+            name: "get_weather".to_string(),
+            description: "Get the current weather for a city".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "city": {
+                        "type": "string",
+                        "description": "The city name"
+                    }
+                },
+                "required": ["city"]
+            }),
+            kind: everruns_contracts::tools::BuiltinToolKind::HttpGet,
+            policy: everruns_contracts::tools::ToolPolicy::Auto,
+        },
+    )])
+    .with_max_iterations(5);
+
+    // Create mock LLM provider with tool call response
+    let llm_provider = MockLlmProvider::new();
+
+    // First response: LLM requests tool call
+    llm_provider
+        .add_response(MockLlmResponse::with_tools(
+            "Let me check the weather for you.",
+            vec![ToolCall {
+                id: "call_123".to_string(),
+                name: "get_weather".to_string(),
+                arguments: serde_json::json!({"city": "New York"}),
+            }],
+        ))
+        .await;
+
+    // Second response: LLM uses tool result
+    llm_provider
+        .add_response(MockLlmResponse::text(
+            "The current weather in New York is 72°F and sunny. Perfect day to go outside!",
+        ))
+        .await;
+
+    // Create message store and seed with user message
+    let message_store = InMemoryMessageStore::new();
+    let session_id = Uuid::now_v7();
+    message_store
+        .seed(
+            session_id,
+            vec![ConversationMessage::user("What's the weather in New York?")],
+        )
+        .await;
+
+    // Build the agent loop with mock tool executor
+    let (agent_loop, event_emitter, _, _, tool_executor) = InMemoryAgentLoopBuilder::new(config)
+        .llm_provider(llm_provider)
+        .message_store(message_store)
+        .build_with_refs();
+
+    // Set up mock tool result
+    tool_executor
+        .set_result(
+            "get_weather",
+            serde_json::json!({
+                "city": "New York",
+                "temperature": 72,
+                "condition": "sunny"
+            }),
+        )
+        .await;
+
+    // Run the loop
+    let result = agent_loop.run(session_id).await?;
+
+    // Print results
+    println!("Session ID: {}", result.session_id);
+    println!("Iterations: {}", result.iterations);
+    println!(
+        "Final response: {}",
+        result.final_response.unwrap_or_default()
+    );
+    println!("Total messages: {}", result.messages.len());
+    println!("Events emitted: {}", event_emitter.count().await);
+
+    // Print tool calls made
+    let calls = tool_executor.calls().await;
+    println!("Tool calls made: {}", calls.len());
+    for call in &calls {
+        println!("  - {} with args: {}", call.name, call.arguments);
+    }
+
+    // Print conversation
+    println!("\nConversation:");
+    for msg in &result.messages {
+        println!("  [{}] {}", msg.role, msg.content.to_llm_string());
+    }
+
+    println!();
+    Ok(())
+}

--- a/crates/everruns-agent-loop/src/config.rs
+++ b/crates/everruns-agent-loop/src/config.rs
@@ -13,7 +13,7 @@ pub struct AgentConfig {
     /// System prompt that defines the agent's behavior
     pub system_prompt: String,
 
-    /// Model identifier (e.g., "gpt-4o", "claude-3-opus")
+    /// Model identifier (e.g., "gpt-5.2", "claude-3-opus")
     pub model: String,
 
     /// Available tools for the agent
@@ -79,7 +79,7 @@ impl Default for AgentConfig {
     fn default() -> Self {
         Self {
             system_prompt: "You are a helpful assistant.".to_string(),
-            model: "gpt-4o".to_string(),
+            model: "gpt-5.2".to_string(),
             tools: Vec::new(),
             max_iterations: default_max_iterations(),
             temperature: None,

--- a/crates/everruns-agent-loop/src/config.rs
+++ b/crates/everruns-agent-loop/src/config.rs
@@ -1,0 +1,156 @@
+// Agent configuration for the loop
+//
+// AgentConfig is a DB-agnostic configuration struct that can be:
+// - Created directly for standalone usage
+// - Built from an Agent entity via the `from_agent` method
+
+use everruns_contracts::tools::ToolDefinition;
+use serde::{Deserialize, Serialize};
+
+/// Configuration for the agent loop
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentConfig {
+    /// System prompt that defines the agent's behavior
+    pub system_prompt: String,
+
+    /// Model identifier (e.g., "gpt-4o", "claude-3-opus")
+    pub model: String,
+
+    /// Available tools for the agent
+    #[serde(default)]
+    pub tools: Vec<ToolDefinition>,
+
+    /// Maximum number of tool-calling iterations (prevents infinite loops)
+    #[serde(default = "default_max_iterations")]
+    pub max_iterations: usize,
+
+    /// Temperature for LLM sampling (0.0 - 2.0)
+    #[serde(default)]
+    pub temperature: Option<f32>,
+
+    /// Maximum tokens to generate per response
+    #[serde(default)]
+    pub max_tokens: Option<u32>,
+}
+
+fn default_max_iterations() -> usize {
+    10
+}
+
+impl AgentConfig {
+    /// Create a new agent configuration
+    pub fn new(system_prompt: impl Into<String>, model: impl Into<String>) -> Self {
+        Self {
+            system_prompt: system_prompt.into(),
+            model: model.into(),
+            tools: Vec::new(),
+            max_iterations: default_max_iterations(),
+            temperature: None,
+            max_tokens: None,
+        }
+    }
+
+    /// Add tools to the configuration
+    pub fn with_tools(mut self, tools: Vec<ToolDefinition>) -> Self {
+        self.tools = tools;
+        self
+    }
+
+    /// Set maximum iterations
+    pub fn with_max_iterations(mut self, max_iterations: usize) -> Self {
+        self.max_iterations = max_iterations;
+        self
+    }
+
+    /// Set temperature
+    pub fn with_temperature(mut self, temperature: f32) -> Self {
+        self.temperature = Some(temperature);
+        self
+    }
+
+    /// Set max tokens
+    pub fn with_max_tokens(mut self, max_tokens: u32) -> Self {
+        self.max_tokens = Some(max_tokens);
+        self
+    }
+}
+
+impl Default for AgentConfig {
+    fn default() -> Self {
+        Self {
+            system_prompt: "You are a helpful assistant.".to_string(),
+            model: "gpt-4o".to_string(),
+            tools: Vec::new(),
+            max_iterations: default_max_iterations(),
+            temperature: None,
+            max_tokens: None,
+        }
+    }
+}
+
+/// Builder for AgentConfig with fluent API
+pub struct AgentConfigBuilder {
+    config: AgentConfig,
+}
+
+impl AgentConfigBuilder {
+    /// Start building a new configuration
+    pub fn new() -> Self {
+        Self {
+            config: AgentConfig::default(),
+        }
+    }
+
+    /// Set the system prompt
+    pub fn system_prompt(mut self, prompt: impl Into<String>) -> Self {
+        self.config.system_prompt = prompt.into();
+        self
+    }
+
+    /// Set the model
+    pub fn model(mut self, model: impl Into<String>) -> Self {
+        self.config.model = model.into();
+        self
+    }
+
+    /// Add a tool
+    pub fn tool(mut self, tool: ToolDefinition) -> Self {
+        self.config.tools.push(tool);
+        self
+    }
+
+    /// Add multiple tools
+    pub fn tools(mut self, tools: impl IntoIterator<Item = ToolDefinition>) -> Self {
+        self.config.tools.extend(tools);
+        self
+    }
+
+    /// Set maximum iterations
+    pub fn max_iterations(mut self, max: usize) -> Self {
+        self.config.max_iterations = max;
+        self
+    }
+
+    /// Set temperature
+    pub fn temperature(mut self, temp: f32) -> Self {
+        self.config.temperature = Some(temp);
+        self
+    }
+
+    /// Set max tokens
+    pub fn max_tokens(mut self, tokens: u32) -> Self {
+        self.config.max_tokens = Some(tokens);
+        self
+    }
+
+    /// Build the configuration
+    pub fn build(self) -> AgentConfig {
+        self.config
+    }
+}
+
+impl Default for AgentConfigBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/everruns-agent-loop/src/error.rs
+++ b/crates/everruns-agent-loop/src/error.rs
@@ -1,0 +1,73 @@
+// Error types for the agent loop
+
+use thiserror::Error;
+
+/// Result type alias for agent loop operations
+pub type Result<T> = std::result::Result<T, AgentLoopError>;
+
+/// Errors that can occur during agent loop execution
+#[derive(Debug, Error)]
+pub enum AgentLoopError {
+    /// LLM provider error
+    #[error("LLM error: {0}")]
+    Llm(String),
+
+    /// Tool execution error
+    #[error("Tool execution error: {0}")]
+    ToolExecution(String),
+
+    /// Message store error
+    #[error("Message store error: {0}")]
+    MessageStore(String),
+
+    /// Event emission error
+    #[error("Event emission error: {0}")]
+    EventEmission(String),
+
+    /// Configuration error
+    #[error("Configuration error: {0}")]
+    Configuration(String),
+
+    /// Loop terminated due to max iterations
+    #[error("Max iterations ({0}) reached")]
+    MaxIterationsReached(usize),
+
+    /// Loop was cancelled
+    #[error("Loop cancelled")]
+    Cancelled,
+
+    /// No messages to process
+    #[error("No messages to process")]
+    NoMessages,
+
+    /// Internal error
+    #[error("Internal error: {0}")]
+    Internal(#[from] anyhow::Error),
+}
+
+impl AgentLoopError {
+    /// Create an LLM error
+    pub fn llm(msg: impl Into<String>) -> Self {
+        AgentLoopError::Llm(msg.into())
+    }
+
+    /// Create a tool execution error
+    pub fn tool(msg: impl Into<String>) -> Self {
+        AgentLoopError::ToolExecution(msg.into())
+    }
+
+    /// Create a message store error
+    pub fn store(msg: impl Into<String>) -> Self {
+        AgentLoopError::MessageStore(msg.into())
+    }
+
+    /// Create an event emission error
+    pub fn event(msg: impl Into<String>) -> Self {
+        AgentLoopError::EventEmission(msg.into())
+    }
+
+    /// Create a configuration error
+    pub fn config(msg: impl Into<String>) -> Self {
+        AgentLoopError::Configuration(msg.into())
+    }
+}

--- a/crates/everruns-agent-loop/src/events.rs
+++ b/crates/everruns-agent-loop/src/events.rs
@@ -1,0 +1,245 @@
+// Loop events for streaming
+//
+// LoopEvent wraps AG-UI events with additional loop-specific context.
+// This allows the loop to emit standard AG-UI events while also providing
+// higher-level loop status events.
+
+use chrono::{DateTime, Utc};
+use everruns_contracts::events::AgUiEvent;
+use serde::{Deserialize, Serialize};
+
+/// Events emitted during loop execution
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum LoopEvent {
+    /// AG-UI protocol event (for SSE streaming compatibility)
+    AgUi(AgUiEvent),
+
+    /// Loop started
+    LoopStarted {
+        session_id: String,
+        timestamp: DateTime<Utc>,
+    },
+
+    /// Loop iteration started
+    IterationStarted {
+        session_id: String,
+        iteration: usize,
+        timestamp: DateTime<Utc>,
+    },
+
+    /// LLM call started
+    LlmCallStarted {
+        session_id: String,
+        iteration: usize,
+        timestamp: DateTime<Utc>,
+    },
+
+    /// LLM streaming text delta
+    TextDelta {
+        session_id: String,
+        message_id: String,
+        delta: String,
+        timestamp: DateTime<Utc>,
+    },
+
+    /// LLM call completed
+    LlmCallCompleted {
+        session_id: String,
+        iteration: usize,
+        has_tool_calls: bool,
+        timestamp: DateTime<Utc>,
+    },
+
+    /// Tool execution started
+    ToolExecutionStarted {
+        session_id: String,
+        tool_call_id: String,
+        tool_name: String,
+        timestamp: DateTime<Utc>,
+    },
+
+    /// Tool execution completed
+    ToolExecutionCompleted {
+        session_id: String,
+        tool_call_id: String,
+        success: bool,
+        timestamp: DateTime<Utc>,
+    },
+
+    /// Loop iteration completed
+    IterationCompleted {
+        session_id: String,
+        iteration: usize,
+        continue_loop: bool,
+        timestamp: DateTime<Utc>,
+    },
+
+    /// Loop completed successfully
+    LoopCompleted {
+        session_id: String,
+        total_iterations: usize,
+        timestamp: DateTime<Utc>,
+    },
+
+    /// Loop failed with error
+    LoopError {
+        session_id: String,
+        error: String,
+        timestamp: DateTime<Utc>,
+    },
+}
+
+impl LoopEvent {
+    /// Create a loop started event
+    pub fn loop_started(session_id: impl Into<String>) -> Self {
+        LoopEvent::LoopStarted {
+            session_id: session_id.into(),
+            timestamp: Utc::now(),
+        }
+    }
+
+    /// Create an iteration started event
+    pub fn iteration_started(session_id: impl Into<String>, iteration: usize) -> Self {
+        LoopEvent::IterationStarted {
+            session_id: session_id.into(),
+            iteration,
+            timestamp: Utc::now(),
+        }
+    }
+
+    /// Create an LLM call started event
+    pub fn llm_call_started(session_id: impl Into<String>, iteration: usize) -> Self {
+        LoopEvent::LlmCallStarted {
+            session_id: session_id.into(),
+            iteration,
+            timestamp: Utc::now(),
+        }
+    }
+
+    /// Create a text delta event
+    pub fn text_delta(
+        session_id: impl Into<String>,
+        message_id: impl Into<String>,
+        delta: impl Into<String>,
+    ) -> Self {
+        LoopEvent::TextDelta {
+            session_id: session_id.into(),
+            message_id: message_id.into(),
+            delta: delta.into(),
+            timestamp: Utc::now(),
+        }
+    }
+
+    /// Create an LLM call completed event
+    pub fn llm_call_completed(
+        session_id: impl Into<String>,
+        iteration: usize,
+        has_tool_calls: bool,
+    ) -> Self {
+        LoopEvent::LlmCallCompleted {
+            session_id: session_id.into(),
+            iteration,
+            has_tool_calls,
+            timestamp: Utc::now(),
+        }
+    }
+
+    /// Create a tool execution started event
+    pub fn tool_started(
+        session_id: impl Into<String>,
+        tool_call_id: impl Into<String>,
+        tool_name: impl Into<String>,
+    ) -> Self {
+        LoopEvent::ToolExecutionStarted {
+            session_id: session_id.into(),
+            tool_call_id: tool_call_id.into(),
+            tool_name: tool_name.into(),
+            timestamp: Utc::now(),
+        }
+    }
+
+    /// Create a tool execution completed event
+    pub fn tool_completed(
+        session_id: impl Into<String>,
+        tool_call_id: impl Into<String>,
+        success: bool,
+    ) -> Self {
+        LoopEvent::ToolExecutionCompleted {
+            session_id: session_id.into(),
+            tool_call_id: tool_call_id.into(),
+            success,
+            timestamp: Utc::now(),
+        }
+    }
+
+    /// Create an iteration completed event
+    pub fn iteration_completed(
+        session_id: impl Into<String>,
+        iteration: usize,
+        continue_loop: bool,
+    ) -> Self {
+        LoopEvent::IterationCompleted {
+            session_id: session_id.into(),
+            iteration,
+            continue_loop,
+            timestamp: Utc::now(),
+        }
+    }
+
+    /// Create a loop completed event
+    pub fn loop_completed(session_id: impl Into<String>, total_iterations: usize) -> Self {
+        LoopEvent::LoopCompleted {
+            session_id: session_id.into(),
+            total_iterations,
+            timestamp: Utc::now(),
+        }
+    }
+
+    /// Create a loop error event
+    pub fn loop_error(session_id: impl Into<String>, error: impl Into<String>) -> Self {
+        LoopEvent::LoopError {
+            session_id: session_id.into(),
+            error: error.into(),
+            timestamp: Utc::now(),
+        }
+    }
+
+    /// Wrap an AG-UI event
+    pub fn ag_ui(event: AgUiEvent) -> Self {
+        LoopEvent::AgUi(event)
+    }
+
+    /// Get the session ID for this event
+    pub fn session_id(&self) -> &str {
+        match self {
+            LoopEvent::AgUi(e) => match e {
+                AgUiEvent::RunStarted(e) => &e.thread_id,
+                AgUiEvent::RunFinished(e) => &e.thread_id,
+                AgUiEvent::RunError(_) => "",
+                AgUiEvent::StepStarted(_) => "",
+                AgUiEvent::StepFinished(_) => "",
+                AgUiEvent::TextMessageStart(e) => &e.message_id,
+                AgUiEvent::TextMessageContent(e) => &e.message_id,
+                AgUiEvent::TextMessageEnd(e) => &e.message_id,
+                AgUiEvent::ToolCallStart(e) => &e.tool_call_id,
+                AgUiEvent::ToolCallArgs(e) => &e.tool_call_id,
+                AgUiEvent::ToolCallEnd(e) => &e.tool_call_id,
+                AgUiEvent::ToolCallResult(e) => &e.tool_call_id,
+                AgUiEvent::StateSnapshot(_) => "",
+                AgUiEvent::StateDelta(_) => "",
+                AgUiEvent::MessagesSnapshot(_) => "",
+                AgUiEvent::Custom(_) => "",
+            },
+            LoopEvent::LoopStarted { session_id, .. } => session_id,
+            LoopEvent::IterationStarted { session_id, .. } => session_id,
+            LoopEvent::LlmCallStarted { session_id, .. } => session_id,
+            LoopEvent::TextDelta { session_id, .. } => session_id,
+            LoopEvent::LlmCallCompleted { session_id, .. } => session_id,
+            LoopEvent::ToolExecutionStarted { session_id, .. } => session_id,
+            LoopEvent::ToolExecutionCompleted { session_id, .. } => session_id,
+            LoopEvent::IterationCompleted { session_id, .. } => session_id,
+            LoopEvent::LoopCompleted { session_id, .. } => session_id,
+            LoopEvent::LoopError { session_id, .. } => session_id,
+        }
+    }
+}

--- a/crates/everruns-agent-loop/src/executor.rs
+++ b/crates/everruns-agent-loop/src/executor.rs
@@ -1,0 +1,575 @@
+// Agent Loop Executor
+//
+// The main orchestrator for the agentic loop. Coordinates:
+// - Loading messages from MessageStore
+// - Calling LLM via LlmProvider
+// - Executing tools via ToolExecutor
+// - Emitting events via EventEmitter
+
+use std::sync::Arc;
+
+use everruns_contracts::events::{AgUiEvent, AgUiMessageRole};
+use futures::StreamExt;
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+use crate::config::AgentConfig;
+use crate::error::{AgentLoopError, Result};
+use crate::events::LoopEvent;
+use crate::message::{ConversationMessage, MessageRole};
+use crate::step::{LoopStep, StepInput, StepOutput, StepResult};
+use crate::traits::{
+    EventEmitter, LlmCallConfig, LlmMessage, LlmMessageRole, LlmProvider, LlmStreamEvent,
+    MessageStore, ToolExecutor,
+};
+
+/// Result of a complete loop execution
+#[derive(Debug, Clone)]
+pub struct LoopResult {
+    /// Session ID
+    pub session_id: Uuid,
+    /// Final messages (including all responses)
+    pub messages: Vec<ConversationMessage>,
+    /// Total iterations executed
+    pub iterations: usize,
+    /// Final assistant response text (if any)
+    pub final_response: Option<String>,
+}
+
+/// The Agent Loop executor
+///
+/// Orchestrates the agentic loop with pluggable backends for:
+/// - Event emission (EventEmitter)
+/// - Message storage (MessageStore)
+/// - LLM calls (LlmProvider)
+/// - Tool execution (ToolExecutor)
+pub struct AgentLoop<E, M, L, T>
+where
+    E: EventEmitter,
+    M: MessageStore,
+    L: LlmProvider,
+    T: ToolExecutor,
+{
+    /// Configuration for this agent
+    config: AgentConfig,
+    /// Event emitter for streaming
+    event_emitter: Arc<E>,
+    /// Message store for persistence
+    message_store: Arc<M>,
+    /// LLM provider for inference
+    llm_provider: Arc<L>,
+    /// Tool executor for tool calls
+    tool_executor: Arc<T>,
+}
+
+impl<E, M, L, T> AgentLoop<E, M, L, T>
+where
+    E: EventEmitter,
+    M: MessageStore,
+    L: LlmProvider,
+    T: ToolExecutor,
+{
+    /// Create a new agent loop
+    pub fn new(
+        config: AgentConfig,
+        event_emitter: E,
+        message_store: M,
+        llm_provider: L,
+        tool_executor: T,
+    ) -> Self {
+        Self {
+            config,
+            event_emitter: Arc::new(event_emitter),
+            message_store: Arc::new(message_store),
+            llm_provider: Arc::new(llm_provider),
+            tool_executor: Arc::new(tool_executor),
+        }
+    }
+
+    /// Create a new agent loop with Arc-wrapped components
+    pub fn with_arcs(
+        config: AgentConfig,
+        event_emitter: Arc<E>,
+        message_store: Arc<M>,
+        llm_provider: Arc<L>,
+        tool_executor: Arc<T>,
+    ) -> Self {
+        Self {
+            config,
+            event_emitter,
+            message_store,
+            llm_provider,
+            tool_executor,
+        }
+    }
+
+    /// Get the configuration
+    pub fn config(&self) -> &AgentConfig {
+        &self.config
+    }
+
+    /// Run the complete agentic loop for a session
+    ///
+    /// This is the main entry point for in-process execution.
+    pub async fn run(&self, session_id: Uuid) -> Result<LoopResult> {
+        info!(session_id = %session_id, "Starting agent loop");
+
+        // Emit loop started event
+        self.event_emitter
+            .emit(LoopEvent::loop_started(session_id.to_string()))
+            .await?;
+
+        // Emit AG-UI session started event
+        self.event_emitter
+            .emit(LoopEvent::ag_ui(AgUiEvent::session_started(
+                session_id.to_string(),
+            )))
+            .await?;
+
+        // Load existing messages
+        let mut messages = self.message_store.load(session_id).await?;
+
+        if messages.is_empty() {
+            warn!(session_id = %session_id, "No messages to process");
+            return Err(AgentLoopError::NoMessages);
+        }
+
+        // Run the loop
+        let mut iteration = 0;
+        let mut final_response = None;
+
+        loop {
+            iteration += 1;
+
+            if iteration > self.config.max_iterations {
+                warn!(
+                    session_id = %session_id,
+                    max = self.config.max_iterations,
+                    "Max iterations reached"
+                );
+                self.event_emitter
+                    .emit(LoopEvent::loop_error(
+                        session_id.to_string(),
+                        format!("Max iterations ({}) reached", self.config.max_iterations),
+                    ))
+                    .await?;
+                return Err(AgentLoopError::MaxIterationsReached(
+                    self.config.max_iterations,
+                ));
+            }
+
+            info!(
+                session_id = %session_id,
+                iteration = iteration,
+                "Starting iteration"
+            );
+
+            // Emit iteration started
+            self.event_emitter
+                .emit(LoopEvent::iteration_started(
+                    session_id.to_string(),
+                    iteration,
+                ))
+                .await?;
+
+            // Call LLM
+            let llm_result = self.call_llm(session_id, iteration, &messages).await?;
+
+            // Store assistant response as message
+            if !llm_result.text.is_empty() {
+                let assistant_msg = if let Some(ref tool_calls) = llm_result.tool_calls {
+                    ConversationMessage::assistant_with_tools(&llm_result.text, tool_calls.clone())
+                } else {
+                    ConversationMessage::assistant(&llm_result.text)
+                };
+
+                self.message_store
+                    .store(session_id, assistant_msg.clone())
+                    .await?;
+                messages.push(assistant_msg);
+                final_response = Some(llm_result.text.clone());
+            }
+
+            // Check if we have tool calls to execute
+            let has_tool_calls = llm_result
+                .tool_calls
+                .as_ref()
+                .is_some_and(|tc| !tc.is_empty());
+
+            // Emit LLM completed
+            self.event_emitter
+                .emit(LoopEvent::llm_call_completed(
+                    session_id.to_string(),
+                    iteration,
+                    has_tool_calls,
+                ))
+                .await?;
+
+            if has_tool_calls {
+                let tool_calls = llm_result.tool_calls.unwrap();
+
+                // Store tool call messages
+                for tool_call in &tool_calls {
+                    let tool_call_msg = ConversationMessage::tool_call(tool_call);
+                    self.message_store
+                        .store(session_id, tool_call_msg.clone())
+                        .await?;
+                    messages.push(tool_call_msg);
+                }
+
+                // Execute tools
+                let tool_results = self.execute_tools(session_id, &tool_calls).await?;
+
+                // Store tool result messages and add to conversation
+                for (tool_call, result) in tool_calls.iter().zip(tool_results.iter()) {
+                    let result_msg = ConversationMessage::tool_result(
+                        &tool_call.id,
+                        result.result.clone(),
+                        result.error.clone(),
+                    );
+                    self.message_store
+                        .store(session_id, result_msg.clone())
+                        .await?;
+                    messages.push(result_msg);
+                }
+
+                // Emit iteration completed (continue loop)
+                self.event_emitter
+                    .emit(LoopEvent::iteration_completed(
+                        session_id.to_string(),
+                        iteration,
+                        true,
+                    ))
+                    .await?;
+
+                // Continue loop with tool results
+                continue;
+            }
+
+            // No tool calls, loop is complete
+            self.event_emitter
+                .emit(LoopEvent::iteration_completed(
+                    session_id.to_string(),
+                    iteration,
+                    false,
+                ))
+                .await?;
+
+            break;
+        }
+
+        // Emit loop completed
+        self.event_emitter
+            .emit(LoopEvent::loop_completed(session_id.to_string(), iteration))
+            .await?;
+
+        // Emit AG-UI session finished event
+        self.event_emitter
+            .emit(LoopEvent::ag_ui(AgUiEvent::session_finished(
+                session_id.to_string(),
+            )))
+            .await?;
+
+        info!(
+            session_id = %session_id,
+            iterations = iteration,
+            "Agent loop completed"
+        );
+
+        Ok(LoopResult {
+            session_id,
+            messages,
+            iterations: iteration,
+            final_response,
+        })
+    }
+
+    /// Execute a single step (for decomposed execution)
+    ///
+    /// This allows the loop to be broken into discrete steps that can be
+    /// executed independently (e.g., as Temporal activities).
+    pub async fn execute_step(&self, input: StepInput) -> Result<StepOutput> {
+        let session_id = input.session_id;
+
+        // If we have pending tool calls, execute them
+        if !input.pending_tool_calls.is_empty() {
+            let step = LoopStep::tool_execution(session_id, input.iteration);
+
+            let tool_results = self
+                .execute_tools(session_id, &input.pending_tool_calls)
+                .await?;
+
+            // Create result messages
+            let mut messages = input.messages;
+            for (tool_call, result) in input.pending_tool_calls.iter().zip(tool_results.iter()) {
+                let result_msg = ConversationMessage::tool_result(
+                    &tool_call.id,
+                    result.result.clone(),
+                    result.error.clone(),
+                );
+                messages.push(result_msg);
+            }
+
+            let step = step.complete(StepResult::ToolExecutionComplete {
+                results: tool_results,
+            });
+
+            // Continue loop - need to call LLM again
+            return Ok(StepOutput::continue_with(step, messages, Vec::new()));
+        }
+
+        // Otherwise, call LLM
+        let step = LoopStep::llm_call(session_id, input.iteration);
+
+        let llm_result = self
+            .call_llm(session_id, input.iteration, &input.messages)
+            .await?;
+
+        let mut messages = input.messages;
+
+        // Add assistant response
+        if !llm_result.text.is_empty() {
+            let assistant_msg = if let Some(ref tool_calls) = llm_result.tool_calls {
+                ConversationMessage::assistant_with_tools(&llm_result.text, tool_calls.clone())
+            } else {
+                ConversationMessage::assistant(&llm_result.text)
+            };
+            messages.push(assistant_msg);
+        }
+
+        let has_tool_calls = llm_result
+            .tool_calls
+            .as_ref()
+            .is_some_and(|tc| !tc.is_empty());
+
+        let step = step.complete(StepResult::LlmCallComplete {
+            response_text: llm_result.text,
+            tool_calls: llm_result.tool_calls.clone().unwrap_or_default(),
+            continue_loop: has_tool_calls,
+        });
+
+        if has_tool_calls {
+            // Add tool call messages
+            let tool_calls = llm_result.tool_calls.unwrap();
+            for tool_call in &tool_calls {
+                messages.push(ConversationMessage::tool_call(tool_call));
+            }
+
+            Ok(StepOutput::continue_with(step, messages, tool_calls))
+        } else {
+            Ok(StepOutput::complete(step, messages))
+        }
+    }
+
+    /// Run a single turn (user message → assistant response)
+    ///
+    /// Convenience method that adds a user message and runs until completion.
+    pub async fn run_turn(
+        &self,
+        session_id: Uuid,
+        user_message: impl Into<String>,
+    ) -> Result<LoopResult> {
+        // Store user message
+        let user_msg = ConversationMessage::user(user_message);
+        self.message_store.store(session_id, user_msg).await?;
+
+        // Run the loop
+        self.run(session_id).await
+    }
+
+    // =========================================================================
+    // Private methods
+    // =========================================================================
+
+    /// Call LLM with streaming and event emission
+    async fn call_llm(
+        &self,
+        session_id: Uuid,
+        iteration: usize,
+        messages: &[ConversationMessage],
+    ) -> Result<LlmCallResult> {
+        // Emit LLM call started
+        self.event_emitter
+            .emit(LoopEvent::llm_call_started(
+                session_id.to_string(),
+                iteration,
+            ))
+            .await?;
+
+        // Build LLM messages
+        let mut llm_messages = Vec::new();
+
+        // Add system prompt if configured
+        if !self.config.system_prompt.is_empty() {
+            llm_messages.push(LlmMessage {
+                role: LlmMessageRole::System,
+                content: self.config.system_prompt.clone(),
+                tool_calls: None,
+                tool_call_id: None,
+            });
+        }
+
+        // Add conversation messages
+        for msg in messages {
+            // Skip tool_call messages as they're represented in assistant messages
+            if msg.role == MessageRole::ToolCall {
+                continue;
+            }
+            llm_messages.push(msg.into());
+        }
+
+        // Build LLM config
+        let llm_config = LlmCallConfig::from(&self.config);
+
+        // Call LLM with streaming
+        let mut stream = self
+            .llm_provider
+            .chat_completion_stream(llm_messages, &llm_config)
+            .await?;
+
+        // Emit text message start
+        let message_id = Uuid::now_v7().to_string();
+        self.event_emitter
+            .emit(LoopEvent::ag_ui(AgUiEvent::text_message_start(
+                &message_id,
+                AgUiMessageRole::Assistant,
+            )))
+            .await?;
+
+        // Process stream
+        let mut text = String::new();
+        let mut tool_calls = None;
+
+        while let Some(event) = stream.next().await {
+            match event? {
+                LlmStreamEvent::TextDelta(delta) => {
+                    if !delta.is_empty() {
+                        text.push_str(&delta);
+
+                        // Emit text delta
+                        self.event_emitter
+                            .emit(LoopEvent::text_delta(
+                                session_id.to_string(),
+                                &message_id,
+                                &delta,
+                            ))
+                            .await?;
+
+                        // Emit AG-UI text content
+                        self.event_emitter
+                            .emit(LoopEvent::ag_ui(AgUiEvent::text_message_content(
+                                &message_id,
+                                &delta,
+                            )))
+                            .await?;
+                    }
+                }
+                LlmStreamEvent::ToolCalls(calls) => {
+                    tool_calls = Some(calls);
+                }
+                LlmStreamEvent::Done(_metadata) => {
+                    // Emit text message end
+                    self.event_emitter
+                        .emit(LoopEvent::ag_ui(AgUiEvent::text_message_end(&message_id)))
+                        .await?;
+                    break;
+                }
+                LlmStreamEvent::Error(err) => {
+                    error!(session_id = %session_id, error = %err, "LLM stream error");
+                    return Err(AgentLoopError::llm(err));
+                }
+            }
+        }
+
+        Ok(LlmCallResult { text, tool_calls })
+    }
+
+    /// Execute tool calls with event emission
+    async fn execute_tools(
+        &self,
+        session_id: Uuid,
+        tool_calls: &[everruns_contracts::tools::ToolCall],
+    ) -> Result<Vec<everruns_contracts::tools::ToolResult>> {
+        let mut results = Vec::with_capacity(tool_calls.len());
+
+        for tool_call in tool_calls {
+            // Emit tool started
+            self.event_emitter
+                .emit(LoopEvent::tool_started(
+                    session_id.to_string(),
+                    &tool_call.id,
+                    &tool_call.name,
+                ))
+                .await?;
+
+            // Emit AG-UI tool call events
+            self.event_emitter
+                .emit(LoopEvent::ag_ui(AgUiEvent::tool_call_start(
+                    &tool_call.id,
+                    &tool_call.name,
+                )))
+                .await?;
+
+            let args_json = serde_json::to_string(&tool_call.arguments).unwrap_or_default();
+            self.event_emitter
+                .emit(LoopEvent::ag_ui(AgUiEvent::tool_call_args(
+                    &tool_call.id,
+                    args_json,
+                )))
+                .await?;
+
+            self.event_emitter
+                .emit(LoopEvent::ag_ui(AgUiEvent::tool_call_end(&tool_call.id)))
+                .await?;
+
+            // Find tool definition
+            let tool_def = self
+                .config
+                .tools
+                .iter()
+                .find(|def| {
+                    let name = match def {
+                        everruns_contracts::tools::ToolDefinition::Webhook(w) => &w.name,
+                        everruns_contracts::tools::ToolDefinition::Builtin(b) => &b.name,
+                    };
+                    name == &tool_call.name
+                })
+                .ok_or_else(|| {
+                    AgentLoopError::tool(format!("Tool not found: {}", tool_call.name))
+                })?;
+
+            // Execute tool
+            let result = self.tool_executor.execute(tool_call, tool_def).await?;
+            let success = result.error.is_none();
+
+            // Emit AG-UI tool result
+            let result_message_id = Uuid::now_v7().to_string();
+            self.event_emitter
+                .emit(LoopEvent::ag_ui(AgUiEvent::tool_call_result(
+                    &result_message_id,
+                    &tool_call.id,
+                    result.result.clone().unwrap_or(serde_json::Value::Null),
+                )))
+                .await?;
+
+            // Emit tool completed
+            self.event_emitter
+                .emit(LoopEvent::tool_completed(
+                    session_id.to_string(),
+                    &tool_call.id,
+                    success,
+                ))
+                .await?;
+
+            results.push(result);
+        }
+
+        Ok(results)
+    }
+}
+
+/// Result from calling the LLM
+struct LlmCallResult {
+    text: String,
+    tool_calls: Option<Vec<everruns_contracts::tools::ToolCall>>,
+}

--- a/crates/everruns-agent-loop/src/lib.rs
+++ b/crates/everruns-agent-loop/src/lib.rs
@@ -1,0 +1,34 @@
+// Agent Loop Abstraction
+//
+// This crate provides a DB-agnostic, streamable, and decomposable implementation
+// of an agentic loop (LLM call → tool execution → repeat).
+//
+// Key design decisions:
+// - Uses traits (EventEmitter, MessageStore, ToolExecutor) for pluggable backends
+// - Can run fully in-process or decomposed into steps (for Temporal integration)
+// - Emits AG-UI compatible events for SSE streaming
+// - Configuration via AgentConfig (can be built from Agent entity or created directly)
+
+pub mod config;
+pub mod error;
+pub mod events;
+pub mod executor;
+pub mod message;
+pub mod step;
+pub mod traits;
+
+// In-memory implementations for examples and testing
+pub mod memory;
+
+// Re-exports for convenience
+pub use config::AgentConfig;
+pub use error::{AgentLoopError, Result};
+pub use events::LoopEvent;
+pub use executor::AgentLoop;
+pub use message::{ConversationMessage, MessageRole};
+pub use step::{LoopStep, StepKind, StepResult};
+pub use traits::{EventEmitter, LlmProvider, MessageStore, ToolExecutor};
+
+// Re-export AG-UI events for compatibility
+pub use everruns_contracts::events::AgUiEvent;
+pub use everruns_contracts::tools::{ToolCall, ToolDefinition, ToolResult};

--- a/crates/everruns-agent-loop/src/memory.rs
+++ b/crates/everruns-agent-loop/src/memory.rs
@@ -1,0 +1,610 @@
+// In-memory implementations for examples and testing
+//
+// These implementations keep all data in memory, making them perfect for:
+// - Standalone examples that don't need a database
+// - Unit tests
+// - Quick prototyping
+
+use async_trait::async_trait;
+use everruns_contracts::tools::{ToolCall, ToolDefinition, ToolResult};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use uuid::Uuid;
+
+use crate::error::Result;
+use crate::events::LoopEvent;
+use crate::message::ConversationMessage;
+use crate::traits::{EventEmitter, MessageStore, ToolExecutor};
+
+// ============================================================================
+// InMemoryEventEmitter - Collects events in memory
+// ============================================================================
+
+/// In-memory event emitter that collects all events
+///
+/// Useful for testing and examples where you want to inspect events after execution.
+#[derive(Debug, Default)]
+pub struct InMemoryEventEmitter {
+    events: Arc<RwLock<Vec<LoopEvent>>>,
+}
+
+impl InMemoryEventEmitter {
+    /// Create a new in-memory event emitter
+    pub fn new() -> Self {
+        Self {
+            events: Arc::new(RwLock::new(Vec::new())),
+        }
+    }
+
+    /// Get all collected events
+    pub async fn events(&self) -> Vec<LoopEvent> {
+        self.events.read().await.clone()
+    }
+
+    /// Clear all events
+    pub async fn clear(&self) {
+        self.events.write().await.clear();
+    }
+
+    /// Get event count
+    pub async fn count(&self) -> usize {
+        self.events.read().await.len()
+    }
+}
+
+#[async_trait]
+impl EventEmitter for InMemoryEventEmitter {
+    async fn emit(&self, event: LoopEvent) -> Result<()> {
+        self.events.write().await.push(event);
+        Ok(())
+    }
+}
+
+// ============================================================================
+// ChannelEventEmitter - Sends events to a channel
+// ============================================================================
+
+/// Event emitter that sends events to a tokio broadcast channel
+///
+/// Useful for real-time streaming to multiple subscribers.
+pub struct ChannelEventEmitter {
+    sender: tokio::sync::broadcast::Sender<LoopEvent>,
+}
+
+impl ChannelEventEmitter {
+    /// Create a new channel event emitter with the given capacity
+    pub fn new(capacity: usize) -> (Self, tokio::sync::broadcast::Receiver<LoopEvent>) {
+        let (sender, receiver) = tokio::sync::broadcast::channel(capacity);
+        (Self { sender }, receiver)
+    }
+
+    /// Subscribe to events
+    pub fn subscribe(&self) -> tokio::sync::broadcast::Receiver<LoopEvent> {
+        self.sender.subscribe()
+    }
+}
+
+#[async_trait]
+impl EventEmitter for ChannelEventEmitter {
+    async fn emit(&self, event: LoopEvent) -> Result<()> {
+        // Ignore send errors (no receivers)
+        let _ = self.sender.send(event);
+        Ok(())
+    }
+}
+
+// ============================================================================
+// NoOpEventEmitter - Discards all events
+// ============================================================================
+
+/// Event emitter that discards all events
+///
+/// Useful when you don't need event streaming.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoOpEventEmitter;
+
+impl NoOpEventEmitter {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl EventEmitter for NoOpEventEmitter {
+    async fn emit(&self, _event: LoopEvent) -> Result<()> {
+        Ok(())
+    }
+}
+
+// ============================================================================
+// InMemoryMessageStore - Stores messages in memory
+// ============================================================================
+
+/// In-memory message store
+///
+/// Stores messages in a HashMap keyed by session ID.
+#[derive(Debug, Default)]
+pub struct InMemoryMessageStore {
+    messages: Arc<RwLock<HashMap<Uuid, Vec<ConversationMessage>>>>,
+}
+
+impl InMemoryMessageStore {
+    /// Create a new in-memory message store
+    pub fn new() -> Self {
+        Self {
+            messages: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Get all sessions
+    pub async fn sessions(&self) -> Vec<Uuid> {
+        self.messages.read().await.keys().copied().collect()
+    }
+
+    /// Clear all messages
+    pub async fn clear(&self) {
+        self.messages.write().await.clear();
+    }
+
+    /// Clear messages for a specific session
+    pub async fn clear_session(&self, session_id: Uuid) {
+        self.messages.write().await.remove(&session_id);
+    }
+
+    /// Pre-populate with messages (useful for testing)
+    pub async fn seed(&self, session_id: Uuid, messages: Vec<ConversationMessage>) {
+        self.messages.write().await.insert(session_id, messages);
+    }
+}
+
+#[async_trait]
+impl MessageStore for InMemoryMessageStore {
+    async fn store(&self, session_id: Uuid, message: ConversationMessage) -> Result<()> {
+        self.messages
+            .write()
+            .await
+            .entry(session_id)
+            .or_default()
+            .push(message);
+        Ok(())
+    }
+
+    async fn load(&self, session_id: Uuid) -> Result<Vec<ConversationMessage>> {
+        Ok(self
+            .messages
+            .read()
+            .await
+            .get(&session_id)
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    async fn count(&self, session_id: Uuid) -> Result<usize> {
+        Ok(self
+            .messages
+            .read()
+            .await
+            .get(&session_id)
+            .map(|m| m.len())
+            .unwrap_or(0))
+    }
+}
+
+// ============================================================================
+// MockToolExecutor - Returns predefined results
+// ============================================================================
+
+/// Mock tool executor for testing
+///
+/// Returns predefined results based on tool name.
+#[derive(Debug, Default)]
+pub struct MockToolExecutor {
+    results: Arc<RwLock<HashMap<String, serde_json::Value>>>,
+    call_log: Arc<RwLock<Vec<ToolCall>>>,
+}
+
+impl MockToolExecutor {
+    /// Create a new mock tool executor
+    pub fn new() -> Self {
+        Self {
+            results: Arc::new(RwLock::new(HashMap::new())),
+            call_log: Arc::new(RwLock::new(Vec::new())),
+        }
+    }
+
+    /// Set the result for a specific tool
+    pub async fn set_result(&self, tool_name: impl Into<String>, result: serde_json::Value) {
+        self.results.write().await.insert(tool_name.into(), result);
+    }
+
+    /// Get the call log
+    pub async fn calls(&self) -> Vec<ToolCall> {
+        self.call_log.read().await.clone()
+    }
+
+    /// Clear the call log
+    pub async fn clear_calls(&self) {
+        self.call_log.write().await.clear();
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for MockToolExecutor {
+    async fn execute(
+        &self,
+        tool_call: &ToolCall,
+        _tool_def: &ToolDefinition,
+    ) -> Result<ToolResult> {
+        // Log the call
+        self.call_log.write().await.push(tool_call.clone());
+
+        // Return predefined result or default
+        let result = self
+            .results
+            .read()
+            .await
+            .get(&tool_call.name)
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({"status": "ok"}));
+
+        Ok(ToolResult {
+            tool_call_id: tool_call.id.clone(),
+            result: Some(result),
+            error: None,
+        })
+    }
+}
+
+// ============================================================================
+// EchoToolExecutor - Echoes back the arguments
+// ============================================================================
+
+/// Tool executor that echoes back the arguments
+///
+/// Useful for simple testing without setting up mock results.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct EchoToolExecutor;
+
+impl EchoToolExecutor {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for EchoToolExecutor {
+    async fn execute(
+        &self,
+        tool_call: &ToolCall,
+        _tool_def: &ToolDefinition,
+    ) -> Result<ToolResult> {
+        Ok(ToolResult {
+            tool_call_id: tool_call.id.clone(),
+            result: Some(serde_json::json!({
+                "echoed_tool": tool_call.name,
+                "echoed_arguments": tool_call.arguments
+            })),
+            error: None,
+        })
+    }
+}
+
+// ============================================================================
+// FailingToolExecutor - Always returns an error
+// ============================================================================
+
+/// Tool executor that always fails
+///
+/// Useful for testing error handling.
+#[derive(Debug, Clone)]
+pub struct FailingToolExecutor {
+    error_message: String,
+}
+
+impl FailingToolExecutor {
+    pub fn new(error_message: impl Into<String>) -> Self {
+        Self {
+            error_message: error_message.into(),
+        }
+    }
+}
+
+impl Default for FailingToolExecutor {
+    fn default() -> Self {
+        Self::new("Tool execution failed")
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for FailingToolExecutor {
+    async fn execute(
+        &self,
+        tool_call: &ToolCall,
+        _tool_def: &ToolDefinition,
+    ) -> Result<ToolResult> {
+        Ok(ToolResult {
+            tool_call_id: tool_call.id.clone(),
+            result: None,
+            error: Some(self.error_message.clone()),
+        })
+    }
+}
+
+// ============================================================================
+// MockLlmProvider - Returns predefined responses
+// ============================================================================
+
+use crate::traits::{
+    LlmCallConfig, LlmCompletionMetadata, LlmMessage, LlmProvider, LlmResponseStream,
+    LlmStreamEvent,
+};
+use futures::stream;
+
+/// Mock LLM provider for testing
+///
+/// Returns predefined responses in sequence.
+#[derive(Debug, Default)]
+pub struct MockLlmProvider {
+    responses: Arc<RwLock<Vec<MockLlmResponse>>>,
+    call_index: Arc<RwLock<usize>>,
+    call_log: Arc<RwLock<Vec<Vec<LlmMessage>>>>,
+}
+
+/// A mock LLM response
+#[derive(Debug, Clone)]
+pub struct MockLlmResponse {
+    pub text: String,
+    pub tool_calls: Option<Vec<ToolCall>>,
+}
+
+impl MockLlmResponse {
+    /// Create a text-only response
+    pub fn text(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            tool_calls: None,
+        }
+    }
+
+    /// Create a response with tool calls
+    pub fn with_tools(text: impl Into<String>, tool_calls: Vec<ToolCall>) -> Self {
+        Self {
+            text: text.into(),
+            tool_calls: Some(tool_calls),
+        }
+    }
+}
+
+impl MockLlmProvider {
+    /// Create a new mock LLM provider
+    pub fn new() -> Self {
+        Self {
+            responses: Arc::new(RwLock::new(Vec::new())),
+            call_index: Arc::new(RwLock::new(0)),
+            call_log: Arc::new(RwLock::new(Vec::new())),
+        }
+    }
+
+    /// Add a response to the queue
+    pub async fn add_response(&self, response: MockLlmResponse) {
+        self.responses.write().await.push(response);
+    }
+
+    /// Set all responses at once
+    pub async fn set_responses(&self, responses: Vec<MockLlmResponse>) {
+        *self.responses.write().await = responses;
+        *self.call_index.write().await = 0;
+    }
+
+    /// Get the call log
+    pub async fn calls(&self) -> Vec<Vec<LlmMessage>> {
+        self.call_log.read().await.clone()
+    }
+
+    /// Reset the provider
+    pub async fn reset(&self) {
+        self.responses.write().await.clear();
+        *self.call_index.write().await = 0;
+        self.call_log.write().await.clear();
+    }
+}
+
+#[async_trait]
+impl LlmProvider for MockLlmProvider {
+    async fn chat_completion_stream(
+        &self,
+        messages: Vec<LlmMessage>,
+        _config: &LlmCallConfig,
+    ) -> Result<LlmResponseStream> {
+        // Log the call
+        self.call_log.write().await.push(messages);
+
+        // Get next response
+        let mut index = self.call_index.write().await;
+        let responses = self.responses.read().await;
+
+        let response = responses.get(*index).cloned().unwrap_or_else(|| {
+            MockLlmResponse::text("Mock response (no more responses configured)")
+        });
+
+        *index += 1;
+        drop(index);
+        drop(responses);
+
+        // Create a stream that emits the response
+        let events = vec![
+            Ok(LlmStreamEvent::TextDelta(response.text.clone())),
+            if let Some(tool_calls) = response.tool_calls {
+                Ok(LlmStreamEvent::ToolCalls(tool_calls))
+            } else {
+                Ok(LlmStreamEvent::Done(LlmCompletionMetadata::default()))
+            },
+            Ok(LlmStreamEvent::Done(LlmCompletionMetadata::default())),
+        ];
+
+        Ok(Box::pin(stream::iter(events)))
+    }
+}
+
+// ============================================================================
+// Builder for easy setup
+// ============================================================================
+
+use crate::config::AgentConfig;
+use crate::executor::AgentLoop;
+
+/// Builder for creating an AgentLoop with in-memory components
+pub struct InMemoryAgentLoopBuilder {
+    config: AgentConfig,
+    event_emitter: Option<InMemoryEventEmitter>,
+    message_store: Option<InMemoryMessageStore>,
+    llm_provider: Option<MockLlmProvider>,
+    tool_executor: Option<MockToolExecutor>,
+}
+
+impl InMemoryAgentLoopBuilder {
+    /// Create a new builder with the given config
+    pub fn new(config: AgentConfig) -> Self {
+        Self {
+            config,
+            event_emitter: None,
+            message_store: None,
+            llm_provider: None,
+            tool_executor: None,
+        }
+    }
+
+    /// Use a custom event emitter
+    pub fn event_emitter(mut self, emitter: InMemoryEventEmitter) -> Self {
+        self.event_emitter = Some(emitter);
+        self
+    }
+
+    /// Use a custom message store
+    pub fn message_store(mut self, store: InMemoryMessageStore) -> Self {
+        self.message_store = Some(store);
+        self
+    }
+
+    /// Use a custom LLM provider
+    pub fn llm_provider(mut self, provider: MockLlmProvider) -> Self {
+        self.llm_provider = Some(provider);
+        self
+    }
+
+    /// Use a custom tool executor
+    pub fn tool_executor(mut self, executor: MockToolExecutor) -> Self {
+        self.tool_executor = Some(executor);
+        self
+    }
+
+    /// Build the agent loop
+    pub fn build(
+        self,
+    ) -> AgentLoop<InMemoryEventEmitter, InMemoryMessageStore, MockLlmProvider, MockToolExecutor>
+    {
+        AgentLoop::new(
+            self.config,
+            self.event_emitter.unwrap_or_default(),
+            self.message_store.unwrap_or_default(),
+            self.llm_provider.unwrap_or_default(),
+            self.tool_executor.unwrap_or_default(),
+        )
+    }
+
+    /// Build and return references to components for inspection
+    #[allow(clippy::type_complexity)]
+    pub fn build_with_refs(
+        self,
+    ) -> (
+        AgentLoop<InMemoryEventEmitter, InMemoryMessageStore, MockLlmProvider, MockToolExecutor>,
+        Arc<InMemoryEventEmitter>,
+        Arc<InMemoryMessageStore>,
+        Arc<MockLlmProvider>,
+        Arc<MockToolExecutor>,
+    ) {
+        let event_emitter = Arc::new(self.event_emitter.unwrap_or_default());
+        let message_store = Arc::new(self.message_store.unwrap_or_default());
+        let llm_provider = Arc::new(self.llm_provider.unwrap_or_default());
+        let tool_executor = Arc::new(self.tool_executor.unwrap_or_default());
+
+        let loop_instance = AgentLoop::with_arcs(
+            self.config,
+            event_emitter.clone(),
+            message_store.clone(),
+            llm_provider.clone(),
+            tool_executor.clone(),
+        );
+
+        (
+            loop_instance,
+            event_emitter,
+            message_store,
+            llm_provider,
+            tool_executor,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_in_memory_event_emitter() {
+        let emitter = InMemoryEventEmitter::new();
+
+        emitter
+            .emit(LoopEvent::loop_started("test-session"))
+            .await
+            .unwrap();
+
+        assert_eq!(emitter.count().await, 1);
+
+        let events = emitter.events().await;
+        assert!(matches!(events[0], LoopEvent::LoopStarted { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_in_memory_message_store() {
+        let store = InMemoryMessageStore::new();
+        let session_id = Uuid::now_v7();
+
+        store
+            .store(session_id, ConversationMessage::user("Hello"))
+            .await
+            .unwrap();
+
+        let messages = store.load(session_id).await.unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].text(), Some("Hello"));
+    }
+
+    #[tokio::test]
+    async fn test_mock_tool_executor() {
+        let executor = MockToolExecutor::new();
+        executor
+            .set_result("get_weather", serde_json::json!({"temp": 72}))
+            .await;
+
+        let tool_call = ToolCall {
+            id: "call_1".to_string(),
+            name: "get_weather".to_string(),
+            arguments: serde_json::json!({"city": "NYC"}),
+        };
+
+        let tool_def = ToolDefinition::Builtin(everruns_contracts::tools::BuiltinTool {
+            name: "get_weather".to_string(),
+            description: "Get weather".to_string(),
+            parameters: serde_json::json!({}),
+            kind: everruns_contracts::tools::BuiltinToolKind::HttpGet,
+            policy: everruns_contracts::tools::ToolPolicy::Auto,
+        });
+
+        let result = executor.execute(&tool_call, &tool_def).await.unwrap();
+
+        assert!(result.error.is_none());
+        assert_eq!(result.result, Some(serde_json::json!({"temp": 72})));
+    }
+}

--- a/crates/everruns-agent-loop/src/message.rs
+++ b/crates/everruns-agent-loop/src/message.rs
@@ -1,0 +1,252 @@
+// Conversation message types
+//
+// ConversationMessage is a DB-agnostic message type that represents
+// a single message in the conversation history.
+
+use chrono::{DateTime, Utc};
+use everruns_contracts::tools::ToolCall;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Message role in the conversation
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageRole {
+    /// System message (instructions)
+    System,
+    /// User message
+    User,
+    /// Assistant response
+    Assistant,
+    /// Tool call request from assistant
+    ToolCall,
+    /// Tool execution result
+    ToolResult,
+}
+
+impl std::fmt::Display for MessageRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MessageRole::System => write!(f, "system"),
+            MessageRole::User => write!(f, "user"),
+            MessageRole::Assistant => write!(f, "assistant"),
+            MessageRole::ToolCall => write!(f, "tool_call"),
+            MessageRole::ToolResult => write!(f, "tool_result"),
+        }
+    }
+}
+
+impl From<&str> for MessageRole {
+    fn from(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "system" => MessageRole::System,
+            "user" => MessageRole::User,
+            "assistant" => MessageRole::Assistant,
+            "tool_call" => MessageRole::ToolCall,
+            "tool_result" => MessageRole::ToolResult,
+            _ => MessageRole::User,
+        }
+    }
+}
+
+/// A message in the conversation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConversationMessage {
+    /// Unique message ID
+    pub id: Uuid,
+
+    /// Message role
+    pub role: MessageRole,
+
+    /// Message content (text for user/assistant/system, structured for tool calls/results)
+    pub content: MessageContent,
+
+    /// Tool call ID (for tool_result messages to correlate with tool_call)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+
+    /// Tool calls requested by assistant (for assistant messages with function calls)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<ToolCall>>,
+
+    /// Timestamp when the message was created
+    pub created_at: DateTime<Utc>,
+}
+
+/// Message content variants
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum MessageContent {
+    /// Text content (for user/assistant/system messages)
+    Text(String),
+
+    /// Tool call content
+    ToolCall {
+        id: String,
+        name: String,
+        arguments: serde_json::Value,
+    },
+
+    /// Tool result content
+    ToolResult {
+        result: Option<serde_json::Value>,
+        error: Option<String>,
+    },
+}
+
+impl MessageContent {
+    /// Get text content if this is a text message
+    pub fn as_text(&self) -> Option<&str> {
+        match self {
+            MessageContent::Text(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// Convert to text representation for LLM
+    pub fn to_llm_string(&self) -> String {
+        match self {
+            MessageContent::Text(s) => s.clone(),
+            MessageContent::ToolCall {
+                name, arguments, ..
+            } => {
+                format!(
+                    "Tool call: {} with arguments: {}",
+                    name,
+                    serde_json::to_string(arguments).unwrap_or_default()
+                )
+            }
+            MessageContent::ToolResult { result, error } => {
+                if let Some(err) = error {
+                    format!("Tool error: {}", err)
+                } else if let Some(res) = result {
+                    serde_json::to_string(res).unwrap_or_else(|_| "{}".to_string())
+                } else {
+                    "{}".to_string()
+                }
+            }
+        }
+    }
+}
+
+impl ConversationMessage {
+    /// Create a new user message
+    pub fn user(content: impl Into<String>) -> Self {
+        Self {
+            id: Uuid::now_v7(),
+            role: MessageRole::User,
+            content: MessageContent::Text(content.into()),
+            tool_call_id: None,
+            tool_calls: None,
+            created_at: Utc::now(),
+        }
+    }
+
+    /// Create a new assistant message
+    pub fn assistant(content: impl Into<String>) -> Self {
+        Self {
+            id: Uuid::now_v7(),
+            role: MessageRole::Assistant,
+            content: MessageContent::Text(content.into()),
+            tool_call_id: None,
+            tool_calls: None,
+            created_at: Utc::now(),
+        }
+    }
+
+    /// Create a new assistant message with tool calls
+    pub fn assistant_with_tools(content: impl Into<String>, tool_calls: Vec<ToolCall>) -> Self {
+        Self {
+            id: Uuid::now_v7(),
+            role: MessageRole::Assistant,
+            content: MessageContent::Text(content.into()),
+            tool_call_id: None,
+            tool_calls: Some(tool_calls),
+            created_at: Utc::now(),
+        }
+    }
+
+    /// Create a new system message
+    pub fn system(content: impl Into<String>) -> Self {
+        Self {
+            id: Uuid::now_v7(),
+            role: MessageRole::System,
+            content: MessageContent::Text(content.into()),
+            tool_call_id: None,
+            tool_calls: None,
+            created_at: Utc::now(),
+        }
+    }
+
+    /// Create a tool call message
+    pub fn tool_call(tool_call: &ToolCall) -> Self {
+        Self {
+            id: Uuid::now_v7(),
+            role: MessageRole::ToolCall,
+            content: MessageContent::ToolCall {
+                id: tool_call.id.clone(),
+                name: tool_call.name.clone(),
+                arguments: tool_call.arguments.clone(),
+            },
+            tool_call_id: Some(tool_call.id.clone()),
+            tool_calls: None,
+            created_at: Utc::now(),
+        }
+    }
+
+    /// Create a tool result message
+    pub fn tool_result(
+        tool_call_id: impl Into<String>,
+        result: Option<serde_json::Value>,
+        error: Option<String>,
+    ) -> Self {
+        Self {
+            id: Uuid::now_v7(),
+            role: MessageRole::ToolResult,
+            content: MessageContent::ToolResult { result, error },
+            tool_call_id: Some(tool_call_id.into()),
+            tool_calls: None,
+            created_at: Utc::now(),
+        }
+    }
+
+    /// Get text content if this is a text message
+    pub fn text(&self) -> Option<&str> {
+        self.content.as_text()
+    }
+
+    /// Check if this message has tool calls
+    pub fn has_tool_calls(&self) -> bool {
+        self.tool_calls.as_ref().is_some_and(|tc| !tc.is_empty())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_user_message() {
+        let msg = ConversationMessage::user("Hello");
+        assert_eq!(msg.role, MessageRole::User);
+        assert_eq!(msg.text(), Some("Hello"));
+    }
+
+    #[test]
+    fn test_assistant_message() {
+        let msg = ConversationMessage::assistant("Hi there!");
+        assert_eq!(msg.role, MessageRole::Assistant);
+        assert_eq!(msg.text(), Some("Hi there!"));
+    }
+
+    #[test]
+    fn test_tool_result_message() {
+        let msg = ConversationMessage::tool_result(
+            "call_123",
+            Some(serde_json::json!({"result": "success"})),
+            None,
+        );
+        assert_eq!(msg.role, MessageRole::ToolResult);
+        assert_eq!(msg.tool_call_id, Some("call_123".to_string()));
+    }
+}

--- a/crates/everruns-agent-loop/src/step.rs
+++ b/crates/everruns-agent-loop/src/step.rs
@@ -1,0 +1,254 @@
+// Loop step representation
+//
+// LoopStep represents a single iteration of the agentic loop.
+// This abstraction allows the loop to be decomposed into discrete steps
+// that can be executed independently (e.g., as Temporal activities).
+
+use chrono::{DateTime, Utc};
+use everruns_contracts::tools::{ToolCall, ToolResult};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::message::ConversationMessage;
+
+/// The kind of step being executed
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum StepKind {
+    /// Initial setup step
+    Setup,
+    /// LLM inference step
+    LlmCall,
+    /// Tool execution step
+    ToolExecution,
+    /// Finalization step
+    Finalize,
+}
+
+impl std::fmt::Display for StepKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StepKind::Setup => write!(f, "setup"),
+            StepKind::LlmCall => write!(f, "llm_call"),
+            StepKind::ToolExecution => write!(f, "tool_execution"),
+            StepKind::Finalize => write!(f, "finalize"),
+        }
+    }
+}
+
+/// A single step in the agentic loop
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoopStep {
+    /// Unique step ID
+    pub id: Uuid,
+
+    /// Session this step belongs to
+    pub session_id: Uuid,
+
+    /// Iteration number (1-indexed)
+    pub iteration: usize,
+
+    /// Kind of step
+    pub kind: StepKind,
+
+    /// When the step started
+    pub started_at: DateTime<Utc>,
+
+    /// When the step completed (None if still running)
+    pub completed_at: Option<DateTime<Utc>>,
+
+    /// Step result (None if still running or failed)
+    pub result: Option<StepResult>,
+}
+
+/// Result of a step execution
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum StepResult {
+    /// Setup completed successfully
+    SetupComplete { message_count: usize },
+
+    /// LLM call completed
+    LlmCallComplete {
+        /// Assistant's text response
+        response_text: String,
+        /// Tool calls requested (empty if none)
+        tool_calls: Vec<ToolCall>,
+        /// Whether to continue the loop
+        continue_loop: bool,
+    },
+
+    /// Tool execution completed
+    ToolExecutionComplete {
+        /// Results for each tool call
+        results: Vec<ToolResult>,
+    },
+
+    /// Finalization completed
+    FinalizeComplete {
+        /// Final assistant response
+        final_response: Option<String>,
+    },
+}
+
+impl LoopStep {
+    /// Create a new setup step
+    pub fn setup(session_id: Uuid) -> Self {
+        Self {
+            id: Uuid::now_v7(),
+            session_id,
+            iteration: 0,
+            kind: StepKind::Setup,
+            started_at: Utc::now(),
+            completed_at: None,
+            result: None,
+        }
+    }
+
+    /// Create a new LLM call step
+    pub fn llm_call(session_id: Uuid, iteration: usize) -> Self {
+        Self {
+            id: Uuid::now_v7(),
+            session_id,
+            iteration,
+            kind: StepKind::LlmCall,
+            started_at: Utc::now(),
+            completed_at: None,
+            result: None,
+        }
+    }
+
+    /// Create a new tool execution step
+    pub fn tool_execution(session_id: Uuid, iteration: usize) -> Self {
+        Self {
+            id: Uuid::now_v7(),
+            session_id,
+            iteration,
+            kind: StepKind::ToolExecution,
+            started_at: Utc::now(),
+            completed_at: None,
+            result: None,
+        }
+    }
+
+    /// Create a new finalize step
+    pub fn finalize(session_id: Uuid, iteration: usize) -> Self {
+        Self {
+            id: Uuid::now_v7(),
+            session_id,
+            iteration,
+            kind: StepKind::Finalize,
+            started_at: Utc::now(),
+            completed_at: None,
+            result: None,
+        }
+    }
+
+    /// Mark the step as completed with a result
+    pub fn complete(mut self, result: StepResult) -> Self {
+        self.completed_at = Some(Utc::now());
+        self.result = Some(result);
+        self
+    }
+
+    /// Check if the step is completed
+    pub fn is_completed(&self) -> bool {
+        self.completed_at.is_some()
+    }
+
+    /// Get duration in milliseconds if completed
+    pub fn duration_ms(&self) -> Option<i64> {
+        self.completed_at
+            .map(|end| (end - self.started_at).num_milliseconds())
+    }
+}
+
+/// Input for executing a step (used for decomposed execution)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StepInput {
+    /// Session ID
+    pub session_id: Uuid,
+
+    /// Current iteration
+    pub iteration: usize,
+
+    /// Current messages in the conversation
+    pub messages: Vec<ConversationMessage>,
+
+    /// Pending tool calls to execute (for tool execution steps)
+    pub pending_tool_calls: Vec<ToolCall>,
+}
+
+impl StepInput {
+    /// Create input for a new loop
+    pub fn new(session_id: Uuid, messages: Vec<ConversationMessage>) -> Self {
+        Self {
+            session_id,
+            iteration: 0,
+            messages,
+            pending_tool_calls: Vec::new(),
+        }
+    }
+
+    /// Create input for a tool execution step
+    pub fn for_tool_execution(
+        session_id: Uuid,
+        iteration: usize,
+        messages: Vec<ConversationMessage>,
+        tool_calls: Vec<ToolCall>,
+    ) -> Self {
+        Self {
+            session_id,
+            iteration,
+            messages,
+            pending_tool_calls: tool_calls,
+        }
+    }
+
+    /// Advance to next iteration
+    pub fn next_iteration(mut self) -> Self {
+        self.iteration += 1;
+        self.pending_tool_calls.clear();
+        self
+    }
+}
+
+/// Output from executing a step (used for decomposed execution)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StepOutput {
+    /// The completed step
+    pub step: LoopStep,
+
+    /// Updated messages (including any new messages from this step)
+    pub messages: Vec<ConversationMessage>,
+
+    /// Whether the loop should continue
+    pub continue_loop: bool,
+
+    /// Pending tool calls for next step (if any)
+    pub pending_tool_calls: Vec<ToolCall>,
+}
+
+impl StepOutput {
+    /// Create output indicating the loop should continue
+    pub fn continue_with(
+        step: LoopStep,
+        messages: Vec<ConversationMessage>,
+        pending_tool_calls: Vec<ToolCall>,
+    ) -> Self {
+        Self {
+            step,
+            messages,
+            continue_loop: true,
+            pending_tool_calls,
+        }
+    }
+
+    /// Create output indicating the loop is complete
+    pub fn complete(step: LoopStep, messages: Vec<ConversationMessage>) -> Self {
+        Self {
+            step,
+            messages,
+            continue_loop: false,
+            pending_tool_calls: Vec::new(),
+        }
+    }
+}

--- a/crates/everruns-agent-loop/src/traits.rs
+++ b/crates/everruns-agent-loop/src/traits.rs
@@ -1,0 +1,329 @@
+// Core traits for pluggable backends
+//
+// These traits allow the agent loop to be used with different backends:
+// - In-memory implementations for examples and testing
+// - Database implementations for production
+// - Channel-based implementations for streaming
+
+use async_trait::async_trait;
+use everruns_contracts::tools::{ToolCall, ToolDefinition, ToolResult};
+use futures::Stream;
+use std::pin::Pin;
+use uuid::Uuid;
+
+use crate::config::AgentConfig;
+use crate::error::Result;
+use crate::events::LoopEvent;
+use crate::message::ConversationMessage;
+
+// ============================================================================
+// EventEmitter - For streaming events during execution
+// ============================================================================
+
+/// Trait for emitting events during loop execution
+///
+/// Implementations can:
+/// - Store events in a database
+/// - Send events to a channel for SSE streaming
+/// - Collect events in memory for testing
+/// - Do nothing (no-op implementation)
+#[async_trait]
+pub trait EventEmitter: Send + Sync {
+    /// Emit a single event
+    async fn emit(&self, event: LoopEvent) -> Result<()>;
+
+    /// Emit multiple events
+    async fn emit_batch(&self, events: Vec<LoopEvent>) -> Result<()> {
+        for event in events {
+            self.emit(event).await?;
+        }
+        Ok(())
+    }
+}
+
+// ============================================================================
+// MessageStore - For persisting conversation messages
+// ============================================================================
+
+/// Trait for storing and retrieving conversation messages
+///
+/// Implementations can:
+/// - Store messages in a database
+/// - Keep messages in memory for testing
+/// - Store messages in a file
+#[async_trait]
+pub trait MessageStore: Send + Sync {
+    /// Store a message
+    async fn store(&self, session_id: Uuid, message: ConversationMessage) -> Result<()>;
+
+    /// Store multiple messages
+    async fn store_batch(
+        &self,
+        session_id: Uuid,
+        messages: Vec<ConversationMessage>,
+    ) -> Result<()> {
+        for message in messages {
+            self.store(session_id, message).await?;
+        }
+        Ok(())
+    }
+
+    /// Load all messages for a session
+    async fn load(&self, session_id: Uuid) -> Result<Vec<ConversationMessage>>;
+
+    /// Load messages with pagination
+    async fn load_page(
+        &self,
+        session_id: Uuid,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Vec<ConversationMessage>> {
+        let all = self.load(session_id).await?;
+        Ok(all.into_iter().skip(offset).take(limit).collect())
+    }
+
+    /// Count messages in a session
+    async fn count(&self, session_id: Uuid) -> Result<usize> {
+        Ok(self.load(session_id).await?.len())
+    }
+}
+
+// ============================================================================
+// LlmProvider - For calling LLM models
+// ============================================================================
+
+/// Type alias for the LLM response stream
+pub type LlmResponseStream = Pin<Box<dyn Stream<Item = Result<LlmStreamEvent>> + Send>>;
+
+/// Events emitted during LLM streaming
+#[derive(Debug, Clone)]
+pub enum LlmStreamEvent {
+    /// Text delta (incremental content)
+    TextDelta(String),
+    /// Tool calls from the LLM
+    ToolCalls(Vec<ToolCall>),
+    /// Streaming completed
+    Done(LlmCompletionMetadata),
+    /// Error during streaming
+    Error(String),
+}
+
+/// Metadata about LLM completion
+#[derive(Debug, Clone, Default)]
+pub struct LlmCompletionMetadata {
+    /// Total tokens used
+    pub total_tokens: Option<u32>,
+    /// Prompt tokens
+    pub prompt_tokens: Option<u32>,
+    /// Completion tokens
+    pub completion_tokens: Option<u32>,
+    /// Model used
+    pub model: Option<String>,
+    /// Finish reason
+    pub finish_reason: Option<String>,
+}
+
+/// Trait for LLM providers
+///
+/// Implementations handle provider-specific API calls and response parsing.
+#[async_trait]
+pub trait LlmProvider: Send + Sync {
+    /// Call the LLM with streaming response
+    async fn chat_completion_stream(
+        &self,
+        messages: Vec<LlmMessage>,
+        config: &LlmCallConfig,
+    ) -> Result<LlmResponseStream>;
+
+    /// Call the LLM without streaming (convenience method)
+    async fn chat_completion(
+        &self,
+        messages: Vec<LlmMessage>,
+        config: &LlmCallConfig,
+    ) -> Result<LlmResponse> {
+        use futures::StreamExt;
+
+        let mut stream = self.chat_completion_stream(messages, config).await?;
+        let mut text = String::new();
+        let mut tool_calls = Vec::new();
+        let mut metadata = LlmCompletionMetadata::default();
+
+        while let Some(event) = stream.next().await {
+            match event? {
+                LlmStreamEvent::TextDelta(delta) => text.push_str(&delta),
+                LlmStreamEvent::ToolCalls(calls) => tool_calls = calls,
+                LlmStreamEvent::Done(meta) => metadata = meta,
+                LlmStreamEvent::Error(err) => return Err(crate::error::AgentLoopError::llm(err)),
+            }
+        }
+
+        Ok(LlmResponse {
+            text,
+            tool_calls: if tool_calls.is_empty() {
+                None
+            } else {
+                Some(tool_calls)
+            },
+            metadata,
+        })
+    }
+}
+
+/// Message format for LLM calls (provider-agnostic)
+#[derive(Debug, Clone)]
+pub struct LlmMessage {
+    pub role: LlmMessageRole,
+    pub content: String,
+    pub tool_calls: Option<Vec<ToolCall>>,
+    pub tool_call_id: Option<String>,
+}
+
+/// Message role for LLM calls
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LlmMessageRole {
+    System,
+    User,
+    Assistant,
+    Tool,
+}
+
+/// Configuration for an LLM call
+#[derive(Debug, Clone)]
+pub struct LlmCallConfig {
+    pub model: String,
+    pub temperature: Option<f32>,
+    pub max_tokens: Option<u32>,
+    pub tools: Vec<ToolDefinition>,
+}
+
+impl From<&AgentConfig> for LlmCallConfig {
+    fn from(config: &AgentConfig) -> Self {
+        Self {
+            model: config.model.clone(),
+            temperature: config.temperature,
+            max_tokens: config.max_tokens,
+            tools: config.tools.clone(),
+        }
+    }
+}
+
+/// Response from an LLM call (non-streaming)
+#[derive(Debug, Clone)]
+pub struct LlmResponse {
+    pub text: String,
+    pub tool_calls: Option<Vec<ToolCall>>,
+    pub metadata: LlmCompletionMetadata,
+}
+
+// ============================================================================
+// ToolExecutor - For executing tool calls
+// ============================================================================
+
+/// Trait for executing tool calls
+///
+/// Implementations handle the actual tool execution:
+/// - Webhook calls
+/// - Built-in function execution
+/// - Mock execution for testing
+#[async_trait]
+pub trait ToolExecutor: Send + Sync {
+    /// Execute a single tool call
+    async fn execute(&self, tool_call: &ToolCall, tool_def: &ToolDefinition) -> Result<ToolResult>;
+
+    /// Execute multiple tool calls (default: sequential)
+    async fn execute_batch(
+        &self,
+        tool_calls: &[ToolCall],
+        tool_defs: &[ToolDefinition],
+    ) -> Result<Vec<ToolResult>> {
+        let mut results = Vec::with_capacity(tool_calls.len());
+
+        // Build a map of tool names to definitions
+        let tool_map: std::collections::HashMap<&str, &ToolDefinition> = tool_defs
+            .iter()
+            .map(|def| {
+                let name = match def {
+                    ToolDefinition::Webhook(w) => w.name.as_str(),
+                    ToolDefinition::Builtin(b) => b.name.as_str(),
+                };
+                (name, def)
+            })
+            .collect();
+
+        for tool_call in tool_calls {
+            let tool_def = tool_map.get(tool_call.name.as_str()).ok_or_else(|| {
+                crate::error::AgentLoopError::tool(format!(
+                    "Tool definition not found: {}",
+                    tool_call.name
+                ))
+            })?;
+
+            results.push(self.execute(tool_call, tool_def).await?);
+        }
+
+        Ok(results)
+    }
+
+    /// Execute multiple tool calls in parallel
+    async fn execute_parallel(
+        &self,
+        tool_calls: &[ToolCall],
+        tool_defs: &[ToolDefinition],
+    ) -> Result<Vec<ToolResult>>
+    where
+        Self: Sized,
+    {
+        use futures::future::join_all;
+
+        // Build a map of tool names to definitions
+        let tool_map: std::collections::HashMap<&str, &ToolDefinition> = tool_defs
+            .iter()
+            .map(|def| {
+                let name = match def {
+                    ToolDefinition::Webhook(w) => w.name.as_str(),
+                    ToolDefinition::Builtin(b) => b.name.as_str(),
+                };
+                (name, def)
+            })
+            .collect();
+
+        let futures: Vec<_> = tool_calls
+            .iter()
+            .map(|tool_call| async {
+                let tool_def = tool_map.get(tool_call.name.as_str()).ok_or_else(|| {
+                    crate::error::AgentLoopError::tool(format!(
+                        "Tool definition not found: {}",
+                        tool_call.name
+                    ))
+                })?;
+                self.execute(tool_call, tool_def).await
+            })
+            .collect();
+
+        let results = join_all(futures).await;
+        results.into_iter().collect()
+    }
+}
+
+// ============================================================================
+// Conversion helpers
+// ============================================================================
+
+impl From<&ConversationMessage> for LlmMessage {
+    fn from(msg: &ConversationMessage) -> Self {
+        let role = match msg.role {
+            crate::message::MessageRole::System => LlmMessageRole::System,
+            crate::message::MessageRole::User => LlmMessageRole::User,
+            crate::message::MessageRole::Assistant => LlmMessageRole::Assistant,
+            crate::message::MessageRole::ToolCall => LlmMessageRole::Assistant,
+            crate::message::MessageRole::ToolResult => LlmMessageRole::Tool,
+        };
+
+        LlmMessage {
+            role,
+            content: msg.content.to_llm_string(),
+            tool_calls: msg.tool_calls.clone(),
+            tool_call_id: msg.tool_call_id.clone(),
+        }
+    }
+}

--- a/crates/everruns-api/tests/integration_test.rs
+++ b/crates/everruns-api/tests/integration_test.rs
@@ -266,8 +266,8 @@ async fn test_llm_provider_and_model_workflow() {
             API_BASE_URL, provider.id
         ))
         .json(&json!({
-            "model_id": "gpt-4o",
-            "display_name": "GPT-4o",
+            "model_id": "gpt-5.2",
+            "display_name": "GPT-5.2",
             "capabilities": ["chat", "vision"],
             "context_window": 128000,
             "is_default": true
@@ -285,7 +285,7 @@ async fn test_llm_provider_and_model_workflow() {
         serde_json::from_str(&model_response_text).expect("Failed to parse model response");
 
     println!("Created model: {} ({})", model.display_name, model.id);
-    assert_eq!(model.model_id, "gpt-4o");
+    assert_eq!(model.model_id, "gpt-5.2");
 
     // Cleanup
     println!("\nCleaning up...");

--- a/crates/everruns-worker/Cargo.toml
+++ b/crates/everruns-worker/Cargo.toml
@@ -17,6 +17,7 @@ sqlx.workspace = true
 
 everruns-contracts = { path = "../everruns-contracts" }
 everruns-storage = { path = "../everruns-storage" }
+everruns-agent-loop = { path = "../everruns-agent-loop" }
 
 chrono.workspace = true
 async-trait = "0.1.89"

--- a/crates/everruns-worker/Cargo.toml
+++ b/crates/everruns-worker/Cargo.toml
@@ -34,3 +34,7 @@ temporal-sdk-core-protos.workspace = true
 prost.workspace = true
 prost-types.workspace = true
 tonic = "0.12"
+
+[[example]]
+name = "openai_agent"
+path = "examples/openai_agent.rs"

--- a/crates/everruns-worker/examples/openai_agent.rs
+++ b/crates/everruns-worker/examples/openai_agent.rs
@@ -1,0 +1,114 @@
+//! OpenAI Agent Example - Agent Loop with Real OpenAI API
+//!
+//! This example demonstrates the agent loop using the actual OpenAI API,
+//! showing real integration with production components.
+//!
+//! Prerequisites:
+//! - Set OPENAI_API_KEY environment variable
+//!
+//! Run with: cargo run --example openai_agent -p everruns-worker
+
+use everruns_agent_loop::{
+    config::AgentConfig,
+    memory::{InMemoryMessageStore, NoOpEventEmitter},
+    message::ConversationMessage,
+    traits::ToolExecutor,
+    AgentLoop, Result, ToolCall, ToolDefinition, ToolResult,
+};
+use everruns_worker::OpenAiLlmAdapter;
+use uuid::Uuid;
+
+/// Simple no-op tool executor for this demo
+struct DemoToolExecutor;
+
+#[async_trait::async_trait]
+impl ToolExecutor for DemoToolExecutor {
+    async fn execute(
+        &self,
+        tool_call: &ToolCall,
+        _tool_def: &ToolDefinition,
+    ) -> Result<ToolResult> {
+        // For demo, return a mock result
+        println!(
+            "  [TOOL] Executing: {} with args: {}",
+            tool_call.name, tool_call.arguments
+        );
+
+        Ok(ToolResult {
+            tool_call_id: tool_call.id.clone(),
+            result: Some(serde_json::json!({
+                "status": "success",
+                "data": "Demo tool result"
+            })),
+            error: None,
+        })
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Set up logging
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .init();
+
+    // Check for API key
+    if std::env::var("OPENAI_API_KEY").is_err() {
+        eprintln!("Error: OPENAI_API_KEY environment variable is not set");
+        eprintln!("Please set it before running this example:");
+        eprintln!("  export OPENAI_API_KEY=your-api-key");
+        std::process::exit(1);
+    }
+
+    println!("=== Agent Loop OpenAI Example ===");
+    println!("(Using real OpenAI API)\n");
+
+    // Create agent configuration
+    let config = AgentConfig::new(
+        "You are a helpful assistant. Keep your responses concise and friendly.",
+        "gpt-5.2",
+    )
+    .with_max_iterations(3);
+
+    // Create components
+    let event_emitter = NoOpEventEmitter;
+    let message_store = InMemoryMessageStore::new();
+    let llm_provider = OpenAiLlmAdapter::new()?;
+    let tool_executor = DemoToolExecutor;
+
+    // Seed with a user message
+    let session_id = Uuid::now_v7();
+    message_store
+        .seed(
+            session_id,
+            vec![ConversationMessage::user(
+                "Hello! Can you tell me a short joke about programming?",
+            )],
+        )
+        .await;
+
+    println!("Session ID: {}", session_id);
+    println!("User: Hello! Can you tell me a short joke about programming?\n");
+    println!("Waiting for response...\n");
+
+    // Build and run the agent loop
+    let agent_loop = AgentLoop::new(
+        config,
+        event_emitter,
+        message_store,
+        llm_provider,
+        tool_executor,
+    );
+
+    let result = agent_loop.run(session_id).await?;
+
+    // Print results
+    println!("--- Response ---");
+    println!("{}", result.final_response.unwrap_or_default());
+    println!("\n--- Stats ---");
+    println!("Iterations: {}", result.iterations);
+    println!("Total messages: {}", result.messages.len());
+
+    println!("\n=== Example completed! ===");
+    Ok(())
+}

--- a/crates/everruns-worker/src/adapters.rs
+++ b/crates/everruns-worker/src/adapters.rs
@@ -1,0 +1,469 @@
+// Database-backed adapters for agent-loop traits
+//
+// These implementations connect the agent-loop abstraction to the
+// actual database and LLM providers used in production.
+
+use async_trait::async_trait;
+use everruns_agent_loop::{
+    traits::{
+        EventEmitter, LlmCallConfig, LlmCompletionMetadata, LlmMessage, LlmMessageRole,
+        LlmProvider, LlmResponseStream, LlmStreamEvent, MessageStore, ToolExecutor,
+    },
+    AgentLoopError, ConversationMessage, LoopEvent, MessageRole, Result, ToolCall, ToolDefinition,
+    ToolResult,
+};
+use everruns_contracts::events::AgUiEvent;
+use everruns_storage::models::CreateMessage;
+use everruns_storage::repositories::Database;
+use futures::StreamExt;
+use reqwest::Client;
+use tracing::{error, info};
+use uuid::Uuid;
+
+use crate::providers::{
+    openai::OpenAiProvider, ChatMessage, LlmConfig, LlmProvider as WorkerLlmProvider,
+    LlmStreamEvent as WorkerLlmStreamEvent, MessageRole as WorkerMessageRole,
+};
+use crate::tools::execute_tool;
+
+// ============================================================================
+// DbEventEmitter - Persists events to database
+// ============================================================================
+
+/// Database-backed event emitter
+///
+/// Persists AG-UI events to the events table for SSE streaming.
+pub struct DbEventEmitter {
+    db: Database,
+}
+
+impl DbEventEmitter {
+    pub fn new(db: Database) -> Self {
+        Self { db }
+    }
+
+    async fn persist_ag_ui_event(&self, session_id: Uuid, event: &AgUiEvent) -> Result<()> {
+        let event_type = match event {
+            AgUiEvent::RunStarted(_) => "session.started",
+            AgUiEvent::RunFinished(_) => "session.finished",
+            AgUiEvent::RunError(_) => "session.error",
+            AgUiEvent::StepStarted(_) => "step.started",
+            AgUiEvent::StepFinished(_) => "step.finished",
+            AgUiEvent::TextMessageStart(_) => "text.start",
+            AgUiEvent::TextMessageContent(_) => "text.delta",
+            AgUiEvent::TextMessageEnd(_) => "text.end",
+            AgUiEvent::ToolCallStart(_) => "tool.call.start",
+            AgUiEvent::ToolCallArgs(_) => "tool.call.args",
+            AgUiEvent::ToolCallEnd(_) => "tool.call.end",
+            AgUiEvent::ToolCallResult(_) => "tool.result",
+            AgUiEvent::StateSnapshot(_) => "state.snapshot",
+            AgUiEvent::StateDelta(_) => "state.delta",
+            AgUiEvent::MessagesSnapshot(_) => "messages.snapshot",
+            AgUiEvent::Custom(_) => "custom",
+        };
+
+        let event_data =
+            serde_json::to_value(event).map_err(|e| AgentLoopError::event(e.to_string()))?;
+
+        sqlx::query(
+            r#"
+            INSERT INTO events (session_id, sequence, event_type, data)
+            VALUES ($1, COALESCE((SELECT MAX(sequence) + 1 FROM events WHERE session_id = $1), 1), $2, $3)
+            "#,
+        )
+        .bind(session_id)
+        .bind(event_type)
+        .bind(event_data)
+        .execute(self.db.pool())
+        .await
+        .map_err(|e| AgentLoopError::event(e.to_string()))?;
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl EventEmitter for DbEventEmitter {
+    async fn emit(&self, event: LoopEvent) -> Result<()> {
+        // Extract session_id from event
+        let session_id_str = event.session_id();
+        let session_id = if session_id_str.is_empty() {
+            // For events without session_id, skip persistence
+            return Ok(());
+        } else {
+            Uuid::parse_str(session_id_str).map_err(|e| AgentLoopError::event(e.to_string()))?
+        };
+
+        // Only persist AG-UI events to the database
+        if let LoopEvent::AgUi(ag_ui_event) = &event {
+            self.persist_ag_ui_event(session_id, ag_ui_event).await?;
+        }
+
+        // Log other events for debugging
+        match &event {
+            LoopEvent::LoopStarted { .. } => info!("Loop started"),
+            LoopEvent::LoopCompleted {
+                total_iterations, ..
+            } => {
+                info!(iterations = total_iterations, "Loop completed")
+            }
+            LoopEvent::LoopError { error, .. } => error!(error = %error, "Loop error"),
+            _ => {}
+        }
+
+        Ok(())
+    }
+}
+
+// ============================================================================
+// DbMessageStore - Stores messages in database
+// ============================================================================
+
+/// Database-backed message store
+///
+/// Stores conversation messages in the messages table.
+pub struct DbMessageStore {
+    db: Database,
+}
+
+impl DbMessageStore {
+    pub fn new(db: Database) -> Self {
+        Self { db }
+    }
+}
+
+#[async_trait]
+impl MessageStore for DbMessageStore {
+    async fn store(&self, session_id: Uuid, message: ConversationMessage) -> Result<()> {
+        let role = message.role.to_string();
+        let content = match &message.content {
+            everruns_agent_loop::message::MessageContent::Text(text) => {
+                serde_json::json!({ "text": text })
+            }
+            everruns_agent_loop::message::MessageContent::ToolCall {
+                id,
+                name,
+                arguments,
+            } => {
+                serde_json::json!({
+                    "id": id,
+                    "name": name,
+                    "arguments": arguments
+                })
+            }
+            everruns_agent_loop::message::MessageContent::ToolResult { result, error } => {
+                serde_json::json!({
+                    "result": result,
+                    "error": error
+                })
+            }
+        };
+
+        let create_msg = CreateMessage {
+            session_id,
+            role,
+            content,
+            tool_call_id: message.tool_call_id,
+        };
+
+        self.db
+            .create_message(create_msg)
+            .await
+            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn load(&self, session_id: Uuid) -> Result<Vec<ConversationMessage>> {
+        let messages = self
+            .db
+            .list_messages(session_id)
+            .await
+            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+
+        let converted: Vec<ConversationMessage> = messages
+            .into_iter()
+            .map(|msg| {
+                let role = MessageRole::from(msg.role.as_str());
+                let content = match role {
+                    MessageRole::User | MessageRole::Assistant | MessageRole::System => {
+                        let text = msg
+                            .content
+                            .get("text")
+                            .and_then(|t| t.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        everruns_agent_loop::message::MessageContent::Text(text)
+                    }
+                    MessageRole::ToolCall => {
+                        let id = msg
+                            .content
+                            .get("id")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let name = msg
+                            .content
+                            .get("name")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let arguments = msg
+                            .content
+                            .get("arguments")
+                            .cloned()
+                            .unwrap_or(serde_json::json!({}));
+                        everruns_agent_loop::message::MessageContent::ToolCall {
+                            id,
+                            name,
+                            arguments,
+                        }
+                    }
+                    MessageRole::ToolResult => {
+                        let result = msg.content.get("result").cloned();
+                        let error = msg
+                            .content
+                            .get("error")
+                            .and_then(|v| v.as_str())
+                            .map(String::from);
+                        everruns_agent_loop::message::MessageContent::ToolResult { result, error }
+                    }
+                };
+
+                // Parse tool_calls from assistant messages if present
+                let tool_calls = if role == MessageRole::Assistant {
+                    msg.content
+                        .get("tool_calls")
+                        .and_then(|tc| serde_json::from_value::<Vec<ToolCall>>(tc.clone()).ok())
+                } else {
+                    None
+                };
+
+                ConversationMessage {
+                    id: msg.id,
+                    role,
+                    content,
+                    tool_call_id: msg.tool_call_id,
+                    tool_calls,
+                    created_at: msg.created_at,
+                }
+            })
+            .collect();
+
+        Ok(converted)
+    }
+
+    async fn count(&self, session_id: Uuid) -> Result<usize> {
+        let messages = self.load(session_id).await?;
+        Ok(messages.len())
+    }
+}
+
+// ============================================================================
+// OpenAiLlmAdapter - Wraps existing OpenAI provider
+// ============================================================================
+
+/// Adapter for the existing OpenAI provider
+///
+/// Wraps the worker's OpenAiProvider to implement the agent-loop's LlmProvider trait.
+pub struct OpenAiLlmAdapter {
+    provider: OpenAiProvider,
+}
+
+impl OpenAiLlmAdapter {
+    pub fn new() -> Result<Self> {
+        let provider = OpenAiProvider::new().map_err(|e| AgentLoopError::llm(e.to_string()))?;
+        Ok(Self { provider })
+    }
+
+    fn convert_message(msg: &LlmMessage) -> ChatMessage {
+        let role = match msg.role {
+            LlmMessageRole::System => WorkerMessageRole::System,
+            LlmMessageRole::User => WorkerMessageRole::User,
+            LlmMessageRole::Assistant => WorkerMessageRole::Assistant,
+            LlmMessageRole::Tool => WorkerMessageRole::Tool,
+        };
+
+        ChatMessage {
+            role,
+            content: msg.content.clone(),
+            tool_calls: msg.tool_calls.clone(),
+            tool_call_id: msg.tool_call_id.clone(),
+        }
+    }
+
+    fn convert_config(config: &LlmCallConfig) -> LlmConfig {
+        LlmConfig {
+            model: config.model.clone(),
+            temperature: config.temperature,
+            max_tokens: config.max_tokens,
+            system_prompt: None, // System prompt is in messages
+            tools: config.tools.clone(),
+        }
+    }
+}
+
+#[async_trait]
+impl LlmProvider for OpenAiLlmAdapter {
+    async fn chat_completion_stream(
+        &self,
+        messages: Vec<LlmMessage>,
+        config: &LlmCallConfig,
+    ) -> Result<LlmResponseStream> {
+        let chat_messages: Vec<ChatMessage> = messages.iter().map(Self::convert_message).collect();
+        let llm_config = Self::convert_config(config);
+
+        let stream = self
+            .provider
+            .chat_completion_stream(chat_messages, &llm_config)
+            .await
+            .map_err(|e| AgentLoopError::llm(e.to_string()))?;
+
+        // Convert the stream events
+        let converted_stream = stream.map(|result| {
+            result
+                .map(|event| match event {
+                    WorkerLlmStreamEvent::TextDelta(delta) => LlmStreamEvent::TextDelta(delta),
+                    WorkerLlmStreamEvent::ToolCalls(calls) => LlmStreamEvent::ToolCalls(calls),
+                    WorkerLlmStreamEvent::Done(meta) => {
+                        LlmStreamEvent::Done(LlmCompletionMetadata {
+                            total_tokens: meta.total_tokens,
+                            prompt_tokens: meta.prompt_tokens,
+                            completion_tokens: meta.completion_tokens,
+                            model: Some(meta.model),
+                            finish_reason: meta.finish_reason,
+                        })
+                    }
+                    WorkerLlmStreamEvent::Error(err) => LlmStreamEvent::Error(err),
+                })
+                .map_err(|e| AgentLoopError::llm(e.to_string()))
+        });
+
+        Ok(Box::pin(converted_stream))
+    }
+}
+
+// ============================================================================
+// WebhookToolExecutor - Executes webhook tools
+// ============================================================================
+
+/// Tool executor that uses webhooks
+///
+/// Wraps the existing tool execution logic.
+pub struct WebhookToolExecutor {
+    client: Client,
+}
+
+impl WebhookToolExecutor {
+    pub fn new() -> Self {
+        Self {
+            client: Client::new(),
+        }
+    }
+}
+
+impl Default for WebhookToolExecutor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for WebhookToolExecutor {
+    async fn execute(&self, tool_call: &ToolCall, tool_def: &ToolDefinition) -> Result<ToolResult> {
+        // Convert to contracts types
+        let tc = everruns_contracts::tools::ToolCall {
+            id: tool_call.id.clone(),
+            name: tool_call.name.clone(),
+            arguments: tool_call.arguments.clone(),
+        };
+
+        let result = execute_tool(&tc, tool_def, &self.client).await;
+
+        Ok(ToolResult {
+            tool_call_id: result.tool_call_id,
+            result: result.result,
+            error: result.error,
+        })
+    }
+}
+
+// ============================================================================
+// Factory functions
+// ============================================================================
+
+/// Create a database-backed event emitter
+pub fn create_db_event_emitter(db: Database) -> DbEventEmitter {
+    DbEventEmitter::new(db)
+}
+
+/// Create a database-backed message store
+pub fn create_db_message_store(db: Database) -> DbMessageStore {
+    DbMessageStore::new(db)
+}
+
+/// Create an OpenAI LLM adapter
+pub fn create_openai_adapter() -> Result<OpenAiLlmAdapter> {
+    OpenAiLlmAdapter::new()
+}
+
+/// Create a webhook tool executor
+pub fn create_webhook_tool_executor() -> WebhookToolExecutor {
+    WebhookToolExecutor::new()
+}
+
+/// Create a fully configured AgentLoop with database backends
+pub fn create_db_agent_loop(
+    config: everruns_agent_loop::AgentConfig,
+    db: Database,
+) -> Result<
+    everruns_agent_loop::AgentLoop<
+        DbEventEmitter,
+        DbMessageStore,
+        OpenAiLlmAdapter,
+        WebhookToolExecutor,
+    >,
+> {
+    let event_emitter = create_db_event_emitter(db.clone());
+    let message_store = create_db_message_store(db);
+    let llm_provider = create_openai_adapter()?;
+    let tool_executor = create_webhook_tool_executor();
+
+    Ok(everruns_agent_loop::AgentLoop::new(
+        config,
+        event_emitter,
+        message_store,
+        llm_provider,
+        tool_executor,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_message_role_conversion() {
+        assert_eq!(
+            OpenAiLlmAdapter::convert_message(&LlmMessage {
+                role: LlmMessageRole::System,
+                content: "test".to_string(),
+                tool_calls: None,
+                tool_call_id: None,
+            })
+            .role,
+            WorkerMessageRole::System
+        );
+
+        assert_eq!(
+            OpenAiLlmAdapter::convert_message(&LlmMessage {
+                role: LlmMessageRole::User,
+                content: "test".to_string(),
+                tool_calls: None,
+                tool_call_id: None,
+            })
+            .role,
+            WorkerMessageRole::User
+        );
+    }
+}

--- a/crates/everruns-worker/src/lib.rs
+++ b/crates/everruns-worker/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod activities;
+pub mod adapters;
 pub mod providers;
 pub mod runner;
 pub mod runner_inprocess;
@@ -10,3 +11,10 @@ pub mod temporal;
 
 // Re-export main types
 pub use runner::{create_runner, AgentRunner, RunnerConfig, RunnerMode};
+
+// Re-export adapters for agent-loop integration
+pub use adapters::{
+    create_db_agent_loop, create_db_event_emitter, create_db_message_store, create_openai_adapter,
+    create_webhook_tool_executor, DbEventEmitter, DbMessageStore, OpenAiLlmAdapter,
+    WebhookToolExecutor,
+};

--- a/crates/everruns-worker/src/temporal/activities.rs
+++ b/crates/everruns-worker/src/temporal/activities.rs
@@ -1,24 +1,34 @@
 // Temporal activity implementations (M2)
 // Decision: Activities are standalone functions that can be registered with Temporal
+// Decision: Each LLM call and each tool execution is a separate Temporal activity (node)
 //
 // These activities handle the actual work of session execution:
 // - Loading data from database
 // - Calling LLMs (with streaming and heartbeats)
-// - Executing tools
+// - Executing tools (each tool = separate activity)
 // - Persisting events
 //
 // All activities must be idempotent and handle their own error scenarios.
 
 use anyhow::{Context, Result};
+use everruns_agent_loop::config::AgentConfig;
+use everruns_agent_loop::memory::NoOpEventEmitter;
+use everruns_agent_loop::step::{LoopStep, StepInput, StepResult};
+use everruns_agent_loop::AgentLoop;
 use everruns_contracts::events::AgUiEvent;
+use everruns_contracts::tools::ToolDefinition;
 use everruns_storage::models::UpdateSession;
 use everruns_storage::repositories::Database;
+use reqwest::Client;
 use tracing::info;
 use uuid::Uuid;
 
 use crate::activities::PersistEventActivity;
+use crate::adapters::{DbMessageStore, OpenAiLlmAdapter, WebhookToolExecutor};
 use crate::providers::openai::OpenAiProvider;
 use crate::providers::{ChatMessage, LlmConfig, LlmProvider, MessageRole as ProviderMessageRole};
+use crate::tools::execute_tool;
+use everruns_agent_loop::traits::MessageStore;
 
 use super::types::*;
 
@@ -354,6 +364,318 @@ pub async fn save_message_activity(
         .context("Database error saving message")?;
 
     Ok(())
+}
+
+// =============================================================================
+// Step-based activities (using step.rs abstractions)
+// Each activity is a separate Temporal node for better observability and retry
+// =============================================================================
+
+/// Setup step activity - loads agent config and messages
+/// This is the first activity in a session workflow
+#[allow(dead_code)]
+pub async fn setup_step_activity(
+    ctx: &ActivityContext,
+    db: &Database,
+    input: SetupStepInput,
+) -> Result<SetupStepOutput> {
+    info!(
+        session_id = %input.session_id,
+        agent_id = %input.agent_id,
+        "Setting up agent loop"
+    );
+
+    ctx.heartbeat("Loading agent configuration");
+
+    // Load agent
+    let agent = db
+        .get_agent(input.agent_id)
+        .await
+        .context("Database error loading agent")?
+        .ok_or_else(|| anyhow::anyhow!("Agent not found: {}", input.agent_id))?;
+
+    let agent_config = LoadAgentOutput {
+        agent_id: agent.id,
+        name: agent.name,
+        model_id: agent
+            .default_model_id
+            .map(|id| id.to_string())
+            .unwrap_or_else(|| "gpt-5.2".to_string()),
+        system_prompt: Some(agent.system_prompt),
+        temperature: None,
+        max_tokens: None,
+    };
+
+    ctx.heartbeat("Loading messages");
+
+    // Load messages using DbMessageStore
+    let message_store = DbMessageStore::new(db.clone());
+    let messages = message_store
+        .load(input.session_id)
+        .await
+        .context("Failed to load messages")?;
+
+    info!(
+        session_id = %input.session_id,
+        message_count = messages.len(),
+        "Setup complete"
+    );
+
+    // Create setup step record
+    let step = LoopStep::setup(input.session_id).complete(StepResult::SetupComplete {
+        message_count: messages.len(),
+    });
+
+    Ok(SetupStepOutput {
+        agent_config,
+        messages,
+        step,
+    })
+}
+
+/// Execute LLM step activity - calls LLM with current messages
+/// Returns whether there are tool calls to execute
+#[allow(dead_code)]
+pub async fn execute_llm_step_activity(
+    ctx: &ActivityContext,
+    db: &Database,
+    input: ExecuteLlmStepInput,
+) -> Result<ExecuteLlmStepOutput> {
+    info!(
+        session_id = %input.session_id,
+        iteration = input.iteration,
+        message_count = input.messages.len(),
+        "Executing LLM step"
+    );
+
+    ctx.heartbeat("Starting LLM call");
+
+    // Build agent config
+    let config = AgentConfig::new(
+        input.agent_config.system_prompt.as_deref().unwrap_or(""),
+        &input.agent_config.model_id,
+    )
+    .with_max_iterations(1); // Single iteration for this step
+
+    // Create agent loop with NoOp event emitter (we'll emit events separately for Temporal)
+    // and DbMessageStore for message storage
+    let event_emitter = NoOpEventEmitter;
+    let message_store = DbMessageStore::new(db.clone());
+    let llm_provider = OpenAiLlmAdapter::new().context("Failed to create LLM adapter")?;
+    let tool_executor = WebhookToolExecutor::new();
+
+    let agent_loop = AgentLoop::new(
+        config,
+        event_emitter,
+        message_store,
+        llm_provider,
+        tool_executor,
+    );
+
+    // Create step input
+    let step_input = StepInput {
+        session_id: input.session_id,
+        iteration: input.iteration,
+        messages: input.messages,
+        pending_tool_calls: Vec::new(),
+    };
+
+    ctx.heartbeat("Calling LLM...");
+
+    // Execute the step
+    let step_output = agent_loop
+        .execute_step(step_input)
+        .await
+        .context("Failed to execute LLM step")?;
+
+    let has_tool_calls = !step_output.pending_tool_calls.is_empty();
+    let pending_tool_calls = step_output.pending_tool_calls.clone();
+
+    info!(
+        session_id = %input.session_id,
+        iteration = input.iteration,
+        has_tool_calls = has_tool_calls,
+        tool_count = pending_tool_calls.len(),
+        "LLM step complete"
+    );
+
+    // Persist step event
+    let persist_activity = PersistEventActivity::new(db.clone());
+    let step_event = AgUiEvent::step_finished(format!("llm_call_{}", input.iteration));
+    persist_activity
+        .persist_event(input.session_id, step_event)
+        .await?;
+
+    Ok(ExecuteLlmStepOutput {
+        step_output,
+        has_tool_calls,
+        pending_tool_calls,
+    })
+}
+
+/// Execute a single tool activity - each tool call is a separate Temporal node
+/// This provides maximum observability and allows individual tool retries
+#[allow(dead_code)]
+pub async fn execute_single_tool_activity(
+    ctx: &ActivityContext,
+    db: &Database,
+    input: ExecuteSingleToolInput,
+) -> Result<ExecuteSingleToolOutput> {
+    info!(
+        session_id = %input.session_id,
+        tool_id = %input.tool_call.id,
+        tool_name = %input.tool_call.name,
+        "Executing single tool"
+    );
+
+    ctx.heartbeat(&format!("Executing tool: {}", input.tool_call.name));
+
+    // Persist tool start events
+    let persist_activity = PersistEventActivity::new(db.clone());
+
+    let start_event = AgUiEvent::tool_call_start(&input.tool_call.id, &input.tool_call.name);
+    persist_activity
+        .persist_event(input.session_id, start_event)
+        .await?;
+
+    let args_json = serde_json::to_string(&input.tool_call.arguments).unwrap_or_default();
+    let args_event = AgUiEvent::tool_call_args(&input.tool_call.id, args_json);
+    persist_activity
+        .persist_event(input.session_id, args_event)
+        .await?;
+
+    let end_event = AgUiEvent::tool_call_end(&input.tool_call.id);
+    persist_activity
+        .persist_event(input.session_id, end_event)
+        .await?;
+
+    // Execute the tool
+    let client = Client::new();
+
+    // Parse tool definition if provided
+    let tool_def: ToolDefinition = if let Some(ref json) = input.tool_definition_json {
+        serde_json::from_str(json).context("Failed to parse tool definition")?
+    } else {
+        // Default to a placeholder - in production this should come from agent config
+        ToolDefinition::Builtin(everruns_contracts::tools::BuiltinTool {
+            name: input.tool_call.name.clone(),
+            description: "Tool execution".to_string(),
+            kind: everruns_contracts::tools::BuiltinToolKind::HttpGet,
+            policy: everruns_contracts::tools::ToolPolicy::Auto,
+            parameters: serde_json::json!({}),
+        })
+    };
+
+    let tool_call_contract = everruns_contracts::tools::ToolCall {
+        id: input.tool_call.id.clone(),
+        name: input.tool_call.name.clone(),
+        arguments: input.tool_call.arguments.clone(),
+    };
+
+    let result = execute_tool(&tool_call_contract, &tool_def, &client).await;
+
+    // Persist tool result event
+    let result_message_id = Uuid::now_v7().to_string();
+    let result_event = AgUiEvent::tool_call_result(
+        &result_message_id,
+        &input.tool_call.id,
+        result.result.clone().unwrap_or_default(),
+    );
+    persist_activity
+        .persist_event(input.session_id, result_event)
+        .await?;
+
+    info!(
+        session_id = %input.session_id,
+        tool_id = %input.tool_call.id,
+        success = result.error.is_none(),
+        "Tool execution complete"
+    );
+
+    // Create tool execution step record
+    let step =
+        LoopStep::tool_execution(input.session_id, 0).complete(StepResult::ToolExecutionComplete {
+            results: vec![everruns_contracts::tools::ToolResult {
+                tool_call_id: result.tool_call_id.clone(),
+                result: result.result.clone(),
+                error: result.error.clone(),
+            }],
+        });
+
+    Ok(ExecuteSingleToolOutput {
+        result: everruns_contracts::tools::ToolResult {
+            tool_call_id: result.tool_call_id,
+            result: result.result,
+            error: result.error,
+        },
+        step,
+    })
+}
+
+/// Finalize step activity - saves final message and updates session status
+#[allow(dead_code)]
+pub async fn finalize_step_activity(
+    ctx: &ActivityContext,
+    db: &Database,
+    input: FinalizeStepInput,
+) -> Result<FinalizeStepOutput> {
+    info!(
+        session_id = %input.session_id,
+        iterations = input.total_iterations,
+        "Finalizing session"
+    );
+
+    ctx.heartbeat("Saving final message");
+
+    // Save final assistant message if present
+    if let Some(ref response) = input.final_response {
+        let create_msg = everruns_storage::models::CreateMessage {
+            session_id: input.session_id,
+            role: "assistant".to_string(),
+            content: serde_json::json!({ "text": response }),
+            tool_call_id: None,
+        };
+
+        db.create_message(create_msg)
+            .await
+            .context("Database error saving final message")?;
+    }
+
+    ctx.heartbeat("Updating session status");
+
+    // Update session status back to pending (ready for more messages)
+    let update = UpdateSession {
+        status: Some("pending".to_string()),
+        ..Default::default()
+    };
+
+    db.update_session(input.session_id, update)
+        .await
+        .context("Database error updating session status")?;
+
+    // Persist session finished event
+    let persist_activity = PersistEventActivity::new(db.clone());
+    let finished_event = AgUiEvent::session_finished(input.session_id.to_string());
+    persist_activity
+        .persist_event(input.session_id, finished_event)
+        .await?;
+
+    info!(
+        session_id = %input.session_id,
+        "Session finalized"
+    );
+
+    // Create finalize step record
+    let step = LoopStep::finalize(input.session_id, input.total_iterations).complete(
+        StepResult::FinalizeComplete {
+            final_response: input.final_response,
+        },
+    );
+
+    Ok(FinalizeStepOutput {
+        status: "pending".to_string(),
+        step,
+    })
 }
 
 #[cfg(test)]

--- a/crates/everruns-worker/src/temporal/activities.rs
+++ b/crates/everruns-worker/src/temporal/activities.rs
@@ -78,7 +78,7 @@ pub async fn load_agent_activity(
         model_id: agent
             .default_model_id
             .map(|id| id.to_string())
-            .unwrap_or_else(|| "gpt-4o".to_string()),
+            .unwrap_or_else(|| "gpt-5.2".to_string()),
         system_prompt: Some(agent.system_prompt),
         temperature: None,
         max_tokens: None,

--- a/crates/everruns-worker/src/temporal/types.rs
+++ b/crates/everruns-worker/src/temporal/types.rs
@@ -1,12 +1,17 @@
 // Temporal workflow and activity type definitions (M2)
 // Decision: Keep Temporal types in a dedicated module for clean separation
+// Decision: Use step.rs abstractions (StepInput/StepOutput) for decomposed execution
 //
 // These types define the inputs/outputs for workflows and activities in the
 // Temporal execution model. All types must be serializable for Temporal's
 // persistence layer.
 //
 // M2 model: Agent → Session → Messages (no separate Thread/Run concepts)
+// Each LLM call and each tool execution is a separate Temporal activity (node).
 
+use everruns_agent_loop::message::ConversationMessage;
+use everruns_agent_loop::step::{LoopStep, StepOutput};
+use everruns_contracts::tools::{ToolCall, ToolResult};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -138,6 +143,7 @@ pub struct SaveMessageInput {
 
 /// Constants for activity names (used for registration and invocation)
 pub mod activity_names {
+    // Legacy activities (still used for compatibility)
     pub const LOAD_AGENT: &str = "load_agent";
     pub const LOAD_MESSAGES: &str = "load_messages";
     pub const UPDATE_STATUS: &str = "update_status";
@@ -145,6 +151,12 @@ pub mod activity_names {
     pub const CALL_LLM: &str = "call_llm";
     pub const EXECUTE_TOOLS: &str = "execute_tools";
     pub const SAVE_MESSAGE: &str = "save_message";
+
+    // Step-based activities (using step.rs abstractions)
+    pub const SETUP_STEP: &str = "setup_step";
+    pub const EXECUTE_LLM_STEP: &str = "execute_llm_step";
+    pub const EXECUTE_SINGLE_TOOL: &str = "execute_single_tool";
+    pub const FINALIZE_STEP: &str = "finalize_step";
 }
 
 /// Constants for workflow names
@@ -159,3 +171,85 @@ pub const TASK_QUEUE: &str = "everruns-agent-runs";
 
 /// Maximum number of tool calling iterations
 pub const MAX_TOOL_ITERATIONS: u32 = 5;
+
+// =============================================================================
+// Step-based activity types (using step.rs abstractions)
+// =============================================================================
+
+/// Input for the SetupStep activity
+/// Loads agent configuration and session messages
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetupStepInput {
+    pub session_id: Uuid,
+    pub agent_id: Uuid,
+}
+
+/// Output from SetupStep activity
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetupStepOutput {
+    /// Agent configuration
+    pub agent_config: LoadAgentOutput,
+    /// Initial messages loaded from the session
+    pub messages: Vec<ConversationMessage>,
+    /// The setup step record
+    pub step: LoopStep,
+}
+
+/// Input for the ExecuteLlmStep activity
+/// Calls LLM with current messages
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecuteLlmStepInput {
+    pub session_id: Uuid,
+    pub agent_config: LoadAgentOutput,
+    pub messages: Vec<ConversationMessage>,
+    pub iteration: usize,
+}
+
+/// Output from ExecuteLlmStep activity
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecuteLlmStepOutput {
+    /// The step output from the agent loop
+    pub step_output: StepOutput,
+    /// Whether there are pending tool calls
+    pub has_tool_calls: bool,
+    /// Pending tool calls (if any)
+    pub pending_tool_calls: Vec<ToolCall>,
+}
+
+/// Input for the ExecuteSingleTool activity
+/// Executes ONE tool call - each tool is a separate Temporal node
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecuteSingleToolInput {
+    pub session_id: Uuid,
+    pub tool_call: ToolCall,
+    /// Tool definition JSON for webhook tools
+    pub tool_definition_json: Option<String>,
+}
+
+/// Output from ExecuteSingleTool activity
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecuteSingleToolOutput {
+    /// The tool result
+    pub result: ToolResult,
+    /// The tool execution step record
+    pub step: LoopStep,
+}
+
+/// Input for the FinalizeStep activity
+/// Saves final message and updates session status
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FinalizeStepInput {
+    pub session_id: Uuid,
+    pub final_messages: Vec<ConversationMessage>,
+    pub total_iterations: usize,
+    pub final_response: Option<String>,
+}
+
+/// Output from FinalizeStep activity
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FinalizeStepOutput {
+    /// Final status
+    pub status: String,
+    /// The finalize step record
+    pub step: LoopStep,
+}

--- a/crates/everruns-worker/src/workflows.rs
+++ b/crates/everruns-worker/src/workflows.rs
@@ -1,18 +1,23 @@
 // Session workflow for agentic loop execution (M2)
 // Uses Agent/Session/Messages model with Events as SSE notifications
+// Now uses everruns-agent-loop for the core loop logic
 
 use anyhow::Result;
 use chrono::Utc;
+use everruns_agent_loop::AgentConfig;
 use everruns_contracts::events::AgUiEvent;
-use everruns_storage::models::{CreateMessage, UpdateSession};
+use everruns_storage::models::UpdateSession;
 use everruns_storage::repositories::Database;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
-use crate::activities::{LlmCallActivity, PersistEventActivity, ToolExecutionActivity};
-use crate::providers::{openai::OpenAiProvider, ChatMessage, LlmConfig, MessageRole};
+use crate::activities::PersistEventActivity;
+use crate::adapters::create_db_agent_loop;
 
 /// Session workflow orchestrating LLM calls and tool execution
+///
+/// This workflow now delegates the core agentic loop to everruns-agent-loop,
+/// while managing session lifecycle (status updates, error handling).
 pub struct SessionWorkflow {
     session_id: Uuid,
     agent_id: Uuid,
@@ -31,7 +36,7 @@ impl SessionWorkflow {
         })
     }
 
-    /// Execute the workflow with real LLM calls
+    /// Execute the workflow using the AgentLoop abstraction
     pub async fn execute(&self) -> Result<()> {
         info!(
             session_id = %self.session_id,
@@ -43,12 +48,6 @@ impl SessionWorkflow {
         self.update_session_status("running", Some(Utc::now()), None)
             .await?;
 
-        // Emit SESSION_STARTED event (SSE notification)
-        let started_event = AgUiEvent::session_started(self.session_id.to_string());
-        self.persist_activity
-            .persist_event(self.session_id, started_event)
-            .await?;
-
         // Load agent to get configuration
         let agent = self
             .db
@@ -56,213 +55,86 @@ impl SessionWorkflow {
             .await?
             .ok_or_else(|| anyhow::anyhow!("Agent not found"))?;
 
-        // Build LLM config from agent settings
+        // Build AgentConfig from agent settings
         let model = agent
             .default_model_id
             .map(|id| id.to_string())
             .unwrap_or_else(|| "gpt-4o".to_string());
 
-        let llm_config = LlmConfig {
-            model,
-            temperature: None, // TODO: Add to session or use default
-            max_tokens: None,  // TODO: Add to session or use default
-            system_prompt: Some(agent.system_prompt.clone()),
-            tools: Vec::new(), // TODO: Parse tools from session
-        };
+        let config = AgentConfig::new(&agent.system_prompt, model)
+            .with_max_iterations(10)
+            .with_tools(Vec::new()); // TODO: Parse tools from agent/session
 
-        // Load messages from session (PRIMARY data)
-        let messages_rows = self.db.list_messages(self.session_id).await?;
-
-        if messages_rows.is_empty() {
+        // Check if there are messages to process
+        let message_count = self.db.list_messages(self.session_id).await?.len();
+        if message_count == 0 {
             warn!(
                 session_id = %self.session_id,
-                "No messages in session, skipping LLM call"
-            );
-        } else {
-            // Convert messages to ChatMessage format
-            let mut messages: Vec<ChatMessage> = Vec::new();
-
-            // Add system prompt as first message
-            if !agent.system_prompt.is_empty() {
-                messages.push(ChatMessage {
-                    role: MessageRole::System,
-                    content: agent.system_prompt.clone(),
-                    tool_calls: None,
-                    tool_call_id: None,
-                });
-            }
-
-            // Add messages from database
-            for msg in &messages_rows {
-                let role = match msg.role.as_str() {
-                    "user" => MessageRole::User,
-                    "assistant" => MessageRole::Assistant,
-                    "system" => MessageRole::System,
-                    "tool_call" => continue, // Tool calls are handled separately
-                    "tool_result" => MessageRole::Tool,
-                    _ => continue,
-                };
-
-                // Extract content from JSON
-                let content = if let Some(text) = msg.content.get("text").and_then(|t| t.as_str()) {
-                    text.to_string()
-                } else if let Some(content_str) = msg.content.as_str() {
-                    content_str.to_string()
-                } else if let Some(result) = msg.content.get("result") {
-                    serde_json::to_string(result).unwrap_or_else(|_| "{}".to_string())
-                } else {
-                    continue;
-                };
-
-                messages.push(ChatMessage {
-                    role,
-                    content,
-                    tool_calls: None,
-                    tool_call_id: msg.tool_call_id.clone(),
-                });
-            }
-
-            info!(
-                session_id = %self.session_id,
-                message_count = messages.len(),
-                model = %llm_config.model,
-                "Calling LLM"
+                "No messages in session, skipping agent loop"
             );
 
-            // Call LLM (use OpenAI provider)
-            let provider = OpenAiProvider::new()?;
-            let llm_activity = LlmCallActivity::new(provider, self.db.clone());
-            let tool_activity = ToolExecutionActivity::new(self.db.clone());
+            // Emit session finished event even if no messages
+            let finished_event = AgUiEvent::session_finished(self.session_id.to_string());
+            self.persist_activity
+                .persist_event(self.session_id, finished_event)
+                .await?;
 
-            // Tool calling loop: Call LLM → Execute tools → Loop back with results
-            const MAX_TOOL_ITERATIONS: usize = 5;
-            let mut iteration = 0;
-            let mut current_messages = messages;
+            // Set session back to pending
+            self.update_session_status("pending", None, None).await?;
 
-            loop {
-                iteration += 1;
-                if iteration > MAX_TOOL_ITERATIONS {
-                    warn!(
-                        session_id = %self.session_id,
-                        "Max tool calling iterations reached, stopping"
-                    );
-                    break;
-                }
-
-                // Call LLM (non-streaming)
-                let result = llm_activity
-                    .call(
-                        self.session_id,
-                        current_messages.clone(),
-                        llm_config.clone(),
-                    )
-                    .await?;
-
-                // If we got a response, persist it as an assistant Message
-                if !result.text.is_empty() {
-                    info!(
-                        session_id = %self.session_id,
-                        response_length = result.text.len(),
-                        "Got assistant response"
-                    );
-
-                    // Store assistant response as Message (PRIMARY data)
-                    let create_msg = CreateMessage {
-                        session_id: self.session_id,
-                        role: "assistant".to_string(),
-                        content: serde_json::json!({ "text": result.text.clone() }),
-                        tool_call_id: None,
-                    };
-                    self.db.create_message(create_msg).await?;
-
-                    current_messages.push(ChatMessage {
-                        role: MessageRole::Assistant,
-                        content: result.text.clone(),
-                        tool_calls: result.tool_calls.clone(),
-                        tool_call_id: None,
-                    });
-                }
-
-                // Check if there are tool calls to execute
-                if let Some(tool_calls) = result.tool_calls {
-                    info!(
-                        session_id = %self.session_id,
-                        tool_count = tool_calls.len(),
-                        "Executing tool calls"
-                    );
-
-                    // Store tool calls as Messages (PRIMARY data)
-                    for tool_call in &tool_calls {
-                        let create_msg = CreateMessage {
-                            session_id: self.session_id,
-                            role: "tool_call".to_string(),
-                            content: serde_json::json!({
-                                "id": tool_call.id,
-                                "name": tool_call.name,
-                                "arguments": tool_call.arguments
-                            }),
-                            tool_call_id: Some(tool_call.id.clone()),
-                        };
-                        self.db.create_message(create_msg).await?;
-                    }
-
-                    // Execute tools in parallel
-                    let tool_results = tool_activity
-                        .execute_tool_calls_parallel(
-                            self.session_id,
-                            &tool_calls,
-                            &llm_config.tools,
-                        )
-                        .await?;
-
-                    // Store tool results as Messages (PRIMARY data) and add to conversation
-                    for (tool_call, tool_result) in tool_calls.iter().zip(tool_results.iter()) {
-                        let result_content = if let Some(result) = &tool_result.result {
-                            serde_json::to_string(result).unwrap_or_else(|_| "{}".to_string())
-                        } else if let Some(error) = &tool_result.error {
-                            format!(r#"{{"error": "{}"}}"#, error)
-                        } else {
-                            "{}".to_string()
-                        };
-
-                        // Store tool result as Message
-                        let create_msg = CreateMessage {
-                            session_id: self.session_id,
-                            role: "tool_result".to_string(),
-                            content: serde_json::json!({
-                                "result": tool_result.result,
-                                "error": tool_result.error
-                            }),
-                            tool_call_id: Some(tool_call.id.clone()),
-                        };
-                        self.db.create_message(create_msg).await?;
-
-                        current_messages.push(ChatMessage {
-                            role: MessageRole::Tool,
-                            content: result_content,
-                            tool_calls: None,
-                            tool_call_id: Some(tool_call.id.clone()),
-                        });
-                    }
-
-                    // Continue loop to call LLM again with tool results
-                    continue;
-                }
-
-                // No tool calls, we're done
-                break;
-            }
+            return Ok(());
         }
 
-        // Emit SESSION_FINISHED event (SSE notification for this message cycle)
-        let finished_event = AgUiEvent::session_finished(self.session_id.to_string());
-        self.persist_activity
-            .persist_event(self.session_id, finished_event)
-            .await?;
+        info!(
+            session_id = %self.session_id,
+            message_count = message_count,
+            model = %config.model,
+            "Running agent loop"
+        );
 
-        // Set session back to pending (ready for more messages)
-        // Sessions work indefinitely - only "failed" is a terminal state
-        self.update_session_status("pending", None, None).await?;
+        // Create and run the agent loop with database-backed components
+        let agent_loop = create_db_agent_loop(config, self.db.clone())?;
+        let result = agent_loop.run(self.session_id).await;
+
+        match result {
+            Ok(loop_result) => {
+                info!(
+                    session_id = %self.session_id,
+                    iterations = loop_result.iterations,
+                    final_messages = loop_result.messages.len(),
+                    "Agent loop completed successfully"
+                );
+
+                // Set session back to pending (ready for more messages)
+                // Sessions work indefinitely - only "failed" is a terminal state
+                self.update_session_status("pending", None, None).await?;
+            }
+            Err(e) => {
+                // Handle specific error types
+                match &e {
+                    everruns_agent_loop::AgentLoopError::NoMessages => {
+                        warn!(session_id = %self.session_id, "No messages to process");
+                        self.update_session_status("pending", None, None).await?;
+                    }
+                    everruns_agent_loop::AgentLoopError::MaxIterationsReached(max) => {
+                        warn!(session_id = %self.session_id, max = max, "Max iterations reached");
+                        // Still set to pending - can continue with more messages
+                        self.update_session_status("pending", None, None).await?;
+                    }
+                    _ => {
+                        error!(session_id = %self.session_id, error = %e, "Agent loop failed");
+                        // Emit error event and set status to failed
+                        let error_event = AgUiEvent::session_error(e.to_string());
+                        self.persist_activity
+                            .persist_event(self.session_id, error_event)
+                            .await?;
+                        self.update_session_status("failed", None, Some(Utc::now()))
+                            .await?;
+                        return Err(e.into());
+                    }
+                }
+            }
+        }
 
         info!(
             session_id = %self.session_id,
@@ -336,5 +208,20 @@ impl AgentRunWorkflow {
         db: Database,
     ) -> Result<Self> {
         SessionWorkflow::new(run_id, agent_id, db).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Integration tests would require a database connection
+    // Unit tests for the workflow structure
+
+    #[test]
+    fn test_workflow_type_alias() {
+        // Verify the type alias works
+        fn _accepts_workflow(_w: AgentRunWorkflow) {}
+        fn _accepts_session(_w: SessionWorkflow) {}
     }
 }

--- a/crates/everruns-worker/src/workflows.rs
+++ b/crates/everruns-worker/src/workflows.rs
@@ -59,7 +59,7 @@ impl SessionWorkflow {
         let model = agent
             .default_model_id
             .map(|id| id.to_string())
-            .unwrap_or_else(|| "gpt-4o".to_string());
+            .unwrap_or_else(|| "gpt-5.2".to_string());
 
         let config = AgentConfig::new(&agent.system_prompt, model)
             .with_max_iterations(10)

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -12,6 +12,7 @@ Everruns is a durable AI agent execution platform built on Rust and Temporal. It
 2. **Crate Separation**:
    - `everruns-api` - HTTP API server (axum), SSE streaming, health endpoints
    - `everruns-worker` - Temporal worker, workflows, activities, LLM providers
+   - `everruns-agent-loop` - DB-agnostic agentic loop abstraction (traits, executor, step decomposition)
    - `everruns-contracts` - DTOs, AG-UI events, OpenAPI schemas
    - `everruns-storage` - PostgreSQL (sqlx), migrations, repositories
 3. **Frontend**: Next.js application in `apps/ui/` for management and chat interfaces
@@ -32,6 +33,30 @@ Everruns is a durable AI agent execution platform built on Rust and Temporal. It
 4. **Event Streaming**: AG-UI protocol over SSE for real-time event delivery via database-backed events
 
 See [specs/temporal-integration.md](temporal-integration.md) for detailed Temporal architecture.
+
+### Agent Loop Abstraction (`everruns-agent-loop`)
+
+The agentic loop is encapsulated in a DB-agnostic crate with pluggable backends:
+
+1. **Trait-Based Design**:
+   - `EventEmitter` - Emit events during loop execution
+   - `MessageStore` - Load/store conversation messages
+   - `LlmProvider` - Call LLM with streaming support
+   - `ToolExecutor` - Execute tool calls
+
+2. **Execution Modes**:
+   - **In-Process**: `AgentLoop::run()` - Complete loop execution in single process
+   - **Decomposed**: `AgentLoop::execute_step()` - Step-by-step execution for Temporal integration
+
+3. **Step Abstraction** (`step.rs`):
+   - `StepInput` / `StepOutput` - Input/output for each step
+   - `LoopStep` - Records for each step (setup, llm_call, tool_execution, finalize)
+   - Enables each LLM call and tool call to be a separate Temporal activity
+
+4. **In-Memory Implementations** (for testing/examples):
+   - `InMemoryMessageStore`, `InMemoryEventEmitter`
+   - `MockLlmProvider`, `MockToolExecutor`
+   - `InMemoryAgentLoopBuilder` for easy test setup
 
 ### API Design
 


### PR DESCRIPTION
Add everruns-agent-loop crate providing a pluggable agentic loop abstraction:

- AgentConfig: Configuration struct for agent behavior (system prompt, model, tools)
- Core traits for pluggable backends:
  - EventEmitter: Emit events during execution (DB, channel, or in-memory)
  - MessageStore: Store/retrieve conversation messages
  - LlmProvider: Call LLM with streaming support
  - ToolExecutor: Execute tool calls
- AgentLoop executor: Orchestrates LLM calls → tool execution → repeat
- LoopStep/StepInput/StepOutput: Decomposable execution for Temporal integration
- LoopEvent: AG-UI compatible events plus loop-specific lifecycle events
- In-memory implementations for examples and testing:
  - InMemoryEventEmitter, InMemoryMessageStore
  - MockLlmProvider, MockToolExecutor
  - InMemoryAgentLoopBuilder for easy setup
- Example demonstrating basic conversation and tool calling

This abstraction allows the agent loop to be:
- Used standalone without a database (for examples, testing)
- Integrated with production storage backends
- Decomposed into steps for Temporal workflow integration
