### PR TITLE
fix(worker): reset terminal workflow for second message in session

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,8 @@ When running in cloud-hosted agent environments (e.g., Claude Code on the web), 
 
 These secrets are pre-configured in the environment and do not require manual setup.
 
+If `gh` tool is not available, use GitHub API with `GITHUB_TOKEN`.
+
 ### Rust conventions
 
 - Use stable Rust (edition 2024) and keep the toolchain pinned via `rust-toolchain.toml`.

--- a/crates/control-plane/tests/integration_test.rs
+++ b/crates/control-plane/tests/integration_test.rs
@@ -1538,6 +1538,335 @@ async fn test_sessions_pagination() {
     println!("Sessions pagination test completed!");
 }
 
+/// Test that a second message in the same session triggers a new workflow
+///
+/// This test verifies:
+/// 1. First message triggers workflow and gets response
+/// 2. Second message triggers a NEW workflow and gets response
+///
+/// This is a regression test for the issue where second messages were not picked up
+/// because the workflow ID was the same as session_id and the completed workflow
+/// blocked creation of a new workflow.
+///
+/// Requirements: API + Worker (uses LlmSim provider, no real API keys needed).
+#[tokio::test]
+async fn test_second_message_triggers_workflow() {
+    use std::time::{Duration, Instant};
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .expect("Failed to create client");
+
+    println!("Testing second message triggers workflow...");
+
+    // Step 0: Create LlmSim provider and model (no real API keys needed)
+    println!("\nStep 0: Creating LlmSim provider and model...");
+    let provider_response = client
+        .post(format!("{}/v1/llm-providers", API_BASE_URL))
+        .json(&json!({
+            "name": "LlmSim Second Message Test",
+            "provider_type": "llmsim"
+        }))
+        .send()
+        .await
+        .expect("Failed to create provider");
+
+    if provider_response.status() != 201 {
+        let status = provider_response.status();
+        let body = provider_response.text().await.unwrap_or_default();
+        panic!(
+            "Failed to create LlmSim provider: status={}, body={}",
+            status, body
+        );
+    }
+    let provider: LlmProvider = provider_response
+        .json()
+        .await
+        .expect("Failed to parse provider");
+    println!("Created LlmSim provider: {}", provider.id);
+
+    let model_response = client
+        .post(format!(
+            "{}/v1/llm-providers/{}/models",
+            API_BASE_URL, provider.id
+        ))
+        .json(&json!({
+            "model_id": "llmsim-second-msg-test",
+            "display_name": "LlmSim Second Message Test Model"
+        }))
+        .send()
+        .await
+        .expect("Failed to create model");
+
+    if model_response.status() != 201 {
+        let status = model_response.status();
+        let body = model_response.text().await.unwrap_or_default();
+        panic!(
+            "Failed to create LlmSim model: status={}, body={}",
+            status, body
+        );
+    }
+    let model: LlmModel = model_response.json().await.expect("Failed to parse model");
+    println!("Created LlmSim model: {}", model.id);
+
+    // Step 1: Create agent with LlmSim model
+    println!("\nStep 1: Creating agent with LlmSim model...");
+    let agent_response = client
+        .post(format!("{}/v1/agents", API_BASE_URL))
+        .json(&json!({
+            "name": "Second Message Test Agent",
+            "system_prompt": "You are a helpful assistant. Respond briefly.",
+            "default_model_id": model.id.to_string()
+        }))
+        .send()
+        .await
+        .expect("Failed to create agent");
+
+    assert_eq!(agent_response.status(), 201);
+    let agent: Agent = agent_response.json().await.expect("Failed to parse agent");
+    println!(
+        "Created agent: {} with model: {:?}",
+        agent.id, agent.default_model_id
+    );
+
+    // Step 2: Create session
+    println!("\nStep 2: Creating session...");
+    let session_response = client
+        .post(format!("{}/v1/agents/{}/sessions", API_BASE_URL, agent.id))
+        .json(&json!({"title": "Second Message Test Session"}))
+        .send()
+        .await
+        .expect("Failed to create session");
+
+    assert_eq!(session_response.status(), 201);
+    let session: Session = session_response
+        .json()
+        .await
+        .expect("Failed to parse session");
+    println!("Created session: {}", session.id);
+
+    // Step 3: Send FIRST message and wait for response
+    println!("\nStep 3: Sending FIRST message...");
+    let first_message_response = client
+        .post(format!(
+            "{}/v1/agents/{}/sessions/{}/messages",
+            API_BASE_URL, agent.id, session.id
+        ))
+        .json(&json!({
+            "message": {
+                "content": [{"type": "text", "text": "Hello, this is the first message."}]
+            }
+        }))
+        .send()
+        .await
+        .expect("Failed to create first message");
+
+    assert_eq!(
+        first_message_response.status(),
+        201,
+        "First message creation should succeed"
+    );
+    println!("First message created");
+
+    // Wait for first response
+    println!("\nWaiting for first agent response...");
+    let mut first_response_found = false;
+    for i in 1..=30 {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        let messages_response = client
+            .get(format!(
+                "{}/v1/agents/{}/sessions/{}/messages",
+                API_BASE_URL, agent.id, session.id
+            ))
+            .send()
+            .await;
+
+        if let Ok(resp) = messages_response
+            && resp.status() == 200
+        {
+            let data: Value = resp.json().await.unwrap_or_default();
+            let empty_vec = vec![];
+            let messages = data["data"].as_array().unwrap_or(&empty_vec);
+
+            // Count agent messages
+            let agent_count = messages.iter().filter(|m| m["role"] == "agent").count();
+            if agent_count >= 1 {
+                first_response_found = true;
+                println!("Found first agent response after {}s", i);
+                break;
+            }
+        }
+
+        if i % 5 == 0 {
+            println!("Still waiting for first response... ({}s)", i);
+        }
+    }
+
+    assert!(
+        first_response_found,
+        "First agent response not received within 30 seconds"
+    );
+
+    // Small delay to ensure workflow is fully completed
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Step 4: Send SECOND message and wait for response
+    println!("\nStep 4: Sending SECOND message...");
+    let second_message_start = Instant::now();
+    let second_message_response = client
+        .post(format!(
+            "{}/v1/agents/{}/sessions/{}/messages",
+            API_BASE_URL, agent.id, session.id
+        ))
+        .json(&json!({
+            "message": {
+                "content": [{"type": "text", "text": "Hello, this is the SECOND message. Please respond."}]
+            }
+        }))
+        .send()
+        .await
+        .expect("Failed to create second message");
+
+    assert_eq!(
+        second_message_response.status(),
+        201,
+        "Second message creation should succeed"
+    );
+    println!(
+        "Second message created in {:?}",
+        second_message_start.elapsed()
+    );
+
+    // Wait for second response
+    println!("\nWaiting for SECOND agent response...");
+    let mut second_response_found = false;
+    for i in 1..=30 {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        let messages_response = client
+            .get(format!(
+                "{}/v1/agents/{}/sessions/{}/messages",
+                API_BASE_URL, agent.id, session.id
+            ))
+            .send()
+            .await;
+
+        if let Ok(resp) = messages_response
+            && resp.status() == 200
+        {
+            let data: Value = resp.json().await.unwrap_or_default();
+            let empty_vec = vec![];
+            let messages = data["data"].as_array().unwrap_or(&empty_vec);
+
+            // Count user and agent messages
+            let user_count = messages.iter().filter(|m| m["role"] == "user").count();
+            let agent_count = messages.iter().filter(|m| m["role"] == "agent").count();
+
+            if i == 1 || i % 5 == 0 {
+                println!(
+                    "  [{}s] Messages: {} user, {} agent",
+                    i, user_count, agent_count
+                );
+            }
+
+            // We expect 2 user messages and 2 agent messages
+            if user_count >= 2 && agent_count >= 2 {
+                second_response_found = true;
+                println!("Found second agent response after {}s", i);
+                break;
+            }
+        }
+    }
+
+    // Debug: if second response not found, show all messages
+    if !second_response_found {
+        println!("\nDebug: Final message state:");
+        if let Ok(resp) = client
+            .get(format!(
+                "{}/v1/agents/{}/sessions/{}/messages",
+                API_BASE_URL, agent.id, session.id
+            ))
+            .send()
+            .await
+            && resp.status() == 200
+        {
+            let data: Value = resp.json().await.unwrap_or_default();
+            let empty_vec = vec![];
+            let messages = data["data"].as_array().unwrap_or(&empty_vec);
+            for (i, msg) in messages.iter().enumerate() {
+                let role = msg["role"].as_str().unwrap_or("?");
+                let content_preview = msg["content"].to_string();
+                let preview: String = content_preview.chars().take(100).collect();
+                println!("  Message {}: role={}, content={}", i, role, preview);
+            }
+        }
+    }
+
+    assert!(
+        second_response_found,
+        "Second agent response not received within 30 seconds. \
+        This indicates the second message workflow was not triggered. \
+        Bug: workflow_id = session_id causes conflict when creating second workflow."
+    );
+
+    // Step 5: Verify we have exactly 2 user messages and 2 agent messages
+    println!("\nStep 5: Verifying message counts...");
+    let final_messages_response = client
+        .get(format!(
+            "{}/v1/agents/{}/sessions/{}/messages",
+            API_BASE_URL, agent.id, session.id
+        ))
+        .send()
+        .await
+        .expect("Failed to get final messages");
+
+    let final_data: Value = final_messages_response
+        .json()
+        .await
+        .expect("Failed to parse final messages");
+    let final_messages = final_data["data"]
+        .as_array()
+        .expect("Expected messages array");
+
+    let user_count = final_messages
+        .iter()
+        .filter(|m| m["role"] == "user")
+        .count();
+    let agent_count = final_messages
+        .iter()
+        .filter(|m| m["role"] == "agent")
+        .count();
+
+    println!(
+        "Final counts: {} user messages, {} agent messages",
+        user_count, agent_count
+    );
+    assert_eq!(user_count, 2, "Expected 2 user messages");
+    assert_eq!(agent_count, 2, "Expected 2 agent messages");
+
+    // Cleanup
+    println!("\nCleaning up...");
+    client
+        .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
+        .send()
+        .await
+        .expect("Failed to delete agent");
+    client
+        .delete(format!("{}/v1/llm-models/{}", API_BASE_URL, model.id))
+        .send()
+        .await
+        .expect("Failed to delete model");
+    client
+        .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
+        .send()
+        .await
+        .expect("Failed to delete provider");
+
+    println!("Second message workflow test passed!");
+}
+
 /// Test MCP server CRUD operations
 ///
 /// This test verifies:

