### PR TITLE
fix(ui): improve message info tooltip formatting

### DIFF
--- a/apps/ui/src/components/chat/message-info-icon.tsx
+++ b/apps/ui/src/components/chat/message-info-icon.tsx
@@ -51,34 +51,30 @@ export function MessageInfoIcon({ event, variant = "default" }: MessageInfoIconP
         <Info className="w-3 h-3" />
       </TooltipTrigger>
       <TooltipContent className="max-w-sm">
-        <div className="space-y-1 text-xs">
-          <div className="flex gap-2">
-            <span className="text-muted-foreground">ID:</span>
-            <span className="font-mono text-[10px] break-all">{event.id}</span>
-          </div>
+        <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
+          <dt className="text-muted-foreground">ID</dt>
+          <dd className="font-mono text-[10px] break-all">{event.id}</dd>
           {model && (
-            <div className="flex gap-2">
-              <span className="text-muted-foreground">Model:</span>
-              <span>{model}</span>
-            </div>
+            <>
+              <dt className="text-muted-foreground">Model</dt>
+              <dd>{model}</dd>
+            </>
           )}
           {reasoningEffort && (
-            <div className="flex gap-2">
-              <span className="text-muted-foreground">Reasoning:</span>
-              <span className="capitalize">{reasoningEffort}</span>
-            </div>
+            <>
+              <dt className="text-muted-foreground">Reasoning</dt>
+              <dd className="capitalize">{reasoningEffort}</dd>
+            </>
           )}
-          <div className="flex gap-2">
-            <span className="text-muted-foreground">Time:</span>
-            <span>{formattedTime}</span>
-          </div>
+          <dt className="text-muted-foreground">Time</dt>
+          <dd>{formattedTime}</dd>
           {usage && (
-            <div className="flex gap-2">
-              <span className="text-muted-foreground">Tokens:</span>
-              <span>{usage.input_tokens} in / {usage.output_tokens} out</span>
-            </div>
+            <>
+              <dt className="text-muted-foreground">Tokens</dt>
+              <dd>{usage.input_tokens} in / {usage.output_tokens} out</dd>
+            </>
           )}
-        </div>
+        </dl>
       </TooltipContent>
     </Tooltip>
   );


### PR DESCRIPTION
## What
Improved the message info tooltip layout to use CSS grid for proper column alignment.

## Why
The previous layout used flexbox with `gap-2`, causing labels (ID, Model, Time, Tokens) to have inconsistent widths and misaligned values.

## How
- Replaced `div` with flexbox to semantic `<dl>`, `<dt>`, `<dd>` elements
- Used CSS grid (`grid-cols-[auto_1fr]`) for two-column layout
- Labels now align in first column, values in second column
- Removed colons from labels for cleaner appearance

## Risk
- Low
- Visual-only change to tooltip formatting

## Checklist
- [x] UI build passes
- [x] Component already showcased in /dev/components page