### PR TITLE
Refactor capabilities and tools system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,6 +767,7 @@ dependencies = [
  "chrono",
  "dotenvy",
  "everruns-contracts",
+ "everruns-core",
  "everruns-storage",
  "everruns-worker",
  "futures",

--- a/crates/everruns-api/Cargo.toml
+++ b/crates/everruns-api/Cargo.toml
@@ -42,6 +42,7 @@ reqwest.workspace = true
 time.workspace = true
 
 everruns-contracts = { path = "../everruns-contracts" }
+everruns-core = { path = "../everruns-core" }
 everruns-storage = { path = "../everruns-storage" }
 everruns-worker = { path = "../everruns-worker" }
 

--- a/crates/everruns-api/src/capabilities.rs
+++ b/crates/everruns-api/src/capabilities.rs
@@ -1,9 +1,8 @@
-// Capability HTTP routes and internal registry
+// Capability HTTP routes
 //
-// Design Decision: Capabilities are external to the Agent Loop.
-// The registry here defines what each capability provides (system prompt additions, tools).
-// When building AgentConfig, we resolve the agent's enabled capabilities and merge their
-// contributions into the final config.
+// Design Decision: Capabilities are defined in everruns-core via the Capability trait.
+// This module provides HTTP endpoints that expose capability information from the
+// CapabilityRegistry in everruns-core.
 
 use axum::{
     extract::{Path, State},
@@ -12,8 +11,7 @@ use axum::{
     Json, Router,
 };
 use everruns_contracts::{
-    AgentCapability, Capability, CapabilityId, CapabilityStatus, ListResponse,
-    UpdateAgentCapabilitiesRequest,
+    AgentCapability, Capability, CapabilityId, ListResponse, UpdateAgentCapabilitiesRequest,
 };
 use everruns_storage::Database;
 use std::sync::Arc;
@@ -134,9 +132,9 @@ pub async fn set_agent_capabilities(
     Path(agent_id): Path<Uuid>,
     Json(req): Json<UpdateAgentCapabilitiesRequest>,
 ) -> Result<Json<ListResponse<AgentCapability>>, StatusCode> {
-    // Validate all capability IDs exist
+    // Validate all capability IDs exist in the registry
     for cap_id in &req.capabilities {
-        if state.service.get(cap_id).is_none() {
+        if !state.service.has(cap_id) {
             return Err(StatusCode::BAD_REQUEST);
         }
     }
@@ -151,237 +149,4 @@ pub async fn set_agent_capabilities(
         })?;
 
     Ok(Json(ListResponse::new(capabilities)))
-}
-
-// ============================================
-// Internal Capability Registry
-// ============================================
-
-/// Internal capability definition with full details
-/// This is used internally to build AgentConfig
-#[allow(dead_code)] // Fields used when capabilities are fully implemented
-pub struct InternalCapability {
-    /// Public info
-    pub info: Capability,
-    /// System prompt addition (prepended to agent's system prompt)
-    pub system_prompt_addition: Option<String>,
-    /// Tools provided by this capability
-    pub tools: Vec<everruns_contracts::tools::ToolDefinition>,
-}
-
-/// Get all internal capability definitions
-pub fn get_capability_registry() -> Vec<InternalCapability> {
-    use everruns_contracts::tools::{BuiltinTool, ToolDefinition, ToolPolicy};
-    use serde_json::json;
-
-    vec![
-        // Noop capability - for testing/demo
-        InternalCapability {
-            info: Capability {
-                id: CapabilityId::noop(),
-                name: "No-Op".to_string(),
-                description: "A no-operation capability for testing and demonstration purposes. Does not add any functionality.".to_string(),
-                status: CapabilityStatus::Available,
-                icon: Some("circle-off".to_string()),
-                category: Some("Testing".to_string()),
-            },
-            system_prompt_addition: None,
-            tools: vec![],
-        },
-        // CurrentTime capability - adds current time tool
-        InternalCapability {
-            info: Capability {
-                id: CapabilityId::current_time(),
-                name: "Current Time".to_string(),
-                description: "Adds a tool to get the current date and time in various formats and timezones.".to_string(),
-                status: CapabilityStatus::Available,
-                icon: Some("clock".to_string()),
-                category: Some("Utilities".to_string()),
-            },
-            system_prompt_addition: None, // No system prompt contribution
-            tools: vec![
-                ToolDefinition::Builtin(BuiltinTool {
-                    name: "get_current_time".to_string(),
-                    description: "Get the current date and time. Can return time in different formats and timezones.".to_string(),
-                    parameters: json!({
-                        "type": "object",
-                        "properties": {
-                            "timezone": {
-                                "type": "string",
-                                "description": "Timezone to return the time in (e.g., 'UTC', 'America/New_York', 'Europe/London'). Defaults to UTC."
-                            },
-                            "format": {
-                                "type": "string",
-                                "enum": ["iso8601", "unix", "human"],
-                                "description": "Output format: 'iso8601' for ISO 8601 format, 'unix' for Unix timestamp, 'human' for human-readable format. Defaults to 'iso8601'."
-                            }
-                        },
-                        "required": []
-                    }),
-                    policy: ToolPolicy::Auto,
-                }),
-            ],
-        },
-        // Research capability - coming soon
-        InternalCapability {
-            info: Capability {
-                id: CapabilityId::research(),
-                name: "Deep Research".to_string(),
-                description: "Enables deep research capabilities with a scratchpad for notes, web search tools, and structured thinking.".to_string(),
-                status: CapabilityStatus::ComingSoon,
-                icon: Some("search".to_string()),
-                category: Some("AI".to_string()),
-            },
-            system_prompt_addition: Some(
-                "You have access to a research scratchpad. Use it to organize your thoughts and findings.".to_string()
-            ),
-            tools: vec![], // Tools would be added here when implemented
-        },
-        // Sandbox capability - coming soon
-        InternalCapability {
-            info: Capability {
-                id: CapabilityId::sandbox(),
-                name: "Sandboxed Execution".to_string(),
-                description: "Enables sandboxed code execution environment for running code safely.".to_string(),
-                status: CapabilityStatus::ComingSoon,
-                icon: Some("box".to_string()),
-                category: Some("Execution".to_string()),
-            },
-            system_prompt_addition: Some(
-                "You can execute code in a sandboxed environment. Use the execute_code tool to run code safely.".to_string()
-            ),
-            tools: vec![], // Tools would be added here when implemented
-        },
-        // FileSystem capability - coming soon
-        InternalCapability {
-            info: Capability {
-                id: CapabilityId::file_system(),
-                name: "File System Access".to_string(),
-                description: "Adds tools to access and manipulate files - read, write, grep, and more.".to_string(),
-                status: CapabilityStatus::ComingSoon,
-                icon: Some("folder".to_string()),
-                category: Some("File Operations".to_string()),
-            },
-            system_prompt_addition: Some(
-                "You have access to file system tools. You can read, write, and search files.".to_string()
-            ),
-            tools: vec![], // Tools would be added here when implemented
-        },
-        // TestMath capability - for testing tool calling
-        InternalCapability {
-            info: Capability {
-                id: CapabilityId::test_math(),
-                name: "Test Math".to_string(),
-                description: "Testing capability: adds calculator tools (add, subtract, multiply, divide) for tool calling tests.".to_string(),
-                status: CapabilityStatus::Available,
-                icon: Some("calculator".to_string()),
-                category: Some("Testing".to_string()),
-            },
-            system_prompt_addition: Some(
-                "You have access to math tools. Use them for calculations: add, subtract, multiply, divide.".to_string()
-            ),
-            tools: vec![
-                ToolDefinition::Builtin(BuiltinTool {
-                    name: "add".to_string(),
-                    description: "Add two numbers together.".to_string(),
-                    parameters: json!({
-                        "type": "object",
-                        "properties": {
-                            "a": { "type": "number", "description": "First number" },
-                            "b": { "type": "number", "description": "Second number" }
-                        },
-                        "required": ["a", "b"]
-                    }),
-                    policy: ToolPolicy::Auto,
-                }),
-                ToolDefinition::Builtin(BuiltinTool {
-                    name: "subtract".to_string(),
-                    description: "Subtract the second number from the first.".to_string(),
-                    parameters: json!({
-                        "type": "object",
-                        "properties": {
-                            "a": { "type": "number", "description": "Number to subtract from" },
-                            "b": { "type": "number", "description": "Number to subtract" }
-                        },
-                        "required": ["a", "b"]
-                    }),
-                    policy: ToolPolicy::Auto,
-                }),
-                ToolDefinition::Builtin(BuiltinTool {
-                    name: "multiply".to_string(),
-                    description: "Multiply two numbers together.".to_string(),
-                    parameters: json!({
-                        "type": "object",
-                        "properties": {
-                            "a": { "type": "number", "description": "First number" },
-                            "b": { "type": "number", "description": "Second number" }
-                        },
-                        "required": ["a", "b"]
-                    }),
-                    policy: ToolPolicy::Auto,
-                }),
-                ToolDefinition::Builtin(BuiltinTool {
-                    name: "divide".to_string(),
-                    description: "Divide the first number by the second.".to_string(),
-                    parameters: json!({
-                        "type": "object",
-                        "properties": {
-                            "a": { "type": "number", "description": "Dividend (number to divide)" },
-                            "b": { "type": "number", "description": "Divisor (number to divide by)" }
-                        },
-                        "required": ["a", "b"]
-                    }),
-                    policy: ToolPolicy::Auto,
-                }),
-            ],
-        },
-        // TestWeather capability - for testing tool calling
-        InternalCapability {
-            info: Capability {
-                id: CapabilityId::test_weather(),
-                name: "Test Weather".to_string(),
-                description: "Testing capability: adds mock weather tools (get_weather, get_forecast) for tool calling tests.".to_string(),
-                status: CapabilityStatus::Available,
-                icon: Some("cloud-sun".to_string()),
-                category: Some("Testing".to_string()),
-            },
-            system_prompt_addition: Some(
-                "You have access to weather tools. Use get_weather for current conditions and get_forecast for multi-day forecasts.".to_string()
-            ),
-            tools: vec![
-                ToolDefinition::Builtin(BuiltinTool {
-                    name: "get_weather".to_string(),
-                    description: "Get current weather for a city.".to_string(),
-                    parameters: json!({
-                        "type": "object",
-                        "properties": {
-                            "city": { "type": "string", "description": "City name (e.g., 'New York', 'London', 'Tokyo')" }
-                        },
-                        "required": ["city"]
-                    }),
-                    policy: ToolPolicy::Auto,
-                }),
-                ToolDefinition::Builtin(BuiltinTool {
-                    name: "get_forecast".to_string(),
-                    description: "Get multi-day weather forecast for a city.".to_string(),
-                    parameters: json!({
-                        "type": "object",
-                        "properties": {
-                            "city": { "type": "string", "description": "City name" },
-                            "days": { "type": "integer", "description": "Number of days (1-7, default: 5)" }
-                        },
-                        "required": ["city"]
-                    }),
-                    policy: ToolPolicy::Auto,
-                }),
-            ],
-        },
-    ]
-}
-
-/// Get a specific capability from the registry
-pub fn get_capability_definition(id: &CapabilityId) -> Option<InternalCapability> {
-    get_capability_registry()
-        .into_iter()
-        .find(|c| c.info.id == *id)
 }

--- a/crates/everruns-api/src/services/capability.rs
+++ b/crates/everruns-api/src/services/capability.rs
@@ -26,7 +26,7 @@ impl CapabilityService {
     }
 
     /// Get a specific capability by ID
-    pub fn get(&self, id: CapabilityId) -> Option<Capability> {
+    pub fn get(&self, id: &CapabilityId) -> Option<Capability> {
         get_capability_definition(id).map(|c| c.info)
     }
 
@@ -36,12 +36,9 @@ impl CapabilityService {
 
         let capabilities: Vec<AgentCapability> = rows
             .into_iter()
-            .filter_map(|row| {
-                let capability_id: Result<CapabilityId, _> = row.capability_id.parse();
-                capability_id.ok().map(|cap_id| AgentCapability {
-                    capability_id: cap_id,
-                    position: row.position,
-                })
+            .map(|row| AgentCapability {
+                capability_id: CapabilityId::new(&row.capability_id),
+                position: row.position,
             })
             .collect();
 
@@ -65,12 +62,9 @@ impl CapabilityService {
 
         let result: Vec<AgentCapability> = rows
             .into_iter()
-            .filter_map(|row| {
-                let capability_id: Result<CapabilityId, _> = row.capability_id.parse();
-                capability_id.ok().map(|cap_id| AgentCapability {
-                    capability_id: cap_id,
-                    position: row.position,
-                })
+            .map(|row| AgentCapability {
+                capability_id: CapabilityId::new(&row.capability_id),
+                position: row.position,
             })
             .collect();
 

--- a/crates/everruns-contracts/src/capability.rs
+++ b/crates/everruns-contracts/src/capability.rs
@@ -31,6 +31,20 @@ pub struct Capability {
     pub category: Option<String>,
 }
 
+impl Capability {
+    /// Create a Capability DTO from a core Capability trait object
+    pub fn from_core(cap: &dyn everruns_core::capabilities::Capability) -> Self {
+        Self {
+            id: CapabilityId::new(cap.id()),
+            name: cap.name().to_string(),
+            description: cap.description().to_string(),
+            status: cap.status(),
+            icon: cap.icon().map(|s| s.to_string()),
+            category: cap.category().map(|s| s.to_string()),
+        }
+    }
+}
+
 /// Agent capability assignment with ordering
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct AgentCapability {

--- a/crates/everruns-contracts/src/capability.rs
+++ b/crates/everruns-contracts/src/capability.rs
@@ -57,7 +57,7 @@ mod tests {
     #[test]
     fn test_capability_serialization() {
         let cap = Capability {
-            id: CapabilityId::Research,
+            id: CapabilityId::research(),
             name: "Research".to_string(),
             description: "Deep research capability".to_string(),
             status: CapabilityStatus::Available,
@@ -73,7 +73,7 @@ mod tests {
     #[test]
     fn test_agent_capability_serialization() {
         let agent_cap = AgentCapability {
-            capability_id: CapabilityId::Sandbox,
+            capability_id: CapabilityId::sandbox(),
             position: 1,
         };
 
@@ -85,15 +85,17 @@ mod tests {
     #[test]
     fn test_test_capabilities() {
         // Verify test math and weather capabilities are available
-        assert_eq!(CapabilityId::TestMath.to_string(), "test_math");
-        assert_eq!(CapabilityId::TestWeather.to_string(), "test_weather");
-        assert_eq!(
-            "test_math".parse::<CapabilityId>().unwrap(),
-            CapabilityId::TestMath
-        );
-        assert_eq!(
-            "test_weather".parse::<CapabilityId>().unwrap(),
-            CapabilityId::TestWeather
-        );
+        assert_eq!(CapabilityId::test_math().to_string(), "test_math");
+        assert_eq!(CapabilityId::test_weather().to_string(), "test_weather");
+    }
+
+    #[test]
+    fn test_custom_capability_id() {
+        // Custom capability IDs should work
+        let custom = CapabilityId::new("my_custom_capability");
+        assert_eq!(custom.to_string(), "my_custom_capability");
+
+        let json = serde_json::to_string(&custom).unwrap();
+        assert_eq!(json, "\"my_custom_capability\"");
     }
 }

--- a/crates/everruns-contracts/src/tools.rs
+++ b/crates/everruns-contracts/src/tools.rs
@@ -5,7 +5,7 @@
 
 // Re-export all tool runtime types from core
 pub use everruns_core::tool_types::{
-    BuiltinTool, BuiltinToolKind, ToolCall, ToolDefinition, ToolPolicy, ToolResult,
+    BuiltinTool, ToolCall, ToolDefinition, ToolPolicy, ToolResult,
 };
 
 #[cfg(test)]
@@ -13,19 +13,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_builtin_tool_http_get() {
+    fn test_builtin_tool_serialization() {
         let json = r#"{
             "type": "builtin",
             "name": "fetch_data",
             "description": "Fetch data from URL",
-            "parameters": {"type": "object"},
-            "kind": "http_get"
+            "parameters": {"type": "object"}
         }"#;
 
         let tool: ToolDefinition = serde_json::from_str(json).unwrap();
         match tool {
             ToolDefinition::Builtin(builtin) => {
-                assert_eq!(builtin.kind, BuiltinToolKind::HttpGet);
+                assert_eq!(builtin.name, "fetch_data");
                 assert_eq!(builtin.policy, ToolPolicy::Auto);
             }
         }
@@ -38,7 +37,6 @@ mod tests {
             "name": "delete_file",
             "description": "Delete a file",
             "parameters": {"type": "object"},
-            "kind": "write_file",
             "policy": "requires_approval"
         }"#;
 

--- a/crates/everruns-core/examples/capabilities.rs
+++ b/crates/everruns-core/examples/capabilities.rs
@@ -38,10 +38,9 @@ use uuid::Uuid;
 struct CalculatorCapability;
 
 impl Capability for CalculatorCapability {
-    fn id(&self) -> CapabilityId {
-        // Using Noop as placeholder since we can't add new variants
-        // In a real application, you'd extend CapabilityId
-        CapabilityId::Noop
+    fn id(&self) -> &str {
+        // Custom capability with a custom ID
+        "calculator"
     }
 
     fn name(&self) -> &str {
@@ -235,7 +234,7 @@ async fn example_builtin_capability() -> anyhow::Result<()> {
     let base_config = AgentConfig::new("You are a helpful assistant.", "gpt-5.2");
 
     // Apply the CurrentTime capability
-    let capability_ids = vec![CapabilityId::CurrentTime];
+    let capability_ids = vec![CapabilityId::CURRENT_TIME.to_string()];
     let applied = apply_capabilities(base_config, &capability_ids, &registry);
 
     println!("Applied capabilities: {:?}", applied.applied_ids);
@@ -285,8 +284,8 @@ async fn example_custom_capability() -> anyhow::Result<()> {
     // Base agent config
     let base_config = AgentConfig::new("You are a helpful math assistant.", "gpt-5.2");
 
-    // Apply the custom capability (using Noop ID as placeholder)
-    let capability_ids = vec![CapabilityId::Noop];
+    // Apply the custom capability
+    let capability_ids = vec!["calculator".to_string()];
     let applied = apply_capabilities(base_config, &capability_ids, &registry);
 
     println!("Applied capabilities: {:?}", applied.applied_ids);
@@ -339,7 +338,10 @@ async fn example_multiple_capabilities() -> anyhow::Result<()> {
     );
 
     // Apply multiple capabilities
-    let capability_ids = vec![CapabilityId::CurrentTime, CapabilityId::Noop];
+    let capability_ids = vec![
+        CapabilityId::CURRENT_TIME.to_string(),
+        CapabilityId::NOOP.to_string(),
+    ];
     let applied = apply_capabilities(base_config, &capability_ids, &registry);
 
     println!("Applied capabilities: {:?}", applied.applied_ids);

--- a/crates/everruns-core/src/capability_types.rs
+++ b/crates/everruns-core/src/capability_types.rs
@@ -1,61 +1,104 @@
 // Capability type definitions
 //
-// These are runtime types for the capability system.
-// They are re-exported by everruns-contracts with ToSchema for API docs.
+// Design Decision: Capability IDs are now String-based to allow adding new capabilities
+// without requiring database migrations or code changes to enums.
+// Validation happens at the registry level rather than the type level.
 
 use serde::{Deserialize, Serialize};
 
-/// Capability identifier
+/// Capability identifier - a string-based ID for extensibility
 ///
-/// These are the internal IDs for built-in capabilities.
-/// Re-exported by contracts with ToSchema for API documentation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum CapabilityId {
-    /// No-op capability for testing/demo purposes
-    Noop,
-    /// CurrentTime capability - adds a tool to get the current time
-    CurrentTime,
-    /// Research capability (coming soon)
-    Research,
-    /// Sandbox capability (coming soon)
-    Sandbox,
-    /// FileSystem capability (coming soon)
-    FileSystem,
-    /// TestMath capability - adds calculator tools for testing (add, subtract, multiply, divide)
-    TestMath,
-    /// TestWeather capability - adds mock weather tools for testing (get_weather, get_forecast)
-    TestWeather,
+/// This allows new capabilities to be added without database changes.
+/// The ID is validated at runtime against the capability registry.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct CapabilityId(String);
+
+impl CapabilityId {
+    /// Create a new capability ID from a string
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    /// Get the ID as a string slice
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    // Built-in capability ID constants for convenience
+    pub const NOOP: &'static str = "noop";
+    pub const CURRENT_TIME: &'static str = "current_time";
+    pub const RESEARCH: &'static str = "research";
+    pub const SANDBOX: &'static str = "sandbox";
+    pub const FILE_SYSTEM: &'static str = "file_system";
+    pub const TEST_MATH: &'static str = "test_math";
+    pub const TEST_WEATHER: &'static str = "test_weather";
+
+    /// Create the noop capability ID
+    pub fn noop() -> Self {
+        Self::new(Self::NOOP)
+    }
+
+    /// Create the current_time capability ID
+    pub fn current_time() -> Self {
+        Self::new(Self::CURRENT_TIME)
+    }
+
+    /// Create the research capability ID
+    pub fn research() -> Self {
+        Self::new(Self::RESEARCH)
+    }
+
+    /// Create the sandbox capability ID
+    pub fn sandbox() -> Self {
+        Self::new(Self::SANDBOX)
+    }
+
+    /// Create the file_system capability ID
+    pub fn file_system() -> Self {
+        Self::new(Self::FILE_SYSTEM)
+    }
+
+    /// Create the test_math capability ID
+    pub fn test_math() -> Self {
+        Self::new(Self::TEST_MATH)
+    }
+
+    /// Create the test_weather capability ID
+    pub fn test_weather() -> Self {
+        Self::new(Self::TEST_WEATHER)
+    }
 }
 
 impl std::fmt::Display for CapabilityId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CapabilityId::Noop => write!(f, "noop"),
-            CapabilityId::CurrentTime => write!(f, "current_time"),
-            CapabilityId::Research => write!(f, "research"),
-            CapabilityId::Sandbox => write!(f, "sandbox"),
-            CapabilityId::FileSystem => write!(f, "file_system"),
-            CapabilityId::TestMath => write!(f, "test_math"),
-            CapabilityId::TestWeather => write!(f, "test_weather"),
-        }
+        write!(f, "{}", self.0)
     }
 }
 
 impl std::str::FromStr for CapabilityId {
-    type Err = String;
+    type Err = std::convert::Infallible;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "noop" => Ok(CapabilityId::Noop),
-            "current_time" => Ok(CapabilityId::CurrentTime),
-            "research" => Ok(CapabilityId::Research),
-            "sandbox" => Ok(CapabilityId::Sandbox),
-            "file_system" => Ok(CapabilityId::FileSystem),
-            "test_math" => Ok(CapabilityId::TestMath),
-            "test_weather" => Ok(CapabilityId::TestWeather),
-            _ => Err(format!("Unknown capability: {}", s)),
-        }
+        Ok(Self::new(s))
+    }
+}
+
+impl From<&str> for CapabilityId {
+    fn from(s: &str) -> Self {
+        Self::new(s)
+    }
+}
+
+impl From<String> for CapabilityId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl AsRef<str> for CapabilityId {
+    fn as_ref(&self) -> &str {
+        &self.0
     }
 }
 
@@ -87,47 +130,73 @@ mod tests {
 
     #[test]
     fn test_capability_id_display() {
-        assert_eq!(CapabilityId::Noop.to_string(), "noop");
-        assert_eq!(CapabilityId::CurrentTime.to_string(), "current_time");
-        assert_eq!(CapabilityId::Research.to_string(), "research");
-        assert_eq!(CapabilityId::Sandbox.to_string(), "sandbox");
-        assert_eq!(CapabilityId::FileSystem.to_string(), "file_system");
-        assert_eq!(CapabilityId::TestMath.to_string(), "test_math");
-        assert_eq!(CapabilityId::TestWeather.to_string(), "test_weather");
+        assert_eq!(CapabilityId::noop().to_string(), "noop");
+        assert_eq!(CapabilityId::current_time().to_string(), "current_time");
+        assert_eq!(CapabilityId::research().to_string(), "research");
+        assert_eq!(CapabilityId::sandbox().to_string(), "sandbox");
+        assert_eq!(CapabilityId::file_system().to_string(), "file_system");
+        assert_eq!(CapabilityId::test_math().to_string(), "test_math");
+        assert_eq!(CapabilityId::test_weather().to_string(), "test_weather");
     }
 
     #[test]
     fn test_capability_id_from_str() {
-        assert_eq!("noop".parse::<CapabilityId>().unwrap(), CapabilityId::Noop);
+        assert_eq!(
+            "noop".parse::<CapabilityId>().unwrap(),
+            CapabilityId::noop()
+        );
         assert_eq!(
             "current_time".parse::<CapabilityId>().unwrap(),
-            CapabilityId::CurrentTime
+            CapabilityId::current_time()
         );
         assert_eq!(
             "research".parse::<CapabilityId>().unwrap(),
-            CapabilityId::Research
+            CapabilityId::research()
         );
         assert_eq!(
             "sandbox".parse::<CapabilityId>().unwrap(),
-            CapabilityId::Sandbox
+            CapabilityId::sandbox()
         );
         assert_eq!(
             "file_system".parse::<CapabilityId>().unwrap(),
-            CapabilityId::FileSystem
+            CapabilityId::file_system()
         );
         assert_eq!(
             "test_math".parse::<CapabilityId>().unwrap(),
-            CapabilityId::TestMath
+            CapabilityId::test_math()
         );
         assert_eq!(
             "test_weather".parse::<CapabilityId>().unwrap(),
-            CapabilityId::TestWeather
+            CapabilityId::test_weather()
         );
     }
 
     #[test]
-    fn test_capability_id_from_str_unknown() {
-        let result = "unknown".parse::<CapabilityId>();
-        assert!(result.is_err());
+    fn test_capability_id_from_custom_string() {
+        // Custom capability IDs should work
+        let custom = CapabilityId::new("my_custom_capability");
+        assert_eq!(custom.to_string(), "my_custom_capability");
+        assert_eq!(custom.as_str(), "my_custom_capability");
+    }
+
+    #[test]
+    fn test_capability_id_serialization() {
+        let id = CapabilityId::current_time();
+        let json = serde_json::to_string(&id).unwrap();
+        assert_eq!(json, "\"current_time\"");
+
+        let parsed: CapabilityId = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, id);
+    }
+
+    #[test]
+    fn test_capability_id_hash() {
+        use std::collections::HashSet;
+        let mut set = HashSet::new();
+        set.insert(CapabilityId::noop());
+        set.insert(CapabilityId::current_time());
+        set.insert(CapabilityId::new("noop")); // Should not add a duplicate
+
+        assert_eq!(set.len(), 2);
     }
 }

--- a/crates/everruns-core/src/lib.rs
+++ b/crates/everruns-core/src/lib.rs
@@ -91,8 +91,6 @@ pub use ag_ui::{
 };
 
 // Tool types (runtime types defined in this crate)
-pub use tool_types::{
-    BuiltinTool, BuiltinToolKind, ToolCall, ToolDefinition, ToolPolicy, ToolResult,
-};
+pub use tool_types::{BuiltinTool, ToolCall, ToolDefinition, ToolPolicy, ToolResult};
 
 // Note: CapabilityId and CapabilityStatus are re-exported via capabilities module

--- a/crates/everruns-core/src/memory.rs
+++ b/crates/everruns-core/src/memory.rs
@@ -598,7 +598,6 @@ mod tests {
             name: "get_weather".to_string(),
             description: "Get weather".to_string(),
             parameters: serde_json::json!({}),
-            kind: crate::tool_types::BuiltinToolKind::HttpGet,
             policy: crate::tool_types::ToolPolicy::Auto,
         });
 

--- a/crates/everruns-core/src/tools.rs
+++ b/crates/everruns-core/src/tools.rs
@@ -16,9 +16,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::error;
 
-use crate::tool_types::{
-    BuiltinTool, BuiltinToolKind, ToolCall, ToolDefinition, ToolPolicy, ToolResult,
-};
+use crate::tool_types::{BuiltinTool, ToolCall, ToolDefinition, ToolPolicy, ToolResult};
 
 use crate::error::Result;
 use crate::traits::ToolExecutor;
@@ -265,7 +263,6 @@ pub trait Tool: Send + Sync {
             name: self.name().to_string(),
             description: self.description().to_string(),
             parameters: self.parameters_schema(),
-            kind: BuiltinToolKind::HttpGet, // Generic kind for custom tools
             policy: self.policy(),
         })
     }

--- a/crates/everruns-core/tests/tool_calling_test.rs
+++ b/crates/everruns-core/tests/tool_calling_test.rs
@@ -10,7 +10,7 @@ use everruns_core::{
     traits::ToolExecutor,
     AgentConfig, AgentLoop, LoopEvent, Message, MessageRole,
 };
-use everruns_core::{BuiltinTool, BuiltinToolKind, ToolCall, ToolDefinition, ToolPolicy};
+use everruns_core::{BuiltinTool, ToolCall, ToolDefinition, ToolPolicy};
 use serde_json::json;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -39,7 +39,6 @@ async fn test_tool_registry_as_executor() {
         name: "echo".to_string(),
         description: "Echo".to_string(),
         parameters: json!({}),
-        kind: BuiltinToolKind::HttpGet,
         policy: ToolPolicy::Auto,
     });
 
@@ -64,7 +63,6 @@ async fn test_get_current_time_tool() {
         name: "get_current_time".to_string(),
         description: "Get time".to_string(),
         parameters: json!({}),
-        kind: BuiltinToolKind::HttpGet,
         policy: ToolPolicy::Auto,
     });
 
@@ -93,7 +91,6 @@ async fn test_tool_error_handling() {
         name: "failing_tool".to_string(),
         description: "A tool that fails".to_string(),
         parameters: json!({}),
-        kind: BuiltinToolKind::HttpGet,
         policy: ToolPolicy::Auto,
     });
 
@@ -121,7 +118,6 @@ async fn test_internal_error_is_hidden() {
         name: "failing_tool".to_string(),
         description: "A tool that fails internally".to_string(),
         parameters: json!({}),
-        kind: BuiltinToolKind::HttpGet,
         policy: ToolPolicy::Auto,
     });
 
@@ -150,7 +146,6 @@ async fn test_tool_not_found_error() {
         name: "nonexistent_tool".to_string(),
         description: "Does not exist".to_string(),
         parameters: json!({}),
-        kind: BuiltinToolKind::HttpGet,
         policy: ToolPolicy::Auto,
     });
 
@@ -192,7 +187,6 @@ async fn test_agent_loop_with_tool_execution() {
             name: "get_current_time".to_string(),
             description: "Get the current time".to_string(),
             parameters: json!({}),
-            kind: BuiltinToolKind::HttpGet,
             policy: ToolPolicy::Auto,
         })]);
 
@@ -238,7 +232,6 @@ async fn test_agent_loop_with_tool_execution() {
             name: "get_current_time".to_string(),
             description: "Get the current time".to_string(),
             parameters: json!({}),
-            kind: BuiltinToolKind::HttpGet,
             policy: ToolPolicy::Auto,
         })]);
 
@@ -338,7 +331,6 @@ async fn test_custom_tool_execution() {
         name: "counter".to_string(),
         description: "Counter".to_string(),
         parameters: json!({}),
-        kind: BuiltinToolKind::HttpGet,
         policy: ToolPolicy::Auto,
     });
 
@@ -377,7 +369,6 @@ async fn test_multiple_tools_in_registry() {
         name: "get_current_time".to_string(),
         description: "Get time".to_string(),
         parameters: json!({}),
-        kind: BuiltinToolKind::HttpGet,
         policy: ToolPolicy::Auto,
     });
 
