### PR TITLE
fix: remove outdated Temporal reference from dev.sh

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -568,8 +568,8 @@ case "$command" in
       sleep 2
     done
 
-    # Start Worker in background with auto-reload (Temporal mode)
-    echo "6️⃣  Starting Temporal worker with auto-reload..."
+    # Start Worker in background with auto-reload
+    echo "6️⃣  Starting worker with auto-reload..."
     cargo watch -w crates -x 'run -p everruns-worker' &
     WORKER_PID=$!
     CHILD_PIDS+=("$WORKER_PID")


### PR DESCRIPTION
## What
Remove stale Temporal reference from worker startup message in dev.sh.

## Why
Temporal was replaced with PostgreSQL-backed durable execution. The startup message still said "Starting Temporal worker..." which is confusing.

## How
Updated comment and echo message in `scripts/dev.sh` to remove Temporal reference.

## Risk
- Low
- No functional change, just message text

## Checklist
- [x] Verified other Temporal references are appropriate (changelog, dismissed-options spec)
- [x] No tests needed (message-only change)