### PR TITLE
Display LLM model in session UI

### DIFF
--- a/apps/ui/src/__tests__/agent-detail-model.test.tsx
+++ b/apps/ui/src/__tests__/agent-detail-model.test.tsx
@@ -15,8 +15,10 @@ jest.mock("next/navigation", () => ({
 // Mock next/link
 jest.mock("next/link", () => ({
   __esModule: true,
+  // eslint-disable-next-line jsx-a11y/anchor-has-content
   default: ({ children, href }: { children: React.ReactNode; href: string }) => (
-    <a href={href}>{children}</a>
+    // Using span instead of anchor to avoid lint errors in tests
+    <span data-href={href}>{children}</span>
   ),
 }));
 

--- a/apps/ui/src/__tests__/agent-detail-model.test.tsx
+++ b/apps/ui/src/__tests__/agent-detail-model.test.tsx
@@ -1,0 +1,231 @@
+import { render, screen, act } from "@testing-library/react";
+import { Suspense } from "react";
+import AgentDetailPage from "@/app/(main)/agents/[agentId]/page";
+import type { Session, Agent, LlmModelWithProvider } from "@/lib/api/types";
+
+// Mock next/navigation
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    back: jest.fn(),
+  }),
+}));
+
+// Mock next/link
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+// Mock prompt-editor to avoid react-markdown ESM issues
+jest.mock("@/components/ui/prompt-editor", () => ({
+  MarkdownDisplay: ({ content }: { content: string }) => <div data-testid="markdown">{content}</div>,
+  PromptEditor: ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
+    <textarea value={value} onChange={(e) => onChange(e.target.value)} />
+  ),
+}));
+
+// Mock data
+const mockAgent: Agent = {
+  id: "agent-1",
+  name: "Test Agent",
+  description: "A test agent",
+  system_prompt: "You are helpful",
+  default_model_id: null,
+  tags: ["test"],
+  status: "active",
+  created_at: "2025-01-01T00:00:00Z",
+  updated_at: "2025-01-01T00:00:00Z",
+};
+
+const mockSessions: Session[] = [
+  {
+    id: "session-1",
+    agent_id: "agent-1",
+    title: "Session with GPT-4o",
+    tags: [],
+    model_id: "model-1",
+    status: "completed",
+    created_at: "2025-01-01T00:00:00Z",
+    started_at: "2025-01-01T00:00:01Z",
+    finished_at: "2025-01-01T00:01:00Z",
+  },
+  {
+    id: "session-2",
+    agent_id: "agent-1",
+    title: "Session with Claude",
+    tags: [],
+    model_id: "model-2",
+    status: "pending",
+    created_at: "2025-01-01T01:00:00Z",
+    started_at: null,
+    finished_at: null,
+  },
+  {
+    id: "session-3",
+    agent_id: "agent-1",
+    title: "Session without model",
+    tags: [],
+    model_id: null,
+    status: "pending",
+    created_at: "2025-01-01T02:00:00Z",
+    started_at: null,
+    finished_at: null,
+  },
+];
+
+const mockLlmModels: LlmModelWithProvider[] = [
+  {
+    id: "model-1",
+    provider_id: "provider-1",
+    model_id: "gpt-4o",
+    display_name: "GPT-4o",
+    capabilities: ["chat"],
+    context_window: 128000,
+    is_default: false,
+    status: "active",
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+    provider_name: "OpenAI",
+    provider_type: "openai",
+  },
+  {
+    id: "model-2",
+    provider_id: "provider-2",
+    model_id: "claude-3-5-sonnet",
+    display_name: "Claude 3.5 Sonnet",
+    capabilities: ["chat"],
+    context_window: 200000,
+    is_default: false,
+    status: "active",
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+    provider_name: "Anthropic",
+    provider_type: "anthropic",
+  },
+];
+
+// Mock hooks
+const mockUseAgent = jest.fn();
+const mockUseSessions = jest.fn();
+const mockUseCreateSession = jest.fn();
+const mockUseAgentCapabilities = jest.fn();
+const mockUseCapabilities = jest.fn();
+const mockUseLlmModels = jest.fn();
+
+jest.mock("@/hooks", () => ({
+  useAgent: (...args: unknown[]) => mockUseAgent(...args),
+  useSessions: (...args: unknown[]) => mockUseSessions(...args),
+  useCreateSession: () => mockUseCreateSession(),
+  useAgentCapabilities: (...args: unknown[]) => mockUseAgentCapabilities(...args),
+  useCapabilities: () => mockUseCapabilities(),
+  useLlmModels: () => mockUseLlmModels(),
+}));
+
+// Helper to render with Suspense for React.use()
+async function renderWithSuspense(params: { agentId: string }) {
+  const paramsPromise = Promise.resolve(params);
+
+  await act(async () => {
+    render(
+      <Suspense fallback={<div>Loading...</div>}>
+        <AgentDetailPage params={paramsPromise} />
+      </Suspense>
+    );
+    // Let the promise resolve
+    await paramsPromise;
+  });
+}
+
+describe("AgentDetailPage - LLM Model Display in Sessions List", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Default mock implementations
+    mockUseAgent.mockReturnValue({ data: mockAgent, isLoading: false });
+    mockUseSessions.mockReturnValue({ data: mockSessions, isLoading: false });
+    mockUseCreateSession.mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
+    mockUseAgentCapabilities.mockReturnValue({ data: [], isLoading: false });
+    mockUseCapabilities.mockReturnValue({ data: [] });
+    mockUseLlmModels.mockReturnValue({ data: mockLlmModels });
+  });
+
+  it("displays model badge for sessions with model_id", async () => {
+    await renderWithSuspense({ agentId: "agent-1" });
+
+    // Model badges should be visible
+    expect(screen.getByText("GPT-4o")).toBeInTheDocument();
+    expect(screen.getByText("Claude 3.5 Sonnet")).toBeInTheDocument();
+  });
+
+  it("does not display model badge for sessions without model_id", async () => {
+    await renderWithSuspense({ agentId: "agent-1" });
+
+    // Count the model badges - should only be 2 (not 3)
+    const gpt4oBadges = screen.getAllByText("GPT-4o");
+    const claudeBadges = screen.getAllByText("Claude 3.5 Sonnet");
+
+    expect(gpt4oBadges).toHaveLength(1);
+    expect(claudeBadges).toHaveLength(1);
+  });
+
+  it("does not display model badge when model data is not loaded", async () => {
+    mockUseLlmModels.mockReturnValue({ data: undefined });
+
+    await renderWithSuspense({ agentId: "agent-1" });
+
+    // Model badges should not be visible
+    expect(screen.queryByText("GPT-4o")).not.toBeInTheDocument();
+    expect(screen.queryByText("Claude 3.5 Sonnet")).not.toBeInTheDocument();
+  });
+
+  it("does not display model badge when model_id has no matching model", async () => {
+    const sessionsWithUnknownModel: Session[] = [
+      {
+        ...mockSessions[0],
+        model_id: "unknown-model",
+      },
+    ];
+    mockUseSessions.mockReturnValue({ data: sessionsWithUnknownModel, isLoading: false });
+
+    await renderWithSuspense({ agentId: "agent-1" });
+
+    // No model badges should be visible
+    expect(screen.queryByText("GPT-4o")).not.toBeInTheDocument();
+  });
+
+  it("displays Completed badge alongside model badge", async () => {
+    await renderWithSuspense({ agentId: "agent-1" });
+
+    // Both model and completion status should be visible for completed session
+    expect(screen.getByText("GPT-4o")).toBeInTheDocument();
+    expect(screen.getByText("Completed")).toBeInTheDocument();
+  });
+
+  it("calls useLlmModels hook", async () => {
+    await renderWithSuspense({ agentId: "agent-1" });
+
+    expect(mockUseLlmModels).toHaveBeenCalled();
+  });
+
+  it("creates model map with correct display names", async () => {
+    await renderWithSuspense({ agentId: "agent-1" });
+
+    // Verify correct model names are displayed
+    expect(screen.getByText("GPT-4o")).toBeInTheDocument();
+    expect(screen.getByText("Claude 3.5 Sonnet")).toBeInTheDocument();
+  });
+
+  it("handles empty sessions list", async () => {
+    mockUseSessions.mockReturnValue({ data: [], isLoading: false });
+
+    await renderWithSuspense({ agentId: "agent-1" });
+
+    expect(
+      screen.getByText("No sessions yet. Start a new session to begin chatting.")
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/__tests__/recent-sessions.test.tsx
+++ b/apps/ui/src/__tests__/recent-sessions.test.tsx
@@ -1,0 +1,175 @@
+import { render, screen } from "@testing-library/react";
+import { RecentSessions } from "@/components/dashboard/recent-sessions";
+import type { Session, Agent, LlmModelWithProvider } from "@/lib/api/types";
+
+// Helper to create a test session
+function createSession(overrides?: Partial<Session>): Session {
+  return {
+    id: "session-1",
+    agent_id: "agent-1",
+    title: "Test Session",
+    tags: [],
+    model_id: null,
+    status: "pending",
+    created_at: "2025-01-01T00:00:00Z",
+    started_at: null,
+    finished_at: null,
+    ...overrides,
+  };
+}
+
+// Helper to create a test agent
+function createAgent(overrides?: Partial<Agent>): Agent {
+  return {
+    id: "agent-1",
+    name: "Test Agent",
+    description: null,
+    system_prompt: "You are helpful",
+    default_model_id: null,
+    tags: [],
+    status: "active",
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+// Helper to create a test LLM model
+function createLlmModel(overrides?: Partial<LlmModelWithProvider>): LlmModelWithProvider {
+  return {
+    id: "model-1",
+    provider_id: "provider-1",
+    model_id: "gpt-4o",
+    display_name: "GPT-4o",
+    capabilities: ["chat"],
+    context_window: 128000,
+    is_default: false,
+    status: "active",
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+    provider_name: "OpenAI",
+    provider_type: "openai",
+    ...overrides,
+  };
+}
+
+describe("RecentSessions", () => {
+  describe("model column", () => {
+    it("renders Model column header", () => {
+      const sessions = [createSession()];
+      const agents = [createAgent()];
+
+      render(<RecentSessions sessions={sessions} agents={agents} />);
+
+      expect(screen.getByText("Model")).toBeInTheDocument();
+    });
+
+    it("displays model name when session has a model_id and model data is provided", () => {
+      const model = createLlmModel({ id: "model-123", display_name: "Claude 3.5 Sonnet" });
+      const session = createSession({ model_id: "model-123" });
+      const agent = createAgent();
+
+      render(
+        <RecentSessions
+          sessions={[session]}
+          agents={[agent]}
+          models={[model]}
+        />
+      );
+
+      expect(screen.getByText("Claude 3.5 Sonnet")).toBeInTheDocument();
+    });
+
+    it("displays dash when session has no model_id", () => {
+      const session = createSession({ model_id: null });
+      const agent = createAgent();
+
+      render(<RecentSessions sessions={[session]} agents={[agent]} />);
+
+      // Find the table cell with dash (excluding header)
+      const cells = screen.getAllByRole("cell");
+      const modelCell = cells.find(cell => cell.textContent === "-");
+      expect(modelCell).toBeInTheDocument();
+    });
+
+    it("displays dash when session has model_id but no matching model data", () => {
+      const session = createSession({ model_id: "unknown-model" });
+      const agent = createAgent();
+
+      render(
+        <RecentSessions
+          sessions={[session]}
+          agents={[agent]}
+          models={[]}
+        />
+      );
+
+      const cells = screen.getAllByRole("cell");
+      const modelCell = cells.find(cell => cell.textContent === "-");
+      expect(modelCell).toBeInTheDocument();
+    });
+
+    it("displays multiple sessions with different models", () => {
+      const model1 = createLlmModel({ id: "model-1", display_name: "GPT-4o" });
+      const model2 = createLlmModel({ id: "model-2", display_name: "Claude 3.5 Sonnet" });
+
+      const session1 = createSession({ id: "s1", model_id: "model-1", title: "Session 1" });
+      const session2 = createSession({ id: "s2", model_id: "model-2", title: "Session 2" });
+      const session3 = createSession({ id: "s3", model_id: null, title: "Session 3" });
+
+      const agent = createAgent();
+
+      render(
+        <RecentSessions
+          sessions={[session1, session2, session3]}
+          agents={[agent]}
+          models={[model1, model2]}
+        />
+      );
+
+      expect(screen.getByText("GPT-4o")).toBeInTheDocument();
+      expect(screen.getByText("Claude 3.5 Sonnet")).toBeInTheDocument();
+    });
+
+    it("renders Sparkles icon with model name", () => {
+      const model = createLlmModel({ id: "model-1", display_name: "GPT-4o" });
+      const session = createSession({ model_id: "model-1" });
+      const agent = createAgent();
+
+      render(
+        <RecentSessions
+          sessions={[session]}
+          agents={[agent]}
+          models={[model]}
+        />
+      );
+
+      // The model name should be in a span with the Sparkles icon
+      const modelText = screen.getByText("GPT-4o");
+      expect(modelText.closest("span")).toHaveClass("inline-flex", "items-center", "gap-1");
+    });
+  });
+
+  describe("empty state", () => {
+    it("shows empty message when no sessions", () => {
+      render(<RecentSessions sessions={[]} agents={[]} />);
+
+      expect(
+        screen.getByText("No sessions yet. Create an agent and start a session to begin.")
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("backwards compatibility", () => {
+    it("works without models prop (defaults to empty array)", () => {
+      const session = createSession({ model_id: "some-model" });
+      const agent = createAgent();
+
+      // Should not throw when models prop is omitted
+      render(<RecentSessions sessions={[session]} agents={[agent]} />);
+
+      // Model column should still render with dash
+      expect(screen.getByText("Model")).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/ui/src/__tests__/session-detail-model.test.tsx
+++ b/apps/ui/src/__tests__/session-detail-model.test.tsx
@@ -19,7 +19,8 @@ jest.mock("next/navigation", () => ({
 jest.mock("next/link", () => ({
   __esModule: true,
   default: ({ children, href }: { children: React.ReactNode; href: string }) => (
-    <a href={href}>{children}</a>
+    // Using span instead of anchor to avoid lint errors in tests
+    <span data-href={href}>{children}</span>
   ),
 }));
 

--- a/apps/ui/src/__tests__/session-detail-model.test.tsx
+++ b/apps/ui/src/__tests__/session-detail-model.test.tsx
@@ -1,0 +1,176 @@
+import { render, screen, act } from "@testing-library/react";
+import { Suspense } from "react";
+import SessionDetailPage from "@/app/(main)/agents/[agentId]/sessions/[sessionId]/page";
+import type { Session, Agent, LlmModelWithProvider } from "@/lib/api/types";
+
+// Mock scrollIntoView for jsdom
+Element.prototype.scrollIntoView = jest.fn();
+
+// Mock next/navigation
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    back: jest.fn(),
+  }),
+}));
+
+// Mock next/link
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+// Mock data
+const mockAgent: Agent = {
+  id: "agent-1",
+  name: "Test Agent",
+  description: null,
+  system_prompt: "You are helpful",
+  default_model_id: null,
+  tags: [],
+  status: "active",
+  created_at: "2025-01-01T00:00:00Z",
+  updated_at: "2025-01-01T00:00:00Z",
+};
+
+const mockSession: Session = {
+  id: "session-1",
+  agent_id: "agent-1",
+  title: "Test Session",
+  tags: [],
+  model_id: "model-1",
+  status: "pending",
+  created_at: "2025-01-01T00:00:00Z",
+  started_at: "2025-01-01T00:00:01Z",
+  finished_at: null,
+};
+
+const mockLlmModel: LlmModelWithProvider = {
+  id: "model-1",
+  provider_id: "provider-1",
+  model_id: "gpt-4o",
+  display_name: "GPT-4o",
+  capabilities: ["chat"],
+  context_window: 128000,
+  is_default: false,
+  status: "active",
+  created_at: "2025-01-01T00:00:00Z",
+  updated_at: "2025-01-01T00:00:00Z",
+  provider_name: "OpenAI",
+  provider_type: "openai",
+};
+
+// Mock hooks module
+const mockUseAgent = jest.fn();
+const mockUseSession = jest.fn();
+const mockUseMessages = jest.fn();
+const mockUseSendMessage = jest.fn();
+const mockUseLlmModel = jest.fn();
+
+jest.mock("@/hooks", () => ({
+  useAgent: (...args: unknown[]) => mockUseAgent(...args),
+  useSession: (...args: unknown[]) => mockUseSession(...args),
+  useMessages: (...args: unknown[]) => mockUseMessages(...args),
+  useSendMessage: () => mockUseSendMessage(),
+  useLlmModel: (...args: unknown[]) => mockUseLlmModel(...args),
+}));
+
+// Helper to render with Suspense for React.use()
+async function renderWithSuspense(params: { agentId: string; sessionId: string }) {
+  const paramsPromise = Promise.resolve(params);
+
+  await act(async () => {
+    render(
+      <Suspense fallback={<div>Loading...</div>}>
+        <SessionDetailPage params={paramsPromise} />
+      </Suspense>
+    );
+    // Let the promise resolve
+    await paramsPromise;
+  });
+}
+
+describe("SessionDetailPage - LLM Model Display", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Default mock implementations
+    mockUseAgent.mockReturnValue({ data: mockAgent, isLoading: false });
+    mockUseSession.mockReturnValue({ data: mockSession, isLoading: false });
+    mockUseMessages.mockReturnValue({ data: [], isLoading: false });
+    mockUseSendMessage.mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
+    mockUseLlmModel.mockReturnValue({ data: mockLlmModel, isLoading: false });
+  });
+
+  it("displays LLM model badge when session has model_id", async () => {
+    await renderWithSuspense({ agentId: "agent-1", sessionId: "session-1" });
+
+    expect(screen.getByText("GPT-4o")).toBeInTheDocument();
+  });
+
+  it("calls useLlmModel with session model_id", async () => {
+    await renderWithSuspense({ agentId: "agent-1", sessionId: "session-1" });
+
+    // Verify useLlmModel was called with the model_id
+    expect(mockUseLlmModel).toHaveBeenCalledWith("model-1");
+  });
+
+  it("does not display model badge when session has no model_id", async () => {
+    const sessionWithoutModel: Session = { ...mockSession, model_id: null };
+    mockUseSession.mockReturnValue({ data: sessionWithoutModel, isLoading: false });
+    mockUseLlmModel.mockReturnValue({ data: undefined, isLoading: false });
+
+    await renderWithSuspense({ agentId: "agent-1", sessionId: "session-1" });
+
+    // Model badge should not be present
+    expect(screen.queryByText("GPT-4o")).not.toBeInTheDocument();
+  });
+
+  it("does not display model badge when model data is not loaded yet", async () => {
+    mockUseLlmModel.mockReturnValue({ data: undefined, isLoading: true });
+
+    await renderWithSuspense({ agentId: "agent-1", sessionId: "session-1" });
+
+    // Model badge should not be present while loading
+    expect(screen.queryByText("GPT-4o")).not.toBeInTheDocument();
+  });
+
+  it("passes empty string to useLlmModel when session model_id is null", async () => {
+    const sessionWithoutModel: Session = { ...mockSession, model_id: null };
+    mockUseSession.mockReturnValue({ data: sessionWithoutModel, isLoading: false });
+
+    await renderWithSuspense({ agentId: "agent-1", sessionId: "session-1" });
+
+    // Should pass empty string when model_id is null
+    expect(mockUseLlmModel).toHaveBeenCalledWith("");
+  });
+
+  it("displays model badge alongside status badge", async () => {
+    await renderWithSuspense({ agentId: "agent-1", sessionId: "session-1" });
+
+    // Both model and status should be visible
+    expect(screen.getByText("GPT-4o")).toBeInTheDocument();
+    expect(screen.getByText("Ready")).toBeInTheDocument(); // pending status
+  });
+
+  it("displays different model names correctly", async () => {
+    const claudeModel: LlmModelWithProvider = {
+      ...mockLlmModel,
+      id: "model-2",
+      display_name: "Claude 3.5 Sonnet",
+      provider_name: "Anthropic",
+      provider_type: "anthropic",
+    };
+    const sessionWithClaude: Session = { ...mockSession, model_id: "model-2" };
+
+    mockUseSession.mockReturnValue({ data: sessionWithClaude, isLoading: false });
+    mockUseLlmModel.mockReturnValue({ data: claudeModel, isLoading: false });
+
+    await renderWithSuspense({ agentId: "agent-1", sessionId: "session-1" });
+
+    expect(screen.getByText("Claude 3.5 Sonnet")).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/page.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { use, useState, useRef, useEffect } from "react";
-import { useAgent, useSession, useMessages, useSendMessage } from "@/hooks";
+import { useAgent, useSession, useMessages, useSendMessage, useLlmModel } from "@/hooks";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
-import { ArrowLeft, Send, User, Bot, Loader2 } from "lucide-react";
+import { ArrowLeft, Send, User, Bot, Loader2, Sparkles } from "lucide-react";
 import type { Message } from "@/lib/api/types";
 import { getTextFromContent, isToolCallPart } from "@/lib/api/types";
 import { ToolCallCard } from "@/components/chat/tool-call-card";
@@ -30,6 +30,9 @@ export default function SessionDetailPage({
     sessionId
   );
   const sendMessage = useSendMessage();
+
+  // Fetch LLM model info if session has a model_id
+  const { data: llmModel } = useLlmModel(session?.model_id ?? "");
 
   // Determine if session is still processing
   const isActive = session?.status === "running" || session?.status === "pending";
@@ -166,6 +169,12 @@ export default function SessionDetailPage({
             </p>
           </div>
           <div className="flex items-center gap-2">
+            {llmModel && (
+              <Badge variant="outline" className="gap-1">
+                <Sparkles className="w-3 h-3" />
+                {llmModel.display_name}
+              </Badge>
+            )}
             {session.status === "running" && (
               <Badge variant="default">Processing...</Badge>
             )}

--- a/apps/ui/src/components/dashboard/recent-sessions.tsx
+++ b/apps/ui/src/components/dashboard/recent-sessions.tsx
@@ -11,16 +11,19 @@ import {
 } from "@/components/ui/table";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import type { Session, Agent } from "@/lib/api/types";
+import { Sparkles } from "lucide-react";
+import type { Session, Agent, LlmModelWithProvider } from "@/lib/api/types";
 
 interface RecentSessionsProps {
   sessions: Session[];
   agents: Agent[];
+  models?: LlmModelWithProvider[];
 }
 
-export function RecentSessions({ sessions, agents }: RecentSessionsProps) {
+export function RecentSessions({ sessions, agents, models = [] }: RecentSessionsProps) {
   const recentSessions = sessions.slice(0, 10);
   const agentMap = new Map(agents.map((a) => [a.id, a]));
+  const modelMap = new Map(models.map((m) => [m.id, m]));
 
   const formatDate = (date: string) => {
     return new Date(date).toLocaleString();
@@ -64,6 +67,7 @@ export function RecentSessions({ sessions, agents }: RecentSessionsProps) {
               <TableRow>
                 <TableHead>Session</TableHead>
                 <TableHead>Agent</TableHead>
+                <TableHead>Model</TableHead>
                 <TableHead>Status</TableHead>
                 <TableHead>Started</TableHead>
                 <TableHead>Duration</TableHead>
@@ -72,6 +76,7 @@ export function RecentSessions({ sessions, agents }: RecentSessionsProps) {
             <TableBody>
               {recentSessions.map((session) => {
                 const agent = agentMap.get(session.agent_id);
+                const model = session.model_id ? modelMap.get(session.model_id) : undefined;
                 return (
                   <TableRow key={session.id}>
                     <TableCell>
@@ -89,6 +94,16 @@ export function RecentSessions({ sessions, agents }: RecentSessionsProps) {
                       >
                         {agent?.name || "Unknown"}
                       </Link>
+                    </TableCell>
+                    <TableCell>
+                      {model ? (
+                        <span className="inline-flex items-center gap-1 text-sm text-muted-foreground">
+                          <Sparkles className="w-3 h-3" />
+                          {model.display_name}
+                        </span>
+                      ) : (
+                        <span className="text-sm text-muted-foreground">-</span>
+                      )}
                     </TableCell>
                     <TableCell>
                       {getStatusBadge(session)}

--- a/crates/everruns-api/src/sessions.rs
+++ b/crates/everruns-api/src/sessions.rs
@@ -224,3 +224,72 @@ pub async fn delete_session(
         Err(StatusCode::NOT_FOUND)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_session_request_minimal() {
+        // Test with minimal fields (all optional)
+        let json = r#"{}"#;
+        let req: CreateSessionRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.title, None);
+        assert!(req.tags.is_empty());
+        assert_eq!(req.model_id, None);
+    }
+
+    #[test]
+    fn test_create_session_request_with_title() {
+        let json = r#"{"title": "Test Session"}"#;
+        let req: CreateSessionRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.title, Some("Test Session".to_string()));
+        assert!(req.tags.is_empty());
+        assert_eq!(req.model_id, None);
+    }
+
+    #[test]
+    fn test_create_session_request_with_model_id() {
+        let model_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let json = format!(r#"{{"model_id": "{}"}}"#, model_uuid);
+        let req: CreateSessionRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(req.model_id, Some(model_uuid));
+    }
+
+    #[test]
+    fn test_create_session_request_full() {
+        let model_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440001").unwrap();
+        let json = format!(
+            r#"{{"title": "Full Session", "tags": ["tag1", "tag2"], "model_id": "{}"}}"#,
+            model_uuid
+        );
+        let req: CreateSessionRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(req.title, Some("Full Session".to_string()));
+        assert_eq!(req.tags, vec!["tag1", "tag2"]);
+        assert_eq!(req.model_id, Some(model_uuid));
+    }
+
+    #[test]
+    fn test_update_session_request_minimal() {
+        let json = r#"{}"#;
+        let req: UpdateSessionRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.title, None);
+        assert_eq!(req.tags, None);
+    }
+
+    #[test]
+    fn test_update_session_request_with_title() {
+        let json = r#"{"title": "Updated Title"}"#;
+        let req: UpdateSessionRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.title, Some("Updated Title".to_string()));
+        assert_eq!(req.tags, None);
+    }
+
+    #[test]
+    fn test_update_session_request_with_tags() {
+        let json = r#"{"tags": ["new-tag"]}"#;
+        let req: UpdateSessionRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.title, None);
+        assert_eq!(req.tags, Some(vec!["new-tag".to_string()]));
+    }
+}


### PR DESCRIPTION
## What
Display the LLM model being used for each session in the UI and fix backend to populate session model_id from agent's default.

## Why
Users need visibility into which LLM model is being used for each session. Previously, the session model_id was never populated, even when the agent had a default_model_id configured.

## How
- **UI Changes:**
  - Session detail page: Added model badge in header next to status
  - Agent detail page: Added model badge in session list items
  - Recent sessions component: Added Model column to the table

- **Backend Fix:**
  - Updated SessionService.create() to inherit model_id from agent's default_model_id when not explicitly provided

- **Tests:**
  - Added UI tests for model display in session views (23 new tests)
  - Added integration test for session model_id inheritance
  - Added unit tests for session request DTO serialization

## Risk
- Low
- UI-only display changes plus a small backend fix that adds fallback behavior
- Extensively tested with unit, integration, and smoke tests

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (explicit model_id still takes precedence)