### PR TITLE
Add field descriptions to API objects

### DIFF
--- a/crates/everruns-api/src/agents.rs
+++ b/crates/everruns-api/src/agents.rs
@@ -11,7 +11,6 @@ use everruns_storage::Database;
 
 use crate::common::ListResponse;
 use serde::Deserialize;
-use serde_json::json;
 use std::sync::Arc;
 use utoipa::ToSchema;
 use uuid::Uuid;

--- a/crates/everruns-api/src/agents.rs
+++ b/crates/everruns-api/src/agents.rs
@@ -11,6 +11,7 @@ use everruns_storage::Database;
 
 use crate::common::ListResponse;
 use serde::Deserialize;
+use serde_json::json;
 use std::sync::Arc;
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -18,29 +19,50 @@ use uuid::Uuid;
 /// Request to create a new agent
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct CreateAgentRequest {
+    /// The name of the agent. Used for display purposes.
+    #[schema(example = "Customer Support Agent")]
     pub name: String,
+    /// A human-readable description of what the agent does.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "Handles customer inquiries and support tickets")]
     pub description: Option<String>,
+    /// The system prompt that defines the agent's behavior and capabilities.
+    /// This is sent as the first message in every conversation.
+    #[schema(example = "You are a helpful customer support agent. Be polite and professional.")]
     pub system_prompt: String,
+    /// The ID of the default LLM model to use for this agent.
+    /// If not specified, the system default model will be used.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_model_id: Option<Uuid>,
+    /// Tags for organizing and filtering agents.
     #[serde(default)]
+    #[schema(example = json!(["support", "customer-facing"]))]
     pub tags: Vec<String>,
 }
 
-/// Request to update an agent
+/// Request to update an agent. Only provided fields will be updated.
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct UpdateAgentRequest {
+    /// The name of the agent. Used for display purposes.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "Updated Support Agent")]
     pub name: Option<String>,
+    /// A human-readable description of what the agent does.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "Updated description for the agent")]
     pub description: Option<String>,
+    /// The system prompt that defines the agent's behavior and capabilities.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "You are an updated helpful assistant.")]
     pub system_prompt: Option<String>,
+    /// The ID of the default LLM model to use for this agent.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_model_id: Option<Uuid>,
+    /// Tags for organizing and filtering agents.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = json!(["updated-tag"]))]
     pub tags: Option<Vec<String>>,
+    /// The status of the agent. Set to "archived" to soft-delete.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<AgentStatus>,
 }

--- a/crates/everruns-api/src/common.rs
+++ b/crates/everruns-api/src/common.rs
@@ -3,7 +3,6 @@
 // These types are shared across multiple API endpoints.
 
 use serde::{Deserialize, Serialize};
-use serde_json::json;
 use utoipa::ToSchema;
 
 /// Response wrapper for list endpoints.

--- a/crates/everruns-api/src/common.rs
+++ b/crates/everruns-api/src/common.rs
@@ -3,12 +3,14 @@
 // These types are shared across multiple API endpoints.
 
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use utoipa::ToSchema;
 
-/// Response wrapper for list endpoints
-/// All list endpoints return responses wrapped in a `data` field
+/// Response wrapper for list endpoints.
+/// All list endpoints return responses wrapped in a `data` field.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ListResponse<T> {
+    /// Array of items returned by the list operation.
     pub data: Vec<T>,
 }
 
@@ -28,15 +30,19 @@ impl<T> From<Vec<T>> for ListResponse<T> {
 #[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct CreateEventRequest {
+    /// The type of event (e.g., "message", "tool_call", "error").
+    #[schema(example = "message")]
     pub event_type: String,
+    /// Event payload as JSON. Structure depends on event_type.
     pub data: serde_json::Value,
 }
 
-/// Request to update agent capabilities
+/// Request to update agent capabilities.
+/// Replaces the agent's current capabilities with the provided list.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct UpdateAgentCapabilitiesRequest {
-    /// List of capability IDs in desired order
-    /// Position is determined by array index
-    #[schema(value_type = Vec<String>)]
+    /// List of capability IDs in desired order.
+    /// Position is determined by array index.
+    #[schema(value_type = Vec<String>, example = json!(["file_operations", "web_search"]))]
     pub capabilities: Vec<everruns_core::CapabilityId>,
 }

--- a/crates/everruns-api/src/llm_models.rs
+++ b/crates/everruns-api/src/llm_models.rs
@@ -9,7 +9,6 @@ use axum::{
 use everruns_core::{LlmModel, LlmModelStatus, LlmModelWithProvider};
 use everruns_storage::Database;
 use serde::{Deserialize, Serialize};
-use serde_json::json;
 use std::sync::Arc;
 use utoipa::ToSchema;
 use uuid::Uuid;

--- a/crates/everruns-api/src/llm_models.rs
+++ b/crates/everruns-api/src/llm_models.rs
@@ -9,6 +9,7 @@ use axum::{
 use everruns_core::{LlmModel, LlmModelStatus, LlmModelWithProvider};
 use everruns_storage::Database;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use std::sync::Arc;
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -28,26 +29,46 @@ impl AppState {
     }
 }
 
+/// Request to create a new LLM model for a provider
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateLlmModelRequest {
+    /// The model identifier used by the provider's API (e.g., "gpt-4", "claude-3-opus").
+    #[schema(example = "gpt-4o")]
     pub model_id: String,
+    /// Human-readable display name for the model.
+    #[schema(example = "GPT-4o")]
     pub display_name: String,
+    /// List of capabilities this model supports (e.g., "chat", "vision", "tools").
     #[serde(default)]
+    #[schema(example = json!(["chat", "vision", "tools"]))]
     pub capabilities: Vec<String>,
+    /// Whether this model should be the default for the provider.
+    /// Only one model per provider can be the default.
     #[serde(default)]
+    #[schema(example = false)]
     pub is_default: bool,
 }
 
+/// Request to update an LLM model. Only provided fields will be updated.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateLlmModelRequest {
+    /// The model identifier used by the provider's API.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "gpt-4o-mini")]
     pub model_id: Option<String>,
+    /// Human-readable display name for the model.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "GPT-4o Mini")]
     pub display_name: Option<String>,
+    /// List of capabilities this model supports.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = json!(["chat", "tools"]))]
     pub capabilities: Option<Vec<String>>,
+    /// Whether this model should be the default for the provider.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = true)]
     pub is_default: Option<bool>,
+    /// The status of the model. Set to "inactive" to disable.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<LlmModelStatus>,
 }

--- a/crates/everruns-api/src/llm_providers.rs
+++ b/crates/everruns-api/src/llm_providers.rs
@@ -30,26 +30,44 @@ impl AppState {
     }
 }
 
+/// Request to create a new LLM provider
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateLlmProviderRequest {
+    /// Display name for the provider.
+    #[schema(example = "OpenAI Production")]
     pub name: String,
+    /// The type of LLM provider (e.g., openai, anthropic).
     pub provider_type: LlmProviderType,
+    /// Base URL for the provider's API. Required for custom endpoints.
+    /// For standard providers, this can be omitted to use the default URL.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "https://api.openai.com/v1")]
     pub base_url: Option<String>,
+    /// API key for authenticating with the provider.
+    /// Will be encrypted at rest if encryption is configured.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub api_key: Option<String>,
 }
 
+/// Request to update an LLM provider. Only provided fields will be updated.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateLlmProviderRequest {
+    /// Display name for the provider.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "OpenAI Development")]
     pub name: Option<String>,
+    /// The type of LLM provider (e.g., openai, anthropic).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider_type: Option<LlmProviderType>,
+    /// Base URL for the provider's API.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "https://api.openai.com/v1")]
     pub base_url: Option<String>,
+    /// API key for authenticating with the provider.
+    /// Will be encrypted at rest if encryption is configured.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub api_key: Option<String>,
+    /// The status of the provider. Set to "inactive" to disable.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<LlmProviderStatus>,
 }

--- a/crates/everruns-api/src/sessions.rs
+++ b/crates/everruns-api/src/sessions.rs
@@ -11,7 +11,6 @@ use everruns_storage::Database;
 
 use crate::common::ListResponse;
 use serde::Deserialize;
-use serde_json::json;
 use std::sync::Arc;
 use utoipa::ToSchema;
 use uuid::Uuid;

--- a/crates/everruns-api/src/sessions.rs
+++ b/crates/everruns-api/src/sessions.rs
@@ -11,6 +11,7 @@ use everruns_storage::Database;
 
 use crate::common::ListResponse;
 use serde::Deserialize;
+use serde_json::json;
 use std::sync::Arc;
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -18,20 +19,30 @@ use uuid::Uuid;
 /// Request to create a session
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct CreateSessionRequest {
+    /// Human-readable title for the session.
     #[serde(default)]
+    #[schema(example = "Debug login issue")]
     pub title: Option<String>,
+    /// Tags for organizing and filtering sessions.
     #[serde(default)]
+    #[schema(example = json!(["debugging", "urgent"]))]
     pub tags: Vec<String>,
+    /// The ID of the LLM model to use for this session.
+    /// Overrides the agent's default model if specified.
     #[serde(default)]
     pub model_id: Option<Uuid>,
 }
 
-/// Request to update a session
+/// Request to update a session. Only provided fields will be updated.
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct UpdateSessionRequest {
+    /// Human-readable title for the session.
     #[serde(default)]
+    #[schema(example = "Updated session title")]
     pub title: Option<String>,
+    /// Tags for organizing and filtering sessions.
     #[serde(default)]
+    #[schema(example = json!(["resolved"]))]
     pub tags: Option<Vec<String>>,
 }
 

