### PR TITLE
feat(api): add workflows API support in DEV_MODE

### DIFF
--- a/crates/control-plane/src/api/durable.rs
+++ b/crates/control-plane/src/api/durable.rs
@@ -16,12 +16,11 @@ use axum::{
 };
 use chrono::{DateTime, Utc};
 use everruns_durable::{
-    CircuitBreakerState, CircuitState, DlqEntry, DlqFilter, Pagination, PostgresWorkflowEventStore,
-    SystemHealth, TaskFilter, TaskInfo, TaskStatus, WorkerFilter, WorkerInfo, WorkflowEventInfo,
-    WorkflowEventStore, WorkflowFilter, WorkflowInfoExtended, WorkflowSignal, WorkflowStatus,
+    CircuitBreakerState, CircuitState, DlqEntry, DlqFilter, Pagination, SystemHealth, TaskFilter,
+    TaskInfo, TaskStatus, WorkerFilter, WorkerInfo, WorkflowEventInfo, WorkflowEventStore,
+    WorkflowFilter, WorkflowInfoExtended, WorkflowSignal, WorkflowStatus,
 };
 use serde::{Deserialize, Serialize};
-use sqlx::PgPool;
 use std::sync::Arc;
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -31,25 +30,24 @@ use super::common::ErrorResponse;
 /// App state for durable routes
 #[derive(Clone)]
 pub struct AppState {
-    store: Option<Arc<PostgresWorkflowEventStore>>,
+    store: Option<Arc<dyn WorkflowEventStore + Send + Sync>>,
 }
 
 impl AppState {
-    pub fn new(pool: Option<PgPool>) -> Self {
-        Self {
-            store: pool.map(|p| Arc::new(PostgresWorkflowEventStore::new(p))),
-        }
+    /// Create new state with an optional workflow event store
+    pub fn new(store: Option<Arc<dyn WorkflowEventStore + Send + Sync>>) -> Self {
+        Self { store }
     }
 
-    /// Get the store, returning an error response if not available (dev mode)
+    /// Get the store, returning an error response if not available
     fn get_store(
         &self,
-    ) -> Result<&Arc<PostgresWorkflowEventStore>, (StatusCode, Json<ErrorResponse>)> {
+    ) -> Result<&Arc<dyn WorkflowEventStore + Send + Sync>, (StatusCode, Json<ErrorResponse>)> {
         self.store.as_ref().ok_or_else(|| {
             (
                 StatusCode::SERVICE_UNAVAILABLE,
                 Json(ErrorResponse {
-                    error: "Durable execution not available in dev mode".to_string(),
+                    error: "Durable execution store not available".to_string(),
                 }),
             )
         })

--- a/crates/control-plane/src/main.rs
+++ b/crates/control-plane/src/main.rs
@@ -17,6 +17,9 @@ use axum::http::{header, HeaderValue, Method};
 use axum::{extract::State, routing::get, Json, Router};
 use everruns_core::telemetry::{init_telemetry, TelemetryConfig};
 use everruns_core::{EventListener, OtelEventListener};
+use everruns_durable::{
+    InMemoryWorkflowEventStore, PostgresWorkflowEventStore, WorkflowEventStore,
+};
 use everruns_worker::{create_runner_with_backend, RunnerBackend};
 use serde::Serialize;
 use std::sync::Arc;
@@ -166,7 +169,17 @@ async fn main() -> Result<()> {
         db: db.clone(),
         auth: auth_state.clone(),
     };
-    let durable_state = api::durable::AppState::new(db.pool().cloned());
+    // Create durable execution store based on mode
+    let durable_store: Option<Arc<dyn WorkflowEventStore + Send + Sync>> = if dev_mode {
+        tracing::info!("Using in-memory workflow event store for DEV MODE");
+        Some(Arc::new(InMemoryWorkflowEventStore::new()))
+    } else {
+        db.pool().cloned().map(|p| {
+            Arc::new(PostgresWorkflowEventStore::new(p))
+                as Arc<dyn WorkflowEventStore + Send + Sync>
+        })
+    };
+    let durable_state = api::durable::AppState::new(durable_store);
     let health_state = HealthState {
         auth_mode: format!("{:?}", auth_config.mode),
     };
@@ -276,7 +289,6 @@ async fn main() -> Result<()> {
 
         // Start background task for stale task reclamation (only with PostgreSQL)
         {
-            use everruns_durable::{PostgresWorkflowEventStore, WorkflowEventStore};
             use std::time::Duration;
 
             if let Some(pool) = db.pool() {


### PR DESCRIPTION
## Summary
- Enable durable execution workflows API in DEV_MODE by using `InMemoryWorkflowEventStore`
- Update `AppState` to use trait object `Arc<dyn WorkflowEventStore + Send + Sync>` for flexibility
- Previously these endpoints returned 503; now they work without PostgreSQL

## Changes
- `crates/control-plane/src/api/durable.rs`: Changed store type to trait object
- `crates/control-plane/src/main.rs`: Conditionally create in-memory or postgres store based on mode

## Test plan
- [x] Rust formatting passes (`cargo fmt --check`)
- [x] Clippy passes with `-D warnings`
- [x] Unit tests pass
- [x] Manual smoke test in DEV_MODE:
  - `GET /v1/durable/health` → 200 OK
  - `GET /v1/durable/workflows` → 200 OK (empty list)
  - `GET /v1/durable/tasks` → 200 OK (empty list)
  - `GET /v1/durable/workers` → 200 OK (empty list)
  - `GET /v1/durable/dlq` → 200 OK (empty list)
  - `GET /v1/durable/circuit-breakers` → 200 OK (empty list)