### PR TITLE
fix(docs): add HTTPS server URL to OpenAPI spec to prevent mixed content warning

### DIFF
--- a/crates/control-plane/src/openapi.rs
+++ b/crates/control-plane/src/openapi.rs
@@ -24,6 +24,9 @@ use utoipa::OpenApi;
 /// OpenAPI documentation for the Everruns API
 #[derive(OpenApi)]
 #[openapi(
+    servers(
+        (url = "https://app.everruns.com/api", description = "Production API"),
+    ),
     paths(
         api::agents::create_agent,
         api::agents::list_agents,

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -9,6 +9,12 @@
     },
     "version": "0.2.0"
   },
+  "servers": [
+    {
+      "url": "https://app.everruns.com/api",
+      "description": "Production API"
+    }
+  ],
   "paths": {
     "/v1/agents": {
       "get": {


### PR DESCRIPTION
## What
Add a `servers` section to the OpenAPI specification with the production HTTPS URL.

## Why
The docs site at https://docs.everruns.com showed a "Not Secure" mixed content warning. The OpenAPI spec lacked a `servers` section, causing the starlight-openapi plugin's "Try It" feature to default to HTTP for API calls.

## How
- Added `servers` attribute to the `#[openapi(...)]` macro in `openapi.rs`
- Regenerated `docs/api/openapi.json` with the new server URL

## Risk
- Low
- No functional changes to the API itself

## Checklist
- [x] Backward compatibility considered
- [x] OpenAPI spec regenerated
