### PR TITLE
feat(capabilities): add per-agent capability configuration

### DIFF
--- a/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
@@ -26,7 +26,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { ArrowLeft, Save, Trash2 } from "lucide-react";
-import type { CapabilityId } from "@/lib/api/types";
+import type { CapabilityId, AgentCapabilityConfig } from "@/lib/api/types";
 import { ProviderIcon } from "@/components/providers/provider-icon";
 
 interface FormData {
@@ -88,8 +88,9 @@ export default function EditAgentPage({
   );
 
   // Capabilities state - now included directly in agent response
+  // Extract just the capability IDs for the selector
   const initialCapabilities = useMemo(() => {
-    return agent?.capabilities ?? [];
+    return (agent?.capabilities ?? []).map((c) => c.ref);
   }, [agent?.capabilities]);
 
   const [localCapabilities, setLocalCapabilities] = useState<
@@ -113,10 +114,16 @@ export default function EditAgentPage({
         .map((t) => t.trim())
         .filter((t) => t.length > 0);
 
-      // Get capabilities to save
-      const capabilitiesToSave = localCapabilities ?? initialCapabilities;
+      // Get capabilities to save (convert IDs to AgentCapabilityConfig format)
+      const capabilityIdsToSave = localCapabilities ?? initialCapabilities;
       const capabilitiesChanged =
-        JSON.stringify(capabilitiesToSave) !== JSON.stringify(initialCapabilities);
+        JSON.stringify(capabilityIdsToSave) !== JSON.stringify(initialCapabilities);
+
+      // Convert capability IDs to AgentCapabilityConfig format
+      const capabilityConfigs: AgentCapabilityConfig[] = capabilityIdsToSave.map(id => ({
+        ref: id,
+        config: {},
+      }));
 
       // Update agent (capabilities are now part of the agent resource)
       await updateAgent.mutateAsync({
@@ -128,7 +135,7 @@ export default function EditAgentPage({
           tags,
           default_model_id: formData.default_model_id || undefined,
           // Only include capabilities if they changed
-          ...(capabilitiesChanged && { capabilities: capabilitiesToSave }),
+          ...(capabilitiesChanged && { capabilities: capabilityConfigs }),
         },
       });
 

--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -240,14 +240,14 @@ export default function AgentDetailPage({
                 </p>
               ) : (
                 <div className="space-y-2">
-                  {agentCapabilities.map((capId) => {
-                    const cap = getCapabilityInfo(capId);
+                  {agentCapabilities.map((capConfig) => {
+                    const cap = getCapabilityInfo(capConfig.ref);
                     if (!cap) return null;
                     const IconComponent = getCapabilityIcon(cap.icon);
 
                     return (
                       <div
-                        key={capId}
+                        key={capConfig.ref}
                         className="flex items-center gap-2 p-2 rounded-md border bg-muted/50"
                       >
                         <IconComponent className="w-4 h-4" />

--- a/apps/ui/src/app/(main)/agents/new/page.tsx
+++ b/apps/ui/src/app/(main)/agents/new/page.tsx
@@ -20,7 +20,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { ProviderIcon } from "@/components/providers/provider-icon";
 import { CapabilitySelector } from "@/components/agents/capability-selector";
-import type { CapabilityId } from "@/lib/api/types";
+import type { CapabilityId, AgentCapabilityConfig } from "@/lib/api/types";
 
 export default function NewAgentPage() {
   const router = useRouter();
@@ -45,12 +45,18 @@ export default function NewAgentPage() {
     e.preventDefault();
 
     try {
+      // Convert capability IDs to AgentCapabilityConfig format
+      const capabilityConfigs: AgentCapabilityConfig[] = selectedCapabilities.map(id => ({
+        ref: id,
+        config: {},
+      }));
+
       const agent = await createAgent.mutateAsync({
         name: formData.name,
         description: formData.description || undefined,
         system_prompt: formData.system_prompt,
         default_model_id: formData.default_model_id || undefined,
-        capabilities: selectedCapabilities.length > 0 ? selectedCapabilities : undefined,
+        capabilities: capabilityConfigs.length > 0 ? capabilityConfigs : undefined,
       });
 
       router.push(`/agents/${agent.id}`);

--- a/apps/ui/src/components/agents/agent-card.tsx
+++ b/apps/ui/src/components/agents/agent-card.tsx
@@ -60,13 +60,13 @@ export function AgentCard({
         {agentCapabilities.length > 0 && (
           <div className="flex flex-wrap gap-1 mb-3">
             <TooltipProvider>
-              {agentCapabilities.map((capId) => {
-                const cap = getCapabilityInfo(capId);
+              {agentCapabilities.map((capConfig) => {
+                const cap = getCapabilityInfo(capConfig.ref);
                 if (!cap) return null;
                 const IconComponent = getCapabilityIcon(cap.icon);
 
                 return (
-                  <Tooltip key={capId}>
+                  <Tooltip key={capConfig.ref}>
                     <TooltipTrigger className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-muted text-xs cursor-default">
                       <IconComponent className="w-3 h-3" />
                       {!compact && <span>{cap.name}</span>}

--- a/apps/ui/src/components/dashboard/agent-list-widget.tsx
+++ b/apps/ui/src/components/dashboard/agent-list-widget.tsx
@@ -72,13 +72,13 @@ export function AgentListWidget({
                         {agentCapabilities.length > 0 && (
                           <TooltipProvider>
                             <div className="flex gap-0.5">
-                              {agentCapabilities.slice(0, 3).map((capId) => {
-                                const cap = getCapabilityInfo(capId);
+                              {agentCapabilities.slice(0, 3).map((capConfig) => {
+                                const cap = getCapabilityInfo(capConfig.ref);
                                 if (!cap) return null;
                                 const IconComponent = getCapabilityIcon(cap.icon);
 
                                 return (
-                                  <Tooltip key={capId}>
+                                  <Tooltip key={capConfig.ref}>
                                     <TooltipTrigger className="p-0.5 rounded bg-muted cursor-default">
                                       <IconComponent className="w-3 h-3 text-muted-foreground" />
                                     </TooltipTrigger>

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -10,6 +10,14 @@ export type AgentStatus = "active" | "archived";
 /** Capability ID - extensible string-based identifier */
 export type CapabilityId = string;
 
+/** Per-agent capability configuration */
+export interface AgentCapabilityConfig {
+  /** Reference to the capability ID */
+  ref: CapabilityId;
+  /** Per-agent configuration for this capability (capability-specific) */
+  config: Record<string, unknown>;
+}
+
 export interface Agent {
   id: string;
   name: string;
@@ -17,7 +25,8 @@ export interface Agent {
   system_prompt: string;
   default_model_id: string | null;
   tags: string[];
-  capabilities: CapabilityId[];
+  /** Capabilities with per-agent configuration */
+  capabilities: AgentCapabilityConfig[];
   status: AgentStatus;
   created_at: string;
   updated_at: string;
@@ -31,7 +40,8 @@ export interface CreateAgentRequest {
   system_prompt: string;
   default_model_id?: string;
   tags?: string[];
-  capabilities?: CapabilityId[];
+  /** Capabilities with per-agent configuration */
+  capabilities?: AgentCapabilityConfig[];
 }
 
 export interface UpdateAgentRequest {
@@ -40,7 +50,8 @@ export interface UpdateAgentRequest {
   system_prompt?: string;
   default_model_id?: string;
   tags?: string[];
-  capabilities?: CapabilityId[];
+  /** Capabilities with per-agent configuration */
+  capabilities?: AgentCapabilityConfig[];
   status?: AgentStatus;
 }
 

--- a/crates/cli/src/commands/agents.rs
+++ b/crates/cli/src/commands/agents.rs
@@ -57,6 +57,57 @@ pub enum AgentsCommand {
 }
 
 /// Agent definition from YAML/JSON file
+/// Capability entry - supports both simple string and object formats for file parsing
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum AgentFileCapability {
+    /// Simple string format (legacy)
+    Simple(String),
+    /// Object format with ref and config
+    WithConfig {
+        #[serde(rename = "ref")]
+        capability_ref: String,
+        #[serde(default)]
+        config: serde_json::Value,
+    },
+}
+
+impl AgentFileCapability {
+    fn to_api_format(&self) -> CapabilityConfig {
+        match self {
+            AgentFileCapability::Simple(id) => CapabilityConfig {
+                capability_ref: id.clone(),
+                config: serde_json::json!({}),
+            },
+            AgentFileCapability::WithConfig {
+                capability_ref,
+                config,
+            } => CapabilityConfig {
+                capability_ref: capability_ref.clone(),
+                config: config.clone(),
+            },
+        }
+    }
+}
+
+/// Capability config for API requests
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CapabilityConfig {
+    #[serde(rename = "ref")]
+    pub capability_ref: String,
+    #[serde(default)]
+    pub config: serde_json::Value,
+}
+
+impl CapabilityConfig {
+    fn new(id: &str) -> Self {
+        Self {
+            capability_ref: id.to_string(),
+            config: serde_json::json!({}),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct AgentFile {
     pub name: Option<String>,
@@ -66,7 +117,7 @@ pub struct AgentFile {
     #[serde(default)]
     pub tags: Vec<String>,
     #[serde(default)]
-    pub capabilities: Vec<String>,
+    pub capabilities: Vec<AgentFileCapability>,
 }
 
 /// Request to create an agent
@@ -81,7 +132,7 @@ struct CreateAgentRequest {
     #[serde(default)]
     tags: Vec<String>,
     #[serde(default)]
-    capabilities: Vec<String>,
+    capabilities: Vec<CapabilityConfig>,
 }
 
 /// Agent response from API
@@ -97,7 +148,7 @@ pub struct Agent {
     #[serde(default)]
     pub tags: Vec<String>,
     #[serde(default)]
-    pub capabilities: Vec<String>,
+    pub capabilities: Vec<CapabilityConfig>,
     pub status: String,
     pub created_at: String,
     pub updated_at: String,
@@ -249,10 +300,20 @@ async fn create(
     } else {
         tags
     };
-    let final_capabilities = if capabilities.is_empty() {
-        file_config.capabilities
+    // Convert capabilities to API format
+    let final_capabilities: Vec<CapabilityConfig> = if capabilities.is_empty() {
+        // Use file capabilities, converting to API format
+        file_config
+            .capabilities
+            .iter()
+            .map(|c| c.to_api_format())
+            .collect()
     } else {
+        // Use CLI capabilities (simple strings), converting to API format
         capabilities
+            .iter()
+            .map(|c| CapabilityConfig::new(c))
+            .collect()
     };
 
     let request = CreateAgentRequest {
@@ -273,7 +334,12 @@ async fn create(
             println!("Created agent: {}", agent.id);
             print_field("Name", &agent.name);
             if !agent.capabilities.is_empty() {
-                print_field("Capabilities", &agent.capabilities.join(", "));
+                let cap_ids: Vec<&str> = agent
+                    .capabilities
+                    .iter()
+                    .map(|c| c.capability_ref.as_str())
+                    .collect();
+                print_field("Capabilities", &cap_ids.join(", "));
             }
         }
     } else {
@@ -303,7 +369,12 @@ async fn list(client: &Client, output: OutputFormat) -> Result<()> {
             let caps = if agent.capabilities.is_empty() {
                 "-".to_string()
             } else {
-                agent.capabilities.join(", ")
+                agent
+                    .capabilities
+                    .iter()
+                    .map(|c| c.capability_ref.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
             };
             print_table_row(&[
                 (&agent.id.to_string(), 36),
@@ -336,7 +407,12 @@ async fn get(client: &Client, output: OutputFormat, agent_id: Uuid) -> Result<()
             print_field("Description", desc);
         }
         if !agent.capabilities.is_empty() {
-            print_field("Capabilities", &agent.capabilities.join(", "));
+            let cap_ids: Vec<&str> = agent
+                .capabilities
+                .iter()
+                .map(|c| c.capability_ref.as_str())
+                .collect();
+            print_field("Capabilities", &cap_ids.join(", "));
         }
         if !agent.tags.is_empty() {
             print_field("Tags", &agent.tags.join(", "));

--- a/crates/control-plane/migrations/007_capability_config.sql
+++ b/crates/control-plane/migrations/007_capability_config.sql
@@ -1,0 +1,9 @@
+-- Migration: Add config column to agent_capabilities table
+-- Purpose: Support per-agent capability configuration
+
+-- Add config column with default empty object
+ALTER TABLE agent_capabilities
+ADD COLUMN config JSONB NOT NULL DEFAULT '{}';
+
+-- Add comment for documentation
+COMMENT ON COLUMN agent_capabilities.config IS 'Per-agent capability configuration (JSON object)';

--- a/crates/control-plane/src/api/agents.rs
+++ b/crates/control-plane/src/api/agents.rs
@@ -10,7 +10,7 @@ use axum::{
     routing::{get, post},
 };
 use chrono::Utc;
-use everruns_core::{Agent, AgentStatus, CapabilityId};
+use everruns_core::{Agent, AgentCapabilityConfig, AgentStatus};
 
 use super::common::{ApiOptionExt, ApiResultExt, ErrorResponse, ListResponse};
 use super::validation::{
@@ -43,11 +43,11 @@ pub struct CreateAgentRequest {
     #[serde(default)]
     #[schema(example = json!(["support", "customer-facing"]))]
     pub tags: Vec<String>,
-    /// Capabilities to enable for this agent.
-    /// Capabilities provide tools and system prompt additions.
+    /// Capabilities to enable for this agent with per-agent configuration.
+    /// Each capability has a `ref` (capability ID) and optional `config`.
     #[serde(default)]
-    #[schema(example = json!(["current_time", "web_fetch"]), value_type = Vec<String>)]
-    pub capabilities: Vec<CapabilityId>,
+    #[schema(example = json!([{"ref": "current_time", "config": {}}, {"ref": "web_fetch", "config": {}}]))]
+    pub capabilities: Vec<AgentCapabilityConfig>,
 }
 
 /// Request to update an agent. Only provided fields will be updated.
@@ -72,17 +72,46 @@ pub struct UpdateAgentRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(example = json!(["updated-tag"]))]
     pub tags: Option<Vec<String>>,
-    /// Capabilities to enable for this agent. Replaces existing capabilities.
+    /// Capabilities to enable for this agent with per-agent configuration.
+    /// Replaces existing capabilities. Each has a `ref` (capability ID) and optional `config`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(example = json!(["current_time", "web_fetch"]), value_type = Option<Vec<String>>)]
-    pub capabilities: Option<Vec<CapabilityId>>,
+    #[schema(example = json!([{"ref": "current_time", "config": {}}, {"ref": "web_fetch", "config": {}}]))]
+    pub capabilities: Option<Vec<AgentCapabilityConfig>>,
     /// The status of the agent. Set to "archived" to soft-delete.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<AgentStatus>,
 }
 
+/// Capability entry in agent file - supports both string and object formats
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+enum AgentFileCapability {
+    /// Legacy format: just capability ID string
+    Simple(String),
+    /// New format: object with ref and config
+    WithConfig {
+        #[serde(rename = "ref")]
+        capability_ref: String,
+        #[serde(default)]
+        config: serde_json::Value,
+    },
+}
+
+impl AgentFileCapability {
+    fn to_agent_capability_config(&self) -> AgentCapabilityConfig {
+        match self {
+            AgentFileCapability::Simple(id) => AgentCapabilityConfig::new(id.clone()),
+            AgentFileCapability::WithConfig {
+                capability_ref,
+                config,
+            } => AgentCapabilityConfig::with_config(capability_ref.clone(), config.clone()),
+        }
+    }
+}
+
 /// Agent file format for import (matches CLI format)
 /// Parsed from YAML front matter in Markdown files.
+/// Supports both legacy (string list) and new (object with ref/config) capability formats.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 struct AgentFile {
     pub name: Option<String>,
@@ -91,8 +120,9 @@ struct AgentFile {
     pub default_model_id: Option<Uuid>,
     #[serde(default)]
     pub tags: Vec<String>,
+    /// Capabilities - supports both string IDs and objects with ref/config
     #[serde(default)]
-    pub capabilities: Vec<String>,
+    pub capabilities: Vec<AgentFileCapability>,
 }
 
 use crate::services::AgentService;
@@ -375,8 +405,8 @@ pub async fn import_agent(
         tags: agent_file.tags,
         capabilities: agent_file
             .capabilities
-            .into_iter()
-            .map(CapabilityId::from)
+            .iter()
+            .map(|c| c.to_agent_capability_config())
             .collect(),
     };
 
@@ -390,46 +420,33 @@ pub async fn import_agent(
 
 /// Convert agent to Markdown format with YAML front matter
 fn agent_to_markdown(agent: &Agent) -> String {
-    let mut front_matter = AgentFile {
-        name: Some(agent.name.clone()),
-        description: agent.description.clone(),
-        system_prompt: None, // System prompt goes in body
-        default_model_id: agent.default_model_id,
-        tags: agent.tags.clone(),
-        capabilities: agent.capabilities.iter().map(|c| c.to_string()).collect(),
-    };
-
-    // Don't include empty arrays in front matter
-    if front_matter.tags.is_empty() {
-        front_matter.tags = vec![];
-    }
-    if front_matter.capabilities.is_empty() {
-        front_matter.capabilities = vec![];
-    }
-
     // Build YAML front matter (skip empty/default fields)
     let mut yaml_lines = vec![];
     yaml_lines.push(format!("name: \"{}\"", agent.name.replace('"', "\\\"")));
 
-    if let Some(ref desc) = front_matter.description {
+    if let Some(desc) = &agent.description {
         yaml_lines.push(format!("description: \"{}\"", desc.replace('"', "\\\"")));
     }
 
-    if let Some(model_id) = front_matter.default_model_id {
+    if let Some(model_id) = agent.default_model_id {
         yaml_lines.push(format!("default_model_id: \"{}\"", model_id));
     }
 
-    if !front_matter.tags.is_empty() {
+    if !agent.tags.is_empty() {
         yaml_lines.push("tags:".to_string());
-        for tag in &front_matter.tags {
+        for tag in &agent.tags {
             yaml_lines.push(format!("  - \"{}\"", tag.replace('"', "\\\"")));
         }
     }
 
-    if !front_matter.capabilities.is_empty() {
+    if !agent.capabilities.is_empty() {
         yaml_lines.push("capabilities:".to_string());
-        for cap in &front_matter.capabilities {
-            yaml_lines.push(format!("  - {}", cap));
+        for cap in &agent.capabilities {
+            // Export capabilities with ref and config (inline JSON for config)
+            let config_json =
+                serde_json::to_string(&cap.config).unwrap_or_else(|_| "{}".to_string());
+            yaml_lines.push(format!("  - ref: {}", cap.capability_ref.as_str()));
+            yaml_lines.push(format!("    config: {}", config_json));
         }
     }
 

--- a/crates/control-plane/src/dev_worker/direct_adapters.rs
+++ b/crates/control-plane/src/dev_worker/direct_adapters.rs
@@ -6,7 +6,7 @@
 // Decision: Worker traits implemented directly against StorageBackend for DEV_MODE
 
 use async_trait::async_trait;
-use everruns_core::capabilities::CapabilityId;
+use everruns_core::capabilities::AgentCapabilityConfig;
 use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::events::{Event, EventRequest, MessageAgentData, MessageUserData};
 use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
@@ -84,7 +84,7 @@ impl AgentStore for DirectAgentStore {
             tags: r.tags,
             capabilities: capabilities
                 .into_iter()
-                .filter_map(|c| c.capability_id.parse::<CapabilityId>().ok())
+                .map(|c| AgentCapabilityConfig::with_config(c.capability_id, c.config))
                 .collect(),
             status: match r.status.as_str() {
                 "active" => AgentStatus::Active,

--- a/crates/control-plane/src/seed.rs
+++ b/crates/control-plane/src/seed.rs
@@ -195,13 +195,19 @@ async fn seed_agents(db: &StorageBackend) -> anyhow::Result<SeedResult> {
 
         match db.create_agent_with_id(seed.id, input).await? {
             Some(row) => {
-                // Set capabilities if any
+                // Set capabilities if any (with empty config)
                 if !seed.capabilities.is_empty() {
-                    let cap_tuples: Vec<(String, i32)> = seed
+                    let cap_tuples: Vec<(String, i32, serde_json::Value)> = seed
                         .capabilities
                         .iter()
                         .enumerate()
-                        .map(|(idx, cap)| (cap.to_string(), idx as i32))
+                        .map(|(idx, cap)| {
+                            (
+                                cap.to_string(),
+                                idx as i32,
+                                serde_json::json!({}), // Empty config for seed data
+                            )
+                        })
                         .collect();
                     db.set_agent_capabilities(row.id, cap_tuples).await?;
                 }

--- a/crates/control-plane/src/services/agent.rs
+++ b/crates/control-plane/src/services/agent.rs
@@ -9,7 +9,7 @@ use crate::storage::{
     models::{CreateAgentRow, UpdateAgent},
 };
 use anyhow::Result;
-use everruns_core::{Agent, AgentStatus, CapabilityId, TokenUsage};
+use everruns_core::{Agent, AgentCapabilityConfig, AgentStatus, TokenUsage};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -39,11 +39,17 @@ impl AgentService {
 
         // Set capabilities if provided
         let capabilities = if !req.capabilities.is_empty() {
-            let cap_tuples: Vec<(String, i32)> = req
+            let cap_tuples: Vec<(String, i32, serde_json::Value)> = req
                 .capabilities
                 .iter()
                 .enumerate()
-                .map(|(idx, cap)| (cap.to_string(), idx as i32))
+                .map(|(idx, cap)| {
+                    (
+                        cap.capability_ref.to_string(),
+                        idx as i32,
+                        cap.config.clone(),
+                    )
+                })
                 .collect();
             self.db.set_agent_capabilities(agent_id, cap_tuples).await?;
             req.capabilities
@@ -93,10 +99,16 @@ impl AgentService {
             Some(row) => {
                 // Update capabilities if provided
                 let capabilities = if let Some(caps) = req.capabilities {
-                    let cap_tuples: Vec<(String, i32)> = caps
+                    let cap_tuples: Vec<(String, i32, serde_json::Value)> = caps
                         .iter()
                         .enumerate()
-                        .map(|(idx, cap)| (cap.to_string(), idx as i32))
+                        .map(|(idx, cap)| {
+                            (
+                                cap.capability_ref.to_string(),
+                                idx as i32,
+                                cap.config.clone(),
+                            )
+                        })
                         .collect();
                     self.db.set_agent_capabilities(id, cap_tuples).await?;
                     caps
@@ -114,15 +126,15 @@ impl AgentService {
         self.db.delete_agent(id).await
     }
 
-    async fn get_capabilities(&self, agent_id: Uuid) -> Result<Vec<CapabilityId>> {
+    async fn get_capabilities(&self, agent_id: Uuid) -> Result<Vec<AgentCapabilityConfig>> {
         let rows = self.db.get_agent_capabilities(agent_id).await?;
         Ok(rows
             .into_iter()
-            .map(|row| CapabilityId::new(&row.capability_id))
+            .map(|row| AgentCapabilityConfig::with_config(row.capability_id, row.config))
             .collect())
     }
 
-    fn row_to_agent(row: AgentRow, capabilities: Vec<CapabilityId>) -> Agent {
+    fn row_to_agent(row: AgentRow, capabilities: Vec<AgentCapabilityConfig>) -> Agent {
         // Convert database usage columns to TokenUsage
         let usage = if row.total_input_tokens > 0 || row.total_output_tokens > 0 {
             Some(TokenUsage::with_cache(

--- a/crates/control-plane/src/storage/agent_store.rs
+++ b/crates/control-plane/src/storage/agent_store.rs
@@ -5,9 +5,8 @@
 
 use async_trait::async_trait;
 use everruns_core::{
-    AgentLoopError, Result,
+    AgentCapabilityConfig, AgentLoopError, Result,
     agent::{Agent, AgentStatus},
-    capability_types::CapabilityId,
     traits::AgentStore,
 };
 use uuid::Uuid;
@@ -51,9 +50,9 @@ impl AgentStore for DbAgentStore {
                     .await
                     .map_err(|e| AgentLoopError::store(e.to_string()))?;
 
-                let capabilities: Vec<CapabilityId> = capability_rows
+                let capabilities: Vec<AgentCapabilityConfig> = capability_rows
                     .into_iter()
-                    .map(|c| CapabilityId::new(c.capability_id))
+                    .map(|c| AgentCapabilityConfig::with_config(c.capability_id, c.config))
                     .collect();
 
                 Ok(Some(Agent {

--- a/crates/control-plane/src/storage/backend.rs
+++ b/crates/control-plane/src/storage/backend.rs
@@ -374,7 +374,7 @@ impl StorageBackend {
     pub async fn set_agent_capabilities(
         &self,
         agent_id: Uuid,
-        capabilities: Vec<(String, i32)>,
+        capabilities: Vec<(String, i32, serde_json::Value)>,
     ) -> Result<Vec<AgentCapabilityRow>> {
         dispatch!(self, set_agent_capabilities, agent_id, capabilities)
     }

--- a/crates/control-plane/src/storage/memory.rs
+++ b/crates/control-plane/src/storage/memory.rs
@@ -938,7 +938,7 @@ impl InMemoryDatabase {
     pub async fn set_agent_capabilities(
         &self,
         agent_id: Uuid,
-        capabilities: Vec<(String, i32)>,
+        capabilities: Vec<(String, i32, serde_json::Value)>,
     ) -> Result<Vec<AgentCapabilityRow>> {
         let now = Self::now();
         let mut caps = self.agent_capabilities.write();
@@ -955,12 +955,13 @@ impl InMemoryDatabase {
 
         // Add new capabilities
         let mut result = Vec::new();
-        for (capability_id, position) in capabilities.into_iter() {
+        for (capability_id, position, config) in capabilities.into_iter() {
             let row = AgentCapabilityRow {
                 id: Uuid::now_v7(),
                 agent_id,
                 capability_id: capability_id.clone(),
                 position,
+                config,
                 created_at: now,
             };
             caps.insert((agent_id, capability_id), row.clone());
@@ -982,6 +983,7 @@ impl InMemoryDatabase {
             agent_id: input.agent_id,
             capability_id: input.capability_id.clone(),
             position: input.position,
+            config: input.config,
             created_at: now,
         };
         caps.insert((input.agent_id, input.capability_id), row.clone());

--- a/crates/control-plane/src/storage/models.rs
+++ b/crates/control-plane/src/storage/models.rs
@@ -341,6 +341,8 @@ pub struct AgentCapabilityRow {
     pub agent_id: Uuid,
     pub capability_id: String,
     pub position: i32,
+    /// Per-agent capability configuration (JSON)
+    pub config: serde_json::Value,
     pub created_at: DateTime<Utc>,
 }
 
@@ -349,6 +351,9 @@ pub struct CreateAgentCapabilityRow {
     pub agent_id: Uuid,
     pub capability_id: String,
     pub position: i32,
+    /// Per-agent capability configuration (JSON)
+    #[allow(dead_code)]
+    pub config: serde_json::Value,
 }
 
 // ============================================

--- a/crates/control-plane/src/storage/repositories.rs
+++ b/crates/control-plane/src/storage/repositories.rs
@@ -1077,7 +1077,7 @@ impl Database {
     pub async fn get_agent_capabilities(&self, agent_id: Uuid) -> Result<Vec<AgentCapabilityRow>> {
         let rows = sqlx::query_as::<_, AgentCapabilityRow>(
             r#"
-            SELECT id, agent_id, capability_id, position, created_at
+            SELECT id, agent_id, capability_id, position, config, created_at
             FROM agent_capabilities
             WHERE agent_id = $1
             ORDER BY position ASC
@@ -1091,11 +1091,11 @@ impl Database {
     }
 
     /// Set capabilities for an agent (replaces existing capabilities)
-    /// capabilities: list of (capability_id, position) tuples
+    /// capabilities: list of (capability_id, position, config) tuples
     pub async fn set_agent_capabilities(
         &self,
         agent_id: Uuid,
-        capabilities: Vec<(String, i32)>,
+        capabilities: Vec<(String, i32, serde_json::Value)>,
     ) -> Result<Vec<AgentCapabilityRow>> {
         // Start a transaction
         let mut tx = self.pool.begin().await?;
@@ -1107,16 +1107,17 @@ impl Database {
             .await?;
 
         // Insert new capabilities
-        for (capability_id, position) in &capabilities {
+        for (capability_id, position, config) in &capabilities {
             sqlx::query(
                 r#"
-                INSERT INTO agent_capabilities (agent_id, capability_id, position)
-                VALUES ($1, $2, $3)
+                INSERT INTO agent_capabilities (agent_id, capability_id, position, config)
+                VALUES ($1, $2, $3, $4)
                 "#,
             )
             .bind(agent_id)
             .bind(capability_id)
             .bind(position)
+            .bind(config)
             .execute(&mut *tx)
             .await?;
         }
@@ -1135,14 +1136,15 @@ impl Database {
     ) -> Result<AgentCapabilityRow> {
         let row = sqlx::query_as::<_, AgentCapabilityRow>(
             r#"
-            INSERT INTO agent_capabilities (agent_id, capability_id, position)
-            VALUES ($1, $2, $3)
-            RETURNING id, agent_id, capability_id, position, created_at
+            INSERT INTO agent_capabilities (agent_id, capability_id, position, config)
+            VALUES ($1, $2, $3, $4)
+            RETURNING id, agent_id, capability_id, position, config, created_at
             "#,
         )
         .bind(input.agent_id)
         .bind(&input.capability_id)
         .bind(input.position)
+        .bind(&input.config)
         .fetch_one(&self.pool)
         .await?;
 

--- a/crates/control-plane/tests/integration_test.rs
+++ b/crates/control-plane/tests/integration_test.rs
@@ -1178,7 +1178,7 @@ async fn test_no_duplicate_tool_calls() {
         .json(&json!({
             "name": "Time Tool Test Agent",
             "system_prompt": "You are a helpful time assistant. When asked about the current time, use the get_current_time tool.",
-            "capabilities": ["current_time"],
+            "capabilities": [{"ref": "current_time", "config": {}}],
             "default_model_id": model.id
         }))
         .send()

--- a/crates/core/src/agent.rs
+++ b/crates/core/src/agent.rs
@@ -7,7 +7,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::capability_types::CapabilityId;
+use crate::capability_types::AgentCapabilityConfig;
 use crate::events::TokenUsage;
 
 #[cfg(feature = "openapi")]
@@ -66,11 +66,10 @@ pub struct Agent {
     /// Tags for organizing and filtering agents.
     #[serde(default)]
     pub tags: Vec<String>,
-    /// Capabilities enabled for this agent.
+    /// Capabilities enabled for this agent with per-agent configuration.
     /// Capabilities add tools and system prompt modifications.
     #[serde(default)]
-    #[cfg_attr(feature = "openapi", schema(value_type = Vec<String>))]
-    pub capabilities: Vec<CapabilityId>,
+    pub capabilities: Vec<AgentCapabilityConfig>,
     /// Current lifecycle status of the agent.
     pub status: AgentStatus,
     /// Timestamp when the agent was created.

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -21,7 +21,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 // Re-export capability types from capability_types module
-pub use crate::capability_types::{CapabilityId, CapabilityStatus};
+pub use crate::capability_types::{AgentCapabilityConfig, CapabilityId, CapabilityStatus};
 
 // ============================================================================
 // Capability Modules

--- a/crates/core/src/capability_types.rs
+++ b/crates/core/src/capability_types.rs
@@ -3,8 +3,15 @@
 // Design Decision: Capability IDs are now String-based to allow adding new capabilities
 // without requiring database migrations or code changes to enums.
 // Validation happens at the registry level rather than the type level.
+//
+// Design Decision: AgentCapabilityConfig uses `ref` for the capability ID to avoid
+// confusion with `id` which typically refers to primary keys. The config field stores
+// per-agent configuration for the capability.
 
 use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "openapi")]
+use utoipa::ToSchema;
 
 /// Capability identifier - a string-based ID for extensibility
 ///
@@ -161,6 +168,63 @@ impl std::fmt::Display for CapabilityStatus {
     }
 }
 
+/// Per-agent capability configuration
+///
+/// Associates a capability with an agent, including optional per-agent configuration.
+/// The config field allows the same capability to behave differently per-agent.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct AgentCapabilityConfig {
+    /// Reference to the capability ID
+    #[serde(rename = "ref")]
+    #[cfg_attr(feature = "openapi", schema(value_type = String))]
+    pub capability_ref: CapabilityId,
+    /// Per-agent configuration for this capability (capability-specific)
+    #[serde(default)]
+    pub config: serde_json::Value,
+}
+
+impl AgentCapabilityConfig {
+    /// Create a new capability config with the given ID and empty config
+    pub fn new(capability_id: impl Into<CapabilityId>) -> Self {
+        Self {
+            capability_ref: capability_id.into(),
+            config: serde_json::Value::Object(serde_json::Map::new()),
+        }
+    }
+
+    /// Create a new capability config with the given ID and config
+    pub fn with_config(capability_id: impl Into<CapabilityId>, config: serde_json::Value) -> Self {
+        Self {
+            capability_ref: capability_id.into(),
+            config,
+        }
+    }
+
+    /// Get the capability ID as a string reference
+    pub fn capability_id(&self) -> &str {
+        self.capability_ref.as_str()
+    }
+}
+
+impl From<CapabilityId> for AgentCapabilityConfig {
+    fn from(id: CapabilityId) -> Self {
+        Self::new(id)
+    }
+}
+
+impl From<&str> for AgentCapabilityConfig {
+    fn from(id: &str) -> Self {
+        Self::new(CapabilityId::new(id))
+    }
+}
+
+impl From<String> for AgentCapabilityConfig {
+    fn from(id: String) -> Self {
+        Self::new(CapabilityId::new(id))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -251,5 +315,80 @@ mod tests {
         set.insert(CapabilityId::new("noop")); // Should not add a duplicate
 
         assert_eq!(set.len(), 2);
+    }
+
+    // AgentCapabilityConfig tests
+
+    #[test]
+    fn test_agent_capability_config_new() {
+        let config = AgentCapabilityConfig::new("current_time");
+        assert_eq!(config.capability_id(), "current_time");
+        assert_eq!(config.config, serde_json::json!({}));
+    }
+
+    #[test]
+    fn test_agent_capability_config_with_config() {
+        let config = AgentCapabilityConfig::with_config(
+            "web_fetch",
+            serde_json::json!({"timeout_ms": 30000}),
+        );
+        assert_eq!(config.capability_id(), "web_fetch");
+        assert_eq!(config.config["timeout_ms"], 30000);
+    }
+
+    #[test]
+    fn test_agent_capability_config_from_capability_id() {
+        let config: AgentCapabilityConfig = CapabilityId::current_time().into();
+        assert_eq!(config.capability_id(), "current_time");
+        assert_eq!(config.config, serde_json::json!({}));
+    }
+
+    #[test]
+    fn test_agent_capability_config_from_str() {
+        let config: AgentCapabilityConfig = "test_math".into();
+        assert_eq!(config.capability_id(), "test_math");
+    }
+
+    #[test]
+    fn test_agent_capability_config_from_string() {
+        let config: AgentCapabilityConfig = String::from("web_fetch").into();
+        assert_eq!(config.capability_id(), "web_fetch");
+    }
+
+    #[test]
+    fn test_agent_capability_config_serialization() {
+        let config = AgentCapabilityConfig::with_config(
+            "current_time",
+            serde_json::json!({"timezone": "UTC"}),
+        );
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(json.contains("\"ref\":\"current_time\""));
+        assert!(json.contains("\"timezone\":\"UTC\""));
+
+        let parsed: AgentCapabilityConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.capability_id(), "current_time");
+        assert_eq!(parsed.config["timezone"], "UTC");
+    }
+
+    #[test]
+    fn test_agent_capability_config_serialization_empty_config() {
+        let config = AgentCapabilityConfig::new("noop");
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(json.contains("\"ref\":\"noop\""));
+
+        let parsed: AgentCapabilityConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.capability_id(), "noop");
+        assert_eq!(parsed.config, serde_json::json!({}));
+    }
+
+    #[test]
+    fn test_agent_capability_config_equality() {
+        let config1 = AgentCapabilityConfig::new("current_time");
+        let config2 = AgentCapabilityConfig::new("current_time");
+        let config3 =
+            AgentCapabilityConfig::with_config("current_time", serde_json::json!({"key": "value"}));
+
+        assert_eq!(config1, config2);
+        assert_ne!(config1, config3); // Different config makes them unequal
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -94,12 +94,12 @@ pub use tools::{
 
 // Capability re-exports
 pub use capabilities::{
-    AddTool, AppliedCapabilities, Capability, CapabilityId, CapabilityRegistry,
-    CapabilityRegistryBuilder, CapabilityStatus, CurrentTimeCapability, DeleteFileTool, DivideTool,
-    FileSystemCapability, GetCurrentTimeTool, GetForecastTool, GetWeatherTool, GrepFilesTool,
-    ListDirectoryTool, MultiplyTool, NoopCapability, ReadFileTool, ResearchCapability,
-    SandboxCapability, StatFileTool, StatelessTodoListCapability, SubtractTool, TestMathCapability,
-    TestWeatherCapability, WriteFileTool, WriteTodosTool, apply_capabilities,
+    AddTool, AgentCapabilityConfig, AppliedCapabilities, Capability, CapabilityId,
+    CapabilityRegistry, CapabilityRegistryBuilder, CapabilityStatus, CurrentTimeCapability,
+    DeleteFileTool, DivideTool, FileSystemCapability, GetCurrentTimeTool, GetForecastTool,
+    GetWeatherTool, GrepFilesTool, ListDirectoryTool, MultiplyTool, NoopCapability, ReadFileTool,
+    ResearchCapability, SandboxCapability, StatFileTool, StatelessTodoListCapability, SubtractTool,
+    TestMathCapability, TestWeatherCapability, WriteFileTool, WriteTodosTool, apply_capabilities,
 };
 
 // Atoms re-exports (stateless atomic operations)

--- a/crates/core/src/runtime_agent.rs
+++ b/crates/core/src/runtime_agent.rs
@@ -109,7 +109,7 @@ impl RuntimeAgentBuilder {
         let capability_ids: Vec<String> = agent
             .capabilities
             .iter()
-            .map(|cap_id| cap_id.as_str().to_string())
+            .map(|cap| cap.capability_id().to_string())
             .collect();
 
         self.system_prompt(&agent.system_prompt)
@@ -214,8 +214,7 @@ impl Default for RuntimeAgentBuilder {
 mod tests {
     use super::*;
     use crate::agent::AgentStatus;
-    use crate::capabilities::CapabilityId;
-    use crate::capability_types::CapabilityId as CapabilityIdType;
+    use crate::capabilities::{AgentCapabilityConfig, CapabilityId};
 
     #[test]
     fn test_runtime_agent_new() {
@@ -341,7 +340,7 @@ mod tests {
             name: "Test Agent".to_string(),
             description: None,
             system_prompt: "Agent prompt.".to_string(),
-            capabilities: vec![CapabilityIdType::from(CapabilityId::CURRENT_TIME)],
+            capabilities: vec![AgentCapabilityConfig::new(CapabilityId::CURRENT_TIME)],
             status: AgentStatus::Active,
             default_model_id: None,
             tags: vec![],

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -299,6 +299,12 @@ pub fn proto_agent_to_schema(value: proto::Agent) -> Result<everruns_core::Agent
     // Serialize proto to JSON, then deserialize to schema type
     // This is simpler and more maintainable than field-by-field conversion
     let tags: Vec<String> = vec![];
+    // Convert capability IDs to AgentCapabilityConfig format with empty config
+    let capabilities: Vec<serde_json::Value> = value
+        .capability_ids
+        .iter()
+        .map(|id| serde_json::json!({"ref": id, "config": {}}))
+        .collect();
     let json = serde_json::json!({
         "id": value.id.as_ref().map(|u| &u.value).unwrap_or(&String::new()),
         "name": value.name,
@@ -306,7 +312,7 @@ pub fn proto_agent_to_schema(value: proto::Agent) -> Result<everruns_core::Agent
         "system_prompt": value.system_prompt,
         "default_model_id": value.default_model_id.as_ref().map(|u| &u.value),
         "tags": tags,
-        "capabilities": value.capability_ids,
+        "capabilities": capabilities,
         "status": value.status,
         "created_at": value.created_at.as_ref().map(|t| proto_timestamp_to_datetime(t).to_rfc3339()),
         "updated_at": value.updated_at.as_ref().map(|t| proto_timestamp_to_datetime(t).to_rfc3339()),
@@ -327,7 +333,12 @@ pub fn schema_agent_to_proto(value: &everruns_core::Agent) -> proto::Agent {
         status: value.status.to_string(),
         created_at: Some(datetime_to_proto_timestamp(value.created_at)),
         updated_at: Some(datetime_to_proto_timestamp(value.updated_at)),
-        capability_ids: value.capabilities.iter().map(|c| c.to_string()).collect(),
+        // Extract capability IDs from AgentCapabilityConfig
+        capability_ids: value
+            .capabilities
+            .iter()
+            .map(|c| c.capability_id().to_string())
+            .collect(),
     }
 }
 
@@ -923,7 +934,7 @@ mod tests {
     #[test]
     fn test_proto_agent_includes_capability_ids() {
         use chrono::Utc;
-        use everruns_core::CapabilityId;
+        use everruns_core::AgentCapabilityConfig;
         use uuid::Uuid;
 
         // Create an Agent with capabilities
@@ -935,8 +946,8 @@ mod tests {
             default_model_id: None,
             tags: vec![],
             capabilities: vec![
-                CapabilityId::new("tools:read_file"),
-                CapabilityId::new("tools:write_file"),
+                AgentCapabilityConfig::new("tools:read_file"),
+                AgentCapabilityConfig::new("tools:write_file"),
             ],
             status: everruns_core::AgentStatus::Active,
             created_at: Utc::now(),
@@ -965,16 +976,14 @@ mod tests {
 
         // Verify capabilities survive roundtrip
         assert_eq!(schema_agent.capabilities.len(), 2);
-        assert!(
-            schema_agent
-                .capabilities
-                .contains(&CapabilityId::new("tools:read_file"))
-        );
-        assert!(
-            schema_agent
-                .capabilities
-                .contains(&CapabilityId::new("tools:write_file"))
-        );
+        // Check capability IDs are preserved (config defaults to empty)
+        let cap_ids: Vec<&str> = schema_agent
+            .capabilities
+            .iter()
+            .map(|c| c.capability_id())
+            .collect();
+        assert!(cap_ids.contains(&"tools:read_file"));
+        assert!(cap_ids.contains(&"tools:write_file"));
     }
 
     #[test]

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -320,7 +320,7 @@ fn proto_agent_to_agent(proto_agent: proto::Agent) -> Result<Agent> {
         capabilities: proto_agent
             .capability_ids
             .into_iter()
-            .filter_map(|s| s.parse().ok())
+            .map(everruns_core::AgentCapabilityConfig::new)
             .collect(),
         status,
         created_at: proto_timestamp_or_now(proto_agent.created_at.as_ref()),

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2095,9 +2095,9 @@
           "capabilities": {
             "type": "array",
             "items": {
-              "type": "string"
+              "$ref": "#/components/schemas/AgentCapabilityConfig"
             },
-            "description": "Capabilities enabled for this agent.\nCapabilities add tools and system prompt modifications."
+            "description": "Capabilities enabled for this agent with per-agent configuration.\nCapabilities add tools and system prompt modifications."
           },
           "created_at": {
             "type": "string",
@@ -2158,6 +2158,22 @@
                 "description": "Cumulative token usage across all sessions for this agent."
               }
             ]
+          }
+        }
+      },
+      "AgentCapabilityConfig": {
+        "type": "object",
+        "description": "Per-agent capability configuration\n\nAssociates a capability with an agent, including optional per-agent configuration.\nThe config field allows the same capability to behave differently per-agent.",
+        "required": [
+          "ref"
+        ],
+        "properties": {
+          "config": {
+            "description": "Per-agent configuration for this capability (capability-specific)"
+          },
+          "ref": {
+            "type": "string",
+            "description": "Reference to the capability ID"
           }
         }
       },
@@ -2376,12 +2392,18 @@
           "capabilities": {
             "type": "array",
             "items": {
-              "type": "string"
+              "$ref": "#/components/schemas/AgentCapabilityConfig"
             },
-            "description": "Capabilities to enable for this agent.\nCapabilities provide tools and system prompt additions.",
+            "description": "Capabilities to enable for this agent with per-agent configuration.\nEach capability has a `ref` (capability ID) and optional `config`.",
             "example": [
-              "current_time",
-              "web_fetch"
+              {
+                "config": {},
+                "ref": "current_time"
+              },
+              {
+                "config": {},
+                "ref": "web_fetch"
+              }
             ]
           },
           "default_model_id": {
@@ -3151,9 +3173,9 @@
                 "capabilities": {
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "$ref": "#/components/schemas/AgentCapabilityConfig"
                   },
-                  "description": "Capabilities enabled for this agent.\nCapabilities add tools and system prompt modifications."
+                  "description": "Capabilities enabled for this agent with per-agent configuration.\nCapabilities add tools and system prompt modifications."
                 },
                 "created_at": {
                   "type": "string",
@@ -5417,12 +5439,18 @@
               "null"
             ],
             "items": {
-              "type": "string"
+              "$ref": "#/components/schemas/AgentCapabilityConfig"
             },
-            "description": "Capabilities to enable for this agent. Replaces existing capabilities.",
+            "description": "Capabilities to enable for this agent with per-agent configuration.\nReplaces existing capabilities. Each has a `ref` (capability ID) and optional `config`.",
             "example": [
-              "current_time",
-              "web_fetch"
+              {
+                "config": {},
+                "ref": "current_time"
+              },
+              {
+                "config": {},
+                "ref": "web_fetch"
+              }
             ]
           },
           "default_model_id": {

--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -80,11 +80,32 @@ system_prompt: |
   You are a helpful research assistant.
   Always cite your sources.
 capabilities:
-  - current_time
-  - web_fetch
+  - ref: current_time
+    config: {}
+  - ref: web_fetch
+    config: {}
 tags:
   - research
   - assistant
+```
+
+For backward compatibility, you can also use the shorthand format:
+
+```yaml
+capabilities:
+  - current_time
+  - web_fetch
+```
+
+The full format with `ref` and `config` allows per-agent capability configuration:
+
+```yaml
+capabilities:
+  - ref: filesystem
+    config:
+      allowed_paths: ["/home/user/projects"]
+  - ref: web_browser
+    config: {}
 ```
 
 **Markdown file format** (`agent.md`):
@@ -94,8 +115,10 @@ tags:
 name: "research-assistant"
 description: "Helps with research tasks"
 capabilities:
-  - current_time
-  - web_fetch
+  - ref: current_time
+    config: {}
+  - ref: web_fetch
+    config: {}
 tags:
   - research
 ---
@@ -104,7 +127,7 @@ You are a helpful research assistant.
 Always cite your sources and provide accurate information.
 ```
 
-The markdown body becomes the system prompt.
+The markdown body becomes the system prompt. Both the full format (`ref` + `config`) and shorthand (just capability ID) are supported in markdown files.
 
 #### List Agents
 
@@ -256,7 +279,11 @@ cat > agent.md << 'EOF'
 name: "code-reviewer"
 description: "Reviews code and suggests improvements"
 capabilities:
-  - current_time
+  - ref: current_time
+    config: {}
+  - ref: filesystem
+    config:
+      allowed_paths: ["/workspace"]
 tags:
   - development
 ---

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -98,6 +98,45 @@ pub enum CapabilityStatus {
 }
 ```
 
+#### AgentCapabilityConfig (Per-agent configuration)
+
+Associates a capability with an agent, including optional per-agent configuration.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ref` | CapabilityId | Reference to the capability |
+| `config` | object | Per-agent configuration (capability-specific) |
+
+```rust
+/// Per-agent capability configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentCapabilityConfig {
+    /// Reference to the capability ID
+    #[serde(rename = "ref")]
+    pub capability_ref: CapabilityId,
+    /// Per-agent configuration for this capability
+    #[serde(default)]
+    pub config: serde_json::Value,
+}
+```
+
+The `config` field is capability-specific and passed to the capability during execution.
+This allows the same capability to behave differently per-agent.
+
+**Example usage:**
+```json
+{
+  "capabilities": [
+    { "ref": "current_time", "config": {} },
+    { "ref": "web_fetch", "config": { "timeout_ms": 30000 } }
+  ]
+}
+```
+
+**Import compatibility:** For backward compatibility, import accepts both formats:
+- New format: `{ "ref": "capability_id", "config": {} }`
+- Legacy format: `"capability_id"` (converted to new format with empty config)
+
 #### Capability Trait (everruns-core)
 
 Capabilities are defined as trait implementations in the core crate:
@@ -447,7 +486,10 @@ Content-Type: application/json
 {
   "name": "Research Assistant",
   "system_prompt": "You are a helpful research assistant.",
-  "capabilities": ["current_time", "test_math"]
+  "capabilities": [
+    { "ref": "current_time", "config": {} },
+    { "ref": "test_math", "config": {} }
+  ]
 }
 
 Response:
@@ -455,7 +497,10 @@ Response:
   "id": "...",
   "name": "Research Assistant",
   "system_prompt": "You are a helpful research assistant.",
-  "capabilities": ["current_time", "test_math"],
+  "capabilities": [
+    { "ref": "current_time", "config": {} },
+    { "ref": "test_math", "config": {} }
+  ],
   "status": "active",
   ...
 }
@@ -468,14 +513,22 @@ PATCH /v1/agents/{agent_id}
 Content-Type: application/json
 
 {
-  "capabilities": ["current_time", "web_fetch", "session_file_system"]
+  "capabilities": [
+    { "ref": "current_time", "config": {} },
+    { "ref": "web_fetch", "config": { "timeout_ms": 30000 } },
+    { "ref": "session_file_system", "config": {} }
+  ]
 }
 
 Response:
 {
   "id": "...",
   "name": "Research Assistant",
-  "capabilities": ["current_time", "web_fetch", "session_file_system"],
+  "capabilities": [
+    { "ref": "current_time", "config": {} },
+    { "ref": "web_fetch", "config": { "timeout_ms": 30000 } },
+    { "ref": "session_file_system", "config": {} }
+  ],
   ...
 }
 ```
@@ -491,6 +544,8 @@ CREATE TABLE agent_capabilities (
     -- Capability ID is a string; validation happens at application layer
     capability_id VARCHAR(50) NOT NULL,
     position INTEGER NOT NULL DEFAULT 0,
+    -- Per-agent capability configuration (JSON)
+    config JSONB NOT NULL DEFAULT '{}',
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     UNIQUE(agent_id, capability_id)
 );
@@ -499,7 +554,7 @@ CREATE INDEX idx_agent_capabilities_agent_id ON agent_capabilities(agent_id);
 CREATE INDEX idx_agent_capabilities_position ON agent_capabilities(agent_id, position);
 ```
 
-**Note**: The `capability_id` column no longer has a CHECK constraint. Validation is performed at the application layer via `CapabilityRegistry`. This allows adding new capabilities without database migrations.
+**Note**: The `capability_id` column no longer has a CHECK constraint. Validation is performed at the application layer via `CapabilityRegistry`. This allows adding new capabilities without database migrations. The `config` column stores per-agent configuration as JSON, allowing capability-specific settings per agent.
 
 ### Design Decisions
 


### PR DESCRIPTION
## Summary

Refactors the capabilities system to support per-agent configuration. Each capability can now have agent-specific settings via a `config` object.

- Add `AgentCapabilityConfig` type with `ref` (capability ID) and `config` (JSON object) fields
- Database migration adds `config` JSONB column to `agent_capabilities` table
- API only accepts the new format: `{ "ref": "capability_id", "config": {} }`
- Import/export supports both formats for backward compatibility:
  - New: `{ "ref": "filesystem", "config": { "allowed_paths": ["/tmp"] } }`
  - Legacy: `"filesystem"` (converted to new format with empty config)

## Changes

**Core types** (`crates/core/`):
- New `AgentCapabilityConfig` struct in `capability_types.rs`
- Updated `Agent` to use `Vec<AgentCapabilityConfig>` instead of `Vec<CapabilityId>`

**Database** (`crates/control-plane/`):
- Migration `007_capability_config.sql` adds `config` column
- Updated storage models and repositories

**API** (`crates/control-plane/src/api/`):
- Updated request/response DTOs
- Import accepts both formats via `#[serde(untagged)]`
- Export uses new format

**Worker/Protocol**:
- Updated gRPC adapters and proto conversions

**CLI** (`crates/cli/`):
- Updated file parsing for both formats
- Updated display logic

**UI** (`apps/ui/`):
- Updated TypeScript types
- Components display capability refs

**Documentation**:
- Updated `specs/capabilities.md` with new data model
- Updated `docs/features/cli.md` with examples
- Regenerated OpenAPI spec

## Test plan

- [x] Unit tests pass (`cargo test`)
- [x] Clippy passes
- [x] UI lint and build pass
- [x] Manual test: create agent with capabilities via CLI
- [x] Manual test: export agent shows new format
- [x] Manual test: import legacy format works
- [x] Manual test: import new format with config works

## Risk

- **Medium** - Breaking change to API contract
- Backward compatibility maintained for import only
- API consumers need to update to new format