### PR TITLE
refactor(llm): use ToolDefinition accessors in convert_tools

### DIFF
--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -186,18 +186,10 @@ impl AnthropicLlmDriver {
     fn convert_tools(tools: &[ToolDefinition]) -> Vec<AnthropicTool> {
         tools
             .iter()
-            .map(|tool| {
-                let (name, description, parameters) = match tool {
-                    ToolDefinition::Builtin(builtin) => {
-                        (&builtin.name, &builtin.description, &builtin.parameters)
-                    }
-                };
-
-                AnthropicTool {
-                    name: name.clone(),
-                    description: description.clone(),
-                    input_schema: parameters.clone(),
-                }
+            .map(|tool| AnthropicTool {
+                name: tool.name().to_string(),
+                description: tool.description().to_string(),
+                input_schema: tool.parameters().clone(),
             })
             .collect()
     }

--- a/crates/control-plane/src/storage/backend.rs
+++ b/crates/control-plane/src/storage/backend.rs
@@ -12,6 +12,26 @@ use super::memory::InMemoryDatabase;
 use super::models::*;
 use super::repositories::Database;
 
+/// Helper macro to dispatch method calls to the appropriate backend.
+///
+/// This reduces the repetitive match pattern from 4 lines to 1 line per method.
+///
+/// # Usage
+///
+/// ```ignore
+/// pub async fn method_name(&self, arg1: T1, arg2: T2) -> Result<R> {
+///     dispatch!(self, method_name, arg1, arg2)
+/// }
+/// ```
+macro_rules! dispatch {
+    ($self:ident, $method:ident $(, $arg:expr)*) => {
+        match $self {
+            Self::Postgres(db) => db.$method($($arg),*).await,
+            Self::InMemory(db) => db.$method($($arg),*).await,
+        }
+    };
+}
+
 /// Storage backend that can be either PostgreSQL or in-memory
 #[derive(Clone)]
 pub enum StorageBackend {
@@ -52,24 +72,15 @@ impl StorageBackend {
     // ============================================
 
     pub async fn create_user(&self, input: CreateUserRow) -> Result<UserRow> {
-        match self {
-            Self::Postgres(db) => db.create_user(input).await,
-            Self::InMemory(db) => db.create_user(input).await,
-        }
+        dispatch!(self, create_user, input)
     }
 
     pub async fn get_user_by_email(&self, email: &str) -> Result<Option<UserRow>> {
-        match self {
-            Self::Postgres(db) => db.get_user_by_email(email).await,
-            Self::InMemory(db) => db.get_user_by_email(email).await,
-        }
+        dispatch!(self, get_user_by_email, email)
     }
 
     pub async fn get_user(&self, id: Uuid) -> Result<Option<UserRow>> {
-        match self {
-            Self::Postgres(db) => db.get_user(id).await,
-            Self::InMemory(db) => db.get_user(id).await,
-        }
+        dispatch!(self, get_user, id)
     }
 
     pub async fn get_user_by_oauth(
@@ -77,24 +88,15 @@ impl StorageBackend {
         provider: &str,
         provider_id: &str,
     ) -> Result<Option<UserRow>> {
-        match self {
-            Self::Postgres(db) => db.get_user_by_oauth(provider, provider_id).await,
-            Self::InMemory(db) => db.get_user_by_oauth(provider, provider_id).await,
-        }
+        dispatch!(self, get_user_by_oauth, provider, provider_id)
     }
 
     pub async fn update_user(&self, id: Uuid, input: UpdateUser) -> Result<Option<UserRow>> {
-        match self {
-            Self::Postgres(db) => db.update_user(id, input).await,
-            Self::InMemory(db) => db.update_user(id, input).await,
-        }
+        dispatch!(self, update_user, id, input)
     }
 
     pub async fn list_users(&self, search: Option<&str>) -> Result<Vec<UserRow>> {
-        match self {
-            Self::Postgres(db) => db.list_users(search).await,
-            Self::InMemory(db) => db.list_users(search).await,
-        }
+        dispatch!(self, list_users, search)
     }
 
     // ============================================
@@ -102,38 +104,23 @@ impl StorageBackend {
     // ============================================
 
     pub async fn create_api_key(&self, input: CreateApiKeyRow) -> Result<ApiKeyRow> {
-        match self {
-            Self::Postgres(db) => db.create_api_key(input).await,
-            Self::InMemory(db) => db.create_api_key(input).await,
-        }
+        dispatch!(self, create_api_key, input)
     }
 
     pub async fn get_api_key_by_hash(&self, key_hash: &str) -> Result<Option<ApiKeyRow>> {
-        match self {
-            Self::Postgres(db) => db.get_api_key_by_hash(key_hash).await,
-            Self::InMemory(db) => db.get_api_key_by_hash(key_hash).await,
-        }
+        dispatch!(self, get_api_key_by_hash, key_hash)
     }
 
     pub async fn list_api_keys_for_user(&self, user_id: Uuid) -> Result<Vec<ApiKeyRow>> {
-        match self {
-            Self::Postgres(db) => db.list_api_keys_for_user(user_id).await,
-            Self::InMemory(db) => db.list_api_keys_for_user(user_id).await,
-        }
+        dispatch!(self, list_api_keys_for_user, user_id)
     }
 
     pub async fn update_api_key_last_used(&self, id: Uuid) -> Result<()> {
-        match self {
-            Self::Postgres(db) => db.update_api_key_last_used(id).await,
-            Self::InMemory(db) => db.update_api_key_last_used(id).await,
-        }
+        dispatch!(self, update_api_key_last_used, id)
     }
 
     pub async fn delete_api_key(&self, id: Uuid, user_id: Uuid) -> Result<bool> {
-        match self {
-            Self::Postgres(db) => db.delete_api_key(id, user_id).await,
-            Self::InMemory(db) => db.delete_api_key(id, user_id).await,
-        }
+        dispatch!(self, delete_api_key, id, user_id)
     }
 
     // ============================================
@@ -144,41 +131,26 @@ impl StorageBackend {
         &self,
         input: CreateRefreshTokenRow,
     ) -> Result<RefreshTokenRow> {
-        match self {
-            Self::Postgres(db) => db.create_refresh_token(input).await,
-            Self::InMemory(db) => db.create_refresh_token(input).await,
-        }
+        dispatch!(self, create_refresh_token, input)
     }
 
     pub async fn get_refresh_token_by_hash(
         &self,
         token_hash: &str,
     ) -> Result<Option<RefreshTokenRow>> {
-        match self {
-            Self::Postgres(db) => db.get_refresh_token_by_hash(token_hash).await,
-            Self::InMemory(db) => db.get_refresh_token_by_hash(token_hash).await,
-        }
+        dispatch!(self, get_refresh_token_by_hash, token_hash)
     }
 
     pub async fn delete_refresh_token(&self, id: Uuid) -> Result<bool> {
-        match self {
-            Self::Postgres(db) => db.delete_refresh_token(id).await,
-            Self::InMemory(db) => db.delete_refresh_token(id).await,
-        }
+        dispatch!(self, delete_refresh_token, id)
     }
 
     pub async fn delete_expired_refresh_tokens(&self) -> Result<u64> {
-        match self {
-            Self::Postgres(db) => db.delete_expired_refresh_tokens().await,
-            Self::InMemory(db) => db.delete_expired_refresh_tokens().await,
-        }
+        dispatch!(self, delete_expired_refresh_tokens)
     }
 
     pub async fn delete_user_refresh_tokens(&self, user_id: Uuid) -> Result<u64> {
-        match self {
-            Self::Postgres(db) => db.delete_user_refresh_tokens(user_id).await,
-            Self::InMemory(db) => db.delete_user_refresh_tokens(user_id).await,
-        }
+        dispatch!(self, delete_user_refresh_tokens, user_id)
     }
 
     // ============================================
@@ -186,10 +158,7 @@ impl StorageBackend {
     // ============================================
 
     pub async fn create_agent(&self, input: CreateAgentRow) -> Result<AgentRow> {
-        match self {
-            Self::Postgres(db) => db.create_agent(input).await,
-            Self::InMemory(db) => db.create_agent(input).await,
-        }
+        dispatch!(self, create_agent, input)
     }
 
     pub async fn create_agent_with_id(
@@ -197,45 +166,27 @@ impl StorageBackend {
         id: Uuid,
         input: CreateAgentRow,
     ) -> Result<Option<AgentRow>> {
-        match self {
-            Self::Postgres(db) => db.create_agent_with_id(id, input).await,
-            Self::InMemory(db) => db.create_agent_with_id(id, input).await,
-        }
+        dispatch!(self, create_agent_with_id, id, input)
     }
 
     pub async fn get_agent(&self, id: Uuid) -> Result<Option<AgentRow>> {
-        match self {
-            Self::Postgres(db) => db.get_agent(id).await,
-            Self::InMemory(db) => db.get_agent(id).await,
-        }
+        dispatch!(self, get_agent, id)
     }
 
     pub async fn list_agents(&self) -> Result<Vec<AgentRow>> {
-        match self {
-            Self::Postgres(db) => db.list_agents().await,
-            Self::InMemory(db) => db.list_agents().await,
-        }
+        dispatch!(self, list_agents)
     }
 
     pub async fn get_agent_by_name(&self, name: &str) -> Result<Option<AgentRow>> {
-        match self {
-            Self::Postgres(db) => db.get_agent_by_name(name).await,
-            Self::InMemory(db) => db.get_agent_by_name(name).await,
-        }
+        dispatch!(self, get_agent_by_name, name)
     }
 
     pub async fn update_agent(&self, id: Uuid, input: UpdateAgent) -> Result<Option<AgentRow>> {
-        match self {
-            Self::Postgres(db) => db.update_agent(id, input).await,
-            Self::InMemory(db) => db.update_agent(id, input).await,
-        }
+        dispatch!(self, update_agent, id, input)
     }
 
     pub async fn delete_agent(&self, id: Uuid) -> Result<bool> {
-        match self {
-            Self::Postgres(db) => db.delete_agent(id).await,
-            Self::InMemory(db) => db.delete_agent(id).await,
-        }
+        dispatch!(self, delete_agent, id)
     }
 
     // ============================================
@@ -243,24 +194,15 @@ impl StorageBackend {
     // ============================================
 
     pub async fn create_session(&self, input: CreateSessionRow) -> Result<SessionRow> {
-        match self {
-            Self::Postgres(db) => db.create_session(input).await,
-            Self::InMemory(db) => db.create_session(input).await,
-        }
+        dispatch!(self, create_session, input)
     }
 
     pub async fn get_session(&self, id: Uuid) -> Result<Option<SessionRow>> {
-        match self {
-            Self::Postgres(db) => db.get_session(id).await,
-            Self::InMemory(db) => db.get_session(id).await,
-        }
+        dispatch!(self, get_session, id)
     }
 
     pub async fn list_sessions(&self, agent_id: Uuid) -> Result<Vec<SessionRow>> {
-        match self {
-            Self::Postgres(db) => db.list_sessions(agent_id).await,
-            Self::InMemory(db) => db.list_sessions(agent_id).await,
-        }
+        dispatch!(self, list_sessions, agent_id)
     }
 
     pub async fn update_session(
@@ -268,17 +210,11 @@ impl StorageBackend {
         id: Uuid,
         input: UpdateSession,
     ) -> Result<Option<SessionRow>> {
-        match self {
-            Self::Postgres(db) => db.update_session(id, input).await,
-            Self::InMemory(db) => db.update_session(id, input).await,
-        }
+        dispatch!(self, update_session, id, input)
     }
 
     pub async fn delete_session(&self, id: Uuid) -> Result<bool> {
-        match self {
-            Self::Postgres(db) => db.delete_session(id).await,
-            Self::InMemory(db) => db.delete_session(id).await,
-        }
+        dispatch!(self, delete_session, id)
     }
 
     // ============================================
@@ -286,10 +222,7 @@ impl StorageBackend {
     // ============================================
 
     pub async fn create_event(&self, input: CreateEventRow) -> Result<EventRow> {
-        match self {
-            Self::Postgres(db) => db.create_event(input).await,
-            Self::InMemory(db) => db.create_event(input).await,
-        }
+        dispatch!(self, create_event, input)
     }
 
     pub async fn list_events(
@@ -298,17 +231,11 @@ impl StorageBackend {
         since_sequence: Option<i32>,
         since_id: Option<Uuid>,
     ) -> Result<Vec<EventRow>> {
-        match self {
-            Self::Postgres(db) => db.list_events(session_id, since_sequence, since_id).await,
-            Self::InMemory(db) => db.list_events(session_id, since_sequence, since_id).await,
-        }
+        dispatch!(self, list_events, session_id, since_sequence, since_id)
     }
 
     pub async fn list_message_events(&self, session_id: Uuid) -> Result<Vec<EventRow>> {
-        match self {
-            Self::Postgres(db) => db.list_message_events(session_id).await,
-            Self::InMemory(db) => db.list_message_events(session_id).await,
-        }
+        dispatch!(self, list_message_events, session_id)
     }
 
     // ============================================
@@ -316,10 +243,7 @@ impl StorageBackend {
     // ============================================
 
     pub async fn create_llm_provider(&self, input: CreateLlmProviderRow) -> Result<LlmProviderRow> {
-        match self {
-            Self::Postgres(db) => db.create_llm_provider(input).await,
-            Self::InMemory(db) => db.create_llm_provider(input).await,
-        }
+        dispatch!(self, create_llm_provider, input)
     }
 
     /// Create a provider with a specific ID (for seeding)
@@ -329,24 +253,15 @@ impl StorageBackend {
         id: Uuid,
         input: CreateLlmProviderRow,
     ) -> Result<Option<LlmProviderRow>> {
-        match self {
-            Self::Postgres(db) => db.create_llm_provider_with_id(id, input).await,
-            Self::InMemory(db) => db.create_llm_provider_with_id(id, input).await,
-        }
+        dispatch!(self, create_llm_provider_with_id, id, input)
     }
 
     pub async fn get_llm_provider(&self, id: Uuid) -> Result<Option<LlmProviderRow>> {
-        match self {
-            Self::Postgres(db) => db.get_llm_provider(id).await,
-            Self::InMemory(db) => db.get_llm_provider(id).await,
-        }
+        dispatch!(self, get_llm_provider, id)
     }
 
     pub async fn list_llm_providers(&self) -> Result<Vec<LlmProviderRow>> {
-        match self {
-            Self::Postgres(db) => db.list_llm_providers().await,
-            Self::InMemory(db) => db.list_llm_providers().await,
-        }
+        dispatch!(self, list_llm_providers)
     }
 
     pub async fn update_llm_provider(
@@ -354,20 +269,15 @@ impl StorageBackend {
         id: Uuid,
         input: UpdateLlmProvider,
     ) -> Result<Option<LlmProviderRow>> {
-        match self {
-            Self::Postgres(db) => db.update_llm_provider(id, input).await,
-            Self::InMemory(db) => db.update_llm_provider(id, input).await,
-        }
+        dispatch!(self, update_llm_provider, id, input)
     }
 
     pub async fn delete_llm_provider(&self, id: Uuid) -> Result<bool> {
-        match self {
-            Self::Postgres(db) => db.delete_llm_provider(id).await,
-            Self::InMemory(db) => db.delete_llm_provider(id).await,
-        }
+        dispatch!(self, delete_llm_provider, id)
     }
 
     /// Get a provider with its decrypted API key
+    /// Note: This is not async, so cannot use dispatch! macro
     pub fn get_provider_with_api_key(
         &self,
         provider: &LlmProviderRow,
@@ -384,24 +294,15 @@ impl StorageBackend {
     // ============================================
 
     pub async fn get_default_llm_model(&self) -> Result<Option<LlmModelWithProviderRow>> {
-        match self {
-            Self::Postgres(db) => db.get_default_llm_model().await,
-            Self::InMemory(db) => db.get_default_llm_model().await,
-        }
+        dispatch!(self, get_default_llm_model)
     }
 
     pub async fn clear_all_model_defaults(&self) -> Result<()> {
-        match self {
-            Self::Postgres(db) => db.clear_all_model_defaults().await,
-            Self::InMemory(db) => db.clear_all_model_defaults().await,
-        }
+        dispatch!(self, clear_all_model_defaults)
     }
 
     pub async fn create_llm_model(&self, input: CreateLlmModelRow) -> Result<LlmModelRow> {
-        match self {
-            Self::Postgres(db) => db.create_llm_model(input).await,
-            Self::InMemory(db) => db.create_llm_model(input).await,
-        }
+        dispatch!(self, create_llm_model, input)
     }
 
     /// Create a model with a specific ID (for seeding)
@@ -411,44 +312,29 @@ impl StorageBackend {
         id: Uuid,
         input: CreateLlmModelRow,
     ) -> Result<Option<LlmModelRow>> {
-        match self {
-            Self::Postgres(db) => db.create_llm_model_with_id(id, input).await,
-            Self::InMemory(db) => db.create_llm_model_with_id(id, input).await,
-        }
+        dispatch!(self, create_llm_model_with_id, id, input)
     }
 
     pub async fn get_llm_model(&self, id: Uuid) -> Result<Option<LlmModelRow>> {
-        match self {
-            Self::Postgres(db) => db.get_llm_model(id).await,
-            Self::InMemory(db) => db.get_llm_model(id).await,
-        }
+        dispatch!(self, get_llm_model, id)
     }
 
     pub async fn get_llm_model_with_provider(
         &self,
         id: Uuid,
     ) -> Result<Option<LlmModelWithProviderRow>> {
-        match self {
-            Self::Postgres(db) => db.get_llm_model_with_provider(id).await,
-            Self::InMemory(db) => db.get_llm_model_with_provider(id).await,
-        }
+        dispatch!(self, get_llm_model_with_provider, id)
     }
 
     pub async fn list_llm_models_for_provider(
         &self,
         provider_id: Uuid,
     ) -> Result<Vec<LlmModelRow>> {
-        match self {
-            Self::Postgres(db) => db.list_llm_models_for_provider(provider_id).await,
-            Self::InMemory(db) => db.list_llm_models_for_provider(provider_id).await,
-        }
+        dispatch!(self, list_llm_models_for_provider, provider_id)
     }
 
     pub async fn list_all_llm_models(&self) -> Result<Vec<LlmModelWithProviderRow>> {
-        match self {
-            Self::Postgres(db) => db.list_all_llm_models().await,
-            Self::InMemory(db) => db.list_all_llm_models().await,
-        }
+        dispatch!(self, list_all_llm_models)
     }
 
     pub async fn update_llm_model(
@@ -456,27 +342,18 @@ impl StorageBackend {
         id: Uuid,
         input: UpdateLlmModel,
     ) -> Result<Option<LlmModelRow>> {
-        match self {
-            Self::Postgres(db) => db.update_llm_model(id, input).await,
-            Self::InMemory(db) => db.update_llm_model(id, input).await,
-        }
+        dispatch!(self, update_llm_model, id, input)
     }
 
     pub async fn delete_llm_model(&self, id: Uuid) -> Result<bool> {
-        match self {
-            Self::Postgres(db) => db.delete_llm_model(id).await,
-            Self::InMemory(db) => db.delete_llm_model(id).await,
-        }
+        dispatch!(self, delete_llm_model, id)
     }
 
     pub async fn get_llm_model_by_model_id(
         &self,
         model_id: &str,
     ) -> Result<Option<LlmModelWithProviderRow>> {
-        match self {
-            Self::Postgres(db) => db.get_llm_model_by_model_id(model_id).await,
-            Self::InMemory(db) => db.get_llm_model_by_model_id(model_id).await,
-        }
+        dispatch!(self, get_llm_model_by_model_id, model_id)
     }
 
     // ============================================
@@ -484,10 +361,7 @@ impl StorageBackend {
     // ============================================
 
     pub async fn get_agent_capabilities(&self, agent_id: Uuid) -> Result<Vec<AgentCapabilityRow>> {
-        match self {
-            Self::Postgres(db) => db.get_agent_capabilities(agent_id).await,
-            Self::InMemory(db) => db.get_agent_capabilities(agent_id).await,
-        }
+        dispatch!(self, get_agent_capabilities, agent_id)
     }
 
     pub async fn set_agent_capabilities(
@@ -495,20 +369,14 @@ impl StorageBackend {
         agent_id: Uuid,
         capabilities: Vec<(String, i32)>,
     ) -> Result<Vec<AgentCapabilityRow>> {
-        match self {
-            Self::Postgres(db) => db.set_agent_capabilities(agent_id, capabilities).await,
-            Self::InMemory(db) => db.set_agent_capabilities(agent_id, capabilities).await,
-        }
+        dispatch!(self, set_agent_capabilities, agent_id, capabilities)
     }
 
     pub async fn add_agent_capability(
         &self,
         input: CreateAgentCapabilityRow,
     ) -> Result<AgentCapabilityRow> {
-        match self {
-            Self::Postgres(db) => db.add_agent_capability(input).await,
-            Self::InMemory(db) => db.add_agent_capability(input).await,
-        }
+        dispatch!(self, add_agent_capability, input)
     }
 
     pub async fn remove_agent_capability(
@@ -516,10 +384,7 @@ impl StorageBackend {
         agent_id: Uuid,
         capability_id: &str,
     ) -> Result<bool> {
-        match self {
-            Self::Postgres(db) => db.remove_agent_capability(agent_id, capability_id).await,
-            Self::InMemory(db) => db.remove_agent_capability(agent_id, capability_id).await,
-        }
+        dispatch!(self, remove_agent_capability, agent_id, capability_id)
     }
 
     // ============================================
@@ -527,10 +392,7 @@ impl StorageBackend {
     // ============================================
 
     pub async fn create_session_file(&self, input: CreateSessionFileRow) -> Result<SessionFileRow> {
-        match self {
-            Self::Postgres(db) => db.create_session_file(input).await,
-            Self::InMemory(db) => db.create_session_file(input).await,
-        }
+        dispatch!(self, create_session_file, input)
     }
 
     pub async fn get_session_file(
@@ -538,17 +400,11 @@ impl StorageBackend {
         session_id: Uuid,
         path: &str,
     ) -> Result<Option<SessionFileRow>> {
-        match self {
-            Self::Postgres(db) => db.get_session_file(session_id, path).await,
-            Self::InMemory(db) => db.get_session_file(session_id, path).await,
-        }
+        dispatch!(self, get_session_file, session_id, path)
     }
 
     pub async fn get_session_file_by_id(&self, id: Uuid) -> Result<Option<SessionFileRow>> {
-        match self {
-            Self::Postgres(db) => db.get_session_file_by_id(id).await,
-            Self::InMemory(db) => db.get_session_file_by_id(id).await,
-        }
+        dispatch!(self, get_session_file_by_id, id)
     }
 
     pub async fn list_session_files(
@@ -556,20 +412,14 @@ impl StorageBackend {
         session_id: Uuid,
         parent_path: &str,
     ) -> Result<Vec<SessionFileInfoRow>> {
-        match self {
-            Self::Postgres(db) => db.list_session_files(session_id, parent_path).await,
-            Self::InMemory(db) => db.list_session_files(session_id, parent_path).await,
-        }
+        dispatch!(self, list_session_files, session_id, parent_path)
     }
 
     pub async fn list_all_session_files(
         &self,
         session_id: Uuid,
     ) -> Result<Vec<SessionFileInfoRow>> {
-        match self {
-            Self::Postgres(db) => db.list_all_session_files(session_id).await,
-            Self::InMemory(db) => db.list_all_session_files(session_id).await,
-        }
+        dispatch!(self, list_all_session_files, session_id)
     }
 
     pub async fn update_session_file(
@@ -578,24 +428,15 @@ impl StorageBackend {
         path: &str,
         input: UpdateSessionFile,
     ) -> Result<Option<SessionFileRow>> {
-        match self {
-            Self::Postgres(db) => db.update_session_file(session_id, path, input).await,
-            Self::InMemory(db) => db.update_session_file(session_id, path, input).await,
-        }
+        dispatch!(self, update_session_file, session_id, path, input)
     }
 
     pub async fn delete_session_file(&self, session_id: Uuid, path: &str) -> Result<bool> {
-        match self {
-            Self::Postgres(db) => db.delete_session_file(session_id, path).await,
-            Self::InMemory(db) => db.delete_session_file(session_id, path).await,
-        }
+        dispatch!(self, delete_session_file, session_id, path)
     }
 
     pub async fn delete_session_file_recursive(&self, session_id: Uuid, path: &str) -> Result<u64> {
-        match self {
-            Self::Postgres(db) => db.delete_session_file_recursive(session_id, path).await,
-            Self::InMemory(db) => db.delete_session_file_recursive(session_id, path).await,
-        }
+        dispatch!(self, delete_session_file_recursive, session_id, path)
     }
 
     pub async fn move_session_file(
@@ -604,16 +445,7 @@ impl StorageBackend {
         source_path: &str,
         dest_path: &str,
     ) -> Result<Option<SessionFileRow>> {
-        match self {
-            Self::Postgres(db) => {
-                db.move_session_file(session_id, source_path, dest_path)
-                    .await
-            }
-            Self::InMemory(db) => {
-                db.move_session_file(session_id, source_path, dest_path)
-                    .await
-            }
-        }
+        dispatch!(self, move_session_file, session_id, source_path, dest_path)
     }
 
     pub async fn copy_session_file(
@@ -622,16 +454,7 @@ impl StorageBackend {
         source_path: &str,
         dest_path: &str,
     ) -> Result<Option<SessionFileRow>> {
-        match self {
-            Self::Postgres(db) => {
-                db.copy_session_file(session_id, source_path, dest_path)
-                    .await
-            }
-            Self::InMemory(db) => {
-                db.copy_session_file(session_id, source_path, dest_path)
-                    .await
-            }
-        }
+        dispatch!(self, copy_session_file, session_id, source_path, dest_path)
     }
 
     pub async fn grep_session_files(
@@ -640,23 +463,11 @@ impl StorageBackend {
         pattern: &str,
         path_prefix: Option<&str>,
     ) -> Result<Vec<SessionFileInfoRow>> {
-        match self {
-            Self::Postgres(db) => {
-                db.grep_session_files(session_id, pattern, path_prefix)
-                    .await
-            }
-            Self::InMemory(db) => {
-                db.grep_session_files(session_id, pattern, path_prefix)
-                    .await
-            }
-        }
+        dispatch!(self, grep_session_files, session_id, pattern, path_prefix)
     }
 
     pub async fn session_file_exists(&self, session_id: Uuid, path: &str) -> Result<bool> {
-        match self {
-            Self::Postgres(db) => db.session_file_exists(session_id, path).await,
-            Self::InMemory(db) => db.session_file_exists(session_id, path).await,
-        }
+        dispatch!(self, session_file_exists, session_id, path)
     }
 
     pub async fn session_directory_has_children(
@@ -664,9 +475,6 @@ impl StorageBackend {
         session_id: Uuid,
         path: &str,
     ) -> Result<bool> {
-        match self {
-            Self::Postgres(db) => db.session_directory_has_children(session_id, path).await,
-            Self::InMemory(db) => db.session_directory_has_children(session_id, path).await,
-        }
+        dispatch!(self, session_directory_has_children, session_id, path)
     }
 }

--- a/crates/core/src/openai_protocol.rs
+++ b/crates/core/src/openai_protocol.rs
@@ -161,21 +161,13 @@ impl OpenAIProtocolLlmDriver {
     fn convert_tools(tools: &[ToolDefinition]) -> Vec<OpenAiTool> {
         tools
             .iter()
-            .map(|tool| {
-                let (name, description, parameters) = match tool {
-                    ToolDefinition::Builtin(builtin) => {
-                        (&builtin.name, &builtin.description, &builtin.parameters)
-                    }
-                };
-
-                OpenAiTool {
-                    r#type: "function".to_string(),
-                    function: OpenAiFunction {
-                        name: name.clone(),
-                        description: description.clone(),
-                        parameters: parameters.clone(),
-                    },
-                }
+            .map(|tool| OpenAiTool {
+                r#type: "function".to_string(),
+                function: OpenAiFunction {
+                    name: tool.name().to_string(),
+                    description: tool.description().to_string(),
+                    parameters: tool.parameters().clone(),
+                },
             })
             .collect()
     }


### PR DESCRIPTION
## What

Simplify convert_tools in OpenAI and Anthropic LLM drivers using ToolDefinition accessor methods.

## Why

Both drivers used pattern matching to extract ToolDefinition fields instead of using the new accessor methods from PR #222.

## How

- Replace pattern matching with tool.name(), tool.description(), tool.parameters()
- Reduces code duplication between drivers

## Risk

- Low
- Output is identical, just cleaner access pattern

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered