### PR TITLE
feat(providers): add default LLM API key env vars for development

### DIFF
--- a/docs/sre/environment-variables.md
+++ b/docs/sre/environment-variables.md
@@ -52,7 +52,7 @@ CORS_ALLOWED_ORIGINS=https://app.example.com,https://admin.example.com
 
 ## LLM Provider API Keys
 
-LLM provider API keys (OpenAI, Anthropic, Azure OpenAI) are **not** configured via environment variables. Instead, they are stored encrypted in the database and managed via the Settings > Providers UI.
+LLM provider API keys (OpenAI, Anthropic, Azure OpenAI) are primarily stored encrypted in the database and managed via the Settings > Providers UI.
 
 | Property | Value |
 |----------|-------|
@@ -72,7 +72,27 @@ python3 -c "import os, base64; print('kek-v1:' + base64.b64encode(os.urandom(32)
 SECRETS_ENCRYPTION_KEY=kek-v1:your-generated-key-here
 ```
 
-**Note:** Environment variables like `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` are NOT used by the system. All API keys must be configured through the database.
+### Default API Keys (Development Convenience)
+
+For development, you can set default API keys via environment variables. These are used as fallbacks when providers don't have keys configured in the database.
+
+| Variable | Description |
+|----------|-------------|
+| `DEFAULT_OPENAI_API_KEY` | Fallback API key for OpenAI providers |
+| `DEFAULT_ANTHROPIC_API_KEY` | Fallback API key for Anthropic providers |
+
+**Example:**
+
+```bash
+# Set in .env or environment
+DEFAULT_OPENAI_API_KEY=sk-...
+DEFAULT_ANTHROPIC_API_KEY=sk-ant-...
+```
+
+**Notes:**
+- Database-stored keys always take priority over environment variables
+- These are intended for development convenience, not production use
+- The `./scripts/dev.sh start-all` command automatically sets these from `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` if present
 
 ## UI API Proxy Architecture
 

--- a/specs/models.md
+++ b/specs/models.md
@@ -331,7 +331,7 @@ Configuration for LLM API providers. Stores encrypted API keys and provider-spec
 - `anthropic` - Anthropic API (Claude models)
 - `azure_openai` - Azure OpenAI Service
 
-**Note:** Ollama and Custom provider types are no longer supported. All LLM provider API keys must be configured in the database (via Settings > Providers UI) - they are not read from environment variables.
+**Note:** Ollama and Custom provider types are no longer supported. LLM provider API keys are primarily configured in the database (via Settings > Providers UI), but environment variables can be used as fallbacks for development convenience.
 
 **Default Providers:**
 
@@ -340,9 +340,14 @@ Default providers (OpenAI, Anthropic) and their models are created via database 
 - OpenAI: `01933b5a-0000-7000-8000-000000000001`
 - Anthropic: `01933b5a-0000-7000-8000-000000000002`
 
-API keys can be set via:
-1. The Settings > Providers UI
-2. The `scripts/patch-provider-keys.sh` script (reads from `OPENAI_API_KEY`, `ANTHROPIC_API_KEY` env vars)
+**API Key Resolution Order:**
+1. **Database** (priority): Encrypted API key stored in `llm_providers.api_key_encrypted`
+2. **Environment Variable** (fallback): `DEFAULT_OPENAI_API_KEY` or `DEFAULT_ANTHROPIC_API_KEY`
+
+API keys can be configured via:
+1. The Settings > Providers UI (stores in database)
+2. The `scripts/patch-provider-keys.sh` script (patches database from `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`)
+3. Environment variables for development: `DEFAULT_OPENAI_API_KEY`, `DEFAULT_ANTHROPIC_API_KEY` (used only when database key is not set)
 
 ### LLM Model
 


### PR DESCRIPTION
## Summary

Add environment variables for default LLM API keys that work as fallbacks when providers don't have keys configured in the database. This simplifies local development by allowing API keys to be set via environment variables instead of requiring database setup.

## Changes

**Code:**
- `crates/control-plane/src/storage/repositories.rs`: Add `get_default_api_key_from_env()` fallback in `get_provider_with_api_key()`
- `scripts/dev.sh`: Set `DEFAULT_*` env vars during `start-all` from `OPENAI_API_KEY`/`ANTHROPIC_API_KEY`, remove API patching step

**Documentation:**
- `docs/sre/environment-variables.md`: Document new env vars
- `specs/models.md`: Update API key resolution order

## API Key Resolution Order

1. **Database** (priority): Encrypted API key stored in `llm_providers.api_key_encrypted`
2. **Environment Variable** (fallback): `DEFAULT_OPENAI_API_KEY` or `DEFAULT_ANTHROPIC_API_KEY`

## Test Plan

- [x] Unit tests for `get_default_api_key_from_env()` function (4 tests)
- [x] Smoke tests pass with env var fallback (`api_key_set: false` but LLM calls succeed)
- [x] Clippy and cargo fmt pass
