### PR TITLE
fix(build): add cargo:rerun-if-changed for proto files

### DIFF
--- a/crates/internal-protocol/build.rs
+++ b/crates/internal-protocol/build.rs
@@ -1,5 +1,8 @@
 // Uses protox (pure Rust protobuf compiler) to avoid requiring external protoc binary
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ensure rebuild triggers when proto files change (protox doesn't emit these automatically)
+    println!("cargo:rerun-if-changed=proto/worker.proto");
+
     let file_descriptors = protox::compile(["proto/worker.proto"], ["proto"])?;
     tonic_build::configure()
         .build_server(true)


### PR DESCRIPTION
## What
Add explicit `cargo:rerun-if-changed` directive for proto files in the internal-protocol build script.

## Why
The recent switch from `tonic_build::compile_protos` to `protox::compile + tonic_build::compile_fds` (#190) removed the automatic `cargo:rerun-if-changed` output that the old method emitted. This caused proto file edits to not trigger rebuilds, leaving stale Rust types until a manual `cargo clean`.

## How
Add `println!("cargo:rerun-if-changed=proto/worker.proto");` before the protox compile call to restore proper rebuild triggering.

## Risk
- Low
- No functional changes to generated code, only build system behavior

## Checklist
- [x] Tests added or updated (N/A - build script change)
- [x] Backward compatibility considered (no breaking changes)
