### PR TITLE
fix(docker): cross-compile sqlx-cli for ARM64 builds

### DIFF
--- a/docker/Dockerfile.unified
+++ b/docker/Dockerfile.unified
@@ -89,7 +89,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/app/target,id=target-${TARGETPLATFORM} \
     xx-cargo build --release --bin reencrypt-secrets && \
     cp target/$(xx-cargo --print-target-triple)/release/reencrypt-secrets /app/reencrypt-secrets && \
-    cargo install sqlx-cli --no-default-features --features postgres,rustls --locked
+    xx-cargo install sqlx-cli --no-default-features --features postgres,rustls --locked
 
 # ============================================================================
 # Stage 3a: Control-Plane Runtime image (distroless for minimal size and security)
@@ -148,7 +148,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy sqlx-cli from builder (host architecture, runs via script)
+# Copy sqlx-cli from builder (cross-compiled for target architecture)
 COPY --from=builder-admin /usr/local/cargo/bin/sqlx /usr/local/bin/sqlx
 
 # Copy the reencrypt-secrets binary


### PR DESCRIPTION
## What
Fix ARM64 Docker image build - the admin container's `sqlx` binary was compiled for x86_64 instead of ARM64.

## Why
ARM64 migrations failed with:

qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory


The `sqlx-cli` was installed using `cargo install` which compiles for the host (x86_64) architecture, not the target (ARM64).

## How
Changed `cargo install` to `xx-cargo install` in `docker/Dockerfile.unified`:
```diff
-    cargo install sqlx-cli --no-default-features --features postgres,rustls --locked
+    xx-cargo install sqlx-cli --no-default-features --features postgres,rustls --locked
```

This uses the same cross-compilation toolchain that reencrypt-secrets already uses.

## Risk
Low
Only affects ARM64 image builds
Uses existing cross-compilation infrastructure

## Checklist
 Backward compatibility considered (no breaking changes)
 Verified ARM64 image runs migrations successfully

