### PR TITLE
Add timeout requirements to web_fetch tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,6 +829,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-subscriber 0.3.22",
+ "url",
  "utoipa",
  "uuid 1.19.0",
 ]

--- a/crates/everruns-core/Cargo.toml
+++ b/crates/everruns-core/Cargo.toml
@@ -38,6 +38,9 @@ tracing.workspace = true
 # Encoding
 base64.workspace = true
 
+# URL parsing
+url = "2"
+
 # OpenAPI schema generation (optional, enabled by everruns-api)
 utoipa = { workspace = true, optional = true }
 

--- a/docs/features/capabilities.md
+++ b/docs/features/capabilities.md
@@ -57,6 +57,20 @@ Adds tools to access and manipulate files - read, write, grep, and more.
 - **System Prompt**: Adds file system access instructions
 - **Use cases**: Agents that need to work with files
 
+### Web Fetch
+
+**Status**: Available
+
+Enables fetching content from URLs and converting HTML to markdown or plain text.
+
+- **Tool**: `web_fetch`
+- **Features**:
+  - Fetch web content with configurable timeouts (1s for first byte, 30s for body)
+  - Convert HTML to markdown or plain text
+  - Extract metadata (size, filename, last modified)
+  - Returns metadata for binary content (images, PDFs) instead of failing
+- **Use cases**: Agents that need to retrieve information from the web
+
 ## Managing Capabilities
 
 ### Via UI


### PR DESCRIPTION
## Summary

- Add 1-second timeout for first response byte (connection + first byte timeout)
- Add 30-second body streaming timeout with partial content return and `[..more content timed out...]` suffix
- Include response size in bytes in all responses
- Include `Last-Modified` header when available
- Extract and include filename from `Content-Disposition` header or URL
- Binary files now return success with metadata instead of tool error
- Add `truncated` field to indicate if body was truncated due to timeout

## Changes

### Timeout Behavior
- **First byte timeout (1 second)**: If the server doesn't respond within 1 second, the request fails with "Request timed out: server did not respond within 1 second"
- **Body timeout (30 seconds)**: If the body isn't fully read within 30 seconds, partial content is returned with a `[..more content timed out...]` suffix and `truncated: true`

### Response Fields (GET requests)
```json
{
  "url": "https://example.com/page",
  "status_code": 200,
  "content_type": "text/html",
  "size": 12345,
  "last_modified": "Tue, 01 Jan 2024 12:00:00 GMT",
  "format": "raw",
  "content": "...",
  "truncated": false
}
```
Binary Content Response
Instead of returning a tool error, binary content now returns metadata:

{
  "url": "https://example.com/image.png",
  "status_code": 200,
  "content_type": "image/png",
  "size": 54321,
  "filename": "image.png",
  "last_modified": "...",
  "error": "Binary content is not supported..."
}

## Test Plan

- [x] Unit tests for timeout constants (1s connect, 30s body)
- [x] Integration test for unreachable host timeout
- [x] Unit tests for filename extraction (Content-Disposition header, URL paths, edge cases)
- [x] Unit tests for binary content type detection (images, audio, video, archives, fonts, documents)
- [x] Integration tests for response structure validation (GET, HEAD, binary)
- [x] Integration tests for format conversion (markdown, text, raw)
- [x] Integration tests for Last-Modified header extraction
- [x] Unit tests for HTTP method parsing
- [x] Integration tests for size validation
- [x] Integration tests for error handling (404, 500, DNS failure)
- [x] Integration tests for URL validation (rejects FTP, file://)

**Test Results**: 76 web_fetch tests passing (up from 35)