### PR TITLE
feat(ui): add message info icon with metadata tooltip

### DIFF
--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/chat/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/chat/page.tsx
@@ -14,6 +14,7 @@ import {
 import { Send, Bot, Loader2, Brain } from "lucide-react";
 import type { Controls, MessageUserData, MessageAgentData } from "@/lib/api/types";
 import { ToolCallCardFromEvent } from "@/components/chat/tool-call-card-from-event";
+import { MessageInfoIcon } from "@/components/chat/message-info-icon";
 import { useSessionContext } from "../session-context";
 import { useLlmModels } from "@/hooks";
 
@@ -168,14 +169,18 @@ export default function ChatPage() {
                     {isUser ? (
                       /* User message - dark box, 90% width */
                       <div className="max-w-[90%] bg-gray-500 text-white rounded-lg p-3">
-                        <p className="text-sm whitespace-pre-wrap">{textContent}</p>
+                        <div className="flex items-start gap-2">
+                          <p className="text-sm whitespace-pre-wrap flex-1">{textContent}</p>
+                          <MessageInfoIcon event={event} variant="light" />
+                        </div>
                       </div>
                     ) : (
                       /* Agent message - darker background with robot icon */
                       <div className="w-full bg-muted/60 rounded-lg p-3">
                         <div className="flex items-start gap-2">
                           <Bot className="w-4 h-4 mt-0.5 flex-shrink-0 text-muted-foreground" />
-                          <p className="text-sm whitespace-pre-wrap">{textContent}</p>
+                          <p className="text-sm whitespace-pre-wrap flex-1">{textContent}</p>
+                          <MessageInfoIcon event={event} />
                         </div>
                       </div>
                     )}

--- a/apps/ui/src/app/dev/components/page.tsx
+++ b/apps/ui/src/app/dev/components/page.tsx
@@ -7,7 +7,8 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Bot, ArrowLeft } from "lucide-react";
 import { ToolCallCard } from "@/components/chat/tool-call-card";
 import { TodoListRenderer } from "@/components/chat/todo-list-renderer";
-import type { Message } from "@/lib/api/types";
+import { MessageInfoIcon } from "@/components/chat/message-info-icon";
+import type { Message, Event } from "@/lib/api/types";
 
 // Check if we're in development mode
 const isDev = process.env.NODE_ENV === "development";
@@ -307,6 +308,88 @@ const sampleTodoData = {
   },
 };
 
+// Sample event data for MessageInfoIcon
+const sampleEvents = {
+  userMessage: {
+    id: "evt-user-123e4567-e89b-12d3-a456-426614174000",
+    type: "message.user",
+    ts: new Date().toISOString(),
+    session_id: "session-1",
+    context: { turn_id: "turn-1" },
+    data: {
+      message: {
+        id: "msg-user-1",
+        session_id: "session-1",
+        sequence: 1,
+        role: "user" as const,
+        content: [{ type: "text" as const, text: "Hello!" }],
+        tool_call_id: null,
+        created_at: new Date().toISOString(),
+      },
+    },
+  } satisfies Event,
+  agentMessage: {
+    id: "evt-agent-987fcdeb-51a2-4bc3-8def-012345678901",
+    type: "message.agent",
+    ts: new Date().toISOString(),
+    session_id: "session-1",
+    context: { turn_id: "turn-1" },
+    data: {
+      message: {
+        id: "msg-agent-1",
+        session_id: "session-1",
+        sequence: 2,
+        role: "agent" as const,
+        content: [{ type: "text" as const, text: "Hi there! How can I help?" }],
+        tool_call_id: null,
+        created_at: new Date().toISOString(),
+      },
+      metadata: {
+        model: "claude-sonnet-4-20250514",
+        model_id: "model-uuid-123",
+        provider_id: "provider-anthropic",
+      },
+      usage: {
+        input_tokens: 128,
+        output_tokens: 45,
+      },
+    },
+    metadata: {
+      reasoning_effort: "medium",
+    },
+  } satisfies Event,
+  agentMessageWithHighReasoning: {
+    id: "evt-agent-abc12345-6789-def0-1234-567890abcdef",
+    type: "message.agent",
+    ts: new Date(Date.now() - 3600000).toISOString(), // 1 hour ago
+    session_id: "session-1",
+    context: { turn_id: "turn-2" },
+    data: {
+      message: {
+        id: "msg-agent-2",
+        session_id: "session-1",
+        sequence: 4,
+        role: "agent" as const,
+        content: [{ type: "text" as const, text: "Let me analyze this complex problem..." }],
+        tool_call_id: null,
+        created_at: new Date(Date.now() - 3600000).toISOString(),
+      },
+      metadata: {
+        model: "o1-preview",
+        model_id: "model-uuid-456",
+        provider_id: "provider-openai",
+      },
+      usage: {
+        input_tokens: 2048,
+        output_tokens: 1536,
+      },
+    },
+    metadata: {
+      reasoning_effort: "high",
+    },
+  } satisfies Event,
+};
+
 // ============================================
 // Main Page Component
 // ============================================