@@ -396,7 +387,6 @@ async fn test_multiple_tools_in_registry() {
         name: "echo".to_string(),
         description: "Echo".to_string(),
         parameters: json!({}),
-        kind: BuiltinToolKind::HttpGet,
         policy: ToolPolicy::Auto,
     });
 

--- a/crates/everruns-storage/migrations/005_remove_capability_check_constraint.sql
+++ b/crates/everruns-storage/migrations/005_remove_capability_check_constraint.sql
@@ -1,0 +1,12 @@
+-- Remove Capability CHECK Constraint (v0.2.3)
+-- Decision: Remove capability_id CHECK constraint to allow dynamic capabilities
+--
+-- Previously capability_id was validated against a fixed list in the database.
+-- Now validation happens at the application layer via CapabilityRegistry.
+-- This allows adding new capabilities without database migrations.
+
+-- ============================================
+-- Drop the check constraint
+-- ============================================
+
+ALTER TABLE agent_capabilities DROP CONSTRAINT agent_capabilities_capability_id_check;

--- a/crates/everruns-worker/src/unified_tool_executor.rs
+++ b/crates/everruns-worker/src/unified_tool_executor.rs
@@ -115,7 +115,7 @@ impl ToolExecutor for UnifiedToolExecutor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use everruns_contracts::tools::{BuiltinTool, BuiltinToolKind, ToolPolicy};
+    use everruns_contracts::tools::{BuiltinTool, ToolPolicy};
     use everruns_core::{EchoTool, FailingTool, GetCurrentTime};
     use serde_json::json;
 
