### PR TITLE
feat(llm): add user-friendly error for request-too-large errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ Available specs:
 - `specs/tool-execution.md` - Tool types and execution flow
 - `specs/capabilities.md` - Agent capabilities system for modular functionality
 - `specs/mcp-servers.md` - MCP (Model Context Protocol) server registration
+- `specs/llm-drivers.md` - LLM driver trait, error types, provider implementations
 - `specs/durable-execution-engine.md` - PostgreSQL-backed durable workflow engine
 - `specs/authentication.md` - Authentication modes and OAuth integration
 - `specs/encryption.md` - Envelope encryption for sensitive data

--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -259,10 +259,14 @@ impl LlmDriver for AnthropicLlmDriver {
         if !response.status().is_success() {
             let status = response.status();
             let error_text = response.text().await.unwrap_or_default();
-            return Err(AgentLoopError::llm(format!(
-                "Anthropic API error ({}): {}",
-                status, error_text
-            )));
+            let error_msg = format!("Anthropic API error ({}): {}", status, error_text);
+
+            // Check if this is a request-too-large error
+            if is_anthropic_request_too_large(status, &error_text) {
+                return Err(AgentLoopError::request_too_large(error_msg));
+            }
+
+            return Err(AgentLoopError::llm(error_msg));
         }
 
         let byte_stream = response.bytes_stream();
@@ -466,6 +470,51 @@ pub fn register_driver(registry: &mut DriverRegistry) {
         };
         Box::new(driver) as BoxedLlmDriver
     });
+}
+
+// ============================================================================
+// Error Detection Helpers
+// ============================================================================
+
+/// Check if an Anthropic API error indicates the request is too large.
+///
+/// Detects:
+/// - 413 Request Entity Too Large
+/// - 400 with "prompt is too long" message
+/// - "request size exceeded" message
+fn is_anthropic_request_too_large(status: reqwest::StatusCode, error_text: &str) -> bool {
+    let error_lower = error_text.to_lowercase();
+
+    // HTTP 413 Request Entity Too Large
+    if status == reqwest::StatusCode::PAYLOAD_TOO_LARGE {
+        return true;
+    }
+
+    // HTTP 400 with prompt/context length errors
+    if status == reqwest::StatusCode::BAD_REQUEST {
+        // "prompt is too long: X tokens > Y maximum"
+        if error_lower.contains("prompt is too long") {
+            return true;
+        }
+        // "request size exceeded maximum"
+        if error_lower.contains("request size exceeded") {
+            return true;
+        }
+        // Generic context length error
+        if error_lower.contains("context length") || error_lower.contains("too many tokens") {
+            return true;
+        }
+    }
+
+    // Generic patterns that could appear with various status codes
+    if error_lower.contains("input is too long")
+        || error_lower.contains("exceeds the maximum")
+        || error_lower.contains("maximum context")
+    {
+        return true;
+    }
+
+    false
 }
 
 // ============================================================================
@@ -846,5 +895,69 @@ mod tests {
             }
             _ => panic!("Expected ToolResult block"),
         }
