### PR TITLE
Implement Claude LLM Provider with model selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,8 @@ When making changes that affect user-facing behavior or operations, update the r
 
 When running in cloud-hosted agent environments (e.g., Claude Code on the web), the following secrets are available:
 
-- `OPENAI_API_KEY`: Available for LLM-related operations
+- `OPENAI_API_KEY`: Available for LLM-related operations (OpenAI models)
+- `ANTHROPIC_API_KEY`: Available for LLM-related operations (Claude models)
 - `GITHUB_TOKEN`: Available for GitHub API operations (PRs, issues, repository access)
 
 These secrets are pre-configured in the environment and do not require manual setup.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -757,6 +757,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "everruns-anthropic"
+version = "0.2.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "eventsource-stream",
+ "everruns-contracts",
+ "everruns-core",
+ "futures",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.22",
+]
+
+[[package]]
 name = "everruns-api"
 version = "0.2.0"
 dependencies = [
@@ -875,6 +894,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "everruns-anthropic",
  "everruns-contracts",
  "everruns-core",
  "everruns-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/everruns-storage",
     "crates/everruns-core",
     "crates/everruns-openai",
+    "crates/everruns-anthropic",
 ]
 
 [workspace.package]

--- a/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
@@ -10,6 +10,7 @@ import {
   useCapabilities,
   useAgentCapabilities,
   useSetAgentCapabilities,
+  useLlmModels,
 } from "@/hooks";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
