### PR TITLE
Implement session file system capability

### DIFF
--- a/crates/everruns-core/examples/decomposed_execution.rs
+++ b/crates/everruns-core/examples/decomposed_execution.rs
@@ -174,6 +174,7 @@ async fn main() -> anyhow::Result<()> {
                     session_id,
                     tool_call: tool_call.clone(),
                     tool_definitions: config.tools.clone(),
+                    tool_context: None, // Example doesn't use context-aware tools
                 })
                 .await?;
 

--- a/crates/everruns-core/src/capabilities/file_system.rs
+++ b/crates/everruns-core/src/capabilities/file_system.rs
@@ -1,8 +1,23 @@
-//! FileSystem Capability - for file system access (coming soon)
+//! FileSystem Capability - for file system access
+//!
+//! This capability provides tools for interacting with the session's virtual
+//! filesystem. Each session has its own isolated filesystem stored in the database.
+//!
+//! Tools provided:
+//! - `read_file`: Read file content
+//! - `write_file`: Create or update a file
+//! - `list_directory`: List files in a directory
+//! - `grep_files`: Search files by regex pattern
+//! - `delete_file`: Delete a file or directory
+//! - `stat_file`: Get file metadata
 
 use super::{Capability, CapabilityId, CapabilityStatus};
+use crate::tools::{Tool, ToolExecutionResult};
+use crate::traits::ToolContext;
+use async_trait::async_trait;
+use serde_json::{json, Value};
 
