### PR TITLE
fix(docker): fix OTEL DNS errors by adding jaeger dependency

### DIFF
--- a/docs/getting-started/docker-compose.md
+++ b/docs/getting-started/docker-compose.md
@@ -40,6 +40,9 @@ SECRETS_ENCRYPTION_KEY=kek-v1:<your-generated-key>
 # Optional: Add API keys here to skip UI configuration
 DEFAULT_OPENAI_API_KEY=sk-...
 DEFAULT_ANTHROPIC_API_KEY=sk-ant-...
+
+# Optional: Enable distributed tracing to Jaeger
+OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317
 ```
 
 ### 4. Start Services
@@ -55,7 +58,7 @@ This starts:
 - 3 worker instances
 - Next.js UI
 - Caddy reverse proxy
-- Jaeger tracing (optional)
+- Jaeger tracing (enabled when `OTEL_EXPORTER_OTLP_ENDPOINT` is set)
 
 ### 5. Access the Platform
 

--- a/docs/getting-started/docker-compose.md
+++ b/docs/getting-started/docker-compose.md
@@ -40,9 +40,6 @@ SECRETS_ENCRYPTION_KEY=kek-v1:<your-generated-key>
 # Optional: Add API keys here to skip UI configuration
 DEFAULT_OPENAI_API_KEY=sk-...
 DEFAULT_ANTHROPIC_API_KEY=sk-ant-...
-
-# Optional: Enable distributed tracing to Jaeger
-OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317
 ```
 
 ### 4. Start Services
@@ -58,7 +55,7 @@ This starts:
 - 3 worker instances
 - Next.js UI
 - Caddy reverse proxy
-- Jaeger tracing (enabled when `OTEL_EXPORTER_OTLP_ENDPOINT` is set)
+- Jaeger tracing
 
 ### 5. Access the Platform
 

--- a/examples/docker-compose-full.yaml
+++ b/examples/docker-compose-full.yaml
@@ -16,6 +16,7 @@
 #      SECRETS_ENCRYPTION_KEY=kek-v1:<your-generated-key>
 #      DEFAULT_OPENAI_API_KEY=sk-...        # Optional: OpenAI API key
 #      DEFAULT_ANTHROPIC_API_KEY=sk-ant-... # Optional: Anthropic API key
+#      OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317  # Optional: Enable tracing
 #
 #   3. Start everything:
 #      docker compose -f docker-compose-full.yaml up -d
@@ -73,7 +74,7 @@ services:
       HOST: 0.0.0.0
       PORT: "9000"
       RUST_LOG: info
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
     depends_on:
       postgres:
         condition: service_healthy
@@ -98,7 +99,7 @@ services:
       DEFAULT_OPENAI_API_KEY: ${DEFAULT_OPENAI_API_KEY:-}
       DEFAULT_ANTHROPIC_API_KEY: ${DEFAULT_ANTHROPIC_API_KEY:-}
       RUST_LOG: info
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
     depends_on:
       api:
         condition: service_started
@@ -113,7 +114,7 @@ services:
       DEFAULT_OPENAI_API_KEY: ${DEFAULT_OPENAI_API_KEY:-}
       DEFAULT_ANTHROPIC_API_KEY: ${DEFAULT_ANTHROPIC_API_KEY:-}
       RUST_LOG: info
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
     depends_on:
       api:
         condition: service_started
@@ -128,7 +129,7 @@ services:
       DEFAULT_OPENAI_API_KEY: ${DEFAULT_OPENAI_API_KEY:-}
       DEFAULT_ANTHROPIC_API_KEY: ${DEFAULT_ANTHROPIC_API_KEY:-}
       RUST_LOG: info
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
     depends_on:
       api:
         condition: service_started
@@ -165,6 +166,7 @@ services:
 
   # ==========================================================================
   # Jaeger (distributed tracing - optional)
+  # Set OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317 in .env to enable
   # ==========================================================================
   jaeger:
     image: jaegertracing/jaeger:2.4.0

--- a/examples/docker-compose-full.yaml
+++ b/examples/docker-compose-full.yaml
@@ -16,7 +16,6 @@
 #      SECRETS_ENCRYPTION_KEY=kek-v1:<your-generated-key>
 #      DEFAULT_OPENAI_API_KEY=sk-...        # Optional: OpenAI API key
 #      DEFAULT_ANTHROPIC_API_KEY=sk-ant-... # Optional: Anthropic API key
-#      OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317  # Optional: Enable tracing
 #
 #   3. Start everything:
 #      docker compose -f docker-compose-full.yaml up -d
@@ -74,7 +73,7 @@ services:
       HOST: 0.0.0.0
       PORT: "9000"
       RUST_LOG: info
-      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
     depends_on:
       postgres:
         condition: service_healthy
@@ -101,7 +100,7 @@ services:
       DEFAULT_OPENAI_API_KEY: ${DEFAULT_OPENAI_API_KEY:-}
       DEFAULT_ANTHROPIC_API_KEY: ${DEFAULT_ANTHROPIC_API_KEY:-}
       RUST_LOG: info
-      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
     depends_on:
       api:
         condition: service_started
@@ -116,7 +115,7 @@ services:
       DEFAULT_OPENAI_API_KEY: ${DEFAULT_OPENAI_API_KEY:-}
       DEFAULT_ANTHROPIC_API_KEY: ${DEFAULT_ANTHROPIC_API_KEY:-}
       RUST_LOG: info
-      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
     depends_on:
       api:
         condition: service_started
@@ -131,7 +130,7 @@ services:
       DEFAULT_OPENAI_API_KEY: ${DEFAULT_OPENAI_API_KEY:-}
       DEFAULT_ANTHROPIC_API_KEY: ${DEFAULT_ANTHROPIC_API_KEY:-}
       RUST_LOG: info
-      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
     depends_on:
       api:
         condition: service_started
@@ -167,8 +166,7 @@ services:
     restart: unless-stopped
 
   # ==========================================================================
-  # Jaeger (distributed tracing - optional)
-  # Set OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317 in .env to enable
+  # Jaeger (distributed tracing)
   # ==========================================================================
   jaeger:
     image: jaegertracing/jaeger:2.4.0

--- a/examples/docker-compose-full.yaml
+++ b/examples/docker-compose-full.yaml
@@ -80,6 +80,8 @@ services:
         condition: service_healthy
       migrate:
         condition: service_completed_successfully
+      jaeger:
+        condition: service_started
     healthcheck:
       test: ["CMD", "/app/everruns-control-plane", "--version"]
       interval: 10s


### PR DESCRIPTION
## What

Fix OpenTelemetry DNS errors that occur on startup when running the full Docker Compose example.

## Why

Services were configured with `OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317` but didn't depend on the jaeger service. When services started before Jaeger was ready, they got continuous DNS resolution errors:

> ERROR opentelemetry_sdk: name="BatchSpanProcessor.ExportError" error="Operation failed: status: Unavailable, message: "dns error""


## How

Added `jaeger` as a dependency for the `api` service with `condition: service_started`. Workers inherit this dependency through their existing dependency on `api`.

## Risk

- Low
- No breaking changes - tracing works by default as before, just without DNS errors

## Checklist

- [x] Tests added or updated (N/A - infrastructure change)
- [x] Backward compatibility considered
