### PR TITLE
feat(api): add input validation for agent create/update/import

### DIFF
--- a/crates/control-plane/src/api/common.rs
+++ b/crates/control-plane/src/api/common.rs
@@ -2,8 +2,30 @@
 //
 // These types are shared across multiple API endpoints.
 
+use axum::http::StatusCode;
+use axum::Json;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
+
+/// Standard error response for API endpoints.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct ErrorResponse {
+    /// Error message describing what went wrong.
+    pub error: String,
+}
+
+impl ErrorResponse {
+    pub fn new(error: impl Into<String>) -> Self {
+        Self {
+            error: error.into(),
+        }
+    }
+
+    /// Convert to axum response tuple
+    pub fn into_response(self, status: StatusCode) -> (StatusCode, Json<Self>) {
+        (status, Json(self))
+    }
+}
 
 /// Response wrapper for list endpoints.
 /// All list endpoints return responses wrapped in a `data` field.

--- a/crates/control-plane/src/api/mod.rs
+++ b/crates/control-plane/src/api/mod.rs
@@ -13,6 +13,7 @@ pub mod messages;
 pub mod session_files;
 pub mod sessions;
 pub mod users;
+pub mod validation;
 
 // Re-export common types
 pub use common::ListResponse;

--- a/crates/control-plane/src/api/mod.rs
+++ b/crates/control-plane/src/api/mod.rs
@@ -16,4 +16,4 @@ pub mod users;
 pub mod validation;
 
 // Re-export common types
-pub use common::ListResponse;
+pub use common::{ErrorResponse, ListResponse};

--- a/crates/control-plane/src/api/validation.rs
+++ b/crates/control-plane/src/api/validation.rs
@@ -4,7 +4,9 @@
 // These are hard limits, not configurable. Values chosen to allow legitimate
 // use while preventing resource exhaustion attacks.
 
+use super::common::ErrorResponse;
 use axum::http::StatusCode;
+use axum::Json;
 
 // =============================================================================
 // Input Size Limits
@@ -30,6 +32,10 @@ pub const MAX_AGENT_CAPABILITIES: usize = 250;
 /// 3 MB accommodates large system prompts with metadata.
 pub const MAX_AGENT_IMPORT_FILE_BYTES: usize = 3 * 1024 * 1024; // 3 MB
 
+/// Generic validation error message returned to clients.
+/// Intentionally vague to avoid leaking which field exceeded limits.
+pub const VALIDATION_ERROR_MESSAGE: &str = "Input exceeds allowed limits";
+
 // =============================================================================
 // Validation Functions
 // =============================================================================
@@ -47,7 +53,16 @@ impl From<ValidationError> for (StatusCode, String) {
     fn from(_: ValidationError) -> Self {
         (
             StatusCode::BAD_REQUEST,
-            "Input exceeds allowed limits".to_string(),
+            VALIDATION_ERROR_MESSAGE.to_string(),
+        )
+    }
+}
+
+impl From<ValidationError> for (StatusCode, Json<ErrorResponse>) {
+    fn from(_: ValidationError) -> Self {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(VALIDATION_ERROR_MESSAGE)),
         )
     }
 }

