### PR TITLE
chore(build): replace protoc with protox for pure Rust proto compilation

### DIFF
--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -355,7 +355,7 @@ For environments without Docker (Cloud Agent, CI, containers):
 ```
 
 This script automatically handles:
-1. **Dependencies** - Installs protoc (required for building) and jq if not present
+1. **Dependencies** - Installs jq if not present
 2. **PostgreSQL detection** - Supports three modes:
    - System install with `pg_ctlcluster` (Debian/Ubuntu standard)
    - Direct binaries (containers without pg_ctlcluster)
@@ -376,7 +376,6 @@ This script automatically handles:
 The no-Docker mode is specifically designed for cloud agent environments like Claude Code on the web:
 
 - **Auto-detects PostgreSQL** even without `pg_ctlcluster` command
-- **Installs protoc automatically** (required for gRPC)
 - **Works in containers** by using direct `pg_ctl` instead of systemd
 - **Supports both API keys** (`OPENAI_API_KEY` or `ANTHROPIC_API_KEY`)
 
@@ -440,15 +439,6 @@ export ANTHROPIC_API_KEY=your-key
 **"must be run as root"**: The PostgreSQL setup requires root access:
 ```bash
 sudo .claude/skills/smoke-test/scripts/run-no-docker.sh
-```
-
-**"protoc not found" during build**: The script auto-installs protoc, but if it fails:
-```bash
-# Debian/Ubuntu
-apt-get update && apt-get install -y protobuf-compiler
-
-# Verify
-protoc --version
 ```
 
 **Messages sent but no assistant response**: Ensure the durable worker is running:

--- a/.claude/skills/smoke-test/scripts/_utils.sh
+++ b/.claude/skills/smoke-test/scripts/_utils.sh
@@ -76,45 +76,6 @@ check_encryption_key() {
     fi
 }
 
-# Check and install protoc (required for building gRPC)
-check_protoc() {
-    if command -v protoc &> /dev/null; then
-        check_pass "protoc install - $(protoc --version)"
-        return 0
-    fi
-
-    log_info "protoc not found, installing..."
-
-    # Try apt-get (Debian/Ubuntu)
-    if command -v apt-get &> /dev/null; then
-        apt-get update -qq > /dev/null 2>&1
-        apt-get install -y -qq protobuf-compiler > /dev/null 2>&1
-        if command -v protoc &> /dev/null; then
-            check_pass "protoc install - $(protoc --version)"
-            return 0
-        fi
-    fi
-
-    # Try downloading from GitHub releases
-    log_info "Installing protoc from GitHub releases..."
-    local protoc_version="25.1"
-    local protoc_url="https://github.com/protocolbuffers/protobuf/releases/download/v${protoc_version}/protoc-${protoc_version}-linux-x86_64.zip"
-
-    curl -L --insecure "$protoc_url" -o /tmp/protoc.zip > /dev/null 2>&1
-    unzip -q /tmp/protoc.zip -d /tmp/protoc_extract > /dev/null 2>&1
-    mv /tmp/protoc_extract/bin/protoc /usr/local/bin/protoc
-    chmod +x /usr/local/bin/protoc
-    rm -rf /tmp/protoc.zip /tmp/protoc_extract
-
-    if command -v protoc &> /dev/null; then
-        check_pass "protoc install - $(protoc --version)"
-        return 0
-    fi
-
-    check_fail "protoc install" "could not install protoc"
-    exit 1
-}
-
 # Check and install jq (required for tests)
 check_jq() {
     if command -v jq &> /dev/null; then

--- a/.claude/skills/smoke-test/scripts/run-no-docker.sh
+++ b/.claude/skills/smoke-test/scripts/run-no-docker.sh
@@ -143,7 +143,6 @@ main() {
     echo ""
 
     # Check and install required tools
-    check_protoc
     check_jq
 
     echo ""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,10 +100,6 @@ When making changes that affect user-facing behavior or operations, update the r
 ### Local dev expectations
 
 - A `harness/docker-compose.yml` brings up Postgres + Jaeger
-- `protoc` (Protocol Buffers compiler) is required for building gRPC dependencies
-  - Debian/Ubuntu: `apt-get install protobuf-compiler`
-  - macOS: `brew install protobuf`
-  - Or download from https://github.com/protocolbuffers/protobuf/releases
 
 ### Smoke test prerequisites
 
@@ -114,9 +110,7 @@ Before running smoke tests, ensure these tools are installed:
    - macOS: `brew install postgresql`
    - Verify: `psql --version`
 
-2. **protoc** - Protocol Buffers compiler (see above)
-
-3. **jq** - JSON processor for test scripts
+2. **jq** - JSON processor for test scripts
    - Debian/Ubuntu: `apt-get install jq`
    - macOS: `brew install jq`
 
@@ -169,7 +163,7 @@ The codebase follows a layered architecture with clear boundaries. See `specs/ar
 
 4. **Internal Protocol Layer** (`internal-protocol/` → `everruns-internal-protocol`):
    - gRPC protocol definitions (proto files) for worker ↔ control-plane
