### PR TITLE
fix(dev): fix dev mode LLM errors and improve DX

### DIFF
--- a/crates/control-plane/src/services/llm_resolver.rs
+++ b/crates/control-plane/src/services/llm_resolver.rs
@@ -9,8 +9,8 @@
 //    - openai: DEFAULT_OPENAI_API_KEY
 //    - anthropic: DEFAULT_ANTHROPIC_API_KEY
 
-use crate::storage::{EncryptionService, StorageBackend};
-use anyhow::{Result, anyhow};
+use crate::storage::{EncryptionService, StorageBackend, models::LlmProviderRow};
+use anyhow::Result;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -67,11 +67,6 @@ impl LlmResolverService {
 
     /// Resolve a model by ID with decrypted provider credentials
     pub async fn resolve_model(&self, model_id: Uuid) -> Result<Option<ResolvedModel>> {
-        let encryption = match &self.encryption {
-            Some(enc) => enc.as_ref().clone(),
-            None => return Err(anyhow!("Encryption service not configured")),
-        };
-
         // Look up the model
         let model_row = self.db.get_llm_model(model_id).await?;
 
@@ -88,31 +83,19 @@ impl LlmResolverService {
             None => return Ok(None),
         };
 
-        // Decrypt the API key from database
-        let provider_with_key = self
-            .db
-            .get_provider_with_api_key(&provider_row, &encryption)?;
-
-        // Apply env fallback if no API key in database
-        let api_key = provider_with_key
-            .api_key
-            .or_else(|| get_default_api_key_from_env(&provider_with_key.provider_type));
+        // Try to decrypt API key if encryption is available and provider has encrypted key
+        let api_key = self.resolve_api_key(&provider_row)?;
 
         Ok(Some(ResolvedModel {
             model_id: model_row.model_id,
-            provider_type: provider_with_key.provider_type,
+            provider_type: provider_row.provider_type.clone(),
             api_key,
-            base_url: provider_with_key.base_url,
+            base_url: provider_row.base_url.clone(),
         }))
     }
 
     /// Resolve the default model with decrypted provider credentials
     pub async fn resolve_default_model(&self) -> Result<Option<ResolvedModel>> {
-        let encryption = match &self.encryption {
-            Some(enc) => enc.as_ref().clone(),
-            None => return Err(anyhow!("Encryption service not configured")),
-        };
-
         // Look up the default model
         let model_row = self.db.get_default_llm_model().await?;
 
@@ -129,22 +112,46 @@ impl LlmResolverService {
             None => return Ok(None),
         };
 
-        // Decrypt the API key from database
-        let provider_with_key = self
-            .db
-            .get_provider_with_api_key(&provider_row, &encryption)?;
-
-        // Apply env fallback if no API key in database
-        let api_key = provider_with_key
-            .api_key
-            .or_else(|| get_default_api_key_from_env(&provider_with_key.provider_type));
+        // Try to decrypt API key if encryption is available and provider has encrypted key
+        let api_key = self.resolve_api_key(&provider_row)?;
 
         Ok(Some(ResolvedModel {
             model_id: model_row.model_id,
-            provider_type: provider_with_key.provider_type,
+            provider_type: provider_row.provider_type.clone(),
             api_key,
-            base_url: provider_with_key.base_url,
+            base_url: provider_row.base_url.clone(),
         }))
+    }
+
+    /// Resolve API key for a provider
+    ///
+    /// Resolution order:
+    /// 1. Decrypt from database if encryption is available and key is set
+    /// 2. Fall back to environment variable (DEFAULT_OPENAI_API_KEY or DEFAULT_ANTHROPIC_API_KEY)
+    ///
+    /// If provider has an encrypted key but encryption service is not available,
+    /// logs a warning and falls back to environment variable.
+    fn resolve_api_key(&self, provider: &LlmProviderRow) -> Result<Option<String>> {
+        // If provider has an encrypted API key, try to decrypt it
+        if provider.api_key_encrypted.is_some() {
+            if let Some(ref encryption) = self.encryption {
+                let provider_with_key = self.db.get_provider_with_api_key(provider, encryption)?;
+                if provider_with_key.api_key.is_some() {
+                    return Ok(provider_with_key.api_key);
+                }
+            } else {
+                // Provider has encrypted key but no encryption service
+                tracing::warn!(
+                    provider_id = %provider.id,
+                    provider_type = %provider.provider_type,
+                    "Provider has encrypted API key but encryption service is not configured. \
+                     Falling back to environment variable."
+                );
+            }
+        }
+
+        // Fall back to environment variable
+        Ok(get_default_api_key_from_env(&provider.provider_type))
     }
 
     /// Check if encryption service is available

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -327,6 +327,21 @@ case "$command" in
     # Enable dev mode
     export DEV_MODE=true
     export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:9100}
