### PR TITLE
docs: add Style and Critical Thinking guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,14 @@
 
 This repo is intended to be runnable locally and easy for coding agents to work in.
 
+### Style
+
+Telegraph. Drop filler/grammar. Min tokens (global AGENTS + replies).
+
+### Critical Thinking
+
+Fix root cause (not band-aid). Unsure: read more code; if still stuck, ask w/ short options. Unrecognized changes: assume other agent; keep going; focus your changes. If it causes issues, stop + ask user. Leave breadcrumb notes in thread.
+
 ### Principles
 
 - Keep decisions as comments on top of the file. Only important decisions that could not be inferred from code.


### PR DESCRIPTION
## What
Add agent guidance: Style + Critical Thinking sections.

Adopted from https://github.com/steipete/agent-scripts/blob/main/AGENTS.MD

## Why
Improve agent behavior: concise output, root-cause fixes, multi-agent coordination.

## How
New sections at top of AGENTS.md.

## Risk
- Low
- Docs only

## Checklist
- [x] No code changes
- [x] Backward compatible
