### PR TITLE
feat(ui): add centralized capability icons

### DIFF
--- a/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
@@ -30,25 +30,12 @@ import {
   ArrowLeft,
   Save,
   Trash2,
-  CircleOff,
-  Clock,
-  Search,
-  Box,
-  Folder,
   ChevronUp,
   ChevronDown,
-  LucideIcon,
 } from "lucide-react";
 import type { Capability, CapabilityId } from "@/lib/api/types";
 import { ProviderIcon } from "@/components/providers/provider-icon";
-
-const iconMap: Record<string, LucideIcon> = {
-  "circle-off": CircleOff,
-  clock: Clock,
-  search: Search,
-  box: Box,
-  folder: Folder,
-};
+import { getCapabilityIcon } from "@/lib/capability-icons";
 
 interface FormData {
   name: string;
@@ -426,9 +413,7 @@ export default function EditAgentPage({
                     {selectedCapabilities.map((capId, index) => {
                       const cap = getCapabilityInfo(capId);
                       if (!cap) return null;
-                      const IconComponent = cap.icon
-                        ? iconMap[cap.icon] || CircleOff
-                        : CircleOff;
+                      const IconComponent = getCapabilityIcon(cap.icon);
 
                       return (
                         <div
@@ -483,9 +468,7 @@ export default function EditAgentPage({
                     {availableCapabilities
                       .filter((c) => !selectedCapabilities.includes(c.id))
                       .map((cap) => {
-                        const IconComponent = cap.icon
-                          ? iconMap[cap.icon] || CircleOff
-                          : CircleOff;
+                        const IconComponent = getCapabilityIcon(cap.icon);
 
                         return (
                           <div
@@ -518,9 +501,7 @@ export default function EditAgentPage({
                       Coming Soon
                     </p>
                     {comingSoonCapabilities.map((cap) => {
-                      const IconComponent = cap.icon
-                        ? iconMap[cap.icon] || CircleOff
-                        : CircleOff;
+                      const IconComponent = getCapabilityIcon(cap.icon);
 
                       return (
                         <div

--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -15,23 +15,10 @@ import {
   Plus,
   MessageSquare,
   Pencil,
-  CircleOff,
-  Clock,
-  Search,
-  Box,
-  Folder,
   Download,
-  LucideIcon,
 } from "lucide-react";
 import type { Capability, LlmModelWithProvider } from "@/lib/api/types";
-
-const iconMap: Record<string, LucideIcon> = {
-  "circle-off": CircleOff,
-  clock: Clock,
-  search: Search,
-  box: Box,
-  folder: Folder,
-};
+import { getCapabilityIcon } from "@/lib/capability-icons";
 
 export default function AgentDetailPage({
   params,
@@ -245,9 +232,7 @@ export default function AgentDetailPage({
                   {agentCapabilities.map((capId) => {
                     const cap = getCapabilityInfo(capId);
                     if (!cap) return null;
-                    const IconComponent = cap.icon
-                      ? iconMap[cap.icon] || CircleOff
-                      : CircleOff;
+                    const IconComponent = getCapabilityIcon(cap.icon);
 
                     return (
                       <div

--- a/apps/ui/src/app/(main)/capabilities/[capabilityId]/page.tsx
+++ b/apps/ui/src/app/(main)/capabilities/[capabilityId]/page.tsx
@@ -10,34 +10,12 @@ import { MarkdownDisplay } from "@/components/ui/prompt-editor";
 import {
   ArrowLeft,
   CircleOff,
-  Clock,
-  Search,
-  Box,
-  Folder,
-  Calculator,
-  Globe,
-  ListChecks,
-  LucideIcon,
   Wrench,
   FileText,
   Code,
-  HardDrive,
-  CloudSun,
 } from "lucide-react";
 import type { CapabilityStatus, ToolDefinition } from "@/lib/api/types";
-
-const iconMap: Record<string, LucideIcon> = {
-  "circle-off": CircleOff,
-  clock: Clock,
-  search: Search,
-  box: Box,
-  folder: Folder,
-  calculator: Calculator,
-  globe: Globe,
-  "list-checks": ListChecks,
-  "hard-drive": HardDrive,
-  "cloud-sun": CloudSun,
-};
+import { getCapabilityIcon } from "@/lib/capability-icons";
 
 function getStatusBadgeVariant(
   status: CapabilityStatus
@@ -137,9 +115,7 @@ export default function CapabilityDetailPage({
     );
   }
 
-  const IconComponent = capability.icon
-    ? iconMap[capability.icon] || CircleOff
-    : CircleOff;
+  const IconComponent = getCapabilityIcon(capability.icon);
 
   const toolDefinitions = capability.tool_definitions || [];
 

--- a/apps/ui/src/app/(main)/capabilities/page.tsx
+++ b/apps/ui/src/app/(main)/capabilities/page.tsx
@@ -9,33 +9,12 @@ import Link from "next/link";
 import {
   CircleOff,
   Clock,
-  Search,
-  Box,
-  Folder,
-  Calculator,
-  Globe,
-  ListChecks,
-  LucideIcon,
   CheckCircle2,
   AlertCircle,
   Info,
-  HardDrive,
-  CloudSun,
 } from "lucide-react";
 import type { Capability, CapabilityStatus } from "@/lib/api/types";
-
-const iconMap: Record<string, LucideIcon> = {
-  "circle-off": CircleOff,
-  clock: Clock,
-  search: Search,
-  box: Box,
-  folder: Folder,
-  calculator: Calculator,
-  globe: Globe,
-  "list-checks": ListChecks,
-  "hard-drive": HardDrive,
-  "cloud-sun": CloudSun,
-};
+import { getCapabilityIcon } from "@/lib/capability-icons";
 
 function getStatusBadgeVariant(
   status: CapabilityStatus
@@ -62,9 +41,7 @@ function getStatusLabel(status: CapabilityStatus): string {
 }
 
 function CapabilityCard({ capability }: { capability: Capability }) {
-  const IconComponent = capability.icon
-    ? iconMap[capability.icon] || CircleOff
-    : CircleOff;
+  const IconComponent = getCapabilityIcon(capability.icon);
 
   return (
     <Link href={`/capabilities/${capability.id}`}>

--- a/apps/ui/src/components/agents/agent-card.tsx
+++ b/apps/ui/src/components/agents/agent-card.tsx
@@ -10,24 +10,9 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import {
-  Pencil,
-  CircleOff,
-  Clock,
-  Search,
-  Box,
-  Folder,
-  LucideIcon,
-} from "lucide-react";
+import { Pencil } from "lucide-react";
 import type { Agent, Capability, CapabilityId } from "@/lib/api/types";
-
-const iconMap: Record<string, LucideIcon> = {
-  "circle-off": CircleOff,
-  clock: Clock,
-  search: Search,
-  box: Box,
-  folder: Folder,
-};
+import { getCapabilityIcon } from "@/lib/capability-icons";
 
 interface AgentCardProps {
   agent: Agent;
@@ -78,9 +63,7 @@ export function AgentCard({
               {agentCapabilities.map((capId) => {
                 const cap = getCapabilityInfo(capId);
                 if (!cap) return null;
-                const IconComponent = cap.icon
-                  ? iconMap[cap.icon] || CircleOff
-                  : CircleOff;
+                const IconComponent = getCapabilityIcon(cap.icon);
 
                 return (
                   <Tooltip key={capId}>

--- a/apps/ui/src/components/dashboard/agent-list-widget.tsx
+++ b/apps/ui/src/components/dashboard/agent-list-widget.tsx
@@ -10,25 +10,9 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import {
-  Boxes,
-  Plus,
-  CircleOff,
-  Clock,
-  Search,
-  Box,
-  Folder,
-  LucideIcon,
-} from "lucide-react";
+import { Boxes, Plus } from "lucide-react";
 import type { Agent, Capability, CapabilityId } from "@/lib/api/types";
-
-const iconMap: Record<string, LucideIcon> = {
-  "circle-off": CircleOff,
-  clock: Clock,
-  search: Search,
-  box: Box,
-  folder: Folder,
-};
+import { getCapabilityIcon } from "@/lib/capability-icons";
 
 interface AgentListWidgetProps {
   agents: Agent[];
@@ -91,9 +75,7 @@ export function AgentListWidget({
                               {agentCapabilities.slice(0, 3).map((capId) => {
                                 const cap = getCapabilityInfo(capId);
                                 if (!cap) return null;
-                                const IconComponent = cap.icon
-                                  ? iconMap[cap.icon] || CircleOff
-                                  : CircleOff;
+                                const IconComponent = getCapabilityIcon(cap.icon);
 
                                 return (
                                   <Tooltip key={capId}>

--- a/apps/ui/src/lib/capability-icons.ts
+++ b/apps/ui/src/lib/capability-icons.ts
@@ -1,0 +1,49 @@
+import {
+  CircleOff,
+  Clock,
+  Search,
+  Box,
+  Folder,
+  Calculator,
+  Globe,
+  ListChecks,
+  HardDrive,
+  CloudSun,
+  Cloud,
+  Users,
+  DollarSign,
+  Package,
+  type LucideIcon,
+} from "lucide-react";
+
+/**
+ * Centralized mapping of capability icon names to Lucide React components.
+ * Icon names are defined in the backend capability implementations.
+ */
+export const capabilityIconMap: Record<string, LucideIcon> = {
+  // Core capabilities
+  "circle-off": CircleOff,
+  clock: Clock,
+  search: Search,
+  box: Box,
+  folder: Folder,
+  calculator: Calculator,
+  globe: Globe,
+  "list-checks": ListChecks,
+  "hard-drive": HardDrive,
+  "cloud-sun": CloudSun,
+  // Additional capability icons
+  cloud: Cloud,
+  users: Users,
+  "dollar-sign": DollarSign,
+  package: Package,
+};
+
+/**
+ * Get the icon component for a capability.
+ * Falls back to CircleOff if the icon is not found.
+ */
+export function getCapabilityIcon(iconName?: string | null): LucideIcon {
+  if (!iconName) return CircleOff;
+  return capabilityIconMap[iconName] ?? CircleOff;
+}


### PR DESCRIPTION
## Summary
- Created a centralized icon utility (`apps/ui/src/lib/capability-icons.ts`) mapping capability icon names to Lucide React components
- Updated 6 UI components to use the centralized `getCapabilityIcon()` function
- Added support for additional icons: `cloud`, `users`, `dollar-sign`, `package`

## What
Before this change, each UI component had its own incomplete `iconMap` which caused capabilities to display the fallback `CircleOff` icon instead of their actual icons (Task Management, Web Fetch, File System).

Now all capabilities render their proper icons:
- Task Management → `list-checks`
- Web Fetch → `globe`
- File System → `hard-drive`
- And all other capabilities

## Why
Users reported capabilities showing generic "circle-off" icons instead of meaningful icons.

## How
- Created a single source of truth for capability icons in `@/lib/capability-icons`
- Replaced duplicated `iconMap` definitions with imports of `getCapabilityIcon()`
- Net reduction of 67 lines of code (removed 132 lines, added 65)

## Risk
- Low - UI-only change with no backend impact
- Build and lint pass locally

## Checklist
- [x] Tests pass (build verified)
- [x] Backward compatible (no API changes)