### PR TITLE
feat(durable): integrate circuit breaker for LLM provider protection

### DIFF
--- a/apps/ui/src/app/(main)/durable/circuit-breakers/page.tsx
+++ b/apps/ui/src/app/(main)/durable/circuit-breakers/page.tsx
@@ -1,0 +1,383 @@
+"use client";
+
+import { Header } from "@/components/layout/header";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useCircuitBreakers } from "@/hooks";
+import { forceOpenCircuitBreaker, forceCloseCircuitBreaker, deleteCircuitBreaker } from "@/lib/api";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import {
+  Zap,
+  ZapOff,
+  Trash2,
+  ShieldAlert,
+  ShieldCheck,
+  Clock,
+} from "lucide-react";
+import type { CircuitBreaker, CircuitBreakerState } from "@/lib/api/types";
+
+function getStateBadgeVariant(state: CircuitBreakerState) {
+  switch (state) {
+    case "closed":
+      return "default" as const;
+    case "open":
+      return "destructive" as const;
+    case "half_open":
+      return "secondary" as const;
+    default:
+      return "outline" as const;
+  }
+}
+
+function getStateIcon(state: CircuitBreakerState) {
+  switch (state) {
+    case "closed":
+      return <ShieldCheck className="h-4 w-4 text-green-500" />;
+    case "open":
+      return <ShieldAlert className="h-4 w-4 text-red-500" />;
+    case "half_open":
+      return <Clock className="h-4 w-4 text-yellow-500" />;
+    default:
+      return <Zap className="h-4 w-4" />;
+  }
+}
+
+function formatDate(dateStr?: string): string {
+  if (!dateStr) return "Never";
+  const date = new Date(dateStr);
+  return date.toLocaleString();
+}
+
+function CircuitBreakerCard({ breaker }: { breaker: CircuitBreaker }) {
+  const queryClient = useQueryClient();
+  const [openDialogOpen, setOpenDialogOpen] = useState(false);
+  const [resetDialogOpen, setResetDialogOpen] = useState(false);
+
+  const forceOpenMutation = useMutation({
+    mutationFn: () => forceOpenCircuitBreaker(breaker.key),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["circuit-breakers"] });
+      queryClient.invalidateQueries({ queryKey: ["durable-health"] });
+      setOpenDialogOpen(false);
+    },
+  });
+
+  const forceCloseMutation = useMutation({
+    mutationFn: () => forceCloseCircuitBreaker(breaker.key),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["circuit-breakers"] });
+      queryClient.invalidateQueries({ queryKey: ["durable-health"] });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteCircuitBreaker(breaker.key),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["circuit-breakers"] });
+      queryClient.invalidateQueries({ queryKey: ["durable-health"] });
+      setResetDialogOpen(false);
+    },
+  });
+
+  return (
+    <Card className={breaker.state === "open" ? "border-red-500/50" : ""}>
+      <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-2">
+        <div className="flex items-center gap-2">
+          {getStateIcon(breaker.state)}
+          <div>
+            <CardTitle className="text-base font-mono">{breaker.key}</CardTitle>
+            <CardDescription className="text-xs">
+              Updated {formatDate(breaker.updated_at)}
+            </CardDescription>
+          </div>
+        </div>
+        <Badge variant={getStateBadgeVariant(breaker.state)}>
+          {breaker.state.replace("_", " ")}
+        </Badge>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Stats */}
+        <div className="grid grid-cols-2 gap-4 text-sm">
+          <div>
+            <span className="text-muted-foreground">Failure Count</span>
+            <p className="font-medium">{breaker.failure_count}</p>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Success Count</span>
+            <p className="font-medium">{breaker.success_count}</p>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Last Failure</span>
+            <p className="font-medium text-xs">{formatDate(breaker.last_failure_at)}</p>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Opened At</span>
+            <p className="font-medium text-xs">{formatDate(breaker.opened_at)}</p>
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex gap-2 pt-2 border-t">
+          {breaker.state !== "open" ? (
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                className="text-red-600 border-red-200 hover:bg-red-50"
+                disabled={forceOpenMutation.isPending}
+                onClick={() => setOpenDialogOpen(true)}
+              >
+                <ZapOff className="h-4 w-4 mr-1" />
+                Force Open
+              </Button>
+              <Dialog open={openDialogOpen} onOpenChange={setOpenDialogOpen}>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>Force Open Circuit Breaker?</DialogTitle>
+                    <DialogDescription>
+                      This will immediately block all calls through the &quot;{breaker.key}&quot; circuit.
+                      Use this to proactively protect against a known issue.
+                    </DialogDescription>
+                  </DialogHeader>
+                  <DialogFooter>
+                    <Button variant="outline" onClick={() => setOpenDialogOpen(false)}>
+                      Cancel
+                    </Button>
+                    <Button
+                      variant="destructive"
+                      onClick={() => forceOpenMutation.mutate()}
+                      disabled={forceOpenMutation.isPending}
+                    >
+                      {forceOpenMutation.isPending ? "Opening..." : "Force Open"}
+                    </Button>
+                  </DialogFooter>
+                </DialogContent>
+              </Dialog>
+            </>
+          ) : (
+            <Button
+              variant="outline"
+              size="sm"
+              className="text-green-600 border-green-200 hover:bg-green-50"
+              onClick={() => forceCloseMutation.mutate()}
+              disabled={forceCloseMutation.isPending}
+            >
+              <ShieldCheck className="h-4 w-4 mr-1" />
+              {forceCloseMutation.isPending ? "Closing..." : "Force Close"}
+            </Button>
+          )}
+
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-muted-foreground hover:text-destructive"
+            disabled={deleteMutation.isPending}
+            onClick={() => setResetDialogOpen(true)}
+          >
+            <Trash2 className="h-4 w-4 mr-1" />
+            Reset
+          </Button>
+          <Dialog open={resetDialogOpen} onOpenChange={setResetDialogOpen}>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Reset Circuit Breaker?</DialogTitle>
+                <DialogDescription>
+                  This will delete the circuit breaker state for &quot;{breaker.key}&quot;.
+                  A new circuit breaker will be created automatically when needed.
+                </DialogDescription>
+              </DialogHeader>
+              <DialogFooter>
+                <Button variant="outline" onClick={() => setResetDialogOpen(false)}>
+                  Cancel
+                </Button>
+                <Button
+                  onClick={() => deleteMutation.mutate()}
+                  disabled={deleteMutation.isPending}
+                >
+                  {deleteMutation.isPending ? "Resetting..." : "Reset"}
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function CircuitBreakersPage() {
+  const { data, isLoading, error } = useCircuitBreakers();
+
+  if (isLoading) {
+    return (
+      <>
+        <Header title="Circuit Breakers" />
+        <div className="p-6 space-y-4">
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {[...Array(3)].map((_, i) => (
+              <Skeleton key={i} className="h-48" />
+            ))}
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  if (error) {
+    return (
+      <>
+        <Header title="Circuit Breakers" />
+        <div className="p-6">
+          <Card>
+            <CardContent className="flex flex-col items-center justify-center py-12">
+              <ShieldAlert className="h-12 w-12 text-muted-foreground mb-4" />
+              <h3 className="text-lg font-medium mb-2">Failed to Load Circuit Breakers</h3>
+              <p className="text-sm text-muted-foreground text-center max-w-md">
+                {error instanceof Error ? error.message : "An error occurred"}
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      </>
+    );
+  }
+
+  const circuitBreakers = data?.data || [];
+  const openBreakers = circuitBreakers.filter(cb => cb.state === "open");
+  const closedBreakers = circuitBreakers.filter(cb => cb.state === "closed");
+  const halfOpenBreakers = circuitBreakers.filter(cb => cb.state === "half_open");
+
+  return (
+    <>
+      <Header title="Circuit Breakers" />
+      <div className="p-6 space-y-6">
+        {/* Summary Cards */}
+        <div className="grid gap-4 md:grid-cols-3">
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Total</CardTitle>
+              <Zap className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{circuitBreakers.length}</div>
+              <p className="text-xs text-muted-foreground">circuit breakers</p>
+            </CardContent>
+          </Card>
+          <Card className={openBreakers.length > 0 ? "border-red-500/50" : ""}>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Open</CardTitle>
+              <ShieldAlert className="h-4 w-4 text-red-500" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold text-red-600">{openBreakers.length}</div>
+              <p className="text-xs text-muted-foreground">blocking calls</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Closed</CardTitle>
+              <ShieldCheck className="h-4 w-4 text-green-500" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold text-green-600">{closedBreakers.length}</div>
+              <p className="text-xs text-muted-foreground">allowing calls</p>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Circuit Breaker List */}
+        {circuitBreakers.length > 0 ? (
+          <div className="space-y-4">
+            {/* Open breakers first */}
+            {openBreakers.length > 0 && (
+              <div>
+                <h3 className="text-lg font-semibold mb-3 flex items-center gap-2">
+                  <ShieldAlert className="h-5 w-5 text-red-500" />
+                  Open Circuit Breakers
+                </h3>
+                <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                  {openBreakers.map((cb) => (
+                    <CircuitBreakerCard key={cb.key} breaker={cb} />
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Half-open breakers */}
+            {halfOpenBreakers.length > 0 && (
+              <div>
+                <h3 className="text-lg font-semibold mb-3 flex items-center gap-2">
+                  <Clock className="h-5 w-5 text-yellow-500" />
+                  Half-Open Circuit Breakers
+                </h3>
+                <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                  {halfOpenBreakers.map((cb) => (
+                    <CircuitBreakerCard key={cb.key} breaker={cb} />
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Closed breakers */}
+            {closedBreakers.length > 0 && (
+              <div>
+                <h3 className="text-lg font-semibold mb-3 flex items-center gap-2">
+                  <ShieldCheck className="h-5 w-5 text-green-500" />
+                  Closed Circuit Breakers
+                </h3>
+                <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                  {closedBreakers.map((cb) => (
+                    <CircuitBreakerCard key={cb.key} breaker={cb} />
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        ) : (
+          <Card>
+            <CardContent className="flex flex-col items-center justify-center py-12">
+              <Zap className="h-12 w-12 text-muted-foreground mb-4" />
+              <h3 className="text-lg font-medium mb-2">No Circuit Breakers</h3>
+              <p className="text-sm text-muted-foreground text-center max-w-md">
+                Circuit breakers are created automatically when protected operations
+                are executed. Check back after running some workflows.
+              </p>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Info Card */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">About Circuit Breakers</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground space-y-2">
+            <p>
+              Circuit breakers protect against cascading failures when external services (like LLM providers) are unavailable.
+            </p>
+            <ul className="list-disc list-inside space-y-1">
+              <li><strong>Closed:</strong> Normal operation - calls are allowed through</li>
+              <li><strong>Open:</strong> Service failing - calls are rejected immediately</li>
+              <li><strong>Half-Open:</strong> Testing recovery - allowing one call to check if service is back</li>
+            </ul>
+            <p className="pt-2">
+              Use <strong>Force Open</strong> to proactively block calls when you know a service has issues.
+              Use <strong>Force Close</strong> to immediately allow calls after a service recovers.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    </>
+  );
+}

--- a/apps/ui/src/app/(main)/durable/page.tsx
+++ b/apps/ui/src/app/(main)/durable/page.tsx
@@ -176,6 +176,9 @@ export default function DurableDashboardPage() {
                     <Zap className="h-4 w-4 inline mr-2" />
                     {health.open_circuit_breakers.length} circuit breakers open: {health.open_circuit_breakers.join(", ")}
                   </span>
+                  <Link href="/durable/circuit-breakers">
+                    <Button variant="outline" size="sm">Manage</Button>
+                  </Link>
                 </div>
               )}
             </CardContent>

--- a/apps/ui/src/hooks/use-durable.ts
+++ b/apps/ui/src/hooks/use-durable.ts
@@ -19,7 +19,9 @@ import {
   deleteDlqEntry,
   purgeDlq,
   listCircuitBreakers,
-  resetCircuitBreaker,
+  forceOpenCircuitBreaker,
+  forceCloseCircuitBreaker,
+  deleteCircuitBreaker,
   getDurableSseUrl,
   getWorkflowSseUrl,
   type ListWorkflowsParams,
@@ -412,11 +414,35 @@ export function useCircuitBreakers() {
   });
 }
 
-export function useResetCircuitBreaker() {
+export function useForceOpenCircuitBreaker() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (key: string) => resetCircuitBreaker(key),
+    mutationFn: (key: string) => forceOpenCircuitBreaker(key),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["durable", "circuit-breakers"] });
+      queryClient.invalidateQueries({ queryKey: ["durable", "health"] });
+    },
+  });
+}
+
+export function useForceCloseCircuitBreaker() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (key: string) => forceCloseCircuitBreaker(key),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["durable", "circuit-breakers"] });
+      queryClient.invalidateQueries({ queryKey: ["durable", "health"] });
+    },
+  });
+}
+
+export function useDeleteCircuitBreaker() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (key: string) => deleteCircuitBreaker(key),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["durable", "circuit-breakers"] });
       queryClient.invalidateQueries({ queryKey: ["durable", "health"] });

--- a/apps/ui/src/lib/api/durable.ts
+++ b/apps/ui/src/lib/api/durable.ts
@@ -191,6 +191,25 @@ export async function listCircuitBreakers(): Promise<CircuitBreakersResponse> {
   return response.data;
 }
 
-export async function resetCircuitBreaker(key: string): Promise<void> {
-  await api.post(`/v1/durable/circuit-breakers/${encodeURIComponent(key)}/reset`);
+/**
+ * Force open a circuit breaker.
+ * Immediately blocks all calls through this circuit.
+ */
+export async function forceOpenCircuitBreaker(key: string): Promise<void> {
+  await api.post(`/v1/durable/circuit-breakers/${encodeURIComponent(key)}/open`);
+}
+
+/**
+ * Force close a circuit breaker.
+ * Immediately allows calls through this circuit.
+ */
+export async function forceCloseCircuitBreaker(key: string): Promise<void> {
+  await api.post(`/v1/durable/circuit-breakers/${encodeURIComponent(key)}/close`);
+}
+
+/**
+ * Delete a circuit breaker (reset to default state).
+ */
+export async function deleteCircuitBreaker(key: string): Promise<void> {
+  await api.delete(`/v1/durable/circuit-breakers/${encodeURIComponent(key)}`);
 }

--- a/apps/ui/src/lib/api/index.ts
+++ b/apps/ui/src/lib/api/index.ts
@@ -8,3 +8,4 @@ export * from "./events";
 export * from "./llm-providers";
 export * from "./mcp-servers";
 export * from "./auth";
+export * from "./durable";

--- a/crates/control-plane/src/api/durable.rs
+++ b/crates/control-plane/src/api/durable.rs
@@ -97,6 +97,22 @@ pub fn routes(state: AppState) -> Router {
         .route("/v1/durable/dlq/:dlq_id/retry", post(retry_dlq))
         // Circuit breakers
         .route("/v1/durable/circuit-breakers", get(list_circuit_breakers))
+        .route(
+            "/v1/durable/circuit-breakers/:key",
+            get(get_circuit_breaker),
+        )
+        .route(
+            "/v1/durable/circuit-breakers/:key/open",
+            post(force_open_circuit_breaker),
+        )
+        .route(
+            "/v1/durable/circuit-breakers/:key/close",
+            post(force_close_circuit_breaker),
+        )
+        .route(
+            "/v1/durable/circuit-breakers/:key",
+            axum::routing::delete(delete_circuit_breaker),
+        )
         .with_state(state)
 }
 
@@ -953,6 +969,168 @@ pub async fn list_circuit_breakers(
         .collect();
 
     Ok(Json(CircuitBreakersListResponse { data, total }))
+}
+
+/// GET /v1/durable/circuit-breakers/:key - Get a single circuit breaker
+#[utoipa::path(
+    get,
+    path = "/v1/durable/circuit-breakers/{key}",
+    params(
+        ("key" = String, Path, description = "Circuit breaker key")
+    ),
+    responses(
+        (status = 200, description = "Circuit breaker details", body = CircuitBreakerResponse),
+        (status = 404, description = "Circuit breaker not found", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "durable"
+)]
+pub async fn get_circuit_breaker(
+    State(state): State<AppState>,
+    Path(key): Path<String>,
+) -> Result<Json<CircuitBreakerResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let store = state.get_store()?;
+    let circuit_breakers = store.list_circuit_breakers().await.map_err(|e| {
+        tracing::error!("Failed to list circuit breakers: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: "Internal server error".to_string(),
+            }),
+        )
+    })?;
+
+    let breaker = circuit_breakers
+        .into_iter()
+        .find(|cb| cb.key == key)
+        .ok_or((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: "Circuit breaker not found".to_string(),
+            }),
+        ))?;
+
+    Ok(Json(CircuitBreakerResponse::from(breaker)))
+}
+
+/// POST /v1/durable/circuit-breakers/:key/open - Force open a circuit breaker
+#[utoipa::path(
+    post,
+    path = "/v1/durable/circuit-breakers/{key}/open",
+    params(
+        ("key" = String, Path, description = "Circuit breaker key")
+    ),
+    responses(
+        (status = 200, description = "Circuit breaker opened"),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "durable"
+)]
+pub async fn force_open_circuit_breaker(
+    State(state): State<AppState>,
+    Path(key): Path<String>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let store = state.get_store()?;
+    store.force_open_circuit_breaker(&key).await.map_err(|e| {
+        tracing::error!("Failed to force open circuit breaker: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: "Internal server error".to_string(),
+            }),
+        )
+    })?;
+
+    tracing::info!(key = %key, "Force opened circuit breaker");
+    Ok(StatusCode::OK)
+}
+
+/// POST /v1/durable/circuit-breakers/:key/close - Force close a circuit breaker
+#[utoipa::path(
+    post,
+    path = "/v1/durable/circuit-breakers/{key}/close",
+    params(
+        ("key" = String, Path, description = "Circuit breaker key")
+    ),
+    responses(
+        (status = 200, description = "Circuit breaker closed"),
+        (status = 404, description = "Circuit breaker not found", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "durable"
+)]
+pub async fn force_close_circuit_breaker(
+    State(state): State<AppState>,
+    Path(key): Path<String>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let store = state.get_store()?;
+    store
+        .force_close_circuit_breaker(&key)
+        .await
+        .map_err(|e| match e {
+            everruns_durable::StoreError::CircuitBreakerNotFound(_) => (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: "Circuit breaker not found".to_string(),
+                }),
+            ),
+            _ => {
+                tracing::error!("Failed to force close circuit breaker: {}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: "Internal server error".to_string(),
+                    }),
+                )
+            }
+        })?;
+
+    tracing::info!(key = %key, "Force closed circuit breaker");
+    Ok(StatusCode::OK)
+}
+
+/// DELETE /v1/durable/circuit-breakers/:key - Delete/reset a circuit breaker
+#[utoipa::path(
+    delete,
+    path = "/v1/durable/circuit-breakers/{key}",
+    params(
+        ("key" = String, Path, description = "Circuit breaker key")
+    ),
+    responses(
+        (status = 200, description = "Circuit breaker deleted"),
+        (status = 404, description = "Circuit breaker not found", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "durable"
+)]
+pub async fn delete_circuit_breaker(
+    State(state): State<AppState>,
+    Path(key): Path<String>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let store = state.get_store()?;
+    store
+        .delete_circuit_breaker(&key)
+        .await
+        .map_err(|e| match e {
+            everruns_durable::StoreError::CircuitBreakerNotFound(_) => (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: "Circuit breaker not found".to_string(),
+                }),
+            ),
+            _ => {
+                tracing::error!("Failed to delete circuit breaker: {}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: "Internal server error".to_string(),
+                    }),
+                )
+            }
+        })?;
+
+    tracing::info!(key = %key, "Deleted circuit breaker");
+    Ok(StatusCode::OK)
 }
 
 // ============================================================================

