### PR TITLE
feat(ui): add LLM message history visualization component

### DIFF
--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/events/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/events/page.tsx
@@ -91,7 +91,7 @@ export default function EventsPage() {
                   </TableCell>
                   <TableCell className="font-mono text-xs">
                     <div className="relative">
-                      <div className="flex items-center gap-1 mb-1">
+                      <div className="absolute right-0 top-0 z-10 flex items-center gap-1 bg-background/80 backdrop-blur-sm rounded px-1">
                         {event.type === "llm.generation" && (
                           <Link
                             href={`${basePath}/llm-history/${event.id}`}

--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/events/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/events/page.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
+import { buttonVariants } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Activity } from "lucide-react";
+import { Activity, Eye } from "lucide-react";
+import { cn } from "@/lib/utils";
 import {
   Table,
   TableBody,
@@ -14,7 +17,9 @@ import {
 import { useSessionContext } from "../session-context";
 
 export default function EventsPage() {
-  const { events, eventsLoading } = useSessionContext();
+  const { events, eventsLoading, agentId, sessionId } = useSessionContext();
+
+  const basePath = `/agents/${agentId}/sessions/${sessionId}`;
 
   return (
     <div className="flex-1 overflow-y-auto p-4">
@@ -39,6 +44,7 @@ export default function EventsPage() {
                 <TableHead className="w-[180px]">Type</TableHead>
                 <TableHead className="w-[200px]">Timestamp</TableHead>
                 <TableHead>Data</TableHead>
+                <TableHead className="w-[100px]">Actions</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -57,6 +63,17 @@ export default function EventsPage() {
                     <pre className="whitespace-pre-wrap break-all text-xs bg-muted p-2 rounded max-h-[200px] overflow-y-auto">
                       {JSON.stringify(event.data, null, 2)}
                     </pre>
+                  </TableCell>
+                  <TableCell>
+                    {event.type === "llm.generation" && (
+                      <Link
+                        href={`${basePath}/llm-history/${event.id}`}
+                        className={cn(buttonVariants({ variant: "outline", size: "sm" }))}
+                      >
+                        <Eye className="w-3 h-3 mr-1" />
+                        View
+                      </Link>
+                    )}
                   </TableCell>
                 </TableRow>
               ))}

--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/events/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/events/page.tsx
@@ -31,7 +31,7 @@ function CopyButton({ data }: { data: unknown }) {
   };
 
   return (
-    <Button variant="outline" size="sm" onClick={handleCopy}>
+    <Button variant="ghost" size="sm" onClick={handleCopy} className="h-6 px-2 text-xs">
       {copied ? (
         <>
           <Check className="w-3 h-3 mr-1" />
@@ -74,7 +74,6 @@ export default function EventsPage() {
                 <TableHead className="w-[80px]">Seq</TableHead>
                 <TableHead className="w-[180px]">Type</TableHead>
                 <TableHead className="w-[200px]">Timestamp</TableHead>
-                <TableHead className="w-[100px]">Actions</TableHead>
                 <TableHead>Data</TableHead>
               </TableRow>
             </TableHeader>
@@ -90,24 +89,24 @@ export default function EventsPage() {
                   <TableCell className="text-xs text-muted-foreground">
                     {new Date(event.ts).toLocaleString()}
                   </TableCell>
-                  <TableCell>
-                    <div className="flex flex-col gap-1">
-                      {event.type === "llm.generation" && (
-                        <Link
-                          href={`${basePath}/llm-history/${event.id}`}
-                          className={cn(buttonVariants({ variant: "outline", size: "sm" }), "w-full justify-center")}
-                        >
-                          <Eye className="w-3 h-3 mr-1" />
-                          View
-                        </Link>
-                      )}
-                      <CopyButton data={event.data} />
+                  <TableCell className="font-mono text-xs">
+                    <div className="relative">
+                      <div className="flex items-center gap-1 mb-1">
+                        {event.type === "llm.generation" && (
+                          <Link
+                            href={`${basePath}/llm-history/${event.id}`}
+                            className={cn(buttonVariants({ variant: "ghost", size: "sm" }), "h-6 px-2 text-xs")}
+                          >
+                            <Eye className="w-3 h-3 mr-1" />
+                            View
+                          </Link>
+                        )}
+                        <CopyButton data={event.data} />
+                      </div>
+                      <pre className="whitespace-pre-wrap break-all text-xs bg-muted p-2 rounded max-h-[200px] overflow-y-auto">
+                        {JSON.stringify(event.data, null, 2)}
+                      </pre>
                     </div>
-                  </TableCell>
-                  <TableCell className="font-mono text-xs max-w-[500px]">
-                    <pre className="whitespace-pre-wrap break-all text-xs bg-muted p-2 rounded max-h-[200px] overflow-y-auto">
-                      {JSON.stringify(event.data, null, 2)}
-                    </pre>
                   </TableCell>
                 </TableRow>
               ))}

--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/events/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/events/page.tsx
@@ -2,10 +2,11 @@
 
 import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
-import { buttonVariants } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Activity, Eye } from "lucide-react";
+import { Activity, Eye, Copy, Check } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useState } from "react";
 import {
   Table,
   TableBody,
@@ -15,6 +16,36 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { useSessionContext } from "../session-context";
+
+function CopyButton({ data }: { data: unknown }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(data, null, 2));
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error("Failed to copy:", err);
+    }
+  };
+
+  return (
+    <Button variant="outline" size="sm" onClick={handleCopy}>
+      {copied ? (
+        <>
+          <Check className="w-3 h-3 mr-1" />
+          Copied
+        </>
+      ) : (
+        <>
+          <Copy className="w-3 h-3 mr-1" />
+          Copy
+        </>
+      )}
+    </Button>
+  );
+}
 
 export default function EventsPage() {
   const { events, eventsLoading, agentId, sessionId } = useSessionContext();
@@ -43,13 +74,13 @@ export default function EventsPage() {
                 <TableHead className="w-[80px]">Seq</TableHead>
                 <TableHead className="w-[180px]">Type</TableHead>
                 <TableHead className="w-[200px]">Timestamp</TableHead>
-                <TableHead>Data</TableHead>
                 <TableHead className="w-[100px]">Actions</TableHead>
+                <TableHead>Data</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {events?.map((event) => (
-                <TableRow key={event.id}>
+                <TableRow key={event.id} className="align-top">
                   <TableCell className="font-mono text-xs">{event.sequence}</TableCell>
                   <TableCell>
                     <Badge variant="outline" className="font-mono text-xs">
@@ -59,21 +90,24 @@ export default function EventsPage() {
                   <TableCell className="text-xs text-muted-foreground">
                     {new Date(event.ts).toLocaleString()}
                   </TableCell>
+                  <TableCell>
+                    <div className="flex flex-col gap-1">
+                      {event.type === "llm.generation" && (
+                        <Link
+                          href={`${basePath}/llm-history/${event.id}`}
+                          className={cn(buttonVariants({ variant: "outline", size: "sm" }), "w-full justify-center")}
+                        >
+                          <Eye className="w-3 h-3 mr-1" />
+                          View
+                        </Link>
+                      )}
+                      <CopyButton data={event.data} />
+                    </div>
+                  </TableCell>
                   <TableCell className="font-mono text-xs max-w-[500px]">
                     <pre className="whitespace-pre-wrap break-all text-xs bg-muted p-2 rounded max-h-[200px] overflow-y-auto">
                       {JSON.stringify(event.data, null, 2)}
                     </pre>
-                  </TableCell>
-                  <TableCell>
-                    {event.type === "llm.generation" && (
-                      <Link
-                        href={`${basePath}/llm-history/${event.id}`}
-                        className={cn(buttonVariants({ variant: "outline", size: "sm" }))}
-                      >
-                        <Eye className="w-3 h-3 mr-1" />
-                        View
-                      </Link>
-                    )}
                   </TableCell>
                 </TableRow>
               ))}

--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/llm-history/[eventId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/llm-history/[eventId]/page.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { use, useMemo } from "react";
+import Link from "next/link";
+import { ArrowLeft, AlertCircle } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { LlmHistoryViewer } from "@/components/llm/llm-history-viewer";
+import { useSessionContext } from "../../session-context";
+import type { LlmGenerationData } from "@/lib/api/types";
+
+interface LlmHistoryPageProps {
+  params: Promise<{ agentId: string; sessionId: string; eventId: string }>;
+}
+
+export default function LlmHistoryPage({ params }: LlmHistoryPageProps) {
+  const { agentId, sessionId, eventId } = use(params);
+  const { events, eventsLoading } = useSessionContext();
+
+  // Find the specific llm.generation event by ID
+  const event = useMemo(() => {
+    if (!events) return null;
+    return events.find(
+      (e) => e.id === eventId && e.type === "llm.generation"
+    );
+  }, [events, eventId]);
+
+  const basePath = `/agents/${agentId}/sessions/${sessionId}`;
+
+  if (eventsLoading) {
+    return (
+      <div className="flex-1 overflow-y-auto p-4">
+        <Skeleton className="h-8 w-48 mb-4" />
+        <Skeleton className="h-32 w-full mb-4" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (!event) {
+    return (
+      <div className="flex-1 overflow-y-auto p-4">
+        <Link
+          href={`${basePath}/events`}
+          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-4"
+        >
+          <ArrowLeft className="w-4 h-4 mr-2" />
+          Back to Events
+        </Link>
+
+        <Card className="border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950/30">
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center gap-2 text-red-700 dark:text-red-400">
+              <AlertCircle className="h-4 w-4" />
+              Event not found
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-red-600 dark:text-red-300">
+              The llm.generation event with ID &quot;{eventId.slice(0, 8)}...&quot; was not found.
+              It may have been deleted or the ID is incorrect.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const data = event.data as LlmGenerationData;
+
+  return (
+    <div className="flex-1 overflow-y-auto p-4">
+      <Link
+        href={`${basePath}/events`}
+        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-4"
+      >
+        <ArrowLeft className="w-4 h-4 mr-2" />
+        Back to Events
+      </Link>
+
+      <h1 className="text-xl font-bold mb-4">LLM Generation History</h1>
+
+      <LlmHistoryViewer
+        data={data}
+        eventId={event.id}
+        timestamp={event.ts}
+        maxHeight="calc(100vh - 280px)"
+      />
+    </div>
+  );
+}

--- a/apps/ui/src/app/dev/components/page.tsx
+++ b/apps/ui/src/app/dev/components/page.tsx
@@ -9,8 +9,8 @@ import { ToolCallCard } from "@/components/chat/tool-call-card";
 import { TodoListRenderer } from "@/components/chat/todo-list-renderer";
 import { MessageInfoIcon } from "@/components/chat/message-info-icon";
 import { ImageAttachments, MessageImage } from "@/components/chat/image-attachments";
-import { SessionCard } from "@/components/session/session-card";
-import type { Message, Event, Session, LlmModelWithProvider, TokenUsage } from "@/lib/api/types";
+import { LlmHistoryViewer } from "@/components/llm/llm-history-viewer";
+import type { Message, Event, TokenUsage, LlmGenerationData } from "@/lib/api/types";
 import type { PendingImage } from "@/lib/api/images";
 
 // Check if we're in development mode
@@ -500,6 +500,139 @@ const sampleEvents = {
   } satisfies Event,
 };
 
+// Sample LLM Generation data for LlmHistoryViewer
+const sampleLlmGenerationData: LlmGenerationData = {
+  messages: [
+    {
+      id: "msg-sys-1",
+      session_id: "session-1",
+      sequence: 0,
+      role: "agent" as const, // System messages shown as agent
+      content: [
+        {
+          type: "text" as const,
+          text: "You are a helpful coding assistant. You help users with programming tasks, code review, and software development best practices.",
+        },
+      ],
+      tool_call_id: null,
+      created_at: new Date(Date.now() - 120000).toISOString(),
+    },
+    {
+      id: "msg-user-1",
+      session_id: "session-1",
+      sequence: 1,
+      role: "user" as const,
+      content: [
+        {
+          type: "text" as const,
+          text: "Can you help me write a function to find prime numbers?",
+        },
+      ],
+      tool_call_id: null,
+      created_at: new Date(Date.now() - 60000).toISOString(),
+    },
+    {
+      id: "msg-agent-1",
+      session_id: "session-1",
+      sequence: 2,
+      role: "agent" as const,
+      content: [
+        {
+          type: "text" as const,
+          text: "I'll help you write a prime number function. Let me create that for you.",
+        },
+        {
+          type: "tool_call" as const,
+          id: "tc-write-1",
+          name: "write_file",
+          arguments: { path: "/src/primes.ts", content: "export function isPrime(n: number): boolean {\n  if (n <= 1) return false;\n  for (let i = 2; i * i <= n; i++) {\n    if (n % i === 0) return false;\n  }\n  return true;\n}" },
+        },
+      ],
+      tool_call_id: null,
+      created_at: new Date(Date.now() - 55000).toISOString(),
+    },
+    {
+      id: "msg-tool-1",
+      session_id: "session-1",
+      sequence: 3,
+      role: "tool_result" as const,
+      content: [
+        {
+          type: "tool_result" as const,
+          tool_call_id: "tc-write-1",
+          result: { success: true, path: "/src/primes.ts" },
+        },
+      ],
+      tool_call_id: "tc-write-1",
+      created_at: new Date(Date.now() - 50000).toISOString(),
+    },
+    {
+      id: "msg-user-2",
+      session_id: "session-1",
+      sequence: 4,
+      role: "user" as const,
+      content: [
+        {
+          type: "text" as const,
+          text: "Can you also add a function to find all primes up to N?",
+        },
+      ],
+      tool_call_id: null,
+      created_at: new Date(Date.now() - 30000).toISOString(),
+    },
+  ],
+  output: {
+    text: "I'll add a function to find all prime numbers up to N using the Sieve of Eratosthenes algorithm, which is more efficient for finding multiple primes.",
+    tool_calls: [
+      {
+        id: "tc-write-2",
+        name: "write_file",
+        arguments: {
+          path: "/src/primes.ts",
+          content: "export function isPrime(n: number): boolean {\n  if (n <= 1) return false;\n  for (let i = 2; i * i <= n; i++) {\n    if (n % i === 0) return false;\n  }\n  return true;\n}\n\nexport function findPrimesUpTo(n: number): number[] {\n  const sieve = new Array(n + 1).fill(true);\n  sieve[0] = sieve[1] = false;\n  for (let i = 2; i * i <= n; i++) {\n    if (sieve[i]) {\n      for (let j = i * i; j <= n; j += i) {\n        sieve[j] = false;\n      }\n    }\n  }\n  return sieve.map((isPrime, i) => isPrime ? i : -1).filter(i => i !== -1);\n}",
+        },
+      },
+    ],
+  },
+  metadata: {
+    model: "claude-sonnet-4-20250514",
+    provider: "anthropic",
+    usage: {
+      input_tokens: 1847,
+      output_tokens: 312,
+      cache_read_tokens: 1200,
+      cache_creation_tokens: 0,
+    },
+    duration_ms: 2345,
+    success: true,
+  },
+};
+
+const sampleLlmGenerationWithError: LlmGenerationData = {
+  messages: [
+    {
+      id: "msg-user-err",
+      session_id: "session-1",
+      sequence: 1,
+      role: "user" as const,
+      content: [{ type: "text" as const, text: "Generate an image of a cat" }],
+      tool_call_id: null,
+      created_at: new Date().toISOString(),
+    },
+  ],
+  output: {
+    text: undefined,
+    tool_calls: [],
+  },
+  metadata: {
+    model: "gpt-4o",
+    provider: "openai",
+    duration_ms: 534,
+    success: false,
+    error: "Model does not support image generation. Please use a model with image generation capabilities.",
+  },
+};
+
 // ============================================
 // Main Page Component
 // ============================================
@@ -824,6 +957,36 @@ export default function DevComponentsPage() {
                     </div>
                   </div>
                 </div>
+              </ShowcaseItem>
+            </ShowcaseSection>
+
+            {/* LLM History Viewer Section */}
+            <ShowcaseSection
+              title="LlmHistoryViewer Component"
+              description="Visualizes the full message history sent to LLM during llm.generation events (components/llm/llm-history-viewer.tsx)"
+            >
+              <ShowcaseItem label="Full View (Multi-turn with Tool Calls)">
+                <LlmHistoryViewer
+                  data={sampleLlmGenerationData}
+                  eventId="evt-llm-12345678-abcd-1234-efgh-567890ijklmn"
+                  timestamp={new Date().toISOString()}
+                  maxHeight="400px"
+                />
+              </ShowcaseItem>
+
+              <ShowcaseItem label="Compact View">
+                <LlmHistoryViewer
+                  data={sampleLlmGenerationData}
+                  compact
+                />
+              </ShowcaseItem>
+
+              <ShowcaseItem label="Error State">
+                <LlmHistoryViewer
+                  data={sampleLlmGenerationWithError}
+                  eventId="evt-llm-error-99999"
+                  timestamp={new Date().toISOString()}
+                />
               </ShowcaseItem>
             </ShowcaseSection>
           </div>

--- a/apps/ui/src/components/llm/llm-history-viewer.tsx
+++ b/apps/ui/src/components/llm/llm-history-viewer.tsx
@@ -146,20 +146,14 @@ function MessageCard({ message, index }: { message: Message; index: number }) {
     user: {
       icon: User,
       label: "User",
-      bgClass: "bg-gray-100 dark:bg-gray-800",
-      borderClass: "border-gray-200 dark:border-gray-700",
     },
     agent: {
       icon: Bot,
       label: "Assistant",
-      bgClass: "bg-blue-50 dark:bg-blue-950/30",
-      borderClass: "border-blue-200 dark:border-blue-800",
     },
     tool_result: {
       icon: Wrench,
       label: "Tool Result",
-      bgClass: "bg-amber-50 dark:bg-amber-950/30",
-      borderClass: "border-amber-200 dark:border-amber-800",
     },
   };
 
@@ -168,17 +162,13 @@ function MessageCard({ message, index }: { message: Message; index: number }) {
   const config = roleConfig[role] || {
     icon: FileText,
     label: message.role,
-    bgClass: "bg-purple-50 dark:bg-purple-950/30",
-    borderClass: "border-purple-200 dark:border-purple-800",
   };
   const Icon = config.icon;
 
   return (
-    <div className={cn("border rounded-lg p-3", config.bgClass, config.borderClass)}>
+    <div className="border rounded-lg p-3 bg-background">
       <div className="flex items-center gap-2 mb-2">
-        <div className="flex items-center justify-center w-6 h-6 rounded-full bg-background border">
-          <Icon className="w-3.5 h-3.5" />
-        </div>
+        <Icon className="w-4 h-4 text-muted-foreground" />
         <span className="text-sm font-medium">{config.label}</span>
         <span className="text-xs text-muted-foreground">#{index + 1}</span>
         {message.tool_call_id && (
@@ -187,7 +177,7 @@ function MessageCard({ message, index }: { message: Message; index: number }) {
           </span>
         )}
       </div>
-      <div className="space-y-2 pl-8">
+      <div className="space-y-2 pl-6">
         {message.content.map((part, partIndex) => (
           <ContentPartRenderer key={partIndex} part={part} />
         ))}

--- a/apps/ui/src/components/llm/llm-history-viewer.tsx
+++ b/apps/ui/src/components/llm/llm-history-viewer.tsx
@@ -201,8 +201,8 @@ function OutputSection({ output }: { output: LlmGenerationOutput }) {
       </CardHeader>
       <CardContent className="space-y-3">
         {output.text && (
-          <div className="bg-green-50 dark:bg-green-950/30 border border-green-200 dark:border-green-800 rounded-lg p-3">
-            <p className="text-xs font-medium text-green-700 dark:text-green-400 mb-1">Text Response</p>
+          <div className="border rounded-lg p-3 bg-muted/30">
+            <p className="text-xs font-medium text-muted-foreground mb-1">Text Response</p>
             <p className="text-sm whitespace-pre-wrap">{output.text}</p>
           </div>
         )}

--- a/apps/ui/src/components/llm/llm-history-viewer.tsx
+++ b/apps/ui/src/components/llm/llm-history-viewer.tsx
@@ -61,7 +61,7 @@ function ToolCallContentPart({ toolCall }: { toolCall: { id: string; name: strin
         <span className="text-xs font-medium">{toolCall.name}</span>
         <span className="text-xs text-muted-foreground font-mono">({toolCall.id})</span>
       </div>
-      <pre className="text-xs bg-background rounded p-2 overflow-x-auto max-h-32">
+      <pre className="text-xs bg-background rounded p-2 overflow-x-auto max-h-48 whitespace-pre-wrap break-all">
         {JSON.stringify(toolCall.arguments, null, 2)}
       </pre>
     </div>
@@ -69,6 +69,26 @@ function ToolCallContentPart({ toolCall }: { toolCall: { id: string; name: strin
 }
 
 function ToolResultContentPart({ toolCallId, result, error }: { toolCallId: string; result?: unknown; error?: string }) {
+  // Format the result for display
+  const formatResult = (value: unknown): string => {
+    if (value === undefined || value === null) {
+      return "null";
+    }
+    if (typeof value === "string") {
+      // Try to parse and format if it's a JSON string
+      try {
+        const parsed = JSON.parse(value);
+        return JSON.stringify(parsed, null, 2);
+      } catch {
+        // Not valid JSON, return as-is but handle long strings
+        return value;
+      }
+    }
+    return JSON.stringify(value, null, 2);
+  };
+
+  const formattedResult = formatResult(result);
+
   return (
     <div className={cn("border rounded-md p-2", error ? "bg-red-50 border-red-200 dark:bg-red-950/20 dark:border-red-900" : "bg-green-50 border-green-200 dark:bg-green-950/20 dark:border-green-900")}>
       <div className="flex items-center gap-2 mb-1">
@@ -83,8 +103,8 @@ function ToolResultContentPart({ toolCallId, result, error }: { toolCallId: stri
       {error ? (
         <p className="text-xs text-red-600 dark:text-red-400">{error}</p>
       ) : (
-        <pre className="text-xs bg-background rounded p-2 overflow-x-auto max-h-32">
-          {typeof result === "string" ? result : JSON.stringify(result, null, 2)}
+        <pre className="text-xs bg-background rounded p-2 overflow-x-auto max-h-48 whitespace-pre-wrap break-all">
+          {formattedResult}
         </pre>
       )}
     </div>

--- a/apps/ui/src/components/llm/llm-history-viewer.tsx
+++ b/apps/ui/src/components/llm/llm-history-viewer.tsx
@@ -1,0 +1,425 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Bot,
+  User,
+  Wrench,
+  Clock,
+  Zap,
+  CheckCircle,
+  XCircle,
+  ChevronRight,
+  FileText,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import type {
+  Message,
+  ContentPart,
+  LlmGenerationData,
+  LlmGenerationOutput,
+  LlmGenerationMetadata,
+  TokenUsage,
+} from "@/lib/api/types";
+
+// ============================================
+// Helper functions
+// ============================================
+
+function formatTokens(tokens: number): string {
+  if (tokens >= 1000000) {
+    return `${(tokens / 1000000).toFixed(1)}M`;
+  }
+  if (tokens >= 1000) {
+    return `${(tokens / 1000).toFixed(1)}K`;
+  }
+  return tokens.toString();
+}
+
+function formatDuration(ms: number): string {
+  if (ms >= 1000) {
+    return `${(ms / 1000).toFixed(2)}s`;
+  }
+  return `${ms}ms`;
+}
+
+// ============================================
+// Content Part Renderers
+// ============================================
+
+function TextContentPart({ text }: { text: string }) {
+  return <p className="text-sm whitespace-pre-wrap">{text}</p>;
+}
+
+function ToolCallContentPart({ toolCall }: { toolCall: { id: string; name: string; arguments: Record<string, unknown> } }) {
+  return (
+    <div className="border rounded-md p-2 bg-muted/50">
+      <div className="flex items-center gap-2 mb-1">
+        <Wrench className="w-3 h-3 text-muted-foreground" />
+        <span className="text-xs font-medium">{toolCall.name}</span>
+        <span className="text-xs text-muted-foreground font-mono">({toolCall.id})</span>
+      </div>
+      <pre className="text-xs bg-background rounded p-2 overflow-x-auto max-h-32">
+        {JSON.stringify(toolCall.arguments, null, 2)}
+      </pre>
+    </div>
+  );
+}
+
+function ToolResultContentPart({ toolCallId, result, error }: { toolCallId: string; result?: unknown; error?: string }) {
+  return (
+    <div className={cn("border rounded-md p-2", error ? "bg-red-50 border-red-200 dark:bg-red-950/20 dark:border-red-900" : "bg-green-50 border-green-200 dark:bg-green-950/20 dark:border-green-900")}>
+      <div className="flex items-center gap-2 mb-1">
+        {error ? (
+          <XCircle className="w-3 h-3 text-red-500" />
+        ) : (
+          <CheckCircle className="w-3 h-3 text-green-500" />
+        )}
+        <span className="text-xs font-medium">Tool Result</span>
+        <span className="text-xs text-muted-foreground font-mono">({toolCallId})</span>
+      </div>
+      {error ? (
+        <p className="text-xs text-red-600 dark:text-red-400">{error}</p>
+      ) : (
+        <pre className="text-xs bg-background rounded p-2 overflow-x-auto max-h-32">
+          {typeof result === "string" ? result : JSON.stringify(result, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+function ImageContentPart({ imageId, filename }: { imageId?: string; filename?: string }) {
+  return (
+    <div className="border rounded-md p-2 bg-muted/50 flex items-center gap-2">
+      <FileText className="w-4 h-4 text-muted-foreground" />
+      <span className="text-xs">{filename || imageId || "Image"}</span>
+    </div>
+  );
+}
+
+function ContentPartRenderer({ part }: { part: ContentPart }) {
+  switch (part.type) {
+    case "text":
+      return <TextContentPart text={part.text} />;
+    case "tool_call":
+      return <ToolCallContentPart toolCall={{ id: part.id, name: part.name, arguments: part.arguments }} />;
+    case "tool_result":
+      return <ToolResultContentPart toolCallId={part.tool_call_id} result={part.result} error={part.error} />;
+    case "image_file":
+      return <ImageContentPart imageId={part.image_id} filename={part.filename} />;
+    case "image":
+      return <ImageContentPart />;
+    default:
+      return <pre className="text-xs">{JSON.stringify(part, null, 2)}</pre>;
+  }
+}
+
+// ============================================
+// Message Components
+// ============================================
+
+function MessageCard({ message, index }: { message: Message; index: number }) {
+  const roleConfig = {
+    user: {
+      icon: User,
+      label: "User",
+      bgClass: "bg-gray-100 dark:bg-gray-800",
+      borderClass: "border-gray-200 dark:border-gray-700",
+    },
+    agent: {
+      icon: Bot,
+      label: "Assistant",
+      bgClass: "bg-blue-50 dark:bg-blue-950/30",
+      borderClass: "border-blue-200 dark:border-blue-800",
+    },
+    tool_result: {
+      icon: Wrench,
+      label: "Tool Result",
+      bgClass: "bg-amber-50 dark:bg-amber-950/30",
+      borderClass: "border-amber-200 dark:border-amber-800",
+    },
+  };
+
+  // Handle system messages (not in roleConfig)
+  const role = message.role as keyof typeof roleConfig;
+  const config = roleConfig[role] || {
+    icon: FileText,
+    label: message.role,
+    bgClass: "bg-purple-50 dark:bg-purple-950/30",
+    borderClass: "border-purple-200 dark:border-purple-800",
+  };
+  const Icon = config.icon;
+
+  return (
+    <div className={cn("border rounded-lg p-3", config.bgClass, config.borderClass)}>
+      <div className="flex items-center gap-2 mb-2">
+        <div className="flex items-center justify-center w-6 h-6 rounded-full bg-background border">
+          <Icon className="w-3.5 h-3.5" />
+        </div>
+        <span className="text-sm font-medium">{config.label}</span>
+        <span className="text-xs text-muted-foreground">#{index + 1}</span>
+        {message.tool_call_id && (
+          <span className="text-xs text-muted-foreground font-mono">
+            (tool_call_id: {message.tool_call_id})
+          </span>
+        )}
+      </div>
+      <div className="space-y-2 pl-8">
+        {message.content.map((part, partIndex) => (
+          <ContentPartRenderer key={partIndex} part={part} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ============================================
+// Output Section
+// ============================================
+
+function OutputSection({ output }: { output: LlmGenerationOutput }) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm flex items-center gap-2">
+          <ChevronRight className="w-4 h-4" />
+          LLM Output
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {output.text && (
+          <div className="bg-green-50 dark:bg-green-950/30 border border-green-200 dark:border-green-800 rounded-lg p-3">
+            <p className="text-xs font-medium text-green-700 dark:text-green-400 mb-1">Text Response</p>
+            <p className="text-sm whitespace-pre-wrap">{output.text}</p>
+          </div>
+        )}
+        {output.tool_calls && output.tool_calls.length > 0 && (
+          <div>
+            <p className="text-xs font-medium text-muted-foreground mb-2">
+              Tool Calls ({output.tool_calls.length})
+            </p>
+            <div className="space-y-2">
+              {output.tool_calls.map((toolCall, index) => (
+                <ToolCallContentPart key={index} toolCall={toolCall} />
+              ))}
+            </div>
+          </div>
+        )}
+        {!output.text && (!output.tool_calls || output.tool_calls.length === 0) && (
+          <p className="text-sm text-muted-foreground italic">No output</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ============================================
+// Metadata Section
+// ============================================
+
+function MetadataSection({ metadata }: { metadata: LlmGenerationMetadata }) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm">Generation Metadata</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div>
+            <p className="text-xs text-muted-foreground">Model</p>
+            <p className="text-sm font-medium">{metadata.model}</p>
+          </div>
+          {metadata.provider && (
+            <div>
+              <p className="text-xs text-muted-foreground">Provider</p>
+              <p className="text-sm font-medium">{metadata.provider}</p>
+            </div>
+          )}
+          {metadata.duration_ms !== undefined && (
+            <div>
+              <p className="text-xs text-muted-foreground flex items-center gap-1">
+                <Clock className="w-3 h-3" /> Duration
+              </p>
+              <p className="text-sm font-medium">{formatDuration(metadata.duration_ms)}</p>
+            </div>
+          )}
+          <div>
+            <p className="text-xs text-muted-foreground">Status</p>
+            <div className="flex items-center gap-1">
+              {metadata.success ? (
+                <>
+                  <CheckCircle className="w-3 h-3 text-green-500" />
+                  <span className="text-sm font-medium text-green-600 dark:text-green-400">Success</span>
+                </>
+              ) : (
+                <>
+                  <XCircle className="w-3 h-3 text-red-500" />
+                  <span className="text-sm font-medium text-red-600 dark:text-red-400">Failed</span>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+        {metadata.error && (
+          <div className="mt-3 p-2 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 rounded">
+            <p className="text-xs font-medium text-red-600 dark:text-red-400">Error</p>
+            <p className="text-sm text-red-700 dark:text-red-300">{metadata.error}</p>
+          </div>
+        )}
+        {metadata.usage && <UsageDisplay usage={metadata.usage} />}
+      </CardContent>
+    </Card>
+  );
+}
+
+function UsageDisplay({ usage }: { usage: TokenUsage }) {
+  const total = usage.input_tokens + usage.output_tokens;
+
+  return (
+    <div className="mt-3 p-3 bg-muted/50 rounded-lg">
+      <div className="flex items-center gap-2 mb-2">
+        <Zap className="w-4 h-4 text-yellow-500" />
+        <span className="text-sm font-medium">Token Usage</span>
+        <Badge variant="outline" className="ml-auto">
+          {formatTokens(total)} total
+        </Badge>
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-xs">
+        <div>
+          <p className="text-muted-foreground">Input</p>
+          <p className="font-medium">{usage.input_tokens.toLocaleString()}</p>
+        </div>
+        <div>
+          <p className="text-muted-foreground">Output</p>
+          <p className="font-medium">{usage.output_tokens.toLocaleString()}</p>
+        </div>
+        {usage.cache_read_tokens !== undefined && usage.cache_read_tokens > 0 && (
+          <div>
+            <p className="text-muted-foreground">Cache Read</p>
+            <p className="font-medium">{usage.cache_read_tokens.toLocaleString()}</p>
+          </div>
+        )}
+        {usage.cache_creation_tokens !== undefined && usage.cache_creation_tokens > 0 && (
+          <div>
+            <p className="text-muted-foreground">Cache Created</p>
+            <p className="font-medium">{usage.cache_creation_tokens.toLocaleString()}</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ============================================
+// Main Component
+// ============================================
+
+export interface LlmHistoryViewerProps {
+  /** The llm.generation event data */
+  data: LlmGenerationData;
+  /** Optional event ID for display */
+  eventId?: string;
+  /** Optional timestamp for display */
+  timestamp?: string;
+  /** Whether to show in compact mode */
+  compact?: boolean;
+  /** Maximum height for the messages scroll area */
+  maxHeight?: string;
+}
+
+export function LlmHistoryViewer({
+  data,
+  eventId,
+  timestamp,
+  compact = false,
+  maxHeight = "600px",
+}: LlmHistoryViewerProps) {
+  const { messages, output, metadata } = data;
+
+  if (compact) {
+    return (
+      <div className="space-y-3">
+        <div className="flex items-center gap-2 text-sm">
+          <Badge variant="outline">{metadata.model}</Badge>
+          <span className="text-muted-foreground">
+            {messages.length} messages
+          </span>
+          {metadata.usage && (
+            <span className="text-muted-foreground">
+              {formatTokens(metadata.usage.input_tokens + metadata.usage.output_tokens)} tokens
+            </span>
+          )}
+          {metadata.duration_ms !== undefined && (
+            <span className="text-muted-foreground">
+              {formatDuration(metadata.duration_ms)}
+            </span>
+          )}
+        </div>
+        <div className="space-y-2">
+          {messages.slice(-3).map((message, index) => (
+            <MessageCard
+              key={message.id || index}
+              message={message}
+              index={messages.length - 3 + index}
+            />
+          ))}
+          {messages.length > 3 && (
+            <p className="text-xs text-muted-foreground text-center">
+              +{messages.length - 3} more messages
+            </p>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      {(eventId || timestamp) && (
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Badge variant="outline" className="font-mono">llm.generation</Badge>
+            {eventId && (
+              <span className="text-xs text-muted-foreground font-mono">
+                {eventId.slice(0, 8)}...
+              </span>
+            )}
+          </div>
+          {timestamp && (
+            <span className="text-xs text-muted-foreground">
+              {new Date(timestamp).toLocaleString()}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Metadata */}
+      <MetadataSection metadata={metadata} />
+
+      {/* Messages */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm">
+            Input Messages ({messages.length})
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          <ScrollArea style={{ maxHeight }} className="p-4">
+            <div className="space-y-3">
+              {messages.map((message, index) => (
+                <MessageCard key={message.id || index} message={message} index={index} />
+              ))}
+            </div>
+          </ScrollArea>
+        </CardContent>
+      </Card>
+
+      {/* Output */}
+      <OutputSection output={output} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `LlmHistoryViewer` component to visualize LLM message history from `llm.generation` events
- Add component showcase to `/dev/components` page
- Create `/llm-history/[eventId]` page for viewing specific events
- Add "View" button in Events table for `llm.generation` events

## What it does
This feature helps debug LLM interactions by showing the full context window sent to the model during each generation:
- Input messages (user, agent, tool results)
- LLM output (text response and tool calls)
- Generation metadata (model, tokens, duration, status)

## Test plan
- [ ] Navigate to `/dev/components` and scroll to LlmHistoryViewer section
- [ ] Create a session with an agent and send a message to generate an `llm.generation` event
- [ ] Navigate to the Events tab and click "View" on an `llm.generation` event
- [ ] Verify the LLM history page shows all messages, output, and metadata correctly

Screenshots will be attached in a comment.