### PR TITLE
refactor: remove outdated decision comments from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,3 @@
-# Decision: Use UUID v7 for time-ordered IDs (better for DB indexing, sortable by creation time)
-# Decision: OpenAI as first LLM provider (most common, stable API)
-# Decision: Auth via OAuth will be added later for dashboard login
-
 [workspace]
 resolver = "2"
 


### PR DESCRIPTION
## What
Remove outdated decision comments from the top of Cargo.toml.

## Why
These decisions are either already documented elsewhere or outdated:
- **UUID v7**: Already documented in `specs/architecture.md:88`
- **OpenAI first provider**: Historical context; Anthropic is now also supported
- **OAuth later**: Fully implemented per `specs/authentication.md`

## How
Deleted the 3 comment lines from Cargo.toml.

## Risk
- Low
- No functional changes

## Checklist
- [x] No tests needed (comment removal only)
- [x] Backward compatibility: N/A