### PR TITLE
fix(dev): ensure Jaeger is started in start-all to prevent span processor errors

### DIFF
--- a/crates/core/src/telemetry.rs
+++ b/crates/core/src/telemetry.rs
@@ -196,6 +196,7 @@ impl TelemetryConfig {
     /// Create configuration from environment variables
     ///
     /// Environment variables:
+    /// - `OTEL_SDK_DISABLED`: If "true", disables OpenTelemetry tracing entirely
     /// - `OTEL_SERVICE_NAME`: Service name (default: "everruns")
     /// - `OTEL_SERVICE_VERSION`: Service version
     /// - `OTEL_EXPORTER_OTLP_ENDPOINT`: OTLP endpoint (e.g., "http://localhost:4317")
@@ -203,11 +204,21 @@ impl TelemetryConfig {
     /// - `RUST_LOG` or `LOG_LEVEL`: Log filter
     /// - `OTEL_RECORD_CONTENT`: Whether to record input/output content ("true" to enable)
     pub fn from_env() -> Self {
+        // Check if SDK is disabled via environment variable
+        let sdk_disabled = std::env::var("OTEL_SDK_DISABLED")
+            .map(|v| v.to_lowercase() == "true")
+            .unwrap_or(false);
+
         Self {
             service_name: std::env::var("OTEL_SERVICE_NAME")
                 .unwrap_or_else(|_| "everruns".to_string()),
             service_version: std::env::var("OTEL_SERVICE_VERSION").ok(),
-            otlp_endpoint: std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok(),
+            // Don't configure OTLP endpoint if SDK is disabled
+            otlp_endpoint: if sdk_disabled {
+                None
+            } else {
+                std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok()
+            },
             environment: std::env::var("OTEL_ENVIRONMENT").ok(),
             enable_console: true,
             log_filter: std::env::var("RUST_LOG")

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -460,19 +460,45 @@ case "$command" in
     # Check PostgreSQL (can be local or Docker)
     echo "1️⃣  Checking PostgreSQL..."
 
+    # Track whether we need to start Jaeger
+    JAEGER_STARTED=false
+
     # Try local postgres first, then Docker
     if pg_isready -h localhost -p 5432 > /dev/null 2>&1; then
       echo "   ✅ Local PostgreSQL is ready"
       export DATABASE_URL=${DATABASE_URL:-postgres://postgres:postgres@localhost/everruns}
+      # Start Jaeger via Docker if available (for tracing support)
+      if resolve_docker_compose 2>/dev/null; then
+        if ! docker ps 2>/dev/null | grep -q jaeger; then
+          echo "   ℹ️  Starting Jaeger for tracing..."
+          ensure_docker_daemon || true
+          cd "$PROJECT_ROOT/harness"
+          "${DOCKER_COMPOSE[@]}" up -d jaeger 2>/dev/null && JAEGER_STARTED=true
+          cd "$PROJECT_ROOT"
+        else
+          JAEGER_STARTED=true
+        fi
+      fi
     elif command -v docker &> /dev/null && docker ps 2>/dev/null | grep -q postgres; then
       echo "   ✅ Docker PostgreSQL is ready"
       export DATABASE_URL=${DATABASE_URL:-postgres://everruns:everruns@localhost:5432/everruns}
+      # Ensure Jaeger is also running
+      if ! docker ps 2>/dev/null | grep -q jaeger; then
+        echo "   ℹ️  Starting Jaeger for tracing..."
+        if resolve_docker_compose 2>/dev/null; then
+          cd "$PROJECT_ROOT/harness"
+          "${DOCKER_COMPOSE[@]}" up -d jaeger 2>/dev/null && JAEGER_STARTED=true
+          cd "$PROJECT_ROOT"
+        fi
+      else
+        JAEGER_STARTED=true
+      fi
     else
       echo "   ⚠️  PostgreSQL not found. Starting via Docker..."
       if resolve_docker_compose; then
         ensure_docker_daemon || exit 1
         cd "$PROJECT_ROOT/harness"
-        "${DOCKER_COMPOSE[@]}" up -d postgres
+        "${DOCKER_COMPOSE[@]}" up -d postgres jaeger
         cd "$PROJECT_ROOT"
         sleep 3
         until docker exec everruns-postgres pg_isready -U everruns -d everruns > /dev/null 2>&1; do
@@ -480,11 +506,18 @@ case "$command" in
           sleep 1
         done
         export DATABASE_URL=${DATABASE_URL:-postgres://everruns:everruns@localhost:5432/everruns}
-        echo "   ✅ Docker PostgreSQL started"
+        echo "   ✅ Docker PostgreSQL and Jaeger started"
+        JAEGER_STARTED=true
       else
         echo "   ❌ No PostgreSQL available. Start PostgreSQL or install Docker."
         exit 1
       fi
+    fi
+
+    # If Jaeger is not running, disable OpenTelemetry to avoid connection errors
+    if [ "$JAEGER_STARTED" = false ]; then
+      echo "   ⚠️  Jaeger not available, disabling OpenTelemetry tracing"
+      export OTEL_SDK_DISABLED=true
     fi
 
     # Run migrations
@@ -561,7 +594,11 @@ case "$command" in
     echo "   📖 API Docs:    http://localhost:9000/swagger-ui/"
     echo "   ⚙️ Worker:      running (auto-reload)"
     echo "   🖥️ UI:          http://localhost:9100 (hot reload)"
-    echo "   🔍 Jaeger UI:   http://localhost:16686"
+    if [ "$JAEGER_STARTED" = true ]; then
+      echo "   🔍 Jaeger UI:   http://localhost:16686"
+    else
+      echo "   🔍 Jaeger:      disabled (no Docker)"
+    fi
     echo ""
     echo "👀 Edit code in crates/ and services will auto-restart"
     echo "💡 Press Ctrl+C to stop services"


### PR DESCRIPTION
## What
Fixes `BatchSpanProcessor.ExportError` "tcp connect error" that occurred when using `./scripts/dev.sh start-all`.

## Why
The OpenTelemetry BatchSpanProcessor was failing because Jaeger was not being started alongside PostgreSQL in the `start-all` command, but the services were still trying to export spans.

## How
1. **`scripts/dev.sh`**: Updated `start-all` to:
   - Start Jaeger container when starting PostgreSQL via Docker
   - Start Jaeger when local/Docker PostgreSQL is already running (if Docker is available)
   - Set `OTEL_SDK_DISABLED=true` as fallback when Jaeger cannot be started
   - Conditionally show Jaeger URL in output based on availability

2. **`crates/core/src/telemetry.rs`**: Updated `TelemetryConfig::from_env()` to:
   - Check and respect `OTEL_SDK_DISABLED=true` environment variable
   - Skip configuring OTLP endpoint when SDK is disabled

## Risk
- Low
- Only affects development tooling, no production impact

## Smoke Test Results

### Environment
- Mode: No-Docker (PostgreSQL started manually)
- Date: 2026-01-15

### API Test Results

| Test | Status |
|------|--------|
| Health Check | PASS |
| Auth Config | PASS |
| Create Agent | PASS |
| Get Agent | PASS |
| Update Agent | PASS |
| List Agents | PASS |
| Create Session | PASS |
| Get Session | PASS |
| Send Message | PASS |
| List Messages | PASS |
| Workflow Execution | PASS |
| List Sessions | PASS |
| OpenAPI Spec | PASS |
| LLM Providers | PASS |

### Durable Execution Engine Results

| Test | Status |
|------|--------|
| Unit Tests (101) | PASS |
| Clippy Lints | PASS |

### Summary
- API Tests: 14/14 passing
- Durable Tests: 101 unit tests + clippy passing
- Blocking issues: None