--- a/crates/control-plane/src/api/validation.rs
+++ b/crates/control-plane/src/api/validation.rs
@@ -1,0 +1,230 @@
+// Input validation for agent APIs
+//
+// Last-resort validation limits to guard Everruns from abuse.
+// These are hard limits, not configurable. Values chosen to allow legitimate
+// use while preventing resource exhaustion attacks.
+
+use axum::http::StatusCode;
+
+// =============================================================================
+// Input Size Limits
+// =============================================================================
+
+/// Maximum size for agent name field.
+/// 2 KB should accommodate any reasonable agent name.
+pub const MAX_AGENT_NAME_BYTES: usize = 2 * 1024; // 2 KB
+
+/// Maximum size for agent description field.
+/// 10 KB allows for detailed descriptions with formatting.
+pub const MAX_AGENT_DESCRIPTION_BYTES: usize = 10 * 1024; // 10 KB
+
+/// Maximum size for agent system prompt.
+/// 1 MB allows for very detailed prompts including embedded context.
+pub const MAX_AGENT_SYSTEM_PROMPT_BYTES: usize = 1024 * 1024; // 1 MB
+
+/// Maximum number of capabilities that can be assigned to an agent.
+/// 250 is generous for any practical use case.
+pub const MAX_AGENT_CAPABILITIES: usize = 250;
+
+/// Maximum size for agent import file.
+/// 3 MB accommodates large system prompts with metadata.
+pub const MAX_AGENT_IMPORT_FILE_BYTES: usize = 3 * 1024 * 1024; // 3 MB
+
+// =============================================================================
+// Validation Functions
+// =============================================================================
+
+/// Validation error - returns generic message to avoid leaking details
+pub struct ValidationError;
+
+impl From<ValidationError> for StatusCode {
+    fn from(_: ValidationError) -> Self {
+        StatusCode::BAD_REQUEST
+    }
+}
+
+impl From<ValidationError> for (StatusCode, String) {
+    fn from(_: ValidationError) -> Self {
+        (
+            StatusCode::BAD_REQUEST,
+            "Input exceeds allowed limits".to_string(),
+        )
+    }
+}
+
+/// Validate agent name size
+pub fn validate_agent_name(name: &str) -> Result<(), ValidationError> {
+    if name.len() > MAX_AGENT_NAME_BYTES {
+        tracing::warn!(
+            "Agent name exceeds limit: {} bytes (max: {})",
+            name.len(),
+            MAX_AGENT_NAME_BYTES
+        );
+        return Err(ValidationError);
+    }
+    Ok(())
+}
+
+/// Validate agent description size
+pub fn validate_agent_description(description: Option<&str>) -> Result<(), ValidationError> {
+    if let Some(desc) = description {
+        if desc.len() > MAX_AGENT_DESCRIPTION_BYTES {
+            tracing::warn!(
+                "Agent description exceeds limit: {} bytes (max: {})",
+                desc.len(),
+                MAX_AGENT_DESCRIPTION_BYTES
+            );
+            return Err(ValidationError);
+        }
+    }
+    Ok(())
+}
+
+/// Validate agent system prompt size
+pub fn validate_agent_system_prompt(system_prompt: &str) -> Result<(), ValidationError> {
+    if system_prompt.len() > MAX_AGENT_SYSTEM_PROMPT_BYTES {
+        tracing::warn!(
+            "Agent system prompt exceeds limit: {} bytes (max: {})",
+            system_prompt.len(),
+            MAX_AGENT_SYSTEM_PROMPT_BYTES
+        );
+        return Err(ValidationError);
+    }
+    Ok(())
+}
+
+/// Validate capabilities count
+pub fn validate_agent_capabilities_count(count: usize) -> Result<(), ValidationError> {
+    if count > MAX_AGENT_CAPABILITIES {
+        tracing::warn!(
+            "Agent capabilities count exceeds limit: {} (max: {})",
+            count,
+            MAX_AGENT_CAPABILITIES
+        );
+        return Err(ValidationError);
+    }
+    Ok(())
+}
+
+/// Validate import file size
+pub fn validate_import_file_size(size: usize) -> Result<(), ValidationError> {
+    if size > MAX_AGENT_IMPORT_FILE_BYTES {
+        tracing::warn!(
+            "Agent import file exceeds limit: {} bytes (max: {})",
+            size,
+            MAX_AGENT_IMPORT_FILE_BYTES
+        );
+        return Err(ValidationError);
+    }
+    Ok(())
+}
+
+/// Validate all fields for CreateAgentRequest
+pub fn validate_create_agent_input(
+    name: &str,
+    description: Option<&str>,
+    system_prompt: &str,
+    capabilities_count: usize,
+) -> Result<(), ValidationError> {
+    validate_agent_name(name)?;
+    validate_agent_description(description)?;
+    validate_agent_system_prompt(system_prompt)?;
+    validate_agent_capabilities_count(capabilities_count)?;
+    Ok(())
+}
+
+/// Validate all provided fields for UpdateAgentRequest
+pub fn validate_update_agent_input(
+    name: Option<&str>,
+    description: Option<&str>,
+    system_prompt: Option<&str>,
+    capabilities_count: Option<usize>,
+) -> Result<(), ValidationError> {
+    if let Some(name) = name {
+        validate_agent_name(name)?;
+    }
+    // For update, description is Option<Option<String>> effectively
+    // but we receive Option<String> - validate if present
+    if let Some(desc) = description {
+        if desc.len() > MAX_AGENT_DESCRIPTION_BYTES {
+            tracing::warn!(
+                "Agent description exceeds limit: {} bytes (max: {})",
+                desc.len(),
+                MAX_AGENT_DESCRIPTION_BYTES
+            );
+            return Err(ValidationError);
+        }
+    }
+    if let Some(prompt) = system_prompt {
+        validate_agent_system_prompt(prompt)?;
+    }
+    if let Some(count) = capabilities_count {
+        validate_agent_capabilities_count(count)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_agent_name() {
+        assert!(validate_agent_name("My Agent").is_ok());
+        assert!(validate_agent_name(&"x".repeat(MAX_AGENT_NAME_BYTES)).is_ok());
+    }
+
+    #[test]
+    fn test_invalid_agent_name() {
+        assert!(validate_agent_name(&"x".repeat(MAX_AGENT_NAME_BYTES + 1)).is_err());
+    }
+
+    #[test]
+    fn test_valid_description() {
+        assert!(validate_agent_description(None).is_ok());
+        assert!(validate_agent_description(Some("Short description")).is_ok());
+        assert!(validate_agent_description(Some(&"x".repeat(MAX_AGENT_DESCRIPTION_BYTES))).is_ok());
+    }
+
+    #[test]
+    fn test_invalid_description() {
+        assert!(
+            validate_agent_description(Some(&"x".repeat(MAX_AGENT_DESCRIPTION_BYTES + 1))).is_err()
+        );
+    }
+
+    #[test]
+    fn test_valid_system_prompt() {
+        assert!(validate_agent_system_prompt("You are helpful.").is_ok());
+        assert!(validate_agent_system_prompt(&"x".repeat(MAX_AGENT_SYSTEM_PROMPT_BYTES)).is_ok());
+    }
+
+    #[test]
+    fn test_invalid_system_prompt() {
+        assert!(
+            validate_agent_system_prompt(&"x".repeat(MAX_AGENT_SYSTEM_PROMPT_BYTES + 1)).is_err()
+        );
+    }
+
+    #[test]
+    fn test_valid_capabilities_count() {
+        assert!(validate_agent_capabilities_count(0).is_ok());
+        assert!(validate_agent_capabilities_count(MAX_AGENT_CAPABILITIES).is_ok());
+    }
+
+    #[test]
+    fn test_invalid_capabilities_count() {
+        assert!(validate_agent_capabilities_count(MAX_AGENT_CAPABILITIES + 1).is_err());
+    }
+
+    #[test]
+    fn test_valid_import_file_size() {
+        assert!(validate_import_file_size(0).is_ok());
+        assert!(validate_import_file_size(MAX_AGENT_IMPORT_FILE_BYTES).is_ok());
+    }
+
+    #[test]
+    fn test_invalid_import_file_size() {
+        assert!(validate_import_file_size(MAX_AGENT_IMPORT_FILE_BYTES + 1).is_err());
+    }
+}

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -66,8 +66,25 @@
               }
             }
           },
