### PR TITLE
feat(ui): add SessionCard component with status display and info button

### DIFF
--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -10,10 +10,10 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { MarkdownDisplay } from "@/components/ui/prompt-editor";
 import { ProviderIcon } from "@/components/providers/provider-icon";
+import { SessionCard } from "@/components/session/session-card";
 import {
   ArrowLeft,
   Plus,
-  MessageSquare,
   Pencil,
   Download,
 } from "lucide-react";
@@ -187,38 +187,12 @@ export default function AgentDetailPage({
               ) : (
                 <div className="space-y-2">
                   {sessions.map((session) => (
-                    <Link
+                    <SessionCard
                       key={session.id}
-                      href={`/agents/${agentId}/sessions/${session.id}`}
-                      className="flex items-center justify-between p-3 rounded-md border hover:bg-muted transition-colors"
-                    >
-                      <div className="flex items-center gap-3">
-                        <MessageSquare className="w-4 h-4 text-muted-foreground" />
-                        <div>
-                          <p className="font-medium">
-                            {session.title || `Session ${session.id.slice(0, 8)}`}
-                          </p>
-                          <p className="text-xs text-muted-foreground">
-                            {new Date(session.created_at).toLocaleString()}
-                          </p>
-                        </div>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        {session.model_id && modelMap.get(session.model_id) && (
-                          <Badge variant="outline" className="gap-1 text-xs">
-                            <ProviderIcon
-                              providerType={modelMap.get(session.model_id)!.provider_type}
-                              size="sm"
-                              showBackground={false}
-                            />
-                            {modelMap.get(session.model_id)!.display_name}
-                          </Badge>
-                        )}
-                        {session.finished_at && (
-                          <Badge variant="outline">Completed</Badge>
-                        )}
-                      </div>
-                    </Link>
+                      session={session}
+                      agentId={agentId}
+                      model={session.model_id ? modelMap.get(session.model_id) : undefined}
+                    />
                   ))}
                   {hasMoreSessions && (
                     <Link

--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/page.tsx
@@ -6,13 +6,11 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ProviderIcon } from "@/components/providers/provider-icon";
+import { SessionCard } from "@/components/session/session-card";
 import {
   ArrowLeft,
   Plus,
-  MessageSquare,
   ChevronLeft,
   ChevronRight,
   Trash2,
@@ -147,50 +145,28 @@ export default function SessionsListPage({
               {sessions.map((session) => (
                 <div
                   key={session.id}
-                  className="flex items-center justify-between p-3 rounded-md border hover:bg-muted transition-colors"
+                  className="flex items-center gap-2"
                 >
-                  <Link
-                    href={`/agents/${agentId}/sessions/${session.id}`}
-                    className="flex items-center gap-3 flex-1"
-                  >
-                    <MessageSquare className="w-4 h-4 text-muted-foreground" />
-                    <div>
-                      <p className="font-medium">
-                        {session.title || `Session ${session.id.slice(0, 8)}`}
-                      </p>
-                      <p className="text-xs text-muted-foreground">
-                        {new Date(session.created_at).toLocaleString()}
-                      </p>
-                    </div>
-                  </Link>
-                  <div className="flex items-center gap-2">
-                    {session.model_id && modelMap.get(session.model_id) && (
-                      <Badge variant="outline" className="gap-1 text-xs">
-                        <ProviderIcon
-                          providerType={modelMap.get(session.model_id)!.provider_type}
-                          size="sm"
-                          showBackground={false}
-                        />
-                        {modelMap.get(session.model_id)!.display_name}
-                      </Badge>
-                    )}
-                    {session.finished_at && (
-                      <Badge variant="outline">Completed</Badge>
-                    )}
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-8 w-8 text-muted-foreground hover:text-destructive"
-                      onClick={() =>
-                        handleDeleteSession(
-                          session.id,
-                          session.title || `Session ${session.id.slice(0, 8)}`
-                        )
-                      }
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
+                  <div className="flex-1">
+                    <SessionCard
+                      session={session}
+                      agentId={agentId}
+                      model={session.model_id ? modelMap.get(session.model_id) : undefined}
+                    />
                   </div>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8 text-muted-foreground hover:text-destructive flex-shrink-0"
+                    onClick={() =>
+                      handleDeleteSession(
+                        session.id,
+                        session.title || `Session ${session.id.slice(0, 8)}`
+                      )
+                    }
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
                 </div>
               ))}
             </div>

--- a/apps/ui/src/app/dev/components/page.tsx
+++ b/apps/ui/src/app/dev/components/page.tsx
@@ -8,7 +8,8 @@ import { Bot, ArrowLeft } from "lucide-react";
 import { ToolCallCard } from "@/components/chat/tool-call-card";
 import { TodoListRenderer } from "@/components/chat/todo-list-renderer";
 import { MessageInfoIcon } from "@/components/chat/message-info-icon";
-import type { Message, Event } from "@/lib/api/types";
+import { SessionCard } from "@/components/session/session-card";
+import type { Message, Event, Session, LlmModelWithProvider } from "@/lib/api/types";
 
 // Check if we're in development mode
 const isDev = process.env.NODE_ENV === "development";
@@ -391,6 +392,86 @@ const sampleEvents = {
 };
 
 // ============================================
+// Sample Data for SessionCard
+// ============================================
+
+const sampleSessions = {
+  running: {
+    id: "019234ab-cdef-7890-1234-567890abcdef",
+    agent_id: "agent-123",
+    title: "Working on implementing user authentication with OAuth 2.0 support for Google and GitHub providers",
+    tags: ["auth", "oauth"],
+    model_id: "model-uuid-anthropic",
+    status: "active" as const,
+    created_at: new Date(Date.now() - 300000).toISOString(), // 5 minutes ago
+    started_at: new Date(Date.now() - 240000).toISOString(), // 4 minutes ago
+    finished_at: null,
+  } satisfies Session,
+  idle: {
+    id: "019234cd-efgh-7890-1234-567890abcdef",
+    agent_id: "agent-123",
+    title: "Completed code review for the API endpoints",
+    tags: ["review"],
+    model_id: "model-uuid-openai",
+    status: "idle" as const,
+    created_at: new Date(Date.now() - 3600000).toISOString(), // 1 hour ago
+    started_at: new Date(Date.now() - 3500000).toISOString(),
+    finished_at: null,
+  } satisfies Session,
+  new: {
+    id: "019234ef-ijkl-7890-1234-567890abcdef",
+    agent_id: "agent-123",
+    title: null,
+    tags: [],
+    model_id: null,
+    status: "started" as const,
+    created_at: new Date().toISOString(),
+    started_at: null,
+    finished_at: null,
+  } satisfies Session,
+  longSummary: {
+    id: "019234gh-mnop-7890-1234-567890abcdef",
+    agent_id: "agent-123",
+    title: "Investigating the performance bottleneck in the database query layer. Found that the N+1 query problem is causing significant slowdowns when fetching related entities. Working on implementing eager loading with batch fetching to reduce the number of database round trips.",
+    tags: ["performance", "database", "optimization"],
+    model_id: "model-uuid-anthropic",
+    status: "active" as const,
+    created_at: new Date(Date.now() - 1800000).toISOString(), // 30 minutes ago
+    started_at: new Date(Date.now() - 1700000).toISOString(),
+    finished_at: null,
+  } satisfies Session,
+};
+
+const sampleModels = {
+  anthropic: {
+    id: "model-uuid-anthropic",
+    provider_id: "provider-anthropic",
+    model_id: "claude-sonnet-4-20250514",
+    display_name: "Claude Sonnet 4",
+    capabilities: ["chat", "tools"],
+    is_default: true,
+    status: "active" as const,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    provider_name: "Anthropic",
+    provider_type: "anthropic" as const,
+  } satisfies LlmModelWithProvider,
+  openai: {
+    id: "model-uuid-openai",
+    provider_id: "provider-openai",
+    model_id: "gpt-4o",
+    display_name: "GPT-4o",
+    capabilities: ["chat", "tools"],
+    is_default: false,
+    status: "active" as const,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    provider_name: "OpenAI",
+    provider_type: "openai" as const,
+  } satisfies LlmModelWithProvider,
+};
+
+// ============================================
 // Main Page Component
 // ============================================
 
@@ -497,6 +578,62 @@ export default function DevComponentsPage() {
                     <span className="text-sm text-white">Light:</span>
                     <MessageInfoIcon event={sampleEvents.userMessage} variant="light" />
                   </div>
+                </div>
+              </ShowcaseItem>
+            </ShowcaseSection>
+
+            {/* SessionCard Section */}
+            <ShowcaseSection
+              title="SessionCard Component"
+              description="Session card with status, summary, and info button (components/session/session-card.tsx)"
+            >
+              <ShowcaseItem label="Running Session">
+                <SessionCard
+                  session={sampleSessions.running}
+                  agentId="agent-123"
+                  model={sampleModels.anthropic}
+                />
+              </ShowcaseItem>
+
+              <ShowcaseItem label="Idle Session">
+                <SessionCard
+                  session={sampleSessions.idle}
+                  agentId="agent-123"
+                  model={sampleModels.openai}
+                />
+              </ShowcaseItem>
+
+              <ShowcaseItem label="New Session (No Title)">
+                <SessionCard
+                  session={sampleSessions.new}
+                  agentId="agent-123"
+                />
+              </ShowcaseItem>
+
+              <ShowcaseItem label="Session with Long Summary (Truncated)">
+                <SessionCard
+                  session={sampleSessions.longSummary}
+                  agentId="agent-123"
+                  model={sampleModels.anthropic}
+                />
+              </ShowcaseItem>
+
+              <ShowcaseItem label="Multiple Sessions (List View)">
+                <div className="space-y-2">
+                  <SessionCard
+                    session={sampleSessions.running}
+                    agentId="agent-123"
+                    model={sampleModels.anthropic}
+                  />
+                  <SessionCard
+                    session={sampleSessions.idle}
+                    agentId="agent-123"
+                    model={sampleModels.openai}
+                  />
+                  <SessionCard
+                    session={sampleSessions.new}
+                    agentId="agent-123"
+                  />
                 </div>
               </ShowcaseItem>
             </ShowcaseSection>

--- a/apps/ui/src/components/session/session-card.tsx
+++ b/apps/ui/src/components/session/session-card.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import Link from "next/link";
+import { Info, MessageSquare, Loader2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { ProviderIcon } from "@/components/providers/provider-icon";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import type { Session, SessionStatus, LlmModelWithProvider } from "@/lib/api/types";
+
+export interface SessionCardProps {
+  /** The session to display */
+  session: Session;
+  /** The agent ID (for building links) */
+  agentId: string;
+  /** Optional LLM model for display */
+  model?: LlmModelWithProvider;
+  /** Optional custom summary text (overrides default title display) */
+  summary?: string;
+  /** Whether to show the delete button (if provided with onDelete) */
+  onDelete?: (sessionId: string, sessionTitle: string) => void;
+}
+
+/**
+ * Truncate text to a specified number of lines (approximate by character limit)
+ * Each "line" is approximately 60 characters
+ */
+function truncateToLines(text: string, lines: number = 2): string {
+  const maxChars = lines * 60;
+  if (text.length <= maxChars) return text;
+  return text.slice(0, maxChars).trim() + "...";
+}
+
+/**
+ * Get display status info for a session status
+ */
+function getStatusInfo(status: SessionStatus): {
+  label: string;
+  variant: "default" | "secondary" | "outline";
+  isRunning: boolean;
+} {
+  switch (status) {
+    case "active":
+      return { label: "Running", variant: "default", isRunning: true };
+    case "idle":
+      return { label: "Idle", variant: "secondary", isRunning: false };
+    case "started":
+    default:
+      return { label: "New", variant: "outline", isRunning: false };
+  }
+}
+
+/**
+ * Session info icon that displays session metadata in a tooltip.
+ * Styled to match MessageInfoIcon component.
+ */
+function SessionInfoIcon({ session }: { session: Session }) {
+  const formattedCreatedAt = new Date(session.created_at).toLocaleString();
+  const formattedStartedAt = session.started_at
+    ? new Date(session.started_at).toLocaleString()
+    : null;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        className={cn(
+          "p-0.5 rounded transition-colors flex-shrink-0",
+          "text-muted-foreground/50 hover:text-muted-foreground hover:bg-muted/80"
+        )}
+        aria-label="Session info"
+        onClick={(e) => e.preventDefault()} // Prevent link navigation when clicking info
+      >
+        <Info className="w-3 h-3" />
+      </TooltipTrigger>
+      <TooltipContent className="max-w-sm">
+        <div className="space-y-1 text-xs">
+          <div className="flex gap-2">
+            <span className="text-muted-foreground">ID:</span>
+            <span className="font-mono text-[10px] break-all">{session.id}</span>
+          </div>
+          <div className="flex gap-2">
+            <span className="text-muted-foreground">Status:</span>
+            <span className="capitalize">{session.status}</span>
+          </div>
+          <div className="flex gap-2">
+            <span className="text-muted-foreground">Created:</span>
+            <span>{formattedCreatedAt}</span>
+          </div>
+          {formattedStartedAt && (
+            <div className="flex gap-2">
+              <span className="text-muted-foreground">Started:</span>
+              <span>{formattedStartedAt}</span>
+            </div>
+          )}
+          {session.tags.length > 0 && (
+            <div className="flex gap-2">
+              <span className="text-muted-foreground">Tags:</span>
+              <span>{session.tags.join(", ")}</span>
+            </div>
+          )}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+/**
+ * SessionCard displays a session with status, summary, and metadata.
+ * Designed for use in session lists and overview pages.
+ */
+export function SessionCard({
+  session,
+  agentId,
+  model,
+  summary,
+}: SessionCardProps) {
+  const statusInfo = getStatusInfo(session.status);
+  const displayTitle = session.title || `Session ${session.id.slice(0, 8)}`;
+  const displaySummary = summary ?? session.title;
+
+  return (
+    <Link
+      href={`/agents/${agentId}/sessions/${session.id}`}
+      className="flex items-start justify-between p-3 rounded-md border hover:bg-muted transition-colors group"
+    >
+      <div className="flex items-start gap-3 flex-1 min-w-0">
+        <div className="flex-shrink-0 mt-0.5">
+          {statusInfo.isRunning ? (
+            <Loader2 className="w-4 h-4 text-primary animate-spin" />
+          ) : (
+            <MessageSquare className="w-4 h-4 text-muted-foreground" />
+          )}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <p className="font-medium truncate">{displayTitle}</p>
+            <Badge variant={statusInfo.variant} className="flex-shrink-0 text-xs">
+              {statusInfo.label}
+            </Badge>
+          </div>
+          {displaySummary && (
+            <p className="text-sm text-muted-foreground mt-1 line-clamp-2">
+              {truncateToLines(displaySummary, 2)}
+            </p>
+          )}
+          <p className="text-xs text-muted-foreground mt-1">
+            {new Date(session.created_at).toLocaleString()}
+          </p>
+        </div>
+      </div>
+      <div className="flex items-center gap-2 flex-shrink-0 ml-2">
+        {model && (
+          <Badge variant="outline" className="gap-1 text-xs">
+            <ProviderIcon
+              providerType={model.provider_type}
+              size="sm"
+              showBackground={false}
+            />
+            {model.display_name}
+          </Badge>
+        )}
+        <SessionInfoIcon session={session} />
+      </div>
+    </Link>
+  );
+}
+
+/**
+ * Export SessionInfoIcon for use in other components if needed
+ */
+export { SessionInfoIcon };


### PR DESCRIPTION
## Summary
- Add SessionCard component showing session status (Running/Idle/New) with visual indicators
- Display session summary text (title) truncated to 1-2 lines
- Add info button with session metadata tooltip (ID, status, timestamps, tags)
- Add SessionCard showcase to dev components page for easy review
- Update sessions list page and agent detail page to use the new component

## Changes
- **New component**: `apps/ui/src/components/session/session-card.tsx`
  - Shows status badge (Running with spinner, Idle, or New)
  - Displays summary text with truncation
  - Info button aligned with MessageInfoIcon style
- **Updated**: Agent detail page to use SessionCard
- **Updated**: Sessions list page to use SessionCard with delete button
- **Updated**: Dev components page with SessionCard showcase

## Test plan
- [x] UI builds successfully (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] Smoke test: API health check passes
- [x] Smoke test: Create agent and session works
- [x] Dev components page renders SessionCard examples correctly