### PR TITLE
fix(worker): emit user-visible error message when LLM call fails

### DIFF
--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/session-context.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/session-context.tsx
@@ -212,7 +212,9 @@ export function SessionProvider({ agentId, sessionId, children }: SessionProvide
     const realChatEvents = events
       ? events.filter(
           (e) =>
-            e.type === "message.user" || e.type === "message.agent" || e.type === "tool.call_completed"
+            e.type === "message.user" ||
+            e.type === "message.agent" ||
+            e.type === "tool.call_completed"
         )
       : [];
 

--- a/crates/control-plane/src/storage/message_store.rs
+++ b/crates/control-plane/src/storage/message_store.rs
@@ -85,24 +85,10 @@ impl MessageStore for DbMessageStore {
         Ok(messages.into_iter().find(|m| m.id == message_id))
     }
 
-    async fn store(&self, session_id: Uuid, message: Message) -> Result<()> {
-        // Only store assistant messages (user messages go through add())
-        // Tool results are stored as tool.call_completed events by ActAtom
-        if message.role != MessageRole::Assistant {
-            return Ok(());
-        }
-
-        let event_request = EventRequest::new(
-            session_id,
-            EventContext::empty(),
-            MessageAgentData::new(message),
-        );
-
-        self.event_service
-            .emit(event_request)
-            .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
-
+    async fn store(&self, _session_id: Uuid, _message: Message) -> Result<()> {
+        // No-op: message.agent events are emitted by ReasonAtom with proper turn context.
+        // This method exists for trait compatibility with InMemoryMessageStore (used in tests).
+        // The actual storage happens via EventEmitter when ReasonAtom emits the message.agent event.
         Ok(())
     }
 

--- a/docs/sre/environment-variables.md
+++ b/docs/sre/environment-variables.md
@@ -93,6 +93,7 @@ DEFAULT_ANTHROPIC_API_KEY=sk-ant-...
 - Database-stored keys always take priority over environment variables
 - These are intended for development convenience, not production use
 - The `./scripts/dev.sh start-all` command automatically sets these from `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` if present
+- If no API key is configured for a provider, LLM calls will fail and users will see an error message in the chat: "I encountered an error while processing your request. Please try again later."
 
 ## UI API Proxy Architecture
 

--- a/specs/events.md
+++ b/specs/events.md
@@ -161,7 +161,12 @@ Turn execution completed successfully.
 
 #### `turn.failed`
 
-Turn execution failed.
+Turn execution failed. This event is emitted when:
+- The LLM call fails (e.g., API key not configured, rate limit exceeded)
+- Max iterations exceeded
+- Other unrecoverable errors during turn execution
+
+When a turn fails, a `message.agent` event with a user-friendly error message is also emitted so users see feedback in the chat.
 
 ```json
 {
@@ -172,11 +177,17 @@ Turn execution failed.
   },
   "data": {
     "turn_id": "...",
-    "error": "Max iterations exceeded",
-    "error_code": "MAX_ITERATIONS"
+    "error": "An error occurred while processing your request.",
+    "error_code": "llm_error"
   }
 }
 ```
+
+**Error Codes:**
+| Code | Description |
+|------|-------------|
+| `llm_error` | LLM call failed (API key missing, rate limit, network error) |
+| `max_iterations` | Maximum iterations exceeded |
 
 ### Atom Lifecycle Events
 
@@ -231,6 +242,23 @@ ReasonAtom lifecycle - LLM inference.
     "text_preview": "First 200 chars...",
     "has_tool_calls": true,
     "tool_call_count": 2
+  }
+}
+```
+
+For failed reasoning (LLM call error):
+
+```json
+{
+  "type": "reason.completed",
+  "session_id": "...",
+  "context": { "turn_id": "...", "exec_id": "..." },
+  "data": {
+    "success": false,
+    "text_preview": null,
+    "has_tool_calls": false,
+    "tool_call_count": 0,
+    "error": "LLM error: API key is required"
   }
 }
 ```


### PR DESCRIPTION
## Summary

When an LLM call fails (e.g., API key not configured, rate limit exceeded), users now see a friendly error message in the chat instead of silence.

**Changes:**
- When ReasonAtom encounters an LLM error, it now stores and emits a `message.agent` event with a user-friendly error message
- The `reason_activity` now emits `turn.failed` event (instead of `turn.completed`) when the LLM call fails
- Error details are logged server-side but not exposed to users (following API error handling guidelines)
- Added `LlmSimConfig::error()` mode to simulate LLM errors in tests
- Updated specs and docs with error handling behavior

## Test plan

- [x] Unit tests pass (`cargo test -p everruns-core`)
- [x] New test `test_reason_atom_handles_llm_error` verifies:
  - Error result contains user-friendly message
  - `message.agent` event is emitted for user visibility  
  - `reason.completed` event indicates failure
  - Error message is stored in conversation history
- [x] Clippy passes with no warnings
- [x] Format check passes

## Risk

- **Low** - Adds error handling without changing happy path behavior
- Existing tests continue to pass
