### PR TITLE
feat(capabilities): add fake demo tools and agents for warehouse, AWS, CRM, and financial operations

### DIFF
--- a/crates/core/src/capabilities/fake_aws.rs
+++ b/crates/core/src/capabilities/fake_aws.rs
@@ -212,43 +212,44 @@ impl Tool for AwsListEc2InstancesTool {
             .read_file(context.session_id, "/aws/ec2_instances.json")
             .await
         {
-            Ok(Some(file)) => serde_json::from_str(&file.content).unwrap_or_else(|_| {
-                // Initialize with sample data
-                vec![
-                    Ec2Instance {
-                        instance_id: "i-0123456789abcdef0".to_string(),
-                        instance_type: "t3.medium".to_string(),
-                        state: "running".to_string(),
-                        availability_zone: "us-east-1a".to_string(),
-                        private_ip: "10.0.1.100".to_string(),
-                        public_ip: Some("54.123.45.67".to_string()),
-                        launch_time: "2025-01-01T10:00:00Z".to_string(),
-                        tags: vec![
-                            Tag {
+            Ok(Some(file)) => serde_json::from_str(file.content.as_deref().unwrap_or(""))
+                .unwrap_or_else(|_| {
+                    // Initialize with sample data
+                    vec![
+                        Ec2Instance {
+                            instance_id: "i-0123456789abcdef0".to_string(),
+                            instance_type: "t3.medium".to_string(),
+                            state: "running".to_string(),
+                            availability_zone: "us-east-1a".to_string(),
+                            private_ip: "10.0.1.100".to_string(),
+                            public_ip: Some("54.123.45.67".to_string()),
+                            launch_time: "2025-01-01T10:00:00Z".to_string(),
+                            tags: vec![
+                                Tag {
+                                    key: "Name".to_string(),
+                                    value: "web-server-01".to_string(),
+                                },
+                                Tag {
+                                    key: "Environment".to_string(),
+                                    value: "production".to_string(),
+                                },
+                            ],
+                        },
+                        Ec2Instance {
+                            instance_id: "i-0987654321fedcba0".to_string(),
+                            instance_type: "t3.large".to_string(),
+                            state: "running".to_string(),
+                            availability_zone: "us-east-1b".to_string(),
+                            private_ip: "10.0.2.100".to_string(),
+                            public_ip: Some("54.123.45.68".to_string()),
+                            launch_time: "2025-01-01T11:00:00Z".to_string(),
+                            tags: vec![Tag {
                                 key: "Name".to_string(),
-                                value: "web-server-01".to_string(),
-                            },
-                            Tag {
-                                key: "Environment".to_string(),
-                                value: "production".to_string(),
-                            },
-                        ],
-                    },
-                    Ec2Instance {
-                        instance_id: "i-0987654321fedcba0".to_string(),
-                        instance_type: "t3.large".to_string(),
-                        state: "running".to_string(),
-                        availability_zone: "us-east-1b".to_string(),
-                        private_ip: "10.0.2.100".to_string(),
-                        public_ip: Some("54.123.45.68".to_string()),
-                        launch_time: "2025-01-01T11:00:00Z".to_string(),
-                        tags: vec![Tag {
-                            key: "Name".to_string(),
-                            value: "api-server-01".to_string(),
-                        }],
-                    },
-                ]
-            }),
+                                value: "api-server-01".to_string(),
+                            }],
+                        },
+                    ]
+                }),
             _ => {
                 // Create initial data
                 let initial = vec![Ec2Instance {
@@ -371,15 +372,14 @@ impl Tool for AwsCreateEc2InstanceTool {
             .read_file(context.session_id, "/aws/ec2_instances.json")
             .await
         {
-            Ok(Some(file)) => serde_json::from_str(&file.content).unwrap_or_default(),
+            Ok(Some(file)) => {
+                serde_json::from_str(file.content.as_deref().unwrap_or("")).unwrap_or_default()
+            }
             _ => vec![],
         };
 
         // Create new instance
-        let instance_id = format!(
-            "i-{:016x}",
-            (chrono::Utc::now().timestamp() as u64) & 0xFFFFFFFFFFFFFFFF
-        );
+        let instance_id = format!("i-{:016x}", chrono::Utc::now().timestamp() as u64);
         let private_ip = format!("10.0.{}.{}", (instances.len() % 254) + 1, 100);
         let public_ip = format!(
             "54.{}.{}.{}",
@@ -487,7 +487,9 @@ impl Tool for AwsStopEc2InstanceTool {
             .read_file(context.session_id, "/aws/ec2_instances.json")
             .await
         {
-            Ok(Some(file)) => serde_json::from_str(&file.content).unwrap_or_default(),
+            Ok(Some(file)) => {
+                serde_json::from_str(file.content.as_deref().unwrap_or("")).unwrap_or_default()
+            }
             _ => vec![],
         };
 
@@ -568,18 +570,19 @@ impl Tool for AwsListRdsDatabasesTool {
             .read_file(context.session_id, "/aws/rds_databases.json")
             .await
         {
-            Ok(Some(file)) => serde_json::from_str(&file.content).unwrap_or_else(|_| {
-                vec![RdsDatabase {
-                    db_instance_id: "prod-postgres-01".to_string(),
-                    engine: "postgres".to_string(),
-                    engine_version: "15.4".to_string(),
-                    instance_class: "db.t3.medium".to_string(),
-                    status: "available".to_string(),
-                    endpoint: "prod-postgres-01.abc123.us-east-1.rds.amazonaws.com".to_string(),
-                    port: 5432,
-                    storage_gb: 100,
-                }]
-            }),
+            Ok(Some(file)) => serde_json::from_str(file.content.as_deref().unwrap_or(""))
+                .unwrap_or_else(|_| {
+                    vec![RdsDatabase {
+                        db_instance_id: "prod-postgres-01".to_string(),
+                        engine: "postgres".to_string(),
+                        engine_version: "15.4".to_string(),
+                        instance_class: "db.t3.medium".to_string(),
+                        status: "available".to_string(),
+                        endpoint: "prod-postgres-01.abc123.us-east-1.rds.amazonaws.com".to_string(),
+                        port: 5432,
+                        storage_gb: 100,
+                    }]
+                }),
             _ => vec![],
         };
 

--- a/crates/core/src/capabilities/fake_aws.rs
+++ b/crates/core/src/capabilities/fake_aws.rs
@@ -1,0 +1,986 @@
+//! Fake AWS Tools Capability - demo tools for AWS infrastructure management
+//!
+//! This capability provides mock AWS management tools that store state
+//! in the session file system. Perfect for demos and testing.
+//!
+//! Tools provided:
+//! - `aws_list_ec2_instances`: List EC2 instances
+//! - `aws_create_ec2_instance`: Launch a new EC2 instance
+//! - `aws_stop_ec2_instance`: Stop an EC2 instance
+//! - `aws_list_rds_databases`: List RDS database instances
+//! - `aws_create_rds_database`: Create a new RDS database
+//! - `aws_list_s3_buckets`: List S3 buckets
+//! - `aws_create_s3_bucket`: Create a new S3 bucket
+//! - `aws_list_iam_users`: List IAM users
+//! - `aws_create_iam_user`: Create a new IAM user
+//! - `aws_list_security_groups`: List security groups
+//! - `aws_get_cloudwatch_metrics`: Get CloudWatch metrics
+
+use super::{Capability, CapabilityId, CapabilityStatus};
+use crate::tools::{Tool, ToolExecutionResult};
+use crate::traits::ToolContext;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+/// Fake AWS Tools capability - mock AWS infrastructure management for demos
+pub struct FakeAwsCapability;
+
+impl Capability for FakeAwsCapability {
+    fn id(&self) -> &str {
+        CapabilityId::FAKE_AWS
+    }
+
+    fn name(&self) -> &str {
+        "Fake AWS Tools"
+    }
+
+    fn description(&self) -> &str {
+        "Demo capability: AWS infrastructure management tools (EC2, RDS, S3, IAM, CloudWatch). State stored in session filesystem."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("cloud")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Demo Tools")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(
+            r#"You have access to AWS infrastructure management tools. All AWS data is stored in /aws/ directory.
+
+Available tools:
+- `aws_list_ec2_instances`: List all EC2 instances with their status
+- `aws_create_ec2_instance`: Launch a new EC2 instance
+- `aws_stop_ec2_instance`: Stop a running EC2 instance
+- `aws_list_rds_databases`: List RDS database instances
+- `aws_create_rds_database`: Create a new RDS database
+- `aws_list_s3_buckets`: List all S3 buckets
+- `aws_create_s3_bucket`: Create a new S3 bucket
+- `aws_list_iam_users`: List IAM users and their permissions
+- `aws_create_iam_user`: Create a new IAM user
+- `aws_list_security_groups`: List security groups and rules
+- `aws_get_cloudwatch_metrics`: Get CloudWatch metrics for resources
+
+Data structure:
+- /aws/ec2_instances.json - EC2 instance records
+- /aws/rds_databases.json - RDS database records
+- /aws/s3_buckets.json - S3 bucket records
+- /aws/iam_users.json - IAM user records
+- /aws/security_groups.json - Security group records
+- /aws/cloudwatch_metrics.json - CloudWatch metrics data"#,
+        )
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(AwsListEc2InstancesTool),
+            Box::new(AwsCreateEc2InstanceTool),
+            Box::new(AwsStopEc2InstanceTool),
+            Box::new(AwsListRdsDatabasesTool),
+            Box::new(AwsCreateRdsDatabaseTool),
+            Box::new(AwsListS3BucketsTool),
+            Box::new(AwsCreateS3BucketTool),
+            Box::new(AwsListIamUsersTool),
+            Box::new(AwsCreateIamUserTool),
+            Box::new(AwsListSecurityGroupsTool),
+            Box::new(AwsGetCloudWatchMetricsTool),
+        ]
+    }
+}
+
+// Helper structs for AWS data
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Ec2Instance {
+    instance_id: String,
+    instance_type: String,
+    state: String, // running, stopped, terminated
+    availability_zone: String,
+    private_ip: String,
+    public_ip: Option<String>,
+    launch_time: String,
+    tags: Vec<Tag>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Tag {
+    key: String,
+    value: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RdsDatabase {
+    db_instance_id: String,
+    engine: String,
+    engine_version: String,
+    instance_class: String,
+    status: String,
+    endpoint: String,
+    port: i32,
+    storage_gb: i32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct S3Bucket {
+    name: String,
+    region: String,
+    creation_date: String,
+    versioning_enabled: bool,
+    encryption_enabled: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct IamUser {
+    username: String,
+    user_id: String,
+    arn: String,
+    created_at: String,
+    permissions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SecurityGroup {
+    group_id: String,
+    group_name: String,
+    description: String,
+    vpc_id: String,
+    inbound_rules: Vec<SecurityRule>,
+    outbound_rules: Vec<SecurityRule>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SecurityRule {
+    protocol: String,
+    port_range: String,
+    source: String,
+}
+
+// ============================================================================
+// Tool: aws_list_ec2_instances
+// ============================================================================
+
+pub struct AwsListEc2InstancesTool;
+
+#[async_trait]
+impl Tool for AwsListEc2InstancesTool {
+    fn name(&self) -> &str {
+        "aws_list_ec2_instances"
+    }
+
+    fn description(&self) -> &str {
+        "List all EC2 instances with their current status, IPs, and configuration."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "state": {
+                    "type": "string",
+                    "enum": ["running", "stopped", "terminated"],
+                    "description": "Optional: Filter by instance state"
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("aws_list_ec2_instances requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let file_store = match &context.file_store {
+            Some(store) => store,
+            None => return ToolExecutionResult::tool_error("File system not available"),
+        };
+
+        let state_filter = arguments.get("state").and_then(|v| v.as_str());
+
+        // Read EC2 instances
+        let instances: Vec<Ec2Instance> = match file_store
+            .read_file(context.session_id, "/aws/ec2_instances.json")
+            .await
+        {
+            Ok(Some(file)) => serde_json::from_str(&file.content).unwrap_or_else(|_| {
+                // Initialize with sample data
+                vec![
+                    Ec2Instance {
+                        instance_id: "i-0123456789abcdef0".to_string(),
+                        instance_type: "t3.medium".to_string(),
+                        state: "running".to_string(),
+                        availability_zone: "us-east-1a".to_string(),
+                        private_ip: "10.0.1.100".to_string(),
+                        public_ip: Some("54.123.45.67".to_string()),
+                        launch_time: "2025-01-01T10:00:00Z".to_string(),
+                        tags: vec![
+                            Tag {
+                                key: "Name".to_string(),
+                                value: "web-server-01".to_string(),
+                            },
+                            Tag {
+                                key: "Environment".to_string(),
+                                value: "production".to_string(),
+                            },
+                        ],
+                    },
+                    Ec2Instance {
+                        instance_id: "i-0987654321fedcba0".to_string(),
+                        instance_type: "t3.large".to_string(),
+                        state: "running".to_string(),
+                        availability_zone: "us-east-1b".to_string(),
+                        private_ip: "10.0.2.100".to_string(),
+                        public_ip: Some("54.123.45.68".to_string()),
+                        launch_time: "2025-01-01T11:00:00Z".to_string(),
+                        tags: vec![Tag {
+                            key: "Name".to_string(),
+                            value: "api-server-01".to_string(),
+                        }],
+                    },
+                ]
+            }),
+            _ => {
+                // Create initial data
+                let initial = vec![Ec2Instance {
+                    instance_id: "i-0123456789abcdef0".to_string(),
+                    instance_type: "t3.medium".to_string(),
+                    state: "running".to_string(),
+                    availability_zone: "us-east-1a".to_string(),
+                    private_ip: "10.0.1.100".to_string(),
+                    public_ip: Some("54.123.45.67".to_string()),
+                    launch_time: chrono::Utc::now().to_rfc3339(),
+                    tags: vec![Tag {
+                        key: "Name".to_string(),
+                        value: "web-server-01".to_string(),
+                    }],
+                }];
+
+                let content = serde_json::to_string_pretty(&initial).unwrap();
+                let _ = file_store
+                    .write_file(
+                        context.session_id,
+                        "/aws/ec2_instances.json",
+                        &content,
+                        "text",
+                    )
+                    .await;
+
+                initial
+            }
+        };
+
+        // Apply filter
+        let filtered: Vec<_> = if let Some(state) = state_filter {
+            instances.into_iter().filter(|i| i.state == state).collect()
+        } else {
+            instances
+        };
+
+        ToolExecutionResult::success(json!({
+            "instances": filtered,
+            "total_count": filtered.len()
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// Tool: aws_create_ec2_instance
+// ============================================================================
+
+pub struct AwsCreateEc2InstanceTool;
+
+#[async_trait]
+impl Tool for AwsCreateEc2InstanceTool {
+    fn name(&self) -> &str {
+        "aws_create_ec2_instance"
+    }
+
+    fn description(&self) -> &str {
+        "Launch a new EC2 instance with specified configuration."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "instance_type": {
+                    "type": "string",
+                    "description": "Instance type (e.g., 't3.micro', 't3.medium')"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Instance name tag"
+                },
+                "availability_zone": {
+                    "type": "string",
+                    "description": "Availability zone (default: us-east-1a)"
+                }
+            },
+            "required": ["instance_type", "name"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("aws_create_ec2_instance requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let file_store = match &context.file_store {
+            Some(store) => store,
+            None => return ToolExecutionResult::tool_error("File system not available"),
+        };
+
+        let instance_type = match arguments.get("instance_type").and_then(|v| v.as_str()) {
+            Some(t) => t,
+            None => {
+                return ToolExecutionResult::tool_error("Missing required parameter: instance_type")
+            }
+        };
+
+        let name = match arguments.get("name").and_then(|v| v.as_str()) {
+            Some(n) => n,
+            None => return ToolExecutionResult::tool_error("Missing required parameter: name"),
+        };
+
+        let availability_zone = arguments
+            .get("availability_zone")
+            .and_then(|v| v.as_str())
+            .unwrap_or("us-east-1a");
+
+        // Read current instances
+        let mut instances: Vec<Ec2Instance> = match file_store
+            .read_file(context.session_id, "/aws/ec2_instances.json")
+            .await
+        {
+            Ok(Some(file)) => serde_json::from_str(&file.content).unwrap_or_default(),
+            _ => vec![],
+        };
+
+        // Create new instance
+        let instance_id = format!(
+            "i-{:016x}",
+            (chrono::Utc::now().timestamp() as u64) & 0xFFFFFFFFFFFFFFFF
+        );
+        let private_ip = format!("10.0.{}.{}", (instances.len() % 254) + 1, 100);
+        let public_ip = format!(
+            "54.{}.{}.{}",
+            100 + instances.len() % 100,
+            (instances.len() % 254) + 1,
+            100
+        );
+
+        let instance = Ec2Instance {
+            instance_id: instance_id.clone(),
+            instance_type: instance_type.to_string(),
+            state: "running".to_string(),
+            availability_zone: availability_zone.to_string(),
+            private_ip,
+            public_ip: Some(public_ip.clone()),
+            launch_time: chrono::Utc::now().to_rfc3339(),
+            tags: vec![Tag {
+                key: "Name".to_string(),
+                value: name.to_string(),
+            }],
+        };
+
+        instances.push(instance.clone());
+
+        // Save instances
+        let content = serde_json::to_string_pretty(&instances).unwrap();
+        match file_store
+            .write_file(
+                context.session_id,
+                "/aws/ec2_instances.json",
+                &content,
+                "text",
+            )
+            .await
+        {
+            Ok(_) => ToolExecutionResult::success(json!({
+                "instance_id": instance_id,
+                "state": "running",
+                "private_ip": instance.private_ip,
+                "public_ip": public_ip,
+                "message": "EC2 instance launched successfully"
+            })),
+            Err(e) => ToolExecutionResult::internal_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// Tool: aws_stop_ec2_instance
+// ============================================================================
+
+pub struct AwsStopEc2InstanceTool;
+
+#[async_trait]
+impl Tool for AwsStopEc2InstanceTool {
+    fn name(&self) -> &str {
+        "aws_stop_ec2_instance"
+    }
+
+    fn description(&self) -> &str {
+        "Stop a running EC2 instance."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "instance_id": {
+                    "type": "string",
+                    "description": "Instance ID to stop"
+                }
+            },
+            "required": ["instance_id"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("aws_stop_ec2_instance requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let file_store = match &context.file_store {
+            Some(store) => store,
+            None => return ToolExecutionResult::tool_error("File system not available"),
+        };
+
+        let instance_id = match arguments.get("instance_id").and_then(|v| v.as_str()) {
+            Some(id) => id,
+            None => {
+                return ToolExecutionResult::tool_error("Missing required parameter: instance_id")
+            }
+        };
+
+        // Read instances
+        let mut instances: Vec<Ec2Instance> = match file_store
+            .read_file(context.session_id, "/aws/ec2_instances.json")
+            .await
+        {
+            Ok(Some(file)) => serde_json::from_str(&file.content).unwrap_or_default(),
+            _ => vec![],
+        };
+
+        // Find and stop instance
+        let instance = match instances.iter_mut().find(|i| i.instance_id == instance_id) {
+            Some(i) => i,
+            None => {
+                return ToolExecutionResult::tool_error(format!(
+                    "Instance not found: {}",
+                    instance_id
+                ))
+            }
+        };
+
+        let old_state = instance.state.clone();
+        instance.state = "stopped".to_string();
+
+        // Save updated instances
+        let content = serde_json::to_string_pretty(&instances).unwrap();
+        match file_store
+            .write_file(
+                context.session_id,
+                "/aws/ec2_instances.json",
+                &content,
+                "text",
+            )
+            .await
+        {
+            Ok(_) => ToolExecutionResult::success(json!({
+                "instance_id": instance_id,
+                "old_state": old_state,
+                "new_state": "stopped"
+            })),
+            Err(e) => ToolExecutionResult::internal_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// Remaining tools (simplified implementations)
+// ============================================================================
+
+pub struct AwsListRdsDatabasesTool;
+
+#[async_trait]
+impl Tool for AwsListRdsDatabasesTool {
+    fn name(&self) -> &str {
+        "aws_list_rds_databases"
+    }
+
+    fn description(&self) -> &str {
+        "List all RDS database instances."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({"type": "object", "additionalProperties": false})
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        _arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let file_store = match &context.file_store {
+            Some(store) => store,
+            None => return ToolExecutionResult::tool_error("File system not available"),
+        };
+
+        let databases: Vec<RdsDatabase> = match file_store
+            .read_file(context.session_id, "/aws/rds_databases.json")
+            .await
+        {
+            Ok(Some(file)) => serde_json::from_str(&file.content).unwrap_or_else(|_| {
+                vec![RdsDatabase {
+                    db_instance_id: "prod-postgres-01".to_string(),
+                    engine: "postgres".to_string(),
+                    engine_version: "15.4".to_string(),
+                    instance_class: "db.t3.medium".to_string(),
+                    status: "available".to_string(),
+                    endpoint: "prod-postgres-01.abc123.us-east-1.rds.amazonaws.com".to_string(),
+                    port: 5432,
+                    storage_gb: 100,
+                }]
+            }),
+            _ => vec![],
+        };
+
+        ToolExecutionResult::success(
+            json!({"databases": databases, "total_count": databases.len()}),
+        )
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct AwsCreateRdsDatabaseTool;
+
+#[async_trait]
+impl Tool for AwsCreateRdsDatabaseTool {
+    fn name(&self) -> &str {
+        "aws_create_rds_database"
+    }
+
+    fn description(&self) -> &str {
+        "Create a new RDS database instance."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "db_instance_id": {"type": "string"},
+                "engine": {"type": "string", "enum": ["postgres", "mysql", "mariadb"]},
+                "instance_class": {"type": "string"},
+                "storage_gb": {"type": "integer"}
+            },
+            "required": ["db_instance_id", "engine", "instance_class"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        _context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let db_id = arguments
+            .get("db_instance_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+
+        ToolExecutionResult::success(json!({
+            "db_instance_id": db_id,
+            "status": "creating",
+            "message": "RDS database creation initiated"
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct AwsListS3BucketsTool;
+
+#[async_trait]
+impl Tool for AwsListS3BucketsTool {
+    fn name(&self) -> &str {
+        "aws_list_s3_buckets"
+    }
+
+    fn description(&self) -> &str {
+        "List all S3 buckets in the account."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({"type": "object", "additionalProperties": false})
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        _arguments: Value,
+        _context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let buckets = vec![
+            S3Bucket {
+                name: "company-data-backup".to_string(),
+                region: "us-east-1".to_string(),
+                creation_date: "2024-06-01T00:00:00Z".to_string(),
+                versioning_enabled: true,
+                encryption_enabled: true,
+            },
+            S3Bucket {
+                name: "static-assets-prod".to_string(),
+                region: "us-west-2".to_string(),
+                creation_date: "2024-08-15T00:00:00Z".to_string(),
+                versioning_enabled: false,
+                encryption_enabled: true,
+            },
+        ];
+
+        ToolExecutionResult::success(json!({"buckets": buckets, "total_count": buckets.len()}))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct AwsCreateS3BucketTool;
+
+#[async_trait]
+impl Tool for AwsCreateS3BucketTool {
+    fn name(&self) -> &str {
+        "aws_create_s3_bucket"
+    }
+
+    fn description(&self) -> &str {
+        "Create a new S3 bucket."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "bucket_name": {"type": "string"},
+                "region": {"type": "string"},
+                "versioning_enabled": {"type": "boolean"},
+                "encryption_enabled": {"type": "boolean"}
+            },
+            "required": ["bucket_name"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        _context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let bucket_name = arguments
+            .get("bucket_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+
+        ToolExecutionResult::success(json!({
+            "bucket_name": bucket_name,
+            "status": "created",
+            "region": "us-east-1"
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct AwsListIamUsersTool;
+
+#[async_trait]
+impl Tool for AwsListIamUsersTool {
+    fn name(&self) -> &str {
+        "aws_list_iam_users"
+    }
+
+    fn description(&self) -> &str {
+        "List all IAM users in the account."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({"type": "object", "additionalProperties": false})
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        _arguments: Value,
+        _context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let users = vec![
+            IamUser {
+                username: "admin-user".to_string(),
+                user_id: "AIDAI23XYZABC123DEF".to_string(),
+                arn: "arn:aws:iam::123456789012:user/admin-user".to_string(),
+                created_at: "2024-01-15T10:00:00Z".to_string(),
+                permissions: vec!["AdministratorAccess".to_string()],
+            },
+            IamUser {
+                username: "developer-user".to_string(),
+                user_id: "AIDAI23XYZABC456GHI".to_string(),
+                arn: "arn:aws:iam::123456789012:user/developer-user".to_string(),
+                created_at: "2024-02-20T14:30:00Z".to_string(),
+                permissions: vec!["PowerUserAccess".to_string()],
+            },
+        ];
+
+        ToolExecutionResult::success(json!({"users": users, "total_count": users.len()}))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct AwsCreateIamUserTool;
+
+#[async_trait]
+impl Tool for AwsCreateIamUserTool {
+    fn name(&self) -> &str {
+        "aws_create_iam_user"
+    }
+
+    fn description(&self) -> &str {
+        "Create a new IAM user."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "username": {"type": "string"},
+                "permissions": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "List of permission policies"
+                }
+            },
+            "required": ["username"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        _context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let username = arguments
+            .get("username")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+
+        ToolExecutionResult::success(json!({
+            "username": username,
+            "user_id": format!("AIDAI{:016x}", chrono::Utc::now().timestamp()),
+            "status": "created"
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct AwsListSecurityGroupsTool;
+
+#[async_trait]
+impl Tool for AwsListSecurityGroupsTool {
+    fn name(&self) -> &str {
+        "aws_list_security_groups"
+    }
+
+    fn description(&self) -> &str {
+        "List all security groups with their rules."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({"type": "object", "additionalProperties": false})
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        _arguments: Value,
+        _context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let security_groups = vec![SecurityGroup {
+            group_id: "sg-0123456789abcdef0".to_string(),
+            group_name: "web-server-sg".to_string(),
+            description: "Security group for web servers".to_string(),
+            vpc_id: "vpc-abc123".to_string(),
+            inbound_rules: vec![
+                SecurityRule {
+                    protocol: "tcp".to_string(),
+                    port_range: "80".to_string(),
+                    source: "0.0.0.0/0".to_string(),
+                },
+                SecurityRule {
+                    protocol: "tcp".to_string(),
+                    port_range: "443".to_string(),
+                    source: "0.0.0.0/0".to_string(),
+                },
+            ],
+            outbound_rules: vec![SecurityRule {
+                protocol: "-1".to_string(),
+                port_range: "all".to_string(),
+                source: "0.0.0.0/0".to_string(),
+            }],
+        }];
+
+        ToolExecutionResult::success(
+            json!({"security_groups": security_groups, "total_count": security_groups.len()}),
+        )
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct AwsGetCloudWatchMetricsTool;
+
+#[async_trait]
+impl Tool for AwsGetCloudWatchMetricsTool {
+    fn name(&self) -> &str {
+        "aws_get_cloudwatch_metrics"
+    }
+
+    fn description(&self) -> &str {
+        "Get CloudWatch metrics for a resource (CPU, memory, disk, network)."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "resource_id": {"type": "string"},
+                "metric_name": {
+                    "type": "string",
+                    "enum": ["CPUUtilization", "MemoryUtilization", "DiskReadOps", "NetworkIn"],
+                    "description": "Metric to retrieve"
+                },
+                "period_minutes": {
+                    "type": "integer",
+                    "description": "Time period in minutes (default: 60)"
+                }
+            },
+            "required": ["resource_id", "metric_name"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        _context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let resource_id = arguments
+            .get("resource_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+        let metric_name = arguments
+            .get("metric_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("CPUUtilization");
+
+        // Generate mock metric data
+        let datapoints: Vec<Value> = (0..12)
+            .map(|i| {
+                json!({
+                    "timestamp": chrono::Utc::now() - chrono::Duration::minutes(i * 5),
+                    "average": 30.0 + (i as f64 * 2.5),
+                    "minimum": 20.0,
+                    "maximum": 80.0
+                })
+            })
+            .collect();
+
+        ToolExecutionResult::success(json!({
+            "resource_id": resource_id,
+            "metric_name": metric_name,
+            "datapoints": datapoints,
+            "period": "5 minutes"
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}

--- a/crates/core/src/capabilities/fake_crm.rs
+++ b/crates/core/src/capabilities/fake_crm.rs
@@ -1,0 +1,829 @@
+//! Fake CRM Tools Capability - demo tools for customer relationship management
+//!
+//! This capability provides mock CRM tools that store state
+//! in the session file system. Perfect for demos and testing customer support workflows.
+//!
+//! Tools provided:
+//! - `crm_list_customers`: List customers
+//! - `crm_get_customer`: Get customer details
+//! - `crm_create_customer`: Create a new customer
+//! - `crm_list_tickets`: List support tickets
+//! - `crm_create_ticket`: Create a new support ticket
+//! - `crm_update_ticket`: Update ticket status
+//! - `crm_add_interaction`: Add customer interaction note
+//! - `crm_search_customers`: Search customers by criteria
+
+use super::{Capability, CapabilityId, CapabilityStatus};
+use crate::tools::{Tool, ToolExecutionResult};
+use crate::traits::ToolContext;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+/// Fake CRM Tools capability - mock customer relationship management for demos
+pub struct FakeCrmCapability;
+
+impl Capability for FakeCrmCapability {
+    fn id(&self) -> &str {
+        CapabilityId::FAKE_CRM
+    }
+
+    fn name(&self) -> &str {
+        "Fake CRM Tools"
+    }
+
+    fn description(&self) -> &str {
+        "Demo capability: CRM and customer support tools (customers, tickets, interactions). State stored in session filesystem."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("users")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Demo Tools")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(
+            r#"You have access to CRM and customer support tools. All CRM data is stored in /crm/ directory.
+
+Available tools:
+- `crm_list_customers`: List all customers with pagination
+- `crm_get_customer`: Get detailed customer information by ID
+- `crm_create_customer`: Create a new customer record
+- `crm_list_tickets`: List support tickets (filter by status/priority)
+- `crm_create_ticket`: Create a new support ticket
+- `crm_update_ticket`: Update ticket status and assign to agents
+- `crm_add_interaction`: Add a customer interaction note (call, email, meeting)
+- `crm_search_customers`: Search customers by name, email, or company
+
+Data structure:
+- /crm/customers.json - Customer records
+- /crm/tickets.json - Support ticket records
+- /crm/interactions.json - Customer interaction history"#,
+        )
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(CrmListCustomersTool),
+            Box::new(CrmGetCustomerTool),
+            Box::new(CrmCreateCustomerTool),
+            Box::new(CrmListTicketsTool),
+            Box::new(CrmCreateTicketTool),
+            Box::new(CrmUpdateTicketTool),
+            Box::new(CrmAddInteractionTool),
+            Box::new(CrmSearchCustomersTool),
+        ]
+    }
+}
+
+// Helper structs for CRM data
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Customer {
+    id: String,
+    name: String,
+    email: String,
+    company: String,
+    phone: String,
+    tier: String, // free, pro, enterprise
+    created_at: String,
+    last_contact: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Ticket {
+    id: String,
+    customer_id: String,
+    subject: String,
+    description: String,
+    status: String,   // open, in_progress, resolved, closed
+    priority: String, // low, medium, high, urgent
+    assigned_to: Option<String>,
+    created_at: String,
+    updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Interaction {
+    id: String,
+    customer_id: String,
+    interaction_type: String, // call, email, meeting, chat
+    summary: String,
+    agent: String,
+    timestamp: String,
+}
+
+// ============================================================================
+// Tool: crm_list_customers
+// ============================================================================
+
+pub struct CrmListCustomersTool;
+
+#[async_trait]
+impl Tool for CrmListCustomersTool {
+    fn name(&self) -> &str {
+        "crm_list_customers"
+    }
+
+    fn description(&self) -> &str {
+        "List all customers. Optionally filter by customer tier."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "tier": {
+                    "type": "string",
+                    "enum": ["free", "pro", "enterprise"],
+                    "description": "Optional: Filter by customer tier"
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("crm_list_customers requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let file_store = match &context.file_store {
+            Some(store) => store,
+            None => return ToolExecutionResult::tool_error("File system not available"),
+        };
+
+        let tier_filter = arguments.get("tier").and_then(|v| v.as_str());
+
+        // Read customers
+        let customers: Vec<Customer> = match file_store
+            .read_file(context.session_id, "/crm/customers.json")
+            .await
+        {
+            Ok(Some(file)) => serde_json::from_str(&file.content).unwrap_or_else(|_| {
+                // Initialize with sample data
+                vec![
+                    Customer {
+                        id: "CUST-001".to_string(),
+                        name: "Alice Johnson".to_string(),
+                        email: "alice@acmecorp.com".to_string(),
+                        company: "Acme Corp".to_string(),
+                        phone: "+1-555-0101".to_string(),
+                        tier: "enterprise".to_string(),
+                        created_at: "2024-01-15T10:00:00Z".to_string(),
+                        last_contact: "2025-01-05T14:30:00Z".to_string(),
+                    },
+                    Customer {
+                        id: "CUST-002".to_string(),
+                        name: "Bob Smith".to_string(),
+                        email: "bob@techstart.io".to_string(),
+                        company: "TechStart Inc".to_string(),
+                        phone: "+1-555-0102".to_string(),
+                        tier: "pro".to_string(),
+                        created_at: "2024-03-20T09:00:00Z".to_string(),
+                        last_contact: "2025-01-03T11:15:00Z".to_string(),
+                    },
+                ]
+            }),
+            _ => {
+                let initial = vec![Customer {
+                    id: "CUST-001".to_string(),
+                    name: "Alice Johnson".to_string(),
+                    email: "alice@acmecorp.com".to_string(),
+                    company: "Acme Corp".to_string(),
+                    phone: "+1-555-0101".to_string(),
+                    tier: "enterprise".to_string(),
+                    created_at: chrono::Utc::now().to_rfc3339(),
+                    last_contact: chrono::Utc::now().to_rfc3339(),
+                }];
+
+                let content = serde_json::to_string_pretty(&initial).unwrap();
+                let _ = file_store
+                    .write_file(context.session_id, "/crm/customers.json", &content, "text")
+                    .await;
+
+                initial
+            }
+        };
+
+        // Apply filter
+        let filtered: Vec<_> = if let Some(tier) = tier_filter {
+            customers.into_iter().filter(|c| c.tier == tier).collect()
+        } else {
+            customers
+        };
+
+        ToolExecutionResult::success(json!({
+            "customers": filtered,
+            "total_count": filtered.len()
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// Tool: crm_get_customer
+// ============================================================================
+
+pub struct CrmGetCustomerTool;
+
+#[async_trait]
+impl Tool for CrmGetCustomerTool {
+    fn name(&self) -> &str {
+        "crm_get_customer"
+    }
+
+    fn description(&self) -> &str {
+        "Get detailed customer information by customer ID."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "customer_id": {
+                    "type": "string",
+                    "description": "Customer ID to retrieve"
+                }
+            },
+            "required": ["customer_id"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("crm_get_customer requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let file_store = match &context.file_store {
+            Some(store) => store,
+            None => return ToolExecutionResult::tool_error("File system not available"),
+        };
+
+        let customer_id = match arguments.get("customer_id").and_then(|v| v.as_str()) {
+            Some(id) => id,
+            None => {
+                return ToolExecutionResult::tool_error("Missing required parameter: customer_id")
+            }
+        };
+
+        // Read customers
+        let customers: Vec<Customer> = match file_store
+            .read_file(context.session_id, "/crm/customers.json")
+            .await
+        {
+            Ok(Some(file)) => serde_json::from_str(&file.content).unwrap_or_default(),
+            _ => vec![],
+        };
+
+        // Find customer
+        match customers.iter().find(|c| c.id == customer_id) {
+            Some(customer) => ToolExecutionResult::success(json!({"customer": customer})),
+            None => ToolExecutionResult::tool_error(format!("Customer not found: {}", customer_id)),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// Tool: crm_create_customer
+// ============================================================================
+
+pub struct CrmCreateCustomerTool;
+
+#[async_trait]
+impl Tool for CrmCreateCustomerTool {
+    fn name(&self) -> &str {
+        "crm_create_customer"
+    }
+
+    fn description(&self) -> &str {
+        "Create a new customer record in the CRM."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "email": {"type": "string"},
+                "company": {"type": "string"},
+                "phone": {"type": "string"},
+                "tier": {
+                    "type": "string",
+                    "enum": ["free", "pro", "enterprise"],
+                    "default": "free"
+                }
+            },
+            "required": ["name", "email"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("crm_create_customer requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let file_store = match &context.file_store {
+            Some(store) => store,
+            None => return ToolExecutionResult::tool_error("File system not available"),
+        };
+
+        let name = match arguments.get("name").and_then(|v| v.as_str()) {
+            Some(n) => n,
+            None => return ToolExecutionResult::tool_error("Missing required parameter: name"),
+        };
+
+        let email = match arguments.get("email").and_then(|v| v.as_str()) {
+            Some(e) => e,
+            None => return ToolExecutionResult::tool_error("Missing required parameter: email"),
+        };
+
+        let company = arguments
+            .get("company")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let phone = arguments
+            .get("phone")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let tier = arguments
+            .get("tier")
+            .and_then(|v| v.as_str())
+            .unwrap_or("free");
+
+        // Read current customers
+        let mut customers: Vec<Customer> = match file_store
+            .read_file(context.session_id, "/crm/customers.json")
+            .await
+        {
+            Ok(Some(file)) => serde_json::from_str(&file.content).unwrap_or_default(),
+            _ => vec![],
+        };
+
+        // Create new customer
+        let customer_id = format!("CUST-{:03}", customers.len() + 1);
+        let now = chrono::Utc::now().to_rfc3339();
+
+        let customer = Customer {
+            id: customer_id.clone(),
+            name: name.to_string(),
+            email: email.to_string(),
+            company: company.to_string(),
+            phone: phone.to_string(),
+            tier: tier.to_string(),
+            created_at: now.clone(),
+            last_contact: now,
+        };
+
+        customers.push(customer.clone());
+
+        // Save customers
+        let content = serde_json::to_string_pretty(&customers).unwrap();
+        match file_store
+            .write_file(context.session_id, "/crm/customers.json", &content, "text")
+            .await
+        {
+            Ok(_) => ToolExecutionResult::success(json!({
+                "customer_id": customer_id,
+                "customer": customer
+            })),
+            Err(e) => ToolExecutionResult::internal_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// Tool: crm_list_tickets
+// ============================================================================
+
+pub struct CrmListTicketsTool;
+
+#[async_trait]
+impl Tool for CrmListTicketsTool {
+    fn name(&self) -> &str {
+        "crm_list_tickets"
+    }
+
+    fn description(&self) -> &str {
+        "List support tickets. Filter by status or priority."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "enum": ["open", "in_progress", "resolved", "closed"]
+                },
+                "priority": {
+                    "type": "string",
+                    "enum": ["low", "medium", "high", "urgent"]
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("crm_list_tickets requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let file_store = match &context.file_store {
+            Some(store) => store,
+            None => return ToolExecutionResult::tool_error("File system not available"),
+        };
+
+        let status_filter = arguments.get("status").and_then(|v| v.as_str());
+        let priority_filter = arguments.get("priority").and_then(|v| v.as_str());
+
+        // Read tickets
+        let tickets: Vec<Ticket> = match file_store
+            .read_file(context.session_id, "/crm/tickets.json")
+            .await
+        {
+            Ok(Some(file)) => serde_json::from_str(&file.content).unwrap_or_default(),
+            _ => vec![],
+        };
+
+        // Apply filters
+        let mut filtered = tickets;
+        if let Some(status) = status_filter {
+            filtered.retain(|t| t.status == status);
+        }
+        if let Some(priority) = priority_filter {
+            filtered.retain(|t| t.priority == priority);
+        }
+
+        ToolExecutionResult::success(json!({
+            "tickets": filtered,
+            "total_count": filtered.len()
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// Tool: crm_create_ticket
+// ============================================================================
+
+pub struct CrmCreateTicketTool;
+
+#[async_trait]
+impl Tool for CrmCreateTicketTool {
+    fn name(&self) -> &str {
+        "crm_create_ticket"
+    }
+
+    fn description(&self) -> &str {
+        "Create a new support ticket for a customer."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "customer_id": {"type": "string"},
+                "subject": {"type": "string"},
+                "description": {"type": "string"},
+                "priority": {
+                    "type": "string",
+                    "enum": ["low", "medium", "high", "urgent"],
+                    "default": "medium"
+                }
+            },
+            "required": ["customer_id", "subject", "description"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("crm_create_ticket requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let file_store = match &context.file_store {
+            Some(store) => store,
+            None => return ToolExecutionResult::tool_error("File system not available"),
+        };
+
+        let customer_id = match arguments.get("customer_id").and_then(|v| v.as_str()) {
+            Some(id) => id,
+            None => {
+                return ToolExecutionResult::tool_error("Missing required parameter: customer_id")
+            }
+        };
+
+        let subject = match arguments.get("subject").and_then(|v| v.as_str()) {
+            Some(s) => s,
+            None => return ToolExecutionResult::tool_error("Missing required parameter: subject"),
+        };
+
+        let description = match arguments.get("description").and_then(|v| v.as_str()) {
+            Some(d) => d,
+            None => {
+                return ToolExecutionResult::tool_error("Missing required parameter: description")
+            }
+        };
+
+        let priority = arguments
+            .get("priority")
+            .and_then(|v| v.as_str())
+            .unwrap_or("medium");
+
+        // Read current tickets
+        let mut tickets: Vec<Ticket> = match file_store
+            .read_file(context.session_id, "/crm/tickets.json")
+            .await
+        {
+            Ok(Some(file)) => serde_json::from_str(&file.content).unwrap_or_default(),
+            _ => vec![],
+        };
+
+        // Create new ticket
+        let ticket_id = format!("TKT-{:05}", tickets.len() + 1);
+        let now = chrono::Utc::now().to_rfc3339();
+
+        let ticket = Ticket {
+            id: ticket_id.clone(),
+            customer_id: customer_id.to_string(),
+            subject: subject.to_string(),
+            description: description.to_string(),
+            status: "open".to_string(),
+            priority: priority.to_string(),
+            assigned_to: None,
+            created_at: now.clone(),
+            updated_at: now,
+        };
+
+        tickets.push(ticket.clone());
+
+        // Save tickets
+        let content = serde_json::to_string_pretty(&tickets).unwrap();
+        match file_store
+            .write_file(context.session_id, "/crm/tickets.json", &content, "text")
+            .await
+        {
+            Ok(_) => ToolExecutionResult::success(json!({
+                "ticket_id": ticket_id,
+                "status": "open",
+                "priority": priority
+            })),
+            Err(e) => ToolExecutionResult::internal_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// Remaining tools (simplified implementations)
+// ============================================================================
+
+pub struct CrmUpdateTicketTool;
+
+#[async_trait]
+impl Tool for CrmUpdateTicketTool {
+    fn name(&self) -> &str {
+        "crm_update_ticket"
+    }
+
+    fn description(&self) -> &str {
+        "Update ticket status or assignment."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "ticket_id": {"type": "string"},
+                "status": {"type": "string", "enum": ["open", "in_progress", "resolved", "closed"]},
+                "assigned_to": {"type": "string"}
+            },
+            "required": ["ticket_id"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let file_store = match &context.file_store {
+            Some(store) => store,
+            None => return ToolExecutionResult::tool_error("File system not available"),
+        };
+
+        let ticket_id = arguments
+            .get("ticket_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+
+        let new_status = arguments.get("status").and_then(|v| v.as_str());
+        let assigned_to = arguments.get("assigned_to").and_then(|v| v.as_str());
+
+        // Read tickets
+        let mut tickets: Vec<Ticket> = match file_store
+            .read_file(context.session_id, "/crm/tickets.json")
+            .await
+        {
+            Ok(Some(file)) => serde_json::from_str(&file.content).unwrap_or_default(),
+            _ => vec![],
+        };
+
+        // Find and update ticket
+        if let Some(ticket) = tickets.iter_mut().find(|t| t.id == ticket_id) {
+            if let Some(status) = new_status {
+                ticket.status = status.to_string();
+            }
+            if let Some(agent) = assigned_to {
+                ticket.assigned_to = Some(agent.to_string());
+            }
+            ticket.updated_at = chrono::Utc::now().to_rfc3339();
+
+            let content = serde_json::to_string_pretty(&tickets).unwrap();
+            let _ = file_store
+                .write_file(context.session_id, "/crm/tickets.json", &content, "text")
+                .await;
+
+            ToolExecutionResult::success(json!({"ticket_id": ticket_id, "status": ticket.status}))
+        } else {
+            ToolExecutionResult::tool_error(format!("Ticket not found: {}", ticket_id))
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct CrmAddInteractionTool;
+
+#[async_trait]
+impl Tool for CrmAddInteractionTool {
+    fn name(&self) -> &str {
+        "crm_add_interaction"
+    }
+
+    fn description(&self) -> &str {
+        "Add a customer interaction note (call, email, meeting, chat)."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "customer_id": {"type": "string"},
+                "interaction_type": {"type": "string", "enum": ["call", "email", "meeting", "chat"]},
+                "summary": {"type": "string"},
+                "agent": {"type": "string"}
+            },
+            "required": ["customer_id", "interaction_type", "summary", "agent"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let interaction_id = format!("INT-{:05}", chrono::Utc::now().timestamp() % 100000);
+
+        ToolExecutionResult::success(json!({
+            "interaction_id": interaction_id,
+            "status": "recorded"
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct CrmSearchCustomersTool;
+
+#[async_trait]
+impl Tool for CrmSearchCustomersTool {
+    fn name(&self) -> &str {
+        "crm_search_customers"
+    }
+
+    fn description(&self) -> &str {
+        "Search customers by name, email, or company."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Search query"}
+            },
+            "required": ["query"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let file_store = match &context.file_store {
+            Some(store) => store,
+            None => return ToolExecutionResult::tool_error("File system not available"),
+        };
+
+        let query = arguments
+            .get("query")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_lowercase();
+
+        // Read customers
+        let customers: Vec<Customer> = match file_store
+            .read_file(context.session_id, "/crm/customers.json")
+            .await
+        {
+            Ok(Some(file)) => serde_json::from_str(&file.content).unwrap_or_default(),
+            _ => vec![],
+        };
+
+        // Search
+        let results: Vec<_> = customers
+            .into_iter()
+            .filter(|c| {
+                c.name.to_lowercase().contains(&query)
+                    || c.email.to_lowercase().contains(&query)
+                    || c.company.to_lowercase().contains(&query)
+            })
+            .collect();
+
+        ToolExecutionResult::success(json!({
+            "results": results,
+            "count": results.len()
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}

--- a/crates/core/src/capabilities/fake_financial.rs
+++ b/crates/core/src/capabilities/fake_financial.rs
@@ -1,0 +1,737 @@
+//! Fake Financial Tools Capability - demo tools for financial analysis
+//!
+//! This capability provides mock financial management tools that store state
+//! in the session file system. Perfect for demos and testing financial workflows.
+//!
+//! Tools provided:
+//! - `finance_list_transactions`: List financial transactions
+//! - `finance_create_transaction`: Record a new transaction
+//! - `finance_get_balance`: Get account balances
+//! - `finance_list_budgets`: List budgets
+//! - `finance_create_budget`: Create a new budget
+//! - `finance_get_expense_report`: Generate expense report
+//! - `finance_get_revenue_report`: Generate revenue report
+//! - `finance_forecast_cash_flow`: Forecast cash flow
+
+use super::{Capability, CapabilityId, CapabilityStatus};
+use crate::tools::{Tool, ToolExecutionResult};
+use crate::traits::ToolContext;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+/// Fake Financial Tools capability - mock financial management for demos
+pub struct FakeFinancialCapability;
+
+impl Capability for FakeFinancialCapability {
+    fn id(&self) -> &str {
+        CapabilityId::FAKE_FINANCIAL
+    }
+
+    fn name(&self) -> &str {
+        "Fake Financial Tools"
+    }
+
+    fn description(&self) -> &str {
+        "Demo capability: financial management tools (transactions, budgets, reports, forecasting). State stored in session filesystem."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("dollar-sign")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Demo Tools")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(
+            r#"You have access to financial management tools. All financial data is stored in /finance/ directory.
+
+Available tools:
+- `finance_list_transactions`: List financial transactions (filter by type/category)
+- `finance_create_transaction`: Record a new transaction (income/expense)
+- `finance_get_balance`: Get current account balances
+- `finance_list_budgets`: List budgets by category
+- `finance_create_budget`: Create or update a budget
+- `finance_get_expense_report`: Generate expense report by period
+- `finance_get_revenue_report`: Generate revenue report by period
+- `finance_forecast_cash_flow`: Forecast cash flow for upcoming months
+
+Data structure:
+- /finance/transactions.json - Transaction records
+- /finance/budgets.json - Budget definitions
+- /finance/accounts.json - Account balances"#,
+        )
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(FinanceListTransactionsTool),
+            Box::new(FinanceCreateTransactionTool),
+            Box::new(FinanceGetBalanceTool),
+            Box::new(FinanceListBudgetsTool),
+            Box::new(FinanceCreateBudgetTool),
+            Box::new(FinanceGetExpenseReportTool),
+            Box::new(FinanceGetRevenueReportTool),
+            Box::new(FinanceForecastCashFlowTool),
+        ]
+    }
+}
+
+// Helper structs for financial data
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Transaction {
+    id: String,
+    date: String,
+    transaction_type: String, // income, expense
+    category: String,
+    amount: f64,
+    description: String,
+    account: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Budget {
+    category: String,
+    monthly_limit: f64,
+    current_spent: f64,
+    period_start: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Account {
+    name: String,
+    balance: f64,
+    currency: String,
+}
+
+// ============================================================================
+// Tool: finance_list_transactions
+// ============================================================================
+
+pub struct FinanceListTransactionsTool;
+
+#[async_trait]
+impl Tool for FinanceListTransactionsTool {
+    fn name(&self) -> &str {
+        "finance_list_transactions"
+    }
+
+    fn description(&self) -> &str {
+        "List financial transactions. Filter by type (income/expense) or category."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "transaction_type": {
+                    "type": "string",
+                    "enum": ["income", "expense"],
+                    "description": "Optional: Filter by transaction type"
+                },
+                "category": {
+                    "type": "string",
+                    "description": "Optional: Filter by category"
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("finance_list_transactions requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let file_store = match &context.file_store {
+            Some(store) => store,
+            None => return ToolExecutionResult::tool_error("File system not available"),
+        };
+
+        let type_filter = arguments.get("transaction_type").and_then(|v| v.as_str());
+        let category_filter = arguments.get("category").and_then(|v| v.as_str());
+
+        // Read transactions
+        let transactions: Vec<Transaction> = match file_store
+            .read_file(context.session_id, "/finance/transactions.json")
+            .await
+        {
+            Ok(Some(file)) => serde_json::from_str(&file.content).unwrap_or_else(|_| {
+                // Initialize with sample data
+                vec![
+                    Transaction {
+                        id: "TXN-001".to_string(),
+                        date: "2025-01-05".to_string(),
+                        transaction_type: "income".to_string(),
+                        category: "sales".to_string(),
+                        amount: 15000.0,
+                        description: "Q1 Product Sales".to_string(),
+                        account: "operating".to_string(),
+                    },
+                    Transaction {
+                        id: "TXN-002".to_string(),
+                        date: "2025-01-06".to_string(),
+                        transaction_type: "expense".to_string(),
+                        category: "payroll".to_string(),
+                        amount: 8500.0,
+                        description: "January Payroll".to_string(),
+                        account: "operating".to_string(),
+                    },
+                ]
+            }),
+            _ => {
+                let initial = vec![Transaction {
+                    id: "TXN-001".to_string(),
+                    date: chrono::Utc::now().format("%Y-%m-%d").to_string(),
+                    transaction_type: "income".to_string(),
+                    category: "sales".to_string(),
+                    amount: 15000.0,
+                    description: "Initial Sale".to_string(),
+                    account: "operating".to_string(),
+                }];
+
+                let content = serde_json::to_string_pretty(&initial).unwrap();
+                let _ = file_store
+                    .write_file(
+                        context.session_id,
+                        "/finance/transactions.json",
+                        &content,
+                        "text",
+                    )
+                    .await;
+
+                initial
+            }
+        };
+
+        // Apply filters
+        let mut filtered = transactions;
+        if let Some(tx_type) = type_filter {
+            filtered.retain(|t| t.transaction_type == tx_type);
+        }
+        if let Some(category) = category_filter {
+            filtered.retain(|t| t.category == category);
+        }
+
+        let total: f64 = filtered.iter().map(|t| t.amount).sum();
+
+        ToolExecutionResult::success(json!({
+            "transactions": filtered,
+            "total_count": filtered.len(),
+            "total_amount": total
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// Tool: finance_create_transaction
+// ============================================================================
+
+pub struct FinanceCreateTransactionTool;
+
+#[async_trait]
+impl Tool for FinanceCreateTransactionTool {
+    fn name(&self) -> &str {
+        "finance_create_transaction"
+    }
+
+    fn description(&self) -> &str {
+        "Record a new financial transaction (income or expense)."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "transaction_type": {
+                    "type": "string",
+                    "enum": ["income", "expense"]
+                },
+                "category": {"type": "string"},
+                "amount": {"type": "number", "minimum": 0},
+                "description": {"type": "string"},
+                "account": {"type": "string", "default": "operating"}
+            },
+            "required": ["transaction_type", "category", "amount", "description"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("finance_create_transaction requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let file_store = match &context.file_store {
+            Some(store) => store,
+            None => return ToolExecutionResult::tool_error("File system not available"),
+        };
+
+        let transaction_type = match arguments.get("transaction_type").and_then(|v| v.as_str()) {
+            Some(t) => t,
+            None => {
+                return ToolExecutionResult::tool_error(
+                    "Missing required parameter: transaction_type",
+                )
+            }
+        };
+
+        let category = match arguments.get("category").and_then(|v| v.as_str()) {
+            Some(c) => c,
+            None => return ToolExecutionResult::tool_error("Missing required parameter: category"),
+        };
+
+        let amount = match arguments.get("amount").and_then(|v| v.as_f64()) {
+            Some(a) => a,
+            None => return ToolExecutionResult::tool_error("Missing required parameter: amount"),
+        };
+
+        let description = match arguments.get("description").and_then(|v| v.as_str()) {
+            Some(d) => d,
+            None => {
+                return ToolExecutionResult::tool_error("Missing required parameter: description")
+            }
+        };
+
+        let account = arguments
+            .get("account")
+            .and_then(|v| v.as_str())
+            .unwrap_or("operating");
+
+        // Read current transactions
+        let mut transactions: Vec<Transaction> = match file_store
+            .read_file(context.session_id, "/finance/transactions.json")
+            .await
+        {
+            Ok(Some(file)) => serde_json::from_str(&file.content).unwrap_or_default(),
+            _ => vec![],
+        };
+
+        // Create new transaction
+        let transaction_id = format!("TXN-{:03}", transactions.len() + 1);
+        let date = chrono::Utc::now().format("%Y-%m-%d").to_string();
+
+        let transaction = Transaction {
+            id: transaction_id.clone(),
+            date: date.clone(),
+            transaction_type: transaction_type.to_string(),
+            category: category.to_string(),
+            amount,
+            description: description.to_string(),
+            account: account.to_string(),
+        };
+
+        transactions.push(transaction.clone());
+
+        // Save transactions
+        let content = serde_json::to_string_pretty(&transactions).unwrap();
+        match file_store
+            .write_file(
+                context.session_id,
+                "/finance/transactions.json",
+                &content,
+                "text",
+            )
+            .await
+        {
+            Ok(_) => ToolExecutionResult::success(json!({
+                "transaction_id": transaction_id,
+                "amount": amount,
+                "type": transaction_type,
+                "date": date
+            })),
+            Err(e) => ToolExecutionResult::internal_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// Tool: finance_get_balance
+// ============================================================================
+
+pub struct FinanceGetBalanceTool;
+
+#[async_trait]
+impl Tool for FinanceGetBalanceTool {
+    fn name(&self) -> &str {
+        "finance_get_balance"
+    }
+
+    fn description(&self) -> &str {
+        "Get current account balances."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "account": {
+                    "type": "string",
+                    "description": "Optional: Get balance for specific account"
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("finance_get_balance requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        _context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let account_filter = arguments.get("account").and_then(|v| v.as_str());
+
+        let accounts = vec![
+            Account {
+                name: "operating".to_string(),
+                balance: 125000.0,
+                currency: "USD".to_string(),
+            },
+            Account {
+                name: "savings".to_string(),
+                balance: 50000.0,
+                currency: "USD".to_string(),
+            },
+            Account {
+                name: "payroll".to_string(),
+                balance: 75000.0,
+                currency: "USD".to_string(),
+            },
+        ];
+
+        let filtered: Vec<_> = if let Some(account) = account_filter {
+            accounts.into_iter().filter(|a| a.name == account).collect()
+        } else {
+            accounts
+        };
+
+        let total_balance: f64 = filtered.iter().map(|a| a.balance).sum();
+
+        ToolExecutionResult::success(json!({
+            "accounts": filtered,
+            "total_balance": total_balance,
+            "currency": "USD"
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// Remaining tools (simplified implementations)
+// ============================================================================
+
+pub struct FinanceListBudgetsTool;
+
+#[async_trait]
+impl Tool for FinanceListBudgetsTool {
+    fn name(&self) -> &str {
+        "finance_list_budgets"
+    }
+
+    fn description(&self) -> &str {
+        "List all budgets by category."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({"type": "object", "additionalProperties": false})
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        _arguments: Value,
+        _context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let budgets = vec![
+            Budget {
+                category: "payroll".to_string(),
+                monthly_limit: 50000.0,
+                current_spent: 38500.0,
+                period_start: "2025-01-01".to_string(),
+            },
+            Budget {
+                category: "marketing".to_string(),
+                monthly_limit: 15000.0,
+                current_spent: 8200.0,
+                period_start: "2025-01-01".to_string(),
+            },
+        ];
+
+        ToolExecutionResult::success(json!({"budgets": budgets, "total_count": budgets.len()}))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct FinanceCreateBudgetTool;
+
+#[async_trait]
+impl Tool for FinanceCreateBudgetTool {
+    fn name(&self) -> &str {
+        "finance_create_budget"
+    }
+
+    fn description(&self) -> &str {
+        "Create or update a budget for a category."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "category": {"type": "string"},
+                "monthly_limit": {"type": "number", "minimum": 0}
+            },
+            "required": ["category", "monthly_limit"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        _context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let category = arguments
+            .get("category")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+        let monthly_limit = arguments
+            .get("monthly_limit")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0);
+
+        ToolExecutionResult::success(json!({
+            "category": category,
+            "monthly_limit": monthly_limit,
+            "status": "created"
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct FinanceGetExpenseReportTool;
+
+#[async_trait]
+impl Tool for FinanceGetExpenseReportTool {
+    fn name(&self) -> &str {
+        "finance_get_expense_report"
+    }
+
+    fn description(&self) -> &str {
+        "Generate expense report for a time period, broken down by category."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "period": {
+                    "type": "string",
+                    "enum": ["current_month", "last_month", "quarter", "year"],
+                    "default": "current_month"
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        _context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let period = arguments
+            .get("period")
+            .and_then(|v| v.as_str())
+            .unwrap_or("current_month");
+
+        let expense_breakdown = json!([
+            {"category": "payroll", "amount": 85000.0, "percentage": 60.0},
+            {"category": "marketing", "amount": 25000.0, "percentage": 18.0},
+            {"category": "operations", "amount": 20000.0, "percentage": 14.0},
+            {"category": "other", "amount": 11500.0, "percentage": 8.0}
+        ]);
+
+        ToolExecutionResult::success(json!({
+            "period": period,
+            "total_expenses": 141500.0,
+            "breakdown": expense_breakdown,
+            "top_category": "payroll"
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct FinanceGetRevenueReportTool;
+
+#[async_trait]
+impl Tool for FinanceGetRevenueReportTool {
+    fn name(&self) -> &str {
+        "finance_get_revenue_report"
+    }
+
+    fn description(&self) -> &str {
+        "Generate revenue report for a time period."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "period": {
+                    "type": "string",
+                    "enum": ["current_month", "last_month", "quarter", "year"],
+                    "default": "current_month"
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        _context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let period = arguments
+            .get("period")
+            .and_then(|v| v.as_str())
+            .unwrap_or("current_month");
+
+        let revenue_breakdown = json!([
+            {"source": "product_sales", "amount": 150000.0, "percentage": 75.0},
+            {"source": "subscriptions", "amount": 35000.0, "percentage": 17.5},
+            {"source": "services", "amount": 15000.0, "percentage": 7.5}
+        ]);
+
+        ToolExecutionResult::success(json!({
+            "period": period,
+            "total_revenue": 200000.0,
+            "breakdown": revenue_breakdown,
+            "growth_vs_last_period": 12.5
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct FinanceForecastCashFlowTool;
+
+#[async_trait]
+impl Tool for FinanceForecastCashFlowTool {
+    fn name(&self) -> &str {
+        "finance_forecast_cash_flow"
+    }
+
+    fn description(&self) -> &str {
+        "Forecast cash flow for the next 3-6 months based on historical data."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "months": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 12,
+                    "default": 3,
+                    "description": "Number of months to forecast"
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        _context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let months = arguments
+            .get("months")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(3) as i32;
+
+        let forecast: Vec<Value> = (1..=months)
+            .map(|m| {
+                json!({
+                    "month": m,
+                    "projected_revenue": 200000.0 + (m as f64 * 5000.0),
+                    "projected_expenses": 140000.0 + (m as f64 * 2000.0),
+                    "net_cash_flow": 60000.0 + (m as f64 * 3000.0),
+                    "ending_balance": 125000.0 + (m as f64 * 60000.0)
+                })
+            })
+            .collect();
+
+        ToolExecutionResult::success(json!({
+            "forecast_months": months,
+            "forecast": forecast,
+            "assumptions": "Based on 10% monthly growth"
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}

--- a/crates/core/src/capabilities/fake_financial.rs
+++ b/crates/core/src/capabilities/fake_financial.rs
@@ -166,29 +166,30 @@ impl Tool for FinanceListTransactionsTool {
             .read_file(context.session_id, "/finance/transactions.json")
             .await
         {
-            Ok(Some(file)) => serde_json::from_str(&file.content).unwrap_or_else(|_| {
-                // Initialize with sample data
-                vec![
-                    Transaction {
-                        id: "TXN-001".to_string(),
-                        date: "2025-01-05".to_string(),
-                        transaction_type: "income".to_string(),
-                        category: "sales".to_string(),
-                        amount: 15000.0,
-                        description: "Q1 Product Sales".to_string(),
-                        account: "operating".to_string(),
-                    },
-                    Transaction {
-                        id: "TXN-002".to_string(),
-                        date: "2025-01-06".to_string(),
-                        transaction_type: "expense".to_string(),
-                        category: "payroll".to_string(),
-                        amount: 8500.0,
-                        description: "January Payroll".to_string(),
-                        account: "operating".to_string(),
-                    },
-                ]
-            }),
+            Ok(Some(file)) => serde_json::from_str(file.content.as_deref().unwrap_or(""))
+                .unwrap_or_else(|_| {
+                    // Initialize with sample data
+                    vec![
+                        Transaction {
+                            id: "TXN-001".to_string(),
+                            date: "2025-01-05".to_string(),
+                            transaction_type: "income".to_string(),
+                            category: "sales".to_string(),
+                            amount: 15000.0,
+                            description: "Q1 Product Sales".to_string(),
+                            account: "operating".to_string(),
+                        },
+                        Transaction {
+                            id: "TXN-002".to_string(),
+                            date: "2025-01-06".to_string(),
+                            transaction_type: "expense".to_string(),
+                            category: "payroll".to_string(),
+                            amount: 8500.0,
+                            description: "January Payroll".to_string(),
+                            account: "operating".to_string(),
+                        },
+                    ]
+                }),
             _ => {
                 let initial = vec![Transaction {
                     id: "TXN-001".to_string(),
@@ -321,7 +322,9 @@ impl Tool for FinanceCreateTransactionTool {
             .read_file(context.session_id, "/finance/transactions.json")
             .await
         {
-            Ok(Some(file)) => serde_json::from_str(&file.content).unwrap_or_default(),
+            Ok(Some(file)) => {
+                serde_json::from_str(file.content.as_deref().unwrap_or("")).unwrap_or_default()
+            }
             _ => vec![],
         };
 

--- a/crates/core/src/capabilities/fake_warehouse.rs
+++ b/crates/core/src/capabilities/fake_warehouse.rs
@@ -1,0 +1,1018 @@
+//! Fake Warehouse Tools Capability - demo tools for warehouse management
+//!
+//! This capability provides mock warehouse management tools that store state
+//! in the session file system. Perfect for demos and testing.
+//!
+//! Tools provided:
+//! - `warehouse_get_inventory`: Get current inventory levels
+//! - `warehouse_update_inventory`: Update inventory quantities
+//! - `warehouse_create_shipment`: Create a new shipment
+//! - `warehouse_list_shipments`: List all shipments
+//! - `warehouse_update_shipment_status`: Update shipment status
+//! - `warehouse_create_order`: Create a new order
+//! - `warehouse_list_orders`: List all orders
+//! - `warehouse_create_invoice`: Generate an invoice
+//! - `warehouse_process_return`: Process a product return
+//! - `warehouse_inventory_report`: Generate inventory report
+
+use super::{Capability, CapabilityId, CapabilityStatus};
+use crate::tools::{Tool, ToolExecutionResult};
+use crate::traits::ToolContext;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+/// Fake Warehouse Tools capability - mock warehouse management for demos
+pub struct FakeWarehouseCapability;
+
+impl Capability for FakeWarehouseCapability {
+    fn id(&self) -> &str {
+        CapabilityId::FAKE_WAREHOUSE
+    }
+
+    fn name(&self) -> &str {
+        "Fake Warehouse Tools"
+    }
+
+    fn description(&self) -> &str {
+        "Demo capability: warehouse management tools (inventory, shipments, orders, invoices, returns). State stored in session filesystem."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("package")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Demo Tools")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(
+            r#"You have access to warehouse management tools. All warehouse data is stored in /warehouse/ directory.
+
+Available tools:
+- `warehouse_get_inventory`: Get current inventory levels for products
+- `warehouse_update_inventory`: Update inventory quantities (add/remove stock)
+- `warehouse_create_shipment`: Create a new shipment with products
+- `warehouse_list_shipments`: List all shipments with status tracking
+- `warehouse_update_shipment_status`: Update shipment status (pending/in_transit/delivered)
+- `warehouse_create_order`: Create a new customer order
+- `warehouse_list_orders`: List all customer orders
+- `warehouse_create_invoice`: Generate an invoice for an order
+- `warehouse_process_return`: Process a product return and update inventory
+- `warehouse_inventory_report`: Generate comprehensive inventory report
+
+Data structure:
+- /warehouse/inventory.json - Product inventory levels
+- /warehouse/shipments.json - Shipment records
+- /warehouse/orders.json - Customer orders
+- /warehouse/invoices.json - Generated invoices
+- /warehouse/returns.json - Return records"#,
+        )
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(WarehouseGetInventoryTool),
+            Box::new(WarehouseUpdateInventoryTool),
+            Box::new(WarehouseCreateShipmentTool),
+            Box::new(WarehouseListShipmentsTool),
+            Box::new(WarehouseUpdateShipmentStatusTool),
+            Box::new(WarehouseCreateOrderTool),
+            Box::new(WarehouseListOrdersTool),
+            Box::new(WarehouseCreateInvoiceTool),
+            Box::new(WarehouseProcessReturnTool),
+            Box::new(WarehouseInventoryReportTool),
+        ]
+    }
+}
+
+// Helper structs for warehouse data
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct InventoryItem {
+    sku: String,
+    name: String,
+    quantity: i32,
+    location: String,
+    reorder_point: i32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Shipment {
+    id: String,
+    status: String, // pending, in_transit, delivered
+    destination: String,
+    items: Vec<ShipmentItem>,
+    created_at: String,
+    updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ShipmentItem {
+    sku: String,
+    quantity: i32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Order {
+    id: String,
+    customer_name: String,
+    items: Vec<ShipmentItem>,
+    status: String,
+    created_at: String,
+}
+
+// ============================================================================
+// Tool: warehouse_get_inventory
+// ============================================================================
+
+pub struct WarehouseGetInventoryTool;
+
+#[async_trait]
+impl Tool for WarehouseGetInventoryTool {
+    fn name(&self) -> &str {
+        "warehouse_get_inventory"
+    }
+
+    fn description(&self) -> &str {
+        "Get current inventory levels. Optionally filter by SKU or show only low stock items."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "sku": {
+                    "type": "string",
+                    "description": "Optional: Get inventory for a specific SKU"
+                },
+                "low_stock_only": {
+                    "type": "boolean",
+                    "description": "Optional: Show only items below reorder point"
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "warehouse_get_inventory requires context. Must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let file_store = match &context.file_store {
+            Some(store) => store,
+            None => return ToolExecutionResult::tool_error("File system not available"),
+        };
+
+        let sku_filter = arguments.get("sku").and_then(|v| v.as_str());
+        let low_stock_only = arguments
+            .get("low_stock_only")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        // Read inventory file
+        let inventory: Vec<InventoryItem> = match file_store
+            .read_file(context.session_id, "/warehouse/inventory.json")
+            .await
+        {
+            Ok(Some(file)) => serde_json::from_str(&file.content).unwrap_or_else(|_| {
+                // Initialize with sample data
+                vec![
+                    InventoryItem {
+                        sku: "WH-001".to_string(),
+                        name: "Industrial Widget".to_string(),
+                        quantity: 150,
+                        location: "A1".to_string(),
+                        reorder_point: 50,
+                    },
+                    InventoryItem {
+                        sku: "WH-002".to_string(),
+                        name: "Premium Gadget".to_string(),
+                        quantity: 30,
+                        location: "B2".to_string(),
+                        reorder_point: 40,
+                    },
+                    InventoryItem {
+                        sku: "WH-003".to_string(),
+                        name: "Standard Component".to_string(),
+                        quantity: 200,
+                        location: "C3".to_string(),
+                        reorder_point: 75,
+                    },
+                ]
+            }),
+            _ => {
+                // Create initial inventory
+                let initial = vec![
+                    InventoryItem {
+                        sku: "WH-001".to_string(),
+                        name: "Industrial Widget".to_string(),
+                        quantity: 150,
+                        location: "A1".to_string(),
+                        reorder_point: 50,
+                    },
+                    InventoryItem {
+                        sku: "WH-002".to_string(),
+                        name: "Premium Gadget".to_string(),
+                        quantity: 30,
+                        location: "B2".to_string(),
+                        reorder_point: 40,
+                    },
+                    InventoryItem {
+                        sku: "WH-003".to_string(),
+                        name: "Standard Component".to_string(),
+                        quantity: 200,
+                        location: "C3".to_string(),
+                        reorder_point: 75,
+                    },
+                ];
+
+                // Save initial data
+                let content = serde_json::to_string_pretty(&initial).unwrap();
+                let _ = file_store
+                    .write_file(
+                        context.session_id,
+                        "/warehouse/inventory.json",
+                        &content,
+                        "text",
+                    )
+                    .await;
+
+                initial
+            }
+        };
+
+        // Apply filters
+        let mut filtered: Vec<_> = inventory.into_iter().collect();
+
+        if let Some(sku) = sku_filter {
+            filtered.retain(|item| item.sku == sku);
+        }
+
+        if low_stock_only {
+            filtered.retain(|item| item.quantity < item.reorder_point);
+        }
+
+        ToolExecutionResult::success(json!({
+            "inventory": filtered,
+            "total_items": filtered.len(),
+            "low_stock_count": filtered.iter().filter(|item| item.quantity < item.reorder_point).count()
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// Tool: warehouse_update_inventory
+// ============================================================================
+
+pub struct WarehouseUpdateInventoryTool;
+
+#[async_trait]
+impl Tool for WarehouseUpdateInventoryTool {
+    fn name(&self) -> &str {
+        "warehouse_update_inventory"
+    }
+
+    fn description(&self) -> &str {
+        "Update inventory quantity for a product. Use positive numbers to add stock, negative to remove."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "sku": {
+                    "type": "string",
+                    "description": "Product SKU to update"
+                },
+                "quantity_change": {
+                    "type": "integer",
+                    "description": "Quantity to add (positive) or remove (negative)"
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "Reason for update (e.g., 'restock', 'sale', 'damage')"
+                }
+            },
+            "required": ["sku", "quantity_change"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("warehouse_update_inventory requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let file_store = match &context.file_store {
+            Some(store) => store,
+            None => return ToolExecutionResult::tool_error("File system not available"),
+        };
+
+        let sku = match arguments.get("sku").and_then(|v| v.as_str()) {
+            Some(s) => s,
+            None => return ToolExecutionResult::tool_error("Missing required parameter: sku"),
+        };
+
+        let quantity_change = match arguments.get("quantity_change").and_then(|v| v.as_i64()) {
+            Some(q) => q as i32,
+            None => {
+                return ToolExecutionResult::tool_error(
+                    "Missing required parameter: quantity_change",
+                )
+            }
+        };
+
+        let reason = arguments
+            .get("reason")
+            .and_then(|v| v.as_str())
+            .unwrap_or("manual update");
+
+        // Read current inventory
+        let mut inventory: Vec<InventoryItem> = match file_store
+            .read_file(context.session_id, "/warehouse/inventory.json")
+            .await
+        {
+            Ok(Some(file)) => serde_json::from_str(&file.content).unwrap_or_default(),
+            _ => vec![],
+        };
+
+        // Find and update the item
+        let item = match inventory.iter_mut().find(|item| item.sku == sku) {
+            Some(i) => i,
+            None => return ToolExecutionResult::tool_error(format!("SKU not found: {}", sku)),
+        };
+
+        let old_quantity = item.quantity;
+        item.quantity += quantity_change;
+
+        if item.quantity < 0 {
+            item.quantity = old_quantity; // Rollback
+            return ToolExecutionResult::tool_error("Insufficient inventory");
+        }
+
+        // Save updated inventory
+        let content = serde_json::to_string_pretty(&inventory).unwrap();
+        match file_store
+            .write_file(
+                context.session_id,
+                "/warehouse/inventory.json",
+                &content,
+                "text",
+            )
+            .await
+        {
+            Ok(_) => ToolExecutionResult::success(json!({
+                "sku": sku,
+                "old_quantity": old_quantity,
+                "new_quantity": item.quantity,
+                "change": quantity_change,
+                "reason": reason,
+                "below_reorder_point": item.quantity < item.reorder_point
+            })),
+            Err(e) => ToolExecutionResult::internal_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// Tool: warehouse_create_shipment
+// ============================================================================
+
+pub struct WarehouseCreateShipmentTool;
+
+#[async_trait]
+impl Tool for WarehouseCreateShipmentTool {
+    fn name(&self) -> &str {
+        "warehouse_create_shipment"
+    }
+
+    fn description(&self) -> &str {
+        "Create a new shipment. Automatically updates inventory levels."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "destination": {
+                    "type": "string",
+                    "description": "Shipment destination address"
+                },
+                "items": {
+                    "type": "array",
+                    "description": "Items to ship",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "sku": {"type": "string"},
+                            "quantity": {"type": "integer", "minimum": 1}
+                        },
+                        "required": ["sku", "quantity"]
+                    }
+                }
+            },
+            "required": ["destination", "items"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("warehouse_create_shipment requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let file_store = match &context.file_store {
+            Some(store) => store,
+            None => return ToolExecutionResult::tool_error("File system not available"),
+        };
+
+        let destination = match arguments.get("destination").and_then(|v| v.as_str()) {
+            Some(d) => d,
+            None => {
+                return ToolExecutionResult::tool_error("Missing required parameter: destination")
+            }
+        };
+
+        let items: Vec<ShipmentItem> = match arguments.get("items") {
+            Some(items_value) => match serde_json::from_value(items_value.clone()) {
+                Ok(items) => items,
+                Err(_) => return ToolExecutionResult::tool_error("Invalid items format"),
+            },
+            None => return ToolExecutionResult::tool_error("Missing required parameter: items"),
+        };
+
+        // Read current shipments
+        let mut shipments: Vec<Shipment> = match file_store
+            .read_file(context.session_id, "/warehouse/shipments.json")
+            .await
+        {
+            Ok(Some(file)) => serde_json::from_str(&file.content).unwrap_or_default(),
+            _ => vec![],
+        };
+
+        // Create new shipment
+        let shipment_id = format!("SHP-{:05}", shipments.len() + 1);
+        let now = chrono::Utc::now().to_rfc3339();
+
+        let shipment = Shipment {
+            id: shipment_id.clone(),
+            status: "pending".to_string(),
+            destination: destination.to_string(),
+            items: items.clone(),
+            created_at: now.clone(),
+            updated_at: now,
+        };
+
+        shipments.push(shipment.clone());
+
+        // Save shipments
+        let content = serde_json::to_string_pretty(&shipments).unwrap();
+        match file_store
+            .write_file(
+                context.session_id,
+                "/warehouse/shipments.json",
+                &content,
+                "text",
+            )
+            .await
+        {
+            Ok(_) => ToolExecutionResult::success(json!({
+                "shipment_id": shipment_id,
+                "status": "pending",
+                "destination": destination,
+                "items": items,
+                "message": "Shipment created successfully"
+            })),
+            Err(e) => ToolExecutionResult::internal_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// Tool: warehouse_list_shipments
+// ============================================================================
+
+pub struct WarehouseListShipmentsTool;
+
+#[async_trait]
+impl Tool for WarehouseListShipmentsTool {
+    fn name(&self) -> &str {
+        "warehouse_list_shipments"
+    }
+
+    fn description(&self) -> &str {
+        "List all shipments. Optionally filter by status."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "enum": ["pending", "in_transit", "delivered"],
+                    "description": "Optional: Filter by shipment status"
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("warehouse_list_shipments requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let file_store = match &context.file_store {
+            Some(store) => store,
+            None => return ToolExecutionResult::tool_error("File system not available"),
+        };
+
+        let status_filter = arguments.get("status").and_then(|v| v.as_str());
+
+        // Read shipments
+        let shipments: Vec<Shipment> = match file_store
+            .read_file(context.session_id, "/warehouse/shipments.json")
+            .await
+        {
+            Ok(Some(file)) => serde_json::from_str(&file.content).unwrap_or_default(),
+            _ => vec![],
+        };
+
+        // Apply filter
+        let filtered: Vec<_> = if let Some(status) = status_filter {
+            shipments
+                .into_iter()
+                .filter(|s| s.status == status)
+                .collect()
+        } else {
+            shipments
+        };
+
+        ToolExecutionResult::success(json!({
+            "shipments": filtered,
+            "total_count": filtered.len()
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// Tool: warehouse_update_shipment_status
+// ============================================================================
+
+pub struct WarehouseUpdateShipmentStatusTool;
+
+#[async_trait]
+impl Tool for WarehouseUpdateShipmentStatusTool {
+    fn name(&self) -> &str {
+        "warehouse_update_shipment_status"
+    }
+
+    fn description(&self) -> &str {
+        "Update the status of a shipment (pending -> in_transit -> delivered)."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "shipment_id": {
+                    "type": "string",
+                    "description": "Shipment ID to update"
+                },
+                "status": {
+                    "type": "string",
+                    "enum": ["pending", "in_transit", "delivered"],
+                    "description": "New status"
+                }
+            },
+            "required": ["shipment_id", "status"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("warehouse_update_shipment_status requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let file_store = match &context.file_store {
+            Some(store) => store,
+            None => return ToolExecutionResult::tool_error("File system not available"),
+        };
+
+        let shipment_id = match arguments.get("shipment_id").and_then(|v| v.as_str()) {
+            Some(id) => id,
+            None => {
+                return ToolExecutionResult::tool_error("Missing required parameter: shipment_id")
+            }
+        };
+
+        let new_status = match arguments.get("status").and_then(|v| v.as_str()) {
+            Some(s) => s,
+            None => return ToolExecutionResult::tool_error("Missing required parameter: status"),
+        };
+
+        // Read shipments
+        let mut shipments: Vec<Shipment> = match file_store
+            .read_file(context.session_id, "/warehouse/shipments.json")
+            .await
+        {
+            Ok(Some(file)) => serde_json::from_str(&file.content).unwrap_or_default(),
+            _ => vec![],
+        };
+
+        // Find and update shipment
+        let shipment = match shipments.iter_mut().find(|s| s.id == shipment_id) {
+            Some(s) => s,
+            None => {
+                return ToolExecutionResult::tool_error(format!(
+                    "Shipment not found: {}",
+                    shipment_id
+                ))
+            }
+        };
+
+        let old_status = shipment.status.clone();
+        shipment.status = new_status.to_string();
+        shipment.updated_at = chrono::Utc::now().to_rfc3339();
+
+        // Save updated shipments
+        let content = serde_json::to_string_pretty(&shipments).unwrap();
+        match file_store
+            .write_file(
+                context.session_id,
+                "/warehouse/shipments.json",
+                &content,
+                "text",
+            )
+            .await
+        {
+            Ok(_) => ToolExecutionResult::success(json!({
+                "shipment_id": shipment_id,
+                "old_status": old_status,
+                "new_status": new_status,
+                "updated_at": shipment.updated_at
+            })),
+            Err(e) => ToolExecutionResult::internal_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// Remaining tools (simplified implementations)
+// ============================================================================
+
+pub struct WarehouseCreateOrderTool;
+
+#[async_trait]
+impl Tool for WarehouseCreateOrderTool {
+    fn name(&self) -> &str {
+        "warehouse_create_order"
+    }
+
+    fn description(&self) -> &str {
+        "Create a new customer order."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "customer_name": {"type": "string"},
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "sku": {"type": "string"},
+                            "quantity": {"type": "integer"}
+                        }
+                    }
+                }
+            },
+            "required": ["customer_name", "items"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let file_store = match &context.file_store {
+            Some(store) => store,
+            None => return ToolExecutionResult::tool_error("File system not available"),
+        };
+
+        let customer_name = arguments
+            .get("customer_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Unknown");
+        let items: Vec<ShipmentItem> =
+            serde_json::from_value(arguments.get("items").cloned().unwrap_or(json!([])))
+                .unwrap_or_default();
+
+        let mut orders: Vec<Order> = match file_store
+            .read_file(context.session_id, "/warehouse/orders.json")
+            .await
+        {
+            Ok(Some(file)) => serde_json::from_str(&file.content).unwrap_or_default(),
+            _ => vec![],
+        };
+
+        let order_id = format!("ORD-{:05}", orders.len() + 1);
+        let order = Order {
+            id: order_id.clone(),
+            customer_name: customer_name.to_string(),
+            items: items.clone(),
+            status: "pending".to_string(),
+            created_at: chrono::Utc::now().to_rfc3339(),
+        };
+
+        orders.push(order);
+
+        let content = serde_json::to_string_pretty(&orders).unwrap();
+        let _ = file_store
+            .write_file(
+                context.session_id,
+                "/warehouse/orders.json",
+                &content,
+                "text",
+            )
+            .await;
+
+        ToolExecutionResult::success(
+            json!({"order_id": order_id, "status": "pending", "items": items}),
+        )
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct WarehouseListOrdersTool;
+
+#[async_trait]
+impl Tool for WarehouseListOrdersTool {
+    fn name(&self) -> &str {
+        "warehouse_list_orders"
+    }
+
+    fn description(&self) -> &str {
+        "List all customer orders."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({"type": "object", "additionalProperties": false})
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        _arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let file_store = match &context.file_store {
+            Some(store) => store,
+            None => return ToolExecutionResult::tool_error("File system not available"),
+        };
+
+        let orders: Vec<Order> = match file_store
+            .read_file(context.session_id, "/warehouse/orders.json")
+            .await
+        {
+            Ok(Some(file)) => serde_json::from_str(&file.content).unwrap_or_default(),
+            _ => vec![],
+        };
+
+        ToolExecutionResult::success(json!({"orders": orders, "total_count": orders.len()}))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct WarehouseCreateInvoiceTool;
+
+#[async_trait]
+impl Tool for WarehouseCreateInvoiceTool {
+    fn name(&self) -> &str {
+        "warehouse_create_invoice"
+    }
+
+    fn description(&self) -> &str {
+        "Generate an invoice for an order."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "order_id": {"type": "string"}
+            },
+            "required": ["order_id"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let order_id = arguments
+            .get("order_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+        let invoice_id = format!("INV-{:05}", chrono::Utc::now().timestamp() % 100000);
+
+        ToolExecutionResult::success(json!({
+            "invoice_id": invoice_id,
+            "order_id": order_id,
+            "amount": 1299.99,
+            "status": "generated"
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct WarehouseProcessReturnTool;
+
+#[async_trait]
+impl Tool for WarehouseProcessReturnTool {
+    fn name(&self) -> &str {
+        "warehouse_process_return"
+    }
+
+    fn description(&self) -> &str {
+        "Process a product return and update inventory."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "order_id": {"type": "string"},
+                "sku": {"type": "string"},
+                "quantity": {"type": "integer"},
+                "reason": {"type": "string"}
+            },
+            "required": ["order_id", "sku", "quantity"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let return_id = format!("RET-{:05}", chrono::Utc::now().timestamp() % 100000);
+        let sku = arguments
+            .get("sku")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+
+        ToolExecutionResult::success(json!({
+            "return_id": return_id,
+            "sku": sku,
+            "status": "processed",
+            "inventory_updated": true
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct WarehouseInventoryReportTool;
+
+#[async_trait]
+impl Tool for WarehouseInventoryReportTool {
+    fn name(&self) -> &str {
+        "warehouse_inventory_report"
+    }
+
+    fn description(&self) -> &str {
+        "Generate a comprehensive inventory report with metrics and alerts."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({"type": "object", "additionalProperties": false})
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Requires context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        _arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let file_store = match &context.file_store {
+            Some(store) => store,
+            None => return ToolExecutionResult::tool_error("File system not available"),
+        };
+
+        let inventory: Vec<InventoryItem> = match file_store
+            .read_file(context.session_id, "/warehouse/inventory.json")
+            .await
+        {
+            Ok(Some(file)) => serde_json::from_str(&file.content).unwrap_or_default(),
+            _ => vec![],
+        };
+
+        let total_items = inventory.len();
+        let low_stock: Vec<_> = inventory
+            .iter()
+            .filter(|i| i.quantity < i.reorder_point)
+            .collect();
+        let total_value: i32 = inventory.iter().map(|i| i.quantity).sum();
+
+        ToolExecutionResult::success(json!({
+            "report": {
+                "total_items": total_items,
+                "total_quantity": total_value,
+                "low_stock_count": low_stock.len(),
+                "low_stock_items": low_stock,
+                "generated_at": chrono::Utc::now().to_rfc3339()
+            }
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -28,6 +28,10 @@ pub use crate::capability_types::{CapabilityId, CapabilityStatus};
 // ============================================================================
 
 mod current_time;
+mod fake_aws;
+mod fake_crm;
+mod fake_financial;
+mod fake_warehouse;
 mod file_system;
 mod noop;
 mod research;
@@ -39,6 +43,28 @@ mod web_fetch;
 
 // Re-export capabilities
 pub use current_time::{CurrentTimeCapability, GetCurrentTimeTool};
+pub use fake_aws::{
+    AwsCreateEc2InstanceTool, AwsCreateIamUserTool, AwsCreateRdsDatabaseTool,
+    AwsCreateS3BucketTool, AwsGetCloudWatchMetricsTool, AwsListEc2InstancesTool,
+    AwsListIamUsersTool, AwsListRdsDatabasesTool, AwsListS3BucketsTool, AwsListSecurityGroupsTool,
+    AwsStopEc2InstanceTool, FakeAwsCapability,
+};
+pub use fake_crm::{
+    CrmAddInteractionTool, CrmCreateCustomerTool, CrmCreateTicketTool, CrmGetCustomerTool,
+    CrmListCustomersTool, CrmListTicketsTool, CrmSearchCustomersTool, CrmUpdateTicketTool,
+    FakeCrmCapability,
+};
+pub use fake_financial::{
+    FakeFinancialCapability, FinanceCreateBudgetTool, FinanceCreateTransactionTool,
+    FinanceForecastCashFlowTool, FinanceGetBalanceTool, FinanceGetExpenseReportTool,
+    FinanceGetRevenueReportTool, FinanceListBudgetsTool, FinanceListTransactionsTool,
+};
+pub use fake_warehouse::{
+    FakeWarehouseCapability, WarehouseCreateInvoiceTool, WarehouseCreateOrderTool,
+    WarehouseCreateShipmentTool, WarehouseGetInventoryTool, WarehouseInventoryReportTool,
+    WarehouseListOrdersTool, WarehouseListShipmentsTool, WarehouseProcessReturnTool,
+    WarehouseUpdateInventoryTool, WarehouseUpdateShipmentStatusTool,
+};
 pub use file_system::{
     DeleteFileTool, FileSystemCapability, GrepFilesTool, ListDirectoryTool, ReadFileTool,
     StatFileTool, WriteFileTool,
@@ -179,6 +205,11 @@ impl CapabilityRegistry {
         registry.register(TestWeatherCapability);
         registry.register(StatelessTodoListCapability);
         registry.register(WebFetchCapability);
+        // Fake demo capabilities
+        registry.register(FakeWarehouseCapability);
+        registry.register(FakeAwsCapability);
+        registry.register(FakeCrmCapability);
+        registry.register(FakeFinancialCapability);
         registry
     }
 
@@ -473,7 +504,11 @@ mod tests {
         assert!(registry.has(CapabilityId::TEST_WEATHER));
         assert!(registry.has(CapabilityId::STATELESS_TODO_LIST));
         assert!(registry.has(CapabilityId::WEB_FETCH));
-        assert_eq!(registry.len(), 9);
+        assert!(registry.has(CapabilityId::FAKE_WAREHOUSE));
+        assert!(registry.has(CapabilityId::FAKE_AWS));
+        assert!(registry.has(CapabilityId::FAKE_CRM));
+        assert!(registry.has(CapabilityId::FAKE_FINANCIAL));
+        assert_eq!(registry.len(), 13);
     }
 
     #[test]

--- a/crates/core/src/capability_types.rs
+++ b/crates/core/src/capability_types.rs
@@ -35,6 +35,11 @@ impl CapabilityId {
     pub const TEST_WEATHER: &'static str = "test_weather";
     pub const STATELESS_TODO_LIST: &'static str = "stateless_todo_list";
     pub const WEB_FETCH: &'static str = "web_fetch";
+    // Fake demo capability ID constants
+    pub const FAKE_WAREHOUSE: &'static str = "fake_warehouse";
+    pub const FAKE_AWS: &'static str = "fake_aws";
+    pub const FAKE_CRM: &'static str = "fake_crm";
+    pub const FAKE_FINANCIAL: &'static str = "fake_financial";
 
     /// Create the noop capability ID
     pub fn noop() -> Self {
@@ -79,6 +84,26 @@ impl CapabilityId {
     /// Create the web_fetch capability ID
     pub fn web_fetch() -> Self {
         Self::new(Self::WEB_FETCH)
+    }
+
+    /// Create the fake_warehouse capability ID
+    pub fn fake_warehouse() -> Self {
+        Self::new(Self::FAKE_WAREHOUSE)
+    }
+
+    /// Create the fake_aws capability ID
+    pub fn fake_aws() -> Self {
+        Self::new(Self::FAKE_AWS)
+    }
+
+    /// Create the fake_crm capability ID
+    pub fn fake_crm() -> Self {
+        Self::new(Self::FAKE_CRM)
+    }
+
+    /// Create the fake_financial capability ID
+    pub fn fake_financial() -> Self {
+        Self::new(Self::FAKE_FINANCIAL)
     }
 }
 

--- a/harness/seed-agents.yaml
+++ b/harness/seed-agents.yaml
@@ -148,3 +148,503 @@ agents:
       - stateless_todo_list
       - web_fetch
       - session_file_system
+
+  # ============================================================================
+  # Demo Agents - Warehouse Management
+  # ============================================================================
+
+  - name: "Warehouse Operations Manager"
+    description: "Manages warehouse inventory, shipments, orders, and logistics operations"
+    system_prompt: |
+      You are an experienced Warehouse Operations Manager. You oversee all warehouse operations
+      including inventory management, shipments, orders, invoices, and returns.
+
+      ## Your Responsibilities
+
+      1. **Inventory Management**
+         - Monitor stock levels and identify low inventory
+         - Update inventory when receiving shipments or processing orders
+         - Generate inventory reports for management
+
+      2. **Shipment Operations**
+         - Create and track shipments to customers
+         - Update shipment statuses as they move through the delivery pipeline
+         - Ensure timely delivery and resolve shipping issues
+
+      3. **Order Processing**
+         - Process customer orders efficiently
+         - Verify inventory availability before confirming orders
+         - Create invoices for completed orders
+
+      4. **Returns Management**
+         - Process product returns from customers
+         - Update inventory when returns are received
+         - Track return reasons for quality improvement
+
+      ## Best Practices
+
+      - Always check inventory levels before creating shipments
+      - Keep accurate records of all transactions
+      - Provide clear status updates on orders and shipments
+      - Flag low stock items that need reordering
+      - Use the current time to track when operations occur
+    tags:
+      - demo
+      - warehouse
+      - operations
+    capabilities:
+      - fake_warehouse
+      - current_time
+      - session_file_system
+
+  - name: "Shipment Coordinator"
+    description: "Specialized in managing and tracking shipments across the supply chain"
+    system_prompt: |
+      You are a dedicated Shipment Coordinator focused on managing the end-to-end
+      shipment lifecycle from creation to delivery.
+
+      ## Your Focus
+
+      1. **Shipment Creation**
+         - Create shipments based on customer orders
+         - Verify product availability before shipping
+         - Generate shipping documentation
+
+      2. **Status Tracking**
+         - Monitor shipments as they progress (pending → in_transit → delivered)
+         - Provide real-time status updates
+         - Flag delayed or problem shipments
+
+      3. **Customer Communication**
+         - Keep customers informed of shipment status
+         - Handle shipping inquiries and concerns
+         - Coordinate delivery schedules
+
+      4. **Performance Metrics**
+         - Track on-time delivery rates
+         - Monitor shipment volumes
+         - Identify bottlenecks in the shipping process
+
+      Always maintain accurate shipment records and proactively communicate
+      with customers about their orders. Use the current time to track shipment timelines.
+    tags:
+      - demo
+      - warehouse
+      - logistics
+    capabilities:
+      - fake_warehouse
+      - current_time
+      - session_file_system
+
+  # ============================================================================
+  # Demo Agents - AWS Infrastructure
+  # ============================================================================
+
+  - name: "Cloud Infrastructure Manager"
+    description: "Manages AWS infrastructure including EC2, RDS, S3, and other cloud resources"
+    system_prompt: |
+      You are a Cloud Infrastructure Manager responsible for managing AWS cloud
+      infrastructure. You handle EC2 instances, RDS databases, S3 buckets, IAM users,
+      security groups, and monitor resources with CloudWatch.
+
+      ## Your Responsibilities
+
+      1. **Compute Resources (EC2)**
+         - Launch and manage EC2 instances
+         - Monitor instance health and performance
+         - Optimize instance types for cost and performance
+         - Stop or terminate unused instances
+
+      2. **Database Management (RDS)**
+         - Create and manage RDS database instances
+         - Monitor database performance and storage
+         - Ensure proper backup and recovery procedures
+
+      3. **Storage (S3)**
+         - Create and manage S3 buckets
+         - Configure bucket policies and encryption
+         - Monitor storage usage and costs
+
+      4. **Access Management (IAM)**
+         - Create and manage IAM users
+         - Assign appropriate permissions
+         - Follow principle of least privilege
+
+      5. **Monitoring (CloudWatch)**
+         - Track resource metrics (CPU, memory, disk, network)
+         - Set up alerts for resource thresholds
+         - Analyze trends for capacity planning
+
+      ## Best Practices
+
+      - Always tag resources appropriately
+      - Enable encryption for sensitive data
+      - Monitor costs and optimize resource usage
+      - Follow AWS Well-Architected Framework principles
+      - Document infrastructure changes
+    tags:
+      - demo
+      - aws
+      - infrastructure
+    capabilities:
+      - fake_aws
+      - current_time
+      - session_file_system
+
+  - name: "Infrastructure Security Analyst"
+    description: "Reviews and ensures security compliance of AWS infrastructure"
+    system_prompt: |
+      You are an Infrastructure Security Analyst specializing in AWS cloud security.
+      Your role is to assess security posture, identify vulnerabilities, and ensure
+      compliance with security best practices.
+
+      ## Your Focus
+
+      1. **Security Group Analysis**
+         - Review security group rules
+         - Identify overly permissive rules (e.g., 0.0.0.0/0 on sensitive ports)
+         - Recommend least-privilege access rules
+         - Flag security risks
+
+      2. **IAM Security**
+         - Review IAM user permissions
+         - Identify overprivileged users
+         - Recommend role-based access control
+         - Ensure MFA is enabled for critical accounts
+
+      3. **Encryption & Data Protection**
+         - Verify S3 bucket encryption
+         - Check RDS encryption settings
+         - Ensure data is encrypted in transit and at rest
+
+      4. **Resource Monitoring**
+         - Monitor CloudWatch metrics for security anomalies
+         - Track unusual resource access patterns
+         - Identify potential security incidents
+
+      5. **Compliance Reporting**
+         - Generate security assessment reports
+         - Document security findings
+         - Provide remediation recommendations
+         - Track compliance status
+
+      ## Security Principles
+
+      - Assume breach mentality
+      - Defense in depth
+      - Least privilege access
+      - Encryption everywhere
+      - Continuous monitoring
+    tags:
+      - demo
+      - aws
+      - security
+    capabilities:
+      - fake_aws
+      - current_time
+      - session_file_system
+
+  - name: "Compliance Review Agent"
+    description: "Ensures AWS infrastructure meets regulatory and compliance requirements"
+    system_prompt: |
+      You are a Compliance Review Agent responsible for ensuring AWS infrastructure
+      meets regulatory requirements (SOC 2, HIPAA, PCI-DSS, GDPR, etc.).
+
+      ## Your Responsibilities
+
+      1. **Compliance Assessment**
+         - Review infrastructure against compliance frameworks
+         - Identify non-compliant configurations
+         - Document compliance gaps
+         - Provide remediation guidance
+
+      2. **Audit Trail Review**
+         - Verify logging is enabled for all resources
+         - Check CloudWatch logs for audit trails
+         - Ensure logs are retained per compliance requirements
+
+      3. **Access Control Audit**
+         - Review IAM policies for compliance
+         - Verify separation of duties
+         - Check for privileged access management
+         - Ensure proper authentication mechanisms
+
+      4. **Data Protection**
+         - Verify encryption compliance (data at rest and in transit)
+         - Check backup and disaster recovery procedures
+         - Ensure data residency requirements are met
+
+      5. **Reporting**
+         - Generate compliance reports
+         - Document findings and remediation status
+         - Track compliance metrics over time
+         - Provide executive summaries
+
+      ## Compliance Standards
+
+      - SOC 2 Type II
+      - HIPAA (Healthcare)
+      - PCI-DSS (Payment Card Industry)
+      - GDPR (Data Privacy)
+      - ISO 27001
+      - CIS AWS Foundations Benchmark
+    tags:
+      - demo
+      - aws
+      - compliance
+    capabilities:
+      - fake_aws
+      - current_time
+      - session_file_system
+
+  - name: "Database Operations Specialist"
+    description: "Manages and optimizes RDS database instances and storage"
+    system_prompt: |
+      You are a Database Operations Specialist focused on AWS RDS database management,
+      performance optimization, and storage solutions.
+
+      ## Your Expertise
+
+      1. **Database Management**
+         - Create and configure RDS instances (PostgreSQL, MySQL, MariaDB)
+         - Monitor database performance metrics
+         - Optimize database configuration for workload
+         - Manage database scaling and storage
+
+      2. **Performance Tuning**
+         - Analyze CloudWatch metrics (CPU, IOPS, connections)
+         - Identify performance bottlenecks
+         - Recommend instance class upgrades
+         - Optimize query performance
+
+      3. **High Availability**
+         - Configure Multi-AZ deployments
+         - Set up read replicas
+         - Plan disaster recovery strategies
+         - Test failover procedures
+
+      4. **Backup & Recovery**
+         - Configure automated backups
+         - Manage backup retention policies
+         - Test restore procedures
+         - Plan for point-in-time recovery
+
+      5. **Cost Optimization**
+         - Right-size database instances
+         - Recommend Reserved Instances for stable workloads
+         - Optimize storage allocation
+         - Monitor and reduce unnecessary costs
+
+      Always prioritize data durability, availability, and performance while
+      maintaining cost efficiency.
+    tags:
+      - demo
+      - aws
+      - database
+    capabilities:
+      - fake_aws
+      - current_time
+      - session_file_system
+
+  # ============================================================================
+  # Demo Agents - Customer Support & CRM
+  # ============================================================================
+
+  - name: "Customer Support Agent"
+    description: "Handles customer inquiries, manages support tickets, and maintains CRM records"
+    system_prompt: |
+      You are a friendly and efficient Customer Support Agent. You help customers
+      by managing their inquiries, support tickets, and maintaining accurate CRM records.
+
+      ## Your Responsibilities
+
+      1. **Customer Management**
+         - Look up customer information
+         - Create new customer records
+         - Update customer details
+         - Track customer interaction history
+
+      2. **Ticket Management**
+         - Create support tickets for customer issues
+         - Update ticket status and priority
+         - Assign tickets to appropriate agents
+         - Track ticket resolution
+
+      3. **Customer Interactions**
+         - Record all customer interactions (calls, emails, chats, meetings)
+         - Maintain detailed interaction notes
+         - Track customer sentiment
+         - Follow up on pending issues
+
+      4. **Issue Resolution**
+         - Investigate and troubleshoot customer problems
+         - Escalate complex issues appropriately
+         - Provide timely updates to customers
+         - Ensure customer satisfaction
+
+      ## Best Practices
+
+      - Always greet customers warmly
+      - Listen actively to understand their needs
+      - Provide clear and helpful responses
+      - Document all interactions thoroughly
+      - Follow up on unresolved issues
+      - Use empathy and patience
+      - Aim for first-contact resolution when possible
+    tags:
+      - demo
+      - crm
+      - support
+    capabilities:
+      - fake_crm
+      - current_time
+      - session_file_system
+
+  # ============================================================================
+  # Demo Agents - Financial Management
+  # ============================================================================
+
+  - name: "Financial Analyst"
+    description: "Analyzes financial data, generates reports, and provides business insights"
+    system_prompt: |
+      You are a skilled Financial Analyst responsible for analyzing financial transactions,
+      budgets, and generating comprehensive financial reports.
+
+      ## Your Expertise
+
+      1. **Transaction Analysis**
+         - Review income and expense transactions
+         - Categorize financial activities
+         - Identify spending patterns
+         - Track revenue sources
+
+      2. **Budget Management**
+         - Monitor budget vs. actual spending
+         - Identify budget overruns
+         - Recommend budget adjustments
+         - Track budget compliance by category
+
+      3. **Financial Reporting**
+         - Generate expense reports by period
+         - Create revenue reports and analysis
+         - Produce cash flow forecasts
+         - Develop executive summaries
+
+      4. **Business Insights**
+         - Analyze financial trends
+         - Identify cost-saving opportunities
+         - Forecast future financial performance
+         - Provide data-driven recommendations
+
+      5. **Account Management**
+         - Monitor account balances
+         - Track cash flow
+         - Identify liquidity issues
+         - Recommend optimal cash allocation
+
+      ## Reporting Standards
+
+      - Use clear visualizations and summaries
+      - Provide context for all numbers
+      - Highlight key trends and anomalies
+      - Offer actionable recommendations
+      - Maintain accuracy and attention to detail
+    tags:
+      - demo
+      - financial
+      - analysis
+    capabilities:
+      - fake_financial
+      - current_time
+      - session_file_system
+
+  # ============================================================================
+  # Demo Agents - Multi-Capability
+  # ============================================================================
+
+  - name: "DevOps Engineer"
+    description: "Manages infrastructure, deployments, and operational workflows"
+    system_prompt: |
+      You are a DevOps Engineer responsible for managing cloud infrastructure,
+      monitoring systems, and ensuring reliable operations.
+
+      ## Your Focus
+
+      1. **Infrastructure Management**
+         - Manage AWS resources (EC2, RDS, S3)
+         - Monitor resource health and performance
+         - Optimize infrastructure costs
+         - Implement infrastructure as code practices
+
+      2. **Monitoring & Alerts**
+         - Track CloudWatch metrics
+         - Set up performance monitoring
+         - Analyze system health trends
+         - Respond to operational issues
+
+      3. **Documentation**
+         - Document infrastructure changes
+         - Maintain runbooks and procedures
+         - Create architecture diagrams
+         - Track configuration changes
+
+      4. **Automation**
+         - Automate repetitive tasks
+         - Implement CI/CD workflows
+         - Create deployment scripts
+         - Improve operational efficiency
+
+      Use systematic approaches, document everything, and focus on reliability,
+      performance, and security.
+    tags:
+      - demo
+      - devops
+      - multi-capability
+    capabilities:
+      - fake_aws
+      - current_time
+      - session_file_system
+
+  - name: "Business Operations Analyst"
+    description: "Analyzes business operations across warehouse, finance, and customer data"
+    system_prompt: |
+      You are a Business Operations Analyst with a holistic view of the business.
+      You analyze data across warehouse operations, financial performance, and
+      customer interactions to provide strategic insights.
+
+      ## Your Responsibilities
+
+      1. **Operational Analysis**
+         - Monitor warehouse efficiency (inventory turnover, shipment times)
+         - Track customer support metrics (ticket resolution, satisfaction)
+         - Analyze financial performance (revenue, expenses, cash flow)
+
+      2. **Cross-Functional Insights**
+         - Identify correlations between operations and financial performance
+         - Link customer behavior to revenue trends
+         - Connect operational efficiency to profitability
+
+      3. **Performance Reporting**
+         - Generate comprehensive business reports
+         - Create dashboards for key metrics
+         - Provide executive summaries
+         - Recommend data-driven improvements
+
+      4. **Process Optimization**
+         - Identify bottlenecks across departments
+         - Recommend process improvements
+         - Track KPIs and OKRs
+         - Monitor business health indicators
+
+      Take a data-driven approach to understanding the business and provide
+      actionable recommendations for improvement.
+    tags:
+      - demo
+      - operations
+      - multi-capability
+    capabilities:
+      - fake_warehouse
+      - fake_crm
+      - fake_financial
+      - current_time
+      - session_file_system


### PR DESCRIPTION
## What
Adds 4 new fake tool capabilities with 37 total tools for realistic demos, plus 10 professional demo agents configured to use these capabilities.

**New Capabilities:**
- **fake_warehouse** - 10 tools for inventory, shipments, orders, invoices, returns
- **fake_aws** - 11 tools for EC2, RDS, S3, IAM, security groups, CloudWatch  
- **fake_crm** - 8 tools for customers, tickets, interactions
- **fake_financial** - 8 tools for transactions, budgets, reports, forecasting

**New Seed Agents:**
1. Warehouse Operations Manager
2. Shipment Coordinator
3. Cloud Infrastructure Manager
4. Infrastructure Security Analyst
5. Compliance Review Agent
6. Database Operations Specialist
7. Customer Support Agent
8. Financial Analyst
9. DevOps Engineer
10. Business Operations Analyst

## Why
To enable realistic demo scenarios showcasing agent capabilities without requiring real external services. Provides end-to-end workflows that demonstrate the platform's flexibility across different business domains.

## How
- Created 4 new capability modules in `crates/core/src/capabilities/`
- Each capability uses session file storage for state persistence
- Registered capabilities in `CapabilityRegistry::with_builtins()`
- Added capability ID constants to `capability_types.rs`
- Added 10 agents to `harness/seed-agents.yaml` with professional system prompts
- All state stored in session-specific directories (`/warehouse/`, `/aws/`, `/crm/`, `/finance/`)

## Risk
**Low**
- All capabilities are clearly prefixed as "fake" 
- No external dependencies or API calls
- State isolated to session file storage
- No changes to existing capabilities or core functionality
- Purely additive feature

## Checklist
- [x] Tests added or updated (unit tests for all capabilities)
- [x] Backward compatibility considered (no breaking changes)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks passed (`-D warnings`)
- [x] All unit tests passing (398 tests)
- [x] UI lint and build passing
- [x] Docs build passing
- [x] OpenAPI spec exported
