### PR TITLE
fix(ci): quote if expression in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     # Only run if commit message matches release pattern
-    if: startsWith(github.event.head_commit.message, 'chore(release): prepare v')
+    if: ${{ startsWith(github.event.head_commit.message, 'chore(release): prepare v') }}
 
     permissions:
       contents: write


### PR DESCRIPTION
## What
Fix YAML syntax error in release workflow that was preventing the auto-tagging from running.

## Why
The `if` condition on line 12 contained `chore(release):` which has a colon - a special YAML character. This caused the workflow file to fail validation.

## How
Wrap the expression in `${{ }}` to ensure proper parsing.

## Risk
- Low
- Only affects release workflow trigger condition

## Note
After this is merged, v0.4.0 tag/release needs to be created manually since the workflow failed for that release commit.