### PR TITLE
fix(docker): fix multi-platform build cache conflicts and eliminate QEMU for Rust images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -41,10 +41,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # QEMU needed for ARM builds (main branch, tags, and test branch)
-      # TODO: Remove temporary branch override after testing
+      # QEMU needed for ARM builds (main branch and tags only)
       - name: Set up QEMU
-        if: github.event_name == 'push' || github.head_ref == 'claude/fix-build-compilation-Affda'
+        if: github.event_name == 'push'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
@@ -70,11 +69,10 @@ jobs:
 
       # Build ARM64 only on main push and version tags (cross-compiled)
       # PRs only build amd64 for faster CI
-      # TODO: Remove temporary branch override after testing
       - name: Determine platforms
         id: platforms
         run: |
-          if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.head_ref }}" = "claude/fix-build-compilation-Affda" ]; then
+          if [ "${{ github.event_name }}" = "push" ]; then
             echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
           else
             echo "platforms=linux/amd64" >> $GITHUB_OUTPUT

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,9 +42,8 @@ jobs:
       - uses: actions/checkout@v4
 
       # QEMU needed for UI ARM builds (runs npm on target platform)
-      # TODO: Remove temporary branch override after testing
       - name: Set up QEMU
-        if: github.event_name == 'push' || github.head_ref == 'claude/fix-build-compilation-Affda'
+        if: github.event_name == 'push'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
@@ -70,11 +69,10 @@ jobs:
 
       # Build ARM64 only on main push and version tags (cross-compiled)
       # PRs only build amd64 for faster CI
-      # TODO: Remove temporary branch override after testing
       - name: Determine platforms
         id: platforms
         run: |
-          if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.head_ref }}" = "claude/fix-build-compilation-Affda" ]; then
+          if [ "${{ github.event_name }}" = "push" ]; then
             echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
           else
             echo "platforms=linux/amd64" >> $GITHUB_OUTPUT

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -44,7 +44,7 @@ jobs:
       # QEMU needed for ARM builds (main branch, tags, and test branch)
       # TODO: Remove temporary branch override after testing
       - name: Set up QEMU
-        if: github.event_name == 'push' || github.head_ref == 'claude/add-arm-image-building-LijHE'
+        if: github.event_name == 'push' || github.head_ref == 'claude/fix-build-compilation-Affda'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
@@ -74,7 +74,7 @@ jobs:
       - name: Determine platforms
         id: platforms
         run: |
-          if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.head_ref }}" = "claude/add-arm-image-building-LijHE" ]; then
+          if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.head_ref }}" = "claude/fix-build-compilation-Affda" ]; then
             echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
           else
             echo "platforms=linux/amd64" >> $GITHUB_OUTPUT

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,8 +42,9 @@ jobs:
       - uses: actions/checkout@v4
 
       # QEMU needed for UI ARM builds (runs npm on target platform)
+      # TODO: Remove temporary branch override after testing
       - name: Set up QEMU
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.head_ref == 'claude/fix-build-compilation-Affda'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
@@ -69,10 +70,11 @@ jobs:
 
       # Build ARM64 only on main push and version tags (cross-compiled)
       # PRs only build amd64 for faster CI
+      # TODO: Remove temporary branch override after testing
       - name: Determine platforms
         id: platforms
         run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
+          if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.head_ref }}" = "claude/fix-build-compilation-Affda" ]; then
             echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
           else
             echo "platforms=linux/amd64" >> $GITHUB_OUTPUT

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # QEMU needed for ARM builds (main branch and tags only)
+      # QEMU needed for UI ARM builds (runs npm on target platform)
       - name: Set up QEMU
         if: github.event_name == 'push'
         uses: docker/setup-qemu-action@v3

--- a/docker/Dockerfile.unified
+++ b/docker/Dockerfile.unified
@@ -143,13 +143,16 @@ CMD ["/app/everruns-worker"]
 # Run key re-encryption:
 #   docker run --rm everruns-admin reencrypt --dry-run
 #
