### PR TITLE
refactor: remove database trigger, implement usage tracking in Rust

### DIFF
--- a/crates/control-plane/migrations/010_remove_usage_trigger.sql
+++ b/crates/control-plane/migrations/010_remove_usage_trigger.sql
@@ -1,0 +1,32 @@
+-- Migration: Remove usage tracking trigger, move logic to Rust
+--
+-- Rationale (see specs/architecture.md):
+-- 1. Triggers are invisible to application code and hard to debug
+-- 2. Triggers don't work in DEV_MODE (in-memory storage)
+-- 3. Triggers create hidden coupling between tables
+-- 4. All primary keys should use uuidv7() for consistency
+--
+-- This migration:
+-- 1. Drops the trigger that auto-populates llm_generations
+-- 2. Drops the trigger function
+-- 3. Changes llm_generations.id default to uuidv7()
+--
+-- The logic is now implemented in Rust via UsageTrackingListener (EventListener pattern).
+
+-- ============================================================================
+-- 1. Drop the trigger
+-- ============================================================================
+
+DROP TRIGGER IF EXISTS trigger_process_llm_generation ON events;
+
+-- ============================================================================
+-- 2. Drop the trigger function
+-- ============================================================================
+
+DROP FUNCTION IF EXISTS process_llm_generation_event();
+
+-- ============================================================================
+-- 3. Change llm_generations.id default to uuidv7()
+-- ============================================================================
+
+ALTER TABLE llm_generations ALTER COLUMN id SET DEFAULT uuidv7();

