### PR TITLE
Downgrade PostgreSQL 18 to PostgreSQL 17

### DIFF
--- a/.claude/skills/smoke-tests/SKILL.md
+++ b/.claude/skills/smoke-tests/SKILL.md
@@ -194,7 +194,7 @@ For environments without Docker (Cloud Agent, CI):
 ```
 
 This script:
-1. Installs PostgreSQL 18 from PGDG repository
+1. Installs PostgreSQL 17 from PGDG repository
 2. Installs Temporal CLI
 3. Starts local PostgreSQL cluster and Temporal dev server
 4. Runs database migrations
@@ -206,7 +206,7 @@ This script:
 | Script | Description |
 |--------|-------------|
 | `scripts/run-no-docker.sh` | Entry point for no-Docker environments |
-| `scripts/_setup-postgres.sh` | PostgreSQL 18 cluster setup (internal) |
+| `scripts/_setup-postgres.sh` | PostgreSQL 17 cluster setup (internal) |
 | `scripts/_setup-temporal.sh` | Temporal dev server setup (internal) |
 | `scripts/_utils.sh` | Shared utilities and configuration (internal) |
 

--- a/.claude/skills/smoke-tests/scripts/_setup-postgres.sh
+++ b/.claude/skills/smoke-tests/scripts/_setup-postgres.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # PostgreSQL setup for smoke tests (no-Docker mode)
-# Sets up a local PostgreSQL 18 cluster without Docker
+# Sets up a local PostgreSQL 17 cluster without Docker
 #
 # This script can be:
 # - Sourced by run-no-docker.sh (_utils.sh must be sourced first)

--- a/.claude/skills/smoke-tests/scripts/_utils.sh
+++ b/.claude/skills/smoke-tests/scripts/_utils.sh
@@ -4,7 +4,7 @@
 # Configuration
 export PGDATA="/tmp/pgdata"
 export PG_LOGFILE="$PGDATA/pg.log"
-export PG_VERSION="18"
+export PG_VERSION="17"
 export PG_BIN="/usr/lib/postgresql/$PG_VERSION/bin"
 export TEMPORAL_BIN="/usr/local/bin/temporal"
 export TEMPORAL_LOG="/tmp/temporal.log"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:18-alpine
+        image: postgres:17-alpine
         env:
           POSTGRES_USER: everruns
           POSTGRES_PASSWORD: everruns
@@ -150,7 +150,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:18-alpine
+        image: postgres:17-alpine
         env:
           POSTGRES_USER: everruns
           POSTGRES_PASSWORD: everruns
@@ -179,7 +179,7 @@ jobs:
       - name: Start Temporal
         run: |
           # Get the postgres container's network
-          POSTGRES_CONTAINER=$(docker ps --filter "ancestor=postgres:18-alpine" -q)
+          POSTGRES_CONTAINER=$(docker ps --filter "ancestor=postgres:17-alpine" -q)
           NETWORK=$(docker inspect $POSTGRES_CONTAINER --format '{{range $key, $value := .NetworkSettings.Networks}}{{$key}}{{end}}')
           echo "Postgres container: $POSTGRES_CONTAINER on network: $NETWORK"
 

--- a/crates/everruns-api/README.md
+++ b/crates/everruns-api/README.md
@@ -154,7 +154,7 @@ cargo clippy -p everrun-api -- -D warnings
 ## Architecture
 
 - **Framework**: Axum (async Rust web framework)
-- **Database**: PostgreSQL 18 with native UUIDv7 support
+- **Database**: PostgreSQL 17 with custom UUIDv7 function
 - **Documentation**: utoipa + Swagger UI
 - **Validation**: Multi-tenant isolation at DB level
 - **Error Handling**: Structured error responses

--- a/harness/docker-compose.yml
+++ b/harness/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:18-alpine
+    image: postgres:17-alpine
     container_name: everruns-postgres
     environment:
       POSTGRES_USER: everruns

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -20,7 +20,8 @@ Everruns is a durable AI agent execution platform built on Rust and Temporal. It
 
 ### Data Layer
 
-1. **Database**: PostgreSQL 18+ with native UUID v7 support
+1. **Database**: PostgreSQL 17 with custom UUID v7 function
+   - Decision: Using PostgreSQL 17 because PostgreSQL 18 is not yet available on managed services like AWS Aurora RDS. This is temporary; we will migrate to PostgreSQL 18 with native uuidv7() when it becomes widely available.
 2. **UUID Strategy**: All IDs use UUID v7 (time-ordered, better indexing, naturally sortable)
 3. **Migrations**: Managed via sqlx-cli in `crates/everruns-storage/migrations/`
 


### PR DESCRIPTION
PostgreSQL 18 is not yet available on managed services like AWS Aurora RDS. This is a temporary change; we will migrate to PostgreSQL 18 with native uuidv7() when it becomes widely available.

Changes:
- Update docker-compose.yml and CI to use postgres:17-alpine
- Add custom uuidv7() function for PostgreSQL 16/17 compatibility
  - Uses pgcrypto extension for gen_random_bytes()
  - Conditionally creates function only if native uuidv7() doesn't exist
  - Preserves native PG18 function when running on PostgreSQL 18+
- Update specs and documentation to reflect PostgreSQL 17