### PR TITLE
fix(api): use cached tools when viewing MCP capability details

### DIFF
--- a/crates/control-plane/src/services/capability.rs
+++ b/crates/control-plane/src/services/capability.rs
@@ -78,10 +78,15 @@ impl CapabilityService {
     }
 
     /// Get a specific capability by ID
+    ///
+    /// For MCP capabilities, uses cached tools only (no external refresh).
+    /// This ensures viewing a capability doesn't fail if the MCP server is unreachable.
+    /// Use the refresh tools endpoint to explicitly update cached tools.
     pub async fn get(&self, id: &CapabilityId) -> Result<Option<CapabilityInfo>> {
         // Check if it's an MCP capability
         if let Some(server_id) = id.mcp_server_id() {
-            let tools = self.mcp_service.get_tools(server_id, false).await?;
+            // Use cached tools only - no external refresh on read
+            let tools = self.mcp_service.get_cached_tools(server_id).await;
             let server = self.mcp_service.get(server_id).await?;
 
             if let Some(server) = server {


### PR DESCRIPTION
## What
Fix 500 error when viewing MCP capability details page.

## Why
The capability detail endpoint was calling `get_tools()` which tries to refresh from the external MCP server when cache is stale. This caused 500 errors when the MCP server was unreachable.

## How
Changed to use `get_cached_tools()` which returns cached data without external calls, consistent with the `list_all()` behavior. Users can explicitly refresh tools via the refresh endpoint when needed.

## Risk
- Low
- Read-only change; MCP capabilities display cached data instead of failing

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered