### PR TITLE
feat(api): add agent import/export endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,6 +1060,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2",
  "sqlx",
  "thiserror 2.0.17",

--- a/apps/ui/src/app/(main)/agents/page.tsx
+++ b/apps/ui/src/app/(main)/agents/page.tsx
@@ -1,16 +1,52 @@
 "use client";
 
-import { useAgents, useCapabilities } from "@/hooks";
+import { useRef, useState, useCallback } from "react";
+import { useAgents, useCapabilities, useImportAgent } from "@/hooks";
+import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Plus } from "lucide-react";
+import { Plus, Upload } from "lucide-react";
 import { AgentCard } from "@/components/agents";
 
 export default function AgentsPage() {
+  const router = useRouter();
   const { data: agents, isLoading, error } = useAgents();
   const { data: allCapabilities } = useCapabilities();
+  const importAgent = useImportAgent();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [importError, setImportError] = useState<string | null>(null);
+
+  const handleImportClick = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleFileChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+
+      setImportError(null);
+
+      try {
+        const content = await file.text();
+        const agent = await importAgent.mutateAsync(content);
+        router.push(`/agents/${agent.id}`);
+      } catch (err) {
+        console.error("Failed to import agent:", err);
+        setImportError(
+          err instanceof Error ? err.message : "Failed to import agent"
+        );
+      }
+
+      // Reset file input
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    },
+    [importAgent, router]
+  );
 
   if (error) {
     return (
@@ -26,13 +62,36 @@ export default function AgentsPage() {
     <div className="container mx-auto p-6">
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold">Agents</h1>
-        <Link href="/agents/new">
-          <Button>
-            <Plus className="w-4 h-4 mr-2" />
-            New Agent
+        <div className="flex gap-2">
+          <input
+            type="file"
+            ref={fileInputRef}
+            onChange={handleFileChange}
+            accept=".md,.yaml,.yml,.json"
+            className="hidden"
+          />
+          <Button
+            variant="outline"
+            onClick={handleImportClick}
+            disabled={importAgent.isPending}
+          >
+            <Upload className="w-4 h-4 mr-2" />
+            {importAgent.isPending ? "Importing..." : "Import"}
           </Button>
-        </Link>
+          <Link href="/agents/new">
+            <Button>
+              <Plus className="w-4 h-4 mr-2" />
+              New Agent
+            </Button>
+          </Link>
+        </div>
       </div>
+
+      {importError && (
+        <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-md text-red-600 text-sm">
+          {importError}
+        </div>
+      )}
 
       {isLoading ? (
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">

--- a/apps/ui/src/hooks/use-agents.ts
+++ b/apps/ui/src/hooks/use-agents.ts
@@ -4,7 +4,9 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   createAgent,
   deleteAgent,
+  exportAgent,
   getAgent,
+  importAgent,
   listAgents,
   updateAgent,
 } from "@/lib/api/agents";
@@ -59,6 +61,23 @@ export function useDeleteAgent() {
 
   return useMutation({
     mutationFn: (agentId: string) => deleteAgent(agentId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["agents"] });
+    },
+  });
+}
+
+export function useExportAgent() {
+  return useMutation({
+    mutationFn: (agentId: string) => exportAgent(agentId),
+  });
+}
+
+export function useImportAgent() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (markdown: string) => importAgent(markdown),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["agents"] });
     },

--- a/apps/ui/src/lib/api/agents.ts
+++ b/apps/ui/src/lib/api/agents.ts
@@ -39,3 +39,31 @@ export async function updateAgent(
 export async function deleteAgent(agentId: string): Promise<void> {
   await api.delete(`/v1/agents/${agentId}`);
 }
+
+export async function exportAgent(agentId: string): Promise<string> {
+  // Use fetch directly since we need to return text, not JSON
+  const response = await fetch(`/api/v1/agents/${agentId}/export`, {
+    credentials: "include",
+  });
+  if (!response.ok) {
+    throw new Error(`Export failed: ${response.statusText}`);
+  }
+  return response.text();
+}
+
+export async function importAgent(markdown: string): Promise<Agent> {
+  // Use fetch directly since we need to send text/markdown content type
+  const response = await fetch("/api/v1/agents/import", {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "text/markdown",
+    },
+    body: markdown,
+  });
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(error || `Import failed: ${response.statusText}`);
+  }
+  return response.json();
+}

