### PR TITLE
refactor(api,core): remove duplicate ErrorResponse, add ToolDefinition accessors

### DIFF
--- a/crates/control-plane/src/api/llm_models.rs
+++ b/crates/control-plane/src/api/llm_models.rs
@@ -1,6 +1,6 @@
 // LLM Model API endpoints
 
-use crate::api::common::ListResponse;
+use crate::api::common::{ErrorResponse, ListResponse};
 use crate::storage::StorageBackend;
 use axum::{
     extract::{Path, State},
@@ -9,7 +9,7 @@ use axum::{
     Json, Router,
 };
 use everruns_core::{LlmModel, LlmModelStatus, LlmModelWithProvider};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::sync::Arc;
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -71,11 +71,6 @@ pub struct UpdateLlmModelRequest {
     /// The status of the model. Set to "inactive" to disable.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<LlmModelStatus>,
-}
-
-#[derive(Debug, Serialize)]
-pub struct ErrorResponse {
-    error: String,
 }
 
 /// Create a new model for a provider
@@ -314,9 +309,7 @@ mod tests {
 
     #[test]
     fn test_error_response_serialization() {
-        let error = ErrorResponse {
-            error: "Internal server error".to_string(),
-        };
+        let error = ErrorResponse::new("Internal server error");
         let json = serde_json::to_string(&error).expect("Failed to serialize");
         assert_eq!(json, r#"{"error":"Internal server error"}"#);
     }
@@ -324,18 +317,14 @@ mod tests {
     #[test]
     fn test_error_response_internal_error_format() {
         // Verify that internal error responses use the generic message
-        let error = ErrorResponse {
-            error: "Internal server error".to_string(),
-        };
+        let error = ErrorResponse::new("Internal server error");
         let parsed: serde_json::Value = serde_json::to_value(&error).expect("Failed to serialize");
         assert_eq!(parsed["error"], "Internal server error");
     }
 
     #[test]
     fn test_error_response_not_found_format() {
-        let error = ErrorResponse {
-            error: "Model not found".to_string(),
-        };
+        let error = ErrorResponse::new("Model not found");
         let parsed: serde_json::Value = serde_json::to_value(&error).expect("Failed to serialize");
         assert_eq!(parsed["error"], "Model not found");
     }

--- a/crates/control-plane/src/api/llm_providers.rs
+++ b/crates/control-plane/src/api/llm_providers.rs
@@ -9,12 +9,12 @@ use axum::{
 };
 use everruns_core::llm_models::LlmProvider;
 use everruns_core::{LlmProviderStatus, LlmProviderType};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::sync::Arc;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-use super::common::ListResponse;
+use super::common::{ErrorResponse, ListResponse};
 use crate::services::LlmProviderService;
 
 #[derive(Clone)]
@@ -70,11 +70,6 @@ pub struct UpdateLlmProviderRequest {
     /// The status of the provider. Set to "inactive" to disable.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<LlmProviderStatus>,
-}
-
-#[derive(Debug, Serialize)]
-pub struct ErrorResponse {
-    error: String,
 }
 
 /// Create a new LLM provider
@@ -293,9 +288,7 @@ mod tests {
 
     #[test]
     fn test_error_response_serialization() {
-        let error = ErrorResponse {
-            error: "Internal server error".to_string(),
-        };
+        let error = ErrorResponse::new("Internal server error");
         let json = serde_json::to_string(&error).expect("Failed to serialize");
         assert_eq!(json, r#"{"error":"Internal server error"}"#);
     }
@@ -303,18 +296,14 @@ mod tests {
     #[test]
     fn test_error_response_internal_error_format() {
         // Verify that internal error responses use the generic message
-        let error = ErrorResponse {
-            error: "Internal server error".to_string(),
-        };
+        let error = ErrorResponse::new("Internal server error");
         let parsed: serde_json::Value = serde_json::to_value(&error).expect("Failed to serialize");
         assert_eq!(parsed["error"], "Internal server error");
     }
 
     #[test]
     fn test_error_response_not_found_format() {
-        let error = ErrorResponse {
-            error: "Provider not found".to_string(),
-        };
+        let error = ErrorResponse::new("Provider not found");
         let parsed: serde_json::Value = serde_json::to_value(&error).expect("Failed to serialize");
         assert_eq!(parsed["error"], "Provider not found");
     }
@@ -322,9 +311,7 @@ mod tests {
     #[test]
     fn test_error_response_encryption_not_configured() {
         // This error is safe to expose - it's a configuration issue, not internal details
-        let error = ErrorResponse {
-            error: "Encryption not configured. Cannot store API key.".to_string(),
-        };
+        let error = ErrorResponse::new("Encryption not configured. Cannot store API key.");
         let parsed: serde_json::Value = serde_json::to_value(&error).expect("Failed to serialize");
         assert_eq!(
             parsed["error"],

--- a/crates/core/src/tool_types.rs
+++ b/crates/core/src/tool_types.rs
@@ -47,6 +47,36 @@ pub struct BuiltinTool {
     pub policy: ToolPolicy,
 }
 
+impl ToolDefinition {
+    /// Get the tool name regardless of variant
+    pub fn name(&self) -> &str {
+        match self {
+            ToolDefinition::Builtin(b) => &b.name,
+        }
+    }
+
+    /// Get the tool description regardless of variant
+    pub fn description(&self) -> &str {
+        match self {
+            ToolDefinition::Builtin(b) => &b.description,
+        }
+    }
+
+    /// Get the tool parameters schema regardless of variant
+    pub fn parameters(&self) -> &serde_json::Value {
+        match self {
+            ToolDefinition::Builtin(b) => &b.parameters,
+        }
+    }
+
+    /// Get the tool policy regardless of variant
+    pub fn policy(&self) -> &ToolPolicy {
+        match self {
+            ToolDefinition::Builtin(b) => &b.policy,
+        }
+    }
+}
+
 /// Tool call from LLM response
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
@@ -140,5 +170,20 @@ mod tests {
         assert_eq!(parsed.tool_call_id, result.tool_call_id);
         assert!(parsed.result.is_some());
         assert!(parsed.error.is_none());
+    }
+
+    #[test]
+    fn test_tool_definition_accessor_methods() {
+        let tool = ToolDefinition::Builtin(BuiltinTool {
+            name: "test_tool".to_string(),
+            description: "A test tool".to_string(),
+            parameters: serde_json::json!({"type": "object"}),
+            policy: ToolPolicy::RequiresApproval,
+        });
+
+        assert_eq!(tool.name(), "test_tool");
+        assert_eq!(tool.description(), "A test tool");
+        assert_eq!(tool.parameters(), &serde_json::json!({"type": "object"}));
+        assert_eq!(tool.policy(), &ToolPolicy::RequiresApproval);
     }
 }

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -10,8 +10,14 @@ use crate::llm_models::LlmProviderType;
 use crate::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
 use crate::tool_types::{ToolCall, ToolDefinition, ToolResult};
 use async_trait::async_trait;
+use std::collections::HashMap;
 use std::sync::Arc;
 use uuid::Uuid;
+
+/// Build a map of tool names to definitions for efficient lookup
+fn build_tool_map(tool_defs: &[ToolDefinition]) -> HashMap<&str, &ToolDefinition> {
+    tool_defs.iter().map(|def| (def.name(), def)).collect()
+}
 
 use crate::error::Result;
 use crate::message::Message;
@@ -241,16 +247,7 @@ pub trait ToolExecutor: Send + Sync {
     ) -> Result<Vec<ToolResult>> {
         let mut results = Vec::with_capacity(tool_calls.len());
 
-        // Build a map of tool names to definitions
-        let tool_map: std::collections::HashMap<&str, &ToolDefinition> = tool_defs
-            .iter()
-            .map(|def| {
-                let name = match def {
-                    ToolDefinition::Builtin(b) => b.name.as_str(),
-                };
-                (name, def)
-            })
-            .collect();
+        let tool_map = build_tool_map(tool_defs);
 
         for tool_call in tool_calls {
             let tool_def = tool_map.get(tool_call.name.as_str()).ok_or_else(|| {
@@ -277,16 +274,7 @@ pub trait ToolExecutor: Send + Sync {
     {
         use futures::future::join_all;
 
-        // Build a map of tool names to definitions
-        let tool_map: std::collections::HashMap<&str, &ToolDefinition> = tool_defs
-            .iter()
-            .map(|def| {
-                let name = match def {
-                    ToolDefinition::Builtin(b) => b.name.as_str(),
-                };
-                (name, def)
-            })
-            .collect();
+        let tool_map = build_tool_map(tool_defs);
 
         let futures: Vec<_> = tool_calls
             .iter()


### PR DESCRIPTION
## What

Remove duplicate ErrorResponse from llm-providers.rs and add accessor methods to ToolDefinition.

## Why

ErrorResponse was duplicated between llm-providers.rs and shared types. ToolDefinition fields were accessed via pattern matching instead of methods.

## How

- Import shared ErrorResponse instead of defining locally
- Add name(), description(), parameters() accessor methods to ToolDefinition

## Risk

- Low
- Pure refactoring with no behavior changes

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered