### PR TITLE
Update Messages tab styling in Session UI

### DIFF
--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/page.tsx
@@ -4,7 +4,6 @@ import { use, useState, useRef, useEffect } from "react";
 import { useAgent, useSession, useEvents, useRawEvents, useSendMessage, useLlmModel } from "@/hooks";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
@@ -15,7 +14,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { ArrowLeft, Send, User, Bot, Loader2, Sparkles, Brain, MessageSquare, Folder, Activity } from "lucide-react";
+import { ArrowLeft, Send, Bot, Loader2, Sparkles, Brain, MessageSquare, Folder, Activity } from "lucide-react";
 import type { Message, Controls, ReasoningEffort, FileInfo } from "@/lib/api/types";
 import { getTextFromContent, isToolCallPart } from "@/lib/api/types";
 import { ToolCallCard } from "@/components/chat/tool-call-card";
@@ -278,20 +277,14 @@ export default function SessionDetailPage({
             ) : (
               messages?.map((message) => {
                 const isUser = message.role === "user";
-                const isAssistant = message.role === "assistant";
-                const isToolResult = message.role === "tool_result";
 
                 // Skip tool_result messages - they're rendered with their tool_call
-                if (isToolResult) {
+                if (message.role === "tool_result") {
                   return null;
                 }
 
                 // For assistant messages, get any embedded tool calls
                 const toolCalls = getToolCallsFromMessage(message);
-
-                // Extract metadata for assistant messages
-                const messageModel = isAssistant ? (message.metadata?.model as string | undefined) : undefined;
-                const messageReasoningEffort = isAssistant ? (message.metadata?.reasoning_effort as string | undefined) : undefined;
 
                 // Get text content (may be empty if only tool calls)
                 const textContent = getMessageContent(message);
@@ -302,51 +295,17 @@ export default function SessionDetailPage({
                     {/* Render text content if present */}
                     {textContent && (
                       <div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
-                        <Card
-                          className={`max-w-[80%] ${
-                            isUser
-                              ? "bg-primary text-primary-foreground"
-                              : "bg-muted"
-                          }`}
-                        >
-                          <CardContent className="p-3">
-                            <div className="flex items-start gap-2">
-                              {!isUser && (
-                                <Bot className="w-5 h-5 mt-0.5 flex-shrink-0" />
-                              )}
-                              <div className="space-y-1">
-                                <div className="flex items-center gap-2">
-                                  <p className="text-xs font-medium opacity-70">
-                                    {isUser ? "You" : "Assistant"}
-                                  </p>
-                                  {/* Show model and reasoning info for assistant messages */}
-                                  {isAssistant && (messageModel || messageReasoningEffort) && (
-                                    <div className="flex items-center gap-1">
-                                      {messageModel && (
-                                        <Badge variant="outline" className="text-[10px] px-1 py-0 h-4 gap-0.5">
-                                          <Sparkles className="w-2.5 h-2.5" />
-                                          {messageModel}
-                                        </Badge>
-                                      )}
-                                      {messageReasoningEffort && (
-                                        <Badge variant="outline" className="text-[10px] px-1 py-0 h-4 gap-0.5">
-                                          <Brain className="w-2.5 h-2.5" />
-                                          {messageReasoningEffort}
-                                        </Badge>
-                                      )}
-                                    </div>
-                                  )}
-                                </div>
-                                <p className="text-sm whitespace-pre-wrap">
-                                  {textContent}
-                                </p>
-                              </div>
-                              {isUser && (
-                                <User className="w-5 h-5 mt-0.5 flex-shrink-0" />
-                              )}
-                            </div>
-                          </CardContent>
-                        </Card>
+                        {isUser ? (
+                          /* User message - dark box, 90% width */
+                          <div className="max-w-[90%] bg-gray-500 text-white rounded-lg p-3">
+                            <p className="text-sm whitespace-pre-wrap">{textContent}</p>
+                          </div>
+                        ) : (
+                          /* Agent message - no box, subtle background */
+                          <div className="w-full bg-muted/30 rounded-lg p-3">
+                            <p className="text-sm whitespace-pre-wrap">{textContent}</p>
+                          </div>
+                        )}
                       </div>
                     )}
 

--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/page.tsx
@@ -301,15 +301,18 @@ export default function SessionDetailPage({
                             <p className="text-sm whitespace-pre-wrap">{textContent}</p>
                           </div>
                         ) : (
-                          /* Agent message - no box, subtle background */
+                          /* Agent message - no box, subtle background, > prefix */
                           <div className="w-full bg-muted/30 rounded-lg p-3">
-                            <p className="text-sm whitespace-pre-wrap">{textContent}</p>
+                            <p className="text-sm whitespace-pre-wrap text-muted-foreground">
+                              <span>&gt; </span>{textContent}
+                            </p>
                           </div>
                         )}
                       </div>
                     )}
 
-                    {/* Render tool calls from assistant message */}
+                    {/* Render tool calls from assistant message - 25px left padding */}
+                    <div className="pl-[25px] space-y-2">
                     {toolCalls.map((tc) => {
                       const toolResult = toolResultsMap.get(tc.id);
                       // Create a synthetic message for ToolCallCard
@@ -330,6 +333,7 @@ export default function SessionDetailPage({
                         />
                       );
                     })}
+                    </div>
                   </div>
                 );
               })

--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/page.tsx
@@ -136,9 +136,16 @@ export default function SessionDetailPage({
   };
 
   // Extract message content - handles new ContentPart[] format
+  // Filters out "Tool call:" lines which are rendered separately
   const getMessageContent = (message: Message): string => {
     if (Array.isArray(message.content)) {
-      return getTextFromContent(message.content);
+      const text = getTextFromContent(message.content);
+      // Filter out lines that describe tool calls (these are rendered separately)
+      return text
+        .split("\n")
+        .filter(line => !line.trim().startsWith("Tool call:"))
+        .join("\n")
+        .trim();
     }
     return JSON.stringify(message.content);
   };

--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/page.tsx
@@ -301,11 +301,12 @@ export default function SessionDetailPage({
                             <p className="text-sm whitespace-pre-wrap">{textContent}</p>
                           </div>
                         ) : (
-                          /* Agent message - no box, subtle background, > prefix */
-                          <div className="w-full bg-muted/30 rounded-lg p-3">
-                            <p className="text-sm whitespace-pre-wrap text-muted-foreground">
-                              <span>&gt; </span>{textContent}
-                            </p>
+                          /* Agent message - darker background with robot icon */
+                          <div className="w-full bg-muted/60 rounded-lg p-3">
+                            <div className="flex items-start gap-2">
+                              <Bot className="w-4 h-4 mt-0.5 flex-shrink-0 text-muted-foreground" />
+                              <p className="text-sm whitespace-pre-wrap">{textContent}</p>
+                            </div>
                           </div>
                         )}
                       </div>

--- a/apps/ui/src/components/chat/tool-call-card.tsx
+++ b/apps/ui/src/components/chat/tool-call-card.tsx
@@ -104,23 +104,23 @@ export function ToolCallCard({ toolCall, toolResult }: ToolCallCardProps) {
     : null;
 
   return (
-    <div className="w-full bg-muted/30 rounded-lg p-3 space-y-1">
+    <div className="w-full space-y-0.5 text-sm text-muted-foreground">
       {/* Tool name and arguments */}
-      <div className="text-sm">
-        <span className="font-semibold">{content.name}:</span>
-        {argsPreview && <span className="text-muted-foreground ml-1">{argsPreview}</span>}
+      <div>
+        <span className="font-medium">{content.name}:</span>
+        {argsPreview && <span className="ml-1">{argsPreview}</span>}
       </div>
 
       {/* Result or executing state */}
       {isComplete ? (
         hasError ? (
-          <div className="text-sm text-red-600">
-            <span className="text-muted-foreground">&gt;</span> Error: {resultContent?.error}
+          <div className="text-red-600">
+            &gt; Error: {resultContent?.error}
           </div>
         ) : resultPreview ? (
           <div className="space-y-0.5">
-            <pre className="text-sm text-muted-foreground whitespace-pre-wrap">
-              <span>&gt; </span>{resultPreview.preview}
+            <pre className="whitespace-pre-wrap">
+              &gt; {resultPreview.preview}
             </pre>
             {(resultPreview.hasMore || isExpanded) && (
               <button
@@ -140,8 +140,8 @@ export function ToolCallCard({ toolCall, toolResult }: ToolCallCardProps) {
           </div>
         ) : null
       ) : (
-        <div className="text-sm text-muted-foreground">
-          <span>&gt;</span> ... executing ...
+        <div>
+          &gt; ... executing ...
         </div>
       )}
     </div>

--- a/apps/ui/src/components/chat/tool-call-card.tsx
+++ b/apps/ui/src/components/chat/tool-call-card.tsx
@@ -1,10 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Wrench, ChevronDown, ChevronRight, CheckCircle2, AlertCircle } from "lucide-react";
 import type { Message, ContentPart } from "@/lib/api/types";
 import { isToolCallPart, isToolResultPart } from "@/lib/api/types";
 
@@ -48,6 +44,29 @@ function extractToolResultContent(content: ContentPart[]): ToolResultContent | n
   return null;
 }
 
+// Format arguments as "arg1: value, arg2: value..." with truncation
+function formatArguments(args: Record<string, unknown>): string {
+  const entries = Object.entries(args);
+  if (entries.length === 0) return "";
+
+  const formatted = entries.map(([key, value]) => {
+    const strValue = typeof value === "string" ? value : JSON.stringify(value);
+    const truncated = strValue.length > 30 ? strValue.substring(0, 30) + "..." : strValue;
+    return `${key}: ${truncated}`;
+  }).join(", ");
+
+  return formatted.length > 80 ? formatted.substring(0, 80) + "..." : formatted;
+}
+
+// Get first N lines of result text
+function getResultPreview(result: unknown, maxLines: number = 2): { preview: string; hasMore: boolean } {
+  const text = typeof result === "string" ? result : JSON.stringify(result, null, 2);
+  const lines = text.split("\n");
+  const hasMore = lines.length > maxLines;
+  const preview = lines.slice(0, maxLines).join("\n");
+  return { preview, hasMore };
+}
+
 interface ToolCallCardProps {
   toolCall: Message;
   toolResult?: Message;
@@ -73,84 +92,52 @@ export function ToolCallCard({ toolCall, toolResult }: ToolCallCardProps) {
     return null;
   }
 
+  const argsPreview = formatArguments(content.arguments);
+  const resultPreview = resultContent?.result !== undefined
+    ? getResultPreview(resultContent.result)
+    : null;
+
   return (
-    <div className="flex justify-start">
-      <Card className="max-w-[90%] bg-muted/50 border-purple-200">
-        <CardContent className="p-3">
-          <div className="flex items-start gap-2">
-            <div className="flex-shrink-0 w-8 h-8 rounded-full bg-purple-100 flex items-center justify-center">
-              <Wrench className="w-4 h-4 text-purple-600" />
-            </div>
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2 flex-wrap">
-                <span className="text-xs font-medium text-muted-foreground">Step</span>
-                <span className="font-medium text-sm">{content.name}</span>
-                {isComplete ? (
-                  hasError ? (
-                    <Badge variant="destructive" className="text-xs">
-                      <AlertCircle className="w-3 h-3 mr-1" />
-                      Failed
-                    </Badge>
-                  ) : (
-                    <Badge variant="outline" className="text-xs bg-green-50 text-green-700 border-green-200">
-                      <CheckCircle2 className="w-3 h-3 mr-1" />
-                      Done
-                    </Badge>
-                  )
-                ) : (
-                  <Badge variant="outline" className="text-xs">
-                    Running...
-                  </Badge>
-                )}
-              </div>
+    <div className="w-full bg-muted/30 rounded-lg p-3 space-y-1">
+      {/* Tool name and arguments */}
+      <div className="text-sm">
+        <span className="font-semibold">{content.name}:</span>
+        {argsPreview && <span className="text-muted-foreground ml-1">{argsPreview}</span>}
+      </div>
 
-              {/* Arguments section */}
-              {content.arguments && Object.keys(content.arguments).length > 0 && (
-                <div className="mt-2">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-6 px-2 text-xs text-muted-foreground hover:text-foreground"
-                    onClick={() => setIsExpanded(!isExpanded)}
-                  >
-                    {isExpanded ? (
-                      <ChevronDown className="w-3 h-3 mr-1" />
-                    ) : (
-                      <ChevronRight className="w-3 h-3 mr-1" />
-                    )}
-                    Arguments
-                  </Button>
-                  {isExpanded && (
-                    <pre className="mt-1 p-2 text-xs bg-white rounded border overflow-x-auto max-h-40">
-                      {JSON.stringify(content.arguments, null, 2)}
-                    </pre>
-                  )}
-                </div>
-              )}
-
-              {/* Result section */}
-              {isComplete && resultContent && (
-                <div className="mt-2">
-                  {hasError ? (
-                    <div className="p-2 text-xs bg-red-50 text-red-700 rounded border border-red-200">
-                      {resultContent.error}
-                    </div>
-                  ) : resultContent.result !== undefined ? (
-                    <div className="mt-1">
-                      <span className="text-xs text-muted-foreground">Result:</span>
-                      <pre className="mt-1 p-2 text-xs bg-white rounded border overflow-x-auto max-h-40">
-                        {typeof resultContent.result === "string"
-                          ? resultContent.result
-                          : JSON.stringify(resultContent.result, null, 2)}
-                      </pre>
-                    </div>
-                  ) : null}
-                </div>
-              )}
-            </div>
+      {/* Result or executing state */}
+      {isComplete ? (
+        hasError ? (
+          <div className="text-sm text-red-600">
+            <span className="text-muted-foreground">&gt;</span> Error: {resultContent?.error}
           </div>
-        </CardContent>
-      </Card>
+        ) : resultPreview ? (
+          <div className="space-y-0.5">
+            <pre className="text-sm text-muted-foreground whitespace-pre-wrap">
+              <span>&gt; </span>{resultPreview.preview}
+            </pre>
+            {(resultPreview.hasMore || isExpanded) && (
+              <button
+                onClick={() => setIsExpanded(!isExpanded)}
+                className="text-xs text-blue-600 hover:underline"
+              >
+                {isExpanded ? "show less" : "> see more..."}
+              </button>
+            )}
+            {isExpanded && resultContent?.result !== undefined && (
+              <pre className="text-xs bg-muted/50 p-2 rounded mt-1 overflow-x-auto max-h-60">
+                {typeof resultContent.result === "string"
+                  ? resultContent.result
+                  : JSON.stringify(resultContent.result, null, 2)}
+              </pre>
+            )}
+          </div>
+        ) : null
+      ) : (
+        <div className="text-sm text-muted-foreground">
+          <span>&gt;</span> ... executing ...
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/ui/src/components/chat/tool-call-card.tsx
+++ b/apps/ui/src/components/chat/tool-call-card.tsx
@@ -58,13 +58,19 @@ function formatArguments(args: Record<string, unknown>): string {
   return formatted.length > 80 ? formatted.substring(0, 80) + "..." : formatted;
 }
 
-// Get first N lines of result text
-function getResultPreview(result: unknown, maxLines: number = 2): { preview: string; hasMore: boolean } {
+// Get first N lines of result text, limited to maxChars
+function getResultPreview(result: unknown, maxLines: number = 2, maxChars: number = 360): { preview: string; hasMore: boolean } {
   const text = typeof result === "string" ? result : JSON.stringify(result, null, 2);
   const lines = text.split("\n");
-  const hasMore = lines.length > maxLines;
-  const preview = lines.slice(0, maxLines).join("\n");
-  return { preview, hasMore };
+  let preview = lines.slice(0, maxLines).join("\n");
+  const truncatedByLines = lines.length > maxLines;
+  const truncatedByChars = preview.length > maxChars;
+
+  if (truncatedByChars) {
+    preview = preview.substring(0, maxChars) + "...";
+  }
+
+  return { preview, hasMore: truncatedByLines || truncatedByChars || text.length > preview.length };
 }
 
 interface ToolCallCardProps {

--- a/apps/ui/src/components/chat/tool-call-card.tsx
+++ b/apps/ui/src/components/chat/tool-call-card.tsx
@@ -119,9 +119,9 @@ export function ToolCallCard({ toolCall, toolResult }: ToolCallCardProps) {
           </div>
         ) : resultPreview ? (
           <div className="space-y-0.5">
-            <pre className="whitespace-pre-wrap">
+            <div className="whitespace-pre-wrap">
               &gt; {resultPreview.preview}
-            </pre>
+            </div>
             {(resultPreview.hasMore || isExpanded) && (
               <button
                 onClick={() => setIsExpanded(!isExpanded)}


### PR DESCRIPTION
## Summary
- Simplify message display in Session UI Messages tab
- User messages: 90% width with dark gray background
- Agent messages: darker background with robot icon prefix
- Tool calls: simplified inline format with 25px indent, showing args preview and result preview (2 lines / 360 chars max)

## Changes
- **User messages**: Dark box (`bg-gray-500`), 90% max width, right-aligned
- **Agent messages**: Darker subtle background (`bg-muted/60`) with Bot icon, full width
- **Tool calls**: Indented 25px from agent messages, no box styling
  - Shows tool name and truncated arguments inline
  - "... executing ..." state while running
  - Result preview (first 2 lines, max 360 chars) with "see more" expansion
- Filter out "Tool call:" text lines from agent messages (rendered separately)
- Removed unused Card/Badge components from message rendering

## Test plan
- [ ] Verify user messages display with dark background at 90% width
- [ ] Verify agent messages show Bot icon with darker background
- [ ] Verify tool calls are indented and visually separate (no box)
- [ ] Verify tool results show preview with "see more" for long results
- [ ] Verify "Tool call:" text lines don't appear in agent message text
- [ ] Verify UI builds without errors