+    }
+
+    // ========================================================================
+    // Request-too-large detection tests
+    // ========================================================================
+
+    #[test]
+    fn test_is_anthropic_request_too_large_413() {
+        let error = r#"{"error":{"message":"Request too large"}}"#;
+        assert!(is_anthropic_request_too_large(
+            reqwest::StatusCode::PAYLOAD_TOO_LARGE,
+            error
+        ));
+    }
+
+    #[test]
+    fn test_is_anthropic_request_too_large_prompt_too_long() {
+        let error = r#"{"error":{"message":"prompt is too long: 250000 tokens > 200000 maximum"}}"#;
+        assert!(is_anthropic_request_too_large(
+            reqwest::StatusCode::BAD_REQUEST,
+            error
+        ));
+    }
+
+    #[test]
+    fn test_is_anthropic_request_too_large_request_size_exceeded() {
+        let error = r#"{"error":{"message":"request size exceeded maximum"}}"#;
+        assert!(is_anthropic_request_too_large(
+            reqwest::StatusCode::BAD_REQUEST,
+            error
+        ));
+    }
+
+    #[test]
+    fn test_is_anthropic_request_too_large_too_many_tokens() {
+        let error = r#"{"error":{"message":"too many tokens in request"}}"#;
+        assert!(is_anthropic_request_too_large(
+            reqwest::StatusCode::BAD_REQUEST,
+            error
+        ));
+    }
+
+    #[test]
+    fn test_is_anthropic_request_too_large_false_for_other_errors() {
+        // Authentication error
+        let error = r#"{"error":{"message":"Invalid API key"}}"#;
+        assert!(!is_anthropic_request_too_large(
+            reqwest::StatusCode::UNAUTHORIZED,
+            error
+        ));
+
+        // Rate limit (not token-related)
+        let error = r#"{"error":{"message":"Rate limit exceeded"}}"#;
+        assert!(!is_anthropic_request_too_large(
+            reqwest::StatusCode::TOO_MANY_REQUESTS,
+            error
+        ));
+
+        // Internal server error
+        let error = r#"{"error":{"message":"Internal server error"}}"#;
+        assert!(!is_anthropic_request_too_large(
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            error
+        ));
     }
 }

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -316,10 +316,16 @@ where
 
                 let error_msg = e.to_string();
 
-                // User-facing error message (don't expose internal details)
-                let user_error_text =
+                // User-facing error message
+                // For request-too-large errors, provide specific guidance
+                let user_error_text = if e.is_request_too_large() {
+                    "The conversation has become too long for the model to process. \
+                     Please start a new session or reduce the context size."
+                        .to_string()
+                } else {
                     "I encountered an error while processing your request. Please try again later."
-                        .to_string();
+                        .to_string()
+                };
 
                 // Create error message for the user to see
                 let error_message = Message::assistant(&user_error_text);

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -100,4 +100,118 @@ impl AgentLoopError {
     pub fn driver_not_registered(provider_type: impl Into<String>) -> Self {
         AgentLoopError::DriverNotRegistered(provider_type.into())
     }
+
+    /// Check if this is a request-too-large error (context length exceeded, token limits, etc.)
+    ///
+    /// Detects errors from various providers:
+    /// - OpenAI: 429 with "Request too large" or "tokens" type, or "context_length_exceeded"
+    /// - Anthropic: 413/400 with context length messages
+    pub fn is_request_too_large(&self) -> bool {
+        match self {
+            AgentLoopError::Llm(msg) => {
+                let msg_lower = msg.to_lowercase();
+
+                // OpenAI patterns
+                // - "Request too large for gpt-4"
+                // - "context_length_exceeded"
+                // - 429 with tokens-related message
+                if msg_lower.contains("request too large")
+                    || msg_lower.contains("context_length_exceeded")
+                    || msg_lower.contains("maximum context length")
+                    || msg_lower.contains("reduce the length")
+                {
+                    return true;
+                }
+
+                // Token limit patterns (common across providers)
+                // - "tokens per min (tpm): limit X, requested Y"
+                // - "input or output tokens must be reduced"
+                if (msg_lower.contains("tokens") || msg_lower.contains("token"))
+                    && (msg_lower.contains("limit")
+                        || msg_lower.contains("exceeded")
+                        || msg_lower.contains("must be reduced"))
+                {
+                    return true;
+                }
+
+                // Anthropic patterns
+                // - "request size exceeded maximum"
+                // - "prompt is too long"
+                if msg_lower.contains("request size exceeded")
+                    || msg_lower.contains("prompt is too long")
+                {
+                    return true;
+                }
+
+                false
+            }
+            _ => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_request_too_large_openai_request_too_large() {
+        let err = AgentLoopError::llm(
+            r#"OpenAI API error (429 Too Many Requests): {"error":{"message":"Request too large for gpt-5-mini in organization org-xxx on tokens per min (TPM): Limit 500000, Requested 538772."}}"#,
+        );
+        assert!(err.is_request_too_large());
+    }
+
+    #[test]
+    fn test_is_request_too_large_openai_context_length_exceeded() {
+        let err = AgentLoopError::llm(
+            r#"OpenAI API error (400): {"error":{"code":"context_length_exceeded","message":"This model's maximum context length is 128000 tokens."}}"#,
+        );
+        assert!(err.is_request_too_large());
+    }
+
+    #[test]
+    fn test_is_request_too_large_token_limit() {
+        let err = AgentLoopError::llm(
+            "The input or output tokens must be reduced in order to run successfully.",
+        );
+        assert!(err.is_request_too_large());
+    }
+
+    #[test]
+    fn test_is_request_too_large_anthropic_prompt_too_long() {
+        let err = AgentLoopError::llm(
+            r#"Anthropic API error (400): {"error":{"message":"prompt is too long: 250000 tokens > 200000 maximum"}}"#,
+        );
+        assert!(err.is_request_too_large());
+    }
+
+    #[test]
+    fn test_is_request_too_large_anthropic_request_size() {
+        let err = AgentLoopError::llm(
+            r#"Anthropic API error (413): {"error":{"message":"request size exceeded maximum"}}"#,
+        );
+        assert!(err.is_request_too_large());
+    }
+
+    #[test]
+    fn test_is_request_too_large_false_for_other_errors() {
+        let err = AgentLoopError::llm("OpenAI API error (500): Internal server error");
+        assert!(!err.is_request_too_large());
+
+        let err = AgentLoopError::llm("Network connection failed");
+        assert!(!err.is_request_too_large());
+
+        let err = AgentLoopError::llm("Rate limit exceeded: too many requests");
+        assert!(!err.is_request_too_large());
+    }
+
+    #[test]
+    fn test_is_request_too_large_false_for_non_llm_errors() {
+        let err = AgentLoopError::ToolExecution("Request too large".to_string());
+        assert!(!err.is_request_too_large());
+
+        let err = AgentLoopError::Cancelled;
+        assert!(!err.is_request_too_large());
+    }
 }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -13,6 +13,11 @@ pub enum AgentLoopError {
     #[error("LLM error: {0}")]
     Llm(String),
 
+    /// Request too large error (context length exceeded, token limits, etc.)
+    /// Contains the original error message for logging
+    #[error("Request too large: {0}")]
+    RequestTooLarge(String),
+
     /// Tool execution error
     #[error("Tool execution error: {0}")]
     ToolExecution(String),
@@ -101,52 +106,14 @@ impl AgentLoopError {
         AgentLoopError::DriverNotRegistered(provider_type.into())
     }
 
-    /// Check if this is a request-too-large error (context length exceeded, token limits, etc.)
-    ///
-    /// Detects errors from various providers:
-    /// - OpenAI: 429 with "Request too large" or "tokens" type, or "context_length_exceeded"
-    /// - Anthropic: 413/400 with context length messages
+    /// Create a request too large error
+    pub fn request_too_large(msg: impl Into<String>) -> Self {
+        AgentLoopError::RequestTooLarge(msg.into())
+    }
+
+    /// Check if this is a request-too-large error
     pub fn is_request_too_large(&self) -> bool {
-        match self {
-            AgentLoopError::Llm(msg) => {
-                let msg_lower = msg.to_lowercase();
-
-                // OpenAI patterns
-                // - "Request too large for gpt-4"
-                // - "context_length_exceeded"
-                // - 429 with tokens-related message
-                if msg_lower.contains("request too large")
-                    || msg_lower.contains("context_length_exceeded")
-                    || msg_lower.contains("maximum context length")
-                    || msg_lower.contains("reduce the length")
-                {
-                    return true;
-                }
-
-                // Token limit patterns (common across providers)
-                // - "tokens per min (tpm): limit X, requested Y"
-                // - "input or output tokens must be reduced"
-                if (msg_lower.contains("tokens") || msg_lower.contains("token"))
-                    && (msg_lower.contains("limit")
-                        || msg_lower.contains("exceeded")
-                        || msg_lower.contains("must be reduced"))
-                {
-                    return true;
-                }
-
-                // Anthropic patterns
-                // - "request size exceeded maximum"
-                // - "prompt is too long"
-                if msg_lower.contains("request size exceeded")
-                    || msg_lower.contains("prompt is too long")
-                {
-                    return true;
-                }
-
-                false
-            }
-            _ => false,
-        }
+        matches!(self, AgentLoopError::RequestTooLarge(_))
     }
 }
 
@@ -155,63 +122,33 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_is_request_too_large_openai_request_too_large() {
-        let err = AgentLoopError::llm(
-            r#"OpenAI API error (429 Too Many Requests): {"error":{"message":"Request too large for gpt-5-mini in organization org-xxx on tokens per min (TPM): Limit 500000, Requested 538772."}}"#,
-        );
+    fn test_is_request_too_large_returns_true_for_typed_error() {
+        let err = AgentLoopError::request_too_large("context length exceeded");
         assert!(err.is_request_too_large());
     }
 
     #[test]
-    fn test_is_request_too_large_openai_context_length_exceeded() {
-        let err = AgentLoopError::llm(
-            r#"OpenAI API error (400): {"error":{"code":"context_length_exceeded","message":"This model's maximum context length is 128000 tokens."}}"#,
-        );
-        assert!(err.is_request_too_large());
-    }
-
-    #[test]
-    fn test_is_request_too_large_token_limit() {
-        let err = AgentLoopError::llm(
-            "The input or output tokens must be reduced in order to run successfully.",
-        );
-        assert!(err.is_request_too_large());
-    }
-
-    #[test]
-    fn test_is_request_too_large_anthropic_prompt_too_long() {
-        let err = AgentLoopError::llm(
-            r#"Anthropic API error (400): {"error":{"message":"prompt is too long: 250000 tokens > 200000 maximum"}}"#,
-        );
-        assert!(err.is_request_too_large());
-    }
-
-    #[test]
-    fn test_is_request_too_large_anthropic_request_size() {
-        let err = AgentLoopError::llm(
-            r#"Anthropic API error (413): {"error":{"message":"request size exceeded maximum"}}"#,
-        );
-        assert!(err.is_request_too_large());
-    }
-
-    #[test]
-    fn test_is_request_too_large_false_for_other_errors() {
+    fn test_is_request_too_large_returns_false_for_llm_error() {
         let err = AgentLoopError::llm("OpenAI API error (500): Internal server error");
         assert!(!err.is_request_too_large());
-
-        let err = AgentLoopError::llm("Network connection failed");
-        assert!(!err.is_request_too_large());
-
-        let err = AgentLoopError::llm("Rate limit exceeded: too many requests");
-        assert!(!err.is_request_too_large());
     }
 
     #[test]
-    fn test_is_request_too_large_false_for_non_llm_errors() {
-        let err = AgentLoopError::ToolExecution("Request too large".to_string());
+    fn test_is_request_too_large_returns_false_for_other_errors() {
+        let err = AgentLoopError::ToolExecution("some error".to_string());
         assert!(!err.is_request_too_large());
 
         let err = AgentLoopError::Cancelled;
         assert!(!err.is_request_too_large());
+    }
+
+    #[test]
+    fn test_request_too_large_error_preserves_message() {
+        let original_msg = "OpenAI API error (429): Request too large for gpt-4";
+        let err = AgentLoopError::request_too_large(original_msg);
+        assert_eq!(
+            err.to_string(),
+            format!("Request too large: {}", original_msg)
+        );
     }
 }

--- a/crates/core/src/openai_protocol.rs
+++ b/crates/core/src/openai_protocol.rs
@@ -218,10 +218,14 @@ impl LlmDriver for OpenAIProtocolLlmDriver {
         if !response.status().is_success() {
             let status = response.status();
             let error_text = response.text().await.unwrap_or_default();
-            return Err(AgentLoopError::llm(format!(
-                "OpenAI API error ({}): {}",
-                status, error_text
-            )));
+            let error_msg = format!("OpenAI API error ({}): {}", status, error_text);
+
+            // Check if this is a request-too-large error
+            if is_openai_request_too_large(status, &error_text) {
+                return Err(AgentLoopError::request_too_large(error_msg));
+            }
+
+            return Err(AgentLoopError::llm(error_msg));
         }
 
         let byte_stream = response.bytes_stream();
@@ -376,6 +380,54 @@ impl std::fmt::Debug for OpenAIProtocolLlmDriver {
             .field("api_key", &"[REDACTED]")
             .finish()
     }
+}
+
+// ============================================================================
+// Error Detection Helpers
+// ============================================================================
+
+/// Check if an OpenAI API error indicates the request is too large.
+///
+/// Detects:
+/// - 429 with "Request too large" or token limit messages
+/// - 400 with "context_length_exceeded" code
+/// - Any message about maximum context length being exceeded
+pub fn is_openai_request_too_large(status: reqwest::StatusCode, error_text: &str) -> bool {
+    let error_lower = error_text.to_lowercase();
+
+    // HTTP 429 with token-related errors
+    if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        // "Request too large for gpt-4" pattern
+        if error_lower.contains("request too large") {
+            return true;
+        }
+        // Token limit errors: "tokens per min (TPM): Limit X, Requested Y"
+        if error_lower.contains("tokens") && error_lower.contains("limit") {
+            return true;
+        }
+    }
+
+    // HTTP 400 with context length errors
+    if status == reqwest::StatusCode::BAD_REQUEST {
+        // "context_length_exceeded" error code
+        if error_lower.contains("context_length_exceeded") {
+            return true;
+        }
+        // "maximum context length" message
+        if error_lower.contains("maximum context length") {
+            return true;
+        }
+    }
+
+    // Generic patterns that could appear with various status codes
+    if error_lower.contains("tokens must be reduced")
+        || error_lower.contains("reduce the length")
+        || error_lower.contains("input is too long")
+    {
+        return true;
+    }
+
+    false
 }
 
 // ============================================================================
@@ -652,5 +704,80 @@ mod tests {
         assert!(chunk.usage.is_none()); // No usage in finish_reason chunk
         assert_eq!(chunk.choices.len(), 1);
         assert_eq!(chunk.choices[0].finish_reason, Some("stop".to_string()));
+    }
+
+    // ========================================================================
+    // Request-too-large detection tests
+    // ========================================================================
+
+    #[test]
+    fn test_is_openai_request_too_large_429_request_too_large() {
+        let error = r#"{"error":{"message":"Request too large for gpt-4o in organization org-xxx on tokens per min (TPM): Limit 500000, Requested 538772."}}"#;
+        assert!(is_openai_request_too_large(
+            reqwest::StatusCode::TOO_MANY_REQUESTS,
+            error
+        ));
+    }
+
+    #[test]
+    fn test_is_openai_request_too_large_429_token_limit() {
+        let error =
+            r#"{"error":{"message":"tokens per min (TPM): Limit 500000, Requested 600000"}}"#;
+        assert!(is_openai_request_too_large(
+            reqwest::StatusCode::TOO_MANY_REQUESTS,
+            error
+        ));
+    }
+
+    #[test]
+    fn test_is_openai_request_too_large_400_context_length() {
+        let error = r#"{"error":{"code":"context_length_exceeded","message":"This model's maximum context length is 128000 tokens."}}"#;
+        assert!(is_openai_request_too_large(
+            reqwest::StatusCode::BAD_REQUEST,
+            error
+        ));
+    }
+
+    #[test]
+    fn test_is_openai_request_too_large_400_max_context() {
+        let error =
+            r#"{"error":{"message":"This model's maximum context length is 128000 tokens"}}"#;
+        assert!(is_openai_request_too_large(
+            reqwest::StatusCode::BAD_REQUEST,
+            error
+        ));
+    }
+
+    #[test]
+    fn test_is_openai_request_too_large_tokens_must_be_reduced() {
+        let error = r#"{"error":{"message":"The input or output tokens must be reduced"}}"#;
+        assert!(is_openai_request_too_large(
+            reqwest::StatusCode::BAD_REQUEST,
+            error
+        ));
+    }
+
+    #[test]
+    fn test_is_openai_request_too_large_false_for_other_errors() {
+        // Regular rate limit (not token-related)
+        let error = r#"{"error":{"message":"Rate limit exceeded: too many requests per minute"}}"#;
+        assert!(!is_openai_request_too_large(
+            reqwest::StatusCode::TOO_MANY_REQUESTS,
+            error
+        ));
+
+        // Internal server error
+        let error = r#"{"error":{"message":"Internal server error"}}"#;
+        assert!(!is_openai_request_too_large(
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            error
+        ));
+
+        // Generic 400 error
+        let error = r#"{"error":{"message":"Invalid request"}}"#;
+        assert!(!is_openai_request_too_large(
+            reqwest::StatusCode::BAD_REQUEST,
+            error
+        ));
     }
 }

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -1,0 +1,182 @@
+# LLM Drivers Specification
+
+## Abstract
+
+LLM drivers provide a provider-agnostic interface for interacting with Large Language Model APIs. The driver abstraction enables dependency inversion - provider implementations (OpenAI, Anthropic) register their drivers at startup, while core business logic operates against the trait interface.
+
+## Architecture
+
+```mermaid
+graph TD
+    subgraph Core [everruns-core]
+        LlmDriver[LlmDriver Trait]
+        Registry[DriverRegistry]
+        Errors[AgentLoopError]
+    end
+
+    subgraph Providers
+        OpenAI[everruns-openai]
+        Anthropic[everruns-anthropic]
+    end
+
+    subgraph Consumer
+        ReasonAtom[ReasonAtom]
+    end
+
+    OpenAI -->|implements| LlmDriver
+    Anthropic -->|implements| LlmDriver
+    OpenAI -->|registers| Registry
+    Anthropic -->|registers| Registry
+    ReasonAtom -->|uses| Registry
+    ReasonAtom -->|handles| Errors
+```
+
+## Requirements
+
+### LlmDriver Trait
+
+1. **Trait Definition** (`everruns-core::llm_driver_registry`):
+   ```rust
+   #[async_trait]
+   pub trait LlmDriver: Send + Sync {
+       async fn chat_completion_stream(
+           &self,
+           messages: Vec<LlmMessage>,
+           config: &LlmCallConfig,
+       ) -> Result<LlmResponseStream>;
+   }
+   ```
+
+2. **Streaming Response**: Drivers MUST return a stream of `LlmStreamEvent`:
+   - `TextDelta(String)` - Incremental text content
+   - `ToolCalls(Vec<ToolCall>)` - Tool calls from the LLM
+   - `Done(LlmCompletionMetadata)` - Stream completed with metadata
+   - `Error(String)` - Error during streaming
+
+3. **Provider Types**: Supported provider types are defined in `ProviderType` enum:
+   - `OpenAI` - OpenAI API
+   - `Anthropic` - Anthropic Claude API
+   - `AzureOpenAI` - Azure OpenAI Service
+   - `LlmSim` - Testing simulator (llmsim crate)
+
+### Error Types (Contract)
+
+Drivers MUST use the following error types from `AgentLoopError`:
+
+1. **`Llm(String)`** - Generic LLM provider error
+   - Use for: network errors, authentication failures, invalid requests, server errors
+   - Example: `AgentLoopError::llm("OpenAI API error (500): Internal server error")`
+
+2. **`RequestTooLarge(String)`** - Context length or token limit exceeded
+   - Use for: context length exceeded, token limits hit, prompt too long
+   - Drivers MUST detect provider-specific error responses and convert to this type
+   - Example: `AgentLoopError::request_too_large("OpenAI API error (429): Request too large...")`
+
+### Error Detection Requirements
+
+Each driver MUST implement provider-specific error detection:
+
+#### OpenAI Driver
+
+Detect `RequestTooLarge` for:
+- HTTP 429 with "Request too large" in message
+- HTTP 429 with "tokens" and "limit" in message (TPM exceeded)
+- HTTP 400 with "context_length_exceeded" code
+- HTTP 400 with "maximum context length" in message
+- Any response with "tokens must be reduced" or "reduce the length"
+
+#### Anthropic Driver
+
+Detect `RequestTooLarge` for:
+- HTTP 413 (Payload Too Large)
+- HTTP 400 with "prompt is too long" in message
+- HTTP 400 with "request size exceeded" in message
+- HTTP 400 with "too many tokens" in message
+- Any response with "maximum context" or "exceeds the maximum"
+
+### Driver Registry
+
+1. **Registration**: Provider crates register factories at startup:
+   ```rust
+   pub fn register_driver(registry: &mut DriverRegistry) {
+       registry.register(ProviderType::OpenAI, |api_key, base_url| {
+           Box::new(OpenAILlmDriver::new(api_key, base_url))
+       });
+   }
+   ```
+
+2. **Creation**: Drivers are created on-demand from `ProviderConfig`:
+   ```rust
+   let driver = registry.create_driver(&config)?;
+   ```
+
+3. **API Key Requirement**: All real providers require API keys. `LlmSim` is exempted for testing.
+
+### Message Types
+
+1. **LlmMessage**: Provider-agnostic message format
+   - `role`: System, User, Assistant, Tool
+   - `content`: Text or multipart (text, images, audio)
+   - `tool_calls`: Optional tool calls (assistant messages)
+   - `tool_call_id`: Optional tool call reference (tool messages)
+
+2. **LlmCallConfig**: Configuration for LLM calls
+   - `model`: Model identifier
+   - `temperature`: Optional sampling temperature
+   - `max_tokens`: Optional token limit
+   - `tools`: Tool definitions
+   - `reasoning_effort`: Optional reasoning level (low, medium, high)
+
+### Completion Metadata
+
+`LlmCompletionMetadata` returned on stream completion:
+- `total_tokens`: Total tokens used
+- `prompt_tokens`: Input tokens
+- `completion_tokens`: Output tokens
+- `cache_read_tokens`: Tokens from cache (provider-specific)
+- `cache_creation_tokens`: Tokens written to cache (Anthropic)
+- `model`: Actual model used
+- `finish_reason`: Why generation stopped
+
+## Error Handling Flow
+
+```mermaid
+sequenceDiagram
+    participant R as ReasonAtom
+    participant D as LlmDriver
+    participant A as API
+
+    R->>D: chat_completion_stream()
+    D->>A: HTTP Request
+    A-->>D: Error Response
+
+    alt Request Too Large
+        D->>D: Detect via is_*_request_too_large()
+        D-->>R: Err(RequestTooLarge(msg))
+        R->>R: is_request_too_large() = true
+        R-->>User: "Conversation too long..."
+    else Other Error
+        D-->>R: Err(Llm(msg))
+        R->>R: is_request_too_large() = false
+        R-->>User: "Error processing request..."
+    end
+
+    Note over R: Full error logged server-side
+```
+
+## Implementation Location
+
+| Component | Location |
+|-----------|----------|
+| LlmDriver trait | `crates/core/src/llm_driver_registry.rs` |
+| AgentLoopError | `crates/core/src/error.rs` |
+| OpenAI driver | `crates/openai/src/driver.rs` |
+| OpenAI protocol | `crates/core/src/openai_protocol.rs` |
+| Anthropic driver | `crates/anthropic/src/driver.rs` |
+| Error handling | `crates/core/src/atoms/reason.rs` |
+
+## Testing
+
+1. **Unit Tests**: Each driver MUST have tests for error detection functions
+2. **LlmSim**: Use `ProviderType::LlmSim` for integration tests without real API keys
+3. **Error Detection Tests**: Cover all documented error patterns for each provider


### PR DESCRIPTION
## What

Add user-friendly error messages when LLM requests fail due to context length or token limits being exceeded.

## Why

When users hit token/context limits, they see a generic error message. This PR provides specific guidance: "The conversation has become too long for the model to process. Please start a new session or reduce the context size."

## How

1. **Typed Error**: Add `RequestTooLarge(String)` variant to `AgentLoopError`
2. **Driver Detection**: Each LLM driver detects provider-specific error patterns and raises the typed error:
   - OpenAI: 429 with "Request too large", 400 with "context_length_exceeded"
   - Anthropic: 413, 400 with "prompt is too long"
3. **ReasonAtom Handling**: Uses `is_request_too_large()` to show context-specific message
4. **Spec**: Added `specs/llm-drivers.md` documenting the error contract

## Test Coverage

- `error::tests` - 4 tests for typed error
- `openai_protocol::tests` - 6 tests for OpenAI error detection
- `driver::tests` (anthropic) - 5 tests for Anthropic error detection

## Risk

- Low
- Only affects error message shown to users when token limits are hit
- Full error still logged server-side for debugging

## Checklist

- [x] Tests added for error detection
- [x] Spec added (`specs/llm-drivers.md`)
- [x] Backward compatibility: N/A (new error variant)