### PR TITLE
fix(ui): apply dotted background pattern to main content areas

### DIFF
--- a/apps/ui/src/app/(auth)/layout.tsx
+++ b/apps/ui/src/app/(auth)/layout.tsx
@@ -5,7 +5,7 @@ export default function AuthLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background p-4">
+    <div className="min-h-screen flex items-center justify-center bg-background bg-brand-dots p-4">
       {children}
     </div>
   );

--- a/apps/ui/src/app/(main)/layout.tsx
+++ b/apps/ui/src/app/(main)/layout.tsx
@@ -39,7 +39,7 @@ export default function MainLayout({ children }: MainLayoutProps) {
   return (
     <div className="flex h-screen">
       <Sidebar />
-      <main className="flex-1 overflow-auto bg-background">{children}</main>
+      <main className="flex-1 overflow-auto bg-background bg-brand-dots">{children}</main>
     </div>
   );
 }


### PR DESCRIPTION
## What

Apply the branded dotted background pattern (defined in `specs/brand.md`) to all main content areas in the UI.

## Why

The `bg-brand-dots` CSS class was defined in `globals.css` and applied to `<body>`, but the main layout containers had solid `bg-background` that completely covered the dots.

## How

Added `bg-brand-dots` class to:
- `apps/ui/src/app/(main)/layout.tsx` - main app layout
- `apps/ui/src/app/(auth)/layout.tsx` - auth pages layout

## Risk

- Low
- Visual change only, no functionality affected

## Checklist

- [x] Follows brand spec (`specs/brand.md`)
- [x] Works in both light mode (navy dots at 8% opacity)
- [ ] Dark mode (gold dots at 10% opacity) - not tested but CSS is correct