### PR TITLE
feat(worker): reclaim tasks on graceful shutdown for immediate reassignment

### DIFF
--- a/crates/control-plane/src/grpc_service.rs
+++ b/crates/control-plane/src/grpc_service.rs
@@ -1299,13 +1299,22 @@ impl WorkerService for WorkerServiceImpl {
         let req = request.into_inner();
         let store = self.durable_store()?;
 
-        store.deregister_worker(&req.worker_id).await.map_err(|e| {
+        let tasks_reclaimed = store.deregister_worker(&req.worker_id).await.map_err(|e| {
             tracing::error!("Failed to deregister worker: {}", e);
             Status::internal("Failed to deregister worker")
         })?;
 
+        if tasks_reclaimed > 0 {
+            tracing::info!(
+                worker_id = %req.worker_id,
+                tasks_reclaimed,
+                "Worker deregistered with task reclamation"
+            );
+        }
+
         Ok(Response::new(DeregisterDurableWorkerResponse {
             deregistered: true,
+            tasks_reclaimed: tasks_reclaimed as i32,
         }))
     }
 }

--- a/crates/durable/src/persistence/postgres.rs
+++ b/crates/durable/src/persistence/postgres.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use sqlx::{PgPool, Row};
-use tracing::{debug, error, instrument};
+use tracing::{debug, error, info, instrument};
 use uuid::Uuid;
 
 use super::store::{
@@ -805,7 +805,29 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
     }
 
     #[instrument(skip(self))]
-    async fn deregister_worker(&self, worker_id: &str) -> Result<(), StoreError> {
+    async fn deregister_worker(&self, worker_id: &str) -> Result<usize, StoreError> {
+        // Reclaim all tasks claimed by this worker (set back to pending)
+        // This allows immediate task reassignment instead of waiting for heartbeat timeout
+        let reclaimed = sqlx::query(
+            r#"
+            UPDATE durable_task_queue
+            SET status = 'pending',
+                claimed_by = NULL,
+                claimed_at = NULL
+            WHERE status = 'claimed'
+              AND claimed_by = $1
+            "#,
+        )
+        .bind(worker_id)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| {
+            error!("Failed to reclaim worker tasks: {}", e);
+            StoreError::Database(e.to_string())
+        })?
+        .rows_affected() as usize;
+
+        // Mark worker as stopped
         sqlx::query(
             r#"
             UPDATE durable_workers
@@ -821,8 +843,16 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
             StoreError::Database(e.to_string())
         })?;
 
-        debug!(worker_id, "deregistered worker");
-        Ok(())
+        if reclaimed > 0 {
+            info!(
+                worker_id,
+                reclaimed, "deregistered worker and reclaimed tasks"
+            );
+        } else {
+            debug!(worker_id, "deregistered worker (no tasks to reclaim)");
+        }
+
+        Ok(reclaimed)
     }
 
     #[instrument(skip(self, error_history))]

--- a/crates/durable/src/persistence/store.rs
+++ b/crates/durable/src/persistence/store.rs
@@ -446,9 +446,10 @@ pub trait WorkflowEventStore: Send + Sync + 'static {
         Ok(vec![])
     }
 
-    /// Deregister a worker
-    async fn deregister_worker(&self, _worker_id: &str) -> Result<(), StoreError> {
-        Ok(())
+    /// Deregister a worker and reclaim all tasks claimed by it
+    /// Returns the number of tasks that were reclaimed
+    async fn deregister_worker(&self, _worker_id: &str) -> Result<usize, StoreError> {
+        Ok(0)
     }
 
     // =========================================================================

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -590,4 +590,6 @@ message DeregisterDurableWorkerRequest {
 
 message DeregisterDurableWorkerResponse {
     bool deregistered = 1;
+    // Number of tasks that were reclaimed (set back to pending) during deregistration
+    int32 tasks_reclaimed = 2;
 }

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -196,13 +196,30 @@ impl DurableWorker {
             }
         }
 
-        // Deregister on shutdown
+        // Deregister on shutdown - this also reclaims any tasks we had claimed
+        // allowing them to be immediately picked up by other workers
         {
             let mut store = self.store.lock().await;
-            if let Err(e) = store.deregister_worker(&self.config.worker_id).await {
-                warn!(worker_id = %self.config.worker_id, error = %e, "Failed to deregister worker");
-            } else {
-                info!(worker_id = %self.config.worker_id, "Worker deregistered");
+            match store.deregister_worker(&self.config.worker_id).await {
+                Ok(tasks_reclaimed) => {
+                    if tasks_reclaimed > 0 {
+                        info!(
+                            worker_id = %self.config.worker_id,
+                            tasks_reclaimed,
+                            "Worker deregistered and tasks reclaimed"
+                        );
+                    } else {
+                        info!(worker_id = %self.config.worker_id, "Worker deregistered");
+                    }
+                }
+                Err(e) => {
+                    // Log but don't fail - the stale task reclamation will handle cleanup
+                    warn!(
+                        worker_id = %self.config.worker_id,
+                        error = %e,
+                        "Failed to deregister worker (tasks will be reclaimed after heartbeat timeout)"
+                    );
+                }
             }
         }
 

--- a/crates/worker/src/grpc_durable_store.rs
+++ b/crates/worker/src/grpc_durable_store.rs
@@ -256,14 +256,15 @@ impl GrpcDurableStore {
         Ok(())
     }
 
-    /// Deregister this worker
-    pub async fn deregister_worker(&mut self, worker_id: &str) -> Result<()> {
+    /// Deregister this worker and reclaim all its tasks
+    /// Returns the number of tasks that were reclaimed (set back to pending)
+    pub async fn deregister_worker(&mut self, worker_id: &str) -> Result<usize> {
         let request = DeregisterDurableWorkerRequest {
             worker_id: worker_id.to_string(),
         };
 
-        self.client.deregister_durable_worker(request).await?;
-        Ok(())
+        let response = self.client.deregister_durable_worker(request).await?;
+        Ok(response.into_inner().tasks_reclaimed as usize)
     }
 }
 


### PR DESCRIPTION
## What

Enhance worker disconnect detection by reclaiming tasks immediately when workers shut down gracefully, instead of waiting for the 30-second heartbeat timeout.

## Why

When a worker shuts down (e.g., Ctrl+C, scale-down), any tasks it had claimed would remain "claimed" until the heartbeat timeout expired (30s). This caused unnecessary delays in task processing during deployments or scaling events.

## How

Enhanced the existing `deregister_worker` to also reclaim all tasks claimed by the worker:

| File | Change |
|------|--------|
| `store.rs` | Changed return type to `Result<usize>` (count of reclaimed tasks) |
| `postgres.rs` | Added task reclamation SQL before marking worker stopped |
| `worker.proto` | Added `tasks_reclaimed` field to response |
| `grpc_service.rs` | Updated handler to return reclaimed count |
| `durable_worker.rs` | Logs reclaimed task count on shutdown |

### Behavior

| Scenario | Recovery Time |
|----------|---------------|
| Graceful shutdown (Ctrl+C) | **Immediate (0s)** |
| Crash/kill -9 | 30 seconds (heartbeat timeout) |

## Risk

- Low
- Only affects shutdown path; crash recovery unchanged
- Backwards compatible (new proto field is additive)

## Checklist

- [x] Tests pass (`cargo test --all-features --lib`)
- [x] Clippy clean
- [x] Backward compatibility maintained