### PR TITLE
Refactor messages UI to use events endpoint

### DIFF
--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -164,6 +164,28 @@ grep "agent_workflow" /tmp/worker.log | head -3
 ```
 Expected: Logs showing `workflow_type: "agent_workflow"` and activities like `load-agent`, `call-model`
 
+#### 9.6. Verify Events (Messages/Events Sync)
+After workflow completes, verify events are created alongside messages:
+```bash
+# List events for the session
+curl -s "http://localhost:9000/v1/agents/$AGENT_ID/sessions/$SESSION_ID/events/list" | jq '.data | length'
+```
+Expected: At least 2 events (message.user and message.assistant)
+
+```bash
+# Check for message.user event
+curl -s "http://localhost:9000/v1/agents/$AGENT_ID/sessions/$SESSION_ID/events/list" | jq '.data[] | select(.event_type == "message.user")'
+```
+Expected: Event with `event_type: "message.user"` and `data` containing `message_id`, `content`
+
+```bash
+# Check for message.assistant event
+curl -s "http://localhost:9000/v1/agents/$AGENT_ID/sessions/$SESSION_ID/events/list" | jq '.data[] | select(.event_type == "message.assistant")'
+```
+Expected: Event with `event_type: "message.assistant"` and `data` containing `message_id`, `role`, `content`
+
+**Note:** The UI uses the events endpoint to render messages. Events contain the same data as messages but are used for SSE/polling to provide real-time updates.
+
 #### 10. List Sessions
 ```bash
 curl -s "http://localhost:9000/v1/agents/$AGENT_ID/sessions" | jq '.data | length'

--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { use, useState, useRef, useEffect } from "react";
-import { useAgent, useSession, useMessages, useSendMessage, useLlmModel } from "@/hooks";
+import { useAgent, useSession, useEvents, useSendMessage, useLlmModel } from "@/hooks";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -46,8 +46,9 @@ export default function SessionDetailPage({
     refetchInterval: shouldPoll ? 1000 : false,
   });
 
-  // Poll for messages while waiting and session is active
-  const { data: messages, isLoading: messagesLoading } = useMessages(
+  // Poll for messages (from events) while waiting and session is active
+  // Uses events endpoint and transforms to Message format for display
+  const { data: messages, isLoading: messagesLoading } = useEvents(
     agentId,
     sessionId,
     { refetchInterval: shouldPoll ? 1000 : false }

--- a/apps/ui/src/hooks/use-sessions.ts
+++ b/apps/ui/src/hooks/use-sessions.ts
@@ -8,7 +8,6 @@ import {
   listSessions,
   updateSession,
   sendUserMessage,
-  listMessages,
   listEvents,
 } from "@/lib/api/sessions";
 import type { CreateSessionRequest, UpdateSessionRequest, Event, Message, ContentPart } from "@/lib/api/types";
@@ -104,27 +103,11 @@ export function useSendMessage() {
       content: string;
     }) => sendUserMessage(agentId, sessionId, content),
     onSuccess: (_, { agentId, sessionId }) => {
-      // Invalidate both messages and events queries for backward compatibility
-      queryClient.invalidateQueries({
-        queryKey: ["messages", agentId, sessionId],
-      });
+      // Invalidate events query to refresh the message list
       queryClient.invalidateQueries({
         queryKey: ["events", agentId, sessionId],
       });
     },
-  });
-}
-
-export function useMessages(
-  agentId: string | undefined,
-  sessionId: string | undefined,
-  options?: { refetchInterval?: number | false }
-) {
-  return useQuery({
-    queryKey: ["messages", agentId, sessionId],
-    queryFn: () => listMessages(agentId!, sessionId!),
-    enabled: !!agentId && !!sessionId,
-    refetchInterval: options?.refetchInterval,
   });
 }
 

--- a/apps/ui/src/hooks/use-sessions.ts
+++ b/apps/ui/src/hooks/use-sessions.ts
@@ -9,8 +9,9 @@ import {
   updateSession,
   sendUserMessage,
   listMessages,
+  listEvents,
 } from "@/lib/api/sessions";