--- a/crates/control-plane/src/grpc_service.rs
+++ b/crates/control-plane/src/grpc_service.rs
@@ -11,15 +11,17 @@ use everruns_control_plane::services::{
 };
 use everruns_control_plane::storage::{EncryptionService, StorageBackend};
 use everruns_durable::{
-    ActivityOptions, PostgresWorkflowEventStore, StoreError, TaskDefinition, TaskFailureOutcome,
-    WorkerInfo, WorkflowError, WorkflowEvent, WorkflowEventStore, WorkflowStatus, append_event,
+    ActivityOptions, CircuitBreakerConfig, CircuitState, DistributedCircuitBreaker,
+    PostgresWorkflowEventStore, StoreError, TaskDefinition, TaskFailureOutcome, WorkerInfo,
+    WorkflowError, WorkflowEvent, WorkflowEventStore, WorkflowStatus, append_event,
     record_activity_completed, record_activity_failed, record_activity_started,
     record_workflow_cancelled, record_workflow_completed, record_workflow_failed,
 };
 use everruns_internal_protocol::proto::{
-    self, AddMessageRequest, AddMessageResponse, ClaimDurableTasksRequest,
-    ClaimDurableTasksResponse, CommitExecRequest, CommitExecResponse, CompleteDurableTaskRequest,
-    CompleteDurableTaskResponse, CountActiveDurableWorkflowsRequest,
+    self, AddMessageRequest, AddMessageResponse, CheckCircuitBreakerRequest,
+    CheckCircuitBreakerResponse, CircuitBreakerState as ProtoCircuitBreakerState,
+    ClaimDurableTasksRequest, ClaimDurableTasksResponse, CommitExecRequest, CommitExecResponse,
+    CompleteDurableTaskRequest, CompleteDurableTaskResponse, CountActiveDurableWorkflowsRequest,
     CountActiveDurableWorkflowsResponse, CreateDurableWorkflowRequest,
     CreateDurableWorkflowResponse, DeregisterDurableWorkerRequest, DeregisterDurableWorkerResponse,
     DurableWorkflowStatus, EmitEventRequest, EmitEventResponse, EmitEventStreamResponse,
@@ -29,7 +31,9 @@ use everruns_internal_protocol::proto::{
     GetModelWithProviderRequest, GetModelWithProviderResponse, GetSessionRequest,
     GetSessionResponse, GetTurnContextRequest, GetTurnContextResponse, HeartbeatDurableTaskRequest,
     HeartbeatDurableTaskResponse, HeartbeatDurableWorkerRequest, HeartbeatDurableWorkerResponse,
-    LoadMessagesRequest, LoadMessagesResponse, RegisterDurableWorkerRequest,
+    LoadMessagesRequest, LoadMessagesResponse, RecordCircuitBreakerFailureRequest,
+    RecordCircuitBreakerFailureResponse, RecordCircuitBreakerSuccessRequest,
+    RecordCircuitBreakerSuccessResponse, RegisterDurableWorkerRequest,
     RegisterDurableWorkerResponse, SessionCreateDirectoryRequest, SessionCreateDirectoryResponse,
     SessionDeleteFileRequest, SessionDeleteFileResponse, SessionGrepFilesRequest,
     SessionGrepFilesResponse, SessionListDirectoryRequest, SessionListDirectoryResponse,
@@ -1428,9 +1432,124 @@ impl WorkerService for WorkerServiceImpl {
             tasks_reclaimed: tasks_reclaimed as i32,
         }))
     }
+
+    // ========================================================================
+    // Circuit breaker operations
+    // ========================================================================
+
+    async fn check_circuit_breaker(
+        &self,
+        request: Request<CheckCircuitBreakerRequest>,
+    ) -> Result<Response<CheckCircuitBreakerResponse>, Status> {
+        let req = request.into_inner();
+        let store = self.durable_store()?;
+
+        // Create a circuit breaker instance for this key
+        let config = CircuitBreakerConfig::default();
+        let store_dyn: Arc<dyn WorkflowEventStore> = store.clone();
+        let breaker = DistributedCircuitBreaker::new(req.key.clone(), config, store_dyn);
+
+        // Try to get a permit (this checks if the circuit allows the call)
+        match breaker.allow().await {
+            Ok(_permit) => {
+                // Permit granted - get current state
+                let state = breaker.state().await.unwrap_or(CircuitState::Closed);
+                Ok(Response::new(CheckCircuitBreakerResponse {
+                    allowed: true,
+                    state: circuit_state_to_proto(state).into(),
+                }))
+            }
+            Err(e) => {
+                // Circuit is open or half-open
+                let state = match e {
+                    everruns_durable::CircuitBreakerError::Open => CircuitState::Open,
+                    _ => {
+                        tracing::error!("Circuit breaker error: {}", e);
+                        CircuitState::Closed
+                    }
+                };
+                Ok(Response::new(CheckCircuitBreakerResponse {
+                    allowed: false,
+                    state: circuit_state_to_proto(state).into(),
+                }))
+            }
+        }
+    }
+
+    async fn record_circuit_breaker_success(
+        &self,
+        request: Request<RecordCircuitBreakerSuccessRequest>,
+    ) -> Result<Response<RecordCircuitBreakerSuccessResponse>, Status> {
+        let req = request.into_inner();
+        let store = self.durable_store()?;
+
+        // Create a circuit breaker instance and record success
+        let config = CircuitBreakerConfig::default();
+        let store_dyn: Arc<dyn WorkflowEventStore> = store.clone();
+        let breaker = DistributedCircuitBreaker::new(req.key.clone(), config, store_dyn);
+
+        // Get permit and record success
+        if let Ok(permit) = breaker.allow().await {
+            permit.success().await.map_err(|e| {
+                tracing::error!("Failed to record circuit breaker success: {}", e);
+                Status::internal("Failed to record success")
+            })?;
+        }
+
+        let state = breaker.state().await.unwrap_or(CircuitState::Closed);
+        Ok(Response::new(RecordCircuitBreakerSuccessResponse {
+            state: circuit_state_to_proto(state).into(),
+        }))
+    }
+
+    async fn record_circuit_breaker_failure(
+        &self,
+        request: Request<RecordCircuitBreakerFailureRequest>,
+    ) -> Result<Response<RecordCircuitBreakerFailureResponse>, Status> {
+        let req = request.into_inner();
+        let store = self.durable_store()?;
+
+        // Create a circuit breaker instance and record failure
+        let config = CircuitBreakerConfig::default();
+        let store_dyn: Arc<dyn WorkflowEventStore> = store.clone();
+        let breaker = DistributedCircuitBreaker::new(req.key.clone(), config, store_dyn);
+
+        // Get the state before recording failure
+        let state_before = breaker.state().await.unwrap_or(CircuitState::Closed);
+
+        // Get permit and record failure
+        if let Ok(permit) = breaker.allow().await {
+            permit.failure().await.map_err(|e| {
+                tracing::error!("Failed to record circuit breaker failure: {}", e);
+                Status::internal("Failed to record failure")
+            })?;
+        }
+
+        // Get the state after recording failure
+        let state_after = breaker.state().await.unwrap_or(CircuitState::Closed);
+        let circuit_opened =
+            state_before != CircuitState::Open && state_after == CircuitState::Open;
+
+        if circuit_opened {
+            tracing::warn!(key = %req.key, "Circuit breaker opened");
+        }
+
+        Ok(Response::new(RecordCircuitBreakerFailureResponse {
+            state: circuit_state_to_proto(state_after).into(),
+            circuit_opened,
+        }))
+    }
 }
 
 // Helper functions for status conversion
