### PR TITLE
Add GPT-5 models and reasoning effort support

### DIFF
--- a/crates/everruns-core/src/model_profiles.rs
+++ b/crates/everruns-core/src/model_profiles.rs
@@ -43,6 +43,61 @@ fn reasoning_effort_high_only() -> ReasoningEffortConfig {
     }
 }
 
+/// Reasoning effort for pre-gpt-5.1 models (gpt-5, gpt-5-mini, gpt-5-nano, gpt-5-codex)
+/// Default: medium, supports: low, medium, high (no none)
+fn reasoning_effort_gpt5_pre51() -> ReasoningEffortConfig {
+    ReasoningEffortConfig {
+        values: vec![
+            effort(ReasoningEffort::Low, "Low"),
+            effort(ReasoningEffort::Medium, "Medium"),
+            effort(ReasoningEffort::High, "High"),
+        ],
+        default: ReasoningEffort::Medium,
+    }
+}
+
+/// Reasoning effort for gpt-5.1 models
+/// Default: none, supports: none, low, medium, high
+fn reasoning_effort_gpt51() -> ReasoningEffortConfig {
+    ReasoningEffortConfig {
+        values: vec![
+            effort(ReasoningEffort::None, "None"),
+            effort(ReasoningEffort::Low, "Low"),
+            effort(ReasoningEffort::Medium, "Medium"),
+            effort(ReasoningEffort::High, "High"),
+        ],
+        default: ReasoningEffort::None,
+    }
+}
+
+/// Reasoning effort for models after gpt-5.1-codex-max (gpt-5.2, gpt-5.2-pro, gpt-5.2-codex)
+/// Default: none, supports: none, low, medium, high, xhigh
+fn reasoning_effort_gpt52() -> ReasoningEffortConfig {
+    ReasoningEffortConfig {
+        values: vec![
+            effort(ReasoningEffort::None, "None"),
+            effort(ReasoningEffort::Low, "Low"),
+            effort(ReasoningEffort::Medium, "Medium"),
+            effort(ReasoningEffort::High, "High"),
+            effort(ReasoningEffort::Xhigh, "Extra High"),
+        ],
+        default: ReasoningEffort::None,
+    }
+}
+
+/// Reasoning effort for gpt-5.2-pro
+/// Default: medium, supports: medium, high, xhigh
+fn reasoning_effort_gpt52_pro() -> ReasoningEffortConfig {
+    ReasoningEffortConfig {
+        values: vec![
+            effort(ReasoningEffort::Medium, "Medium"),
+            effort(ReasoningEffort::High, "High"),
+            effort(ReasoningEffort::Xhigh, "Extra High"),
+        ],
+        default: ReasoningEffort::Medium,
+    }
+}
+
 /// Get a model profile by matching provider_type and model_id
 /// Returns None if no matching profile is found
 pub fn get_model_profile(
@@ -227,6 +282,347 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_standard()),
+        }),
+
+        // GPT-5 family models
+        // Pre-5.1 models: default medium, supports low/medium/high (no none)
+        "gpt-5" => Some(LlmModelProfile {
+            name: "GPT-5".into(),
+            family: "gpt-5".into(),
+            release_date: Some("2025-08-07".into()),
+            last_updated: Some("2025-08-07".into()),
+            attachment: true,
+            reasoning: true,
+            temperature: true,
+            knowledge: Some("2024-10-01".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 1.25,
+                output: 10.00,
+                cache_read: Some(0.125),
+            }),
+            limits: Some(LlmModelLimits {
+                context: 128_000,
+                output: 128_000,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: Some(reasoning_effort_gpt5_pre51()),
+        }),
+
+        "gpt-5-mini" => Some(LlmModelProfile {
+            name: "GPT-5 mini".into(),
+            family: "gpt-5-mini".into(),
+            release_date: Some("2025-08-13".into()),
+            last_updated: Some("2025-08-13".into()),
+            attachment: true,
+            reasoning: true,
+            temperature: true,
+            knowledge: Some("2024-06-01".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 0.25,
+                output: 2.00,
+                cache_read: Some(0.025),
+            }),
+            limits: Some(LlmModelLimits {
+                context: 128_000,
+                output: 64_000,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: Some(reasoning_effort_gpt5_pre51()),
+        }),
+
+        "gpt-5-nano" => Some(LlmModelProfile {
+            name: "GPT-5 nano".into(),
+            family: "gpt-5-nano".into(),
+            release_date: Some("2025-08-13".into()),
+            last_updated: Some("2025-08-13".into()),
+            attachment: true,
+            reasoning: true,
+            temperature: true,
+            knowledge: Some("2024-05-31".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 0.05,
+                output: 0.40,
+                cache_read: Some(0.005),
+            }),
+            limits: Some(LlmModelLimits {
+                context: 128_000,
+                output: 64_000,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: Some(reasoning_effort_gpt5_pre51()),
+        }),
+
+        "gpt-5-pro" => Some(LlmModelProfile {
+            name: "GPT-5 Pro".into(),
+            family: "gpt-5-pro".into(),
+            release_date: Some("2025-08-07".into()),
+            last_updated: Some("2025-08-07".into()),
+            attachment: true,
+            reasoning: true,
+            temperature: true,
+            knowledge: Some("2024-10-01".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 15.00,
+                output: 60.00,
+                cache_read: None,
+            }),
+            limits: Some(LlmModelLimits {
+                context: 128_000,
+                output: 128_000,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: Some(reasoning_effort_high_only()),
+        }),
+
+        "gpt-5-codex" => Some(LlmModelProfile {
+            name: "GPT-5 Codex".into(),
+            family: "gpt-5-codex".into(),
+            release_date: Some("2025-08-07".into()),
+            last_updated: Some("2025-08-07".into()),
+            attachment: true,
+            reasoning: true,
+            temperature: true,
+            knowledge: Some("2024-09-30".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 1.25,
+                output: 10.00,
+                cache_read: Some(0.125),
+            }),
+            limits: Some(LlmModelLimits {
+                context: 128_000,
+                output: 128_000,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: Some(reasoning_effort_gpt5_pre51()),
+        }),
+
+        // GPT-5.1 models: default none, supports none/low/medium/high
+        "gpt-5.1" => Some(LlmModelProfile {
+            name: "GPT-5.1".into(),
+            family: "gpt-5.1".into(),
+            release_date: Some("2025-11-13".into()),
+            last_updated: Some("2025-11-13".into()),
+            attachment: true,
+            reasoning: true,
+            temperature: true,
+            knowledge: Some("2024-09-30".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 1.50,
+                output: 12.00,
+                cache_read: Some(0.15),
+            }),
+            limits: Some(LlmModelLimits {
+                context: 128_000,
+                output: 128_000,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: Some(reasoning_effort_gpt51()),
+        }),
+
+        "gpt-5.1-codex" => Some(LlmModelProfile {
+            name: "GPT-5.1 Codex".into(),
+            family: "gpt-5.1-codex".into(),
+            release_date: Some("2025-11-13".into()),
+            last_updated: Some("2025-11-13".into()),
+            attachment: true,
+            reasoning: true,
+            temperature: true,
+            knowledge: Some("2024-09-30".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 1.50,
+                output: 12.00,
+                cache_read: Some(0.15),
+            }),
+            limits: Some(LlmModelLimits {
+                context: 128_000,
+                output: 128_000,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: Some(reasoning_effort_gpt51()),
+        }),
+
+        "gpt-5.1-codex-mini" => Some(LlmModelProfile {
+            name: "GPT-5.1 Codex mini".into(),
+            family: "gpt-5.1-codex-mini".into(),
+            release_date: Some("2025-11-13".into()),
+            last_updated: Some("2025-11-13".into()),
+            attachment: true,
+            reasoning: true,
+            temperature: true,
+            knowledge: Some("2024-09-30".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 0.30,
+                output: 2.40,
+                cache_read: Some(0.03),
+            }),
+            limits: Some(LlmModelLimits {
+                context: 128_000,
+                output: 100_000,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: Some(reasoning_effort_gpt51()),
+        }),
+
+        // GPT-5.1-codex-max and after: supports xhigh
+        "gpt-5.1-codex-max" => Some(LlmModelProfile {
+            name: "GPT-5.1 Codex max".into(),
+            family: "gpt-5.1-codex-max".into(),
+            release_date: Some("2025-11-13".into()),
+            last_updated: Some("2025-11-13".into()),
+            attachment: true,
+            reasoning: true,
+            temperature: true,
+            knowledge: Some("2024-09-30".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 3.00,
+                output: 24.00,
+                cache_read: Some(0.30),
+            }),
+            limits: Some(LlmModelLimits {
+                context: 128_000,
+                output: 128_000,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: Some(reasoning_effort_gpt52()),
+        }),
+
+        // GPT-5.2 models: supports xhigh
+        "gpt-5.2" => Some(LlmModelProfile {
+            name: "GPT-5.2".into(),
+            family: "gpt-5.2".into(),
+            release_date: Some("2025-12-11".into()),
+            last_updated: Some("2025-12-11".into()),
+            attachment: true,
+            reasoning: true,
+            temperature: false,
+            knowledge: Some("2025-08-31".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 1.75,
+                output: 14.00,
+                cache_read: Some(0.175),
+            }),
+            limits: Some(LlmModelLimits {
+                context: 128_000,
+                output: 64_000,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: Some(reasoning_effort_gpt52()),
+        }),
+
+        "gpt-5.2-pro" => Some(LlmModelProfile {
+            name: "GPT-5.2 Pro".into(),
+            family: "gpt-5.2-pro".into(),
+            release_date: Some("2025-12-11".into()),
+            last_updated: Some("2025-12-11".into()),
+            attachment: true,
+            reasoning: true,
+            temperature: false,
+            knowledge: Some("2025-08-31".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 17.50,
+                output: 70.00,
+                cache_read: None,
+            }),
+            limits: Some(LlmModelLimits {
+                context: 128_000,
+                output: 128_000,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: Some(reasoning_effort_gpt52_pro()),
+        }),
+
+        "gpt-5.2-codex" => Some(LlmModelProfile {
+            name: "GPT-5.2 Codex".into(),
+            family: "gpt-5.2-codex".into(),
+            release_date: Some("2025-12-11".into()),
+            last_updated: Some("2025-12-11".into()),
+            attachment: true,
+            reasoning: true,
+            temperature: false,
+            knowledge: Some("2025-08-31".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 1.75,
+                output: 14.00,
+                cache_read: Some(0.175),
+            }),
+            limits: Some(LlmModelLimits {
+                context: 128_000,
+                output: 128_000,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: Some(reasoning_effort_gpt52()),
         }),
 
         _ => None,
@@ -441,8 +837,24 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
 /// Normalize OpenAI model ID to base name
 /// e.g., "gpt-4o-2024-11-20" -> "gpt-4o"
 fn normalize_model_id(model_id: &str) -> &str {
-    // Known base model patterns
+    // Known base model patterns (order matters - more specific first)
     let patterns = [
+        // GPT-5.2 models
+        "gpt-5.2-codex",
+        "gpt-5.2-pro",
+        "gpt-5.2",
+        // GPT-5.1 models
+        "gpt-5.1-codex-max",
+        "gpt-5.1-codex-mini",
+        "gpt-5.1-codex",
+        "gpt-5.1",
+        // GPT-5 models
+        "gpt-5-codex",
+        "gpt-5-nano",
+        "gpt-5-mini",
+        "gpt-5-pro",
+        "gpt-5",
+        // GPT-4 and reasoning models
         "gpt-4o-mini",
         "gpt-4o",
         "o1-mini",
@@ -600,5 +1012,139 @@ mod tests {
         let profile = get_model_profile(&LlmProviderType::AzureOpenai, "gpt-4o");
         assert!(profile.is_some());
         assert_eq!(profile.unwrap().name, "GPT-4o");
+    }
+
+    // GPT-5 model tests
+
+    #[test]
+    fn test_gpt5_profile() {
+        let profile = get_model_profile(&LlmProviderType::Openai, "gpt-5").unwrap();
+        assert_eq!(profile.name, "GPT-5");
+        assert_eq!(profile.family, "gpt-5");
+        assert!(profile.reasoning);
+        assert!(profile.tool_call);
+
+        // Pre-5.1 reasoning effort: default medium, supports low/medium/high
+        let effort = profile.reasoning_effort.unwrap();
+        assert_eq!(effort.default, ReasoningEffort::Medium);
+        assert_eq!(effort.values.len(), 3);
+        assert!(!effort
+            .values
+            .iter()
+            .any(|v| v.value == ReasoningEffort::None));
+    }
+
+    #[test]
+    fn test_gpt5_mini_profile() {
+        let profile = get_model_profile(&LlmProviderType::Openai, "gpt-5-mini").unwrap();
+        assert_eq!(profile.name, "GPT-5 mini");
+        assert!(profile.reasoning);
+
+        let effort = profile.reasoning_effort.unwrap();
+        assert_eq!(effort.default, ReasoningEffort::Medium);
+    }
+
+    #[test]
+    fn test_gpt5_pro_profile() {
+        let profile = get_model_profile(&LlmProviderType::Openai, "gpt-5-pro").unwrap();
+        assert_eq!(profile.name, "GPT-5 Pro");
+        assert!(profile.reasoning);
+
+        // gpt-5-pro: only supports high
+        let effort = profile.reasoning_effort.unwrap();
+        assert_eq!(effort.default, ReasoningEffort::High);
+        assert_eq!(effort.values.len(), 1);
+        assert_eq!(effort.values[0].value, ReasoningEffort::High);
+    }
+
+    #[test]
+    fn test_gpt51_profile() {
+        let profile = get_model_profile(&LlmProviderType::Openai, "gpt-5.1").unwrap();
+        assert_eq!(profile.name, "GPT-5.1");
+        assert!(profile.reasoning);
+        assert!(profile.tool_call);
+
+        // gpt-5.1: default none, supports none/low/medium/high
+        let effort = profile.reasoning_effort.unwrap();
+        assert_eq!(effort.default, ReasoningEffort::None);
+        assert_eq!(effort.values.len(), 4);
+        assert!(effort
+            .values
+            .iter()
+            .any(|v| v.value == ReasoningEffort::None));
+        assert!(!effort
+            .values
+            .iter()
+            .any(|v| v.value == ReasoningEffort::Xhigh));
+    }
+
+    #[test]
+    fn test_gpt51_codex_max_profile() {
+        let profile = get_model_profile(&LlmProviderType::Openai, "gpt-5.1-codex-max").unwrap();
+        assert_eq!(profile.name, "GPT-5.1 Codex max");
+        assert!(profile.reasoning);
+
+        // After gpt-5.1-codex-max: supports xhigh
+        let effort = profile.reasoning_effort.unwrap();
+        assert!(effort
+            .values
+            .iter()
+            .any(|v| v.value == ReasoningEffort::Xhigh));
+    }
+
+    #[test]
+    fn test_gpt52_profile() {
+        let profile = get_model_profile(&LlmProviderType::Openai, "gpt-5.2").unwrap();
+        assert_eq!(profile.name, "GPT-5.2");
+        assert!(profile.reasoning);
+
+        // gpt-5.2: default none, supports none/low/medium/high/xhigh
+        let effort = profile.reasoning_effort.unwrap();
+        assert_eq!(effort.default, ReasoningEffort::None);
+        assert_eq!(effort.values.len(), 5);
+        assert!(effort
+            .values
+            .iter()
+            .any(|v| v.value == ReasoningEffort::Xhigh));
+    }
+
+    #[test]
+    fn test_gpt52_pro_profile() {
+        let profile = get_model_profile(&LlmProviderType::Openai, "gpt-5.2-pro").unwrap();
+        assert_eq!(profile.name, "GPT-5.2 Pro");
+        assert!(profile.reasoning);
+
+        // gpt-5.2-pro: default medium, supports medium/high/xhigh
+        let effort = profile.reasoning_effort.unwrap();
+        assert_eq!(effort.default, ReasoningEffort::Medium);
+        assert_eq!(effort.values.len(), 3);
+        assert!(effort
+            .values
+            .iter()
+            .any(|v| v.value == ReasoningEffort::Xhigh));
+        assert!(!effort
+            .values
+            .iter()
+            .any(|v| v.value == ReasoningEffort::None));
+    }
+
+    #[test]
+    fn test_normalize_gpt5_model_ids() {
+        assert_eq!(normalize_model_id("gpt-5"), "gpt-5");
+        assert_eq!(normalize_model_id("gpt-5-2025-08-07"), "gpt-5");
+        assert_eq!(normalize_model_id("gpt-5-mini"), "gpt-5-mini");
+        assert_eq!(normalize_model_id("gpt-5-nano"), "gpt-5-nano");
+        assert_eq!(normalize_model_id("gpt-5-pro"), "gpt-5-pro");
+        assert_eq!(normalize_model_id("gpt-5-codex"), "gpt-5-codex");
+        assert_eq!(normalize_model_id("gpt-5.1"), "gpt-5.1");
+        assert_eq!(normalize_model_id("gpt-5.1-codex"), "gpt-5.1-codex");
+        assert_eq!(
+            normalize_model_id("gpt-5.1-codex-mini"),
+            "gpt-5.1-codex-mini"
+        );
+        assert_eq!(normalize_model_id("gpt-5.1-codex-max"), "gpt-5.1-codex-max");
+        assert_eq!(normalize_model_id("gpt-5.2"), "gpt-5.2");
+        assert_eq!(normalize_model_id("gpt-5.2-pro"), "gpt-5.2-pro");
+        assert_eq!(normalize_model_id("gpt-5.2-codex"), "gpt-5.2-codex");
     }
 }

--- a/harness/seed-agents.yaml
+++ b/harness/seed-agents.yaml
@@ -26,19 +26,47 @@ providers:
     api_key_env: "OPENAI_API_KEY"
     is_default: true
     models:
-      - model_id: "gpt-5"
-        display_name: "GPT-5"
-        context_window: 200000
-        is_default: true
-      - model_id: "gpt-5-mini"
-        display_name: "GPT-5 Mini"
-        context_window: 200000
-      - model_id: "gpt-5-nano"
-        display_name: "GPT-5 Nano"
+      # GPT-5.2 models (latest, supports xhigh reasoning)
+      - model_id: "gpt-5.2"
+        display_name: "GPT-5.2"
         context_window: 128000
+        is_default: true
+      - model_id: "gpt-5.2-pro"
+        display_name: "GPT-5.2 Pro"
+        context_window: 128000
+      - model_id: "gpt-5.2-codex"
+        display_name: "GPT-5.2 Codex"
+        context_window: 128000
+      # GPT-5.1 models (default none reasoning, supports none/low/medium/high)
       - model_id: "gpt-5.1"
         display_name: "GPT-5.1"
-        context_window: 200000
+        context_window: 128000
+      - model_id: "gpt-5.1-codex"
+        display_name: "GPT-5.1 Codex"
+        context_window: 128000
+      - model_id: "gpt-5.1-codex-mini"
+        display_name: "GPT-5.1 Codex mini"
+        context_window: 128000
+      - model_id: "gpt-5.1-codex-max"
+        display_name: "GPT-5.1 Codex max"
+        context_window: 128000
+      # GPT-5 models (default medium reasoning, supports low/medium/high)
+      - model_id: "gpt-5"
+        display_name: "GPT-5"
+        context_window: 128000
+      - model_id: "gpt-5-mini"
+        display_name: "GPT-5 mini"
+        context_window: 128000
+      - model_id: "gpt-5-nano"
+        display_name: "GPT-5 nano"
+        context_window: 128000
+      - model_id: "gpt-5-pro"
+        display_name: "GPT-5 Pro"
+        context_window: 128000
+      - model_id: "gpt-5-codex"
+        display_name: "GPT-5 Codex"
+        context_window: 128000
+      # GPT-4 and reasoning models
       - model_id: "gpt-4o"
         display_name: "GPT-4o"
         context_window: 128000


### PR DESCRIPTION
## Summary

- Add model profiles for all GPT-5 variants (gpt-5, gpt-5.1, gpt-5.2 families) with correct reasoning effort configurations
- Add all GPT-5 models to seed configuration for development database
- Fix context window values in seed file (128K for GPT-5 models)

## Changes

### Model Profiles (`model_profiles.rs`)

Added 13 new GPT-5 model profiles:

| Model Family | Models | Reasoning Effort |
|--------------|--------|------------------|
| GPT-5 (pre-5.1) | gpt-5, gpt-5-mini, gpt-5-nano, gpt-5-codex | Default: medium, Supports: low/medium/high |
| GPT-5 Pro | gpt-5-pro | Default: high, Supports: high only |
| GPT-5.1 | gpt-5.1, gpt-5.1-codex, gpt-5.1-codex-mini | Default: none, Supports: none/low/medium/high |
| GPT-5.1 Codex max+ | gpt-5.1-codex-max | Default: none, Supports: none/low/medium/high/xhigh |
| GPT-5.2 | gpt-5.2, gpt-5.2-codex | Default: none, Supports: none/low/medium/high/xhigh |
| GPT-5.2 Pro | gpt-5.2-pro | Default: medium, Supports: medium/high/xhigh |

### Seed Configuration (`seed-agents.yaml`)

- Added all 13 GPT-5 models to OpenAI provider seed
- Changed default model to gpt-5.2 (latest flagship)
- Fixed context window values (128K instead of incorrect 200K)

## Test plan

- [x] `cargo fmt` - Code formatted
- [x] `cargo clippy -- -D warnings` - No warnings
- [x] `cargo test -p everruns-core model_profiles` - All 20 tests pass
- [ ] Run seed script to verify models are created correctly
