### PR TITLE
fix(scripts): remove stale Temporal references from dev.sh

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -515,8 +515,8 @@ case "$command" in
       echo "   ⚠️  Agent upload failed"
     fi
 
-    # Start Worker in background with auto-reload (Temporal mode)
-    echo "7️⃣  Starting Temporal worker with auto-reload..."
+    # Start Worker in background with auto-reload
+    echo "7️⃣  Starting worker with auto-reload..."
     cargo watch -w crates -x 'run -p everruns-worker' &
     WORKER_PID=$!
     CHILD_PIDS+=("$WORKER_PID")


### PR DESCRIPTION
## What
Remove outdated references to "Temporal" in dev.sh worker startup message and comment.

## Why
The project uses a custom durable execution system, not Temporal. The stale references were confusing.

## How
Updated the comment and echo message from "Temporal worker" to just "worker".

## Risk
- Low
- No functional change, just message text

## Checklist
- [x] Tests added or updated (N/A - message change only)
- [x] Backward compatibility considered (N/A)