### PR TITLE
fix(ui): remove max-width constraint from agent edit page

### DIFF
--- a/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
@@ -183,7 +183,7 @@ export default function EditAgentPage({
   }
 
   return (
-    <div className="container mx-auto p-6 max-w-4xl">
+    <div className="container mx-auto p-6">
       <Link
         href={`/agents/${agentId}`}
         className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-6"


### PR DESCRIPTION
## What
Remove the `max-w-4xl` constraint from the Agent edit page to match the Create Agent page width.

## Why
The Edit Agent page had a narrower max-width than the Create Agent page, causing inconsistent UI experience.

## How
Removed the `max-w-4xl` class from the container div in the edit page.

## Risk
- Low
- Visual change only, no functional impact

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered