### PR TITLE
fix(ui): maintain input focus after sending chat message

### DIFF
--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/chat/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/chat/page.tsx
@@ -39,6 +39,7 @@ export default function ChatPage() {
   const [inputValue, setInputValue] = useState("");
   const [selectedModelId, setSelectedModelId] = useState("");
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
   const hasUserSelectedModel = useRef(false);
   const modelSelectionStorageKey = useMemo(
     () => `everruns:chat:model-selection:${agentId}:${sessionId}`,
@@ -119,6 +120,8 @@ export default function ChatPage() {
         window.localStorage.setItem(modelSelectionStorageKey, selectedModelId);
       }
       setInputValue("");
+      // Refocus the input after sending (use setTimeout to ensure React has processed state updates)
+      setTimeout(() => inputRef.current?.focus(), 0);
       // Start polling for the response
       setIsWaitingForResponse(true);
     } catch (error) {
@@ -209,6 +212,7 @@ export default function ChatPage() {
       <div className="border-t p-4">
         <form onSubmit={handleSubmit} className="flex gap-2">
           <Textarea
+            ref={inputRef}
             value={inputValue}
             onChange={(e) => setInputValue(e.target.value)}
             onKeyDown={handleKeyDown}

--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/chat/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/chat/page.tsx
@@ -39,7 +39,6 @@ export default function ChatPage() {
   const [inputValue, setInputValue] = useState("");
   const [selectedModelId, setSelectedModelId] = useState("");
   const messagesEndRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLTextAreaElement>(null);
   const hasUserSelectedModel = useRef(false);
   const modelSelectionStorageKey = useMemo(
     () => `everruns:chat:model-selection:${agentId}:${sessionId}`,
@@ -120,8 +119,6 @@ export default function ChatPage() {
         window.localStorage.setItem(modelSelectionStorageKey, selectedModelId);
       }
       setInputValue("");
-      // Refocus the input after sending (use setTimeout to ensure React has processed state updates)
-      setTimeout(() => inputRef.current?.focus(), 0);
       // Start polling for the response
       setIsWaitingForResponse(true);
     } catch (error) {
@@ -212,13 +209,11 @@ export default function ChatPage() {
       <div className="border-t p-4">
         <form onSubmit={handleSubmit} className="flex gap-2">
           <Textarea
-            ref={inputRef}
             value={inputValue}
             onChange={(e) => setInputValue(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="Type a message... (Enter to send, Shift+Enter for newline)"
             className="flex-1 min-h-[60px] max-h-[200px] resize-none"
-            disabled={sendMessage.isPending}
           />
           <Button
             type="submit"


### PR DESCRIPTION
## Summary
- Remove `disabled` state from chat Textarea to prevent focus loss when sending messages
- Users can now type ahead while messages are being sent

## Why
The Textarea was disabled during message send (`disabled={sendMessage.isPending}`), which caused the browser to remove focus. This was disruptive UX - users had to click back into the input after each message.

## How
Simply removed the `disabled` prop. The submit handler already prevents double-sends via early return check.

## Risk
- Low
- Button still shows loading state and is disabled during send

## Checklist
- [x] UI build passes
- [x] No new dependencies