+          "400": {
+            "description": "Input exceeds allowed limits",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -102,10 +119,24 @@
             }
           },
           "400": {
-            "description": "Invalid format"
+            "description": "Invalid format or input exceeds limits",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -217,11 +248,35 @@
               }
             }
           },
+          "400": {
+            "description": "Input exceeds allowed limits",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "404": {
-            "description": "Agent not found"
+            "description": "Agent not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -2321,6 +2376,19 @@
         "properties": {
           "deleted": {
             "type": "boolean"
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "description": "Standard error response for API endpoints.",
+        "required": [
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "Error message describing what went wrong."
           }
         }
       },

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -43,6 +43,12 @@ See [authentication.md](authentication.md) for full authentication specification
 | GET | `/v1/agents/{id}` | Get agent by ID |
 | PATCH | `/v1/agents/{id}` | Update agent |
 | DELETE | `/v1/agents/{id}` | Archive agent (soft delete) |
+| POST | `/v1/agents/import` | Import agent from file content |
+| GET | `/v1/agents/{id}/export` | Export agent as Markdown |
+
+**Input Validation:**
+
+All agent create/update/import endpoints enforce input size limits as last-resort protection against abuse. See [models.md](models.md#agent) for limit details. Validation failures return `400 Bad Request` with generic message "Input exceeds allowed limits".
 
 ### Sessions
 

--- a/specs/models.md
+++ b/specs/models.md
@@ -18,9 +18,22 @@ Configuration for an agentic loop. An agent can have many concurrent sessions.
 | `system_prompt` | string | System prompt for the LLM |
 | `default_model_id` | UUID? | Reference to llm_models table |
 | `tags` | string[] | Tags for organization/filtering |
+| `capabilities` | CapabilityId[] | Enabled capabilities |
 | `status` | enum | `active` or `archived` |
 | `created_at` | timestamp | Creation time |
 | `updated_at` | timestamp | Last modification time |
+
+**Input Validation Limits:**
+
+Last-resort validation limits to guard against abuse. API returns generic `400 Bad Request` with message "Input exceeds allowed limits" when violated.
+
+| Field | Max Size | Notes |
+|-------|----------|-------|
+| `name` | 2 KB | Display name |
+| `description` | 10 KB | Optional description |
+| `system_prompt` | 1 MB | Allows large prompts with embedded context |
+| `capabilities` | 250 items | Maximum capabilities per agent |
+| Import file | 3 MB | Maximum size for `/v1/agents/import` body |
 
 ### Session
 


### PR DESCRIPTION
## Summary
- Add last-resort input validation limits to guard Everruns from abuse
- Validation constants defined in `validation.rs` with documented rationale
- Generic error response ("Input exceeds allowed limits") avoids leaking field details

## Validation Limits
| Field | Max Size |
|-------|----------|
| `name` | 2 KB |
| `description` | 10 KB |
| `system_prompt` | 1 MB |
| `capabilities` | 250 items |
| Import file | 3 MB |

## Test plan
- [x] Unit tests for all validation functions pass
- [x] `cargo clippy` passes
- [x] `cargo fmt --check` passes
- [ ] Smoke tests verify endpoints still work with valid inputs
- [ ] Verify 400 response when limits exceeded