@@ -134,7 +134,6 @@ mod tests {
             name: "get_current_time".to_string(),
             description: "Get current time".to_string(),
             parameters: json!({}),
-            kind: BuiltinToolKind::HttpGet,
             policy: ToolPolicy::Auto,
         });
 
@@ -161,7 +160,6 @@ mod tests {
             name: "echo".to_string(),
             description: "Echo message".to_string(),
             parameters: json!({}),
-            kind: BuiltinToolKind::HttpGet,
             policy: ToolPolicy::Auto,
         });
 
@@ -188,7 +186,6 @@ mod tests {
             name: "nonexistent_tool".to_string(),
             description: "Does not exist".to_string(),
             parameters: json!({}),
-            kind: BuiltinToolKind::HttpGet,
             policy: ToolPolicy::Auto,
         });
 
@@ -215,7 +212,6 @@ mod tests {
             name: "failing_tool".to_string(),
             description: "Always fails".to_string(),
             parameters: json!({}),
-            kind: BuiltinToolKind::HttpGet,
             policy: ToolPolicy::Auto,
         });
 


### PR DESCRIPTION
This refactoring allows adding new Capabilities and Tools without requiring database migrations:

1. Replace CapabilityId enum with String-based identifier
   - CapabilityId is now a newtype wrapper around String
   - Provides constants (NOOP, CURRENT_TIME, etc.) for built-in IDs
   - Any string can be used as a capability ID for custom capabilities

2. Remove BuiltinToolKind enum from tool_types.rs
   - Tools are now identified solely by name
   - Tool execution happens via ToolRegistry lookup by name
   - Simplifies tool definition structure

3. Create database migration (005) to remove CHECK constraint
   - Drops agent_capabilities_capability_id_check constraint
   - Validation now happens at application layer via CapabilityRegistry

4. Update CapabilityRegistry to use String keys
   - get() and has() methods now take &str instead of CapabilityId enum
   - apply_capabilities() takes &[String] instead of &[CapabilityId]

5. Update specs/capabilities.md documentation
   - Document new extensibility approach
   - Add guide for adding new capabilities without DB changes

Benefits:
- Adding new capabilities only requires implementing Capability trait
- Adding new tools only requires implementing Tool trait
- No database migrations needed for new capabilities/tools
- Validation happens at runtime via registry lookup