### PR TITLE
feat(auth): add full authentication mode support and UI fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,8 +22,21 @@ TEMPORAL_ADDRESS=localhost:7233
 TEMPORAL_NAMESPACE=default
 TEMPORAL_TASK_QUEUE=everruns-agent-runs
 
-# Authentication (Admin Mode)
+# Authentication (Admin Mode) - Single admin user for development
 # AUTH_MODE=admin
 # AUTH_JWT_SECRET=MJ5SiIlm9mTmiVJV8O2NLrxnuEZDFuO/iXkjVXGqWD0=
 # AUTH_ADMIN_EMAIL=admin@example.com
 # AUTH_ADMIN_PASSWORD=changeme
+
+# Authentication (Full Mode) - User registration + optional OAuth
+# AUTH_MODE=full
+# AUTH_JWT_SECRET=MJ5SiIlm9mTmiVJV8O2NLrxnuEZDFuO/iXkjVXGqWD0=
+# AUTH_DISABLE_SIGNUP=false
+# AUTH_DISABLE_PASSWORD=false
+#
+# OAuth (optional) - requires AUTH_BASE_URL for callback URLs
+# AUTH_BASE_URL=http://localhost:9000
+# AUTH_GOOGLE_CLIENT_ID=your-google-client-id
+# AUTH_GOOGLE_CLIENT_SECRET=your-google-client-secret
+# AUTH_GITHUB_CLIENT_ID=your-github-client-id
+# AUTH_GITHUB_CLIENT_SECRET=your-github-client-secret

--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -3,8 +3,14 @@ import { Sidebar } from "@/components/layout/sidebar";
 
 // Mock next/navigation
 const mockPathname = jest.fn();
+const mockPush = jest.fn();
 jest.mock("next/navigation", () => ({
   usePathname: () => mockPathname(),
+  useRouter: () => ({
+    push: mockPush,
+    replace: jest.fn(),
+    back: jest.fn(),
+  }),
 }));
 
 // Mock next/image
@@ -16,9 +22,29 @@ jest.mock("next/image", () => ({
   ),
 }));
 
+// Mock auth provider
+jest.mock("@/providers/auth-provider", () => ({
+  useAuth: () => ({
+    user: null,
+    requiresAuth: false,
+    isAuthenticated: true,
+    config: { mode: "none" },
+    isLoading: false,
+  }),
+}));
+
+// Mock auth hooks
+jest.mock("@/hooks/use-auth", () => ({
+  useLogout: () => ({
+    mutateAsync: jest.fn(),
+    isPending: false,
+  }),
+}));
+
 describe("Sidebar", () => {
   beforeEach(() => {
     mockPathname.mockReturnValue("/dashboard");
+    mockPush.mockClear();
   });
 
   it("renders the Everruns logo and title", () => {
@@ -33,6 +59,7 @@ describe("Sidebar", () => {
 
     expect(screen.getByText("Dashboard")).toBeInTheDocument();
     expect(screen.getByText("Agents")).toBeInTheDocument();
+    expect(screen.getByText("Capabilities")).toBeInTheDocument();
     expect(screen.getByText("Settings")).toBeInTheDocument();
   });
 
@@ -41,10 +68,12 @@ describe("Sidebar", () => {
 
     const dashboardLink = screen.getByRole("link", { name: "Dashboard" });
     const agentsLink = screen.getByRole("link", { name: "Agents" });
+    const capabilitiesLink = screen.getByRole("link", { name: "Capabilities" });
     const settingsLink = screen.getByRole("link", { name: "Settings" });
 
     expect(dashboardLink).toHaveAttribute("href", "/dashboard");
     expect(agentsLink).toHaveAttribute("href", "/agents");
+    expect(capabilitiesLink).toHaveAttribute("href", "/capabilities");
     expect(settingsLink).toHaveAttribute("href", "/settings");
   });
 
@@ -79,18 +108,18 @@ describe("Sidebar", () => {
     expect(screen.getByText("Everruns v0.1.0")).toBeInTheDocument();
   });
 
-  it("has exactly 3 navigation items", () => {
+  it("has exactly 4 navigation items", () => {
     render(<Sidebar />);
 
     // Get nav links (excluding logo link)
     const navLinks = screen.getAllByRole("link").filter(
       link => link.getAttribute("href") !== "/dashboard" || link.textContent?.includes("Dashboard")
     );
-    // Filter to only nav items (Dashboard, Agents, Settings)
-    const navItems = ["Dashboard", "Agents", "Settings"];
+    // Filter to only nav items (Dashboard, Agents, Capabilities, Settings)
+    const navItems = ["Dashboard", "Agents", "Capabilities", "Settings"];
     const foundNavLinks = navLinks.filter(link =>
       navItems.some(item => link.textContent?.includes(item))
     );
-    expect(foundNavLinks).toHaveLength(3);
+    expect(foundNavLinks).toHaveLength(4);
   });
 });

--- a/apps/ui/src/__tests__/use-auth.test.tsx
+++ b/apps/ui/src/__tests__/use-auth.test.tsx
@@ -1,0 +1,365 @@
+import { renderHook, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import {
+  useLogin,
+  useRegister,
+  useLogout,
+  useCurrentUser,
+  authKeys,
+} from "@/hooks/use-auth";
+
+// Mock the API functions
+jest.mock("@/lib/api/auth", () => ({
+  login: jest.fn(),
+  register: jest.fn(),
+  logout: jest.fn(),
+  getCurrentUser: jest.fn(),
+  getAuthConfig: jest.fn(),
+  listApiKeys: jest.fn(),
+  createApiKey: jest.fn(),
+  deleteApiKey: jest.fn(),
+}));
+
+import * as authApi from "@/lib/api/auth";
+
+const mockLogin = authApi.login as jest.MockedFunction<typeof authApi.login>;
+const mockRegister = authApi.register as jest.MockedFunction<typeof authApi.register>;
+const mockLogout = authApi.logout as jest.MockedFunction<typeof authApi.logout>;
+const mockGetCurrentUser = authApi.getCurrentUser as jest.MockedFunction<typeof authApi.getCurrentUser>;
+
+describe("Auth Hooks", () => {
+  let queryClient: QueryClient;
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+        mutations: {
+          retry: false,
+        },
+      },
+    });
+    jest.clearAllMocks();
+  });
+
+  // Helper to initialize the user query so refetchQueries has something to refetch
+  async function initializeUserQuery(initialUser: unknown = null) {
+    mockGetCurrentUser.mockResolvedValueOnce(initialUser as Awaited<ReturnType<typeof authApi.getCurrentUser>>);
+    const { result } = renderHook(() => useCurrentUser(true), { wrapper });
+    // Wait for initial fetch to complete
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+    mockGetCurrentUser.mockClear();
+    return result;
+  }
+
+  describe("useLogin", () => {
+    it("should call login API and refetch user data on success", async () => {
+      // Initialize the user query first (simulating app state)
+      await initializeUserQuery(null);
+
+      const mockTokenResponse = {
+        access_token: "test-token",
+        refresh_token: "test-refresh",
+        token_type: "Bearer",
+        expires_in: 900,
+      };
+      const mockUser = {
+        id: "user-1",
+        email: "test@example.com",
+        name: "Test User",
+        roles: ["user"],
+      };
+
+      mockLogin.mockResolvedValueOnce(mockTokenResponse);
+      mockGetCurrentUser.mockResolvedValueOnce(mockUser);
+
+      const { result } = renderHook(() => useLogin(), { wrapper });
+
+      await act(async () => {
+        await result.current.mutateAsync({
+          email: "test@example.com",
+          password: "password123",
+        });
+      });
+
+      expect(mockLogin).toHaveBeenCalledWith({
+        email: "test@example.com",
+        password: "password123",
+      });
+      expect(mockGetCurrentUser).toHaveBeenCalled();
+    });
+
+    it("should wait for user refetch to complete before mutation resolves", async () => {
+      // Initialize the user query first
+      mockGetCurrentUser.mockResolvedValueOnce(null as unknown as Awaited<ReturnType<typeof authApi.getCurrentUser>>);
+      renderHook(() => useCurrentUser(true), { wrapper });
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+      mockGetCurrentUser.mockClear();
+
+      const callOrder: string[] = [];
+
+      mockLogin.mockImplementation(async () => {
+        callOrder.push("login");
+        return {
+          access_token: "test-token",
+          refresh_token: "test-refresh",
+          token_type: "Bearer",
+          expires_in: 900,
+        };
+      });
+
+      mockGetCurrentUser.mockImplementation(async () => {
+        // Simulate a delay in fetching user
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        callOrder.push("getCurrentUser");
+        return {
+          id: "user-1",
+          email: "test@example.com",
+          name: "Test User",
+          roles: ["user"],
+        };
+      });
+
+      const { result } = renderHook(() => useLogin(), { wrapper });
+
+      await act(async () => {
+        await result.current.mutateAsync({
+          email: "test@example.com",
+          password: "password123",
+        });
+        callOrder.push("mutation-resolved");
+      });
+
+      // Verify the order: login -> getCurrentUser -> mutation resolved
+      expect(callOrder).toEqual(["login", "getCurrentUser", "mutation-resolved"]);
+    });
+
+    it("should update user cache after successful login", async () => {
+      // Initialize the user query first
+      await initializeUserQuery(null);
+
+      const mockUser = {
+        id: "user-1",
+        email: "test@example.com",
+        name: "Test User",
+        roles: ["user"],
+      };
+
+      mockLogin.mockResolvedValueOnce({
+        access_token: "test-token",
+        refresh_token: "test-refresh",
+        token_type: "Bearer",
+        expires_in: 900,
+      });
+      mockGetCurrentUser.mockResolvedValueOnce(mockUser);
+
+      const { result } = renderHook(() => useLogin(), { wrapper });
+
+      await act(async () => {
+        await result.current.mutateAsync({
+          email: "test@example.com",
+          password: "password123",
+        });
+      });
+
+      // Check that user data is in cache
+      const cachedUser = queryClient.getQueryData(authKeys.user());
+      expect(cachedUser).toEqual(mockUser);
+    });
+  });
+
+  describe("useRegister", () => {
+    it("should call register API and refetch user data on success", async () => {
+      // Initialize the user query first
+      await initializeUserQuery(null);
+
+      const mockTokenResponse = {
+        access_token: "test-token",
+        refresh_token: "test-refresh",
+        token_type: "Bearer",
+        expires_in: 900,
+      };
+      const mockUser = {
+        id: "user-1",
+        email: "new@example.com",
+        name: "New User",
+        roles: ["user"],
+      };
+
+      mockRegister.mockResolvedValueOnce(mockTokenResponse);
+      mockGetCurrentUser.mockResolvedValueOnce(mockUser);
+
+      const { result } = renderHook(() => useRegister(), { wrapper });
+
+      await act(async () => {
+        await result.current.mutateAsync({
+          name: "New User",
+          email: "new@example.com",
+          password: "password123",
+        });
+      });
+
+      expect(mockRegister).toHaveBeenCalledWith({
+        name: "New User",
+        email: "new@example.com",
+        password: "password123",
+      });
+      expect(mockGetCurrentUser).toHaveBeenCalled();
+    });
+
+    it("should wait for user refetch to complete before mutation resolves", async () => {
+      // Initialize the user query first
+      mockGetCurrentUser.mockResolvedValueOnce(null as unknown as Awaited<ReturnType<typeof authApi.getCurrentUser>>);
+      renderHook(() => useCurrentUser(true), { wrapper });
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+      mockGetCurrentUser.mockClear();
+
+      const callOrder: string[] = [];
+
+      mockRegister.mockImplementation(async () => {
+        callOrder.push("register");
+        return {
+          access_token: "test-token",
+          refresh_token: "test-refresh",
+          token_type: "Bearer",
+          expires_in: 900,
+        };
+      });
+
+      mockGetCurrentUser.mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        callOrder.push("getCurrentUser");
+        return {
+          id: "user-1",
+          email: "new@example.com",
+          name: "New User",
+          roles: ["user"],
+        };
+      });
+
+      const { result } = renderHook(() => useRegister(), { wrapper });
+
+      await act(async () => {
+        await result.current.mutateAsync({
+          name: "New User",
+          email: "new@example.com",
+          password: "password123",
+        });
+        callOrder.push("mutation-resolved");
+      });
+
+      // Verify the order: register -> getCurrentUser -> mutation resolved
+      expect(callOrder).toEqual(["register", "getCurrentUser", "mutation-resolved"]);
+    });
+
+    it("should replace old user data with new user after registration", async () => {
+      // Initialize the user query with old user (simulating previously logged in user)
+      const oldUser = {
+        id: "old-user",
+        email: "old@example.com",
+        name: "Old User",
+        roles: ["admin"],
+      };
+      await initializeUserQuery(oldUser);
+
+      const newUser = {
+        id: "new-user",
+        email: "new@example.com",
+        name: "New User",
+        roles: ["user"],
+      };
+
+      mockRegister.mockResolvedValueOnce({
+        access_token: "test-token",
+        refresh_token: "test-refresh",
+        token_type: "Bearer",
+        expires_in: 900,
+      });
+      mockGetCurrentUser.mockResolvedValueOnce(newUser);
+
+      const { result } = renderHook(() => useRegister(), { wrapper });
+
+      await act(async () => {
+        await result.current.mutateAsync({
+          name: "New User",
+          email: "new@example.com",
+          password: "password123",
+        });
+      });
+
+      // Verify old user is replaced with new user
+      const cachedUser = queryClient.getQueryData(authKeys.user());
+      expect(cachedUser).toEqual(newUser);
+      expect(cachedUser).not.toEqual(oldUser);
+    });
+  });
+
+  describe("useLogout", () => {
+    it("should call logout API and remove user data from cache", async () => {
+      // Pre-populate cache with user data
+      const mockUser = {
+        id: "user-1",
+        email: "test@example.com",
+        name: "Test User",
+        roles: ["user"],
+      };
+      queryClient.setQueryData(authKeys.user(), mockUser);
+      queryClient.setQueryData(authKeys.apiKeys(), [{ id: "key-1", name: "Test Key" }]);
+
+      mockLogout.mockResolvedValueOnce();
+
+      const { result } = renderHook(() => useLogout(), { wrapper });
+
+      await act(async () => {
+        await result.current.mutateAsync();
+      });
+
+      expect(mockLogout).toHaveBeenCalled();
+
+      // Verify user data is removed from cache
+      const cachedUser = queryClient.getQueryData(authKeys.user());
+      expect(cachedUser).toBeUndefined();
+
+      // Verify API keys are also removed
+      const cachedApiKeys = queryClient.getQueryData(authKeys.apiKeys());
+      expect(cachedApiKeys).toBeUndefined();
+    });
+
+    it("should clear user cache even if user was previously set", async () => {
+      // Set initial user
+      queryClient.setQueryData(authKeys.user(), {
+        id: "user-1",
+        email: "test@example.com",
+        name: "Test User",
+        roles: ["user"],
+      });
+
+      // Verify user exists before logout
+      expect(queryClient.getQueryData(authKeys.user())).toBeDefined();
+
+      mockLogout.mockResolvedValueOnce();
+
+      const { result } = renderHook(() => useLogout(), { wrapper });
+
+      await act(async () => {
+        await result.current.mutateAsync();
+      });
+
+      // Verify user is cleared after logout
+      expect(queryClient.getQueryData(authKeys.user())).toBeUndefined();
+    });
+  });
+});

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -12,6 +12,7 @@ import {
   DropdownMenuTrigger,
   DropdownMenuPositioner,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuLabel,
@@ -106,16 +107,17 @@ export function Sidebar() {
             </DropdownMenuTrigger>
             <DropdownMenuPositioner side="top" align="start">
               <DropdownMenuContent className="w-56">
-                <DropdownMenuLabel>My Account</DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={() => router.push("/settings")}>
-                  <User className="mr-2 h-4 w-4" />
-                  Profile
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => router.push("/settings#api-keys")}>
-                  <Key className="mr-2 h-4 w-4" />
-                  API Keys
-                </DropdownMenuItem>
+                <DropdownMenuGroup>
+                  <DropdownMenuLabel>My Account</DropdownMenuLabel>
+                  <DropdownMenuItem onClick={() => router.push("/settings")}>
+                    <User className="mr-2 h-4 w-4" />
+                    Profile
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => router.push("/settings#api-keys")}>
+                    <Key className="mr-2 h-4 w-4" />
+                    API Keys
+                  </DropdownMenuItem>
+                </DropdownMenuGroup>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
                   variant="destructive"