+    export RUST_LOG=${RUST_LOG:-info}
+
+    # Configure LLM API keys from environment
+    if [ -n "${OPENAI_API_KEY:-}" ]; then
+      export DEFAULT_OPENAI_API_KEY="$OPENAI_API_KEY"
+      echo "   ✅ OpenAI API key configured"
+    else
+      echo "   ⚠️  OPENAI_API_KEY not set (OpenAI models may not work)"
+    fi
+    if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+      export DEFAULT_ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY"
+      echo "   ✅ Anthropic API key configured"
+    else
+      echo "   ⚠️  ANTHROPIC_API_KEY not set (Anthropic models may not work)"
+    fi
 
     # Start control-plane in background with auto-reload (dev mode)
     echo "1️⃣  Starting control-plane (DEV MODE) with auto-reload..."

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -343,6 +343,13 @@ case "$command" in
       echo "   ⚠️  ANTHROPIC_API_KEY not set (Anthropic models may not work)"
     fi
 
+    # Disable OpenTelemetry in dev mode (no Jaeger running)
+    # Set OTEL_SDK_DISABLED=false to enable if you have a collector running
+    if [ -z "${OTEL_SDK_DISABLED:-}" ]; then
+      export OTEL_SDK_DISABLED=true
+      echo "   ℹ️  OpenTelemetry disabled (no collector in dev mode)"
+    fi
+
     # Start control-plane in background with auto-reload (dev mode)
     echo "1️⃣  Starting control-plane (DEV MODE) with auto-reload..."
     cargo watch -w crates -x 'run -p everruns-control-plane' &


### PR DESCRIPTION
## Summary
- Fix LLM model resolution failing in dev mode when encryption service is not configured
- Add missing API key configuration to `start-dev` (was only in `start-all`)
- Disable OpenTelemetry by default in dev mode to reduce noise

## What
Three fixes for dev mode:

1. **LlmResolverService encryption fix** (`crates/control-plane/src/services/llm_resolver.rs`)
   - Was failing immediately with "Encryption service not configured" even when no encrypted API key existed
   - Now only requires encryption if provider actually has an encrypted key
   - Falls back to environment variables (`DEFAULT_OPENAI_API_KEY`, `DEFAULT_ANTHROPIC_API_KEY`)

2. **API key configuration in start-dev** (`scripts/dev.sh`)
   - Added `DEFAULT_OPENAI_API_KEY` and `DEFAULT_ANTHROPIC_API_KEY` exports from environment
   - Added `RUST_LOG=info` default so logs are visible
   - Matches the configuration that `start-all` already had

3. **Disable OTEL in dev mode** (`scripts/dev.sh`)
   - OTEL was trying to connect to Jaeger (not running in dev mode), causing error spam
   - Now sets `OTEL_SDK_DISABLED=true` by default
   - Can be overridden with `OTEL_SDK_DISABLED=false` if collector is available

## Why
Dev mode was showing "I encountered an error while processing your request" with no visible error logs, making debugging impossible.

## How
- Changed LlmResolverService to check for encrypted key before requiring encryption service
- Added environment variable exports to start-dev script
- Added OTEL_SDK_DISABLED to start-dev script

## Test plan
- [ ] Run `./scripts/dev.sh start-dev` with `OPENAI_API_KEY` set
- [ ] Verify API key configuration message appears
- [ ] Verify no OTEL error spam
- [ ] Send a message and verify LLM call works (or shows meaningful error)