--- a/crates/control-plane/Cargo.toml
+++ b/crates/control-plane/Cargo.toml
@@ -27,6 +27,7 @@ tower.workspace = true
 tower-http.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+serde_yaml.workspace = true
 uuid.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/control-plane/src/api/agents.rs
+++ b/crates/control-plane/src/api/agents.rs
@@ -2,15 +2,18 @@
 
 use crate::storage::Database;
 use axum::{
+    body::Body,
     extract::{Path, State},
-    http::StatusCode,
+    http::{header, StatusCode},
+    response::Response,
     routing::{get, post},
     Json, Router,
 };
+use chrono::Utc;
 use everruns_core::{Agent, AgentStatus, CapabilityId};
 
 use super::common::ListResponse;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -75,6 +78,20 @@ pub struct UpdateAgentRequest {
     pub status: Option<AgentStatus>,
 }
 
+/// Agent file format for import (matches CLI format)
+/// Parsed from YAML front matter in Markdown files.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct AgentFile {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub system_prompt: Option<String>,
+    pub default_model_id: Option<Uuid>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+}
+
 use crate::services::AgentService;
 
 /// App state for agents routes
@@ -95,10 +112,12 @@ impl AppState {
 pub fn routes(state: AppState) -> Router {
     Router::new()
         .route("/v1/agents", post(create_agent).get(list_agents))
+        .route("/v1/agents/import", post(import_agent))
         .route(
             "/v1/agents/:agent_id",
             get(get_agent).patch(update_agent).delete(delete_agent),
         )
+        .route("/v1/agents/:agent_id/export", get(export_agent))
         .with_state(state)
 }
 
@@ -238,4 +257,234 @@ pub async fn delete_agent(
     } else {
         Err(StatusCode::NOT_FOUND)
     }
+}
+
+/// GET /v1/agents/{agent_id}/export - Export agent in Markdown format with YAML front matter
+#[utoipa::path(
+    get,
+    path = "/v1/agents/{agent_id}/export",
+    params(
+        ("agent_id" = Uuid, Path, description = "Agent ID")
+    ),
+    responses(
+        (status = 200, description = "Agent exported as Markdown", content_type = "text/markdown"),
+        (status = 404, description = "Agent not found"),
+        (status = 500, description = "Internal server error")
+    ),
+    tag = "agents"
+)]
+pub async fn export_agent(
+    State(state): State<AppState>,
+    Path(agent_id): Path<Uuid>,
+) -> Result<Response, StatusCode> {
+    let agent = state
+        .service
+        .get(agent_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to get agent for export: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    let markdown = agent_to_markdown(&agent);
+    let filename = format!("{}.md", slugify(&agent.name));
+
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "text/markdown; charset=utf-8")
+        .header(
+            header::CONTENT_DISPOSITION,
+            format!("attachment; filename=\"{}\"", filename),
+        )
+        .body(Body::from(markdown))
+        .unwrap())
+}
+
+/// POST /v1/agents/import - Import agent from Markdown, YAML, or JSON
+///
+/// Accepts agent definition in multiple formats:
+/// - Markdown with YAML front matter (if starts with ---)
+/// - Pure YAML
+/// - Pure JSON
+/// - Plain text (treated as system prompt, name auto-generated)
+#[utoipa::path(
+    post,
+    path = "/v1/agents/import",
+    request_body(content = String, content_type = "text/plain"),
+    responses(
+        (status = 201, description = "Agent imported successfully", body = Agent),
+        (status = 400, description = "Invalid format"),
+        (status = 500, description = "Internal server error")
+    ),
+    tag = "agents"
+)]
+pub async fn import_agent(
+    State(state): State<AppState>,
+    body: String,
+) -> Result<(StatusCode, Json<Agent>), (StatusCode, String)> {
+    let agent_file = parse_agent_content(&body)
+        .map_err(|e| (StatusCode::BAD_REQUEST, format!("Invalid format: {}", e)))?;
+
+    // Generate date-based name if not provided
+    let name = agent_file
+        .name
+        .unwrap_or_else(|| format!("agent-{}", Utc::now().format("%Y%m%d-%H%M%S")));
+
+    // System prompt is required (either from body or front matter)
+    let system_prompt = agent_file.system_prompt.unwrap_or_default();
+    if system_prompt.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "System prompt is required (provide in front matter or as markdown body)".to_string(),
+        ));
+    }
+
+    let request = CreateAgentRequest {
+        name,
+        description: agent_file.description,
+        system_prompt,
+        default_model_id: agent_file.default_model_id,
+        tags: agent_file.tags,
+        capabilities: agent_file
+            .capabilities
+            .into_iter()
+            .map(CapabilityId::from)
+            .collect(),
+    };
+
+    let agent = state.service.create(request).await.map_err(|e| {
+        tracing::error!("Failed to import agent: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Internal server error".to_string(),
+        )
+    })?;
+
+    Ok((StatusCode::CREATED, Json(agent)))
+}
+
+/// Convert agent to Markdown format with YAML front matter
+fn agent_to_markdown(agent: &Agent) -> String {
+    let mut front_matter = AgentFile {
+        name: Some(agent.name.clone()),
+        description: agent.description.clone(),
+        system_prompt: None, // System prompt goes in body
+        default_model_id: agent.default_model_id,
+        tags: agent.tags.clone(),
+        capabilities: agent.capabilities.iter().map(|c| c.to_string()).collect(),
+    };
+
+    // Don't include empty arrays in front matter
+    if front_matter.tags.is_empty() {
+        front_matter.tags = vec![];
+    }
+    if front_matter.capabilities.is_empty() {
+        front_matter.capabilities = vec![];
+    }
+
+    // Build YAML front matter (skip empty/default fields)
+    let mut yaml_lines = vec![];
+    yaml_lines.push(format!("name: \"{}\"", agent.name.replace('"', "\\\"")));
+
+    if let Some(ref desc) = front_matter.description {
+        yaml_lines.push(format!("description: \"{}\"", desc.replace('"', "\\\"")));
+    }
+
+    if let Some(model_id) = front_matter.default_model_id {
+        yaml_lines.push(format!("default_model_id: \"{}\"", model_id));
+    }
+
+    if !front_matter.tags.is_empty() {
+        yaml_lines.push("tags:".to_string());
+        for tag in &front_matter.tags {
+            yaml_lines.push(format!("  - \"{}\"", tag.replace('"', "\\\"")));
+        }
+    }
+
+    if !front_matter.capabilities.is_empty() {
+        yaml_lines.push("capabilities:".to_string());
+        for cap in &front_matter.capabilities {
+            yaml_lines.push(format!("  - {}", cap));
+        }
+    }
+
+    format!(
+        "---\n{}\n---\n{}",
+        yaml_lines.join("\n"),
+        agent.system_prompt
+    )
+}
+
+/// Parse agent content from multiple formats (matches CLI behavior).
+/// Tries: Markdown with front matter, JSON, YAML, plain text.
+fn parse_agent_content(content: &str) -> Result<AgentFile, String> {
+    let content = content.trim();
+
+    // Try markdown with front matter first (if starts with ---)
+    if content.starts_with("---") {
+        if let Ok(agent) = parse_markdown_frontmatter(content) {
+            return Ok(agent);
+        }
+    }
+
+    // Try JSON (if starts with {)
+    if content.starts_with('{') {
+        if let Ok(agent) = serde_json::from_str::<AgentFile>(content) {
+            return Ok(agent);
+        }
+    }
+
+    // Try YAML
+    if let Ok(agent) = serde_yaml::from_str::<AgentFile>(content) {
+        // Only accept if it parsed something meaningful (has name or system_prompt)
+        if agent.name.is_some() || agent.system_prompt.is_some() {
+            return Ok(agent);
+        }
+    }
+
+    // Fall back to treating entire content as system prompt
+    Ok(AgentFile {
+        name: None, // Will be auto-generated
+        description: None,
+        system_prompt: Some(content.to_string()),
+        default_model_id: None,
+        tags: vec![],
+        capabilities: vec![],
+    })
+}
+
+/// Parse markdown with YAML front matter.
+fn parse_markdown_frontmatter(content: &str) -> Result<AgentFile, String> {
+    // Find the closing delimiter
+    let rest = &content[3..];
+    let end_pos = rest
+        .find("\n---")
+        .ok_or("Missing closing front matter delimiter (---)")?;
+
+    let front_matter = rest[..end_pos].trim();
+    let body = rest.get(end_pos + 4..).unwrap_or("").trim();
+
+    // Parse front matter as YAML
+    let mut config: AgentFile =
+        serde_yaml::from_str(front_matter).map_err(|e| format!("Invalid YAML: {}", e))?;
+
+    // Body becomes system_prompt if not empty
+    if !body.is_empty() {
+        config.system_prompt = Some(body.to_string());
+    }
+
+    Ok(config)
+}
+
+/// Convert string to URL-safe slug
+fn slugify(s: &str) -> String {
+    s.to_lowercase()
+        .chars()
+        .map(|c| if c.is_alphanumeric() { c } else { '-' })
+        .collect::<String>()
+        .split('-')
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("-")
 }

--- a/crates/control-plane/src/openapi.rs
+++ b/crates/control-plane/src/openapi.rs
@@ -30,6 +30,8 @@ use utoipa::OpenApi;
         api::agents::get_agent,
         api::agents::update_agent,
         api::agents::delete_agent,
+        api::agents::export_agent,
+        api::agents::import_agent,
         api::sessions::create_session,
         api::sessions::list_sessions,
         api::sessions::get_session,

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -66,6 +66,44 @@
         }
       }
     },
+    "/v1/agents/import": {
+      "post": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "POST /v1/agents/import - Import agent from Markdown, YAML, or JSON",
+        "description": "Accepts agent definition in multiple formats:\n- Markdown with YAML front matter (if starts with ---)\n- Pure YAML\n- Pure JSON\n- Plain text (treated as system prompt, name auto-generated)",
+        "operationId": "import_agent",
+        "requestBody": {
+          "content": {
+            "text/plain": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Agent imported successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Agent"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid format"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
     "/v1/agents/{agent_id}": {
       "get": {
         "tags": [
@@ -171,6 +209,41 @@
                   "$ref": "#/components/schemas/Agent"
                 }
               }
+            }
+          },
+          "404": {
+            "description": "Agent not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/v1/agents/{agent_id}/export": {
+      "get": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "GET /v1/agents/{agent_id}/export - Export agent in Markdown format with YAML front matter",
+        "operationId": "export_agent",
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "path",
+            "description": "Agent ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Agent exported as Markdown",
+            "content": {
+              "text/markdown": {}
             }
           },
           "404": {


### PR DESCRIPTION
# feat(api): add agent import/export endpoints

## What

Add API endpoints and UI for importing/exporting agents in Markdown format with YAML front matter, matching the format used by the CLI.

## Why

Enables users to:
- Share agent configurations as portable Markdown files
- Back up and restore agents
- Version control agent configurations in Git
- Create agents from simple Markdown documents

## How

### API Endpoints

- `GET /v1/agents/{id}/export` - Export agent as Markdown with YAML front matter
- `POST /v1/agents/import` - Import agent from Markdown content

### Markdown Format (matches CLI)

```markdown
---
name: "Agent Name"
description: "Optional description"
capabilities:
  - current_time
  - web_fetch
tags:
  - tag1
---
System prompt goes here as the body.
```

Relaxed Import
If no front matter is provided, import creates an agent with:

Auto-generated date-based name (agent-20260107-142530)
Entire content treated as system prompt
UI Changes
Agent detail page: Export button downloads agent as .md file
Agents list page: Import button with file upload (accepts .md, .yaml, .yml, .json)
Risk
Low
Endpoints are additive, no changes to existing behavior
Checklist
 API endpoints implemented with OpenAPI docs
 UI import/export buttons added
 Format matches CLI implementation
 OpenAPI spec updated
 cargo fmt/clippy pass
 Unit tests pass
 UI builds successfully