### PR TITLE
Add Events tab to Session UI

### DIFF
--- a/apps/ui/src/hooks/use-sessions.ts
+++ b/apps/ui/src/hooks/use-sessions.ts
@@ -197,3 +197,20 @@ export function useEvents(
     refetchInterval: options?.refetchInterval,
   });
 }
+
+/**
+ * Fetch raw events without transformation for developer debugging
+ * Returns all events including non-message events (step.*, tool.*, session.*)
+ */
+export function useRawEvents(
+  agentId: string | undefined,
+  sessionId: string | undefined,
+  options?: { refetchInterval?: number | false }
+) {
+  return useQuery({
+    queryKey: ["raw-events", agentId, sessionId],
+    queryFn: () => listEvents(agentId!, sessionId!),
+    enabled: !!agentId && !!sessionId,
+    refetchInterval: options?.refetchInterval,
+  });
+}


### PR DESCRIPTION
## What
Add an Events tab to the Session detail page that displays all raw events for developer debugging purposes.

## Why
Agent developers need visibility into the complete event stream during session execution to debug workflows, understand execution flow, and inspect all events (not just messages). The existing Chat tab only shows transformed message events, hiding important debugging information like `step.*`, `tool.*`, and `session.*` events.

## How
- Added `useRawEvents` hook in `use-sessions.ts` that fetches events without transforming them to messages
- Added a new "Events" tab alongside "Chat" and "File System" tabs in the session detail page
- Events are displayed in a table with columns for sequence number, event type, timestamp, and JSON data
- Includes loading skeleton and empty state handling
- Automatic polling for updates when session is active

## Risk
- Low
- UI-only change with no backend modifications
- Uses existing events API endpoint
- No changes to existing Chat or Files tab functionality

## Checklist
- [x] Tests added or updated (N/A - UI display change using existing hook patterns)
- [x] Backward compatibility considered (additive change only)
- [x] UI lint passes
- [x] UI build passes