### PR TITLE
ci: add lockfile check to verify Cargo.lock is up to date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,18 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+  lockfile:
+    name: Lockfile Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Check Cargo.lock is up to date
+        run: cargo fetch --locked
+
   clippy:
     name: Clippy Lints
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What
Adds a lightweight CI job to verify Cargo.lock stays in sync with Cargo.toml.

## Why
Catches cases where someone modifies Cargo.toml but forgets to update the lock file.

## How
Uses `cargo fetch --locked` which fails if Cargo.lock needs updating. This is the lightest option (faster than `build` or `check`) since it only downloads/verifies dependencies without compiling.

## Risk
- Low
- No impact on existing workflows

## Checklist
- [x] Tests added or updated (N/A - CI config change)
- [x] Backward compatibility considered (N/A)