### PR TITLE
feat(ui): auto-focus message input when session loads

### DIFF
--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/chat/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/chat/page.tsx
@@ -117,6 +117,13 @@ export default function ChatPage() {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [chatEvents]);
 
+  // Auto-focus message input when session loads
+  useEffect(() => {
+    if (!eventsLoading) {
+      textareaRef.current?.focus();
+    }
+  }, [eventsLoading]);
+
   // Mutation for sending message with images
   const sendMessageWithImages = useMutation({
     mutationFn: async ({


### PR DESCRIPTION
## What
Auto-focus the message textarea when navigating to a session's chat page.

## Why
Users expect to immediately start typing when opening a session, without needing to click the input first.

## How
Added a `useEffect` that focuses the textarea when `eventsLoading` becomes false.

## Risk
- Low
- Pure UI enhancement, no backend changes