### PR TITLE
Fix missing web_fetch tool error

### DIFF
--- a/crates/everruns-core/src/tools.rs
+++ b/crates/everruns-core/src/tools.rs
@@ -350,11 +350,12 @@ impl ToolRegistry {
     /// - TestWeather tools: get_weather, get_forecast
     /// - TaskList tools: write_todos
     /// - FileSystem tools: read_file, write_file, list_directory, grep_files, delete_file, stat_file
+    /// - WebFetch tools: web_fetch
     pub fn with_defaults() -> Self {
         use crate::capabilities::{
             AddTool, DeleteFileTool, DivideTool, GetCurrentTimeTool, GetForecastTool,
             GetWeatherTool, GrepFilesTool, ListDirectoryTool, MultiplyTool, ReadFileTool,
-            StatFileTool, SubtractTool, WriteFileTool, WriteTodosTool,
+            StatFileTool, SubtractTool, WebFetchTool, WriteFileTool, WriteTodosTool,
         };
 
         ToolRegistry::builder()
@@ -377,6 +378,8 @@ impl ToolRegistry {
             .tool(GrepFilesTool)
             .tool(DeleteFileTool)
             .tool(StatFileTool)
+            // WebFetch capability tools
+            .tool(WebFetchTool)
             .build()
     }
 
@@ -808,8 +811,11 @@ mod tests {
         assert!(registry.has("delete_file"), "should have delete_file");
         assert!(registry.has("stat_file"), "should have stat_file");
 
+        // WebFetch capability tools
+        assert!(registry.has("web_fetch"), "should have web_fetch");
+
         // Total count
-        assert_eq!(registry.len(), 15, "should have 15 default tools");
+        assert_eq!(registry.len(), 16, "should have 16 default tools");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What
Adds `WebFetchTool` to `ToolRegistry::with_defaults()` so the `web_fetch` tool is available during agent workflow execution.

## Why
The worker was failing with error:

> Tool execution error: Tool not found: web_fetch

The `WebFetchTool` was implemented in the capabilities module and registered in `CapabilityRegistry::with_builtins()`, but was missing from `ToolRegistry::with_defaults()` which is used by the agent loop for tool execution.

## How
- Added `WebFetchTool` import to `ToolRegistry::with_defaults()`
- Added `.tool(WebFetchTool)` to the builder chain
- Updated docstring to document the new tool
- Updated test to verify registration and adjusted tool count from 15 to 16

## Risk
- Low
- This is an additive change that enables missing functionality
- All 147 existing tests pass

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered