### PR TITLE
feat(control-plane): add DEV_MODE for in-memory storage without PostgreSQL

### DIFF
--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -345,6 +345,28 @@ curl -s -o /dev/null -w "%{http_code}" "http://localhost:9100/agents/$AGENT_ID/s
 ```
 Expected: 200
 
+## DEV_MODE (UI-Only Changes)
+
+For changes that only impact the UI (no backend/API changes), DEV_MODE provides a faster testing workflow:
+
+```bash
+# Start in DEV_MODE - no Docker/PostgreSQL required
+./scripts/dev.sh start-dev
+```
+
+**When to use DEV_MODE:**
+- UI component changes (styling, layout, interactions)
+- Frontend-only bug fixes
+- UI development and iteration
+- Quick visual testing
+
+**Limitations:**
+- Data is not persisted (lost on restart)
+- No worker (LLM execution happens in-process)
+- Not suitable for testing backend changes or full integration
+
+For full end-to-end testing including backend changes, use the standard smoke tests below.
+
 ## No-Docker Mode
 
 For environments without Docker (Cloud Agent, CI, containers):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,18 @@ When making changes that affect user-facing behavior or operations, update the r
 
 ### Local dev expectations
 
+**Full mode (with PostgreSQL):**
 - A `harness/docker-compose.yml` brings up Postgres + Jaeger
+
+**DEV_MODE (no database required):**
+```bash
+# Quick start - no Docker/PostgreSQL needed
+./scripts/dev.sh start-dev
+```
+- Uses in-memory storage (data lost on restart)
+- Execution happens in-process (no separate worker)
+- Ideal for UI development and quick API testing
+- See `docs/sre/environment-variables.md` for details
 
 ### Smoke test prerequisites
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1040,6 +1040,7 @@ dependencies = [
  "hex",
  "http-body-util",
  "jsonwebtoken",
+ "parking_lot",
  "prost",
  "rand 0.8.5",
  "regex",
@@ -2008,6 +2009,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # Database
-sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "migrate", "uuid", "chrono"] }
+sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "sqlite", "migrate", "uuid", "chrono"] }
 
 # UUID and time
 uuid = { version = "1.11", features = ["v7", "serde"] }
@@ -85,6 +85,7 @@ serde_yaml = "0.9"
 eventsource-stream = "0.2"
 regex = "1.11"
 time = "0.3"
+parking_lot = "0.12"
 
 # Protocol Buffers (used by tonic/gRPC)
 prost = "0.13"

--- a/crates/control-plane/Cargo.toml
+++ b/crates/control-plane/Cargo.toml
@@ -49,6 +49,7 @@ regex.workspace = true
 async-trait.workspace = true
 aes-gcm.workspace = true
 argon2.workspace = true
+parking_lot.workspace = true
 
 everruns-core = { path = "../core", features = ["openapi"] }
 everruns-worker = { path = "../worker" }  # For AgentRunner trait

--- a/crates/control-plane/src/api/agents.rs
+++ b/crates/control-plane/src/api/agents.rs
@@ -1,6 +1,6 @@
 // Agent CRUD HTTP routes (M2)
 
-use crate::storage::Database;
+use crate::storage::StorageBackend;
 use axum::{
     body::Body,
     extract::{Path, State},
@@ -104,7 +104,7 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn new(db: Arc<Database>) -> Self {
+    pub fn new(db: Arc<StorageBackend>) -> Self {
         Self {
             service: Arc::new(AgentService::new(db)),
         }

--- a/crates/control-plane/src/api/events.rs
+++ b/crates/control-plane/src/api/events.rs
@@ -1,7 +1,7 @@
 // Event streaming HTTP routes (SSE)
 // Events are notifications streamed to clients, NOT primary data storage
 
-use crate::storage::Database;
+use crate::storage::StorageBackend;
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
@@ -45,7 +45,7 @@ pub struct AppState {
 impl AppState {
     /// Create app state with default event service (no listeners)
     #[allow(dead_code)]
-    pub fn new(db: Arc<Database>) -> Self {
+    pub fn new(db: Arc<StorageBackend>) -> Self {
         Self {
             session_service: Arc::new(SessionService::new(db.clone())),
             event_service: Arc::new(EventService::new(db)),
@@ -53,7 +53,7 @@ impl AppState {
     }
 
     /// Create app state with event listeners for observability
-    pub fn with_listeners(db: Arc<Database>, listeners: Vec<Arc<dyn EventListener>>) -> Self {
+    pub fn with_listeners(db: Arc<StorageBackend>, listeners: Vec<Arc<dyn EventListener>>) -> Self {
         Self {
             session_service: Arc::new(SessionService::new(db.clone())),
             event_service: Arc::new(EventService::with_listeners(db, listeners)),

--- a/crates/control-plane/src/api/llm_models.rs
+++ b/crates/control-plane/src/api/llm_models.rs
@@ -1,6 +1,6 @@
 // LLM Model API endpoints
 
-use crate::storage::Database;
+use crate::storage::StorageBackend;
 use axum::{
     extract::{Path, State},
     http::StatusCode,
@@ -21,7 +21,7 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn new(db: Arc<Database>) -> Self {
+    pub fn new(db: Arc<StorageBackend>) -> Self {
         Self {
             service: Arc::new(LlmModelService::new(db)),
         }

--- a/crates/control-plane/src/api/llm_providers.rs
+++ b/crates/control-plane/src/api/llm_providers.rs
@@ -1,6 +1,6 @@
 // LLM Provider API endpoints
 
-use crate::storage::{Database, EncryptionService};
+use crate::storage::{EncryptionService, StorageBackend};
 use axum::{
     extract::{Path, State},
     http::StatusCode,
@@ -23,7 +23,7 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn new(db: Arc<Database>, encryption: Option<Arc<EncryptionService>>) -> Self {
+    pub fn new(db: Arc<StorageBackend>, encryption: Option<Arc<EncryptionService>>) -> Self {
         Self {
             service: Arc::new(LlmProviderService::new(db, encryption)),
         }

--- a/crates/control-plane/src/api/messages.rs
+++ b/crates/control-plane/src/api/messages.rs
@@ -7,7 +7,7 @@
 // ContentPart and InputContentPart are defined in everruns-core.
 // We re-export them here with ToSchema for OpenAPI documentation.
 
-use crate::storage::Database;
+use crate::storage::StorageBackend;
 use axum::{
     extract::{Path, State},
     http::StatusCode,
@@ -148,7 +148,7 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn new(db: Arc<Database>, runner: Arc<dyn AgentRunner>) -> Self {
+    pub fn new(db: Arc<StorageBackend>, runner: Arc<dyn AgentRunner>) -> Self {
         Self {
             session_service: Arc::new(SessionService::new(db.clone())),
             message_service: Arc::new(MessageService::new(db, runner)),

--- a/crates/control-plane/src/api/session_files.rs
+++ b/crates/control-plane/src/api/session_files.rs
@@ -13,7 +13,7 @@
 // Note: Paths starting with "_" are reserved for actions and cannot be
 // used for file creation or updates.
 
-use crate::storage::Database;
+use crate::storage::StorageBackend;
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
@@ -136,7 +136,7 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn new(db: Arc<Database>) -> Self {
+    pub fn new(db: Arc<StorageBackend>) -> Self {
         Self {
             file_service: Arc::new(SessionFileService::new(db)),
         }

--- a/crates/control-plane/src/api/sessions.rs
+++ b/crates/control-plane/src/api/sessions.rs
@@ -1,6 +1,6 @@
 // Session CRUD HTTP routes
 
-use crate::storage::Database;
+use crate::storage::StorageBackend;
 use axum::{
     extract::{Path, State},
     http::StatusCode,
@@ -54,7 +54,7 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn new(db: Arc<Database>) -> Self {
+    pub fn new(db: Arc<StorageBackend>) -> Self {
         Self {
             session_service: Arc::new(SessionService::new(db)),
         }

--- a/crates/control-plane/src/api/users.rs
+++ b/crates/control-plane/src/api/users.rs
@@ -1,7 +1,7 @@
 // Users API routes
 // Decision: Expose user listing for admin settings page (member management)
 
-use crate::storage::Database;
+use crate::storage::StorageBackend;
 use axum::{
     extract::{Query, State},
     http::StatusCode,
@@ -20,7 +20,7 @@ use crate::auth::middleware::{AuthState, AuthUser, FromRef};
 /// App state for users routes
 #[derive(Clone)]
 pub struct UsersState {
-    pub db: Arc<Database>,
+    pub db: Arc<StorageBackend>,
     pub auth: AuthState,
 }
 

--- a/crates/control-plane/src/auth/middleware.rs
+++ b/crates/control-plane/src/auth/middleware.rs
@@ -18,7 +18,7 @@ use super::{
     config::{AuthConfig, AuthMode},
     jwt::JwtService,
 };
-use crate::storage::Database;
+use crate::storage::StorageBackend;
 
 /// Authentication error
 #[derive(Debug, Clone, Serialize)]
@@ -107,11 +107,11 @@ pub enum AuthMethod {
 pub struct AuthState {
     pub config: AuthConfig,
     pub jwt_service: Arc<JwtService>,
-    pub db: Arc<Database>,
+    pub db: Arc<StorageBackend>,
 }
 
 impl AuthState {
-    pub fn new(config: AuthConfig, db: Arc<Database>) -> Self {
+    pub fn new(config: AuthConfig, db: Arc<StorageBackend>) -> Self {
         let jwt_service = Arc::new(JwtService::new(config.jwt.clone()));
         Self {
             config,

--- a/crates/control-plane/src/services/agent.rs
+++ b/crates/control-plane/src/services/agent.rs
@@ -6,7 +6,7 @@
 
 use crate::storage::{
     models::{CreateAgentRow, UpdateAgent},
-    AgentRow, Database,
+    AgentRow, StorageBackend,
 };
 use anyhow::Result;
 use everruns_core::{Agent, AgentStatus, CapabilityId};
@@ -16,11 +16,11 @@ use uuid::Uuid;
 use crate::api::agents::{CreateAgentRequest, UpdateAgentRequest};
 
 pub struct AgentService {
-    db: Arc<Database>,
+    db: Arc<StorageBackend>,
 }
 
 impl AgentService {
-    pub fn new(db: Arc<Database>) -> Self {
+    pub fn new(db: Arc<StorageBackend>) -> Self {
         Self { db }
     }
 

--- a/crates/control-plane/src/services/capability.rs
+++ b/crates/control-plane/src/services/capability.rs
@@ -5,19 +5,19 @@
 //
 // Note: Agent-specific capability management is handled by AgentService.
 
-use crate::storage::Database;
+use crate::storage::StorageBackend;
 use everruns_core::capabilities::CapabilityRegistry;
 use everruns_core::{CapabilityId, CapabilityInfo};
 use std::sync::Arc;
 
 pub struct CapabilityService {
     #[allow(dead_code)]
-    db: Arc<Database>,
+    db: Arc<StorageBackend>,
     registry: CapabilityRegistry,
 }
 
 impl CapabilityService {
-    pub fn new(db: Arc<Database>) -> Self {
+    pub fn new(db: Arc<StorageBackend>) -> Self {
         Self {
             db,
             registry: CapabilityRegistry::with_builtins(),

--- a/crates/control-plane/src/services/event.rs
+++ b/crates/control-plane/src/services/event.rs
@@ -13,7 +13,7 @@
 // observability integrations (OTel spans, metrics, etc.). Listeners are
 // called synchronously but should be non-blocking.
 
-use crate::storage::{models::CreateEventRow, Database, EventRow};
+use crate::storage::{models::CreateEventRow, EventRow, StorageBackend};
 use anyhow::Result;
 use everruns_core::{Event, EventData, EventListener, EventRequest};
 use std::sync::Arc;
@@ -21,13 +21,13 @@ use uuid::Uuid;
 
 #[derive(Clone)]
 pub struct EventService {
-    db: Arc<Database>,
+    db: Arc<StorageBackend>,
     /// Registered event listeners for observability
     listeners: Arc<Vec<Arc<dyn EventListener>>>,
 }
 
 impl EventService {
-    pub fn new(db: Arc<Database>) -> Self {
+    pub fn new(db: Arc<StorageBackend>) -> Self {
         Self {
             db,
             listeners: Arc::new(Vec::new()),
@@ -35,7 +35,7 @@ impl EventService {
     }
 
     /// Create an EventService with registered listeners
-    pub fn with_listeners(db: Arc<Database>, listeners: Vec<Arc<dyn EventListener>>) -> Self {
+    pub fn with_listeners(db: Arc<StorageBackend>, listeners: Vec<Arc<dyn EventListener>>) -> Self {
         Self {
             db,
             listeners: Arc::new(listeners),

--- a/crates/control-plane/src/services/llm_model.rs
+++ b/crates/control-plane/src/services/llm_model.rs
@@ -2,7 +2,7 @@
 
 use crate::storage::{
     models::{CreateLlmModelRow, LlmModelRow, LlmModelWithProviderRow, UpdateLlmModel},
-    Database,
+    StorageBackend,
 };
 use anyhow::Result;
 use everruns_core::{
@@ -14,11 +14,11 @@ use uuid::Uuid;
 use crate::api::llm_models::{CreateLlmModelRequest, UpdateLlmModelRequest};
 
 pub struct LlmModelService {
-    db: Arc<Database>,
+    db: Arc<StorageBackend>,
 }
 
 impl LlmModelService {
-    pub fn new(db: Arc<Database>) -> Self {
+    pub fn new(db: Arc<StorageBackend>) -> Self {
         Self { db }
     }
 

--- a/crates/control-plane/src/services/llm_provider.rs
+++ b/crates/control-plane/src/services/llm_provider.rs
@@ -2,7 +2,7 @@
 
 use crate::storage::{
     models::{CreateLlmProviderRow, LlmProviderRow, UpdateLlmProvider},
-    Database, EncryptionService,
+    EncryptionService, StorageBackend,
 };
 use anyhow::{anyhow, Result};
 use everruns_core::llm_models::LlmProvider;
@@ -13,12 +13,12 @@ use uuid::Uuid;
 use crate::api::llm_providers::{CreateLlmProviderRequest, UpdateLlmProviderRequest};
 
 pub struct LlmProviderService {
-    db: Arc<Database>,
+    db: Arc<StorageBackend>,
     encryption: Option<Arc<EncryptionService>>,
 }
 
 impl LlmProviderService {
-    pub fn new(db: Arc<Database>, encryption: Option<Arc<EncryptionService>>) -> Self {
+    pub fn new(db: Arc<StorageBackend>, encryption: Option<Arc<EncryptionService>>) -> Self {
         Self { db, encryption }
     }
 

--- a/crates/control-plane/src/services/llm_resolver.rs
+++ b/crates/control-plane/src/services/llm_resolver.rs
@@ -3,7 +3,7 @@
 // This service handles the resolution of LLM models with their provider credentials,
 // including API key decryption. Used by gRPC service for worker communication.
 
-use crate::storage::{Database, EncryptionService};
+use crate::storage::{EncryptionService, StorageBackend};
 use anyhow::{anyhow, Result};
 use std::sync::Arc;
 use uuid::Uuid;
@@ -25,12 +25,12 @@ pub struct ResolvedModel {
 }
 
 pub struct LlmResolverService {
-    db: Arc<Database>,
+    db: Arc<StorageBackend>,
     encryption: Option<Arc<EncryptionService>>,
 }
 
 impl LlmResolverService {
-    pub fn new(db: Arc<Database>, encryption: Option<Arc<EncryptionService>>) -> Self {
+    pub fn new(db: Arc<StorageBackend>, encryption: Option<Arc<EncryptionService>>) -> Self {
         Self { db, encryption }
     }
 

--- a/crates/control-plane/src/services/message.rs
+++ b/crates/control-plane/src/services/message.rs
@@ -7,7 +7,7 @@
 
 use super::EventService;
 use crate::api::messages::{ContentPart, CreateMessageRequest, Message, MessageRole};
-use crate::storage::Database;
+use crate::storage::StorageBackend;
 use anyhow::Result;
 use chrono::Utc;
 use everruns_core::events::{EventContext, EventRequest, MessageUserData};
@@ -17,13 +17,13 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 pub struct MessageService {
-    db: Arc<Database>,
+    db: Arc<StorageBackend>,
     event_service: EventService,
     runner: Arc<dyn AgentRunner>,
 }
 
 impl MessageService {
-    pub fn new(db: Arc<Database>, runner: Arc<dyn AgentRunner>) -> Self {
+    pub fn new(db: Arc<StorageBackend>, runner: Arc<dyn AgentRunner>) -> Self {
         let event_service = EventService::new(db.clone());
         Self {
             db,

--- a/crates/control-plane/src/services/session.rs
+++ b/crates/control-plane/src/services/session.rs
@@ -2,7 +2,7 @@
 
 use crate::storage::{
     models::{CreateSessionRow, UpdateSession},
-    Database,
+    StorageBackend,
 };
 use anyhow::Result;
 use everruns_core::{Session, SessionStatus};
@@ -12,11 +12,11 @@ use uuid::Uuid;
 use crate::api::sessions::{CreateSessionRequest, UpdateSessionRequest};
 
 pub struct SessionService {
-    db: Arc<Database>,
+    db: Arc<StorageBackend>,
 }
 
 impl SessionService {
-    pub fn new(db: Arc<Database>) -> Self {
+    pub fn new(db: Arc<StorageBackend>) -> Self {
         Self { db }
     }
 

--- a/crates/control-plane/src/services/session_file.rs
+++ b/crates/control-plane/src/services/session_file.rs
@@ -2,7 +2,7 @@
 
 use crate::storage::{
     models::{CreateSessionFileRow, SessionFileInfoRow, SessionFileRow, UpdateSessionFile},
-    Database,
+    StorageBackend,
 };
 use anyhow::{anyhow, Result};
 use everruns_core::{FileInfo, FileStat, GrepMatch, GrepResult, SessionFile};
@@ -49,11 +49,11 @@ pub struct GrepInput {
 }
 
 pub struct SessionFileService {
-    db: Arc<Database>,
+    db: Arc<StorageBackend>,
 }
 
 impl SessionFileService {
-    pub fn new(db: Arc<Database>) -> Self {
+    pub fn new(db: Arc<StorageBackend>) -> Self {
         Self { db }
     }
 

--- a/crates/control-plane/src/storage/backend.rs
+++ b/crates/control-plane/src/storage/backend.rs
@@ -1,0 +1,628 @@
+// Storage backend abstraction
+// Decision: Use enum dispatch for simplicity over trait objects
+//
+// This module provides a unified StorageBackend enum that can work with
+// either PostgreSQL (production) or in-memory (dev mode) storage.
+
+use anyhow::Result;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use super::memory::InMemoryDatabase;
+use super::models::*;
+use super::repositories::Database;
+
+/// Storage backend that can be either PostgreSQL or in-memory
+#[derive(Clone)]
+pub enum StorageBackend {
+    /// PostgreSQL database (production)
+    Postgres(Database),
+    /// In-memory database (dev mode)
+    InMemory(std::sync::Arc<InMemoryDatabase>),
+}
+
+impl StorageBackend {
+    /// Create a PostgreSQL storage backend from a database URL
+    pub async fn postgres(database_url: &str) -> Result<Self> {
+        let db = Database::from_url(database_url).await?;
+        Ok(Self::Postgres(db))
+    }
+
+    /// Create an in-memory storage backend
+    pub fn in_memory() -> Self {
+        Self::InMemory(std::sync::Arc::new(InMemoryDatabase::new()))
+    }
+
+    /// Check if this is dev mode (in-memory)
+    pub fn is_dev_mode(&self) -> bool {
+        matches!(self, Self::InMemory(_))
+    }
+
+    /// Get the PostgreSQL pool if using PostgreSQL backend
+    /// Returns None for in-memory backend
+    pub fn pool(&self) -> Option<&PgPool> {
+        match self {
+            Self::Postgres(db) => Some(db.pool()),
+            Self::InMemory(_) => None,
+        }
+    }
+
+    // ============================================
+    // Users
+    // ============================================
+
+    pub async fn create_user(&self, input: CreateUserRow) -> Result<UserRow> {
+        match self {
+            Self::Postgres(db) => db.create_user(input).await,
+            Self::InMemory(db) => db.create_user(input).await,
+        }
+    }
+
+    pub async fn get_user_by_email(&self, email: &str) -> Result<Option<UserRow>> {
+        match self {
+            Self::Postgres(db) => db.get_user_by_email(email).await,
+            Self::InMemory(db) => db.get_user_by_email(email).await,
+        }
+    }
+
+    pub async fn get_user(&self, id: Uuid) -> Result<Option<UserRow>> {
+        match self {
+            Self::Postgres(db) => db.get_user(id).await,
+            Self::InMemory(db) => db.get_user(id).await,
+        }
+    }
+
+    pub async fn get_user_by_oauth(
+        &self,
+        provider: &str,
+        provider_id: &str,
+    ) -> Result<Option<UserRow>> {
+        match self {
+            Self::Postgres(db) => db.get_user_by_oauth(provider, provider_id).await,
+            Self::InMemory(db) => db.get_user_by_oauth(provider, provider_id).await,
+        }
+    }
+
+    pub async fn update_user(&self, id: Uuid, input: UpdateUser) -> Result<Option<UserRow>> {
+        match self {
+            Self::Postgres(db) => db.update_user(id, input).await,
+            Self::InMemory(db) => db.update_user(id, input).await,
+        }
+    }
+
+    pub async fn list_users(&self, search: Option<&str>) -> Result<Vec<UserRow>> {
+        match self {
+            Self::Postgres(db) => db.list_users(search).await,
+            Self::InMemory(db) => db.list_users(search).await,
+        }
+    }
+
+    // ============================================
+    // API Keys
+    // ============================================
+
+    pub async fn create_api_key(&self, input: CreateApiKeyRow) -> Result<ApiKeyRow> {
+        match self {
+            Self::Postgres(db) => db.create_api_key(input).await,
+            Self::InMemory(db) => db.create_api_key(input).await,
+        }
+    }
+
+    pub async fn get_api_key_by_hash(&self, key_hash: &str) -> Result<Option<ApiKeyRow>> {
+        match self {
+            Self::Postgres(db) => db.get_api_key_by_hash(key_hash).await,
+            Self::InMemory(db) => db.get_api_key_by_hash(key_hash).await,
+        }
+    }
+
+    pub async fn list_api_keys_for_user(&self, user_id: Uuid) -> Result<Vec<ApiKeyRow>> {
+        match self {
+            Self::Postgres(db) => db.list_api_keys_for_user(user_id).await,
+            Self::InMemory(db) => db.list_api_keys_for_user(user_id).await,
+        }
+    }
+
+    pub async fn update_api_key_last_used(&self, id: Uuid) -> Result<()> {
+        match self {
+            Self::Postgres(db) => db.update_api_key_last_used(id).await,
+            Self::InMemory(db) => db.update_api_key_last_used(id).await,
+        }
+    }
+
+    pub async fn delete_api_key(&self, id: Uuid, user_id: Uuid) -> Result<bool> {
+        match self {
+            Self::Postgres(db) => db.delete_api_key(id, user_id).await,
+            Self::InMemory(db) => db.delete_api_key(id, user_id).await,
+        }
+    }
+
+    // ============================================
+    // Refresh Tokens
+    // ============================================
+
+    pub async fn create_refresh_token(
+        &self,
+        input: CreateRefreshTokenRow,
+    ) -> Result<RefreshTokenRow> {
+        match self {
+            Self::Postgres(db) => db.create_refresh_token(input).await,
+            Self::InMemory(db) => db.create_refresh_token(input).await,
+        }
+    }
+
+    pub async fn get_refresh_token_by_hash(
+        &self,
+        token_hash: &str,
+    ) -> Result<Option<RefreshTokenRow>> {
+        match self {
+            Self::Postgres(db) => db.get_refresh_token_by_hash(token_hash).await,
+            Self::InMemory(db) => db.get_refresh_token_by_hash(token_hash).await,
+        }
+    }
+
+    pub async fn delete_refresh_token(&self, id: Uuid) -> Result<bool> {
+        match self {
+            Self::Postgres(db) => db.delete_refresh_token(id).await,
+            Self::InMemory(db) => db.delete_refresh_token(id).await,
+        }
+    }
+
+    pub async fn delete_expired_refresh_tokens(&self) -> Result<u64> {
+        match self {
+            Self::Postgres(db) => db.delete_expired_refresh_tokens().await,
+            Self::InMemory(db) => db.delete_expired_refresh_tokens().await,
+        }
+    }
+
+    pub async fn delete_user_refresh_tokens(&self, user_id: Uuid) -> Result<u64> {
+        match self {
+            Self::Postgres(db) => db.delete_user_refresh_tokens(user_id).await,
+            Self::InMemory(db) => db.delete_user_refresh_tokens(user_id).await,
+        }
+    }
+
+    // ============================================
+    // Agents
+    // ============================================
+
+    pub async fn create_agent(&self, input: CreateAgentRow) -> Result<AgentRow> {
+        match self {
+            Self::Postgres(db) => db.create_agent(input).await,
+            Self::InMemory(db) => db.create_agent(input).await,
+        }
+    }
+
+    pub async fn get_agent(&self, id: Uuid) -> Result<Option<AgentRow>> {
+        match self {
+            Self::Postgres(db) => db.get_agent(id).await,
+            Self::InMemory(db) => db.get_agent(id).await,
+        }
+    }
+
+    pub async fn list_agents(&self) -> Result<Vec<AgentRow>> {
+        match self {
+            Self::Postgres(db) => db.list_agents().await,
+            Self::InMemory(db) => db.list_agents().await,
+        }
+    }
+
+    pub async fn update_agent(&self, id: Uuid, input: UpdateAgent) -> Result<Option<AgentRow>> {
+        match self {
+            Self::Postgres(db) => db.update_agent(id, input).await,
+            Self::InMemory(db) => db.update_agent(id, input).await,
+        }
+    }
+
+    pub async fn delete_agent(&self, id: Uuid) -> Result<bool> {
+        match self {
+            Self::Postgres(db) => db.delete_agent(id).await,
+            Self::InMemory(db) => db.delete_agent(id).await,
+        }
+    }
+
+    // ============================================
+    // Sessions
+    // ============================================
+
+    pub async fn create_session(&self, input: CreateSessionRow) -> Result<SessionRow> {
+        match self {
+            Self::Postgres(db) => db.create_session(input).await,
+            Self::InMemory(db) => db.create_session(input).await,
+        }
+    }
+
+    pub async fn get_session(&self, id: Uuid) -> Result<Option<SessionRow>> {
+        match self {
+            Self::Postgres(db) => db.get_session(id).await,
+            Self::InMemory(db) => db.get_session(id).await,
+        }
+    }
+
+    pub async fn list_sessions(&self, agent_id: Uuid) -> Result<Vec<SessionRow>> {
+        match self {
+            Self::Postgres(db) => db.list_sessions(agent_id).await,
+            Self::InMemory(db) => db.list_sessions(agent_id).await,
+        }
+    }
+
+    pub async fn update_session(
+        &self,
+        id: Uuid,
+        input: UpdateSession,
+    ) -> Result<Option<SessionRow>> {
+        match self {
+            Self::Postgres(db) => db.update_session(id, input).await,
+            Self::InMemory(db) => db.update_session(id, input).await,
+        }
+    }
+
+    pub async fn delete_session(&self, id: Uuid) -> Result<bool> {
+        match self {
+            Self::Postgres(db) => db.delete_session(id).await,
+            Self::InMemory(db) => db.delete_session(id).await,
+        }
+    }
+
+    // ============================================
+    // Events
+    // ============================================
+
+    pub async fn create_event(&self, input: CreateEventRow) -> Result<EventRow> {
+        match self {
+            Self::Postgres(db) => db.create_event(input).await,
+            Self::InMemory(db) => db.create_event(input).await,
+        }
+    }
+
+    pub async fn list_events(
+        &self,
+        session_id: Uuid,
+        since_sequence: Option<i32>,
+        since_id: Option<Uuid>,
+    ) -> Result<Vec<EventRow>> {
+        match self {
+            Self::Postgres(db) => db.list_events(session_id, since_sequence, since_id).await,
+            Self::InMemory(db) => db.list_events(session_id, since_sequence, since_id).await,
+        }
+    }
+
+    pub async fn list_message_events(&self, session_id: Uuid) -> Result<Vec<EventRow>> {
+        match self {
+            Self::Postgres(db) => db.list_message_events(session_id).await,
+            Self::InMemory(db) => db.list_message_events(session_id).await,
+        }
+    }
+
+    // ============================================
+    // LLM Providers
+    // ============================================
+
+    pub async fn create_llm_provider(&self, input: CreateLlmProviderRow) -> Result<LlmProviderRow> {
+        match self {
+            Self::Postgres(db) => db.create_llm_provider(input).await,
+            Self::InMemory(db) => db.create_llm_provider(input).await,
+        }
+    }
+
+    pub async fn get_llm_provider(&self, id: Uuid) -> Result<Option<LlmProviderRow>> {
+        match self {
+            Self::Postgres(db) => db.get_llm_provider(id).await,
+            Self::InMemory(db) => db.get_llm_provider(id).await,
+        }
+    }
+
+    pub async fn list_llm_providers(&self) -> Result<Vec<LlmProviderRow>> {
+        match self {
+            Self::Postgres(db) => db.list_llm_providers().await,
+            Self::InMemory(db) => db.list_llm_providers().await,
+        }
+    }
+
+    pub async fn update_llm_provider(
+        &self,
+        id: Uuid,
+        input: UpdateLlmProvider,
+    ) -> Result<Option<LlmProviderRow>> {
+        match self {
+            Self::Postgres(db) => db.update_llm_provider(id, input).await,
+            Self::InMemory(db) => db.update_llm_provider(id, input).await,
+        }
+    }
+
+    pub async fn delete_llm_provider(&self, id: Uuid) -> Result<bool> {
+        match self {
+            Self::Postgres(db) => db.delete_llm_provider(id).await,
+            Self::InMemory(db) => db.delete_llm_provider(id).await,
+        }
+    }
+
+    /// Get a provider with its decrypted API key
+    pub fn get_provider_with_api_key(
+        &self,
+        provider: &LlmProviderRow,
+        encryption: &super::EncryptionService,
+    ) -> Result<LlmProviderWithApiKey> {
+        match self {
+            Self::Postgres(db) => db.get_provider_with_api_key(provider, encryption),
+            Self::InMemory(db) => db.get_provider_with_api_key(provider, encryption),
+        }
+    }
+
+    // ============================================
+    // LLM Models
+    // ============================================
+
+    pub async fn get_default_llm_model(&self) -> Result<Option<LlmModelWithProviderRow>> {
+        match self {
+            Self::Postgres(db) => db.get_default_llm_model().await,
+            Self::InMemory(db) => db.get_default_llm_model().await,
+        }
+    }
+
+    pub async fn clear_all_model_defaults(&self) -> Result<()> {
+        match self {
+            Self::Postgres(db) => db.clear_all_model_defaults().await,
+            Self::InMemory(db) => db.clear_all_model_defaults().await,
+        }
+    }
+
+    pub async fn create_llm_model(&self, input: CreateLlmModelRow) -> Result<LlmModelRow> {
+        match self {
+            Self::Postgres(db) => db.create_llm_model(input).await,
+            Self::InMemory(db) => db.create_llm_model(input).await,
+        }
+    }
+
+    pub async fn get_llm_model(&self, id: Uuid) -> Result<Option<LlmModelRow>> {
+        match self {
+            Self::Postgres(db) => db.get_llm_model(id).await,
+            Self::InMemory(db) => db.get_llm_model(id).await,
+        }
+    }
+
+    pub async fn get_llm_model_with_provider(
+        &self,
+        id: Uuid,
+    ) -> Result<Option<LlmModelWithProviderRow>> {
+        match self {
+            Self::Postgres(db) => db.get_llm_model_with_provider(id).await,
+            Self::InMemory(db) => db.get_llm_model_with_provider(id).await,
+        }
+    }
+
+    pub async fn list_llm_models_for_provider(
+        &self,
+        provider_id: Uuid,
+    ) -> Result<Vec<LlmModelRow>> {
+        match self {
+            Self::Postgres(db) => db.list_llm_models_for_provider(provider_id).await,
+            Self::InMemory(db) => db.list_llm_models_for_provider(provider_id).await,
+        }
+    }
+
+    pub async fn list_all_llm_models(&self) -> Result<Vec<LlmModelWithProviderRow>> {
+        match self {
+            Self::Postgres(db) => db.list_all_llm_models().await,
+            Self::InMemory(db) => db.list_all_llm_models().await,
+        }
+    }
+
+    pub async fn update_llm_model(
+        &self,
+        id: Uuid,
+        input: UpdateLlmModel,
+    ) -> Result<Option<LlmModelRow>> {
+        match self {
+            Self::Postgres(db) => db.update_llm_model(id, input).await,
+            Self::InMemory(db) => db.update_llm_model(id, input).await,
+        }
+    }
+
+    pub async fn delete_llm_model(&self, id: Uuid) -> Result<bool> {
+        match self {
+            Self::Postgres(db) => db.delete_llm_model(id).await,
+            Self::InMemory(db) => db.delete_llm_model(id).await,
+        }
+    }
+
+    pub async fn get_llm_model_by_model_id(
+        &self,
+        model_id: &str,
+    ) -> Result<Option<LlmModelWithProviderRow>> {
+        match self {
+            Self::Postgres(db) => db.get_llm_model_by_model_id(model_id).await,
+            Self::InMemory(db) => db.get_llm_model_by_model_id(model_id).await,
+        }
+    }
+
+    // ============================================
+    // Agent Capabilities
+    // ============================================
+
+    pub async fn get_agent_capabilities(&self, agent_id: Uuid) -> Result<Vec<AgentCapabilityRow>> {
+        match self {
+            Self::Postgres(db) => db.get_agent_capabilities(agent_id).await,
+            Self::InMemory(db) => db.get_agent_capabilities(agent_id).await,
+        }
+    }
+
+    pub async fn set_agent_capabilities(
+        &self,
+        agent_id: Uuid,
+        capabilities: Vec<(String, i32)>,
+    ) -> Result<Vec<AgentCapabilityRow>> {
+        match self {
+            Self::Postgres(db) => db.set_agent_capabilities(agent_id, capabilities).await,
+            Self::InMemory(db) => db.set_agent_capabilities(agent_id, capabilities).await,
+        }
+    }
+
+    pub async fn add_agent_capability(
+        &self,
+        input: CreateAgentCapabilityRow,
+    ) -> Result<AgentCapabilityRow> {
+        match self {
+            Self::Postgres(db) => db.add_agent_capability(input).await,
+            Self::InMemory(db) => db.add_agent_capability(input).await,
+        }
+    }
+
+    pub async fn remove_agent_capability(
+        &self,
+        agent_id: Uuid,
+        capability_id: &str,
+    ) -> Result<bool> {
+        match self {
+            Self::Postgres(db) => db.remove_agent_capability(agent_id, capability_id).await,
+            Self::InMemory(db) => db.remove_agent_capability(agent_id, capability_id).await,
+        }
+    }
+
+    // ============================================
+    // Session Files
+    // ============================================
+
+    pub async fn create_session_file(&self, input: CreateSessionFileRow) -> Result<SessionFileRow> {
+        match self {
+            Self::Postgres(db) => db.create_session_file(input).await,
+            Self::InMemory(db) => db.create_session_file(input).await,
+        }
+    }
+
+    pub async fn get_session_file(
+        &self,
+        session_id: Uuid,
+        path: &str,
+    ) -> Result<Option<SessionFileRow>> {
+        match self {
+            Self::Postgres(db) => db.get_session_file(session_id, path).await,
+            Self::InMemory(db) => db.get_session_file(session_id, path).await,
+        }
+    }
+
+    pub async fn get_session_file_by_id(&self, id: Uuid) -> Result<Option<SessionFileRow>> {
+        match self {
+            Self::Postgres(db) => db.get_session_file_by_id(id).await,
+            Self::InMemory(db) => db.get_session_file_by_id(id).await,
+        }
+    }
+
+    pub async fn list_session_files(
+        &self,
+        session_id: Uuid,
+        parent_path: &str,
+    ) -> Result<Vec<SessionFileInfoRow>> {
+        match self {
+            Self::Postgres(db) => db.list_session_files(session_id, parent_path).await,
+            Self::InMemory(db) => db.list_session_files(session_id, parent_path).await,
+        }
+    }
+
+    pub async fn list_all_session_files(
+        &self,
+        session_id: Uuid,
+    ) -> Result<Vec<SessionFileInfoRow>> {
+        match self {
+            Self::Postgres(db) => db.list_all_session_files(session_id).await,
+            Self::InMemory(db) => db.list_all_session_files(session_id).await,
+        }
+    }
+
+    pub async fn update_session_file(
+        &self,
+        session_id: Uuid,
+        path: &str,
+        input: UpdateSessionFile,
+    ) -> Result<Option<SessionFileRow>> {
+        match self {
+            Self::Postgres(db) => db.update_session_file(session_id, path, input).await,
+            Self::InMemory(db) => db.update_session_file(session_id, path, input).await,
+        }
+    }
+
+    pub async fn delete_session_file(&self, session_id: Uuid, path: &str) -> Result<bool> {
+        match self {
+            Self::Postgres(db) => db.delete_session_file(session_id, path).await,
+            Self::InMemory(db) => db.delete_session_file(session_id, path).await,
+        }
+    }
+
+    pub async fn delete_session_file_recursive(&self, session_id: Uuid, path: &str) -> Result<u64> {
+        match self {
+            Self::Postgres(db) => db.delete_session_file_recursive(session_id, path).await,
+            Self::InMemory(db) => db.delete_session_file_recursive(session_id, path).await,
+        }
+    }
+
+    pub async fn move_session_file(
+        &self,
+        session_id: Uuid,
+        source_path: &str,
+        dest_path: &str,
+    ) -> Result<Option<SessionFileRow>> {
+        match self {
+            Self::Postgres(db) => {
+                db.move_session_file(session_id, source_path, dest_path)
+                    .await
+            }
+            Self::InMemory(db) => {
+                db.move_session_file(session_id, source_path, dest_path)
+                    .await
+            }
+        }
+    }
+
+    pub async fn copy_session_file(
+        &self,
+        session_id: Uuid,
+        source_path: &str,
+        dest_path: &str,
+    ) -> Result<Option<SessionFileRow>> {
+        match self {
+            Self::Postgres(db) => {
+                db.copy_session_file(session_id, source_path, dest_path)
+                    .await
+            }
+            Self::InMemory(db) => {
+                db.copy_session_file(session_id, source_path, dest_path)
+                    .await
+            }
+        }
+    }
+
+    pub async fn grep_session_files(
+        &self,
+        session_id: Uuid,
+        pattern: &str,
+        path_prefix: Option<&str>,
+    ) -> Result<Vec<SessionFileInfoRow>> {
+        match self {
+            Self::Postgres(db) => {
+                db.grep_session_files(session_id, pattern, path_prefix)
+                    .await
+            }
+            Self::InMemory(db) => {
+                db.grep_session_files(session_id, pattern, path_prefix)
+                    .await
+            }
+        }
+    }
+
+    pub async fn session_file_exists(&self, session_id: Uuid, path: &str) -> Result<bool> {
+        match self {
+            Self::Postgres(db) => db.session_file_exists(session_id, path).await,
+            Self::InMemory(db) => db.session_file_exists(session_id, path).await,
+        }
+    }
+
+    pub async fn session_directory_has_children(
+        &self,
+        session_id: Uuid,
+        path: &str,
+    ) -> Result<bool> {
+        match self {
+            Self::Postgres(db) => db.session_directory_has_children(session_id, path).await,
+            Self::InMemory(db) => db.session_directory_has_children(session_id, path).await,
+        }
+    }
+}

--- a/crates/control-plane/src/storage/memory.rs
+++ b/crates/control-plane/src/storage/memory.rs
@@ -1,0 +1,1275 @@
+// In-memory storage implementation for dev mode
+// Decision: Use parking_lot for thread-safe access
+// Decision: UUIDs generated via uuid v7 (time-ordered)
+//
+// This implementation provides a PostgreSQL-compatible API backed by in-memory
+// HashMaps, allowing the control-plane to run without a database for development.
+
+use anyhow::{anyhow, Result};
+use chrono::{DateTime, Utc};
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use uuid::Uuid;
+
+use super::models::*;
+
+/// In-memory database for dev mode
+/// All data is stored in memory and lost on restart
+#[derive(Default)]
+pub struct InMemoryDatabase {
+    users: RwLock<HashMap<Uuid, UserRow>>,
+    api_keys: RwLock<HashMap<Uuid, ApiKeyRow>>,
+    refresh_tokens: RwLock<HashMap<Uuid, RefreshTokenRow>>,
+    agents: RwLock<HashMap<Uuid, AgentRow>>,
+    sessions: RwLock<HashMap<Uuid, SessionRow>>,
+    events: RwLock<HashMap<Uuid, EventRow>>,
+    llm_providers: RwLock<HashMap<Uuid, LlmProviderRow>>,
+    llm_models: RwLock<HashMap<Uuid, LlmModelRow>>,
+    agent_capabilities: RwLock<HashMap<(Uuid, String), AgentCapabilityRow>>,
+    session_files: RwLock<HashMap<Uuid, SessionFileRow>>,
+    // Event sequence counter per session
+    event_sequences: RwLock<HashMap<Uuid, i32>>,
+}
+
+impl InMemoryDatabase {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn now() -> DateTime<Utc> {
+        Utc::now()
+    }
+
+    // ============================================
+    // Users
+    // ============================================
+
+    pub async fn create_user(&self, input: CreateUserRow) -> Result<UserRow> {
+        let now = Self::now();
+        let id = Uuid::now_v7();
+        let row = UserRow {
+            id,
+            email: input.email,
+            name: input.name,
+            avatar_url: input.avatar_url,
+            roles: serde_json::to_value(&input.roles)?,
+            password_hash: input.password_hash,
+            email_verified: input.email_verified,
+            auth_provider: input.auth_provider,
+            auth_provider_id: input.auth_provider_id,
+            created_at: now,
+            updated_at: now,
+        };
+        self.users.write().insert(id, row.clone());
+        Ok(row)
+    }
+
+    pub async fn get_user_by_email(&self, email: &str) -> Result<Option<UserRow>> {
+        Ok(self
+            .users
+            .read()
+            .values()
+            .find(|u| u.email == email)
+            .cloned())
+    }
+
+    pub async fn get_user(&self, id: Uuid) -> Result<Option<UserRow>> {
+        Ok(self.users.read().get(&id).cloned())
+    }
+
+    pub async fn get_user_by_oauth(
+        &self,
+        provider: &str,
+        provider_id: &str,
+    ) -> Result<Option<UserRow>> {
+        Ok(self
+            .users
+            .read()
+            .values()
+            .find(|u| {
+                u.auth_provider.as_deref() == Some(provider)
+                    && u.auth_provider_id.as_deref() == Some(provider_id)
+            })
+            .cloned())
+    }
+
+    pub async fn update_user(&self, id: Uuid, input: UpdateUser) -> Result<Option<UserRow>> {
+        let mut users = self.users.write();
+        if let Some(user) = users.get_mut(&id) {
+            if let Some(name) = input.name {
+                user.name = name;
+            }
+            if let Some(avatar_url) = input.avatar_url {
+                user.avatar_url = Some(avatar_url);
+            }
+            if let Some(roles) = input.roles {
+                user.roles = serde_json::to_value(&roles)?;
+            }
+            if let Some(password_hash) = input.password_hash {
+                user.password_hash = Some(password_hash);
+            }
+            if let Some(email_verified) = input.email_verified {
+                user.email_verified = email_verified;
+            }
+            user.updated_at = Self::now();
+            return Ok(Some(user.clone()));
+        }
+        Ok(None)
+    }
+
+    pub async fn list_users(&self, search: Option<&str>) -> Result<Vec<UserRow>> {
+        let users = self.users.read();
+        let mut result: Vec<_> = match search {
+            Some(query) if !query.trim().is_empty() => {
+                let pattern = query.trim().to_lowercase();
+                users
+                    .values()
+                    .filter(|u| {
+                        u.name.to_lowercase().contains(&pattern)
+                            || u.email.to_lowercase().contains(&pattern)
+                    })
+                    .cloned()
+                    .collect()
+            }
+            _ => users.values().cloned().collect(),
+        };
+        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(result)
+    }
+
+    // ============================================
+    // API Keys
+    // ============================================
+
+    pub async fn create_api_key(&self, input: CreateApiKeyRow) -> Result<ApiKeyRow> {
+        let now = Self::now();
+        let id = Uuid::now_v7();
+        let row = ApiKeyRow {
+            id,
+            user_id: input.user_id,
+            name: input.name,
+            key_hash: input.key_hash,
+            key_prefix: input.key_prefix,
+            scopes: serde_json::to_value(&input.scopes)?,
+            expires_at: input.expires_at,
+            last_used_at: None,
+            created_at: now,
+        };
+        self.api_keys.write().insert(id, row.clone());
+        Ok(row)
+    }
+
+    pub async fn get_api_key_by_hash(&self, key_hash: &str) -> Result<Option<ApiKeyRow>> {
+        Ok(self
+            .api_keys
+            .read()
+            .values()
+            .find(|k| k.key_hash == key_hash)
+            .cloned())
+    }
+
+    pub async fn list_api_keys_for_user(&self, user_id: Uuid) -> Result<Vec<ApiKeyRow>> {
+        let keys = self.api_keys.read();
+        let mut result: Vec<_> = keys
+            .values()
+            .filter(|k| k.user_id == user_id)
+            .cloned()
+            .collect();
+        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(result)
+    }
+
+    pub async fn update_api_key_last_used(&self, id: Uuid) -> Result<()> {
+        if let Some(key) = self.api_keys.write().get_mut(&id) {
+            key.last_used_at = Some(Self::now());
+        }
+        Ok(())
+    }
+
+    pub async fn delete_api_key(&self, id: Uuid, user_id: Uuid) -> Result<bool> {
+        let mut keys = self.api_keys.write();
+        if let Some(key) = keys.get(&id) {
+            if key.user_id == user_id {
+                keys.remove(&id);
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    // ============================================
+    // Refresh Tokens
+    // ============================================
+
+    pub async fn create_refresh_token(
+        &self,
+        input: CreateRefreshTokenRow,
+    ) -> Result<RefreshTokenRow> {
+        let now = Self::now();
+        let id = Uuid::now_v7();
+        let row = RefreshTokenRow {
+            id,
+            user_id: input.user_id,
+            token_hash: input.token_hash,
+            expires_at: input.expires_at,
+            created_at: now,
+        };
+        self.refresh_tokens.write().insert(id, row.clone());
+        Ok(row)
+    }
+
+    pub async fn get_refresh_token_by_hash(
+        &self,
+        token_hash: &str,
+    ) -> Result<Option<RefreshTokenRow>> {
+        Ok(self
+            .refresh_tokens
+            .read()
+            .values()
+            .find(|t| t.token_hash == token_hash)
+            .cloned())
+    }
+
+    pub async fn delete_refresh_token(&self, id: Uuid) -> Result<bool> {
+        Ok(self.refresh_tokens.write().remove(&id).is_some())
+    }
+
+    pub async fn delete_expired_refresh_tokens(&self) -> Result<u64> {
+        let now = Self::now();
+        let mut tokens = self.refresh_tokens.write();
+        let to_remove: Vec<Uuid> = tokens
+            .iter()
+            .filter(|(_, t)| t.expires_at < now)
+            .map(|(id, _)| *id)
+            .collect();
+        let count = to_remove.len() as u64;
+        for id in to_remove {
+            tokens.remove(&id);
+        }
+        Ok(count)
+    }
+
+    pub async fn delete_user_refresh_tokens(&self, user_id: Uuid) -> Result<u64> {
+        let mut tokens = self.refresh_tokens.write();
+        let to_remove: Vec<Uuid> = tokens
+            .iter()
+            .filter(|(_, t)| t.user_id == user_id)
+            .map(|(id, _)| *id)
+            .collect();
+        let count = to_remove.len() as u64;
+        for id in to_remove {
+            tokens.remove(&id);
+        }
+        Ok(count)
+    }
+
+    // ============================================
+    // Agents
+    // ============================================
+
+    pub async fn create_agent(&self, input: CreateAgentRow) -> Result<AgentRow> {
+        let now = Self::now();
+        let id = Uuid::now_v7();
+        let row = AgentRow {
+            id,
+            name: input.name,
+            description: input.description,
+            system_prompt: input.system_prompt,
+            default_model_id: input.default_model_id,
+            tags: input.tags,
+            status: "active".to_string(), // Default status for new agents
+            created_at: now,
+            updated_at: now,
+        };
+        self.agents.write().insert(id, row.clone());
+        Ok(row)
+    }
+
+    pub async fn get_agent(&self, id: Uuid) -> Result<Option<AgentRow>> {
+        Ok(self.agents.read().get(&id).cloned())
+    }
+
+    pub async fn list_agents(&self) -> Result<Vec<AgentRow>> {
+        let agents = self.agents.read();
+        let mut result: Vec<_> = agents.values().cloned().collect();
+        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(result)
+    }
+
+    pub async fn update_agent(&self, id: Uuid, input: UpdateAgent) -> Result<Option<AgentRow>> {
+        let mut agents = self.agents.write();
+        if let Some(agent) = agents.get_mut(&id) {
+            if let Some(name) = input.name {
+                agent.name = name;
+            }
+            if let Some(description) = input.description {
+                agent.description = Some(description);
+            }
+            if let Some(system_prompt) = input.system_prompt {
+                agent.system_prompt = system_prompt;
+            }
+            if let Some(default_model_id) = input.default_model_id {
+                agent.default_model_id = Some(default_model_id);
+            }
+            if let Some(tags) = input.tags {
+                agent.tags = tags;
+            }
+            if let Some(status) = input.status {
+                agent.status = status;
+            }
+            agent.updated_at = Self::now();
+            return Ok(Some(agent.clone()));
+        }
+        Ok(None)
+    }
+
+    pub async fn delete_agent(&self, id: Uuid) -> Result<bool> {
+        // Delete capabilities first
+        {
+            let mut caps = self.agent_capabilities.write();
+            let to_remove: Vec<_> = caps.keys().filter(|(aid, _)| *aid == id).cloned().collect();
+            for key in to_remove {
+                caps.remove(&key);
+            }
+        }
+        Ok(self.agents.write().remove(&id).is_some())
+    }
+
+    // ============================================
+    // Sessions
+    // ============================================
+
+    pub async fn create_session(&self, input: CreateSessionRow) -> Result<SessionRow> {
+        let now = Self::now();
+        let id = Uuid::now_v7();
+        let row = SessionRow {
+            id,
+            agent_id: input.agent_id,
+            title: input.title,
+            tags: input.tags,
+            model_id: input.model_id,
+            status: "pending".to_string(), // Default status for new sessions
+            created_at: now,
+            started_at: None,
+            finished_at: None,
+        };
+        self.sessions.write().insert(id, row.clone());
+        Ok(row)
+    }
+
+    pub async fn get_session(&self, id: Uuid) -> Result<Option<SessionRow>> {
+        Ok(self.sessions.read().get(&id).cloned())
+    }
+
+    pub async fn list_sessions(&self, agent_id: Uuid) -> Result<Vec<SessionRow>> {
+        let sessions = self.sessions.read();
+        let mut result: Vec<_> = sessions
+            .values()
+            .filter(|s| s.agent_id == agent_id)
+            .cloned()
+            .collect();
+        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(result)
+    }
+
+    pub async fn update_session(
+        &self,
+        id: Uuid,
+        input: UpdateSession,
+    ) -> Result<Option<SessionRow>> {
+        let mut sessions = self.sessions.write();
+        if let Some(session) = sessions.get_mut(&id) {
+            if let Some(title) = input.title {
+                session.title = Some(title);
+            }
+            if let Some(tags) = input.tags {
+                session.tags = tags;
+            }
+            if let Some(status) = input.status {
+                session.status = status;
+            }
+            if let Some(started_at) = input.started_at {
+                session.started_at = Some(started_at);
+            }
+            if input.finished_at.is_some() {
+                session.finished_at = input.finished_at;
+            }
+            return Ok(Some(session.clone()));
+        }
+        Ok(None)
+    }
+
+    pub async fn delete_session(&self, id: Uuid) -> Result<bool> {
+        // Delete events first
+        {
+            let mut events = self.events.write();
+            let to_remove: Vec<Uuid> = events
+                .iter()
+                .filter(|(_, e)| e.session_id == id)
+                .map(|(eid, _)| *eid)
+                .collect();
+            for eid in to_remove {
+                events.remove(&eid);
+            }
+        }
+        // Delete session files
+        {
+            let mut files = self.session_files.write();
+            let to_remove: Vec<Uuid> = files
+                .iter()
+                .filter(|(_, f)| f.session_id == id)
+                .map(|(fid, _)| *fid)
+                .collect();
+            for fid in to_remove {
+                files.remove(&fid);
+            }
+        }
+        Ok(self.sessions.write().remove(&id).is_some())
+    }
+
+    // ============================================
+    // Events
+    // ============================================
+
+    pub async fn create_event(&self, input: CreateEventRow) -> Result<EventRow> {
+        let now = Self::now();
+        let id = Uuid::now_v7();
+
+        // Get next sequence for this session
+        let sequence = {
+            let mut sequences = self.event_sequences.write();
+            let seq = sequences.entry(input.session_id).or_insert(0);
+            *seq += 1;
+            *seq
+        };
+
+        let row = EventRow {
+            id,
+            session_id: input.session_id,
+            sequence,
+            event_type: input.event_type,
+            ts: input.ts,
+            context: input.context,
+            data: input.data,
+            metadata: input.metadata,
+            tags: input.tags,
+            created_at: now,
+        };
+        self.events.write().insert(id, row.clone());
+        Ok(row)
+    }
+
+    pub async fn list_events(
+        &self,
+        session_id: Uuid,
+        since_sequence: Option<i32>,
+        since_id: Option<Uuid>,
+    ) -> Result<Vec<EventRow>> {
+        let events = self.events.read();
+        let mut result: Vec<_> = events
+            .values()
+            .filter(|e| {
+                if e.session_id != session_id {
+                    return false;
+                }
+                // Prefer since_id (UUID v7 monotonically increasing) over sequence
+                if let Some(id) = since_id {
+                    if e.id <= id {
+                        return false;
+                    }
+                } else if let Some(seq) = since_sequence {
+                    if e.sequence <= seq {
+                        return false;
+                    }
+                }
+                true
+            })
+            .cloned()
+            .collect();
+
+        result.sort_by_key(|e| e.sequence);
+        Ok(result)
+    }
+
+    pub async fn list_message_events(&self, session_id: Uuid) -> Result<Vec<EventRow>> {
+        let message_types = [
+            "message.user",
+            "message.assistant",
+            "message.tool_call",
+            "message.tool_result",
+        ];
+        let events = self.events.read();
+        let mut result: Vec<_> = events
+            .values()
+            .filter(|e| {
+                e.session_id == session_id && message_types.contains(&e.event_type.as_str())
+            })
+            .cloned()
+            .collect();
+        result.sort_by_key(|e| e.sequence);
+        Ok(result)
+    }
+
+    // ============================================
+    // LLM Providers
+    // ============================================
+
+    pub async fn create_llm_provider(&self, input: CreateLlmProviderRow) -> Result<LlmProviderRow> {
+        let now = Self::now();
+        let id = Uuid::now_v7();
+        let api_key_set = input.api_key_encrypted.is_some();
+        let row = LlmProviderRow {
+            id,
+            name: input.name,
+            provider_type: input.provider_type,
+            base_url: input.base_url,
+            api_key_encrypted: input.api_key_encrypted,
+            api_key_set,
+            status: "active".to_string(), // Default status for new providers
+            settings: input.settings.unwrap_or(serde_json::json!({})),
+            created_at: now,
+            updated_at: now,
+        };
+        self.llm_providers.write().insert(id, row.clone());
+        Ok(row)
+    }
+
+    pub async fn get_llm_provider(&self, id: Uuid) -> Result<Option<LlmProviderRow>> {
+        Ok(self.llm_providers.read().get(&id).cloned())
+    }
+
+    pub async fn list_llm_providers(&self) -> Result<Vec<LlmProviderRow>> {
+        let providers = self.llm_providers.read();
+        let mut result: Vec<_> = providers.values().cloned().collect();
+        result.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(result)
+    }
+
+    pub async fn update_llm_provider(
+        &self,
+        id: Uuid,
+        input: UpdateLlmProvider,
+    ) -> Result<Option<LlmProviderRow>> {
+        let mut providers = self.llm_providers.write();
+        if let Some(provider) = providers.get_mut(&id) {
+            if let Some(name) = input.name {
+                provider.name = name;
+            }
+            if let Some(base_url) = input.base_url {
+                provider.base_url = Some(base_url);
+            }
+            if let Some(api_key_encrypted) = input.api_key_encrypted {
+                provider.api_key_encrypted = Some(api_key_encrypted);
+                provider.api_key_set = true;
+            }
+            if let Some(status) = input.status {
+                provider.status = status;
+            }
+            if let Some(settings) = input.settings {
+                provider.settings = settings;
+            }
+            provider.updated_at = Self::now();
+            return Ok(Some(provider.clone()));
+        }
+        Ok(None)
+    }
+
+    pub async fn delete_llm_provider(&self, id: Uuid) -> Result<bool> {
+        // Delete models first
+        {
+            let mut models = self.llm_models.write();
+            let to_remove: Vec<Uuid> = models
+                .iter()
+                .filter(|(_, m)| m.provider_id == id)
+                .map(|(mid, _)| *mid)
+                .collect();
+            for mid in to_remove {
+                models.remove(&mid);
+            }
+        }
+        Ok(self.llm_providers.write().remove(&id).is_some())
+    }
+
+    /// Get a provider with its decrypted API key
+    pub fn get_provider_with_api_key(
+        &self,
+        provider: &LlmProviderRow,
+        encryption: &super::EncryptionService,
+    ) -> Result<LlmProviderWithApiKey> {
+        let api_key = if let Some(ref encrypted) = provider.api_key_encrypted {
+            Some(encryption.decrypt_to_string(encrypted)?)
+        } else {
+            None
+        };
+
+        // Convert settings from sqlx JsonValue to serde_json::Value
+        let settings: serde_json::Value =
+            serde_json::from_str(&provider.settings.to_string()).unwrap_or_default();
+
+        Ok(LlmProviderWithApiKey {
+            id: provider.id,
+            name: provider.name.clone(),
+            provider_type: provider.provider_type.clone(),
+            base_url: provider.base_url.clone(),
+            api_key,
+            settings,
+        })
+    }
+
+    // ============================================
+    // LLM Models
+    // ============================================
+
+    pub async fn get_default_llm_model(&self) -> Result<Option<LlmModelWithProviderRow>> {
+        let models = self.llm_models.read();
+        let providers = self.llm_providers.read();
+
+        for model in models.values() {
+            if model.is_default {
+                if let Some(provider) = providers.get(&model.provider_id) {
+                    return Ok(Some(LlmModelWithProviderRow {
+                        id: model.id,
+                        provider_id: model.provider_id,
+                        model_id: model.model_id.clone(),
+                        display_name: model.display_name.clone(),
+                        capabilities: model.capabilities.clone(),
+                        is_default: model.is_default,
+                        status: model.status.clone(),
+                        created_at: model.created_at,
+                        updated_at: model.updated_at,
+                        provider_name: provider.name.clone(),
+                        provider_type: provider.provider_type.clone(),
+                    }));
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    pub async fn clear_all_model_defaults(&self) -> Result<()> {
+        for model in self.llm_models.write().values_mut() {
+            model.is_default = false;
+        }
+        Ok(())
+    }
+
+    pub async fn create_llm_model(&self, input: CreateLlmModelRow) -> Result<LlmModelRow> {
+        let now = Self::now();
+        let id = Uuid::now_v7();
+        let row = LlmModelRow {
+            id,
+            provider_id: input.provider_id,
+            model_id: input.model_id,
+            display_name: input.display_name,
+            capabilities: serde_json::to_value(&input.capabilities)?,
+            is_default: input.is_default,
+            status: "active".to_string(), // Default status for new models
+            created_at: now,
+            updated_at: now,
+        };
+        self.llm_models.write().insert(id, row.clone());
+        Ok(row)
+    }
+
+    pub async fn get_llm_model(&self, id: Uuid) -> Result<Option<LlmModelRow>> {
+        Ok(self.llm_models.read().get(&id).cloned())
+    }
+
+    pub async fn get_llm_model_with_provider(
+        &self,
+        id: Uuid,
+    ) -> Result<Option<LlmModelWithProviderRow>> {
+        let models = self.llm_models.read();
+        let providers = self.llm_providers.read();
+
+        if let Some(model) = models.get(&id) {
+            if let Some(provider) = providers.get(&model.provider_id) {
+                return Ok(Some(LlmModelWithProviderRow {
+                    id: model.id,
+                    provider_id: model.provider_id,
+                    model_id: model.model_id.clone(),
+                    display_name: model.display_name.clone(),
+                    capabilities: model.capabilities.clone(),
+                    is_default: model.is_default,
+                    status: model.status.clone(),
+                    created_at: model.created_at,
+                    updated_at: model.updated_at,
+                    provider_name: provider.name.clone(),
+                    provider_type: provider.provider_type.clone(),
+                }));
+            }
+        }
+        Ok(None)
+    }
+
+    pub async fn list_llm_models_for_provider(
+        &self,
+        provider_id: Uuid,
+    ) -> Result<Vec<LlmModelRow>> {
+        let models = self.llm_models.read();
+        let mut result: Vec<_> = models
+            .values()
+            .filter(|m| m.provider_id == provider_id)
+            .cloned()
+            .collect();
+        result.sort_by(|a, b| a.display_name.cmp(&b.display_name));
+        Ok(result)
+    }
+
+    pub async fn list_all_llm_models(&self) -> Result<Vec<LlmModelWithProviderRow>> {
+        let models = self.llm_models.read();
+        let providers = self.llm_providers.read();
+
+        let mut result: Vec<_> = models
+            .values()
+            .filter_map(|model| {
+                providers
+                    .get(&model.provider_id)
+                    .map(|provider| LlmModelWithProviderRow {
+                        id: model.id,
+                        provider_id: model.provider_id,
+                        model_id: model.model_id.clone(),
+                        display_name: model.display_name.clone(),
+                        capabilities: model.capabilities.clone(),
+                        is_default: model.is_default,
+                        status: model.status.clone(),
+                        created_at: model.created_at,
+                        updated_at: model.updated_at,
+                        provider_name: provider.name.clone(),
+                        provider_type: provider.provider_type.clone(),
+                    })
+            })
+            .collect();
+        result.sort_by(|a, b| a.display_name.cmp(&b.display_name));
+        Ok(result)
+    }
+
+    pub async fn update_llm_model(
+        &self,
+        id: Uuid,
+        input: UpdateLlmModel,
+    ) -> Result<Option<LlmModelRow>> {
+        let mut models = self.llm_models.write();
+        if let Some(model) = models.get_mut(&id) {
+            if let Some(display_name) = input.display_name {
+                model.display_name = display_name;
+            }
+            if let Some(capabilities) = input.capabilities {
+                model.capabilities = serde_json::to_value(&capabilities)?;
+            }
+            if let Some(is_default) = input.is_default {
+                model.is_default = is_default;
+            }
+            if let Some(status) = input.status {
+                model.status = status;
+            }
+            model.updated_at = Self::now();
+            return Ok(Some(model.clone()));
+        }
+        Ok(None)
+    }
+
+    pub async fn delete_llm_model(&self, id: Uuid) -> Result<bool> {
+        Ok(self.llm_models.write().remove(&id).is_some())
+    }
+
+    pub async fn get_llm_model_by_model_id(
+        &self,
+        model_id: &str,
+    ) -> Result<Option<LlmModelWithProviderRow>> {
+        let models = self.llm_models.read();
+        let providers = self.llm_providers.read();
+
+        for model in models.values() {
+            if model.model_id == model_id {
+                if let Some(provider) = providers.get(&model.provider_id) {
+                    return Ok(Some(LlmModelWithProviderRow {
+                        id: model.id,
+                        provider_id: model.provider_id,
+                        model_id: model.model_id.clone(),
+                        display_name: model.display_name.clone(),
+                        capabilities: model.capabilities.clone(),
+                        is_default: model.is_default,
+                        status: model.status.clone(),
+                        created_at: model.created_at,
+                        updated_at: model.updated_at,
+                        provider_name: provider.name.clone(),
+                        provider_type: provider.provider_type.clone(),
+                    }));
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    // ============================================
+    // Agent Capabilities
+    // ============================================
+
+    pub async fn get_agent_capabilities(&self, agent_id: Uuid) -> Result<Vec<AgentCapabilityRow>> {
+        let caps = self.agent_capabilities.read();
+        let mut result: Vec<_> = caps
+            .iter()
+            .filter(|((aid, _), _)| *aid == agent_id)
+            .map(|(_, c)| c.clone())
+            .collect();
+        result.sort_by_key(|c| c.position);
+        Ok(result)
+    }
+
+    pub async fn set_agent_capabilities(
+        &self,
+        agent_id: Uuid,
+        capabilities: Vec<(String, i32)>,
+    ) -> Result<Vec<AgentCapabilityRow>> {
+        let now = Self::now();
+        let mut caps = self.agent_capabilities.write();
+
+        // Remove existing capabilities for this agent
+        let to_remove: Vec<_> = caps
+            .keys()
+            .filter(|(aid, _)| *aid == agent_id)
+            .cloned()
+            .collect();
+        for key in to_remove {
+            caps.remove(&key);
+        }
+
+        // Add new capabilities
+        let mut result = Vec::new();
+        for (capability_id, position) in capabilities.into_iter() {
+            let row = AgentCapabilityRow {
+                id: Uuid::now_v7(),
+                agent_id,
+                capability_id: capability_id.clone(),
+                position,
+                created_at: now,
+            };
+            caps.insert((agent_id, capability_id), row.clone());
+            result.push(row);
+        }
+
+        Ok(result)
+    }
+
+    pub async fn add_agent_capability(
+        &self,
+        input: CreateAgentCapabilityRow,
+    ) -> Result<AgentCapabilityRow> {
+        let now = Self::now();
+        let mut caps = self.agent_capabilities.write();
+
+        let row = AgentCapabilityRow {
+            id: Uuid::now_v7(),
+            agent_id: input.agent_id,
+            capability_id: input.capability_id.clone(),
+            position: input.position,
+            created_at: now,
+        };
+        caps.insert((input.agent_id, input.capability_id), row.clone());
+        Ok(row)
+    }
+
+    pub async fn remove_agent_capability(
+        &self,
+        agent_id: Uuid,
+        capability_id: &str,
+    ) -> Result<bool> {
+        Ok(self
+            .agent_capabilities
+            .write()
+            .remove(&(agent_id, capability_id.to_string()))
+            .is_some())
+    }
+
+    // ============================================
+    // Session Files
+    // ============================================
+
+    pub async fn create_session_file(&self, input: CreateSessionFileRow) -> Result<SessionFileRow> {
+        let now = Self::now();
+        let id = Uuid::now_v7();
+        let content_len = input.content.as_ref().map(|c| c.len() as i64).unwrap_or(0);
+        let row = SessionFileRow {
+            id,
+            session_id: input.session_id,
+            path: input.path,
+            content: input.content,
+            is_directory: input.is_directory,
+            is_readonly: input.is_readonly,
+            size_bytes: content_len,
+            created_at: now,
+            updated_at: now,
+        };
+        self.session_files.write().insert(id, row.clone());
+        Ok(row)
+    }
+
+    pub async fn get_session_file(
+        &self,
+        session_id: Uuid,
+        path: &str,
+    ) -> Result<Option<SessionFileRow>> {
+        Ok(self
+            .session_files
+            .read()
+            .values()
+            .find(|f| f.session_id == session_id && f.path == path)
+            .cloned())
+    }
+
+    pub async fn get_session_file_by_id(&self, id: Uuid) -> Result<Option<SessionFileRow>> {
+        Ok(self.session_files.read().get(&id).cloned())
+    }
+
+    /// Convert SessionFileRow to SessionFileInfoRow (strips content)
+    fn file_to_info(f: &SessionFileRow) -> SessionFileInfoRow {
+        SessionFileInfoRow {
+            id: f.id,
+            session_id: f.session_id,
+            path: f.path.clone(),
+            is_directory: f.is_directory,
+            is_readonly: f.is_readonly,
+            size_bytes: f.size_bytes,
+            created_at: f.created_at,
+            updated_at: f.updated_at,
+        }
+    }
+
+    pub async fn list_session_files(
+        &self,
+        session_id: Uuid,
+        parent_path: &str,
+    ) -> Result<Vec<SessionFileInfoRow>> {
+        let files = self.session_files.read();
+        let prefix = if parent_path == "/" {
+            "/".to_string()
+        } else {
+            format!("{}/", parent_path.trim_end_matches('/'))
+        };
+
+        let mut result: Vec<_> = files
+            .values()
+            .filter(|f| {
+                if f.session_id != session_id {
+                    return false;
+                }
+                if parent_path == "/" {
+                    // Root level: files directly under /
+                    f.path.starts_with('/') && !f.path[1..].contains('/')
+                } else {
+                    // Under specific directory
+                    f.path.starts_with(&prefix) && !f.path[prefix.len()..].contains('/')
+                }
+            })
+            .map(Self::file_to_info)
+            .collect();
+        result.sort_by(|a, b| a.path.cmp(&b.path));
+        Ok(result)
+    }
+
+    pub async fn list_all_session_files(
+        &self,
+        session_id: Uuid,
+    ) -> Result<Vec<SessionFileInfoRow>> {
+        let files = self.session_files.read();
+        let mut result: Vec<_> = files
+            .values()
+            .filter(|f| f.session_id == session_id)
+            .map(Self::file_to_info)
+            .collect();
+        result.sort_by(|a, b| a.path.cmp(&b.path));
+        Ok(result)
+    }
+
+    pub async fn update_session_file(
+        &self,
+        session_id: Uuid,
+        path: &str,
+        input: UpdateSessionFile,
+    ) -> Result<Option<SessionFileRow>> {
+        let mut files = self.session_files.write();
+        if let Some(file) = files
+            .values_mut()
+            .find(|f| f.session_id == session_id && f.path == path)
+        {
+            if let Some(content) = input.content {
+                file.size_bytes = content.len() as i64;
+                file.content = Some(content);
+            }
+            if let Some(is_readonly) = input.is_readonly {
+                file.is_readonly = is_readonly;
+            }
+            file.updated_at = Self::now();
+            return Ok(Some(file.clone()));
+        }
+        Ok(None)
+    }
+
+    pub async fn delete_session_file(&self, session_id: Uuid, path: &str) -> Result<bool> {
+        let mut files = self.session_files.write();
+        let to_remove: Option<Uuid> = files
+            .iter()
+            .find(|(_, f)| f.session_id == session_id && f.path == path)
+            .map(|(id, _)| *id);
+
+        if let Some(id) = to_remove {
+            files.remove(&id);
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    pub async fn delete_session_file_recursive(&self, session_id: Uuid, path: &str) -> Result<u64> {
+        let mut files = self.session_files.write();
+        let prefix = format!("{}/", path.trim_end_matches('/'));
+
+        let to_remove: Vec<Uuid> = files
+            .iter()
+            .filter(|(_, f)| {
+                f.session_id == session_id && (f.path == path || f.path.starts_with(&prefix))
+            })
+            .map(|(id, _)| *id)
+            .collect();
+
+        let count = to_remove.len() as u64;
+        for id in to_remove {
+            files.remove(&id);
+        }
+        Ok(count)
+    }
+
+    pub async fn move_session_file(
+        &self,
+        session_id: Uuid,
+        source_path: &str,
+        dest_path: &str,
+    ) -> Result<Option<SessionFileRow>> {
+        // Check if destination exists
+        {
+            let files = self.session_files.read();
+            if files
+                .values()
+                .any(|f| f.session_id == session_id && f.path == dest_path)
+            {
+                return Err(anyhow!("Destination path already exists"));
+            }
+        }
+
+        let mut files = self.session_files.write();
+        if let Some(file) = files
+            .values_mut()
+            .find(|f| f.session_id == session_id && f.path == source_path)
+        {
+            file.path = dest_path.to_string();
+            file.updated_at = Self::now();
+            return Ok(Some(file.clone()));
+        }
+        Ok(None)
+    }
+
+    pub async fn copy_session_file(
+        &self,
+        session_id: Uuid,
+        source_path: &str,
+        dest_path: &str,
+    ) -> Result<Option<SessionFileRow>> {
+        // Check if destination exists
+        {
+            let files = self.session_files.read();
+            if files
+                .values()
+                .any(|f| f.session_id == session_id && f.path == dest_path)
+            {
+                return Err(anyhow!("Destination path already exists"));
+            }
+        }
+
+        let source = {
+            let files = self.session_files.read();
+            files
+                .values()
+                .find(|f| f.session_id == session_id && f.path == source_path)
+                .cloned()
+        };
+
+        if let Some(source) = source {
+            let now = Self::now();
+            let id = Uuid::now_v7();
+            let new_file = SessionFileRow {
+                id,
+                session_id,
+                path: dest_path.to_string(),
+                content: source.content,
+                is_directory: source.is_directory,
+                is_readonly: source.is_readonly,
+                size_bytes: source.size_bytes,
+                created_at: now,
+                updated_at: now,
+            };
+            self.session_files.write().insert(id, new_file.clone());
+            return Ok(Some(new_file));
+        }
+        Ok(None)
+    }
+
+    pub async fn grep_session_files(
+        &self,
+        session_id: Uuid,
+        pattern: &str,
+        path_prefix: Option<&str>,
+    ) -> Result<Vec<SessionFileInfoRow>> {
+        let regex = regex::Regex::new(pattern)?;
+        let files = self.session_files.read();
+
+        let result: Vec<_> = files
+            .values()
+            .filter(|f| {
+                if f.session_id != session_id || f.is_directory {
+                    return false;
+                }
+                if let Some(prefix) = path_prefix {
+                    if !f.path.starts_with(prefix) {
+                        return false;
+                    }
+                }
+                // Content is Vec<u8>, convert to str for regex matching
+                f.content
+                    .as_ref()
+                    .and_then(|c| std::str::from_utf8(c).ok())
+                    .map(|s| regex.is_match(s))
+                    .unwrap_or(false)
+            })
+            .map(Self::file_to_info)
+            .collect();
+
+        Ok(result)
+    }
+
+    pub async fn session_file_exists(&self, session_id: Uuid, path: &str) -> Result<bool> {
+        Ok(self
+            .session_files
+            .read()
+            .values()
+            .any(|f| f.session_id == session_id && f.path == path))
+    }
+
+    pub async fn session_directory_has_children(
+        &self,
+        session_id: Uuid,
+        path: &str,
+    ) -> Result<bool> {
+        let prefix = format!("{}/", path.trim_end_matches('/'));
+        Ok(self
+            .session_files
+            .read()
+            .values()
+            .any(|f| f.session_id == session_id && f.path.starts_with(&prefix)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_create_and_get_agent() {
+        let db = InMemoryDatabase::new();
+
+        let agent = db
+            .create_agent(CreateAgentRow {
+                name: "Test Agent".to_string(),
+                description: Some("A test agent".to_string()),
+                system_prompt: "You are helpful".to_string(),
+                default_model_id: None,
+                tags: vec!["test".to_string()],
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(agent.name, "Test Agent");
+
+        let fetched = db.get_agent(agent.id).await.unwrap();
+        assert!(fetched.is_some());
+        assert_eq!(fetched.unwrap().name, "Test Agent");
+    }
+
+    #[tokio::test]
+    async fn test_create_and_list_sessions() {
+        let db = InMemoryDatabase::new();
+
+        let agent = db
+            .create_agent(CreateAgentRow {
+                name: "Test Agent".to_string(),
+                description: None,
+                system_prompt: String::new(),
+                default_model_id: None,
+                tags: vec![],
+            })
+            .await
+            .unwrap();
+
+        let session = db
+            .create_session(CreateSessionRow {
+                agent_id: agent.id,
+                title: Some("Test Session".to_string()),
+                tags: vec![],
+                model_id: None,
+            })
+            .await
+            .unwrap();
+
+        let sessions = db.list_sessions(agent.id).await.unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].id, session.id);
+    }
+
+    #[tokio::test]
+    async fn test_events_sequence() {
+        use chrono::Utc;
+
+        let db = InMemoryDatabase::new();
+
+        let agent = db
+            .create_agent(CreateAgentRow {
+                name: "Test Agent".to_string(),
+                description: None,
+                system_prompt: String::new(),
+                default_model_id: None,
+                tags: vec![],
+            })
+            .await
+            .unwrap();
+
+        let session = db
+            .create_session(CreateSessionRow {
+                agent_id: agent.id,
+                title: None,
+                tags: vec![],
+                model_id: None,
+            })
+            .await
+            .unwrap();
+
+        // Create multiple events
+        for i in 0..3 {
+            db.create_event(CreateEventRow {
+                session_id: session.id,
+                event_type: "message.user".to_string(),
+                ts: Utc::now(),
+                context: serde_json::json!({}),
+                data: serde_json::json!({"content": format!("Message {}", i)}),
+                metadata: None,
+                tags: None,
+            })
+            .await
+            .unwrap();
+        }
+
+        let events = db.list_events(session.id, None, None).await.unwrap();
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0].sequence, 1);
+        assert_eq!(events[1].sequence, 2);
+        assert_eq!(events[2].sequence, 3);
+    }
+}

--- a/crates/control-plane/src/storage/message_store.rs
+++ b/crates/control-plane/src/storage/message_store.rs
@@ -17,7 +17,7 @@ use everruns_core::{
 use std::sync::Arc;
 use uuid::Uuid;
 
-use super::repositories::Database;
+use super::StorageBackend;
 use crate::EventService;
 
 // ============================================================================
@@ -30,13 +30,13 @@ use crate::EventService;
 /// Used by activities to load/store messages during workflow execution.
 #[derive(Clone)]
 pub struct DbMessageStore {
-    db: Database,
+    db: Arc<StorageBackend>,
     event_service: EventService,
 }
 
 impl DbMessageStore {
-    pub fn new(db: Database) -> Self {
-        let event_service = EventService::new(Arc::new(db.clone()));
+    pub fn new(db: Arc<StorageBackend>) -> Self {
+        let event_service = EventService::new(db.clone());
         Self { db, event_service }
     }
 }
@@ -195,7 +195,7 @@ fn tool_call_to_message(data: ToolCallCompletedData) -> Message {
 // ============================================================================
 
 /// Create a database-backed message store
-pub fn create_db_message_store(db: Database) -> DbMessageStore {
+pub fn create_db_message_store(db: Arc<StorageBackend>) -> DbMessageStore {
     DbMessageStore::new(db)
 }
 

--- a/crates/control-plane/src/storage/mod.rs
+++ b/crates/control-plane/src/storage/mod.rs
@@ -1,4 +1,5 @@
-// Postgres storage layer with sqlx
+// Storage layer for Everruns control-plane
+// Decision: Support both PostgreSQL (production) and in-memory (dev mode)
 //
 // This crate provides database implementations for core traits:
 // - DbAgentStore: implements AgentStore for agent retrieval
@@ -8,8 +9,10 @@
 // - DbLlmProviderStore: implements LlmProviderStore for LLM provider retrieval
 
 pub mod agent_store;
+pub mod backend;
 pub mod encryption;
 pub mod llm_provider_store;
+pub mod memory;
 pub mod message_store;
 pub mod models;
 pub mod password;
@@ -21,11 +24,13 @@ pub mod session_store;
 mod event_tests;
 
 pub use agent_store::{create_db_agent_store, DbAgentStore};
+pub use backend::StorageBackend;
 pub use encryption::{
     generate_encryption_key, EncryptedColumn, EncryptedPayload, EncryptionService,
     ENCRYPTED_COLUMNS,
 };
 pub use llm_provider_store::{create_db_llm_provider_store, DbLlmProviderStore};
+pub use memory::InMemoryDatabase;
 pub use message_store::{create_db_message_store, DbMessageStore};
 pub use models::*;
 pub use repositories::*;

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -9,13 +9,14 @@ pub mod runner;
 // Re-export main types
 pub use durable_runner::{
     DirectDurableStore, DurableRunner, DurableStoreBackend, DurableTurnInput, DurableTurnOutput,
+    InMemoryDurableStore,
 };
 pub use durable_worker::{DurableWorker, DurableWorkerConfig};
 pub use grpc_durable_store::{
     ClaimedTask as GrpcClaimedTask, GrpcDurableStore, HeartbeatResponse as GrpcHeartbeatResponse,
     WorkflowStatus as GrpcWorkflowStatus,
 };
-pub use runner::{create_runner, AgentRunner};
+pub use runner::{create_runner, create_runner_with_backend, AgentRunner, RunnerBackend};
 
 // Re-export LLM driver factory helpers
 pub use adapters::{create_driver_registry, create_llm_driver};

--- a/docs/sre/environment-variables.md
+++ b/docs/sre/environment-variables.md
@@ -3,6 +3,39 @@ title: Environment Variables
 description: Configuration environment variables for Everruns
 ---
 
+## DEV_MODE
+
+Enable development mode with in-memory storage. No PostgreSQL required.
+
+| Property | Value |
+|----------|-------|
+| **Required** | No |
+| **Default** | `false` |
+
+**Example:**
+
+```bash
+# Start in dev mode (no database required)
+DEV_MODE=true ./target/debug/everruns-api
+
+# Or with 1
+DEV_MODE=1 ./target/debug/everruns-api
+```
+
+**Notes:**
+- When enabled, uses in-memory storage instead of PostgreSQL
+- All data is lost when the server stops
+- gRPC server and worker communication are disabled
+- Stale task reclamation is disabled
+- Useful for quick local development and testing
+- Not suitable for production or multi-instance deployments
+
+**Limitations in dev mode:**
+- No persistence (data is lost on restart)
+- No worker support (all execution happens in-process)
+- No distributed tracing of worker activities
+- Single-instance only
+
 ## API_PREFIX
 
 Optional prefix for all API routes.

--- a/docs/sre/environment-variables.md
+++ b/docs/sre/environment-variables.md
@@ -16,10 +16,10 @@ Enable development mode with in-memory storage. No PostgreSQL required.
 
 ```bash
 # Start in dev mode (no database required)