@@ -20,6 +21,13 @@ import { PromptEditor } from "@/components/ui/prompt-editor";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import {
   ArrowLeft,
   Save,
@@ -48,6 +56,7 @@ interface FormData {
   description: string;
   system_prompt: string;
   tags: string;
+  default_model_id: string;
 }
 
 export default function EditAgentPage({
@@ -70,19 +79,23 @@ export default function EditAgentPage({
     useAgentCapabilities(agentId);
   const setCapabilities = useSetAgentCapabilities();
 
+  // LLM Models data
+  const { data: models = [] } = useLlmModels();
+
   // Form state - track user changes separately from initial values
   const [formChanges, setFormChanges] = useState<Partial<FormData>>({});
 
   // Compute initial values from agent data
   const initialFormData = useMemo((): FormData => {
     if (!agent) {
-      return { name: "", description: "", system_prompt: "", tags: "" };
+      return { name: "", description: "", system_prompt: "", tags: "", default_model_id: "" };
     }
     return {
       name: agent.name,
       description: agent.description || "",
       system_prompt: agent.system_prompt,
       tags: agent.tags.join(", "),
+      default_model_id: agent.default_model_id || "",
     };
   }, [agent]);
 
@@ -180,6 +193,7 @@ export default function EditAgentPage({
           description: formData.description || undefined,
           system_prompt: formData.system_prompt,
           tags,
+          default_model_id: formData.default_model_id || undefined,
         },
       });
 
@@ -307,6 +321,31 @@ export default function EditAgentPage({
                   />
                   <p className="text-xs text-muted-foreground">
                     Comma-separated list of tags
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="model">Model (optional)</Label>
+                  <Select
+                    value={formData.default_model_id || "none"}
+                    onValueChange={(value) =>
+                      handleFormChange("default_model_id", value === "none" ? "" : value)
+                    }
+                  >
+                    <SelectTrigger className="w-full">
+                      <SelectValue placeholder="Use default model" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="none">Use default model</SelectItem>
+                      {models.map((model) => (
+                        <SelectItem key={model.id} value={model.id}>
+                          {model.display_name} ({model.provider_name})
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-muted-foreground">
+                    Select a specific model or leave empty to use the default
                   </p>
                 </div>
 

--- a/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
@@ -333,7 +333,14 @@ export default function EditAgentPage({
                     }
                   >
                     <SelectTrigger className="w-full">
-                      <SelectValue placeholder="Use default model" />
+                      <SelectValue>
+                        {formData.default_model_id
+                          ? models.find((m) => m.id === formData.default_model_id)?.display_name +
+                            " (" +
+                            models.find((m) => m.id === formData.default_model_id)?.provider_name +
+                            ")"
+                          : "Use default model"}
+                      </SelectValue>
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="none">Use default model</SelectItem>

--- a/apps/ui/src/app/(main)/agents/new/page.tsx
+++ b/apps/ui/src/app/(main)/agents/new/page.tsx
@@ -93,13 +93,20 @@ export default function NewAgentPage() {
             <div className="space-y-2">
               <Label htmlFor="model">Model (optional)</Label>
               <Select
-                value={formData.default_model_id}
+                value={formData.default_model_id || "none"}
                 onValueChange={(value) =>
                   setFormData({ ...formData, default_model_id: value === "none" ? "" : value })
                 }
               >
                 <SelectTrigger className="w-full">
-                  <SelectValue placeholder="Use default model" />
+                  <SelectValue>
+                    {formData.default_model_id
+                      ? models.find((m) => m.id === formData.default_model_id)?.display_name +
+                        " (" +
+                        models.find((m) => m.id === formData.default_model_id)?.provider_name +
+                        ")"
+                      : "Use default model"}
+                  </SelectValue>
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="none">Use default model</SelectItem>

--- a/apps/ui/src/app/(main)/agents/new/page.tsx
+++ b/apps/ui/src/app/(main)/agents/new/page.tsx
@@ -2,24 +2,33 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { useCreateAgent } from "@/hooks";
+import { useCreateAgent, useLlmModels } from "@/hooks";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { PromptEditor } from "@/components/ui/prompt-editor";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 
 export default function NewAgentPage() {
   const router = useRouter();
   const createAgent = useCreateAgent();
+  const { data: models = [] } = useLlmModels();
 
   const [formData, setFormData] = useState({
     name: "",
     description: "",
     system_prompt: "",
+    default_model_id: "",
   });
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -30,6 +39,7 @@ export default function NewAgentPage() {
         name: formData.name,
         description: formData.description || undefined,
         system_prompt: formData.system_prompt,
+        default_model_id: formData.default_model_id || undefined,
       });
 
       router.push(`/agents/${agent.id}`);
@@ -78,6 +88,31 @@ export default function NewAgentPage() {
                 }
                 rows={2}
               />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="model">Model (optional)</Label>
+              <Select
+                value={formData.default_model_id}
+                onValueChange={(value) =>
+                  setFormData({ ...formData, default_model_id: value === "none" ? "" : value })
+                }
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Use default model" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">Use default model</SelectItem>
+                  {models.map((model) => (
+                    <SelectItem key={model.id} value={model.id}>
+                      {model.display_name} ({model.provider_name})
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                Select a specific model or leave empty to use the default
+              </p>
             </div>
 
             <div className="space-y-2">

--- a/apps/ui/src/app/(main)/settings/providers/page.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/page.tsx
@@ -57,9 +57,21 @@ const PROVIDER_TYPES: { value: LlmProviderType; label: string }[] = [
   { value: "openai", label: "OpenAI" },
   { value: "anthropic", label: "Anthropic" },
   { value: "azure_openai", label: "Azure OpenAI" },
-  { value: "ollama", label: "Ollama" },
-  { value: "custom", label: "Custom" },
 ];
+
+// Get API key placeholder based on provider type
+function getApiKeyPlaceholder(providerType: LlmProviderType): string {
+  switch (providerType) {
+    case "openai":
+      return "sk-...";
+    case "anthropic":
+      return "sk-ant-api03-...";
+    case "azure_openai":
+      return "your-azure-api-key";
+    default:
+      return "your-api-key";
+  }
+}
 
 function ProviderCard({
   provider,
@@ -280,7 +292,7 @@ function AddProviderDialog({
               type="password"
               value={apiKey}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => setApiKey(e.target.value)}
-              placeholder="sk-..."
+              placeholder={getApiKeyPlaceholder(providerType)}
             />
           </div>
           <div className="flex items-center gap-2">
@@ -348,7 +360,7 @@ function SetApiKeyDialog({
               type="password"
               value={apiKey}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => setApiKey(e.target.value)}
-              placeholder="sk-..."
+              placeholder={provider ? getApiKeyPlaceholder(provider.provider_type) : "your-api-key"}
               required
             />
           </div>

--- a/crates/everruns-anthropic/Cargo.toml
+++ b/crates/everruns-anthropic/Cargo.toml
@@ -1,0 +1,40 @@
+# Anthropic Provider Implementation
+# Decision: Implements the core LlmProvider trait for Claude API
+# Decision: Uses Anthropic's messages API with streaming support
+
+[package]
+name = "everruns-anthropic"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Anthropic Claude provider implementation for Everruns"
+
+[dependencies]
+# Core dependencies
+anyhow.workspace = true
+thiserror.workspace = true
+async-trait.workspace = true
+
+# Async runtime
+tokio.workspace = true
+futures.workspace = true
+
+# HTTP client
+reqwest.workspace = true
+eventsource-stream.workspace = true
+
+# Serialization
+serde.workspace = true
+serde_json.workspace = true
+
+# Tracing
+tracing.workspace = true
+
+# Internal dependencies
+everruns-core = { path = "../everruns-core" }
+everruns-contracts = { path = "../everruns-contracts" }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full", "test-util"] }
+tracing-subscriber.workspace = true

--- a/crates/everruns-anthropic/src/lib.rs
+++ b/crates/everruns-anthropic/src/lib.rs
@@ -1,0 +1,15 @@
+// Anthropic Provider Implementation
+//
+// This crate provides an Anthropic Claude LLM provider implementation.
+// It implements the LlmProvider trait from everruns-core, enabling
+// the agent loop to communicate with Anthropic's Messages API.
+
+mod provider;
+
+#[cfg(test)]
+mod tests;
+
+pub use provider::AnthropicProvider;
+
+// Re-export core types for convenience
+pub use everruns_core::llm::LlmProvider;

--- a/crates/everruns-anthropic/src/provider.rs
+++ b/crates/everruns-anthropic/src/provider.rs
@@ -1,0 +1,72 @@
+// Anthropic Provider Implementation
+//
+// This module provides AnthropicProvider as a wrapper around the core
+// AnthropicLlmProvider implementation.
+
+use anyhow::Result;
+
+/// Anthropic Claude LLM provider
+///
+/// This is a thin wrapper around `everruns_core::anthropic::AnthropicLlmProvider`
+/// that provides a clean API for the worker and other components.
+pub struct AnthropicProvider {
+    inner: everruns_core::anthropic::AnthropicLlmProvider,
+}
+
+impl AnthropicProvider {
+    /// Create a new Anthropic provider
+    /// Requires ANTHROPIC_API_KEY environment variable
+    pub fn new() -> Result<Self> {
+        let inner = everruns_core::anthropic::AnthropicLlmProvider::from_env()
+            .map_err(|e| anyhow::anyhow!("{}", e))?;
+        Ok(Self { inner })
+    }
+
+    /// Create a new Anthropic provider with a custom API key
+    pub fn with_api_key(api_key: String) -> Self {
+        Self {
+            inner: everruns_core::anthropic::AnthropicLlmProvider::new(api_key),
+        }
+    }
+
+    /// Create a new Anthropic provider with a custom API key and base URL
+    pub fn with_base_url(api_key: String, base_url: String) -> Self {
+        Self {
+            inner: everruns_core::anthropic::AnthropicLlmProvider::with_base_url(api_key, base_url),
+        }
+    }
+
+    /// Get a reference to the inner provider
+    pub fn inner(&self) -> &everruns_core::anthropic::AnthropicLlmProvider {
+        &self.inner
+    }
+}
+
+impl Default for AnthropicProvider {
+    fn default() -> Self {
+        Self::new().expect("Failed to create Anthropic provider")
+    }
+}
+
+// Delegate LlmProvider implementation to inner
+use async_trait::async_trait;
+use everruns_core::llm::{LlmCallConfig, LlmMessage, LlmProvider, LlmResponseStream};
+
+#[async_trait]
+impl LlmProvider for AnthropicProvider {
+    async fn chat_completion_stream(
+        &self,
+        messages: Vec<LlmMessage>,
+        config: &LlmCallConfig,
+    ) -> everruns_core::error::Result<LlmResponseStream> {
+        self.inner.chat_completion_stream(messages, config).await
+    }
+}
+
+impl std::fmt::Debug for AnthropicProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AnthropicProvider")
+            .field("inner", &self.inner)
+            .finish()
+    }
+}

--- a/crates/everruns-anthropic/src/tests.rs
+++ b/crates/everruns-anthropic/src/tests.rs
@@ -1,0 +1,19 @@
+// Unit tests for Anthropic provider
+
+use crate::AnthropicProvider;
+
+#[test]
+fn test_provider_with_api_key() {
+    let provider = AnthropicProvider::with_api_key("test-key".to_string());
+    // Just verify it can be created
+    assert!(format!("{:?}", provider).contains("AnthropicProvider"));
+}
+
+#[test]
+fn test_provider_with_base_url() {
+    let provider = AnthropicProvider::with_base_url(
+        "test-key".to_string(),
+        "https://custom.api.com/v1/messages".to_string(),
+    );
+    assert!(format!("{:?}", provider).contains("AnthropicProvider"));
+}

--- a/crates/everruns-core/src/anthropic.rs
+++ b/crates/everruns-core/src/anthropic.rs
@@ -1,0 +1,526 @@
+// Anthropic Claude LLM Provider
+//
+// Implementation of LlmProvider for Anthropic's Claude API.
+// Uses the Messages API with streaming support.
+
+use async_trait::async_trait;
+use eventsource_stream::Eventsource;
+use futures::StreamExt;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::sync::{Arc, Mutex};
+
+use crate::error::{AgentLoopError, Result};
+use crate::llm::{
+    LlmCallConfig, LlmCompletionMetadata, LlmContentPart, LlmMessage, LlmMessageContent,
+    LlmMessageRole, LlmProvider, LlmResponseStream, LlmStreamEvent,
+};
+use crate::tool_types::{ToolCall, ToolDefinition};
+
+const DEFAULT_API_URL: &str = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_VERSION: &str = "2023-06-01";
+
+/// Anthropic Claude LLM Provider
+///
+/// Implements `LlmProvider` for Anthropic's Messages API.
+/// Supports streaming responses and tool calls.
+///
+/// # Example
+///
+/// ```ignore
+/// use everruns_core::anthropic::AnthropicLlmProvider;
+///
+/// let provider = AnthropicLlmProvider::from_env()?;
+/// // or
+/// let provider = AnthropicLlmProvider::new("your-api-key");
+/// // or with custom endpoint
+/// let provider = AnthropicLlmProvider::with_base_url("your-api-key", "https://api.example.com/v1/messages");
+/// ```
+#[derive(Clone)]
+pub struct AnthropicLlmProvider {
+    client: Client,
+    api_key: String,
+    api_url: String,
+}
+
+impl AnthropicLlmProvider {
+    /// Create a new provider with the given API key
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self {
+            client: Client::new(),
+            api_key: api_key.into(),
+            api_url: DEFAULT_API_URL.to_string(),
+        }
+    }
+
+    /// Create a new provider from the ANTHROPIC_API_KEY environment variable
+    pub fn from_env() -> Result<Self> {
+        let api_key = std::env::var("ANTHROPIC_API_KEY")
+            .map_err(|_| AgentLoopError::llm("ANTHROPIC_API_KEY environment variable not set"))?;
+        Ok(Self::new(api_key))
+    }
+
+    /// Create a new provider with a custom API URL
+    pub fn with_base_url(api_key: impl Into<String>, api_url: impl Into<String>) -> Self {
+        Self {
+            client: Client::new(),
+            api_key: api_key.into(),
+            api_url: api_url.into(),
+        }
+    }
+
+    fn convert_role(role: &LlmMessageRole) -> &'static str {
+        match role {
+            LlmMessageRole::System => "user", // System is handled separately in Anthropic
+            LlmMessageRole::User => "user",
+            LlmMessageRole::Assistant => "assistant",
+            LlmMessageRole::Tool => "user", // Tool results are sent as user messages
+        }
+    }
+
+    fn convert_content(content: &LlmMessageContent) -> Vec<AnthropicContentBlock> {
+        match content {
+            LlmMessageContent::Text(text) => {
+                vec![AnthropicContentBlock::Text { text: text.clone() }]
+            }
+            LlmMessageContent::Parts(parts) => parts
+                .iter()
+                .map(|part| match part {
+                    LlmContentPart::Text { text } => {
+                        AnthropicContentBlock::Text { text: text.clone() }
+                    }
+                    LlmContentPart::Image { url } => {
+                        // Parse data URL or use as-is
+                        if url.starts_with("data:") {
+                            // Parse data URL: data:image/jpeg;base64,/9j/4AAQ...
+                            let parts: Vec<&str> = url.splitn(2, ',').collect();
+                            let (media_type, data) = if parts.len() == 2 {
+                                let type_part = parts[0]
+                                    .trim_start_matches("data:")
+                                    .trim_end_matches(";base64");
+                                (type_part.to_string(), parts[1].to_string())
+                            } else {
+                                ("image/jpeg".to_string(), url.clone())
+                            };
+                            AnthropicContentBlock::Image {
+                                source: AnthropicImageSource::Base64 { media_type, data },
+                            }
+                        } else {
+                            // HTTP URL
+                            AnthropicContentBlock::Image {
+                                source: AnthropicImageSource::Url { url: url.clone() },
+                            }
+                        }
+                    }
+                    LlmContentPart::Audio { .. } => {
+                        // Anthropic doesn't support audio input yet, convert to text note
+                        AnthropicContentBlock::Text {
+                            text: "[Audio content not supported]".to_string(),
+                        }
+                    }
+                })
+                .collect(),
+        }
+    }
+
+    fn convert_messages(messages: &[LlmMessage]) -> (Option<String>, Vec<AnthropicMessage>) {
+        let mut system_prompt = None;
+        let mut converted = Vec::new();
+
+        for msg in messages {
+            match msg.role {
+                LlmMessageRole::System => {
+                    // Extract system prompt (Anthropic handles it separately)
+                    system_prompt = Some(msg.content.to_text());
+                }
+                LlmMessageRole::Tool => {
+                    // Tool results in Anthropic are user messages with tool_result content blocks
+                    if let Some(tool_call_id) = &msg.tool_call_id {
+                        converted.push(AnthropicMessage {
+                            role: "user".to_string(),
+                            content: vec![AnthropicContentBlock::ToolResult {
+                                tool_use_id: tool_call_id.clone(),
+                                content: msg.content.to_text(),
+                                is_error: None,
+                            }],
+                        });
+                    }
+                }
+                LlmMessageRole::Assistant => {
+                    let mut content = Self::convert_content(&msg.content);
+
+                    // Add tool_use blocks if present
+                    if let Some(tool_calls) = &msg.tool_calls {
+                        for tc in tool_calls {
+                            content.push(AnthropicContentBlock::ToolUse {
+                                id: tc.id.clone(),
+                                name: tc.name.clone(),
+                                input: tc.arguments.clone(),
+                            });
+                        }
+                    }
+
+                    converted.push(AnthropicMessage {
+                        role: Self::convert_role(&msg.role).to_string(),
+                        content,
+                    });
+                }
+                _ => {
+                    converted.push(AnthropicMessage {
+                        role: Self::convert_role(&msg.role).to_string(),
+                        content: Self::convert_content(&msg.content),
+                    });
+                }
+            }
+        }
+
+        (system_prompt, converted)
+    }
+
+    fn convert_tools(tools: &[ToolDefinition]) -> Vec<AnthropicTool> {
+        tools
+            .iter()
+            .map(|tool| {
+                let (name, description, parameters) = match tool {
+                    ToolDefinition::Builtin(builtin) => {
+                        (&builtin.name, &builtin.description, &builtin.parameters)
+                    }
+                };
+
+                AnthropicTool {
+                    name: name.clone(),
+                    description: description.clone(),
+                    input_schema: parameters.clone(),
+                }
+            })
+            .collect()
+    }
+}
+
+#[async_trait]
+impl LlmProvider for AnthropicLlmProvider {
+    async fn chat_completion_stream(
+        &self,
+        messages: Vec<LlmMessage>,
+        config: &LlmCallConfig,
+    ) -> Result<LlmResponseStream> {
+        let (system_prompt, anthropic_messages) = Self::convert_messages(&messages);
+
+        let tools = if config.tools.is_empty() {
+            None
+        } else {
+            Some(Self::convert_tools(&config.tools))
+        };
+
+        let mut request = AnthropicRequest {
+            model: config.model.clone(),
+            messages: anthropic_messages,
+            max_tokens: config.max_tokens.unwrap_or(4096),
+            temperature: config.temperature,
+            system: system_prompt,
+            stream: true,
+            tools,
+        };
+
+        // Ensure max_tokens is set (required by Anthropic)
+        if request.max_tokens == 0 {
+            request.max_tokens = 4096;
+        }
+
+        let response = self
+            .client
+            .post(&self.api_url)
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", ANTHROPIC_VERSION)
+            .header("Content-Type", "application/json")
+            .json(&request)
+            .send()
+            .await
+            .map_err(|e| AgentLoopError::llm(format!("Failed to send request: {}", e)))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await.unwrap_or_default();
+            return Err(AgentLoopError::llm(format!(
+                "Anthropic API error ({}): {}",
+                status, error_text
+            )));
+        }
+
+        let byte_stream = response.bytes_stream();
+        let event_stream = byte_stream.eventsource();
+
+        let model = config.model.clone();
+        let input_tokens = Arc::new(Mutex::new(0u32));
+        let output_tokens = Arc::new(Mutex::new(0u32));
+        let current_tool_call = Arc::new(Mutex::new(Option::<ToolCall>::None));
+        let accumulated_tool_calls = Arc::new(Mutex::new(Vec::<ToolCall>::new()));
+
+        let converted_stream: LlmResponseStream = Box::pin(event_stream.then(move |result| {
+            let model = model.clone();
+            let input_tokens = Arc::clone(&input_tokens);
+            let output_tokens = Arc::clone(&output_tokens);
+            let current_tool_call = Arc::clone(&current_tool_call);
+            let accumulated_tool_calls = Arc::clone(&accumulated_tool_calls);
+
+            async move {
+                match result {
+                    Ok(event) => {
+                        // Anthropic uses different event types
+                        match event.event.as_str() {
+                            "message_start" => {
+                                // Parse message_start for input token count
+                                if let Ok(data) =
+                                    serde_json::from_str::<AnthropicMessageStart>(&event.data)
+                                {
+                                    if let Some(usage) = data.message.usage {
+                                        *input_tokens.lock().unwrap() = usage.input_tokens;
+                                    }
+                                }
+                                Ok(LlmStreamEvent::TextDelta(String::new()))
+                            }
+                            "content_block_start" => {
+                                // Check if starting a tool use block
+                                if let Ok(data) =
+                                    serde_json::from_str::<AnthropicContentBlockStart>(&event.data)
+                                {
+                                    if let AnthropicContentBlockDelta::ToolUse { id, name } =
+                                        data.content_block
+                                    {
+                                        let mut current = current_tool_call.lock().unwrap();
+                                        *current = Some(ToolCall {
+                                            id,
+                                            name,
+                                            arguments: json!(""),
+                                        });
+                                    }
+                                }
+                                Ok(LlmStreamEvent::TextDelta(String::new()))
+                            }
+                            "content_block_delta" => {
+                                if let Ok(data) = serde_json::from_str::<
+                                    AnthropicContentBlockDeltaEvent,
+                                >(&event.data)
+                                {
+                                    match data.delta {
+                                        AnthropicDelta::TextDelta { text } => {
+                                            *output_tokens.lock().unwrap() += 1;
+                                            return Ok(LlmStreamEvent::TextDelta(text));
+                                        }
+                                        AnthropicDelta::InputJsonDelta { partial_json } => {
+                                            // Accumulate tool input JSON
+                                            let mut current = current_tool_call.lock().unwrap();
+                                            if let Some(ref mut tc) = *current {
+                                                let current_args =
+                                                    tc.arguments.as_str().unwrap_or("");
+                                                let combined =
+                                                    format!("{}{}", current_args, partial_json);
+                                                tc.arguments = json!(combined);
+                                            }
+                                            return Ok(LlmStreamEvent::TextDelta(String::new()));
+                                        }
+                                    }
+                                }
+                                Ok(LlmStreamEvent::TextDelta(String::new()))
+                            }
+                            "content_block_stop" => {
+                                // Finalize current tool call if any
+                                let mut current = current_tool_call.lock().unwrap();
+                                if let Some(mut tc) = current.take() {
+                                    // Parse the accumulated JSON string
+                                    if let Some(args_str) = tc.arguments.as_str() {
+                                        tc.arguments =
+                                            serde_json::from_str(args_str).unwrap_or(json!({}));
+                                    }
+                                    accumulated_tool_calls.lock().unwrap().push(tc);
+                                }
+                                Ok(LlmStreamEvent::TextDelta(String::new()))
+                            }
+                            "message_delta" => {
+                                // Check for stop_reason and output tokens
+                                if let Ok(data) =
+                                    serde_json::from_str::<AnthropicMessageDelta>(&event.data)
+                                {
+                                    if let Some(usage) = data.usage {
+                                        *output_tokens.lock().unwrap() = usage.output_tokens;
+                                    }
+
+                                    if let Some(stop_reason) = data.delta.stop_reason {
+                                        if stop_reason == "tool_use" {
+                                            let tool_calls =
+                                                accumulated_tool_calls.lock().unwrap().clone();
+                                            if !tool_calls.is_empty() {
+                                                return Ok(LlmStreamEvent::ToolCalls(tool_calls));
+                                            }
+                                        }
+                                    }
+                                }
+                                Ok(LlmStreamEvent::TextDelta(String::new()))
+                            }
+                            "message_stop" => {
+                                let in_tokens = *input_tokens.lock().unwrap();
+                                let out_tokens = *output_tokens.lock().unwrap();
+                                Ok(LlmStreamEvent::Done(LlmCompletionMetadata {
+                                    total_tokens: Some(in_tokens + out_tokens),
+                                    prompt_tokens: Some(in_tokens),
+                                    completion_tokens: Some(out_tokens),
+                                    model: Some(model),
+                                    finish_reason: Some("stop".to_string()),
+                                }))
+                            }
+                            "error" => Ok(LlmStreamEvent::Error(format!(
+                                "Anthropic stream error: {}",
+                                event.data
+                            ))),
+                            "ping" => {
+                                // Keep-alive ping, ignore
+                                Ok(LlmStreamEvent::TextDelta(String::new()))
+                            }
+                            _ => {
+                                // Unknown event type, ignore
+                                Ok(LlmStreamEvent::TextDelta(String::new()))
+                            }
+                        }
+                    }
+                    Err(e) => Ok(LlmStreamEvent::Error(format!("Stream error: {}", e))),
+                }
+            }
+        }));
+
+        Ok(converted_stream)
+    }
+}
+
+impl std::fmt::Debug for AnthropicLlmProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AnthropicLlmProvider")
+            .field("api_url", &self.api_url)
+            .field("api_key", &"[REDACTED]")
+            .finish()
+    }
+}
+
+// ============================================================================
+// Anthropic API Types
+// ============================================================================
+
+#[derive(Debug, Serialize)]
+struct AnthropicRequest {
+    model: String,
+    messages: Vec<AnthropicMessage>,
+    max_tokens: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system: Option<String>,
+    stream: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tools: Option<Vec<AnthropicTool>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct AnthropicMessage {
+    role: String,
+    content: Vec<AnthropicContentBlock>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+enum AnthropicContentBlock {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "image")]
+    Image { source: AnthropicImageSource },
+    #[serde(rename = "tool_use")]
+    ToolUse {
+        id: String,
+        name: String,
+        input: Value,
+    },
+    #[serde(rename = "tool_result")]
+    ToolResult {
+        tool_use_id: String,
+        content: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        is_error: Option<bool>,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+enum AnthropicImageSource {
+    #[serde(rename = "base64")]
+    Base64 { media_type: String, data: String },
+    #[serde(rename = "url")]
+    Url { url: String },
+}
+
+#[derive(Debug, Serialize)]
+struct AnthropicTool {
+    name: String,
+    description: String,
+    input_schema: Value,
+}
+
+// Streaming response types
+
+#[derive(Debug, Deserialize)]
+struct AnthropicMessageStart {
+    message: AnthropicMessageInfo,
+}
+
+#[derive(Debug, Deserialize)]
+struct AnthropicMessageInfo {
+    #[serde(default)]
+    usage: Option<AnthropicUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AnthropicUsage {
+    #[serde(default)]
+    input_tokens: u32,
+    #[serde(default)]
+    output_tokens: u32,
+}
+
+#[derive(Debug, Deserialize)]
+struct AnthropicContentBlockStart {
+    content_block: AnthropicContentBlockDelta,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+#[allow(dead_code)] // Fields used for deserialization
+enum AnthropicContentBlockDelta {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "tool_use")]
+    ToolUse { id: String, name: String },
+}
+
+#[derive(Debug, Deserialize)]
+struct AnthropicContentBlockDeltaEvent {
+    delta: AnthropicDelta,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+enum AnthropicDelta {
+    #[serde(rename = "text_delta")]
+    TextDelta { text: String },
+    #[serde(rename = "input_json_delta")]
+    InputJsonDelta { partial_json: String },
+}
+
+#[derive(Debug, Deserialize)]
+struct AnthropicMessageDelta {
+    delta: AnthropicMessageDeltaData,
+    #[serde(default)]
+    usage: Option<AnthropicUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AnthropicMessageDeltaData {
+    stop_reason: Option<String>,
+}

--- a/crates/everruns-core/src/lib.rs
+++ b/crates/everruns-core/src/lib.rs
@@ -36,8 +36,10 @@ pub mod traits;
 // In-memory implementations for examples and testing
 pub mod memory;
 
-// OpenAI Protocol provider
+// LLM Protocol providers
+pub mod anthropic;
 pub mod openai;
+pub mod provider_factory;
 
 // Re-exports for convenience
 pub use config::AgentConfig;
@@ -92,5 +94,11 @@ pub use ag_ui::{
 
 // Tool types (runtime types defined in this crate)
 pub use tool_types::{BuiltinTool, ToolCall, ToolDefinition, ToolPolicy, ToolResult};
+
+// Provider factory re-exports
+pub use provider_factory::{
+    create_default_provider, create_provider, create_provider_from_env, BoxedLlmProvider,
+    ProviderConfig, ProviderType,
+};
 
 // Note: CapabilityId and CapabilityStatus are re-exported via capabilities module

--- a/crates/everruns-core/src/llm.rs
+++ b/crates/everruns-core/src/llm.rs
@@ -92,6 +92,26 @@ pub trait LlmProvider: Send + Sync {
     }
 }
 
+/// Implement LlmProvider for Box<dyn LlmProvider> to allow dynamic dispatch
+#[async_trait]
+impl LlmProvider for Box<dyn LlmProvider> {
+    async fn chat_completion_stream(
+        &self,
+        messages: Vec<LlmMessage>,
+        config: &LlmCallConfig,
+    ) -> Result<LlmResponseStream> {
+        (**self).chat_completion_stream(messages, config).await
+    }
+
+    async fn chat_completion(
+        &self,
+        messages: Vec<LlmMessage>,
+        config: &LlmCallConfig,
+    ) -> Result<LlmResponse> {
+        (**self).chat_completion(messages, config).await
+    }
+}
+
 // ============================================================================
 // Message Types
 // ============================================================================

--- a/crates/everruns-core/src/provider_factory.rs
+++ b/crates/everruns-core/src/provider_factory.rs
@@ -1,0 +1,207 @@
+// LLM Provider Factory
+//
+// Factory for creating LlmProvider instances based on provider type and configuration.
+// This enables dynamic provider selection at runtime based on model/provider configuration.
+
+use crate::anthropic::AnthropicLlmProvider;
+use crate::error::{AgentLoopError, Result};
+use crate::llm::LlmProvider;
+use crate::openai::OpenAIProtocolLlmProvider;
+
+/// Provider type enumeration matching the database/contracts
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProviderType {
+    OpenAI,
+    Anthropic,
+    AzureOpenAI,
+    Ollama,
+    Custom,
+}
+
+impl std::str::FromStr for ProviderType {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "openai" => Ok(ProviderType::OpenAI),
+            "anthropic" => Ok(ProviderType::Anthropic),
+            "azure_openai" => Ok(ProviderType::AzureOpenAI),
+            "ollama" => Ok(ProviderType::Ollama),
+            "custom" => Ok(ProviderType::Custom),
+            _ => Err(format!("Unknown provider type: {}", s)),
+        }
+    }
+}
+
+impl std::fmt::Display for ProviderType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ProviderType::OpenAI => write!(f, "openai"),
+            ProviderType::Anthropic => write!(f, "anthropic"),
+            ProviderType::AzureOpenAI => write!(f, "azure_openai"),
+            ProviderType::Ollama => write!(f, "ollama"),
+            ProviderType::Custom => write!(f, "custom"),
+        }
+    }
+}
+
+/// Configuration for creating an LLM provider
+#[derive(Debug, Clone)]
+pub struct ProviderConfig {
+    /// Type of provider
+    pub provider_type: ProviderType,
+    /// API key for authentication
+    pub api_key: Option<String>,
+    /// Base URL override (optional)
+    pub base_url: Option<String>,
+}
+
+impl ProviderConfig {
+    /// Create a new provider config
+    pub fn new(provider_type: ProviderType) -> Self {
+        Self {
+            provider_type,
+            api_key: None,
+            base_url: None,
+        }
+    }
+
+    /// Set the API key
+    pub fn with_api_key(mut self, api_key: impl Into<String>) -> Self {
+        self.api_key = Some(api_key.into());
+        self
+    }
+
+    /// Set the base URL
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = Some(base_url.into());
+        self
+    }
+}
+
+/// Boxed LLM provider for dynamic dispatch
+pub type BoxedLlmProvider = Box<dyn LlmProvider>;
+
+/// Create an LLM provider based on configuration
+///
+/// If no API key is provided, falls back to environment variables.
+pub fn create_provider(config: &ProviderConfig) -> Result<BoxedLlmProvider> {
+    match config.provider_type {
+        ProviderType::OpenAI | ProviderType::AzureOpenAI => {
+            let provider = match (&config.api_key, &config.base_url) {
+                (Some(key), Some(url)) => OpenAIProtocolLlmProvider::with_base_url(key, url),
+                (Some(key), None) => OpenAIProtocolLlmProvider::new(key),
+                (None, Some(url)) => {
+                    // Get key from env since none was provided
+                    let key = std::env::var("OPENAI_API_KEY").map_err(|_| {
+                        AgentLoopError::llm("OPENAI_API_KEY environment variable not set")
+                    })?;
+                    OpenAIProtocolLlmProvider::with_base_url(key, url)
+                }
+                (None, None) => OpenAIProtocolLlmProvider::from_env()?,
+            };
+            Ok(Box::new(provider))
+        }
+        ProviderType::Anthropic => {
+            let provider = match (&config.api_key, &config.base_url) {
+                (Some(key), Some(url)) => AnthropicLlmProvider::with_base_url(key, url),
+                (Some(key), None) => AnthropicLlmProvider::new(key),
+                (None, Some(url)) => {
+                    let key = std::env::var("ANTHROPIC_API_KEY").map_err(|_| {
+                        AgentLoopError::llm("ANTHROPIC_API_KEY environment variable not set")
+                    })?;
+                    AnthropicLlmProvider::with_base_url(key, url)
+                }
+                (None, None) => AnthropicLlmProvider::from_env()?,
+            };
+            Ok(Box::new(provider))
+        }
+        ProviderType::Ollama => {
+            // Ollama uses OpenAI-compatible API
+            let api_key = config
+                .api_key
+                .clone()
+                .unwrap_or_else(|| "ollama".to_string());
+            let base_url = config
+                .base_url
+                .clone()
+                .unwrap_or_else(|| "http://localhost:11434/v1/chat/completions".to_string());
+            let provider = OpenAIProtocolLlmProvider::with_base_url(api_key, base_url);
+            Ok(Box::new(provider))
+        }
+        ProviderType::Custom => {
+            // Custom providers use OpenAI-compatible API with required base_url
+            let base_url = config
+                .base_url
+                .as_ref()
+                .ok_or_else(|| AgentLoopError::llm("Custom provider requires base_url"))?;
+            let api_key = config
+                .api_key
+                .clone()
+                .or_else(|| std::env::var("CUSTOM_LLM_API_KEY").ok())
+                .unwrap_or_else(|| "custom".to_string());
+            let provider = OpenAIProtocolLlmProvider::with_base_url(api_key, base_url);
+            Ok(Box::new(provider))
+        }
+    }
+}
+
+/// Create a provider from environment variables based on provider type
+pub fn create_provider_from_env(provider_type: &str) -> Result<BoxedLlmProvider> {
+    let ptype: ProviderType = provider_type
+        .parse()
+        .map_err(|e: String| AgentLoopError::llm(e))?;
+
+    create_provider(&ProviderConfig::new(ptype))
+}
+
+/// Create the default provider (OpenAI from environment)
+pub fn create_default_provider() -> Result<BoxedLlmProvider> {
+    create_provider(&ProviderConfig::new(ProviderType::OpenAI))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_provider_type_parsing() {
+        assert_eq!(
+            "openai".parse::<ProviderType>().unwrap(),
+            ProviderType::OpenAI
+        );
+        assert_eq!(
+            "anthropic".parse::<ProviderType>().unwrap(),
+            ProviderType::Anthropic
+        );
+        assert_eq!(
+            "azure_openai".parse::<ProviderType>().unwrap(),
+            ProviderType::AzureOpenAI
+        );
+        assert_eq!(
+            "ollama".parse::<ProviderType>().unwrap(),
+            ProviderType::Ollama
+        );
+        assert_eq!(
+            "custom".parse::<ProviderType>().unwrap(),
+            ProviderType::Custom
+        );
+    }
+
+    #[test]
+    fn test_provider_type_display() {
+        assert_eq!(ProviderType::OpenAI.to_string(), "openai");
+        assert_eq!(ProviderType::Anthropic.to_string(), "anthropic");
+    }
+
+    #[test]
+    fn test_provider_config_builder() {
+        let config = ProviderConfig::new(ProviderType::Anthropic)
+            .with_api_key("test-key")
+            .with_base_url("https://custom.api.com");
+
+        assert_eq!(config.provider_type, ProviderType::Anthropic);
+        assert_eq!(config.api_key, Some("test-key".to_string()));
+        assert_eq!(config.base_url, Some("https://custom.api.com".to_string()));
+    }
+}

--- a/crates/everruns-worker/Cargo.toml
+++ b/crates/everruns-worker/Cargo.toml
@@ -19,6 +19,7 @@ everruns-contracts = { path = "../everruns-contracts" }
 everruns-storage = { path = "../everruns-storage" }
 everruns-core = { path = "../everruns-core" }
 everruns-openai = { path = "../everruns-openai" }
+everruns-anthropic = { path = "../everruns-anthropic" }
 
 chrono.workspace = true
 async-trait.workspace = true

--- a/crates/everruns-worker/src/adapters.rs
+++ b/crates/everruns-worker/src/adapters.rs
@@ -4,3 +4,32 @@
 // This file re-exports them for backward compatibility.
 
 pub use everruns_storage::{create_db_message_store, DbMessageStore};
+
+// Provider factory helper for creating LLM providers
+use everruns_core::{
+    provider_factory::{create_provider, BoxedLlmProvider, ProviderConfig, ProviderType},
+    AgentLoopError, Result,
+};
+
+/// Create an LLM provider based on configuration
+///
+/// This factory supports all provider types: OpenAI, Anthropic, Azure, Ollama, and Custom.
+pub fn create_llm_provider(
+    provider_type: &str,
+    api_key: Option<&str>,
+    base_url: Option<&str>,
+) -> Result<BoxedLlmProvider> {
+    let ptype: ProviderType = provider_type
+        .parse()
+        .map_err(|e: String| AgentLoopError::llm(e))?;
+
+    let mut config = ProviderConfig::new(ptype);
+    if let Some(key) = api_key {
+        config = config.with_api_key(key);
+    }
+    if let Some(url) = base_url {
+        config = config.with_base_url(url);
+    }
+
+    create_provider(&config)
+}

--- a/crates/everruns-worker/src/agent_workflow.rs
+++ b/crates/everruns-worker/src/agent_workflow.rs
@@ -68,16 +68,32 @@ pub struct ToolResultData {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentConfigData {
     pub model: String,
+    /// Provider type (openai, anthropic, azure_openai, ollama, custom)
+    #[serde(default = "default_provider_type")]
+    pub provider_type: String,
+    /// Optional API key (only passed when provider-specific key is configured)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_key: Option<String>,
+    /// Optional base URL override
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_url: Option<String>,
     pub system_prompt: Option<String>,
     pub tools: Vec<ToolDefinitionData>,
     #[serde(default)]
     pub max_iterations: u8,
 }
 
+fn default_provider_type() -> String {
+    "openai".to_string()
+}
+
 impl Default for AgentConfigData {
     fn default() -> Self {
         Self {
-            model: "gpt-5.2".to_string(),
+            model: "gpt-4o".to_string(),
+            provider_type: "openai".to_string(),
+            api_key: None,
+            base_url: None,
             system_prompt: None,
             tools: Vec::new(),
             max_iterations: 10,

--- a/harness/seed-agents.yaml
+++ b/harness/seed-agents.yaml
@@ -1,13 +1,63 @@
-# Seed Agents Configuration
-# Agents defined here will be seeded into the local development database.
-# Seeding is idempotent - agents with matching names will be skipped.
+# Seed Configuration
+# Providers and agents defined here will be seeded into the local development database.
+# Seeding is idempotent - items with matching names will be skipped.
 #
-# Schema:
+# Provider Schema:
+#   name: string (required) - Provider display name
+#   provider_type: string (required) - openai, anthropic, azure_openai
+#   api_key_env: string (optional) - Environment variable name for API key
+#   is_default: boolean (optional) - Set as default provider
+#   models: array (optional) - Models to create under this provider
+#     - model_id: string (required) - Model identifier (e.g., "gpt-4o")
+#       display_name: string (required) - Display name
+#       context_window: number (optional) - Context window size
+#       is_default: boolean (optional) - Set as default model
+#
+# Agent Schema:
 #   name: string (required) - Agent display name
 #   description: string (optional) - Agent description
 #   system_prompt: string (required) - System prompt for the LLM
 #   tags: string[] (optional) - Tags for organization
 #   capabilities: string[] (optional) - Capability IDs to enable
+
+providers:
+  - name: "OpenAI"
+    provider_type: "openai"
+    api_key_env: "OPENAI_API_KEY"
+    is_default: true
+    models:
+      - model_id: "gpt-5"
+        display_name: "GPT-5"
+        context_window: 200000
+        is_default: true
+      - model_id: "gpt-5-mini"
+        display_name: "GPT-5 Mini"
+        context_window: 200000
+      - model_id: "gpt-5-nano"
+        display_name: "GPT-5 Nano"
+        context_window: 128000
+      - model_id: "gpt-5.1"
+        display_name: "GPT-5.1"
+        context_window: 200000
+      - model_id: "gpt-4o"
+        display_name: "GPT-4o"
+        context_window: 128000
+      - model_id: "gpt-4o-mini"
+        display_name: "GPT-4o Mini"
+        context_window: 128000
+
+  - name: "Anthropic"
+    provider_type: "anthropic"
+    api_key_env: "ANTHROPIC_API_KEY"
+    is_default: false
+    models:
+      - model_id: "claude-sonnet-4-20250514"
+        display_name: "Claude Sonnet 4"
+        context_window: 200000
+        is_default: true
+      - model_id: "claude-3-5-haiku-20241022"
+        display_name: "Claude 3.5 Haiku"
+        context_window: 200000
 
 agents:
   - name: "Dad Jokes Agent"

--- a/scripts/seed-agents.sh
+++ b/scripts/seed-agents.sh
@@ -92,6 +92,57 @@ wait_for_api() {
   exit 1
 }
 
+# Get existing providers and return their names
+get_existing_provider_names() {
+  curl -s "$API_URL/v1/llm-providers" | jq -r '.data[].name'
+}
+
+# Check if provider with name already exists
+provider_exists() {
+  local name="$1"
+  local existing_names
+  existing_names=$(get_existing_provider_names)
+
+  echo "$existing_names" | grep -Fxq "$name"
+}
+
+# Get provider ID by name
+get_provider_id_by_name() {
+  local name="$1"
+  curl -s "$API_URL/v1/llm-providers" | jq -r ".data[] | select(.name == \"$name\") | .id"
+}
+
+# Get existing model IDs for a provider
+get_existing_model_ids() {
+  local provider_id="$1"
+  curl -s "$API_URL/v1/llm-providers/$provider_id/models" | jq -r '.[].model_id'
+}
+
+# Create a provider from JSON payload
+create_provider() {
+  local payload="$1"
+  local response
+
+  response=$(curl -s -X POST "$API_URL/v1/llm-providers" \
+    -H "Content-Type: application/json" \
+    -d "$payload")
+
+  echo "$response"
+}
+
+# Create a model under a provider
+create_model() {
+  local provider_id="$1"
+  local payload="$2"
+  local response
+
+  response=$(curl -s -X POST "$API_URL/v1/llm-providers/$provider_id/models" \
+    -H "Content-Type: application/json" \
+    -d "$payload")
+
+  echo "$response"
+}
+
 # Get existing agents and return their names as JSON array
 get_existing_agent_names() {
   curl -s "$API_URL/v1/agents" | jq -r '.items[].name'
@@ -128,6 +179,196 @@ set_agent_capabilities() {
       -H "Content-Type: application/json" \
       -d "$capabilities" > /dev/null
   fi
+}
+
+# Seed providers from YAML file
+seed_providers() {
+  if [[ ! -f "$SEED_FILE" ]]; then
+    echo "❌ Seed file not found: $SEED_FILE"
+    exit 1
+  fi
+
+  echo "📖 Reading seed providers from $SEED_FILE"
+
+  # Get number of providers in YAML
+  local provider_count
+  provider_count=$(yq '.providers | length' "$SEED_FILE")
+
+  if [[ "$provider_count" -eq 0 || "$provider_count" == "null" ]]; then
+    echo "   No providers defined in seed file"
+    return 0
+  fi
+
+  echo "   Found $provider_count provider(s) to seed"
+
+  local created=0
+  local skipped=0
+
+  # Process each provider
+  for i in $(seq 0 $((provider_count - 1))); do
+    local name
+    local provider_type
+    local api_key_env
+    local is_default
+    local api_key=""
+
+    # Extract provider fields
+    name=$(yq ".providers[$i].name" "$SEED_FILE")
+    provider_type=$(yq ".providers[$i].provider_type" "$SEED_FILE")
+    api_key_env=$(yq ".providers[$i].api_key_env // \"\"" "$SEED_FILE")
+    is_default=$(yq ".providers[$i].is_default // false" "$SEED_FILE")
+
+    # Get API key from environment variable if specified
+    if [[ -n "$api_key_env" && "$api_key_env" != "null" && "$api_key_env" != "" ]]; then
+      api_key="${!api_key_env:-}"
+    fi
+
+    # Check if provider already exists
+    if provider_exists "$name"; then
+      echo "   ⏭️  Skipping provider '$name' (already exists)"
+      skipped=$((skipped + 1))
+
+      # Still seed models for existing provider
+      local provider_id
+      provider_id=$(get_provider_id_by_name "$name")
+      if [[ -n "$provider_id" ]]; then
+        seed_models_for_provider "$i" "$provider_id"
+      fi
+      continue
+    fi
+
+    # Build create payload
+    local payload
+    if [[ -n "$api_key" ]]; then
+      payload=$(jq -n \
+        --arg name "$name" \
+        --arg provider_type "$provider_type" \
+        --argjson is_default "$is_default" \
+        --arg api_key "$api_key" \
+        '{
+          name: $name,
+          provider_type: $provider_type,
+          is_default: $is_default,
+          api_key: $api_key
+        }'
+      )
+    else
+      payload=$(jq -n \
+        --arg name "$name" \
+        --arg provider_type "$provider_type" \
+        --argjson is_default "$is_default" \
+        '{
+          name: $name,
+          provider_type: $provider_type,
+          is_default: $is_default
+        }'
+      )
+    fi
+
+    # Create the provider
+    echo "   🌱 Creating provider '$name'..."
+    local response
+    response=$(create_provider "$payload")
+
+    local provider_id
+    provider_id=$(echo "$response" | jq -r '.id // empty')
+
+    if [[ -z "$provider_id" ]]; then
+      echo "      ❌ Failed to create provider: $response"
+      continue
+    fi
+
+    if [[ -n "$api_key" ]]; then
+      echo "      ✅ Created with API key from \$$api_key_env"
+    else
+      echo "      ✅ Created (no API key - set \$$api_key_env to configure)"
+    fi
+
+    created=$((created + 1))
+
+    # Seed models for this provider
+    seed_models_for_provider "$i" "$provider_id"
+  done
+
+  echo ""
+  echo "📊 Provider seeding complete: $created created, $skipped skipped"
+}
+
+# Seed models for a specific provider
+seed_models_for_provider() {
+  local provider_index="$1"
+  local provider_id="$2"
+
+  local model_count
+  model_count=$(yq ".providers[$provider_index].models | length" "$SEED_FILE")
+
+  if [[ "$model_count" -eq 0 || "$model_count" == "null" ]]; then
+    return 0
+  fi
+
+  # Get existing model IDs for this provider
+  local existing_models
+  existing_models=$(get_existing_model_ids "$provider_id")
+
+  for j in $(seq 0 $((model_count - 1))); do
+    local model_id
+    local display_name
+    local context_window
+    local is_default
+
+    model_id=$(yq ".providers[$provider_index].models[$j].model_id" "$SEED_FILE")
+    display_name=$(yq ".providers[$provider_index].models[$j].display_name" "$SEED_FILE")
+    context_window=$(yq ".providers[$provider_index].models[$j].context_window // 0" "$SEED_FILE")
+    is_default=$(yq ".providers[$provider_index].models[$j].is_default // false" "$SEED_FILE")
+
+    # Check if model already exists
+    if echo "$existing_models" | grep -Fxq "$model_id"; then
+      echo "      ⏭️  Skipping model '$display_name' (already exists)"
+      continue
+    fi
+
+    # Build model payload
+    local payload
+    if [[ "$context_window" -gt 0 ]]; then
+      payload=$(jq -n \
+        --arg model_id "$model_id" \
+        --arg display_name "$display_name" \
+        --argjson context_window "$context_window" \
+        --argjson is_default "$is_default" \
+        '{
+          model_id: $model_id,
+          display_name: $display_name,
+          context_window: $context_window,
+          is_default: $is_default
+        }'
+      )
+    else
+      payload=$(jq -n \
+        --arg model_id "$model_id" \
+        --arg display_name "$display_name" \
+        --argjson is_default "$is_default" \
+        '{
+          model_id: $model_id,
+          display_name: $display_name,
+          is_default: $is_default
+        }'
+      )
+    fi
+
+    # Create the model
+    local response
+    response=$(create_model "$provider_id" "$payload")
+
+    local created_model_id
+    created_model_id=$(echo "$response" | jq -r '.id // empty')
+
+    if [[ -z "$created_model_id" ]]; then
+      echo "      ❌ Failed to create model '$display_name': $response"
+      continue
+    fi
+
+    echo "      🔧 Created model '$display_name' ($model_id)"
+  done
 }
 
 # Seed agents from YAML file
@@ -221,11 +462,16 @@ seed_agents() {
 
 # Main execution
 main() {
-  echo "🌱 Seeding development agents..."
+  echo "🌱 Seeding development database..."
   echo ""
 
   check_tools
   wait_for_api
+
+  echo ""
+  seed_providers
+
+  echo ""
   seed_agents
 
   echo ""


### PR DESCRIPTION
## Summary

Implement Claude (Anthropic) LLM provider support with dynamic provider selection and model configuration UI.

**Key changes:**
- Add Anthropic Claude provider implementation with full API support
- Implement provider factory pattern for dynamic LLM provider selection at runtime
- Add model selection UI to agent creation and edit forms
- Add LLM provider and model seeding for development environments
- Fix model selector to display model names instead of UUIDs

## Features

### Claude LLM Provider
- New `everruns-anthropic` crate with Anthropic API client
- Support for Claude models (claude-sonnet-4, claude-3-5-haiku, etc.)
- Provider factory that routes to correct provider based on `provider_type`

### Model Selection UI
- Optional model selector dropdown on agent create/edit pages
- Shows model display name with provider (e.g., "GPT-5 (OpenAI)")
- Falls back to system default when not specified

### Provider Management
- Removed Ollama and Custom provider options (not yet implemented)
- Dynamic API key placeholder based on provider type:
  - OpenAI: `sk-...`
  - Anthropic: `sk-ant-api03-...`
  - Azure: `your-azure-api-key`

### Database Seeding
- Idempotent seeding of OpenAI and Anthropic providers with models
- Reads API keys from environment variables (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`)
- Pre-configured models: GPT-5, GPT-5-mini, GPT-4o, Claude Sonnet 4, Claude 3.5 Haiku

## Technical Details

- Worker correctly resolves `default_model_id` UUID to actual `model_id` and `provider_type`
- Provider type flows through: Agent → Session → Workflow → LLM API call
- Backward compatible: agents without model selection use system default (gpt-4o)

## Test Plan

- [x] `cargo fmt && cargo clippy -- -D warnings`
- [x] `cargo test` - all tests pass
- [x] `npm run lint && npm run build` - UI builds successfully
- [x] Smoke test: model selection saves and retrieves correctly
- [x] Smoke test: workflow resolves correct provider type from database
- [ ] Manual test: create agent with Claude model, verify API calls use Anthropic
