### PR TITLE
feat(release): add automated release workflow with CHANGELOG.md as source of truth

### DIFF
--- a/.claude/commands/prepare-release.md
+++ b/.claude/commands/prepare-release.md
@@ -1,6 +1,8 @@
 # Prepare Release
 
-Prepare a new release for Everruns. This command helps generate changelog entries and update version numbers.
+Prepare a new release for Everruns. This command generates changelog entries, updates version numbers, and creates a PR for review.
+
+See `specs/release-process.md` for the full release process specification.
 
 ## Arguments
 
@@ -11,41 +13,98 @@ Prepare a new release for Everruns. This command helps generate changelog entrie
 1. **Validate version argument**
    - If no version provided, ask for one
    - Version should follow semver (e.g., 0.4.0)
+   - Confirm the version makes sense (check current version in Cargo.toml)
 
 2. **Generate changelog draft using git-cliff**
    ```bash
    # Check if git-cliff is installed
    which git-cliff || cargo install git-cliff
 
-   # Generate unreleased changes since last tag
+   # Generate unreleased changes since last tag (or all if no tags)
    git cliff --unreleased --strip header
    ```
 
 3. **Show the generated draft to the user** and ask them to:
    - Review which items are significant enough for the changelog
    - Identify any items that need rewording
-   - Add any manual notes (migration warnings, breaking changes, etc.)
+   - Decide if highlights section is needed
 
 4. **After user approval**, update these files:
-   - `Cargo.toml` - Update `workspace.package.version`
-   - `apps/ui/package.json` - Update `version`
-   - `CHANGELOG.md` - Add new version section at the top (after the header)
+
+   **Cargo.toml** - Update `workspace.package.version`:
+   ```toml
+   [workspace.package]
+   version = "X.Y.Z"
+   ```
+
+   **apps/ui/package.json** - Update `version`:
+   ```json
+   {
+     "version": "X.Y.Z"
+   }
+   ```
+
+   **CHANGELOG.md** - Add new version section after `## [Unreleased]`:
+   ```markdown
+   ## [X.Y.Z] - YYYY-MM-DD
+
+   ### Highlights
+
+   <!-- Add key highlights, screenshots, or notes here -->
+
+   ### Added
+   - Feature 1
+   - Feature 2
+
+   ### Changed
+   - Change 1
+
+   ### Fixed
+   - Fix 1
+   ```
 
 5. **Ask about migrations**:
-   - "Does this release require database changes? Should migrations be squashed?"
-   - If yes, help squash migrations as needed
+   - "Does this release include database schema changes?"
+   - If yes, add migration notes to CHANGELOG.md and remind about fresh DB requirement
 
 6. **Create commit**:
-   ```
-   chore(release): prepare vX.Y.Z
+   ```bash
+   git add -A
+   git commit -m "chore(release): prepare vX.Y.Z"
    ```
 
-7. **Remind user** to:
-   - Create PR for review
-   - After merge, create GitHub release with tag `vX.Y.Z`
+7. **Create PR**:
+   ```bash
+   git push -u origin <current-branch>
+   gh pr create --title "chore(release): prepare vX.Y.Z" --body "$(cat <<'EOF'
+   ## Release vX.Y.Z
+
+   This PR prepares the vX.Y.Z release.
+
+   ### Checklist
+   - [ ] Review CHANGELOG.md entries
+   - [ ] Add highlights/screenshots if needed
+   - [ ] Verify version numbers updated
+   - [ ] CI passes
+
+   ### Post-merge
+   After merging, the release workflow will automatically:
+   - Create git tag `vX.Y.Z`
+   - Create GitHub Release with notes from CHANGELOG.md
+   - Trigger Docker image build with version tag
+   EOF
+   )"
+   ```
+
+8. **Remind user**:
+   - Review the PR, especially CHANGELOG.md
+   - Add any highlights or screenshots by editing CHANGELOG.md
+   - Merge when CI is green
+   - Tag and GitHub Release will be created automatically
 
 ## Notes
 
 - Always preserve the CHANGELOG.md header and versioning policy section
-- New versions go after the `## [Unreleased]` section (or create one if missing)
-- Include the "no automatic migration" warning for minor/major versions with schema changes
+- The Highlights section is optional but recommended for minor/major releases
+- Include screenshots for UI changes (can be added as links in CHANGELOG.md)
+- The `chore(release): prepare vX.Y.Z` commit message triggers auto-tagging on merge

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Only run if commit message matches release pattern
+    if: startsWith(github.event.head_commit.message, 'chore(release): prepare v')
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from commit message
+        id: version
+        run: |
+          # Extract version from commit message like "chore(release): prepare v0.4.0"
+          VERSION=$(echo "${{ github.event.head_commit.message }}" | grep -oP 'prepare v\K[0-9]+\.[0-9]+\.[0-9]+')
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not extract version from commit message"
+            exit 1
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION"
+
+      - name: Check if tag already exists
+        id: check_tag
+        run: |
+          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "::error::Tag v${{ steps.version.outputs.version }} already exists"
+            exit 1
+          fi
+          echo "Tag does not exist, proceeding..."
+
+      - name: Extract release notes from CHANGELOG.md
+        id: changelog
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Extract the section for this version from CHANGELOG.md
+          # Matches from "## [X.Y.Z]" until the next "## [" or end of significant content
+          NOTES=$(awk -v ver="$VERSION" '
+            /^## \[/ {
+              if (found) exit
+              if (index($0, "[" ver "]")) found=1
+              next
+            }
+            found && /^## \[/ { exit }
+            found { print }
+          ' CHANGELOG.md)
+
+          if [ -z "$NOTES" ]; then
+            echo "::warning::No changelog entry found for version $VERSION"
+            NOTES="Release v$VERSION"
+          fi
+
+          # Write to file to preserve formatting
+          echo "$NOTES" > release_notes.md
+          echo "Release notes extracted:"
+          cat release_notes.md
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ steps.version.outputs.version }}" \
+            --title "v${{ steps.version.outputs.version }}" \
+            --notes-file release_notes.md \
+            --target "${{ github.sha }}"
+
+          echo "Created release v${{ steps.version.outputs.version }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ Available specs:
 - `specs/brand.md` - Brand identity, colors, typography, voice
 - `specs/dismissed-options.md` - Technical options considered but dismissed
 - `specs/multitenancy.md` - Organization-based multitenancy and resource isolation
+- `specs/release-process.md` - Release workflow with CHANGELOG.md as source of truth
 
 Specification format: Abstract and Requirements sections.
 

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -1,0 +1,59 @@
+# Release Process Specification
+
+## Abstract
+
+This specification defines the release process for Everruns. The process is designed to be coding-agent-friendly while keeping CHANGELOG.md as the single source of truth for release notes. Releases are triggered by asking an agent to prepare a release, which creates a PR. After review and merge, GitHub Actions automatically creates the tag and GitHub Release.
+
+## Requirements
+
+### Workflow
+
+1. **Agent-driven release preparation**: User asks coding agent to release changes (e.g., "release the changes as 0.4.0")
+2. **Agent runs `/prepare-release`**: Generates changelog, updates versions, creates PR
+3. **User edits CHANGELOG.md**: Add highlights, screenshots, additional notes directly in the PR
+4. **CI validates**: All checks must pass
+5. **User merges PR**: Squash merge to main
+6. **Auto-tagging**: GitHub Action detects release commit, creates tag + GitHub Release using CHANGELOG.md content
+
+### CHANGELOG.md as Source of Truth
+
+1. CHANGELOG.md is the canonical source for release notes
+2. GitHub Release notes are extracted from the corresponding version section in CHANGELOG.md
+3. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+4. Each version section may include:
+   - **Highlights** - Key features or changes (user-written)
+   - **Added/Changed/Fixed/Removed** - Generated from conventional commits
+   - **Screenshots** - Links to images demonstrating changes
+   - **Migration Notes** - Breaking changes or upgrade instructions
+
+### Version Updates
+
+The `/prepare-release` command updates version in:
+- `Cargo.toml` (workspace.package.version)
+- `apps/ui/package.json` (version field)
+- `CHANGELOG.md` (new version section)
+
+### Commit Convention
+
+Release commits use: `chore(release): prepare vX.Y.Z`
+
+This commit message triggers the auto-tagging workflow on merge to main.
+
+### GitHub Release
+
+1. Tag format: `vX.Y.Z` (e.g., `v0.4.0`)
+2. Release title: `vX.Y.Z`
+3. Release body: Extracted from CHANGELOG.md section for that version
+4. Docker images tagged with version (triggered by tag push)
+
+### Tooling
+
+- **git-cliff**: Generates changelog entries from conventional commits
+- **GitHub Actions**: Auto-creates tag and release on merge
+- **`/prepare-release` command**: Agent-invocable command for release preparation
+
+## Non-Requirements
+
+- No automatic version calculation (user specifies version)
+- No release branches (releases from main only)
+- No release candidates or pre-releases (can be added later if needed)


### PR DESCRIPTION
## What

Adds automated release workflow where CHANGELOG.md is the single source of truth for release notes.

## Why

Current release process documents tag/release creation but it was never executed (no tags exist for v0.1.0-v0.3.0). This closes the gap by automating tag/release creation on merge.

## How

- New `specs/release-process.md` documenting requirements
- Updated `/prepare-release` command to create PRs automatically
- New `.github/workflows/release.yml` that:
  - Triggers on `chore(release): prepare vX.Y.Z` commits to main
  - Extracts release notes from CHANGELOG.md
  - Creates git tag and GitHub Release

## Workflow

```
User: "release as 0.4.0"
  → Agent: /prepare-release 0.4.0
  → Updates versions, CHANGELOG.md, creates PR
  → User edits CHANGELOG.md (highlights, screenshots)
  → CI green → Merge
  → release.yml auto-creates tag + GitHub Release
```

## Risk

- Low
- Only affects release process, no runtime changes

## Checklist

- [x] Spec added (`specs/release-process.md`)
- [x] Command updated (`.claude/commands/prepare-release.md`)
- [x] Workflow added (`.github/workflows/release.yml`)
- [x] AGENTS.md updated with new spec