--- a/crates/control-plane/src/main.rs
+++ b/crates/control-plane/src/main.rs
@@ -164,14 +164,17 @@ async fn main() -> Result<()> {
     let sessions_state = api::sessions::AppState::new(db.clone());
     let messages_state = api::messages::AppState::new(db.clone(), runner.clone());
 
-    // Create event listeners for observability
+    // Create event listeners for observability and tracking
     // OtelEventListener generates gen-ai semantic convention spans from events
     let otel_listener: Arc<dyn EventListener> = Arc::new(OtelEventListener::new());
+    // UsageTrackingListener tracks LLM token usage in llm_generations table
+    let usage_listener: Arc<dyn EventListener> =
+        Arc::new(services::UsageTrackingListener::new(db.clone()));
 
     // Create EventService with listeners - shared between HTTP API and gRPC service
     let event_service = Arc::new(services::EventService::with_listeners(
         db.clone(),
-        vec![otel_listener],
+        vec![otel_listener, usage_listener],
     ));
 
     let events_state = api::events::AppState {

--- a/crates/control-plane/src/services/mod.rs
+++ b/crates/control-plane/src/services/mod.rs
@@ -11,6 +11,7 @@ pub mod mcp_server;
 pub mod message;
 pub mod session;
 pub mod session_file;
+pub mod usage_tracking;
 
 pub use agent::AgentService;
 pub use capability::CapabilityService;
@@ -22,3 +23,4 @@ pub use mcp_server::McpServerService;
 pub use message::MessageService;
 pub use session::SessionService;
 pub use session_file::SessionFileService;
+pub use usage_tracking::UsageTrackingListener;

--- a/crates/control-plane/src/services/usage_tracking.rs
+++ b/crates/control-plane/src/services/usage_tracking.rs
@@ -1,0 +1,121 @@
+// Usage Tracking Listener
+//
+// This listener processes llm.generation events and:
+// 1. Inserts records into llm_generations table
+// 2. Updates denormalized totals on sessions and agents
+//
+// This replaces the database trigger that was previously used
+// (see specs/architecture.md for rationale on no-trigger policy).
+
+use async_trait::async_trait;
+use everruns_core::{Event, EventData, EventListener, LLM_GENERATION};
+use std::sync::Arc;
+use tracing::{error, instrument};
+
+use crate::storage::StorageBackend;
+
+/// Event listener that tracks LLM usage statistics.
+///
+/// Processes `llm.generation` events and updates:
+/// - `llm_generations` table (source of truth for individual generations)
+/// - `sessions` table (denormalized totals)
+/// - `agents` table (denormalized totals)
+pub struct UsageTrackingListener {
+    db: Arc<StorageBackend>,
+}
+
+impl UsageTrackingListener {
+    pub fn new(db: Arc<StorageBackend>) -> Self {
+        Self { db }
+    }
+}
+
+#[async_trait]
+impl EventListener for UsageTrackingListener {
+    #[instrument(skip(self, event), fields(event_id = %event.id, session_id = %event.session_id))]
+    async fn on_event(&self, event: &Event) {
+        // Extract LLM generation data
+        let EventData::LlmGeneration(data) = &event.data else {
+            return;
+        };
+
+        // Extract usage data
+        let usage = match &data.metadata.usage {
+            Some(u) => u,
+            None => {
+                // No usage data, nothing to track
+                return;
+            }
+        };
+
+        let input_tokens = usage.input_tokens as i64;
+        let output_tokens = usage.output_tokens as i64;
+        let cache_read_tokens = usage.cache_read_tokens.unwrap_or(0) as i64;
+        let cache_creation_tokens = usage.cache_creation_tokens.unwrap_or(0) as i64;
+
+        // Insert into llm_generations
+        if let Err(e) = self
+            .db
+            .create_llm_generation(
+                event.session_id,
+                event.context.turn_id,
+                Some(event.id),
+                data.metadata.model.clone(),
+                data.metadata.provider.clone(),
+                input_tokens,
+                output_tokens,
+                cache_read_tokens,
+                cache_creation_tokens,
+                data.metadata.duration_ms.map(|d| d as i32),
+                data.metadata
+                    .finish_reasons
+                    .as_ref()
+                    .and_then(|r| r.first().cloned()),
+                event.ts,
+            )
+            .await
+        {
+            error!("Failed to insert llm_generation: {}", e);
+            return;
+        }
+
+        // Update session totals
+        if let Err(e) = self
+            .db
+            .increment_session_usage(
+                event.session_id,
+                input_tokens,
+                output_tokens,
+                cache_read_tokens,
+                cache_creation_tokens,
+            )
+            .await
+        {
+            error!("Failed to update session usage: {}", e);
+        }
+
+        // Update agent totals (need to get agent_id from session)
+        if let Ok(Some(session)) = self.db.get_session(event.session_id).await
+            && let Err(e) = self
+                .db
+                .increment_agent_usage(
+                    session.agent_id,
+                    input_tokens,
+                    output_tokens,
+                    cache_read_tokens,
+                    cache_creation_tokens,
+                )
+                .await
+        {
+            error!("Failed to update agent usage: {}", e);
+        }
+    }
+
+    fn event_types(&self) -> Option<Vec<&'static str>> {
+        Some(vec![LLM_GENERATION])
+    }
+
+    fn name(&self) -> &'static str {
+        "UsageTrackingListener"
+    }
+}

--- a/crates/control-plane/src/storage/backend.rs
+++ b/crates/control-plane/src/storage/backend.rs
@@ -532,4 +532,80 @@ impl StorageBackend {
     pub async fn delete_mcp_server(&self, id: Uuid) -> Result<bool> {
         dispatch!(self, delete_mcp_server, id)
     }
+
+    // ============================================
+    // LLM Generations (Usage Tracking)
+    // ============================================
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn create_llm_generation(
+        &self,
+        session_id: Uuid,
+        turn_id: Option<Uuid>,
+        event_id: Option<Uuid>,
+        model: String,
+        provider: Option<String>,
+        input_tokens: i64,
+        output_tokens: i64,
+        cache_read_tokens: i64,
+        cache_creation_tokens: i64,
+        duration_ms: Option<i32>,
+        finish_reason: Option<String>,
+        created_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<()> {
+        dispatch!(
+            self,
+            create_llm_generation,
+            session_id,
+            turn_id,
+            event_id,
+            model,
+            provider,
+            input_tokens,
+            output_tokens,
+            cache_read_tokens,
+            cache_creation_tokens,
+            duration_ms,
+            finish_reason,
+            created_at
+        )
+    }
+
+    pub async fn increment_session_usage(
+        &self,
+        session_id: Uuid,
+        input_tokens: i64,
+        output_tokens: i64,
+        cache_read_tokens: i64,
+        cache_creation_tokens: i64,
+    ) -> Result<()> {
+        dispatch!(
+            self,
+            increment_session_usage,
+            session_id,
+            input_tokens,
+            output_tokens,
+            cache_read_tokens,
+            cache_creation_tokens
+        )
+    }
+
+    pub async fn increment_agent_usage(
+        &self,
+        agent_id: Uuid,
+        input_tokens: i64,
+        output_tokens: i64,
+        cache_read_tokens: i64,
+        cache_creation_tokens: i64,
+    ) -> Result<()> {
+        dispatch!(
+            self,
+            increment_agent_usage,
+            agent_id,
+            input_tokens,
+            output_tokens,
+            cache_read_tokens,
+            cache_creation_tokens
+        )
+    }
 }

--- a/crates/control-plane/src/storage/memory.rs
+++ b/crates/control-plane/src/storage/memory.rs
@@ -1472,6 +1472,71 @@ impl InMemoryDatabase {
     pub async fn delete_mcp_server(&self, id: Uuid) -> Result<bool> {
         Ok(self.mcp_servers.write().remove(&id).is_some())
     }
+
+    // ============================================
+    // LLM Generations (Usage Tracking)
+    // ============================================
+    //
+    // In-memory implementations for dev mode.
+    // Note: llm_generations table is not stored in memory since it's only
+    // used for analytics. We just update the denormalized totals.
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn create_llm_generation(
+        &self,
+        _session_id: Uuid,
+        _turn_id: Option<Uuid>,
+        _event_id: Option<Uuid>,
+        _model: String,
+        _provider: Option<String>,
+        _input_tokens: i64,
+        _output_tokens: i64,
+        _cache_read_tokens: i64,
+        _cache_creation_tokens: i64,
+        _duration_ms: Option<i32>,
+        _finish_reason: Option<String>,
+        _created_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<()> {
+        // In dev mode, we don't store individual generations
+        // Usage totals are updated via increment_session_usage/increment_agent_usage
+        Ok(())
+    }
+
+    pub async fn increment_session_usage(
+        &self,
+        session_id: Uuid,
+        input_tokens: i64,
+        output_tokens: i64,
+        cache_read_tokens: i64,
+        cache_creation_tokens: i64,
+    ) -> Result<()> {
+        let mut sessions = self.sessions.write();
+        if let Some(session) = sessions.get_mut(&session_id) {
+            session.total_input_tokens += input_tokens;
+            session.total_output_tokens += output_tokens;
+            session.total_cache_read_tokens += cache_read_tokens;
+            session.total_cache_creation_tokens += cache_creation_tokens;
+        }
+        Ok(())
+    }
+
+    pub async fn increment_agent_usage(
+        &self,
+        agent_id: Uuid,
+        input_tokens: i64,
+        output_tokens: i64,
+        cache_read_tokens: i64,
+        cache_creation_tokens: i64,
+    ) -> Result<()> {
+        let mut agents = self.agents.write();
+        if let Some(agent) = agents.get_mut(&agent_id) {
+            agent.total_input_tokens += input_tokens;
+            agent.total_output_tokens += output_tokens;
+            agent.total_cache_read_tokens += cache_read_tokens;
+            agent.total_cache_creation_tokens += cache_creation_tokens;
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/control-plane/src/storage/repositories.rs
+++ b/crates/control-plane/src/storage/repositories.rs
@@ -1740,4 +1740,111 @@ impl Database {
 
         Ok(result.rows_affected() > 0)
     }
+
+    // ============================================
+    // LLM Generations (Usage Tracking)
+    // ============================================
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn create_llm_generation(
+        &self,
+        session_id: Uuid,
+        turn_id: Option<Uuid>,
+        event_id: Option<Uuid>,
+        model: String,
+        provider: Option<String>,
+        input_tokens: i64,
+        output_tokens: i64,
+        cache_read_tokens: i64,
+        cache_creation_tokens: i64,
+        duration_ms: Option<i32>,
+        finish_reason: Option<String>,
+        created_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<()> {
+        sqlx::query(
+            r#"
+            INSERT INTO llm_generations (
+                session_id, turn_id, event_id, model, provider,
+                input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
+                duration_ms, finish_reason, created_at
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+            "#,
+        )
+        .bind(session_id)
+        .bind(turn_id)
+        .bind(event_id)
+        .bind(&model)
+        .bind(&provider)
+        .bind(input_tokens)
+        .bind(output_tokens)
+        .bind(cache_read_tokens)
+        .bind(cache_creation_tokens)
+        .bind(duration_ms)
+        .bind(&finish_reason)
+        .bind(created_at)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn increment_session_usage(
+        &self,
+        session_id: Uuid,
+        input_tokens: i64,
+        output_tokens: i64,
+        cache_read_tokens: i64,
+        cache_creation_tokens: i64,
+    ) -> Result<()> {
+        sqlx::query(
+            r#"
+            UPDATE sessions
+            SET
+                total_input_tokens = total_input_tokens + $2,
+                total_output_tokens = total_output_tokens + $3,
+                total_cache_read_tokens = total_cache_read_tokens + $4,
+                total_cache_creation_tokens = total_cache_creation_tokens + $5
+            WHERE id = $1
+            "#,
+        )
+        .bind(session_id)
+        .bind(input_tokens)
+        .bind(output_tokens)
+        .bind(cache_read_tokens)
+        .bind(cache_creation_tokens)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn increment_agent_usage(
+        &self,
+        agent_id: Uuid,
+        input_tokens: i64,
+        output_tokens: i64,
+        cache_read_tokens: i64,
+        cache_creation_tokens: i64,
+    ) -> Result<()> {
+        sqlx::query(
+            r#"
+            UPDATE agents
+            SET
+                total_input_tokens = total_input_tokens + $2,
+                total_output_tokens = total_output_tokens + $3,
+                total_cache_read_tokens = total_cache_read_tokens + $4,
+                total_cache_creation_tokens = total_cache_creation_tokens + $5
+            WHERE id = $1
+            "#,
+        )
+        .bind(agent_id)
+        .bind(input_tokens)
+        .bind(output_tokens)
+        .bind(cache_read_tokens)
+        .bind(cache_creation_tokens)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
 }

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -92,6 +92,19 @@ graph TD
    - TEXT avoids artificial length limits that may cause issues later
    - No need to guess the "right" length for model names, provider names, etc.
 
+### Database Conventions
+
+1. **Primary Keys**: All tables MUST use `UUID PRIMARY KEY DEFAULT uuidv7()` unless explicitly documented otherwise
+   - UUIDv7 provides time-ordering for better B-tree index performance
+   - Enables keyset pagination via `WHERE id > $cursor ORDER BY id`
+   - Never use `gen_random_uuid()` for primary keys
+
+2. **No Database Triggers**: Business logic MUST be implemented in Rust, not in PostgreSQL triggers
+   - Triggers are invisible to application code and hard to debug
+   - Triggers don't work in DEV_MODE (in-memory storage)
+   - Triggers create hidden coupling between tables
+   - Use EventListener pattern for event-driven side effects instead
+
 ### Execution Layer
 
 1. **Runner Abstraction**: `AgentRunner` trait provides the execution backend interface


### PR DESCRIPTION
## Summary

- Add database conventions to `specs/architecture.md`:
  - All primary keys MUST use `UUID PRIMARY KEY DEFAULT uuidv7()`
  - No database triggers - business logic must be in Rust (EventListener pattern)
- Remove `trigger_process_llm_generation` trigger and its function via migration
- Change `llm_generations.id` default from `gen_random_uuid()` to `uuidv7()`
- Implement `UsageTrackingListener` in Rust to handle LLM usage tracking

## Why

Database triggers have several problems:
- Invisible to application code and hard to debug
- Don't work in DEV_MODE (in-memory storage)
- Create hidden coupling between tables

The EventListener pattern makes the same logic visible, testable, and portable.

## Test plan

- [x] Run migrations - trigger removed, UUID default changed
- [x] Verify `llm_generations` table receives records via Rust listener
- [x] Verify session denormalized totals are updated
- [x] Verify agent denormalized totals are updated
- [x] Pre-PR checks pass (fmt, clippy, tests)