### PR TITLE
Package tool errors as tool_result in agent loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +593,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -832,6 +860,7 @@ dependencies = [
  "url",
  "utoipa",
  "uuid 1.19.0",
+ "wiremock",
 ]
 
 [[package]]
@@ -2489,7 +2518,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -2526,9 +2555,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4729,6 +4758,29 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/crates/everruns-core/Cargo.toml
+++ b/crates/everruns-core/Cargo.toml
@@ -59,6 +59,7 @@ openapi = ["utoipa"]
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }
 tracing-subscriber.workspace = true
+wiremock = "0.6"
 
 [[example]]
 name = "tool_calling"

--- a/crates/everruns-core/tests/tool_calling_test.rs
+++ b/crates/everruns-core/tests/tool_calling_test.rs
@@ -94,11 +94,14 @@ async fn test_tool_error_handling() {
         policy: ToolPolicy::Auto,
     });
 
-    // Execute and verify error is returned
+    // Execute and verify error is packaged as {"error": "..."} in result field
     let result = registry.execute(&tool_call, &tool_def).await.unwrap();
 
-    assert!(result.result.is_none());
-    assert_eq!(result.error, Some("Expected test failure".to_string()));
+    assert!(result.error.is_none());
+    assert_eq!(
+        result.result,
+        Some(json!({"error": "Expected test failure"}))
+    );
 }
 
 #[tokio::test]
@@ -121,14 +124,14 @@ async fn test_internal_error_is_hidden() {
         policy: ToolPolicy::Auto,
     });
 
-    // Execute and verify internal error is hidden
+    // Execute and verify internal error is hidden (packaged as {"error": "..."} with generic message)
     let result = registry.execute(&tool_call, &tool_def).await.unwrap();
 
-    assert!(result.result.is_none());
-    // Internal error message should be replaced with generic message
+    assert!(result.error.is_none());
+    // Internal error message should be replaced with generic message in result field
     assert_eq!(
-        result.error,
-        Some("An internal error occurred while executing the tool".to_string())
+        result.result,
+        Some(json!({"error": "An internal error occurred while executing the tool"}))
     );
 }
 

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -24,9 +24,11 @@ pub trait Tool: Send + Sync {
 ```
 
 **Error Handling Contract:**
-- `ToolExecutionResult::Success(Value)` - Successful result returned to LLM
-- `ToolExecutionResult::ToolError(String)` - User-visible error shown to LLM (e.g., "City not found")
-- `ToolExecutionResult::InternalError` - System error logged but hidden from LLM (security)
+- `ToolExecutionResult::Success(Value)` - Successful result returned to LLM as `result` field
+- `ToolExecutionResult::ToolError(String)` - User-visible error packaged as `{"error": "..."}` in `result` field (e.g., `{"error": "City not found"}`)
+- `ToolExecutionResult::InternalError` - System error logged, generic message packaged as `{"error": "..."}` in `result` field (security)
+
+All error types continue the agent loop the same way as success - they are all packaged in the `result` field with no `error` field set. The LLM can interpret the `{"error": "..."}` payload and decide how to proceed.
 
 **Provided Tools:**
 - `GetCurrentTime` - Returns current timestamp in various formats (iso8601, unix, human)


### PR DESCRIPTION
## What
Change `ToolExecutionResult::ToolError` and `InternalError` to be packaged as `{"error": "..."}` in the result field instead of using the separate error field.

## Why
This provides a consistent contract where the result field always contains the payload:
- Success results are in the `result` field
- Tool errors are in the `result` field as `{"error": "..."}`
- Internal errors are in the `result` field as `{"error": "..."}` (with generic message)

All outcomes continue the agent loop the same way.

## Risk
- Low - Internal contract change only