### PR TITLE
Update Session File System capability icon

### DIFF
--- a/apps/ui/src/app/(main)/capabilities/[capabilityId]/page.tsx
+++ b/apps/ui/src/app/(main)/capabilities/[capabilityId]/page.tsx
@@ -21,6 +21,8 @@ import {
   Wrench,
   FileText,
   Code,
+  HardDrive,
+  CloudSun,
 } from "lucide-react";
 import type { CapabilityStatus, ToolDefinition } from "@/lib/api/types";
 
@@ -33,6 +35,8 @@ const iconMap: Record<string, LucideIcon> = {
   calculator: Calculator,
   globe: Globe,
   "list-checks": ListChecks,
+  "hard-drive": HardDrive,
+  "cloud-sun": CloudSun,
 };
 
 function getStatusBadgeVariant(

--- a/apps/ui/src/app/(main)/capabilities/page.tsx
+++ b/apps/ui/src/app/(main)/capabilities/page.tsx
@@ -19,6 +19,8 @@ import {
   CheckCircle2,
   AlertCircle,
   Info,
+  HardDrive,
+  CloudSun,
 } from "lucide-react";
 import type { Capability, CapabilityStatus } from "@/lib/api/types";
 
@@ -31,6 +33,8 @@ const iconMap: Record<string, LucideIcon> = {
   calculator: Calculator,
   globe: Globe,
   "list-checks": ListChecks,
+  "hard-drive": HardDrive,
+  "cloud-sun": CloudSun,
 };
 
 function getStatusBadgeVariant(

--- a/crates/everruns-core/src/capabilities/file_system.rs
+++ b/crates/everruns-core/src/capabilities/file_system.rs
@@ -38,7 +38,7 @@ impl Capability for FileSystemCapability {
     }
 
     fn icon(&self) -> Option<&str> {
-        Some("folder")
+        Some("hard-drive")
     }
 
     fn category(&self) -> Option<&str> {
@@ -629,7 +629,7 @@ mod tests {
         assert_eq!(cap.id(), CapabilityId::FILE_SYSTEM);
         assert_eq!(cap.name(), "File System");
         assert_eq!(cap.status(), CapabilityStatus::Available);
-        assert_eq!(cap.icon(), Some("folder"));
+        assert_eq!(cap.icon(), Some("hard-drive"));
         assert_eq!(cap.category(), Some("File Operations"));
     }
 


### PR DESCRIPTION
## What
Update the Session File System capability icon and add missing icon mappings to the UI.

## Why
- The `folder` icon was too generic for a file system capability that provides read/write/grep operations
- The `hard-drive` icon better represents storage and file system operations
- The UI was missing icon mappings for `hard-drive` and `cloud-sun` (Test Weather capability)

## How
- Changed the File System capability icon from `folder` to `hard-drive` in the backend
- Added `HardDrive` and `CloudSun` imports and mappings to both capabilities UI pages
- Updated the corresponding unit test

## Risk
- Low
- Visual-only change, no functional impact

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
