### PR TITLE
chore: update lock files and document release requirements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-control-plane"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5172,9 +5172,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"
+checksum = "94f63c051f4fe3c1509da62131a678643c5b6fbdc9273b2b79d4378ebda003d2"
 
 [[package]]
 name = "zopfli"

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "everruns-ui",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "everruns-ui",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@base-ui/react": "^1.0.0",
         "@tanstack/react-query": "^5.90.16",

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -31,6 +31,16 @@ The `/prepare-release` command updates version in:
 - `apps/ui/package.json` (version field)
 - `CHANGELOG.md` (new version section)
 
+All packages (Rust crates and UI) are released together with the same version number.
+
+### Lock File Updates
+
+Lock files must be updated when preparing a release:
+- `Cargo.lock` - Run `cargo update` to sync with new workspace version
+- `apps/ui/package-lock.json` - Run `npm install` in apps/ui to regenerate
+
+This ensures lock files reflect the current version and any dependency updates.
+
 ### Commit Convention
 
 Release commits use: `chore(release): prepare vX.Y.Z`


### PR DESCRIPTION
## What
Update lock files to sync with v0.4.0 release and document lock file update requirements in release process spec.

## Why
Lock files were out of sync with workspace version. Release process spec lacked documentation on updating lock files.

## How
- Run `cargo update` to sync Cargo.lock
- Run `npm install` in apps/ui to regenerate package-lock.json
- Add "Lock File Updates" section to specs/release-process.md

## Risk
- Low
- Lock file updates only, no code changes

## Checklist
- [x] Tests added or updated (N/A - no code changes)
- [x] Backward compatibility considered (N/A)