+# CA certificates stage - runs on build platform to avoid QEMU
+FROM --platform=$BUILDPLATFORM debian:bookworm-slim AS ca-certs
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+
 FROM debian:bookworm-slim AS admin
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+# Copy CA certificates from build platform stage (no QEMU needed)
+COPY --from=ca-certs /etc/ssl/certs /etc/ssl/certs
 
 # Copy sqlx-cli from builder (cross-compiled for target architecture)
 COPY --from=builder-admin /usr/local/cargo/bin/sqlx /usr/local/bin/sqlx
@@ -160,9 +163,8 @@ COPY --from=builder-admin /app/reencrypt-secrets /app/reencrypt-secrets
 # Copy migrations
 COPY crates/control-plane/migrations /app/migrations
 
-# Copy entrypoint script
-COPY docker/admin-entrypoint.sh /app/entrypoint.sh
-RUN chmod +x /app/entrypoint.sh
+# Copy entrypoint script (--chmod avoids RUN on target platform)
+COPY --chmod=755 docker/admin-entrypoint.sh /app/entrypoint.sh
 
 ENV RUST_LOG=info
 

--- a/docker/Dockerfile.unified
+++ b/docker/Dockerfile.unified
@@ -58,8 +58,9 @@ FROM builder-base AS builder-control-plane
 ARG TARGETPLATFORM
 
 # Use cache mount for cargo registry and target directory
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
+# Each cache has platform-specific ID to avoid conflicts during multi-platform builds
+RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARGETPLATFORM} \
+    --mount=type=cache,target=/usr/local/cargo/git,id=cargo-git-${TARGETPLATFORM} \
     --mount=type=cache,target=/app/target,id=target-${TARGETPLATFORM} \
     xx-cargo build --release -p everruns-control-plane && \
     cp target/$(xx-cargo --print-target-triple)/release/everruns-control-plane /app/everruns-control-plane
@@ -71,8 +72,9 @@ FROM builder-base AS builder-worker
 
 ARG TARGETPLATFORM
 
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
+# Each cache has platform-specific ID to avoid conflicts during multi-platform builds
+RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARGETPLATFORM} \
+    --mount=type=cache,target=/usr/local/cargo/git,id=cargo-git-${TARGETPLATFORM} \
     --mount=type=cache,target=/app/target,id=target-${TARGETPLATFORM} \
     xx-cargo build --release -p everruns-worker && \
     cp target/$(xx-cargo --print-target-triple)/release/everruns-worker /app/everruns-worker
@@ -84,8 +86,9 @@ FROM builder-base AS builder-admin
 
 ARG TARGETPLATFORM
 
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
+# Each cache has platform-specific ID to avoid conflicts during multi-platform builds
+RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARGETPLATFORM} \
+    --mount=type=cache,target=/usr/local/cargo/git,id=cargo-git-${TARGETPLATFORM} \
     --mount=type=cache,target=/app/target,id=target-${TARGETPLATFORM} \
     xx-cargo build --release --bin reencrypt-secrets && \
     cp target/$(xx-cargo --print-target-triple)/release/reencrypt-secrets /app/reencrypt-secrets && \


### PR DESCRIPTION
## What
Fix cargo cache conflicts during multi-platform Docker builds and eliminate QEMU dependency for all Rust-based images (control-plane, worker, admin).

## Why
1. **Cache conflicts**: Shared cargo registry/git caches caused "File exists (os error 17)" errors when AMD64 and ARM64 builds tried to unpack crates simultaneously
2. **Slow ARM builds**: Admin stage ran `apt-get` on target platform, requiring QEMU emulation

## How
- Added platform-specific IDs to cargo cache mounts (`cargo-registry-${TARGETPLATFORM}`, `cargo-git-${TARGETPLATFORM}`)
- Added `ca-certs` stage running on `$BUILDPLATFORM` to fetch CA certificates
- Admin stage now copies certs instead of running `apt-get` on target
- Used `COPY --chmod=755` instead of `RUN chmod` for entrypoint

## Result
- All unified Dockerfile stages use pure cross-compilation + COPY (no QEMU)
- QEMU only needed for UI builds (npm runs on target platform)

## Risk
- Low
- Only affects Docker builds; no runtime changes

## Checklist
- [x] Tests added or updated (N/A - tested via CI ARM64 builds)
- [x] Backward compatibility considered (no breaking changes)
