### PR TITLE
Add tool results to Messages UI display

### DIFF
--- a/apps/ui/src/__tests__/session-detail-model.test.tsx
+++ b/apps/ui/src/__tests__/session-detail-model.test.tsx
@@ -66,14 +66,14 @@ const mockLlmModel: LlmModelWithProvider = {
 // Mock hooks module
 const mockUseAgent = jest.fn();
 const mockUseSession = jest.fn();
-const mockUseMessages = jest.fn();
+const mockUseEvents = jest.fn();
 const mockUseSendMessage = jest.fn();
 const mockUseLlmModel = jest.fn();
 
 jest.mock("@/hooks", () => ({
   useAgent: (...args: unknown[]) => mockUseAgent(...args),
   useSession: (...args: unknown[]) => mockUseSession(...args),
-  useMessages: (...args: unknown[]) => mockUseMessages(...args),
+  useEvents: (...args: unknown[]) => mockUseEvents(...args),
   useSendMessage: () => mockUseSendMessage(),
   useLlmModel: (...args: unknown[]) => mockUseLlmModel(...args),
 }));
@@ -100,7 +100,7 @@ describe("SessionDetailPage - LLM Model Display", () => {
     // Default mock implementations
     mockUseAgent.mockReturnValue({ data: mockAgent, isLoading: false });
     mockUseSession.mockReturnValue({ data: mockSession, isLoading: false });
-    mockUseMessages.mockReturnValue({ data: [], isLoading: false });
+    mockUseEvents.mockReturnValue({ data: [], isLoading: false });
     mockUseSendMessage.mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
     mockUseLlmModel.mockReturnValue({ data: mockLlmModel, isLoading: false });
   });

--- a/apps/ui/src/components/chat/tool-call-card.tsx
+++ b/apps/ui/src/components/chat/tool-call-card.tsx
@@ -15,6 +15,7 @@ interface ToolCallContent {
 }
 
 interface ToolResultContent {
+  tool_call_id: string;
   result?: unknown;
   error?: string;
 }
@@ -38,6 +39,7 @@ function extractToolResultContent(content: ContentPart[]): ToolResultContent | n
   for (const part of content) {
     if (isToolResultPart(part)) {
       return {
+        tool_call_id: part.tool_call_id,
         result: part.result,
         error: part.error,
       };

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -77,7 +77,7 @@ export type ContentPart =
   | { type: "text"; text: string }
   | { type: "image"; url?: string; base64?: string; media_type?: string }
   | { type: "tool_call"; id: string; name: string; arguments: Record<string, unknown> }
-  | { type: "tool_result"; result?: unknown; error?: string };
+  | { type: "tool_result"; tool_call_id: string; result?: unknown; error?: string };
 
 // Helper type guards for ContentPart
 export function isTextPart(part: ContentPart): part is { type: "text"; text: string } {
@@ -88,7 +88,7 @@ export function isToolCallPart(part: ContentPart): part is { type: "tool_call"; 
   return part.type === "tool_call";
 }
 
-export function isToolResultPart(part: ContentPart): part is { type: "tool_result"; result?: unknown; error?: string } {
+export function isToolResultPart(part: ContentPart): part is { type: "tool_result"; tool_call_id: string; result?: unknown; error?: string } {
   return part.type === "tool_result";
 }
 


### PR DESCRIPTION
## What

Link tool_result messages to their corresponding tool_call cards in the session Messages UI, enabling the UI to show both arguments and results together with proper status updates.

## Why

Previously, tool_result events were not properly linked to their tool_call counterparts because the `tool_call_id` field was missing from the `tool_result` ContentPart type. This prevented the UI from pairing tool results with their tool calls, so status wouldn't update and results wouldn't display.

## How

1. **Added `tool_call_id` to `tool_result` ContentPart type** (`types.ts`)
   - Updated the discriminated union to include `tool_call_id: string`
   - Updated `isToolResultPart` type guard to include the field

2. **Extract `tool_call_id` in event transformation** (`use-sessions.ts`)
   - Added `extractToolCallId` helper function
   - `eventsToMessages` now extracts `tool_call_id` from content for tool_result messages
   - This enables `toolResultsMap` in the session page to properly pair results with calls

3. **Updated ToolCallCard extraction** (`tool-call-card.tsx`)
   - Added `tool_call_id` to `ToolResultContent` interface
   - Updated `extractToolResultContent` to include the field

4. **Fixed test mock** (`session-detail-model.test.tsx`)
   - Updated mock from `useMessages` to `useEvents` to match refactored component

## Data Flow

Event (message.tool_result)
↓ content has ToolResultContentPart with tool_call_id
eventsToMessages()
↓ extracts tool_call_id, sets on Message
Session Page
↓ builds toolResultsMap keyed by tool_call_id
ToolCallCard
↓ receives paired toolCall + toolResult
UI renders: status (Running→Done/Failed), arguments, and result

## Risk

- **Low** - Additive change to types with no breaking changes
- Existing functionality preserved through backward-compatible type casts
- Fully tested with existing test suite

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] UI lint passes (`npm run lint`)
- [x] UI build passes (`npm run build`)
- [x] All tests pass (108/108)