### PR TITLE
refactor(ui): replace durable polling with SSE streaming

### DIFF
--- a/apps/ui/src/app/(main)/durable/layout.tsx
+++ b/apps/ui/src/app/(main)/durable/layout.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useDurableSSE } from "@/hooks";
+
+/**
+ * Layout for durable execution pages.
+ * Establishes SSE connection for real-time updates across all durable pages.
+ */
+export default function DurableLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  // Connect to global durable SSE stream
+  // This single connection updates React Query cache for all durable data
+  useDurableSSE();
+
+  return <>{children}</>;
+}

--- a/apps/ui/src/app/(main)/durable/workflows/[workflowId]/page.tsx
+++ b/apps/ui/src/app/(main)/durable/workflows/[workflowId]/page.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
-import { useWorkflow, useWorkflowEvents, useCancelWorkflow, useSignalWorkflow } from "@/hooks";
+import { useWorkflow, useWorkflowEvents, useWorkflowSSE, useCancelWorkflow, useSignalWorkflow } from "@/hooks";
 import type { WorkflowStatus, WorkflowEvent } from "@/lib/api/types";
 import {
   AlertTriangle,
@@ -163,6 +163,10 @@ function EventTimeline({ events }: { events: WorkflowEvent[] }) {
 
 export default function WorkflowDetailPage({ params }: { params: Promise<{ workflowId: string }> }) {
   const { workflowId } = use(params);
+
+  // Connect to workflow-specific SSE for real-time updates
+  useWorkflowSSE(workflowId);
+
   const { data: workflow, isLoading: workflowLoading, error: workflowError, refetch } = useWorkflow(workflowId);
   const { data: events, isLoading: eventsLoading } = useWorkflowEvents(workflowId);
   const cancelMutation = useCancelWorkflow();

--- a/apps/ui/src/hooks/use-durable.ts
+++ b/apps/ui/src/hooks/use-durable.ts
@@ -1,5 +1,7 @@
 // Durable Execution hooks
+// Uses SSE for real-time updates instead of polling
 
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   getDurableHealth,
@@ -18,32 +20,235 @@ import {
   purgeDlq,
   listCircuitBreakers,
   resetCircuitBreaker,
+  getDurableSseUrl,
+  getWorkflowSseUrl,
   type ListWorkflowsParams,
   type ListTasksParams,
   type ListDlqParams,
 } from "@/lib/api/durable";
+import type {
+  DurableSystemHealth,
+  DurableWorker,
+  DurableWorkflow,
+  WorkflowEvent,
+  DurableTask,
+  DlqEntry,
+  CircuitBreaker,
+} from "@/lib/api/types";
 
 // ============================================
-// System Health
+// SSE Snapshot Types (match backend response)
+// ============================================
+
+interface DurableSnapshot {
+  health: DurableSystemHealth;
+  workers: DurableWorker[];
+  workflows: { data: DurableWorkflow[]; total: number };
+  tasks: { data: DurableTask[]; total: number };
+  dlq: { data: DlqEntry[]; total: number };
+  circuit_breakers: { data: CircuitBreaker[]; total: number };
+}
+
+interface WorkflowSnapshot {
+  workflow: DurableWorkflow;
+  events: WorkflowEvent[];
+}
+
+// ============================================
+// Global Durable SSE Hook
+// ============================================
+
+/**
+ * Connect to global durable SSE stream and update React Query cache.
+ * This single connection provides real-time updates for all durable data.
+ */
+export function useDurableSSE(options?: { enabled?: boolean }) {
+  const queryClient = useQueryClient();
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const [isConnected, setIsConnected] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const isEnabled = options?.enabled !== false;
+
+  const cleanup = useCallback(() => {
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isEnabled) {
+      cleanup();
+      setIsConnected(false);
+      return;
+    }
+
+    const connectSSE = () => {
+      cleanup();
+
+      const sseUrl = getDurableSseUrl();
+      const eventSource = new EventSource(sseUrl, { withCredentials: true });
+      eventSourceRef.current = eventSource;
+
+      eventSource.addEventListener("connected", () => {
+        setIsConnected(true);
+        setError(null);
+      });
+
+      eventSource.addEventListener("snapshot", (event) => {
+        try {
+          const snapshot: DurableSnapshot = JSON.parse(event.data);
+
+          // Update all durable query caches
+          queryClient.setQueryData(["durable", "health"], snapshot.health);
+          queryClient.setQueryData(["durable", "workers"], {
+            data: snapshot.workers,
+            total: snapshot.workers.length,
+          });
+          queryClient.setQueryData(["durable", "workflows", undefined], snapshot.workflows);
+          queryClient.setQueryData(["durable", "tasks", undefined], snapshot.tasks);
+          queryClient.setQueryData(["durable", "dlq", undefined], snapshot.dlq);
+          queryClient.setQueryData(
+            ["durable", "circuit-breakers"],
+            snapshot.circuit_breakers
+          );
+        } catch (e) {
+          console.error("Failed to parse durable SSE snapshot:", e);
+        }
+      });
+
+      eventSource.onerror = () => {
+        setError(new Error("Durable SSE connection error"));
+        setIsConnected(false);
+        cleanup();
+        // Reconnect after delay
+        setTimeout(() => {
+          if (isEnabled) {
+            connectSSE();
+          }
+        }, 2000);
+      };
+    };
+
+    connectSSE();
+
+    return cleanup;
+  }, [isEnabled, cleanup, queryClient]);
+
+  return { isConnected, error };
+}
+
+// ============================================
+// Per-Workflow SSE Hook
+// ============================================
+
+/**
+ * Connect to workflow-specific SSE stream for real-time workflow updates.
+ * Updates the specific workflow and its events in React Query cache.
+ */
+export function useWorkflowSSE(
+  workflowId: string | undefined,
+  options?: { enabled?: boolean }
+) {
+  const queryClient = useQueryClient();
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const [isConnected, setIsConnected] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const isEnabled = options?.enabled !== false && !!workflowId;
+
+  const cleanup = useCallback(() => {
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
+    }
+  }, []);
+
+  // Reset state when workflow changes
+  useEffect(() => {
+    setIsConnected(false);
+    setError(null);
+  }, [workflowId]);
+
+  useEffect(() => {
+    if (!isEnabled || !workflowId) {
+      cleanup();
+      setIsConnected(false);
+      return;
+    }
+
+    const connectSSE = () => {
+      cleanup();
+
+      const sseUrl = getWorkflowSseUrl(workflowId);
+      const eventSource = new EventSource(sseUrl, { withCredentials: true });
+      eventSourceRef.current = eventSource;
+
+      eventSource.addEventListener("connected", () => {
+        setIsConnected(true);
+        setError(null);
+      });
+
+      eventSource.addEventListener("snapshot", (event) => {
+        try {
+          const snapshot: WorkflowSnapshot = JSON.parse(event.data);
+
+          // Update workflow and events caches
+          queryClient.setQueryData(
+            ["durable", "workflow", workflowId],
+            snapshot.workflow
+          );
+          queryClient.setQueryData(
+            ["durable", "workflow", workflowId, "events"],
+            snapshot.events
+          );
+        } catch (e) {
+          console.error("Failed to parse workflow SSE snapshot:", e);
+        }
+      });
+
+      eventSource.onerror = () => {
+        setError(new Error("Workflow SSE connection error"));
+        setIsConnected(false);
+        cleanup();
+        // Reconnect after delay
+        setTimeout(() => {
+          if (isEnabled && workflowId) {
+            connectSSE();
+          }
+        }, 2000);
+      };
+    };
+
+    connectSSE();
+
+    return cleanup;
+  }, [workflowId, isEnabled, cleanup, queryClient]);
+
+  return { isConnected, error };
+}
+
+// ============================================
+// System Health (SSE-backed)
 // ============================================
 
 export function useDurableHealth() {
   return useQuery({
     queryKey: ["durable", "health"],
     queryFn: getDurableHealth,
-    refetchInterval: 5000, // Refresh every 5 seconds
+    // No refetchInterval - SSE provides updates
+    staleTime: Infinity, // Data is always fresh from SSE
   });
 }
 
 // ============================================
-// Workers
+// Workers (SSE-backed)
 // ============================================
 
 export function useWorkers() {
   return useQuery({
     queryKey: ["durable", "workers"],
     queryFn: listWorkers,
-    refetchInterval: 5000, // Refresh every 5 seconds
+    staleTime: Infinity,
   });
 }
 
@@ -53,6 +258,7 @@ export function useDrainWorker() {
   return useMutation({
     mutationFn: (workerId: string) => drainWorker(workerId),
     onSuccess: () => {
+      // Invalidate to trigger immediate refetch; SSE will update shortly
       queryClient.invalidateQueries({ queryKey: ["durable", "workers"] });
       queryClient.invalidateQueries({ queryKey: ["durable", "health"] });
     },
@@ -60,14 +266,14 @@ export function useDrainWorker() {
 }
 
 // ============================================
-// Workflows
+// Workflows (SSE-backed)
 // ============================================
 
 export function useWorkflows(params?: ListWorkflowsParams) {
   return useQuery({
     queryKey: ["durable", "workflows", params],
     queryFn: () => listWorkflows(params),
-    refetchInterval: 5000,
+    staleTime: Infinity,
   });
 }
 
@@ -76,7 +282,7 @@ export function useWorkflow(workflowId: string | undefined) {
     queryKey: ["durable", "workflow", workflowId],
     queryFn: () => getWorkflow(workflowId!),
     enabled: !!workflowId,
-    refetchInterval: 2000,
+    staleTime: Infinity,
   });
 }
 
@@ -85,7 +291,7 @@ export function useWorkflowEvents(workflowId: string | undefined) {
     queryKey: ["durable", "workflow", workflowId, "events"],
     queryFn: () => getWorkflowEvents(workflowId!),
     enabled: !!workflowId,
-    refetchInterval: 2000,
+    staleTime: Infinity,
   });
 }
 
@@ -126,14 +332,14 @@ export function useSignalWorkflow() {
 }
 
 // ============================================
-// Tasks
+// Tasks (SSE-backed)
 // ============================================
 
 export function useTasks(params?: ListTasksParams) {
   return useQuery({
     queryKey: ["durable", "tasks", params],
     queryFn: () => listTasks(params),
-    refetchInterval: 5000,
+    staleTime: Infinity,
   });
 }
 
@@ -141,19 +347,19 @@ export function useTaskStats() {
   return useQuery({
     queryKey: ["durable", "tasks", "stats"],
     queryFn: getTaskStats,
-    refetchInterval: 5000,
+    staleTime: Infinity,
   });
 }
 
 // ============================================
-// Dead Letter Queue
+// Dead Letter Queue (SSE-backed)
 // ============================================
 
 export function useDlq(params?: ListDlqParams) {
   return useQuery({
     queryKey: ["durable", "dlq", params],
     queryFn: () => listDlq(params),
-    refetchInterval: 10000, // DLQ changes less frequently
+    staleTime: Infinity,
   });
 }
 
@@ -195,14 +401,14 @@ export function usePurgeDlq() {
 }
 
 // ============================================
-// Circuit Breakers
+// Circuit Breakers (SSE-backed)
 // ============================================
 
 export function useCircuitBreakers() {
   return useQuery({
     queryKey: ["durable", "circuit-breakers"],
     queryFn: listCircuitBreakers,
-    refetchInterval: 10000,
+    staleTime: Infinity,
   });
 }
 

