### PR TITLE
Create Capability abstraction for Agent customization

### DIFF
--- a/apps/ui/src/app/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/agents/[agentId]/page.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { MarkdownDisplay } from "@/components/ui/prompt-editor";
+import { CapabilitySelector } from "@/components/capabilities";
 import { ArrowLeft, Plus, MessageSquare } from "lucide-react";
 
 export default function AgentDetailPage({
@@ -141,6 +142,8 @@ export default function AgentDetailPage({
         </div>
 
         <div className="space-y-6">
+          <CapabilitySelector agentId={agentId} />
+
           <Card>
             <CardHeader>
               <CardTitle>Configuration</CardTitle>

--- a/apps/ui/src/app/capabilities/page.tsx
+++ b/apps/ui/src/app/capabilities/page.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   CircleOff,
+  Clock,
   Search,
   Box,
   Folder,
@@ -15,6 +16,7 @@ import type { Capability, CapabilityStatus } from "@/lib/api/types";
 
 const iconMap: Record<string, LucideIcon> = {
   "circle-off": CircleOff,
+  clock: Clock,
   search: Search,
   box: Box,
   folder: Folder,

--- a/apps/ui/src/app/capabilities/page.tsx
+++ b/apps/ui/src/app/capabilities/page.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useCapabilities } from "@/hooks";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  CircleOff,
+  Search,
+  Box,
+  Folder,
+  LucideIcon,
+} from "lucide-react";
+import type { Capability, CapabilityStatus } from "@/lib/api/types";
+
+const iconMap: Record<string, LucideIcon> = {
+  "circle-off": CircleOff,
+  search: Search,
+  box: Box,
+  folder: Folder,
+};
+
+function getStatusBadgeVariant(
+  status: CapabilityStatus
+): "default" | "secondary" | "outline" {
+  switch (status) {
+    case "available":
+      return "default";
+    case "coming_soon":
+      return "secondary";
+    case "deprecated":
+      return "outline";
+  }
+}
+
+function getStatusLabel(status: CapabilityStatus): string {
+  switch (status) {
+    case "available":
+      return "Available";
+    case "coming_soon":
+      return "Coming Soon";
+    case "deprecated":
+      return "Deprecated";
+  }
+}
+
+function CapabilityCard({ capability }: { capability: Capability }) {
+  const IconComponent = capability.icon
+    ? iconMap[capability.icon] || CircleOff
+    : CircleOff;
+
+  return (
+    <Card className="hover:shadow-md transition-shadow">
+      <CardHeader className="flex flex-row items-start justify-between space-y-0">
+        <div className="flex items-center gap-3">
+          <div className="p-2 bg-muted rounded-lg">
+            <IconComponent className="w-5 h-5" />
+          </div>
+          <div>
+            <CardTitle className="text-lg">{capability.name}</CardTitle>
+            <p className="text-sm text-muted-foreground font-mono">
+              {capability.id}
+            </p>
+          </div>
+        </div>
+        <Badge variant={getStatusBadgeVariant(capability.status)}>
+          {getStatusLabel(capability.status)}
+        </Badge>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground mb-4">
+          {capability.description}
+        </p>
+        {capability.category && (
+          <Badge variant="outline" className="text-xs">
+            {capability.category}
+          </Badge>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function CapabilitiesPage() {
+  const { data: capabilities, isLoading, error } = useCapabilities();
+
+  if (error) {
+    return (
+      <div className="container mx-auto p-6">
+        <div className="text-red-500">
+          Error loading capabilities: {error.message}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto p-6">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold">Capabilities</h1>
+        <p className="text-muted-foreground">
+          Capabilities add functionality to agents - tools, system prompt
+          additions, and behavior modifications.
+        </p>
+      </div>
+
+      {isLoading ? (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {[...Array(4)].map((_, i) => (
+            <Card key={i}>
+              <CardHeader>
+                <Skeleton className="h-6 w-3/4" />
+              </CardHeader>
+              <CardContent>
+                <Skeleton className="h-4 w-full mb-2" />
+                <Skeleton className="h-4 w-2/3" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      ) : capabilities?.length === 0 ? (
+        <div className="text-center py-12">
+          <p className="text-muted-foreground">No capabilities available</p>
+        </div>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {capabilities?.map((capability) => (
+            <CapabilityCard key={capability.id} capability={capability} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/components/capabilities/capability-selector.tsx
+++ b/apps/ui/src/components/capabilities/capability-selector.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { useState, useMemo, useCallback } from "react";
+import { useCapabilities, useAgentCapabilities, useSetAgentCapabilities } from "@/hooks";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  CircleOff,
+  Search,
+  Box,
+  Folder,
+  ChevronUp,
+  ChevronDown,
+  Save,
+  LucideIcon,
+} from "lucide-react";
+import type { Capability, CapabilityId } from "@/lib/api/types";
+
+const iconMap: Record<string, LucideIcon> = {
+  "circle-off": CircleOff,
+  search: Search,
+  box: Box,
+  folder: Folder,
+};
+
+interface CapabilitySelectorProps {
+  agentId: string;
+}
+
+export function CapabilitySelector({ agentId }: CapabilitySelectorProps) {
+  const { data: allCapabilities, isLoading: capabilitiesLoading } = useCapabilities();
+  const { data: agentCapabilities, isLoading: agentCapabilitiesLoading } = useAgentCapabilities(agentId);
+  const setCapabilities = useSetAgentCapabilities();
+
+  // Compute initial capabilities from server data
+  const initialCapabilities = useMemo(() => {
+    if (!agentCapabilities) return [];
+    return agentCapabilities
+      .sort((a, b) => a.position - b.position)
+      .map((ac) => ac.capability_id);
+  }, [agentCapabilities]);
+
+  const [localCapabilities, setLocalCapabilities] = useState<CapabilityId[] | null>(null);
+
+  // Use local state if user has made changes, otherwise use server data
+  const selectedCapabilities = localCapabilities ?? initialCapabilities;
+  const hasChanges = localCapabilities !== null &&
+    JSON.stringify(localCapabilities) !== JSON.stringify(initialCapabilities);
+
+  const handleToggle = useCallback((capabilityId: CapabilityId, checked: boolean) => {
+    const current = localCapabilities ?? initialCapabilities;
+    let newSelected: CapabilityId[];
+    if (checked) {
+      newSelected = [...current, capabilityId];
+    } else {
+      newSelected = current.filter((id) => id !== capabilityId);
+    }
+    setLocalCapabilities(newSelected);
+  }, [localCapabilities, initialCapabilities]);
+
+  const handleSave = useCallback(async () => {
+    if (!localCapabilities) return;
+    try {
+      await setCapabilities.mutateAsync({
+        agentId,
+        request: { capabilities: localCapabilities },
+      });
+      setLocalCapabilities(null); // Reset to use server data
+    } catch (error) {
+      console.error("Failed to save capabilities:", error);
+    }
+  }, [agentId, localCapabilities, setCapabilities]);
+
+  const moveUp = useCallback((index: number) => {
+    if (index === 0) return;
+    const current = localCapabilities ?? initialCapabilities;
+    const newSelected = [...current];
+    [newSelected[index - 1], newSelected[index]] = [newSelected[index], newSelected[index - 1]];
+    setLocalCapabilities(newSelected);
+  }, [localCapabilities, initialCapabilities]);
+
+  const moveDown = useCallback((index: number) => {
+    const current = localCapabilities ?? initialCapabilities;
+    if (index === current.length - 1) return;
+    const newSelected = [...current];
+    [newSelected[index], newSelected[index + 1]] = [newSelected[index + 1], newSelected[index]];
+    setLocalCapabilities(newSelected);
+  }, [localCapabilities, initialCapabilities]);
+
+  // Get capability info by ID
+  const getCapabilityInfo = useCallback((id: CapabilityId): Capability | undefined =>
+    allCapabilities?.find((c) => c.id === id), [allCapabilities]);
+
+  if (capabilitiesLoading || agentCapabilitiesLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Capabilities</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            <Skeleton className="h-12 w-full" />
+            <Skeleton className="h-12 w-full" />
+            <Skeleton className="h-12 w-full" />
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Filter to only show available capabilities
+  const availableCapabilities = allCapabilities?.filter(
+    (c) => c.status === "available"
+  ) || [];
+
+  const comingSoonCapabilities = allCapabilities?.filter(
+    (c) => c.status === "coming_soon"
+  ) || [];
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle>Capabilities</CardTitle>
+        {hasChanges && (
+          <Button
+            size="sm"
+            onClick={handleSave}
+            disabled={setCapabilities.isPending}
+          >
+            <Save className="w-4 h-4 mr-2" />
+            {setCapabilities.isPending ? "Saving..." : "Save"}
+          </Button>
+        )}
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Selected capabilities with reordering */}
+        {selectedCapabilities.length > 0 && (
+          <div className="space-y-2">
+            <p className="text-sm font-medium text-muted-foreground">
+              Enabled ({selectedCapabilities.length})
+            </p>
+            {selectedCapabilities.map((capId, index) => {
+              const cap = getCapabilityInfo(capId);
+              if (!cap) return null;
+              const IconComponent = cap.icon ? iconMap[cap.icon] || CircleOff : CircleOff;
+
+              return (
+                <div
+                  key={capId}
+                  className="flex items-center gap-2 p-2 rounded-md border bg-muted/50"
+                >
+                  <div className="flex flex-col gap-0.5">
+                    <button
+                      onClick={() => moveUp(index)}
+                      disabled={index === 0}
+                      className="text-muted-foreground hover:text-foreground disabled:opacity-30 p-0.5"
+                      aria-label="Move up"
+                    >
+                      <ChevronUp className="w-3 h-3" />
+                    </button>
+                    <button
+                      onClick={() => moveDown(index)}
+                      disabled={index === selectedCapabilities.length - 1}
+                      className="text-muted-foreground hover:text-foreground disabled:opacity-30 p-0.5"
+                      aria-label="Move down"
+                    >
+                      <ChevronDown className="w-3 h-3" />
+                    </button>
+                  </div>
+                  <span className="text-xs text-muted-foreground w-4">
+                    {index + 1}
+                  </span>
+                  <IconComponent className="w-4 h-4" />
+                  <span className="flex-1">{cap.name}</span>
+                  <Checkbox
+                    checked={true}
+                    onCheckedChange={(checked) =>
+                      handleToggle(capId, checked as boolean)
+                    }
+                  />
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Available capabilities not yet selected */}
+        {availableCapabilities.filter(
+          (c) => !selectedCapabilities.includes(c.id)
+        ).length > 0 && (
+          <div className="space-y-2">
+            <p className="text-sm font-medium text-muted-foreground">
+              Available
+            </p>
+            {availableCapabilities
+              .filter((c) => !selectedCapabilities.includes(c.id))
+              .map((cap) => {
+                const IconComponent = cap.icon
+                  ? iconMap[cap.icon] || CircleOff
+                  : CircleOff;
+
+                return (
+                  <div
+                    key={cap.id}
+                    className="flex items-center gap-2 p-2 rounded-md border hover:bg-muted/50"
+                  >
+                    <IconComponent className="w-4 h-4" />
+                    <div className="flex-1">
+                      <p className="text-sm">{cap.name}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {cap.description}
+                      </p>
+                    </div>
+                    <Checkbox
+                      checked={false}
+                      onCheckedChange={(checked) =>
+                        handleToggle(cap.id, checked as boolean)
+                      }
+                    />
+                  </div>
+                );
+              })}
+          </div>
+        )}
+
+        {/* Coming soon capabilities */}
+        {comingSoonCapabilities.length > 0 && (
+          <div className="space-y-2">
+            <p className="text-sm font-medium text-muted-foreground">
+              Coming Soon
+            </p>
+            {comingSoonCapabilities.map((cap) => {
+              const IconComponent = cap.icon
+                ? iconMap[cap.icon] || CircleOff
+                : CircleOff;
+
+              return (
+                <div
+                  key={cap.id}
+                  className="flex items-center gap-2 p-2 rounded-md border opacity-60"
+                >
+                  <IconComponent className="w-4 h-4" />
+                  <div className="flex-1">
+                    <p className="text-sm">{cap.name}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {cap.description}
+                    </p>
+                  </div>
+                  <Badge variant="secondary">Coming Soon</Badge>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {selectedCapabilities.length === 0 && availableCapabilities.length === 0 && (
+          <p className="text-center py-4 text-muted-foreground">
+            No capabilities available
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/ui/src/components/capabilities/capability-selector.tsx
+++ b/apps/ui/src/components/capabilities/capability-selector.tsx
@@ -9,6 +9,7 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   CircleOff,
+  Clock,
   Search,
   Box,
   Folder,
@@ -21,6 +22,7 @@ import type { Capability, CapabilityId } from "@/lib/api/types";
 
 const iconMap: Record<string, LucideIcon> = {
   "circle-off": CircleOff,
+  clock: Clock,
   search: Search,
   box: Box,
   folder: Folder,

--- a/apps/ui/src/components/capabilities/index.ts
+++ b/apps/ui/src/components/capabilities/index.ts
@@ -1,0 +1,1 @@
+export { CapabilitySelector } from "./capability-selector";

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -7,12 +7,14 @@ import { cn } from "@/lib/utils";
 import {
   LayoutDashboard,
   Boxes,
+  Puzzle,
   Settings,
 } from "lucide-react";
 
 const navigation = [
   { name: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
   { name: "Agents", href: "/agents", icon: Boxes },
+  { name: "Capabilities", href: "/capabilities", icon: Puzzle },
   { name: "Settings", href: "/settings", icon: Settings },
 ];
 

--- a/apps/ui/src/components/ui/checkbox.tsx
+++ b/apps/ui/src/components/ui/checkbox.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { Check } from "lucide-react";
+
+interface CheckboxProps {
+  checked?: boolean;
+  onCheckedChange?: (checked: boolean) => void;
+  disabled?: boolean;
+  className?: string;
+  id?: string;
+}
+
+function Checkbox({
+  checked = false,
+  onCheckedChange,
+  disabled = false,
+  className,
+  id,
+}: CheckboxProps) {
+  return (
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={checked}
+      id={id}
+      disabled={disabled}
+      onClick={() => onCheckedChange?.(!checked)}
+      className={cn(
+        "peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+        checked && "bg-primary text-primary-foreground",
+        className
+      )}
+    >
+      {checked && <Check className="h-3.5 w-3.5" />}
+    </button>
+  );
+}
+
+export { Checkbox };

--- a/apps/ui/src/hooks/index.ts
+++ b/apps/ui/src/hooks/index.ts
@@ -1,5 +1,6 @@
 // Hooks exports (M2)
 export * from "./use-agents";
+export * from "./use-capabilities";
 export * from "./use-sessions";
 export * from "./use-llm-providers";
 export * from "./use-sse-events";

--- a/apps/ui/src/hooks/use-capabilities.ts
+++ b/apps/ui/src/hooks/use-capabilities.ts
@@ -1,0 +1,50 @@
+// Capability hooks
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  getAgentCapabilities,
+  getCapability,
+  listCapabilities,
+  setAgentCapabilities,
+} from "@/lib/api/capabilities";
+import type { CapabilityId, UpdateAgentCapabilitiesRequest } from "@/lib/api/types";
+
+export function useCapabilities() {
+  return useQuery({
+    queryKey: ["capabilities"],
+    queryFn: listCapabilities,
+  });
+}
+
+export function useCapability(capabilityId: CapabilityId | undefined) {
+  return useQuery({
+    queryKey: ["capability", capabilityId],
+    queryFn: () => getCapability(capabilityId!),
+    enabled: !!capabilityId,
+  });
+}
+
+export function useAgentCapabilities(agentId: string | undefined) {
+  return useQuery({
+    queryKey: ["agent-capabilities", agentId],
+    queryFn: () => getAgentCapabilities(agentId!),
+    enabled: !!agentId,
+  });
+}
+
+export function useSetAgentCapabilities() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      agentId,
+      request,
+    }: {
+      agentId: string;
+      request: UpdateAgentCapabilitiesRequest;
+    }) => setAgentCapabilities(agentId, request),
+    onSuccess: (_, { agentId }) => {
+      queryClient.invalidateQueries({ queryKey: ["agent-capabilities", agentId] });
+    },
+  });
+}

--- a/apps/ui/src/lib/api/capabilities.ts
+++ b/apps/ui/src/lib/api/capabilities.ts
@@ -1,0 +1,44 @@
+// Capability API functions
+
+import { api } from "./client";
+import type {
+  AgentCapability,
+  Capability,
+  CapabilityId,
+  ListResponse,
+  UpdateAgentCapabilitiesRequest,
+} from "./types";
+
+export async function listCapabilities(): Promise<Capability[]> {
+  const response = await api.get<ListResponse<Capability>>("/v1/capabilities");
+  return response.data.data;
+}
+
+export async function getCapability(
+  capabilityId: CapabilityId
+): Promise<Capability> {
+  const response = await api.get<Capability>(
+    `/v1/capabilities/${capabilityId}`
+  );
+  return response.data;
+}
+
+export async function getAgentCapabilities(
+  agentId: string
+): Promise<AgentCapability[]> {
+  const response = await api.get<ListResponse<AgentCapability>>(
+    `/v1/agents/${agentId}/capabilities`
+  );
+  return response.data.data;
+}
+
+export async function setAgentCapabilities(
+  agentId: string,
+  request: UpdateAgentCapabilitiesRequest
+): Promise<AgentCapability[]> {
+  const response = await api.put<ListResponse<AgentCapability>>(
+    `/v1/agents/${agentId}/capabilities`,
+    request
+  );
+  return response.data.data;
+}

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -237,7 +237,7 @@ export interface UpdateLlmModelRequest {
 // Capability types
 // ============================================
 
-export type CapabilityId = "noop" | "research" | "sandbox" | "file_system";
+export type CapabilityId = "noop" | "current_time" | "research" | "sandbox" | "file_system";
 
 export type CapabilityStatus = "available" | "coming_soon" | "deprecated";
 

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -232,3 +232,29 @@ export interface UpdateLlmModelRequest {
   is_default?: boolean;
   status?: LlmModelStatus;
 }
+
+// ============================================
+// Capability types
+// ============================================
+
+export type CapabilityId = "noop" | "research" | "sandbox" | "file_system";
+
+export type CapabilityStatus = "available" | "coming_soon" | "deprecated";
+
+export interface Capability {
+  id: CapabilityId;
+  name: string;
+  description: string;
+  status: CapabilityStatus;
+  icon?: string;
+  category?: string;
+}
+
+export interface AgentCapability {
+  capability_id: CapabilityId;
+  position: number;
+}
+
+export interface UpdateAgentCapabilitiesRequest {
+  capabilities: CapabilityId[];
+}

--- a/crates/everruns-api/src/capabilities.rs
+++ b/crates/everruns-api/src/capabilities.rs
@@ -171,6 +171,9 @@ pub struct InternalCapability {
 
 /// Get all internal capability definitions
 pub fn get_capability_registry() -> Vec<InternalCapability> {
+    use everruns_contracts::tools::{BuiltinTool, BuiltinToolKind, ToolDefinition, ToolPolicy};
+    use serde_json::json;
+
     vec![
         // Noop capability - for testing/demo
         InternalCapability {
@@ -184,6 +187,41 @@ pub fn get_capability_registry() -> Vec<InternalCapability> {
             },
             system_prompt_addition: None,
             tools: vec![],
+        },
+        // CurrentTime capability - adds current time tool
+        InternalCapability {
+            info: Capability {
+                id: CapabilityId::CurrentTime,
+                name: "Current Time".to_string(),
+                description: "Adds a tool to get the current date and time in various formats and timezones.".to_string(),
+                status: CapabilityStatus::Available,
+                icon: Some("clock".to_string()),
+                category: Some("Utilities".to_string()),
+            },
+            system_prompt_addition: None, // No system prompt contribution
+            tools: vec![
+                ToolDefinition::Builtin(BuiltinTool {
+                    name: "get_current_time".to_string(),
+                    description: "Get the current date and time. Can return time in different formats and timezones.".to_string(),
+                    parameters: json!({
+                        "type": "object",
+                        "properties": {
+                            "timezone": {
+                                "type": "string",
+                                "description": "Timezone to return the time in (e.g., 'UTC', 'America/New_York', 'Europe/London'). Defaults to UTC."
+                            },
+                            "format": {
+                                "type": "string",
+                                "enum": ["iso8601", "unix", "human"],
+                                "description": "Output format: 'iso8601' for ISO 8601 format, 'unix' for Unix timestamp, 'human' for human-readable format. Defaults to 'iso8601'."
+                            }
+                        },
+                        "required": []
+                    }),
+                    kind: BuiltinToolKind::CurrentTime,
+                    policy: ToolPolicy::Auto,
+                }),
+            ],
         },
         // Research capability - coming soon
         InternalCapability {

--- a/crates/everruns-api/src/capabilities.rs
+++ b/crates/everruns-api/src/capabilities.rs
@@ -1,0 +1,241 @@
+// Capability HTTP routes and internal registry
+//
+// Design Decision: Capabilities are external to the Agent Loop.
+// The registry here defines what each capability provides (system prompt additions, tools).
+// When building AgentConfig, we resolve the agent's enabled capabilities and merge their
+// contributions into the final config.
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    routing::get,
+    Json, Router,
+};
+use everruns_contracts::{
+    AgentCapability, Capability, CapabilityId, CapabilityStatus, ListResponse,
+    UpdateAgentCapabilitiesRequest,
+};
+use everruns_storage::Database;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::services::CapabilityService;
+
+/// App state for capability routes
+#[derive(Clone)]
+pub struct AppState {
+    pub service: Arc<CapabilityService>,
+}
+
+impl AppState {
+    pub fn new(db: Arc<Database>) -> Self {
+        Self {
+            service: Arc::new(CapabilityService::new(db)),
+        }
+    }
+}
+
+/// Create capability routes
+pub fn routes(state: AppState) -> Router {
+    Router::new()
+        .route("/v1/capabilities", get(list_capabilities))
+        .route("/v1/capabilities/:capability_id", get(get_capability))
+        .route(
+            "/v1/agents/:agent_id/capabilities",
+            get(get_agent_capabilities).put(set_agent_capabilities),
+        )
+        .with_state(state)
+}
+
+/// GET /v1/capabilities - List all available capabilities
+#[utoipa::path(
+    get,
+    path = "/v1/capabilities",
+    responses(
+        (status = 200, description = "List of available capabilities", body = ListResponse<Capability>),
+    ),
+    tag = "capabilities"
+)]
+pub async fn list_capabilities(State(state): State<AppState>) -> Json<ListResponse<Capability>> {
+    let capabilities = state.service.list_all();
+    Json(ListResponse::new(capabilities))
+}
+
+/// GET /v1/capabilities/{capability_id} - Get a specific capability
+#[utoipa::path(
+    get,
+    path = "/v1/capabilities/{capability_id}",
+    params(
+        ("capability_id" = String, Path, description = "Capability ID")
+    ),
+    responses(
+        (status = 200, description = "Capability found", body = Capability),
+        (status = 404, description = "Capability not found"),
+    ),
+    tag = "capabilities"
+)]
+pub async fn get_capability(
+    State(state): State<AppState>,
+    Path(capability_id): Path<String>,
+) -> Result<Json<Capability>, StatusCode> {
+    let cap_id: CapabilityId = capability_id.parse().map_err(|_| StatusCode::NOT_FOUND)?;
+
+    let capability = state.service.get(cap_id).ok_or(StatusCode::NOT_FOUND)?;
+
+    Ok(Json(capability))
+}
+
+/// GET /v1/agents/{agent_id}/capabilities - Get capabilities for an agent
+#[utoipa::path(
+    get,
+    path = "/v1/agents/{agent_id}/capabilities",
+    params(
+        ("agent_id" = Uuid, Path, description = "Agent ID")
+    ),
+    responses(
+        (status = 200, description = "Agent capabilities", body = ListResponse<AgentCapability>),
+        (status = 500, description = "Internal server error"),
+    ),
+    tag = "capabilities"
+)]
+pub async fn get_agent_capabilities(
+    State(state): State<AppState>,
+    Path(agent_id): Path<Uuid>,
+) -> Result<Json<ListResponse<AgentCapability>>, StatusCode> {
+    let capabilities = state
+        .service
+        .get_agent_capabilities(agent_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to get agent capabilities: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    Ok(Json(ListResponse::new(capabilities)))
+}
+
+/// PUT /v1/agents/{agent_id}/capabilities - Set capabilities for an agent
+#[utoipa::path(
+    put,
+    path = "/v1/agents/{agent_id}/capabilities",
+    params(
+        ("agent_id" = Uuid, Path, description = "Agent ID")
+    ),
+    request_body = UpdateAgentCapabilitiesRequest,
+    responses(
+        (status = 200, description = "Agent capabilities updated", body = ListResponse<AgentCapability>),
+        (status = 400, description = "Invalid capability ID"),
+        (status = 500, description = "Internal server error"),
+    ),
+    tag = "capabilities"
+)]
+pub async fn set_agent_capabilities(
+    State(state): State<AppState>,
+    Path(agent_id): Path<Uuid>,
+    Json(req): Json<UpdateAgentCapabilitiesRequest>,
+) -> Result<Json<ListResponse<AgentCapability>>, StatusCode> {
+    // Validate all capability IDs exist
+    for cap_id in &req.capabilities {
+        if state.service.get(*cap_id).is_none() {
+            return Err(StatusCode::BAD_REQUEST);
+        }
+    }
+
+    let capabilities = state
+        .service
+        .set_agent_capabilities(agent_id, req.capabilities)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to set agent capabilities: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    Ok(Json(ListResponse::new(capabilities)))
+}
+
+// ============================================
+// Internal Capability Registry
+// ============================================
+
+/// Internal capability definition with full details
+/// This is used internally to build AgentConfig
+#[allow(dead_code)] // Fields used when capabilities are fully implemented
+pub struct InternalCapability {
+    /// Public info
+    pub info: Capability,
+    /// System prompt addition (prepended to agent's system prompt)
+    pub system_prompt_addition: Option<String>,
+    /// Tools provided by this capability
+    pub tools: Vec<everruns_contracts::tools::ToolDefinition>,
+}
+
+/// Get all internal capability definitions
+pub fn get_capability_registry() -> Vec<InternalCapability> {
+    vec![
+        // Noop capability - for testing/demo
+        InternalCapability {
+            info: Capability {
+                id: CapabilityId::Noop,
+                name: "No-Op".to_string(),
+                description: "A no-operation capability for testing and demonstration purposes. Does not add any functionality.".to_string(),
+                status: CapabilityStatus::Available,
+                icon: Some("circle-off".to_string()),
+                category: Some("Testing".to_string()),
+            },
+            system_prompt_addition: None,
+            tools: vec![],
+        },
+        // Research capability - coming soon
+        InternalCapability {
+            info: Capability {
+                id: CapabilityId::Research,
+                name: "Deep Research".to_string(),
+                description: "Enables deep research capabilities with a scratchpad for notes, web search tools, and structured thinking.".to_string(),
+                status: CapabilityStatus::ComingSoon,
+                icon: Some("search".to_string()),
+                category: Some("AI".to_string()),
+            },
+            system_prompt_addition: Some(
+                "You have access to a research scratchpad. Use it to organize your thoughts and findings.".to_string()
+            ),
+            tools: vec![], // Tools would be added here when implemented
+        },
+        // Sandbox capability - coming soon
+        InternalCapability {
+            info: Capability {
+                id: CapabilityId::Sandbox,
+                name: "Sandboxed Execution".to_string(),
+                description: "Enables sandboxed code execution environment for running code safely.".to_string(),
+                status: CapabilityStatus::ComingSoon,
+                icon: Some("box".to_string()),
+                category: Some("Execution".to_string()),
+            },
+            system_prompt_addition: Some(
+                "You can execute code in a sandboxed environment. Use the execute_code tool to run code safely.".to_string()
+            ),
+            tools: vec![], // Tools would be added here when implemented
+        },
+        // FileSystem capability - coming soon
+        InternalCapability {
+            info: Capability {
+                id: CapabilityId::FileSystem,
+                name: "File System Access".to_string(),
+                description: "Adds tools to access and manipulate files - read, write, grep, and more.".to_string(),
+                status: CapabilityStatus::ComingSoon,
+                icon: Some("folder".to_string()),
+                category: Some("File Operations".to_string()),
+            },
+            system_prompt_addition: Some(
+                "You have access to file system tools. You can read, write, and search files.".to_string()
+            ),
+            tools: vec![], // Tools would be added here when implemented
+        },
+    ]
+}
+
+/// Get a specific capability from the registry
+pub fn get_capability_definition(id: CapabilityId) -> Option<InternalCapability> {
+    get_capability_registry()
+        .into_iter()
+        .find(|c| c.info.id == id)
+}

--- a/crates/everruns-api/src/services/capability.rs
+++ b/crates/everruns-api/src/services/capability.rs
@@ -1,0 +1,79 @@
+// Capability service - business logic for capabilities
+
+use anyhow::Result;
+use everruns_contracts::{AgentCapability, Capability, CapabilityId};
+use everruns_storage::Database;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::capabilities::{get_capability_definition, get_capability_registry};
+
+pub struct CapabilityService {
+    db: Arc<Database>,
+}
+
+impl CapabilityService {
+    pub fn new(db: Arc<Database>) -> Self {
+        Self { db }
+    }
+
+    /// List all available capabilities (public info only)
+    pub fn list_all(&self) -> Vec<Capability> {
+        get_capability_registry()
+            .into_iter()
+            .map(|c| c.info)
+            .collect()
+    }
+
+    /// Get a specific capability by ID
+    pub fn get(&self, id: CapabilityId) -> Option<Capability> {
+        get_capability_definition(id).map(|c| c.info)
+    }
+
+    /// Get capabilities for an agent
+    pub async fn get_agent_capabilities(&self, agent_id: Uuid) -> Result<Vec<AgentCapability>> {
+        let rows = self.db.get_agent_capabilities(agent_id).await?;
+
+        let capabilities: Vec<AgentCapability> = rows
+            .into_iter()
+            .filter_map(|row| {
+                let capability_id: Result<CapabilityId, _> = row.capability_id.parse();
+                capability_id.ok().map(|cap_id| AgentCapability {
+                    capability_id: cap_id,
+                    position: row.position,
+                })
+            })
+            .collect();
+
+        Ok(capabilities)
+    }
+
+    /// Set capabilities for an agent (replaces existing)
+    pub async fn set_agent_capabilities(
+        &self,
+        agent_id: Uuid,
+        capabilities: Vec<CapabilityId>,
+    ) -> Result<Vec<AgentCapability>> {
+        // Convert to (capability_id string, position) tuples
+        let cap_tuples: Vec<(String, i32)> = capabilities
+            .iter()
+            .enumerate()
+            .map(|(idx, cap)| (cap.to_string(), idx as i32))
+            .collect();
+
+        let rows = self.db.set_agent_capabilities(agent_id, cap_tuples).await?;
+
+        let result: Vec<AgentCapability> = rows
+            .into_iter()
+            .filter_map(|row| {
+                let capability_id: Result<CapabilityId, _> = row.capability_id.parse();
+                capability_id.ok().map(|cap_id| AgentCapability {
+                    capability_id: cap_id,
+                    position: row.position,
+                })
+            })
+            .collect();
+
+        Ok(result)
+    }
+}

--- a/crates/everruns-api/src/services/mod.rs
+++ b/crates/everruns-api/src/services/mod.rs
@@ -2,11 +2,13 @@
 // Services own business logic and validation, calling storage directly
 
 pub mod agent;
+pub mod capability;
 pub mod event;
 pub mod message;
 pub mod session;
 
 pub use agent::AgentService;
+pub use capability::CapabilityService;
 pub use event::EventService;
 pub use message::MessageService;
 pub use session::SessionService;

--- a/crates/everruns-contracts/src/capability.rs
+++ b/crates/everruns-contracts/src/capability.rs
@@ -15,6 +15,8 @@ use utoipa::ToSchema;
 pub enum CapabilityId {
     /// No-op capability for testing/demo purposes
     Noop,
+    /// CurrentTime capability - adds a tool to get the current time
+    CurrentTime,
     /// Research capability - enables deep research with scratchpad and web tools
     Research,
     /// Sandbox capability - enables sandboxed code execution
@@ -27,6 +29,7 @@ impl std::fmt::Display for CapabilityId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             CapabilityId::Noop => write!(f, "noop"),
+            CapabilityId::CurrentTime => write!(f, "current_time"),
             CapabilityId::Research => write!(f, "research"),
             CapabilityId::Sandbox => write!(f, "sandbox"),
             CapabilityId::FileSystem => write!(f, "file_system"),
@@ -40,6 +43,7 @@ impl std::str::FromStr for CapabilityId {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "noop" => Ok(CapabilityId::Noop),
+            "current_time" => Ok(CapabilityId::CurrentTime),
             "research" => Ok(CapabilityId::Research),
             "sandbox" => Ok(CapabilityId::Sandbox),
             "file_system" => Ok(CapabilityId::FileSystem),
@@ -114,6 +118,7 @@ mod tests {
     #[test]
     fn test_capability_id_display() {
         assert_eq!(CapabilityId::Noop.to_string(), "noop");
+        assert_eq!(CapabilityId::CurrentTime.to_string(), "current_time");
         assert_eq!(CapabilityId::Research.to_string(), "research");
         assert_eq!(CapabilityId::Sandbox.to_string(), "sandbox");
         assert_eq!(CapabilityId::FileSystem.to_string(), "file_system");
@@ -122,6 +127,10 @@ mod tests {
     #[test]
     fn test_capability_id_from_str() {
         assert_eq!("noop".parse::<CapabilityId>().unwrap(), CapabilityId::Noop);
+        assert_eq!(
+            "current_time".parse::<CapabilityId>().unwrap(),
+            CapabilityId::CurrentTime
+        );
         assert_eq!(
             "research".parse::<CapabilityId>().unwrap(),
             CapabilityId::Research

--- a/crates/everruns-contracts/src/capability.rs
+++ b/crates/everruns-contracts/src/capability.rs
@@ -1,0 +1,172 @@
+// Capability DTOs - defines agent capabilities that add functionality
+//
+// Design Decision: Capabilities are external to the Agent Loop.
+// They are resolved at the service/API layer and contribute to AgentConfig
+// (system prompt additions, tools, etc.). The Agent Loop remains focused on
+// execution and receives a fully-configured AgentConfig.
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// Known capability identifiers
+/// These are the internal IDs for built-in capabilities
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum CapabilityId {
+    /// No-op capability for testing/demo purposes
+    Noop,
+    /// Research capability - enables deep research with scratchpad and web tools
+    Research,
+    /// Sandbox capability - enables sandboxed code execution
+    Sandbox,
+    /// FileSystem capability - adds file system access tools
+    FileSystem,
+}
+
+impl std::fmt::Display for CapabilityId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CapabilityId::Noop => write!(f, "noop"),
+            CapabilityId::Research => write!(f, "research"),
+            CapabilityId::Sandbox => write!(f, "sandbox"),
+            CapabilityId::FileSystem => write!(f, "file_system"),
+        }
+    }
+}
+
+impl std::str::FromStr for CapabilityId {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "noop" => Ok(CapabilityId::Noop),
+            "research" => Ok(CapabilityId::Research),
+            "sandbox" => Ok(CapabilityId::Sandbox),
+            "file_system" => Ok(CapabilityId::FileSystem),
+            _ => Err(format!("Unknown capability: {}", s)),
+        }
+    }
+}
+
+/// Capability status
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum CapabilityStatus {
+    /// Capability is available for use
+    Available,
+    /// Capability is coming soon (not yet implemented)
+    ComingSoon,
+    /// Capability is deprecated
+    Deprecated,
+}
+
+impl std::fmt::Display for CapabilityStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CapabilityStatus::Available => write!(f, "available"),
+            CapabilityStatus::ComingSoon => write!(f, "coming_soon"),
+            CapabilityStatus::Deprecated => write!(f, "deprecated"),
+        }
+    }
+}
+
+/// Public capability information (without internal details)
+/// This is what gets returned from the API
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct Capability {
+    /// Unique capability identifier
+    pub id: CapabilityId,
+    /// Display name
+    pub name: String,
+    /// Description of what this capability provides
+    pub description: String,
+    /// Current status
+    pub status: CapabilityStatus,
+    /// Icon name (for UI rendering)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
+    /// Category for grouping in UI
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,
+}
+
+/// Agent capability assignment with ordering
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AgentCapability {
+    /// The capability ID
+    pub capability_id: CapabilityId,
+    /// Position in the chain (lower = earlier)
+    pub position: i32,
+}
+
+/// Request to update agent capabilities
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct UpdateAgentCapabilitiesRequest {
+    /// List of capability IDs in desired order
+    /// Position is determined by array index
+    pub capabilities: Vec<CapabilityId>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_capability_id_display() {
+        assert_eq!(CapabilityId::Noop.to_string(), "noop");
+        assert_eq!(CapabilityId::Research.to_string(), "research");
+        assert_eq!(CapabilityId::Sandbox.to_string(), "sandbox");
+        assert_eq!(CapabilityId::FileSystem.to_string(), "file_system");
+    }
+
+    #[test]
+    fn test_capability_id_from_str() {
+        assert_eq!("noop".parse::<CapabilityId>().unwrap(), CapabilityId::Noop);
+        assert_eq!(
+            "research".parse::<CapabilityId>().unwrap(),
+            CapabilityId::Research
+        );
+        assert_eq!(
+            "sandbox".parse::<CapabilityId>().unwrap(),
+            CapabilityId::Sandbox
+        );
+        assert_eq!(
+            "file_system".parse::<CapabilityId>().unwrap(),
+            CapabilityId::FileSystem
+        );
+    }
+
+    #[test]
+    fn test_capability_id_from_str_unknown() {
+        let result = "unknown".parse::<CapabilityId>();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_capability_serialization() {
+        let cap = Capability {
+            id: CapabilityId::Research,
+            name: "Research".to_string(),
+            description: "Deep research capability".to_string(),
+            status: CapabilityStatus::Available,
+            icon: Some("search".to_string()),
+            category: Some("AI".to_string()),
+        };
+
+        let json = serde_json::to_string(&cap).unwrap();
+        assert!(json.contains("\"id\":\"research\""));
+        assert!(json.contains("\"status\":\"available\""));
+    }
+
+    #[test]
+    fn test_agent_capability_serialization() {
+        let agent_cap = AgentCapability {
+            capability_id: CapabilityId::Sandbox,
+            position: 1,
+        };
+
+        let json = serde_json::to_string(&agent_cap).unwrap();
+        assert!(json.contains("\"capability_id\":\"sandbox\""));
+        assert!(json.contains("\"position\":1"));
+    }
+}

--- a/crates/everruns-contracts/src/lib.rs
+++ b/crates/everruns-contracts/src/lib.rs
@@ -3,6 +3,7 @@
 // M2: Agent/Session/Messages model with Events as SSE notification channel
 
 pub mod agent;
+pub mod capability;
 pub mod common;
 pub mod events;
 pub mod llm;
@@ -11,6 +12,7 @@ pub mod session;
 pub mod tools;
 
 pub use agent::*;
+pub use capability::*;
 pub use common::*;
 pub use events::*;
 pub use llm::*;

--- a/crates/everruns-contracts/src/tools.rs
+++ b/crates/everruns-contracts/src/tools.rs
@@ -94,6 +94,8 @@ pub enum BuiltinToolKind {
     ReadFile,
     /// Write file (future)
     WriteFile,
+    /// Get current time in various formats
+    CurrentTime,
 }
 
 /// Tool call from LLM response

--- a/crates/everruns-storage/migrations/002_agent_capabilities.sql
+++ b/crates/everruns-storage/migrations/002_agent_capabilities.sql
@@ -1,0 +1,22 @@
+-- Agent Capabilities Schema (v0.2.1)
+-- Decision: Capabilities are stored as a junction table with ordering
+-- Design: Capabilities are external to Agent Loop - resolved at API layer to configure AgentConfig
+
+-- ============================================
+-- Agent Capabilities (junction table)
+-- ============================================
+
+CREATE TABLE agent_capabilities (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    -- Capability ID is a string enum (noop, research, sandbox, file_system)
+    capability_id VARCHAR(50) NOT NULL CHECK (capability_id IN ('noop', 'research', 'sandbox', 'file_system')),
+    -- Position determines the order in the capability chain (lower = earlier)
+    position INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- Each agent can have each capability only once
+    UNIQUE(agent_id, capability_id)
+);
+
+CREATE INDEX idx_agent_capabilities_agent_id ON agent_capabilities(agent_id);
+CREATE INDEX idx_agent_capabilities_position ON agent_capabilities(agent_id, position);

--- a/crates/everruns-storage/migrations/002_agent_capabilities.sql
+++ b/crates/everruns-storage/migrations/002_agent_capabilities.sql
@@ -9,8 +9,8 @@
 CREATE TABLE agent_capabilities (
     id UUID PRIMARY KEY DEFAULT uuidv7(),
     agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
-    -- Capability ID is a string enum (noop, research, sandbox, file_system)
-    capability_id VARCHAR(50) NOT NULL CHECK (capability_id IN ('noop', 'research', 'sandbox', 'file_system')),
+    -- Capability ID is a string enum (noop, current_time, research, sandbox, file_system)
+    capability_id VARCHAR(50) NOT NULL CHECK (capability_id IN ('noop', 'current_time', 'research', 'sandbox', 'file_system')),
     -- Position determines the order in the capability chain (lower = earlier)
     position INTEGER NOT NULL DEFAULT 0,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),

--- a/crates/everruns-storage/src/models.rs
+++ b/crates/everruns-storage/src/models.rs
@@ -310,3 +310,23 @@ pub struct UpdateLlmModel {
     pub is_default: Option<bool>,
     pub status: Option<String>,
 }
+
+// ============================================
+// Agent Capability models
+// ============================================
+
+#[derive(Debug, Clone, FromRow)]
+pub struct AgentCapabilityRow {
+    pub id: Uuid,
+    pub agent_id: Uuid,
+    pub capability_id: String,
+    pub position: i32,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateAgentCapability {
+    pub agent_id: Uuid,
+    pub capability_id: String,
+    pub position: i32,
+}


### PR DESCRIPTION
Implement Capability system that allows extending agent functionality:
- Add Capability types (CapabilityId, Capability, AgentCapability) in everruns-contracts
- Create database migration for agent_capabilities junction table with ordering
- Add repository methods for managing agent capabilities
- Implement internal capability registry with Noop capability as demo
- Add API routes: GET /v1/capabilities, PUT /v1/agents/{id}/capabilities
- Create UI page to list available capabilities
- Add CapabilitySelector component for managing agent capabilities with ordering

Design Decision: Capabilities are external to Agent Loop. They are resolved at the service/API layer and contribute to AgentConfig (system prompt, tools). This keeps the Agent Loop focused on execution while allowing flexible capability management via DB and API.

Available capabilities:
- noop (available) - No-op for testing
- research (coming_soon) - Deep research with scratchpad
- sandbox (coming_soon) - Sandboxed code execution
- file_system (coming_soon) - File system access tools