### PR TITLE
feat(dev): add llmsim provider support and seed data

### DIFF
--- a/crates/control-plane/src/seed.rs
+++ b/crates/control-plane/src/seed.rs
@@ -20,12 +20,14 @@ use uuid::Uuid;
 ///   - 0x100-0x1FF: Agents
 ///   - 0x200-0x2FF: OpenAI Models
 ///   - 0x300-0x3FF: Anthropic Models
+///   - 0x400-0x4FF: LlmSim Models
 mod seed_ids {
     use uuid::Uuid;
 
     // LLM Providers (0x001-0x0FF)
     pub const OPENAI_PROVIDER: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000001);
     pub const ANTHROPIC_PROVIDER: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000002);
+    pub const LLMSIM_PROVIDER: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000003);
 
     // Agents (0x100-0x1FF)
     pub const DAD_JOKES_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000101);
@@ -72,6 +74,9 @@ mod seed_ids {
     pub const CLAUDE_3_7_SONNET: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000306);
     pub const CLAUDE_3_5_SONNET: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000307);
     pub const CLAUDE_3_5_HAIKU: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000308);
+
+    // LlmSim Models (0x400-0x4FF)
+    pub const LLMSIM_DEFAULT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000401);
 }
 
 // ============================================
@@ -246,6 +251,11 @@ const SEED_PROVIDERS: &[SeedProvider] = &[
         id: seed_ids::ANTHROPIC_PROVIDER,
         name: "Anthropic",
         provider_type: "anthropic",
+    },
+    SeedProvider {
+        id: seed_ids::LLMSIM_PROVIDER,
+        name: "LlmSim",
+        provider_type: "llmsim",
     },
 ];
 
@@ -566,6 +576,14 @@ const SEED_MODELS: &[SeedModel] = &[
         provider_id: seed_ids::ANTHROPIC_PROVIDER,
         model_id: "claude-3-5-haiku-20241022",
         display_name: "Claude 3.5 Haiku",
+        is_default: false,
+    },
+    // LlmSim (simulated LLM for testing)
+    SeedModel {
+        id: seed_ids::LLMSIM_DEFAULT,
+        provider_id: seed_ids::LLMSIM_PROVIDER,
+        model_id: "llmsim-default",
+        display_name: "LlmSim Default",
         is_default: false,
     },
 ];

--- a/crates/control-plane/src/storage/llm_provider_store.rs
+++ b/crates/control-plane/src/storage/llm_provider_store.rs
@@ -128,6 +128,7 @@ fn parse_provider_type(provider_type_str: &str) -> LlmProviderType {
         "openai" => LlmProviderType::Openai,
         "anthropic" => LlmProviderType::Anthropic,
         "azure_openai" | "azure-openai" | "azureopenai" => LlmProviderType::AzureOpenAI,
+        "llmsim" => LlmProviderType::LlmSim,
         _ => LlmProviderType::Openai, // Default to OpenAI
     }
 }

--- a/crates/core/src/llm_model_profiles.rs
+++ b/crates/core/src/llm_model_profiles.rs
@@ -1307,7 +1307,7 @@ fn get_llmsim_profile(model_id: &str) -> Option<LlmModelProfile> {
             structured_output: true,
             open_weights: false,
             cost: Some(LlmModelCost {
-                input: 0.00,  // Free for testing
+                input: 0.00, // Free for testing
                 output: 0.00,
                 cache_read: Some(0.00),
             }),

--- a/crates/core/src/llm_model_profiles.rs
+++ b/crates/core/src/llm_model_profiles.rs
@@ -108,7 +108,7 @@ pub fn get_model_profile(
         LlmProviderType::Openai => get_openai_profile(model_id),
         LlmProviderType::Anthropic => get_anthropic_profile(model_id),
         LlmProviderType::AzureOpenAI => get_openai_profile(model_id), // Azure uses same model IDs
-        LlmProviderType::LlmSim => None, // No profile for simulated LLM
+        LlmProviderType::LlmSim => get_llmsim_profile(model_id),
     }
 }
 
@@ -1286,6 +1286,41 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
             reasoning_effort: None,
         }),
 
+        _ => None,
+    }
+}
+
+/// Get LlmSim model profile (simulated LLM for testing)
+/// Profile is modeled close to GPT-5.2 for realistic testing
+fn get_llmsim_profile(model_id: &str) -> Option<LlmModelProfile> {
+    match model_id {
+        "llmsim-default" | "llmsim" => Some(LlmModelProfile {
+            name: "LlmSim Default".into(),
+            family: "llmsim".into(),
+            release_date: Some("2025-01-01".into()),
+            last_updated: Some("2025-01-01".into()),
+            attachment: true,
+            reasoning: true,
+            temperature: false, // Like gpt-5.2
+            knowledge: Some("2025-08-31".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 0.00,  // Free for testing
+                output: 0.00,
+                cache_read: Some(0.00),
+            }),
+            limits: Some(LlmModelLimits {
+                context: 128_000,
+                output: 64_000,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: Some(reasoning_effort_gpt52()), // Same as GPT-5.2
+        }),
         _ => None,
     }
 }


### PR DESCRIPTION
## What
Adds llmsim provider support for DEV_MODE testing.

## Why
Enable testing with simulated LLM without requiring real API keys.

## Changes
1. **fix(dev)**: Add llmsim to `parse_provider_type` function - was defaulting to OpenAI
2. **feat(seed)**: Add llmsim provider and model to seed data with GPT-5.2-like profile

## Test
- Verified llmsim provider works in DEV_MODE
- Seeded model responds correctly

## Risk
- Low - only affects dev/testing paths