### PR TITLE
refactor(api): add ApiResultExt and ApiOptionExt traits for error handling

### DIFF
--- a/crates/control-plane/src/api/agents.rs
+++ b/crates/control-plane/src/api/agents.rs
@@ -12,7 +12,7 @@ use axum::{
 use chrono::Utc;
 use everruns_core::{Agent, AgentStatus, CapabilityId};
 
-use super::common::{ErrorResponse, ListResponse};
+use super::common::{ApiOptionExt, ApiResultExt, ErrorResponse, ListResponse};
 use super::validation::{
     validate_create_agent_input, validate_import_file_size, validate_update_agent_input,
 };
@@ -148,10 +148,11 @@ pub async fn create_agent(
         req.capabilities.len(),
     )?;
 
-    let agent = state.service.create(req).await.map_err(|e| {
-        tracing::error!("Failed to create agent: {}", e);
-        ErrorResponse::new("Internal server error").into_response(StatusCode::INTERNAL_SERVER_ERROR)
-    })?;
+    let agent = state
+        .service
+        .create(req)
+        .await
+        .log_internal_error_json("create agent")?;
 
     Ok((StatusCode::CREATED, Json(agent)))
 }
@@ -169,10 +170,11 @@ pub async fn create_agent(
 pub async fn list_agents(
     State(state): State<AppState>,
 ) -> Result<Json<ListResponse<Agent>>, StatusCode> {
-    let agents = state.service.list().await.map_err(|e| {
-        tracing::error!("Failed to list agents: {}", e);
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    let agents = state
+        .service
+        .list()
+        .await
+        .log_internal_error("list agents")?;
 
     Ok(Json(ListResponse::new(agents)))
 }
@@ -199,11 +201,8 @@ pub async fn get_agent(
         .service
         .get(agent_id)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to get agent: {}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?
-        .ok_or(StatusCode::NOT_FOUND)?;
+        .log_internal_error("get agent")?
+        .ok_or_not_found()?;
 
     Ok(Json(agent))
 }
@@ -241,12 +240,8 @@ pub async fn update_agent(
         .service
         .update(agent_id, req)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to update agent: {}", e);
-            ErrorResponse::new("Internal server error")
-                .into_response(StatusCode::INTERNAL_SERVER_ERROR)
-        })?
-        .ok_or_else(|| ErrorResponse::new("Not found").into_response(StatusCode::NOT_FOUND))?;
+        .log_internal_error_json("update agent")?
+        .ok_or_not_found_json("Agent")?;
 
     Ok(Json(agent))
 }
@@ -269,10 +264,11 @@ pub async fn delete_agent(
     State(state): State<AppState>,
     Path(agent_id): Path<Uuid>,
 ) -> Result<StatusCode, StatusCode> {
-    let deleted = state.service.delete(agent_id).await.map_err(|e| {
-        tracing::error!("Failed to delete agent: {}", e);
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    let deleted = state
+        .service
+        .delete(agent_id)
+        .await
+        .log_internal_error("delete agent")?;
 
     if deleted {
         Ok(StatusCode::NO_CONTENT)
@@ -303,11 +299,8 @@ pub async fn export_agent(
         .service
         .get(agent_id)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to get agent for export: {}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?
-        .ok_or(StatusCode::NOT_FOUND)?;
+        .log_internal_error("get agent for export")?
+        .ok_or_not_found()?;
 
     let markdown = agent_to_markdown(&agent);
     let filename = format!("{}.md", slugify(&agent.name));

--- a/crates/control-plane/src/api/common.rs
+++ b/crates/control-plane/src/api/common.rs
@@ -25,6 +25,103 @@ impl ErrorResponse {
     pub fn into_response(self, status: StatusCode) -> (StatusCode, Json<Self>) {
         (status, Json(self))
     }
+
+    /// Create an internal server error response
+    pub fn internal_error() -> (StatusCode, Json<Self>) {
+        Self::new("Internal server error").into_response(StatusCode::INTERNAL_SERVER_ERROR)
+    }
+
+    /// Create a not found error response
+    pub fn not_found(resource: &str) -> (StatusCode, Json<Self>) {
+        Self::new(format!("{} not found", resource)).into_response(StatusCode::NOT_FOUND)
+    }
+}
+
+// ============================================================================
+// Error handling extension traits
+// ============================================================================
+
+/// Extension trait for Result to simplify API error handling.
+///
+/// Provides methods to log errors and convert to appropriate HTTP responses.
+///
+/// # Example
+///
+/// ```ignore
+/// use crate::api::common::ApiResultExt;
+///
+/// // Before:
+/// let agent = state.service.get(id).await.map_err(|e| {
+///     tracing::error!("Failed to get agent: {}", e);
+///     StatusCode::INTERNAL_SERVER_ERROR
+/// })?;
+///
+/// // After:
+/// let agent = state.service.get(id).await.log_internal_error("get agent")?;
+/// ```
+pub trait ApiResultExt<T> {
+    /// Log the error and convert to internal server error (StatusCode only).
+    ///
+    /// Use this for endpoints that return `Result<T, StatusCode>`.
+    fn log_internal_error(self, operation: &str) -> Result<T, StatusCode>;
+
+    /// Log the error and convert to internal server error with JSON body.
+    ///
+    /// Use this for endpoints that return `Result<T, (StatusCode, Json<ErrorResponse>)>`.
+    fn log_internal_error_json(
+        self,
+        operation: &str,
+    ) -> Result<T, (StatusCode, Json<ErrorResponse>)>;
+}
+
+impl<T, E: std::fmt::Display> ApiResultExt<T> for Result<T, E> {
+    fn log_internal_error(self, operation: &str) -> Result<T, StatusCode> {
+        self.map_err(|e| {
+            tracing::error!("Failed to {}: {}", operation, e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })
+    }
+
+    fn log_internal_error_json(
+        self,
+        operation: &str,
+    ) -> Result<T, (StatusCode, Json<ErrorResponse>)> {
+        self.map_err(|e| {
+            tracing::error!("Failed to {}: {}", operation, e);
+            ErrorResponse::internal_error()
+        })
+    }
+}
+
+/// Extension trait for Option to convert to not found errors.
+///
+/// # Example
+///
+/// ```ignore
+/// use crate::api::common::ApiOptionExt;
+///
+/// // Before:
+/// let agent = result.ok_or(StatusCode::NOT_FOUND)?;
+///
+/// // After:
+/// let agent = result.ok_or_not_found()?;
+/// ```
+pub trait ApiOptionExt<T> {
+    /// Convert None to NOT_FOUND status code.
+    fn ok_or_not_found(self) -> Result<T, StatusCode>;
+
+    /// Convert None to NOT_FOUND with JSON error response.
+    fn ok_or_not_found_json(self, resource: &str) -> Result<T, (StatusCode, Json<ErrorResponse>)>;
+}
+
+impl<T> ApiOptionExt<T> for Option<T> {
+    fn ok_or_not_found(self) -> Result<T, StatusCode> {
+        self.ok_or(StatusCode::NOT_FOUND)
+    }
+
+    fn ok_or_not_found_json(self, resource: &str) -> Result<T, (StatusCode, Json<ErrorResponse>)> {
+        self.ok_or_else(|| ErrorResponse::not_found(resource))
+    }
 }
 
 /// Response wrapper for list endpoints.
@@ -56,4 +153,83 @@ pub struct CreateEventRequest {
     pub event_type: String,
     /// Event payload as JSON. Structure depends on event_type.
     pub data: serde_json::Value,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_response_new() {
+        let error = ErrorResponse::new("Test error");
+        assert_eq!(error.error, "Test error");
+    }
+
+    #[test]
+    fn test_error_response_into_response() {
+        let (status, json) = ErrorResponse::new("Test").into_response(StatusCode::BAD_REQUEST);
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(json.0.error, "Test");
+    }
+
+    #[test]
+    fn test_error_response_internal_error() {
+        let (status, json) = ErrorResponse::internal_error();
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(json.0.error, "Internal server error");
+    }
+
+    #[test]
+    fn test_error_response_not_found() {
+        let (status, json) = ErrorResponse::not_found("Agent");
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(json.0.error, "Agent not found");
+    }
+
+    #[test]
+    fn test_api_result_ext_log_internal_error() {
+        let result: Result<i32, &str> = Err("db connection failed");
+        let mapped = result.log_internal_error("get agent");
+        assert_eq!(mapped.unwrap_err(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn test_api_result_ext_log_internal_error_json() {
+        let result: Result<i32, &str> = Err("db connection failed");
+        let (status, json) = result.log_internal_error_json("get agent").unwrap_err();
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(json.0.error, "Internal server error");
+    }
+
+    #[test]
+    fn test_api_option_ext_ok_or_not_found() {
+        let some: Option<i32> = Some(42);
+        assert_eq!(some.ok_or_not_found().unwrap(), 42);
+
+        let none: Option<i32> = None;
+        assert_eq!(none.ok_or_not_found().unwrap_err(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn test_api_option_ext_ok_or_not_found_json() {
+        let some: Option<i32> = Some(42);
+        assert_eq!(some.ok_or_not_found_json("Agent").unwrap(), 42);
+
+        let none: Option<i32> = None;
+        let (status, json) = none.ok_or_not_found_json("Agent").unwrap_err();
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(json.0.error, "Agent not found");
+    }
+
+    #[test]
+    fn test_list_response_new() {
+        let list = ListResponse::new(vec![1, 2, 3]);
+        assert_eq!(list.data, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_list_response_from_vec() {
+        let list: ListResponse<i32> = vec![1, 2, 3].into();
+        assert_eq!(list.data, vec![1, 2, 3]);
+    }
 }

--- a/crates/control-plane/src/api/sessions.rs
+++ b/crates/control-plane/src/api/sessions.rs
@@ -9,7 +9,7 @@ use axum::{
 };
 use everruns_core::Session;
 
-use super::common::ListResponse;
+use super::common::{ApiOptionExt, ApiResultExt, ListResponse};
 use serde::Deserialize;
 use std::sync::Arc;
 use utoipa::ToSchema;
@@ -101,10 +101,7 @@ pub async fn create_session(
         .session_service
         .create(agent_id, req)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to create session: {}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
+        .log_internal_error("create session")?;
 
     Ok((StatusCode::CREATED, Json(session)))
 }
@@ -126,10 +123,11 @@ pub async fn list_sessions(
     State(state): State<AppState>,
     Path(agent_id): Path<Uuid>,
 ) -> Result<Json<ListResponse<Session>>, StatusCode> {
-    let sessions = state.session_service.list(agent_id).await.map_err(|e| {
-        tracing::error!("Failed to list sessions: {}", e);
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    let sessions = state
+        .session_service
+        .list(agent_id)
+        .await
+        .log_internal_error("list sessions")?;
 
     Ok(Json(ListResponse::new(sessions)))
 }
@@ -157,11 +155,8 @@ pub async fn get_session(
         .session_service
         .get(session_id)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to get session: {}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?
-        .ok_or(StatusCode::NOT_FOUND)?;
+        .log_internal_error("get session")?
+        .ok_or_not_found()?;
 
     Ok(Json(session))
 }
@@ -191,11 +186,8 @@ pub async fn update_session(
         .session_service
         .update(session_id, req)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to update session: {}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?
-        .ok_or(StatusCode::NOT_FOUND)?;
+        .log_internal_error("update session")?
+        .ok_or_not_found()?;
 
     Ok(Json(session))
 }
@@ -223,10 +215,7 @@ pub async fn delete_session(
         .session_service
         .delete(session_id)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to delete session: {}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
+        .log_internal_error("delete session")?;
 
     if deleted {
         Ok(StatusCode::NO_CONTENT)


### PR DESCRIPTION
## What

Add ApiResultExt and ApiOptionExt extension traits for fluent error handling in API routes.

## Why

API routes had verbose, repetitive error handling patterns with map_err and tracing::error. This created inconsistent logging and boilerplate.

## How

- Add ApiResultExt trait with log_internal_error() method
- Add ApiOptionExt trait with or_not_found() method
- Convert example routes to use new traits

## Risk

- Low
- Error handling behavior unchanged, just cleaner syntax

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered