### PR TITLE
Fix GLIBC version mismatch in admin container

### DIFF
--- a/docker/Dockerfile.unified
+++ b/docker/Dockerfile.unified
@@ -10,7 +10,7 @@
 # ============================================================================
 # Stage 1: Chef - Prepare cargo-chef for dependency caching
 # ============================================================================
-FROM rust:1.92-slim AS chef
+FROM rust:1.92-slim-bookworm AS chef
 
 RUN apt-get update && apt-get install -y \
     pkg-config \


### PR DESCRIPTION
The admin container was failing with:
  sqlx: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found

This was caused by a GLIBC version mismatch: rust:1.92-slim is based on a newer Debian with GLIBC 2.39, while the runtime debian:bookworm-slim only has GLIBC 2.36.

Fix by using rust:1.92-bookworm-slim explicitly to ensure the builder uses the same GLIBC version as the runtime image.