### PR TITLE
Add reasoning effort selection to UI

### DIFF
--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/page.tsx
@@ -69,6 +69,17 @@ export default function SessionDetailPage({
   const supportsReasoning = llmModel?.profile?.reasoning && llmModel?.profile?.reasoning_effort;
   const reasoningEffortConfig = llmModel?.profile?.reasoning_effort;
 
+  // Get display name for a reasoning effort value
+  const getReasoningEffortName = (value: string): string => {
+    const effort = reasoningEffortConfig?.values.find(e => e.value === value);
+    return effort?.name ?? value;
+  };
+
+  // Get the default effort display name
+  const defaultEffortName = reasoningEffortConfig?.default
+    ? getReasoningEffortName(reasoningEffortConfig.default)
+    : "Medium";
+
   // Auto-scroll to bottom when new messages arrive
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -325,11 +336,15 @@ export default function SessionDetailPage({
               value={reasoningEffort}
               onValueChange={(value) => setReasoningEffort(value as ReasoningEffort | "")}
             >
-              <SelectTrigger size="sm" className="w-[140px]">
-                <SelectValue placeholder="Default" />
+              <SelectTrigger size="sm" className="w-[180px]">
+                <SelectValue>
+                  {reasoningEffort
+                    ? getReasoningEffortName(reasoningEffort)
+                    : `Default (${defaultEffortName})`}
+                </SelectValue>
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="">Default</SelectItem>
+                <SelectItem value="">{`Default (${defaultEffortName})`}</SelectItem>
                 {reasoningEffortConfig.values.map((effort) => (
                   <SelectItem key={effort.value} value={effort.value}>
                     {effort.name}

--- a/apps/ui/src/hooks/use-sessions.ts
+++ b/apps/ui/src/hooks/use-sessions.ts
@@ -10,7 +10,7 @@ import {
   sendUserMessage,
   listEvents,
 } from "@/lib/api/sessions";
-import type { CreateSessionRequest, UpdateSessionRequest, Event, Message, ContentPart } from "@/lib/api/types";
+import type { CreateSessionRequest, UpdateSessionRequest, Event, Message, ContentPart, Controls } from "@/lib/api/types";
 
 export function useSessions(agentId: string | undefined) {
   return useQuery({
@@ -97,11 +97,13 @@ export function useSendMessage() {
       agentId,
       sessionId,
       content,
+      controls,
     }: {
       agentId: string;
       sessionId: string;
       content: string;
-    }) => sendUserMessage(agentId, sessionId, content),
+      controls?: Controls;
+    }) => sendUserMessage(agentId, sessionId, content, controls),
     onSuccess: (_, { agentId, sessionId }) => {
       // Invalidate events query to refresh the message list
       queryClient.invalidateQueries({

--- a/apps/ui/src/lib/api/llm-providers.ts
+++ b/apps/ui/src/lib/api/llm-providers.ts
@@ -54,8 +54,8 @@ export async function getLlmProviderModels(
   return apiClient<LlmModel[]>(`/v1/llm-providers/${providerId}/models`);
 }
 
-export async function getLlmModel(modelId: string): Promise<LlmModel> {
-  return apiClient<LlmModel>(`/v1/llm-models/${modelId}`);
+export async function getLlmModel(modelId: string): Promise<LlmModelWithProvider> {
+  return apiClient<LlmModelWithProvider>(`/v1/llm-models/${modelId}`);
 }
 
 export async function createLlmModel(

--- a/apps/ui/src/lib/api/messages.ts
+++ b/apps/ui/src/lib/api/messages.ts
@@ -7,6 +7,7 @@ import type {
   Event,
   CreateMessageRequest,
   ListResponse,
+  Controls,
 } from "./types";
 
 // ============================================
@@ -39,13 +40,15 @@ export async function listMessages(
 export async function sendUserMessage(
   agentId: string,
   sessionId: string,
-  content: string
+  content: string,
+  controls?: Controls
 ): Promise<Message> {
   return createMessage(agentId, sessionId, {
     message: {
       role: "user",
       content: [{ type: "text", text: content }],
     },
+    controls,
   });
 }
 

--- a/crates/everruns-api/src/llm_models.rs
+++ b/crates/everruns-api/src/llm_models.rs
@@ -152,7 +152,7 @@ pub async fn list_all_models(
     Ok(Json(models))
 }
 
-/// Get a specific model
+/// Get a specific model with provider info and profile
 #[utoipa::path(
     get,
     path = "/v1/llm-models/{id}",
@@ -160,7 +160,7 @@ pub async fn list_all_models(
         ("id" = Uuid, Path, description = "Model ID")
     ),
     responses(
-        (status = 200, description = "Model found", body = LlmModel),
+        (status = 200, description = "Model found", body = LlmModelWithProvider),
         (status = 404, description = "Model not found")
     ),
     tag = "llm-models"
@@ -168,10 +168,10 @@ pub async fn list_all_models(
 pub async fn get_model(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
-) -> Result<Json<LlmModel>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<LlmModelWithProvider>, (StatusCode, Json<ErrorResponse>)> {
     let model = state
         .service
-        .get(id)
+        .get_with_provider(id)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get LLM model: {}", e);

--- a/crates/everruns-api/src/services/llm_model.rs
+++ b/crates/everruns-api/src/services/llm_model.rs
@@ -36,11 +36,6 @@ impl LlmModelService {
         Ok(Self::row_to_model(&row))
     }
 
-    pub async fn get(&self, id: Uuid) -> Result<Option<LlmModel>> {
-        let row = self.db.get_llm_model(id).await?;
-        Ok(row.as_ref().map(Self::row_to_model))
-    }
-
     pub async fn get_with_provider(&self, id: Uuid) -> Result<Option<LlmModelWithProvider>> {
         let row = self.db.get_llm_model_with_provider(id).await?;
         Ok(row.as_ref().map(Self::row_to_model_with_provider))

--- a/crates/everruns-api/src/services/llm_model.rs
+++ b/crates/everruns-api/src/services/llm_model.rs
@@ -41,6 +41,11 @@ impl LlmModelService {
         Ok(row.as_ref().map(Self::row_to_model))
     }
 
+    pub async fn get_with_provider(&self, id: Uuid) -> Result<Option<LlmModelWithProvider>> {
+        let row = self.db.get_llm_model_with_provider(id).await?;
+        Ok(row.as_ref().map(Self::row_to_model_with_provider))
+    }
+
     pub async fn list_for_provider(&self, provider_id: Uuid) -> Result<Vec<LlmModel>> {
         let rows = self.db.list_llm_models_for_provider(provider_id).await?;
         Ok(rows.iter().map(Self::row_to_model).collect())

--- a/crates/everruns-core/src/llm.rs
+++ b/crates/everruns-core/src/llm.rs
@@ -248,6 +248,8 @@ pub struct LlmCallConfig {
     pub temperature: Option<f32>,
     pub max_tokens: Option<u32>,
     pub tools: Vec<ToolDefinition>,
+    /// Reasoning effort level (for models that support it: low, medium, high)
+    pub reasoning_effort: Option<String>,
 }
 
 impl From<&AgentConfig> for LlmCallConfig {
@@ -257,6 +259,7 @@ impl From<&AgentConfig> for LlmCallConfig {
             temperature: config.temperature,
             max_tokens: config.max_tokens,
             tools: config.tools.clone(),
+            reasoning_effort: None, // Set by CallModelAtom from user message controls
         }
     }
 }

--- a/crates/everruns-core/src/openai.rs
+++ b/crates/everruns-core/src/openai.rs
@@ -173,6 +173,7 @@ impl LlmProvider for OpenAIProtocolLlmProvider {
             max_tokens: config.max_tokens,
             stream: true,
             tools,
+            reasoning_effort: config.reasoning_effort.clone(),
         };
 
         let response = self
@@ -336,6 +337,9 @@ struct OpenAiRequest {
     stream: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     tools: Option<Vec<OpenAiTool>>,
+    /// Reasoning effort for o1/o3 models (low, medium, high)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reasoning_effort: Option<String>,
 }
 
 /// Content can be either a simple string or an array of content parts

--- a/crates/everruns-storage/src/repositories.rs
+++ b/crates/everruns-storage/src/repositories.rs
@@ -832,6 +832,26 @@ impl Database {
         Ok(row)
     }
 
+    pub async fn get_llm_model_with_provider(
+        &self,
+        id: Uuid,
+    ) -> Result<Option<LlmModelWithProviderRow>> {
+        let row = sqlx::query_as::<_, LlmModelWithProviderRow>(
+            r#"
+            SELECT m.id, m.provider_id, m.model_id, m.display_name, m.capabilities, m.context_window, m.is_default, m.status, m.created_at, m.updated_at,
+                   p.name as provider_name, p.provider_type
+            FROM llm_models m
+            JOIN llm_providers p ON m.provider_id = p.id
+            WHERE m.id = $1
+            "#,
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
     pub async fn list_llm_models_for_provider(
         &self,
         provider_id: Uuid,


### PR DESCRIPTION
## What

Add UI support for selecting reasoning effort levels when using LLM models that support extended thinking/reasoning (e.g., Claude with extended thinking, OpenAI o-series models).

## Why

Models with reasoning capabilities can produce better results when given explicit reasoning effort levels. This allows users to balance response quality vs. cost/latency by selecting low, medium, high, or extra-high reasoning efforts.

## How

### Backend Changes
- Extended `LlmCallConfig` with `reasoning_effort` field
- **Anthropic provider**: Maps reasoning effort to extended thinking `budget_tokens` (low=1024, medium=4096, high=16384, xhigh=32768)
- **OpenAI provider**: Passes `reasoning_effort` parameter directly to API
- `CallModelAtom` extracts reasoning effort from user message controls and records model + reasoning_effort in AI message metadata
- Added `get_llm_model_with_provider` to storage layer for fetching model with profile

### API Changes
- Updated `GET /api/v1/llm-models/{id}` to return `LlmModelWithProvider` (includes profile with reasoning config)

### UI Changes
- Added reasoning effort dropdown selector in session chat (only shown for models that support it)
- Dropdown shows display names (e.g., "Low", "Medium") and indicates the default value
- AI message bubbles display model and reasoning effort badges when available
- Updated `sendUserMessage` to accept and pass `Controls` with reasoning config

## Risk
- Low
- Changes are additive and only affect models with reasoning support
- Existing behavior unchanged for models without reasoning capabilities

## Checklist
- [x] Tests pass (`cargo test`)
- [x] UI linting passes (`npm run lint`)
- [x] UI builds successfully (`npm run build`)
- [x] Backward compatible - no breaking changes