--- a/crates/everruns-core/src/agent.rs
+++ b/crates/everruns-core/src/agent.rs
@@ -10,12 +10,16 @@ use uuid::Uuid;
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
 
-/// Agent status
+/// Agent lifecycle status.
+/// - `active`: Agent is available for use
+/// - `archived`: Agent is soft-deleted and hidden from listings
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 #[serde(rename_all = "lowercase")]
 pub enum AgentStatus {
+    /// Agent is available for use.
     Active,
+    /// Agent is soft-deleted and hidden from listings.
     Archived,
 }
 
@@ -37,20 +41,32 @@ impl From<&str> for AgentStatus {
     }
 }
 
-/// Agent configuration for agentic loop
+/// Agent configuration for agentic loop.
+/// An agent defines the behavior and capabilities of an AI assistant.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct Agent {
+    /// Unique identifier for the agent.
     pub id: Uuid,
+    /// Display name of the agent.
     pub name: String,
+    /// Human-readable description of what the agent does.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// System prompt that defines the agent's behavior.
+    /// Sent as the first message in every conversation.
     pub system_prompt: String,
+    /// Default LLM model ID for this agent.
+    /// Can be overridden at the session level.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_model_id: Option<Uuid>,
+    /// Tags for organizing and filtering agents.
     #[serde(default)]
     pub tags: Vec<String>,
+    /// Current lifecycle status of the agent.
     pub status: AgentStatus,
+    /// Timestamp when the agent was created.
     pub created_at: DateTime<Utc>,
+    /// Timestamp when the agent was last updated.
     pub updated_at: DateTime<Utc>,
 }

--- a/crates/everruns-core/src/session.rs
+++ b/crates/everruns-core/src/session.rs
@@ -10,14 +10,22 @@ use uuid::Uuid;
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
 
-/// Session status
+/// Session execution status.
+/// - `pending`: Session created but not yet started
+/// - `running`: Session is actively processing messages
+/// - `completed`: Session finished successfully
+/// - `failed`: Session terminated due to an error
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 #[serde(rename_all = "lowercase")]
 pub enum SessionStatus {
+    /// Session created but not yet started.
     Pending,
+    /// Session is actively processing messages.
     Running,
+    /// Session finished successfully.
     Completed,
+    /// Session terminated due to an error.
     Failed,
 }
 
@@ -43,22 +51,33 @@ impl From<&str> for SessionStatus {
     }
 }
 
-/// Session - instance of agentic loop execution
+/// Session - instance of agentic loop execution.
+/// A session represents a single conversation with an agent.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct Session {
+    /// Unique identifier for the session.
     pub id: Uuid,
+    /// ID of the agent this session belongs to.
     pub agent_id: Uuid,
+    /// Human-readable title for the session.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
+    /// Tags for organizing and filtering sessions.
     #[serde(default)]
     pub tags: Vec<String>,
+    /// LLM model ID to use for this session.
+    /// Overrides the agent's default model if set.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model_id: Option<Uuid>,
+    /// Current execution status of the session.
     pub status: SessionStatus,
+    /// Timestamp when the session was created.
     pub created_at: DateTime<Utc>,
+    /// Timestamp when the session started executing.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub started_at: Option<DateTime<Utc>>,
+    /// Timestamp when the session finished (completed or failed).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub finished_at: Option<DateTime<Utc>>,
 }


### PR DESCRIPTION
## What
Add documentation comments and OpenAPI schema examples to all API request/response types and core domain types.

## Why
Improve API discoverability and usability by providing field descriptions and examples in the OpenAPI spec and Swagger UI. This helps API consumers understand the purpose of each field without needing to read source code.

## How
- Added `///` doc comments to all struct fields (picked up by utoipa for OpenAPI descriptions)
- Added `#[schema(example = ...)]` attributes for realistic example values
- Used `serde_json::json!()` macro for array examples (e.g., tags)

**Files updated:**
- `crates/everruns-api/src/agents.rs` - CreateAgentRequest, UpdateAgentRequest
- `crates/everruns-api/src/sessions.rs` - CreateSessionRequest, UpdateSessionRequest
- `crates/everruns-api/src/llm_providers.rs` - CreateLlmProviderRequest, UpdateLlmProviderRequest
- `crates/everruns-api/src/llm_models.rs` - CreateLlmModelRequest, UpdateLlmModelRequest
- `crates/everruns-api/src/common.rs` - ListResponse, CreateEventRequest, UpdateAgentCapabilitiesRequest
- `crates/everruns-core/src/agent.rs` - Agent, AgentStatus
- `crates/everruns-core/src/session.rs` - Session, SessionStatus

## Risk
- Low
- Documentation-only changes, no behavior changes

## Checklist
- [x] Tests added or updated (existing tests pass)
- [x] Backward compatibility considered (no breaking changes)
