### PR TITLE
Add TLS support to admin image

### DIFF
--- a/docker/Dockerfile.unified
+++ b/docker/Dockerfile.unified
@@ -112,9 +112,9 @@ FROM deps AS builder-admin
 COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
 COPY crates crates
 
-# Build the reencrypt-secrets binary and install sqlx-cli
+# Build the reencrypt-secrets binary and install sqlx-cli with TLS support
 RUN cargo build --release --bin reencrypt-secrets && \
-    cargo install sqlx-cli --no-default-features --features postgres --locked
+    cargo install sqlx-cli --no-default-features --features postgres,native-tls --locked
 
 # ============================================================================
 # Stage 5c: Admin Runtime image

--- a/docs/sre/admin-container.md
+++ b/docs/sre/admin-container.md
@@ -70,37 +70,7 @@ docker run --rm \
 The admin container supports TLS connections to PostgreSQL. Use the `sslmode` parameter in your connection string:
 
 ```bash
-# Require TLS (recommended for production)
 DATABASE_URL="postgres://user:pass@host:5432/db?sslmode=require"
-
-# Verify server certificate against system CA certificates
-DATABASE_URL="postgres://user:pass@host:5432/db?sslmode=verify-ca"
-
-# Verify server certificate and hostname
-DATABASE_URL="postgres://user:pass@host:5432/db?sslmode=verify-full"
-```
-
-### Cloud Database Examples
-
-**AWS RDS:**
-```bash
-docker run --rm \
-    -e DATABASE_URL="postgres://user:pass@mydb.abc123.us-east-1.rds.amazonaws.com:5432/db?sslmode=require" \
-    everruns-admin migrate
-```
-
-**Azure Database for PostgreSQL:**
-```bash
-docker run --rm \
-    -e DATABASE_URL="postgres://user@server:pass@server.postgres.database.azure.com:5432/db?sslmode=require" \
-    everruns-admin migrate
-```
-
-**Google Cloud SQL:**
-```bash
-docker run --rm \
-    -e DATABASE_URL="postgres://user:pass@/db?host=/cloudsql/project:region:instance&sslmode=require" \
-    everruns-admin migrate
 ```
 
 ## Production Deployment

--- a/docs/sre/admin-container.md
+++ b/docs/sre/admin-container.md
@@ -65,6 +65,44 @@ docker run --rm \
 | `SECRETS_ENCRYPTION_KEY_PREVIOUS` | For rotation | Previous encryption key |
 | `RUST_LOG` | No | Log level (default: info) |
 
+## TLS/SSL Connections
+
+The admin container supports TLS connections to PostgreSQL. Use the `sslmode` parameter in your connection string:
+
+```bash
+# Require TLS (recommended for production)
+DATABASE_URL="postgres://user:pass@host:5432/db?sslmode=require"
+
+# Verify server certificate against system CA certificates
+DATABASE_URL="postgres://user:pass@host:5432/db?sslmode=verify-ca"
+
+# Verify server certificate and hostname
+DATABASE_URL="postgres://user:pass@host:5432/db?sslmode=verify-full"
+```
+
+### Cloud Database Examples
+
+**AWS RDS:**
+```bash
+docker run --rm \
+    -e DATABASE_URL="postgres://user:pass@mydb.abc123.us-east-1.rds.amazonaws.com:5432/db?sslmode=require" \
+    everruns-admin migrate
+```
+
+**Azure Database for PostgreSQL:**
+```bash
+docker run --rm \
+    -e DATABASE_URL="postgres://user@server:pass@server.postgres.database.azure.com:5432/db?sslmode=require" \
+    everruns-admin migrate
+```
+
+**Google Cloud SQL:**
+```bash
+docker run --rm \
+    -e DATABASE_URL="postgres://user:pass@/db?host=/cloudsql/project:region:instance&sslmode=require" \
+    everruns-admin migrate
+```
+
 ## Production Deployment
 
 The admin container can be run as a one-off task in any container orchestration platform:


### PR DESCRIPTION
Enable TLS/SSL connections in the admin container by adding the native-tls feature to sqlx-cli. This allows the admin container to connect to databases using sslmode=require and other TLS modes.

Also adds documentation for TLS connection configuration with examples for AWS RDS, Azure, and Google Cloud SQL.