-   - Generated Rust types via tonic-build
+   - Generated Rust types via tonic-build + protox (pure Rust, no external protoc binary)
    - Batched operations: `GetTurnContext`, `EmitEventStream`
 
 #### Naming conventions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d809780667f4410e7c41b07f52439b94d2bdf8528eeedc287fa38d3b7f95d82"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,7 +978,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -989,7 +995,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror",
+ "thiserror 2.0.17",
  "tokio",
  "uuid",
 ]
@@ -1024,7 +1030,7 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "sqlx",
- "thiserror",
+ "thiserror 2.0.17",
  "time",
  "tokio",
  "tokio-stream",
@@ -1057,7 +1063,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -1088,7 +1094,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "test-log",
- "thiserror",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-test",
  "tokio-util",
@@ -1107,6 +1113,7 @@ dependencies = [
  "everruns-core",
  "prost",
  "prost-types",
+ "protox",
  "serde",
  "serde_json",
  "tonic",
@@ -1126,7 +1133,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1151,7 +1158,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sqlx",
- "thiserror",
+ "thiserror 2.0.17",
  "tokio",
  "tonic",
  "tracing",
@@ -2007,7 +2014,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror",
+ "thiserror 2.0.17",
  "tiktoken-rs",
  "tokio",
  "tower 0.5.2",
@@ -2031,6 +2038,39 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "logos"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7251356ef8cb7aec833ddf598c6cb24d17b689d20b993f9d11a3d764e34e6458"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59f80069600c0d66734f5ff52cc42f2dabd6b29d205f333d61fd7832e9e9963f"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "syn",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24fb722b06a9dc12adb0963ed585f19fc61dc5413e6a9be9422ef92c091e731d"
+dependencies = [
+ "logos-codegen",
+]
 
 [[package]]
 name = "lru"
@@ -2077,6 +2117,28 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "mime"
@@ -2331,7 +2393,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror",
+ "thiserror 2.0.17",
  "tracing",
 ]
 
@@ -2364,7 +2426,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest",
- "thiserror",
+ "thiserror 2.0.17",
  "tokio",
  "tonic",
  "tracing",
