### PR TITLE
Debug SSE endpoint event streaming

### DIFF
--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -172,8 +172,9 @@ message Event {
 
 message EventContext {
     Uuid session_id = 1;
-    optional int32 turn = 2;
+    optional Uuid turn_id = 2;  // Turn UUID
     optional Uuid exec_id = 3;  // For idempotency
+    optional Uuid input_message_id = 4;  // Input message that triggered the turn
 }
 
 message EmitEventRequest {

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -239,8 +239,16 @@ pub fn proto_event_to_schema(value: proto::Event) -> Result<everruns_core::Event
     let session_id = proto_uuid_to_uuid(session_id)?;
 
     let context = everruns_core::EventContext {
-        turn_id: proto_context.turn.map(|t| uuid::Uuid::from_u128(t as u128)), // Simplified
-        input_message_id: None,
+        turn_id: proto_context
+            .turn_id
+            .as_ref()
+            .map(proto_uuid_to_uuid)
+            .transpose()?,
+        input_message_id: proto_context
+            .input_message_id
+            .as_ref()
+            .map(proto_uuid_to_uuid)
+            .transpose()?,
         exec_id: proto_context
             .exec_id
             .as_ref()
@@ -271,7 +279,8 @@ pub fn schema_event_to_proto(value: &everruns_core::Event) -> proto::Event {
         ts: Some(datetime_to_proto_timestamp(value.ts)),
         context: Some(proto::EventContext {
             session_id: Some(uuid_to_proto_uuid(value.session_id)),
-            turn: value.context.turn_id.map(|u| u.as_u128() as i32), // Simplified
+            turn_id: value.context.turn_id.map(uuid_to_proto_uuid),
+            input_message_id: value.context.input_message_id.map(uuid_to_proto_uuid),
             exec_id: value.context.exec_id.map(uuid_to_proto_uuid),
         }),
         data_json: serde_json::to_string(&value.data).unwrap_or_default(),

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -772,8 +772,9 @@ fn core_event_to_proto(event: &Event) -> Result<proto::Event> {
         ts: Some(datetime_to_proto_timestamp(event.ts)),
         context: Some(proto::EventContext {
             session_id: Some(uuid_to_proto(event.session_id)),
-            turn: event.context.turn_id.map(|u| u.as_u128() as i32),
+            turn_id: event.context.turn_id.map(uuid_to_proto),
             exec_id: event.context.exec_id.map(uuid_to_proto),
+            input_message_id: event.context.input_message_id.map(uuid_to_proto),
         }),
         data_json,
     })


### PR DESCRIPTION
The SSE endpoint was not streaming events correctly because the gRPC emit_event and emit_event_stream handlers were storing only the EventData portion instead of the full Event struct.

When events were read back in EventService::row_to_event(), the deserialization of the full Event failed, causing a fallback path that created malformed events with EventContext::empty() and the data wrapped in EventData::Raw().

Changes:
- Reconstruct full Event struct from proto in emit_event handler
- Reconstruct full Event struct from proto in emit_event_stream handler
- Update proto EventContext to use Uuid for turn_id instead of int32
- Add input_message_id field to proto EventContext
- Update internal-protocol conversion functions for new proto format
- Update worker grpc_adapters to use new proto format

This ensures events emitted via gRPC are stored in the same format as events emitted via DbEventEmitter, enabling proper SSE streaming.

## What
Clear description of the change.

## Why
Problem or motivation.

## How
High-level approach.

## Risk
- Low / Medium / High
- What can break

## Checklist
- [ ] Tests added or updated
- [ ] Backward compatibility considered
