### PR TITLE
chore: upgrade to Rust edition 2024

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,7 +148,7 @@ These secrets are pre-configured in the environment and do not require manual se
 
 ### Rust conventions
 
-- Use stable Rust (edition 2021) and keep the toolchain pinned via `rust-toolchain.toml`.
+- Use stable Rust (edition 2024) and keep the toolchain pinned via `rust-toolchain.toml`.
 - Run `cargo fmt` and `cargo clippy -- -D warnings` for touched crates.
 - Prefer `axum`/`tower` for HTTP, `sqlx` for Postgres, `serde` for DTOs.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 
 [workspace.package]
 version = "0.3.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 authors = ["Everruns Contributors"]
 

--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -12,7 +12,7 @@ use eventsource_stream::Eventsource;
 use futures::StreamExt;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::sync::{Arc, Mutex};
 
 use everruns_core::error::{AgentLoopError, Result};
@@ -280,10 +280,9 @@ impl LlmDriver for AnthropicLlmDriver {
                                 // Parse message_start for input token count
                                 if let Ok(data) =
                                     serde_json::from_str::<AnthropicMessageStart>(&event.data)
+                                    && let Some(usage) = data.message.usage
                                 {
-                                    if let Some(usage) = data.message.usage {
-                                        *input_tokens.lock().unwrap() = usage.input_tokens;
-                                    }
+                                    *input_tokens.lock().unwrap() = usage.input_tokens;
                                 }
                                 Ok(LlmStreamEvent::TextDelta(String::new()))
                             }
@@ -291,17 +290,15 @@ impl LlmDriver for AnthropicLlmDriver {
                                 // Check if starting a tool use block
                                 if let Ok(data) =
                                     serde_json::from_str::<AnthropicContentBlockStart>(&event.data)
-                                {
-                                    if let AnthropicContentBlockDelta::ToolUse { id, name } =
+                                    && let AnthropicContentBlockDelta::ToolUse { id, name } =
                                         data.content_block
-                                    {
-                                        let mut current = current_tool_call.lock().unwrap();
-                                        *current = Some(ToolCall {
-                                            id,
-                                            name,
-                                            arguments: json!(""),
-                                        });
-                                    }
+                                {
+                                    let mut current = current_tool_call.lock().unwrap();
+                                    *current = Some(ToolCall {
+                                        id,
+                                        name,
+                                        arguments: json!(""),
+                                    });
                                 }
                                 Ok(LlmStreamEvent::TextDelta(String::new()))
                             }
@@ -353,13 +350,13 @@ impl LlmDriver for AnthropicLlmDriver {
                                         *output_tokens.lock().unwrap() = usage.output_tokens;
                                     }
 
-                                    if let Some(stop_reason) = data.delta.stop_reason {
-                                        if stop_reason == "tool_use" {
-                                            let tool_calls =
-                                                accumulated_tool_calls.lock().unwrap().clone();
-                                            if !tool_calls.is_empty() {
-                                                return Ok(LlmStreamEvent::ToolCalls(tool_calls));
-                                            }
+                                    if let Some(stop_reason) = data.delta.stop_reason
+                                        && stop_reason == "tool_use"
+                                    {
+                                        let tool_calls =
+                                            accumulated_tool_calls.lock().unwrap().clone();
+                                        if !tool_calls.is_empty() {
+                                            return Ok(LlmStreamEvent::ToolCalls(tool_calls));
                                         }
                                     }
                                 }

--- a/crates/anthropic/src/lib.rs
+++ b/crates/anthropic/src/lib.rs
@@ -13,7 +13,7 @@ mod driver;
 #[cfg(test)]
 mod tests;
 
-pub use driver::{register_driver, AnthropicLlmDriver};
+pub use driver::{AnthropicLlmDriver, register_driver};
 
 // Re-export core types for convenience
 pub use everruns_core::llm_driver_registry::{DriverRegistry, LlmDriver};

--- a/crates/anthropic/src/tests.rs
+++ b/crates/anthropic/src/tests.rs
@@ -1,6 +1,6 @@
 // Unit tests for Anthropic driver
 
-use crate::{register_driver, AnthropicLlmDriver, DriverRegistry};
+use crate::{AnthropicLlmDriver, DriverRegistry, register_driver};
 use everruns_core::llm_driver_registry::{ProviderConfig, ProviderType};
 
 #[test]

--- a/crates/cli/src/client.rs
+++ b/crates/cli/src/client.rs
@@ -1,7 +1,7 @@
 // HTTP client wrapper for Everruns API
 
 use reqwest::StatusCode;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/crates/cli/src/commands/agents.rs
+++ b/crates/cli/src/commands/agents.rs
@@ -1,7 +1,7 @@
 // Agent management commands
 
 use crate::client::{Client, ClientError};
-use crate::output::{print_field, print_table_header, print_table_row, OutputFormat};
+use crate::output::{OutputFormat, print_field, print_table_header, print_table_row};
 use anyhow::{Context, Result};
 use clap::Subcommand;
 use serde::{Deserialize, Serialize};

--- a/crates/cli/src/commands/capabilities.rs
+++ b/crates/cli/src/commands/capabilities.rs
@@ -1,7 +1,7 @@
 // Capabilities listing command
 
 use crate::client::Client;
-use crate::output::{print_table_header, print_table_row, OutputFormat};
+use crate::output::{OutputFormat, print_table_header, print_table_row};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 

--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -124,12 +124,12 @@ pub async fn run(
                         .data
                         .get("content")
                         .or_else(|| event.data.get("message").and_then(|m| m.get("content")));
-                    if let Some(content) = content {
-                        if let Some(parts) = content.as_array() {
-                            for part in parts {
-                                if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
-                                    agent_content.push_str(text);
-                                }
+                    if let Some(content) = content
+                        && let Some(parts) = content.as_array()
+                    {
+                        for part in parts {
+                            if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
+                                agent_content.push_str(text);
                             }
                         }
                     }

--- a/crates/cli/src/commands/sessions.rs
+++ b/crates/cli/src/commands/sessions.rs
@@ -1,7 +1,7 @@
 // Session management commands
 
 use crate::client::{Client, ClientError};
-use crate::output::{print_field, print_table_header, print_table_row, OutputFormat};
+use crate::output::{OutputFormat, print_field, print_table_header, print_table_row};
 use anyhow::Result;
 use clap::Subcommand;
 use serde::{Deserialize, Serialize};

--- a/crates/control-plane/examples/dad_joke_agent.rs
+++ b/crates/control-plane/examples/dad_joke_agent.rs
@@ -223,14 +223,13 @@ async fn listen_to_sse(url: &str) -> Result<String, Box<dyn std::error::Error + 
                                 // Parse the agent's response
                                 if let Ok(msg_data) =
                                     serde_json::from_value::<MessageData>(event.data.clone())
+                                    && let Some(content) = msg_data.content
                                 {
-                                    if let Some(content) = msg_data.content {
-                                        for part in content {
-                                            if part.content_type == "text" {
-                                                if let Some(text) = part.text {
-                                                    agent_response = text;
-                                                }
-                                            }
+                                    for part in content {
+                                        if part.content_type == "text"
+                                            && let Some(text) = part.text
+                                        {
+                                            agent_response = text;
                                         }
                                     }
                                 }

--- a/crates/control-plane/src/api/agents.rs
+++ b/crates/control-plane/src/api/agents.rs
@@ -2,12 +2,12 @@
 
 use crate::storage::StorageBackend;
 use axum::{
+    Json, Router,
     body::Body,
     extract::{Path, State},
-    http::{header, StatusCode},
+    http::{StatusCode, header},
     response::Response,
     routing::{get, post},
-    Json, Router,
 };
 use chrono::Utc;
 use everruns_core::{Agent, AgentStatus, CapabilityId};
@@ -446,17 +446,17 @@ fn parse_agent_content(content: &str) -> Result<AgentFile, String> {
     let content = content.trim();
 
     // Try markdown with front matter first (if starts with ---)
-    if content.starts_with("---") {
-        if let Ok(agent) = parse_markdown_frontmatter(content) {
-            return Ok(agent);
-        }
+    if content.starts_with("---")
+        && let Ok(agent) = parse_markdown_frontmatter(content)
+    {
+        return Ok(agent);
     }
 
     // Try JSON (if starts with {)
-    if content.starts_with('{') {
-        if let Ok(agent) = serde_json::from_str::<AgentFile>(content) {
-            return Ok(agent);
-        }
+    if content.starts_with('{')
+        && let Ok(agent) = serde_json::from_str::<AgentFile>(content)
+    {
+        return Ok(agent);
     }
 
     // Try YAML

--- a/crates/control-plane/src/api/capabilities.rs
+++ b/crates/control-plane/src/api/capabilities.rs
@@ -7,10 +7,10 @@
 // Agent capabilities are managed through the agents API (POST/PATCH /v1/agents).
 
 use axum::{
+    Json, Router,
     extract::{Path, State},
     http::StatusCode,
     routing::get,
-    Json, Router,
 };
 use everruns_core::{CapabilityId, CapabilityInfo};
 

--- a/crates/control-plane/src/api/common.rs
+++ b/crates/control-plane/src/api/common.rs
@@ -2,8 +2,8 @@
 //
 // These types are shared across multiple API endpoints.
 
-use axum::http::StatusCode;
 use axum::Json;
+use axum::http::StatusCode;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 

--- a/crates/control-plane/src/api/durable.rs
+++ b/crates/control-plane/src/api/durable.rs
@@ -9,10 +9,10 @@
 // - Circuit breaker status
 
 use axum::{
+    Json, Router,
     extract::{Path, Query, State},
     http::StatusCode,
     routing::{get, post},
-    Json, Router,
 };
 use chrono::{DateTime, Utc};
 use everruns_durable::{

--- a/crates/control-plane/src/api/events.rs
+++ b/crates/control-plane/src/api/events.rs
@@ -3,11 +3,11 @@
 
 use crate::storage::StorageBackend;
 use axum::{
+    Json, Router,
     extract::{Path, Query, State},
     http::StatusCode,
     response::sse::{Event as SseEvent, KeepAlive, Sse},
     routing::get,
-    Json, Router,
 };
 use everruns_core::{Event, EventListener};
 use serde::Deserialize;
@@ -15,8 +15,8 @@ use serde::Deserialize;
 use super::common::ListResponse;
 use crate::services::EventService;
 use futures::{
-    stream::{self, Stream},
     StreamExt,
+    stream::{self, Stream},
 };
 use std::{convert::Infallible, sync::Arc, time::Duration};
 use uuid::Uuid;

--- a/crates/control-plane/src/api/llm_models.rs
+++ b/crates/control-plane/src/api/llm_models.rs
@@ -3,10 +3,10 @@
 use crate::api::common::{ErrorResponse, ListResponse};
 use crate::storage::StorageBackend;
 use axum::{
+    Json, Router,
     extract::{Path, State},
     http::StatusCode,
     routing::{get, post},
-    Json, Router,
 };
 use everruns_core::{LlmModel, LlmModelStatus, LlmModelWithProvider};
 use serde::Deserialize;

--- a/crates/control-plane/src/api/llm_providers.rs
+++ b/crates/control-plane/src/api/llm_providers.rs
@@ -2,10 +2,10 @@
 
 use crate::storage::{EncryptionService, StorageBackend};
 use axum::{
+    Json, Router,
     extract::{Path, State},
     http::StatusCode,
     routing::{get, post},
-    Json, Router,
 };
 use everruns_core::llm_models::LlmProvider;
 use everruns_core::{LlmProviderStatus, LlmProviderType};

--- a/crates/control-plane/src/api/messages.rs
+++ b/crates/control-plane/src/api/messages.rs
@@ -9,10 +9,10 @@
 
 use crate::storage::StorageBackend;
 use axum::{
+    Json, Router,
     extract::{Path, State},
     http::StatusCode,
     routing::post,
-    Json, Router,
 };
 use chrono::{DateTime, Utc};
 

--- a/crates/control-plane/src/api/session_files.rs
+++ b/crates/control-plane/src/api/session_files.rs
@@ -15,10 +15,10 @@
 
 use crate::storage::StorageBackend;
 use axum::{
+    Json, Router,
     extract::{Path, Query, State},
     http::StatusCode,
     routing::{get, post},
-    Json, Router,
 };
 use everruns_core::{FileInfo, FileStat, GrepResult, SessionFile};
 

--- a/crates/control-plane/src/api/sessions.rs
+++ b/crates/control-plane/src/api/sessions.rs
@@ -2,10 +2,10 @@
 
 use crate::storage::StorageBackend;
 use axum::{
+    Json, Router,
     extract::{Path, State},
     http::StatusCode,
     routing::{get, post},
-    Json, Router,
 };
 use everruns_core::Session;
 

--- a/crates/control-plane/src/api/users.rs
+++ b/crates/control-plane/src/api/users.rs
@@ -3,10 +3,10 @@
 
 use crate::storage::StorageBackend;
 use axum::{
+    Json, Router,
     extract::{Query, State},
     http::StatusCode,
     routing::get,
-    Json, Router,
 };
 use chrono::{DateTime, Utc};
 

--- a/crates/control-plane/src/api/validation.rs
+++ b/crates/control-plane/src/api/validation.rs
@@ -5,8 +5,8 @@
 // use while preventing resource exhaustion attacks.
 
 use super::common::ErrorResponse;
-use axum::http::StatusCode;
 use axum::Json;
+use axum::http::StatusCode;
 
 // =============================================================================
 // Input Size Limits
@@ -82,15 +82,15 @@ pub fn validate_agent_name(name: &str) -> Result<(), ValidationError> {
 
 /// Validate agent description size
 pub fn validate_agent_description(description: Option<&str>) -> Result<(), ValidationError> {
-    if let Some(desc) = description {
-        if desc.len() > MAX_AGENT_DESCRIPTION_BYTES {
-            tracing::warn!(
-                "Agent description exceeds limit: {} bytes (max: {})",
-                desc.len(),
-                MAX_AGENT_DESCRIPTION_BYTES
-            );
-            return Err(ValidationError);
-        }
+    if let Some(desc) = description
+        && desc.len() > MAX_AGENT_DESCRIPTION_BYTES
+    {
+        tracing::warn!(
+            "Agent description exceeds limit: {} bytes (max: {})",
+            desc.len(),
+            MAX_AGENT_DESCRIPTION_BYTES
+        );
+        return Err(ValidationError);
     }
     Ok(())
 }
@@ -160,15 +160,15 @@ pub fn validate_update_agent_input(
     }
     // For update, description is Option<Option<String>> effectively
     // but we receive Option<String> - validate if present
-    if let Some(desc) = description {
-        if desc.len() > MAX_AGENT_DESCRIPTION_BYTES {
-            tracing::warn!(
-                "Agent description exceeds limit: {} bytes (max: {})",
-                desc.len(),
-                MAX_AGENT_DESCRIPTION_BYTES
-            );
-            return Err(ValidationError);
-        }
+    if let Some(desc) = description
+        && desc.len() > MAX_AGENT_DESCRIPTION_BYTES
+    {
+        tracing::warn!(
+            "Agent description exceeds limit: {} bytes (max: {})",
+            desc.len(),
+            MAX_AGENT_DESCRIPTION_BYTES
+        );
+        return Err(ValidationError);
     }
     if let Some(prompt) = system_prompt {
         validate_agent_system_prompt(prompt)?;

--- a/crates/control-plane/src/auth/api_key.rs
+++ b/crates/control-plane/src/auth/api_key.rs
@@ -26,7 +26,7 @@ pub struct GeneratedApiKey {
 pub fn generate_api_key() -> GeneratedApiKey {
     // Generate random bytes
     let mut rng = rand::thread_rng();
-    let random_bytes: Vec<u8> = (0..API_KEY_LENGTH).map(|_| rng.gen()).collect();
+    let random_bytes: Vec<u8> = (0..API_KEY_LENGTH).map(|_| rng.r#gen()).collect();
     let random_hex = hex::encode(&random_bytes);
 
     // Full key with prefix

--- a/crates/control-plane/src/auth/config.rs
+++ b/crates/control-plane/src/auth/config.rs
@@ -135,7 +135,7 @@ impl AuthConfig {
             if mode == AuthMode::None {
                 // Generate a random secret for dev mode
                 use rand::Rng;
-                let bytes: [u8; 32] = rand::thread_rng().gen();
+                let bytes: [u8; 32] = rand::thread_rng().r#gen();
                 hex::encode(bytes)
             } else {
                 tracing::warn!("AUTH_JWT_SECRET not set, using insecure default");

--- a/crates/control-plane/src/auth/jwt.rs
+++ b/crates/control-plane/src/auth/jwt.rs
@@ -4,7 +4,7 @@
 
 use anyhow::{Context, Result};
 use chrono::{Duration, Utc};
-use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
+use jsonwebtoken::{DecodingKey, EncodingKey, Header, Validation, decode, encode};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -14,7 +14,7 @@ use super::config::JwtConfig;
 /// Generate a random identifier string (32 hex characters)
 fn generate_random_id() -> String {
     let mut rng = rand::thread_rng();
-    let bytes: [u8; 16] = rng.gen();
+    let bytes: [u8; 16] = rng.r#gen();
     hex::encode(bytes)
 }
 

--- a/crates/control-plane/src/auth/middleware.rs
+++ b/crates/control-plane/src/auth/middleware.rs
@@ -3,10 +3,10 @@
 // Decision: In "none" mode, create an anonymous user context
 
 use axum::{
-    extract::FromRequestParts,
-    http::{header, request::Parts, StatusCode},
-    response::{IntoResponse, Response},
     Json,
+    extract::FromRequestParts,
+    http::{StatusCode, header, request::Parts},
+    response::{IntoResponse, Response},
 };
 use axum_extra::extract::CookieJar;
 use serde::Serialize;
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 use super::{
-    api_key::{hash_api_key, is_valid_api_key_format, ValidatedApiKey, API_KEY_PREFIX},
+    api_key::{API_KEY_PREFIX, ValidatedApiKey, hash_api_key, is_valid_api_key_format},
     config::{AuthConfig, AuthMode},
     jwt::JwtService,
 };

--- a/crates/control-plane/src/auth/routes.rs
+++ b/crates/control-plane/src/auth/routes.rs
@@ -3,11 +3,11 @@
 // Decision: Support both JSON and cookie-based sessions
 
 use axum::{
+    Json, Router,
     extract::{Path, Query, State},
     http::StatusCode,
     response::Redirect,
     routing::{delete, get, post},
-    Json, Router,
 };
 use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 use chrono::{Duration, Utc};
@@ -32,7 +32,7 @@ use crate::storage::{
 /// Generate a random state string for OAuth (32 hex characters)
 fn generate_oauth_state() -> String {
     let mut rng = rand::thread_rng();
-    let bytes: [u8; 16] = rng.gen();
+    let bytes: [u8; 16] = rng.r#gen();
     hex::encode(bytes)
 }
 
@@ -182,12 +182,13 @@ pub async fn login(
 ) -> Result<(CookieJar, Json<TokenResponse>), AuthError> {
     // In admin mode, check admin credentials directly (no database lookup)
     if state.config.mode == AuthMode::Admin {
-        if let Some(admin) = &state.config.admin {
-            if req.email == admin.email && req.password == admin.password {
-                // Create or get admin user
-                let user = get_or_create_admin_user(&state, admin).await?;
-                return generate_token_response(&state, jar, &user).await;
-            }
+        if let Some(admin) = &state.config.admin
+            && req.email == admin.email
+            && req.password == admin.password
+        {
+            // Create or get admin user
+            let user = get_or_create_admin_user(&state, admin).await?;
+            return generate_token_response(&state, jar, &user).await;
         }
         // Admin mode only allows the configured admin credentials
         return Err(AuthError::unauthorized("Invalid email or password"));

--- a/crates/control-plane/src/bin/reencrypt_secrets.rs
+++ b/crates/control-plane/src/bin/reencrypt_secrets.rs
@@ -2,7 +2,7 @@
 // Run with: cargo run --bin reencrypt-secrets -- --help
 
 use anyhow::{Context, Result};
-use everruns_control_plane::storage::{EncryptionService, ENCRYPTED_COLUMNS};
+use everruns_control_plane::storage::{ENCRYPTED_COLUMNS, EncryptionService};
 use sqlx::PgPool;
 use std::env;
 

--- a/crates/control-plane/src/dev_worker/direct_adapters.rs
+++ b/crates/control-plane/src/dev_worker/direct_adapters.rs
@@ -22,8 +22,8 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::services::{EventService, LlmResolverService};
-use crate::storage::models::UpdateSession;
 use crate::storage::StorageBackend;
+use crate::storage::models::UpdateSession;
 
 // Helper to create store errors
 fn store_error(msg: impl Into<String>) -> AgentLoopError {
@@ -158,8 +158,8 @@ impl DirectMessageStore {
 #[async_trait]
 impl MessageStore for DirectMessageStore {
     async fn add(&self, session_id: Uuid, input: InputMessage) -> Result<Message> {
-        use everruns_core::events::EventContext;
         use everruns_core::EventData;
+        use everruns_core::events::EventContext;
 
         // Create a Message from the input
         let message = Message {

--- a/crates/control-plane/src/dev_worker/worker.rs
+++ b/crates/control-plane/src/dev_worker/worker.rs
@@ -7,14 +7,14 @@
 // using direct access to the storage backend.
 
 use anyhow::Result;
+use everruns_core::ToolRegistry;
 use everruns_core::atoms::{ActAtom, Atom, AtomContext, InputAtom, ReasonAtom};
 use everruns_core::capabilities::CapabilityRegistry;
-use everruns_core::ToolRegistry;
 use everruns_core::{ActInput, InputAtomInput, ReasonInput, ReasonResult};
 use everruns_durable::{
     ClaimedTask, InMemoryWorkflowEventStore, WorkerInfo, WorkflowEventStore, WorkflowStatus,
 };
-use everruns_worker::{create_driver_registry, DurableTurnInput};
+use everruns_worker::{DurableTurnInput, create_driver_registry};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::watch;

--- a/crates/control-plane/src/grpc_service.rs
+++ b/crates/control-plane/src/grpc_service.rs
@@ -6,8 +6,8 @@
 // Decision: No direct database access - all operations go through services layer
 
 use everruns_control_plane::services::{
-    session_file::{CreateDirectoryInput, CreateFileInput, GrepInput, UpdateFileInput},
     AgentService, EventService, LlmResolverService, SessionFileService, SessionService,
+    session_file::{CreateDirectoryInput, CreateFileInput, GrepInput, UpdateFileInput},
 };
 use everruns_control_plane::storage::{EncryptionService, StorageBackend};
 use everruns_durable::{
@@ -37,8 +37,8 @@ use everruns_internal_protocol::proto::{
     UpdateDurableWorkflowStatusResponse,
 };
 use everruns_internal_protocol::{
-    proto_event_request_to_schema, schema_agent_to_proto, schema_event_to_proto, WorkerService,
-    WorkerServiceServer,
+    WorkerService, WorkerServiceServer, proto_event_request_to_schema, schema_agent_to_proto,
+    schema_event_to_proto,
 };
 use std::sync::Arc;
 use tonic::{Request, Response, Status, Streaming};
@@ -130,10 +130,10 @@ fn event_to_message(event: &everruns_core::Event) -> Option<everruns_core::Messa
         EventData::MessageAgent(d) => Some(d.message.clone()),
         EventData::ToolCallCompleted(d) => {
             let result: Option<serde_json::Value> = d.result.as_ref().map(|parts| {
-                if parts.len() == 1 {
-                    if let ContentPart::Text(t) = &parts[0] {
-                        return serde_json::Value::String(t.text.clone());
-                    }
+                if parts.len() == 1
+                    && let ContentPart::Text(t) = &parts[0]
+                {
+                    return serde_json::Value::String(t.text.clone());
                 }
                 serde_json::to_value(parts).unwrap_or_default()
             });

--- a/crates/control-plane/src/main.rs
+++ b/crates/control-plane/src/main.rs
@@ -16,14 +16,14 @@ use everruns_control_plane::services;
 use everruns_control_plane::storage::{EncryptionService, StorageBackend};
 
 use anyhow::{Context, Result};
-use axum::http::{header, HeaderValue, Method};
-use axum::{extract::State, routing::get, Json, Router};
-use everruns_core::telemetry::{init_telemetry, TelemetryConfig};
+use axum::http::{HeaderValue, Method, header};
+use axum::{Json, Router, extract::State, routing::get};
+use everruns_core::telemetry::{TelemetryConfig, init_telemetry};
 use everruns_core::{EventListener, OtelEventListener};
 use everruns_durable::{
     InMemoryWorkflowEventStore, PostgresWorkflowEventStore, WorkflowEventStore,
 };
-use everruns_worker::{create_runner_with_backend, RunnerBackend};
+use everruns_worker::{RunnerBackend, create_runner_with_backend};
 use serde::Serialize;
 use std::sync::Arc;
 use tower_http::cors::{AllowOrigin, CorsLayer};
@@ -138,7 +138,10 @@ async fn main() -> Result<()> {
             Some(Arc::new(svc))
         }
         Err(e) => {
-            tracing::warn!("Encryption service not configured (SECRETS_ENCRYPTION_KEY not set): {}. API key storage disabled.", e);
+            tracing::warn!(
+                "Encryption service not configured (SECRETS_ENCRYPTION_KEY not set): {}. API key storage disabled.",
+                e
+            );
             None
         }
     };

--- a/crates/control-plane/src/openapi.rs
+++ b/crates/control-plane/src/openapi.rs
@@ -8,6 +8,9 @@ use crate::api;
 use crate::api::ListResponse;
 use everruns_core::llm_models::LlmProvider;
 use everruns_core::{
+    Agent, AgentStatus, CapabilityInfo, Event, EventContext, EventData, FileInfo, FileStat,
+    GrepMatch, GrepResult, LlmModel, LlmModelStatus, LlmModelWithProvider, LlmProviderStatus,
+    LlmProviderType, Session, SessionFile, SessionStatus, ToolCall,
     events::{
         ActCompletedData, ActStartedData, InputReceivedData, LlmGenerationData,
         LlmGenerationMetadata, LlmGenerationOutput, MessageAgentData, MessageUserData,
@@ -15,9 +18,6 @@ use everruns_core::{
         ToolCallCompletedData, ToolCallStartedData, ToolCallSummary, TurnCompletedData,
         TurnFailedData, TurnStartedData,
     },
-    Agent, AgentStatus, CapabilityInfo, Event, EventContext, EventData, FileInfo, FileStat,
-    GrepMatch, GrepResult, LlmModel, LlmModelStatus, LlmModelWithProvider, LlmProviderStatus,
-    LlmProviderType, Session, SessionFile, SessionStatus, ToolCall,
 };
 use utoipa::OpenApi;
 

--- a/crates/control-plane/src/seed.rs
+++ b/crates/control-plane/src/seed.rs
@@ -6,8 +6,8 @@
 // Decision: Modular design allows easy addition of new seeders
 
 use everruns_control_plane::storage::{
-    models::{CreateAgentRow, CreateLlmModelRow, CreateLlmProviderRow},
     StorageBackend,
+    models::{CreateAgentRow, CreateLlmModelRow, CreateLlmProviderRow},
 };
 use std::sync::Arc;
 use std::time::Duration;

--- a/crates/control-plane/src/services/agent.rs
+++ b/crates/control-plane/src/services/agent.rs
@@ -5,8 +5,8 @@
 // by event listeners rather than direct spans.
 
 use crate::storage::{
-    models::{CreateAgentRow, UpdateAgent},
     AgentRow, StorageBackend,
+    models::{CreateAgentRow, UpdateAgent},
 };
 use anyhow::Result;
 use everruns_core::{Agent, AgentStatus, CapabilityId};

--- a/crates/control-plane/src/services/event.rs
+++ b/crates/control-plane/src/services/event.rs
@@ -13,8 +13,8 @@
 // observability integrations (OTel spans, metrics, etc.). Listeners are
 // called synchronously but should be non-blocking.
 
-use crate::storage::{models::CreateEventRow, EventRow, StorageBackend};
-use anyhow::{bail, Result};
+use crate::storage::{EventRow, StorageBackend, models::CreateEventRow};
+use anyhow::{Result, bail};
 use everruns_core::{Event, EventData, EventListener, EventRequest, UNKNOWN};
 use std::sync::Arc;
 use uuid::Uuid;

--- a/crates/control-plane/src/services/llm_model.rs
+++ b/crates/control-plane/src/services/llm_model.rs
@@ -1,12 +1,12 @@
 // LLM Model service for business logic
 
 use crate::storage::{
-    models::{CreateLlmModelRow, LlmModelRow, LlmModelWithProviderRow, UpdateLlmModel},
     StorageBackend,
+    models::{CreateLlmModelRow, LlmModelRow, LlmModelWithProviderRow, UpdateLlmModel},
 };
 use anyhow::Result;
 use everruns_core::{
-    get_model_profile, LlmModel, LlmModelStatus, LlmModelWithProvider, LlmProviderType,
+    LlmModel, LlmModelStatus, LlmModelWithProvider, LlmProviderType, get_model_profile,
 };
 use std::sync::Arc;
 use uuid::Uuid;

--- a/crates/control-plane/src/services/llm_provider.rs
+++ b/crates/control-plane/src/services/llm_provider.rs
@@ -1,10 +1,10 @@
 // LLM Provider service for business logic
 
 use crate::storage::{
-    models::{CreateLlmProviderRow, LlmProviderRow, UpdateLlmProvider},
     EncryptionService, StorageBackend,
+    models::{CreateLlmProviderRow, LlmProviderRow, UpdateLlmProvider},
 };
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use everruns_core::llm_models::LlmProvider;
 use everruns_core::{LlmProviderStatus, LlmProviderType};
 use std::sync::Arc;

--- a/crates/control-plane/src/services/llm_resolver.rs
+++ b/crates/control-plane/src/services/llm_resolver.rs
@@ -4,7 +4,7 @@
 // including API key decryption. Used by gRPC service for worker communication.
 
 use crate::storage::{EncryptionService, StorageBackend};
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use std::sync::Arc;
 use uuid::Uuid;
 

--- a/crates/control-plane/src/services/message.rs
+++ b/crates/control-plane/src/services/message.rs
@@ -10,8 +10,8 @@ use crate::api::messages::{ContentPart, CreateMessageRequest, Message, MessageRo
 use crate::storage::StorageBackend;
 use anyhow::Result;
 use chrono::Utc;
-use everruns_core::events::{EventContext, EventRequest, MessageUserData};
 use everruns_core::Event;
+use everruns_core::events::{EventContext, EventRequest, MessageUserData};
 use everruns_worker::AgentRunner;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -151,10 +151,10 @@ impl MessageService {
                     everruns_core::EventData::ToolCallCompleted(data) => {
                         // Convert tool result to message
                         let result: Option<serde_json::Value> = data.result.as_ref().map(|parts| {
-                            if parts.len() == 1 {
-                                if let everruns_core::ContentPart::Text(t) = &parts[0] {
-                                    return serde_json::Value::String(t.text.clone());
-                                }
+                            if parts.len() == 1
+                                && let everruns_core::ContentPart::Text(t) = &parts[0]
+                            {
+                                return serde_json::Value::String(t.text.clone());
                             }
                             serde_json::to_value(parts).unwrap_or_default()
                         });

--- a/crates/control-plane/src/services/session.rs
+++ b/crates/control-plane/src/services/session.rs
@@ -1,8 +1,8 @@
 // Session service for business logic (M2)
 
 use crate::storage::{
-    models::{CreateSessionRow, UpdateSession},
     StorageBackend,
+    models::{CreateSessionRow, UpdateSession},
 };
 use anyhow::Result;
 use everruns_core::{Session, SessionStatus};

--- a/crates/control-plane/src/services/session_file.rs
+++ b/crates/control-plane/src/services/session_file.rs
@@ -1,10 +1,10 @@
 // Session Files service for virtual filesystem operations
 
 use crate::storage::{
-    models::{CreateSessionFileRow, SessionFileInfoRow, SessionFileRow, UpdateSessionFile},
     StorageBackend,
+    models::{CreateSessionFileRow, SessionFileInfoRow, SessionFileRow, UpdateSessionFile},
 };
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use everruns_core::{FileInfo, FileStat, GrepMatch, GrepResult, SessionFile};
 use regex::Regex;
 use std::sync::Arc;
@@ -250,7 +250,7 @@ impl SessionFileService {
             let dir = self.db.get_session_file(session_id, &path).await?;
             match dir {
                 Some(d) if !d.is_directory => {
-                    return Err(anyhow!("Path is not a directory: {}", path))
+                    return Err(anyhow!("Path is not a directory: {}", path));
                 }
                 None => return Err(anyhow!("Directory not found: {}", path)),
                 _ => {}
@@ -332,17 +332,18 @@ impl SessionFileService {
 
         // Check if it's a directory with children
         let file = self.db.get_session_file(session_id, &path).await?;
-        if let Some(ref f) = file {
-            if f.is_directory && !recursive {
-                let has_children = self
-                    .db
-                    .session_directory_has_children(session_id, &path)
-                    .await?;
-                if has_children {
-                    return Err(anyhow!(
-                        "Directory is not empty. Use recursive=true to delete"
-                    ));
-                }
+        if let Some(ref f) = file
+            && f.is_directory
+            && !recursive
+        {
+            let has_children = self
+                .db
+                .session_directory_has_children(session_id, &path)
+                .await?;
+            if has_children {
+                return Err(anyhow!(
+                    "Directory is not empty. Use recursive=true to delete"
+                ));
             }
         }
 
@@ -407,7 +408,7 @@ impl SessionFileService {
         match source {
             None => return Err(anyhow!("Source not found: {}", src_path)),
             Some(ref s) if s.is_directory => {
-                return Err(anyhow!("Cannot copy directories: {}", src_path))
+                return Err(anyhow!("Cannot copy directories: {}", src_path));
             }
             _ => {}
         }
@@ -449,27 +450,27 @@ impl SessionFileService {
                 .db
                 .get_session_file(session_id, &file_info.path)
                 .await?;
-            if let Some(f) = file {
-                if let Some(content) = f.content {
-                    // Try to decode as text
-                    if let Ok(text) = String::from_utf8(content) {
-                        let matches: Vec<GrepMatch> = text
-                            .lines()
-                            .enumerate()
-                            .filter(|(_, line)| regex.is_match(line))
-                            .map(|(i, line)| GrepMatch {
-                                path: file_info.path.clone(),
-                                line_number: i + 1,
-                                line: line.to_string(),
-                            })
-                            .collect();
+            if let Some(f) = file
+                && let Some(content) = f.content
+            {
+                // Try to decode as text
+                if let Ok(text) = String::from_utf8(content) {
+                    let matches: Vec<GrepMatch> = text
+                        .lines()
+                        .enumerate()
+                        .filter(|(_, line)| regex.is_match(line))
+                        .map(|(i, line)| GrepMatch {
+                            path: file_info.path.clone(),
+                            line_number: i + 1,
+                            line: line.to_string(),
+                        })
+                        .collect();
 
-                        if !matches.is_empty() {
-                            results.push(GrepResult {
-                                path: file_info.path.clone(),
-                                matches,
-                            });
-                        }
+                    if !matches.is_empty() {
+                        results.push(GrepResult {
+                            path: file_info.path.clone(),
+                            matches,
+                        });
                     }
                 }
             }

--- a/crates/control-plane/src/storage/agent_store.rs
+++ b/crates/control-plane/src/storage/agent_store.rs
@@ -5,10 +5,10 @@
 
 use async_trait::async_trait;
 use everruns_core::{
+    AgentLoopError, Result,
     agent::{Agent, AgentStatus},
     capability_types::CapabilityId,
     traits::AgentStore,
-    AgentLoopError, Result,
 };
 use uuid::Uuid;
 

--- a/crates/control-plane/src/storage/encryption.rs
+++ b/crates/control-plane/src/storage/encryption.rs
@@ -3,11 +3,11 @@
 // See specs/encryption.md for full specification.
 
 use aes_gcm::{
-    aead::{Aead, KeyInit},
     Aes256Gcm, Nonce,
+    aead::{Aead, KeyInit},
 };
 use anyhow::{Context, Result};
-use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -577,10 +577,10 @@ mod tests {
                 let words: Vec<&str> = trimmed.split_whitespace().collect();
                 if !words.is_empty() {
                     let first_word = words[0].trim_start_matches('(').trim_end_matches(',');
-                    if first_word.ends_with("_encrypted") {
-                        if let Some(ref table) = current_table {
-                            found.insert((table.clone(), first_word.to_string()));
-                        }
+                    if first_word.ends_with("_encrypted")
+                        && let Some(ref table) = current_table
+                    {
+                        found.insert((table.clone(), first_word.to_string()));
                     }
                 }
 

--- a/crates/control-plane/src/storage/llm_provider_store.rs
+++ b/crates/control-plane/src/storage/llm_provider_store.rs
@@ -5,9 +5,9 @@
 
 use async_trait::async_trait;
 use everruns_core::{
+    AgentLoopError, Result,
     llm_models::LlmProviderType,
     traits::{LlmProviderStore, ModelWithProvider},
-    AgentLoopError, Result,
 };
 use uuid::Uuid;
 

--- a/crates/control-plane/src/storage/memory.rs
+++ b/crates/control-plane/src/storage/memory.rs
@@ -5,7 +5,7 @@
 // This implementation provides a PostgreSQL-compatible API backed by in-memory
 // HashMaps, allowing the control-plane to run without a database for development.
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use chrono::{DateTime, Utc};
 use parking_lot::RwLock;
 use std::collections::HashMap;
@@ -188,11 +188,11 @@ impl InMemoryDatabase {
 
     pub async fn delete_api_key(&self, id: Uuid, user_id: Uuid) -> Result<bool> {
         let mut keys = self.api_keys.write();
-        if let Some(key) = keys.get(&id) {
-            if key.user_id == user_id {
-                keys.remove(&id);
-                return Ok(true);
-            }
+        if let Some(key) = keys.get(&id)
+            && key.user_id == user_id
+        {
+            keys.remove(&id);
+            return Ok(true);
         }
         Ok(false)
     }
@@ -512,10 +512,10 @@ impl InMemoryDatabase {
                     if e.id <= id {
                         return false;
                     }
-                } else if let Some(seq) = since_sequence {
-                    if e.sequence <= seq {
-                        return false;
-                    }
+                } else if let Some(seq) = since_sequence
+                    && e.sequence <= seq
+                {
+                    return false;
                 }
                 true
             })
@@ -689,22 +689,22 @@ impl InMemoryDatabase {
         let providers = self.llm_providers.read();
 
         for model in models.values() {
-            if model.is_default {
-                if let Some(provider) = providers.get(&model.provider_id) {
-                    return Ok(Some(LlmModelWithProviderRow {
-                        id: model.id,
-                        provider_id: model.provider_id,
-                        model_id: model.model_id.clone(),
-                        display_name: model.display_name.clone(),
-                        capabilities: model.capabilities.clone(),
-                        is_default: model.is_default,
-                        status: model.status.clone(),
-                        created_at: model.created_at,
-                        updated_at: model.updated_at,
-                        provider_name: provider.name.clone(),
-                        provider_type: provider.provider_type.clone(),
-                    }));
-                }
+            if model.is_default
+                && let Some(provider) = providers.get(&model.provider_id)
+            {
+                return Ok(Some(LlmModelWithProviderRow {
+                    id: model.id,
+                    provider_id: model.provider_id,
+                    model_id: model.model_id.clone(),
+                    display_name: model.display_name.clone(),
+                    capabilities: model.capabilities.clone(),
+                    is_default: model.is_default,
+                    status: model.status.clone(),
+                    created_at: model.created_at,
+                    updated_at: model.updated_at,
+                    provider_name: provider.name.clone(),
+                    provider_type: provider.provider_type.clone(),
+                }));
             }
         }
         Ok(None)
@@ -773,22 +773,22 @@ impl InMemoryDatabase {
         let models = self.llm_models.read();
         let providers = self.llm_providers.read();
 
-        if let Some(model) = models.get(&id) {
-            if let Some(provider) = providers.get(&model.provider_id) {
-                return Ok(Some(LlmModelWithProviderRow {
-                    id: model.id,
-                    provider_id: model.provider_id,
-                    model_id: model.model_id.clone(),
-                    display_name: model.display_name.clone(),
-                    capabilities: model.capabilities.clone(),
-                    is_default: model.is_default,
-                    status: model.status.clone(),
-                    created_at: model.created_at,
-                    updated_at: model.updated_at,
-                    provider_name: provider.name.clone(),
-                    provider_type: provider.provider_type.clone(),
-                }));
-            }
+        if let Some(model) = models.get(&id)
+            && let Some(provider) = providers.get(&model.provider_id)
+        {
+            return Ok(Some(LlmModelWithProviderRow {
+                id: model.id,
+                provider_id: model.provider_id,
+                model_id: model.model_id.clone(),
+                display_name: model.display_name.clone(),
+                capabilities: model.capabilities.clone(),
+                is_default: model.is_default,
+                status: model.status.clone(),
+                created_at: model.created_at,
+                updated_at: model.updated_at,
+                provider_name: provider.name.clone(),
+                provider_type: provider.provider_type.clone(),
+            }));
         }
         Ok(None)
     }
@@ -872,22 +872,22 @@ impl InMemoryDatabase {
         let providers = self.llm_providers.read();
 
         for model in models.values() {
-            if model.model_id == model_id {
-                if let Some(provider) = providers.get(&model.provider_id) {
-                    return Ok(Some(LlmModelWithProviderRow {
-                        id: model.id,
-                        provider_id: model.provider_id,
-                        model_id: model.model_id.clone(),
-                        display_name: model.display_name.clone(),
-                        capabilities: model.capabilities.clone(),
-                        is_default: model.is_default,
-                        status: model.status.clone(),
-                        created_at: model.created_at,
-                        updated_at: model.updated_at,
-                        provider_name: provider.name.clone(),
-                        provider_type: provider.provider_type.clone(),
-                    }));
-                }
+            if model.model_id == model_id
+                && let Some(provider) = providers.get(&model.provider_id)
+            {
+                return Ok(Some(LlmModelWithProviderRow {
+                    id: model.id,
+                    provider_id: model.provider_id,
+                    model_id: model.model_id.clone(),
+                    display_name: model.display_name.clone(),
+                    capabilities: model.capabilities.clone(),
+                    is_default: model.is_default,
+                    status: model.status.clone(),
+                    created_at: model.created_at,
+                    updated_at: model.updated_at,
+                    provider_name: provider.name.clone(),
+                    provider_type: provider.provider_type.clone(),
+                }));
             }
         }
         Ok(None)
@@ -1219,10 +1219,10 @@ impl InMemoryDatabase {
                 if f.session_id != session_id || f.is_directory {
                     return false;
                 }
-                if let Some(prefix) = path_prefix {
-                    if !f.path.starts_with(prefix) {
-                        return false;
-                    }
+                if let Some(prefix) = path_prefix
+                    && !f.path.starts_with(prefix)
+                {
+                    return false;
                 }
                 // Content is Vec<u8>, convert to str for regex matching
                 f.content

--- a/crates/control-plane/src/storage/message_store.rs
+++ b/crates/control-plane/src/storage/message_store.rs
@@ -8,11 +8,11 @@
 use async_trait::async_trait;
 use chrono::Utc;
 use everruns_core::{
+    AgentLoopError, ContentPart, Event, EventData, Message, MessageRole, Result,
     events::{
         EventContext, EventRequest, MessageAgentData, MessageUserData, ToolCallCompletedData,
     },
     traits::{InputMessage, MessageStore},
-    AgentLoopError, ContentPart, Event, EventData, Message, MessageRole, Result,
 };
 use std::sync::Arc;
 use uuid::Uuid;
@@ -179,10 +179,10 @@ fn tool_call_to_message(data: ToolCallCompletedData) -> Message {
     // Extract result as JSON value
     let result: Option<serde_json::Value> = data.result.map(|parts| {
         // For simple text results, extract just the text
-        if parts.len() == 1 {
-            if let ContentPart::Text(t) = &parts[0] {
-                return serde_json::Value::String(t.text.clone());
-            }
+        if parts.len() == 1
+            && let ContentPart::Text(t) = &parts[0]
+        {
+            return serde_json::Value::String(t.text.clone());
         }
         serde_json::to_value(&parts).unwrap_or_default()
     });

--- a/crates/control-plane/src/storage/mod.rs
+++ b/crates/control-plane/src/storage/mod.rs
@@ -23,16 +23,16 @@ pub mod session_store;
 #[cfg(test)]
 mod event_tests;
 
-pub use agent_store::{create_db_agent_store, DbAgentStore};
+pub use agent_store::{DbAgentStore, create_db_agent_store};
 pub use backend::StorageBackend;
 pub use encryption::{
-    generate_encryption_key, EncryptedColumn, EncryptedPayload, EncryptionService,
-    ENCRYPTED_COLUMNS,
+    ENCRYPTED_COLUMNS, EncryptedColumn, EncryptedPayload, EncryptionService,
+    generate_encryption_key,
 };
-pub use llm_provider_store::{create_db_llm_provider_store, DbLlmProviderStore};
+pub use llm_provider_store::{DbLlmProviderStore, create_db_llm_provider_store};
 pub use memory::InMemoryDatabase;
-pub use message_store::{create_db_message_store, DbMessageStore};
+pub use message_store::{DbMessageStore, create_db_message_store};
 pub use models::*;
 pub use repositories::*;
-pub use session_file_store::{create_db_session_file_store, DbSessionFileStore};
-pub use session_store::{create_db_session_store, DbSessionStore};
+pub use session_file_store::{DbSessionFileStore, create_db_session_file_store};
+pub use session_store::{DbSessionStore, create_db_session_store};

--- a/crates/control-plane/src/storage/password.rs
+++ b/crates/control-plane/src/storage/password.rs
@@ -4,8 +4,8 @@
 
 use anyhow::Result;
 use argon2::{
-    password_hash::{rand_core::OsRng, PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
     Argon2,
+    password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString, rand_core::OsRng},
 };
 
 /// Hash a password using Argon2id

--- a/crates/control-plane/src/storage/session_file_store.rs
+++ b/crates/control-plane/src/storage/session_file_store.rs
@@ -5,7 +5,7 @@
 
 use async_trait::async_trait;
 use everruns_core::{
-    traits::SessionFileStore, AgentLoopError, FileInfo, FileStat, GrepMatch, Result, SessionFile,
+    AgentLoopError, FileInfo, FileStat, GrepMatch, Result, SessionFile, traits::SessionFileStore,
 };
 use regex::Regex;
 use uuid::Uuid;
@@ -240,18 +240,19 @@ impl SessionFileStore for DbSessionFileStore {
             .await
             .map_err(|e| AgentLoopError::store(e.to_string()))?;
 
-        if let Some(ref f) = file {
-            if f.is_directory && !recursive {
-                let has_children = self
-                    .db
-                    .session_directory_has_children(session_id, &path)
-                    .await
-                    .map_err(|e| AgentLoopError::store(e.to_string()))?;
-                if has_children {
-                    return Err(AgentLoopError::store(
-                        "Directory is not empty. Use recursive=true to delete",
-                    ));
-                }
+        if let Some(ref f) = file
+            && f.is_directory
+            && !recursive
+        {
+            let has_children = self
+                .db
+                .session_directory_has_children(session_id, &path)
+                .await
+                .map_err(|e| AgentLoopError::store(e.to_string()))?;
+            if has_children {
+                return Err(AgentLoopError::store(
+                    "Directory is not empty. Use recursive=true to delete",
+                ));
             }
         }
 
@@ -285,13 +286,13 @@ impl SessionFileStore for DbSessionFileStore {
                     return Err(AgentLoopError::store(format!(
                         "Path is not a directory: {}",
                         path
-                    )))
+                    )));
                 }
                 None => {
                     return Err(AgentLoopError::store(format!(
                         "Directory not found: {}",
                         path
-                    )))
+                    )));
                 }
                 _ => {}
             }
@@ -380,18 +381,18 @@ impl SessionFileStore for DbSessionFileStore {
                 .await
                 .map_err(|e| AgentLoopError::store(e.to_string()))?;
 
-            if let Some(f) = file {
-                if let Some(content) = f.content {
-                    // Try to decode as text
-                    if let Ok(text) = String::from_utf8(content) {
-                        for (i, line) in text.lines().enumerate() {
-                            if regex.is_match(line) {
-                                results.push(GrepMatch {
-                                    path: file_info.path.clone(),
-                                    line_number: i + 1,
-                                    line: line.to_string(),
-                                });
-                            }
+            if let Some(f) = file
+                && let Some(content) = f.content
+            {
+                // Try to decode as text
+                if let Ok(text) = String::from_utf8(content) {
+                    for (i, line) in text.lines().enumerate() {
+                        if regex.is_match(line) {
+                            results.push(GrepMatch {
+                                path: file_info.path.clone(),
+                                line_number: i + 1,
+                                line: line.to_string(),
+                            });
                         }
                     }
                 }

--- a/crates/control-plane/src/storage/session_store.rs
+++ b/crates/control-plane/src/storage/session_store.rs
@@ -5,9 +5,9 @@
 
 use async_trait::async_trait;
 use everruns_core::{
+    AgentLoopError, Result,
     session::{Session, SessionStatus},
     traits::SessionStore,
-    AgentLoopError, Result,
 };
 use uuid::Uuid;
 

--- a/crates/control-plane/tests/integration_test.rs
+++ b/crates/control-plane/tests/integration_test.rs
@@ -4,7 +4,7 @@
 
 use everruns_core::llm_models::LlmProvider;
 use everruns_core::{Agent, LlmModel, Session, SessionFile};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 const API_BASE_URL: &str = "http://localhost:9000";
 
@@ -991,38 +991,38 @@ async fn test_message_triggers_agent_workflow() {
             .send()
             .await;
 
-        if let Ok(resp) = messages_response {
-            if resp.status() == 200 {
-                let data: Value = resp.json().await.unwrap_or_default();
-                let empty_vec = vec![];
-                let messages = data["data"].as_array().unwrap_or(&empty_vec);
+        if let Ok(resp) = messages_response
+            && resp.status() == 200
+        {
+            let data: Value = resp.json().await.unwrap_or_default();
+            let empty_vec = vec![];
+            let messages = data["data"].as_array().unwrap_or(&empty_vec);
 
-                // Debug: print message count and roles on first check and every 10s
-                if i == 1 || i % 10 == 0 {
-                    println!(
-                        "  [{}s] Found {} messages, roles: {:?}",
-                        i,
-                        messages.len(),
-                        messages
-                            .iter()
-                            .map(|m| m["role"].as_str().unwrap_or("?"))
-                            .collect::<Vec<_>>()
-                    );
-                }
+            // Debug: print message count and roles on first check and every 10s
+            if i == 1 || i % 10 == 0 {
+                println!(
+                    "  [{}s] Found {} messages, roles: {:?}",
+                    i,
+                    messages.len(),
+                    messages
+                        .iter()
+                        .map(|m| m["role"].as_str().unwrap_or("?"))
+                        .collect::<Vec<_>>()
+                );
+            }
 
-                for msg in messages {
-                    // API returns "agent" role (not "assistant")
-                    if msg["role"] == "agent" {
-                        assistant_found = true;
-                        let content = &msg["content"];
-                        println!("Found agent response after {}s: {:?}", i, content);
-                        break;
-                    }
-                }
-
-                if assistant_found {
+            for msg in messages {
+                // API returns "agent" role (not "assistant")
+                if msg["role"] == "agent" {
+                    assistant_found = true;
+                    let content = &msg["content"];
+                    println!("Found agent response after {}s: {:?}", i, content);
                     break;
                 }
+            }
+
+            if assistant_found {
+                break;
             }
         }
 
@@ -1041,25 +1041,23 @@ async fn test_message_triggers_agent_workflow() {
             ))
             .send()
             .await
+            && resp.status() == 200
+            && let Ok(data) = resp.json::<Value>().await
         {
-            if resp.status() == 200 {
-                if let Ok(data) = resp.json::<Value>().await {
-                    let events = data["data"].as_array();
-                    println!("  Events count: {}", events.map(|e| e.len()).unwrap_or(0));
-                    if let Some(events) = events {
-                        for (i, event) in events.iter().enumerate().take(10) {
-                            println!(
-                                "  Event {}: type={}, data_preview={}",
-                                i,
-                                event["type"].as_str().unwrap_or("?"),
-                                &event["data"]
-                                    .to_string()
-                                    .chars()
-                                    .take(100)
-                                    .collect::<String>()
-                            );
-                        }
-                    }
+            let events = data["data"].as_array();
+            println!("  Events count: {}", events.map(|e| e.len()).unwrap_or(0));
+            if let Some(events) = events {
+                for (i, event) in events.iter().enumerate().take(10) {
+                    println!(
+                        "  Event {}: type={}, data_preview={}",
+                        i,
+                        event["type"].as_str().unwrap_or("?"),
+                        &event["data"]
+                            .to_string()
+                            .chars()
+                            .take(100)
+                            .collect::<String>()
+                    );
                 }
             }
         }

--- a/crates/core/examples/turn_based_execution.rs
+++ b/crates/core/examples/turn_based_execution.rs
@@ -24,6 +24,7 @@
 
 use chrono::Utc;
 use everruns_core::{
+    InputMessage, MessageStore,
     agent::{Agent, AgentStatus},
     atoms::{
         ActAtom, ActInput, Atom, AtomContext, InputAtom, InputAtomInput, ReasonAtom, ReasonInput,
@@ -36,9 +37,8 @@ use everruns_core::{
     },
     session::{Session, SessionStatus},
     tools::{Tool, ToolExecutionResult, ToolRegistry, ToolRegistryBuilder},
-    InputMessage, MessageStore,
 };
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use uuid::Uuid;
 
 /// A simple weather tool for demonstration

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -352,7 +352,7 @@ where
             self.tool_executor.execute(&tool_call, tool_def).await
         };
 
-        let tool_call_result = match result {
+        match result {
             Ok(tool_result) => {
                 let success = tool_result.error.is_none();
                 let status = if success { "success" } else { "error" };
@@ -456,9 +456,7 @@ where
                     status: "error".to_string(),
                 }
             }
-        };
-
-        tool_call_result
+        }
     }
 }
 
@@ -520,11 +518,13 @@ mod tests {
         assert_eq!(result.results.len(), 1);
         assert!(!result.results[0].success);
         assert_eq!(result.results[0].status, "error");
-        assert!(result.results[0]
-            .result
-            .error
-            .as_ref()
-            .unwrap()
-            .contains("not found"));
+        assert!(
+            result.results[0]
+                .result
+                .error
+                .as_ref()
+                .unwrap()
+                .contains("not found")
+        );
     }
 }

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -590,36 +590,33 @@ where
         agent_model_id: Option<Uuid>,
     ) -> Result<ModelWithProvider> {
         // Try controls.model_id first (highest priority)
-        if let Some(model_id) = controls_model_id {
-            if let Some(model_with_provider) = self
+        if let Some(model_id) = controls_model_id
+            && let Some(model_with_provider) = self
                 .provider_store
                 .get_model_with_provider(model_id)
                 .await?
-            {
-                return Ok(model_with_provider);
-            }
+        {
+            return Ok(model_with_provider);
         }
 
         // Try session.model_id second
-        if let Some(model_id) = session_model_id {
-            if let Some(model_with_provider) = self
+        if let Some(model_id) = session_model_id
+            && let Some(model_with_provider) = self
                 .provider_store
                 .get_model_with_provider(model_id)
                 .await?
-            {
-                return Ok(model_with_provider);
-            }
+        {
+            return Ok(model_with_provider);
         }
 
         // Try agent.default_model_id third
-        if let Some(model_id) = agent_model_id {
-            if let Some(model_with_provider) = self
+        if let Some(model_id) = agent_model_id
+            && let Some(model_with_provider) = self
                 .provider_store
                 .get_model_with_provider(model_id)
                 .await?
-            {
-                return Ok(model_with_provider);
-            }
+        {
+            return Ok(model_with_provider);
         }
 
         // Fall back to system default model

--- a/crates/core/src/capabilities/fake_aws.rs
+++ b/crates/core/src/capabilities/fake_aws.rs
@@ -21,7 +21,7 @@ use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 /// Fake AWS Tools capability - mock AWS infrastructure management for demos
 pub struct FakeAwsCapability;
@@ -353,7 +353,9 @@ impl Tool for AwsCreateEc2InstanceTool {
         let instance_type = match arguments.get("instance_type").and_then(|v| v.as_str()) {
             Some(t) => t,
             None => {
-                return ToolExecutionResult::tool_error("Missing required parameter: instance_type")
+                return ToolExecutionResult::tool_error(
+                    "Missing required parameter: instance_type",
+                );
             }
         };
 
@@ -478,7 +480,7 @@ impl Tool for AwsStopEc2InstanceTool {
         let instance_id = match arguments.get("instance_id").and_then(|v| v.as_str()) {
             Some(id) => id,
             None => {
-                return ToolExecutionResult::tool_error("Missing required parameter: instance_id")
+                return ToolExecutionResult::tool_error("Missing required parameter: instance_id");
             }
         };
 
@@ -500,7 +502,7 @@ impl Tool for AwsStopEc2InstanceTool {
                 return ToolExecutionResult::tool_error(format!(
                     "Instance not found: {}",
                     instance_id
-                ))
+                ));
             }
         };
 

--- a/crates/core/src/capabilities/fake_crm.rs
+++ b/crates/core/src/capabilities/fake_crm.rs
@@ -18,7 +18,7 @@ use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 /// Fake CRM Tools capability - mock customer relationship management for demos
 pub struct FakeCrmCapability;
@@ -283,7 +283,7 @@ impl Tool for CrmGetCustomerTool {
         let customer_id = match arguments.get("customer_id").and_then(|v| v.as_str()) {
             Some(id) => id,
             None => {
-                return ToolExecutionResult::tool_error("Missing required parameter: customer_id")
+                return ToolExecutionResult::tool_error("Missing required parameter: customer_id");
             }
         };
 
@@ -561,7 +561,7 @@ impl Tool for CrmCreateTicketTool {
         let customer_id = match arguments.get("customer_id").and_then(|v| v.as_str()) {
             Some(id) => id,
             None => {
-                return ToolExecutionResult::tool_error("Missing required parameter: customer_id")
+                return ToolExecutionResult::tool_error("Missing required parameter: customer_id");
             }
         };
 
@@ -573,7 +573,7 @@ impl Tool for CrmCreateTicketTool {
         let description = match arguments.get("description").and_then(|v| v.as_str()) {
             Some(d) => d,
             None => {
-                return ToolExecutionResult::tool_error("Missing required parameter: description")
+                return ToolExecutionResult::tool_error("Missing required parameter: description");
             }
         };
 

--- a/crates/core/src/capabilities/fake_financial.rs
+++ b/crates/core/src/capabilities/fake_financial.rs
@@ -18,7 +18,7 @@ use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 /// Fake Financial Tools capability - mock financial management for demos
 pub struct FakeFinancialCapability;
@@ -291,7 +291,7 @@ impl Tool for FinanceCreateTransactionTool {
             None => {
                 return ToolExecutionResult::tool_error(
                     "Missing required parameter: transaction_type",
-                )
+                );
             }
         };
 
@@ -308,7 +308,7 @@ impl Tool for FinanceCreateTransactionTool {
         let description = match arguments.get("description").and_then(|v| v.as_str()) {
             Some(d) => d,
             None => {
-                return ToolExecutionResult::tool_error("Missing required parameter: description")
+                return ToolExecutionResult::tool_error("Missing required parameter: description");
             }
         };
 

--- a/crates/core/src/capabilities/fake_warehouse.rs
+++ b/crates/core/src/capabilities/fake_warehouse.rs
@@ -20,7 +20,7 @@ use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 /// Fake Warehouse Tools capability - mock warehouse management for demos
 pub struct FakeWarehouseCapability;
@@ -339,7 +339,7 @@ impl Tool for WarehouseUpdateInventoryTool {
             None => {
                 return ToolExecutionResult::tool_error(
                     "Missing required parameter: quantity_change",
-                )
+                );
             }
         };
 
@@ -462,7 +462,7 @@ impl Tool for WarehouseCreateShipmentTool {
         let destination = match arguments.get("destination").and_then(|v| v.as_str()) {
             Some(d) => d,
             None => {
-                return ToolExecutionResult::tool_error("Missing required parameter: destination")
+                return ToolExecutionResult::tool_error("Missing required parameter: destination");
             }
         };
 
@@ -657,7 +657,7 @@ impl Tool for WarehouseUpdateShipmentStatusTool {
         let shipment_id = match arguments.get("shipment_id").and_then(|v| v.as_str()) {
             Some(id) => id,
             None => {
-                return ToolExecutionResult::tool_error("Missing required parameter: shipment_id")
+                return ToolExecutionResult::tool_error("Missing required parameter: shipment_id");
             }
         };
 
@@ -684,7 +684,7 @@ impl Tool for WarehouseUpdateShipmentStatusTool {
                 return ToolExecutionResult::tool_error(format!(
                     "Shipment not found: {}",
                     shipment_id
-                ))
+                ));
             }
         };
 

--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -15,7 +15,7 @@ use super::{Capability, CapabilityId, CapabilityStatus};
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 /// Session File System capability - provides file operations for session storage
 pub struct FileSystemCapability;
@@ -128,7 +128,9 @@ impl Tool for ReadFileTool {
         let file_store = match &context.file_store {
             Some(store) => store,
             None => {
-                return ToolExecutionResult::tool_error("File system not available in this context")
+                return ToolExecutionResult::tool_error(
+                    "File system not available in this context",
+                );
             }
         };
 
@@ -228,7 +230,9 @@ impl Tool for WriteFileTool {
         let file_store = match &context.file_store {
             Some(store) => store,
             None => {
-                return ToolExecutionResult::tool_error("File system not available in this context")
+                return ToolExecutionResult::tool_error(
+                    "File system not available in this context",
+                );
             }
         };
 
@@ -308,7 +312,9 @@ impl Tool for ListDirectoryTool {
         let file_store = match &context.file_store {
             Some(store) => store,
             None => {
-                return ToolExecutionResult::tool_error("File system not available in this context")
+                return ToolExecutionResult::tool_error(
+                    "File system not available in this context",
+                );
             }
         };
 
@@ -405,7 +411,9 @@ impl Tool for GrepFilesTool {
         let file_store = match &context.file_store {
             Some(store) => store,
             None => {
-                return ToolExecutionResult::tool_error("File system not available in this context")
+                return ToolExecutionResult::tool_error(
+                    "File system not available in this context",
+                );
             }
         };
 
@@ -507,7 +515,9 @@ impl Tool for DeleteFileTool {
         let file_store = match &context.file_store {
             Some(store) => store,
             None => {
-                return ToolExecutionResult::tool_error("File system not available in this context")
+                return ToolExecutionResult::tool_error(
+                    "File system not available in this context",
+                );
             }
         };
 
@@ -591,7 +601,9 @@ impl Tool for StatFileTool {
         let file_store = match &context.file_store {
             Some(store) => store,
             None => {
-                return ToolExecutionResult::tool_error("File system not available in this context")
+                return ToolExecutionResult::tool_error(
+                    "File system not available in this context",
+                );
             }
         };
 

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -711,10 +711,12 @@ mod tests {
         );
 
         // TestWeather has system prompt addition and 2 tools
-        assert!(applied
-            .runtime_agent
-            .system_prompt
-            .contains("weather tools"));
+        assert!(
+            applied
+                .runtime_agent
+                .system_prompt
+                .contains("weather tools")
+        );
         assert!(applied.tool_registry.has("get_weather"));
         assert!(applied.tool_registry.has("get_forecast"));
         assert_eq!(applied.tool_registry.len(), 2);
@@ -752,10 +754,12 @@ mod tests {
         );
 
         // StatelessTodoList has system prompt addition and 1 tool
-        assert!(applied
-            .runtime_agent
-            .system_prompt
-            .contains("Task Management"));
+        assert!(
+            applied
+                .runtime_agent
+                .system_prompt
+                .contains("Task Management")
+        );
         assert!(applied.runtime_agent.system_prompt.contains("write_todos"));
         assert!(applied.tool_registry.has("write_todos"));
         assert_eq!(applied.tool_registry.len(), 1);

--- a/crates/core/src/capabilities/research.rs
+++ b/crates/core/src/capabilities/research.rs
@@ -31,6 +31,8 @@ impl Capability for ResearchCapability {
     }
 
     fn system_prompt_addition(&self) -> Option<&str> {
-        Some("You have access to a research scratchpad. Use it to organize your thoughts and findings.")
+        Some(
+            "You have access to a research scratchpad. Use it to organize your thoughts and findings.",
+        )
     }
 }

--- a/crates/core/src/capabilities/stateless_todo_list.rs
+++ b/crates/core/src/capabilities/stateless_todo_list.rs
@@ -243,7 +243,8 @@ impl Tool for WriteTodosTool {
                 Some(other) => {
                     return ToolExecutionResult::tool_error(format!(
                         "Task {} has invalid status '{}'. Must be 'pending', 'in_progress', or 'completed'",
-                        idx + 1, other
+                        idx + 1,
+                        other
                     ));
                 }
                 None => {
@@ -265,7 +266,9 @@ impl Tool for WriteTodosTool {
         let warning = if in_progress_count == 0 && pending_count > 0 {
             Some("No task is marked as 'in_progress'. Consider marking one task as in_progress.")
         } else if in_progress_count > 1 {
-            Some("Multiple tasks are marked as 'in_progress'. Best practice is to have exactly one in_progress task at a time.")
+            Some(
+                "Multiple tasks are marked as 'in_progress'. Best practice is to have exactly one in_progress task at a time.",
+            )
         } else {
             None
         };
@@ -367,12 +370,14 @@ mod tests {
 
         if let ToolExecutionResult::Success(value) = result {
             assert!(value.get("warning").is_some());
-            assert!(value
-                .get("warning")
-                .unwrap()
-                .as_str()
-                .unwrap()
-                .contains("No task is marked as 'in_progress'"));
+            assert!(
+                value
+                    .get("warning")
+                    .unwrap()
+                    .as_str()
+                    .unwrap()
+                    .contains("No task is marked as 'in_progress'")
+            );
         } else {
             panic!("Expected success");
         }
@@ -392,12 +397,14 @@ mod tests {
 
         if let ToolExecutionResult::Success(value) = result {
             assert!(value.get("warning").is_some());
-            assert!(value
-                .get("warning")
-                .unwrap()
-                .as_str()
-                .unwrap()
-                .contains("Multiple tasks"));
+            assert!(
+                value
+                    .get("warning")
+                    .unwrap()
+                    .as_str()
+                    .unwrap()
+                    .contains("Multiple tasks")
+            );
         } else {
             panic!("Expected success");
         }

--- a/crates/core/src/capabilities/test_math.rs
+++ b/crates/core/src/capabilities/test_math.rs
@@ -34,7 +34,9 @@ impl Capability for TestMathCapability {
     }
 
     fn system_prompt_addition(&self) -> Option<&str> {
-        Some("You have access to math tools. Use them for calculations: add, subtract, multiply, divide.")
+        Some(
+            "You have access to math tools. Use them for calculations: add, subtract, multiply, divide.",
+        )
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {

--- a/crates/core/src/capabilities/test_weather.rs
+++ b/crates/core/src/capabilities/test_weather.rs
@@ -34,7 +34,9 @@ impl Capability for TestWeatherCapability {
     }
 
     fn system_prompt_addition(&self) -> Option<&str> {
-        Some("You have access to weather tools. Use get_weather for current conditions and get_forecast for multi-day forecasts.")
+        Some(
+            "You have access to weather tools. Use get_weather for current conditions and get_forecast for multi-day forecasts.",
+        )
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {

--- a/crates/core/src/capabilities/web_fetch.rs
+++ b/crates/core/src/capabilities/web_fetch.rs
@@ -16,7 +16,7 @@ use crate::tools::{Tool, ToolExecutionResult};
 use async_trait::async_trait;
 use futures::StreamExt;
 use reqwest::header::{
-    HeaderMap, HeaderValue, ACCEPT, CONTENT_DISPOSITION, CONTENT_LENGTH, CONTENT_TYPE,
+    ACCEPT, CONTENT_DISPOSITION, CONTENT_LENGTH, CONTENT_TYPE, HeaderMap, HeaderValue,
     LAST_MODIFIED, USER_AGENT,
 };
 use serde_json::Value;
@@ -269,18 +269,18 @@ impl Tool for WebFetchTool {
         let filename = extract_filename_from_headers(response.headers(), url);
 
         // Check for binary content - return metadata instead of error
-        if let Some(ref ct) = content_type {
-            if is_binary_content_type(ct) {
-                return ToolExecutionResult::success(serde_json::json!({
-                    "url": url,
-                    "status_code": status_code,
-                    "content_type": content_type,
-                    "size": content_length,
-                    "filename": filename,
-                    "last_modified": last_modified,
-                    "error": "Binary content is not supported. Only textual content (HTML, text, JSON, etc.) can be fetched."
-                }));
-            }
+        if let Some(ref ct) = content_type
+            && is_binary_content_type(ct)
+        {
+            return ToolExecutionResult::success(serde_json::json!({
+                "url": url,
+                "status_code": status_code,
+                "content_type": content_type,
+                "size": content_length,
+                "filename": filename,
+                "last_modified": last_modified,
+                "error": "Binary content is not supported. Only textual content (HTML, text, JSON, etc.) can be fetched."
+            }));
         }
 
         // For HEAD requests, return headers info only
@@ -416,36 +416,35 @@ async fn read_body_with_timeout(
 /// Extract filename from Content-Disposition header or URL
 fn extract_filename_from_headers(headers: &HeaderMap, url: &str) -> Option<String> {
     // Try Content-Disposition header first
-    if let Some(disposition) = headers.get(CONTENT_DISPOSITION) {
-        if let Ok(value) = disposition.to_str() {
-            // Look for filename="..." or filename*=...
-            if let Some(start) = value.find("filename=") {
-                let rest = &value[start + 9..];
-                let filename = if let Some(stripped) = rest.strip_prefix('"') {
-                    // Quoted filename
-                    stripped.split('"').next()
-                } else {
-                    // Unquoted filename
-                    rest.split([';', ' ']).next()
-                };
-                if let Some(name) = filename {
-                    if !name.is_empty() {
-                        return Some(name.to_string());
-                    }
-                }
+    if let Some(disposition) = headers.get(CONTENT_DISPOSITION)
+        && let Ok(value) = disposition.to_str()
+    {
+        // Look for filename="..." or filename*=...
+        if let Some(start) = value.find("filename=") {
+            let rest = &value[start + 9..];
+            let filename = if let Some(stripped) = rest.strip_prefix('"') {
+                // Quoted filename
+                stripped.split('"').next()
+            } else {
+                // Unquoted filename
+                rest.split([';', ' ']).next()
+            };
+            if let Some(name) = filename
+                && !name.is_empty()
+            {
+                return Some(name.to_string());
             }
         }
     }
 
     // Fall back to extracting filename from URL path
-    if let Ok(parsed) = url::Url::parse(url) {
-        if let Some(mut segments) = parsed.path_segments() {
-            if let Some(last) = segments.next_back() {
-                if !last.is_empty() && last.contains('.') {
-                    return Some(last.to_string());
-                }
-            }
-        }
+    if let Ok(parsed) = url::Url::parse(url)
+        && let Some(mut segments) = parsed.path_segments()
+        && let Some(last) = segments.next_back()
+        && !last.is_empty()
+        && last.contains('.')
+    {
+        return Some(last.to_string());
     }
 
     None
@@ -928,10 +927,12 @@ mod tests {
 
         if let ToolExecutionResult::Success(value) = result {
             assert_eq!(value["status_code"], 200);
-            assert!(value["content"]
-                .as_str()
-                .unwrap()
-                .contains("Herman Melville"));
+            assert!(
+                value["content"]
+                    .as_str()
+                    .unwrap()
+                    .contains("Herman Melville")
+            );
         } else {
             panic!("Expected successful response");
         }
@@ -1026,14 +1027,18 @@ mod tests {
         // Binary content should return success with error message and metadata
         if let ToolExecutionResult::Success(value) = result {
             assert_eq!(value["status_code"], 200);
-            assert!(value["content_type"]
-                .as_str()
-                .unwrap()
-                .contains("image/png"));
-            assert!(value["error"]
-                .as_str()
-                .unwrap()
-                .contains("Binary content is not supported"));
+            assert!(
+                value["content_type"]
+                    .as_str()
+                    .unwrap()
+                    .contains("image/png")
+            );
+            assert!(
+                value["error"]
+                    .as_str()
+                    .unwrap()
+                    .contains("Binary content is not supported")
+            );
             // Should have size metadata if available
             assert!(value.get("size").is_some() || value["size"].is_null());
         } else {
@@ -1696,10 +1701,10 @@ mod tests {
         // Binary content returns metadata with size
         if let ToolExecutionResult::Success(value) = result {
             // For binary content, size comes from Content-Length header
-            if let Some(size) = value.get("size") {
-                if !size.is_null() {
-                    assert_eq!(size.as_u64().unwrap(), 100);
-                }
+            if let Some(size) = value.get("size")
+                && !size.is_null()
+            {
+                assert_eq!(size.as_u64().unwrap(), 100);
             }
         }
     }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -54,7 +54,9 @@ pub enum AgentLoopError {
     Internal(#[from] anyhow::Error),
 
     /// Driver not registered for provider type
-    #[error("No driver registered for provider type '{0}'. Make sure the driver is registered at startup.")]
+    #[error(
+        "No driver registered for provider type '{0}'. Make sure the driver is registered at startup."
+    )]
     DriverNotRegistered(String),
 }
 

--- a/crates/core/src/event_listeners.rs
+++ b/crates/core/src/event_listeners.rs
@@ -127,10 +127,10 @@ impl EventListener for CompositeEventListener {
     async fn on_event(&self, event: &Event) {
         for listener in &self.listeners {
             // Check if listener wants this event type
-            if let Some(types) = listener.event_types() {
-                if !types.contains(&event.event_type.as_str()) {
-                    continue;
-                }
+            if let Some(types) = listener.event_types()
+                && !types.contains(&event.event_type.as_str())
+            {
+                continue;
             }
             listener.on_event(event).await;
         }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -90,12 +90,12 @@ pub use tools::{
 
 // Capability re-exports
 pub use capabilities::{
-    apply_capabilities, AddTool, AppliedCapabilities, Capability, CapabilityId, CapabilityRegistry,
+    AddTool, AppliedCapabilities, Capability, CapabilityId, CapabilityRegistry,
     CapabilityRegistryBuilder, CapabilityStatus, CurrentTimeCapability, DeleteFileTool, DivideTool,
     FileSystemCapability, GetCurrentTimeTool, GetForecastTool, GetWeatherTool, GrepFilesTool,
     ListDirectoryTool, MultiplyTool, NoopCapability, ReadFileTool, ResearchCapability,
     SandboxCapability, StatFileTool, StatelessTodoListCapability, SubtractTool, TestMathCapability,
-    TestWeatherCapability, WriteFileTool, WriteTodosTool,
+    TestWeatherCapability, WriteFileTool, WriteTodosTool, apply_capabilities,
 };
 
 // Atoms re-exports (stateless atomic operations)
@@ -114,13 +114,14 @@ pub use tool_types::{BuiltinTool, ToolCall, ToolDefinition, ToolPolicy, ToolResu
 pub use agent::{Agent, AgentStatus};
 pub use capability_dto::{AgentCapability, CapabilityInfo};
 pub use events::{
-    ActCompletedData, ActStartedData, Event, EventBuilder, EventContext, EventData, EventRequest,
-    InputReceivedData, LlmGenerationData, LlmGenerationMetadata, LlmGenerationOutput,
-    MessageAgentData, MessageUserData, ModelMetadata, ReasonCompletedData, ReasonStartedData,
-    SessionStartedData, TokenUsage, ToolCallCompletedData, ToolCallStartedData, ToolCallSummary,
-    TurnCompletedData, TurnFailedData, TurnStartedData, ACT_COMPLETED, ACT_STARTED, INPUT_RECEIVED,
-    LLM_GENERATION, MESSAGE_AGENT, MESSAGE_USER, REASON_COMPLETED, REASON_STARTED, SESSION_STARTED,
-    TOOL_CALL_COMPLETED, TOOL_CALL_STARTED, TURN_COMPLETED, TURN_FAILED, TURN_STARTED, UNKNOWN,
+    ACT_COMPLETED, ACT_STARTED, ActCompletedData, ActStartedData, Event, EventBuilder,
+    EventContext, EventData, EventRequest, INPUT_RECEIVED, InputReceivedData, LLM_GENERATION,
+    LlmGenerationData, LlmGenerationMetadata, LlmGenerationOutput, MESSAGE_AGENT, MESSAGE_USER,
+    MessageAgentData, MessageUserData, ModelMetadata, REASON_COMPLETED, REASON_STARTED,
+    ReasonCompletedData, ReasonStartedData, SESSION_STARTED, SessionStartedData,
+    TOOL_CALL_COMPLETED, TOOL_CALL_STARTED, TURN_COMPLETED, TURN_FAILED, TURN_STARTED, TokenUsage,
+    ToolCallCompletedData, ToolCallStartedData, ToolCallSummary, TurnCompletedData, TurnFailedData,
+    TurnStartedData, UNKNOWN,
 };
 pub use llm_model_profiles::get_model_profile;
 pub use llm_models::{

--- a/crates/core/src/llm_model_profiles.rs
+++ b/crates/core/src/llm_model_profiles.rs
@@ -1507,10 +1507,12 @@ mod tests {
         let effort = profile.reasoning_effort.unwrap();
         assert_eq!(effort.default, ReasoningEffort::Medium);
         assert_eq!(effort.values.len(), 3);
-        assert!(!effort
-            .values
-            .iter()
-            .any(|v| v.value == ReasoningEffort::None));
+        assert!(
+            !effort
+                .values
+                .iter()
+                .any(|v| v.value == ReasoningEffort::None)
+        );
     }
 
     #[test]
@@ -1547,14 +1549,18 @@ mod tests {
         let effort = profile.reasoning_effort.unwrap();
         assert_eq!(effort.default, ReasoningEffort::None);
         assert_eq!(effort.values.len(), 4);
-        assert!(effort
-            .values
-            .iter()
-            .any(|v| v.value == ReasoningEffort::None));
-        assert!(!effort
-            .values
-            .iter()
-            .any(|v| v.value == ReasoningEffort::Xhigh));
+        assert!(
+            effort
+                .values
+                .iter()
+                .any(|v| v.value == ReasoningEffort::None)
+        );
+        assert!(
+            !effort
+                .values
+                .iter()
+                .any(|v| v.value == ReasoningEffort::Xhigh)
+        );
     }
 
     #[test]
@@ -1565,10 +1571,12 @@ mod tests {
 
         // After gpt-5.1-codex-max: supports xhigh
         let effort = profile.reasoning_effort.unwrap();
-        assert!(effort
-            .values
-            .iter()
-            .any(|v| v.value == ReasoningEffort::Xhigh));
+        assert!(
+            effort
+                .values
+                .iter()
+                .any(|v| v.value == ReasoningEffort::Xhigh)
+        );
     }
 
     #[test]
@@ -1581,10 +1589,12 @@ mod tests {
         let effort = profile.reasoning_effort.unwrap();
         assert_eq!(effort.default, ReasoningEffort::None);
         assert_eq!(effort.values.len(), 5);
-        assert!(effort
-            .values
-            .iter()
-            .any(|v| v.value == ReasoningEffort::Xhigh));
+        assert!(
+            effort
+                .values
+                .iter()
+                .any(|v| v.value == ReasoningEffort::Xhigh)
+        );
     }
 
     #[test]
@@ -1597,14 +1607,18 @@ mod tests {
         let effort = profile.reasoning_effort.unwrap();
         assert_eq!(effort.default, ReasoningEffort::Medium);
         assert_eq!(effort.values.len(), 3);
-        assert!(effort
-            .values
-            .iter()
-            .any(|v| v.value == ReasoningEffort::Xhigh));
-        assert!(!effort
-            .values
-            .iter()
-            .any(|v| v.value == ReasoningEffort::None));
+        assert!(
+            effort
+                .values
+                .iter()
+                .any(|v| v.value == ReasoningEffort::Xhigh)
+        );
+        assert!(
+            !effort
+                .values
+                .iter()
+                .any(|v| v.value == ReasoningEffort::None)
+        );
     }
 
     #[test]

--- a/crates/core/src/llmsim_driver.rs
+++ b/crates/core/src/llmsim_driver.rs
@@ -12,8 +12,8 @@
 
 use async_trait::async_trait;
 use futures::stream;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::error::Result;
 use crate::llm_driver_registry::{

--- a/crates/core/src/memory.rs
+++ b/crates/core/src/memory.rs
@@ -806,8 +806,8 @@ mod tests {
     #[tokio::test]
     async fn test_in_memory_event_emitter_filter_by_type() {
         use crate::events::{
-            EventContext, EventRequest, InputReceivedData, ReasonStartedData, INPUT_RECEIVED,
-            REASON_STARTED,
+            EventContext, EventRequest, INPUT_RECEIVED, InputReceivedData, REASON_STARTED,
+            ReasonStartedData,
         };
 
         let emitter = InMemoryEventEmitter::new();

--- a/crates/core/src/observation/otel.rs
+++ b/crates/core/src/observation/otel.rs
@@ -19,9 +19,9 @@ use uuid::Uuid;
 
 use crate::event_listeners::EventListener;
 use crate::events::{
-    Event, EventData, LlmGenerationData, ToolCallCompletedData, ToolCallStartedData,
-    TurnCompletedData, TurnStartedData, LLM_GENERATION, TOOL_CALL_COMPLETED, TOOL_CALL_STARTED,
-    TURN_COMPLETED, TURN_STARTED,
+    Event, EventData, LLM_GENERATION, LlmGenerationData, TOOL_CALL_COMPLETED, TOOL_CALL_STARTED,
+    TURN_COMPLETED, TURN_STARTED, ToolCallCompletedData, ToolCallStartedData, TurnCompletedData,
+    TurnStartedData,
 };
 use crate::telemetry::gen_ai;
 

--- a/crates/core/src/openai_protocol.rs
+++ b/crates/core/src/openai_protocol.rs
@@ -15,7 +15,7 @@ use eventsource_stream::Eventsource;
 use futures::StreamExt;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::sync::{Arc, Mutex};
 
 use crate::error::{AgentLoopError, Result};

--- a/crates/core/src/runtime_agent.rs
+++ b/crates/core/src/runtime_agent.rs
@@ -5,7 +5,7 @@
 // - Built from an Agent entity via the `with_agent` builder method
 
 use crate::agent::Agent;
-use crate::capabilities::{collect_capabilities, CapabilityRegistry};
+use crate::capabilities::{CapabilityRegistry, collect_capabilities};
 use crate::tool_types::ToolDefinition;
 use serde::{Deserialize, Serialize};
 

--- a/crates/core/src/session_file.rs
+++ b/crates/core/src/session_file.rs
@@ -3,7 +3,7 @@
 // These types represent files and directories stored within a session's
 // virtual filesystem. Each session has its own isolated filesystem.
 
-use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;

--- a/crates/core/src/telemetry.rs
+++ b/crates/core/src/telemetry.rs
@@ -5,15 +5,15 @@
 // - Initialization helpers for OTLP exporters
 // - Span creation helpers with proper attribute naming
 
-use opentelemetry::trace::TracerProvider as _;
 use opentelemetry::KeyValue;
+use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_otlp::{SpanExporter, WithExportConfig};
 use opentelemetry_sdk::{
-    trace::{RandomIdGenerator, Sampler, SdkTracerProvider},
     Resource,
+    trace::{RandomIdGenerator, Sampler, SdkTracerProvider},
 };
 use std::time::Duration;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
+use tracing_subscriber::{EnvFilter, Layer, layer::SubscriberExt, util::SubscriberInitExt};
 
 // ============================================================================
 // Gen-AI Semantic Conventions
@@ -231,10 +231,10 @@ pub struct TelemetryGuard {
 
 impl Drop for TelemetryGuard {
     fn drop(&mut self) {
-        if let Some(provider) = self._provider.take() {
-            if let Err(e) = provider.shutdown() {
-                eprintln!("Failed to shutdown tracer provider: {:?}", e);
-            }
+        if let Some(provider) = self._provider.take()
+            && let Err(e) = provider.shutdown()
+        {
+            eprintln!("Failed to shutdown tracer provider: {:?}", e);
         }
     }
 }

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -10,7 +10,7 @@ use everruns_core::atoms::{Atom, AtomContext, ReasonAtom, ReasonInput};
 use everruns_core::capabilities::CapabilityRegistry;
 use everruns_core::llm_driver_registry::{DriverRegistry, ProviderType};
 use everruns_core::llm_models::LlmProviderType;
-use everruns_core::llmsim_driver::{register_driver, LlmSimConfig, LlmSimDriver};
+use everruns_core::llmsim_driver::{LlmSimConfig, LlmSimDriver, register_driver};
 use everruns_core::memory::{
     InMemoryAgentStore, InMemoryLlmProviderStore, InMemoryMessageStore, InMemorySessionStore,
 };

--- a/crates/core/tests/tool_calling_test.rs
+++ b/crates/core/tests/tool_calling_test.rs
@@ -4,16 +4,16 @@
 // the ToolExecutor trait work correctly together.
 
 use async_trait::async_trait;
+use everruns_core::{BuiltinTool, ToolCall, ToolDefinition, ToolPolicy};
 use everruns_core::{
+    GetCurrentTimeTool, Message, MessageRole,
     memory::InMemoryMessageStore,
     tools::{EchoTool, FailingTool, Tool, ToolExecutionResult, ToolRegistry},
     traits::ToolExecutor,
-    GetCurrentTimeTool, Message, MessageRole,
 };
-use everruns_core::{BuiltinTool, ToolCall, ToolDefinition, ToolPolicy};
 use serde_json::json;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use uuid::Uuid;
 
 // =============================================================================

--- a/crates/durable/benches/concurrent_workers.rs
+++ b/crates/durable/benches/concurrent_workers.rs
@@ -9,8 +9,8 @@
 //!   cargo bench -p everruns-durable --bench concurrent_workers -- --save --moniker ci-4cpu-8gb
 
 use std::env;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use indicatif::{ProgressBar, ProgressStyle};
@@ -18,8 +18,8 @@ use tokio::runtime::Runtime;
 use tokio::sync::Semaphore;
 
 use everruns_durable::bench::{
-    clear_terminal_progress, set_terminal_progress, ActivityDuration, BenchmarkCheckpoint,
-    BenchmarkMetrics, BenchmarkReport, CheckpointStore, EnvironmentInfo, ReportConfig,
+    ActivityDuration, BenchmarkCheckpoint, BenchmarkMetrics, BenchmarkReport, CheckpointStore,
+    EnvironmentInfo, ReportConfig, clear_terminal_progress, set_terminal_progress,
 };
 use everruns_durable::persistence::{
     InMemoryWorkflowEventStore, TaskDefinition, WorkflowEventStore,

--- a/crates/durable/benches/workflow_throughput.rs
+++ b/crates/durable/benches/workflow_throughput.rs
@@ -9,16 +9,16 @@
 //!   cargo bench -p everruns-durable --bench workflow_throughput -- --save --moniker ci-4cpu-8gb
 
 use std::env;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use indicatif::{ProgressBar, ProgressStyle};
 use tokio::runtime::Runtime;
 
 use everruns_durable::bench::{
-    clear_terminal_progress, set_terminal_progress, BenchmarkCheckpoint, BenchmarkMetrics,
-    BenchmarkReport, CheckpointStore, EnvironmentInfo, ReportConfig,
+    BenchmarkCheckpoint, BenchmarkMetrics, BenchmarkReport, CheckpointStore, EnvironmentInfo,
+    ReportConfig, clear_terminal_progress, set_terminal_progress,
 };
 use everruns_durable::persistence::{
     InMemoryWorkflowEventStore, TaskDefinition, WorkflowEventStore,

--- a/crates/durable/src/activity/context.rs
+++ b/crates/durable/src/activity/context.rs
@@ -1,7 +1,7 @@
 //! Activity execution context
 
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use tokio::sync::mpsc;
 use uuid::Uuid;

--- a/crates/durable/src/activity/definition.rs
+++ b/crates/durable/src/activity/definition.rs
@@ -1,7 +1,7 @@
 //! Activity trait definition
 
 use async_trait::async_trait;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use super::ActivityContext;
 

--- a/crates/durable/src/bench/checkpoint.rs
+++ b/crates/durable/src/bench/checkpoint.rs
@@ -239,12 +239,11 @@ impl CheckpointStore {
         for entry in fs::read_dir(&self.directory)? {
             let entry = entry?;
             let path = entry.path();
-            if path.extension().map(|e| e == "json").unwrap_or(false) {
-                if let Ok(checkpoint) = self.load(path.file_name().unwrap().to_str().unwrap()) {
-                    if checkpoint.id.starts_with(id_prefix) {
-                        return Ok(path);
-                    }
-                }
+            if path.extension().map(|e| e == "json").unwrap_or(false)
+                && let Ok(checkpoint) = self.load(path.file_name().unwrap().to_str().unwrap())
+                && checkpoint.id.starts_with(id_prefix)
+            {
+                return Ok(path);
             }
         }
         Err(io::Error::new(
@@ -265,12 +264,11 @@ impl CheckpointStore {
             let entry = entry?;
             let path = entry.path();
 
-            if path.extension().map(|e| e == "json").unwrap_or(false) {
-                if let Ok(checkpoint) = self.load(path.file_name().unwrap().to_str().unwrap()) {
-                    if filter.map(|f| f.matches(&checkpoint)).unwrap_or(true) {
-                        checkpoints.push(checkpoint);
-                    }
-                }
+            if path.extension().map(|e| e == "json").unwrap_or(false)
+                && let Ok(checkpoint) = self.load(path.file_name().unwrap().to_str().unwrap())
+                && filter.map(|f| f.matches(&checkpoint)).unwrap_or(true)
+            {
+                checkpoints.push(checkpoint);
             }
         }
 
@@ -350,34 +348,34 @@ pub struct CheckpointFilter {
 impl CheckpointFilter {
     /// Check if a checkpoint matches this filter
     pub fn matches(&self, checkpoint: &BenchmarkCheckpoint) -> bool {
-        if let Some(ref name) = self.benchmark_name {
-            if !checkpoint.benchmark_name.contains(name) {
-                return false;
-            }
+        if let Some(ref name) = self.benchmark_name
+            && !checkpoint.benchmark_name.contains(name)
+        {
+            return false;
         }
 
-        if let Some(ref moniker) = self.moniker {
-            if !checkpoint.environment.moniker.contains(moniker) {
-                return false;
-            }
+        if let Some(ref moniker) = self.moniker
+            && !checkpoint.environment.moniker.contains(moniker)
+        {
+            return false;
         }
 
-        if let Some(ref tag) = self.tag {
-            if !checkpoint.tags.contains(tag) {
-                return false;
-            }
+        if let Some(ref tag) = self.tag
+            && !checkpoint.tags.contains(tag)
+        {
+            return false;
         }
 
-        if let Some(after) = self.after {
-            if checkpoint.timestamp < after {
-                return false;
-            }
+        if let Some(after) = self.after
+            && checkpoint.timestamp < after
+        {
+            return false;
         }
 
-        if let Some(before) = self.before {
-            if checkpoint.timestamp > before {
-                return false;
-            }
+        if let Some(before) = self.before
+            && checkpoint.timestamp > before
+        {
+            return false;
         }
 
         true
@@ -567,12 +565,10 @@ mod tests {
         assert!(EnvironmentInfo::generate_moniker("Apple M4 Pro", 12, 48.0).contains("M4-Pro"));
 
         // Intel
-        assert!(EnvironmentInfo::generate_moniker(
-            "Intel(R) Core(TM) i9-12900K @ 3.20GHz",
-            24,
-            64.0
-        )
-        .contains("i9-12900K"));
+        assert!(
+            EnvironmentInfo::generate_moniker("Intel(R) Core(TM) i9-12900K @ 3.20GHz", 24, 64.0)
+                .contains("i9-12900K")
+        );
 
         // AMD
         assert!(

--- a/crates/durable/src/bench/metrics.rs
+++ b/crates/durable/src/bench/metrics.rs
@@ -2,8 +2,8 @@
 //!
 //! Collects latency distributions, throughput, and resource usage.
 
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use parking_lot::Mutex;

--- a/crates/durable/src/bench/mod.rs
+++ b/crates/durable/src/bench/mod.rs
@@ -34,6 +34,6 @@ pub use metrics::{
 };
 pub use report::{BenchmarkReport, ReportConfig};
 pub use runner::{
-    clear_terminal_progress, set_terminal_progress, ActivityDuration, BenchmarkRunner,
-    BenchmarkScenario, CheckpointSaveResult, ScenarioConfig,
+    ActivityDuration, BenchmarkRunner, BenchmarkScenario, CheckpointSaveResult, ScenarioConfig,
+    clear_terminal_progress, set_terminal_progress,
 };

--- a/crates/durable/src/bench/report.rs
+++ b/crates/durable/src/bench/report.rs
@@ -5,7 +5,7 @@
 use std::fs;
 use std::path::Path;
 
-use minijinja::{context, Environment};
+use minijinja::{Environment, context};
 
 use super::metrics::{BenchmarkMetrics, LatencySummary, ResourceSnapshot};
 

--- a/crates/durable/src/bench/runner.rs
+++ b/crates/durable/src/bench/runner.rs
@@ -4,8 +4,8 @@
 
 use std::future::Future;
 use std::io::Write;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use indicatif::{ProgressBar, ProgressStyle};
@@ -197,11 +197,11 @@ impl BenchmarkRunner {
 
         for task_id in 0..total {
             // Check deadline
-            if let Some(deadline) = deadline {
-                if Instant::now() >= deadline {
-                    pb.set_message("deadline reached");
-                    break;
-                }
+            if let Some(deadline) = deadline
+                && Instant::now() >= deadline
+            {
+                pb.set_message("deadline reached");
+                break;
             }
 
             // Rate limiting
@@ -441,7 +441,9 @@ impl CheckpointSaveResult {
         if let Some(ref comparison) = self.comparison {
             comparison.print_summary();
         } else {
-            println!("   (No baseline for comparison - this is the first run for this benchmark+environment)");
+            println!(
+                "   (No baseline for comparison - this is the first run for this benchmark+environment)"
+            );
         }
     }
 }

--- a/crates/durable/src/persistence/memory.rs
+++ b/crates/durable/src/persistence/memory.rs
@@ -484,15 +484,15 @@ impl WorkflowEventStore for InMemoryWorkflowEventStore {
         let mut entries: Vec<_> = dlq
             .values()
             .filter(|e| {
-                if let Some(wid) = filter.workflow_id {
-                    if e.workflow_id != wid {
-                        return false;
-                    }
+                if let Some(wid) = filter.workflow_id
+                    && e.workflow_id != wid
+                {
+                    return false;
                 }
-                if let Some(ref at) = filter.activity_type {
-                    if &e.activity_type != at {
-                        return false;
-                    }
+                if let Some(ref at) = filter.activity_type
+                    && &e.activity_type != at
+                {
+                    return false;
                 }
                 true
             })
@@ -624,16 +624,16 @@ impl WorkflowEventStore for InMemoryWorkflowEventStore {
             .values()
             .filter(|w| {
                 // Apply status filter
-                if let Some(ref status) = filter.status {
-                    if &w.status != status {
-                        return false;
-                    }
+                if let Some(ref status) = filter.status
+                    && &w.status != status
+                {
+                    return false;
                 }
                 // Apply worker_group filter
-                if let Some(ref group) = filter.worker_group {
-                    if w.worker_group.as_ref() != Some(group) {
-                        return false;
-                    }
+                if let Some(ref group) = filter.worker_group
+                    && w.worker_group.as_ref() != Some(group)
+                {
+                    return false;
                 }
                 true
             })
@@ -653,16 +653,16 @@ impl WorkflowEventStore for InMemoryWorkflowEventStore {
             .iter()
             .filter(|(_, w)| {
                 // Apply status filter
-                if let Some(ref status) = filter.status {
-                    if &w.status != status {
-                        return false;
-                    }
+                if let Some(ref status) = filter.status
+                    && &w.status != status
+                {
+                    return false;
                 }
                 // Apply workflow_type filter
-                if let Some(ref wf_type) = filter.workflow_type {
-                    if &w.workflow_type != wf_type {
-                        return false;
-                    }
+                if let Some(ref wf_type) = filter.workflow_type
+                    && &w.workflow_type != wf_type
+                {
+                    return false;
                 }
                 true
             })
@@ -695,22 +695,22 @@ impl WorkflowEventStore for InMemoryWorkflowEventStore {
             .iter()
             .filter(|(_, t)| {
                 // Apply status filter
-                if let Some(ref status) = filter.status {
-                    if &t.status != status {
-                        return false;
-                    }
+                if let Some(ref status) = filter.status
+                    && &t.status != status
+                {
+                    return false;
                 }
                 // Apply activity_type filter
-                if let Some(ref activity_type) = filter.activity_type {
-                    if &t.definition.activity_type != activity_type {
-                        return false;
-                    }
+                if let Some(ref activity_type) = filter.activity_type
+                    && &t.definition.activity_type != activity_type
+                {
+                    return false;
                 }
                 // Apply workflow_id filter
-                if let Some(ref wf_id) = filter.workflow_id {
-                    if &t.definition.workflow_id != wf_id {
-                        return false;
-                    }
+                if let Some(ref wf_id) = filter.workflow_id
+                    && &t.definition.workflow_id != wf_id
+                {
+                    return false;
                 }
                 true
             })

--- a/crates/durable/src/persistence/mod.rs
+++ b/crates/durable/src/persistence/mod.rs
@@ -12,8 +12,8 @@ mod store;
 pub use memory::InMemoryWorkflowEventStore;
 pub use postgres::PostgresWorkflowEventStore;
 pub use store::{
-    event_type_name, CircuitBreakerState, ClaimedTask, DlqEntry, DlqFilter, HeartbeatResponse,
-    Pagination, StoreError, SystemHealth, TaskDefinition, TaskFailureOutcome, TaskFilter, TaskInfo,
-    TaskStatus, TraceContext, WorkerFilter, WorkerInfo, WorkflowEventInfo, WorkflowEventStore,
-    WorkflowFilter, WorkflowInfo, WorkflowInfoExtended, WorkflowStatus,
+    CircuitBreakerState, ClaimedTask, DlqEntry, DlqFilter, HeartbeatResponse, Pagination,
+    StoreError, SystemHealth, TaskDefinition, TaskFailureOutcome, TaskFilter, TaskInfo, TaskStatus,
+    TraceContext, WorkerFilter, WorkerInfo, WorkflowEventInfo, WorkflowEventStore, WorkflowFilter,
+    WorkflowInfo, WorkflowInfoExtended, WorkflowStatus, event_type_name,
 };

--- a/crates/durable/src/persistence/store.rs
+++ b/crates/durable/src/persistence/store.rs
@@ -353,7 +353,7 @@ pub trait WorkflowEventStore: Send + Sync + 'static {
 
     /// Load all events for a workflow (for replay)
     async fn load_events(&self, workflow_id: Uuid)
-        -> Result<Vec<(i32, WorkflowEvent)>, StoreError>;
+    -> Result<Vec<(i32, WorkflowEvent)>, StoreError>;
 
     /// Update workflow status
     async fn update_workflow_status(
@@ -404,11 +404,11 @@ pub trait WorkflowEventStore: Send + Sync + 'static {
 
     /// Fail a task (may requeue or send to DLQ)
     async fn fail_task(&self, task_id: Uuid, error: &str)
-        -> Result<TaskFailureOutcome, StoreError>;
+    -> Result<TaskFailureOutcome, StoreError>;
 
     /// Find and reclaim stale tasks (no heartbeat)
     async fn reclaim_stale_tasks(&self, stale_threshold: Duration)
-        -> Result<Vec<Uuid>, StoreError>;
+    -> Result<Vec<Uuid>, StoreError>;
 
     // =========================================================================
     // Signal Operations

--- a/crates/durable/src/reliability/distributed_circuit_breaker.rs
+++ b/crates/durable/src/reliability/distributed_circuit_breaker.rs
@@ -269,10 +269,10 @@ impl DistributedCircuitBreaker {
         // Check local cache first
         {
             let cache = self.local_cache.read().await;
-            if let Some(cached) = cache.as_ref() {
-                if !cached.is_stale(self.cache_duration) {
-                    return Ok(cached.clone());
-                }
+            if let Some(cached) = cache.as_ref()
+                && !cached.is_stale(self.cache_duration)
+            {
+                return Ok(cached.clone());
             }
         }
 

--- a/crates/durable/src/worker/pool.rs
+++ b/crates/durable/src/worker/pool.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
-use tokio::sync::{watch, Semaphore};
+use tokio::sync::{Semaphore, watch};
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, instrument, warn};
 use uuid::Uuid;

--- a/crates/durable/src/workflow/definition.rs
+++ b/crates/durable/src/workflow/definition.rs
@@ -1,6 +1,6 @@
 //! Workflow trait definition
 
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 
 use super::{WorkflowAction, WorkflowSignal};
 use crate::activity::ActivityError;

--- a/crates/durable/src/workflow/event.rs
+++ b/crates/durable/src/workflow/event.rs
@@ -264,20 +264,26 @@ mod tests {
     #[test]
     fn test_is_terminal() {
         assert!(WorkflowEvent::WorkflowCompleted { result: json!({}) }.is_terminal());
-        assert!(WorkflowEvent::WorkflowFailed {
-            error: WorkflowError::new("error")
-        }
-        .is_terminal());
-        assert!(WorkflowEvent::WorkflowCancelled {
-            reason: "cancelled".to_string()
-        }
-        .is_terminal());
+        assert!(
+            WorkflowEvent::WorkflowFailed {
+                error: WorkflowError::new("error")
+            }
+            .is_terminal()
+        );
+        assert!(
+            WorkflowEvent::WorkflowCancelled {
+                reason: "cancelled".to_string()
+            }
+            .is_terminal()
+        );
 
         assert!(!WorkflowEvent::WorkflowStarted { input: json!({}) }.is_terminal());
-        assert!(!WorkflowEvent::ActivityCompleted {
-            activity_id: "x".to_string(),
-            result: json!({})
-        }
-        .is_terminal());
+        assert!(
+            !WorkflowEvent::ActivityCompleted {
+                activity_id: "x".to_string(),
+                result: json!({})
+            }
+            .is_terminal()
+        );
     }
 }

--- a/crates/durable/src/workflow/mod.rs
+++ b/crates/durable/src/workflow/mod.rs
@@ -14,4 +14,4 @@ mod signal;
 pub use action::{ActivityOptions, WorkflowAction};
 pub use definition::{Workflow, WorkflowError};
 pub use event::{TimeoutType, WorkflowEvent};
-pub use signal::{signal_types, WorkflowSignal};
+pub use signal::{WorkflowSignal, signal_types};

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -5,7 +5,7 @@
 // Decision: Proto is transport layer, Rust schemas remain source of truth
 
 use chrono::{DateTime, TimeZone, Utc};
-use prost_types::{value::Kind, ListValue, Struct, Value};
+use prost_types::{ListValue, Struct, Value, value::Kind};
 
 // Generated protobuf code
 pub mod proto {
@@ -196,8 +196,8 @@ fn deserialize_event_data(
     event_type: &str,
     data: serde_json::Value,
 ) -> Result<everruns_core::EventData, ConversionError> {
-    use everruns_core::events::*;
     use everruns_core::EventData;
+    use everruns_core::events::*;
 
     Ok(match event_type {
         MESSAGE_USER => {
@@ -948,24 +948,32 @@ mod tests {
 
         // Verify capability_ids are preserved
         assert_eq!(proto_agent.capability_ids.len(), 2);
-        assert!(proto_agent
-            .capability_ids
-            .contains(&"tools:read_file".to_string()));
-        assert!(proto_agent
-            .capability_ids
-            .contains(&"tools:write_file".to_string()));
+        assert!(
+            proto_agent
+                .capability_ids
+                .contains(&"tools:read_file".to_string())
+        );
+        assert!(
+            proto_agent
+                .capability_ids
+                .contains(&"tools:write_file".to_string())
+        );
 
         // Convert back to schema
         let schema_agent = proto_agent_to_schema(proto_agent).unwrap();
 
         // Verify capabilities survive roundtrip
         assert_eq!(schema_agent.capabilities.len(), 2);
-        assert!(schema_agent
-            .capabilities
-            .contains(&CapabilityId::new("tools:read_file")));
-        assert!(schema_agent
-            .capabilities
-            .contains(&CapabilityId::new("tools:write_file")));
+        assert!(
+            schema_agent
+                .capabilities
+                .contains(&CapabilityId::new("tools:read_file"))
+        );
+        assert!(
+            schema_agent
+                .capabilities
+                .contains(&CapabilityId::new("tools:write_file"))
+        );
     }
 
     #[test]

--- a/crates/openai/src/driver.rs
+++ b/crates/openai/src/driver.rs
@@ -5,12 +5,12 @@
 
 use async_trait::async_trait;
 
+use everruns_core::OpenAIProtocolLlmDriver;
 use everruns_core::error::Result;
 use everruns_core::llm_driver_registry::{
     BoxedLlmDriver, DriverRegistry, LlmCallConfig, LlmDriver, LlmMessage, LlmResponseStream,
     ProviderType,
 };
-use everruns_core::OpenAIProtocolLlmDriver;
 
 /// OpenAI LLM Driver
 ///

--- a/crates/openai/src/lib.rs
+++ b/crates/openai/src/lib.rs
@@ -17,7 +17,7 @@ mod types;
 #[cfg(test)]
 mod tests;
 
-pub use driver::{register_driver, OpenAILlmDriver};
+pub use driver::{OpenAILlmDriver, register_driver};
 pub use types::{
     ChatMessage, ChatRequest, CompletionMetadata, LlmConfig, LlmStreamEvent, MessageRole,
 };

--- a/crates/openai/src/tests.rs
+++ b/crates/openai/src/tests.rs
@@ -2,7 +2,7 @@
 
 #[cfg(test)]
 mod driver_tests {
-    use crate::{register_driver, DriverRegistry, OpenAILlmDriver};
+    use crate::{DriverRegistry, OpenAILlmDriver, register_driver};
     use everruns_core::llm_driver_registry::{ProviderConfig, ProviderType};
 
     #[test]

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -13,9 +13,9 @@
 // Atoms emit events via EventEmitter for observability.
 
 use anyhow::{Context, Result};
+use everruns_core::ToolRegistry;
 use everruns_core::atoms::{ActAtom, Atom, InputAtom, ReasonAtom};
 use everruns_core::capabilities::CapabilityRegistry;
-use everruns_core::ToolRegistry;
 use std::sync::Arc;
 
 use crate::adapters::create_driver_registry;

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -6,13 +6,13 @@ use anyhow::Result;
 use everruns_core::atoms::AtomContext;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{watch, Mutex};
+use tokio::sync::{Mutex, watch};
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use crate::activities::{
-    act_activity, input_activity, reason_activity, ActInput, InputAtomInput, ReasonInput,
-    ReasonResult,
+    ActInput, InputAtomInput, ReasonInput, ReasonResult, act_activity, input_activity,
+    reason_activity,
 };
 use crate::durable_runner::DurableTurnInput;
 use crate::grpc_adapters::GrpcClient;

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -17,8 +17,8 @@ use everruns_core::traits::{
 use everruns_core::{Agent, Message, Session};
 use everruns_internal_protocol::proto;
 use everruns_internal_protocol::{
-    json_to_proto_list, json_to_proto_struct, proto_list_to_json, proto_struct_to_json,
-    WorkerServiceClient,
+    WorkerServiceClient, json_to_proto_list, json_to_proto_struct, proto_list_to_json,
+    proto_struct_to_json,
 };
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -112,11 +112,7 @@ fn proto_timestamp_or_now(ts: Option<&proto::Timestamp>) -> chrono::DateTime<chr
 /// Helper to convert empty string to None.
 /// Reduces the repeated `if s.is_empty() { None } else { Some(s) }` pattern.
 fn non_empty_string(s: String) -> Option<String> {
-    if s.is_empty() {
-        None
-    } else {
-        Some(s)
-    }
+    if s.is_empty() { None } else { Some(s) }
 }
 
 // ============================================================================
@@ -466,7 +462,7 @@ fn proto_model_with_provider_to_model(
             return Err(grpc_error(format!(
                 "Unknown provider type: {}",
                 proto.provider_type
-            )))
+            )));
         }
     };
 

--- a/crates/worker/src/grpc_durable_store.rs
+++ b/crates/worker/src/grpc_durable_store.rs
@@ -10,7 +10,7 @@ use everruns_internal_protocol::proto::{
     GetDurableWorkflowStatusRequest, HeartbeatDurableTaskRequest, HeartbeatDurableWorkerRequest,
     RegisterDurableWorkerRequest, UpdateDurableWorkflowStatusRequest,
 };
-use everruns_internal_protocol::{json_to_proto_struct, uuid_to_proto_uuid, WorkerServiceClient};
+use everruns_internal_protocol::{WorkerServiceClient, json_to_proto_struct, uuid_to_proto_uuid};
 use tonic::transport::Channel;
 use uuid::Uuid;
 

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -16,15 +16,15 @@ pub use grpc_durable_store::{
     ClaimedTask as GrpcClaimedTask, GrpcDurableStore, HeartbeatResponse as GrpcHeartbeatResponse,
     WorkflowStatus as GrpcWorkflowStatus,
 };
-pub use runner::{create_runner, create_runner_with_backend, AgentRunner, RunnerBackend};
+pub use runner::{AgentRunner, RunnerBackend, create_runner, create_runner_with_backend};
 
 // Re-export LLM driver factory helpers
 pub use adapters::{create_driver_registry, create_llm_driver};
 
 // Re-export gRPC adapters for worker communication with control plane
 pub use grpc_adapters::{
-    load_turn_context, GrpcAgentStore, GrpcClient, GrpcEventEmitter, GrpcLlmProviderStore,
-    GrpcMessageStore, GrpcSessionFileStore, GrpcSessionStore, TurnContext,
+    GrpcAgentStore, GrpcClient, GrpcEventEmitter, GrpcLlmProviderStore, GrpcMessageStore,
+    GrpcSessionFileStore, GrpcSessionStore, TurnContext, load_turn_context,
 };
 
 // Re-export OpenAI driver from the openai crate

--- a/crates/worker/src/main.rs
+++ b/crates/worker/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use everruns_core::telemetry::{init_telemetry, TelemetryConfig};
+use everruns_core::telemetry::{TelemetryConfig, init_telemetry};
 use everruns_worker::{DurableWorker, DurableWorkerConfig};
 
 #[tokio::main]


### PR DESCRIPTION
## What
Upgrade the codebase from Rust edition 2021 to edition 2024.

## Why
Edition 2024 was released in Rust 1.85.0 (Feb 2025) and is now stable. It brings:
- Let chains in if statements (stabilized)
- `gen` reserved keyword for future generators

## How
- Updated `workspace.package.edition` in Cargo.toml
- Updated AGENTS.md documentation
- Escaped `gen` calls to `r#gen` (4 occurrences in auth code)
- Applied clippy auto-fixes for let-chains
- Reformatted imports with cargo fmt

## Risk
- Low
- All unit tests pass
- Edition changes are backwards compatible within the same major version

## Checklist
- [x] Tests pass (unit tests)
- [x] Backward compatibility considered (edition 2024 is stable)