### PR TITLE
feat(worker): add tool call support for Temporal workflows

### DIFF
--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/page.tsx
@@ -111,6 +111,18 @@ export default function SessionDetailPage({
     return null;
   };
 
+  // Check if assistant message has embedded tool_calls (for LLM context only, not UI display)
+  const hasEmbeddedToolCalls = (message: Message): boolean => {
+    if (message.role !== "assistant") return false;
+    if (typeof message.content === "object" && message.content !== null) {
+      const content = message.content as Record<string, unknown>;
+      if (Array.isArray(content.tool_calls) && content.tool_calls.length > 0) {
+        return true;
+      }
+    }
+    return false;
+  };
+
   if (sessionLoading) {
     return (
       <div className="container mx-auto p-6">
@@ -193,6 +205,12 @@ export default function SessionDetailPage({
 
             // Skip tool_result messages - they're rendered with their tool_call
             if (isToolResult) {
+              return null;
+            }
+
+            // Skip assistant messages with embedded tool_calls - they're for LLM context only
+            // The actual tool calls are rendered as separate ToolCallCard components
+            if (hasEmbeddedToolCalls(message)) {
               return null;
             }
 

--- a/crates/everruns-worker/src/main.rs
+++ b/crates/everruns-worker/src/main.rs
@@ -5,11 +5,15 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Initialize logging with LOG_LEVEL env var (default: debug)
+    // Supports: trace, debug, info, warn, error
+    // Can also use RUST_LOG for more fine-grained control
+    let log_level = std::env::var("LOG_LEVEL").unwrap_or_else(|_| "debug".to_string());
+    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| format!("everruns_worker={}", log_level).into());
+
     tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "everruns_worker=debug".into()),
-        )
+        .with(env_filter)
         .with(tracing_subscriber::fmt::layer())
         .init();
 


### PR DESCRIPTION
## Summary

- Add full tool call/result support to Temporal workflows with capabilities integration
- Fix race conditions in workflow state machine for parallel activity completions
- Save proper message structure for UI tool call display (ToolCallCard component)
- Add comprehensive debug logging for troubleshooting

## Changes

### Temporal Worker (`crates/everruns-worker`)
- **activities.rs**: Load agent capabilities, apply them to LLM calls to get tools
- **types.rs**: Add `tool_calls`, `tool_call_id` to MessageData; add `capability_ids` to activity inputs/outputs
- **workflows.rs**: 
  - Save `tool_call` messages (for UI) alongside assistant messages with embedded tool_calls (for LLM context)
  - Save `tool_result` messages with proper `tool_call_id` linking
  - Handle race conditions: ignore save message completions in CallingLlm/ExecutingTools states
  - Fix database constraint: use `"tool_result"` role instead of `"tool"`
- **worker.rs**: Improved activity result logging
- **main.rs**: Add `LOG_LEVEL` environment variable support

### UI (`apps/ui`)
- **page.tsx**: Skip rendering assistant messages with embedded `tool_calls` (they're for LLM context only; tool calls shown via ToolCallCard)

## Test plan
- [x] All 50 Rust tests pass (`cargo test`)
- [x] ESLint passes for UI
- [ ] Manual test: Create agent with `current_time` capability, send message asking for time, verify tool call shows in UI

## Risk
- **Medium** - Changes workflow state machine logic and message persistence format
- Backward compatible: old messages without tool fields still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)