### PR TITLE
feat(api,ui): add pagination to sessions API

### DIFF
--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -28,7 +28,11 @@ export default function AgentDetailPage({
   const { agentId } = use(params);
   const router = useRouter();
   const { data: agent, isLoading: agentLoading } = useAgent(agentId);
-  const { data: sessions, isLoading: sessionsLoading } = useSessions(agentId);
+  // Fetch only top 10 sessions for the overview
+  const { data: sessionsResponse, isLoading: sessionsLoading } = useSessions(agentId, { limit: 10 });
+  const sessions = sessionsResponse?.data ?? [];
+  const totalSessions = sessionsResponse?.total ?? 0;
+  const hasMoreSessions = totalSessions > 10;
   const { data: allCapabilities } = useCapabilities();
   const { data: llmModels } = useLlmModels();
   const createSession = useCreateSession();
@@ -159,8 +163,16 @@ export default function AgentDetailPage({
           </Card>
 
           <Card>
-            <CardHeader>
+            <CardHeader className="flex flex-row items-center justify-between">
               <CardTitle>Sessions</CardTitle>
+              {hasMoreSessions && (
+                <Link
+                  href={`/agents/${agentId}/sessions`}
+                  className="text-sm text-muted-foreground hover:text-foreground"
+                >
+                  View all {totalSessions} sessions →
+                </Link>
+              )}
             </CardHeader>
             <CardContent>
               {sessionsLoading ? (
@@ -168,13 +180,13 @@ export default function AgentDetailPage({
                   <Skeleton className="h-12 w-full" />
                   <Skeleton className="h-12 w-full" />
                 </div>
-              ) : sessions?.length === 0 ? (
+              ) : sessions.length === 0 ? (
                 <p className="text-center py-8 text-muted-foreground">
                   No sessions yet. Start a new session to begin chatting.
                 </p>
               ) : (
                 <div className="space-y-2">
-                  {sessions?.map((session) => (
+                  {sessions.map((session) => (
                     <Link
                       key={session.id}
                       href={`/agents/${agentId}/sessions/${session.id}`}
@@ -208,6 +220,14 @@ export default function AgentDetailPage({
                       </div>
                     </Link>
                   ))}
+                  {hasMoreSessions && (
+                    <Link
+                      href={`/agents/${agentId}/sessions`}
+                      className="flex items-center justify-center p-3 rounded-md border border-dashed hover:bg-muted transition-colors text-muted-foreground"
+                    >
+                      View all {totalSessions} sessions
+                    </Link>
+                  )}
                 </div>
               )}
             </CardContent>

--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/page.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { use, useState, useMemo } from "react";
+import { useAgent, useSessions, useCreateSession, useLlmModels, useDeleteSession } from "@/hooks";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ProviderIcon } from "@/components/providers/provider-icon";
+import {
+  ArrowLeft,
+  Plus,
+  MessageSquare,
+  ChevronLeft,
+  ChevronRight,
+  Trash2,
+} from "lucide-react";
+import type { LlmModelWithProvider } from "@/lib/api/types";
+
+const PAGE_SIZE = 20;
+
+export default function SessionsListPage({
+  params,
+}: {
+  params: Promise<{ agentId: string }>;
+}) {
+  const { agentId } = use(params);
+  const router = useRouter();
+  const [page, setPage] = useState(0);
+  const offset = page * PAGE_SIZE;
+
+  const { data: agent, isLoading: agentLoading } = useAgent(agentId);
+  const { data: sessionsResponse, isLoading: sessionsLoading } = useSessions(
+    agentId,
+    { offset, limit: PAGE_SIZE }
+  );
+  const { data: llmModels } = useLlmModels();
+  const createSession = useCreateSession();
+  const deleteSession = useDeleteSession();
+
+  const sessions = sessionsResponse?.data ?? [];
+  const totalSessions = sessionsResponse?.total ?? 0;
+  const totalPages = Math.ceil(totalSessions / PAGE_SIZE);
+
+  // Create a map of model_id -> model for quick lookups
+  const modelMap = useMemo(() => {
+    if (!llmModels) return new Map<string, LlmModelWithProvider>();
+    return new Map(llmModels.map((m) => [m.id, m]));
+  }, [llmModels]);
+
+  const handleNewSession = async () => {
+    try {
+      const session = await createSession.mutateAsync({
+        agentId,
+        request: {},
+      });
+      router.push(`/agents/${agentId}/sessions/${session.id}`);
+    } catch (error) {
+      console.error("Failed to create session:", error);
+    }
+  };
+
+  const handleDeleteSession = async (sessionId: string, sessionTitle: string) => {
+    const confirmed = window.confirm(
+      `Are you sure you want to delete "${sessionTitle}"? This action cannot be undone.`
+    );
+    if (!confirmed) return;
+
+    try {
+      await deleteSession.mutateAsync({ agentId, sessionId });
+    } catch (error) {
+      console.error("Failed to delete session:", error);
+    }
+  };
+
+  const handlePreviousPage = () => {
+    setPage((p) => Math.max(0, p - 1));
+  };
+
+  const handleNextPage = () => {
+    setPage((p) => Math.min(totalPages - 1, p + 1));
+  };
+
+  if (agentLoading) {
+    return (
+      <div className="container mx-auto p-6">
+        <Skeleton className="h-8 w-1/3 mb-4" />
+        <Skeleton className="h-4 w-2/3 mb-8" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (!agent) {
+    return (
+      <div className="container mx-auto p-6">
+        <div className="text-red-500">Agent not found</div>
+        <Link href="/agents" className="text-blue-500 hover:underline">
+          Back to agents
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto p-6">
+      <Link
+        href={`/agents/${agentId}`}
+        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-6"
+      >
+        <ArrowLeft className="w-4 h-4 mr-2" />
+        Back to {agent.name}
+      </Link>
+
+      <div className="flex items-start justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold">{agent.name} - Sessions</h1>
+          <p className="text-muted-foreground">
+            {totalSessions} session{totalSessions !== 1 ? "s" : ""} total
+          </p>
+        </div>
+        <Button onClick={handleNewSession} disabled={createSession.isPending}>
+          <Plus className="w-4 h-4 mr-2" />
+          {createSession.isPending ? "Creating..." : "New Session"}
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>All Sessions</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {sessionsLoading ? (
+            <div className="space-y-2">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Skeleton key={i} className="h-16 w-full" />
+              ))}
+            </div>
+          ) : sessions.length === 0 ? (
+            <p className="text-center py-8 text-muted-foreground">
+              No sessions yet. Start a new session to begin chatting.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {sessions.map((session) => (
+                <div
+                  key={session.id}
+                  className="flex items-center justify-between p-3 rounded-md border hover:bg-muted transition-colors"
+                >
+                  <Link
+                    href={`/agents/${agentId}/sessions/${session.id}`}
+                    className="flex items-center gap-3 flex-1"
+                  >
+                    <MessageSquare className="w-4 h-4 text-muted-foreground" />
+                    <div>
+                      <p className="font-medium">
+                        {session.title || `Session ${session.id.slice(0, 8)}`}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {new Date(session.created_at).toLocaleString()}
+                      </p>
+                    </div>
+                  </Link>
+                  <div className="flex items-center gap-2">
+                    {session.model_id && modelMap.get(session.model_id) && (
+                      <Badge variant="outline" className="gap-1 text-xs">
+                        <ProviderIcon
+                          providerType={modelMap.get(session.model_id)!.provider_type}
+                          size="sm"
+                          showBackground={false}
+                        />
+                        {modelMap.get(session.model_id)!.display_name}
+                      </Badge>
+                    )}
+                    {session.finished_at && (
+                      <Badge variant="outline">Completed</Badge>
+                    )}
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                      onClick={() =>
+                        handleDeleteSession(
+                          session.id,
+                          session.title || `Session ${session.id.slice(0, 8)}`
+                        )
+                      }
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Pagination controls */}
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between mt-4 pt-4 border-t">
+              <p className="text-sm text-muted-foreground">
+                Showing {offset + 1}-{Math.min(offset + PAGE_SIZE, totalSessions)} of{" "}
+                {totalSessions} sessions
+              </p>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handlePreviousPage}
+                  disabled={page === 0}
+                >
+                  <ChevronLeft className="h-4 w-4 mr-1" />
+                  Previous
+                </Button>
+                <span className="text-sm text-muted-foreground">
+                  Page {page + 1} of {totalPages}
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleNextPage}
+                  disabled={page >= totalPages - 1}
+                >
+                  Next
+                  <ChevronRight className="h-4 w-4 ml-1" />
+                </Button>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/ui/src/hooks/use-sessions.ts
+++ b/apps/ui/src/hooks/use-sessions.ts
@@ -13,12 +13,19 @@ import {
 } from "@/lib/api/sessions";
 import { getSseUrl } from "@/lib/api/events";
 import { queryKeys } from "@/lib/query-keys";
-import type { CreateSessionRequest, UpdateSessionRequest, Controls, Event } from "@/lib/api/types";
+import type { CreateSessionRequest, UpdateSessionRequest, Controls, Event, PaginationParams } from "@/lib/api/types";
 
-export function useSessions(agentId: string | undefined) {
+/**
+ * Fetch paginated sessions for an agent.
+ * Returns { data, total, offset, limit } for pagination controls.
+ */
+export function useSessions(
+  agentId: string | undefined,
+  params?: PaginationParams
+) {
   return useQuery({
-    queryKey: queryKeys.sessions.list(agentId!),
-    queryFn: () => listSessions(agentId!),
+    queryKey: [...queryKeys.sessions.list(agentId!), params?.offset ?? 0, params?.limit ?? 20],
+    queryFn: () => listSessions(agentId!, params),
     enabled: !!agentId,
   });
 }

--- a/apps/ui/src/lib/api/sessions.ts
+++ b/apps/ui/src/lib/api/sessions.ts
@@ -5,7 +5,8 @@ import type {
   Session,
   CreateSessionRequest,
   UpdateSessionRequest,
-  ListResponse,
+  PaginatedResponse,
+  PaginationParams,
 } from "./types";
 
 // Re-export message and event functions for convenience
@@ -27,11 +28,21 @@ export async function createSession(
   return response.data;
 }
 
-export async function listSessions(agentId: string): Promise<Session[]> {
-  const response = await api.get<ListResponse<Session>>(
-    `/v1/agents/${agentId}/sessions`
-  );
-  return response.data.data;
+export async function listSessions(
+  agentId: string,
+  params?: PaginationParams
+): Promise<PaginatedResponse<Session>> {
+  const searchParams = new URLSearchParams();
+  if (params?.offset !== undefined) {
+    searchParams.set("offset", String(params.offset));
+  }
+  if (params?.limit !== undefined) {
+    searchParams.set("limit", String(params.limit));
+  }
+  const query = searchParams.toString();
+  const url = `/v1/agents/${agentId}/sessions${query ? `?${query}` : ""}`;
+  const response = await api.get<PaginatedResponse<Session>>(url);
+  return response.data;
 }
 
 export async function getSession(

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -394,11 +394,23 @@ export interface CreateEventRequest {
 }
 
 // ============================================
-// List response wrapper
+// List response wrappers
 // ============================================
 
 export interface ListResponse<T> {
   data: T[];
+}
+
+export interface PaginatedResponse<T> {
+  data: T[];
+  total: number;
+  offset: number;
+  limit: number;
+}
+
+export interface PaginationParams {
+  offset?: number;
+  limit?: number;
 }
 
 // ============================================

--- a/crates/control-plane/src/api/common.rs
+++ b/crates/control-plane/src/api/common.rs
@@ -270,4 +270,40 @@ mod tests {
         let list: ListResponse<i32> = vec![1, 2, 3].into();
         assert_eq!(list.data, vec![1, 2, 3]);
     }
+
+    #[test]
+    fn test_paginated_response_new() {
+        let response = PaginatedResponse::new(vec![1, 2, 3], 100, 0, 20);
+        assert_eq!(response.data, vec![1, 2, 3]);
+        assert_eq!(response.total, 100);
+        assert_eq!(response.offset, 0);
+        assert_eq!(response.limit, 20);
+    }
+
+    #[test]
+    fn test_paginated_response_serialization() {
+        let response = PaginatedResponse::new(vec!["a", "b"], 50, 10, 5);
+        let json = serde_json::to_string(&response).unwrap();
+
+        // Verify JSON structure
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["data"], serde_json::json!(["a", "b"]));
+        assert_eq!(parsed["total"], 50);
+        assert_eq!(parsed["offset"], 10);
+        assert_eq!(parsed["limit"], 5);
+    }
+
+    #[test]
+    fn test_pagination_new() {
+        let pagination = Pagination::new(10, 20);
+        assert_eq!(pagination.offset, 10);
+        assert_eq!(pagination.limit, 20);
+    }
+
+    #[test]
+    fn test_pagination_default() {
+        let pagination = Pagination::default();
+        assert_eq!(pagination.offset, 0);
+        assert_eq!(pagination.limit, 0);
+    }
 }

--- a/crates/control-plane/src/api/common.rs
+++ b/crates/control-plane/src/api/common.rs
@@ -144,6 +144,44 @@ impl<T> From<Vec<T>> for ListResponse<T> {
     }
 }
 
+/// Response wrapper for paginated list endpoints.
+/// Includes pagination metadata along with the data array.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct PaginatedResponse<T> {
+    /// Array of items returned by the list operation.
+    pub data: Vec<T>,
+    /// Total number of items matching the query (across all pages).
+    pub total: u32,
+    /// Current offset (starting position).
+    pub offset: u32,
+    /// Maximum number of items per page.
+    pub limit: u32,
+}
+
+impl<T> PaginatedResponse<T> {
+    pub fn new(data: Vec<T>, total: u32, offset: u32, limit: u32) -> Self {
+        Self {
+            data,
+            total,
+            offset,
+            limit,
+        }
+    }
+}
+
+/// Pagination parameters for list endpoints.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Pagination {
+    pub offset: u32,
+    pub limit: u32,
+}
+
+impl Pagination {
+    pub fn new(offset: u32, limit: u32) -> Self {
+        Self { offset, limit }
+    }
+}
+
 /// Request to create an event (for internal use)
 #[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/crates/control-plane/src/api/mod.rs
+++ b/crates/control-plane/src/api/mod.rs
@@ -17,4 +17,4 @@ pub mod users;
 pub mod validation;
 
 // Re-export common types
-pub use common::{ErrorResponse, ListResponse};
+pub use common::{ErrorResponse, ListResponse, PaginatedResponse};

--- a/crates/control-plane/src/api/sessions.rs
+++ b/crates/control-plane/src/api/sessions.rs
@@ -3,16 +3,16 @@
 use crate::storage::StorageBackend;
 use axum::{
     Json, Router,
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     routing::{get, post},
 };
 use everruns_core::Session;
 
-use super::common::{ApiOptionExt, ApiResultExt, ListResponse};
+use super::common::{ApiOptionExt, ApiResultExt, PaginatedResponse, Pagination};
 use serde::Deserialize;
 use std::sync::Arc;
-use utoipa::ToSchema;
+use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
 
 /// Request to create a session
@@ -44,6 +44,22 @@ pub struct UpdateSessionRequest {
     #[schema(example = json!(["resolved"]))]
     pub tags: Option<Vec<String>>,
 }
+
+/// Query parameters for listing sessions with pagination.
+#[derive(Debug, Clone, Deserialize, IntoParams)]
+pub struct ListSessionsQuery {
+    /// Number of items to skip (for pagination).
+    #[param(minimum = 0, default = 0)]
+    pub offset: Option<u32>,
+    /// Maximum number of items to return (for pagination).
+    #[param(minimum = 1, maximum = 100, default = 20)]
+    pub limit: Option<u32>,
+}
+
+/// Default limit for session listing
+const DEFAULT_LIMIT: u32 = 20;
+/// Maximum allowed limit for session listing
+const MAX_LIMIT: u32 = 100;
 
 use crate::services::SessionService;
 
@@ -111,10 +127,11 @@ pub async fn create_session(
     get,
     path = "/v1/agents/{agent_id}/sessions",
     params(
-        ("agent_id" = Uuid, Path, description = "Agent ID")
+        ("agent_id" = Uuid, Path, description = "Agent ID"),
+        ListSessionsQuery
     ),
     responses(
-        (status = 200, description = "List of sessions", body = ListResponse<Session>),
+        (status = 200, description = "Paginated list of sessions", body = PaginatedResponse<Session>),
         (status = 500, description = "Internal server error")
     ),
     tag = "sessions"
@@ -122,14 +139,19 @@ pub async fn create_session(
 pub async fn list_sessions(
     State(state): State<AppState>,
     Path(agent_id): Path<Uuid>,
-) -> Result<Json<ListResponse<Session>>, StatusCode> {
-    let sessions = state
+    Query(query): Query<ListSessionsQuery>,
+) -> Result<Json<PaginatedResponse<Session>>, StatusCode> {
+    let offset = query.offset.unwrap_or(0);
+    let limit = query.limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT);
+    let pagination = Pagination::new(offset, limit);
+
+    let (sessions, total) = state
         .session_service
-        .list(agent_id)
+        .list(agent_id, pagination)
         .await
         .log_internal_error("list sessions")?;
 
-    Ok(Json(ListResponse::new(sessions)))
+    Ok(Json(PaginatedResponse::new(sessions, total, offset, limit)))
 }
 
 /// GET /v1/agents/{agent_id}/sessions/{session_id} - Get session

--- a/crates/control-plane/src/openapi.rs
+++ b/crates/control-plane/src/openapi.rs
@@ -5,7 +5,7 @@
 // and the export-openapi binary (for static spec generation).
 
 use crate::api;
-use crate::api::ListResponse;
+use crate::api::{ListResponse, PaginatedResponse};
 use everruns_core::llm_models::LlmProvider;
 use everruns_core::{
     Agent, AgentStatus, CapabilityInfo, Event, EventContext, EventData, FileInfo, FileStat,
@@ -87,7 +87,7 @@ use utoipa::OpenApi;
             api::messages::CreateMessageRequest, api::messages::InputMessage,
             api::messages::Controls, api::messages::ReasoningConfig,
             ListResponse<Agent>,
-            ListResponse<Session>,
+            PaginatedResponse<Session>,
             ListResponse<api::messages::Message>,
             ListResponse<Event>,
             LlmProvider, LlmProviderType, LlmProviderStatus,

--- a/crates/control-plane/src/services/session.rs
+++ b/crates/control-plane/src/services/session.rs
@@ -1,5 +1,6 @@
 // Session service for business logic (M2)
 
+use crate::api::common::Pagination;
 use crate::storage::{
     StorageBackend,
     models::{CreateSessionRow, UpdateSession},
@@ -46,9 +47,15 @@ impl SessionService {
         Ok(row.map(Self::row_to_session))
     }
 
-    pub async fn list(&self, agent_id: Uuid) -> Result<Vec<Session>> {
-        let rows = self.db.list_sessions(agent_id).await?;
-        Ok(rows.into_iter().map(Self::row_to_session).collect())
+    /// List sessions for an agent with pagination.
+    /// Returns (sessions, total_count).
+    pub async fn list(
+        &self,
+        agent_id: Uuid,
+        pagination: Pagination,
+    ) -> Result<(Vec<Session>, u32)> {
+        let (rows, total) = self.db.list_sessions(agent_id, pagination).await?;
+        Ok((rows.into_iter().map(Self::row_to_session).collect(), total))
     }
 
     pub async fn update(&self, id: Uuid, req: UpdateSessionRequest) -> Result<Option<Session>> {

--- a/crates/control-plane/src/storage/backend.rs
+++ b/crates/control-plane/src/storage/backend.rs
@@ -11,6 +11,7 @@ use uuid::Uuid;
 use super::memory::InMemoryDatabase;
 use super::models::*;
 use super::repositories::Database;
+use crate::api::common::Pagination;
 
 /// Helper macro to dispatch method calls to the appropriate backend.
 ///
@@ -201,8 +202,14 @@ impl StorageBackend {
         dispatch!(self, get_session, id)
     }
 
-    pub async fn list_sessions(&self, agent_id: Uuid) -> Result<Vec<SessionRow>> {
-        dispatch!(self, list_sessions, agent_id)
+    /// List sessions for an agent with pagination.
+    /// Returns (sessions, total_count).
+    pub async fn list_sessions(
+        &self,
+        agent_id: Uuid,
+        pagination: Pagination,
+    ) -> Result<(Vec<SessionRow>, u32)> {
+        dispatch!(self, list_sessions, agent_id, pagination)
     }
 
     pub async fn update_session(

--- a/crates/control-plane/src/storage/memory.rs
+++ b/crates/control-plane/src/storage/memory.rs
@@ -1379,4 +1379,101 @@ mod tests {
         assert_eq!(events[1].sequence, 2);
         assert_eq!(events[2].sequence, 3);
     }
+
+    #[tokio::test]
+    async fn test_sessions_pagination() {
+        let db = InMemoryDatabase::new();
+
+        let agent = db
+            .create_agent(CreateAgentRow {
+                name: "Test Agent".to_string(),
+                description: None,
+                system_prompt: String::new(),
+                default_model_id: None,
+                tags: vec![],
+            })
+            .await
+            .unwrap();
+
+        // Create 15 sessions
+        for i in 0..15 {
+            db.create_session(CreateSessionRow {
+                agent_id: agent.id,
+                title: Some(format!("Session {}", i)),
+                tags: vec![],
+                model_id: None,
+            })
+            .await
+            .unwrap();
+        }
+
+        // Test default pagination (all sessions fit within limit)
+        let pagination = crate::api::common::Pagination::new(0, 20);
+        let (sessions, total) = db.list_sessions(agent.id, pagination).await.unwrap();
+        assert_eq!(total, 15);
+        assert_eq!(sessions.len(), 15);
+
+        // Test with limit=5
+        let pagination = crate::api::common::Pagination::new(0, 5);
+        let (sessions, total) = db.list_sessions(agent.id, pagination).await.unwrap();
+        assert_eq!(total, 15);
+        assert_eq!(sessions.len(), 5);
+
+        // Test with offset=5, limit=5
+        let pagination = crate::api::common::Pagination::new(5, 5);
+        let (sessions, total) = db.list_sessions(agent.id, pagination).await.unwrap();
+        assert_eq!(total, 15);
+        assert_eq!(sessions.len(), 5);
+
+        // Test last partial page (offset=10, limit=10 should return 5)
+        let pagination = crate::api::common::Pagination::new(10, 10);
+        let (sessions, total) = db.list_sessions(agent.id, pagination).await.unwrap();
+        assert_eq!(total, 15);
+        assert_eq!(sessions.len(), 5);
+
+        // Test beyond range (offset=20)
+        let pagination = crate::api::common::Pagination::new(20, 10);
+        let (sessions, total) = db.list_sessions(agent.id, pagination).await.unwrap();
+        assert_eq!(total, 15);
+        assert_eq!(sessions.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_sessions_pagination_ordering() {
+        let db = InMemoryDatabase::new();
+
+        let agent = db
+            .create_agent(CreateAgentRow {
+                name: "Test Agent".to_string(),
+                description: None,
+                system_prompt: String::new(),
+                default_model_id: None,
+                tags: vec![],
+            })
+            .await
+            .unwrap();
+
+        // Create sessions with sequential titles
+        for i in 1..=5 {
+            db.create_session(CreateSessionRow {
+                agent_id: agent.id,
+                title: Some(format!("Session {}", i)),
+                tags: vec![],
+                model_id: None,
+            })
+            .await
+            .unwrap();
+            // Small delay to ensure different created_at timestamps
+            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        }
+
+        // Sessions should be ordered by created_at DESC (newest first)
+        let pagination = crate::api::common::Pagination::new(0, 10);
+        let (sessions, _) = db.list_sessions(agent.id, pagination).await.unwrap();
+
+        assert_eq!(sessions.len(), 5);
+        // Most recent session should be first
+        assert_eq!(sessions[0].title, Some("Session 5".to_string()));
+        assert_eq!(sessions[4].title, Some("Session 1".to_string()));
+    }
 }

--- a/crates/control-plane/src/storage/memory.rs
+++ b/crates/control-plane/src/storage/memory.rs
@@ -396,7 +396,13 @@ impl InMemoryDatabase {
         Ok(self.sessions.read().get(&id).cloned())
     }
 
-    pub async fn list_sessions(&self, agent_id: Uuid) -> Result<Vec<SessionRow>> {
+    /// List sessions for an agent with pagination.
+    /// Returns (sessions, total_count).
+    pub async fn list_sessions(
+        &self,
+        agent_id: Uuid,
+        pagination: crate::api::common::Pagination,
+    ) -> Result<(Vec<SessionRow>, u32)> {
         let sessions = self.sessions.read();
         let mut result: Vec<_> = sessions
             .values()
@@ -404,7 +410,15 @@ impl InMemoryDatabase {
             .cloned()
             .collect();
         result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
-        Ok(result)
+
+        let total = result.len() as u32;
+        let offset = pagination.offset as usize;
+        let limit = pagination.limit as usize;
+
+        // Apply pagination
+        let paginated = result.into_iter().skip(offset).take(limit).collect();
+
+        Ok((paginated, total))
     }
 
     pub async fn update_session(
@@ -1310,8 +1324,10 @@ mod tests {
             .await
             .unwrap();
 
-        let sessions = db.list_sessions(agent.id).await.unwrap();
+        let pagination = crate::api::common::Pagination::new(0, 20);
+        let (sessions, total) = db.list_sessions(agent.id, pagination).await.unwrap();
         assert_eq!(sessions.len(), 1);
+        assert_eq!(total, 1);
         assert_eq!(sessions[0].id, session.id);
     }
 

--- a/crates/control-plane/src/storage/repositories.rs
+++ b/crates/control-plane/src/storage/repositories.rs
@@ -489,20 +489,42 @@ impl Database {
         Ok(row)
     }
 
-    pub async fn list_sessions(&self, agent_id: Uuid) -> Result<Vec<SessionRow>> {
+    /// List sessions for an agent with pagination.
+    /// Returns (sessions, total_count).
+    pub async fn list_sessions(
+        &self,
+        agent_id: Uuid,
+        pagination: crate::api::common::Pagination,
+    ) -> Result<(Vec<SessionRow>, u32)> {
+        // Get total count
+        let total: (i64,) = sqlx::query_as(
+            r#"
+            SELECT COUNT(*) as count
+            FROM sessions
+            WHERE agent_id = $1
+            "#,
+        )
+        .bind(agent_id)
+        .fetch_one(&self.pool)
+        .await?;
+
+        // Get paginated results
         let rows = sqlx::query_as::<_, SessionRow>(
             r#"
             SELECT id, agent_id, title, tags, model_id, status, created_at, started_at, finished_at
             FROM sessions
             WHERE agent_id = $1
             ORDER BY created_at DESC
+            LIMIT $2 OFFSET $3
             "#,
         )
         .bind(agent_id)
+        .bind(pagination.limit as i64)
+        .bind(pagination.offset as i64)
         .fetch_all(&self.pool)
         .await?;
 
-        Ok(rows)
+        Ok((rows, total.0 as u32))
     }
 
     pub async fn update_session(

--- a/crates/control-plane/tests/integration_test.rs
+++ b/crates/control-plane/tests/integration_test.rs
@@ -1367,3 +1367,173 @@ async fn test_no_duplicate_tool_calls() {
 
     println!("No duplicate tool calls test completed!");
 }
+
+#[tokio::test]
+async fn test_sessions_pagination() {
+    let client = reqwest::Client::new();
+
+    println!("Testing sessions pagination...");
+
+    // Create an agent for the test
+    let agent_response = client
+        .post(format!("{}/v1/agents", API_BASE_URL))
+        .json(&json!({
+            "name": "Pagination Test Agent",
+            "system_prompt": "Test agent"
+        }))
+        .send()
+        .await
+        .expect("Failed to create agent");
+
+    assert_eq!(agent_response.status(), 201);
+    let agent: Agent = agent_response.json().await.expect("Failed to parse agent");
+    println!("Created agent: {}", agent.id);
+
+    // Create 15 sessions
+    println!("Creating 15 sessions...");
+    for i in 1..=15 {
+        let response = client
+            .post(format!("{}/v1/agents/{}/sessions", API_BASE_URL, agent.id))
+            .json(&json!({ "title": format!("Session {}", i) }))
+            .send()
+            .await
+            .expect("Failed to create session");
+        assert_eq!(response.status(), 201, "Failed to create session {}", i);
+    }
+    println!("Created 15 sessions");
+
+    // Test 1: Default pagination returns all with metadata
+    println!("\nTest 1: Default pagination...");
+    let response = client
+        .get(format!("{}/v1/agents/{}/sessions", API_BASE_URL, agent.id))
+        .send()
+        .await
+        .expect("Failed to list sessions");
+
+    assert_eq!(response.status(), 200);
+    let body: Value = response.json().await.expect("Failed to parse");
+
+    assert_eq!(body["total"], 15, "Expected total=15");
+    assert_eq!(body["offset"], 0, "Expected offset=0");
+    assert_eq!(body["limit"], 20, "Expected default limit=20");
+    assert_eq!(
+        body["data"].as_array().unwrap().len(),
+        15,
+        "Expected 15 sessions"
+    );
+    println!("✓ Default pagination works");
+
+    // Test 2: Custom limit
+    println!("\nTest 2: Custom limit=5...");
+    let response = client
+        .get(format!(
+            "{}/v1/agents/{}/sessions?limit=5",
+            API_BASE_URL, agent.id
+        ))
+        .send()
+        .await
+        .expect("Failed to list sessions with limit");
+
+    assert_eq!(response.status(), 200);
+    let body: Value = response.json().await.expect("Failed to parse");
+
+    assert_eq!(body["total"], 15, "Total should still be 15");
+    assert_eq!(body["limit"], 5, "Limit should be 5");
+    assert_eq!(
+        body["data"].as_array().unwrap().len(),
+        5,
+        "Expected 5 sessions"
+    );
+    println!("✓ Custom limit works");
+
+    // Test 3: Offset pagination
+    println!("\nTest 3: Offset=5, limit=5...");
+    let response = client
+        .get(format!(
+            "{}/v1/agents/{}/sessions?offset=5&limit=5",
+            API_BASE_URL, agent.id
+        ))
+        .send()
+        .await
+        .expect("Failed to list sessions with offset");
+
+    assert_eq!(response.status(), 200);
+    let body: Value = response.json().await.expect("Failed to parse");
+
+    assert_eq!(body["total"], 15);
+    assert_eq!(body["offset"], 5);
+    assert_eq!(body["limit"], 5);
+    assert_eq!(body["data"].as_array().unwrap().len(), 5);
+    println!("✓ Offset pagination works");
+
+    // Test 4: Last partial page
+    println!("\nTest 4: Last partial page (offset=10, limit=10)...");
+    let response = client
+        .get(format!(
+            "{}/v1/agents/{}/sessions?offset=10&limit=10",
+            API_BASE_URL, agent.id
+        ))
+        .send()
+        .await
+        .expect("Failed to list sessions");
+
+    assert_eq!(response.status(), 200);
+    let body: Value = response.json().await.expect("Failed to parse");
+
+    assert_eq!(body["total"], 15);
+    assert_eq!(
+        body["data"].as_array().unwrap().len(),
+        5,
+        "Expected 5 remaining sessions"
+    );
+    println!("✓ Last partial page works");
+
+    // Test 5: Beyond range returns empty data
+    println!("\nTest 5: Beyond range (offset=20)...");
+    let response = client
+        .get(format!(
+            "{}/v1/agents/{}/sessions?offset=20",
+            API_BASE_URL, agent.id
+        ))
+        .send()
+        .await
+        .expect("Failed to list sessions");
+
+    assert_eq!(response.status(), 200);
+    let body: Value = response.json().await.expect("Failed to parse");
+
+    assert_eq!(body["total"], 15);
+    assert_eq!(
+        body["data"].as_array().unwrap().len(),
+        0,
+        "Expected empty data"
+    );
+    println!("✓ Beyond range returns empty data");
+
+    // Test 6: Max limit enforcement
+    println!("\nTest 6: Max limit enforcement (limit=200 should cap to 100)...");
+    let response = client
+        .get(format!(
+            "{}/v1/agents/{}/sessions?limit=200",
+            API_BASE_URL, agent.id
+        ))
+        .send()
+        .await
+        .expect("Failed to list sessions");
+
+    assert_eq!(response.status(), 200);
+    let body: Value = response.json().await.expect("Failed to parse");
+
+    assert_eq!(body["limit"], 100, "Limit should be capped at 100");
+    println!("✓ Max limit enforcement works");
+
+    // Cleanup
+    println!("\nCleaning up...");
+    client
+        .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
+        .send()
+        .await
+        .expect("Failed to delete agent");
+
+    println!("Sessions pagination test completed!");
+}

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -333,15 +333,46 @@
               "type": "string",
               "format": "uuid"
             }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Number of items to skip (for pagination).",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of items to return (for pagination).",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32",
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "List of sessions",
+            "description": "Paginated list of sessions",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponse_Session"
+                  "$ref": "#/components/schemas/PaginatedResponse_Session"
                 }
               }
             }
@@ -3422,88 +3453,6 @@
           }
         }
       },
-      "ListResponse_Session": {
-        "type": "object",
-        "description": "Response wrapper for list endpoints.\nAll list endpoints return responses wrapped in a `data` field.",
-        "required": [
-          "data"
-        ],
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "description": "Session - instance of agentic loop execution.\nA session represents a single conversation with an agent.",
-              "required": [
-                "id",
-                "agent_id",
-                "status",
-                "created_at"
-              ],
-              "properties": {
-                "agent_id": {
-                  "type": "string",
-                  "format": "uuid",
-                  "description": "ID of the agent this session belongs to."
-                },
-                "created_at": {
-                  "type": "string",
-                  "format": "date-time",
-                  "description": "Timestamp when the session was created."
-                },
-                "finished_at": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "format": "date-time",
-                  "description": "Timestamp when the session finished (completed or failed)."
-                },
-                "id": {
-                  "type": "string",
-                  "format": "uuid",
-                  "description": "Unique identifier for the session."
-                },
-                "model_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "format": "uuid",
-                  "description": "LLM model ID to use for this session.\nOverrides the agent's default model if set."
-                },
-                "started_at": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "format": "date-time",
-                  "description": "Timestamp when the session started executing."
-                },
-                "status": {
-                  "$ref": "#/components/schemas/SessionStatus",
-                  "description": "Current execution status of the session."
-                },
-                "tags": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Tags for organizing and filtering sessions."
-                },
-                "title": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Human-readable title for the session."
-                }
-              }
-            },
-            "description": "Array of items returned by the list operation."
-          }
-        }
-      },
       "ListResponse_User": {
         "type": "object",
         "description": "Response wrapper for list endpoints.\nAll list endpoints return responses wrapped in a `data` field.",
@@ -4237,6 +4186,109 @@
           "src_path": {
             "type": "string",
             "description": "Source path"
+          }
+        }
+      },
+      "PaginatedResponse_Session": {
+        "type": "object",
+        "description": "Response wrapper for paginated list endpoints.\nIncludes pagination metadata along with the data array.",
+        "required": [
+          "data",
+          "total",
+          "offset",
+          "limit"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "description": "Session - instance of agentic loop execution.\nA session represents a single conversation with an agent.",
+              "required": [
+                "id",
+                "agent_id",
+                "status",
+                "created_at"
+              ],
+              "properties": {
+                "agent_id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "ID of the agent this session belongs to."
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Timestamp when the session was created."
+                },
+                "finished_at": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "format": "date-time",
+                  "description": "Timestamp when the session finished (completed or failed)."
+                },
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "Unique identifier for the session."
+                },
+                "model_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "format": "uuid",
+                  "description": "LLM model ID to use for this session.\nOverrides the agent's default model if set."
+                },
+                "started_at": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "format": "date-time",
+                  "description": "Timestamp when the session started executing."
+                },
+                "status": {
+                  "$ref": "#/components/schemas/SessionStatus",
+                  "description": "Current execution status of the session."
+                },
+                "tags": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Tags for organizing and filtering sessions."
+                },
+                "title": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Human-readable title for the session."
+                }
+              }
+            },
+            "description": "Array of items returned by the list operation."
+          },
+          "limit": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Maximum number of items per page.",
+            "minimum": 0
+          },
+          "offset": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Current offset (starting position).",
+            "minimum": 0
+          },
+          "total": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Total number of items matching the query (across all pages).",
+            "minimum": 0
           }
         }
       },

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -246,6 +246,62 @@ The `ApiDoc` struct is shared between:
 
 All endpoints return JSON. Event streaming uses Server-Sent Events (SSE) with `text/event-stream` content type.
 