--- a/apps/ui/src/hooks/use-auth.ts
+++ b/apps/ui/src/hooks/use-auth.ts
@@ -60,9 +60,9 @@ export function useLogin() {
 
   return useMutation({
     mutationFn: (request: LoginRequest) => login(request),
-    onSuccess: () => {
-      // Invalidate and refetch user data after login
-      queryClient.invalidateQueries({ queryKey: authKeys.user() });
+    onSuccess: async () => {
+      // Refetch user data after login and wait for it to complete
+      await queryClient.refetchQueries({ queryKey: authKeys.user() });
     },
   });
 }
@@ -75,9 +75,9 @@ export function useRegister() {
 
   return useMutation({
     mutationFn: (request: RegisterRequest) => register(request),
-    onSuccess: () => {
-      // Invalidate and refetch user data after registration
-      queryClient.invalidateQueries({ queryKey: authKeys.user() });
+    onSuccess: async () => {
+      // Refetch user data after registration and wait for it to complete
+      await queryClient.refetchQueries({ queryKey: authKeys.user() });
     },
   });
 }

--- a/apps/ui/src/lib/api/client.ts
+++ b/apps/ui/src/lib/api/client.ts
@@ -40,12 +40,18 @@ async function request<T>(
     throw new ApiError(response.status, response.statusText, errorMessage);
   }
 
-  // Handle empty responses (204 No Content)
+  // Handle empty responses (204 No Content or empty body)
   if (response.status === 204) {
     return { data: {} as T };
   }
 
-  const data = await response.json();
+  // Check if response has content before parsing JSON
+  const text = await response.text();
+  if (!text) {
+    return { data: {} as T };
+  }
+
+  const data = JSON.parse(text);
   return { data };
 }
 

--- a/crates/everruns-api/src/auth/config.rs
+++ b/crates/everruns-api/src/auth/config.rs
@@ -127,6 +127,9 @@ impl AuthConfig {
             .or_else(|_| std::env::var("BASE_URL"))
             .unwrap_or_else(|_| "http://localhost:9000".to_string());
 
+        // API prefix for constructing OAuth callback URLs
+        let api_prefix = std::env::var("API_PREFIX").unwrap_or_default();
+
         // JWT configuration
         let jwt_secret = std::env::var("AUTH_JWT_SECRET").unwrap_or_else(|_| {
             if mode == AuthMode::None {
@@ -177,8 +180,9 @@ impl AuthConfig {
             (Ok(client_id), Ok(client_secret))
                 if !client_id.is_empty() && !client_secret.is_empty() =>
             {
-                let redirect_uri = std::env::var("AUTH_GOOGLE_REDIRECT_URI")
-                    .unwrap_or_else(|_| format!("{}/v1/auth/callback/google", base_url));
+                let redirect_uri = std::env::var("AUTH_GOOGLE_REDIRECT_URI").unwrap_or_else(|_| {
+                    format!("{}{}/v1/auth/callback/google", base_url, api_prefix)
+                });
                 let allowed_domains = std::env::var("AUTH_GOOGLE_ALLOWED_DOMAINS")
                     .ok()
                     .map(|s| s.split(',').map(|s| s.trim().to_string()).collect());
@@ -202,8 +206,9 @@ impl AuthConfig {
             (Ok(client_id), Ok(client_secret))
                 if !client_id.is_empty() && !client_secret.is_empty() =>
             {
-                let redirect_uri = std::env::var("AUTH_GITHUB_REDIRECT_URI")
-                    .unwrap_or_else(|_| format!("{}/v1/auth/callback/github", base_url));
+                let redirect_uri = std::env::var("AUTH_GITHUB_REDIRECT_URI").unwrap_or_else(|_| {
+                    format!("{}{}/v1/auth/callback/github", base_url, api_prefix)
+                });
                 Some(GitHubOAuthConfig {
                     base: OAuthProviderConfig {
                         client_id,

--- a/docs/sre/environment-variables.md
+++ b/docs/sre/environment-variables.md
@@ -18,6 +18,8 @@ API_PREFIX=/api
 
 **Notes:**
 - `/health`, `/swagger-ui`, and `/api-doc/openapi.json` are not affected by this prefix
+- All API routes including auth (`/v1/auth/*`) are affected by this prefix
+- OAuth callback URLs automatically include this prefix when using defaults
 - Use when running behind a reverse proxy or API gateway that expects a path prefix
 
 ## CORS_ALLOWED_ORIGINS

--- a/docs/sre/runbooks/authentication.md
+++ b/docs/sre/runbooks/authentication.md
@@ -168,7 +168,8 @@ DELETE FROM refresh_tokens WHERE user_id = 'user-uuid-here';
 ### OAuth Redirect Fails
 
 - Verify `AUTH_BASE_URL` matches the OAuth app configuration
-- Check that redirect URI in provider matches `{AUTH_BASE_URL}/v1/auth/callback/{provider}`
+- Check that redirect URI in provider matches `{AUTH_BASE_URL}{API_PREFIX}/v1/auth/callback/{provider}`
+- If using `API_PREFIX`, ensure it's included in OAuth provider redirect URI configuration
 - Ensure client ID and secret are correct
 
 ### Password Login Returns Unauthorized

--- a/specs/authentication.md
+++ b/specs/authentication.md
@@ -77,11 +77,11 @@ Account linking by email is supported (same email = same account).
 | `AUTH_DISABLE_SIGNUP` | Disable user registration | `false` |
 | `AUTH_GOOGLE_CLIENT_ID` | Google OAuth client ID | - |
 | `AUTH_GOOGLE_CLIENT_SECRET` | Google OAuth client secret | - |
-| `AUTH_GOOGLE_REDIRECT_URI` | Google OAuth redirect URI | `{base_url}/v1/auth/callback/google` |
+| `AUTH_GOOGLE_REDIRECT_URI` | Google OAuth redirect URI | `{base_url}{api_prefix}/v1/auth/callback/google` |
 | `AUTH_GOOGLE_ALLOWED_DOMAINS` | Comma-separated allowed email domains | - |
 | `AUTH_GITHUB_CLIENT_ID` | GitHub OAuth client ID | - |
 | `AUTH_GITHUB_CLIENT_SECRET` | GitHub OAuth client secret | - |
-| `AUTH_GITHUB_REDIRECT_URI` | GitHub OAuth redirect URI | `{base_url}/v1/auth/callback/github` |
+| `AUTH_GITHUB_REDIRECT_URI` | GitHub OAuth redirect URI | `{base_url}{api_prefix}/v1/auth/callback/github` |
 | `CORS_ALLOWED_ORIGINS` | Comma-separated allowed CORS origins (only if cross-origin) | Not set |
 
 ### Database Schema

--- a/test_cases/admin_login/TC003_signout.md
+++ b/test_cases/admin_login/TC003_signout.md
@@ -1,0 +1,36 @@
+# TC003: Admin Login - Sign-out
+
+## Description
+
+Verify that an admin user can successfully sign out after logging in when AUTH_MODE is set to admin.
+
+## Preconditions
+
+- `AUTH_MODE=admin`
+- `AUTH_ADMIN_EMAIL=test-admin-1@example.com`
+- `AUTH_ADMIN_PASSWORD=1-admin-test`
+
+## Test Data
+
+| Field    | Value                      |
+|----------|----------------------------|
+| Email    | test-admin-1@example.com   |
+| Password | 1-admin-test               |
+
+## Steps
+
+1. Navigate to the login page
+2. Enter email: `test-admin-1@example.com`
+3. Enter password: `1-admin-test`
+4. Click the login button
+5. Verify user is logged in and on the dashboard
+6. Click on the user avatar/menu in the sidebar
+7. Click the "Sign out" button
+
+## Expected Result
+
+- User is successfully signed out
+- User session is terminated
+- User is redirected to the login page
+- Attempting to access protected pages redirects to login
+- User avatar/menu is no longer visible in the sidebar

--- a/test_cases/full_auth/TC001_user_signup.md
+++ b/test_cases/full_auth/TC001_user_signup.md
@@ -1,0 +1,37 @@
+# TC001: Full Auth - User Sign-up
+
+## Description
+
+Verify that a new user can successfully sign up when AUTH_MODE is set to full and signup is enabled.
+
+## Preconditions
+
+- `AUTH_MODE=full`
+- `AUTH_JWT_SECRET=MJ5SiIlm9mTmiVJV8O2NLrxnuEZDFuO/iXkjVXGqWD0=`
+- `AUTH_DISABLE_SIGNUP=false`
+- `AUTH_DISABLE_PASSWORD=false`
+
+## Test Data
+
+| Field    | Value                    |
+|----------|--------------------------|
+| Name     | Test User                |
+| Email    | testuser@example.com     |
+| Password | TestPassword123!         |
+
+## Steps
+
+1. Navigate to the login page
+2. Click the "Sign up" or "Create account" link
+3. Enter name: `Test User`
+4. Enter email: `testuser@example.com`
+5. Enter password: `TestPassword123!`
+6. Click the "Create account" button
+
+## Expected Result
+
+- Account is created successfully
+- User is automatically logged in after signup
+- User is redirected to the dashboard/main application
+- User session is established with the new account
+- User profile shows the correct name and email

--- a/test_cases/full_auth/TC002_signout_after_signin.md
+++ b/test_cases/full_auth/TC002_signout_after_signin.md
@@ -1,0 +1,38 @@
+# TC002: Full Auth - Sign-out After Sign-in
+
+## Description
+
+Verify that a user can successfully sign out after signing in when AUTH_MODE is set to full.
+
+## Preconditions
+
+- `AUTH_MODE=full`
+- `AUTH_JWT_SECRET=MJ5SiIlm9mTmiVJV8O2NLrxnuEZDFuO/iXkjVXGqWD0=`
+- `AUTH_DISABLE_SIGNUP=false`
+- `AUTH_DISABLE_PASSWORD=false`
+- A user account exists (created via TC001 or pre-existing)
+
+## Test Data
+
+| Field    | Value                    |
+|----------|--------------------------|
+| Email    | testuser@example.com     |
+| Password | TestPassword123!         |
+
+## Steps
+
+1. Navigate to the login page
+2. Enter email: `testuser@example.com`
+3. Enter password: `TestPassword123!`
+4. Click the login button
+5. Verify user is logged in and on the dashboard
+6. Click on the user avatar/menu in the sidebar
+7. Click the "Sign out" button
+
+## Expected Result
+
+- User is successfully signed out
+- User session is terminated
+- User is redirected to the login page
+- Attempting to access protected pages redirects to login
+- User avatar/menu is no longer visible in the sidebar

--- a/test_cases/full_auth/TC003_login_signout_flow.md
+++ b/test_cases/full_auth/TC003_login_signout_flow.md
@@ -1,0 +1,44 @@
+# TC003: Full Auth - Login with Signed Up User, Sign-out
+
+## Description
+
+Verify the complete flow of logging in with a previously signed up user and then signing out.
+
+## Preconditions
+
+- `AUTH_MODE=full`
+- `AUTH_JWT_SECRET=MJ5SiIlm9mTmiVJV8O2NLrxnuEZDFuO/iXkjVXGqWD0=`
+- `AUTH_DISABLE_SIGNUP=false`
+- `AUTH_DISABLE_PASSWORD=false`
+- User has previously signed up (TC001 completed)
+
+## Test Data
+
+| Field    | Value                    |
+|----------|--------------------------|
+| Email    | testuser@example.com     |
+| Password | TestPassword123!         |
+
+## Steps
+
+1. Navigate to the login page (ensure not already logged in)
+2. Enter email: `testuser@example.com`
+3. Enter password: `TestPassword123!`
+4. Click the login button
+5. Verify successful login:
+   - User is redirected to dashboard
+   - User name and email are displayed in sidebar
+6. Navigate to different pages (Dashboard, Agents, Capabilities)
+7. Return to Dashboard
+8. Click on the user avatar/menu in the sidebar
+9. Click the "Sign out" button
+10. Verify successful sign-out:
+    - User is redirected to login page
+    - Session is cleared
+
+## Expected Result
+
+- Login succeeds with the signed up user credentials
+- User can navigate freely within the application while logged in
+- Sign-out succeeds and terminates the session
+- After sign-out, user cannot access protected pages without re-authenticating

--- a/test_cases/full_auth/TC004_failed_login_random_user.md
+++ b/test_cases/full_auth/TC004_failed_login_random_user.md
@@ -1,0 +1,34 @@
+# TC004: Full Auth - Failed Login with Random User
+
+## Description
+
+Verify that login fails when attempting to log in with credentials for a non-existent user in full authentication mode.
+
+## Preconditions
+
+- `AUTH_MODE=full`
+- `AUTH_JWT_SECRET=MJ5SiIlm9mTmiVJV8O2NLrxnuEZDFuO/iXkjVXGqWD0=`
+- `AUTH_DISABLE_SIGNUP=false`
+- `AUTH_DISABLE_PASSWORD=false`
+
+## Test Data
+
+| Field    | Value                       |
+|----------|-----------------------------|
+| Email    | randomuser123@example.com   |
+| Password | RandomPassword456!          |
+
+## Steps
+
+1. Navigate to the login page
+2. Enter email: `randomuser123@example.com`
+3. Enter password: `RandomPassword456!`
+4. Click the login button
+
+## Expected Result
+
+- Login fails
+- User is not authenticated
+- An appropriate error message is displayed (e.g., "Invalid credentials")
+- User remains on the login page
+- No session is established


### PR DESCRIPTION
## Summary

- Add full authentication mode configuration example to `.env.example`
- Fix auth routes to respect `API_PREFIX` for reverse proxy deployments
- Fix OAuth callback URL defaults to include `API_PREFIX`
- Fix UI bugs: DropdownMenuLabel context error, logout empty response handling, login/register cache synchronization
- Add comprehensive unit tests for auth hooks
- Add manual test cases for full authentication mode

## Changes

### Backend
- Auth routes now correctly included in `api_routes` (affected by `API_PREFIX`)
- OAuth callback URL defaults now include `API_PREFIX` when set

### Frontend
- Fixed `DropdownMenuLabel` used outside `DropdownMenuGroup` context in sidebar
- Fixed API client to handle empty response bodies (logout endpoint)
- Changed `invalidateQueries` to `refetchQueries` with async/await in login/register hooks to ensure user data is fetched before navigation

### Tests
- Added 8 unit tests for `useLogin`, `useRegister`, `useLogout` hooks
- Updated sidebar tests for current navigation structure (4 items)
- Added manual test cases for full auth mode:
  - `test_cases/full_auth/TC001_user_signup.md`
  - `test_cases/full_auth/TC002_signout_after_signin.md`
  - `test_cases/full_auth/TC003_login_signout_flow.md`
  - `test_cases/full_auth/TC004_failed_login_random_user.md`
- Added `test_cases/admin_login/TC003_signout.md`

### Documentation
- Updated `docs/sre/environment-variables.md` with API_PREFIX notes
- Updated `docs/sre/runbooks/authentication.md` with OAuth troubleshooting
- Updated `specs/authentication.md` with redirect URI defaults

## Risk
- Low
- Changes are additive and fix existing bugs

## Test plan
- [x] All Rust tests pass (`cargo test`)
- [x] UI tests pass (`npm test` in apps/ui)
- [x] Manual testing of login/logout/signup flows
- [ ] Run smoke tests with `AUTH_MODE=full`

🤖 Generated with [Claude Code](https://claude.com/claude-code)