### PR TITLE
fix(api): standardize list endpoints to use ListResponse envelope

### DIFF
--- a/apps/ui/src/lib/api/auth.ts
+++ b/apps/ui/src/lib/api/auth.ts
@@ -9,6 +9,7 @@ import type {
   ApiKeyListItem,
   ApiKeyResponse,
   CreateApiKeyRequest,
+  ListResponse,
 } from "./types";
 
 /**
@@ -75,8 +76,8 @@ export function getOAuthUrl(provider: string): string {
  * List API keys for current user
  */
 export async function listApiKeys(): Promise<ApiKeyListItem[]> {
-  const { data } = await api.get<ApiKeyListItem[]>("/v1/auth/api-keys");
-  return data;
+  const { data } = await api.get<ListResponse<ApiKeyListItem>>("/v1/auth/api-keys");
+  return data.data;
 }
 
 /**

--- a/apps/ui/src/lib/api/llm-providers.ts
+++ b/apps/ui/src/lib/api/llm-providers.ts
@@ -42,15 +42,15 @@ export async function deleteLlmProvider(providerId: string): Promise<void> {
 
 // Model CRUD
 export async function getLlmModels(): Promise<LlmModelWithProvider[]> {
-  const response = await api.get<LlmModelWithProvider[]>("/v1/llm-models");
-  return response.data;
+  const response = await api.get<ListResponse<LlmModelWithProvider>>("/v1/llm-models");
+  return response.data.data;
 }
 
 export async function getLlmProviderModels(
   providerId: string
 ): Promise<LlmModel[]> {
-  const response = await api.get<LlmModel[]>(`/v1/llm-providers/${providerId}/models`);
-  return response.data;
+  const response = await api.get<ListResponse<LlmModel>>(`/v1/llm-providers/${providerId}/models`);
+  return response.data.data;
 }
 
 export async function getLlmModel(modelId: string): Promise<LlmModelWithProvider> {

--- a/crates/control-plane/src/api/llm_models.rs
+++ b/crates/control-plane/src/api/llm_models.rs
@@ -1,5 +1,6 @@
 // LLM Model API endpoints
 
+use crate::api::common::ListResponse;
 use crate::storage::StorageBackend;
 use axum::{
     extract::{Path, State},
@@ -118,14 +119,14 @@ pub async fn create_model(
         ("provider_id" = Uuid, Path, description = "Provider ID")
     ),
     responses(
-        (status = 200, description = "List of models", body = Vec<LlmModel>)
+        (status = 200, description = "List of models", body = ListResponse<LlmModel>)
     ),
     tag = "llm-models"
 )]
 pub async fn list_provider_models(
     State(state): State<AppState>,
     Path(provider_id): Path<Uuid>,
-) -> Result<Json<Vec<LlmModel>>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<ListResponse<LlmModel>>, (StatusCode, Json<ErrorResponse>)> {
     let models = state
         .service
         .list_for_provider(provider_id)
@@ -140,7 +141,7 @@ pub async fn list_provider_models(
             )
         })?;
 
-    Ok(Json(models))
+    Ok(Json(ListResponse::new(models)))
 }
 
 /// List all models across all providers
@@ -148,13 +149,13 @@ pub async fn list_provider_models(
     get,
     path = "/v1/llm-models",
     responses(
-        (status = 200, description = "List of all models", body = Vec<LlmModelWithProvider>)
+        (status = 200, description = "List of all models", body = ListResponse<LlmModelWithProvider>)
     ),
     tag = "llm-models"
 )]
 pub async fn list_all_models(
     State(state): State<AppState>,
-) -> Result<Json<Vec<LlmModelWithProvider>>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<ListResponse<LlmModelWithProvider>>, (StatusCode, Json<ErrorResponse>)> {
     let models = state.service.list_all().await.map_err(|e| {
         tracing::error!("Failed to list all LLM models: {}", e);
         (
@@ -165,7 +166,7 @@ pub async fn list_all_models(
         )
     })?;
 
-    Ok(Json(models))
+    Ok(Json(ListResponse::new(models)))
 }
 
 /// Get a specific model with provider info and profile

--- a/crates/control-plane/src/auth/routes.rs
+++ b/crates/control-plane/src/auth/routes.rs
@@ -23,6 +23,7 @@ use super::{
     middleware::{AuthError, AuthState, AuthUser},
     oauth::{GitHubOAuthService, GoogleOAuthService, OAuthProvider},
 };
+use crate::api::common::ListResponse;
 use crate::storage::{
     models::{CreateApiKeyRow, CreateRefreshTokenRow, CreateUserRow},
     password::{hash_password, verify_password},
@@ -530,7 +531,7 @@ pub async fn oauth_callback(
 pub async fn list_api_keys(
     State(state): State<AuthState>,
     user: AuthUser,
-) -> Result<Json<Vec<ApiKeyListItem>>, AuthError> {
+) -> Result<Json<ListResponse<ApiKeyListItem>>, AuthError> {
     let keys = state
         .db
         .list_api_keys_for_user(user.id)
@@ -556,7 +557,7 @@ pub async fn list_api_keys(
         })
         .collect();
 
-    Ok(Json(items))
+    Ok(Json(ListResponse::new(items)))
 }
 
 /// POST /v1/auth/api-keys - Create a new API key

--- a/crates/control-plane/tests/integration_test.rs
+++ b/crates/control-plane/tests/integration_test.rs
@@ -368,10 +368,13 @@ async fn test_llm_model_profile() {
         .expect("Failed to list models");
 
     assert_eq!(list_models_response.status(), 200);
-    let models: Vec<Value> = list_models_response
+    let list_response: Value = list_models_response
         .json()
         .await
         .expect("Failed to parse models response");
+    let models = list_response["data"]
+        .as_array()
+        .expect("Response should have data array");
 
     let gpt4o_model = models
         .iter()

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1393,10 +1393,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/LlmModelWithProvider"
-                  }
+                  "$ref": "#/components/schemas/ListResponse_LlmModelWithProvider"
                 }
               }
             }
@@ -1699,10 +1696,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/LlmModel"
-                  }
+                  "$ref": "#/components/schemas/ListResponse_LlmModel"
                 }
               }
             }
@@ -3140,6 +3134,153 @@
                 },
                 "path": {
                   "type": "string"
+                }
+              }
+            },
+            "description": "Array of items returned by the list operation."
+          }
+        }
+      },
+      "ListResponse_LlmModel": {
+        "type": "object",
+        "description": "Response wrapper for list endpoints.\nAll list endpoints return responses wrapped in a `data` field.",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "description": "LLM Model entity",
+              "required": [
+                "id",
+                "provider_id",
+                "model_id",
+                "display_name",
+                "capabilities",
+                "is_default",
+                "status",
+                "created_at",
+                "updated_at"
+              ],
+              "properties": {
+                "capabilities": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "display_name": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "is_default": {
+                  "type": "boolean"
+                },
+                "model_id": {
+                  "type": "string"
+                },
+                "provider_id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "status": {
+                  "$ref": "#/components/schemas/LlmModelStatus"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            },
+            "description": "Array of items returned by the list operation."
+          }
+        }
+      },
+      "ListResponse_LlmModelWithProvider": {
+        "type": "object",
+        "description": "Response wrapper for list endpoints.\nAll list endpoints return responses wrapped in a `data` field.",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "description": "LLM Model with provider info",
+              "required": [
+                "id",
+                "provider_id",
+                "model_id",
+                "display_name",
+                "capabilities",
+                "is_default",
+                "status",
+                "created_at",
+                "updated_at",
+                "provider_name",
+                "provider_type"
+              ],
+              "properties": {
+                "capabilities": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "display_name": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "is_default": {
+                  "type": "boolean"
+                },
+                "model_id": {
+                  "type": "string"
+                },
+                "profile": {
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "$ref": "#/components/schemas/LlmModelProfile",
+                      "description": "Readonly profile with model capabilities (not persisted to database)"
+                    }
+                  ]
+                },
+                "provider_id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "provider_name": {
+                  "type": "string"
+                },
+                "provider_type": {
+                  "$ref": "#/components/schemas/LlmProviderType"
+                },
+                "status": {
+                  "$ref": "#/components/schemas/LlmModelStatus"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time"
                 }
               }
             },


### PR DESCRIPTION
## What
Standardize all list API endpoints to return responses wrapped in a `{"data": [...]}` envelope structure for consistency.

## Why
Some list endpoints were returning raw arrays while others used the `ListResponse<T>` wrapper. This inconsistency made it harder for API consumers to handle responses uniformly.

## How
Updated 3 backend endpoints and their corresponding UI API clients:
- `GET /v1/llm-providers/{provider_id}/models`
- `GET /v1/llm-models`
- `GET /v1/auth/api-keys`

All list endpoints now consistently return:
```json
{
  "data": [...]
}
```

## Files Changed
- `crates/control-plane/src/api/llm_models.rs` - Updated to use `ListResponse<T>`
- `crates/control-plane/src/auth/routes.rs` - Updated to use `ListResponse<T>`
- `docs/api/openapi.json` - Regenerated OpenAPI spec
- `apps/ui/src/lib/api/llm-providers.ts` - Updated to extract `data.data`
- `apps/ui/src/lib/api/auth.ts` - Updated to extract `data.data`

## Risk
- Low
- Breaking change for external API consumers expecting raw arrays from these 3 endpoints

## Checklist
- [x] Tests added or updated (unit tests pass)
- [x] Backward compatibility considered (documented as breaking change)
- [x] OpenAPI spec regenerated
- [x] UI clients updated