@@ -2397,7 +2459,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.8.5",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2670,12 +2732,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-reflect"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5edd582b62f5cde844716e66d92565d7faf7ab1445c8cebce6e00fba83ddb2"
+dependencies = [
+ "logos",
+ "miette",
+ "once_cell",
+ "prost",
+ "prost-types",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "protox"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f352af331bf637b8ecc720f7c87bf903d2571fa2e14a66e9b2558846864b54a"
+dependencies = [
+ "bytes",
+ "miette",
+ "prost",
+ "prost-reflect",
+ "prost-types",
+ "protox-parse",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protox-parse"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3a462d115462c080ae000c29a47f0b3985737e5d3a995fcdbcaa5c782068dde"
+dependencies = [
+ "logos",
+ "miette",
+ "prost-types",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2692,7 +2794,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustls",
  "socket2 0.6.1",
- "thiserror",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "web-time",
@@ -2713,7 +2815,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.17",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3324,7 +3426,7 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 2.0.17",
  "time",
 ]
 
@@ -3424,7 +3526,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -3509,7 +3611,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.17",
  "tracing",
  "uuid",
  "whoami",
@@ -3548,7 +3650,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.17",
  "tracing",
  "uuid",
  "whoami",
@@ -3574,7 +3676,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror",
+ "thiserror 2.0.17",
  "tracing",
  "url",
  "uuid",
@@ -3726,11 +3828,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.17",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4958,7 +5080,7 @@ dependencies = [
  "flate2",
  "indexmap 2.13.0",
  "memchr",
- "thiserror",
+ "thiserror 2.0.17",
  "zopfli",
 ]
 

--- a/crates/internal-protocol/Cargo.toml
+++ b/crates/internal-protocol/Cargo.toml
@@ -37,3 +37,4 @@ chrono.workspace = true
 
 [build-dependencies]
 tonic-build = "0.12"
+protox = "0.7"

--- a/crates/internal-protocol/build.rs
+++ b/crates/internal-protocol/build.rs
@@ -1,7 +1,9 @@
+// Uses protox (pure Rust protobuf compiler) to avoid requiring external protoc binary
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let file_descriptors = protox::compile(["proto/worker.proto"], ["proto"])?;
     tonic_build::configure()
         .build_server(true)
         .build_client(true)
-        .compile_protos(&["proto/worker.proto"], &["proto"])?;
+        .compile_fds(file_descriptors)?;
     Ok(())
 }

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -35,29 +35,6 @@ ensure_docker_daemon() {
   return 1
 }
 
-ensure_protoc() {
-  if command -v protoc &> /dev/null; then
-    return 0
-  fi
-
-  echo "ℹ️  protoc not found. Attempting installation..."
-  if [[ "$OSTYPE" == "darwin"* ]] && command -v brew &> /dev/null; then
-    brew install protobuf || true
-  elif command -v apt-get &> /dev/null; then
-    sudo apt-get update && sudo apt-get install -y protobuf-compiler || true
-  fi
-
-  if command -v protoc &> /dev/null; then
-    echo "   ✅ protoc installed: $(protoc --version)"
-    return 0
-  fi
-
-  echo "❌ protoc is required (Protocol Buffers compiler). Install manually, e.g.:"
-  echo "   macOS:   brew install protobuf"
-  echo "   Debian:  sudo apt-get install -y protobuf-compiler"
-  return 1
-}
-
 # Load .env file if it exists
 if [ -f .env ]; then
   set -a
@@ -296,7 +273,6 @@ case "$command" in
       fi
     }
 
-    ensure_protoc || exit 1
     require_command cargo-watch "Run: ./scripts/dev.sh init"
     require_command sqlx "Run: ./scripts/dev.sh init"
     require_command npm "Install Node.js/npm to start the UI (see README.md)."
@@ -491,7 +467,6 @@ case "$command" in
     }
 
     echo "🧪 Preflight checks..."
-    ensure_protoc || exit 1
 
     # Rust tools
     echo "📦 Rust tools:"


### PR DESCRIPTION
## What
Replace external `protoc` binary dependency with `protox`, a pure Rust protobuf compiler.

## Why
The `protoc` binary requirement frequently confuses coding agents:
- Agents waste time troubleshooting "protoc not found" errors
- Installation varies by platform (apt, brew, manual download)
- Binary dependency adds setup friction

## How
- Add `protox = "0.7"` to internal-protocol build-dependencies
- Use `protox::compile()` + `compile_fds()` instead of `tonic_build::compile_protos()`
- Remove `ensure_protoc` from dev scripts
- Remove `check_protoc` from smoke test utils
- Update AGENTS.md and smoke test docs

## Risk
- Low
- First build takes ~10-15s longer (compiling protox crates)
- Incremental builds unaffected

## Checklist
- [x] Tests pass (197 unit tests)
- [x] Clippy clean
- [x] UI lint/build pass
- [x] Documentation updated
