### PR TITLE
feat(durable): add durable execution monitoring dashboard

### DIFF
--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -12,6 +12,7 @@
         "@tanstack/react-query": "^5.90.16",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "date-fns": "^4.1.0",
         "lucide-react": "^0.562.0",
         "next": "16.1.1",
         "react": "19.2.3",
@@ -3683,6 +3684,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -19,6 +19,7 @@
     "@tanstack/react-query": "^5.90.16",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "lucide-react": "^0.562.0",
     "next": "16.1.1",
     "react": "19.2.3",

--- a/apps/ui/src/app/(main)/durable/page.tsx
+++ b/apps/ui/src/app/(main)/durable/page.tsx
@@ -1,0 +1,357 @@
+"use client";
+
+import { Header } from "@/components/layout/header";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useDurableHealth, useWorkers, useWorkflows } from "@/hooks";
+import {
+  Server,
+  Workflow,
+  Clock,
+  AlertTriangle,
+  CheckCircle,
+  Activity,
+  Inbox,
+  Zap,
+} from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+function getHealthStatusColor(status: string) {
+  switch (status) {
+    case "healthy":
+      return "bg-green-500";
+    case "degraded":
+      return "bg-yellow-500";
+    case "unhealthy":
+      return "bg-red-500";
+    default:
+      return "bg-gray-500";
+  }
+}
+
+function getHealthBadgeVariant(status: string) {
+  switch (status) {
+    case "healthy":
+      return "default" as const;
+    case "degraded":
+      return "secondary" as const;
+    case "unhealthy":
+      return "destructive" as const;
+    default:
+      return "outline" as const;
+  }
+}
+
+export default function DurableDashboardPage() {
+  const { data: health, isLoading: healthLoading, error: healthError } = useDurableHealth();
+  const { data: workersData, isLoading: workersLoading } = useWorkers();
+  const { data: workflowsData, isLoading: workflowsLoading } = useWorkflows({ limit: 5 });
+
+  const isLoading = healthLoading || workersLoading || workflowsLoading;
+
+  if (isLoading) {
+    return (
+      <>
+        <Header title="Durable Execution" />
+        <div className="p-6 space-y-6">
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+            {[...Array(4)].map((_, i) => (
+              <Skeleton key={i} className="h-32" />
+            ))}
+          </div>
+          <div className="grid gap-6 md:grid-cols-2">
+            <Skeleton className="h-80" />
+            <Skeleton className="h-80" />
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  // Handle error state - show empty state when API not available
+  if (healthError) {
+    return (
+      <>
+        <Header title="Durable Execution" />
+        <div className="p-6">
+          <Card>
+            <CardContent className="flex flex-col items-center justify-center py-12">
+              <AlertTriangle className="h-12 w-12 text-muted-foreground mb-4" />
+              <h3 className="text-lg font-medium mb-2">Durable API Not Available</h3>
+              <p className="text-sm text-muted-foreground text-center max-w-md">
+                The durable execution API endpoints are not yet available.
+                This dashboard will show worker and workflow information once the backend is ready.
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      </>
+    );
+  }
+
+  const stats = [
+    {
+      title: "System Health",
+      value: health?.status || "unknown",
+      description: `Load: ${health?.load_percentage?.toFixed(1) || 0}%`,
+      icon: Activity,
+      color: getHealthStatusColor(health?.status || "unknown"),
+      isBadge: true,
+    },
+    {
+      title: "Active Workers",
+      value: health?.active_workers || 0,
+      description: `${health?.workers_accepting || 0} accepting tasks`,
+      icon: Server,
+      color: "text-blue-600",
+    },
+    {
+      title: "Running Workflows",
+      value: health?.running_workflows || 0,
+      description: `${health?.pending_workflows || 0} pending`,
+      icon: Workflow,
+      color: "text-green-600",
+    },
+    {
+      title: "Pending Tasks",
+      value: health?.pending_tasks || 0,
+      description: `${health?.claimed_tasks || 0} claimed`,
+      icon: Clock,
+      color: "text-yellow-600",
+    },
+  ];
+
+  return (
+    <>
+      <Header title="Durable Execution" />
+      <div className="p-6 space-y-6">
+        {/* Stats Cards */}
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          {stats.map((stat) => (
+            <Card key={stat.title}>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">{stat.title}</CardTitle>
+                <stat.icon className={`h-4 w-4 ${stat.color}`} />
+              </CardHeader>
+              <CardContent>
+                {stat.isBadge ? (
+                  <Badge variant={getHealthBadgeVariant(String(stat.value))} className="text-lg px-3 py-1">
+                    {String(stat.value).toUpperCase()}
+                  </Badge>
+                ) : (
+                  <div className="text-2xl font-bold">{stat.value}</div>
+                )}
+                <p className="text-xs text-muted-foreground mt-1">{stat.description}</p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+
+        {/* Alert for issues */}
+        {health && (health.dlq_size > 0 || health.open_circuit_breakers.length > 0) && (
+          <Card className="border-yellow-500/50 bg-yellow-500/5">
+            <CardHeader className="pb-2">
+              <div className="flex items-center gap-2">
+                <AlertTriangle className="h-5 w-5 text-yellow-600" />
+                <CardTitle className="text-base">Attention Required</CardTitle>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {health.dlq_size > 0 && (
+                <div className="flex items-center justify-between">
+                  <span className="text-sm">
+                    <Inbox className="h-4 w-4 inline mr-2" />
+                    {health.dlq_size} items in dead letter queue
+                  </span>
+                  <Link href="/durable/workflows?tab=dlq">
+                    <Button variant="outline" size="sm">View DLQ</Button>
+                  </Link>
+                </div>
+              )}
+              {health.open_circuit_breakers.length > 0 && (
+                <div className="flex items-center justify-between">
+                  <span className="text-sm">
+                    <Zap className="h-4 w-4 inline mr-2" />
+                    {health.open_circuit_breakers.length} circuit breakers open: {health.open_circuit_breakers.join(", ")}
+                  </span>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Main content grid */}
+        <div className="grid gap-6 md:grid-cols-2">
+          {/* Workers Summary */}
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between">
+              <div>
+                <CardTitle>Workers</CardTitle>
+                <CardDescription>Active worker pool status</CardDescription>
+              </div>
+              <Link href="/durable/workers">
+                <Button variant="outline" size="sm">View All</Button>
+              </Link>
+            </CardHeader>
+            <CardContent>
+              {workersData && workersData.workers.length > 0 ? (
+                <div className="space-y-4">
+                  {/* Capacity bar */}
+                  <div>
+                    <div className="flex justify-between text-sm mb-1">
+                      <span className="text-muted-foreground">Capacity Usage</span>
+                      <span className="font-medium">
+                        {workersData.summary.total_load} / {workersData.summary.total_capacity}
+                      </span>
+                    </div>
+                    <div className="h-2 bg-muted rounded-full overflow-hidden">
+                      <div
+                        className="h-full bg-primary transition-all"
+                        style={{
+                          width: `${workersData.summary.total_capacity > 0
+                            ? (workersData.summary.total_load / workersData.summary.total_capacity) * 100
+                            : 0}%`,
+                        }}
+                      />
+                    </div>
+                  </div>
+
+                  {/* Worker list */}
+                  <div className="space-y-2">
+                    {workersData.workers.slice(0, 5).map((worker) => (
+                      <div
+                        key={worker.id}
+                        className="flex items-center justify-between p-2 rounded-lg bg-muted/50"
+                      >
+                        <div className="flex items-center gap-2">
+                          <div
+                            className={`w-2 h-2 rounded-full ${
+                              worker.status === "active" ? "bg-green-500" :
+                              worker.status === "draining" ? "bg-yellow-500" : "bg-red-500"
+                            }`}
+                          />
+                          <span className="text-sm font-medium truncate max-w-[150px]">
+                            {worker.hostname || worker.id.slice(0, 12)}
+                          </span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <span className="text-xs text-muted-foreground">
+                            {worker.current_load}/{worker.max_concurrency}
+                          </span>
+                          <Badge variant={worker.accepting_tasks ? "default" : "secondary"} className="text-xs">
+                            {worker.accepting_tasks ? "accepting" : "busy"}
+                          </Badge>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : (
+                <div className="flex flex-col items-center justify-center py-8 text-muted-foreground">
+                  <Server className="h-8 w-8 mb-2" />
+                  <p className="text-sm">No workers connected</p>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Recent Workflows */}
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between">
+              <div>
+                <CardTitle>Recent Workflows</CardTitle>
+                <CardDescription>Latest workflow executions</CardDescription>
+              </div>
+              <Link href="/durable/workflows">
+                <Button variant="outline" size="sm">View All</Button>
+              </Link>
+            </CardHeader>
+            <CardContent>
+              {workflowsData && workflowsData.data.length > 0 ? (
+                <div className="space-y-2">
+                  {workflowsData.data.map((workflow) => (
+                    <Link
+                      key={workflow.id}
+                      href={`/durable/workflows/${workflow.id}`}
+                      className="flex items-center justify-between p-2 rounded-lg bg-muted/50 hover:bg-muted transition-colors"
+                    >
+                      <div className="flex items-center gap-2">
+                        <WorkflowStatusIcon status={workflow.status} />
+                        <div>
+                          <p className="text-sm font-medium">{workflow.workflow_type}</p>
+                          <p className="text-xs text-muted-foreground">
+                            {workflow.id.slice(0, 8)}...
+                          </p>
+                        </div>
+                      </div>
+                      <Badge variant={getWorkflowStatusVariant(workflow.status)}>
+                        {workflow.status}
+                      </Badge>
+                    </Link>
+                  ))}
+                </div>
+              ) : (
+                <div className="flex flex-col items-center justify-center py-8 text-muted-foreground">
+                  <Workflow className="h-8 w-8 mb-2" />
+                  <p className="text-sm">No workflows yet</p>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Task Queue by Type */}
+        {health && Object.keys(health.queue_depth_by_type).length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Task Queue by Type</CardTitle>
+              <CardDescription>Pending tasks grouped by activity type</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="grid gap-2 md:grid-cols-3 lg:grid-cols-4">
+                {Object.entries(health.queue_depth_by_type).map(([type, count]) => (
+                  <div key={type} className="flex items-center justify-between p-3 rounded-lg bg-muted/50">
+                    <span className="text-sm font-medium">{type}</span>
+                    <Badge variant="outline">{count}</Badge>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </>
+  );
+}
+
+function WorkflowStatusIcon({ status }: { status: string }) {
+  switch (status) {
+    case "completed":
+      return <CheckCircle className="h-4 w-4 text-green-500" />;
+    case "running":
+      return <Activity className="h-4 w-4 text-blue-500 animate-pulse" />;
+    case "failed":
+      return <AlertTriangle className="h-4 w-4 text-red-500" />;
+    case "cancelled":
+      return <AlertTriangle className="h-4 w-4 text-yellow-500" />;
+    default:
+      return <Clock className="h-4 w-4 text-gray-500" />;
+  }
+}
+
+function getWorkflowStatusVariant(status: string) {
+  switch (status) {
+    case "completed":
+      return "default" as const;
+    case "running":
+      return "secondary" as const;
+    case "failed":
+      return "destructive" as const;
+    case "cancelled":
+      return "outline" as const;
+    default:
+      return "outline" as const;
+  }
+}

--- a/apps/ui/src/app/(main)/durable/page.tsx
+++ b/apps/ui/src/app/(main)/durable/page.tsx
@@ -196,15 +196,15 @@ export default function DurableDashboardPage() {
               </Link>
             </CardHeader>
             <CardContent>
-              {workersData && workersData.workers.length > 0 ? (
+              {workersData && workersData.data.length > 0 ? (
                 <div className="space-y-4">
                   {/* Capacity bar */}
                   {(() => {
                     // Compute summary from workers if not provided
                     const totalLoad = workersData.summary?.total_load ??
-                      workersData.workers.reduce((sum, w) => sum + w.current_load, 0);
+                      workersData.data.reduce((sum, w) => sum + w.current_load, 0);
                     const totalCapacity = workersData.summary?.total_capacity ??
-                      workersData.workers.reduce((sum, w) => sum + w.max_concurrency, 0);
+                      workersData.data.reduce((sum, w) => sum + w.max_concurrency, 0);
                     return (
                       <div>
                         <div className="flex justify-between text-sm mb-1">
@@ -229,7 +229,7 @@ export default function DurableDashboardPage() {
 
                   {/* Worker list */}
                   <div className="space-y-2">
-                    {workersData.workers.slice(0, 5).map((worker) => (
+                    {workersData.data.slice(0, 5).map((worker) => (
                       <div
                         key={worker.id}
                         className="flex items-center justify-between p-2 rounded-lg bg-muted/50"

--- a/apps/ui/src/app/(main)/durable/page.tsx
+++ b/apps/ui/src/app/(main)/durable/page.tsx
@@ -150,7 +150,7 @@ export default function DurableDashboardPage() {
         </div>
 
         {/* Alert for issues */}
-        {health && (health.dlq_size > 0 || health.open_circuit_breakers.length > 0) && (
+        {health && (health.dlq_size > 0 || (health.open_circuit_breakers && health.open_circuit_breakers.length > 0)) && (
           <Card className="border-yellow-500/50 bg-yellow-500/5">
             <CardHeader className="pb-2">
               <div className="flex items-center gap-2">
@@ -170,7 +170,7 @@ export default function DurableDashboardPage() {
                   </Link>
                 </div>
               )}
-              {health.open_circuit_breakers.length > 0 && (
+              {health.open_circuit_breakers && health.open_circuit_breakers.length > 0 && (
                 <div className="flex items-center justify-between">
                   <span className="text-sm">
                     <Zap className="h-4 w-4 inline mr-2" />
@@ -199,24 +199,33 @@ export default function DurableDashboardPage() {
               {workersData && workersData.workers.length > 0 ? (
                 <div className="space-y-4">
                   {/* Capacity bar */}
-                  <div>
-                    <div className="flex justify-between text-sm mb-1">
-                      <span className="text-muted-foreground">Capacity Usage</span>
-                      <span className="font-medium">
-                        {workersData.summary.total_load} / {workersData.summary.total_capacity}
-                      </span>
-                    </div>
-                    <div className="h-2 bg-muted rounded-full overflow-hidden">
-                      <div
-                        className="h-full bg-primary transition-all"
-                        style={{
-                          width: `${workersData.summary.total_capacity > 0
-                            ? (workersData.summary.total_load / workersData.summary.total_capacity) * 100
-                            : 0}%`,
-                        }}
-                      />
-                    </div>
-                  </div>
+                  {(() => {
+                    // Compute summary from workers if not provided
+                    const totalLoad = workersData.summary?.total_load ??
+                      workersData.workers.reduce((sum, w) => sum + w.current_load, 0);
+                    const totalCapacity = workersData.summary?.total_capacity ??
+                      workersData.workers.reduce((sum, w) => sum + w.max_concurrency, 0);
+                    return (
+                      <div>
+                        <div className="flex justify-between text-sm mb-1">
+                          <span className="text-muted-foreground">Capacity Usage</span>
+                          <span className="font-medium">
+                            {totalLoad} / {totalCapacity}
+                          </span>
+                        </div>
+                        <div className="h-2 bg-muted rounded-full overflow-hidden">
+                          <div
+                            className="h-full bg-primary transition-all"
+                            style={{
+                              width: `${totalCapacity > 0
+                                ? (totalLoad / totalCapacity) * 100
+                                : 0}%`,
+                            }}
+                          />
+                        </div>
+                      </div>
+                    );
+                  })()}
 
                   {/* Worker list */}
                   <div className="space-y-2">
@@ -233,7 +242,7 @@ export default function DurableDashboardPage() {
                             }`}
                           />
                           <span className="text-sm font-medium truncate max-w-[150px]">
-                            {worker.hostname || worker.id.slice(0, 12)}
+                            {worker.id.slice(0, 12)}
                           </span>
                         </div>
                         <div className="flex items-center gap-2">
@@ -303,7 +312,7 @@ export default function DurableDashboardPage() {
         </div>
 
         {/* Task Queue by Type */}
-        {health && Object.keys(health.queue_depth_by_type).length > 0 && (
+        {health && health.queue_depth_by_type && Object.keys(health.queue_depth_by_type).length > 0 && (
           <Card>
             <CardHeader>
               <CardTitle>Task Queue by Type</CardTitle>

--- a/apps/ui/src/app/(main)/durable/workers/page.tsx
+++ b/apps/ui/src/app/(main)/durable/workers/page.tsx
@@ -1,0 +1,368 @@
+"use client";
+
+import { Header } from "@/components/layout/header";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useWorkers, useDrainWorker } from "@/hooks";
+import type { DurableWorker, WorkerStatus } from "@/lib/api/types";
+import {
+  Server,
+  AlertTriangle,
+  Activity,
+  Clock,
+  RefreshCw,
+  Pause,
+  CheckCircle,
+} from "lucide-react";
+
+function formatDistanceToNow(date: Date, options?: { addSuffix?: boolean }): string {
+  const now = new Date();
+  const diff = now.getTime() - date.getTime();
+  const seconds = Math.floor(diff / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  let result = "";
+  if (days > 0) {
+    result = `${days} day${days > 1 ? "s" : ""}`;
+  } else if (hours > 0) {
+    result = `${hours} hour${hours > 1 ? "s" : ""}`;
+  } else if (minutes > 0) {
+    result = `${minutes} minute${minutes > 1 ? "s" : ""}`;
+  } else {
+    result = "less than a minute";
+  }
+
+  return options?.addSuffix ? `${result} ago` : result;
+}
+
+function getStatusColor(status: WorkerStatus) {
+  switch (status) {
+    case "active":
+      return "bg-green-500";
+    case "draining":
+      return "bg-yellow-500";
+    case "stopped":
+      return "bg-red-500";
+    case "stale":
+      return "bg-gray-500";
+    default:
+      return "bg-gray-500";
+  }
+}
+
+function getStatusBadgeVariant(status: WorkerStatus) {
+  switch (status) {
+    case "active":
+      return "default" as const;
+    case "draining":
+      return "secondary" as const;
+    case "stopped":
+      return "destructive" as const;
+    case "stale":
+      return "outline" as const;
+    default:
+      return "outline" as const;
+  }
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms.toFixed(0)}ms`;
+  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${(ms / 60000).toFixed(1)}m`;
+}
+
+function WorkerRow({ worker, onDrain }: { worker: DurableWorker; onDrain: (id: string) => void }) {
+  const loadPercentage = worker.max_concurrency > 0
+    ? (worker.current_load / worker.max_concurrency) * 100
+    : 0;
+
+  return (
+    <TableRow>
+      <TableCell>
+        <div className="flex items-center gap-2">
+          <div className={`w-2 h-2 rounded-full ${getStatusColor(worker.status)}`} />
+          <div>
+            <p className="font-medium">{worker.hostname || worker.id.slice(0, 20)}</p>
+            <p className="text-xs text-muted-foreground font-mono">{worker.id.slice(0, 16)}...</p>
+          </div>
+        </div>
+      </TableCell>
+      <TableCell>
+        <Badge variant={getStatusBadgeVariant(worker.status)}>{worker.status}</Badge>
+      </TableCell>
+      <TableCell>
+        <Badge variant="outline">{worker.worker_group}</Badge>
+      </TableCell>
+      <TableCell>
+        <div className="space-y-1">
+          <div className="flex items-center justify-between text-sm">
+            <span>{worker.current_load}/{worker.max_concurrency}</span>
+            <span className="text-muted-foreground text-xs">{loadPercentage.toFixed(0)}%</span>
+          </div>
+          <div className="h-1.5 bg-muted rounded-full overflow-hidden w-20">
+            <div
+              className={`h-full transition-all ${
+                loadPercentage > 80 ? "bg-red-500" :
+                loadPercentage > 60 ? "bg-yellow-500" : "bg-green-500"
+              }`}
+              style={{ width: `${loadPercentage}%` }}
+            />
+          </div>
+        </div>
+      </TableCell>
+      <TableCell>
+        {worker.accepting_tasks ? (
+          <div className="flex items-center gap-1 text-green-600">
+            <CheckCircle className="h-3 w-3" />
+            <span className="text-xs">Yes</span>
+          </div>
+        ) : (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger>
+                <div className="flex items-center gap-1 text-yellow-600">
+                  <Pause className="h-3 w-3" />
+                  <span className="text-xs">No</span>
+                </div>
+              </TooltipTrigger>
+              <TooltipContent>
+                {worker.backpressure_reason || "Under backpressure"}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
+      </TableCell>
+      <TableCell>
+        <div className="flex flex-wrap gap-1">
+          {worker.activity_types.slice(0, 3).map((type) => (
+            <Badge key={type} variant="outline" className="text-xs">
+              {type}
+            </Badge>
+          ))}
+          {worker.activity_types.length > 3 && (
+            <Badge variant="outline" className="text-xs">
+              +{worker.activity_types.length - 3}
+            </Badge>
+          )}
+        </div>
+      </TableCell>
+      <TableCell>
+        <div className="text-sm">
+          <p className="text-green-600">{worker.tasks_completed.toLocaleString()}</p>
+          {worker.tasks_failed > 0 && (
+            <p className="text-xs text-red-600">{worker.tasks_failed} failed</p>
+          )}
+        </div>
+      </TableCell>
+      <TableCell>
+        <span className="text-sm">{formatDuration(worker.avg_task_duration_ms)}</span>
+      </TableCell>
+      <TableCell>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger className="text-sm text-muted-foreground">
+              {formatDistanceToNow(new Date(worker.last_heartbeat_at), { addSuffix: true })}
+            </TooltipTrigger>
+            <TooltipContent>
+              {new Date(worker.last_heartbeat_at).toLocaleString()}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </TableCell>
+      <TableCell>
+        {worker.status === "active" && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onDrain(worker.id)}
+          >
+            <Pause className="h-3 w-3 mr-1" />
+            Drain
+          </Button>
+        )}
+      </TableCell>
+    </TableRow>
+  );
+}
+
+export default function WorkersPage() {
+  const { data, isLoading, error, refetch } = useWorkers();
+  const drainMutation = useDrainWorker();
+
+  if (isLoading) {
+    return (
+      <>
+        <Header title="Workers" />
+        <div className="p-6 space-y-6">
+          <div className="grid gap-4 md:grid-cols-4">
+            {[...Array(4)].map((_, i) => (
+              <Skeleton key={i} className="h-24" />
+            ))}
+          </div>
+          <Skeleton className="h-96" />
+        </div>
+      </>
+    );
+  }
+
+  if (error) {
+    return (
+      <>
+        <Header title="Workers" />
+        <div className="p-6">
+          <Card>
+            <CardContent className="flex flex-col items-center justify-center py-12">
+              <AlertTriangle className="h-12 w-12 text-muted-foreground mb-4" />
+              <h3 className="text-lg font-medium mb-2">Unable to Load Workers</h3>
+              <p className="text-sm text-muted-foreground text-center max-w-md mb-4">
+                The durable workers API is not available. Please ensure the backend is running.
+              </p>
+              <Button onClick={() => refetch()} variant="outline">
+                <RefreshCw className="h-4 w-4 mr-2" />
+                Retry
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </>
+    );
+  }
+
+  const summary = data?.summary;
+  const workers = data?.workers || [];
+
+  const summaryStats = [
+    {
+      title: "Total Workers",
+      value: data?.total || 0,
+      description: `${summary?.active || 0} active`,
+      icon: Server,
+      color: "text-blue-600",
+    },
+    {
+      title: "Total Capacity",
+      value: summary?.total_capacity || 0,
+      description: `${summary?.total_load || 0} in use`,
+      icon: Activity,
+      color: "text-green-600",
+    },
+    {
+      title: "Load",
+      value: summary?.total_capacity
+        ? `${((summary.total_load / summary.total_capacity) * 100).toFixed(1)}%`
+        : "0%",
+      description: `${summary?.total_load || 0}/${summary?.total_capacity || 0} slots`,
+      icon: Clock,
+      color: "text-yellow-600",
+    },
+    {
+      title: "Draining",
+      value: summary?.draining || 0,
+      description: `${summary?.stopped || 0} stopped`,
+      icon: Pause,
+      color: "text-orange-600",
+    },
+  ];
+
+  const handleDrain = (workerId: string) => {
+    if (confirm(`Are you sure you want to drain worker ${workerId.slice(0, 12)}...?`)) {
+      drainMutation.mutate(workerId);
+    }
+  };
+
+  return (
+    <>
+      <Header title="Workers" />
+      <div className="p-6 space-y-6">
+        {/* Summary Stats */}
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          {summaryStats.map((stat) => (
+            <Card key={stat.title}>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">{stat.title}</CardTitle>
+                <stat.icon className={`h-4 w-4 ${stat.color}`} />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{stat.value}</div>
+                <p className="text-xs text-muted-foreground">{stat.description}</p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+
+        {/* Workers Table */}
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between">
+            <div>
+              <CardTitle>Worker Pool</CardTitle>
+              <CardDescription>
+                All registered workers and their current status
+              </CardDescription>
+            </div>
+            <Button variant="outline" size="sm" onClick={() => refetch()}>
+              <RefreshCw className="h-4 w-4 mr-2" />
+              Refresh
+            </Button>
+          </CardHeader>
+          <CardContent>
+            {workers.length > 0 ? (
+              <div className="rounded-md border">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Worker</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead>Group</TableHead>
+                      <TableHead>Load</TableHead>
+                      <TableHead>Accepting</TableHead>
+                      <TableHead>Activities</TableHead>
+                      <TableHead>Completed</TableHead>
+                      <TableHead>Avg Duration</TableHead>
+                      <TableHead>Last Heartbeat</TableHead>
+                      <TableHead>Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {workers.map((worker) => (
+                      <WorkerRow
+                        key={worker.id}
+                        worker={worker}
+                        onDrain={handleDrain}
+                      />
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            ) : (
+              <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
+                <Server className="h-12 w-12 mb-4" />
+                <h3 className="text-lg font-medium mb-2">No Workers Connected</h3>
+                <p className="text-sm text-center max-w-md">
+                  No workers have registered with the system. Start a worker process to begin processing tasks.
+                </p>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </>
+  );
+}

--- a/apps/ui/src/app/(main)/durable/workers/page.tsx
+++ b/apps/ui/src/app/(main)/durable/workers/page.tsx
@@ -166,14 +166,14 @@ function WorkerRow({ worker, onDrain }: { worker: DurableWorker; onDrain: (id: s
       </TableCell>
       <TableCell>
         <div className="text-sm">
-          <p className="text-green-600">{worker.tasks_completed.toLocaleString()}</p>
-          {worker.tasks_failed > 0 && (
+          <p className="text-green-600">{(worker.tasks_completed ?? 0).toLocaleString()}</p>
+          {(worker.tasks_failed ?? 0) > 0 && (
             <p className="text-xs text-red-600">{worker.tasks_failed} failed</p>
           )}
         </div>
       </TableCell>
       <TableCell>
-        <span className="text-sm">{formatDuration(worker.avg_task_duration_ms)}</span>
+        <span className="text-sm">{formatDuration(worker.avg_task_duration_ms ?? 0)}</span>
       </TableCell>
       <TableCell>
         <TooltipProvider>

--- a/apps/ui/src/app/(main)/durable/workers/page.tsx
+++ b/apps/ui/src/app/(main)/durable/workers/page.tsx
@@ -247,7 +247,7 @@ export default function WorkersPage() {
   }
 
   const summary = data?.summary;
-  const workers = data?.workers || [];
+  const workers = data?.data || [];
 
   const summaryStats = [
     {

--- a/apps/ui/src/app/(main)/durable/workflows/[workflowId]/page.tsx
+++ b/apps/ui/src/app/(main)/durable/workflows/[workflowId]/page.tsx
@@ -1,0 +1,377 @@
+"use client";
+
+import { use } from "react";
+import { Header } from "@/components/layout/header";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
+import { useWorkflow, useWorkflowEvents, useCancelWorkflow, useSignalWorkflow } from "@/hooks";
+import type { WorkflowStatus, WorkflowEvent } from "@/lib/api/types";
+import {
+  AlertTriangle,
+  CheckCircle,
+  Clock,
+  XCircle,
+  Activity,
+  RefreshCw,
+  ArrowLeft,
+  ExternalLink,
+  Play,
+  Pause,
+  Timer,
+  Zap,
+  MessageSquare,
+} from "lucide-react";
+import Link from "next/link";
+
+function formatDistanceToNow(date: Date, options?: { addSuffix?: boolean }): string {
+  const now = new Date();
+  const diff = now.getTime() - date.getTime();
+  const seconds = Math.floor(diff / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  let result = "";
+  if (days > 0) {
+    result = `${days} day${days > 1 ? "s" : ""}`;
+  } else if (hours > 0) {
+    result = `${hours} hour${hours > 1 ? "s" : ""}`;
+  } else if (minutes > 0) {
+    result = `${minutes} minute${minutes > 1 ? "s" : ""}`;
+  } else {
+    result = "less than a minute";
+  }
+
+  return options?.addSuffix ? `${result} ago` : result;
+}
+
+function getStatusIcon(status: WorkflowStatus, size: "sm" | "lg" = "sm") {
+  const sizeClass = size === "lg" ? "h-6 w-6" : "h-4 w-4";
+  switch (status) {
+    case "completed":
+      return <CheckCircle className={`${sizeClass} text-green-500`} />;
+    case "running":
+      return <Activity className={`${sizeClass} text-blue-500 animate-pulse`} />;
+    case "failed":
+      return <XCircle className={`${sizeClass} text-red-500`} />;
+    case "cancelled":
+      return <AlertTriangle className={`${sizeClass} text-yellow-500`} />;
+    default:
+      return <Clock className={`${sizeClass} text-gray-500`} />;
+  }
+}
+
+function getStatusBadgeVariant(status: WorkflowStatus) {
+  switch (status) {
+    case "completed":
+      return "default" as const;
+    case "running":
+      return "secondary" as const;
+    case "failed":
+      return "destructive" as const;
+    case "cancelled":
+    case "pending":
+      return "outline" as const;
+    default:
+      return "outline" as const;
+  }
+}
+
+function getEventIcon(eventType: string) {
+  if (eventType.startsWith("Workflow")) {
+    if (eventType === "WorkflowStarted") return <Play className="h-4 w-4 text-green-500" />;
+    if (eventType === "WorkflowCompleted") return <CheckCircle className="h-4 w-4 text-green-500" />;
+    if (eventType === "WorkflowFailed") return <XCircle className="h-4 w-4 text-red-500" />;
+    if (eventType === "WorkflowCancelled") return <AlertTriangle className="h-4 w-4 text-yellow-500" />;
+    return <Activity className="h-4 w-4 text-blue-500" />;
+  }
+  if (eventType.startsWith("Activity")) {
+    if (eventType === "ActivityScheduled") return <Clock className="h-4 w-4 text-blue-500" />;
+    if (eventType === "ActivityStarted") return <Play className="h-4 w-4 text-blue-500" />;
+    if (eventType === "ActivityCompleted") return <CheckCircle className="h-4 w-4 text-green-500" />;
+    if (eventType === "ActivityFailed") return <XCircle className="h-4 w-4 text-red-500" />;
+    if (eventType === "ActivityTimedOut") return <Clock className="h-4 w-4 text-yellow-500" />;
+    return <Activity className="h-4 w-4 text-gray-500" />;
+  }
+  if (eventType.startsWith("Timer")) {
+    return <Timer className="h-4 w-4 text-purple-500" />;
+  }
+  if (eventType.startsWith("Signal")) {
+    return <Zap className="h-4 w-4 text-yellow-500" />;
+  }
+  if (eventType.startsWith("ChildWorkflow")) {
+    return <MessageSquare className="h-4 w-4 text-blue-500" />;
+  }
+  return <Activity className="h-4 w-4 text-gray-500" />;
+}
+
+function EventTimeline({ events }: { events: WorkflowEvent[] }) {
+  if (events.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-8 text-muted-foreground">
+        <Activity className="h-8 w-8 mb-2" />
+        <p className="text-sm">No events yet</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {events.map((event, index) => (
+        <div key={event.id} className="flex gap-4">
+          <div className="flex flex-col items-center">
+            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-muted">
+              {getEventIcon(event.event_type)}
+            </div>
+            {index < events.length - 1 && (
+              <div className="w-px h-full bg-border min-h-[20px]" />
+            )}
+          </div>
+          <div className="flex-1 pb-4">
+            <div className="flex items-center justify-between">
+              <p className="font-medium text-sm">{event.event_type}</p>
+              <span className="text-xs text-muted-foreground">
+                #{event.sequence_num} · {formatDistanceToNow(new Date(event.created_at), { addSuffix: true })}
+              </span>
+            </div>
+            {event.event_data && Object.keys(event.event_data).length > 0 && (
+              <div className="mt-2 p-2 rounded bg-muted/50">
+                <pre className="text-xs overflow-auto max-h-32">
+                  {JSON.stringify(event.event_data, null, 2)}
+                </pre>
+              </div>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function WorkflowDetailPage({ params }: { params: Promise<{ workflowId: string }> }) {
+  const { workflowId } = use(params);
+  const { data: workflow, isLoading: workflowLoading, error: workflowError, refetch } = useWorkflow(workflowId);
+  const { data: events, isLoading: eventsLoading } = useWorkflowEvents(workflowId);
+  const cancelMutation = useCancelWorkflow();
+  const signalMutation = useSignalWorkflow();
+
+  if (workflowLoading) {
+    return (
+      <>
+        <Header title="Workflow Details" />
+        <div className="p-6 space-y-6">
+          <Skeleton className="h-8 w-32" />
+          <div className="grid gap-6 md:grid-cols-2">
+            <Skeleton className="h-64" />
+            <Skeleton className="h-64" />
+          </div>
+          <Skeleton className="h-96" />
+        </div>
+      </>
+    );
+  }
+
+  if (workflowError || !workflow) {
+    return (
+      <>
+        <Header title="Workflow Details" />
+        <div className="p-6">
+          <Card>
+            <CardContent className="flex flex-col items-center justify-center py-12">
+              <AlertTriangle className="h-12 w-12 text-muted-foreground mb-4" />
+              <h3 className="text-lg font-medium mb-2">Workflow Not Found</h3>
+              <p className="text-sm text-muted-foreground text-center max-w-md mb-4">
+                The workflow could not be loaded. It may not exist or the API is unavailable.
+              </p>
+              <div className="flex gap-2">
+                <Link href="/durable/workflows">
+                  <Button variant="outline">
+                    <ArrowLeft className="h-4 w-4 mr-2" />
+                    Back to Workflows
+                  </Button>
+                </Link>
+                <Button onClick={() => refetch()} variant="outline">
+                  <RefreshCw className="h-4 w-4 mr-2" />
+                  Retry
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </>
+    );
+  }
+
+  const handleCancel = () => {
+    if (confirm("Are you sure you want to cancel this workflow?")) {
+      cancelMutation.mutate(workflowId);
+    }
+  };
+
+  const handleSignal = (signalType: string) => {
+    if (confirm(`Send "${signalType}" signal to this workflow?`)) {
+      signalMutation.mutate({ workflowId, signalType });
+    }
+  };
+
+  return (
+    <>
+      <Header title="Workflow Details" />
+      <div className="p-6 space-y-6">
+        {/* Back link */}
+        <Link
+          href="/durable/workflows"
+          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="h-4 w-4 mr-1" />
+          Back to Workflows
+        </Link>
+
+        {/* Header */}
+        <div className="flex items-start justify-between">
+          <div className="flex items-center gap-4">
+            {getStatusIcon(workflow.status, "lg")}
+            <div>
+              <h2 className="text-2xl font-bold">{workflow.workflow_type}</h2>
+              <p className="text-sm text-muted-foreground font-mono">{workflow.id}</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Badge variant={getStatusBadgeVariant(workflow.status)} className="text-lg px-3 py-1">
+              {workflow.status}
+            </Badge>
+            {workflow.status === "running" && (
+              <>
+                <Button variant="outline" onClick={() => handleSignal("shutdown")}>
+                  <Pause className="h-4 w-4 mr-2" />
+                  Shutdown
+                </Button>
+                <Button variant="destructive" onClick={handleCancel}>
+                  Cancel
+                </Button>
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* Info cards */}
+        <div className="grid gap-6 md:grid-cols-2">
+          <Card>
+            <CardHeader>
+              <CardTitle>Details</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <p className="text-sm text-muted-foreground">Created</p>
+                  <p className="font-medium">
+                    {new Date(workflow.created_at).toLocaleString()}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-sm text-muted-foreground">Updated</p>
+                  <p className="font-medium">
+                    {new Date(workflow.updated_at).toLocaleString()}
+                  </p>
+                </div>
+                {workflow.started_at && (
+                  <div>
+                    <p className="text-sm text-muted-foreground">Started</p>
+                    <p className="font-medium">
+                      {new Date(workflow.started_at).toLocaleString()}
+                    </p>
+                  </div>
+                )}
+                {workflow.completed_at && (
+                  <div>
+                    <p className="text-sm text-muted-foreground">Completed</p>
+                    <p className="font-medium">
+                      {new Date(workflow.completed_at).toLocaleString()}
+                    </p>
+                  </div>
+                )}
+              </div>
+
+              {workflow.session_id && (
+                <>
+                  <Separator />
+                  <div>
+                    <p className="text-sm text-muted-foreground mb-1">Linked Session</p>
+                    <Link
+                      href={`/agents/${workflow.agent_id}/sessions/${workflow.session_id}`}
+                      className="inline-flex items-center gap-1 text-primary hover:underline"
+                    >
+                      <ExternalLink className="h-4 w-4" />
+                      View Session
+                    </Link>
+                  </div>
+                </>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Input</CardTitle>
+              <CardDescription>Workflow input parameters</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ScrollArea className="h-[150px]">
+                <pre className="text-sm bg-muted p-3 rounded">
+                  {JSON.stringify(workflow.input, null, 2)}
+                </pre>
+              </ScrollArea>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Result/Error */}
+        {(workflow.result || workflow.error) && (
+          <Card>
+            <CardHeader>
+              <CardTitle>{workflow.error ? "Error" : "Result"}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ScrollArea className="h-[200px]">
+                <pre className={`text-sm p-3 rounded ${workflow.error ? "bg-red-500/10" : "bg-muted"}`}>
+                  {JSON.stringify(workflow.error || workflow.result, null, 2)}
+                </pre>
+              </ScrollArea>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Event Timeline */}
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between">
+            <div>
+              <CardTitle>Event History</CardTitle>
+              <CardDescription>Timeline of workflow events</CardDescription>
+            </div>
+            <Button variant="outline" size="sm" onClick={() => refetch()}>
+              <RefreshCw className="h-4 w-4 mr-2" />
+              Refresh
+            </Button>
+          </CardHeader>
+          <CardContent>
+            {eventsLoading ? (
+              <div className="space-y-4">
+                {[...Array(3)].map((_, i) => (
+                  <Skeleton key={i} className="h-20" />
+                ))}
+              </div>
+            ) : (
+              <ScrollArea className="h-[400px] pr-4">
+                <EventTimeline events={events || []} />
+              </ScrollArea>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </>
+  );
+}

--- a/apps/ui/src/app/(main)/durable/workflows/page.tsx
+++ b/apps/ui/src/app/(main)/durable/workflows/page.tsx
@@ -1,0 +1,622 @@
+"use client";
+
+import { useState } from "react";
+import { Header } from "@/components/layout/header";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useWorkflows, useCancelWorkflow, useTasks, useDlq, useRequeueDlqEntry } from "@/hooks";
+import type { DurableWorkflow, WorkflowStatus, DurableTask, DlqEntry } from "@/lib/api/types";
+import {
+  Workflow,
+  AlertTriangle,
+  CheckCircle,
+  Clock,
+  XCircle,
+  Activity,
+  RefreshCw,
+  Search,
+  ExternalLink,
+  RotateCcw,
+  Inbox,
+  ListTodo,
+} from "lucide-react";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+
+type TabValue = "workflows" | "tasks" | "dlq";
+
+function formatDistanceToNow(date: Date, options?: { addSuffix?: boolean }): string {
+  const now = new Date();
+  const diff = now.getTime() - date.getTime();
+  const seconds = Math.floor(diff / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  let result = "";
+  if (days > 0) {
+    result = `${days} day${days > 1 ? "s" : ""}`;
+  } else if (hours > 0) {
+    result = `${hours} hour${hours > 1 ? "s" : ""}`;
+  } else if (minutes > 0) {
+    result = `${minutes} minute${minutes > 1 ? "s" : ""}`;
+  } else {
+    result = "less than a minute";
+  }
+
+  return options?.addSuffix ? `${result} ago` : result;
+}
+
+function getStatusIcon(status: WorkflowStatus) {
+  switch (status) {
+    case "completed":
+      return <CheckCircle className="h-4 w-4 text-green-500" />;
+    case "running":
+      return <Activity className="h-4 w-4 text-blue-500 animate-pulse" />;
+    case "failed":
+      return <XCircle className="h-4 w-4 text-red-500" />;
+    case "cancelled":
+      return <AlertTriangle className="h-4 w-4 text-yellow-500" />;
+    default:
+      return <Clock className="h-4 w-4 text-gray-500" />;
+  }
+}
+
+function getStatusBadgeVariant(status: WorkflowStatus) {
+  switch (status) {
+    case "completed":
+      return "default" as const;
+    case "running":
+      return "secondary" as const;
+    case "failed":
+      return "destructive" as const;
+    case "cancelled":
+    case "pending":
+      return "outline" as const;
+    default:
+      return "outline" as const;
+  }
+}
+
+function WorkflowRow({ workflow, onCancel }: { workflow: DurableWorkflow; onCancel: (id: string) => void }) {
+  return (
+    <TableRow>
+      <TableCell>
+        <div className="flex items-center gap-2">
+          {getStatusIcon(workflow.status)}
+          <div>
+            <p className="font-medium">{workflow.workflow_type}</p>
+            <p className="text-xs text-muted-foreground font-mono">{workflow.id.slice(0, 16)}...</p>
+          </div>
+        </div>
+      </TableCell>
+      <TableCell>
+        <Badge variant={getStatusBadgeVariant(workflow.status)}>{workflow.status}</Badge>
+      </TableCell>
+      <TableCell>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger className="text-sm text-muted-foreground">
+              {formatDistanceToNow(new Date(workflow.created_at), { addSuffix: true })}
+            </TooltipTrigger>
+            <TooltipContent>
+              {new Date(workflow.created_at).toLocaleString()}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </TableCell>
+      <TableCell>
+        {workflow.started_at ? (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger className="text-sm text-muted-foreground">
+                {formatDistanceToNow(new Date(workflow.started_at), { addSuffix: true })}
+              </TooltipTrigger>
+              <TooltipContent>
+                {new Date(workflow.started_at).toLocaleString()}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ) : (
+          <span className="text-sm text-muted-foreground">-</span>
+        )}
+      </TableCell>
+      <TableCell>
+        {workflow.completed_at ? (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger className="text-sm text-muted-foreground">
+                {formatDistanceToNow(new Date(workflow.completed_at), { addSuffix: true })}
+              </TooltipTrigger>
+              <TooltipContent>
+                {new Date(workflow.completed_at).toLocaleString()}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ) : (
+          <span className="text-sm text-muted-foreground">-</span>
+        )}
+      </TableCell>
+      <TableCell>
+        {workflow.session_id ? (
+          <Link
+            href={`/agents/${workflow.agent_id}/sessions/${workflow.session_id}`}
+            className="flex items-center gap-1 text-sm text-primary hover:underline"
+          >
+            <ExternalLink className="h-3 w-3" />
+            View Session
+          </Link>
+        ) : (
+          <span className="text-sm text-muted-foreground">-</span>
+        )}
+      </TableCell>
+      <TableCell>
+        <div className="flex items-center gap-2">
+          <Link href={`/durable/workflows/${workflow.id}`}>
+            <Button variant="outline" size="sm">
+              View
+            </Button>
+          </Link>
+          {workflow.status === "running" && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onCancel(workflow.id)}
+            >
+              Cancel
+            </Button>
+          )}
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function TaskRow({ task }: { task: DurableTask }) {
+  return (
+    <TableRow>
+      <TableCell>
+        <div>
+          <p className="font-medium">{task.activity_type}</p>
+          <p className="text-xs text-muted-foreground">{task.activity_id}</p>
+        </div>
+      </TableCell>
+      <TableCell>
+        <Badge variant={task.status === "pending" ? "outline" : task.status === "claimed" ? "secondary" : "default"}>
+          {task.status}
+        </Badge>
+      </TableCell>
+      <TableCell>
+        <Badge variant="outline">{task.priority}</Badge>
+      </TableCell>
+      <TableCell>
+        <span className="text-sm">{task.attempt}/{task.max_attempts}</span>
+      </TableCell>
+      <TableCell>
+        {task.claimed_by ? (
+          <span className="text-sm font-mono text-muted-foreground">
+            {task.claimed_by.slice(0, 12)}...
+          </span>
+        ) : (
+          <span className="text-sm text-muted-foreground">-</span>
+        )}
+      </TableCell>
+      <TableCell>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger className="text-sm text-muted-foreground">
+              {formatDistanceToNow(new Date(task.scheduled_at), { addSuffix: true })}
+            </TooltipTrigger>
+            <TooltipContent>
+              {new Date(task.scheduled_at).toLocaleString()}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </TableCell>
+      <TableCell>
+        <Link href={`/durable/workflows/${task.workflow_id}`}>
+          <Button variant="ghost" size="sm">
+            <ExternalLink className="h-3 w-3" />
+          </Button>
+        </Link>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function DlqRow({ entry, onRequeue }: { entry: DlqEntry; onRequeue: (id: string) => void }) {
+  return (
+    <TableRow>
+      <TableCell>
+        <div>
+          <p className="font-medium">{entry.activity_type}</p>
+          <p className="text-xs text-muted-foreground">{entry.activity_id}</p>
+        </div>
+      </TableCell>
+      <TableCell>
+        <span className="text-sm">{entry.attempts}</span>
+      </TableCell>
+      <TableCell>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger className="text-sm text-red-600 max-w-[200px] truncate block">
+              {entry.last_error}
+            </TooltipTrigger>
+            <TooltipContent className="max-w-sm">
+              <pre className="text-xs whitespace-pre-wrap">{entry.last_error}</pre>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </TableCell>
+      <TableCell>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger className="text-sm text-muted-foreground">
+              {formatDistanceToNow(new Date(entry.dead_at), { addSuffix: true })}
+            </TooltipTrigger>
+            <TooltipContent>
+              {new Date(entry.dead_at).toLocaleString()}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </TableCell>
+      <TableCell>
+        <span className="text-sm">{entry.requeue_count}</span>
+      </TableCell>
+      <TableCell>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={() => onRequeue(entry.id)}>
+            <RotateCcw className="h-3 w-3 mr-1" />
+            Requeue
+          </Button>
+          <Link href={`/durable/workflows/${entry.workflow_id}`}>
+            <Button variant="ghost" size="sm">
+              <ExternalLink className="h-3 w-3" />
+            </Button>
+          </Link>
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+export default function WorkflowsPage() {
+  const [activeTab, setActiveTab] = useState<TabValue>("workflows");
+  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const workflowParams = statusFilter !== "all" ? { status: statusFilter } : undefined;
+  const { data: workflowsData, isLoading: workflowsLoading, error: workflowsError, refetch: refetchWorkflows } = useWorkflows(workflowParams);
+  const { data: tasksData, isLoading: tasksLoading, refetch: refetchTasks } = useTasks({ limit: 50 });
+  const { data: dlqData, isLoading: dlqLoading, refetch: refetchDlq } = useDlq({ limit: 50 });
+  const cancelMutation = useCancelWorkflow();
+  const requeueMutation = useRequeueDlqEntry();
+
+  const isLoading = workflowsLoading;
+
+  if (isLoading) {
+    return (
+      <>
+        <Header title="Workflows" />
+        <div className="p-6 space-y-6">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-96" />
+        </div>
+      </>
+    );
+  }
+
+  if (workflowsError) {
+    return (
+      <>
+        <Header title="Workflows" />
+        <div className="p-6">
+          <Card>
+            <CardContent className="flex flex-col items-center justify-center py-12">
+              <AlertTriangle className="h-12 w-12 text-muted-foreground mb-4" />
+              <h3 className="text-lg font-medium mb-2">Unable to Load Workflows</h3>
+              <p className="text-sm text-muted-foreground text-center max-w-md mb-4">
+                The durable workflows API is not available.
+              </p>
+              <Button onClick={() => refetchWorkflows()} variant="outline">
+                <RefreshCw className="h-4 w-4 mr-2" />
+                Retry
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </>
+    );
+  }
+
+  const workflows = workflowsData?.data || [];
+  const filteredWorkflows = searchQuery
+    ? workflows.filter(w =>
+        w.workflow_type.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        w.id.toLowerCase().includes(searchQuery.toLowerCase())
+      )
+    : workflows;
+
+  const tasks = tasksData?.data || [];
+  const dlqEntries = dlqData?.data || [];
+
+  const handleCancel = (workflowId: string) => {
+    if (confirm("Are you sure you want to cancel this workflow?")) {
+      cancelMutation.mutate(workflowId);
+    }
+  };
+
+  const handleRequeue = (dlqId: string) => {
+    if (confirm("Are you sure you want to requeue this task?")) {
+      requeueMutation.mutate(dlqId);
+    }
+  };
+
+  return (
+    <>
+      <Header title="Workflows" />
+      <div className="p-6 space-y-6">
+        {/* Tab Navigation */}
+        <div className="flex items-center gap-1 p-1 bg-muted rounded-lg w-fit">
+          <button
+            onClick={() => setActiveTab("workflows")}
+            className={cn(
+              "flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-colors",
+              activeTab === "workflows"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            )}
+          >
+            <Workflow className="h-4 w-4" />
+            Workflows
+            {workflows.length > 0 && (
+              <Badge variant="secondary" className="ml-1">{workflowsData?.total || 0}</Badge>
+            )}
+          </button>
+          <button
+            onClick={() => setActiveTab("tasks")}
+            className={cn(
+              "flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-colors",
+              activeTab === "tasks"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            )}
+          >
+            <ListTodo className="h-4 w-4" />
+            Tasks
+            {tasks.length > 0 && (
+              <Badge variant="secondary" className="ml-1">{tasksData?.total || 0}</Badge>
+            )}
+          </button>
+          <button
+            onClick={() => setActiveTab("dlq")}
+            className={cn(
+              "flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-colors",
+              activeTab === "dlq"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            )}
+          >
+            <Inbox className="h-4 w-4" />
+            Dead Letter Queue
+            {dlqEntries.length > 0 && (
+              <Badge variant="destructive" className="ml-1">{dlqData?.total || 0}</Badge>
+            )}
+          </button>
+        </div>
+
+        {/* Workflows Tab Content */}
+        {activeTab === "workflows" && (
+          <div className="space-y-4">
+            {/* Filters */}
+            <div className="flex items-center gap-4">
+              <div className="relative flex-1 max-w-sm">
+                <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+                <Input
+                  placeholder="Search workflows..."
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="pl-8"
+                />
+              </div>
+              <Select value={statusFilter} onValueChange={setStatusFilter}>
+                <SelectTrigger className="w-40">
+                  <SelectValue placeholder="Status" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All Status</SelectItem>
+                  <SelectItem value="pending">Pending</SelectItem>
+                  <SelectItem value="running">Running</SelectItem>
+                  <SelectItem value="completed">Completed</SelectItem>
+                  <SelectItem value="failed">Failed</SelectItem>
+                  <SelectItem value="cancelled">Cancelled</SelectItem>
+                </SelectContent>
+              </Select>
+              <Button variant="outline" size="sm" onClick={() => refetchWorkflows()}>
+                <RefreshCw className="h-4 w-4 mr-2" />
+                Refresh
+              </Button>
+            </div>
+
+            {/* Workflows Table */}
+            <Card>
+              <CardContent className="pt-6">
+                {filteredWorkflows.length > 0 ? (
+                  <div className="rounded-md border">
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>Workflow</TableHead>
+                          <TableHead>Status</TableHead>
+                          <TableHead>Created</TableHead>
+                          <TableHead>Started</TableHead>
+                          <TableHead>Completed</TableHead>
+                          <TableHead>Session</TableHead>
+                          <TableHead>Actions</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {filteredWorkflows.map((workflow) => (
+                          <WorkflowRow
+                            key={workflow.id}
+                            workflow={workflow}
+                            onCancel={handleCancel}
+                          />
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </div>
+                ) : (
+                  <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
+                    <Workflow className="h-12 w-12 mb-4" />
+                    <h3 className="text-lg font-medium mb-2">No Workflows Found</h3>
+                    <p className="text-sm text-center max-w-md">
+                      {searchQuery || statusFilter !== "all"
+                        ? "No workflows match your search criteria."
+                        : "No workflows have been created yet."}
+                    </p>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+        )}
+
+        {/* Tasks Tab Content */}
+        {activeTab === "tasks" && (
+          <div className="space-y-4">
+            <div className="flex justify-end">
+              <Button variant="outline" size="sm" onClick={() => refetchTasks()}>
+                <RefreshCw className="h-4 w-4 mr-2" />
+                Refresh
+              </Button>
+            </div>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Task Queue</CardTitle>
+                <CardDescription>Active and pending tasks in the queue</CardDescription>
+              </CardHeader>
+              <CardContent>
+                {!tasksLoading && tasks.length > 0 ? (
+                  <div className="rounded-md border">
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>Activity</TableHead>
+                          <TableHead>Status</TableHead>
+                          <TableHead>Priority</TableHead>
+                          <TableHead>Attempt</TableHead>
+                          <TableHead>Claimed By</TableHead>
+                          <TableHead>Scheduled</TableHead>
+                          <TableHead>Workflow</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {tasks.map((task) => (
+                          <TaskRow key={task.id} task={task} />
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </div>
+                ) : tasksLoading ? (
+                  <Skeleton className="h-48" />
+                ) : (
+                  <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
+                    <ListTodo className="h-12 w-12 mb-4" />
+                    <h3 className="text-lg font-medium mb-2">No Tasks in Queue</h3>
+                    <p className="text-sm text-center max-w-md">
+                      The task queue is empty. Tasks will appear here when workflows schedule activities.
+                    </p>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+        )}
+
+        {/* DLQ Tab Content */}
+        {activeTab === "dlq" && (
+          <div className="space-y-4">
+            <div className="flex justify-end">
+              <Button variant="outline" size="sm" onClick={() => refetchDlq()}>
+                <RefreshCw className="h-4 w-4 mr-2" />
+                Refresh
+              </Button>
+            </div>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Dead Letter Queue</CardTitle>
+                <CardDescription>
+                  Tasks that have exhausted all retry attempts
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                {!dlqLoading && dlqEntries.length > 0 ? (
+                  <div className="rounded-md border">
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>Activity</TableHead>
+                          <TableHead>Attempts</TableHead>
+                          <TableHead>Last Error</TableHead>
+                          <TableHead>Dead At</TableHead>
+                          <TableHead>Requeue Count</TableHead>
+                          <TableHead>Actions</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {dlqEntries.map((entry) => (
+                          <DlqRow
+                            key={entry.id}
+                            entry={entry}
+                            onRequeue={handleRequeue}
+                          />
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </div>
+                ) : dlqLoading ? (
+                  <Skeleton className="h-48" />
+                ) : (
+                  <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
+                    <CheckCircle className="h-12 w-12 mb-4 text-green-500" />
+                    <h3 className="text-lg font-medium mb-2">DLQ is Empty</h3>
+                    <p className="text-sm text-center max-w-md">
+                      No tasks have failed permanently. All tasks are being processed successfully.
+                    </p>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -27,6 +27,9 @@ import {
   Key,
   ChevronUp,
   FlaskConical,
+  Cog,
+  Server,
+  Workflow,
 } from "lucide-react";
 
 const isDev = process.env.NODE_ENV === "development";
@@ -36,6 +39,12 @@ const navigation = [
   { name: "Agents", href: "/agents", icon: Boxes },
   { name: "Capabilities", href: "/capabilities", icon: Puzzle },
   { name: "Settings", href: "/settings", icon: Settings },
+];
+
+const durableNavigation = [
+  { name: "Overview", href: "/durable", icon: Cog },
+  { name: "Workers", href: "/durable/workers", icon: Server },
+  { name: "Workflows", href: "/durable/workflows", icon: Workflow },
 ];
 
 const devNavigation = [
@@ -75,6 +84,29 @@ export function Sidebar() {
       {/* Navigation */}
       <nav className="flex-1 space-y-1 px-3 py-4">
         {navigation.map((item) => {
+          const isActive =
+            pathname === item.href || pathname.startsWith(`${item.href}/`);
+          return (
+            <Link
+              key={item.name}
+              href={item.href}
+              className={cn(
+                "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+                isActive
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+              )}
+            >
+              <item.icon className="h-5 w-5" />
+              {item.name}
+            </Link>
+          );
+        })}
+
+        {/* Durable Execution section */}
+        <div className="my-3 border-t" />
+        <p className="px-3 py-1 text-xs font-medium text-muted-foreground">Durable Execution</p>
+        {durableNavigation.map((item) => {
           const isActive =
             pathname === item.href || pathname.startsWith(`${item.href}/`);
           return (

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -42,7 +42,7 @@ const navigation = [
 ];
 
 const durableNavigation = [
-  { name: "Overview", href: "/durable", icon: Cog },
+  { name: "Overview", href: "/durable", icon: Cog, exact: true },
   { name: "Workers", href: "/durable/workers", icon: Server },
   { name: "Workflows", href: "/durable/workflows", icon: Workflow },
 ];
@@ -107,8 +107,9 @@ export function Sidebar() {
         <div className="my-3 border-t" />
         <p className="px-3 py-1 text-xs font-medium text-muted-foreground">Durable Execution</p>
         {durableNavigation.map((item) => {
-          const isActive =
-            pathname === item.href || pathname.startsWith(`${item.href}/`);
+          const isActive = item.exact
+            ? pathname === item.href
+            : pathname === item.href || pathname.startsWith(`${item.href}/`);
           return (
             <Link
               key={item.name}

--- a/apps/ui/src/hooks/index.ts
+++ b/apps/ui/src/hooks/index.ts
@@ -4,3 +4,4 @@ export * from "./use-capabilities";
 export * from "./use-sessions";
 export * from "./use-llm-providers";
 export * from "./use-auth";
+export * from "./use-durable";

--- a/apps/ui/src/hooks/use-durable.ts
+++ b/apps/ui/src/hooks/use-durable.ts
@@ -1,0 +1,219 @@
+// Durable Execution hooks
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  getDurableHealth,
+  listWorkers,
+  drainWorker,
+  listWorkflows,
+  getWorkflow,
+  getWorkflowEvents,
+  cancelWorkflow,
+  signalWorkflow,
+  listTasks,
+  getTaskStats,
+  listDlq,
+  requeueDlqEntry,
+  deleteDlqEntry,
+  purgeDlq,
+  listCircuitBreakers,
+  resetCircuitBreaker,
+  type ListWorkflowsParams,
+  type ListTasksParams,
+  type ListDlqParams,
+} from "@/lib/api/durable";
+
+// ============================================
+// System Health
+// ============================================
+
+export function useDurableHealth() {
+  return useQuery({
+    queryKey: ["durable", "health"],
+    queryFn: getDurableHealth,
+    refetchInterval: 5000, // Refresh every 5 seconds
+  });
+}
+
+// ============================================
+// Workers
+// ============================================
+
+export function useWorkers() {
+  return useQuery({
+    queryKey: ["durable", "workers"],
+    queryFn: listWorkers,
+    refetchInterval: 5000, // Refresh every 5 seconds
+  });
+}
+
+export function useDrainWorker() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (workerId: string) => drainWorker(workerId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["durable", "workers"] });
+      queryClient.invalidateQueries({ queryKey: ["durable", "health"] });
+    },
+  });
+}
+
+// ============================================
+// Workflows
+// ============================================
+
+export function useWorkflows(params?: ListWorkflowsParams) {
+  return useQuery({
+    queryKey: ["durable", "workflows", params],
+    queryFn: () => listWorkflows(params),
+    refetchInterval: 5000,
+  });
+}
+
+export function useWorkflow(workflowId: string | undefined) {
+  return useQuery({
+    queryKey: ["durable", "workflow", workflowId],
+    queryFn: () => getWorkflow(workflowId!),
+    enabled: !!workflowId,
+    refetchInterval: 2000,
+  });
+}
+
+export function useWorkflowEvents(workflowId: string | undefined) {
+  return useQuery({
+    queryKey: ["durable", "workflow", workflowId, "events"],
+    queryFn: () => getWorkflowEvents(workflowId!),
+    enabled: !!workflowId,
+    refetchInterval: 2000,
+  });
+}
+
+export function useCancelWorkflow() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (workflowId: string) => cancelWorkflow(workflowId),
+    onSuccess: (_, workflowId) => {
+      queryClient.invalidateQueries({ queryKey: ["durable", "workflows"] });
+      queryClient.invalidateQueries({
+        queryKey: ["durable", "workflow", workflowId],
+      });
+      queryClient.invalidateQueries({ queryKey: ["durable", "health"] });
+    },
+  });
+}
+
+export function useSignalWorkflow() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      workflowId,
+      signalType,
+      payload,
+    }: {
+      workflowId: string;
+      signalType: string;
+      payload?: Record<string, unknown>;
+    }) => signalWorkflow(workflowId, signalType, payload),
+    onSuccess: (_, { workflowId }) => {
+      queryClient.invalidateQueries({
+        queryKey: ["durable", "workflow", workflowId],
+      });
+    },
+  });
+}
+
+// ============================================
+// Tasks
+// ============================================
+
+export function useTasks(params?: ListTasksParams) {
+  return useQuery({
+    queryKey: ["durable", "tasks", params],
+    queryFn: () => listTasks(params),
+    refetchInterval: 5000,
+  });
+}
+
+export function useTaskStats() {
+  return useQuery({
+    queryKey: ["durable", "tasks", "stats"],
+    queryFn: getTaskStats,
+    refetchInterval: 5000,
+  });
+}
+
+// ============================================
+// Dead Letter Queue
+// ============================================
+
+export function useDlq(params?: ListDlqParams) {
+  return useQuery({
+    queryKey: ["durable", "dlq", params],
+    queryFn: () => listDlq(params),
+    refetchInterval: 10000, // DLQ changes less frequently
+  });
+}
+
+export function useRequeueDlqEntry() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (dlqId: string) => requeueDlqEntry(dlqId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["durable", "dlq"] });
+      queryClient.invalidateQueries({ queryKey: ["durable", "tasks"] });
+      queryClient.invalidateQueries({ queryKey: ["durable", "health"] });
+    },
+  });
+}
+
+export function useDeleteDlqEntry() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (dlqId: string) => deleteDlqEntry(dlqId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["durable", "dlq"] });
+      queryClient.invalidateQueries({ queryKey: ["durable", "health"] });
+    },
+  });
+}
+
+export function usePurgeDlq() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: purgeDlq,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["durable", "dlq"] });
+      queryClient.invalidateQueries({ queryKey: ["durable", "health"] });
+    },
+  });
+}
+
+// ============================================
+// Circuit Breakers
+// ============================================
+
+export function useCircuitBreakers() {
+  return useQuery({
+    queryKey: ["durable", "circuit-breakers"],
+    queryFn: listCircuitBreakers,
+    refetchInterval: 10000,
+  });
+}
+
+export function useResetCircuitBreaker() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (key: string) => resetCircuitBreaker(key),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["durable", "circuit-breakers"] });
+      queryClient.invalidateQueries({ queryKey: ["durable", "health"] });
+    },
+  });
+}

--- a/apps/ui/src/lib/api/durable.ts
+++ b/apps/ui/src/lib/api/durable.ts
@@ -1,0 +1,173 @@
+// Durable Execution API functions
+
+import { api } from "./client";
+import type {
+  WorkersResponse,
+  WorkflowsResponse,
+  DurableWorkflow,
+  WorkflowEvent,
+  TasksResponse,
+  TaskQueueStats,
+  DlqResponse,
+  CircuitBreaker,
+  DurableSystemHealth,
+} from "./types";
+
+// ============================================
+// System Health
+// ============================================
+
+export async function getDurableHealth(): Promise<DurableSystemHealth> {
+  const response = await api.get<DurableSystemHealth>("/v1/durable/health");
+  return response.data;
+}
+
+// ============================================
+// Workers
+// ============================================
+
+export async function listWorkers(): Promise<WorkersResponse> {
+  const response = await api.get<WorkersResponse>("/v1/durable/workers");
+  return response.data;
+}
+
+export async function drainWorker(workerId: string): Promise<void> {
+  await api.post(`/v1/durable/workers/${encodeURIComponent(workerId)}/drain`);
+}
+
+// ============================================
+// Workflows
+// ============================================
+
+export interface ListWorkflowsParams {
+  status?: string;
+  workflow_type?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export async function listWorkflows(
+  params?: ListWorkflowsParams
+): Promise<WorkflowsResponse> {
+  const searchParams = new URLSearchParams();
+  if (params?.status) searchParams.set("status", params.status);
+  if (params?.workflow_type) searchParams.set("workflow_type", params.workflow_type);
+  if (params?.limit) searchParams.set("limit", String(params.limit));
+  if (params?.offset) searchParams.set("offset", String(params.offset));
+
+  const query = searchParams.toString();
+  const url = `/v1/durable/workflows${query ? `?${query}` : ""}`;
+  const response = await api.get<WorkflowsResponse>(url);
+  return response.data;
+}
+
+export async function getWorkflow(workflowId: string): Promise<DurableWorkflow> {
+  const response = await api.get<DurableWorkflow>(
+    `/v1/durable/workflows/${workflowId}`
+  );
+  return response.data;
+}
+
+export async function getWorkflowEvents(
+  workflowId: string
+): Promise<WorkflowEvent[]> {
+  const response = await api.get<WorkflowEvent[]>(
+    `/v1/durable/workflows/${workflowId}/events`
+  );
+  return response.data;
+}
+
+export async function cancelWorkflow(workflowId: string): Promise<void> {
+  await api.post(`/v1/durable/workflows/${workflowId}/cancel`);
+}
+
+export async function signalWorkflow(
+  workflowId: string,
+  signalType: string,
+  payload?: Record<string, unknown>
+): Promise<void> {
+  await api.post(`/v1/durable/workflows/${workflowId}/signal`, {
+    signal_type: signalType,
+    payload: payload || {},
+  });
+}
+
+// ============================================
+// Tasks
+// ============================================
+
+export interface ListTasksParams {
+  status?: string;
+  activity_type?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export async function listTasks(params?: ListTasksParams): Promise<TasksResponse> {
+  const searchParams = new URLSearchParams();
+  if (params?.status) searchParams.set("status", params.status);
+  if (params?.activity_type) searchParams.set("activity_type", params.activity_type);
+  if (params?.limit) searchParams.set("limit", String(params.limit));
+  if (params?.offset) searchParams.set("offset", String(params.offset));
+
+  const query = searchParams.toString();
+  const url = `/v1/durable/tasks${query ? `?${query}` : ""}`;
+  const response = await api.get<TasksResponse>(url);
+  return response.data;
+}
+
+export async function getTaskStats(): Promise<TaskQueueStats> {
+  const response = await api.get<TaskQueueStats>("/v1/durable/tasks/stats");
+  return response.data;
+}
+
+// ============================================
+// Dead Letter Queue
+// ============================================
+
+export interface ListDlqParams {
+  activity_type?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export async function listDlq(params?: ListDlqParams): Promise<DlqResponse> {
+  const searchParams = new URLSearchParams();
+  if (params?.activity_type) searchParams.set("activity_type", params.activity_type);
+  if (params?.limit) searchParams.set("limit", String(params.limit));
+  if (params?.offset) searchParams.set("offset", String(params.offset));
+
+  const query = searchParams.toString();
+  const url = `/v1/durable/dlq${query ? `?${query}` : ""}`;
+  const response = await api.get<DlqResponse>(url);
+  return response.data;
+}
+
+export async function requeueDlqEntry(dlqId: string): Promise<string> {
+  const response = await api.post<{ task_id: string }>(
+    `/v1/durable/dlq/${dlqId}/requeue`
+  );
+  return response.data.task_id;
+}
+
+export async function deleteDlqEntry(dlqId: string): Promise<void> {
+  await api.delete(`/v1/durable/dlq/${dlqId}`);
+}
+
+export async function purgeDlq(): Promise<{ deleted: number }> {
+  const response = await api.post<{ deleted: number }>("/v1/durable/dlq/purge");
+  return response.data;
+}
+
+// ============================================
+// Circuit Breakers
+// ============================================
+
+export async function listCircuitBreakers(): Promise<CircuitBreaker[]> {
+  const response = await api.get<CircuitBreaker[]>("/v1/durable/circuit-breakers");
+  return response.data;
+}
+
+export async function resetCircuitBreaker(key: string): Promise<void> {
+  await api.post(`/v1/durable/circuit-breakers/${encodeURIComponent(key)}/reset`);
+}

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -843,7 +843,7 @@ export interface WorkersSummary {
 
 /** Workers list response */
 export interface WorkersResponse {
-  workers: DurableWorker[];
+  data: DurableWorker[];
   total: number;
   summary?: WorkersSummary;
 }

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -845,7 +845,7 @@ export interface WorkersSummary {
 export interface WorkersResponse {
   workers: DurableWorker[];
   total: number;
-  summary: WorkersSummary;
+  summary?: WorkersSummary;
 }
 
 /** Workflow instance */
@@ -954,14 +954,14 @@ export interface DurableSystemHealth {
   // Task queue
   pending_tasks: number;
   claimed_tasks: number;
-  queue_depth_by_type: Record<string, number>;
+  queue_depth_by_type?: Record<string, number>;
   // Workflows
   running_workflows: number;
   pending_workflows: number;
   // DLQ
   dlq_size: number;
-  // Circuit breakers
-  open_circuit_breakers: string[];
+  // Circuit breakers (optional - computed from circuit-breakers endpoint if needed)
+  open_circuit_breakers?: string[];
 }
 
 /** Workflows list response */

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -826,10 +826,10 @@ export interface DurableWorker {
   hostname?: string;
   version?: string;
   metadata?: Record<string, unknown>;
-  // Live stats
-  tasks_completed: number;
-  tasks_failed: number;
-  avg_task_duration_ms: number;
+  // Live stats (optional - may not be tracked)
+  tasks_completed?: number;
+  tasks_failed?: number;
+  avg_task_duration_ms?: number;
 }
 
 /** Workers list summary */

--- a/apps/ui/tsconfig.json
+++ b/apps/ui/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "playwright.config.ts", "e2e"]
 }

--- a/crates/control-plane/src/api/durable.rs
+++ b/crates/control-plane/src/api/durable.rs
@@ -1,0 +1,931 @@
+// Durable Execution API routes
+//
+// Provides monitoring and management endpoints for the durable execution engine:
+// - System health
+// - Worker management
+// - Workflow inspection
+// - Task queue monitoring
+// - Dead letter queue management
+// - Circuit breaker status
+
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    routing::{get, post},
+    Json, Router,
+};
+use chrono::{DateTime, Utc};
+use everruns_durable::{
+    CircuitBreakerState, CircuitState, DlqEntry, DlqFilter, Pagination, PostgresWorkflowEventStore,
+    SystemHealth, TaskFilter, TaskInfo, TaskStatus, WorkerFilter, WorkerInfo, WorkflowEventInfo,
+    WorkflowEventStore, WorkflowFilter, WorkflowInfoExtended, WorkflowSignal, WorkflowStatus,
+};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use std::sync::Arc;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use super::common::ErrorResponse;
+
+/// App state for durable routes
+#[derive(Clone)]
+pub struct AppState {
+    store: Arc<PostgresWorkflowEventStore>,
+}
+
+impl AppState {
+    pub fn new(pool: PgPool) -> Self {
+        Self {
+            store: Arc::new(PostgresWorkflowEventStore::new(pool)),
+        }
+    }
+}
+
+/// Create durable routes
+pub fn routes(state: AppState) -> Router {
+    Router::new()
+        // System health
+        .route("/v1/durable/health", get(get_health))
+        // Workers
+        .route("/v1/durable/workers", get(list_workers))
+        .route("/v1/durable/workers/:worker_id/drain", post(drain_worker))
+        // Workflows
+        .route("/v1/durable/workflows", get(list_workflows))
+        .route("/v1/durable/workflows/:workflow_id", get(get_workflow))
+        .route(
+            "/v1/durable/workflows/:workflow_id/events",
+            get(get_workflow_events),
+        )
+        .route(
+            "/v1/durable/workflows/:workflow_id/cancel",
+            post(cancel_workflow),
+        )
+        .route(
+            "/v1/durable/workflows/:workflow_id/signal",
+            post(send_signal),
+        )
+        // Tasks
+        .route("/v1/durable/tasks", get(list_tasks))
+        // DLQ
+        .route("/v1/durable/dlq", get(list_dlq))
+        .route("/v1/durable/dlq/:dlq_id/retry", post(retry_dlq))
+        // Circuit breakers
+        .route("/v1/durable/circuit-breakers", get(list_circuit_breakers))
+        .with_state(state)
+}
+
+// ============================================================================
+// Response types
+// ============================================================================
+
+/// System health response
+#[derive(Debug, Serialize, ToSchema)]
+pub struct HealthResponse {
+    pub status: String,
+    pub total_workers: usize,
+    pub active_workers: usize,
+    pub workers_accepting: usize,
+    pub total_capacity: usize,
+    pub current_load: usize,
+    pub load_percentage: f64,
+    pub pending_tasks: usize,
+    pub claimed_tasks: usize,
+    pub running_workflows: usize,
+    pub pending_workflows: usize,
+    pub dlq_size: usize,
+}
+
+impl From<SystemHealth> for HealthResponse {
+    fn from(h: SystemHealth) -> Self {
+        let load_percentage = if h.total_capacity > 0 {
+            (h.current_load as f64 / h.total_capacity as f64) * 100.0
+        } else {
+            0.0
+        };
+
+        let status = if h.active_workers == 0 {
+            "degraded"
+        } else if h.dlq_size > 0 {
+            "warning"
+        } else {
+            "healthy"
+        };
+
+        Self {
+            status: status.to_string(),
+            total_workers: h.total_workers,
+            active_workers: h.active_workers,
+            workers_accepting: h.workers_accepting,
+            total_capacity: h.total_capacity,
+            current_load: h.current_load,
+            load_percentage,
+            pending_tasks: h.pending_tasks,
+            claimed_tasks: h.claimed_tasks,
+            running_workflows: h.running_workflows,
+            pending_workflows: h.pending_workflows,
+            dlq_size: h.dlq_size,
+        }
+    }
+}
+
+/// Worker response
+#[derive(Debug, Serialize, ToSchema)]
+pub struct WorkerResponse {
+    pub id: String,
+    pub worker_group: String,
+    pub activity_types: Vec<String>,
+    pub max_concurrency: u32,
+    pub current_load: u32,
+    pub status: String,
+    pub accepting_tasks: bool,
+    pub started_at: DateTime<Utc>,
+    pub last_heartbeat_at: DateTime<Utc>,
+}
+
+impl From<WorkerInfo> for WorkerResponse {
+    fn from(w: WorkerInfo) -> Self {
+        Self {
+            id: w.id,
+            worker_group: w.worker_group,
+            activity_types: w.activity_types,
+            max_concurrency: w.max_concurrency,
+            current_load: w.current_load,
+            status: w.status,
+            accepting_tasks: w.accepting_tasks,
+            started_at: w.started_at,
+            last_heartbeat_at: w.last_heartbeat_at,
+        }
+    }
+}
+
+/// Workers list response
+#[derive(Debug, Serialize, ToSchema)]
+pub struct WorkersListResponse {
+    pub workers: Vec<WorkerResponse>,
+    pub total: usize,
+}
+
+/// Workflow response
+#[derive(Debug, Serialize, ToSchema)]
+pub struct WorkflowResponse {
+    pub id: Uuid,
+    pub workflow_type: String,
+    pub status: String,
+    pub input: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<serde_json::Value>,
+    pub created_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+impl From<WorkflowInfoExtended> for WorkflowResponse {
+    fn from(w: WorkflowInfoExtended) -> Self {
+        Self {
+            id: w.id,
+            workflow_type: w.workflow_type,
+            status: w.status.to_string(),
+            input: w.input,
+            result: w.result,
+            error: w.error.map(|e| serde_json::to_value(e).unwrap_or_default()),
+            created_at: w.created_at,
+            started_at: w.started_at,
+            completed_at: w.completed_at,
+        }
+    }
+}
+
+/// Workflows list response
+#[derive(Debug, Serialize, ToSchema)]
+pub struct WorkflowsListResponse {
+    pub workflows: Vec<WorkflowResponse>,
+    pub total: usize,
+}
+
+/// Workflow event response
+#[derive(Debug, Serialize, ToSchema)]
+pub struct WorkflowEventResponse {
+    pub sequence_num: i32,
+    pub event_type: String,
+    pub event_data: serde_json::Value,
+    pub created_at: DateTime<Utc>,
+}
+
+impl From<WorkflowEventInfo> for WorkflowEventResponse {
+    fn from(e: WorkflowEventInfo) -> Self {
+        Self {
+            sequence_num: e.sequence_num,
+            event_type: e.event_type,
+            event_data: e.event_data,
+            created_at: e.created_at,
+        }
+    }
+}
+
+/// Task response
+#[derive(Debug, Serialize, ToSchema)]
+pub struct TaskResponse {
+    pub id: Uuid,
+    pub workflow_id: Uuid,
+    pub activity_id: String,
+    pub activity_type: String,
+    pub status: String,
+    pub priority: i32,
+    pub attempt: u32,
+    pub max_attempts: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub claimed_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+    pub created_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub claimed_at: Option<DateTime<Utc>>,
+}
+
+impl From<TaskInfo> for TaskResponse {
+    fn from(t: TaskInfo) -> Self {
+        let status = match t.status {
+            TaskStatus::Pending => "pending",
+            TaskStatus::Claimed => "claimed",
+            TaskStatus::Completed => "completed",
+            TaskStatus::Failed => "failed",
+            TaskStatus::Dead => "dead",
+            TaskStatus::Cancelled => "cancelled",
+        };
+
+        Self {
+            id: t.id,
+            workflow_id: t.workflow_id,
+            activity_id: t.activity_id,
+            activity_type: t.activity_type,
+            status: status.to_string(),
+            priority: t.priority,
+            attempt: t.attempt,
+            max_attempts: t.max_attempts,
+            claimed_by: t.claimed_by,
+            last_error: t.last_error,
+            created_at: t.created_at,
+            claimed_at: t.claimed_at,
+        }
+    }
+}
+
+/// Tasks list response
+#[derive(Debug, Serialize, ToSchema)]
+pub struct TasksListResponse {
+    pub tasks: Vec<TaskResponse>,
+    pub total: usize,
+}
+
+/// DLQ entry response
+#[derive(Debug, Serialize, ToSchema)]
+pub struct DlqEntryResponse {
+    pub id: Uuid,
+    pub original_task_id: Uuid,
+    pub workflow_id: Uuid,
+    pub activity_id: String,
+    pub activity_type: String,
+    pub input: serde_json::Value,
+    pub attempts: u32,
+    pub last_error: String,
+    pub error_history: Vec<String>,
+    pub dead_at: DateTime<Utc>,
+}
+
+impl From<DlqEntry> for DlqEntryResponse {
+    fn from(d: DlqEntry) -> Self {
+        Self {
+            id: d.id,
+            original_task_id: d.original_task_id,
+            workflow_id: d.workflow_id,
+            activity_id: d.activity_id,
+            activity_type: d.activity_type,
+            input: d.input,
+            attempts: d.attempts,
+            last_error: d.last_error,
+            error_history: d.error_history,
+            dead_at: d.dead_at,
+        }
+    }
+}
+
+/// DLQ list response
+#[derive(Debug, Serialize, ToSchema)]
+pub struct DlqListResponse {
+    pub entries: Vec<DlqEntryResponse>,
+    pub total: usize,
+}
+
+/// Circuit breaker response
+#[derive(Debug, Serialize, ToSchema)]
+pub struct CircuitBreakerResponse {
+    pub key: String,
+    pub state: String,
+    pub failure_count: u32,
+    pub success_count: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_failure_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub opened_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub half_open_at: Option<DateTime<Utc>>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl From<CircuitBreakerState> for CircuitBreakerResponse {
+    fn from(cb: CircuitBreakerState) -> Self {
+        let state = match cb.state {
+            CircuitState::Closed => "closed",
+            CircuitState::Open => "open",
+            CircuitState::HalfOpen => "half_open",
+        };
+
+        Self {
+            key: cb.key,
+            state: state.to_string(),
+            failure_count: cb.failure_count,
+            success_count: cb.success_count,
+            last_failure_at: cb.last_failure_at,
+            opened_at: cb.opened_at,
+            half_open_at: cb.half_open_at,
+            updated_at: cb.updated_at,
+        }
+    }
+}
+
+/// Circuit breakers list response
+#[derive(Debug, Serialize, ToSchema)]
+pub struct CircuitBreakersListResponse {
+    pub circuit_breakers: Vec<CircuitBreakerResponse>,
+    pub total: usize,
+}
+
+// ============================================================================
+// Query parameters
+// ============================================================================
+
+#[derive(Debug, Deserialize)]
+pub struct ListWorkersQuery {
+    pub status: Option<String>,
+    pub worker_group: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListWorkflowsQuery {
+    pub status: Option<String>,
+    pub workflow_type: Option<String>,
+    pub offset: Option<u32>,
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListTasksQuery {
+    pub status: Option<String>,
+    pub activity_type: Option<String>,
+    pub workflow_id: Option<Uuid>,
+    pub offset: Option<u32>,
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListDlqQuery {
+    pub workflow_id: Option<Uuid>,
+    pub activity_type: Option<String>,
+    pub offset: Option<u32>,
+    pub limit: Option<u32>,
+}
+
+/// Request to send a signal to a workflow
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct SendSignalRequest {
+    pub signal_type: String,
+    #[serde(default)]
+    pub payload: serde_json::Value,
+}
+
+// ============================================================================
+// Route handlers
+// ============================================================================
+
+/// GET /v1/durable/health - Get system health
+#[utoipa::path(
+    get,
+    path = "/v1/durable/health",
+    responses(
+        (status = 200, description = "System health", body = HealthResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "durable"
+)]
+pub async fn get_health(
+    State(state): State<AppState>,
+) -> Result<Json<HealthResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let health = state.store.get_system_health().await.map_err(|e| {
+        tracing::error!("Failed to get system health: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: "Internal server error".to_string(),
+            }),
+        )
+    })?;
+
+    Ok(Json(HealthResponse::from(health)))
+}
+
+/// GET /v1/durable/workers - List workers
+#[utoipa::path(
+    get,
+    path = "/v1/durable/workers",
+    params(
+        ("status" = Option<String>, Query, description = "Filter by status"),
+        ("worker_group" = Option<String>, Query, description = "Filter by worker group")
+    ),
+    responses(
+        (status = 200, description = "List of workers", body = WorkersListResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "durable"
+)]
+pub async fn list_workers(
+    State(state): State<AppState>,
+    Query(query): Query<ListWorkersQuery>,
+) -> Result<Json<WorkersListResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let filter = WorkerFilter {
+        status: query.status,
+        worker_group: query.worker_group,
+    };
+
+    let workers = state.store.list_workers(filter).await.map_err(|e| {
+        tracing::error!("Failed to list workers: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: "Internal server error".to_string(),
+            }),
+        )
+    })?;
+
+    let total = workers.len();
+    let workers: Vec<WorkerResponse> = workers.into_iter().map(WorkerResponse::from).collect();
+
+    Ok(Json(WorkersListResponse { workers, total }))
+}
+
+/// POST /v1/durable/workers/:worker_id/drain - Drain a worker
+#[utoipa::path(
+    post,
+    path = "/v1/durable/workers/{worker_id}/drain",
+    params(
+        ("worker_id" = String, Path, description = "Worker ID")
+    ),
+    responses(
+        (status = 200, description = "Worker drained"),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "durable"
+)]
+pub async fn drain_worker(
+    State(state): State<AppState>,
+    Path(worker_id): Path<String>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    state.store.drain_worker(&worker_id).await.map_err(|e| {
+        tracing::error!("Failed to drain worker: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: "Internal server error".to_string(),
+            }),
+        )
+    })?;
+
+    Ok(StatusCode::OK)
+}
+
+/// GET /v1/durable/workflows - List workflows
+#[utoipa::path(
+    get,
+    path = "/v1/durable/workflows",
+    params(
+        ("status" = Option<String>, Query, description = "Filter by status"),
+        ("workflow_type" = Option<String>, Query, description = "Filter by workflow type"),
+        ("offset" = Option<u32>, Query, description = "Pagination offset"),
+        ("limit" = Option<u32>, Query, description = "Pagination limit")
+    ),
+    responses(
+        (status = 200, description = "List of workflows", body = WorkflowsListResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "durable"
+)]
+pub async fn list_workflows(
+    State(state): State<AppState>,
+    Query(query): Query<ListWorkflowsQuery>,
+) -> Result<Json<WorkflowsListResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let status = query.status.and_then(|s| match s.as_str() {
+        "pending" => Some(WorkflowStatus::Pending),
+        "running" => Some(WorkflowStatus::Running),
+        "completed" => Some(WorkflowStatus::Completed),
+        "failed" => Some(WorkflowStatus::Failed),
+        "cancelled" => Some(WorkflowStatus::Cancelled),
+        _ => None,
+    });
+
+    let filter = WorkflowFilter {
+        status,
+        workflow_type: query.workflow_type,
+    };
+
+    let pagination = Pagination {
+        offset: query.offset.unwrap_or(0),
+        limit: query.limit.unwrap_or(100),
+    };
+
+    let workflows = state
+        .store
+        .list_workflows(filter, pagination)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to list workflows: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "Internal server error".to_string(),
+                }),
+            )
+        })?;
+
+    let total = workflows.len();
+    let workflows: Vec<WorkflowResponse> =
+        workflows.into_iter().map(WorkflowResponse::from).collect();
+
+    Ok(Json(WorkflowsListResponse { workflows, total }))
+}
+
+/// GET /v1/durable/workflows/:workflow_id - Get workflow details
+#[utoipa::path(
+    get,
+    path = "/v1/durable/workflows/{workflow_id}",
+    params(
+        ("workflow_id" = Uuid, Path, description = "Workflow ID")
+    ),
+    responses(
+        (status = 200, description = "Workflow details", body = WorkflowResponse),
+        (status = 404, description = "Workflow not found", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "durable"
+)]
+pub async fn get_workflow(
+    State(state): State<AppState>,
+    Path(workflow_id): Path<Uuid>,
+) -> Result<Json<WorkflowResponse>, (StatusCode, Json<ErrorResponse>)> {
+    // Use list_workflows with a filter to get the extended info
+    let filter = WorkflowFilter::default();
+    let pagination = Pagination {
+        offset: 0,
+        limit: 1000,
+    };
+
+    let workflows = state
+        .store
+        .list_workflows(filter, pagination)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to get workflow: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "Internal server error".to_string(),
+                }),
+            )
+        })?;
+
+    let workflow = workflows.into_iter().find(|w| w.id == workflow_id).ok_or((
+        StatusCode::NOT_FOUND,
+        Json(ErrorResponse {
+            error: "Workflow not found".to_string(),
+        }),
+    ))?;
+
+    Ok(Json(WorkflowResponse::from(workflow)))
+}
+
+/// GET /v1/durable/workflows/:workflow_id/events - Get workflow events
+#[utoipa::path(
+    get,
+    path = "/v1/durable/workflows/{workflow_id}/events",
+    params(
+        ("workflow_id" = Uuid, Path, description = "Workflow ID")
+    ),
+    responses(
+        (status = 200, description = "Workflow events", body = Vec<WorkflowEventResponse>),
+        (status = 404, description = "Workflow not found", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "durable"
+)]
+pub async fn get_workflow_events(
+    State(state): State<AppState>,
+    Path(workflow_id): Path<Uuid>,
+) -> Result<Json<Vec<WorkflowEventResponse>>, (StatusCode, Json<ErrorResponse>)> {
+    let events = state
+        .store
+        .get_workflow_events(workflow_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to get workflow events: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "Internal server error".to_string(),
+                }),
+            )
+        })?;
+
+    let events: Vec<WorkflowEventResponse> =
+        events.into_iter().map(WorkflowEventResponse::from).collect();
+
+    Ok(Json(events))
+}
+
+/// POST /v1/durable/workflows/:workflow_id/cancel - Cancel a workflow
+#[utoipa::path(
+    post,
+    path = "/v1/durable/workflows/{workflow_id}/cancel",
+    params(
+        ("workflow_id" = Uuid, Path, description = "Workflow ID")
+    ),
+    responses(
+        (status = 200, description = "Workflow cancelled"),
+        (status = 404, description = "Workflow not found", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "durable"
+)]
+pub async fn cancel_workflow(
+    State(state): State<AppState>,
+    Path(workflow_id): Path<Uuid>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    state
+        .store
+        .cancel_workflow(workflow_id)
+        .await
+        .map_err(|e| match e {
+            everruns_durable::StoreError::WorkflowNotFound(_) => (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: "Workflow not found".to_string(),
+                }),
+            ),
+            _ => {
+                tracing::error!("Failed to cancel workflow: {}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: "Internal server error".to_string(),
+                    }),
+                )
+            }
+        })?;
+
+    Ok(StatusCode::OK)
+}
+
+/// POST /v1/durable/workflows/:workflow_id/signal - Send signal to workflow
+#[utoipa::path(
+    post,
+    path = "/v1/durable/workflows/{workflow_id}/signal",
+    params(
+        ("workflow_id" = Uuid, Path, description = "Workflow ID")
+    ),
+    request_body = SendSignalRequest,
+    responses(
+        (status = 200, description = "Signal sent"),
+        (status = 404, description = "Workflow not found", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "durable"
+)]
+pub async fn send_signal(
+    State(state): State<AppState>,
+    Path(workflow_id): Path<Uuid>,
+    Json(req): Json<SendSignalRequest>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let signal = WorkflowSignal {
+        signal_type: req.signal_type,
+        payload: req.payload,
+        sent_at: Utc::now(),
+    };
+
+    state
+        .store
+        .send_signal(workflow_id, signal)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to send signal: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "Internal server error".to_string(),
+                }),
+            )
+        })?;
+
+    Ok(StatusCode::OK)
+}
+
+/// GET /v1/durable/tasks - List tasks
+#[utoipa::path(
+    get,
+    path = "/v1/durable/tasks",
+    params(
+        ("status" = Option<String>, Query, description = "Filter by status"),
+        ("activity_type" = Option<String>, Query, description = "Filter by activity type"),
+        ("workflow_id" = Option<Uuid>, Query, description = "Filter by workflow ID"),
+        ("offset" = Option<u32>, Query, description = "Pagination offset"),
+        ("limit" = Option<u32>, Query, description = "Pagination limit")
+    ),
+    responses(
+        (status = 200, description = "List of tasks", body = TasksListResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "durable"
+)]
+pub async fn list_tasks(
+    State(state): State<AppState>,
+    Query(query): Query<ListTasksQuery>,
+) -> Result<Json<TasksListResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let status = query.status.and_then(|s| match s.as_str() {
+        "pending" => Some(TaskStatus::Pending),
+        "claimed" => Some(TaskStatus::Claimed),
+        "completed" => Some(TaskStatus::Completed),
+        "failed" => Some(TaskStatus::Failed),
+        "dead" => Some(TaskStatus::Dead),
+        "cancelled" => Some(TaskStatus::Cancelled),
+        _ => None,
+    });
+
+    let filter = TaskFilter {
+        status,
+        activity_type: query.activity_type,
+        workflow_id: query.workflow_id,
+    };
+
+    let pagination = Pagination {
+        offset: query.offset.unwrap_or(0),
+        limit: query.limit.unwrap_or(100),
+    };
+
+    let tasks = state
+        .store
+        .list_tasks(filter, pagination)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to list tasks: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "Internal server error".to_string(),
+                }),
+            )
+        })?;
+
+    let total = tasks.len();
+    let tasks: Vec<TaskResponse> = tasks.into_iter().map(TaskResponse::from).collect();
+
+    Ok(Json(TasksListResponse { tasks, total }))
+}
+
+/// GET /v1/durable/dlq - List dead letter queue entries
+#[utoipa::path(
+    get,
+    path = "/v1/durable/dlq",
+    params(
+        ("workflow_id" = Option<Uuid>, Query, description = "Filter by workflow ID"),
+        ("activity_type" = Option<String>, Query, description = "Filter by activity type"),
+        ("offset" = Option<u32>, Query, description = "Pagination offset"),
+        ("limit" = Option<u32>, Query, description = "Pagination limit")
+    ),
+    responses(
+        (status = 200, description = "List of DLQ entries", body = DlqListResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "durable"
+)]
+pub async fn list_dlq(
+    State(state): State<AppState>,
+    Query(query): Query<ListDlqQuery>,
+) -> Result<Json<DlqListResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let filter = DlqFilter {
+        workflow_id: query.workflow_id,
+        activity_type: query.activity_type,
+    };
+
+    let pagination = Pagination {
+        offset: query.offset.unwrap_or(0),
+        limit: query.limit.unwrap_or(100),
+    };
+
+    let entries = state
+        .store
+        .list_dlq(filter, pagination)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to list DLQ: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "Internal server error".to_string(),
+                }),
+            )
+        })?;
+
+    let total = entries.len();
+    let entries: Vec<DlqEntryResponse> = entries.into_iter().map(DlqEntryResponse::from).collect();
+
+    Ok(Json(DlqListResponse { entries, total }))
+}
+
+/// POST /v1/durable/dlq/:dlq_id/retry - Retry a DLQ entry
+#[utoipa::path(
+    post,
+    path = "/v1/durable/dlq/{dlq_id}/retry",
+    params(
+        ("dlq_id" = Uuid, Path, description = "DLQ entry ID")
+    ),
+    responses(
+        (status = 200, description = "Task requeued", body = Uuid),
+        (status = 404, description = "DLQ entry not found", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "durable"
+)]
+pub async fn retry_dlq(
+    State(state): State<AppState>,
+    Path(dlq_id): Path<Uuid>,
+) -> Result<Json<Uuid>, (StatusCode, Json<ErrorResponse>)> {
+    let task_id = state
+        .store
+        .requeue_from_dlq(dlq_id)
+        .await
+        .map_err(|e| match e {
+            everruns_durable::StoreError::TaskNotFound(_) => (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: "DLQ entry not found".to_string(),
+                }),
+            ),
+            _ => {
+                tracing::error!("Failed to retry DLQ entry: {}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: "Internal server error".to_string(),
+                    }),
+                )
+            }
+        })?;
+
+    Ok(Json(task_id))
+}
+
+/// GET /v1/durable/circuit-breakers - List circuit breakers
+#[utoipa::path(
+    get,
+    path = "/v1/durable/circuit-breakers",
+    responses(
+        (status = 200, description = "List of circuit breakers", body = CircuitBreakersListResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "durable"
+)]
+pub async fn list_circuit_breakers(
+    State(state): State<AppState>,
+) -> Result<Json<CircuitBreakersListResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let circuit_breakers = state.store.list_circuit_breakers().await.map_err(|e| {
+        tracing::error!("Failed to list circuit breakers: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: "Internal server error".to_string(),
+            }),
+        )
+    })?;
+
+    let total = circuit_breakers.len();
+    let circuit_breakers: Vec<CircuitBreakerResponse> = circuit_breakers
+        .into_iter()
+        .map(CircuitBreakerResponse::from)
+        .collect();
+
+    Ok(Json(CircuitBreakersListResponse {
+        circuit_breakers,
+        total,
+    }))
+}

--- a/crates/control-plane/src/api/durable.rs
+++ b/crates/control-plane/src/api/durable.rs
@@ -31,14 +31,26 @@ use super::common::ErrorResponse;
 /// App state for durable routes
 #[derive(Clone)]
 pub struct AppState {
-    store: Arc<PostgresWorkflowEventStore>,
+    store: Option<Arc<PostgresWorkflowEventStore>>,
 }
 
 impl AppState {
-    pub fn new(pool: PgPool) -> Self {
+    pub fn new(pool: Option<PgPool>) -> Self {
         Self {
-            store: Arc::new(PostgresWorkflowEventStore::new(pool)),
+            store: pool.map(|p| Arc::new(PostgresWorkflowEventStore::new(p))),
         }
+    }
+
+    /// Get the store, returning an error response if not available (dev mode)
+    fn get_store(&self) -> Result<&Arc<PostgresWorkflowEventStore>, (StatusCode, Json<ErrorResponse>)> {
+        self.store.as_ref().ok_or_else(|| {
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(ErrorResponse {
+                    error: "Durable execution not available in dev mode".to_string(),
+                }),
+            )
+        })
     }
 }
 
@@ -426,7 +438,8 @@ pub struct SendSignalRequest {
 pub async fn get_health(
     State(state): State<AppState>,
 ) -> Result<Json<HealthResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let health = state.store.get_system_health().await.map_err(|e| {
+    let store = state.get_store()?;
+    let health = store.get_system_health().await.map_err(|e| {
         tracing::error!("Failed to get system health: {}", e);
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -457,12 +470,13 @@ pub async fn list_workers(
     State(state): State<AppState>,
     Query(query): Query<ListWorkersQuery>,
 ) -> Result<Json<WorkersListResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let store = state.get_store()?;
     let filter = WorkerFilter {
         status: query.status,
         worker_group: query.worker_group,
     };
 
-    let workers = state.store.list_workers(filter).await.map_err(|e| {
+    let workers = store.list_workers(filter).await.map_err(|e| {
         tracing::error!("Failed to list workers: {}", e);
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -495,7 +509,8 @@ pub async fn drain_worker(
     State(state): State<AppState>,
     Path(worker_id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    state.store.drain_worker(&worker_id).await.map_err(|e| {
+    let store = state.get_store()?;
+    store.drain_worker(&worker_id).await.map_err(|e| {
         tracing::error!("Failed to drain worker: {}", e);
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -528,6 +543,7 @@ pub async fn list_workflows(
     State(state): State<AppState>,
     Query(query): Query<ListWorkflowsQuery>,
 ) -> Result<Json<WorkflowsListResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let store = state.get_store()?;
     let status = query.status.and_then(|s| match s.as_str() {
         "pending" => Some(WorkflowStatus::Pending),
         "running" => Some(WorkflowStatus::Running),
@@ -547,8 +563,7 @@ pub async fn list_workflows(
         limit: query.limit.unwrap_or(100),
     };
 
-    let workflows = state
-        .store
+    let workflows = store
         .list_workflows(filter, pagination)
         .await
         .map_err(|e| {
@@ -585,6 +600,7 @@ pub async fn get_workflow(
     State(state): State<AppState>,
     Path(workflow_id): Path<Uuid>,
 ) -> Result<Json<WorkflowResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let store = state.get_store()?;
     // Use list_workflows with a filter to get the extended info
     let filter = WorkflowFilter::default();
     let pagination = Pagination {
@@ -592,8 +608,7 @@ pub async fn get_workflow(
         limit: 1000,
     };
 
-    let workflows = state
-        .store
+    let workflows = store
         .list_workflows(filter, pagination)
         .await
         .map_err(|e| {
@@ -634,8 +649,8 @@ pub async fn get_workflow_events(
     State(state): State<AppState>,
     Path(workflow_id): Path<Uuid>,
 ) -> Result<Json<Vec<WorkflowEventResponse>>, (StatusCode, Json<ErrorResponse>)> {
-    let events = state
-        .store
+    let store = state.get_store()?;
+    let events = store
         .get_workflow_events(workflow_id)
         .await
         .map_err(|e| {
@@ -674,8 +689,8 @@ pub async fn cancel_workflow(
     State(state): State<AppState>,
     Path(workflow_id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    state
-        .store
+    let store = state.get_store()?;
+    store
         .cancel_workflow(workflow_id)
         .await
         .map_err(|e| match e {
@@ -719,14 +734,14 @@ pub async fn send_signal(
     Path(workflow_id): Path<Uuid>,
     Json(req): Json<SendSignalRequest>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let store = state.get_store()?;
     let signal = WorkflowSignal {
         signal_type: req.signal_type,
         payload: req.payload,
         sent_at: Utc::now(),
     };
 
-    state
-        .store
+    store
         .send_signal(workflow_id, signal)
         .await
         .map_err(|e| {
@@ -763,6 +778,7 @@ pub async fn list_tasks(
     State(state): State<AppState>,
     Query(query): Query<ListTasksQuery>,
 ) -> Result<Json<TasksListResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let store = state.get_store()?;
     let status = query.status.and_then(|s| match s.as_str() {
         "pending" => Some(TaskStatus::Pending),
         "claimed" => Some(TaskStatus::Claimed),
@@ -784,8 +800,7 @@ pub async fn list_tasks(
         limit: query.limit.unwrap_or(100),
     };
 
-    let tasks = state
-        .store
+    let tasks = store
         .list_tasks(filter, pagination)
         .await
         .map_err(|e| {
@@ -824,6 +839,7 @@ pub async fn list_dlq(
     State(state): State<AppState>,
     Query(query): Query<ListDlqQuery>,
 ) -> Result<Json<DlqListResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let store = state.get_store()?;
     let filter = DlqFilter {
         workflow_id: query.workflow_id,
         activity_type: query.activity_type,
@@ -834,8 +850,7 @@ pub async fn list_dlq(
         limit: query.limit.unwrap_or(100),
     };
 
-    let entries = state
-        .store
+    let entries = store
         .list_dlq(filter, pagination)
         .await
         .map_err(|e| {
@@ -872,8 +887,8 @@ pub async fn retry_dlq(
     State(state): State<AppState>,
     Path(dlq_id): Path<Uuid>,
 ) -> Result<Json<Uuid>, (StatusCode, Json<ErrorResponse>)> {
-    let task_id = state
-        .store
+    let store = state.get_store()?;
+    let task_id = store
         .requeue_from_dlq(dlq_id)
         .await
         .map_err(|e| match e {
@@ -910,7 +925,8 @@ pub async fn retry_dlq(
 pub async fn list_circuit_breakers(
     State(state): State<AppState>,
 ) -> Result<Json<CircuitBreakersListResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let circuit_breakers = state.store.list_circuit_breakers().await.map_err(|e| {
+    let store = state.get_store()?;
+    let circuit_breakers = store.list_circuit_breakers().await.map_err(|e| {
         tracing::error!("Failed to list circuit breakers: {}", e);
         (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/control-plane/src/api/durable.rs
+++ b/crates/control-plane/src/api/durable.rs
@@ -204,7 +204,7 @@ impl From<WorkflowInfoExtended> for WorkflowResponse {
 /// Workflows list response
 #[derive(Debug, Serialize, ToSchema)]
 pub struct WorkflowsListResponse {
-    pub workflows: Vec<WorkflowResponse>,
+    pub data: Vec<WorkflowResponse>,
     pub total: usize,
 }
 
@@ -279,7 +279,7 @@ impl From<TaskInfo> for TaskResponse {
 /// Tasks list response
 #[derive(Debug, Serialize, ToSchema)]
 pub struct TasksListResponse {
-    pub tasks: Vec<TaskResponse>,
+    pub data: Vec<TaskResponse>,
     pub total: usize,
 }
 
@@ -318,7 +318,7 @@ impl From<DlqEntry> for DlqEntryResponse {
 /// DLQ list response
 #[derive(Debug, Serialize, ToSchema)]
 pub struct DlqListResponse {
-    pub entries: Vec<DlqEntryResponse>,
+    pub data: Vec<DlqEntryResponse>,
     pub total: usize,
 }
 
@@ -562,10 +562,10 @@ pub async fn list_workflows(
         })?;
 
     let total = workflows.len();
-    let workflows: Vec<WorkflowResponse> =
+    let data: Vec<WorkflowResponse> =
         workflows.into_iter().map(WorkflowResponse::from).collect();
 
-    Ok(Json(WorkflowsListResponse { workflows, total }))
+    Ok(Json(WorkflowsListResponse { data, total }))
 }
 
 /// GET /v1/durable/workflows/:workflow_id - Get workflow details
@@ -798,9 +798,9 @@ pub async fn list_tasks(
         })?;
 
     let total = tasks.len();
-    let tasks: Vec<TaskResponse> = tasks.into_iter().map(TaskResponse::from).collect();
+    let data: Vec<TaskResponse> = tasks.into_iter().map(TaskResponse::from).collect();
 
-    Ok(Json(TasksListResponse { tasks, total }))
+    Ok(Json(TasksListResponse { data, total }))
 }
 
 /// GET /v1/durable/dlq - List dead letter queue entries
@@ -848,9 +848,9 @@ pub async fn list_dlq(
         })?;
 
     let total = entries.len();
-    let entries: Vec<DlqEntryResponse> = entries.into_iter().map(DlqEntryResponse::from).collect();
+    let data: Vec<DlqEntryResponse> = entries.into_iter().map(DlqEntryResponse::from).collect();
 
-    Ok(Json(DlqListResponse { entries, total }))
+    Ok(Json(DlqListResponse { data, total }))
 }
 
 /// POST /v1/durable/dlq/:dlq_id/retry - Retry a DLQ entry

--- a/crates/control-plane/src/api/durable.rs
+++ b/crates/control-plane/src/api/durable.rs
@@ -562,8 +562,7 @@ pub async fn list_workflows(
         })?;
 
     let total = workflows.len();
-    let data: Vec<WorkflowResponse> =
-        workflows.into_iter().map(WorkflowResponse::from).collect();
+    let data: Vec<WorkflowResponse> = workflows.into_iter().map(WorkflowResponse::from).collect();
 
     Ok(Json(WorkflowsListResponse { data, total }))
 }
@@ -649,8 +648,10 @@ pub async fn get_workflow_events(
             )
         })?;
 
-    let events: Vec<WorkflowEventResponse> =
-        events.into_iter().map(WorkflowEventResponse::from).collect();
+    let events: Vec<WorkflowEventResponse> = events
+        .into_iter()
+        .map(WorkflowEventResponse::from)
+        .collect();
 
     Ok(Json(events))
 }

--- a/crates/control-plane/src/api/durable.rs
+++ b/crates/control-plane/src/api/durable.rs
@@ -42,7 +42,9 @@ impl AppState {
     }
 
     /// Get the store, returning an error response if not available (dev mode)
-    fn get_store(&self) -> Result<&Arc<PostgresWorkflowEventStore>, (StatusCode, Json<ErrorResponse>)> {
+    fn get_store(
+        &self,
+    ) -> Result<&Arc<PostgresWorkflowEventStore>, (StatusCode, Json<ErrorResponse>)> {
         self.store.as_ref().ok_or_else(|| {
             (
                 StatusCode::SERVICE_UNAVAILABLE,
@@ -650,18 +652,15 @@ pub async fn get_workflow_events(
     Path(workflow_id): Path<Uuid>,
 ) -> Result<Json<Vec<WorkflowEventResponse>>, (StatusCode, Json<ErrorResponse>)> {
     let store = state.get_store()?;
-    let events = store
-        .get_workflow_events(workflow_id)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to get workflow events: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: "Internal server error".to_string(),
-                }),
-            )
-        })?;
+    let events = store.get_workflow_events(workflow_id).await.map_err(|e| {
+        tracing::error!("Failed to get workflow events: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: "Internal server error".to_string(),
+            }),
+        )
+    })?;
 
     let events: Vec<WorkflowEventResponse> = events
         .into_iter()
@@ -741,18 +740,15 @@ pub async fn send_signal(
         sent_at: Utc::now(),
     };
 
-    store
-        .send_signal(workflow_id, signal)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to send signal: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: "Internal server error".to_string(),
-                }),
-            )
-        })?;
+    store.send_signal(workflow_id, signal).await.map_err(|e| {
+        tracing::error!("Failed to send signal: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: "Internal server error".to_string(),
+            }),
+        )
+    })?;
 
     Ok(StatusCode::OK)
 }
@@ -800,18 +796,15 @@ pub async fn list_tasks(
         limit: query.limit.unwrap_or(100),
     };
 
-    let tasks = store
-        .list_tasks(filter, pagination)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to list tasks: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: "Internal server error".to_string(),
-                }),
-            )
-        })?;
+    let tasks = store.list_tasks(filter, pagination).await.map_err(|e| {
+        tracing::error!("Failed to list tasks: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: "Internal server error".to_string(),
+            }),
+        )
+    })?;
 
     let total = tasks.len();
     let data: Vec<TaskResponse> = tasks.into_iter().map(TaskResponse::from).collect();
@@ -850,18 +843,15 @@ pub async fn list_dlq(
         limit: query.limit.unwrap_or(100),
     };
 
-    let entries = store
-        .list_dlq(filter, pagination)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to list DLQ: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: "Internal server error".to_string(),
-                }),
-            )
-        })?;
+    let entries = store.list_dlq(filter, pagination).await.map_err(|e| {
+        tracing::error!("Failed to list DLQ: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: "Internal server error".to_string(),
+            }),
+        )
+    })?;
 
     let total = entries.len();
     let data: Vec<DlqEntryResponse> = entries.into_iter().map(DlqEntryResponse::from).collect();
@@ -888,26 +878,23 @@ pub async fn retry_dlq(
     Path(dlq_id): Path<Uuid>,
 ) -> Result<Json<Uuid>, (StatusCode, Json<ErrorResponse>)> {
     let store = state.get_store()?;
-    let task_id = store
-        .requeue_from_dlq(dlq_id)
-        .await
-        .map_err(|e| match e {
-            everruns_durable::StoreError::TaskNotFound(_) => (
-                StatusCode::NOT_FOUND,
+    let task_id = store.requeue_from_dlq(dlq_id).await.map_err(|e| match e {
+        everruns_durable::StoreError::TaskNotFound(_) => (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: "DLQ entry not found".to_string(),
+            }),
+        ),
+        _ => {
+            tracing::error!("Failed to retry DLQ entry: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse {
-                    error: "DLQ entry not found".to_string(),
+                    error: "Internal server error".to_string(),
                 }),
-            ),
-            _ => {
-                tracing::error!("Failed to retry DLQ entry: {}", e);
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorResponse {
-                        error: "Internal server error".to_string(),
-                    }),
-                )
-            }
-        })?;
+            )
+        }
+    })?;
 
     Ok(Json(task_id))
 }

--- a/crates/control-plane/src/api/durable.rs
+++ b/crates/control-plane/src/api/durable.rs
@@ -163,7 +163,7 @@ impl From<WorkerInfo> for WorkerResponse {
 /// Workers list response
 #[derive(Debug, Serialize, ToSchema)]
 pub struct WorkersListResponse {
-    pub workers: Vec<WorkerResponse>,
+    pub data: Vec<WorkerResponse>,
     pub total: usize,
 }
 
@@ -473,9 +473,9 @@ pub async fn list_workers(
     })?;
 
     let total = workers.len();
-    let workers: Vec<WorkerResponse> = workers.into_iter().map(WorkerResponse::from).collect();
+    let data: Vec<WorkerResponse> = workers.into_iter().map(WorkerResponse::from).collect();
 
-    Ok(Json(WorkersListResponse { workers, total }))
+    Ok(Json(WorkersListResponse { data, total }))
 }
 
 /// POST /v1/durable/workers/:worker_id/drain - Drain a worker

--- a/crates/control-plane/src/api/durable.rs
+++ b/crates/control-plane/src/api/durable.rs
@@ -133,7 +133,8 @@ impl From<SystemHealth> for HealthResponse {
 #[derive(Debug, Serialize, ToSchema)]
 pub struct WorkerResponse {
     pub id: String,
-    pub worker_group: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worker_group: Option<String>,
     pub activity_types: Vec<String>,
     pub max_concurrency: u32,
     pub current_load: u32,

--- a/crates/control-plane/src/api/mod.rs
+++ b/crates/control-plane/src/api/mod.rs
@@ -6,6 +6,7 @@
 pub mod agents;
 pub mod capabilities;
 pub mod common;
+pub mod durable;
 pub mod events;
 pub mod llm_models;
 pub mod llm_providers;

--- a/crates/control-plane/src/grpc_service.rs
+++ b/crates/control-plane/src/grpc_service.rs
@@ -19,19 +19,18 @@ use everruns_internal_protocol::proto::{
     ClaimDurableTasksResponse, CommitExecRequest, CommitExecResponse, CompleteDurableTaskRequest,
     CompleteDurableTaskResponse, CountActiveDurableWorkflowsRequest,
     CountActiveDurableWorkflowsResponse, CreateDurableWorkflowRequest,
-    CreateDurableWorkflowResponse, DurableWorkflowStatus, EmitEventRequest, EmitEventResponse,
-    EmitEventStreamResponse, EnqueueDurableTaskRequest, EnqueueDurableTaskResponse,
-    FailDurableTaskRequest, FailDurableTaskResponse, GetAgentRequest, GetAgentResponse,
-    GetDefaultModelRequest, GetDefaultModelResponse, GetDurableWorkflowStatusRequest,
-    GetDurableWorkflowStatusResponse, GetModelWithProviderRequest, GetModelWithProviderResponse,
-    GetSessionRequest, GetSessionResponse, GetTurnContextRequest, GetTurnContextResponse,
-    HeartbeatDurableTaskRequest, HeartbeatDurableTaskResponse, LoadMessagesRequest,
-    LoadMessagesResponse, SessionCreateDirectoryRequest, SessionCreateDirectoryResponse,
+    CreateDurableWorkflowResponse, DeregisterDurableWorkerRequest, DeregisterDurableWorkerResponse,
+    DurableWorkflowStatus, EmitEventRequest, EmitEventResponse, EmitEventStreamResponse,
+    EnqueueDurableTaskRequest, EnqueueDurableTaskResponse, FailDurableTaskRequest,
+    FailDurableTaskResponse, GetAgentRequest, GetAgentResponse, GetDefaultModelRequest,
+    GetDefaultModelResponse, GetDurableWorkflowStatusRequest, GetDurableWorkflowStatusResponse,
+    GetModelWithProviderRequest, GetModelWithProviderResponse, GetSessionRequest,
+    GetSessionResponse, GetTurnContextRequest, GetTurnContextResponse, HeartbeatDurableTaskRequest,
+    HeartbeatDurableTaskResponse, HeartbeatDurableWorkerRequest, HeartbeatDurableWorkerResponse,
+    LoadMessagesRequest, LoadMessagesResponse, RegisterDurableWorkerRequest,
+    RegisterDurableWorkerResponse, SessionCreateDirectoryRequest, SessionCreateDirectoryResponse,
     SessionDeleteFileRequest, SessionDeleteFileResponse, SessionGrepFilesRequest,
     SessionGrepFilesResponse, SessionListDirectoryRequest, SessionListDirectoryResponse,
-    DeregisterDurableWorkerRequest, DeregisterDurableWorkerResponse,
-    HeartbeatDurableWorkerRequest, HeartbeatDurableWorkerResponse,
-    RegisterDurableWorkerRequest, RegisterDurableWorkerResponse,
     SessionReadFileRequest, SessionReadFileResponse, SessionStatFileRequest,
     SessionStatFileResponse, SessionWriteFileRequest, SessionWriteFileResponse,
     SetSessionStatusRequest, SetSessionStatusResponse, UpdateDurableWorkflowStatusRequest,
@@ -1277,7 +1276,11 @@ impl WorkerService for WorkerServiceImpl {
         let store = self.durable_store()?;
 
         store
-            .worker_heartbeat(&req.worker_id, req.current_load as usize, req.accepting_tasks)
+            .worker_heartbeat(
+                &req.worker_id,
+                req.current_load as usize,
+                req.accepting_tasks,
+            )
             .await
             .map_err(|e| {
                 tracing::error!("Failed to heartbeat worker: {}", e);

--- a/crates/control-plane/src/grpc_service.rs
+++ b/crates/control-plane/src/grpc_service.rs
@@ -12,7 +12,7 @@ use everruns_control_plane::services::{
 use everruns_control_plane::storage::{EncryptionService, StorageBackend};
 use everruns_durable::{
     ActivityOptions, PostgresWorkflowEventStore, StoreError, TaskDefinition, TaskFailureOutcome,
-    WorkflowError, WorkflowEventStore, WorkflowStatus,
+    WorkerInfo, WorkflowError, WorkflowEventStore, WorkflowStatus,
 };
 use everruns_internal_protocol::proto::{
     self, AddMessageRequest, AddMessageResponse, ClaimDurableTasksRequest,
@@ -29,6 +29,9 @@ use everruns_internal_protocol::proto::{
     LoadMessagesResponse, SessionCreateDirectoryRequest, SessionCreateDirectoryResponse,
     SessionDeleteFileRequest, SessionDeleteFileResponse, SessionGrepFilesRequest,
     SessionGrepFilesResponse, SessionListDirectoryRequest, SessionListDirectoryResponse,
+    DeregisterDurableWorkerRequest, DeregisterDurableWorkerResponse,
+    HeartbeatDurableWorkerRequest, HeartbeatDurableWorkerResponse,
+    RegisterDurableWorkerRequest, RegisterDurableWorkerResponse,
     SessionReadFileRequest, SessionReadFileResponse, SessionStatFileRequest,
     SessionStatFileResponse, SessionWriteFileRequest, SessionWriteFileResponse,
     SetSessionStatusRequest, SetSessionStatusResponse, UpdateDurableWorkflowStatusRequest,
@@ -1235,6 +1238,72 @@ impl WorkerService for WorkerServiceImpl {
         })?;
 
         Ok(Response::new(CountActiveDurableWorkflowsResponse { count }))
+    }
+
+    async fn register_durable_worker(
+        &self,
+        request: Request<RegisterDurableWorkerRequest>,
+    ) -> Result<Response<RegisterDurableWorkerResponse>, Status> {
+        let req = request.into_inner();
+        let store = self.durable_store()?;
+
+        let worker_info = WorkerInfo {
+            id: req.worker_id,
+            worker_group: req.worker_group,
+            activity_types: req.activity_types,
+            max_concurrency: req.max_concurrency as u32,
+            current_load: 0,
+            status: "active".to_string(),
+            accepting_tasks: true,
+            started_at: chrono::Utc::now(),
+            last_heartbeat_at: chrono::Utc::now(),
+        };
+
+        store.register_worker(worker_info).await.map_err(|e| {
+            tracing::error!("Failed to register worker: {}", e);
+            Status::internal("Failed to register worker")
+        })?;
+
+        Ok(Response::new(RegisterDurableWorkerResponse {
+            registered: true,
+        }))
+    }
+
+    async fn heartbeat_durable_worker(
+        &self,
+        request: Request<HeartbeatDurableWorkerRequest>,
+    ) -> Result<Response<HeartbeatDurableWorkerResponse>, Status> {
+        let req = request.into_inner();
+        let store = self.durable_store()?;
+
+        store
+            .worker_heartbeat(&req.worker_id, req.current_load as usize, req.accepting_tasks)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to heartbeat worker: {}", e);
+                Status::internal("Failed to heartbeat worker")
+            })?;
+
+        Ok(Response::new(HeartbeatDurableWorkerResponse {
+            acknowledged: true,
+        }))
+    }
+
+    async fn deregister_durable_worker(
+        &self,
+        request: Request<DeregisterDurableWorkerRequest>,
+    ) -> Result<Response<DeregisterDurableWorkerResponse>, Status> {
+        let req = request.into_inner();
+        let store = self.durable_store()?;
+
+        store.deregister_worker(&req.worker_id).await.map_err(|e| {
+            tracing::error!("Failed to deregister worker: {}", e);
+            Status::internal("Failed to deregister worker")
+        })?;
+
+        Ok(Response::new(DeregisterDurableWorkerResponse {
+            deregistered: true,
+        }))
     }
 }
 

--- a/crates/control-plane/src/main.rs
+++ b/crates/control-plane/src/main.rs
@@ -166,7 +166,7 @@ async fn main() -> Result<()> {
         db: db.clone(),
         auth: auth_state.clone(),
     };
-    let durable_state = api::durable::AppState::new(db.pool().clone());
+    let durable_state = api::durable::AppState::new(db.pool().cloned());
     let health_state = HealthState {
         auth_mode: format!("{:?}", auth_config.mode),
     };

--- a/crates/control-plane/src/main.rs
+++ b/crates/control-plane/src/main.rs
@@ -166,6 +166,7 @@ async fn main() -> Result<()> {
         db: db.clone(),
         auth: auth_state.clone(),
     };
+    let durable_state = api::durable::AppState::new(db.pool().clone());
     let health_state = HealthState {
         auth_mode: format!("{:?}", auth_config.mode),
     };
@@ -206,6 +207,7 @@ async fn main() -> Result<()> {
         .merge(api::capabilities::routes(capabilities_state))
         .merge(api::session_files::routes(session_files_state))
         .merge(api::users::routes(users_state))
+        .merge(api::durable::routes(durable_state))
         .merge(auth::routes(auth_state));
 
     // Build main router with health (not prefixed) and prefixed API routes

--- a/crates/durable/src/lib.rs
+++ b/crates/durable/src/lib.rs
@@ -98,11 +98,13 @@ pub mod prelude {
 pub use activity::{Activity, ActivityContext, ActivityError};
 pub use engine::{ExecutorConfig, ExecutorError, WorkflowExecutor, WorkflowRegistry};
 pub use persistence::{
-    ClaimedTask, HeartbeatResponse, InMemoryWorkflowEventStore, PostgresWorkflowEventStore,
-    StoreError, TaskDefinition, TaskFailureOutcome, TraceContext, WorkflowEventStore, WorkflowInfo,
-    WorkflowStatus,
+    CircuitBreakerState, ClaimedTask, DlqEntry, DlqFilter, HeartbeatResponse,
+    InMemoryWorkflowEventStore, Pagination, PostgresWorkflowEventStore, StoreError, SystemHealth,
+    TaskDefinition, TaskFailureOutcome, TaskFilter, TaskInfo, TaskStatus, TraceContext,
+    WorkerFilter, WorkerInfo, WorkflowEventInfo, WorkflowEventStore, WorkflowFilter, WorkflowInfo,
+    WorkflowInfoExtended, WorkflowStatus,
 };
-pub use reliability::{CircuitBreakerConfig, RetryPolicy};
+pub use reliability::{CircuitBreakerConfig, CircuitState, RetryPolicy};
 pub use worker::{WorkerPool, WorkerPoolConfig, WorkerPoolError};
 pub use workflow::{
     ActivityOptions, Workflow, WorkflowAction, WorkflowError, WorkflowEvent, WorkflowSignal,

--- a/crates/durable/src/persistence/mod.rs
+++ b/crates/durable/src/persistence/mod.rs
@@ -13,7 +13,7 @@ pub use memory::InMemoryWorkflowEventStore;
 pub use postgres::PostgresWorkflowEventStore;
 pub use store::{
     event_type_name, CircuitBreakerState, ClaimedTask, DlqEntry, DlqFilter, HeartbeatResponse,
-    Pagination, StoreError, SystemHealth, TaskDefinition, TaskFailureOutcome, TaskFilter,
-    TaskInfo, TaskStatus, TraceContext, WorkerFilter, WorkerInfo, WorkflowEventInfo,
-    WorkflowEventStore, WorkflowFilter, WorkflowInfo, WorkflowInfoExtended, WorkflowStatus,
+    Pagination, StoreError, SystemHealth, TaskDefinition, TaskFailureOutcome, TaskFilter, TaskInfo,
+    TaskStatus, TraceContext, WorkerFilter, WorkerInfo, WorkflowEventInfo, WorkflowEventStore,
+    WorkflowFilter, WorkflowInfo, WorkflowInfoExtended, WorkflowStatus,
 };

--- a/crates/durable/src/persistence/mod.rs
+++ b/crates/durable/src/persistence/mod.rs
@@ -12,7 +12,8 @@ mod store;
 pub use memory::InMemoryWorkflowEventStore;
 pub use postgres::PostgresWorkflowEventStore;
 pub use store::{
-    CircuitBreakerState, ClaimedTask, DlqEntry, DlqFilter, HeartbeatResponse, Pagination,
-    StoreError, TaskDefinition, TaskFailureOutcome, TaskStatus, TraceContext, WorkerFilter,
-    WorkerInfo, WorkflowEventStore, WorkflowInfo, WorkflowStatus,
+    event_type_name, CircuitBreakerState, ClaimedTask, DlqEntry, DlqFilter, HeartbeatResponse,
+    Pagination, StoreError, SystemHealth, TaskDefinition, TaskFailureOutcome, TaskFilter,
+    TaskInfo, TaskStatus, TraceContext, WorkerFilter, WorkerInfo, WorkflowEventInfo,
+    WorkflowEventStore, WorkflowFilter, WorkflowInfo, WorkflowInfoExtended, WorkflowStatus,
 };

--- a/crates/durable/src/persistence/postgres.rs
+++ b/crates/durable/src/persistence/postgres.rs
@@ -693,6 +693,9 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
 
     #[instrument(skip(self, worker))]
     async fn register_worker(&self, worker: WorkerInfo) -> Result<(), StoreError> {
+        // Default worker_group to "default" if not specified
+        let worker_group = worker.worker_group.as_deref().unwrap_or("default");
+
         sqlx::query(
             r#"
             INSERT INTO durable_workers (
@@ -711,7 +714,7 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
             "#,
         )
         .bind(&worker.id)
-        .bind(&worker.worker_group)
+        .bind(worker_group)
         .bind(&worker.activity_types)
         .bind(worker.max_concurrency as i32)
         .bind(worker.current_load as i32)

--- a/crates/durable/src/persistence/postgres.rs
+++ b/crates/durable/src/persistence/postgres.rs
@@ -15,9 +15,9 @@ use uuid::Uuid;
 
 use super::store::{
     CircuitBreakerState, ClaimedTask, DlqEntry, DlqFilter, HeartbeatResponse, Pagination,
-    StoreError, SystemHealth, TaskDefinition, TaskFailureOutcome, TaskFilter, TaskInfo,
-    TaskStatus, TraceContext, WorkerFilter, WorkerInfo, WorkflowEventInfo, WorkflowEventStore,
-    WorkflowFilter, WorkflowInfo, WorkflowInfoExtended, WorkflowStatus,
+    StoreError, SystemHealth, TaskDefinition, TaskFailureOutcome, TaskFilter, TaskInfo, TaskStatus,
+    TraceContext, WorkerFilter, WorkerInfo, WorkflowEventInfo, WorkflowEventStore, WorkflowFilter,
+    WorkflowInfo, WorkflowInfoExtended, WorkflowStatus,
 };
 use crate::reliability::{CircuitBreakerConfig, CircuitState};
 use crate::workflow::{ActivityOptions, WorkflowError, WorkflowEvent, WorkflowSignal};

--- a/crates/durable/src/persistence/postgres.rs
+++ b/crates/durable/src/persistence/postgres.rs
@@ -766,23 +766,17 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
 
     #[instrument(skip(self))]
     async fn list_workers(&self, filter: WorkerFilter) -> Result<Vec<WorkerInfo>, StoreError> {
-        let mut query = String::from(
-            r#"
+        // Only show workers with recent heartbeat (within 60 seconds)
+        let query = r#"
             SELECT id, worker_group, activity_types, max_concurrency, current_load,
                    status, started_at, last_heartbeat_at, accepting_tasks
             FROM durable_workers
-            WHERE 1=1
-            "#,
-        );
+            WHERE last_heartbeat_at > NOW() - INTERVAL '60 seconds'
+              AND ($1::text IS NULL OR status = $1)
+              AND ($2::text IS NULL OR worker_group = $2)
+            "#;
 
-        if filter.status.is_some() {
-            query.push_str(" AND status = $1");
-        }
-        if filter.worker_group.is_some() {
-            query.push_str(" AND worker_group = $2");
-        }
-
-        let rows = sqlx::query(&query)
+        let rows = sqlx::query(query)
             .bind(&filter.status)
             .bind(&filter.worker_group)
             .fetch_all(&self.pool)

--- a/crates/durable/src/persistence/postgres.rs
+++ b/crates/durable/src/persistence/postgres.rs
@@ -1209,7 +1209,7 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
             LIMIT $5
             "#,
         )
-        .bind(&status_str)
+        .bind(status_str)
         .bind(&filter.activity_type)
         .bind(filter.workflow_id)
         .bind(pagination.offset as i64)

--- a/crates/durable/src/persistence/postgres.rs
+++ b/crates/durable/src/persistence/postgres.rs
@@ -13,7 +13,12 @@ use sqlx::{PgPool, Row};
 use tracing::{debug, error, instrument};
 use uuid::Uuid;
 
-use super::store::*;
+use super::store::{
+    CircuitBreakerState, ClaimedTask, DlqEntry, DlqFilter, HeartbeatResponse, Pagination,
+    StoreError, SystemHealth, TaskDefinition, TaskFailureOutcome, TaskFilter, TaskInfo,
+    TaskStatus, TraceContext, WorkerFilter, WorkerInfo, WorkflowEventInfo, WorkflowEventStore,
+    WorkflowFilter, WorkflowInfo, WorkflowInfoExtended, WorkflowStatus,
+};
 use crate::reliability::{CircuitBreakerConfig, CircuitState};
 use crate::workflow::{ActivityOptions, WorkflowError, WorkflowEvent, WorkflowSignal};
 
@@ -1118,6 +1123,307 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
         })?;
 
         Ok(row.get("count"))
+    }
+
+    #[instrument(skip(self))]
+    async fn list_workflows(
+        &self,
+        filter: WorkflowFilter,
+        pagination: Pagination,
+    ) -> Result<Vec<WorkflowInfoExtended>, StoreError> {
+        let status_str = filter.status.map(|s| s.to_string());
+
+        let rows = sqlx::query(
+            r#"
+            SELECT id, workflow_type, status, input, result, error,
+                   created_at, started_at, completed_at
+            FROM durable_workflow_instances
+            WHERE ($1::text IS NULL OR status = $1)
+              AND ($2::text IS NULL OR workflow_type = $2)
+            ORDER BY created_at DESC
+            OFFSET $3
+            LIMIT $4
+            "#,
+        )
+        .bind(&status_str)
+        .bind(&filter.workflow_type)
+        .bind(pagination.offset as i64)
+        .bind(pagination.limit as i64)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| {
+            error!("Failed to list workflows: {}", e);
+            StoreError::Database(e.to_string())
+        })?;
+
+        let mut workflows = Vec::with_capacity(rows.len());
+        for row in rows {
+            let status_str: String = row.get("status");
+            let error_json: Option<serde_json::Value> = row.get("error");
+
+            workflows.push(WorkflowInfoExtended {
+                id: row.get("id"),
+                workflow_type: row.get("workflow_type"),
+                status: parse_workflow_status(&status_str)?,
+                input: row.get("input"),
+                result: row.get("result"),
+                error: error_json.and_then(|v| serde_json::from_value(v).ok()),
+                created_at: row.get("created_at"),
+                started_at: row.get("started_at"),
+                completed_at: row.get("completed_at"),
+            });
+        }
+
+        Ok(workflows)
+    }
+
+    #[instrument(skip(self))]
+    async fn list_tasks(
+        &self,
+        filter: TaskFilter,
+        pagination: Pagination,
+    ) -> Result<Vec<TaskInfo>, StoreError> {
+        let status_str = filter.status.map(|s| match s {
+            TaskStatus::Pending => "pending",
+            TaskStatus::Claimed => "claimed",
+            TaskStatus::Completed => "completed",
+            TaskStatus::Failed => "failed",
+            TaskStatus::Dead => "dead",
+            TaskStatus::Cancelled => "cancelled",
+        });
+
+        let rows = sqlx::query(
+            r#"
+            SELECT id, workflow_id, activity_id, activity_type, status,
+                   priority, attempt, max_attempts, claimed_by, last_error,
+                   created_at, claimed_at
+            FROM durable_task_queue
+            WHERE ($1::text IS NULL OR status = $1)
+              AND ($2::text IS NULL OR activity_type = $2)
+              AND ($3::uuid IS NULL OR workflow_id = $3)
+            ORDER BY created_at DESC
+            OFFSET $4
+            LIMIT $5
+            "#,
+        )
+        .bind(&status_str)
+        .bind(&filter.activity_type)
+        .bind(filter.workflow_id)
+        .bind(pagination.offset as i64)
+        .bind(pagination.limit as i64)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| {
+            error!("Failed to list tasks: {}", e);
+            StoreError::Database(e.to_string())
+        })?;
+
+        let tasks = rows
+            .into_iter()
+            .map(|row| {
+                let status_str: String = row.get("status");
+                let status = match status_str.as_str() {
+                    "pending" => TaskStatus::Pending,
+                    "claimed" => TaskStatus::Claimed,
+                    "completed" => TaskStatus::Completed,
+                    "failed" => TaskStatus::Failed,
+                    "dead" => TaskStatus::Dead,
+                    "cancelled" => TaskStatus::Cancelled,
+                    _ => TaskStatus::Pending,
+                };
+
+                TaskInfo {
+                    id: row.get("id"),
+                    workflow_id: row.get("workflow_id"),
+                    activity_id: row.get("activity_id"),
+                    activity_type: row.get("activity_type"),
+                    status,
+                    priority: row.get("priority"),
+                    attempt: row.get::<i32, _>("attempt") as u32,
+                    max_attempts: row.get::<i32, _>("max_attempts") as u32,
+                    claimed_by: row.get("claimed_by"),
+                    last_error: row.get("last_error"),
+                    created_at: row.get("created_at"),
+                    claimed_at: row.get("claimed_at"),
+                }
+            })
+            .collect();
+
+        Ok(tasks)
+    }
+
+    #[instrument(skip(self))]
+    async fn list_circuit_breakers(&self) -> Result<Vec<CircuitBreakerState>, StoreError> {
+        let rows = sqlx::query(
+            r#"
+            SELECT key, state, failure_count, success_count,
+                   last_failure_at, opened_at, half_open_at, updated_at
+            FROM durable_circuit_breaker_state
+            ORDER BY key
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| {
+            error!("Failed to list circuit breakers: {}", e);
+            StoreError::Database(e.to_string())
+        })?;
+
+        let mut breakers = Vec::with_capacity(rows.len());
+        for row in rows {
+            let state_str: String = row.get("state");
+            breakers.push(CircuitBreakerState {
+                key: row.get("key"),
+                state: parse_circuit_state(&state_str)?,
+                failure_count: row.get::<i32, _>("failure_count") as u32,
+                success_count: row.get::<i32, _>("success_count") as u32,
+                last_failure_at: row.get("last_failure_at"),
+                opened_at: row.get("opened_at"),
+                half_open_at: row.get("half_open_at"),
+                updated_at: row.get("updated_at"),
+            });
+        }
+
+        Ok(breakers)
+    }
+
+    #[instrument(skip(self))]
+    async fn drain_worker(&self, worker_id: &str) -> Result<(), StoreError> {
+        sqlx::query(
+            r#"
+            UPDATE durable_workers
+            SET status = 'draining',
+                accepting_tasks = false
+            WHERE id = $1
+            "#,
+        )
+        .bind(worker_id)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| {
+            error!("Failed to drain worker: {}", e);
+            StoreError::Database(e.to_string())
+        })?;
+
+        debug!(worker_id, "drained worker");
+        Ok(())
+    }
+
+    #[instrument(skip(self))]
+    async fn get_system_health(&self) -> Result<SystemHealth, StoreError> {
+        // Single query to get all health stats
+        let row = sqlx::query(
+            r#"
+            SELECT
+                (SELECT COUNT(*) FROM durable_workers) as total_workers,
+                (SELECT COUNT(*) FROM durable_workers WHERE status = 'active') as active_workers,
+                (SELECT COUNT(*) FROM durable_workers WHERE status = 'active' AND accepting_tasks = true) as workers_accepting,
+                (SELECT COALESCE(SUM(max_concurrency), 0) FROM durable_workers WHERE status = 'active') as total_capacity,
+                (SELECT COALESCE(SUM(current_load), 0) FROM durable_workers WHERE status = 'active') as current_load,
+                (SELECT COUNT(*) FROM durable_task_queue WHERE status = 'pending') as pending_tasks,
+                (SELECT COUNT(*) FROM durable_task_queue WHERE status = 'claimed') as claimed_tasks,
+                (SELECT COUNT(*) FROM durable_workflow_instances WHERE status = 'running') as running_workflows,
+                (SELECT COUNT(*) FROM durable_workflow_instances WHERE status = 'pending') as pending_workflows,
+                (SELECT COUNT(*) FROM durable_dead_letter_queue WHERE requeued_at IS NULL) as dlq_size
+            "#,
+        )
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| {
+            error!("Failed to get system health: {}", e);
+            StoreError::Database(e.to_string())
+        })?;
+
+        Ok(SystemHealth {
+            total_workers: row.get::<i64, _>("total_workers") as usize,
+            active_workers: row.get::<i64, _>("active_workers") as usize,
+            workers_accepting: row.get::<i64, _>("workers_accepting") as usize,
+            total_capacity: row.get::<i64, _>("total_capacity") as usize,
+            current_load: row.get::<i64, _>("current_load") as usize,
+            pending_tasks: row.get::<i64, _>("pending_tasks") as usize,
+            claimed_tasks: row.get::<i64, _>("claimed_tasks") as usize,
+            running_workflows: row.get::<i64, _>("running_workflows") as usize,
+            pending_workflows: row.get::<i64, _>("pending_workflows") as usize,
+            dlq_size: row.get::<i64, _>("dlq_size") as usize,
+        })
+    }
+
+    #[instrument(skip(self))]
+    async fn cancel_workflow(&self, workflow_id: Uuid) -> Result<(), StoreError> {
+        // Update workflow status to cancelled
+        let result = sqlx::query(
+            r#"
+            UPDATE durable_workflow_instances
+            SET status = 'cancelled',
+                completed_at = NOW()
+            WHERE id = $1 AND status IN ('pending', 'running')
+            RETURNING id
+            "#,
+        )
+        .bind(workflow_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| {
+            error!("Failed to cancel workflow: {}", e);
+            StoreError::Database(e.to_string())
+        })?;
+
+        if result.is_none() {
+            return Err(StoreError::WorkflowNotFound(workflow_id));
+        }
+
+        // Cancel any pending tasks for this workflow
+        sqlx::query(
+            r#"
+            UPDATE durable_task_queue
+            SET status = 'cancelled'
+            WHERE workflow_id = $1 AND status = 'pending'
+            "#,
+        )
+        .bind(workflow_id)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| {
+            error!("Failed to cancel workflow tasks: {}", e);
+            StoreError::Database(e.to_string())
+        })?;
+
+        debug!(%workflow_id, "cancelled workflow");
+        Ok(())
+    }
+
+    #[instrument(skip(self))]
+    async fn get_workflow_events(
+        &self,
+        workflow_id: Uuid,
+    ) -> Result<Vec<WorkflowEventInfo>, StoreError> {
+        let rows = sqlx::query(
+            r#"
+            SELECT sequence_num, event_type, event_data, created_at
+            FROM durable_workflow_events
+            WHERE workflow_id = $1
+            ORDER BY sequence_num
+            "#,
+        )
+        .bind(workflow_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| {
+            error!("Failed to get workflow events: {}", e);
+            StoreError::Database(e.to_string())
+        })?;
+
+        let events = rows
+            .into_iter()
+            .map(|row| WorkflowEventInfo {
+                sequence_num: row.get("sequence_num"),
+                event_type: row.get("event_type"),
+                event_data: row.get("event_data"),
+                created_at: row.get("created_at"),
+            })
+            .collect();
+
+        Ok(events)
     }
 }
 

--- a/crates/durable/src/persistence/store.rs
+++ b/crates/durable/src/persistence/store.rs
@@ -146,6 +146,99 @@ impl WorkerFilter {
     }
 }
 
+/// Filter for listing workflows
+#[derive(Debug, Clone, Default)]
+pub struct WorkflowFilter {
+    pub status: Option<WorkflowStatus>,
+    pub workflow_type: Option<String>,
+}
+
+/// Filter for listing tasks
+#[derive(Debug, Clone, Default)]
+pub struct TaskFilter {
+    pub status: Option<TaskStatus>,
+    pub activity_type: Option<String>,
+    pub workflow_id: Option<Uuid>,
+}
+
+/// Task information for listing
+#[derive(Debug, Clone)]
+pub struct TaskInfo {
+    pub id: Uuid,
+    pub workflow_id: Uuid,
+    pub activity_id: String,
+    pub activity_type: String,
+    pub status: TaskStatus,
+    pub priority: i32,
+    pub attempt: u32,
+    pub max_attempts: u32,
+    pub claimed_by: Option<String>,
+    pub last_error: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub claimed_at: Option<DateTime<Utc>>,
+}
+
+/// Extended workflow information with timestamps
+#[derive(Debug, Clone)]
+pub struct WorkflowInfoExtended {
+    pub id: Uuid,
+    pub workflow_type: String,
+    pub status: WorkflowStatus,
+    pub input: serde_json::Value,
+    pub result: Option<serde_json::Value>,
+    pub error: Option<crate::workflow::WorkflowError>,
+    pub created_at: DateTime<Utc>,
+    pub started_at: Option<DateTime<Utc>>,
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+/// System health summary
+#[derive(Debug, Clone)]
+pub struct SystemHealth {
+    pub total_workers: usize,
+    pub active_workers: usize,
+    pub workers_accepting: usize,
+    pub total_capacity: usize,
+    pub current_load: usize,
+    pub pending_tasks: usize,
+    pub claimed_tasks: usize,
+    pub running_workflows: usize,
+    pub pending_workflows: usize,
+    pub dlq_size: usize,
+}
+
+/// Workflow event info for API responses
+#[derive(Debug, Clone)]
+pub struct WorkflowEventInfo {
+    pub sequence_num: i32,
+    pub event_type: String,
+    pub event_data: serde_json::Value,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Helper to get event type name
+pub fn event_type_name(event: &WorkflowEvent) -> &'static str {
+    match event {
+        WorkflowEvent::WorkflowStarted { .. } => "workflow_started",
+        WorkflowEvent::WorkflowCompleted { .. } => "workflow_completed",
+        WorkflowEvent::WorkflowFailed { .. } => "workflow_failed",
+        WorkflowEvent::WorkflowCancelled { .. } => "workflow_cancelled",
+        WorkflowEvent::ActivityScheduled { .. } => "activity_scheduled",
+        WorkflowEvent::ActivityStarted { .. } => "activity_started",
+        WorkflowEvent::ActivityCompleted { .. } => "activity_completed",
+        WorkflowEvent::ActivityFailed { .. } => "activity_failed",
+        WorkflowEvent::ActivityTimedOut { .. } => "activity_timed_out",
+        WorkflowEvent::ActivityCancelled { .. } => "activity_cancelled",
+        WorkflowEvent::TimerStarted { .. } => "timer_started",
+        WorkflowEvent::TimerFired { .. } => "timer_fired",
+        WorkflowEvent::TimerCancelled { .. } => "timer_cancelled",
+        WorkflowEvent::SignalReceived { .. } => "signal_received",
+        WorkflowEvent::ChildWorkflowStarted { .. } => "child_workflow_started",
+        WorkflowEvent::ChildWorkflowCompleted { .. } => "child_workflow_completed",
+        WorkflowEvent::ChildWorkflowFailed { .. } => "child_workflow_failed",
+    }
+}
+
 /// Worker information
 #[derive(Debug, Clone)]
 pub struct WorkerInfo {
@@ -422,6 +515,73 @@ pub trait WorkflowEventStore: Send + Sync + 'static {
     /// Count active (non-terminal) workflows
     async fn count_active_workflows(&self) -> Result<i64, StoreError> {
         Ok(0)
+    }
+
+    /// List workflows with filtering and pagination
+    async fn list_workflows(
+        &self,
+        _filter: WorkflowFilter,
+        _pagination: Pagination,
+    ) -> Result<Vec<WorkflowInfoExtended>, StoreError> {
+        Ok(vec![])
+    }
+
+    /// List tasks with filtering and pagination
+    async fn list_tasks(
+        &self,
+        _filter: TaskFilter,
+        _pagination: Pagination,
+    ) -> Result<Vec<TaskInfo>, StoreError> {
+        Ok(vec![])
+    }
+
+    /// List all circuit breakers
+    async fn list_circuit_breakers(&self) -> Result<Vec<CircuitBreakerState>, StoreError> {
+        Ok(vec![])
+    }
+
+    /// Drain a worker (set status to draining, stop accepting new tasks)
+    async fn drain_worker(&self, _worker_id: &str) -> Result<(), StoreError> {
+        Ok(())
+    }
+
+    /// Get system health summary
+    async fn get_system_health(&self) -> Result<SystemHealth, StoreError> {
+        Ok(SystemHealth {
+            total_workers: 0,
+            active_workers: 0,
+            workers_accepting: 0,
+            total_capacity: 0,
+            current_load: 0,
+            pending_tasks: 0,
+            claimed_tasks: 0,
+            running_workflows: 0,
+            pending_workflows: 0,
+            dlq_size: 0,
+        })
+    }
+
+    /// Cancel a workflow
+    async fn cancel_workflow(&self, _workflow_id: Uuid) -> Result<(), StoreError> {
+        Ok(())
+    }
+
+    /// Get workflow events
+    async fn get_workflow_events(
+        &self,
+        workflow_id: Uuid,
+    ) -> Result<Vec<WorkflowEventInfo>, StoreError> {
+        // Default implementation uses load_events
+        let events = self.load_events(workflow_id).await?;
+        Ok(events
+            .into_iter()
+            .map(|(seq, event)| WorkflowEventInfo {
+                sequence_num: seq,
+                event_type: event_type_name(&event).to_string(),
+                event_data: serde_json::to_value(&event).unwrap_or_default(),
+                created_at: Utc::now(), // Not available in base events
+            })
+            .collect())
     }
 }
 

--- a/crates/durable/src/persistence/store.rs
+++ b/crates/durable/src/persistence/store.rs
@@ -243,7 +243,7 @@ pub fn event_type_name(event: &WorkflowEvent) -> &'static str {
 #[derive(Debug, Clone)]
 pub struct WorkerInfo {
     pub id: String,
-    pub worker_group: String,
+    pub worker_group: Option<String>,
     pub activity_types: Vec<String>,
     pub max_concurrency: u32,
     pub current_load: u32,

--- a/crates/durable/src/worker/pool.rs
+++ b/crates/durable/src/worker/pool.rs
@@ -359,7 +359,7 @@ impl WorkerPool {
     async fn register_worker(&self) -> Result<(), WorkerPoolError> {
         let worker_info = WorkerInfo {
             id: self.config.worker_id.clone(),
-            worker_group: self.config.worker_group.clone(),
+            worker_group: Some(self.config.worker_group.clone()),
             activity_types: self.config.activity_types.clone(),
             max_concurrency: self.config.max_concurrency as u32,
             current_load: 0,

--- a/crates/durable/tests/postgres_integration_test.rs
+++ b/crates/durable/tests/postgres_integration_test.rs
@@ -698,7 +698,7 @@ async fn test_worker_registration() {
     store
         .register_worker(WorkerInfo {
             id: worker_id.clone(),
-            worker_group: "default".to_string(),
+            worker_group: Some("default".to_string()),
             activity_types: vec!["task_a".to_string(), "task_b".to_string()],
             max_concurrency: 10,
             current_load: 0,

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -81,6 +81,15 @@ service WorkerService {
 
     // Count active (non-terminal) workflows
     rpc CountActiveDurableWorkflows(CountActiveDurableWorkflowsRequest) returns (CountActiveDurableWorkflowsResponse);
+
+    // Register a durable worker
+    rpc RegisterDurableWorker(RegisterDurableWorkerRequest) returns (RegisterDurableWorkerResponse);
+
+    // Heartbeat for a durable worker (keeps worker alive)
+    rpc HeartbeatDurableWorker(HeartbeatDurableWorkerRequest) returns (HeartbeatDurableWorkerResponse);
+
+    // Deregister a durable worker
+    rpc DeregisterDurableWorker(DeregisterDurableWorkerRequest) returns (DeregisterDurableWorkerResponse);
 }
 
 // ============================================================================
@@ -546,4 +555,39 @@ message CountActiveDurableWorkflowsRequest {}
 
 message CountActiveDurableWorkflowsResponse {
     int64 count = 1;
+}
+
+// === Register worker ===
+
+message RegisterDurableWorkerRequest {
+    string worker_id = 1;
+    optional string worker_group = 2;
+    repeated string activity_types = 3;
+    int32 max_concurrency = 4;
+}
+
+message RegisterDurableWorkerResponse {
+    bool registered = 1;
+}
+
+// === Heartbeat worker ===
+
+message HeartbeatDurableWorkerRequest {
+    string worker_id = 1;
+    int32 current_load = 2;
+    bool accepting_tasks = 3;
+}
+
+message HeartbeatDurableWorkerResponse {
+    bool acknowledged = 1;
+}
+
+// === Deregister worker ===
+
+message DeregisterDurableWorkerRequest {
+    string worker_id = 1;
+}
+
+message DeregisterDurableWorkerResponse {
+    bool deregistered = 1;
 }

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -131,12 +131,46 @@ impl DurableWorker {
             "Starting durable worker"
         );
 
+        // Register with control-plane
+        {
+            let mut store = self.store.lock().await;
+            match store
+                .register_worker(
+                    &self.config.worker_id,
+                    None, // worker_group
+                    self.config.activity_types.clone(),
+                    self.config.max_concurrent_tasks as u32,
+                )
+                .await
+            {
+                Ok(()) => info!(worker_id = %self.config.worker_id, "Worker registered"),
+                Err(e) => warn!(worker_id = %self.config.worker_id, error = %e, "Failed to register worker (will continue anyway)"),
+            }
+        }
+
+        // Track time since last heartbeat
+        let mut last_heartbeat = std::time::Instant::now();
+        let heartbeat_interval = self.config.heartbeat_interval;
+
         // Main poll loop
         loop {
             // Check for shutdown
             if *self.shutdown_rx.borrow() {
                 info!("Shutdown signal received, stopping worker");
                 break;
+            }
+
+            // Send heartbeat if interval has passed
+            if last_heartbeat.elapsed() >= heartbeat_interval {
+                let mut store = self.store.lock().await;
+                // TODO: track actual current_load
+                if let Err(e) = store
+                    .heartbeat_worker(&self.config.worker_id, 0, true)
+                    .await
+                {
+                    debug!("Failed to send worker heartbeat: {}", e);
+                }
+                last_heartbeat = std::time::Instant::now();
             }
 
             // Poll for tasks
@@ -157,6 +191,16 @@ impl DurableWorker {
                     error!("Error polling tasks: {}", e);
                     tokio::time::sleep(Duration::from_secs(5)).await;
                 }
+            }
+        }
+
+        // Deregister on shutdown
+        {
+            let mut store = self.store.lock().await;
+            if let Err(e) = store.deregister_worker(&self.config.worker_id).await {
+                warn!(worker_id = %self.config.worker_id, error = %e, "Failed to deregister worker");
+            } else {
+                info!(worker_id = %self.config.worker_id, "Worker deregistered");
             }
         }
 

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -144,7 +144,9 @@ impl DurableWorker {
                 .await
             {
                 Ok(()) => info!(worker_id = %self.config.worker_id, "Worker registered"),
-                Err(e) => warn!(worker_id = %self.config.worker_id, error = %e, "Failed to register worker (will continue anyway)"),
+                Err(e) => {
+                    warn!(worker_id = %self.config.worker_id, error = %e, "Failed to register worker (will continue anyway)")
+                }
             }
         }
 

--- a/crates/worker/src/grpc_durable_store.rs
+++ b/crates/worker/src/grpc_durable_store.rs
@@ -5,9 +5,10 @@
 use anyhow::Result;
 use everruns_internal_protocol::proto::{
     self, ClaimDurableTasksRequest, CompleteDurableTaskRequest, CountActiveDurableWorkflowsRequest,
-    CreateDurableWorkflowRequest, DurableActivityOptions, DurableTaskDefinition,
-    EnqueueDurableTaskRequest, FailDurableTaskRequest, GetDurableWorkflowStatusRequest,
-    HeartbeatDurableTaskRequest, UpdateDurableWorkflowStatusRequest,
+    CreateDurableWorkflowRequest, DeregisterDurableWorkerRequest, DurableActivityOptions,
+    DurableTaskDefinition, EnqueueDurableTaskRequest, FailDurableTaskRequest,
+    GetDurableWorkflowStatusRequest, HeartbeatDurableTaskRequest, HeartbeatDurableWorkerRequest,
+    RegisterDurableWorkerRequest, UpdateDurableWorkflowStatusRequest,
 };
 use everruns_internal_protocol::{json_to_proto_struct, uuid_to_proto_uuid, WorkerServiceClient};
 use tonic::transport::Channel;
@@ -217,6 +218,52 @@ impl GrpcDurableStore {
         let request = CountActiveDurableWorkflowsRequest {};
         let response = self.client.count_active_durable_workflows(request).await?;
         Ok(response.into_inner().count as usize)
+    }
+
+    /// Register this worker with the control-plane
+    pub async fn register_worker(
+        &mut self,
+        worker_id: &str,
+        worker_group: Option<String>,
+        activity_types: Vec<String>,
+        max_concurrency: u32,
+    ) -> Result<()> {
+        let request = RegisterDurableWorkerRequest {
+            worker_id: worker_id.to_string(),
+            worker_group,
+            activity_types,
+            max_concurrency: max_concurrency as i32,
+        };
+
+        self.client.register_durable_worker(request).await?;
+        Ok(())
+    }
+
+    /// Send worker heartbeat
+    pub async fn heartbeat_worker(
+        &mut self,
+        worker_id: &str,
+        current_load: u32,
+        accepting_tasks: bool,
+    ) -> Result<()> {
+        let request = HeartbeatDurableWorkerRequest {
+            worker_id: worker_id.to_string(),
+            current_load: current_load as i32,
+            accepting_tasks,
+        };
+
+        self.client.heartbeat_durable_worker(request).await?;
+        Ok(())
+    }
+
+    /// Deregister this worker
+    pub async fn deregister_worker(&mut self, worker_id: &str) -> Result<()> {
+        let request = DeregisterDurableWorkerRequest {
+            worker_id: worker_id.to_string(),
+        };
+
+        self.client.deregister_durable_worker(request).await?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary
Add comprehensive durable execution monitoring UI and API endpoints for observing workers, workflows, tasks, and system health.

## Changes

### UI (`apps/ui/`)
- **Dashboard** (`/durable`) - Health overview, worker summary, workflow stats
- **Workers** (`/durable/workers`) - Pool status, capacity usage, worker details
- **Workflows** (`/durable/workflows`) - Filtering, pagination, detail view with events
- React Query hooks for data fetching (`use-durable.ts`)
- Sidebar navigation with proper active state handling

### API (`crates/control-plane/`)
- `/v1/durable/health` - System health and statistics
- `/v1/durable/workers` - List/manage workers
- `/v1/durable/workflows` - List/browse/cancel workflows
- `/v1/durable/tasks` - List pending tasks
- `/v1/durable/dlq` - Dead letter queue management
- `/v1/durable/circuit-breakers` - Circuit breaker status
- DEV_MODE compatible (returns 503 when PostgreSQL unavailable)

### Worker Registration (`crates/worker/`, `crates/internal-protocol/`)
- gRPC RPCs: `RegisterDurableWorker`, `HeartbeatDurableWorker`, `DeregisterDurableWorker`
- Auto-registration on startup with periodic heartbeats
- Stale worker filtering (>60s without heartbeat)

### Persistence (`crates/durable/`)
- Extended PostgreSQL store for workers, workflows, tasks, DLQ queries
- Worker heartbeat tracking and automatic cleanup

## Risk
- Low
- New feature, no changes to existing functionality

## Test plan
- [x] CI passes (clippy, fmt, unit tests, integration tests)
- [ ] Start API and worker, verify worker appears in dashboard
- [ ] Kill worker, verify it disappears after 60 seconds
- [ ] Navigate durable pages without errors
- [ ] Verify DEV_MODE returns 503 for durable endpoints