### PR TITLE
fix(ui): connect SSE directly to backend in development mode

### DIFF
--- a/apps/ui/src/lib/api/client.ts
+++ b/apps/ui/src/lib/api/client.ts
@@ -104,16 +104,22 @@ export function getBackendUrl(): string {
 /**
  * Get the direct backend URL for SSE connections.
  *
- * In production: Uses origin + /api (reverse proxies like Caddy don't buffer SSE)
- * In development: Set NEXT_PUBLIC_API_URL=http://localhost:9000 to bypass
- *                 Next.js proxy which may buffer SSE responses
+ * In development: Connect directly to backend at localhost:9000
+ *                 (Next.js rewrites don't handle SSE streaming properly)
+ * In production: Uses origin + /api (reverse proxies like Caddy stream SSE correctly)
+ *
+ * Override with NEXT_PUBLIC_API_URL if needed.
  */
 export function getDirectBackendUrl(): string {
-  // Use NEXT_PUBLIC_API_URL if explicitly set (e.g., for local dev to bypass Next.js proxy)
+  // Use NEXT_PUBLIC_API_URL if explicitly set
   if (typeof window !== 'undefined' && process.env.NEXT_PUBLIC_API_URL) {
     return process.env.NEXT_PUBLIC_API_URL;
   }
-  // Default to origin + /api for production (works with any reverse proxy)
+  // In development, connect directly to backend (Next.js rewrites buffer SSE)
+  if (process.env.NODE_ENV === 'development') {
+    return 'http://localhost:9000';
+  }
+  // In production, use origin + /api (reverse proxy handles SSE correctly)
   if (typeof window !== 'undefined') {
     return window.location.origin + '/api';
   }


### PR DESCRIPTION
## What
Fix SSE (Server-Sent Events) connections returning 404 in development mode.

## Why
Next.js rewrites buffer SSE responses, causing the EventSource connection to fail with 404 errors when going through the proxy at `localhost:9100/api/*`.

## How
Modified `getDirectBackendUrl()` to detect development mode and return `http://localhost:9000` directly, bypassing the Next.js proxy. Production mode continues to use `origin + /api` which works correctly with reverse proxies like Caddy that stream SSE properly.

**Before:** SSE requests went to `http://localhost:9100/api/v1/.../sse` → 404
**After:** SSE requests go to `http://localhost:9000/v1/.../sse` → works

## Risk
- Low
- Only affects development mode (`NODE_ENV === 'development'`)
- Production Docker deployments (docker-compose-full.yaml) unaffected since UI is built with `NODE_ENV=production`

## Checklist
- [x] Tested locally with `dev.sh start-all`
- [x] Verified production setup (Caddy) still works
- [x] No breaking changes to existing behavior