-DEV_MODE=true ./target/debug/everruns-api
+DEV_MODE=true ./target/debug/everruns-control-plane
 
 # Or with 1
-DEV_MODE=1 ./target/debug/everruns-api
+DEV_MODE=1 ./target/debug/everruns-control-plane
 ```
 
 **Notes:**

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -301,7 +301,6 @@ case "$command" in
       fi
     }
 
-    ensure_protoc || exit 1
     require_command cargo-watch "Run: ./scripts/dev.sh init"
     require_command npm "Install Node.js/npm to start the UI (see README.md)."
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -286,6 +286,108 @@ case "$command" in
     echo "✅ Docs dependencies installed!"
     ;;
 
+  start-dev)
+    echo "🚀 Starting Everruns in DEV MODE (in-memory storage, no database required)..."
+    echo ""
+
+    # Required tool checks
+    require_command() {
+      local cmd="$1"
+      local hint="$2"
+
+      if ! command -v "$cmd" &> /dev/null; then
+        echo "❌ $cmd not installed. $hint"
+        exit 1
+      fi
+    }
+
+    ensure_protoc || exit 1
+    require_command cargo-watch "Run: ./scripts/dev.sh init"
+    require_command npm "Install Node.js/npm to start the UI (see README.md)."
+
+    # Track child PIDs for cleanup
+    CHILD_PIDS=()
+
+    # Cleanup function to kill child processes on exit
+    cleanup() {
+      echo ""
+      echo "🛑 Stopping services..."
+      for pid in "${CHILD_PIDS[@]}"; do
+        if kill -0 "$pid" 2>/dev/null; then
+          kill "$pid" 2>/dev/null || true
+        fi
+      done
+      pkill -f "cargo-watch" 2>/dev/null || true
+      pkill -f "everruns-control-plane" 2>/dev/null || true
+      pkill -f "next dev" 2>/dev/null || true
+      echo "✅ Services stopped"
+      exit 0
+    }
+
+    trap cleanup SIGINT SIGTERM
+
+    # Enable dev mode
+    export DEV_MODE=true
+    export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:9100}
+
+    # Start API in background with auto-reload (dev mode)
+    echo "1️⃣  Starting API server (DEV MODE) with auto-reload..."
+    cargo watch -w crates -x 'run -p everruns-control-plane' &
+    API_PID=$!
+    CHILD_PIDS+=("$API_PID")
+    sleep 3
+
+    # Check if API is running
+    if curl -s http://localhost:9000/health > /dev/null 2>&1; then
+      echo "   ✅ API is running (PID: $API_PID)"
+    else
+      echo "   ⚠️  API compiling (will auto-reload on changes)..."
+    fi
+
+    # Wait for API to be ready
+    echo "2️⃣  Waiting for API to be ready..."
+    for i in {1..30}; do
+      if curl -s http://localhost:9000/health > /dev/null 2>&1; then
+        echo "   ✅ API is ready"
+        break
+      fi
+      sleep 2
+    done
+
+    # Note: Worker is NOT started in dev mode (execution happens in-process)
+    echo "3️⃣  Worker: Not needed in DEV MODE (execution happens in-process)"
+
+    # Start UI in background
+    echo "4️⃣  Starting UI server..."
+    cd apps/ui
+    npm run dev &
+    UI_PID=$!
+    CHILD_PIDS+=("$UI_PID")
+    cd "$PROJECT_ROOT"
+    sleep 5
+    echo "   ✅ UI is starting (PID: $UI_PID)"
+
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "✅ DEV MODE started (in-memory storage)!"
+    echo ""
+    echo "   🌐 API:         http://localhost:9000 (auto-reload)"
+    echo "   📖 API Docs:    http://localhost:9000/swagger-ui/"
+    echo "   🖥️  UI:          http://localhost:9100 (hot reload)"
+    echo ""
+    echo "⚠️  DEV MODE limitations:"
+    echo "   - Data is stored in memory (lost on restart)"
+    echo "   - No PostgreSQL or Docker required"
+    echo "   - No separate worker process"
+    echo ""
+    echo "👀 Edit code in crates/ and services will auto-restart"
+    echo "💡 Press Ctrl+C to stop services"
+    echo ""
+
+    # Wait for processes
+    wait
+    ;;
+
   start-all)
     echo "🚀 Starting Everruns development environment..."
     echo ""
@@ -668,6 +770,7 @@ Commands:
   init        Install all development dependencies (Rust tools + UI + Docs)
   start       Start Docker services (Postgres, Jaeger)
   stop        Stop Docker services
+  start-dev   Start in DEV MODE (in-memory storage, no Docker/PostgreSQL required)
   start-all   Start everything with auto-reload (Docker, API, Worker, UI)
   stop-all    Stop all services (API, UI, Docker)
   reset       Stop and remove all Docker volumes
@@ -695,7 +798,8 @@ Commands:
 
 Examples:
   $0 init                  # First-time setup (install all dependencies)
-  $0 start-all             # Start everything with auto-reload
+  $0 start-dev             # Start DEV MODE (no Docker/PostgreSQL needed)
+  $0 start-all             # Start everything with auto-reload (requires PostgreSQL)
   $0 pre-pr                # Run all checks before creating a PR
   $0 watch-api             # Just run API with auto-reload
   $0 docs                  # Start docs dev server

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -248,8 +248,39 @@ Capabilities are modular functionality units that extend Agent behavior. See [sp
 ### Infrastructure
 
 1. **Local Development**: Docker Compose in `harness/` for Postgres, Jaeger
-2. **CI/CD**: GitHub Actions for format, lint, test, smoke test, Docker build
-3. **License Compliance**: cargo-deny for dependency license checking
+2. **Dev Mode**: In-memory storage mode for quick local development without PostgreSQL
+3. **CI/CD**: GitHub Actions for format, lint, test, smoke test, Docker build
+4. **License Compliance**: cargo-deny for dependency license checking
+
+### Development Mode (DEV_MODE)
+
+For rapid local development without infrastructure dependencies:
+
+```bash
+# Start in dev mode (no Docker/PostgreSQL required)
+DEV_MODE=true cargo run -p everruns-control-plane
+
+# Or use the convenience script
+./scripts/dev.sh start-dev
+```
+
+**DEV_MODE behavior:**
+- Uses in-memory storage (data lost on restart)
+- Execution happens in-process (no separate worker)
+- gRPC server disabled (not needed without workers)
+- No migrations required
+
+**Use cases:**
+- Quick UI development and testing
+- API endpoint development
+- Debugging without infrastructure setup
+
+**Limitations:**
+- No persistence
+- No worker/gRPC functionality
+- Single-instance only
+
+See [docs/sre/environment-variables.md](../docs/sre/environment-variables.md) for configuration details.
 
 ### Observability
 


### PR DESCRIPTION
## What
Add DEV_MODE environment variable that enables in-memory storage, allowing the control-plane to run without PostgreSQL or Docker infrastructure.

## Why
- Faster iteration for UI development and quick API testing
- Lower barrier to entry for new contributors
- Enables development in environments where Docker/PostgreSQL aren't available
- Reduces setup complexity for frontend-only changes

## How
- Added `InMemoryDatabase` implementation in `crates/control-plane/src/storage/memory.rs`
- Created `StorageBackend` enum that abstracts over PostgreSQL and in-memory storage
- Updated all services and API handlers to use `StorageBackend` instead of direct `Database`
- Added `InProcessRunner` in worker crate for synchronous execution without gRPC
- Added `start-dev` command to `scripts/dev.sh` for easy DEV_MODE startup
- Updated documentation in specs, AGENTS.md, and smoke test skill

## Changes
- **New files:**
  - `storage/memory.rs` - Full in-memory implementation of all repositories
  - `storage/backend.rs` - `StorageBackend` enum with PostgreSQL/Memory variants
  - `worker/runner.rs` - `InProcessRunner` trait for DEV_MODE execution

- **Modified:**
  - `main.rs` - DEV_MODE detection, conditional gRPC server, in-process runner setup
  - All services - Accept `StorageBackend` instead of `Database`
  - `scripts/dev.sh` - New `start-dev` command

## Usage
```bash
# Quick start - no Docker/PostgreSQL needed
./scripts/dev.sh start-dev
```

EV_MODE=true cargo run -p everruns-control-plane

## Risk
Low
DEV_MODE is opt-in via environment variable
No changes to default PostgreSQL behavior
In-memory storage is clearly documented as non-persistent

## Checklist
 Tests added or updated (unit tests for InMemoryDatabase)
 Backward compatibility considered (existing PostgreSQL flow unchanged)
 Documentation updated (specs, AGENTS.md, smoke tests, environment-variables.md)