### PR TITLE
fix(ui): remove Invalid Date from workflow details

### DIFF
--- a/apps/ui/src/app/(main)/durable/workflows/[workflowId]/page.tsx
+++ b/apps/ui/src/app/(main)/durable/workflows/[workflowId]/page.tsx
@@ -272,12 +272,6 @@ export default function WorkflowDetailPage({ params }: { params: Promise<{ workf
                     {new Date(workflow.created_at).toLocaleString()}
                   </p>
                 </div>
-                <div>
-                  <p className="text-sm text-muted-foreground">Updated</p>
-                  <p className="font-medium">
-                    {new Date(workflow.updated_at).toLocaleString()}
-                  </p>
-                </div>
                 {workflow.started_at && (
                   <div>
                     <p className="text-sm text-muted-foreground">Started</p>

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -857,7 +857,7 @@ export interface DurableWorkflow {
   result?: Record<string, unknown>;
   error?: Record<string, unknown>;
   created_at: string;
-  updated_at: string;
+  updated_at?: string;
   started_at?: string;
   completed_at?: string;
   // Optional linked session

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -857,7 +857,6 @@ export interface DurableWorkflow {
   result?: Record<string, unknown>;
   error?: Record<string, unknown>;
   created_at: string;
-  updated_at?: string;
   started_at?: string;
   completed_at?: string;
   // Optional linked session


### PR DESCRIPTION
## What
Fix "Invalid Date" display in the workflow details page "Updated" field.

## Why
The backend `WorkflowResponse` struct doesn't include an `updated_at` field, but the UI was unconditionally trying to display it. This resulted in `new Date(undefined).toLocaleString()` returning "Invalid Date".

## How
- Removed the "Updated" field from the workflow details page since the backend doesn't provide this data
- Made `updated_at` optional in the `DurableWorkflow` TypeScript interface

## Risk
- Low
- No functional changes, just removes display of non-existent data

## Checklist
- [x] Tests added or updated (N/A - UI display fix)
- [x] Backward compatibility considered (no breaking changes)

## Screenshot
Before: The "Updated" field showed "Invalid Date"
After: The "Updated" field is no longer displayed (only Created, Started, Completed are shown)