### PR TITLE
Update default LLM model selection logic

### DIFF
--- a/apps/ui/src/__tests__/session-detail-model.test.tsx
+++ b/apps/ui/src/__tests__/session-detail-model.test.tsx
@@ -66,14 +66,14 @@ const mockLlmModel: LlmModelWithProvider = {
 // Mock hooks module
 const mockUseAgent = jest.fn();
 const mockUseSession = jest.fn();
-const mockUseMessages = jest.fn();
+const mockUseEvents = jest.fn();
 const mockUseSendMessage = jest.fn();
 const mockUseLlmModel = jest.fn();
 
 jest.mock("@/hooks", () => ({
   useAgent: (...args: unknown[]) => mockUseAgent(...args),
   useSession: (...args: unknown[]) => mockUseSession(...args),
-  useMessages: (...args: unknown[]) => mockUseMessages(...args),
+  useEvents: (...args: unknown[]) => mockUseEvents(...args),
   useSendMessage: () => mockUseSendMessage(),
   useLlmModel: (...args: unknown[]) => mockUseLlmModel(...args),
 }));
@@ -100,7 +100,7 @@ describe("SessionDetailPage - LLM Model Display", () => {
     // Default mock implementations
     mockUseAgent.mockReturnValue({ data: mockAgent, isLoading: false });
     mockUseSession.mockReturnValue({ data: mockSession, isLoading: false });
-    mockUseMessages.mockReturnValue({ data: [], isLoading: false });
+    mockUseEvents.mockReturnValue({ data: [], isLoading: false });
     mockUseSendMessage.mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
     mockUseLlmModel.mockReturnValue({ data: mockLlmModel, isLoading: false });
   });

--- a/apps/ui/src/__tests__/settings-providers.test.tsx
+++ b/apps/ui/src/__tests__/settings-providers.test.tsx
@@ -10,7 +10,6 @@ const mockProviders = [
     name: "OpenAI Production",
     provider_type: "openai",
     status: "active",
-    is_default: true,
     api_key_set: true,
     base_url: "https://api.openai.com/v1",
     created_at: "2024-01-01T00:00:00Z",
@@ -21,7 +20,6 @@ const mockProviders = [
     name: "Anthropic Dev",
     provider_type: "anthropic",
     status: "active",
-    is_default: false,
     api_key_set: false,
     base_url: null,
     created_at: "2024-01-01T00:00:00Z",
@@ -244,12 +242,12 @@ describe("ProvidersPage", () => {
     expect(headerButton).toBeDisabled();
   });
 
-  it("shows default star icon for default provider", () => {
+  it("shows default star icon for default model", () => {
     render(<ProvidersPage />, { wrapper });
 
-    // OpenAI Production is the default provider
-    const providerCard = screen.getByText("OpenAI Production").closest("div");
-    expect(providerCard).toBeInTheDocument();
+    // GPT-4 is the default model
+    const modelRow = screen.getByText("GPT-4").closest("div");
+    expect(modelRow).toBeInTheDocument();
     // Check for the star icon (it has fill-yellow-500 class)
     const starIcons = document.querySelectorAll('[class*="fill-yellow-500"]');
     expect(starIcons.length).toBeGreaterThan(0);

--- a/apps/ui/src/app/(main)/settings/providers/page.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/page.tsx
@@ -52,6 +52,7 @@ import {
   ChevronDown,
   ChevronUp,
 } from "lucide-react";
+// Note: Star is still used in ModelRow for default model indicator
 import { ProviderIcon, getProviderLabel } from "@/components/providers/provider-icon";
 import type {
   LlmProvider,
@@ -98,9 +99,6 @@ function ProviderCard({
           <div>
             <CardTitle className="text-lg flex items-center gap-2">
               {provider.name}
-              {provider.is_default && (
-                <Star className="h-4 w-4 text-yellow-500 fill-yellow-500" />
-              )}
             </CardTitle>
             <CardDescription className="text-sm">
               {getProviderLabel(provider.provider_type)}
@@ -382,7 +380,6 @@ function AddProviderDialog({
   const [providerType, setProviderType] = useState<LlmProviderType>("openai");
   const [baseUrl, setBaseUrl] = useState("");
   const [apiKey, setApiKey] = useState("");
-  const [isDefault, setIsDefault] = useState(false);
 
   const createProvider = useCreateLlmProvider();
 
@@ -393,7 +390,6 @@ function AddProviderDialog({
       provider_type: providerType,
       base_url: baseUrl || undefined,
       api_key: apiKey || undefined,
-      is_default: isDefault,
     };
     await createProvider.mutateAsync(data);
     onOpenChange(false);
@@ -401,7 +397,6 @@ function AddProviderDialog({
     setProviderType("openai");
     setBaseUrl("");
     setApiKey("");
-    setIsDefault(false);
   };
 
   return (
@@ -463,16 +458,6 @@ function AddProviderDialog({
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => setApiKey(e.target.value)}
               placeholder={getApiKeyPlaceholder(providerType)}
             />
-          </div>
-          <div className="flex items-center gap-2">
-            <input
-              type="checkbox"
-              id="is-default"
-              checked={isDefault}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setIsDefault(e.target.checked)}
-              className="h-4 w-4"
-            />
-            <Label htmlFor="is-default">Set as default provider</Label>
           </div>
           <DialogFooter>
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
@@ -635,7 +620,7 @@ function AddModelDialog({
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => setIsDefault(e.target.checked)}
               className="h-4 w-4"
             />
-            <Label htmlFor="model-is-default">Set as default for this provider</Label>
+            <Label htmlFor="model-is-default">Set as default model</Label>
           </div>
           <DialogFooter>
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -299,7 +299,6 @@ export interface LlmProvider {
   provider_type: LlmProviderType;
   base_url?: string;
   api_key_set: boolean;
-  is_default: boolean;
   status: LlmProviderStatus;
   created_at: string;
   updated_at: string;
@@ -419,7 +418,6 @@ export interface CreateLlmProviderRequest {
   provider_type: LlmProviderType;
   base_url?: string;
   api_key?: string;
-  is_default?: boolean;
 }
 
 export interface UpdateLlmProviderRequest {
@@ -427,7 +425,6 @@ export interface UpdateLlmProviderRequest {
   provider_type?: LlmProviderType;
   base_url?: string;
   api_key?: string;
-  is_default?: boolean;
   status?: LlmProviderStatus;
 }
 

--- a/crates/everruns-api/src/llm_providers.rs
+++ b/crates/everruns-api/src/llm_providers.rs
@@ -38,8 +38,6 @@ pub struct CreateLlmProviderRequest {
     pub base_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub api_key: Option<String>,
-    #[serde(default)]
-    pub is_default: bool,
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
@@ -52,8 +50,6 @@ pub struct UpdateLlmProviderRequest {
     pub base_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub api_key: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub is_default: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<LlmProviderStatus>,
 }

--- a/crates/everruns-api/src/services/llm_model.rs
+++ b/crates/everruns-api/src/services/llm_model.rs
@@ -23,6 +23,11 @@ impl LlmModelService {
     }
 
     pub async fn create(&self, provider_id: Uuid, req: CreateLlmModelRequest) -> Result<LlmModel> {
+        // If setting this model as default, clear all other defaults first ("last wins")
+        if req.is_default {
+            self.db.clear_all_model_defaults().await?;
+        }
+
         let input = CreateLlmModelRow {
             provider_id,
             model_id: req.model_id,
@@ -51,6 +56,11 @@ impl LlmModelService {
     }
 
     pub async fn update(&self, id: Uuid, req: UpdateLlmModelRequest) -> Result<Option<LlmModel>> {
+        // If setting this model as default, clear all other defaults first ("last wins")
+        if req.is_default == Some(true) {
+            self.db.clear_all_model_defaults().await?;
+        }
+
         let input = UpdateLlmModel {
             model_id: req.model_id,
             display_name: req.display_name,

--- a/crates/everruns-api/src/services/llm_provider.rs
+++ b/crates/everruns-api/src/services/llm_provider.rs
@@ -39,7 +39,6 @@ impl LlmProviderService {
             provider_type: req.provider_type.to_string(),
             base_url: req.base_url,
             api_key_encrypted,
-            is_default: req.is_default,
             settings: None,
         };
 
@@ -78,7 +77,6 @@ impl LlmProviderService {
             provider_type: req.provider_type.map(|t| t.to_string()),
             base_url: req.base_url,
             api_key_encrypted,
-            is_default: req.is_default,
             status: req.status.map(|s| match s {
                 LlmProviderStatus::Active => "active".to_string(),
                 LlmProviderStatus::Disabled => "disabled".to_string(),
@@ -101,7 +99,6 @@ impl LlmProviderService {
             provider_type: row.provider_type.parse().unwrap_or(LlmProviderType::Openai),
             base_url: row.base_url.clone(),
             api_key_set: row.api_key_set,
-            is_default: row.is_default,
             status: match row.status.as_str() {
                 "active" => LlmProviderStatus::Active,
                 _ => LlmProviderStatus::Disabled,

--- a/crates/everruns-core/src/llm_entities.rs
+++ b/crates/everruns-core/src/llm_entities.rs
@@ -73,7 +73,6 @@ pub struct LlmProvider {
     pub base_url: Option<String>,
     /// Whether an API key is configured (key is never returned)
     pub api_key_set: bool,
-    pub is_default: bool,
     pub status: LlmProviderStatus,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,

--- a/crates/everruns-storage/migrations/012_update_llm_default_logic.sql
+++ b/crates/everruns-storage/migrations/012_update_llm_default_logic.sql
@@ -1,0 +1,15 @@
+-- Migration: Update LLM default logic
+-- 1. Remove is_default from llm_providers entirely
+-- 2. Change llm_models default to be global (only one default model across all providers)
+
+-- Drop the unique index on providers default
+DROP INDEX IF EXISTS idx_llm_providers_default;
+
+-- Remove is_default column from llm_providers
+ALTER TABLE llm_providers DROP COLUMN IF EXISTS is_default;
+
+-- Drop the per-provider unique index on model default
+DROP INDEX IF EXISTS idx_llm_models_provider_default;
+
+-- Create a new global unique index for model default (only one default model globally)
+CREATE UNIQUE INDEX idx_llm_models_default ON llm_models(is_default) WHERE is_default = TRUE;

--- a/crates/everruns-storage/src/models.rs
+++ b/crates/everruns-storage/src/models.rs
@@ -246,7 +246,6 @@ pub struct LlmProviderRow {
     pub base_url: Option<String>,
     pub api_key_encrypted: Option<Vec<u8>>,
     pub api_key_set: bool,
-    pub is_default: bool,
     pub status: String,
     pub settings: sqlx::types::JsonValue,
     pub created_at: DateTime<Utc>,
@@ -300,7 +299,6 @@ pub struct CreateLlmProviderRow {
     pub provider_type: String,
     pub base_url: Option<String>,
     pub api_key_encrypted: Option<Vec<u8>>,
-    pub is_default: bool,
     pub settings: Option<serde_json::Value>,
 }
 
@@ -310,7 +308,6 @@ pub struct UpdateLlmProvider {
     pub provider_type: Option<String>,
     pub base_url: Option<String>,
     pub api_key_encrypted: Option<Vec<u8>>,
-    pub is_default: Option<bool>,
     pub status: Option<String>,
     pub settings: Option<serde_json::Value>,
 }


### PR DESCRIPTION
## Summary

- Remove `is_default` from LLM Provider (default concept now only exists at model level)
- Change LLM Model default from per-provider to global (only one default model across all providers)
- Implement "last wins" logic: setting a model as default automatically unsets all other defaults

## What Changed

**Backend:**
- Removed `is_default` field from `LlmProvider` entity, storage models, API DTOs, and services
- Added `get_default_llm_model()` and `clear_all_model_defaults()` repository methods
- Updated worker to fall back to default model instead of default provider
- Database migration 012: drops `is_default` from `llm_providers`, changes model default index from per-provider to global

**Frontend:**
- Removed `is_default` from `LlmProvider` TypeScript interface and request types
- Removed default checkbox from "Add Provider" dialog
- Removed star icon from provider cards
- Updated model default label to "Set as default model"

## Risk

- **Low** - Breaking change for API consumers expecting `is_default` on providers, but field was not widely used

## Test plan

- [ ] Verify existing providers work without `is_default` field
- [ ] Create a model with `is_default=true`, verify it becomes the only default
- [ ] Create another model with `is_default=true`, verify previous default is unset
- [ ] Verify worker falls back to default model when agent has no model set
- [ ] Verify UI no longer shows default star on provider cards
- [ ] Verify UI shows default star on model rows