-import type { CreateSessionRequest, UpdateSessionRequest } from "@/lib/api/types";
+import type { CreateSessionRequest, UpdateSessionRequest, Event, Message, ContentPart } from "@/lib/api/types";
 
 export function useSessions(agentId: string | undefined) {
   return useQuery({
@@ -103,8 +104,12 @@ export function useSendMessage() {
       content: string;
     }) => sendUserMessage(agentId, sessionId, content),
     onSuccess: (_, { agentId, sessionId }) => {
+      // Invalidate both messages and events queries for backward compatibility
       queryClient.invalidateQueries({
         queryKey: ["messages", agentId, sessionId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["events", agentId, sessionId],
       });
     },
   });
@@ -118,6 +123,73 @@ export function useMessages(
   return useQuery({
     queryKey: ["messages", agentId, sessionId],
     queryFn: () => listMessages(agentId!, sessionId!),
+    enabled: !!agentId && !!sessionId,
+    refetchInterval: options?.refetchInterval,
+  });
+}
+
+// ============================================
+// Events hooks and helpers
+// ============================================
+
+/**
+ * Transform events to Message-like objects for UI rendering
+ * This allows the UI to render from events while still displaying as "messages"
+ */
+function eventsToMessages(events: Event[]): Message[] {
+  // Filter only message events and transform them
+  const messageEvents = events.filter(e =>
+    e.event_type === "message.user" ||
+    e.event_type === "message.assistant" ||
+    e.event_type === "message.tool_call" ||
+    e.event_type === "message.tool_result"
+  );
+
+  return messageEvents.map(event => {
+    const data = event.data as {
+      message_id: string;
+      role: string;
+      content: ContentPart[];
+      sequence: number;
+      created_at: string;
+    };
+
+    // Map event type to message role
+    const roleMap: Record<string, Message["role"]> = {
+      "message.user": "user",
+      "message.assistant": "assistant",
+      "message.tool_call": "tool_call",
+      "message.tool_result": "tool_result",
+    };
+
+    return {
+      id: data.message_id,
+      session_id: event.session_id,
+      sequence: data.sequence ?? event.sequence,
+      role: roleMap[event.event_type] ?? data.role as Message["role"],
+      content: data.content,
+      metadata: undefined,
+      tool_call_id: null, // Derived from content if needed
+      created_at: data.created_at ?? event.created_at,
+    };
+  });
+}
+
+/**
+ * Fetch events and transform them to messages for UI rendering
+ * This hook replaces useMessages for event-based rendering
+ */
+export function useEvents(
+  agentId: string | undefined,
+  sessionId: string | undefined,
+  options?: { refetchInterval?: number | false }
+) {
+  return useQuery({
+    queryKey: ["events", agentId, sessionId],
+    queryFn: async () => {
+      const events = await listEvents(agentId!, sessionId!);
+      return eventsToMessages(events);
+    },
     enabled: !!agentId && !!sessionId,
     refetchInterval: options?.refetchInterval,
   });

--- a/apps/ui/src/lib/api/messages.ts
+++ b/apps/ui/src/lib/api/messages.ts
@@ -4,6 +4,7 @@
 import { api } from "./client";
 import type {
   Message,
+  Event,
   CreateMessageRequest,
   ListResponse,
 } from "./types";
@@ -51,6 +52,17 @@ export async function sendUserMessage(
 // ============================================
 // Events (SSE notifications)
 // ============================================
+
+// List events for a session (polling alternative to SSE)
+export async function listEvents(
+  agentId: string,
+  sessionId: string
+): Promise<Event[]> {
+  const response = await api.get<ListResponse<Event>>(
+    `/v1/agents/${agentId}/sessions/${sessionId}/events/list`
+  );
+  return response.data.data;
+}
 
 // SSE event stream URL builder
 export function getEventStreamUrl(agentId: string, sessionId: string): string {

--- a/apps/ui/src/lib/api/sessions.ts
+++ b/apps/ui/src/lib/api/sessions.ts
@@ -13,6 +13,7 @@ export {
   createMessage,
   listMessages,
   sendUserMessage,
+  listEvents,
   getEventStreamUrl,
 } from "./messages";
 


### PR DESCRIPTION
## What
Refactor the Session UI to render messages from the events endpoint instead of the messages endpoint.

## Why
- Events provide a unified streaming model for real-time updates
- Enables future SSE-based live message rendering

## How
- Backend: DbMessageStore emits events when storing messages
- Backend: Add GET /events/list endpoint for JSON polling
- UI: Add useEvents hook that transforms events to Message format
- UI: Session page uses useEvents instead of useMessages
- Tests: Add events verification to smoke tests

## Risk
- Low - Messages endpoint remains available for backward compatibility