### PR TITLE
fix(ui): show API key as configured when DEFAULT_ env var is set

### DIFF
--- a/specs/models.md
+++ b/specs/models.md
@@ -319,7 +319,7 @@ Configuration for LLM API providers. Stores encrypted API keys and provider-spec
 | `provider_type` | enum | `openai`, `anthropic`, `azure_openai` |
 | `base_url` | string? | Custom API endpoint (for Azure or proxies) |
 | `api_key_encrypted` | bytes? | AES-256-GCM encrypted API key |
-| `api_key_set` | boolean | Whether API key is configured |
+| `api_key_set` | boolean | Whether API key is configured (database or DEFAULT_ env var) |
 | `is_default` | boolean | Default provider for new agents |
 | `status` | enum | `active` or `disabled` |
 | `settings` | JSON | Provider-specific settings (e.g., Azure deployment_name) |


### PR DESCRIPTION
## What

When an LLM provider's API key is set via `DEFAULT_OPENAI_API_KEY` or `DEFAULT_ANTHROPIC_API_KEY` environment variables, the UI now correctly shows "API Key: Configured" instead of "API Key: Not set".

## Why

Previously, the `api_key_set` field only reflected whether an API key was stored in the database. When using the DEFAULT_ environment variables (a development convenience feature added in #183), the UI would misleadingly show "Not set" even though the provider would work correctly at runtime.

## How

Modified `LlmProviderService::row_to_provider()` to check both:
1. The database `api_key_set` flag (existing behavior)
2. Whether a DEFAULT_ environment variable is available for the provider type (new)

Added helper function `has_default_api_key_from_env()` that checks for:
- `DEFAULT_OPENAI_API_KEY` for OpenAI providers
- `DEFAULT_ANTHROPIC_API_KEY` for Anthropic providers

## Risk

- **Low** - Purely additive change to the `api_key_set` logic
- The change is read-only (no database modifications)
- Falls back gracefully for unknown provider types

## Checklist

- [x] Tests added (4 unit tests for `has_default_api_key_from_env`)
- [x] Format check passes (`cargo fmt --check`)
- [ ] Full build/lint (requires protoc - CI will verify)
- [x] Backward compatibility maintained
