### PR TITLE
Add Capability details page with tools

### DIFF
--- a/.claude/skills/smoke-test/scenarios/tool-calling.md
+++ b/.claude/skills/smoke-test/scenarios/tool-calling.md
@@ -54,6 +54,7 @@ Run all tool calling tests automatically:
 | Combined Capabilities | Using both `test_math` and `test_weather` |
 | Tool Error Handling | Division by zero error response |
 | WebFetch Capability Available | Verify `web_fetch` capability is registered |
+| Capability Detail Endpoint | Verify capability details include `system_prompt` and `tool_definitions` |
 | WebFetch Tool (Input Validation) | Test `web_fetch` tool handles invalid URLs |
 
 ## Troubleshooting

--- a/apps/ui/src/app/(main)/capabilities/[capabilityId]/page.tsx
+++ b/apps/ui/src/app/(main)/capabilities/[capabilityId]/page.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { use } from "react";
+import { useCapability } from "@/hooks";
+import Link from "next/link";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { MarkdownDisplay } from "@/components/ui/prompt-editor";
+import {
+  ArrowLeft,
+  CircleOff,
+  Clock,
+  Search,
+  Box,
+  Folder,
+  Calculator,
+  Globe,
+  ListChecks,
+  LucideIcon,
+  Wrench,
+  FileText,
+  Code,
+} from "lucide-react";
+import type { CapabilityStatus, ToolDefinition } from "@/lib/api/types";
+
+const iconMap: Record<string, LucideIcon> = {
+  "circle-off": CircleOff,
+  clock: Clock,
+  search: Search,
+  box: Box,
+  folder: Folder,
+  calculator: Calculator,
+  globe: Globe,
+  "list-checks": ListChecks,
+};
+
+function getStatusBadgeVariant(
+  status: CapabilityStatus
+): "default" | "secondary" | "outline" {
+  switch (status) {
+    case "available":
+      return "default";
+    case "coming_soon":
+      return "secondary";
+    case "deprecated":
+      return "outline";
+  }
+}
+
+function getStatusLabel(status: CapabilityStatus): string {
+  switch (status) {
+    case "available":
+      return "Available";
+    case "coming_soon":
+      return "Coming Soon";
+    case "deprecated":
+      return "Deprecated";
+  }
+}
+
+function ToolCard({ tool }: { tool: ToolDefinition }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between">
+          <div className="flex items-center gap-2">
+            <div className="p-1.5 bg-muted rounded">
+              <Wrench className="w-4 h-4" />
+            </div>
+            <div>
+              <CardTitle className="text-base font-mono">{tool.name}</CardTitle>
+            </div>
+          </div>
+          {tool.policy && (
+            <Badge
+              variant={tool.policy === "auto" ? "default" : "secondary"}
+              className="text-xs"
+            >
+              {tool.policy === "auto" ? "Auto" : "Requires Approval"}
+            </Badge>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-muted-foreground">{tool.description}</p>
+
+        {tool.parameters && Object.keys(tool.parameters).length > 0 && (
+          <div>
+            <h4 className="text-sm font-medium mb-2 flex items-center gap-2">
+              <Code className="w-4 h-4" />
+              Parameters
+            </h4>
+            <pre className="text-xs bg-muted p-3 rounded-md overflow-x-auto">
+              {JSON.stringify(tool.parameters, null, 2)}
+            </pre>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function CapabilityDetailPage({
+  params,
+}: {
+  params: Promise<{ capabilityId: string }>;
+}) {
+  const { capabilityId } = use(params);
+  const { data: capability, isLoading, error } = useCapability(capabilityId);
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto p-6">
+        <Skeleton className="h-4 w-24 mb-6" />
+        <Skeleton className="h-8 w-1/3 mb-4" />
+        <Skeleton className="h-4 w-2/3 mb-8" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (error || !capability) {
+    return (
+      <div className="container mx-auto p-6">
+        <div className="text-red-500 mb-4">
+          {error ? `Error loading capability: ${error.message}` : "Capability not found"}
+        </div>
+        <Link href="/capabilities" className="text-blue-500 hover:underline">
+          Back to capabilities
+        </Link>
+      </div>
+    );
+  }
+
+  const IconComponent = capability.icon
+    ? iconMap[capability.icon] || CircleOff
+    : CircleOff;
+
+  const toolDefinitions = capability.tool_definitions || [];
+
+  return (
+    <div className="container mx-auto p-6">
+      <Link
+        href="/capabilities"
+        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-6"
+      >
+        <ArrowLeft className="w-4 h-4 mr-2" />
+        Back to Capabilities
+      </Link>
+
+      <div className="flex items-start justify-between mb-6">
+        <div className="flex items-center gap-4">
+          <div className="p-3 bg-muted rounded-lg">
+            <IconComponent className="w-6 h-6" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold flex items-center gap-3">
+              {capability.name}
+              <Badge variant={getStatusBadgeVariant(capability.status)}>
+                {getStatusLabel(capability.status)}
+              </Badge>
+            </h1>
+            <p className="text-muted-foreground font-mono text-sm">
+              {capability.id}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <div className="lg:col-span-2 space-y-6">
+          {/* Description Card */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Description</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-muted-foreground">{capability.description}</p>
+            </CardContent>
+          </Card>
+
+          {/* System Prompt Card */}
+          {capability.system_prompt && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <FileText className="w-5 h-5" />
+                  System Prompt Addition
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <MarkdownDisplay content={capability.system_prompt} />
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Tools Section */}
+          {toolDefinitions.length > 0 && (
+            <div className="space-y-4">
+              <h2 className="text-lg font-semibold flex items-center gap-2">
+                <Wrench className="w-5 h-5" />
+                Tools ({toolDefinitions.length})
+              </h2>
+              <div className="space-y-4">
+                {toolDefinitions.map((tool) => (
+                  <ToolCard key={tool.name} tool={tool} />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* No contributions message */}
+          {!capability.system_prompt && toolDefinitions.length === 0 && (
+            <Card className="p-8 text-center">
+              <CircleOff className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+              <h3 className="text-lg font-medium mb-2">No contributions</h3>
+              <p className="text-muted-foreground">
+                This capability does not contribute any system prompt additions or tools.
+              </p>
+            </Card>
+          )}
+        </div>
+
+        {/* Sidebar */}
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Details</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <p className="text-sm font-medium">Status</p>
+                <Badge
+                  variant={getStatusBadgeVariant(capability.status)}
+                  className="mt-1"
+                >
+                  {getStatusLabel(capability.status)}
+                </Badge>
+              </div>
+
+              {capability.category && (
+                <div>
+                  <p className="text-sm font-medium">Category</p>
+                  <Badge variant="outline" className="mt-1">
+                    {capability.category}
+                  </Badge>
+                </div>
+              )}
+
+              <div>
+                <p className="text-sm font-medium">ID</p>
+                <p className="text-sm text-muted-foreground font-mono">
+                  {capability.id}
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Summary</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2 text-sm">
+                  <FileText className="h-4 w-4 text-muted-foreground" />
+                  <span>System Prompt</span>
+                </div>
+                <Badge variant={capability.system_prompt ? "default" : "outline"}>
+                  {capability.system_prompt ? "Yes" : "No"}
+                </Badge>
+              </div>
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2 text-sm">
+                  <Wrench className="h-4 w-4 text-muted-foreground" />
+                  <span>Tools</span>
+                </div>
+                <span className="font-medium">{toolDefinitions.length}</span>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/app/(main)/capabilities/page.tsx
+++ b/apps/ui/src/app/(main)/capabilities/page.tsx
@@ -5,12 +5,16 @@ import { Header } from "@/components/layout/header";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import Link from "next/link";
 import {
   CircleOff,
   Clock,
   Search,
   Box,
   Folder,
+  Calculator,
+  Globe,
+  ListChecks,
   LucideIcon,
   CheckCircle2,
   AlertCircle,
@@ -24,6 +28,9 @@ const iconMap: Record<string, LucideIcon> = {
   search: Search,
   box: Box,
   folder: Folder,
+  calculator: Calculator,
+  globe: Globe,
+  "list-checks": ListChecks,
 };
 
 function getStatusBadgeVariant(
@@ -56,34 +63,36 @@ function CapabilityCard({ capability }: { capability: Capability }) {
     : CircleOff;
 
   return (
-    <Card className="hover:shadow-md transition-shadow">
-      <CardHeader className="flex flex-row items-start justify-between space-y-0">
-        <div className="flex items-center gap-3">
-          <div className="p-2 bg-muted rounded-lg">
-            <IconComponent className="w-5 h-5" />
+    <Link href={`/capabilities/${capability.id}`}>
+      <Card className="hover:shadow-md transition-shadow cursor-pointer h-full">
+        <CardHeader className="flex flex-row items-start justify-between space-y-0">
+          <div className="flex items-center gap-3">
+            <div className="p-2 bg-muted rounded-lg">
+              <IconComponent className="w-5 h-5" />
+            </div>
+            <div>
+              <CardTitle className="text-lg">{capability.name}</CardTitle>
+              <p className="text-sm text-muted-foreground font-mono">
+                {capability.id}
+              </p>
+            </div>
           </div>
-          <div>
-            <CardTitle className="text-lg">{capability.name}</CardTitle>
-            <p className="text-sm text-muted-foreground font-mono">
-              {capability.id}
-            </p>
-          </div>
-        </div>
-        <Badge variant={getStatusBadgeVariant(capability.status)}>
-          {getStatusLabel(capability.status)}
-        </Badge>
-      </CardHeader>
-      <CardContent>
-        <p className="text-sm text-muted-foreground mb-4">
-          {capability.description}
-        </p>
-        {capability.category && (
-          <Badge variant="outline" className="text-xs">
-            {capability.category}
+          <Badge variant={getStatusBadgeVariant(capability.status)}>
+            {getStatusLabel(capability.status)}
           </Badge>
-        )}
-      </CardContent>
-    </Card>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground mb-4">
+            {capability.description}
+          </p>
+          {capability.category && (
+            <Badge variant="outline" className="text-xs">
+              {capability.category}
+            </Badge>
+          )}
+        </CardContent>
+      </Card>
+    </Link>
   );
 }
 

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -191,16 +191,21 @@ export interface ListResponse<T> {
 
 export type ToolPolicy = "auto" | "requires_approval";
 
-export type ToolDefinition = BuiltinTool;
-
+/** Tool definition - builtin tool configuration */
 export interface BuiltinTool {
   type: "builtin";
+  /** Tool name (used by LLM and for registry lookup) */
   name: string;
+  /** Tool description for LLM */
   description: string;
+  /** JSON schema for tool parameters */
   parameters: Record<string, unknown>;
-  kind: "http_get" | "http_post" | "read_file" | "write_file" | "current_time";
+  /** Tool policy (auto or requires_approval) */
   policy?: ToolPolicy;
 }
+
+/** Tool definition - currently only supports builtin tools */
+export type ToolDefinition = BuiltinTool;
 
 // ============================================
 // Health check
@@ -447,7 +452,8 @@ export interface UpdateLlmModelRequest {
 // Capability types
 // ============================================
 
-export type CapabilityId = "noop" | "current_time" | "research" | "sandbox" | "file_system";
+/** Capability ID - extensible string-based identifier */
+export type CapabilityId = string;
 
 export type CapabilityStatus = "available" | "coming_soon" | "deprecated";
 
@@ -458,6 +464,10 @@ export interface Capability {
   status: CapabilityStatus;
   icon?: string;
   category?: string;
+  /** System prompt addition contributed by this capability */
+  system_prompt?: string;
+  /** Tool definitions provided by this capability */
+  tool_definitions?: ToolDefinition[];
 }
 
 export interface AgentCapability {


### PR DESCRIPTION
## What

Add a capability details page to the UI that displays the full information about a capability, including its system prompt addition and tool definitions.

## Why

Users need visibility into what each capability contributes to an agent - specifically what instructions are added to the system prompt and what tools become available. This helps users understand and configure agent behaviors more effectively.

## How

### Backend (Rust)
- Extended `CapabilityInfo` DTO with `system_prompt` and `tool_definitions` fields
- Updated `CapabilityInfo::from_core()` to populate these fields from the `Capability` trait
- Updated `BuiltinTool` type to remove deprecated `kind` field

### Frontend (React/TypeScript)
- Created `/capabilities/[capabilityId]` detail page showing:
  - Capability header with icon, name, status badge
  - Description card
  - System prompt addition card with markdown rendering
  - Tools section with cards showing name, description, policy, and parameter schemas
  - Sidebar with status, category, and summary
- Made capability cards on the list page clickable
- Updated TypeScript types to include new fields

### Testing
- Added `test_capability_detail` smoke test to verify the endpoint returns `system_prompt` and `tool_definitions`
- Updated tool-calling test documentation

## Risk

- **Low**
- API change is additive (new optional fields), fully backward compatible
- No changes to capability execution or agent behavior

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] UI lint passes
- [x] UI build passes
- [x] Rust tests pass (136 tests)