+
+fn circuit_state_to_proto(state: CircuitState) -> ProtoCircuitBreakerState {
+    match state {
+        CircuitState::Closed => ProtoCircuitBreakerState::Closed,
+        CircuitState::Open => ProtoCircuitBreakerState::Open,
+        CircuitState::HalfOpen => ProtoCircuitBreakerState::HalfOpen,
+    }
+}
 
 fn workflow_status_to_proto(status: WorkflowStatus) -> DurableWorkflowStatus {
     match status {

--- a/crates/durable/src/lib.rs
+++ b/crates/durable/src/lib.rs
@@ -105,7 +105,9 @@ pub use persistence::{
     WorkerFilter, WorkerInfo, WorkflowEventInfo, WorkflowEventStore, WorkflowFilter, WorkflowInfo,
     WorkflowInfoExtended, WorkflowStatus,
 };
-pub use reliability::{CircuitBreakerConfig, CircuitState, RetryPolicy};
+pub use reliability::{
+    CircuitBreakerConfig, CircuitBreakerError, CircuitState, DistributedCircuitBreaker, RetryPolicy,
+};
 pub use worker::{WorkerPool, WorkerPoolConfig, WorkerPoolError};
 pub use workflow::{
     ActivityOptions, Workflow, WorkflowAction, WorkflowError, WorkflowEvent, WorkflowSignal,

--- a/crates/durable/src/persistence/memory.rs
+++ b/crates/durable/src/persistence/memory.rs
@@ -611,6 +611,59 @@ impl WorkflowEventStore for InMemoryWorkflowEventStore {
         Ok(())
     }
 
+    async fn list_circuit_breakers(&self) -> Result<Vec<CircuitBreakerState>, StoreError> {
+        let breakers = self.circuit_breakers.read();
+        Ok(breakers
+            .iter()
+            .map(|(k, b)| CircuitBreakerState {
+                key: k.clone(),
+                state: b.state,
+                failure_count: b.failure_count,
+                success_count: b.success_count,
+                last_failure_at: None,
+                opened_at: b.opened_at,
+                half_open_at: None,
+                updated_at: Utc::now(),
+            })
+            .collect())
+    }
+
+    async fn force_open_circuit_breaker(&self, key: &str) -> Result<(), StoreError> {
+        let mut breakers = self.circuit_breakers.write();
+        breakers.insert(
+            key.to_string(),
+            CircuitBreakerMemState {
+                state: crate::reliability::CircuitState::Open,
+                failure_count: 0,
+                success_count: 0,
+                opened_at: Some(Utc::now()),
+            },
+        );
+        Ok(())
+    }
+
+    async fn force_close_circuit_breaker(&self, key: &str) -> Result<(), StoreError> {
+        let mut breakers = self.circuit_breakers.write();
+        if let Some(b) = breakers.get_mut(key) {
+            b.state = crate::reliability::CircuitState::Closed;
+            b.failure_count = 0;
+            b.success_count = 0;
+            b.opened_at = None;
+            Ok(())
+        } else {
+            Err(StoreError::CircuitBreakerNotFound(key.to_string()))
+        }
+    }
+
+    async fn delete_circuit_breaker(&self, key: &str) -> Result<(), StoreError> {
+        let mut breakers = self.circuit_breakers.write();
+        if breakers.remove(key).is_some() {
+            Ok(())
+        } else {
+            Err(StoreError::CircuitBreakerNotFound(key.to_string()))
+        }
+    }
+
     // Worker management methods
     async fn register_worker(&self, worker: WorkerInfo) -> Result<(), StoreError> {
         let mut workers = self.workers.write();

--- a/crates/durable/src/persistence/postgres.rs
+++ b/crates/durable/src/persistence/postgres.rs
@@ -1378,6 +1378,103 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
     }
 
     #[instrument(skip(self))]
+    async fn force_open_circuit_breaker(&self, key: &str) -> Result<(), StoreError> {
+        let result = sqlx::query(
+            r#"
+            UPDATE durable_circuit_breaker_state
+            SET state = 'open',
+                failure_count = 0,
+                success_count = 0,
+                opened_at = NOW(),
+                updated_at = NOW()
+            WHERE key = $1
+            "#,
+        )
+        .bind(key)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| {
+            error!("Failed to force open circuit breaker: {}", e);
+            StoreError::Database(e.to_string())
+        })?;
+
+        if result.rows_affected() == 0 {
+            // Circuit breaker doesn't exist, create it in open state
+            sqlx::query(
+                r#"
+                INSERT INTO durable_circuit_breaker_state
+                    (key, state, failure_count, success_count, opened_at, updated_at)
+                VALUES ($1, 'open', 0, 0, NOW(), NOW())
+                "#,
+            )
+            .bind(key)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| {
+                error!("Failed to create circuit breaker in open state: {}", e);
+                StoreError::Database(e.to_string())
+            })?;
+        }
+
+        info!(key, "force opened circuit breaker");
+        Ok(())
+    }
+
+    #[instrument(skip(self))]
+    async fn force_close_circuit_breaker(&self, key: &str) -> Result<(), StoreError> {
+        let result = sqlx::query(
+            r#"
+            UPDATE durable_circuit_breaker_state
+            SET state = 'closed',
+                failure_count = 0,
+                success_count = 0,
+                opened_at = NULL,
+                half_open_at = NULL,
+                updated_at = NOW()
+            WHERE key = $1
+            "#,
+        )
+        .bind(key)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| {
+            error!("Failed to force close circuit breaker: {}", e);
+            StoreError::Database(e.to_string())
+        })?;
+
+        if result.rows_affected() == 0 {
+            return Err(StoreError::CircuitBreakerNotFound(key.to_string()));
+        }
+
+        info!(key, "force closed circuit breaker");
+        Ok(())
+    }
+
+    #[instrument(skip(self))]
+    async fn delete_circuit_breaker(&self, key: &str) -> Result<(), StoreError> {
+        let result = sqlx::query(
+            r#"
+            DELETE FROM durable_circuit_breaker_state
+            WHERE key = $1
+            "#,
+        )
+        .bind(key)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| {
+            error!("Failed to delete circuit breaker: {}", e);
+            StoreError::Database(e.to_string())
+        })?;
+
+        if result.rows_affected() == 0 {
+            return Err(StoreError::CircuitBreakerNotFound(key.to_string()));
+        }
+
+        info!(key, "deleted circuit breaker");
+        Ok(())
+    }
+
+    #[instrument(skip(self))]
     async fn drain_worker(&self, worker_id: &str) -> Result<(), StoreError> {
         sqlx::query(
             r#"

--- a/crates/durable/src/persistence/store.rs
+++ b/crates/durable/src/persistence/store.rs
@@ -24,6 +24,10 @@ pub enum StoreError {
     #[error("task {0} not owned by worker (was reclaimed or already completed)")]
     TaskNotOwned(Uuid),
 
+    /// Circuit breaker not found
+    #[error("circuit breaker not found: {0}")]
+    CircuitBreakerNotFound(String),
+
     /// Concurrency conflict (optimistic locking failed)
     #[error("concurrency conflict: expected sequence {expected}, got {actual}")]
     ConcurrencyConflict { expected: i32, actual: i32 },
@@ -554,6 +558,21 @@ pub trait WorkflowEventStore: Send + Sync + 'static {
     /// List all circuit breakers
     async fn list_circuit_breakers(&self) -> Result<Vec<CircuitBreakerState>, StoreError> {
         Ok(vec![])
+    }
+
+    /// Force a circuit breaker to open (admin operation)
+    async fn force_open_circuit_breaker(&self, _key: &str) -> Result<(), StoreError> {
+        Ok(())
+    }
+
+    /// Force a circuit breaker to close (admin operation)
+    async fn force_close_circuit_breaker(&self, _key: &str) -> Result<(), StoreError> {
+        Ok(())
+    }
+
+    /// Delete a circuit breaker (reset to default)
+    async fn delete_circuit_breaker(&self, _key: &str) -> Result<(), StoreError> {
+        Ok(())
     }
 
     /// Drain a worker (set status to draining, stop accepting new tasks)

--- a/crates/durable/src/reliability/distributed_circuit_breaker.rs
+++ b/crates/durable/src/reliability/distributed_circuit_breaker.rs
@@ -352,6 +352,24 @@ impl DistributedCircuitBreaker {
     pub async fn reset(&self) -> Result<(), CircuitBreakerError> {
         self.transition_to_closed().await
     }
+
+    /// Force the circuit breaker to open (admin operation)
+    ///
+    /// This immediately opens the circuit, rejecting all subsequent calls
+    /// until either the reset timeout passes or force_close is called.
+    pub async fn force_open(&self) -> Result<(), CircuitBreakerError> {
+        tracing::info!(key = %self.key, "Force opening circuit breaker");
+        self.transition_to_open().await
+    }
+
+    /// Force the circuit breaker to close (admin operation)
+    ///
+    /// This immediately closes the circuit, allowing calls to proceed.
+    /// Alias for reset() but with clearer intent for admin operations.
+    pub async fn force_close(&self) -> Result<(), CircuitBreakerError> {
+        tracing::info!(key = %self.key, "Force closing circuit breaker");
+        self.transition_to_closed().await
+    }
 }
 
 #[cfg(test)]
@@ -480,5 +498,51 @@ mod tests {
         breaker.reset().await.unwrap();
         let state = breaker.state().await.unwrap();
         assert_eq!(state, CircuitState::Closed);
+    }
+
+    #[tokio::test]
+    async fn test_force_open() {
+        let breaker = create_test_breaker().await;
+
+        // Circuit starts closed
+        let state = breaker.state().await.unwrap();
+        assert_eq!(state, CircuitState::Closed);
+
+        // Force open should work immediately
+        breaker.force_open().await.unwrap();
+
+        // Circuit should be open now
+        let state = breaker.state().await.unwrap();
+        assert_eq!(state, CircuitState::Open);
+
+        // Calls should be rejected
+        let result = breaker.allow().await;
+        assert!(matches!(result, Err(CircuitBreakerError::Open)));
+    }
+
+    #[tokio::test]
+    async fn test_force_close() {
+        let breaker = create_test_breaker().await;
+
+        // Open the circuit via failures
+        for _ in 0..3 {
+            let permit = breaker.allow().await.unwrap();
+            permit.failure().await.unwrap();
+        }
+
+        // Circuit should be open
+        let state = breaker.state().await.unwrap();
+        assert_eq!(state, CircuitState::Open);
+
+        // Force close should work immediately (without waiting for timeout)
+        breaker.force_close().await.unwrap();
+
+        // Circuit should be closed now
+        let state = breaker.state().await.unwrap();
+        assert_eq!(state, CircuitState::Closed);
+
+        // Calls should be allowed
+        let permit = breaker.allow().await;
+        assert!(permit.is_ok());
     }
 }

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -90,6 +90,18 @@ service WorkerService {
 
     // Deregister a durable worker
     rpc DeregisterDurableWorker(DeregisterDurableWorkerRequest) returns (DeregisterDurableWorkerResponse);
+
+    // === Circuit breaker operations ===
+    // Used by workers to check circuit breaker state before external calls
+
+    // Check if a circuit breaker allows the call
+    rpc CheckCircuitBreaker(CheckCircuitBreakerRequest) returns (CheckCircuitBreakerResponse);
+
+    // Record a successful call (circuit breaker tracking)
+    rpc RecordCircuitBreakerSuccess(RecordCircuitBreakerSuccessRequest) returns (RecordCircuitBreakerSuccessResponse);
+
+    // Record a failed call (circuit breaker tracking)
+    rpc RecordCircuitBreakerFailure(RecordCircuitBreakerFailureRequest) returns (RecordCircuitBreakerFailureResponse);
 }
 
 // ============================================================================
@@ -595,4 +607,54 @@ message DeregisterDurableWorkerResponse {
     bool deregistered = 1;
     // Number of tasks that were reclaimed (set back to pending) during deregistration
     int32 tasks_reclaimed = 2;
+}
+
+// ============================================================================
+// Circuit breaker types
+// ============================================================================
+
+// Circuit breaker state enum
+enum CircuitBreakerState {
+    CIRCUIT_BREAKER_STATE_UNSPECIFIED = 0;
+    CIRCUIT_BREAKER_STATE_CLOSED = 1;
+    CIRCUIT_BREAKER_STATE_OPEN = 2;
+    CIRCUIT_BREAKER_STATE_HALF_OPEN = 3;
+}
+
+// === Check circuit breaker ===
+
+message CheckCircuitBreakerRequest {
+    // Key identifying the circuit breaker (e.g., "llm:openai", "llm:anthropic")
+    string key = 1;
+}
+
+message CheckCircuitBreakerResponse {
+    // Whether the call is allowed
+    bool allowed = 1;
+    // Current state of the circuit breaker
+    CircuitBreakerState state = 2;
+}
+
+// === Record success ===
+
+message RecordCircuitBreakerSuccessRequest {
+    string key = 1;
+}
+
+message RecordCircuitBreakerSuccessResponse {
+    // New state after recording success
+    CircuitBreakerState state = 1;
+}
+
+// === Record failure ===
+
+message RecordCircuitBreakerFailureRequest {
+    string key = 1;
+}
+
+message RecordCircuitBreakerFailureResponse {
+    // New state after recording failure
+    CircuitBreakerState state = 1;
+    // Whether the circuit is now open (tripped)
+    bool circuit_opened = 2;
 }

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -331,7 +331,10 @@ impl DurableWorker {
                     .map_err(|e| anyhow::anyhow!("Failed to parse task input: {}", e))?;
                 let res = match task.activity_type.as_str() {
                     "process_input" => self.execute_input_activity(grpc_client, &turn_input).await,
-                    "reason" => self.execute_reason_activity(grpc_client, &turn_input).await,
+                    "reason" => {
+                        self.execute_reason_activity(grpc_client, &turn_input, self.store.clone())
+                            .await
+                    }
                     _ => unreachable!(),
                 };
                 (res, Some(turn_input))
@@ -451,15 +454,47 @@ impl DurableWorker {
     }
 
     /// Execute reasoning activity (LLM call)
+    ///
+    /// This activity is protected by a circuit breaker to prevent cascading
+    /// failures when the LLM provider is unavailable.
     async fn execute_reason_activity(
         &self,
         grpc_client: GrpcClient,
         input: &DurableTurnInput,
+        store: Arc<Mutex<GrpcDurableStore>>,
     ) -> Result<serde_json::Value> {
         debug!(
             session_id = %input.session_id,
             "Executing reason activity"
         );
+
+        // Circuit breaker key for LLM calls
+        // TODO: Make this per-provider (openai, anthropic) based on model config
+        let circuit_key = "llm";
+
+        // Check circuit breaker before making LLM call
+        {
+            let mut store_guard = store.lock().await;
+            let check = store_guard.check_circuit_breaker(circuit_key).await;
+            match check {
+                Ok(result) => {
+                    if !result.allowed {
+                        warn!(
+                            circuit_key = circuit_key,
+                            state = ?result.state,
+                            "Circuit breaker is open - rejecting LLM call"
+                        );
+                        return Err(anyhow::anyhow!(
+                            "LLM provider temporarily unavailable (circuit breaker open)"
+                        ));
+                    }
+                }
+                Err(e) => {
+                    // Log but continue - don't block on circuit breaker check failure
+                    warn!(error = %e, "Failed to check circuit breaker, proceeding anyway");
+                }
+            }
+        }
 
         // Create AtomContext for this execution
         let context = AtomContext {
@@ -475,8 +510,42 @@ impl DurableWorker {
         };
 
         // Use the existing reason_activity function with gRPC adapters
-        let result = reason_activity(grpc_client, reason_input).await?;
+        let result = reason_activity(grpc_client, reason_input).await;
 
+        // Record circuit breaker outcome
+        {
+            let mut store_guard = store.lock().await;
+            match &result {
+                Ok(_) => {
+                    if let Err(e) = store_guard
+                        .record_circuit_breaker_success(circuit_key)
+                        .await
+                    {
+                        warn!(error = %e, "Failed to record circuit breaker success");
+                    }
+                }
+                Err(_) => {
+                    match store_guard
+                        .record_circuit_breaker_failure(circuit_key)
+                        .await
+                    {
+                        Ok(failure_result) => {
+                            if failure_result.circuit_opened {
+                                warn!(
+                                    circuit_key = circuit_key,
+                                    "Circuit breaker opened due to LLM failures"
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            warn!(error = %e, "Failed to record circuit breaker failure");
+                        }
+                    }
+                }
+            }
+        }
+
+        let result = result?;
         Ok(serde_json::to_value(&result)?)
     }
 

--- a/crates/worker/src/grpc_durable_store.rs
+++ b/crates/worker/src/grpc_durable_store.rs
@@ -4,11 +4,13 @@
 
 use anyhow::Result;
 use everruns_internal_protocol::proto::{
-    self, ClaimDurableTasksRequest, CompleteDurableTaskRequest, CountActiveDurableWorkflowsRequest,
-    CreateDurableWorkflowRequest, DeregisterDurableWorkerRequest, DurableActivityOptions,
-    DurableTaskDefinition, EnqueueDurableTaskRequest, FailDurableTaskRequest,
-    GetDurableWorkflowStatusRequest, HeartbeatDurableTaskRequest, HeartbeatDurableWorkerRequest,
-    RegisterDurableWorkerRequest, UpdateDurableWorkflowStatusRequest,
+    self, CheckCircuitBreakerRequest, ClaimDurableTasksRequest, CompleteDurableTaskRequest,
+    CountActiveDurableWorkflowsRequest, CreateDurableWorkflowRequest,
+    DeregisterDurableWorkerRequest, DurableActivityOptions, DurableTaskDefinition,
+    EnqueueDurableTaskRequest, FailDurableTaskRequest, GetDurableWorkflowStatusRequest,
+    HeartbeatDurableTaskRequest, HeartbeatDurableWorkerRequest, RecordCircuitBreakerFailureRequest,
+    RecordCircuitBreakerSuccessRequest, RegisterDurableWorkerRequest,
+    UpdateDurableWorkflowStatusRequest,
 };
 use everruns_internal_protocol::{WorkerServiceClient, json_to_proto_struct, uuid_to_proto_uuid};
 use tonic::transport::Channel;
@@ -280,6 +282,57 @@ impl GrpcDurableStore {
         let response = self.client.deregister_durable_worker(request).await?;
         Ok(response.into_inner().tasks_reclaimed as usize)
     }
+
+    // ========================================================================
+    // Circuit breaker operations
+    // ========================================================================
+
+    /// Check if a circuit breaker allows a call
+    ///
+    /// Returns true if the call is allowed, false if the circuit is open.
+    pub async fn check_circuit_breaker(&mut self, key: &str) -> Result<CircuitBreakerCheck> {
+        let request = CheckCircuitBreakerRequest {
+            key: key.to_string(),
+        };
+
+        let response = self.client.check_circuit_breaker(request).await?;
+        let inner = response.into_inner();
+
+        Ok(CircuitBreakerCheck {
+            allowed: inner.allowed,
+            state: proto_state_to_circuit_state(inner.state()),
+        })
+    }
+
+    /// Record a successful call to update circuit breaker state
+    pub async fn record_circuit_breaker_success(&mut self, key: &str) -> Result<CircuitState> {
+        let request = RecordCircuitBreakerSuccessRequest {
+            key: key.to_string(),
+        };
+
+        let response = self.client.record_circuit_breaker_success(request).await?;
+        Ok(proto_state_to_circuit_state(response.into_inner().state()))
+    }
+
+    /// Record a failed call to update circuit breaker state
+    ///
+    /// Returns the new state and whether the circuit just opened (tripped).
+    pub async fn record_circuit_breaker_failure(
+        &mut self,
+        key: &str,
+    ) -> Result<CircuitBreakerFailureResult> {
+        let request = RecordCircuitBreakerFailureRequest {
+            key: key.to_string(),
+        };
+
+        let response = self.client.record_circuit_breaker_failure(request).await?;
+        let inner = response.into_inner();
+
+        Ok(CircuitBreakerFailureResult {
+            state: proto_state_to_circuit_state(inner.state()),
+            circuit_opened: inner.circuit_opened,
+        })
+    }
 }
 
 // ============================================================================
@@ -302,6 +355,28 @@ pub struct ClaimedTask {
 pub struct HeartbeatResponse {
     pub acknowledged: bool,
     pub should_cancel: bool,
+}
+
+/// Circuit breaker state
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CircuitState {
+    Closed,
+    Open,
+    HalfOpen,
+}
+
+/// Result of checking a circuit breaker
+#[derive(Debug, Clone)]
+pub struct CircuitBreakerCheck {
+    pub allowed: bool,
+    pub state: CircuitState,
+}
+
+/// Result of recording a circuit breaker failure
+#[derive(Debug, Clone)]
+pub struct CircuitBreakerFailureResult {
+    pub state: CircuitState,
+    pub circuit_opened: bool,
 }
 
 /// Workflow status (mirrors everruns_durable::WorkflowStatus)
@@ -347,6 +422,15 @@ fn proto_status_to_workflow(status: proto::DurableWorkflowStatus) -> WorkflowSta
         proto::DurableWorkflowStatus::Failed => WorkflowStatus::Failed,
         proto::DurableWorkflowStatus::Cancelled => WorkflowStatus::Cancelled,
         proto::DurableWorkflowStatus::Unspecified => WorkflowStatus::Pending,
+    }
+}
+
+fn proto_state_to_circuit_state(state: proto::CircuitBreakerState) -> CircuitState {
+    match state {
+        proto::CircuitBreakerState::Closed => CircuitState::Closed,
+        proto::CircuitBreakerState::Open => CircuitState::Open,
+        proto::CircuitBreakerState::HalfOpen => CircuitState::HalfOpen,
+        proto::CircuitBreakerState::Unspecified => CircuitState::Closed,
     }
 }
 


### PR DESCRIPTION
## What
Integrates circuit breaker pattern into the durable execution engine to protect against LLM provider failures.

## Why
When LLM providers experience outages or high latency, we need to fail fast rather than let requests queue up and timeout. Circuit breakers automatically detect failures and temporarily block new requests.

## How

### Circuit Breaker States
- **Closed**: Normal operation - calls go through
- **Open**: Provider failing - calls rejected immediately
- **Half-Open**: Testing recovery - one call allowed to check if service recovered

### Changes
1. **Durable Engine**: Abstract circuit breaker with PostgreSQL-backed state
2. **gRPC Protocol**: Worker-control-plane communication for circuit breaker ops
3. **Worker**: Check circuit before LLM calls, record success/failure after
4. **HTTP API**: Admin endpoints for viewing and managing circuit breakers
5. **UI**: Admin page at /durable/circuit-breakers with Force Open/Close controls

### API Endpoints
- GET /v1/durable/circuit-breakers - List all
- GET /v1/durable/circuit-breakers/:key - Get one
- POST /v1/durable/circuit-breakers/:key/open - Force open
- POST /v1/durable/circuit-breakers/:key/close - Force close
- DELETE /v1/durable/circuit-breakers/:key - Reset/delete

## Risk
- Medium - New functionality, doesn't change existing behavior unless circuit trips

## Test Plan
- [x] Unit tests (103 tests pass)
- [x] Clippy passes
- [x] UI builds successfully