-/// FileSystem capability - for file system access (coming soon)
+/// FileSystem capability - for file system access
 pub struct FileSystemCapability;
 
 impl Capability for FileSystemCapability {
@@ -15,11 +30,11 @@ impl Capability for FileSystemCapability {
     }
 
     fn description(&self) -> &str {
-        "Adds tools to access and manipulate files - read, write, grep, and more."
+        "Adds tools to access and manipulate files - read, write, list, grep, and more."
     }
 
     fn status(&self) -> CapabilityStatus {
-        CapabilityStatus::ComingSoon
+        CapabilityStatus::Available
     }
 
     fn icon(&self) -> Option<&str> {
@@ -31,6 +46,681 @@ impl Capability for FileSystemCapability {
     }
 
     fn system_prompt_addition(&self) -> Option<&str> {
-        Some("You have access to file system tools. You can read, write, and search files.")
+        Some(
+            r#"You have access to file system tools for working with the session's virtual filesystem.
+
+Available tools:
+- `read_file`: Read the content of a file by path
+- `write_file`: Create a new file or update existing file content
+- `list_directory`: List files and directories at a given path
+- `grep_files`: Search file contents using regex patterns
+- `delete_file`: Delete a file or directory
+- `stat_file`: Get metadata about a file (size, dates, etc.)
+
+Best practices:
+- Use `list_directory` first to explore the filesystem structure
+- Use `stat_file` to check if a file exists before reading/writing
+- Use `grep_files` to search across multiple files efficiently
+- The root directory is `/` - all paths should be absolute
+- Directories are created automatically when writing files"#,
+        )
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(ReadFileTool),
+            Box::new(WriteFileTool),
+            Box::new(ListDirectoryTool),
+            Box::new(GrepFilesTool),
+            Box::new(DeleteFileTool),
+            Box::new(StatFileTool),
+        ]
+    }
+}
+
+// ============================================================================
+// ReadFileTool
+// ============================================================================
+
+/// Tool to read file content
+pub struct ReadFileTool;
+
+#[async_trait]
+impl Tool for ReadFileTool {
+    fn name(&self) -> &str {
+        "read_file"
+    }
+
+    fn description(&self) -> &str {
+        "Read the content of a file. Returns the file content as text or base64-encoded binary."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute path to the file (e.g., '/docs/readme.txt')"
+                }
+            },
+            "required": ["path"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "read_file requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let path = match arguments.get("path").and_then(|v| v.as_str()) {
+            Some(p) => p,
+            None => return ToolExecutionResult::tool_error("Missing required parameter: path"),
+        };
+
+        let file_store = match &context.file_store {
+            Some(store) => store,
+            None => {
+                return ToolExecutionResult::tool_error("File system not available in this context")
+            }
+        };
+
+        match file_store.read_file(context.session_id, path).await {
+            Ok(Some(file)) => {
+                if file.is_directory {
+                    ToolExecutionResult::tool_error(format!(
+                        "Path '{}' is a directory, not a file. Use list_directory instead.",
+                        path
+                    ))
+                } else {
+                    ToolExecutionResult::success(json!({
+                        "path": file.path,
+                        "content": file.content,
+                        "encoding": file.encoding,
+                        "size_bytes": file.size_bytes
+                    }))
+                }
+            }
+            Ok(None) => ToolExecutionResult::tool_error(format!("File not found: {}", path)),
+            Err(e) => ToolExecutionResult::internal_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// WriteFileTool
+// ============================================================================
+
+/// Tool to write/create a file
+pub struct WriteFileTool;
+
+#[async_trait]
+impl Tool for WriteFileTool {
+    fn name(&self) -> &str {
+        "write_file"
+    }
+
+    fn description(&self) -> &str {
+        "Create a new file or update an existing file's content. Parent directories are created automatically."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute path for the file (e.g., '/docs/notes.txt')"
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Content to write to the file"
+                },
+                "encoding": {
+                    "type": "string",
+                    "enum": ["text", "base64"],
+                    "default": "text",
+                    "description": "Content encoding: 'text' for plain text, 'base64' for binary data"
+                }
+            },
+            "required": ["path", "content"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "write_file requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let path = match arguments.get("path").and_then(|v| v.as_str()) {
+            Some(p) => p,
+            None => return ToolExecutionResult::tool_error("Missing required parameter: path"),
+        };
+
+        let content = match arguments.get("content").and_then(|v| v.as_str()) {
+            Some(c) => c,
+            None => return ToolExecutionResult::tool_error("Missing required parameter: content"),
+        };
+
+        let encoding = arguments
+            .get("encoding")
+            .and_then(|v| v.as_str())
+            .unwrap_or("text");
+
+        let file_store = match &context.file_store {
+            Some(store) => store,
+            None => {
+                return ToolExecutionResult::tool_error("File system not available in this context")
+            }
+        };
+
+        match file_store
+            .write_file(context.session_id, path, content, encoding)
+            .await
+        {
+            Ok(file) => ToolExecutionResult::success(json!({
+                "path": file.path,
+                "size_bytes": file.size_bytes,
+                "created": true
+            })),
+            Err(e) => {
+                // Check if it's a user-facing error (like readonly file)
+                let msg = e.to_string();
+                if msg.contains("readonly") || msg.contains("is a directory") {
+                    ToolExecutionResult::tool_error(msg)
+                } else {
+                    ToolExecutionResult::internal_error(e)
+                }
+            }
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// ListDirectoryTool
+// ============================================================================
+
+/// Tool to list directory contents
+pub struct ListDirectoryTool;
+
+#[async_trait]
+impl Tool for ListDirectoryTool {
+    fn name(&self) -> &str {
+        "list_directory"
+    }
+
+    fn description(&self) -> &str {
+        "List files and directories at a given path. Returns file metadata including size and type."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "default": "/",
+                    "description": "Directory path to list (default: root '/')"
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "list_directory requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let path = arguments
+            .get("path")
+            .and_then(|v| v.as_str())
+            .unwrap_or("/");
+
+        let file_store = match &context.file_store {
+            Some(store) => store,
+            None => {
+                return ToolExecutionResult::tool_error("File system not available in this context")
+            }
+        };
+
+        match file_store.list_directory(context.session_id, path).await {
+            Ok(files) => {
+                let entries: Vec<Value> = files
+                    .iter()
+                    .map(|f| {
+                        json!({
+                            "name": f.name,
+                            "path": f.path,
+                            "is_directory": f.is_directory,
+                            "size_bytes": f.size_bytes,
+                            "is_readonly": f.is_readonly
+                        })
+                    })
+                    .collect();
+
+                ToolExecutionResult::success(json!({
+                    "path": path,
+                    "entries": entries,
+                    "count": entries.len()
+                }))
+            }
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("not found") || msg.contains("not a directory") {
+                    ToolExecutionResult::tool_error(msg)
+                } else {
+                    ToolExecutionResult::internal_error(e)
+                }
+            }
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// GrepFilesTool
+// ============================================================================
+
+/// Tool to search files by pattern
+pub struct GrepFilesTool;
+
+#[async_trait]
+impl Tool for GrepFilesTool {
+    fn name(&self) -> &str {
+        "grep_files"
+    }
+
+    fn description(&self) -> &str {
+        "Search file contents using a regex pattern. Returns matching lines with file paths and line numbers."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": "Regex pattern to search for"
+                },
+                "path_pattern": {
+                    "type": "string",
+                    "description": "Optional path pattern to filter files (e.g., '*.txt', '/docs/*')"
+                }
+            },
+            "required": ["pattern"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "grep_files requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let pattern = match arguments.get("pattern").and_then(|v| v.as_str()) {
+            Some(p) => p,
+            None => return ToolExecutionResult::tool_error("Missing required parameter: pattern"),
+        };
+
+        let path_pattern = arguments.get("path_pattern").and_then(|v| v.as_str());
+
+        let file_store = match &context.file_store {
+            Some(store) => store,
+            None => {
+                return ToolExecutionResult::tool_error("File system not available in this context")
+            }
+        };
+
+        match file_store
+            .grep_files(context.session_id, pattern, path_pattern)
+            .await
+        {
+            Ok(matches) => {
+                let results: Vec<Value> = matches
+                    .iter()
+                    .map(|m| {
+                        json!({
+                            "path": m.path,
+                            "line_number": m.line_number,
+                            "line": m.line
+                        })
+                    })
+                    .collect();
+
+                ToolExecutionResult::success(json!({
+                    "pattern": pattern,
+                    "matches": results,
+                    "match_count": results.len()
+                }))
+            }
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("regex") || msg.contains("pattern") {
+                    ToolExecutionResult::tool_error(format!("Invalid regex pattern: {}", msg))
+                } else {
+                    ToolExecutionResult::internal_error(e)
+                }
+            }
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// DeleteFileTool
+// ============================================================================
+
+/// Tool to delete a file or directory
+pub struct DeleteFileTool;
+
+#[async_trait]
+impl Tool for DeleteFileTool {
+    fn name(&self) -> &str {
+        "delete_file"
+    }
+
+    fn description(&self) -> &str {
+        "Delete a file or directory. Use recursive=true to delete non-empty directories."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path to the file or directory to delete"
+                },
+                "recursive": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "If true, delete directories and all contents recursively"
+                }
+            },
+            "required": ["path"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "delete_file requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let path = match arguments.get("path").and_then(|v| v.as_str()) {
+            Some(p) => p,
+            None => return ToolExecutionResult::tool_error("Missing required parameter: path"),
+        };
+
+        let recursive = arguments
+            .get("recursive")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        let file_store = match &context.file_store {
+            Some(store) => store,
+            None => {
+                return ToolExecutionResult::tool_error("File system not available in this context")
+            }
+        };
+
+        match file_store
+            .delete_file(context.session_id, path, recursive)
+            .await
+        {
+            Ok(deleted) => {
+                if deleted {
+                    ToolExecutionResult::success(json!({
+                        "path": path,
+                        "deleted": true
+                    }))
+                } else {
+                    ToolExecutionResult::tool_error(format!("File not found: {}", path))
+                }
+            }
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("not empty") || msg.contains("recursive") {
+                    ToolExecutionResult::tool_error(msg)
+                } else {
+                    ToolExecutionResult::internal_error(e)
+                }
+            }
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// StatFileTool
+// ============================================================================
+
+/// Tool to get file metadata
+pub struct StatFileTool;
+
+#[async_trait]
+impl Tool for StatFileTool {
+    fn name(&self) -> &str {
+        "stat_file"
+    }
+
+    fn description(&self) -> &str {
+        "Get metadata about a file or directory (exists, size, type, dates)."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path to the file or directory"
+                }
+            },
+            "required": ["path"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "stat_file requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let path = match arguments.get("path").and_then(|v| v.as_str()) {
+            Some(p) => p,
+            None => return ToolExecutionResult::tool_error("Missing required parameter: path"),
+        };
+
+        let file_store = match &context.file_store {
+            Some(store) => store,
+            None => {
+                return ToolExecutionResult::tool_error("File system not available in this context")
+            }
+        };
+
+        match file_store.stat_file(context.session_id, path).await {
+            Ok(Some(stat)) => ToolExecutionResult::success(json!({
+                "path": stat.path,
+                "name": stat.name,
+                "exists": true,
+                "is_directory": stat.is_directory,
+                "is_readonly": stat.is_readonly,
+                "size_bytes": stat.size_bytes,
+                "created_at": stat.created_at.to_rfc3339(),
+                "updated_at": stat.updated_at.to_rfc3339()
+            })),
+            Ok(None) => ToolExecutionResult::success(json!({
+                "path": path,
+                "exists": false
+            })),
+            Err(e) => ToolExecutionResult::internal_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_capability_metadata() {
+        let cap = FileSystemCapability;
+        assert_eq!(cap.id(), CapabilityId::FILE_SYSTEM);
+        assert_eq!(cap.name(), "File System Access");
+        assert_eq!(cap.status(), CapabilityStatus::Available);
+        assert_eq!(cap.icon(), Some("folder"));
+        assert_eq!(cap.category(), Some("File Operations"));
+    }
+
+    #[test]
+    fn test_capability_has_tools() {
+        let cap = FileSystemCapability;
+        let tools = cap.tools();
+
+        assert_eq!(tools.len(), 6);
+
+        let tool_names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(tool_names.contains(&"read_file"));
+        assert!(tool_names.contains(&"write_file"));
+        assert!(tool_names.contains(&"list_directory"));
+        assert!(tool_names.contains(&"grep_files"));
+        assert!(tool_names.contains(&"delete_file"));
+        assert!(tool_names.contains(&"stat_file"));
+    }
+
+    #[test]
+    fn test_capability_has_system_prompt() {
+        let cap = FileSystemCapability;
+        let prompt = cap.system_prompt_addition().unwrap();
+        assert!(prompt.contains("read_file"));
+        assert!(prompt.contains("write_file"));
+        assert!(prompt.contains("list_directory"));
+    }
+
+    #[test]
+    fn test_tools_require_context() {
+        assert!(ReadFileTool.requires_context());
+        assert!(WriteFileTool.requires_context());
+        assert!(ListDirectoryTool.requires_context());
+        assert!(GrepFilesTool.requires_context());
+        assert!(DeleteFileTool.requires_context());
+        assert!(StatFileTool.requires_context());
+    }
+
+    #[tokio::test]
+    async fn test_read_file_without_context() {
+        let tool = ReadFileTool;
+        let result = tool.execute(json!({"path": "/test.txt"})).await;
+
+        if let ToolExecutionResult::ToolError(msg) = result {
+            assert!(msg.contains("requires context"));
+        } else {
+            panic!("Expected tool error");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_write_file_without_context() {
+        let tool = WriteFileTool;
+        let result = tool
+            .execute(json!({"path": "/test.txt", "content": "hello"}))
+            .await;
+
+        if let ToolExecutionResult::ToolError(msg) = result {
+            assert!(msg.contains("requires context"));
+        } else {
+            panic!("Expected tool error");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_read_file_missing_path() {
+        let tool = ReadFileTool;
+        let context = ToolContext::new(uuid::Uuid::nil());
+
+        let result = tool.execute_with_context(json!({}), &context).await;
+
+        if let ToolExecutionResult::ToolError(msg) = result {
+            assert!(msg.contains("Missing required parameter"));
+        } else {
+            panic!("Expected tool error for missing path");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_read_file_no_file_store() {
+        let tool = ReadFileTool;
+        let context = ToolContext::new(uuid::Uuid::nil());
+
+        let result = tool
+            .execute_with_context(json!({"path": "/test.txt"}), &context)
+            .await;
+
+        if let ToolExecutionResult::ToolError(msg) = result {
+            assert!(msg.contains("not available"));
+        } else {
+            panic!("Expected tool error for missing file store");
+        }
     }
 }

--- a/crates/everruns-core/src/capabilities/mod.rs
+++ b/crates/everruns-core/src/capabilities/mod.rs
@@ -39,7 +39,10 @@ mod web_fetch;
 
 // Re-export capabilities
 pub use current_time::{CurrentTimeCapability, GetCurrentTimeTool};
-pub use file_system::FileSystemCapability;
+pub use file_system::{
+    DeleteFileTool, FileSystemCapability, GrepFilesTool, ListDirectoryTool, ReadFileTool,
+    StatFileTool, WriteFileTool,
+};
 pub use noop::NoopCapability;
 pub use research::ResearchCapability;
 pub use sandbox::SandboxCapability;

--- a/crates/everruns-core/src/lib.rs
+++ b/crates/everruns-core/src/lib.rs
@@ -60,7 +60,7 @@ pub use message::{
     ReasoningConfig, TextContentPart, ToolCallContentPart, ToolResultContentPart,
 };
 pub use step::{LoopStep, StepKind, StepResult};
-pub use traits::{EventEmitter, MessageStore, ToolExecutor};
+pub use traits::{EventEmitter, MessageStore, SessionFileStore, ToolContext, ToolExecutor};
 
 // LLM types re-exports
 pub use llm::{
@@ -77,10 +77,11 @@ pub use tools::{
 // Capability re-exports
 pub use capabilities::{
     apply_capabilities, AddTool, AppliedCapabilities, Capability, CapabilityId, CapabilityRegistry,
-    CapabilityRegistryBuilder, CapabilityStatus, CurrentTimeCapability, DivideTool,
-    FileSystemCapability, GetCurrentTimeTool, GetForecastTool, GetWeatherTool, MultiplyTool,
-    NoopCapability, ResearchCapability, SandboxCapability, StatelessTodoListCapability,
-    SubtractTool, TestMathCapability, TestWeatherCapability, WriteTodosTool,
+    CapabilityRegistryBuilder, CapabilityStatus, CurrentTimeCapability, DeleteFileTool, DivideTool,
+    FileSystemCapability, GetCurrentTimeTool, GetForecastTool, GetWeatherTool, GrepFilesTool,
+    ListDirectoryTool, MultiplyTool, NoopCapability, ReadFileTool, ResearchCapability,
+    SandboxCapability, StatFileTool, StatelessTodoListCapability, SubtractTool, TestMathCapability,
+    TestWeatherCapability, WriteFileTool, WriteTodosTool,
 };
 
 // Atoms re-exports (stateless atomic operations)

--- a/crates/everruns-core/src/loop.rs
+++ b/crates/everruns-core/src/loop.rs
@@ -176,6 +176,7 @@ where
                             session_id,
                             tool_call,
                             tool_definitions: tool_defs,
+                            tool_context: None, // Context-aware tools need Temporal execution
                         })
                         .await
                     }

--- a/crates/everruns-storage/src/lib.rs
+++ b/crates/everruns-storage/src/lib.rs
@@ -2,12 +2,14 @@
 //
 // This crate provides database implementations for core traits:
 // - DbMessageStore: implements MessageStore for message persistence
+// - DbSessionFileStore: implements SessionFileStore for session filesystem
 
 pub mod encryption;
 pub mod message_store;
 pub mod models;
 pub mod password;
 pub mod repositories;
+pub mod session_file_store;
 
 pub use encryption::{
     generate_encryption_key, EncryptedColumn, EncryptedPayload, EncryptionService,
@@ -16,3 +18,4 @@ pub use encryption::{
 pub use message_store::{create_db_message_store, DbMessageStore};
 pub use models::*;
 pub use repositories::*;
+pub use session_file_store::{create_db_session_file_store, DbSessionFileStore};

--- a/crates/everruns-storage/src/session_file_store.rs
+++ b/crates/everruns-storage/src/session_file_store.rs
@@ -1,0 +1,489 @@
+// Database-backed SessionFileStore implementation
+//
+// This module implements the core SessionFileStore trait for persisting
+// session files to the database.
+
+use async_trait::async_trait;
+use everruns_core::{
+    traits::SessionFileStore, AgentLoopError, FileInfo, FileStat, GrepMatch, Result, SessionFile,
+};
+use regex::Regex;
+use uuid::Uuid;
+
+use crate::models::{CreateSessionFileRow, UpdateSessionFile};
+use crate::repositories::Database;
+
+// ============================================================================
+// DbSessionFileStore - Stores session files in database
+// ============================================================================
+
+/// Database-backed session file store
+///
+/// Stores session files in the session_files table.
+/// Used by tools that need to read/write the session's virtual filesystem.
+#[derive(Clone)]
+pub struct DbSessionFileStore {
+    db: Database,
+}
+
+impl DbSessionFileStore {
+    pub fn new(db: Database) -> Self {
+        Self { db }
+    }
+
+    /// Normalize a path: ensure it starts with /, no trailing slash, no double slashes
+    fn normalize_path(path: &str) -> String {
+        let mut normalized = path.trim().to_string();
+
+        // Ensure starts with /
+        if !normalized.starts_with('/') {
+            normalized = format!("/{}", normalized);
+        }
+
+        // Remove trailing slash (except for root)
+        if normalized.len() > 1 && normalized.ends_with('/') {
+            normalized.pop();
+        }
+
+        // Remove double slashes
+        while normalized.contains("//") {
+            normalized = normalized.replace("//", "/");
+        }
+
+        normalized
+    }
+
+    /// Ensure a directory exists, creating it and parents if needed
+    async fn ensure_directory_exists(&self, session_id: Uuid, path: &str) -> Result<()> {
+        if path == "/" {
+            return Ok(()); // Root always exists
+        }
+
+        // Check if directory exists
+        if let Some(existing) = self.db.get_session_file(session_id, path).await? {
+            if existing.is_directory {
+                return Ok(());
+            } else {
+                return Err(AgentLoopError::store(format!(
+                    "A file exists at path: {}",
+                    path
+                )));
+            }
+        }
+
+        // Create parent first
+        if let Some(parent) = FileInfo::parent_path(path) {
+            Box::pin(self.ensure_directory_exists(session_id, &parent)).await?;
+        }
+
+        // Create this directory
+        let input = CreateSessionFileRow {
+            session_id,
+            path: path.to_string(),
+            content: None,
+            is_directory: true,
+            is_readonly: false,
+        };
+
+        self.db.create_session_file(input).await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl SessionFileStore for DbSessionFileStore {
+    async fn read_file(&self, session_id: Uuid, path: &str) -> Result<Option<SessionFile>> {
+        let path = Self::normalize_path(path);
+        let row = self
+            .db
+            .get_session_file(session_id, &path)
+            .await
+            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+
+        Ok(row.map(|r| {
+            let (content, encoding) = if let Some(bytes) = r.content {
+                let (c, e) = SessionFile::encode_content(&bytes);
+                (Some(c), e)
+            } else {
+                (None, "text".to_string())
+            };
+
+            SessionFile {
+                id: r.id,
+                session_id: r.session_id,
+                path: r.path.clone(),
+                name: FileInfo::name_from_path(&r.path),
+                content,
+                encoding,
+                is_directory: r.is_directory,
+                is_readonly: r.is_readonly,
+                size_bytes: r.size_bytes,
+                created_at: r.created_at,
+                updated_at: r.updated_at,
+            }
+        }))
+    }
+
+    async fn write_file(
+        &self,
+        session_id: Uuid,
+        path: &str,
+        content: &str,
+        encoding: &str,
+    ) -> Result<SessionFile> {
+        let path = Self::normalize_path(path);
+
+        // Decode content
+        let bytes = SessionFile::decode_content(content, encoding)
+            .map_err(|e| AgentLoopError::store(format!("Invalid content encoding: {}", e)))?;
+
+        // Ensure parent directory exists
+        if let Some(parent) = FileInfo::parent_path(&path) {
+            self.ensure_directory_exists(session_id, &parent).await?;
+        }
+
+        // Check if file exists
+        let existing = self
+            .db
+            .get_session_file(session_id, &path)
+            .await
+            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+
+        let row = if let Some(existing) = existing {
+            // Update existing file
+            if existing.is_directory {
+                return Err(AgentLoopError::store(format!(
+                    "Cannot write to directory: {}",
+                    path
+                )));
+            }
+            if existing.is_readonly {
+                return Err(AgentLoopError::store(format!(
+                    "Cannot modify readonly file: {}",
+                    path
+                )));
+            }
+
+            self.db
+                .update_session_file(
+                    session_id,
+                    &path,
+                    UpdateSessionFile {
+                        content: Some(bytes),
+                        is_readonly: None,
+                    },
+                )
+                .await
+                .map_err(|e| AgentLoopError::store(e.to_string()))?
+                .ok_or_else(|| AgentLoopError::store("File not found after update"))?
+        } else {
+            // Create new file
+            let input = CreateSessionFileRow {
+                session_id,
+                path: path.clone(),
+                content: Some(bytes),
+                is_directory: false,
+                is_readonly: false,
+            };
+
+            self.db
+                .create_session_file(input)
+                .await
+                .map_err(|e| AgentLoopError::store(e.to_string()))?
+        };
+
+        // Convert row to SessionFile
+        let (content, encoding) = if let Some(bytes) = row.content {
+            let (c, e) = SessionFile::encode_content(&bytes);
+            (Some(c), e)
+        } else {
+            (None, "text".to_string())
+        };
+
+        Ok(SessionFile {
+            id: row.id,
+            session_id: row.session_id,
+            path: row.path.clone(),
+            name: FileInfo::name_from_path(&row.path),
+            content,
+            encoding,
+            is_directory: row.is_directory,
+            is_readonly: row.is_readonly,
+            size_bytes: row.size_bytes,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+        })
+    }
+
+    async fn delete_file(&self, session_id: Uuid, path: &str, recursive: bool) -> Result<bool> {
+        let path = Self::normalize_path(path);
+
+        if path == "/" {
+            if recursive {
+                // Delete all files in session
+                self.db
+                    .delete_session_file_recursive(session_id, "/")
+                    .await
+                    .map_err(|e| AgentLoopError::store(e.to_string()))?;
+                return Ok(true);
+            } else {
+                return Err(AgentLoopError::store(
+                    "Cannot delete root directory without recursive flag",
+                ));
+            }
+        }
+
+        // Check if it's a directory with children
+        let file = self
+            .db
+            .get_session_file(session_id, &path)
+            .await
+            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+
+        if let Some(ref f) = file {
+            if f.is_directory && !recursive {
+                let has_children = self
+                    .db
+                    .session_directory_has_children(session_id, &path)
+                    .await
+                    .map_err(|e| AgentLoopError::store(e.to_string()))?;
+                if has_children {
+                    return Err(AgentLoopError::store(
+                        "Directory is not empty. Use recursive=true to delete",
+                    ));
+                }
+            }
+        }
+
+        if recursive {
+            let deleted = self
+                .db
+                .delete_session_file_recursive(session_id, &path)
+                .await
+                .map_err(|e| AgentLoopError::store(e.to_string()))?;
+            Ok(deleted > 0)
+        } else {
+            self.db
+                .delete_session_file(session_id, &path)
+                .await
+                .map_err(|e| AgentLoopError::store(e.to_string()))
+        }
+    }
+
+    async fn list_directory(&self, session_id: Uuid, path: &str) -> Result<Vec<FileInfo>> {
+        let path = Self::normalize_path(path);
+
+        // Verify directory exists (root always exists)
+        if path != "/" {
+            let dir = self
+                .db
+                .get_session_file(session_id, &path)
+                .await
+                .map_err(|e| AgentLoopError::store(e.to_string()))?;
+            match dir {
+                Some(d) if !d.is_directory => {
+                    return Err(AgentLoopError::store(format!(
+                        "Path is not a directory: {}",
+                        path
+                    )))
+                }
+                None => {
+                    return Err(AgentLoopError::store(format!(
+                        "Directory not found: {}",
+                        path
+                    )))
+                }
+                _ => {}
+            }
+        }
+
+        let rows = self
+            .db
+            .list_session_files(session_id, &path)
+            .await
+            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+
+        Ok(rows
+            .into_iter()
+            .map(|r| FileInfo {
+                id: r.id,
+                session_id: r.session_id,
+                path: r.path.clone(),
+                name: FileInfo::name_from_path(&r.path),
+                is_directory: r.is_directory,
+                is_readonly: r.is_readonly,
+                size_bytes: r.size_bytes,
+                created_at: r.created_at,
+                updated_at: r.updated_at,
+            })
+            .collect())
+    }
+
+    async fn stat_file(&self, session_id: Uuid, path: &str) -> Result<Option<FileStat>> {
+        let path = Self::normalize_path(path);
+
+        // Handle root directory specially
+        if path == "/" {
+            return Ok(Some(FileStat {
+                path: "/".to_string(),
+                name: "/".to_string(),
+                is_directory: true,
+                is_readonly: false,
+                size_bytes: 0,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            }));
+        }
+
+        let row = self
+            .db
+            .get_session_file(session_id, &path)
+            .await
+            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+
+        Ok(row.map(|r| FileStat {
+            path: r.path.clone(),
+            name: FileInfo::name_from_path(&r.path),
+            is_directory: r.is_directory,
+            is_readonly: r.is_readonly,
+            size_bytes: r.size_bytes,
+            created_at: r.created_at,
+            updated_at: r.updated_at,
+        }))
+    }
+
+    async fn grep_files(
+        &self,
+        session_id: Uuid,
+        pattern: &str,
+        path_pattern: Option<&str>,
+    ) -> Result<Vec<GrepMatch>> {
+        // Validate regex pattern
+        let regex = Regex::new(pattern)
+            .map_err(|e| AgentLoopError::store(format!("Invalid regex pattern: {}", e)))?;
+
+        // Get matching files from database
+        let files = self
+            .db
+            .grep_session_files(session_id, pattern, path_pattern)
+            .await
+            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+
+        let mut results = Vec::new();
+
+        // For each matching file, find the actual line matches
+        for file_info in files {
+            // Read full file content
+            let file = self
+                .db
+                .get_session_file(session_id, &file_info.path)
+                .await
+                .map_err(|e| AgentLoopError::store(e.to_string()))?;
+
+            if let Some(f) = file {
+                if let Some(content) = f.content {
+                    // Try to decode as text
+                    if let Ok(text) = String::from_utf8(content) {
+                        for (i, line) in text.lines().enumerate() {
+                            if regex.is_match(line) {
+                                results.push(GrepMatch {
+                                    path: file_info.path.clone(),
+                                    line_number: i + 1,
+                                    line: line.to_string(),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(results)
+    }
+
+    async fn create_directory(&self, session_id: Uuid, path: &str) -> Result<FileInfo> {
+        let path = Self::normalize_path(path);
+
+        // Check if already exists
+        if let Some(existing) = self
+            .db
+            .get_session_file(session_id, &path)
+            .await
+            .map_err(|e| AgentLoopError::store(e.to_string()))?
+        {
+            if existing.is_directory {
+                return Ok(FileInfo {
+                    id: existing.id,
+                    session_id: existing.session_id,
+                    path: existing.path.clone(),
+                    name: FileInfo::name_from_path(&existing.path),
+                    is_directory: existing.is_directory,
+                    is_readonly: existing.is_readonly,
+                    size_bytes: existing.size_bytes,
+                    created_at: existing.created_at,
+                    updated_at: existing.updated_at,
+                });
+            } else {
+                return Err(AgentLoopError::store(format!(
+                    "A file exists at path: {}",
+                    path
+                )));
+            }
+        }
+
+        // Create parent directories recursively
+        if let Some(parent) = FileInfo::parent_path(&path) {
+            self.ensure_directory_exists(session_id, &parent).await?;
+        }
+
+        let input = CreateSessionFileRow {
+            session_id,
+            path: path.clone(),
+            content: None,
+            is_directory: true,
+            is_readonly: false,
+        };
+
+        let row = self
+            .db
+            .create_session_file(input)
+            .await
+            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+
+        Ok(FileInfo {
+            id: row.id,
+            session_id: row.session_id,
+            path: row.path.clone(),
+            name: FileInfo::name_from_path(&row.path),
+            is_directory: row.is_directory,
+            is_readonly: row.is_readonly,
+            size_bytes: row.size_bytes,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+        })
+    }
+}
+
+// ============================================================================
+// Factory functions
+// ============================================================================
+
+/// Create a database-backed session file store
+pub fn create_db_session_file_store(db: Database) -> DbSessionFileStore {
+    DbSessionFileStore::new(db)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_path() {
+        assert_eq!(DbSessionFileStore::normalize_path("/foo"), "/foo");
+        assert_eq!(DbSessionFileStore::normalize_path("foo"), "/foo");
+        assert_eq!(DbSessionFileStore::normalize_path("/foo/"), "/foo");
+        assert_eq!(DbSessionFileStore::normalize_path("/foo//bar"), "/foo/bar");
+        assert_eq!(DbSessionFileStore::normalize_path("/"), "/");
+        assert_eq!(DbSessionFileStore::normalize_path(""), "/");
+    }
+}

--- a/crates/everruns-worker/src/adapters.rs
+++ b/crates/everruns-worker/src/adapters.rs
@@ -3,7 +3,9 @@
 // These implementations are now in everruns-storage.
 // This file re-exports them for backward compatibility.
 
-pub use everruns_storage::{create_db_message_store, DbMessageStore};
+pub use everruns_storage::{
+    create_db_message_store, create_db_session_file_store, DbMessageStore, DbSessionFileStore,
+};
 
 // Provider factory helper for creating LLM providers
 use everruns_core::{

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -180,14 +180,63 @@ The `CapabilityRegistry` in core holds all registered capability implementations
 - **Icon**: "box"
 - **Category**: "Execution"
 
-#### FileSystem (Coming Soon)
+#### FileSystem
 
-- **Status**: ComingSoon
-- **Purpose**: File system access tools
-- **System Prompt**: "You have access to file system tools. You can read, write, and search files."
-- **Tools**: To be added (read, write, grep, glob)
+- **Status**: Available
+- **ID**: `file_system`
+- **Purpose**: Session-level virtual file system access tools
+- **System Prompt**: Guidance on using file system tools, best practices for exploration and file operations
+- **Tools**:
+  - `read_file` - Read file content by path
+    - Parameters:
+      - `path`: string (required) - Absolute path to the file (e.g., '/docs/readme.txt')
+    - Returns: Object containing path, content, encoding, size_bytes
+    - Policy: Auto
+  - `write_file` - Create or update a file
+    - Parameters:
+      - `path`: string (required) - Absolute path for the file
+      - `content`: string (required) - Content to write
+      - `encoding`: enum (text, base64) - Content encoding, defaults to text
+    - Returns: Object containing path, size_bytes, created status
+    - Policy: Auto
+  - `list_directory` - List files and directories at a path
+    - Parameters:
+      - `path`: string - Directory path to list, defaults to root '/'
+    - Returns: Object containing path, entries array, count
+    - Policy: Auto
+  - `grep_files` - Search file contents using regex
+    - Parameters:
+      - `pattern`: string (required) - Regex pattern to search for
+      - `path_pattern`: string - Optional path pattern filter (e.g., '*.txt')
+    - Returns: Object containing pattern, matches array, match_count
+    - Policy: Auto
+  - `delete_file` - Delete a file or directory
+    - Parameters:
+      - `path`: string (required) - Path to file or directory
+      - `recursive`: boolean - If true, delete directories recursively, defaults to false
+    - Returns: Object containing path, deleted status
+    - Policy: Auto
+  - `stat_file` - Get file or directory metadata
+    - Parameters:
+      - `path`: string (required) - Path to the file or directory
+    - Returns: Object containing path, name, exists, is_directory, is_readonly, size_bytes, timestamps
+    - Policy: Auto
 - **Icon**: "folder"
 - **Category**: "File Operations"
+
+##### Design Decision: Context-Aware Tools
+
+FileSystem tools require session context to access the isolated virtual filesystem. Each tool implements `requires_context() -> true` and uses `execute_with_context()` instead of the standard `execute()`. The `ToolContext` provides:
+- `session_id`: The session whose filesystem to access
+- `file_store`: A `SessionFileStore` trait implementation for file operations
+
+##### Design Decision: Session Isolation
+
+Each session has its own isolated filesystem stored in PostgreSQL. Files are session-scoped and cannot be accessed across sessions. This provides security isolation and clean separation between conversations.
+
+##### Design Decision: Auto-Create Parents
+
+When writing a file like `/a/b/c.txt`, parent directories `/a` and `/a/b` are automatically created if they don't exist. This follows common filesystem patterns and reduces tool call overhead.
 
 #### WebFetch
 


### PR DESCRIPTION
… tools

Adds a new FileSystem capability that provides tools for interacting with the session's virtual filesystem. This includes:

Tools:
- read_file: Read file content from the session filesystem
- write_file: Create or update files with automatic parent directory creation
- list_directory: List files and directories at a path
- grep_files: Search file contents using regex patterns
- delete_file: Delete files or directories (with optional recursive flag)
- stat_file: Get file metadata (exists, size, type, dates)

Architecture changes:
- Add ToolContext struct to pass session context to tools during execution
- Add SessionFileStore trait in everruns-core for abstracting file operations
- Add execute_with_context method to Tool trait (with default delegation)
- Update ToolExecutor trait with execute_with_context method
- Create DbSessionFileStore implementation in everruns-storage
- Update ExecuteToolAtom to pass tool context when executing
- Update UnifiedToolExecutor to support context-aware execution
- Wire up file store in worker activities

The FileSystem capability is now Available (no longer ComingSoon).
