### PR TITLE
fix(durable): prevent duplicate atom scheduling via task ownership verification

### DIFF
--- a/crates/control-plane/src/dev_worker/worker.rs
+++ b/crates/control-plane/src/dev_worker/worker.rs
@@ -270,27 +270,40 @@ impl InProcessWorker {
 
         match result {
             Ok(output) => {
-                // Complete the task
-                self.durable_store
-                    .complete_task(task.id, output.clone())
-                    .await
-                    .map_err(|e| anyhow::anyhow!("Failed to complete task: {}", e))?;
+                // Complete the task - verify we still own it
+                let complete_result = self
+                    .durable_store
+                    .complete_task(task.id, &self.config.worker_id, output.clone())
+                    .await;
 
-                info!(
-                    task_id = %task.id,
-                    activity_type = %task.activity_type,
-                    "Task completed successfully"
-                );
+                match complete_result {
+                    Ok(()) => {
+                        info!(
+                            task_id = %task.id,
+                            activity_type = %task.activity_type,
+                            "Task completed successfully"
+                        );
 
-                // Schedule next activity if needed
-                if let Some(turn_input) = turn_input_opt {
-                    self.schedule_next_activity(
-                        task.workflow_id,
-                        &task.activity_type,
-                        &turn_input,
-                        &output,
-                    )
-                    .await?;
+                        // Schedule next activity if needed
+                        if let Some(turn_input) = turn_input_opt {
+                            self.schedule_next_activity(
+                                task.workflow_id,
+                                &task.activity_type,
+                                &turn_input,
+                                &output,
+                            )
+                            .await?;
+                        }
+                    }
+                    Err(e) => {
+                        // Task was reclaimed - don't schedule next activity
+                        warn!(
+                            task_id = %task.id,
+                            activity_type = %task.activity_type,
+                            error = %e,
+                            "Task completion rejected - skipping next activity"
+                        );
+                    }
                 }
             }
             Err(e) => {

--- a/crates/control-plane/src/grpc_service.rs
+++ b/crates/control-plane/src/grpc_service.rs
@@ -1161,20 +1161,32 @@ impl WorkerService for WorkerServiceImpl {
         let req = request.into_inner();
         let store = self.durable_store()?;
         let task_id = parse_uuid(req.task_id.as_ref())?;
+        let worker_id = &req.worker_id;
 
         let output = req
             .output
             .map(|s| everruns_internal_protocol::proto_struct_to_json(&s))
             .unwrap_or_else(|| serde_json::json!({}));
 
-        store.complete_task(task_id, output).await.map_err(|e| {
-            tracing::error!("Failed to complete task: {}", e);
-            Status::internal("Failed to complete task")
-        })?;
-
-        Ok(Response::new(CompleteDurableTaskResponse {
-            completed: true,
-        }))
+        // complete_task now verifies worker ownership to prevent duplicate scheduling
+        match store.complete_task(task_id, worker_id, output).await {
+            Ok(()) => Ok(Response::new(CompleteDurableTaskResponse { success: true })),
+            Err(StoreError::TaskNotOwned(_)) => {
+                // Task was reclaimed by another worker - not an error, just return false
+                tracing::info!(
+                    %task_id,
+                    %worker_id,
+                    "Task completion rejected: task was reclaimed or already completed"
+                );
+                Ok(Response::new(CompleteDurableTaskResponse {
+                    success: false,
+                }))
+            }
+            Err(e) => {
+                tracing::error!("Failed to complete task: {}", e);
+                Err(Status::internal("Failed to complete task"))
+            }
+        }
     }
 
     async fn fail_durable_task(

--- a/crates/durable/benches/concurrent_workers.rs
+++ b/crates/durable/benches/concurrent_workers.rs
@@ -143,9 +143,9 @@ impl TestScenario {
                         let exec_time = exec_start.elapsed();
                         execution.record(exec_time);
 
-                        // Complete task
+                        // Complete task (pass worker_name to verify ownership)
                         store
-                            .complete_task(task.id, serde_json::json!({"ok": true}))
+                            .complete_task(task.id, &worker_name, serde_json::json!({"ok": true}))
                             .await
                             .unwrap();
 

--- a/crates/durable/benches/workflow_throughput.rs
+++ b/crates/durable/benches/workflow_throughput.rs
@@ -177,9 +177,9 @@ impl WorkflowScenario {
                         }
                         execution.record(exec_start.elapsed());
 
-                        // Complete task
+                        // Complete task (pass worker_name to verify ownership)
                         store
-                            .complete_task(task.id, serde_json::json!({"ok": true}))
+                            .complete_task(task.id, &worker_name, serde_json::json!({"ok": true}))
                             .await
                             .unwrap();
 

--- a/crates/durable/src/persistence/memory.rs
+++ b/crates/durable/src/persistence/memory.rs
@@ -937,4 +937,249 @@ mod tests {
         let signals = store.get_pending_signals(workflow_id).await.unwrap();
         assert_eq!(signals.len(), 0);
     }
+
+    // ========================================================================
+    // Task ownership verification tests (duplicate scheduling prevention)
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_complete_task_wrong_worker_rejected() {
+        // Scenario: Worker A claims task, Worker B tries to complete it
+        let store = InMemoryWorkflowEventStore::new();
+        let workflow_id = Uuid::now_v7();
+
+        store
+            .create_workflow(workflow_id, "test", serde_json::json!({}), None)
+            .await
+            .unwrap();
+
+        let task_id = store
+            .enqueue_task(TaskDefinition {
+                workflow_id,
+                activity_id: "step-1".to_string(),
+                activity_type: "test_activity".to_string(),
+                input: serde_json::json!({}),
+                options: ActivityOptions::default(),
+            })
+            .await
+            .unwrap();
+
+        // Worker A claims the task
+        let claimed = store
+            .claim_task("worker-A", &["test_activity".to_string()], 1)
+            .await
+            .unwrap();
+        assert_eq!(claimed.len(), 1);
+        assert_eq!(claimed[0].id, task_id);
+
+        // Worker B tries to complete the task (should fail)
+        let result = store
+            .complete_task(task_id, "worker-B", serde_json::json!({"result": "ok"}))
+            .await;
+
+        assert!(
+            matches!(result, Err(StoreError::TaskNotOwned(_))),
+            "Expected TaskNotOwned error, got: {:?}",
+            result
+        );
+
+        // Worker A can still complete it
+        store
+            .complete_task(task_id, "worker-A", serde_json::json!({"result": "ok"}))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_complete_task_already_completed_rejected() {
+        // Scenario: Worker A completes task, then tries to complete again
+        let store = InMemoryWorkflowEventStore::new();
+        let workflow_id = Uuid::now_v7();
+
+        store
+            .create_workflow(workflow_id, "test", serde_json::json!({}), None)
+            .await
+            .unwrap();
+
+        let task_id = store
+            .enqueue_task(TaskDefinition {
+                workflow_id,
+                activity_id: "step-1".to_string(),
+                activity_type: "test_activity".to_string(),
+                input: serde_json::json!({}),
+                options: ActivityOptions::default(),
+            })
+            .await
+            .unwrap();
+
+        // Claim and complete
+        store
+            .claim_task("worker-A", &["test_activity".to_string()], 1)
+            .await
+            .unwrap();
+
+        store
+            .complete_task(task_id, "worker-A", serde_json::json!({"result": "ok"}))
+            .await
+            .unwrap();
+
+        // Try to complete again (should fail)
+        let result = store
+            .complete_task(task_id, "worker-A", serde_json::json!({"result": "ok2"}))
+            .await;
+
+        assert!(
+            matches!(result, Err(StoreError::TaskNotOwned(_))),
+            "Expected TaskNotOwned error for already completed task, got: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_two_workers_race_condition_prevented() {
+        // Scenario: Simulates the race condition that causes duplicate atoms
+        // 1. Worker A claims task
+        // 2. Task heartbeat times out, task is reclaimed (simulated by failing)
+        // 3. Worker B claims the same task
+        // 4. Worker B completes the task
+        // 5. Worker A tries to complete (should be rejected)
+        let store = InMemoryWorkflowEventStore::new();
+        let workflow_id = Uuid::now_v7();
+
+        store
+            .create_workflow(workflow_id, "test", serde_json::json!({}), None)
+            .await
+            .unwrap();
+
+        let task_id = store
+            .enqueue_task(TaskDefinition {
+                workflow_id,
+                activity_id: "act-1".to_string(),
+                activity_type: "act".to_string(),
+                input: serde_json::json!({"step": 1}),
+                options: ActivityOptions::default(),
+            })
+            .await
+            .unwrap();
+
+        // Step 1: Worker A claims the task
+        let claimed_a = store
+            .claim_task("worker-A", &["act".to_string()], 1)
+            .await
+            .unwrap();
+        assert_eq!(claimed_a.len(), 1);
+
+        // Step 2: Simulate heartbeat timeout - task goes back to pending
+        // (In real scenario, reclaim_stale_tasks would do this)
+        {
+            let mut tasks = store.tasks.write();
+            let task = tasks.get_mut(&task_id).unwrap();
+            task.status = TaskStatus::Pending;
+            task.claimed_by = None;
+        }
+
+        // Step 3: Worker B claims the same task
+        let claimed_b = store
+            .claim_task("worker-B", &["act".to_string()], 1)
+            .await
+            .unwrap();
+        assert_eq!(claimed_b.len(), 1);
+        assert_eq!(claimed_b[0].id, task_id);
+
+        // Step 4: Worker B completes the task successfully
+        store
+            .complete_task(task_id, "worker-B", serde_json::json!({"result": "from B"}))
+            .await
+            .unwrap();
+
+        // Step 5: Worker A (late) tries to complete - should be REJECTED
+        let result_a = store
+            .complete_task(task_id, "worker-A", serde_json::json!({"result": "from A"}))
+            .await;
+
+        assert!(
+            matches!(result_a, Err(StoreError::TaskNotOwned(_))),
+            "Worker A should be rejected since task was reclaimed and completed by Worker B. Got: {:?}",
+            result_a
+        );
+    }
+
+    #[tokio::test]
+    async fn test_duplicate_scheduling_prevention_workflow() {
+        // End-to-end scenario testing the fix prevents duplicate atom scheduling
+        // This simulates the full workflow that was causing duplicate atoms
+        let store = InMemoryWorkflowEventStore::new();
+        let workflow_id = Uuid::now_v7();
+
+        store
+            .create_workflow(
+                workflow_id,
+                "message_processing",
+                serde_json::json!({}),
+                None,
+            )
+            .await
+            .unwrap();
+
+        // Enqueue an "act" task (triggered by user message)
+        let task_id = store
+            .enqueue_task(TaskDefinition {
+                workflow_id,
+                activity_id: "act-0".to_string(),
+                activity_type: "act".to_string(),
+                input: serde_json::json!({"message": "hello"}),
+                options: ActivityOptions::default(),
+            })
+            .await
+            .unwrap();
+
+        // Worker A claims and starts processing
+        let _ = store
+            .claim_task("worker-A", &["act".to_string()], 1)
+            .await
+            .unwrap();
+
+        // Simulate: Worker A takes too long, task reclaimed
+        {
+            let mut tasks = store.tasks.write();
+            let task = tasks.get_mut(&task_id).unwrap();
+            task.status = TaskStatus::Pending;
+            task.claimed_by = None;
+        }
+
+        // Worker B claims and completes
+        let _ = store
+            .claim_task("worker-B", &["act".to_string()], 1)
+            .await
+            .unwrap();
+
+        // Worker B completes successfully
+        let result_b = store
+            .complete_task(
+                task_id,
+                "worker-B",
+                serde_json::json!({"turn_complete": true}),
+            )
+            .await;
+        assert!(result_b.is_ok(), "Worker B should complete successfully");
+
+        // Now we simulate what WOULD happen in the old buggy code:
+        // Worker A finishes processing and tries to complete
+        let result_a = store
+            .complete_task(
+                task_id,
+                "worker-A",
+                serde_json::json!({"turn_complete": true}),
+            )
+            .await;
+
+        // The fix ensures Worker A is REJECTED
+        assert!(
+            matches!(result_a, Err(StoreError::TaskNotOwned(_))),
+            "Worker A must be rejected to prevent duplicate atom scheduling"
+        );
+
+        // In the real workflow, after complete_task fails, the worker
+        // should NOT call schedule_next_activity, preventing duplicate atoms
+    }
 }

--- a/crates/durable/src/persistence/memory.rs
+++ b/crates/durable/src/persistence/memory.rs
@@ -303,12 +303,21 @@ impl WorkflowEventStore for InMemoryWorkflowEventStore {
     async fn complete_task(
         &self,
         task_id: Uuid,
+        worker_id: &str,
         _result: serde_json::Value,
     ) -> Result<(), StoreError> {
         let mut tasks = self.tasks.write();
         let task = tasks
             .get_mut(&task_id)
             .ok_or(StoreError::TaskNotFound(task_id))?;
+
+        // Verify the task is still claimed by this worker
+        if task.status != TaskStatus::Claimed {
+            return Err(StoreError::TaskNotOwned(task_id));
+        }
+        if task.claimed_by.as_deref() != Some(worker_id) {
+            return Err(StoreError::TaskNotOwned(task_id));
+        }
 
         task.status = TaskStatus::Completed;
         Ok(())
@@ -855,9 +864,9 @@ mod tests {
         assert_eq!(claimed.len(), 1);
         assert_eq!(claimed[0].id, task_id);
 
-        // Complete task
+        // Complete task (pass worker_id that claimed it)
         store
-            .complete_task(task_id, serde_json::json!({"result": "ok"}))
+            .complete_task(task_id, "worker-1", serde_json::json!({"result": "ok"}))
             .await
             .unwrap();
 

--- a/crates/durable/src/persistence/postgres.rs
+++ b/crates/durable/src/persistence/postgres.rs
@@ -464,25 +464,41 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
     async fn complete_task(
         &self,
         task_id: Uuid,
+        worker_id: &str,
         _result: serde_json::Value,
     ) -> Result<(), StoreError> {
-        sqlx::query(
+        // Only complete if:
+        // 1. Task is still claimed by this worker, OR
+        // 2. Task is still claimed (status = 'claimed') by this worker
+        // This prevents duplicate scheduling when a task is reclaimed due to heartbeat timeout
+        let result = sqlx::query(
             r#"
             UPDATE durable_task_queue
             SET status = 'completed'
-            WHERE id = $1
+            WHERE id = $1 AND claimed_by = $2 AND status = 'claimed'
+            RETURNING id
             "#,
         )
         .bind(task_id)
-        .execute(&self.pool)
+        .bind(worker_id)
+        .fetch_optional(&self.pool)
         .await
         .map_err(|e| {
             error!("Failed to complete task: {}", e);
             StoreError::Database(e.to_string())
         })?;
 
-        debug!(%task_id, "completed task");
-        Ok(())
+        match result {
+            Some(_) => {
+                debug!(%task_id, %worker_id, "completed task");
+                Ok(())
+            }
+            None => {
+                // Task was reclaimed by another worker or already completed
+                debug!(%task_id, %worker_id, "task not owned - was reclaimed or already completed");
+                Err(StoreError::TaskNotOwned(task_id))
+            }
+        }
     }
 
     #[instrument(skip(self))]

--- a/crates/durable/src/persistence/store.rs
+++ b/crates/durable/src/persistence/store.rs
@@ -20,6 +20,10 @@ pub enum StoreError {
     #[error("task not found: {0}")]
     TaskNotFound(Uuid),
 
+    /// Task not owned by the worker (was reclaimed)
+    #[error("task {0} not owned by worker (was reclaimed or already completed)")]
+    TaskNotOwned(Uuid),
+
     /// Concurrency conflict (optimistic locking failed)
     #[error("concurrency conflict: expected sequence {expected}, got {actual}")]
     ConcurrencyConflict { expected: i32, actual: i32 },
@@ -386,9 +390,15 @@ pub trait WorkflowEventStore: Send + Sync + 'static {
     ) -> Result<HeartbeatResponse, StoreError>;
 
     /// Complete a task successfully
+    ///
+    /// The worker_id must match the worker that claimed the task.
+    /// Returns `StoreError::TaskNotOwned` if the task was reclaimed by another worker.
+    /// This prevents duplicate next activity scheduling when a task is reclaimed
+    /// due to heartbeat timeout while the original worker is still completing it.
     async fn complete_task(
         &self,
         task_id: Uuid,
+        worker_id: &str,
         result: serde_json::Value,
     ) -> Result<(), StoreError>;
 

--- a/crates/durable/src/worker/pool.rs
+++ b/crates/durable/src/worker/pool.rs
@@ -453,6 +453,7 @@ impl WorkerPool {
                             // Spawn task execution
                             let store = Arc::clone(&store);
                             let bp = Arc::clone(&backpressure);
+                            let worker_id = config.worker_id.clone();
 
                             tokio::spawn(async move {
                                 let task_id = task.id;
@@ -461,7 +462,10 @@ impl WorkerPool {
                                 // Report result
                                 match result {
                                     Ok(output) => {
-                                        if let Err(e) = store.complete_task(task_id, output).await {
+                                        // Pass worker_id to verify ownership (prevents duplicate scheduling)
+                                        if let Err(e) =
+                                            store.complete_task(task_id, &worker_id, output).await
+                                        {
                                             error!(%task_id, "Failed to complete task: {}", e);
                                         }
                                     }

--- a/crates/durable/tests/postgres_integration_test.rs
+++ b/crates/durable/tests/postgres_integration_test.rs
@@ -403,9 +403,9 @@ async fn test_task_complete() {
         .await
         .unwrap();
 
-    // Complete the task
+    // Complete the task (must pass worker_id that claimed it)
     store
-        .complete_task(task_id, json!({"status": "done"}))
+        .complete_task(task_id, "worker", json!({"status": "done"}))
         .await
         .unwrap();
 
@@ -880,6 +880,274 @@ async fn test_concurrent_task_claiming() {
     all_ids.sort();
     all_ids.dedup();
     assert_eq!(all_ids.len(), 10);
+
+    cleanup_workflow(&store, workflow_id).await;
+}
+
+// ============================================
+// Task Completion Ownership Tests (Duplicate Prevention)
+// ============================================
+
+/// Test that task completion fails when task was reclaimed by another worker
+///
+/// This test verifies the fix for the duplicate act atoms bug:
+/// When a task's heartbeat times out and is reclaimed by another worker,
+/// the original worker must NOT be able to complete the task.
+#[tokio::test]
+async fn test_task_completion_rejected_when_reclaimed() {
+    let store = create_test_store().await;
+    let workflow_id = Uuid::now_v7();
+
+    store
+        .create_workflow(workflow_id, "reclaim_test", json!({}), None)
+        .await
+        .unwrap();
+
+    let task_id = store
+        .enqueue_task(TaskDefinition {
+            workflow_id,
+            activity_id: "step".to_string(),
+            activity_type: "process".to_string(),
+            input: json!({}),
+            options: ActivityOptions::default(),
+        })
+        .await
+        .unwrap();
+
+    // Worker 1 claims the task
+    store
+        .claim_task("worker-1", &["process".to_string()], 1)
+        .await
+        .unwrap();
+
+    // Simulate heartbeat timeout: manually set heartbeat_at to the past
+    sqlx::query(
+        r#"
+        UPDATE durable_task_queue
+        SET heartbeat_at = NOW() - INTERVAL '1 hour'
+        WHERE id = $1
+        "#,
+    )
+    .bind(task_id)
+    .execute(store.pool())
+    .await
+    .unwrap();
+
+    // Reclaim stale tasks
+    let reclaimed = store
+        .reclaim_stale_tasks(Duration::from_secs(30))
+        .await
+        .unwrap();
+    assert_eq!(reclaimed.len(), 1);
+
+    // Worker 2 claims the reclaimed task
+    let claimed = store
+        .claim_task("worker-2", &["process".to_string()], 1)
+        .await
+        .unwrap();
+    assert_eq!(claimed.len(), 1);
+    assert_eq!(claimed[0].id, task_id);
+
+    // Worker 1 tries to complete the task (should fail - task was reclaimed)
+    let result = store
+        .complete_task(task_id, "worker-1", json!({"status": "done"}))
+        .await;
+    assert!(
+        matches!(result, Err(StoreError::TaskNotOwned(_))),
+        "Expected TaskNotOwned error, got {:?}",
+        result
+    );
+
+    // Worker 2 should be able to complete the task
+    store
+        .complete_task(task_id, "worker-2", json!({"status": "done"}))
+        .await
+        .expect("Worker 2 should be able to complete the task it claimed");
+
+    cleanup_workflow(&store, workflow_id).await;
+}
+
+/// Test that task completion fails when wrong worker tries to complete
+#[tokio::test]
+async fn test_task_completion_rejected_wrong_worker() {
+    let store = create_test_store().await;
+    let workflow_id = Uuid::now_v7();
+
+    store
+        .create_workflow(workflow_id, "wrong_worker_test", json!({}), None)
+        .await
+        .unwrap();
+
+    let task_id = store
+        .enqueue_task(TaskDefinition {
+            workflow_id,
+            activity_id: "step".to_string(),
+            activity_type: "process".to_string(),
+            input: json!({}),
+            options: ActivityOptions::default(),
+        })
+        .await
+        .unwrap();
+
+    // Worker 1 claims the task
+    store
+        .claim_task("worker-1", &["process".to_string()], 1)
+        .await
+        .unwrap();
+
+    // Wrong worker (worker-2) tries to complete the task
+    let result = store
+        .complete_task(task_id, "worker-2", json!({"status": "done"}))
+        .await;
+    assert!(
+        matches!(result, Err(StoreError::TaskNotOwned(_))),
+        "Expected TaskNotOwned error when wrong worker tries to complete"
+    );
+
+    // Correct worker (worker-1) should be able to complete
+    store
+        .complete_task(task_id, "worker-1", json!({"status": "done"}))
+        .await
+        .expect("Correct worker should be able to complete");
+
+    cleanup_workflow(&store, workflow_id).await;
+}
+
+/// Test that task completion fails when task is already completed
+#[tokio::test]
+async fn test_task_completion_rejected_already_completed() {
+    let store = create_test_store().await;
+    let workflow_id = Uuid::now_v7();
+
+    store
+        .create_workflow(workflow_id, "double_complete_test", json!({}), None)
+        .await
+        .unwrap();
+
+    let task_id = store
+        .enqueue_task(TaskDefinition {
+            workflow_id,
+            activity_id: "step".to_string(),
+            activity_type: "process".to_string(),
+            input: json!({}),
+            options: ActivityOptions::default(),
+        })
+        .await
+        .unwrap();
+
+    // Worker claims and completes the task
+    store
+        .claim_task("worker-1", &["process".to_string()], 1)
+        .await
+        .unwrap();
+
+    store
+        .complete_task(task_id, "worker-1", json!({"status": "done"}))
+        .await
+        .unwrap();
+
+    // Same worker tries to complete again (should fail - already completed)
+    let result = store
+        .complete_task(task_id, "worker-1", json!({"status": "done again"}))
+        .await;
+    assert!(
+        matches!(result, Err(StoreError::TaskNotOwned(_))),
+        "Expected TaskNotOwned error when task already completed"
+    );
+
+    cleanup_workflow(&store, workflow_id).await;
+}
+
+/// Test the full race condition scenario that causes duplicate act atoms
+///
+/// Scenario:
+/// 1. Worker A claims task
+/// 2. Worker A executes task (slow)
+/// 3. Heartbeat times out, task reclaimed
+/// 4. Worker B claims and executes same task
+/// 5. Worker B completes task (succeeds)
+/// 6. Worker A finishes execution, tries to complete (must fail)
+///
+/// Without the fix, both workers would complete and schedule next activity,
+/// causing duplicate atoms.
+#[tokio::test]
+async fn test_duplicate_scheduling_prevention() {
+    let store = create_test_store().await;
+    let workflow_id = Uuid::now_v7();
+
+    store
+        .create_workflow(workflow_id, "duplicate_prevention_test", json!({}), None)
+        .await
+        .unwrap();
+
+    let task_id = store
+        .enqueue_task(TaskDefinition {
+            workflow_id,
+            activity_id: "reason_1".to_string(),
+            activity_type: "reason".to_string(),
+            input: json!({"test": true}),
+            options: ActivityOptions::default(),
+        })
+        .await
+        .unwrap();
+
+    // Step 1: Worker A claims the task
+    store
+        .claim_task("worker-A", &["reason".to_string()], 1)
+        .await
+        .unwrap();
+
+    // Step 2-3: Simulate heartbeat timeout (worker A is slow)
+    sqlx::query(
+        r#"
+        UPDATE durable_task_queue
+        SET heartbeat_at = NOW() - INTERVAL '1 hour'
+        WHERE id = $1
+        "#,
+    )
+    .bind(task_id)
+    .execute(store.pool())
+    .await
+    .unwrap();
+
+    store
+        .reclaim_stale_tasks(Duration::from_secs(30))
+        .await
+        .unwrap();
+
+    // Step 4: Worker B claims the reclaimed task
+    let claimed = store
+        .claim_task("worker-B", &["reason".to_string()], 1)
+        .await
+        .unwrap();
+    assert_eq!(claimed.len(), 1);
+
+    // Step 5: Worker B completes the task first
+    store
+        .complete_task(task_id, "worker-B", json!({"has_tool_calls": true}))
+        .await
+        .expect("Worker B should complete successfully");
+
+    // Step 6: Worker A finishes and tries to complete (must fail!)
+    let result = store
+        .complete_task(task_id, "worker-A", json!({"has_tool_calls": true}))
+        .await;
+
+    assert!(
+        matches!(result, Err(StoreError::TaskNotOwned(_))),
+        "Worker A must NOT be able to complete the reclaimed task. Got: {:?}",
+        result
+    );
+
+    // Verify task is completed (not duplicated in queue)
+    let pending_tasks = store
+        .claim_task("worker-C", &["reason".to_string()], 10)
+        .await
+        .unwrap();
+    assert!(
+        pending_tasks.is_empty(),
+        "No duplicate pending tasks should exist"
+    );
 
     cleanup_workflow(&store, workflow_id).await;
 }

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -517,11 +517,14 @@ message ClaimDurableTasksResponse {
 
 message CompleteDurableTaskRequest {
     Uuid task_id = 1;
-    google.protobuf.Struct output = 2;
+    string worker_id = 2;  // Required: prevents duplicate completion when task is reclaimed
+    google.protobuf.Struct output = 3;
 }
 
 message CompleteDurableTaskResponse {
-    bool completed = 1;
+    // Whether the task was successfully completed
+    // False if task was reclaimed by another worker or already completed
+    bool success = 1;
 }
 
 // === Fail task ===

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -364,30 +364,46 @@ impl DurableWorker {
 
         match result {
             Ok(output) => {
-                // Complete the task
-                {
+                // Complete the task - this verifies we still own it
+                // If task was reclaimed while we were executing, we must NOT schedule next activity
+                let complete_result = {
                     let mut store = self.store.lock().await;
                     store
-                        .complete_task(task.id, output.clone())
+                        .complete_task(task.id, &self.config.worker_id, output.clone())
                         .await
-                        .map_err(|e| anyhow::anyhow!("Failed to complete task: {}", e))?;
-                }
+                };
 
-                info!(
-                    task_id = %task.id,
-                    activity_type = %task.activity_type,
-                    "Task completed successfully"
-                );
+                match complete_result {
+                    Ok(()) => {
+                        info!(
+                            task_id = %task.id,
+                            activity_type = %task.activity_type,
+                            "Task completed successfully"
+                        );
 
-                // Check if workflow is complete and schedule next activity
-                if let Some(turn_input) = turn_input_opt {
-                    self.schedule_next_activity(
-                        task.workflow_id,
-                        &task.activity_type,
-                        &turn_input,
-                        &output,
-                    )
-                    .await?;
+                        // Only schedule next activity if we successfully completed the task
+                        // This prevents duplicate scheduling when task was reclaimed
+                        if let Some(turn_input) = turn_input_opt {
+                            self.schedule_next_activity(
+                                task.workflow_id,
+                                &task.activity_type,
+                                &turn_input,
+                                &output,
+                            )
+                            .await?;
+                        }
+                    }
+                    Err(e) => {
+                        // Task was reclaimed by another worker or already completed
+                        // This is expected during heartbeat timeout recovery
+                        // Do NOT schedule next activity - the other worker will do it
+                        warn!(
+                            task_id = %task.id,
+                            activity_type = %task.activity_type,
+                            error = %e,
+                            "Task completion rejected (reclaimed or already completed) - skipping next activity scheduling"
+                        );
+                    }
                 }
             }
             Err(e) => {

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -394,15 +394,24 @@ impl DurableWorker {
                         }
                     }
                     Err(e) => {
-                        // Task was reclaimed by another worker or already completed
-                        // This is expected during heartbeat timeout recovery
-                        // Do NOT schedule next activity - the other worker will do it
-                        warn!(
-                            task_id = %task.id,
-                            activity_type = %task.activity_type,
-                            error = %e,
-                            "Task completion rejected (reclaimed or already completed) - skipping next activity scheduling"
-                        );
+                        // Check if this is a "task not owned" error (expected during reclaim)
+                        // vs other errors (network, database) that should be propagated
+                        let error_str = e.to_string();
+                        if error_str.contains("not owned") || error_str.contains("reclaimed") {
+                            // Task was reclaimed by another worker or already completed
+                            // This is expected during heartbeat timeout recovery
+                            // Do NOT schedule next activity - the other worker will do it
+                            warn!(
+                                task_id = %task.id,
+                                activity_type = %task.activity_type,
+                                error = %e,
+                                "Task completion rejected (reclaimed or already completed) - skipping next activity scheduling"
+                            );
+                        } else {
+                            // Other errors (network, database) should be propagated
+                            // so the failure handler can run and retry the task
+                            return Err(e);
+                        }
                     }
                 }
             }

--- a/crates/worker/src/grpc_durable_store.rs
+++ b/crates/worker/src/grpc_durable_store.rs
@@ -170,13 +170,27 @@ impl GrpcDurableStore {
     }
 
     /// Complete a task
-    pub async fn complete_task(&mut self, task_id: Uuid, output: serde_json::Value) -> Result<()> {
+    ///
+    /// The worker_id must match the worker that claimed the task.
+    /// Returns an error if the task was reclaimed by another worker.
+    pub async fn complete_task(
+        &mut self,
+        task_id: Uuid,
+        worker_id: &str,
+        output: serde_json::Value,
+    ) -> Result<()> {
         let request = CompleteDurableTaskRequest {
             task_id: Some(uuid_to_proto_uuid(task_id)),
+            worker_id: worker_id.to_string(),
             output: Some(json_to_proto_struct(&output)),
         };
 
-        self.client.complete_durable_task(request).await?;
+        let response = self.client.complete_durable_task(request).await?;
+        let inner = response.into_inner();
+
+        if !inner.success {
+            anyhow::bail!("Task not owned by worker (was reclaimed or already completed)")
+        }
         Ok(())
     }
 

--- a/specs/durable-execution-engine.md
+++ b/specs/durable-execution-engine.md
@@ -678,9 +678,20 @@ pub trait WorkflowEventStore: Send + Sync + 'static {
     ) -> Result<HeartbeatResponse, StoreError>;
 
     /// Complete a task
+    ///
+    /// Verifies that the worker still owns the task (claimed_by matches worker_id
+    /// and status is still 'claimed'). Returns TaskNotOwned error if the task was
+    /// reclaimed by another worker due to heartbeat timeout.
+    ///
+    /// This ownership check prevents duplicate activity scheduling when:
+    /// 1. Worker A claims task and starts execution
+    /// 2. Worker A's heartbeat times out, task is reclaimed
+    /// 3. Worker B claims and completes the task
+    /// 4. Worker A finishes late - complete_task rejects with TaskNotOwned
     async fn complete_task(
         &self,
         task_id: Uuid,
+        worker_id: &str,
         result: serde_json::Value,
     ) -> Result<(), StoreError>;
 


### PR DESCRIPTION
## What
Prevents duplicate workflow atoms from being scheduled when a task is reclaimed due to heartbeat timeout.

## Why
When a worker's heartbeat times out and its task is reclaimed by another worker:
1. Worker A claims task, starts execution
2. Heartbeat times out, task is reclaimed
3. Worker B claims and completes the same task
4. Worker A finishes late and tries to complete - this was succeeding and scheduling a duplicate next activity

This race condition caused duplicate "act" atoms when users added messages.

## How
- Added `worker_id` parameter to `complete_task` to verify task ownership
- PostgreSQL implementation checks `claimed_by = worker_id AND status = 'claimed'` atomically
- In-memory implementation has equivalent ownership checks
- Worker skips `schedule_next_activity` when completion is rejected with `TaskNotOwned`
- Added new `TaskNotOwned` error variant to distinguish from other failures

## Test Coverage
**Unit tests (In-memory store):** 4 new tests
**Integration tests (PostgreSQL):** 4 new tests

## Risk
- Low - Changes are isolated to task completion path