### PR TITLE
Refactor message contract and database storage

### DIFF
--- a/.claude/skills/smoke-test/scripts/tool-calling-tests.sh
+++ b/.claude/skills/smoke-test/scripts/tool-calling-tests.sh
@@ -171,7 +171,7 @@ send_message() {
 
     curl -s -X POST "$API_URL/v1/agents/$agent_id/sessions/$session_id/messages" \
         -H "Content-Type: application/json" \
-        -d "{\"role\": \"user\", \"content\": {\"text\": \"$message\"}}" > /dev/null
+        -d "{\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"$message\"}]}}" > /dev/null
 
     log_verbose "Waiting ${wait_seconds}s for workflow to complete..."
     sleep "$wait_seconds"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,7 @@ jobs:
           echo "Creating message..."
           MESSAGE=$(curl -s -X POST "http://localhost:9000/v1/agents/$AGENT_ID/sessions/$SESSION_ID/messages" \
             -H 'Content-Type: application/json' \
-            -d '{"role":"user","content":{"text":"Hello, world!"}}')
+            -d '{"message":{"role":"user","content":[{"type":"text","text":"Hello, world!"}]}}')
           echo "Message response: $MESSAGE"
           MESSAGE_ID=$(echo "$MESSAGE" | jq -r '.id')
           echo "Message ID: $MESSAGE_ID"

--- a/apps/ui/src/components/chat/chat-messages.tsx
+++ b/apps/ui/src/components/chat/chat-messages.tsx
@@ -8,6 +8,7 @@ import { Separator } from "@/components/ui/separator";
 import { Bot, User, Wrench, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { Message } from "@/lib/api/types";
+import { getTextFromContent } from "@/lib/api/types";
 import type { AggregatedMessage, AggregatedToolCall } from "@/hooks/use-sse-events";
 
 interface ChatMessagesProps {
@@ -123,8 +124,8 @@ export function ChatMessages({
           <MessageBubble
             key={msg.id}
             role={msg.role}
-            content={typeof msg.content === "object" && msg.content !== null && "text" in msg.content
-              ? String(msg.content.text)
+            content={Array.isArray(msg.content)
+              ? getTextFromContent(msg.content)
               : JSON.stringify(msg.content)}
           />
         ))}

--- a/apps/ui/src/lib/api/sessions.ts
+++ b/apps/ui/src/lib/api/sessions.ts
@@ -95,8 +95,10 @@ export async function sendUserMessage(
   content: string
 ): Promise<Message> {
   return createMessage(agentId, sessionId, {
-    role: "user",
-    content: { text: content },
+    message: {
+      role: "user",
+      content: [{ type: "text", text: content }],
+    },
   });
 }
 

--- a/crates/everruns-api/src/services/message.rs
+++ b/crates/everruns-api/src/services/message.rs
@@ -1,9 +1,13 @@
 // Message service for business logic (M2)
 // Messages are the PRIMARY conversation data store
+//
+// The new message contract uses ContentPart arrays for flexible content types.
+// This service handles conversion between the API contract and database storage.
 
 use anyhow::Result;
-use everruns_contracts::{Message, MessageRole};
+use everruns_contracts::{ContentPart, Message, MessageRole};
 use everruns_storage::{models::CreateMessage, Database};
+use std::collections::HashMap;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -32,15 +36,164 @@ impl MessageService {
         Ok(rows.into_iter().map(Self::row_to_message).collect())
     }
 
+    /// Convert database row to API Message
     fn row_to_message(row: everruns_storage::MessageRow) -> Message {
+        let role = MessageRole::from(row.role.as_str());
+        let content = Self::json_to_content_parts(&role, &row.content);
+        let metadata = row
+            .metadata
+            .and_then(|m| serde_json::from_value::<HashMap<String, serde_json::Value>>(m).ok());
+
         Message {
             id: row.id,
             session_id: row.session_id,
             sequence: row.sequence,
-            role: MessageRole::from(row.role.as_str()),
-            content: row.content,
+            role,
+            content,
+            metadata,
             tool_call_id: row.tool_call_id,
             created_at: row.created_at,
+        }
+    }
+
+    /// Convert stored JSON content to ContentPart array
+    fn json_to_content_parts(role: &MessageRole, content: &serde_json::Value) -> Vec<ContentPart> {
+        match role {
+            MessageRole::User | MessageRole::Assistant | MessageRole::System => {
+                // Text content: { "text": "..." }
+                let text = content
+                    .get("text")
+                    .and_then(|t| t.as_str())
+                    .unwrap_or("")
+                    .to_string();
+
+                let mut parts = vec![ContentPart::Text { text }];
+
+                // For assistant messages, also include any tool_calls
+                if *role == MessageRole::Assistant {
+                    if let Some(tool_calls) = content.get("tool_calls").and_then(|tc| tc.as_array())
+                    {
+                        for tc in tool_calls {
+                            if let (Some(id), Some(name), Some(args)) = (
+                                tc.get("id").and_then(|v| v.as_str()),
+                                tc.get("name").and_then(|v| v.as_str()),
+                                tc.get("arguments"),
+                            ) {
+                                parts.push(ContentPart::ToolCall {
+                                    id: id.to_string(),
+                                    name: name.to_string(),
+                                    arguments: args.clone(),
+                                });
+                            }
+                        }
+                    }
+                }
+
+                parts
+            }
+            MessageRole::ToolCall => {
+                // Tool call content: { "id": "...", "name": "...", "arguments": {...} }
+                let id = content
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let name = content
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let arguments = content
+                    .get("arguments")
+                    .cloned()
+                    .unwrap_or(serde_json::json!({}));
+
+                vec![ContentPart::ToolCall {
+                    id,
+                    name,
+                    arguments,
+                }]
+            }
+            MessageRole::ToolResult => {
+                // Tool result content: { "result": {...}, "error": "..." }
+                let result = content.get("result").cloned();
+                let error = content
+                    .get("error")
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
+
+                vec![ContentPart::ToolResult { result, error }]
+            }
+        }
+    }
+}
+
+/// Convert ContentPart array to stored JSON content
+pub fn content_parts_to_json(role: &MessageRole, parts: &[ContentPart]) -> serde_json::Value {
+    match role {
+        MessageRole::User | MessageRole::Assistant | MessageRole::System => {
+            // Collect text parts and tool call parts
+            let mut texts = Vec::new();
+            let mut tool_calls = Vec::new();
+
+            for part in parts {
+                match part {
+                    ContentPart::Text { text } => texts.push(text.clone()),
+                    ContentPart::ToolCall {
+                        id,
+                        name,
+                        arguments,
+                    } => {
+                        tool_calls.push(serde_json::json!({
+                            "id": id,
+                            "name": name,
+                            "arguments": arguments
+                        }));
+                    }
+                    _ => {} // Skip image and tool_result in user/assistant/system messages
+                }
+            }
+
+            let combined_text = texts.join("\n");
+
+            if tool_calls.is_empty() {
+                serde_json::json!({ "text": combined_text })
+            } else {
+                serde_json::json!({
+                    "text": combined_text,
+                    "tool_calls": tool_calls
+                })
+            }
+        }
+        MessageRole::ToolCall => {
+            // Find the first tool call part
+            for part in parts {
+                if let ContentPart::ToolCall {
+                    id,
+                    name,
+                    arguments,
+                } = part
+                {
+                    return serde_json::json!({
+                        "id": id,
+                        "name": name,
+                        "arguments": arguments
+                    });
+                }
+            }
+            serde_json::json!({})
+        }
+        MessageRole::ToolResult => {
+            // Find the first tool result part
+            for part in parts {
+                if let ContentPart::ToolResult { result, error } = part {
+                    return serde_json::json!({
+                        "result": result,
+                        "error": error
+                    });
+                }
+            }
+            serde_json::json!({})
         }
     }
 }

--- a/crates/everruns-contracts/src/message.rs
+++ b/crates/everruns-contracts/src/message.rs
@@ -1,7 +1,13 @@
 // Message DTOs (PRIMARY conversation data)
+//
+// New contract design:
+// - Content is an array of ContentPart (text, image, etc.)
+// - Messages have optional metadata (locale, etc.)
+// - CreateMessageRequest includes controls and request-level metadata
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
@@ -40,6 +46,137 @@ impl From<&str> for MessageRole {
     }
 }
 
+// ============================================
+// Content Parts - discriminated union for message content
+// ============================================
+
+/// Content part type discriminator
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ContentPartType {
+    Text,
+    Image,
+    ToolCall,
+    ToolResult,
+}
+
+/// A part of message content - can be text, image, tool_call, or tool_result
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ContentPart {
+    /// Text content
+    Text { text: String },
+    /// Image content (base64 or URL)
+    Image {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        url: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        base64: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        media_type: Option<String>,
+    },
+    /// Tool call content (assistant requesting tool execution)
+    ToolCall {
+        id: String,
+        name: String,
+        arguments: serde_json::Value,
+    },
+    /// Tool result content (result of tool execution)
+    ToolResult {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        result: Option<serde_json::Value>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
+}
+
+impl ContentPart {
+    /// Create a text content part
+    pub fn text(text: impl Into<String>) -> Self {
+        ContentPart::Text { text: text.into() }
+    }
+
+    /// Create an image content part from URL
+    pub fn image_url(url: impl Into<String>) -> Self {
+        ContentPart::Image {
+            url: Some(url.into()),
+            base64: None,
+            media_type: None,
+        }
+    }
+
+    /// Create an image content part from base64
+    pub fn image_base64(base64: impl Into<String>, media_type: impl Into<String>) -> Self {
+        ContentPart::Image {
+            url: None,
+            base64: Some(base64.into()),
+            media_type: Some(media_type.into()),
+        }
+    }
+
+    /// Create a tool call content part
+    pub fn tool_call(
+        id: impl Into<String>,
+        name: impl Into<String>,
+        arguments: serde_json::Value,
+    ) -> Self {
+        ContentPart::ToolCall {
+            id: id.into(),
+            name: name.into(),
+            arguments,
+        }
+    }
+
+    /// Create a tool result content part
+    pub fn tool_result(result: Option<serde_json::Value>, error: Option<String>) -> Self {
+        ContentPart::ToolResult { result, error }
+    }
+
+    /// Get text if this is a text part
+    pub fn as_text(&self) -> Option<&str> {
+        match self {
+            ContentPart::Text { text } => Some(text),
+            _ => None,
+        }
+    }
+}
+
+// ============================================
+// Controls - runtime controls for message processing
+// ============================================
+
+/// Reasoning configuration for the model
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct ReasoningConfig {
+    /// Effort level for reasoning (low, medium, high)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effort: Option<String>,
+}
+
+/// Runtime controls for message processing
+#[derive(Debug, Clone, Serialize, Deserialize, Default, ToSchema)]
+pub struct Controls {
+    /// Model ID to use for this message (format: "provider/model-name")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_id: Option<String>,
+
+    /// Reasoning configuration
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<ReasoningConfig>,
+
+    /// Maximum tokens to generate
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<i32>,
+
+    /// Temperature for generation
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+}
+
+// ============================================
+// Message - primary conversation data (response)
+// ============================================
+
 /// Message - primary conversation data
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct Message {
@@ -47,20 +184,80 @@ pub struct Message {
     pub session_id: Uuid,
     pub sequence: i32,
     pub role: MessageRole,
-    pub content: serde_json::Value,
+    /// Array of content parts
+    pub content: Vec<ContentPart>,
+    /// Message-level metadata (locale, etc.)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, serde_json::Value>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_call_id: Option<String>,
     pub created_at: DateTime<Utc>,
 }
 
-/// Request to create a message
+// ============================================
+// Message Input - the message part of CreateMessageRequest
+// ============================================
+
+/// Message input for creating a message
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-pub struct CreateMessageRequest {
+pub struct MessageInput {
+    /// Message role
     pub role: MessageRole,
-    pub content: serde_json::Value,
+    /// Array of content parts
+    pub content: Vec<ContentPart>,
+    /// Message-level metadata (locale, etc.)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, serde_json::Value>>,
+    /// Tool call ID (for tool_result messages)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_call_id: Option<String>,
 }
+
+// ============================================
+// CreateMessageRequest - full request structure
+// ============================================
+
+/// Request to create a message
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct CreateMessageRequest {
+    /// The message to create
+    pub message: MessageInput,
+    /// Runtime controls (model, reasoning, etc.)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub controls: Option<Controls>,
+    /// Request-level metadata
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, serde_json::Value>>,
+    /// Tags for the message
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+}
+
+impl CreateMessageRequest {
+    /// Create a simple text message request
+    pub fn text(role: MessageRole, text: impl Into<String>) -> Self {
+        Self {
+            message: MessageInput {
+                role,
+                content: vec![ContentPart::text(text)],
+                metadata: None,
+                tool_call_id: None,
+            },
+            controls: None,
+            metadata: None,
+            tags: None,
+        }
+    }
+
+    /// Create a user message with text
+    pub fn user(text: impl Into<String>) -> Self {
+        Self::text(MessageRole::User, text)
+    }
+}
+
+// ============================================
+// Legacy content types (kept for backwards compatibility)
+// ============================================
 
 /// Text content for user/assistant/system messages
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -83,4 +280,107 @@ pub struct ToolResultContent {
     pub result: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+}
+
+// ============================================
+// Tests
+// ============================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_content_part_text_serialization() {
+        let part = ContentPart::text("Hello, world!");
+        let json = serde_json::to_string(&part).unwrap();
+        assert!(json.contains(r#""type":"text""#));
+        assert!(json.contains(r#""text":"Hello, world!""#));
+    }
+
+    #[test]
+    fn test_content_part_image_url_serialization() {
+        let part = ContentPart::image_url("https://example.com/image.png");
+        let json = serde_json::to_string(&part).unwrap();
+        assert!(json.contains(r#""type":"image""#));
+        assert!(json.contains(r#""url":"https://example.com/image.png""#));
+    }
+
+    #[test]
+    fn test_content_part_tool_call_serialization() {
+        let part = ContentPart::tool_call(
+            "call_123",
+            "get_weather",
+            serde_json::json!({"city": "Tokyo"}),
+        );
+        let json = serde_json::to_string(&part).unwrap();
+        assert!(json.contains(r#""type":"tool_call""#));
+        assert!(json.contains(r#""id":"call_123""#));
+        assert!(json.contains(r#""name":"get_weather""#));
+    }
+
+    #[test]
+    fn test_content_part_deserialization() {
+        let json = r#"{"type":"text","text":"Hello!"}"#;
+        let part: ContentPart = serde_json::from_str(json).unwrap();
+        assert_eq!(part.as_text(), Some("Hello!"));
+    }
+
+    #[test]
+    fn test_create_message_request_user() {
+        let req = CreateMessageRequest::user("Hello, how are you?");
+        assert_eq!(req.message.role, MessageRole::User);
+        assert_eq!(req.message.content.len(), 1);
+        assert_eq!(
+            req.message.content[0].as_text(),
+            Some("Hello, how are you?")
+        );
+    }
+
+    #[test]
+    fn test_create_message_request_with_controls() {
+        let req = CreateMessageRequest {
+            message: MessageInput {
+                role: MessageRole::User,
+                content: vec![ContentPart::text("Hello")],
+                metadata: Some(HashMap::from([(
+                    "locale".to_string(),
+                    serde_json::json!("en-US"),
+                )])),
+                tool_call_id: None,
+            },
+            controls: Some(Controls {
+                model_id: Some("anthropic/claude-3-5-sonnet".to_string()),
+                reasoning: Some(ReasoningConfig {
+                    effort: Some("medium".to_string()),
+                }),
+                max_tokens: None,
+                temperature: None,
+            }),
+            metadata: None,
+            tags: Some(vec!["important".to_string()]),
+        };
+
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains(r#""model_id":"anthropic/claude-3-5-sonnet""#));
+        assert!(json.contains(r#""locale":"en-US""#));
+        assert!(json.contains(r#""important""#));
+    }
+
+    #[test]
+    fn test_message_role_display() {
+        assert_eq!(MessageRole::User.to_string(), "user");
+        assert_eq!(MessageRole::Assistant.to_string(), "assistant");
+        assert_eq!(MessageRole::ToolCall.to_string(), "tool_call");
+        assert_eq!(MessageRole::ToolResult.to_string(), "tool_result");
+        assert_eq!(MessageRole::System.to_string(), "system");
+    }
+
+    #[test]
+    fn test_message_role_from_str() {
+        assert_eq!(MessageRole::from("user"), MessageRole::User);
+        assert_eq!(MessageRole::from("assistant"), MessageRole::Assistant);
+        assert_eq!(MessageRole::from("tool_call"), MessageRole::ToolCall);
+        assert_eq!(MessageRole::from("unknown"), MessageRole::User);
+    }
 }

--- a/crates/everruns-storage/migrations/006_message_metadata.sql
+++ b/crates/everruns-storage/migrations/006_message_metadata.sql
@@ -1,0 +1,15 @@
+-- Add metadata column to messages table
+-- This supports the new message contract with message-level metadata
+
+ALTER TABLE messages
+    ADD COLUMN metadata JSONB;
+
+-- Add tags column to messages table (for request-level tags)
+ALTER TABLE messages
+    ADD COLUMN tags TEXT[] NOT NULL DEFAULT '{}';
+
+-- Create index for metadata queries (GIN for JSONB)
+CREATE INDEX idx_messages_metadata ON messages USING GIN(metadata) WHERE metadata IS NOT NULL;
+
+-- Create index for tags
+CREATE INDEX idx_messages_tags ON messages USING GIN(tags);

--- a/crates/everruns-storage/src/adapters.rs
+++ b/crates/everruns-storage/src/adapters.rs
@@ -2,6 +2,10 @@
 //
 // These implementations connect the core agent-loop abstraction to the
 // actual database used in production.
+//
+// Note: The database stores content as JSONB with a flexible schema.
+// The core Message type uses MessageContent enum for type safety.
+// The API contracts use ContentPart array for the new message contract.
 
 use async_trait::async_trait;
 use everruns_core::{
@@ -143,6 +147,8 @@ impl MessageStore for DbMessageStore {
             session_id,
             role,
             content,
+            metadata: None, // Core messages don't have metadata currently
+            tags: vec![],   // Core messages don't have tags currently
             tool_call_id: message.tool_call_id,
         };
 

--- a/crates/everruns-storage/src/models.rs
+++ b/crates/everruns-storage/src/models.rs
@@ -190,6 +190,8 @@ pub struct MessageRow {
     pub sequence: i32,
     pub role: String,
     pub content: sqlx::types::JsonValue,
+    pub metadata: Option<sqlx::types::JsonValue>,
+    pub tags: Vec<String>,
     pub tool_call_id: Option<String>,
     pub created_at: DateTime<Utc>,
 }
@@ -199,6 +201,8 @@ pub struct CreateMessage {
     pub session_id: Uuid,
     pub role: String,
     pub content: serde_json::Value,
+    pub metadata: Option<serde_json::Value>,
+    pub tags: Vec<String>,
     pub tool_call_id: Option<String>,
 }
 

--- a/crates/everruns-storage/src/repositories.rs
+++ b/crates/everruns-storage/src/repositories.rs
@@ -509,14 +509,16 @@ impl Database {
         // Get next sequence number for this session
         let row = sqlx::query_as::<_, MessageRow>(
             r#"
-            INSERT INTO messages (session_id, sequence, role, content, tool_call_id)
-            VALUES ($1, COALESCE((SELECT MAX(sequence) + 1 FROM messages WHERE session_id = $1), 1), $2, $3, $4)
-            RETURNING id, session_id, sequence, role, content, tool_call_id, created_at
+            INSERT INTO messages (session_id, sequence, role, content, metadata, tags, tool_call_id)
+            VALUES ($1, COALESCE((SELECT MAX(sequence) + 1 FROM messages WHERE session_id = $1), 1), $2, $3, $4, $5, $6)
+            RETURNING id, session_id, sequence, role, content, metadata, tags, tool_call_id, created_at
             "#,
         )
         .bind(input.session_id)
         .bind(&input.role)
         .bind(&input.content)
+        .bind(&input.metadata)
+        .bind(&input.tags)
         .bind(&input.tool_call_id)
         .fetch_one(&self.pool)
         .await?;
@@ -527,7 +529,7 @@ impl Database {
     pub async fn get_message(&self, id: Uuid) -> Result<Option<MessageRow>> {
         let row = sqlx::query_as::<_, MessageRow>(
             r#"
-            SELECT id, session_id, sequence, role, content, tool_call_id, created_at
+            SELECT id, session_id, sequence, role, content, metadata, tags, tool_call_id, created_at
             FROM messages
             WHERE id = $1
             "#,
@@ -542,7 +544,7 @@ impl Database {
     pub async fn list_messages(&self, session_id: Uuid) -> Result<Vec<MessageRow>> {
         let rows = sqlx::query_as::<_, MessageRow>(
             r#"
-            SELECT id, session_id, sequence, role, content, tool_call_id, created_at
+            SELECT id, session_id, sequence, role, content, metadata, tags, tool_call_id, created_at
             FROM messages
             WHERE session_id = $1
             ORDER BY sequence ASC
@@ -563,7 +565,7 @@ impl Database {
     ) -> Result<Vec<MessageRow>> {
         let rows = sqlx::query_as::<_, MessageRow>(
             r#"
-            SELECT id, session_id, sequence, role, content, tool_call_id, created_at
+            SELECT id, session_id, sequence, role, content, metadata, tags, tool_call_id, created_at
             FROM messages
             WHERE session_id = $1 AND role = $2
             ORDER BY sequence ASC


### PR DESCRIPTION
## Summary

Refactor the external Message contract to use a flexible ContentPart array format that supports multiple content types (text, images, tool calls, tool results) and adds metadata/controls support.

## What

- **New Message Contract**: Changed `Message.content` from arbitrary JSON to a typed `ContentPart[]` array
- **ContentPart Types**: Discriminated union supporting `text`, `image`, `tool_call`, and `tool_result`
- **Message Metadata**: Added optional metadata field for message-level context (e.g., locale)
- **Request Controls**: Added `Controls` struct for runtime settings (model_id, reasoning, max_tokens, temperature)
- **Request Structure**: Updated `CreateMessageRequest` to nested format with `message`, `controls`, `metadata`, and `tags`

## Why

The new contract provides:
- Type safety for message content
- Support for multimodal content (images)
- Clear separation between message content and runtime controls
- Extensibility for future content types
- Better alignment with modern LLM API patterns

## How

### Backend (Rust)

1. **Contracts** (`everruns-contracts`):
   - Added `ContentPart` enum with variants for text, image, tool_call, tool_result
   - Added `Controls` and `ReasoningConfig` structs
   - Updated `Message` to use `Vec<ContentPart>` and added `metadata` field
   - Updated `CreateMessageRequest` with nested structure

2. **Database** (`everruns-storage`):
   - Added migration `006_message_metadata.sql` with `metadata JSONB` and `tags TEXT[]` columns
   - Updated `MessageRow` and `CreateMessage` models
   - Updated repository SQL queries

3. **API** (`everruns-api`):
   - Added `content_parts_to_json()` and `json_to_content_parts()` conversion functions
   - Updated `create_message` endpoint to handle new request format

### Frontend (TypeScript)

1. **Types** (`lib/api/types.ts`):
   - Added `ContentPart` discriminated union type
   - Added type guards: `isTextPart`, `isToolCallPart`, `isToolResultPart`
   - Added helpers: `getTextFromContent`, `getToolCallsFromContent`
   - Updated `Message` and `CreateMessageRequest` interfaces

2. **Components**:
   - Updated `chat-messages.tsx` to extract text from ContentPart array
   - Updated `tool-call-card.tsx` to handle ContentPart array format
   - Updated session detail page helper functions

3. **API** (`lib/api/sessions.ts`):
   - Updated `sendUserMessage` to use new contract format

## New Contract Format

### CreateMessageRequest
```json
{
  "message": {
    "role": "user",
    "content": [
      { "type": "text", "text": "Compare these two images." }
    ],
    "metadata": { "locale": "en-US" }
  },
  "controls": {
    "model_id": "anthropic/claude-3-5-sonnet",
    "reasoning": { "effort": "medium" },
    "max_tokens": 4096
  },
  "metadata": { "request_id": "..." },
  "tags": ["important"]
}

### Message Response

{
  "id": "...",
  "session_id": "...",
  "sequence": 1,
  "role": "user",
  "content": [
    { "type": "text", "text": "Hello!" }
  ],
  "metadata": { "locale": "en-US" },
  "tool_call_id": null,
  "created_at": "..."
}

Risk
- Medium - Changes API contract format
- Backwards compatible for database storage (internal JSON format unchanged)
- UI updated to handle new format