--- a/apps/ui/src/lib/api/durable.ts
+++ b/apps/ui/src/lib/api/durable.ts
@@ -1,6 +1,6 @@
 // Durable Execution API functions
 
-import { api } from "./client";
+import { api, getDirectBackendUrl } from "./client";
 import type {
   WorkersResponse,
   WorkflowsResponse,
@@ -13,6 +13,28 @@ import type {
   CircuitBreakersResponse,
   DurableSystemHealth,
 } from "./types";
+
+// ============================================
+// SSE URLs (bypasses Next.js proxy buffering)
+// ============================================
+
+/**
+ * Get SSE URL for global durable state streaming.
+ * Returns health, workers, workflows, tasks, DLQ, and circuit breakers.
+ */
+export function getDurableSseUrl(): string {
+  const baseUrl = getDirectBackendUrl();
+  return `${baseUrl}/v1/durable/sse`;
+}
+
+/**
+ * Get SSE URL for workflow-specific state streaming.
+ * Returns workflow details and events.
+ */
+export function getWorkflowSseUrl(workflowId: string): string {
+  const baseUrl = getDirectBackendUrl();
+  return `${baseUrl}/v1/durable/workflows/${workflowId}/sse`;
+}
 
 // ============================================
 // System Health

--- a/crates/control-plane/src/api/durable.rs
+++ b/crates/control-plane/src/api/durable.rs
@@ -7,11 +7,13 @@
 // - Task queue monitoring
 // - Dead letter queue management
 // - Circuit breaker status
+// - SSE streaming for real-time updates
 
 use axum::{
     Json, Router,
     extract::{Path, Query, State},
     http::StatusCode,
+    response::sse::{Event as SseEvent, KeepAlive, Sse},
     routing::{get, post},
 };
 use chrono::{DateTime, Utc};
@@ -20,12 +22,17 @@ use everruns_durable::{
     TaskInfo, TaskStatus, WorkerFilter, WorkerInfo, WorkflowEventInfo, WorkflowEventStore,
     WorkflowFilter, WorkflowInfoExtended, WorkflowSignal, WorkflowStatus,
 };
+use futures::{
+    StreamExt,
+    stream::{self, Stream},
+};
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use std::{convert::Infallible, sync::Arc, time::Duration};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
 use super::common::ErrorResponse;
+use super::sse::SseStreamConfig;
 
 /// App state for durable routes
 #[derive(Clone)]
@@ -57,6 +64,12 @@ impl AppState {
 /// Create durable routes
 pub fn routes(state: AppState) -> Router {
     Router::new()
+        // SSE streaming
+        .route("/v1/durable/sse", get(stream_durable_sse))
+        .route(
+            "/v1/durable/workflows/:workflow_id/sse",
+            get(stream_workflow_sse),
+        )
         // System health
         .route("/v1/durable/health", get(get_health))
         // Workers
@@ -940,4 +953,389 @@ pub async fn list_circuit_breakers(
         .collect();
 
     Ok(Json(CircuitBreakersListResponse { data, total }))
+}
+
+// ============================================================================
+// SSE Streaming
+// ============================================================================
+
+/// SSE snapshot data for global durable state
+#[derive(Debug, Serialize)]
+struct DurableSnapshot {
+    health: HealthResponse,
+    workers: Vec<WorkerResponse>,
+    workflows: WorkflowsListResponse,
+    tasks: TasksListResponse,
+    dlq: DlqListResponse,
+    circuit_breakers: CircuitBreakersListResponse,
+}
+
+/// SSE snapshot data for a single workflow
+#[derive(Debug, Serialize)]
+struct WorkflowSnapshot {
+    workflow: WorkflowResponse,
+    events: Vec<WorkflowEventResponse>,
+}
+
+/// GET /v1/durable/sse - Stream global durable state (SSE)
+#[utoipa::path(
+    get,
+    path = "/v1/durable/sse",
+    responses(
+        (status = 200, description = "SSE event stream", content_type = "text/event-stream"),
+        (status = 503, description = "Durable store not available")
+    ),
+    tag = "durable"
+)]
+pub async fn stream_durable_sse(
+    State(state): State<AppState>,
+) -> Result<Sse<impl Stream<Item = Result<SseEvent, Infallible>>>, StatusCode> {
+    // Verify store is available
+    let _ = state
+        .get_store()
+        .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?;
+
+    tracing::info!("Starting global durable SSE stream");
+
+    // Use monitoring config (relaxed polling for dashboards)
+    let config = SseStreamConfig::monitoring();
+
+    #[derive(Clone)]
+    struct StreamState {
+        backoff_ms: u64,
+        sent_connected: bool,
+        config: SseStreamConfig,
+        // Track last snapshot hash to detect changes
+        last_hash: Option<u64>,
+    }
+
+    let initial_state = StreamState {
+        backoff_ms: config.min_backoff_ms,
+        sent_connected: false,
+        config,
+        last_hash: None,
+    };
+
+    let stream = stream::unfold((state, initial_state), |(state, stream_state)| async move {
+        // Send initial "connected" event
+        if !stream_state.sent_connected {
+            tracing::debug!("Durable SSE: sending connected event");
+            let connected_event = Ok(SseEvent::default()
+                .event("connected")
+                .data(r#"{"status":"connected"}"#));
+            let new_state = StreamState {
+                sent_connected: true,
+                ..stream_state
+            };
+            return Some((stream::iter(vec![connected_event]), (state, new_state)));
+        }
+
+        // Fetch current state
+        let store = match state.get_store() {
+            Ok(s) => s,
+            Err(_) => return None,
+        };
+
+        // Fetch all data in parallel-ish manner
+        let health = match store.get_system_health().await {
+            Ok(h) => HealthResponse::from(h),
+            Err(e) => {
+                tracing::error!("Failed to fetch health: {}", e);
+                return None;
+            }
+        };
+
+        let workers: Vec<WorkerResponse> = match store.list_workers(WorkerFilter::default()).await {
+            Ok(w) => w.into_iter().map(WorkerResponse::from).collect(),
+            Err(e) => {
+                tracing::error!("Failed to fetch workers: {}", e);
+                return None;
+            }
+        };
+
+        let workflows_data = match store
+            .list_workflows(
+                WorkflowFilter::default(),
+                Pagination {
+                    offset: 0,
+                    limit: 100,
+                },
+            )
+            .await
+        {
+            Ok(w) => w,
+            Err(e) => {
+                tracing::error!("Failed to fetch workflows: {}", e);
+                return None;
+            }
+        };
+        let workflows = WorkflowsListResponse {
+            total: workflows_data.len(),
+            data: workflows_data
+                .into_iter()
+                .map(WorkflowResponse::from)
+                .collect(),
+        };
+
+        let tasks_data = match store
+            .list_tasks(
+                TaskFilter::default(),
+                Pagination {
+                    offset: 0,
+                    limit: 100,
+                },
+            )
+            .await
+        {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::error!("Failed to fetch tasks: {}", e);
+                return None;
+            }
+        };
+        let tasks = TasksListResponse {
+            total: tasks_data.len(),
+            data: tasks_data.into_iter().map(TaskResponse::from).collect(),
+        };
+
+        let dlq_data = match store
+            .list_dlq(
+                DlqFilter::default(),
+                Pagination {
+                    offset: 0,
+                    limit: 100,
+                },
+            )
+            .await
+        {
+            Ok(d) => d,
+            Err(e) => {
+                tracing::error!("Failed to fetch DLQ: {}", e);
+                return None;
+            }
+        };
+        let dlq = DlqListResponse {
+            total: dlq_data.len(),
+            data: dlq_data.into_iter().map(DlqEntryResponse::from).collect(),
+        };
+
+        let cb_data = match store.list_circuit_breakers().await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::error!("Failed to fetch circuit breakers: {}", e);
+                return None;
+            }
+        };
+        let circuit_breakers = CircuitBreakersListResponse {
+            total: cb_data.len(),
+            data: cb_data
+                .into_iter()
+                .map(CircuitBreakerResponse::from)
+                .collect(),
+        };
+
+        let snapshot = DurableSnapshot {
+            health,
+            workers,
+            workflows,
+            tasks,
+            dlq,
+            circuit_breakers,
+        };
+
+        // Simple hash based on key metrics to detect changes
+        let current_hash = {
+            use std::hash::{Hash, Hasher};
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            snapshot.health.status.hash(&mut hasher);
+            snapshot.health.active_workers.hash(&mut hasher);
+            snapshot.health.running_workflows.hash(&mut hasher);
+            snapshot.health.pending_tasks.hash(&mut hasher);
+            snapshot.health.dlq_size.hash(&mut hasher);
+            snapshot.workers.len().hash(&mut hasher);
+            snapshot.workflows.total.hash(&mut hasher);
+            snapshot.tasks.total.hash(&mut hasher);
+            snapshot.dlq.total.hash(&mut hasher);
+            snapshot.circuit_breakers.total.hash(&mut hasher);
+            hasher.finish()
+        };
+
+        // Only send if changed or first snapshot
+        let has_changes = stream_state.last_hash != Some(current_hash);
+
+        if has_changes {
+            let json = serde_json::to_string(&snapshot).unwrap_or_else(|_| "{}".to_string());
+            let event = Ok(SseEvent::default().event("snapshot").data(json));
+
+            let new_state = StreamState {
+                backoff_ms: stream_state.config.min_backoff_ms,
+                last_hash: Some(current_hash),
+                ..stream_state
+            };
+            Some((stream::iter(vec![event]), (state, new_state)))
+        } else {
+            // No changes, wait with backoff
+            tokio::time::sleep(Duration::from_millis(stream_state.backoff_ms)).await;
+            let new_backoff = stream_state.config.next_backoff(stream_state.backoff_ms);
+            let new_state = StreamState {
+                backoff_ms: new_backoff,
+                ..stream_state
+            };
+            Some((stream::iter(vec![]), (state, new_state)))
+        }
+    })
+    .flatten();
+
+    Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
+}
+
+/// GET /v1/durable/workflows/:workflow_id/sse - Stream workflow state (SSE)
+#[utoipa::path(
+    get,
+    path = "/v1/durable/workflows/{workflow_id}/sse",
+    params(
+        ("workflow_id" = Uuid, Path, description = "Workflow ID")
+    ),
+    responses(
+        (status = 200, description = "SSE event stream", content_type = "text/event-stream"),
+        (status = 404, description = "Workflow not found"),
+        (status = 503, description = "Durable store not available")
+    ),
+    tag = "durable"
+)]
+pub async fn stream_workflow_sse(
+    State(state): State<AppState>,
+    Path(workflow_id): Path<Uuid>,
+) -> Result<Sse<impl Stream<Item = Result<SseEvent, Infallible>>>, StatusCode> {
+    // Verify store is available
+    let store = state
+        .get_store()
+        .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?;
+
+    // Verify workflow exists
+    let workflows = store
+        .list_workflows(
+            WorkflowFilter::default(),
+            Pagination {
+                offset: 0,
+                limit: 1000,
+            },
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to get workflows: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    let workflow_exists = workflows.iter().any(|w| w.id == workflow_id);
+    if !workflow_exists {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    tracing::info!(workflow_id = %workflow_id, "Starting workflow SSE stream");
+
+    // Use monitoring config
+    let config = SseStreamConfig::monitoring();
+
+    #[derive(Clone)]
+    struct StreamState {
+        workflow_id: Uuid,
+        backoff_ms: u64,
+        sent_connected: bool,
+        config: SseStreamConfig,
+        last_event_count: usize,
+        last_status: Option<String>,
+    }
+
+    let initial_state = StreamState {
+        workflow_id,
+        backoff_ms: config.min_backoff_ms,
+        sent_connected: false,
+        config,
+        last_event_count: 0,
+        last_status: None,
+    };
+
+    let stream = stream::unfold((state, initial_state), |(state, stream_state)| async move {
+        // Send initial "connected" event
+        if !stream_state.sent_connected {
+            tracing::debug!(workflow_id = %stream_state.workflow_id, "Workflow SSE: sending connected event");
+            let connected_event = Ok(SseEvent::default()
+                .event("connected")
+                .data(r#"{"status":"connected"}"#));
+            let new_state = StreamState {
+                sent_connected: true,
+                ..stream_state
+            };
+            return Some((stream::iter(vec![connected_event]), (state, new_state)));
+        }
+
+        let store = match state.get_store() {
+            Ok(s) => s,
+            Err(_) => return None,
+        };
+
+        // Fetch workflow
+        let workflows = match store
+            .list_workflows(WorkflowFilter::default(), Pagination { offset: 0, limit: 1000 })
+            .await
+        {
+            Ok(w) => w,
+            Err(e) => {
+                tracing::error!("Failed to fetch workflows: {}", e);
+                return None;
+            }
+        };
+
+        let workflow = match workflows.into_iter().find(|w| w.id == stream_state.workflow_id) {
+            Some(w) => WorkflowResponse::from(w),
+            None => {
+                // Workflow deleted, end stream
+                return None;
+            }
+        };
+
+        // Fetch events
+        let events: Vec<WorkflowEventResponse> =
+            match store.get_workflow_events(stream_state.workflow_id).await {
+                Ok(e) => e.into_iter().map(WorkflowEventResponse::from).collect(),
+                Err(e) => {
+                    tracing::error!("Failed to fetch workflow events: {}", e);
+                    return None;
+                }
+            };
+
+        // Detect changes
+        let status_changed = stream_state.last_status.as_ref() != Some(&workflow.status);
+        let events_changed = events.len() != stream_state.last_event_count;
+        let has_changes = status_changed || events_changed;
+
+        if has_changes {
+            let new_status = workflow.status.clone();
+            let event_count = events.len();
+            let snapshot = WorkflowSnapshot { workflow, events };
+            let json = serde_json::to_string(&snapshot).unwrap_or_else(|_| "{}".to_string());
+            let event = Ok(SseEvent::default().event("snapshot").data(json));
+
+            let new_state = StreamState {
+                backoff_ms: stream_state.config.min_backoff_ms,
+                last_event_count: event_count,
+                last_status: Some(new_status),
+                ..stream_state
+            };
+            Some((stream::iter(vec![event]), (state, new_state)))
+        } else {
+            // No changes, wait with backoff
+            tokio::time::sleep(Duration::from_millis(stream_state.backoff_ms)).await;
+            let new_backoff = stream_state.config.next_backoff(stream_state.backoff_ms);
+            let new_state = StreamState {
+                backoff_ms: new_backoff,
+                ..stream_state
+            };
+            Some((stream::iter(vec![]), (state, new_state)))
+        }
+    })
+    .flatten();
+
+    Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
 }

--- a/crates/control-plane/src/api/durable.rs
+++ b/crates/control-plane/src/api/durable.rs
@@ -1339,3 +1339,160 @@ pub async fn stream_workflow_sse(
 
     Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_durable_snapshot_serialization() {
+        let snapshot = DurableSnapshot {
+            health: HealthResponse {
+                status: "healthy".to_string(),
+                total_workers: 2,
+                active_workers: 2,
+                workers_accepting: 2,
+                total_capacity: 10,
+                current_load: 3,
+                load_percentage: 30.0,
+                pending_tasks: 5,
+                claimed_tasks: 3,
+                running_workflows: 1,
+                pending_workflows: 0,
+                dlq_size: 0,
+            },
+            workers: vec![],
+            workflows: WorkflowsListResponse {
+                data: vec![],
+                total: 0,
+            },
+            tasks: TasksListResponse {
+                data: vec![],
+                total: 0,
+            },
+            dlq: DlqListResponse {
+                data: vec![],
+                total: 0,
+            },
+            circuit_breakers: CircuitBreakersListResponse {
+                data: vec![],
+                total: 0,
+            },
+        };
+
+        let json = serde_json::to_string(&snapshot).unwrap();
+        assert!(json.contains("\"status\":\"healthy\""));
+        assert!(json.contains("\"active_workers\":2"));
+        assert!(json.contains("\"load_percentage\":30.0"));
+    }
+
+    #[test]
+    fn test_workflow_snapshot_serialization() {
+        let snapshot = WorkflowSnapshot {
+            workflow: WorkflowResponse {
+                id: Uuid::nil(),
+                workflow_type: "test_workflow".to_string(),
+                status: "running".to_string(),
+                input: serde_json::json!({"key": "value"}),
+                result: None,
+                error: None,
+                created_at: Utc::now(),
+                started_at: Some(Utc::now()),
+                completed_at: None,
+            },
+            events: vec![],
+        };
+
+        let json = serde_json::to_string(&snapshot).unwrap();
+        assert!(json.contains("\"workflow_type\":\"test_workflow\""));
+        assert!(json.contains("\"status\":\"running\""));
+        assert!(json.contains("\"events\":[]"));
+    }
+
+    #[test]
+    fn test_health_response_from_system_health() {
+        let health = SystemHealth {
+            total_workers: 5,
+            active_workers: 3,
+            workers_accepting: 2,
+            total_capacity: 50,
+            current_load: 10,
+            pending_tasks: 5,
+            claimed_tasks: 10,
+            running_workflows: 2,
+            pending_workflows: 1,
+            dlq_size: 0,
+        };
+
+        let response = HealthResponse::from(health);
+
+        assert_eq!(response.status, "healthy");
+        assert_eq!(response.total_workers, 5);
+        assert_eq!(response.active_workers, 3);
+        assert_eq!(response.load_percentage, 20.0); // 10/50 * 100
+    }
+
+    #[test]
+    fn test_health_status_degraded_when_no_active_workers() {
+        let health = SystemHealth {
+            total_workers: 5,
+            active_workers: 0,
+            workers_accepting: 0,
+            total_capacity: 0,
+            current_load: 0,
+            pending_tasks: 0,
+            claimed_tasks: 0,
+            running_workflows: 0,
+            pending_workflows: 0,
+            dlq_size: 0,
+        };
+
+        let response = HealthResponse::from(health);
+        assert_eq!(response.status, "degraded");
+    }
+
+    #[test]
+    fn test_health_status_warning_when_dlq_has_items() {
+        let health = SystemHealth {
+            total_workers: 2,
+            active_workers: 2,
+            workers_accepting: 2,
+            total_capacity: 10,
+            current_load: 0,
+            pending_tasks: 0,
+            claimed_tasks: 0,
+            running_workflows: 0,
+            pending_workflows: 0,
+            dlq_size: 5,
+        };
+
+        let response = HealthResponse::from(health);
+        assert_eq!(response.status, "warning");
+    }
+
+    #[test]
+    fn test_load_percentage_zero_when_no_capacity() {
+        let health = SystemHealth {
+            total_workers: 0,
+            active_workers: 0,
+            workers_accepting: 0,
+            total_capacity: 0,
+            current_load: 0,
+            pending_tasks: 0,
+            claimed_tasks: 0,
+            running_workflows: 0,
+            pending_workflows: 0,
+            dlq_size: 0,
+        };
+
+        let response = HealthResponse::from(health);
+        assert_eq!(response.load_percentage, 0.0);
+    }
+
+    #[test]
+    fn test_app_state_get_store_none() {
+        let state = AppState::new(None);
+        let result = state.get_store();
+        assert!(result.is_err());
+    }
+}

--- a/crates/control-plane/src/api/events.rs
+++ b/crates/control-plane/src/api/events.rs
@@ -13,6 +13,7 @@ use everruns_core::{Event, EventListener};
 use serde::Deserialize;
 
 use super::common::ListResponse;
+use super::sse::SseStreamConfig;
 use crate::services::EventService;
 use futures::{
     StreamExt,
@@ -116,11 +117,8 @@ pub async fn stream_sse(
     let event_service = state.event_service.clone();
     let initial_since_id = query.since_id;
 
-    // Backoff configuration
-    // Keep max backoff low (500ms) to ensure responsive event delivery
-    // The backoff resets to MIN when new events arrive
-    const MIN_BACKOFF_MS: u64 = 100;
-    const MAX_BACKOFF_MS: u64 = 500;
+    // Use realtime config for session events (fast updates for interactive UX)
+    let config = SseStreamConfig::realtime();
 
     // State for stream: (last_id, backoff_ms, sent_connected)
     #[derive(Clone)]
@@ -128,12 +126,14 @@ pub async fn stream_sse(
         last_id: Option<Uuid>,
         backoff_ms: u64,
         sent_connected: bool,
+        config: SseStreamConfig,
     }
 
     let initial_state = StreamState {
         last_id: initial_since_id,
-        backoff_ms: MIN_BACKOFF_MS,
+        backoff_ms: config.min_backoff_ms,
         sent_connected: false,
+        config,
     };
 
     // Create stream that replays events from database
@@ -190,8 +190,9 @@ pub async fn stream_sse(
                     // Reset backoff on new events
                     let new_state = StreamState {
                         last_id: new_last_id,
-                        backoff_ms: MIN_BACKOFF_MS,
+                        backoff_ms: state.config.min_backoff_ms,
                         sent_connected: true,
+                        config: state.config,
                     };
                     Some((stream::iter(sse_events), new_state))
                 }
@@ -200,7 +201,7 @@ pub async fn stream_sse(
                     tokio::time::sleep(Duration::from_millis(state.backoff_ms)).await;
 
                     // Increase backoff for next iteration (double, up to max)
-                    let new_backoff = (state.backoff_ms * 2).min(MAX_BACKOFF_MS);
+                    let new_backoff = state.config.next_backoff(state.backoff_ms);
                     let new_state = StreamState {
                         backoff_ms: new_backoff,
                         ..state

--- a/crates/control-plane/src/api/mod.rs
+++ b/crates/control-plane/src/api/mod.rs
@@ -14,6 +14,7 @@ pub mod mcp_servers;
 pub mod messages;
 pub mod session_files;
 pub mod sessions;
+pub mod sse;
 pub mod users;
 pub mod validation;
 

--- a/crates/control-plane/src/api/sse.rs
+++ b/crates/control-plane/src/api/sse.rs
@@ -90,4 +90,65 @@ mod tests {
         assert_eq!(config.next_backoff(10000), 20000);
         assert_eq!(config.next_backoff(15000), 20000); // Capped
     }
+
+    #[test]
+    fn test_min_backoff_duration() {
+        let config = SseStreamConfig::realtime();
+        assert_eq!(config.min_backoff(), Duration::from_millis(100));
+
+        let config = SseStreamConfig::monitoring();
+        assert_eq!(config.min_backoff(), Duration::from_millis(1000));
+    }
+
+    #[test]
+    fn test_default_is_realtime() {
+        let config = SseStreamConfig::default();
+        assert_eq!(config.min_backoff_ms, 100);
+        assert_eq!(config.max_backoff_ms, 500);
+    }
+
+    #[test]
+    fn test_config_is_copy() {
+        let config = SseStreamConfig::realtime();
+        let config2 = config; // Copy
+        assert_eq!(config.min_backoff_ms, config2.min_backoff_ms);
+    }
+
+    #[test]
+    fn test_exponential_backoff_sequence_realtime() {
+        let config = SseStreamConfig::realtime();
+        let mut backoff = config.min_backoff_ms;
+
+        // Sequence: 100 -> 200 -> 400 -> 500 (capped)
+        assert_eq!(backoff, 100);
+        backoff = config.next_backoff(backoff);
+        assert_eq!(backoff, 200);
+        backoff = config.next_backoff(backoff);
+        assert_eq!(backoff, 400);
+        backoff = config.next_backoff(backoff);
+        assert_eq!(backoff, 500); // Capped
+        backoff = config.next_backoff(backoff);
+        assert_eq!(backoff, 500); // Stays at max
+    }
+
+    #[test]
+    fn test_exponential_backoff_sequence_monitoring() {
+        let config = SseStreamConfig::monitoring();
+        let mut backoff = config.min_backoff_ms;
+
+        // Sequence: 1000 -> 2000 -> 4000 -> 8000 -> 16000 -> 20000 (capped)
+        assert_eq!(backoff, 1000);
+        backoff = config.next_backoff(backoff);
+        assert_eq!(backoff, 2000);
+        backoff = config.next_backoff(backoff);
+        assert_eq!(backoff, 4000);
+        backoff = config.next_backoff(backoff);
+        assert_eq!(backoff, 8000);
+        backoff = config.next_backoff(backoff);
+        assert_eq!(backoff, 16000);
+        backoff = config.next_backoff(backoff);
+        assert_eq!(backoff, 20000); // Capped
+        backoff = config.next_backoff(backoff);
+        assert_eq!(backoff, 20000); // Stays at max
+    }
 }

--- a/crates/control-plane/src/api/sse.rs
+++ b/crates/control-plane/src/api/sse.rs
@@ -1,0 +1,93 @@
+// Shared SSE (Server-Sent Events) utilities
+//
+// Provides unified backoff configuration for all SSE endpoints.
+// Different use cases have different latency requirements:
+// - Real-time (sessions): Fast updates for interactive UX
+// - Monitoring (durable): Relaxed updates for dashboards
+
+use std::time::Duration;
+
+/// SSE stream configuration with backoff parameters
+#[derive(Debug, Clone, Copy)]
+pub struct SseStreamConfig {
+    /// Minimum backoff when polling for new events (ms)
+    pub min_backoff_ms: u64,
+    /// Maximum backoff when no new events (ms)
+    pub max_backoff_ms: u64,
+}
+
+impl SseStreamConfig {
+    /// Fast polling for real-time session events
+    /// Min: 100ms, Max: 500ms
+    pub fn realtime() -> Self {
+        Self {
+            min_backoff_ms: 100,
+            max_backoff_ms: 500,
+        }
+    }
+
+    /// Relaxed polling for monitoring dashboards
+    /// Min: 1000ms, Max: 20000ms
+    pub fn monitoring() -> Self {
+        Self {
+            min_backoff_ms: 1000,
+            max_backoff_ms: 20000,
+        }
+    }
+
+    /// Get minimum backoff as Duration
+    pub fn min_backoff(&self) -> Duration {
+        Duration::from_millis(self.min_backoff_ms)
+    }
+
+    /// Calculate next backoff (exponential, capped at max)
+    pub fn next_backoff(&self, current_ms: u64) -> u64 {
+        (current_ms * 2).min(self.max_backoff_ms)
+    }
+}
+
+impl Default for SseStreamConfig {
+    fn default() -> Self {
+        Self::realtime()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_realtime_config() {
+        let config = SseStreamConfig::realtime();
+        assert_eq!(config.min_backoff_ms, 100);
+        assert_eq!(config.max_backoff_ms, 500);
+    }
+
+    #[test]
+    fn test_monitoring_config() {
+        let config = SseStreamConfig::monitoring();
+        assert_eq!(config.min_backoff_ms, 1000);
+        assert_eq!(config.max_backoff_ms, 20000);
+    }
+
+    #[test]
+    fn test_next_backoff_doubles() {
+        let config = SseStreamConfig::realtime();
+        assert_eq!(config.next_backoff(100), 200);
+        assert_eq!(config.next_backoff(200), 400);
+    }
+
+    #[test]
+    fn test_next_backoff_caps_at_max() {
+        let config = SseStreamConfig::realtime();
+        assert_eq!(config.next_backoff(400), 500); // Capped at max
+        assert_eq!(config.next_backoff(500), 500); // Already at max
+    }
+
+    #[test]
+    fn test_monitoring_backoff_caps() {
+        let config = SseStreamConfig::monitoring();
+        assert_eq!(config.next_backoff(10000), 20000);
+        assert_eq!(config.next_backoff(15000), 20000); // Capped
+    }
+}


### PR DESCRIPTION
## What
Replace polling-based updates in durable execution UI with Server-Sent Events (SSE) for real-time streaming.

## Why
Polling creates unnecessary load and introduces latency for updates. SSE provides efficient, real-time updates with lower overhead.

## How
- Added shared `SseStreamConfig` in `api/sse.rs` with two profiles:
  - `realtime()` (100-500ms backoff) for session events
  - `monitoring()` (1000-20000ms backoff) for durable monitoring
- Added two SSE endpoints:
  - `/v1/durable/sse` - Global durable snapshot (health, workers, workflows, tasks, dlq, circuit breakers)
  - `/v1/durable/workflows/:id/sse` - Per-workflow snapshot (workflow details + events)
- Change detection via hash comparison to avoid sending unchanged data
- Created `useDurableSSE()` and `useWorkflowSSE()` hooks that update React Query cache directly
- Removed `refetchInterval` from all durable hooks, replaced with `staleTime: Infinity`
- Added durable layout to establish global SSE connection

## Risk
- Low
- SSE connection errors are handled with automatic reconnection (2s delay)
- Mutations still invalidate queries to trigger immediate refetch if SSE lags

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered