### PR TITLE
refactor(control-plane): move DEFAULT_*_API_KEY fallback from repo to service layer

### DIFF
--- a/crates/control-plane/src/services/llm_resolver.rs
+++ b/crates/control-plane/src/services/llm_resolver.rs
@@ -2,11 +2,42 @@
 //
 // This service handles the resolution of LLM models with their provider credentials,
 // including API key decryption. Used by gRPC service for worker communication.
+//
+// API key resolution order (handled at service layer):
+// 1. Decrypted key from database (if set)
+// 2. Environment variable fallback (for development convenience):
+//    - openai: DEFAULT_OPENAI_API_KEY
+//    - anthropic: DEFAULT_ANTHROPIC_API_KEY
 
 use crate::storage::{EncryptionService, StorageBackend};
 use anyhow::{anyhow, Result};
 use std::sync::Arc;
 use uuid::Uuid;
+
+/// Get default API key from environment variable based on provider type.
+///
+/// Environment variables (for development convenience):
+/// - DEFAULT_OPENAI_API_KEY: Fallback API key for OpenAI providers
+/// - DEFAULT_ANTHROPIC_API_KEY: Fallback API key for Anthropic providers
+///
+/// These are only used when the provider doesn't have an API key set in the database.
+pub fn get_default_api_key_from_env(provider_type: &str) -> Option<String> {
+    get_default_api_key_with_lookup(provider_type, |name| std::env::var(name).ok())
+}
+
+/// Testable version with injectable env lookup.
+fn get_default_api_key_with_lookup<F>(provider_type: &str, env_lookup: F) -> Option<String>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let env_var = match provider_type.to_lowercase().as_str() {
+        "openai" => "DEFAULT_OPENAI_API_KEY",
+        "anthropic" => "DEFAULT_ANTHROPIC_API_KEY",
+        _ => return None,
+    };
+
+    env_lookup(env_var).filter(|s| !s.is_empty())
+}
 
 /// Resolved model with provider credentials (decrypted API key)
 ///
@@ -57,15 +88,20 @@ impl LlmResolverService {
             None => return Ok(None),
         };
 
-        // Decrypt the API key
+        // Decrypt the API key from database
         let provider_with_key = self
             .db
             .get_provider_with_api_key(&provider_row, &encryption)?;
 
+        // Apply env fallback if no API key in database
+        let api_key = provider_with_key
+            .api_key
+            .or_else(|| get_default_api_key_from_env(&provider_with_key.provider_type));
+
         Ok(Some(ResolvedModel {
             model_id: model_row.model_id,
             provider_type: provider_with_key.provider_type,
-            api_key: provider_with_key.api_key,
+            api_key,
             base_url: provider_with_key.base_url,
         }))
     }
@@ -93,15 +129,20 @@ impl LlmResolverService {
             None => return Ok(None),
         };
 
-        // Decrypt the API key
+        // Decrypt the API key from database
         let provider_with_key = self
             .db
             .get_provider_with_api_key(&provider_row, &encryption)?;
 
+        // Apply env fallback if no API key in database
+        let api_key = provider_with_key
+            .api_key
+            .or_else(|| get_default_api_key_from_env(&provider_with_key.provider_type));
+
         Ok(Some(ResolvedModel {
             model_id: model_row.model_id,
             provider_type: provider_with_key.provider_type,
-            api_key: provider_with_key.api_key,
+            api_key,
             base_url: provider_with_key.base_url,
         }))
     }