--- a/crates/worker/src/durable_runner.rs
+++ b/crates/worker/src/durable_runner.rs
@@ -479,8 +479,8 @@ impl AgentRunner for DurableRunner {
 
         let mut store = self.store.lock().await;
 
-        // Check if workflow already exists (idempotency)
-        match store.get_workflow_status(workflow_id).await {
+        // Check if workflow already exists
+        let workflow_exists = match store.get_workflow_status(workflow_id).await {
             Ok((status, _, _)) => {
                 if !status.is_terminal() {
                     info!(
@@ -491,6 +491,14 @@ impl AgentRunner for DurableRunner {
                     );
                     return Ok(());
                 }
+                // Workflow exists but is terminal - we'll reset it for a new turn
+                info!(
+                    session_id = %session_id,
+                    workflow_id = %workflow_id,
+                    status = ?status,
+                    "Existing workflow is terminal, resetting for new turn"
+                );
+                true
             }
             Err(e) => {
                 // Check if it's a not found error (expected for new workflows)
@@ -498,47 +506,70 @@ impl AgentRunner for DurableRunner {
                 if !err_str.contains("not found") && !err_str.contains("NOT_FOUND") {
                     return Err(anyhow::anyhow!("Failed to check workflow status: {}", e));
                 }
+                false
             }
-        }
-
-        // Create new workflow
-        store
-            .create_workflow(workflow_id, "turn_workflow", input_json.clone())
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to create workflow: {}", e))?;
-
-        // Append WorkflowStarted event
-        let started_event = WorkflowEvent::WorkflowStarted {
-            input: input_json.clone(),
         };
-        let sequence = store
-            .append_events(workflow_id, 0, vec![started_event])
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to append WorkflowStarted event: {}", e))?;
 
         // Enqueue the initial activity (input processing)
         let activity_id = format!("input_{}", Uuid::now_v7());
-        store
-            .enqueue_task(
-                workflow_id,
-                activity_id.clone(),
-                "process_input".to_string(),
-                input_json.clone(),
-            )
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to enqueue task: {}", e))?;
 
-        // Append ActivityScheduled event
-        let scheduled_event = WorkflowEvent::ActivityScheduled {
-            activity_id,
-            activity_type: "process_input".to_string(),
-            input: input_json,
-            options: ActivityOptions::default(),
-        };
-        let _ = store
-            .append_events(workflow_id, sequence, vec![scheduled_event])
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to append ActivityScheduled event: {}", e))?;
+        if workflow_exists {
+            // Reset existing workflow to pending for new turn
+            store
+                .update_workflow_status(workflow_id, WorkflowStatus::Pending, None, None)
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to reset workflow status: {}", e))?;
+
+            // Enqueue task for the new turn (skip appending events for reset workflows
+            // as the task input contains all necessary information)
+            store
+                .enqueue_task(
+                    workflow_id,
+                    activity_id,
+                    "process_input".to_string(),
+                    input_json,
+                )
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to enqueue task: {}", e))?;
+        } else {
+            // Create new workflow
+            store
+                .create_workflow(workflow_id, "turn_workflow", input_json.clone())
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to create workflow: {}", e))?;
+
+            // Append WorkflowStarted event
+            let started_event = WorkflowEvent::WorkflowStarted {
+                input: input_json.clone(),
+            };
+            let sequence = store
+                .append_events(workflow_id, 0, vec![started_event])
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to append WorkflowStarted event: {}", e))?;
+
+            // Enqueue task
+            store
+                .enqueue_task(
+                    workflow_id,
+                    activity_id.clone(),
+                    "process_input".to_string(),
+                    input_json.clone(),
+                )
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to enqueue task: {}", e))?;
+
+            // Append ActivityScheduled event
+            let scheduled_event = WorkflowEvent::ActivityScheduled {
+                activity_id,
+                activity_type: "process_input".to_string(),
+                input: input_json,
+                options: ActivityOptions::default(),
+            };
+            let _ = store
+                .append_events(workflow_id, sequence, vec![scheduled_event])
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to append ActivityScheduled event: {}", e))?;
+        }
 
         info!(
             session_id = %session_id,
@@ -609,5 +640,145 @@ mod tests {
         assert_eq!(input.session_id, parsed.session_id);
         assert_eq!(input.agent_id, parsed.agent_id);
         assert_eq!(input.input_message_id, parsed.input_message_id);
+    }
+
+    /// Test that start_run works for a new session (first message)
+    #[tokio::test]
+    async fn test_start_run_creates_new_workflow() {
+        let runner = DurableRunner::new_in_memory();
+
+        let session_id = Uuid::now_v7();
+        let agent_id = Uuid::now_v7();
+        let message_id = Uuid::now_v7();
+
+        // First call should create a new workflow
+        runner
+            .start_run(session_id, agent_id, message_id)
+            .await
+            .expect("First start_run should succeed");
+
+        // Workflow should be running
+        assert!(runner.is_running(session_id).await);
+    }
+
+    /// Test that start_run skips if workflow is already running
+    #[tokio::test]
+    async fn test_start_run_skips_if_running() {
+        let runner = DurableRunner::new_in_memory();
+
+        let session_id = Uuid::now_v7();
+        let agent_id = Uuid::now_v7();
+        let message_id1 = Uuid::now_v7();
+        let message_id2 = Uuid::now_v7();
+
+        // First message
+        runner
+            .start_run(session_id, agent_id, message_id1)
+            .await
+            .expect("First start_run should succeed");
+
+        assert!(runner.is_running(session_id).await);
+
+        // Second message while still running - should skip (not error)
+        runner
+            .start_run(session_id, agent_id, message_id2)
+            .await
+            .expect("Second start_run should skip gracefully");
+
+        // Still running (not double-started)
+        assert!(runner.is_running(session_id).await);
+    }
+
+    /// Test that start_run resets a completed workflow for a second message
+    ///
+    /// This is the key test for the second message bug fix:
+    /// When a workflow is completed and a new message arrives, the workflow
+    /// should be reset to pending so it can process the new message.
+    #[tokio::test]
+    async fn test_start_run_resets_completed_workflow() {
+        let runner = DurableRunner::new_in_memory();
+
+        let session_id = Uuid::now_v7();
+        let agent_id = Uuid::now_v7();
+        let message_id1 = Uuid::now_v7();
+        let message_id2 = Uuid::now_v7();
+
+        // First message - creates workflow
+        runner
+            .start_run(session_id, agent_id, message_id1)
+            .await
+            .expect("First start_run should succeed");
+
+        assert!(runner.is_running(session_id).await);
+
+        // Simulate workflow completion by updating status to Completed
+        {
+            let mut store = runner.store.lock().await;
+            store
+                .update_workflow_status(session_id, WorkflowStatus::Completed, None, None)
+                .await
+                .expect("Should update workflow status");
+        }
+
+        // Workflow should now be terminal (not running)
+        assert!(
+            !runner.is_running(session_id).await,
+            "Workflow should be completed"
+        );
+
+        // Second message - should reset and create new turn
+        // This is the bug fix - previously this would fail because it tried
+        // to create a workflow with the same ID
+        runner
+            .start_run(session_id, agent_id, message_id2)
+            .await
+            .expect("Second start_run should succeed (reset workflow)");
+
+        // Workflow should be running again (reset to pending, new task enqueued)
+        assert!(
+            runner.is_running(session_id).await,
+            "Workflow should be running again after reset"
+        );
+    }
+
+    /// Test that start_run resets a failed workflow for retry
+    #[tokio::test]
+    async fn test_start_run_resets_failed_workflow() {
+        let runner = DurableRunner::new_in_memory();
+
+        let session_id = Uuid::now_v7();
+        let agent_id = Uuid::now_v7();
+        let message_id1 = Uuid::now_v7();
+        let message_id2 = Uuid::now_v7();
+
+        // First message
+        runner
+            .start_run(session_id, agent_id, message_id1)
+            .await
+            .expect("First start_run should succeed");
+
+        // Simulate workflow failure
+        {
+            let mut store = runner.store.lock().await;
+            store
+                .update_workflow_status(
+                    session_id,
+                    WorkflowStatus::Failed,
+                    None,
+                    Some("Test error".to_string()),
+                )
+                .await
+                .expect("Should update workflow status");
+        }
+
+        assert!(!runner.is_running(session_id).await);
+
+        // Second message - should reset failed workflow
+        runner
+            .start_run(session_id, agent_id, message_id2)
+            .await
+            .expect("Second start_run should reset failed workflow");
+
+        assert!(runner.is_running(session_id).await);
     }
 }


### PR DESCRIPTION
## What
Fix bug where second message in a session wasn't being processed after the first workflow completed.

## Why
When a second message was sent in the same session after the first workflow completed, the workflow would not process it because:
1. `workflow_id = session_id` (same for all messages in a session)
2. When workflow exists and is terminal, `start_run()` tried to create a new workflow with the same ID, which failed

## How
Reset existing terminal workflows to pending state instead of creating a new one. This allows the session to process multiple messages sequentially.

### Changes
- **crates/worker/src/durable_runner.rs**: Modified `start_run()` to reset terminal workflows instead of creating new ones
- **crates/control-plane/tests/integration_test.rs**: Added integration test `test_second_message_triggers_workflow` that sends two messages and verifies both get responses
- **AGENTS.md**: Added note about using GitHub API with GITHUB_TOKEN when gh tool is unavailable

### Unit tests added
- `test_start_run_creates_new_workflow`
- `test_start_run_skips_if_running`
- `test_start_run_resets_completed_workflow`
- `test_start_run_resets_failed_workflow`

## Risk
- Medium
- Core workflow state machine change; well-tested with unit and integration tests

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered