### PR TITLE
Remove duplicate GetCurrentTime tools

### DIFF
--- a/crates/everruns-core/src/lib.rs
+++ b/crates/everruns-core/src/lib.rs
@@ -58,8 +58,8 @@ pub use llm::{
 
 // Tool abstraction re-exports
 pub use tools::{
-    EchoTool, FailingTool, GetCurrentTime, Tool, ToolExecutionResult, ToolInternalError,
-    ToolRegistry, ToolRegistryBuilder,
+    EchoTool, FailingTool, Tool, ToolExecutionResult, ToolInternalError, ToolRegistry,
+    ToolRegistryBuilder,
 };
 
 // Capability re-exports

--- a/crates/everruns-core/tests/tool_calling_test.rs
+++ b/crates/everruns-core/tests/tool_calling_test.rs
@@ -6,9 +6,9 @@
 use async_trait::async_trait;
 use everruns_core::{
     memory::{InMemoryEventEmitter, InMemoryMessageStore, MockLlmProvider, MockLlmResponse},
-    tools::{EchoTool, FailingTool, GetCurrentTime, Tool, ToolExecutionResult, ToolRegistry},
+    tools::{EchoTool, FailingTool, Tool, ToolExecutionResult, ToolRegistry},
     traits::ToolExecutor,
-    AgentConfig, AgentLoop, LoopEvent, Message, MessageRole,
+    AgentConfig, AgentLoop, GetCurrentTimeTool, LoopEvent, Message, MessageRole,
 };
 use everruns_core::{BuiltinTool, ToolCall, ToolDefinition, ToolPolicy};
 use serde_json::json;
@@ -24,7 +24,7 @@ use uuid::Uuid;
 async fn test_tool_registry_as_executor() {
     // Create a registry with built-in tools
     let registry = ToolRegistry::builder()
-        .tool(GetCurrentTime)
+        .tool(GetCurrentTimeTool)
         .tool(EchoTool)
         .build();
 
@@ -51,7 +51,7 @@ async fn test_tool_registry_as_executor() {
 
 #[tokio::test]
 async fn test_get_current_time_tool() {
-    let registry = ToolRegistry::builder().tool(GetCurrentTime).build();
+    let registry = ToolRegistry::builder().tool(GetCurrentTimeTool).build();
 
     let tool_call = ToolCall {
         id: "call_time".to_string(),
@@ -191,7 +191,7 @@ async fn test_agent_loop_with_tool_execution() {
         })]);
 
     // Create a registry with built-in tools
-    let registry = ToolRegistry::builder().tool(GetCurrentTime).build();
+    let registry = ToolRegistry::builder().tool(GetCurrentTimeTool).build();
 
     // Create in-memory backends
     let event_emitter = InMemoryEventEmitter::new();
@@ -223,7 +223,7 @@ async fn test_agent_loop_with_tool_execution() {
         ])
         .await;
 
-    let registry = ToolRegistry::builder().tool(GetCurrentTime).build();
+    let registry = ToolRegistry::builder().tool(GetCurrentTimeTool).build();
     let event_emitter = InMemoryEventEmitter::new();
 
     let config = AgentConfig::new("You are a helpful assistant", "gpt-test")
@@ -354,7 +354,7 @@ async fn test_custom_tool_execution() {
 #[tokio::test]
 async fn test_multiple_tools_in_registry() {
     let registry = ToolRegistry::builder()
-        .tool(GetCurrentTime)
+        .tool(GetCurrentTimeTool)
         .tool(EchoTool)
         .build();
 

--- a/crates/everruns-worker/src/unified_tool_executor.rs
+++ b/crates/everruns-worker/src/unified_tool_executor.rs
@@ -14,12 +14,12 @@ use tracing::{error, info};
 /// # Example
 ///
 /// ```ignore
-/// use everruns_core::{ToolRegistry, GetCurrentTime, EchoTool};
+/// use everruns_core::{ToolRegistry, GetCurrentTimeTool, EchoTool};
 /// use everruns_worker::unified_tool_executor::UnifiedToolExecutor;
 ///
 /// // Create registry with built-in tools
 /// let registry = ToolRegistry::builder()
-///     .tool(GetCurrentTime)
+///     .tool(GetCurrentTimeTool)
 ///     .tool(EchoTool)
 ///     .build();
 ///
@@ -52,7 +52,7 @@ impl UnifiedToolExecutor {
     /// - TaskList tools: write_todos
     pub fn with_default_tools() -> Self {
         let registry = ToolRegistry::builder()
-            .tool(everruns_core::GetCurrentTime)
+            .tool(everruns_core::GetCurrentTimeTool)
             .tool(everruns_core::EchoTool)
             // TestMath capability tools
             .tool(everruns_core::AddTool)
@@ -119,12 +119,12 @@ impl ToolExecutor for UnifiedToolExecutor {
 mod tests {
     use super::*;
     use everruns_contracts::tools::{BuiltinTool, ToolPolicy};
-    use everruns_core::{EchoTool, FailingTool, GetCurrentTime};
+    use everruns_core::{EchoTool, FailingTool, GetCurrentTimeTool};
     use serde_json::json;
 
     #[tokio::test]
     async fn test_execute_builtin_tool_from_registry() {
-        let registry = ToolRegistry::builder().tool(GetCurrentTime).build();
+        let registry = ToolRegistry::builder().tool(GetCurrentTimeTool).build();
         let executor = UnifiedToolExecutor::new(registry);
 
         let tool_call = ToolCall {


### PR DESCRIPTION
Remove the duplicate GetCurrentTime tool from tools.rs that had the same name ("get_current_time") as GetCurrentTimeTool in the capabilities module. Keep only GetCurrentTimeTool from current_time.rs since it's part of the proper capability system and has additional features (timezone parameter).

- Remove GetCurrentTime struct and impl from tools.rs
- Update lib.rs to remove GetCurrentTime from exports
- Update tests to use GetCurrentTimeTool from capabilities
- Update unified_tool_executor.rs to use GetCurrentTimeTool