+### Pagination
+
+Endpoints that return lists support pagination via query parameters:
+
+| Parameter | Type | Default | Max | Description |
+|-----------|------|---------|-----|-------------|
+| `offset` | integer | 0 | - | Number of items to skip |
+| `limit` | integer | 20 | 100 | Maximum items to return |
+
+**Paginated Response Format:**
+
+```json
+{
+  "data": [...],
+  "total": 150,
+  "offset": 0,
+  "limit": 20
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data` | array | Items for the current page |
+| `total` | integer | Total count across all pages |
+| `offset` | integer | Current offset (echoed from request) |
+| `limit` | integer | Current limit (echoed from request) |
+
+**Endpoints with Pagination:**
+
+| Endpoint | Default Limit | Notes |
+|----------|---------------|-------|
+| `GET /v1/agents/{agent_id}/sessions` | 20 | Ordered by `created_at DESC` |
+
+**Non-Paginated List Endpoints:**
+
+These endpoints return all items wrapped in `{"data": [...]}`:
+- `GET /v1/agents` - Returns all agents
+- `GET /v1/agents/{agent_id}/sessions/{session_id}/messages` - Returns all messages
+- `GET /v1/agents/{agent_id}/sessions/{session_id}/events` - Returns all events
+- `GET /v1/llm-providers` - Returns all providers
+- `GET /v1/llm-models` - Returns all models
+- `GET /v1/capabilities` - Returns all capabilities
+
+**Example Usage:**
+
+```bash
+# First page (default)
+GET /v1/agents/{id}/sessions
+
+# Second page
+GET /v1/agents/{id}/sessions?offset=20&limit=20
+
+# Custom page size
+GET /v1/agents/{id}/sessions?limit=10
+```
+
 ### Error Responses
 
 ```json


### PR DESCRIPTION
## What

Add pagination support to the sessions list API endpoint, enabling efficient handling of large numbers of sessions per agent.

## Why

When agents have thousands of sessions, loading all sessions at once creates performance issues:
- Slow API responses
- High memory usage on both client and server
- Poor UX in the management UI

Pagination allows fetching sessions in smaller chunks, improving performance and user experience.

## How

### Backend Changes
- **New Types**: `PaginatedResponse<T>` and `Pagination` structs for pagination
- **Sessions API**: Updated `GET /v1/agents/{agent_id}/sessions` to accept `offset` and `limit` query params
- **Storage Layer**: Both PostgreSQL and in-memory backends support paginated queries with total count
- **OpenAPI**: Updated spec to document pagination parameters and response format

### Frontend Changes
- **Agent Detail Page**: Shows only top 10 sessions with "View all X sessions" link
- **New Sessions Page**: Dedicated `/agents/{agentId}/sessions` page with pagination controls
- **API Hooks**: Updated `useSessions` hook to support pagination parameters

### API Contract
```
GET /v1/agents/{agent_id}/sessions?offset=0&limit=20

Response:
{
  "data": [...],
  "total": 150,
  "offset": 0,
  "limit": 20
}
```

Default limit: 20, Max limit: 100

## Risk
- Low
- This is additive functionality
- Existing API consumers will get the same data (now with extra metadata)

## Checklist
- [x] Unit tests added for pagination types and storage layer
- [x] Integration test for sessions pagination API
- [x] API specs updated (specs/apis.md)
- [x] OpenAPI spec regenerated
- [x] Smoke tested pagination functionality
- [x] Backward compatibility maintained (data field still contains sessions)