### PR TITLE
fix(docker): move API keys config to control-plane only

### DIFF
--- a/docs/sre/environment-variables.md
+++ b/docs/sre/environment-variables.md
@@ -62,19 +62,19 @@ LLM provider API keys (OpenAI, Anthropic, Azure OpenAI) are primarily stored enc
 
 **Required for encryption:**
 
-The `SECRETS_ENCRYPTION_KEY` environment variable must be set for the API and Worker to encrypt/decrypt API keys:
+The `SECRETS_ENCRYPTION_KEY` environment variable must be set for the control-plane API to encrypt/decrypt API keys. Workers receive decrypted API keys via gRPC and do not need this variable.
 
 ```bash
 # Generate a new key
 python3 -c "import os, base64; print('kek-v1:' + base64.b64encode(os.urandom(32)).decode())"
 
-# Set in environment
+# Set in environment (control-plane only)
 SECRETS_ENCRYPTION_KEY=kek-v1:your-generated-key-here
 ```
 
 ### Default API Keys (Development Convenience)
 
-For development, you can set default API keys via environment variables. These are used as fallbacks when providers don't have keys configured in the database.
+For development, you can set default API keys via environment variables on the **control-plane only**. These are used as fallbacks when providers don't have keys configured in the database.
 
 | Variable | Description |
 |----------|-------------|
@@ -84,12 +84,14 @@ For development, you can set default API keys via environment variables. These a
 **Example:**
 
 ```bash
-# Set in .env or environment
+# Set in .env or environment (control-plane only)
 DEFAULT_OPENAI_API_KEY=sk-...
 DEFAULT_ANTHROPIC_API_KEY=sk-ant-...
 ```
 
 **Notes:**
+- These variables are only used by the control-plane, not workers
+- Workers receive API keys via gRPC from the control-plane
 - Database-stored keys always take priority over environment variables
 - These are intended for development convenience, not production use
 - The `./scripts/dev.sh start-all` command automatically sets these from `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` if present

--- a/examples/docker-compose-full.yaml
+++ b/examples/docker-compose-full.yaml
@@ -70,6 +70,8 @@ services:
     environment:
       DATABASE_URL: postgres://everruns:everruns@postgres:5432/everruns
       SECRETS_ENCRYPTION_KEY: ${SECRETS_ENCRYPTION_KEY}
+      DEFAULT_OPENAI_API_KEY: ${DEFAULT_OPENAI_API_KEY:-}
+      DEFAULT_ANTHROPIC_API_KEY: ${DEFAULT_ANTHROPIC_API_KEY:-}
       HOST: 0.0.0.0
       PORT: "9000"
       RUST_LOG: info
@@ -94,9 +96,6 @@ services:
     container_name: everruns-worker-1
     environment:
       GRPC_ADDRESS: api:9001
-      SECRETS_ENCRYPTION_KEY: ${SECRETS_ENCRYPTION_KEY}
-      DEFAULT_OPENAI_API_KEY: ${DEFAULT_OPENAI_API_KEY:-}
-      DEFAULT_ANTHROPIC_API_KEY: ${DEFAULT_ANTHROPIC_API_KEY:-}
       RUST_LOG: info
       OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
     depends_on:
@@ -109,9 +108,6 @@ services:
     container_name: everruns-worker-2
     environment:
       GRPC_ADDRESS: api:9001
-      SECRETS_ENCRYPTION_KEY: ${SECRETS_ENCRYPTION_KEY}
-      DEFAULT_OPENAI_API_KEY: ${DEFAULT_OPENAI_API_KEY:-}
-      DEFAULT_ANTHROPIC_API_KEY: ${DEFAULT_ANTHROPIC_API_KEY:-}
       RUST_LOG: info
       OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
     depends_on:
@@ -124,9 +120,6 @@ services:
     container_name: everruns-worker-3
     environment:
       GRPC_ADDRESS: api:9001
-      SECRETS_ENCRYPTION_KEY: ${SECRETS_ENCRYPTION_KEY}
-      DEFAULT_OPENAI_API_KEY: ${DEFAULT_OPENAI_API_KEY:-}
-      DEFAULT_ANTHROPIC_API_KEY: ${DEFAULT_ANTHROPIC_API_KEY:-}
       RUST_LOG: info
       OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
     depends_on:


### PR DESCRIPTION
## Summary
- Move `DEFAULT_OPENAI_API_KEY` and `DEFAULT_ANTHROPIC_API_KEY` to control-plane service
- Remove `SECRETS_ENCRYPTION_KEY` and default API key env vars from worker services
- Update documentation to clarify control-plane-only requirements

## Why
Workers receive decrypted API keys via gRPC from the control-plane (see `worker.proto:268`). They don't need encryption keys or default API keys - these are only used by the control-plane.

## Test plan
- [ ] Verify docker-compose starts correctly with `.env` containing only control-plane secrets
- [ ] Confirm workers can still make LLM calls (keys passed via gRPC)
