### PR TITLE
Configure Next.js build caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,6 +348,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: apps/ui/.next/cache
+          # Generate a new cache whenever packages or source files change
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('apps/ui/package-lock.json') }}-${{ hashFiles('apps/ui/src/**/*', 'apps/ui/app/**/*') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('apps/ui/package-lock.json') }}-
+            ${{ runner.os }}-nextjs-
+
       - name: Lint
         run: npm run lint
 


### PR DESCRIPTION
Configure GitHub Actions to cache the .next/cache directory, eliminating the "No build cache found" warning and improving build times for subsequent runs.

The cache key is based on package-lock.json and source files, so cache is invalidated when dependencies or code change.
