### PR TITLE
Simplify message events and tool call handling

### DIFF
--- a/apps/ui/src/__tests__/tool-call-card.test.tsx
+++ b/apps/ui/src/__tests__/tool-call-card.test.tsx
@@ -2,18 +2,19 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { ToolCallCard } from "@/components/chat/tool-call-card";
 import type { Message } from "@/lib/api/types";
 
-// Helper to create tool call message
+// Helper to create tool call message (as assistant message with tool_call in content)
 function createToolCallMessage(overrides?: Partial<Message>): Message {
   return {
     id: "msg-tool-call-1",
     session_id: "session-1",
     sequence: 1,
-    role: "tool_call",
-    content: {
+    role: "assistant",
+    content: [{
+      type: "tool_call" as const,
       id: "call_123",
       name: "get_current_time",
       arguments: { timezone: "UTC" },
-    },
+    }],
     tool_call_id: null,
     created_at: "2025-01-01T00:00:00Z",
     ...overrides,
@@ -27,9 +28,11 @@ function createToolResultMessage(overrides?: Partial<Message>): Message {
     session_id: "session-1",
     sequence: 2,
     role: "tool_result",
-    content: {
+    content: [{
+      type: "tool_result" as const,
+      tool_call_id: "call_123",
       result: "2025-01-01T12:00:00Z",
-    },
+    }],
     tool_call_id: "call_123",
     created_at: "2025-01-01T00:00:01Z",
     ...overrides,
@@ -61,11 +64,12 @@ describe("ToolCallCard", () => {
 
     it("does not render Arguments button when arguments are empty", () => {
       const toolCall = createToolCallMessage({
-        content: {
+        content: [{
+          type: "tool_call" as const,
           id: "call_123",
           name: "noop",
           arguments: {},
-        },
+        }],
       });
       render(<ToolCallCard toolCall={toolCall} />);
 
@@ -93,9 +97,11 @@ describe("ToolCallCard", () => {
     it("shows 'Failed' badge when tool result has error", () => {
       const toolCall = createToolCallMessage();
       const toolResult = createToolResultMessage({
-        content: {
+        content: [{
+          type: "tool_result" as const,
+          tool_call_id: "call_123",
           error: "Something went wrong",
-        },
+        }],
       });
       render(<ToolCallCard toolCall={toolCall} toolResult={toolResult} />);
 
@@ -144,9 +150,11 @@ describe("ToolCallCard", () => {
     it("displays successful result", () => {
       const toolCall = createToolCallMessage();
       const toolResult = createToolResultMessage({
-        content: {
+        content: [{
+          type: "tool_result" as const,
+          tool_call_id: "call_123",
           result: "2025-01-01T12:00:00Z",
-        },
+        }],
       });
       render(<ToolCallCard toolCall={toolCall} toolResult={toolResult} />);
 
@@ -157,9 +165,11 @@ describe("ToolCallCard", () => {
     it("displays JSON result for objects", () => {
       const toolCall = createToolCallMessage();
       const toolResult = createToolResultMessage({
-        content: {
+        content: [{
+          type: "tool_result" as const,
+          tool_call_id: "call_123",
           result: { time: "12:00", date: "2025-01-01" },
-        },
+        }],
       });
       render(<ToolCallCard toolCall={toolCall} toolResult={toolResult} />);
 
@@ -170,9 +180,11 @@ describe("ToolCallCard", () => {
     it("displays error message when tool fails", () => {
       const toolCall = createToolCallMessage();
       const toolResult = createToolResultMessage({
-        content: {
+        content: [{
+          type: "tool_result" as const,
+          tool_call_id: "call_123",
           error: "Network timeout occurred",
-        },
+        }],
       });
       render(<ToolCallCard toolCall={toolCall} toolResult={toolResult} />);
 
@@ -191,7 +203,8 @@ describe("ToolCallCard", () => {
   describe("different tool types", () => {
     it("renders tool with complex arguments", () => {
       const toolCall = createToolCallMessage({
-        content: {
+        content: [{
+          type: "tool_call" as const,
           id: "call_456",
           name: "http_get",
           arguments: {
@@ -202,7 +215,7 @@ describe("ToolCallCard", () => {
             },
             timeout: 5000,
           },
-        },
+        }],
       });
       render(<ToolCallCard toolCall={toolCall} />);
 
@@ -216,9 +229,11 @@ describe("ToolCallCard", () => {
     it("renders tool with no result value (null/undefined)", () => {
       const toolCall = createToolCallMessage();
       const toolResult = createToolResultMessage({
-        content: {
+        content: [{
+          type: "tool_result" as const,
+          tool_call_id: "call_123",
           result: undefined,
-        },
+        }],
       });
       render(<ToolCallCard toolCall={toolCall} toolResult={toolResult} />);
 

--- a/apps/ui/src/hooks/use-sessions.ts
+++ b/apps/ui/src/hooks/use-sessions.ts
@@ -136,10 +136,10 @@ function extractToolCallId(content: ContentPart[]): string | null {
  */
 function eventsToMessages(events: Event[]): Message[] {
   // Filter only message events and transform them
+  // Note: Tool calls are embedded in message.agent events via ContentPart::ToolCall
   const messageEvents = events.filter(e =>
     e.event_type === "message.user" ||
     e.event_type === "message.agent" ||
-    e.event_type === "message.tool_call" ||
     e.event_type === "message.tool_result"
   );
 
@@ -153,10 +153,10 @@ function eventsToMessages(events: Event[]): Message[] {
     };
 
     // Map event type to message role
+    // Note: Tool calls are embedded in message.agent content, not separate events
     const roleMap: Record<string, Message["role"]> = {
       "message.user": "user",
       "message.agent": "assistant",
-      "message.tool_call": "tool_call",
       "message.tool_result": "tool_result",
     };
 

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -76,7 +76,7 @@ export interface UpdateSessionRequest {
 // Message types (M2) - PRIMARY data
 // ============================================
 
-export type MessageRole = "user" | "assistant" | "tool_call" | "tool_result" | "system";
+export type MessageRole = "user" | "assistant" | "tool_result" | "system";
 
 // ContentPart discriminated union - message content parts
 export type ContentPart =

--- a/crates/everruns-api/src/messages.rs
+++ b/crates/everruns-api/src/messages.rs
@@ -39,7 +39,6 @@ pub use everruns_core::{
 pub enum MessageRole {
     User,
     Assistant,
-    ToolCall,
     ToolResult,
     System,
 }
@@ -49,7 +48,6 @@ impl std::fmt::Display for MessageRole {
         match self {
             MessageRole::User => write!(f, "user"),
             MessageRole::Assistant => write!(f, "assistant"),
-            MessageRole::ToolCall => write!(f, "tool_call"),
             MessageRole::ToolResult => write!(f, "tool_result"),
             MessageRole::System => write!(f, "system"),
         }
@@ -60,7 +58,6 @@ impl From<&str> for MessageRole {
     fn from(s: &str) -> Self {
         match s {
             "assistant" => MessageRole::Assistant,
-            "tool_call" => MessageRole::ToolCall,
             "tool_result" => MessageRole::ToolResult,
             "system" => MessageRole::System,
             _ => MessageRole::User,
@@ -88,7 +85,7 @@ pub struct Message {
 
 /// Input message for creating a user message
 ///
-/// Only user messages can be created via the API. Assistant, tool_call,
+/// Only user messages can be created via the API. Assistant,
 /// tool_result, and system messages are created internally by the system.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct InputMessage {
@@ -276,7 +273,6 @@ mod tests {
     fn test_message_role_display() {
         assert_eq!(MessageRole::User.to_string(), "user");
         assert_eq!(MessageRole::Assistant.to_string(), "assistant");
-        assert_eq!(MessageRole::ToolCall.to_string(), "tool_call");
         assert_eq!(MessageRole::ToolResult.to_string(), "tool_result");
         assert_eq!(MessageRole::System.to_string(), "system");
     }
@@ -285,7 +281,7 @@ mod tests {
     fn test_message_role_from_str() {
         assert_eq!(MessageRole::from("user"), MessageRole::User);
         assert_eq!(MessageRole::from("assistant"), MessageRole::Assistant);
-        assert_eq!(MessageRole::from("tool_call"), MessageRole::ToolCall);
+        assert_eq!(MessageRole::from("tool_result"), MessageRole::ToolResult);
         assert_eq!(MessageRole::from("unknown"), MessageRole::User);
     }
 }

--- a/crates/everruns-core/examples/capabilities.rs
+++ b/crates/everruns-core/examples/capabilities.rs
@@ -169,9 +169,6 @@ fn print_conversation_steps(messages: &[Message]) {
                     println!("    {}. [Assistant] {}", i + 1, text);
                 }
             }
-            MessageRole::ToolCall => {
-                // Skip - already shown in assistant message
-            }
             MessageRole::ToolResult => {
                 if let Some(tr) = msg.tool_result_content() {
                     if let Some(ref err) = tr.error {

--- a/crates/everruns-core/examples/task_list.rs
+++ b/crates/everruns-core/examples/task_list.rs
@@ -79,9 +79,6 @@ fn print_conversation_steps(messages: &[Message]) {
                     println!("    {}. [Assistant] {}", i + 1, text);
                 }
             }
-            MessageRole::ToolCall => {
-                // Skip - already shown in assistant message
-            }
             MessageRole::ToolResult => {
                 if let Some(tr) = msg.tool_result_content() {
                     if let Some(ref err) = tr.error {

--- a/crates/everruns-core/examples/tool_calling.rs
+++ b/crates/everruns-core/examples/tool_calling.rs
@@ -228,9 +228,6 @@ fn print_conversation_steps(messages: &[Message]) {
                     println!("    {}. [Assistant] {}", i + 1, text);
                 }
             }
-            MessageRole::ToolCall => {
-                // Skip - already shown in assistant message
-            }
             MessageRole::ToolResult => {
                 if let Some(tr) = msg.tool_result_content() {
                     if let Some(ref err) = tr.error {

--- a/crates/everruns-core/src/atoms/call_model.rs
+++ b/crates/everruns-core/src/atoms/call_model.rs
@@ -171,14 +171,9 @@ where
             });
         }
 
-        // Add conversation messages (user, assistant, tool calls, tool results)
-        // Note: ToolCall role messages are skipped as tool calls are already embedded
-        // in their corresponding Assistant messages via ContentPart::ToolCall.
-        // This avoids duplicate tool call information being sent to the LLM.
+        // Add conversation messages (user, assistant, tool results)
+        // Tool calls are embedded in Assistant messages via ContentPart::ToolCall.
         for msg in &patched_messages {
-            if msg.role == MessageRole::ToolCall {
-                continue;
-            }
             llm_messages.push(msg.into());
         }
 
@@ -237,14 +232,6 @@ where
         self.message_store
             .store(session_id, assistant_message.clone())
             .await?;
-
-        // 8. If there are tool calls, store tool_call messages too
-        if has_tool_calls {
-            for tool_call in &tool_calls {
-                let tool_call_msg = Message::tool_call(tool_call);
-                self.message_store.store(session_id, tool_call_msg).await?;
-            }
-        }
 
         Ok(CallModelResult {
             text,

--- a/crates/everruns-core/src/llm.rs
+++ b/crates/everruns-core/src/llm.rs
@@ -282,7 +282,6 @@ impl From<&crate::message::Message> for LlmMessage {
             crate::message::MessageRole::System => LlmMessageRole::System,
             crate::message::MessageRole::User => LlmMessageRole::User,
             crate::message::MessageRole::Assistant => LlmMessageRole::Assistant,
-            crate::message::MessageRole::ToolCall => LlmMessageRole::Assistant,
             crate::message::MessageRole::ToolResult => LlmMessageRole::Tool,
         };
 

--- a/crates/everruns-core/src/message.rs
+++ b/crates/everruns-core/src/message.rs
@@ -21,10 +21,8 @@ pub enum MessageRole {
     System,
     /// User message
     User,
-    /// Assistant response
+    /// Assistant response (may contain tool calls in content)
     Assistant,
-    /// Tool call request from assistant
-    ToolCall,
     /// Tool execution result
     ToolResult,
 }
@@ -35,7 +33,6 @@ impl std::fmt::Display for MessageRole {
             MessageRole::System => write!(f, "system"),
             MessageRole::User => write!(f, "user"),
             MessageRole::Assistant => write!(f, "assistant"),
-            MessageRole::ToolCall => write!(f, "tool_call"),
             MessageRole::ToolResult => write!(f, "tool_result"),
         }
     }
@@ -47,7 +44,6 @@ impl From<&str> for MessageRole {
             "system" => MessageRole::System,
             "user" => MessageRole::User,
             "assistant" => MessageRole::Assistant,
-            "tool_call" => MessageRole::ToolCall,
             "tool_result" => MessageRole::ToolResult,
             _ => MessageRole::User,
         }
@@ -431,22 +427,6 @@ impl Message {
             id: Uuid::now_v7(),
             role: MessageRole::System,
             content: vec![ContentPart::text(content)],
-            controls: None,
-            metadata: None,
-            created_at: Utc::now(),
-        }
-    }
-
-    /// Create a tool call message
-    pub fn tool_call(tool_call: &crate::tool_types::ToolCall) -> Self {
-        Self {
-            id: Uuid::now_v7(),
-            role: MessageRole::ToolCall,
-            content: vec![ContentPart::ToolCall(ToolCallContentPart {
-                id: tool_call.id.clone(),
-                name: tool_call.name.clone(),
-                arguments: tool_call.arguments.clone(),
-            })],
             controls: None,
             metadata: None,
             created_at: Utc::now(),

--- a/crates/everruns-storage/migrations/002_remove_tool_call_from_index.sql
+++ b/crates/everruns-storage/migrations/002_remove_tool_call_from_index.sql
@@ -1,0 +1,11 @@
+-- Remove redundant idx_events_messages partial index
+--
+-- This partial index was created for message event queries, but:
+-- 1. idx_events_session_sequence already covers (session_id, sequence) perfectly
+-- 2. The event_type filter is a cheap row filter after index lookup
+-- 3. The partial index adds maintenance overhead with minimal benefit
+--
+-- Additionally, message.tool_call events are now deprecated - tool calls are
+-- embedded in message.agent events via ContentPart::ToolCall.
+
+DROP INDEX IF EXISTS idx_events_messages;

--- a/crates/everruns-storage/src/repositories.rs
+++ b/crates/everruns-storage/src/repositories.rs
@@ -566,15 +566,16 @@ impl Database {
 
     /// List only message events for a session (for MessageStore implementation)
     ///
-    /// Returns events with types: message.user, message.agent, message.tool_call, message.tool_result
+    /// Returns events with types: message.user, message.agent, message.tool_result
     /// Ordered by sequence for conversation reconstruction.
+    /// Note: Tool calls are embedded in message.agent events via ContentPart::ToolCall.
     pub async fn list_message_events(&self, session_id: Uuid) -> Result<Vec<EventRow>> {
         let rows = sqlx::query_as::<_, EventRow>(
             r#"
             SELECT id, session_id, sequence, event_type, data, created_at
             FROM events
             WHERE session_id = $1
-              AND event_type IN ('message.user', 'message.agent', 'message.tool_call', 'message.tool_result')
+              AND event_type IN ('message.user', 'message.agent', 'message.tool_result')
             ORDER BY sequence ASC
             "#,
         )


### PR DESCRIPTION
## Summary

Simplifies the message event model by removing redundant `message.tool_call` events. Tool calls are already embedded in `message.agent` events via `ContentPart::ToolCall`, making separate tool_call events unnecessary duplication.

### Before (4 event types)
- `message.user` - User input
- `message.agent` - Agent response (with tool calls in content)
- `message.tool_call` - Separate tool call event **(redundant)**
- `message.tool_result` - Tool execution result

### After (3 event types)
- `message.user` - User input
- `message.agent` - Agent response (with tool calls embedded in `ContentPart::ToolCall`)
- `message.tool_result` - Tool execution result

## Why

The `message.tool_call` events were:
1. **Stored twice** - Tool calls were saved in `message.agent` content AND as separate `message.tool_call` events
2. **Immediately filtered out** - When building LLM context, tool_call messages were explicitly skipped because the data was already in assistant messages
3. **No unique value** - Tool results reference tool call IDs that exist in `message.agent.content`

## Changes

**Backend:**
- Remove `ToolCall` variant from `MessageRole` enum (core + API)
- Remove `Message::tool_call()` factory method
- Remove separate tool_call message storage in `call_model.rs` and `executor.rs`
- Update `list_message_events` query to exclude `message.tool_call`
- Remove redundant `idx_events_messages` partial index (migration)

**Frontend:**
- Remove `tool_call` from `MessageRole` type
- Update event-to-message transformation to exclude `message.tool_call`
- Update session page to extract tool calls from assistant message content

**Documentation:**
- Update `specs/models.md` to reflect simplified event model

## Migration

Includes `002_remove_tool_call_from_index.sql` which drops the redundant `idx_events_messages` partial index. The existing `idx_events_session_sequence` index already covers message queries efficiently.

## Risk

- **Low** - This is a simplification that removes unused code paths
- Existing `message.tool_call` events in the database will be ignored (not deleted)
- No breaking changes to API contracts

## Checklist

- [x] `cargo fmt && cargo clippy -- -D warnings`
- [x] `cargo test`
- [x] UI builds (`npm run build`)
- [x] Updated specs
- [x] Migration for index cleanup