### PR TITLE
docs: update integration test commands and add llmsim documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,8 +266,8 @@ PRs should include appropriate tests for the changes being made:
   # Unit tests (no external dependencies)
   cargo test
 
-  # Integration tests (requires API running)
-  cargo test --test integration_test -- --ignored
+  # Integration tests (requires API + Worker + Temporal running)
+  cargo test -p everruns-control-plane --test integration_test -- --test-threads=1
   ```
 
 ### Commit message conventions
@@ -366,9 +366,9 @@ Expected output:
 
 ### Alternative testing methods
 
-**Integration tests** (requires API running):
+**Integration tests** (requires API + Worker + Temporal running):
 ```bash
-cargo test --test integration_test -- --ignored
+cargo test -p everruns-control-plane --test integration_test -- --test-threads=1
 ```
 
 **Examples** (requires API running):

--- a/crates/control-plane/README.md
+++ b/crates/control-plane/README.md
@@ -79,11 +79,11 @@ This will:
 ### Run Tests
 
 ```bash
-# Run all integration tests
-cargo test --test integration_test -- --ignored
+# Run all integration tests (requires API + Worker + Temporal running)
+cargo test -p everruns-control-plane --test integration_test -- --test-threads=1
 
 # Run a specific test
-cargo test --test integration_test test_full_agent_workflow -- --ignored
+cargo test -p everruns-control-plane --test integration_test test_full_agent_session_workflow -- --test-threads=1
 ```
 
 ### Test Coverage

--- a/crates/control-plane/tests/integration_test.rs
+++ b/crates/control-plane/tests/integration_test.rs
@@ -1,5 +1,6 @@
-// Integration tests for Everruns API (M2)
-// Run with: cargo test --test integration_test
+// Integration tests for Everruns API
+// Run with: cargo test -p everruns-control-plane --test integration_test -- --test-threads=1
+// Requires: API + Worker + Temporal running (uses LlmSim for workflow tests, no real API keys needed)
 
 use everruns_core::llm_models::LlmProvider;
 use everruns_core::{Agent, LlmModel, Session, SessionFile};

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -185,6 +185,26 @@ OpenAI-specific LLM provider implementation:
 3. **Streaming Support**: Full SSE streaming with tool call support
 4. **Native API Access**: Direct methods for OpenAI-specific functionality
 
+### LlmSim Driver (Testing)
+
+For integration testing without real API keys, Everruns uses [llmsim](https://github.com/chaliy/llmsim) - a simulated LLM driver:
+
+1. **Provider Type**: `llmsim` - registered as `LlmProviderType::LlmSim`
+2. **No API Keys Required**: Tests can run without external dependencies
+3. **Configurable Responses**: Supports fixed responses, echo mode, lorem ipsum generation, and tool call simulation
+4. **Latency Simulation**: Optional latency profiles for realistic timing
+5. **Usage**: Create an `llmsim` provider and model in tests, then use it as the agent's default model
+
+Example test setup:
+```rust
+// Create LlmSim provider (no API key needed)
+let provider = create_provider("llmsim", "Test Provider");
+let model = create_model(provider.id, "llmsim-test", "LlmSim Test Model");
+
+// Create agent with LlmSim model
+let agent = create_agent("Test Agent", model.id);
+```
+
 ### Capabilities System
 
 Capabilities are modular functionality units that extend Agent behavior. See [specs/capabilities.md](capabilities.md) for detailed specification.


### PR DESCRIPTION
## What
Remove outdated `--ignored` flag from integration test commands and add documentation for the LlmSim driver integration.

## Why
- Integration tests are no longer marked with `#[ignore]` - they run as regular tests
- The old test commands (`cargo test --test integration_test -- --ignored`) no longer work
- LlmSim was recently integrated (#148) but not documented in specs

## How
- Updated test commands in `AGENTS.md`, `crates/control-plane/README.md`, and the integration test file header
- Added LlmSim Driver section to `specs/architecture.md` with link to https://github.com/chaliy/llmsim
- Clarified that integration tests require API + Worker + Temporal running

## Changes
- `AGENTS.md` - Updated integration test commands (2 locations)
- `crates/control-plane/README.md` - Updated test commands
- `crates/control-plane/tests/integration_test.rs` - Updated header comment
- `specs/architecture.md` - Added LlmSim Driver documentation section

## Risk
- Low
- Documentation-only changes, no code behavior affected

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
