### PR TITLE
Improve Agent edit and capabilities UX

### DIFF
--- a/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
@@ -6,12 +6,13 @@ import Link from "next/link";
 import {
   useAgent,
   useUpdateAgent,
+  useDeleteAgent,
   useCapabilities,
   useAgentCapabilities,
   useSetAgentCapabilities,
 } from "@/hooks";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -22,6 +23,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import {
   ArrowLeft,
   Save,
+  Trash2,
   CircleOff,
   Clock,
   Search,
@@ -59,6 +61,7 @@ export default function EditAgentPage({
   // Agent data
   const { data: agent, isLoading: agentLoading } = useAgent(agentId);
   const updateAgent = useUpdateAgent();
+  const deleteAgent = useDeleteAgent();
 
   // Capabilities data
   const { data: allCapabilities, isLoading: capabilitiesLoading } =
@@ -198,6 +201,20 @@ export default function EditAgentPage({
     }
   };
 
+  // Delete handler
+  const handleDelete = async () => {
+    if (!confirm("Are you sure you want to delete this agent? This action cannot be undone.")) {
+      return;
+    }
+
+    try {
+      await deleteAgent.mutateAsync(agentId);
+      router.push("/agents");
+    } catch (error) {
+      console.error("Failed to delete agent:", error);
+    }
+  };
+
   const isLoading =
     agentLoading || capabilitiesLoading || agentCapabilitiesLoading;
   const isSaving = updateAgent.isPending || setCapabilities.isPending;
@@ -307,6 +324,35 @@ export default function EditAgentPage({
                   <p className="text-xs text-muted-foreground">
                     Instructions for the AI model (supports Markdown)
                   </p>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Danger Zone */}
+            <Card className="border-destructive/50">
+              <CardHeader>
+                <CardTitle className="text-destructive">Danger Zone</CardTitle>
+                <CardDescription>
+                  Irreversible actions that affect this agent
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="font-medium">Delete this agent</p>
+                    <p className="text-sm text-muted-foreground">
+                      Once deleted, this agent and all its sessions will be permanently removed.
+                    </p>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    onClick={handleDelete}
+                    disabled={deleteAgent.isPending}
+                  >
+                    <Trash2 className="w-4 h-4 mr-2" />
+                    {deleteAgent.isPending ? "Deleting..." : "Delete Agent"}
+                  </Button>
                 </div>
               </CardContent>
             </Card>

--- a/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
@@ -1,0 +1,481 @@
+"use client";
+
+import { use, useState, useMemo, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import {
+  useAgent,
+  useUpdateAgent,
+  useCapabilities,
+  useAgentCapabilities,
+  useSetAgentCapabilities,
+} from "@/hooks";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { PromptEditor } from "@/components/ui/prompt-editor";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  ArrowLeft,
+  Save,
+  CircleOff,
+  Clock,
+  Search,
+  Box,
+  Folder,
+  ChevronUp,
+  ChevronDown,
+  LucideIcon,
+} from "lucide-react";
+import type { Capability, CapabilityId } from "@/lib/api/types";
+
+const iconMap: Record<string, LucideIcon> = {
+  "circle-off": CircleOff,
+  clock: Clock,
+  search: Search,
+  box: Box,
+  folder: Folder,
+};
+
+interface FormData {
+  name: string;
+  description: string;
+  system_prompt: string;
+  tags: string;
+}
+
+export default function EditAgentPage({
+  params,
+}: {
+  params: Promise<{ agentId: string }>;
+}) {
+  const { agentId } = use(params);
+  const router = useRouter();
+
+  // Agent data
+  const { data: agent, isLoading: agentLoading } = useAgent(agentId);
+  const updateAgent = useUpdateAgent();
+
+  // Capabilities data
+  const { data: allCapabilities, isLoading: capabilitiesLoading } =
+    useCapabilities();
+  const { data: agentCapabilities, isLoading: agentCapabilitiesLoading } =
+    useAgentCapabilities(agentId);
+  const setCapabilities = useSetAgentCapabilities();
+
+  // Form state - track user changes separately from initial values
+  const [formChanges, setFormChanges] = useState<Partial<FormData>>({});
+
+  // Compute initial values from agent data
+  const initialFormData = useMemo((): FormData => {
+    if (!agent) {
+      return { name: "", description: "", system_prompt: "", tags: "" };
+    }
+    return {
+      name: agent.name,
+      description: agent.description || "",
+      system_prompt: agent.system_prompt,
+      tags: agent.tags.join(", "),
+    };
+  }, [agent]);
+
+  // Merge initial values with user changes
+  const formData = useMemo(
+    () => ({ ...initialFormData, ...formChanges }),
+    [initialFormData, formChanges]
+  );
+
+  const handleFormChange = useCallback(
+    (field: keyof FormData, value: string) => {
+      setFormChanges((prev) => ({ ...prev, [field]: value }));
+    },
+    []
+  );
+
+  // Capabilities state
+  const initialCapabilities = useMemo(() => {
+    if (!agentCapabilities) return [];
+    return agentCapabilities
+      .sort((a, b) => a.position - b.position)
+      .map((ac) => ac.capability_id);
+  }, [agentCapabilities]);
+
+  const [localCapabilities, setLocalCapabilities] = useState<
+    CapabilityId[] | null
+  >(null);
+  const selectedCapabilities = localCapabilities ?? initialCapabilities;
+
+  // Capabilities handlers
+  const handleToggle = useCallback(
+    (capabilityId: CapabilityId, checked: boolean) => {
+      const current = localCapabilities ?? initialCapabilities;
+      let newSelected: CapabilityId[];
+      if (checked) {
+        newSelected = [...current, capabilityId];
+      } else {
+        newSelected = current.filter((id) => id !== capabilityId);
+      }
+      setLocalCapabilities(newSelected);
+    },
+    [localCapabilities, initialCapabilities]
+  );
+
+  const moveUp = useCallback(
+    (index: number) => {
+      if (index === 0) return;
+      const current = localCapabilities ?? initialCapabilities;
+      const newSelected = [...current];
+      [newSelected[index - 1], newSelected[index]] = [
+        newSelected[index],
+        newSelected[index - 1],
+      ];
+      setLocalCapabilities(newSelected);
+    },
+    [localCapabilities, initialCapabilities]
+  );
+
+  const moveDown = useCallback(
+    (index: number) => {
+      const current = localCapabilities ?? initialCapabilities;
+      if (index === current.length - 1) return;
+      const newSelected = [...current];
+      [newSelected[index], newSelected[index + 1]] = [
+        newSelected[index + 1],
+        newSelected[index],
+      ];
+      setLocalCapabilities(newSelected);
+    },
+    [localCapabilities, initialCapabilities]
+  );
+
+  const getCapabilityInfo = useCallback(
+    (id: CapabilityId): Capability | undefined =>
+      allCapabilities?.find((c) => c.id === id),
+    [allCapabilities]
+  );
+
+  // Submit handler
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    try {
+      // Parse tags
+      const tags = formData.tags
+        .split(",")
+        .map((t) => t.trim())
+        .filter((t) => t.length > 0);
+
+      // Update agent
+      await updateAgent.mutateAsync({
+        agentId,
+        request: {
+          name: formData.name,
+          description: formData.description || undefined,
+          system_prompt: formData.system_prompt,
+          tags,
+        },
+      });
+
+      // Update capabilities if changed
+      const capabilitiesToSave = localCapabilities ?? initialCapabilities;
+      if (
+        JSON.stringify(capabilitiesToSave) !==
+        JSON.stringify(initialCapabilities)
+      ) {
+        await setCapabilities.mutateAsync({
+          agentId,
+          request: { capabilities: capabilitiesToSave },
+        });
+      }
+
+      router.push(`/agents/${agentId}`);
+    } catch (error) {
+      console.error("Failed to update agent:", error);
+    }
+  };
+
+  const isLoading =
+    agentLoading || capabilitiesLoading || agentCapabilitiesLoading;
+  const isSaving = updateAgent.isPending || setCapabilities.isPending;
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto p-6 max-w-4xl">
+        <Skeleton className="h-8 w-1/4 mb-6" />
+        <div className="grid gap-6 lg:grid-cols-3">
+          <div className="lg:col-span-2">
+            <Skeleton className="h-[500px] w-full" />
+          </div>
+          <div>
+            <Skeleton className="h-[300px] w-full" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!agent) {
+    return (
+      <div className="container mx-auto p-6">
+        <div className="text-red-500">Agent not found</div>
+        <Link href="/agents" className="text-blue-500 hover:underline">
+          Back to agents
+        </Link>
+      </div>
+    );
+  }
+
+  // Filter capabilities
+  const availableCapabilities =
+    allCapabilities?.filter((c) => c.status === "available") || [];
+  const comingSoonCapabilities =
+    allCapabilities?.filter((c) => c.status === "coming_soon") || [];
+
+  return (
+    <div className="container mx-auto p-6 max-w-4xl">
+      <Link
+        href={`/agents/${agentId}`}
+        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-6"
+      >
+        <ArrowLeft className="w-4 h-4 mr-2" />
+        Back to Agent
+      </Link>
+
+      <h1 className="text-2xl font-bold mb-6">Edit Agent</h1>
+
+      <form onSubmit={handleSubmit}>
+        <div className="grid gap-6 lg:grid-cols-3">
+          {/* Main form */}
+          <div className="lg:col-span-2 space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Agent Details</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <div className="space-y-2">
+                  <Label htmlFor="name">Name</Label>
+                  <Input
+                    id="name"
+                    placeholder="My Agent"
+                    value={formData.name}
+                    onChange={(e) => handleFormChange("name", e.target.value)}
+                    required
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="description">Description</Label>
+                  <Textarea
+                    id="description"
+                    placeholder="Describe what this agent does..."
+                    value={formData.description}
+                    onChange={(e) =>
+                      handleFormChange("description", e.target.value)
+                    }
+                    rows={2}
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="tags">Tags</Label>
+                  <Input
+                    id="tags"
+                    placeholder="tag1, tag2, tag3"
+                    value={formData.tags}
+                    onChange={(e) => handleFormChange("tags", e.target.value)}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Comma-separated list of tags
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="system_prompt">System Prompt</Label>
+                  <PromptEditor
+                    id="system_prompt"
+                    placeholder="You are a helpful assistant..."
+                    value={formData.system_prompt}
+                    onChange={(value) =>
+                      handleFormChange("system_prompt", value)
+                    }
+                    required
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Instructions for the AI model (supports Markdown)
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Capabilities sidebar */}
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Capabilities</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {/* Selected capabilities with reordering */}
+                {selectedCapabilities.length > 0 && (
+                  <div className="space-y-2">
+                    <p className="text-sm font-medium text-muted-foreground">
+                      Enabled ({selectedCapabilities.length})
+                    </p>
+                    {selectedCapabilities.map((capId, index) => {
+                      const cap = getCapabilityInfo(capId);
+                      if (!cap) return null;
+                      const IconComponent = cap.icon
+                        ? iconMap[cap.icon] || CircleOff
+                        : CircleOff;
+
+                      return (
+                        <div
+                          key={capId}
+                          className="flex items-center gap-2 p-2 rounded-md border bg-muted/50"
+                        >
+                          <div className="flex flex-col gap-0.5">
+                            <button
+                              type="button"
+                              onClick={() => moveUp(index)}
+                              disabled={index === 0}
+                              className="text-muted-foreground hover:text-foreground disabled:opacity-30 p-0.5"
+                              aria-label="Move up"
+                            >
+                              <ChevronUp className="w-3 h-3" />
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => moveDown(index)}
+                              disabled={index === selectedCapabilities.length - 1}
+                              className="text-muted-foreground hover:text-foreground disabled:opacity-30 p-0.5"
+                              aria-label="Move down"
+                            >
+                              <ChevronDown className="w-3 h-3" />
+                            </button>
+                          </div>
+                          <span className="text-xs text-muted-foreground w-4">
+                            {index + 1}
+                          </span>
+                          <IconComponent className="w-4 h-4" />
+                          <span className="flex-1 text-sm">{cap.name}</span>
+                          <Checkbox
+                            checked={true}
+                            onCheckedChange={(checked) =>
+                              handleToggle(capId, checked as boolean)
+                            }
+                          />
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+
+                {/* Available capabilities not yet selected */}
+                {availableCapabilities.filter(
+                  (c) => !selectedCapabilities.includes(c.id)
+                ).length > 0 && (
+                  <div className="space-y-2">
+                    <p className="text-sm font-medium text-muted-foreground">
+                      Available
+                    </p>
+                    {availableCapabilities
+                      .filter((c) => !selectedCapabilities.includes(c.id))
+                      .map((cap) => {
+                        const IconComponent = cap.icon
+                          ? iconMap[cap.icon] || CircleOff
+                          : CircleOff;
+
+                        return (
+                          <div
+                            key={cap.id}
+                            className="flex items-center gap-2 p-2 rounded-md border hover:bg-muted/50"
+                          >
+                            <IconComponent className="w-4 h-4" />
+                            <div className="flex-1">
+                              <p className="text-sm">{cap.name}</p>
+                              <p className="text-xs text-muted-foreground">
+                                {cap.description}
+                              </p>
+                            </div>
+                            <Checkbox
+                              checked={false}
+                              onCheckedChange={(checked) =>
+                                handleToggle(cap.id, checked as boolean)
+                              }
+                            />
+                          </div>
+                        );
+                      })}
+                  </div>
+                )}
+
+                {/* Coming soon capabilities */}
+                {comingSoonCapabilities.length > 0 && (
+                  <div className="space-y-2">
+                    <p className="text-sm font-medium text-muted-foreground">
+                      Coming Soon
+                    </p>
+                    {comingSoonCapabilities.map((cap) => {
+                      const IconComponent = cap.icon
+                        ? iconMap[cap.icon] || CircleOff
+                        : CircleOff;
+
+                      return (
+                        <div
+                          key={cap.id}
+                          className="flex items-center gap-2 p-2 rounded-md border opacity-60"
+                        >
+                          <IconComponent className="w-4 h-4" />
+                          <div className="flex-1">
+                            <p className="text-sm">{cap.name}</p>
+                            <p className="text-xs text-muted-foreground">
+                              {cap.description}
+                            </p>
+                          </div>
+                          <Badge variant="secondary">Coming Soon</Badge>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+
+                {selectedCapabilities.length === 0 &&
+                  availableCapabilities.length === 0 && (
+                    <p className="text-center py-4 text-muted-foreground">
+                      No capabilities available
+                    </p>
+                  )}
+              </CardContent>
+            </Card>
+
+            {/* Save button */}
+            <div className="flex gap-4">
+              <Button type="submit" disabled={isSaving} className="flex-1">
+                <Save className="w-4 h-4 mr-2" />
+                {isSaving ? "Saving..." : "Save Changes"}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => router.back()}
+              >
+                Cancel
+              </Button>
+            </div>
+
+            {(updateAgent.error || setCapabilities.error) && (
+              <p className="text-sm text-destructive">
+                Error:{" "}
+                {updateAgent.error?.message || setCapabilities.error?.message}
+              </p>
+            )}
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { use } from "react";
-import { useAgent, useSessions, useCreateSession } from "@/hooks";
+import { useAgent, useSessions, useCreateSession, useAgentCapabilities, useCapabilities } from "@/hooks";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
@@ -9,8 +9,27 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { MarkdownDisplay } from "@/components/ui/prompt-editor";
-import { CapabilitySelector } from "@/components/capabilities";
-import { ArrowLeft, Plus, MessageSquare, Pencil } from "lucide-react";
+import {
+  ArrowLeft,
+  Plus,
+  MessageSquare,
+  Pencil,
+  CircleOff,
+  Clock,
+  Search,
+  Box,
+  Folder,
+  LucideIcon,
+} from "lucide-react";
+import type { Capability } from "@/lib/api/types";
+
+const iconMap: Record<string, LucideIcon> = {
+  "circle-off": CircleOff,
+  clock: Clock,
+  search: Search,
+  box: Box,
+  folder: Folder,
+};
 
 export default function AgentDetailPage({
   params,
@@ -21,6 +40,8 @@ export default function AgentDetailPage({
   const router = useRouter();
   const { data: agent, isLoading: agentLoading } = useAgent(agentId);
   const { data: sessions, isLoading: sessionsLoading } = useSessions(agentId);
+  const { data: agentCapabilities, isLoading: capabilitiesLoading } = useAgentCapabilities(agentId);
+  const { data: allCapabilities } = useCapabilities();
   const createSession = useCreateSession();
 
   const handleNewSession = async () => {
@@ -34,6 +55,13 @@ export default function AgentDetailPage({
       console.error("Failed to create session:", error);
     }
   };
+
+  const getCapabilityInfo = (capabilityId: string): Capability | undefined =>
+    allCapabilities?.find((c) => c.id === capabilityId);
+
+  const sortedCapabilities = agentCapabilities
+    ? [...agentCapabilities].sort((a, b) => a.position - b.position)
+    : [];
 
   if (agentLoading) {
     return (
@@ -150,7 +178,51 @@ export default function AgentDetailPage({
         </div>
 
         <div className="space-y-6">
-          <CapabilitySelector agentId={agentId} />
+          <Card>
+            <CardHeader>
+              <CardTitle>Capabilities</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {capabilitiesLoading ? (
+                <div className="space-y-2">
+                  <Skeleton className="h-8 w-full" />
+                  <Skeleton className="h-8 w-full" />
+                </div>
+              ) : sortedCapabilities.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No capabilities enabled.{" "}
+                  <Link href={`/agents/${agentId}/edit`} className="text-primary hover:underline">
+                    Add some
+                  </Link>
+                </p>
+              ) : (
+                <div className="space-y-2">
+                  {sortedCapabilities.map((ac) => {
+                    const cap = getCapabilityInfo(ac.capability_id);
+                    if (!cap) return null;
+                    const IconComponent = cap.icon
+                      ? iconMap[cap.icon] || CircleOff
+                      : CircleOff;
+
+                    return (
+                      <div
+                        key={ac.capability_id}
+                        className="flex items-center gap-2 p-2 rounded-md border bg-muted/50"
+                      >
+                        <IconComponent className="w-4 h-4" />
+                        <div className="flex-1">
+                          <p className="text-sm font-medium">{cap.name}</p>
+                          <p className="text-xs text-muted-foreground">
+                            {cap.description}
+                          </p>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </CardContent>
+          </Card>
 
           <Card>
             <CardHeader>

--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -10,7 +10,7 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { MarkdownDisplay } from "@/components/ui/prompt-editor";
 import { CapabilitySelector } from "@/components/capabilities";
-import { ArrowLeft, Plus, MessageSquare } from "lucide-react";
+import { ArrowLeft, Plus, MessageSquare, Pencil } from "lucide-react";
 
 export default function AgentDetailPage({
   params,
@@ -80,10 +80,18 @@ export default function AgentDetailPage({
             ID: {agent.id.slice(0, 8)}...
           </p>
         </div>
-        <Button onClick={handleNewSession} disabled={createSession.isPending}>
-          <Plus className="w-4 h-4 mr-2" />
-          {createSession.isPending ? "Creating..." : "New Session"}
-        </Button>
+        <div className="flex gap-2">
+          <Link href={`/agents/${agentId}/edit`}>
+            <Button variant="outline">
+              <Pencil className="w-4 h-4 mr-2" />
+              Edit
+            </Button>
+          </Link>
+          <Button onClick={handleNewSession} disabled={createSession.isPending}>
+            <Plus className="w-4 h-4 mr-2" />
+            {createSession.isPending ? "Creating..." : "New Session"}
+          </Button>
+        </div>
       </div>
 
       <div className="grid gap-6 lg:grid-cols-3">

--- a/apps/ui/src/app/(main)/agents/page.tsx
+++ b/apps/ui/src/app/(main)/agents/page.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-import {
-  useAgents,
-  useDeleteAgent,
-  useCapabilities,
-} from "@/hooks";
+import { useAgents, useCapabilities } from "@/hooks";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
@@ -16,17 +12,10 @@ import { useAgentCapabilitiesBulk } from "@/hooks/use-agent-capabilities-bulk";
 export default function AgentsPage() {
   const { data: agents, isLoading, error } = useAgents();
   const { data: allCapabilities } = useCapabilities();
-  const deleteAgent = useDeleteAgent();
 
   // Get agent IDs for bulk capabilities fetch
   const agentIds = agents?.map((a) => a.id) || [];
   const { data: agentCapabilitiesMap } = useAgentCapabilitiesBulk(agentIds);
-
-  const handleDelete = async (agentId: string) => {
-    if (confirm("Are you sure you want to archive this agent?")) {
-      await deleteAgent.mutateAsync(agentId);
-    }
-  };
 
   if (error) {
     return (
@@ -82,8 +71,6 @@ export default function AgentsPage() {
               agent={agent}
               capabilities={agentCapabilitiesMap?.[agent.id]}
               allCapabilities={allCapabilities}
-              onDelete={handleDelete}
-              isDeleting={deleteAgent.isPending}
               showEditButton
             />
           ))}

--- a/apps/ui/src/app/(main)/agents/page.tsx
+++ b/apps/ui/src/app/(main)/agents/page.tsx
@@ -1,16 +1,26 @@
 "use client";
 
-import { useAgents, useDeleteAgent } from "@/hooks";
+import {
+  useAgents,
+  useDeleteAgent,
+  useCapabilities,
+} from "@/hooks";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Plus, Trash2 } from "lucide-react";
+import { Plus } from "lucide-react";
+import { AgentCard } from "@/components/agents";
+import { useAgentCapabilitiesBulk } from "@/hooks/use-agent-capabilities-bulk";
 
 export default function AgentsPage() {
   const { data: agents, isLoading, error } = useAgents();
+  const { data: allCapabilities } = useCapabilities();
   const deleteAgent = useDeleteAgent();
+
+  // Get agent IDs for bulk capabilities fetch
+  const agentIds = agents?.map((a) => a.id) || [];
+  const { data: agentCapabilitiesMap } = useAgentCapabilitiesBulk(agentIds);
 
   const handleDelete = async (agentId: string) => {
     if (confirm("Are you sure you want to archive this agent?")) {
@@ -67,54 +77,15 @@ export default function AgentsPage() {
       ) : (
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           {agents?.map((agent) => (
-            <Card key={agent.id} className="hover:shadow-md transition-shadow">
-              <CardHeader className="flex flex-row items-start justify-between space-y-0">
-                <div>
-                  <CardTitle className="text-lg">
-                    <Link
-                      href={`/agents/${agent.id}`}
-                      className="hover:underline"
-                    >
-                      {agent.name}
-                    </Link>
-                  </CardTitle>
-                  <p className="text-sm text-muted-foreground font-mono">
-                    {agent.id.slice(0, 8)}...
-                  </p>
-                </div>
-                <Badge variant={agent.status === "active" ? "default" : "secondary"}>
-                  {agent.status}
-                </Badge>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm text-muted-foreground mb-4 line-clamp-2">
-                  {agent.description || "No description"}
-                </p>
-                {agent.tags.length > 0 && (
-                  <div className="flex flex-wrap gap-1 mb-4">
-                    {agent.tags.map((tag) => (
-                      <Badge key={tag} variant="outline" className="text-xs">
-                        {tag}
-                      </Badge>
-                    ))}
-                  </div>
-                )}
-                <div className="flex items-center justify-between">
-                  <span className="text-xs text-muted-foreground">
-                    Created {new Date(agent.created_at).toLocaleDateString()}
-                  </span>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="text-destructive hover:text-destructive"
-                    onClick={() => handleDelete(agent.id)}
-                    disabled={deleteAgent.isPending}
-                  >
-                    <Trash2 className="w-4 h-4" />
-                  </Button>
-                </div>
-              </CardContent>
-            </Card>
+            <AgentCard
+              key={agent.id}
+              agent={agent}
+              capabilities={agentCapabilitiesMap?.[agent.id]}
+              allCapabilities={allCapabilities}
+              onDelete={handleDelete}
+              isDeleting={deleteAgent.isPending}
+              showEditButton
+            />
           ))}
         </div>
       )}

--- a/apps/ui/src/app/(main)/dashboard/page.tsx
+++ b/apps/ui/src/app/(main)/dashboard/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useAgents } from "@/hooks";
+import { useAgents, useCapabilities, useAgentCapabilitiesBulk } from "@/hooks";
 import { Header } from "@/components/layout/header";
 import { StatsCards } from "@/components/dashboard/stats-cards";
 import { AgentListWidget } from "@/components/dashboard/agent-list-widget";
@@ -12,6 +12,11 @@ import { Plus, Boxes } from "lucide-react";
 
 export default function DashboardPage() {
   const { data: agents = [], isLoading: agentsLoading } = useAgents();
+  const { data: allCapabilities } = useCapabilities();
+
+  // Get agent IDs for bulk capabilities fetch
+  const agentIds = agents?.map((a) => a.id) || [];
+  const { data: agentCapabilitiesMap } = useAgentCapabilitiesBulk(agentIds);
 
   if (agentsLoading) {
     return (
@@ -41,7 +46,11 @@ export default function DashboardPage() {
       <div className="p-6 space-y-6">
         <StatsCards agents={agents} sessions={sessions} />
         <div className="grid gap-6 md:grid-cols-2">
-          <AgentListWidget agents={agents} />
+          <AgentListWidget
+            agents={agents}
+            agentCapabilitiesMap={agentCapabilitiesMap}
+            allCapabilities={allCapabilities}
+          />
 
           <Card>
             <CardHeader className="flex flex-row items-center justify-between">

--- a/apps/ui/src/components/agents/agent-card.tsx
+++ b/apps/ui/src/components/agents/agent-card.tsx
@@ -11,7 +11,6 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import {
-  Trash2,
   Pencil,
   CircleOff,
   Clock,
@@ -34,8 +33,6 @@ interface AgentCardProps {
   agent: Agent;
   capabilities?: AgentCapability[];
   allCapabilities?: Capability[];
-  onDelete?: (agentId: string) => void;
-  isDeleting?: boolean;
   showEditButton?: boolean;
   compact?: boolean;
 }
@@ -44,8 +41,6 @@ export function AgentCard({
   agent,
   capabilities,
   allCapabilities,
-  onDelete,
-  isDeleting,
   showEditButton = false,
   compact = false,
 }: AgentCardProps) {
@@ -126,26 +121,13 @@ export function AgentCard({
           <span className="text-xs text-muted-foreground">
             Created {new Date(agent.created_at).toLocaleDateString()}
           </span>
-          <div className="flex gap-1">
-            {showEditButton && (
-              <Link href={`/agents/${agent.id}/edit`}>
-                <Button variant="ghost" size="icon" className="h-8 w-8">
-                  <Pencil className="w-4 h-4" />
-                </Button>
-              </Link>
-            )}
-            {onDelete && (
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8 text-destructive hover:text-destructive"
-                onClick={() => onDelete(agent.id)}
-                disabled={isDeleting}
-              >
-                <Trash2 className="w-4 h-4" />
+          {showEditButton && (
+            <Link href={`/agents/${agent.id}/edit`}>
+              <Button variant="ghost" size="icon" className="h-8 w-8">
+                <Pencil className="w-4 h-4" />
               </Button>
-            )}
-          </div>
+            </Link>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/apps/ui/src/components/agents/agent-card.tsx
+++ b/apps/ui/src/components/agents/agent-card.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import Link from "next/link";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  Trash2,
+  Pencil,
+  CircleOff,
+  Clock,
+  Search,
+  Box,
+  Folder,
+  LucideIcon,
+} from "lucide-react";
+import type { Agent, AgentCapability, Capability } from "@/lib/api/types";
+
+const iconMap: Record<string, LucideIcon> = {
+  "circle-off": CircleOff,
+  clock: Clock,
+  search: Search,
+  box: Box,
+  folder: Folder,
+};
+
+interface AgentCardProps {
+  agent: Agent;
+  capabilities?: AgentCapability[];
+  allCapabilities?: Capability[];
+  onDelete?: (agentId: string) => void;
+  isDeleting?: boolean;
+  showEditButton?: boolean;
+  compact?: boolean;
+}
+
+export function AgentCard({
+  agent,
+  capabilities,
+  allCapabilities,
+  onDelete,
+  isDeleting,
+  showEditButton = false,
+  compact = false,
+}: AgentCardProps) {
+  // Get capability info for display
+  const getCapabilityInfo = (capabilityId: string): Capability | undefined =>
+    allCapabilities?.find((c) => c.id === capabilityId);
+
+  // Sort capabilities by position
+  const sortedCapabilities = capabilities
+    ? [...capabilities].sort((a, b) => a.position - b.position)
+    : [];
+
+  return (
+    <Card className="hover:shadow-md transition-shadow">
+      <CardHeader className="flex flex-row items-start justify-between space-y-0">
+        <div className="space-y-1">
+          <CardTitle className="text-lg">
+            <Link href={`/agents/${agent.id}`} className="hover:underline">
+              {agent.name}
+            </Link>
+          </CardTitle>
+          <p className="text-sm text-muted-foreground font-mono">
+            {agent.id.slice(0, 8)}...
+          </p>
+        </div>
+        <Badge variant={agent.status === "active" ? "default" : "secondary"}>
+          {agent.status}
+        </Badge>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground mb-3 line-clamp-2">
+          {agent.description || "No description"}
+        </p>
+
+        {/* Capabilities display */}
+        {sortedCapabilities.length > 0 && (
+          <div className="flex flex-wrap gap-1 mb-3">
+            <TooltipProvider>
+              {sortedCapabilities.map((ac) => {
+                const cap = getCapabilityInfo(ac.capability_id);
+                if (!cap) return null;
+                const IconComponent = cap.icon
+                  ? iconMap[cap.icon] || CircleOff
+                  : CircleOff;
+
+                return (
+                  <Tooltip key={ac.capability_id}>
+                    <TooltipTrigger className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-muted text-xs cursor-default">
+                      <IconComponent className="w-3 h-3" />
+                      {!compact && <span>{cap.name}</span>}
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p className="font-medium">{cap.name}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {cap.description}
+                      </p>
+                    </TooltipContent>
+                  </Tooltip>
+                );
+              })}
+            </TooltipProvider>
+          </div>
+        )}
+
+        {/* Tags */}
+        {agent.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1 mb-3">
+            {agent.tags.map((tag) => (
+              <Badge key={tag} variant="outline" className="text-xs">
+                {tag}
+              </Badge>
+            ))}
+          </div>
+        )}
+
+        {/* Footer */}
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-muted-foreground">
+            Created {new Date(agent.created_at).toLocaleDateString()}
+          </span>
+          <div className="flex gap-1">
+            {showEditButton && (
+              <Link href={`/agents/${agent.id}/edit`}>
+                <Button variant="ghost" size="icon" className="h-8 w-8">
+                  <Pencil className="w-4 h-4" />
+                </Button>
+              </Link>
+            )}
+            {onDelete && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 text-destructive hover:text-destructive"
+                onClick={() => onDelete(agent.id)}
+                disabled={isDeleting}
+              >
+                <Trash2 className="w-4 h-4" />
+              </Button>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/ui/src/components/agents/index.ts
+++ b/apps/ui/src/components/agents/index.ts
@@ -1,0 +1,1 @@
+export { AgentCard } from "./agent-card";

--- a/apps/ui/src/components/dashboard/agent-list-widget.tsx
+++ b/apps/ui/src/components/dashboard/agent-list-widget.tsx
@@ -4,15 +4,47 @@ import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Boxes, Plus } from "lucide-react";
-import type { Agent } from "@/lib/api/types";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  Boxes,
+  Plus,
+  CircleOff,
+  Clock,
+  Search,
+  Box,
+  Folder,
+  LucideIcon,
+} from "lucide-react";
+import type { Agent, AgentCapability, Capability } from "@/lib/api/types";
+
+const iconMap: Record<string, LucideIcon> = {
+  "circle-off": CircleOff,
+  clock: Clock,
+  search: Search,
+  box: Box,
+  folder: Folder,
+};
 
 interface AgentListWidgetProps {
   agents: Agent[];
+  agentCapabilitiesMap?: Record<string, AgentCapability[]>;
+  allCapabilities?: Capability[];
 }
 
-export function AgentListWidget({ agents }: AgentListWidgetProps) {
+export function AgentListWidget({
+  agents,
+  agentCapabilitiesMap,
+  allCapabilities,
+}: AgentListWidgetProps) {
   const activeAgents = agents.filter((a) => a.status === "active").slice(0, 5);
+
+  const getCapabilityInfo = (capabilityId: string): Capability | undefined =>
+    allCapabilities?.find((c) => c.id === capabilityId);
 
   return (
     <Card>
@@ -36,29 +68,68 @@ export function AgentListWidget({ agents }: AgentListWidgetProps) {
           </div>
         ) : (
           <div className="space-y-3">
-            {activeAgents.map((agent) => (
-              <Link
-                key={agent.id}
-                href={`/agents/${agent.id}`}
-                className="flex items-center justify-between p-3 rounded-lg border hover:bg-accent transition-colors"
-              >
-                <div className="flex items-center gap-3">
-                  <Boxes className="h-5 w-5 text-muted-foreground" />
-                  <div>
-                    <p className="font-medium">{agent.name}</p>
-                    <p className="text-xs text-muted-foreground font-mono">
-                      {agent.id.slice(0, 8)}...
-                    </p>
-                  </div>
-                </div>
-                <Badge
-                  variant="outline"
-                  className="bg-green-100 text-green-800"
+            {activeAgents.map((agent) => {
+              const capabilities = agentCapabilitiesMap?.[agent.id] || [];
+              const sortedCapabilities = [...capabilities].sort(
+                (a, b) => a.position - b.position
+              );
+
+              return (
+                <Link
+                  key={agent.id}
+                  href={`/agents/${agent.id}`}
+                  className="flex items-center justify-between p-3 rounded-lg border hover:bg-accent transition-colors"
                 >
-                  Active
-                </Badge>
-              </Link>
-            ))}
+                  <div className="flex items-center gap-3">
+                    <Boxes className="h-5 w-5 text-muted-foreground" />
+                    <div>
+                      <p className="font-medium">{agent.name}</p>
+                      <div className="flex items-center gap-2">
+                        <p className="text-xs text-muted-foreground font-mono">
+                          {agent.id.slice(0, 8)}...
+                        </p>
+                        {/* Capabilities icons */}
+                        {sortedCapabilities.length > 0 && (
+                          <TooltipProvider>
+                            <div className="flex gap-0.5">
+                              {sortedCapabilities.slice(0, 3).map((ac) => {
+                                const cap = getCapabilityInfo(ac.capability_id);
+                                if (!cap) return null;
+                                const IconComponent = cap.icon
+                                  ? iconMap[cap.icon] || CircleOff
+                                  : CircleOff;
+
+                                return (
+                                  <Tooltip key={ac.capability_id}>
+                                    <TooltipTrigger className="p-0.5 rounded bg-muted cursor-default">
+                                      <IconComponent className="w-3 h-3 text-muted-foreground" />
+                                    </TooltipTrigger>
+                                    <TooltipContent>
+                                      <p>{cap.name}</p>
+                                    </TooltipContent>
+                                  </Tooltip>
+                                );
+                              })}
+                              {sortedCapabilities.length > 3 && (
+                                <span className="text-xs text-muted-foreground ml-1">
+                                  +{sortedCapabilities.length - 3}
+                                </span>
+                              )}
+                            </div>
+                          </TooltipProvider>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                  <Badge
+                    variant="outline"
+                    className="bg-green-100 text-green-800"
+                  >
+                    Active
+                  </Badge>
+                </Link>
+              );
+            })}
             {agents.length > 5 && (
               <Link href="/agents">
                 <Button variant="ghost" className="w-full">

--- a/apps/ui/src/components/ui/tooltip.tsx
+++ b/apps/ui/src/components/ui/tooltip.tsx
@@ -1,0 +1,49 @@
+import * as React from "react";
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
+
+import { cn } from "@/lib/utils";
+
+function TooltipProvider({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}
+
+function Tooltip({ ...props }: TooltipPrimitive.Root.Props) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+}
+
+function TooltipTrigger({
+  children,
+  ...props
+}: TooltipPrimitive.Trigger.Props & { children: React.ReactNode }) {
+  return (
+    <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props}>
+      {children}
+    </TooltipPrimitive.Trigger>
+  );
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 4,
+  children,
+  ...props
+}: TooltipPrimitive.Popup.Props & { sideOffset?: number }) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Positioner sideOffset={sideOffset}>
+        <TooltipPrimitive.Popup
+          data-slot="tooltip-content"
+          className={cn(
+            "bg-popover text-popover-foreground data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 data-[closed]:zoom-out-95 data-[open]:zoom-in-95 z-50 max-w-xs origin-(--transform-origin) overflow-hidden rounded-md border px-3 py-1.5 text-sm shadow-md",
+            className
+          )}
+          {...props}
+        >
+          {children}
+        </TooltipPrimitive.Popup>
+      </TooltipPrimitive.Positioner>
+    </TooltipPrimitive.Portal>
+  );
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/apps/ui/src/hooks/index.ts
+++ b/apps/ui/src/hooks/index.ts
@@ -1,6 +1,7 @@
 // Hooks exports (M2)
 export * from "./use-agents";
 export * from "./use-capabilities";
+export * from "./use-agent-capabilities-bulk";
 export * from "./use-sessions";
 export * from "./use-llm-providers";
 export * from "./use-sse-events";

--- a/apps/ui/src/hooks/use-agent-capabilities-bulk.ts
+++ b/apps/ui/src/hooks/use-agent-capabilities-bulk.ts
@@ -1,0 +1,33 @@
+// Hook to fetch capabilities for multiple agents in parallel
+
+import { useQueries } from "@tanstack/react-query";
+import { getAgentCapabilities } from "@/lib/api/capabilities";
+import type { AgentCapability } from "@/lib/api/types";
+
+export function useAgentCapabilitiesBulk(agentIds: string[]) {
+  const queries = useQueries({
+    queries: agentIds.map((agentId) => ({
+      queryKey: ["agent-capabilities", agentId],
+      queryFn: () => getAgentCapabilities(agentId),
+      enabled: !!agentId,
+    })),
+  });
+
+  // Build a map of agentId -> capabilities
+  const data: Record<string, AgentCapability[]> = {};
+  const isLoading = queries.some((q) => q.isLoading);
+  const isError = queries.some((q) => q.isError);
+
+  agentIds.forEach((agentId, index) => {
+    const result = queries[index];
+    if (result.data) {
+      data[agentId] = result.data;
+    }
+  });
+
+  return {
+    data: Object.keys(data).length > 0 ? data : undefined,
+    isLoading,
+    isError,
+  };
+}


### PR DESCRIPTION
…splay

- Convert Agent edit from non-existent modal to dedicated page at /agents/[agentId]/edit
- Add Capabilities editing integrated into the edit page
- Create reusable AgentCard component with capability display
- Display agent capabilities on agent cards in list view and dashboard
- Add Edit button to agent detail page header
- Add Tooltip component using Base UI for capability descriptions
- Add useAgentCapabilitiesBulk hook for efficient bulk capability fetching