@@ -365,6 +448,56 @@ export default function DevComponentsPage() {
 
               <ShowcaseItem label="Assistant Message (Multiline)">
                 <AssistantMessage content={"Here's my analysis of the codebase:\n\n1. Current auth uses session cookies\n2. User model has email/password fields\n3. No OAuth support exists yet\n\nI recommend starting with the OAuth provider abstraction."} />
+              </ShowcaseItem>
+            </ShowcaseSection>
+
+            {/* MessageInfoIcon Section */}
+            <ShowcaseSection
+              title="MessageInfoIcon Component"
+              description="Small info icon showing message metadata on hover (components/chat/message-info-icon.tsx)"
+            >
+              <ShowcaseItem label="User Message (Light Variant)">
+                <div className="flex justify-end">
+                  <div className="max-w-[90%] bg-gray-500 text-white rounded-lg p-3">
+                    <div className="flex items-start gap-2">
+                      <p className="text-sm whitespace-pre-wrap flex-1">Hello! Can you help me?</p>
+                      <MessageInfoIcon event={sampleEvents.userMessage} variant="light" />
+                    </div>
+                  </div>
+                </div>
+              </ShowcaseItem>
+
+              <ShowcaseItem label="Agent Message (Default Variant)">
+                <div className="w-full bg-muted/60 rounded-lg p-3">
+                  <div className="flex items-start gap-2">
+                    <Bot className="w-4 h-4 mt-0.5 flex-shrink-0 text-muted-foreground" />
+                    <p className="text-sm whitespace-pre-wrap flex-1">Hi there! How can I help?</p>
+                    <MessageInfoIcon event={sampleEvents.agentMessage} />
+                  </div>
+                </div>
+              </ShowcaseItem>
+
+              <ShowcaseItem label="Agent Message with High Reasoning Effort">
+                <div className="w-full bg-muted/60 rounded-lg p-3">
+                  <div className="flex items-start gap-2">
+                    <Bot className="w-4 h-4 mt-0.5 flex-shrink-0 text-muted-foreground" />
+                    <p className="text-sm whitespace-pre-wrap flex-1">Let me analyze this complex problem...</p>
+                    <MessageInfoIcon event={sampleEvents.agentMessageWithHighReasoning} />
+                  </div>
+                </div>
+              </ShowcaseItem>
+
+              <ShowcaseItem label="Standalone Icons (hover to see tooltip)">
+                <div className="flex items-center gap-4">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm text-muted-foreground">Default:</span>
+                    <MessageInfoIcon event={sampleEvents.agentMessage} />
+                  </div>
+                  <div className="flex items-center gap-2 bg-gray-500 rounded px-2 py-1">
+                    <span className="text-sm text-white">Light:</span>
+                    <MessageInfoIcon event={sampleEvents.userMessage} variant="light" />
+                  </div>
+                </div>
               </ShowcaseItem>
             </ShowcaseSection>
 

--- a/apps/ui/src/components/chat/message-info-icon.tsx
+++ b/apps/ui/src/components/chat/message-info-icon.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { Info } from "lucide-react";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import type { Event, MessageAgentData, ModelMetadata, TokenUsage } from "@/lib/api/types";
+
+interface MessageInfoIconProps {
+  /** The event containing message data */
+  event: Event;
+  /** Visual variant - "default" for dark text contexts, "light" for light text contexts (e.g., user messages) */
+  variant?: "default" | "light";
+}
+
+/**
+ * Small info icon that displays message metadata in a tooltip.
+ * Shows: message ID, model, reasoning effort, timestamp, and token usage.
+ */
+export function MessageInfoIcon({ event, variant = "default" }: MessageInfoIconProps) {
+  const isAgentMessage = event.type === "message.agent";
+  const agentData = isAgentMessage ? (event.data as MessageAgentData) : null;
+  const modelMetadata: ModelMetadata | undefined = agentData?.metadata;
+  const usage: TokenUsage | undefined = agentData?.usage;
+
+  // Extract reasoning effort from event metadata if available
+  const reasoningEffort = (event.metadata as Record<string, unknown> | undefined)?.reasoning_effort as string | undefined;
+
+  // Format timestamp
+  const timestamp = new Date(event.ts);
+  const formattedTime = timestamp.toLocaleString();
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        className={cn(
+          "p-0.5 rounded transition-colors flex-shrink-0",
+          variant === "light"
+            ? "text-white/50 hover:text-white hover:bg-white/10"
+            : "text-muted-foreground/50 hover:text-muted-foreground hover:bg-muted/80"
+        )}
+        aria-label="Message info"
+      >
+        <Info className="w-3 h-3" />
+      </TooltipTrigger>
+      <TooltipContent className="max-w-sm">
+        <div className="space-y-1 text-xs">
+          <div className="flex gap-2">
+            <span className="text-muted-foreground">ID:</span>
+            <span className="font-mono text-[10px] break-all">{event.id}</span>
+          </div>
+          {modelMetadata?.model && (
+            <div className="flex gap-2">
+              <span className="text-muted-foreground">Model:</span>
+              <span>{modelMetadata.model}</span>
+            </div>
+          )}
+          {reasoningEffort && (
+            <div className="flex gap-2">
+              <span className="text-muted-foreground">Reasoning:</span>
+              <span className="capitalize">{reasoningEffort}</span>
+            </div>
+          )}
+          <div className="flex gap-2">
+            <span className="text-muted-foreground">Time:</span>
+            <span>{formattedTime}</span>
+          </div>
+          {usage && (
+            <div className="flex gap-2">
+              <span className="text-muted-foreground">Tokens:</span>
+              <span>{usage.input_tokens} in / {usage.output_tokens} out</span>
+            </div>
+          )}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/ui/src/components/chat/message-info-icon.tsx
+++ b/apps/ui/src/components/chat/message-info-icon.tsx
@@ -7,7 +7,7 @@ import {
   TooltipContent,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import type { Event, MessageAgentData, ModelMetadata, TokenUsage } from "@/lib/api/types";
+import type { Event, MessageAgentData, TokenUsage } from "@/lib/api/types";
 
 interface MessageInfoIconProps {
   /** The event containing message data */
@@ -23,11 +23,15 @@ interface MessageInfoIconProps {
 export function MessageInfoIcon({ event, variant = "default" }: MessageInfoIconProps) {
   const isAgentMessage = event.type === "message.agent";
   const agentData = isAgentMessage ? (event.data as MessageAgentData) : null;
-  const modelMetadata: ModelMetadata | undefined = agentData?.metadata;
-  const usage: TokenUsage | undefined = agentData?.usage;
 
-  // Extract reasoning effort from event metadata if available
-  const reasoningEffort = (event.metadata as Record<string, unknown> | undefined)?.reasoning_effort as string | undefined;
+  // Model and reasoning are stored on message.metadata (set by ReasonAtom)
+  // Fallback to agentData.metadata for backward compatibility
+  const messageMetadata = agentData?.message?.metadata as Record<string, unknown> | undefined;
+  const model = (messageMetadata?.model as string) ?? agentData?.metadata?.model;
+  const reasoningEffort = messageMetadata?.reasoning_effort as string | undefined;
+
+  // Token usage from MessageAgentData (if populated)
+  const usage: TokenUsage | undefined = agentData?.usage;
 
   // Format timestamp
   const timestamp = new Date(event.ts);
@@ -52,10 +56,10 @@ export function MessageInfoIcon({ event, variant = "default" }: MessageInfoIconP
             <span className="text-muted-foreground">ID:</span>
             <span className="font-mono text-[10px] break-all">{event.id}</span>
           </div>
-          {modelMetadata?.model && (
+          {model && (
             <div className="flex gap-2">
               <span className="text-muted-foreground">Model:</span>
-              <span>{modelMetadata.model}</span>
+              <span>{model}</span>
             </div>
           )}
           {reasoningEffort && (


### PR DESCRIPTION
## Summary
- Add small info icon (ℹ) to messages in the Chat UI
- Hovering shows tooltip with message metadata: ID, model, reasoning effort, timestamp, and token usage
- Two visual variants: "default" (for agent messages) and "light" (for user messages on dark background)
- Demo added to `/dev/components` page

## Changes
- `apps/ui/src/components/chat/message-info-icon.tsx` - New component
- `apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/chat/page.tsx` - Integrate icon into messages
- `apps/ui/src/app/dev/components/page.tsx` - Add showcase section for MessageInfoIcon

## Test plan
- [x] UI build passes (`npm run build`)
- [x] Dev components page loads at `/dev/components`
- [x] MessageInfoIcon section visible with all variants
- [x] Info icons appear on messages (light variant for user, default for agent)

## Risk
- Low - UI-only change, no backend modifications