@@ -109,5 +150,78 @@ impl LlmResolverService {
     /// Check if encryption service is available
     pub fn has_encryption(&self) -> bool {
         self.encryption.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mock_env<'a>(vars: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<String> + 'a {
+        move |name| {
+            vars.iter()
+                .find(|(k, _)| *k == name)
+                .map(|(_, v)| v.to_string())
+        }
+    }
+
+    #[test]
+    fn test_get_default_api_key_openai() {
+        // Not set
+        assert_eq!(
+            get_default_api_key_with_lookup("openai", mock_env(&[])),
+            None
+        );
+        assert_eq!(
+            get_default_api_key_with_lookup("OpenAI", mock_env(&[])),
+            None
+        );
+
+        // Set
+        let env = mock_env(&[("DEFAULT_OPENAI_API_KEY", "sk-test-key")]);
+        assert_eq!(
+            get_default_api_key_with_lookup("openai", &env),
+            Some("sk-test-key".to_string())
+        );
+        assert_eq!(
+            get_default_api_key_with_lookup("OpenAI", &env),
+            Some("sk-test-key".to_string())
+        );
+    }
+
+    #[test]
+    fn test_get_default_api_key_anthropic() {
+        // Not set
+        assert_eq!(
+            get_default_api_key_with_lookup("anthropic", mock_env(&[])),
+            None
+        );
+
+        // Set
+        let env = mock_env(&[("DEFAULT_ANTHROPIC_API_KEY", "sk-ant-test-key")]);
+        assert_eq!(
+            get_default_api_key_with_lookup("anthropic", &env),
+            Some("sk-ant-test-key".to_string())
+        );
+        assert_eq!(
+            get_default_api_key_with_lookup("Anthropic", &env),
+            Some("sk-ant-test-key".to_string())
+        );
+    }
+
+    #[test]
+    fn test_get_default_api_key_unknown_provider() {
+        let env = mock_env(&[
+            ("DEFAULT_OPENAI_API_KEY", "sk-test"),
+            ("DEFAULT_ANTHROPIC_API_KEY", "sk-ant-test"),
+        ]);
+        assert_eq!(get_default_api_key_with_lookup("azure_openai", &env), None);
+        assert_eq!(get_default_api_key_with_lookup("unknown", &env), None);
+    }
+
+    #[test]
+    fn test_get_default_api_key_empty_value() {
+        let env = mock_env(&[("DEFAULT_OPENAI_API_KEY", "")]);
+        assert_eq!(get_default_api_key_with_lookup("openai", &env), None);
     }
 }

--- a/crates/control-plane/src/storage/repositories.rs
+++ b/crates/control-plane/src/storage/repositories.rs
@@ -816,25 +816,19 @@ impl Database {
         Ok(())
     }
 
-    /// Get a provider with its decrypted API key for use in LLM calls.
-    /// This should only be called by worker activities that need to make LLM requests.
+    /// Get a provider with its decrypted API key from database.
     ///
-    /// API key resolution order:
-    /// 1. Decrypted key from database (if set)
-    /// 2. Environment variable fallback (for development convenience):
-    ///    - openai: DEFAULT_OPENAI_API_KEY
-    ///    - anthropic: DEFAULT_ANTHROPIC_API_KEY
+    /// Note: Environment variable fallback (DEFAULT_*_API_KEY) is handled
+    /// at the service layer (LlmResolverService), not here.
     pub fn get_provider_with_api_key(
         &self,
         provider: &LlmProviderRow,
         encryption: &super::EncryptionService,
     ) -> Result<LlmProviderWithApiKey> {
-        // Try decrypted key from database first
         let api_key = if let Some(ref encrypted) = provider.api_key_encrypted {
             Some(encryption.decrypt_to_string(encrypted)?)
         } else {
-            // Fall back to environment variable based on provider type
-            get_default_api_key_from_env(&provider.provider_type)
+            None
         };
 
         // Convert settings from sqlx JsonValue to serde_json::Value
@@ -1485,111 +1479,5 @@ impl Database {
         .await?;
 
         Ok(result.is_some())
-    }
-}
-
-// ============================================================================
-// Helper functions
-// ============================================================================
-
-/// Get default API key from environment variable based on provider type.
-///
-/// Environment variables (for development convenience):
-/// - DEFAULT_OPENAI_API_KEY: Fallback API key for OpenAI providers
-/// - DEFAULT_ANTHROPIC_API_KEY: Fallback API key for Anthropic providers
-///
-/// These are only used when the provider doesn't have an API key set in the database.
-fn get_default_api_key_from_env(provider_type: &str) -> Option<String> {
-    let env_var = match provider_type.to_lowercase().as_str() {
-        "openai" => "DEFAULT_OPENAI_API_KEY",
-        "anthropic" => "DEFAULT_ANTHROPIC_API_KEY",
-        _ => return None,
-    };
-
-    std::env::var(env_var).ok().filter(|s| !s.is_empty())
-}
-
-#[cfg(test)]
-mod tests {
-    /// Testable version with injectable env lookup (test-only).
-    fn get_default_api_key_with_lookup<F>(provider_type: &str, env_lookup: F) -> Option<String>
-    where
-        F: Fn(&str) -> Option<String>,
-    {
-        let env_var = match provider_type.to_lowercase().as_str() {
-            "openai" => "DEFAULT_OPENAI_API_KEY",
-            "anthropic" => "DEFAULT_ANTHROPIC_API_KEY",
-            _ => return None,
-        };
-
-        env_lookup(env_var).filter(|s| !s.is_empty())
-    }
-
-    fn mock_env<'a>(vars: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<String> + 'a {
-        move |name| {
-            vars.iter()
-                .find(|(k, _)| *k == name)
-                .map(|(_, v)| v.to_string())
-        }
-    }
-
-    #[test]
-    fn test_get_default_api_key_openai() {
-        // Not set
-        assert_eq!(
-            get_default_api_key_with_lookup("openai", mock_env(&[])),
-            None
-        );
-        assert_eq!(
-            get_default_api_key_with_lookup("OpenAI", mock_env(&[])),
-            None
-        );
-
-        // Set
-        let env = mock_env(&[("DEFAULT_OPENAI_API_KEY", "sk-test-key")]);
-        assert_eq!(
-            get_default_api_key_with_lookup("openai", &env),
-            Some("sk-test-key".to_string())
-        );
-        assert_eq!(
-            get_default_api_key_with_lookup("OpenAI", &env),
-            Some("sk-test-key".to_string())
-        );
-    }
-
-    #[test]
-    fn test_get_default_api_key_anthropic() {
-        // Not set
-        assert_eq!(
-            get_default_api_key_with_lookup("anthropic", mock_env(&[])),
-            None
-        );
-
-        // Set
-        let env = mock_env(&[("DEFAULT_ANTHROPIC_API_KEY", "sk-ant-test-key")]);
-        assert_eq!(
-            get_default_api_key_with_lookup("anthropic", &env),
-            Some("sk-ant-test-key".to_string())
-        );
-        assert_eq!(
-            get_default_api_key_with_lookup("Anthropic", &env),
-            Some("sk-ant-test-key".to_string())
-        );
-    }
-
-    #[test]
-    fn test_get_default_api_key_unknown_provider() {
-        let env = mock_env(&[
-            ("DEFAULT_OPENAI_API_KEY", "sk-test"),
-            ("DEFAULT_ANTHROPIC_API_KEY", "sk-ant-test"),
-        ]);
-        assert_eq!(get_default_api_key_with_lookup("azure_openai", &env), None);
-        assert_eq!(get_default_api_key_with_lookup("unknown", &env), None);
-    }
-
-    #[test]
-    fn test_get_default_api_key_empty_value() {
-        let env = mock_env(&[("DEFAULT_OPENAI_API_KEY", "")]);
-        assert_eq!(get_default_api_key_with_lookup("openai", &env), None);
     }
 }


### PR DESCRIPTION
## What
Move the DEFAULT_*_API_KEY environment variable fallback logic from the repository layer to the service layer (LlmResolverService).

## Why
The in-memory storage (memory.rs) was missing the DEFAULT_*_API_KEY environment variable fallback that exists in the PostgreSQL implementation (repositories.rs). This caused LLM calls to fail with "API key is required" in dev mode.

Rather than duplicate the logic in both storage implementations, moving it to the service layer is architecturally correct - repositories should only handle data storage/retrieval, not business logic like environment variable fallbacks.

## How
- Add `get_default_api_key_from_env()` to `llm_resolver.rs`
- Apply env fallback after provider lookup in `resolve_model()` / `resolve_default_model()`
- Remove fallback logic from `repositories.rs::get_provider_with_api_key()`
- Move tests from repositories.rs to llm_resolver.rs

## Risk
- Low
- Both PostgreSQL and in-memory backends now have consistent behavior

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered