### PR TITLE
Add LLM Model Profile type

### DIFF
--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -176,6 +176,25 @@ curl -s http://localhost:9000/api-doc/openapi.json | jq '.info.title'
 ```
 Expected: "Everruns API"
 
+#### 12. LLM Providers and Models
+```bash
+# List LLM providers
+curl -s http://localhost:9000/v1/llm-providers | jq '.data | length'
+```
+Expected: At least 1 provider
+
+```bash
+# List all models with profile data
+curl -s http://localhost:9000/v1/llm-models | jq '.data[0]'
+```
+Expected: Model object with `profile` field (null for unknown models, object for known models like gpt-4o)
+
+```bash
+# Verify profile contains expected fields for known models
+curl -s http://localhost:9000/v1/llm-models | jq '.data[] | select(.profile != null) | {model_id: .model_id, profile_name: .profile.name, has_cost: (.profile.cost != null)}'
+```
+Expected: Models like gpt-4o, claude-3-5-sonnet show profile with name and cost data
+
 ### Scenario Tests
 
 Additional test scenarios are available in the `scenarios/` folder:

--- a/apps/ui/src/app/(main)/settings/providers/page.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/page.tsx
@@ -284,7 +284,7 @@ function ModelRow({
       {/* Expanded profile details */}
       {expanded && profile && (
         <div className="border-t bg-muted/30 p-4">
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm mb-3">
             {/* Limits */}
             {profile.limits && (
               <div>
@@ -352,6 +352,17 @@ function ModelRow({
                 </div>
               )}
             </div>
+          </div>
+          <div className="text-xs text-muted-foreground border-t pt-2 mt-2">
+            Profile data from{" "}
+            <a
+              href="https://models.dev"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:text-foreground"
+            >
+              models.dev
+            </a>
           </div>
         </div>
       )}

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -321,6 +321,77 @@ export interface LlmModel {
 export interface LlmModelWithProvider extends LlmModel {
   provider_name: string;
   provider_type: LlmProviderType;
+  /** Readonly profile with model capabilities (not persisted to database) */
+  profile?: LlmModelProfile;
+}
+
+// ============================================
+// LLM Model Profile types
+// Based on models.dev structure
+// ============================================
+
+/** Cost information for the model (per million tokens in USD) */
+export interface LlmModelCost {
+  /** Input cost per million tokens */
+  input: number;
+  /** Output cost per million tokens */
+  output: number;
+  /** Cached read cost per million tokens, if supported */
+  cache_read?: number;
+}
+
+/** Token limits for the model */
+export interface LlmModelLimits {
+  /** Maximum context window size in tokens */
+  context: number;
+  /** Maximum output tokens */
+  output: number;
+}
+
+/** Modality type */
+export type Modality = "text" | "image" | "audio" | "video";
+
+/** Model modalities for input and output */
+export interface LlmModelModalities {
+  /** Supported input modalities */
+  input: Modality[];
+  /** Supported output modalities */
+  output: Modality[];
+}
+
+/**
+ * LLM Model Profile describing model capabilities
+ * Based on models.dev structure (https://models.dev/api.json)
+ */
+export interface LlmModelProfile {
+  /** Display name of the model */
+  name: string;
+  /** Model family (e.g., "gpt-4o", "claude-3-5-sonnet") */
+  family: string;
+  /** Release date (YYYY-MM-DD format) */
+  release_date?: string;
+  /** Last updated date (YYYY-MM-DD format) */
+  last_updated?: string;
+  /** Whether the model supports file/image attachments */
+  attachment: boolean;
+  /** Whether the model has reasoning/chain-of-thought capabilities */
+  reasoning: boolean;
+  /** Whether temperature control is supported */
+  temperature: boolean;
+  /** Knowledge cutoff date (YYYY-MM-DD format) */
+  knowledge?: string;
+  /** Whether the model supports tool/function calling */
+  tool_call: boolean;
+  /** Whether the model supports structured output (JSON mode) */
+  structured_output: boolean;
+  /** Whether the model has open weights */
+  open_weights: boolean;
+  /** Cost per million tokens */
+  cost?: LlmModelCost;
+  /** Token limits */
+  limits?: LlmModelLimits;
+  /** Supported modalities */
+  modalities?: LlmModelModalities;
 }
 
 export interface CreateLlmProviderRequest {

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -359,6 +359,25 @@ export interface LlmModelModalities {
   output: Modality[];
 }
 
+/** Reasoning effort level for models that support it */
+export type ReasoningEffort = "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
+
+/** Named reasoning effort value for UI display */
+export interface ReasoningEffortValue {
+  /** The API value (e.g., "low", "medium") */
+  value: ReasoningEffort;
+  /** Display name (e.g., "Low", "Medium") */
+  name: string;
+}
+
+/** Reasoning effort configuration for a model */
+export interface ReasoningEffortConfig {
+  /** Available reasoning effort values for this model */
+  values: ReasoningEffortValue[];
+  /** Default reasoning effort for this model */
+  default: ReasoningEffort;
+}
+
 /**
  * LLM Model Profile describing model capabilities
  * Based on models.dev structure (https://models.dev/api.json)
@@ -392,6 +411,8 @@ export interface LlmModelProfile {
   limits?: LlmModelLimits;
   /** Supported modalities */
   modalities?: LlmModelModalities;
+  /** Reasoning effort configuration (for reasoning models) */
+  reasoning_effort?: ReasoningEffortConfig;
 }
 
 export interface CreateLlmProviderRequest {

--- a/crates/everruns-core/src/lib.rs
+++ b/crates/everruns-core/src/lib.rs
@@ -26,6 +26,7 @@ pub mod agent;
 pub mod capability_dto;
 pub mod event;
 pub mod llm_entities;
+pub mod model_profiles;
 pub mod session;
 
 pub mod atoms;
@@ -118,6 +119,8 @@ pub use agent::{Agent, AgentStatus};
 pub use capability_dto::{AgentCapability, CapabilityInfo};
 pub use event::Event;
 pub use llm_entities::{
-    LlmModel, LlmModelStatus, LlmModelWithProvider, LlmProviderStatus, LlmProviderType,
+    LlmModel, LlmModelCost, LlmModelLimits, LlmModelModalities, LlmModelProfile, LlmModelStatus,
+    LlmModelWithProvider, LlmProviderStatus, LlmProviderType, Modality,
 };
+pub use model_profiles::get_model_profile;
 pub use session::{Session, SessionStatus};

--- a/crates/everruns-core/src/lib.rs
+++ b/crates/everruns-core/src/lib.rs
@@ -120,7 +120,8 @@ pub use capability_dto::{AgentCapability, CapabilityInfo};
 pub use event::Event;
 pub use llm_entities::{
     LlmModel, LlmModelCost, LlmModelLimits, LlmModelModalities, LlmModelProfile, LlmModelStatus,
-    LlmModelWithProvider, LlmProviderStatus, LlmProviderType, Modality,
+    LlmModelWithProvider, LlmProviderStatus, LlmProviderType, Modality, ReasoningEffort,
+    ReasoningEffortConfig, ReasoningEffortValue,
 };
 pub use model_profiles::get_model_profile;
 pub use session::{Session, SessionStatus};

--- a/crates/everruns-core/src/llm_entities.rs
+++ b/crates/everruns-core/src/llm_entities.rs
@@ -167,6 +167,39 @@ pub struct LlmModelModalities {
     pub output: Vec<Modality>,
 }
 
+/// Reasoning effort level for models that support it
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum ReasoningEffort {
+    None,
+    Minimal,
+    Low,
+    Medium,
+    High,
+    Xhigh,
+}
+
+/// Named reasoning effort value for UI display
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct ReasoningEffortValue {
+    /// The API value (e.g., "low", "medium")
+    pub value: ReasoningEffort,
+    /// Display name (e.g., "Low", "Medium")
+    pub name: String,
+}
+
+/// Reasoning effort configuration for a model
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct ReasoningEffortConfig {
+    /// Available reasoning effort values for this model
+    pub values: Vec<ReasoningEffortValue>,
+    /// Default reasoning effort for this model
+    pub default: ReasoningEffort,
+}
+
 /// LLM Model Profile describing model capabilities
 /// Based on models.dev structure (https://models.dev/api.json)
 ///
@@ -212,4 +245,7 @@ pub struct LlmModelProfile {
     /// Supported modalities
     #[serde(skip_serializing_if = "Option::is_none")]
     pub modalities: Option<LlmModelModalities>,
+    /// Reasoning effort configuration (for reasoning models)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<ReasoningEffortConfig>,
 }

--- a/crates/everruns-core/src/llm_entities.rs
+++ b/crates/everruns-core/src/llm_entities.rs
@@ -113,4 +113,103 @@ pub struct LlmModelWithProvider {
     pub updated_at: DateTime<Utc>,
     pub provider_name: String,
     pub provider_type: LlmProviderType,
+    /// Readonly profile with model capabilities (not persisted to database)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<LlmModelProfile>,
+}
+
+// ============================================
+// LLM Model Profile types
+// Based on models.dev structure
+// ============================================
+
+/// Cost information for the model (per million tokens)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct LlmModelCost {
+    /// Input cost per million tokens (USD)
+    pub input: f64,
+    /// Output cost per million tokens (USD)
+    pub output: f64,
+    /// Cached read cost per million tokens (USD), if supported
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_read: Option<f64>,
+}
+
+/// Token limits for the model
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct LlmModelLimits {
+    /// Maximum context window size in tokens
+    pub context: i32,
+    /// Maximum output tokens
+    pub output: i32,
+}
+
+/// Modality type (text, image, audio, video)
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum Modality {
+    Text,
+    Image,
+    Audio,
+    Video,
+}
+
+/// Model modalities for input and output
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct LlmModelModalities {
+    /// Supported input modalities
+    pub input: Vec<Modality>,
+    /// Supported output modalities
+    pub output: Vec<Modality>,
+}
+
+/// LLM Model Profile describing model capabilities
+/// Based on models.dev structure (https://models.dev/api.json)
+///
+/// NOTE: Currently only includes profiles for:
+/// - OpenAI: gpt-4o, gpt-4o-mini, o1, o1-mini, o1-pro, o3-mini
+/// - Anthropic: claude-3-5-sonnet, claude-3-5-haiku, claude-3-opus, claude-3-sonnet, claude-3-haiku, claude-sonnet-4, claude-opus-4
+///
+/// Additional model profiles can be added as needed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct LlmModelProfile {
+    /// Display name of the model
+    pub name: String,
+    /// Model family (e.g., "gpt-4o", "claude-3-5-sonnet")
+    pub family: String,
+    /// Release date (YYYY-MM-DD format)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub release_date: Option<String>,
+    /// Last updated date (YYYY-MM-DD format)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_updated: Option<String>,
+    /// Whether the model supports file/image attachments
+    pub attachment: bool,
+    /// Whether the model has reasoning/chain-of-thought capabilities
+    pub reasoning: bool,
+    /// Whether temperature control is supported
+    pub temperature: bool,
+    /// Knowledge cutoff date (YYYY-MM-DD format)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub knowledge: Option<String>,
+    /// Whether the model supports tool/function calling
+    pub tool_call: bool,
+    /// Whether the model supports structured output (JSON mode)
+    pub structured_output: bool,
+    /// Whether the model has open weights
+    pub open_weights: bool,
+    /// Cost per million tokens
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cost: Option<LlmModelCost>,
+    /// Token limits
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limits: Option<LlmModelLimits>,
+    /// Supported modalities
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub modalities: Option<LlmModelModalities>,
 }

--- a/crates/everruns-core/src/model_profiles.rs
+++ b/crates/everruns-core/src/model_profiles.rs
@@ -1,0 +1,560 @@
+// Hardcoded LLM Model Profiles
+//
+// This module provides model profiles based on models.dev structure.
+// Profiles are matched by provider_type + model_id.
+//
+// NOTE: Currently only includes profiles for selected models.
+// Additional model profiles can be added as needed by extending the match arms.
+//
+// Data source: https://models.dev/api.json
+
+use crate::llm_entities::{
+    LlmModelCost, LlmModelLimits, LlmModelModalities, LlmModelProfile, LlmProviderType, Modality,
+};
+
+/// Get a model profile by matching provider_type and model_id
+/// Returns None if no matching profile is found
+pub fn get_model_profile(
+    provider_type: &LlmProviderType,
+    model_id: &str,
+) -> Option<LlmModelProfile> {
+    match provider_type {
+        LlmProviderType::Openai => get_openai_profile(model_id),
+        LlmProviderType::Anthropic => get_anthropic_profile(model_id),
+        LlmProviderType::AzureOpenai => get_openai_profile(model_id), // Azure uses same model IDs
+    }
+}
+
+fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
+    // Normalize model ID by extracting base name
+    let base_id = normalize_model_id(model_id);
+
+    match base_id {
+        "gpt-4o" => Some(LlmModelProfile {
+            name: "GPT-4o".into(),
+            family: "gpt-4o".into(),
+            release_date: Some("2024-05-13".into()),
+            last_updated: Some("2024-11-20".into()),
+            attachment: true,
+            reasoning: false,
+            temperature: true,
+            knowledge: Some("2023-10-01".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 2.50,
+                output: 10.00,
+                cache_read: Some(1.25),
+            }),
+            limits: Some(LlmModelLimits {
+                context: 128_000,
+                output: 16_384,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image, Modality::Audio],
+                output: vec![Modality::Text, Modality::Audio],
+            }),
+        }),
+
+        "gpt-4o-mini" => Some(LlmModelProfile {
+            name: "GPT-4o mini".into(),
+            family: "gpt-4o-mini".into(),
+            release_date: Some("2024-07-18".into()),
+            last_updated: Some("2024-07-18".into()),
+            attachment: true,
+            reasoning: false,
+            temperature: true,
+            knowledge: Some("2023-10-01".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 0.15,
+                output: 0.60,
+                cache_read: Some(0.075),
+            }),
+            limits: Some(LlmModelLimits {
+                context: 128_000,
+                output: 16_384,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image],
+                output: vec![Modality::Text],
+            }),
+        }),
+
+        "o1" => Some(LlmModelProfile {
+            name: "o1".into(),
+            family: "o1".into(),
+            release_date: Some("2024-12-17".into()),
+            last_updated: Some("2024-12-17".into()),
+            attachment: true,
+            reasoning: true,
+            temperature: true,
+            knowledge: Some("2023-10-01".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 15.00,
+                output: 60.00,
+                cache_read: Some(7.50),
+            }),
+            limits: Some(LlmModelLimits {
+                context: 200_000,
+                output: 100_000,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image],
+                output: vec![Modality::Text],
+            }),
+        }),
+
+        "o1-mini" => Some(LlmModelProfile {
+            name: "o1-mini".into(),
+            family: "o1-mini".into(),
+            release_date: Some("2024-09-12".into()),
+            last_updated: Some("2024-09-12".into()),
+            attachment: false,
+            reasoning: true,
+            temperature: true,
+            knowledge: Some("2023-10-01".into()),
+            tool_call: false,
+            structured_output: false,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 3.00,
+                output: 12.00,
+                cache_read: Some(1.50),
+            }),
+            limits: Some(LlmModelLimits {
+                context: 128_000,
+                output: 65_536,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text],
+                output: vec![Modality::Text],
+            }),
+        }),
+
+        "o1-pro" => Some(LlmModelProfile {
+            name: "o1-pro".into(),
+            family: "o1-pro".into(),
+            release_date: Some("2025-03-19".into()),
+            last_updated: Some("2025-03-19".into()),
+            attachment: true,
+            reasoning: true,
+            temperature: true,
+            knowledge: Some("2023-10-01".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 150.00,
+                output: 600.00,
+                cache_read: None,
+            }),
+            limits: Some(LlmModelLimits {
+                context: 200_000,
+                output: 100_000,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image],
+                output: vec![Modality::Text],
+            }),
+        }),
+
+        "o3-mini" => Some(LlmModelProfile {
+            name: "o3-mini".into(),
+            family: "o3-mini".into(),
+            release_date: Some("2025-01-31".into()),
+            last_updated: Some("2025-01-31".into()),
+            attachment: false,
+            reasoning: true,
+            temperature: true,
+            knowledge: Some("2023-10-01".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 1.10,
+                output: 4.40,
+                cache_read: Some(0.55),
+            }),
+            limits: Some(LlmModelLimits {
+                context: 200_000,
+                output: 100_000,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text],
+                output: vec![Modality::Text],
+            }),
+        }),
+
+        _ => None,
+    }
+}
+
+fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
+    // Normalize model ID by extracting base name
+    let base_id = normalize_anthropic_model_id(model_id);
+
+    match base_id {
+        "claude-sonnet-4" => Some(LlmModelProfile {
+            name: "Claude Sonnet 4".into(),
+            family: "claude-sonnet-4".into(),
+            release_date: Some("2025-05-14".into()),
+            last_updated: Some("2025-05-14".into()),
+            attachment: true,
+            reasoning: false,
+            temperature: true,
+            knowledge: Some("2025-03-01".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 3.00,
+                output: 15.00,
+                cache_read: Some(0.30),
+            }),
+            limits: Some(LlmModelLimits {
+                context: 200_000,
+                output: 16_000,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image],
+                output: vec![Modality::Text],
+            }),
+        }),
+
+        "claude-opus-4" => Some(LlmModelProfile {
+            name: "Claude Opus 4".into(),
+            family: "claude-opus-4".into(),
+            release_date: Some("2025-05-14".into()),
+            last_updated: Some("2025-05-14".into()),
+            attachment: true,
+            reasoning: true,
+            temperature: true,
+            knowledge: Some("2025-03-01".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 15.00,
+                output: 75.00,
+                cache_read: Some(1.50),
+            }),
+            limits: Some(LlmModelLimits {
+                context: 200_000,
+                output: 32_000,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image],
+                output: vec![Modality::Text],
+            }),
+        }),
+
+        "claude-3-5-sonnet" => Some(LlmModelProfile {
+            name: "Claude 3.5 Sonnet".into(),
+            family: "claude-3-5-sonnet".into(),
+            release_date: Some("2024-06-20".into()),
+            last_updated: Some("2024-10-22".into()),
+            attachment: true,
+            reasoning: false,
+            temperature: true,
+            knowledge: Some("2024-04-01".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 3.00,
+                output: 15.00,
+                cache_read: Some(0.30),
+            }),
+            limits: Some(LlmModelLimits {
+                context: 200_000,
+                output: 8_192,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image],
+                output: vec![Modality::Text],
+            }),
+        }),
+
+        "claude-3-5-haiku" => Some(LlmModelProfile {
+            name: "Claude 3.5 Haiku".into(),
+            family: "claude-3-5-haiku".into(),
+            release_date: Some("2024-10-22".into()),
+            last_updated: Some("2024-10-22".into()),
+            attachment: true,
+            reasoning: false,
+            temperature: true,
+            knowledge: Some("2024-07-01".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 1.00,
+                output: 5.00,
+                cache_read: Some(0.10),
+            }),
+            limits: Some(LlmModelLimits {
+                context: 200_000,
+                output: 8_192,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image],
+                output: vec![Modality::Text],
+            }),
+        }),
+
+        "claude-3-opus" => Some(LlmModelProfile {
+            name: "Claude 3 Opus".into(),
+            family: "claude-3-opus".into(),
+            release_date: Some("2024-02-29".into()),
+            last_updated: Some("2024-02-29".into()),
+            attachment: true,
+            reasoning: false,
+            temperature: true,
+            knowledge: Some("2023-08-01".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 15.00,
+                output: 75.00,
+                cache_read: Some(1.50),
+            }),
+            limits: Some(LlmModelLimits {
+                context: 200_000,
+                output: 4_096,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image],
+                output: vec![Modality::Text],
+            }),
+        }),
+
+        "claude-3-sonnet" => Some(LlmModelProfile {
+            name: "Claude 3 Sonnet".into(),
+            family: "claude-3-sonnet".into(),
+            release_date: Some("2024-02-29".into()),
+            last_updated: Some("2024-02-29".into()),
+            attachment: true,
+            reasoning: false,
+            temperature: true,
+            knowledge: Some("2023-08-01".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 3.00,
+                output: 15.00,
+                cache_read: Some(0.30),
+            }),
+            limits: Some(LlmModelLimits {
+                context: 200_000,
+                output: 4_096,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image],
+                output: vec![Modality::Text],
+            }),
+        }),
+
+        "claude-3-haiku" => Some(LlmModelProfile {
+            name: "Claude 3 Haiku".into(),
+            family: "claude-3-haiku".into(),
+            release_date: Some("2024-03-07".into()),
+            last_updated: Some("2024-03-07".into()),
+            attachment: true,
+            reasoning: false,
+            temperature: true,
+            knowledge: Some("2023-08-01".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 0.25,
+                output: 1.25,
+                cache_read: Some(0.03),
+            }),
+            limits: Some(LlmModelLimits {
+                context: 200_000,
+                output: 4_096,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image],
+                output: vec![Modality::Text],
+            }),
+        }),
+
+        _ => None,
+    }
+}
+
+/// Normalize OpenAI model ID to base name
+/// e.g., "gpt-4o-2024-11-20" -> "gpt-4o"
+fn normalize_model_id(model_id: &str) -> &str {
+    // Known base model patterns
+    let patterns = [
+        "gpt-4o-mini",
+        "gpt-4o",
+        "o1-mini",
+        "o1-pro",
+        "o3-mini",
+        "o1",
+    ];
+
+    for pattern in patterns {
+        if model_id == pattern || model_id.starts_with(&format!("{}-", pattern)) {
+            return pattern;
+        }
+    }
+
+    model_id
+}
+
+/// Normalize Anthropic model ID to base name
+/// e.g., "claude-3-5-sonnet-20241022" -> "claude-3-5-sonnet"
+fn normalize_anthropic_model_id(model_id: &str) -> &str {
+    // Known base model patterns (order matters - more specific first)
+    let patterns = [
+        "claude-sonnet-4",
+        "claude-opus-4",
+        "claude-3-5-sonnet",
+        "claude-3-5-haiku",
+        "claude-3-opus",
+        "claude-3-sonnet",
+        "claude-3-haiku",
+    ];
+
+    for pattern in patterns {
+        if model_id == pattern
+            || model_id.starts_with(&format!("{}-", pattern))
+            || model_id == format!("{}-latest", pattern)
+        {
+            return pattern;
+        }
+    }
+
+    model_id
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_profile_openai_gpt4o() {
+        let profile = get_model_profile(&LlmProviderType::Openai, "gpt-4o");
+        assert!(profile.is_some());
+        let profile = profile.unwrap();
+        assert_eq!(profile.name, "GPT-4o");
+        assert_eq!(profile.family, "gpt-4o");
+        assert!(profile.tool_call);
+        assert!(profile.structured_output);
+    }
+
+    #[test]
+    fn test_get_profile_openai_gpt4o_versioned() {
+        let profile = get_model_profile(&LlmProviderType::Openai, "gpt-4o-2024-11-20");
+        assert!(profile.is_some());
+        let profile = profile.unwrap();
+        assert_eq!(profile.name, "GPT-4o");
+    }
+
+    #[test]
+    fn test_get_profile_anthropic_claude35_sonnet() {
+        let profile = get_model_profile(&LlmProviderType::Anthropic, "claude-3-5-sonnet-20241022");
+        assert!(profile.is_some());
+        let profile = profile.unwrap();
+        assert_eq!(profile.name, "Claude 3.5 Sonnet");
+        assert!(profile.tool_call);
+    }
+
+    #[test]
+    fn test_get_profile_anthropic_claude_sonnet4() {
+        let profile = get_model_profile(&LlmProviderType::Anthropic, "claude-sonnet-4-20250514");
+        assert!(profile.is_some());
+        let profile = profile.unwrap();
+        assert_eq!(profile.name, "Claude Sonnet 4");
+    }
+
+    #[test]
+    fn test_get_profile_unknown_model() {
+        let profile = get_model_profile(&LlmProviderType::Openai, "unknown-model");
+        assert!(profile.is_none());
+    }
+
+    #[test]
+    fn test_get_profile_wrong_provider() {
+        // Try to get an OpenAI model with Anthropic provider
+        let profile = get_model_profile(&LlmProviderType::Anthropic, "gpt-4o");
+        assert!(profile.is_none());
+    }
+
+    #[test]
+    fn test_profile_has_cost_and_limits() {
+        let profile = get_model_profile(&LlmProviderType::Openai, "gpt-4o").unwrap();
+        assert!(profile.cost.is_some());
+        assert!(profile.limits.is_some());
+
+        let cost = profile.cost.unwrap();
+        assert!(cost.input > 0.0);
+        assert!(cost.output > 0.0);
+
+        let limits = profile.limits.unwrap();
+        assert!(limits.context > 0);
+        assert!(limits.output > 0);
+    }
+
+    #[test]
+    fn test_o1_has_reasoning() {
+        let profile = get_model_profile(&LlmProviderType::Openai, "o1").unwrap();
+        assert!(profile.reasoning);
+    }
+
+    #[test]
+    fn test_claude_opus_4_has_reasoning() {
+        let profile = get_model_profile(&LlmProviderType::Anthropic, "claude-opus-4").unwrap();
+        assert!(profile.reasoning);
+    }
+
+    #[test]
+    fn test_normalize_openai_model_id() {
+        assert_eq!(normalize_model_id("gpt-4o"), "gpt-4o");
+        assert_eq!(normalize_model_id("gpt-4o-2024-11-20"), "gpt-4o");
+        assert_eq!(normalize_model_id("gpt-4o-mini"), "gpt-4o-mini");
+        assert_eq!(normalize_model_id("o1-2024-12-17"), "o1");
+        assert_eq!(normalize_model_id("o1-mini"), "o1-mini");
+    }
+
+    #[test]
+    fn test_normalize_anthropic_model_id() {
+        assert_eq!(
+            normalize_anthropic_model_id("claude-3-5-sonnet"),
+            "claude-3-5-sonnet"
+        );
+        assert_eq!(
+            normalize_anthropic_model_id("claude-3-5-sonnet-20241022"),
+            "claude-3-5-sonnet"
+        );
+        assert_eq!(
+            normalize_anthropic_model_id("claude-3-5-sonnet-latest"),
+            "claude-3-5-sonnet"
+        );
+        assert_eq!(
+            normalize_anthropic_model_id("claude-sonnet-4-20250514"),
+            "claude-sonnet-4"
+        );
+    }
+
+    #[test]
+    fn test_azure_uses_openai_profiles() {
+        let profile = get_model_profile(&LlmProviderType::AzureOpenai, "gpt-4o");
+        assert!(profile.is_some());
+        assert_eq!(profile.unwrap().name, "GPT-4o");
+    }
+}

--- a/crates/everruns-core/src/model_profiles.rs
+++ b/crates/everruns-core/src/model_profiles.rs
@@ -10,7 +10,38 @@
 
 use crate::llm_entities::{
     LlmModelCost, LlmModelLimits, LlmModelModalities, LlmModelProfile, LlmProviderType, Modality,
+    ReasoningEffort, ReasoningEffortConfig, ReasoningEffortValue,
 };
+
+// Helper functions for creating reasoning effort configurations
+
+fn effort(value: ReasoningEffort, name: &str) -> ReasoningEffortValue {
+    ReasoningEffortValue {
+        value,
+        name: name.into(),
+    }
+}
+
+/// Standard reasoning efforts for pre-gpt-5.1 models (o1, o1-mini, o3-mini)
+/// Default: medium, supports: low, medium, high
+fn reasoning_effort_standard() -> ReasoningEffortConfig {
+    ReasoningEffortConfig {
+        values: vec![
+            effort(ReasoningEffort::Low, "Low"),
+            effort(ReasoningEffort::Medium, "Medium"),
+            effort(ReasoningEffort::High, "High"),
+        ],
+        default: ReasoningEffort::Medium,
+    }
+}
+
+/// Reasoning effort for o1-pro (only high)
+fn reasoning_effort_high_only() -> ReasoningEffortConfig {
+    ReasoningEffortConfig {
+        values: vec![effort(ReasoningEffort::High, "High")],
+        default: ReasoningEffort::High,
+    }
+}
 
 /// Get a model profile by matching provider_type and model_id
 /// Returns None if no matching profile is found
@@ -55,6 +86,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 input: vec![Modality::Text, Modality::Image, Modality::Audio],
                 output: vec![Modality::Text, Modality::Audio],
             }),
+            reasoning_effort: None,
         }),
 
         "gpt-4o-mini" => Some(LlmModelProfile {
@@ -82,6 +114,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 input: vec![Modality::Text, Modality::Image],
                 output: vec![Modality::Text],
             }),
+            reasoning_effort: None,
         }),
 
         "o1" => Some(LlmModelProfile {
@@ -109,6 +142,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 input: vec![Modality::Text, Modality::Image],
                 output: vec![Modality::Text],
             }),
+            reasoning_effort: Some(reasoning_effort_standard()),
         }),
 
         "o1-mini" => Some(LlmModelProfile {
@@ -136,6 +170,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 input: vec![Modality::Text],
                 output: vec![Modality::Text],
             }),
+            reasoning_effort: Some(reasoning_effort_standard()),
         }),
 
         "o1-pro" => Some(LlmModelProfile {
@@ -163,6 +198,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 input: vec![Modality::Text, Modality::Image],
                 output: vec![Modality::Text],
             }),
+            reasoning_effort: Some(reasoning_effort_high_only()),
         }),
 
         "o3-mini" => Some(LlmModelProfile {
@@ -190,6 +226,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 input: vec![Modality::Text],
                 output: vec![Modality::Text],
             }),
+            reasoning_effort: Some(reasoning_effort_standard()),
         }),
 
         _ => None,
@@ -226,6 +263,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
                 input: vec![Modality::Text, Modality::Image],
                 output: vec![Modality::Text],
             }),
+            reasoning_effort: None,
         }),
 
         "claude-opus-4" => Some(LlmModelProfile {
@@ -253,6 +291,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
                 input: vec![Modality::Text, Modality::Image],
                 output: vec![Modality::Text],
             }),
+            reasoning_effort: None, // Anthropic uses extended thinking, not reasoning effort
         }),
 
         "claude-3-5-sonnet" => Some(LlmModelProfile {
@@ -280,6 +319,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
                 input: vec![Modality::Text, Modality::Image],
                 output: vec![Modality::Text],
             }),
+            reasoning_effort: None,
         }),
 
         "claude-3-5-haiku" => Some(LlmModelProfile {
@@ -307,6 +347,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
                 input: vec![Modality::Text, Modality::Image],
                 output: vec![Modality::Text],
             }),
+            reasoning_effort: None,
         }),
 
         "claude-3-opus" => Some(LlmModelProfile {
@@ -334,6 +375,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
                 input: vec![Modality::Text, Modality::Image],
                 output: vec![Modality::Text],
             }),
+            reasoning_effort: None,
         }),
 
         "claude-3-sonnet" => Some(LlmModelProfile {
@@ -361,6 +403,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
                 input: vec![Modality::Text, Modality::Image],
                 output: vec![Modality::Text],
             }),
+            reasoning_effort: None,
         }),
 
         "claude-3-haiku" => Some(LlmModelProfile {
@@ -388,6 +431,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
                 input: vec![Modality::Text, Modality::Image],
                 output: vec![Modality::Text],
             }),
+            reasoning_effort: None,
         }),
 
         _ => None,

--- a/specs/models.md
+++ b/specs/models.md
@@ -293,6 +293,70 @@ Configuration for a specific model within a provider.
 | `created_at` | timestamp | Creation time |
 | `updated_at` | timestamp | Last modification time |
 
+### LLM Model Profile
+
+Read-only metadata describing model capabilities, costs, and limits. Profiles are computed at runtime (not stored in database) and attached to model responses.
+
+**Data Source:** https://models.dev/api.json
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Display name (e.g., "GPT-4o") |
+| `family` | string | Model family (e.g., "gpt-4o") |
+| `release_date` | string? | Release date (YYYY-MM-DD) |
+| `last_updated` | string? | Last update date (YYYY-MM-DD) |
+| `attachment` | boolean | Supports file attachments |
+| `reasoning` | boolean | Is a reasoning model |
+| `temperature` | boolean | Supports temperature parameter |
+| `knowledge` | string? | Knowledge cutoff date |
+| `tool_call` | boolean | Supports tool/function calling |
+| `structured_output` | boolean | Supports structured output |
+| `open_weights` | boolean | Has open weights |
+| `cost` | LlmModelCost? | Pricing per million tokens |
+| `limits` | LlmModelLimits? | Context and output limits |
+| `modalities` | LlmModelModalities? | Input/output modalities |
+| `reasoning_effort` | ReasoningEffortConfig? | Reasoning effort options |
+
+**LlmModelCost:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `input` | float | Input cost per million tokens (USD) |
+| `output` | float | Output cost per million tokens (USD) |
+| `cache_read` | float? | Cached input cost per million tokens |
+
+**LlmModelLimits:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `context` | integer | Maximum context window tokens |
+| `output` | integer | Maximum output tokens |
+
+**LlmModelModalities:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `input` | Modality[] | Supported input types (text, image, audio, video) |
+| `output` | Modality[] | Supported output types |
+
+**ReasoningEffortConfig:**
+
+Configuration for reasoning models (OpenAI o1, o1-mini, o3-mini, o1-pro).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `values` | ReasoningEffortValue[] | Available effort levels |
+| `default` | ReasoningEffort | Default effort level |
+
+**ReasoningEffort enum:** `none`, `minimal`, `low`, `medium`, `high`, `xhigh`
+
+**Supported Models:**
+
+- **OpenAI:** gpt-4o, gpt-4o-mini, o1, o1-mini, o1-pro, o3-mini
+- **Anthropic:** claude-sonnet-4, claude-opus-4, claude-3-5-sonnet, claude-3-5-haiku, claude-3-opus, claude-3-sonnet, claude-3-haiku
+
+Profiles are matched by provider_type + model_id with version normalization (e.g., "gpt-4o-2024-11-20" → "gpt-4o").
+
 ## Design Decisions
 
 | Question | Decision |


### PR DESCRIPTION
## What
Add `LlmModelProfile` type with capabilities, costs, limits, and reasoning effort configuration for LLM models.

## Why
Users need visibility into model capabilities and pricing when selecting LLM models.

## How
- Added `LlmModelProfile` and supporting types to `everruns-core`
- Created `model_profiles.rs` with profiles for OpenAI/Anthropic models (data from models.dev)
- API attaches profiles to model responses (computed at runtime, not stored in DB)
- UI shows expandable profile details with capability badges and models.dev attribution

## Risk
- Low
- Read-only feature, no database changes

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
