### PR TITLE
refactor(scripts): remove duplicate jq/yq check in dev.sh

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -367,12 +367,7 @@ PY
         sleep 1
       done
 
-      # Check if yq and jq are available for seeding
-      if command -v yq &> /dev/null && command -v jq &> /dev/null; then
-        "$SCRIPT_DIR/seed-agents.sh" 2>&1 | sed 's/^/   /'
-      else
-        echo "   ⚠️  Skipping seed: yq and jq required (install with: pip install yq && apt-get install jq)"
-      fi
+      "$SCRIPT_DIR/seed-agents.sh" 2>&1 | sed 's/^/   /'
     ) &
     SEED_PID=$!
 


### PR DESCRIPTION
## What
Remove duplicate jq/yq dependency check from `dev.sh` when calling `seed-agents.sh`.

## Why
The check in `dev.sh` was redundant because `seed-agents.sh` already performs comprehensive validation that:
- Checks if jq is installed
- Checks if yq is installed
- Validates it's the correct yq version (mikefarah/yq, not kislyuk/yq)
- Provides accurate installation instructions

Additionally, the removed check had an incorrect error message suggesting `pip install yq`, which would install the wrong yq version (kislyuk/yq instead of mikefarah/yq).

## How
Removed the conditional check and directly call `seed-agents.sh`, letting it handle its own dependency validation.

## Risk
- Low
- No functional change; seed-agents.sh already exits with clear error messages if dependencies are missing

## Checklist
- [x] Tests added or updated (N/A - script change)
- [x] Backward compatibility considered (no breaking changes)
