### PR TITLE
fix(dev.sh): restore terminal settings in signal handler

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -304,6 +304,8 @@ case "$command" in
 
     # Cleanup function to kill child processes on exit
     cleanup() {
+      # Restore terminal settings first (child processes may have modified them)
+      stty sane 2>/dev/null || true
       echo ""
       echo "🛑 Stopping services..."
       for pid in "${CHILD_PIDS[@]}"; do
@@ -314,6 +316,8 @@ case "$command" in
       pkill -f "cargo-watch" 2>/dev/null || true
       pkill -f "everruns-control-plane" 2>/dev/null || true
       pkill -f "next dev" 2>/dev/null || true
+      # Restore terminal settings again after killing processes
+      stty sane 2>/dev/null || true
       echo "✅ Services stopped"
       exit 0
     }
@@ -408,6 +412,8 @@ case "$command" in
 
     # Cleanup function to kill child processes on exit
     cleanup() {
+      # Restore terminal settings first (child processes may have modified them)
+      stty sane 2>/dev/null || true
       echo ""
       echo "🛑 Stopping services..."
       for pid in "${CHILD_PIDS[@]}"; do
@@ -420,6 +426,8 @@ case "$command" in
       pkill -f "everruns-control-plane" 2>/dev/null || true
       pkill -f "everruns-worker" 2>/dev/null || true
       pkill -f "next dev" 2>/dev/null || true
+      # Restore terminal settings again after killing processes
+      stty sane 2>/dev/null || true
       echo "✅ Services stopped (Docker still running if started)"
       exit 0
     }


### PR DESCRIPTION
## What
Add `stty sane` calls to cleanup functions in `start-dev` and `start-all` commands.

## Why
Child processes (`cargo-watch`, `next dev`) modify terminal settings (raw mode for progress spinners, etc.). When interrupted with Ctrl+C, these settings weren't being restored, causing garbled input until a second Ctrl+C.

## How
Call `stty sane` twice in cleanup:
1. At the start - restore before any output
2. After killing processes - in case dying processes corrupt settings

## Risk
- Low
- No functional change, only terminal settings restoration

## Checklist
- [x] Tested locally - terminal settings properly restored after Ctrl+C
- [x] Backward compatibility - `stty sane` fails silently if unavailable