### PR TITLE
fix(ci): update Docker tag strategy for stable latest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -84,10 +84,11 @@ jobs:
         with:
           images: ${{ env.IMAGE_BASE }}/${{ matrix.image_name }}
           tags: |
-            # On main push: tag as 'latest'
-            type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-            # On version tags: use the tag name (e.g., v1.0.0)
+            # On version tags (v*): use the tag name + update latest
             type=ref,event=tag
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            # On main push: tag as 'development' (mutable, tracks main branch)
+            type=raw,value=development,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
             # Always tag with short and full SHA
             type=raw,value=${{ steps.sha.outputs.sha_short }}
             type=raw,value=${{ steps.sha.outputs.sha }}

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -46,6 +46,18 @@ This commit message triggers the auto-tagging workflow on merge to main.
 3. Release body: Extracted from CHANGELOG.md section for that version
 4. Docker images tagged with version (triggered by tag push)
 
+### Docker Image Tagging
+
+| Event | Tags Generated |
+|-------|----------------|
+| Version tag (v0.4.0) | `v0.4.0`, `latest`, SHA |
+| Main branch push | `development`, SHA |
+| Pull request | SHA only (no push) |
+
+- **`latest`**: Only updated on version tags. Safe for production use.
+- **`development`**: Tracks main branch. Updated on every commit to main.
+- **SHA tags**: Always generated for traceability (short + full SHA).
+
 ### Tooling
 
 - **git-cliff**: Generates changelog entries from conventional commits


### PR DESCRIPTION
## What
Changes Docker image tagging strategy so `latest` is only updated on version tags.

## Why
Examples and deployments using `latest` should not break between releases. Currently every main push updates `latest`, which can cause instability.

## How
- Version tags (v*) → `v0.4.0` + `latest` + SHA
- Main branch pushes → `development` + SHA
- PRs → SHA only

## Risk
- Low
- Only affects tag naming, not build process

## Checklist
- [x] Specs updated (`specs/release-process.md`)
- [x] No breaking changes