### PR TITLE
feat(capabilities): add experimental Docker container capability

### DIFF
--- a/crates/control-plane/src/dev_worker/worker.rs
+++ b/crates/control-plane/src/dev_worker/worker.rs
@@ -9,7 +9,7 @@
 use anyhow::Result;
 use everruns_core::ToolRegistry;
 use everruns_core::atoms::{ActAtom, Atom, AtomContext, InputAtom, ReasonAtom};
-use everruns_core::capabilities::CapabilityRegistry;
+use everruns_core::capabilities::{CapabilityRegistry, collect_capabilities, is_mcp_capability};
 use everruns_core::{
     ActInput, DEFAULT_ORG_ID, InputAtomInput, ReasonInput, ReasonResult, TokenUsage,
 };
@@ -71,6 +71,7 @@ pub struct InProcessWorker {
     event_service: Arc<EventService>,
     llm_resolver: Arc<LlmResolverService>,
     mcp_server_service: Arc<McpServerService>,
+    capability_registry: CapabilityRegistry,
     shutdown_tx: watch::Sender<bool>,
     shutdown_rx: watch::Receiver<bool>,
 }
@@ -84,6 +85,7 @@ impl InProcessWorker {
         event_service: Arc<EventService>,
         llm_resolver: Arc<LlmResolverService>,
         mcp_server_service: Arc<McpServerService>,
+        capability_registry: CapabilityRegistry,
     ) -> Self {
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
@@ -99,6 +101,7 @@ impl InProcessWorker {
             event_service,
             llm_resolver,
             mcp_server_service,
+            capability_registry,
             shutdown_tx,
             shutdown_rx,
         }
@@ -446,7 +449,7 @@ impl InProcessWorker {
         let message_retriever =
             DirectMessageRetriever::new(self.db.clone(), self.event_service.clone());
         let provider_store = DirectLlmProviderStore::new(self.llm_resolver.clone());
-        let capability_registry = CapabilityRegistry::with_builtins();
+        let capability_registry = self.capability_registry.clone();
         let driver_registry = create_driver_registry();
         let event_emitter = DirectEventEmitter::new(self.event_service.clone());
 
@@ -569,11 +572,33 @@ impl InProcessWorker {
             "Executing act activity"
         );
 
-        let tool_executor = ToolRegistry::with_defaults();
+        // Build tool registry with defaults and capability tools
+        let mut tool_registry = ToolRegistry::with_defaults();
+
+        // Get agent's capabilities and add their tools to the registry
+        let capability_rows = self.db.get_agent_capabilities(input.agent_id).await?;
+        let builtin_cap_ids: Vec<String> = capability_rows
+            .iter()
+            .map(|r| r.capability_id.clone())
+            .filter(|id| !is_mcp_capability(id))
+            .collect();
+
+        if !builtin_cap_ids.is_empty() {
+            let collected = collect_capabilities(&builtin_cap_ids, &self.capability_registry);
+            for tool in collected.tools {
+                tool_registry.register_boxed(tool);
+            }
+            debug!(
+                capability_count = builtin_cap_ids.len(),
+                tool_count = collected.tool_definitions.len(),
+                "Registered capability tools for act activity"
+            );
+        }
+
         let event_emitter = DirectEventEmitter::new(self.event_service.clone());
         let file_store = Arc::new(DirectSessionFileStore::new(self.db.clone()));
 
-        let atom = ActAtom::with_file_store(tool_executor, event_emitter, file_store);
+        let atom = ActAtom::with_file_store(tool_registry, event_emitter, file_store);
 
         let result = atom.execute(input.clone()).await?;
 

--- a/crates/control-plane/src/main.rs
+++ b/crates/control-plane/src/main.rs
@@ -19,6 +19,7 @@ use everruns_control_plane::task_notifications::TaskNotificationBroadcaster;
 use anyhow::{Context, Result};
 use axum::http::{HeaderValue, Method, header};
 use axum::{Json, Router, extract::State, routing::get};
+use everruns_core::CapabilityRegistry;
 use everruns_core::telemetry::{TelemetryConfig, init_telemetry};
 use everruns_core::{EventListener, OtelEventListener};
 use everruns_durable::{
@@ -404,6 +405,9 @@ async fn main() -> Result<()> {
             // Create in-process worker configuration
             let worker_config = InProcessWorkerConfig::default();
 
+            // Create capability registry for tool execution
+            let capability_registry = CapabilityRegistry::with_builtins();
+
             // Create and spawn the in-process worker
             let worker_db = db.clone();
             let worker_event_service = event_service.clone();
@@ -415,6 +419,7 @@ async fn main() -> Result<()> {
                     worker_event_service,
                     llm_resolver,
                     mcp_server_service,
+                    capability_registry,
                 );
 
                 if let Err(e) = worker.run().await {

--- a/crates/control-plane/src/seed.rs
+++ b/crates/control-plane/src/seed.rs
@@ -37,6 +37,7 @@ mod seed_ids {
     pub const DAD_JOKES_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000101);
     pub const RESEARCH_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000102);
     pub const MS_LEARN_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000103);
+    pub const PYTHON_CODER_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000104);
 
     // MCP Servers (0x500-0x5FF)
     pub const MS_LEARN_MCP: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000501);
@@ -264,6 +265,58 @@ You have access to Microsoft Learn MCP tools that allow you to:
         tags: &["microsoft", "documentation", "mcp", "demo", "seed"],
         // MCP capability ID format: "mcp:{server_uuid}"
         capabilities: &["mcp:01933b5a-0000-7000-8000-000000000501"],
+    },
+    SeedAgent {
+        id: seed_ids::PYTHON_CODER_AGENT,
+        name: "[Experimental] Python Coder",
+        description: "A fast coding agent that writes, executes, and debugs Python code in a Docker container",
+        system_prompt: r#"You are a Python Coder Agent with access to a Docker container running Python.
+You can write code, execute it, and iterate quickly to solve programming tasks.
+
+## Your Capabilities
+
+You have access to a Docker container with Python installed. You can:
+- **docker_exec**: Execute shell commands including running Python scripts
+- **docker_write_file**: Create or update files in the container
+- **docker_read_file**: Read files from the container
+
+## Workflow
+
+1. **Understand the Task**: Clarify requirements before coding
+2. **Write Code**: Create Python files using `docker_write_file`
+3. **Execute & Test**: Run your code with `docker_exec`
+4. **Iterate**: Fix errors, refine, and improve until it works
+
+## Best Practices
+
+- Start with a simple solution, then iterate
+- Write clean, readable code with comments
+- Test early and often - run code after each significant change
+- Use print statements or logging for debugging
+- Save your work to files so it persists across executions
+
+## Example Usage
+
+To write and run a Python script:
+1. `docker_write_file` to `/workspace/main.py` with your code
+2. `docker_exec` with `python /workspace/main.py`
+3. Check output, fix issues, repeat
+
+## Container Info
+
+- Working directory: `/workspace`
+- Python is pre-installed
+- You can install packages with `pip install <package>`
+- The container persists for the session - installed packages stay available
+
+## Guidelines
+
+- Be concise in explanations, focus on working code
+- Show your reasoning when debugging
+- Ask clarifying questions if the task is ambiguous
+- Celebrate when things work! 🎉"#,
+        tags: &["python", "coding", "docker", "experimental", "demo", "seed"],
+        capabilities: &["docker_container"],
     },
 ];
 

--- a/crates/control-plane/src/seed.rs
+++ b/crates/control-plane/src/seed.rs
@@ -941,7 +941,10 @@ pub fn spawn_seed_task(db: Arc<StorageBackend>) {
 }
 
 /// Run seeding with retry logic for transient errors
-async fn run_seed_with_retry(db: &StorageBackend, grade: DeploymentGrade) -> Result<SeedResult, String> {
+async fn run_seed_with_retry(
+    db: &StorageBackend,
+    grade: DeploymentGrade,
+) -> Result<SeedResult, String> {
     let mut retry_count = 0;
     let mut delay = INITIAL_RETRY_DELAY;
 

--- a/crates/control-plane/src/seed.rs
+++ b/crates/control-plane/src/seed.rs
@@ -12,7 +12,7 @@ use everruns_control_plane::storage::{
         CreateOrganizationRow,
     },
 };
-use everruns_core::{DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID};
+use everruns_core::{DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, DeploymentGrade};
 use std::sync::Arc;
 use std::time::Duration;
 use uuid::Uuid;
@@ -156,6 +156,8 @@ struct SeedAgent {
     system_prompt: &'static str,
     tags: &'static [&'static str],
     capabilities: &'static [&'static str],
+    /// If true, only seed in dev environments (experimental features)
+    dev_only: bool,
 }
 
 /// Built-in seed agents
@@ -180,6 +182,7 @@ Example jokes you might tell:
 - "What do you call a fake noodle? An impasta!""#,
         tags: &["humor", "demo", "seed"],
         capabilities: &["current_time"],
+        dev_only: false,
     },
     SeedAgent {
         id: seed_ids::RESEARCH_AGENT,
@@ -229,6 +232,7 @@ Use this structure for organizing research:
 ```"#,
         tags: &["research", "example", "multi-capability"],
         capabilities: &["stateless_todo_list", "web_fetch", "session_file_system"],
+        dev_only: false,
     },
     SeedAgent {
         id: seed_ids::MS_LEARN_AGENT,
@@ -265,6 +269,7 @@ You have access to Microsoft Learn MCP tools that allow you to:
         tags: &["microsoft", "documentation", "mcp", "demo", "seed"],
         // MCP capability ID format: "mcp:{server_uuid}"
         capabilities: &["mcp:01933b5a-0000-7000-8000-000000000501"],
+        dev_only: false,
     },
     SeedAgent {
         id: seed_ids::PYTHON_CODER_AGENT,
@@ -317,14 +322,28 @@ To write and run a Python script:
 - Celebrate when things work! 🎉"#,
         tags: &["python", "coding", "docker", "experimental", "demo", "seed"],
         capabilities: &["docker_container"],
+        dev_only: true, // Experimental capability, only in dev environments
     },
 ];
 
 /// Seed agents into the database
-async fn seed_agents(db: &StorageBackend) -> anyhow::Result<SeedResult> {
+///
+/// Filters out dev-only agents when not in dev environment.
+async fn seed_agents(db: &StorageBackend, grade: DeploymentGrade) -> anyhow::Result<SeedResult> {
     let mut result = SeedResult::default();
+    let include_dev_only = grade.experimental_features_enabled();
 
     for seed in SEED_AGENTS {
+        // Skip dev-only agents in non-dev environments
+        if seed.dev_only && !include_dev_only {
+            tracing::debug!(
+                name = seed.name,
+                id = %seed.id,
+                "Skipping dev-only agent (deployment_grade={})",
+                grade
+            );
+            continue;
+        }
         let input = CreateAgentRow {
             name: seed.name.to_string(),
             description: Some(seed.description.to_string()),
@@ -884,22 +903,29 @@ const INITIAL_RETRY_DELAY: Duration = Duration::from_secs(2);
 /// Spawn seeding as a background task (non-blocking)
 /// This allows the HTTP server to start immediately while seeding runs in background.
 /// Seeding failures are non-fatal - logged as warnings but don't crash the server.
+///
+/// Uses `DeploymentGrade::from_env()` to determine which agents to seed.
 pub fn spawn_seed_task(db: Arc<StorageBackend>) {
+    let grade = DeploymentGrade::from_env();
+    tracing::info!(deployment_grade = %grade, "Starting seeding task");
+
     tokio::spawn(async move {
         // Small delay to let the server start first
         tokio::time::sleep(Duration::from_millis(500)).await;
 
-        match run_seed_with_retry(&db).await {
+        match run_seed_with_retry(&db, grade).await {
             Ok(result) => {
                 if result.created > 0 {
                     tracing::info!(
                         created = result.created,
                         skipped = result.skipped,
+                        deployment_grade = %grade,
                         "Seeding complete"
                     );
                 } else {
                     tracing::debug!(
                         skipped = result.skipped,
+                        deployment_grade = %grade,
                         "Seeding complete (all items exist)"
                     );
                 }
@@ -915,12 +941,12 @@ pub fn spawn_seed_task(db: Arc<StorageBackend>) {
 }
 
 /// Run seeding with retry logic for transient errors
-async fn run_seed_with_retry(db: &StorageBackend) -> Result<SeedResult, String> {
+async fn run_seed_with_retry(db: &StorageBackend, grade: DeploymentGrade) -> Result<SeedResult, String> {
     let mut retry_count = 0;
     let mut delay = INITIAL_RETRY_DELAY;
 
     loop {
-        match seed_all(db).await {
+        match seed_all(db, grade).await {
             Ok(result) => return Ok(result),
             Err(e) => {
                 let error_str = e.to_string();
@@ -964,7 +990,7 @@ async fn run_seed_with_retry(db: &StorageBackend) -> Result<SeedResult, String> 
 /// Run all seeders in order
 /// Order: organization → providers → models → mcp_servers → agents
 /// Organization must be seeded first (all resources have org_id FK)
-async fn seed_all(db: &StorageBackend) -> anyhow::Result<SeedResult> {
+async fn seed_all(db: &StorageBackend, grade: DeploymentGrade) -> anyhow::Result<SeedResult> {
     let mut result = SeedResult::default();
 
     // Seed default organization first (all other resources depend on it)
@@ -1003,8 +1029,8 @@ async fn seed_all(db: &StorageBackend) -> anyhow::Result<SeedResult> {
     );
     result.merge(mcp_result);
 
-    // Seed agents
-    let agent_result = seed_agents(db).await?;
+    // Seed agents (respects deployment grade for dev-only agents)
+    let agent_result = seed_agents(db, grade).await?;
     tracing::debug!(
         created = agent_result.created,
         skipped = agent_result.skipped,

--- a/crates/core/src/capabilities/docker_container.rs
+++ b/crates/core/src/capabilities/docker_container.rs
@@ -1,0 +1,797 @@
+//! Docker Container Capability (Experimental)
+//!
+//! This capability provides tools for running and interacting with a Docker container
+//! tied to the session lifecycle. The container is lazily started on first tool use
+//! and persists for the duration of the session.
+//!
+//! **EXPERIMENTAL**: This capability is experimental and may change significantly.
+//!
+//! Configuration (via AgentCapabilityConfig.config):
+//! ```json
+//! {
+//!   "image": "mcr.microsoft.com/devcontainers/python:3.11",
+//!   "working_dir": "/workspace"  // optional, defaults to /workspace
+//! }
+//! ```
+//!
+//! Tools provided:
+//! - `docker_exec`: Execute a command inside the container
+//! - `docker_read_file`: Read a file from the container
+//! - `docker_write_file`: Write a file to the container
+
+use super::{Capability, CapabilityId, CapabilityStatus};
+use crate::tools::{Tool, ToolExecutionResult};
+use crate::traits::ToolContext;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::process::Stdio;
+use tokio::process::Command;
+use tracing::{debug, error, info, warn};
+
+/// Default Docker image if none specified in config
+const DEFAULT_IMAGE: &str = "mcr.microsoft.com/devcontainers/python:3.11";
+
+/// Default working directory inside the container
+const DEFAULT_WORKING_DIR: &str = "/workspace";
+
+/// Container name prefix
+const CONTAINER_PREFIX: &str = "everruns";
+
+/// Configuration schema for the Docker Container capability
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DockerContainerConfig {
+    /// Docker image to use (e.g., "mcr.microsoft.com/devcontainers/python:3.11")
+    #[serde(default = "default_image")]
+    pub image: String,
+
+    /// Working directory inside the container
+    #[serde(default = "default_working_dir")]
+    pub working_dir: String,
+}
+
+fn default_image() -> String {
+    DEFAULT_IMAGE.to_string()
+}
+
+fn default_working_dir() -> String {
+    DEFAULT_WORKING_DIR.to_string()
+}
+
+impl Default for DockerContainerConfig {
+    fn default() -> Self {
+        Self {
+            image: default_image(),
+            working_dir: default_working_dir(),
+        }
+    }
+}
+
+/// Docker Container capability - provides tools to interact with a Docker container
+pub struct DockerContainerCapability;
+
+impl Capability for DockerContainerCapability {
+    fn id(&self) -> &str {
+        CapabilityId::DOCKER_CONTAINER
+    }
+
+    fn name(&self) -> &str {
+        "[Experimental] Docker Container"
+    }
+
+    fn description(&self) -> &str {
+        "Run commands and manage files in a Docker container tied to the session. \
+         Container is lazily started on first use and persists for the session duration. \
+         EXPERIMENTAL: This capability may change significantly."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("container")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Development")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(
+            r#"You have access to a Docker container for executing commands and managing files.
+The container is tied to this session and persists across tool calls.
+
+IMPORTANT: This is an EXPERIMENTAL capability. The container uses host networking.
+
+Available tools:
+- `docker_exec`: Execute a shell command inside the container. Returns stdout, stderr, and exit code.
+- `docker_read_file`: Read a file from the container filesystem.
+- `docker_write_file`: Write content to a file in the container filesystem.
+
+The container is lazily started on first tool use. Subsequent calls reuse the same container.
+
+Best practices:
+- Use `docker_exec` with `bash -c "..."` for complex commands
+- Check exit codes to verify command success
+- The working directory defaults to /workspace
+- Files written persist for the session duration"#,
+        )
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(DockerExecTool),
+            Box::new(DockerReadFileTool),
+            Box::new(DockerWriteFileTool),
+        ]
+    }
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/// Generate container name from session ID
+fn container_name(session_id: &uuid::Uuid) -> String {
+    format!("{}-{}", CONTAINER_PREFIX, session_id)
+}
+
+/// Check if Docker is available on the system
+async fn is_docker_available() -> bool {
+    match Command::new("docker")
+        .arg("version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+    {
+        Ok(status) => status.success(),
+        Err(e) => {
+            debug!("Docker not available: {}", e);
+            false
+        }
+    }
+}
+
+/// Check if a container exists and is running
+async fn is_container_running(name: &str) -> bool {
+    match Command::new("docker")
+        .args(["inspect", "-f", "{{.State.Running}}", name])
+        .output()
+        .await
+    {
+        Ok(output) => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            stdout.trim() == "true"
+        }
+        Err(_) => false,
+    }
+}
+
+/// Check if a container exists (running or stopped)
+async fn container_exists(name: &str) -> bool {
+    Command::new("docker")
+        .args(["inspect", name])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Ensure container is running, starting it if necessary
+async fn ensure_container_running(
+    name: &str,
+    config: &DockerContainerConfig,
+) -> Result<(), String> {
+    // Check if Docker is available
+    if !is_docker_available().await {
+        return Err(
+            "Docker is not available. Please ensure Docker is installed and running.".to_string(),
+        );
+    }
+
+    // If container is already running, we're done
+    if is_container_running(name).await {
+        debug!("Container {} is already running", name);
+        return Ok(());
+    }
+
+    // If container exists but is stopped, start it
+    if container_exists(name).await {
+        info!("Starting existing container: {}", name);
+        let output = Command::new("docker")
+            .args(["start", name])
+            .output()
+            .await
+            .map_err(|e| format!("Failed to start container: {}", e))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(format!("Failed to start container: {}", stderr));
+        }
+        return Ok(());
+    }
+
+    // Create and start a new container
+    info!(
+        "Creating new container: {} with image: {}",
+        name, config.image
+    );
+
+    let output = Command::new("docker")
+        .args([
+            "run",
+            "-d", // Detached mode
+            "--name",
+            name, // Container name
+            "--network",
+            "host", // Host networking
+            "-w",
+            &config.working_dir, // Working directory
+            "--init",            // Use init process
+            &config.image,       // Image
+            "tail",
+            "-f",
+            "/dev/null", // Keep container running
+        ])
+        .output()
+        .await
+        .map_err(|e| format!("Failed to create container: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        error!("Failed to create container {}: {}", name, stderr);
+        return Err(format!("Failed to create container: {}", stderr));
+    }
+
+    info!("Container {} created and running", name);
+    Ok(())
+}
+
+/// Parse capability config from JSON value
+fn parse_config(config: &Value) -> DockerContainerConfig {
+    serde_json::from_value(config.clone()).unwrap_or_default()
+}
+
+// ============================================================================
+// DockerExecTool
+// ============================================================================
+
+/// Tool to execute commands inside the Docker container
+pub struct DockerExecTool;
+
+#[async_trait]
+impl Tool for DockerExecTool {
+    fn name(&self) -> &str {
+        "docker_exec"
+    }
+
+    fn description(&self) -> &str {
+        "Execute a command inside the Docker container. Returns stdout, stderr, and exit code. \
+         The container is automatically started if not already running."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "description": "The command to execute (e.g., 'ls -la' or 'python script.py')"
+                },
+                "working_dir": {
+                    "type": "string",
+                    "description": "Working directory for the command (optional, defaults to container's working dir)"
+                },
+                "config": {
+                    "type": "object",
+                    "description": "Container configuration (image, working_dir). Usually provided by capability config.",
+                    "properties": {
+                        "image": { "type": "string" },
+                        "working_dir": { "type": "string" }
+                    }
+                }
+            },
+            "required": ["command"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "docker_exec requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let command = match arguments.get("command").and_then(|v| v.as_str()) {
+            Some(c) => c,
+            None => return ToolExecutionResult::tool_error("Missing required parameter: command"),
+        };
+
+        let config = arguments
+            .get("config")
+            .map(parse_config)
+            .unwrap_or_default();
+
+        let working_dir = arguments
+            .get("working_dir")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let name = container_name(&context.session_id);
+
+        // Ensure container is running
+        if let Err(e) = ensure_container_running(&name, &config).await {
+            return ToolExecutionResult::tool_error(e);
+        }
+
+        // Build exec command
+        let mut args = vec!["exec".to_string()];
+
+        if let Some(ref wd) = working_dir {
+            args.push("-w".to_string());
+            args.push(wd.clone());
+        }
+
+        args.push(name.clone());
+        args.push("sh".to_string());
+        args.push("-c".to_string());
+        args.push(command.to_string());
+
+        debug!("Executing in container {}: {}", name, command);
+
+        // Execute command
+        let output = match Command::new("docker").args(&args).output().await {
+            Ok(o) => o,
+            Err(e) => {
+                error!("Failed to execute command in container: {}", e);
+                return ToolExecutionResult::internal_error_msg(format!(
+                    "Failed to execute command: {}",
+                    e
+                ));
+            }
+        };
+
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let exit_code = output.status.code().unwrap_or(-1);
+
+        ToolExecutionResult::success(json!({
+            "stdout": stdout,
+            "stderr": stderr,
+            "exit_code": exit_code,
+            "success": exit_code == 0
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// DockerReadFileTool
+// ============================================================================
+
+/// Tool to read a file from the Docker container
+pub struct DockerReadFileTool;
+
+#[async_trait]
+impl Tool for DockerReadFileTool {
+    fn name(&self) -> &str {
+        "docker_read_file"
+    }
+
+    fn description(&self) -> &str {
+        "Read a file from the Docker container filesystem. \
+         The container is automatically started if not already running."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute path to the file inside the container (e.g., '/workspace/main.py')"
+                },
+                "config": {
+                    "type": "object",
+                    "description": "Container configuration (image, working_dir). Usually provided by capability config.",
+                    "properties": {
+                        "image": { "type": "string" },
+                        "working_dir": { "type": "string" }
+                    }
+                }
+            },
+            "required": ["path"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "docker_read_file requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let path = match arguments.get("path").and_then(|v| v.as_str()) {
+            Some(p) => p,
+            None => return ToolExecutionResult::tool_error("Missing required parameter: path"),
+        };
+
+        let config = arguments
+            .get("config")
+            .map(parse_config)
+            .unwrap_or_default();
+
+        let name = container_name(&context.session_id);
+
+        // Ensure container is running
+        if let Err(e) = ensure_container_running(&name, &config).await {
+            return ToolExecutionResult::tool_error(e);
+        }
+
+        debug!("Reading file from container {}: {}", name, path);
+
+        // Use docker exec to cat the file
+        let output = match Command::new("docker")
+            .args(["exec", &name, "cat", path])
+            .output()
+            .await
+        {
+            Ok(o) => o,
+            Err(e) => {
+                error!("Failed to read file from container: {}", e);
+                return ToolExecutionResult::internal_error_msg(format!(
+                    "Failed to read file: {}",
+                    e
+                ));
+            }
+        };
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return ToolExecutionResult::tool_error(format!("Failed to read file: {}", stderr));
+        }
+
+        let content = String::from_utf8_lossy(&output.stdout).to_string();
+
+        ToolExecutionResult::success(json!({
+            "path": path,
+            "content": content,
+            "size_bytes": content.len()
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// DockerWriteFileTool
+// ============================================================================
+
+/// Tool to write a file to the Docker container
+pub struct DockerWriteFileTool;
+
+#[async_trait]
+impl Tool for DockerWriteFileTool {
+    fn name(&self) -> &str {
+        "docker_write_file"
+    }
+
+    fn description(&self) -> &str {
+        "Write content to a file in the Docker container filesystem. \
+         Parent directories are created automatically. \
+         The container is automatically started if not already running."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute path for the file inside the container (e.g., '/workspace/main.py')"
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Content to write to the file"
+                },
+                "config": {
+                    "type": "object",
+                    "description": "Container configuration (image, working_dir). Usually provided by capability config.",
+                    "properties": {
+                        "image": { "type": "string" },
+                        "working_dir": { "type": "string" }
+                    }
+                }
+            },
+            "required": ["path", "content"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "docker_write_file requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let path = match arguments.get("path").and_then(|v| v.as_str()) {
+            Some(p) => p,
+            None => return ToolExecutionResult::tool_error("Missing required parameter: path"),
+        };
+
+        let content = match arguments.get("content").and_then(|v| v.as_str()) {
+            Some(c) => c,
+            None => return ToolExecutionResult::tool_error("Missing required parameter: content"),
+        };
+
+        let config = arguments
+            .get("config")
+            .map(parse_config)
+            .unwrap_or_default();
+
+        let name = container_name(&context.session_id);
+
+        // Ensure container is running
+        if let Err(e) = ensure_container_running(&name, &config).await {
+            return ToolExecutionResult::tool_error(e);
+        }
+
+        debug!("Writing file to container {}: {}", name, path);
+
+        // Get parent directory
+        let parent_dir = std::path::Path::new(path)
+            .parent()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|| "/".to_string());
+
+        // Create parent directories if needed
+        let mkdir_output = Command::new("docker")
+            .args(["exec", &name, "mkdir", "-p", &parent_dir])
+            .output()
+            .await;
+
+        if let Err(e) = mkdir_output {
+            warn!("Failed to create parent directory: {}", e);
+        }
+
+        // Write content using docker exec with heredoc-style input via stdin
+        // We use base64 encoding to handle special characters safely
+        let encoded = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, content);
+
+        let output = match Command::new("docker")
+            .args([
+                "exec",
+                &name,
+                "sh",
+                "-c",
+                &format!("echo '{}' | base64 -d > '{}'", encoded, path),
+            ])
+            .output()
+            .await
+        {
+            Ok(o) => o,
+            Err(e) => {
+                error!("Failed to write file to container: {}", e);
+                return ToolExecutionResult::internal_error_msg(format!(
+                    "Failed to write file: {}",
+                    e
+                ));
+            }
+        };
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return ToolExecutionResult::tool_error(format!("Failed to write file: {}", stderr));
+        }
+
+        ToolExecutionResult::success(json!({
+            "path": path,
+            "size_bytes": content.len(),
+            "success": true
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_capability_metadata() {
+        let cap = DockerContainerCapability;
+        assert_eq!(cap.id(), CapabilityId::DOCKER_CONTAINER);
+        assert_eq!(cap.name(), "[Experimental] Docker Container");
+        assert_eq!(cap.status(), CapabilityStatus::Available);
+        assert_eq!(cap.icon(), Some("container"));
+        assert_eq!(cap.category(), Some("Development"));
+    }
+
+    #[test]
+    fn test_capability_has_tools() {
+        let cap = DockerContainerCapability;
+        let tools = cap.tools();
+
+        assert_eq!(tools.len(), 3);
+
+        let tool_names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(tool_names.contains(&"docker_exec"));
+        assert!(tool_names.contains(&"docker_read_file"));
+        assert!(tool_names.contains(&"docker_write_file"));
+    }
+
+    #[test]
+    fn test_capability_has_system_prompt() {
+        let cap = DockerContainerCapability;
+        let prompt = cap.system_prompt_addition().unwrap();
+        assert!(prompt.contains("docker_exec"));
+        assert!(prompt.contains("docker_read_file"));
+        assert!(prompt.contains("docker_write_file"));
+        assert!(prompt.contains("EXPERIMENTAL"));
+    }
+
+    #[test]
+    fn test_tools_require_context() {
+        assert!(DockerExecTool.requires_context());
+        assert!(DockerReadFileTool.requires_context());
+        assert!(DockerWriteFileTool.requires_context());
+    }
+
+    #[test]
+    fn test_config_default() {
+        let config = DockerContainerConfig::default();
+        assert_eq!(config.image, DEFAULT_IMAGE);
+        assert_eq!(config.working_dir, DEFAULT_WORKING_DIR);
+    }
+
+    #[test]
+    fn test_config_parse() {
+        let json = json!({
+            "image": "ubuntu:22.04",
+            "working_dir": "/app"
+        });
+        let config = parse_config(&json);
+        assert_eq!(config.image, "ubuntu:22.04");
+        assert_eq!(config.working_dir, "/app");
+    }
+
+    #[test]
+    fn test_config_parse_partial() {
+        let json = json!({
+            "image": "node:18"
+        });
+        let config = parse_config(&json);
+        assert_eq!(config.image, "node:18");
+        assert_eq!(config.working_dir, DEFAULT_WORKING_DIR);
+    }
+
+    #[test]
+    fn test_container_name() {
+        let session_id = uuid::Uuid::parse_str("12345678-1234-1234-1234-123456789012").unwrap();
+        let name = container_name(&session_id);
+        assert_eq!(name, "everruns-12345678-1234-1234-1234-123456789012");
+    }
+
+    #[tokio::test]
+    async fn test_docker_exec_without_context() {
+        let tool = DockerExecTool;
+        let result = tool.execute(json!({"command": "echo hello"})).await;
+
+        if let ToolExecutionResult::ToolError(msg) = result {
+            assert!(msg.contains("requires context"));
+        } else {
+            panic!("Expected tool error");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_docker_read_file_without_context() {
+        let tool = DockerReadFileTool;
+        let result = tool.execute(json!({"path": "/test.txt"})).await;
+
+        if let ToolExecutionResult::ToolError(msg) = result {
+            assert!(msg.contains("requires context"));
+        } else {
+            panic!("Expected tool error");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_docker_write_file_without_context() {
+        let tool = DockerWriteFileTool;
+        let result = tool
+            .execute(json!({"path": "/test.txt", "content": "hello"}))
+            .await;
+
+        if let ToolExecutionResult::ToolError(msg) = result {
+            assert!(msg.contains("requires context"));
+        } else {
+            panic!("Expected tool error");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_docker_exec_missing_command() {
+        let tool = DockerExecTool;
+        let context = ToolContext::new(uuid::Uuid::nil());
+
+        let result = tool.execute_with_context(json!({}), &context).await;
+
+        if let ToolExecutionResult::ToolError(msg) = result {
+            assert!(msg.contains("Missing required parameter"));
+        } else {
+            panic!("Expected tool error for missing command");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_docker_read_file_missing_path() {
+        let tool = DockerReadFileTool;
+        let context = ToolContext::new(uuid::Uuid::nil());
+
+        let result = tool.execute_with_context(json!({}), &context).await;
+
+        if let ToolExecutionResult::ToolError(msg) = result {
+            assert!(msg.contains("Missing required parameter"));
+        } else {
+            panic!("Expected tool error for missing path");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_docker_write_file_missing_params() {
+        let tool = DockerWriteFileTool;
+        let context = ToolContext::new(uuid::Uuid::nil());
+
+        // Missing path
+        let result = tool
+            .execute_with_context(json!({"content": "hello"}), &context)
+            .await;
+        if let ToolExecutionResult::ToolError(msg) = result {
+            assert!(msg.contains("Missing required parameter"));
+        } else {
+            panic!("Expected tool error for missing path");
+        }
+
+        // Missing content
+        let result = tool
+            .execute_with_context(json!({"path": "/test.txt"}), &context)
+            .await;
+        if let ToolExecutionResult::ToolError(msg) = result {
+            assert!(msg.contains("Missing required parameter"));
+        } else {
+            panic!("Expected tool error for missing content");
+        }
+    }
+}

--- a/crates/core/src/capabilities/docker_container.rs
+++ b/crates/core/src/capabilities/docker_container.rs
@@ -18,6 +18,7 @@
 //! - `docker_exec`: Execute a command inside the container
 //! - `docker_read_file`: Read a file from the container
 //! - `docker_write_file`: Write a file to the container
+//! - `docker_stop`: Stop and remove the container
 
 use super::{Capability, CapabilityId, CapabilityStatus};
 use crate::tools::{Tool, ToolExecutionResult};
@@ -108,6 +109,7 @@ Available tools:
 - `docker_exec`: Execute a shell command inside the container. Returns stdout, stderr, and exit code.
 - `docker_read_file`: Read a file from the container filesystem.
 - `docker_write_file`: Write content to a file in the container filesystem.
+- `docker_stop`: Stop and remove the container (for cleanup or to reset state).
 
 The container is lazily started on first tool use. Subsequent calls reuse the same container.
 
@@ -115,7 +117,8 @@ Best practices:
 - Use `docker_exec` with `bash -c "..."` for complex commands
 - Check exit codes to verify command success
 - The working directory defaults to /workspace
-- Files written persist for the session duration"#,
+- Files written persist for the session duration
+- Use `docker_stop` to clean up when done or to reset container state"#,
         )
     }
 
@@ -124,6 +127,7 @@ Best practices:
             Box::new(DockerExecTool),
             Box::new(DockerReadFileTool),
             Box::new(DockerWriteFileTool),
+            Box::new(DockerStopTool),
         ]
     }
 }
@@ -621,6 +625,137 @@ impl Tool for DockerWriteFileTool {
 }
 
 // ============================================================================
+// DockerStopTool
+// ============================================================================
+
+/// Tool to stop and remove the Docker container
+pub struct DockerStopTool;
+
+#[async_trait]
+impl Tool for DockerStopTool {
+    fn name(&self) -> &str {
+        "docker_stop"
+    }
+
+    fn description(&self) -> &str {
+        "Stop and remove the Docker container associated with this session. \
+         Use this to clean up resources or reset the container state. \
+         A new container will be created on the next docker_exec/read/write call."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "force": {
+                    "type": "boolean",
+                    "description": "Force stop (kill) the container if it doesn't stop gracefully (default: false)"
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "docker_stop requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let force = arguments
+            .get("force")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        let name = container_name(&context.session_id);
+
+        // Check if container exists
+        if !container_exists(&name).await {
+            return ToolExecutionResult::success(json!({
+                "stopped": false,
+                "removed": false,
+                "message": "Container does not exist",
+                "container_name": name
+            }));
+        }
+
+        debug!("Stopping container: {}", name);
+
+        // Stop the container
+        let stop_args = if force {
+            vec!["kill", &name]
+        } else {
+            vec!["stop", &name]
+        };
+
+        let stop_output = match Command::new("docker").args(&stop_args).output().await {
+            Ok(o) => o,
+            Err(e) => {
+                error!("Failed to stop container: {}", e);
+                return ToolExecutionResult::internal_error_msg(format!(
+                    "Failed to stop container: {}",
+                    e
+                ));
+            }
+        };
+
+        let stopped = stop_output.status.success();
+        if !stopped {
+            let stderr = String::from_utf8_lossy(&stop_output.stderr);
+            warn!("Failed to stop container {}: {}", name, stderr);
+        }
+
+        // Remove the container
+        debug!("Removing container: {}", name);
+
+        let rm_output = match Command::new("docker")
+            .args(["rm", "-f", &name])
+            .output()
+            .await
+        {
+            Ok(o) => o,
+            Err(e) => {
+                error!("Failed to remove container: {}", e);
+                return ToolExecutionResult::internal_error_msg(format!(
+                    "Failed to remove container: {}",
+                    e
+                ));
+            }
+        };
+
+        let removed = rm_output.status.success();
+        if !removed {
+            let stderr = String::from_utf8_lossy(&rm_output.stderr);
+            warn!("Failed to remove container {}: {}", name, stderr);
+        }
+
+        info!("Container {} stopped and removed", name);
+
+        ToolExecutionResult::success(json!({
+            "stopped": stopped,
+            "removed": removed,
+            "container_name": name,
+            "message": if stopped && removed {
+                "Container stopped and removed successfully"
+            } else if removed {
+                "Container removed (was not running)"
+            } else {
+                "Failed to fully clean up container"
+            }
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
 // Tests
 // ============================================================================
 
@@ -643,12 +778,13 @@ mod tests {
         let cap = DockerContainerCapability;
         let tools = cap.tools();
 
-        assert_eq!(tools.len(), 3);
+        assert_eq!(tools.len(), 4);
 
         let tool_names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
         assert!(tool_names.contains(&"docker_exec"));
         assert!(tool_names.contains(&"docker_read_file"));
         assert!(tool_names.contains(&"docker_write_file"));
+        assert!(tool_names.contains(&"docker_stop"));
     }
 
     #[test]
@@ -658,6 +794,7 @@ mod tests {
         assert!(prompt.contains("docker_exec"));
         assert!(prompt.contains("docker_read_file"));
         assert!(prompt.contains("docker_write_file"));
+        assert!(prompt.contains("docker_stop"));
         assert!(prompt.contains("EXPERIMENTAL"));
     }
 
@@ -666,6 +803,7 @@ mod tests {
         assert!(DockerExecTool.requires_context());
         assert!(DockerReadFileTool.requires_context());
         assert!(DockerWriteFileTool.requires_context());
+        assert!(DockerStopTool.requires_context());
     }
 
     #[test]
@@ -792,6 +930,18 @@ mod tests {
             assert!(msg.contains("Missing required parameter"));
         } else {
             panic!("Expected tool error for missing content");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_docker_stop_without_context() {
+        let tool = DockerStopTool;
+        let result = tool.execute(json!({})).await;
+
+        if let ToolExecutionResult::ToolError(msg) = result {
+            assert!(msg.contains("requires context"));
+        } else {
+            panic!("Expected tool error");
         }
     }
 }

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -31,6 +31,7 @@ pub use crate::capability_types::{
 // ============================================================================
 
 mod current_time;
+mod docker_container;
 mod fake_aws;
 mod fake_crm;
 mod fake_financial;
@@ -48,6 +49,10 @@ mod web_fetch;
 
 // Re-export capabilities
 pub use current_time::{CurrentTimeCapability, GetCurrentTimeTool};
+pub use docker_container::{
+    DockerContainerCapability, DockerContainerConfig, DockerExecTool, DockerReadFileTool,
+    DockerWriteFileTool,
+};
 pub use fake_aws::{
     AwsCreateEc2InstanceTool, AwsCreateIamUserTool, AwsCreateRdsDatabaseTool,
     AwsCreateS3BucketTool, AwsGetCloudWatchMetricsTool, AwsListEc2InstancesTool,
@@ -233,6 +238,8 @@ impl CapabilityRegistry {
         registry.register(FakeAwsCapability);
         registry.register(FakeCrmCapability);
         registry.register(FakeFinancialCapability);
+        // Experimental capabilities
+        registry.register(DockerContainerCapability);
         registry
     }
 
@@ -539,7 +546,8 @@ mod tests {
         assert!(registry.has(CapabilityId::FAKE_AWS));
         assert!(registry.has(CapabilityId::FAKE_CRM));
         assert!(registry.has(CapabilityId::FAKE_FINANCIAL));
-        assert_eq!(registry.len(), 14);
+        assert!(registry.has(CapabilityId::DOCKER_CONTAINER));
+        assert_eq!(registry.len(), 15);
     }
 
     #[test]

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -14,6 +14,7 @@
 //!
 //! Each capability is in its own file with collocated tools.
 
+use crate::deployment::DeploymentGrade;
 use crate::runtime_agent::RuntimeAgent;
 use crate::tool_types::ToolDefinition;
 use crate::tools::{Tool, ToolRegistry};
@@ -220,8 +221,20 @@ impl CapabilityRegistry {
     }
 
     /// Create a registry with all built-in capabilities registered
+    ///
+    /// Uses `DeploymentGrade::from_env()` to determine which capabilities to include.
+    /// For explicit control, use `with_builtins_for_grade()`.
     pub fn with_builtins() -> Self {
+        Self::with_builtins_for_grade(DeploymentGrade::from_env())
+    }
+
+    /// Create a registry with built-in capabilities for a specific deployment grade
+    ///
+    /// Experimental capabilities (like DockerContainer) are only included in dev environments.
+    pub fn with_builtins_for_grade(grade: DeploymentGrade) -> Self {
         let mut registry = Self::new();
+
+        // Core capabilities (all environments)
         registry.register(NoopCapability);
         registry.register(CurrentTimeCapability);
         registry.register(ResearchCapability);
@@ -231,15 +244,21 @@ impl CapabilityRegistry {
         registry.register(TestWeatherCapability);
         registry.register(StatelessTodoListCapability);
         registry.register(WebFetchCapability);
-        // Demo capability with mount points
+
+        // Demo capability with mount points (all environments)
         registry.register(SampleDataCapability);
-        // Fake demo capabilities
+
+        // Fake demo capabilities (all environments)
         registry.register(FakeWarehouseCapability);
         registry.register(FakeAwsCapability);
         registry.register(FakeCrmCapability);
         registry.register(FakeFinancialCapability);
-        // Experimental capabilities
-        registry.register(DockerContainerCapability);
+
+        // Experimental capabilities (dev only)
+        if grade.experimental_features_enabled() {
+            registry.register(DockerContainerCapability);
+        }
+
         registry
     }
 
@@ -529,8 +548,9 @@ mod tests {
     // =========================================================================
 
     #[test]
-    fn test_capability_registry_with_builtins() {
-        let registry = CapabilityRegistry::with_builtins();
+    fn test_capability_registry_with_builtins_dev() {
+        // Dev mode includes all capabilities including experimental
+        let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
 
         assert!(registry.has(CapabilityId::NOOP));
         assert!(registry.has(CapabilityId::CURRENT_TIME));
@@ -546,8 +566,33 @@ mod tests {
         assert!(registry.has(CapabilityId::FAKE_AWS));
         assert!(registry.has(CapabilityId::FAKE_CRM));
         assert!(registry.has(CapabilityId::FAKE_FINANCIAL));
+        // Experimental capability included in dev
         assert!(registry.has(CapabilityId::DOCKER_CONTAINER));
         assert_eq!(registry.len(), 15);
+    }
+
+    #[test]
+    fn test_capability_registry_with_builtins_prod() {
+        // Prod mode excludes experimental capabilities
+        let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Prod);
+
+        assert!(registry.has(CapabilityId::NOOP));
+        assert!(registry.has(CapabilityId::CURRENT_TIME));
+        assert!(registry.has(CapabilityId::RESEARCH));
+        assert!(registry.has(CapabilityId::SANDBOX));
+        assert!(registry.has(CapabilityId::FILE_SYSTEM));
+        assert!(registry.has(CapabilityId::TEST_MATH));
+        assert!(registry.has(CapabilityId::TEST_WEATHER));
+        assert!(registry.has(CapabilityId::STATELESS_TODO_LIST));
+        assert!(registry.has(CapabilityId::WEB_FETCH));
+        assert!(registry.has(CapabilityId::SAMPLE_DATA));
+        assert!(registry.has(CapabilityId::FAKE_WAREHOUSE));
+        assert!(registry.has(CapabilityId::FAKE_AWS));
+        assert!(registry.has(CapabilityId::FAKE_CRM));
+        assert!(registry.has(CapabilityId::FAKE_FINANCIAL));
+        // Experimental capability NOT included in prod
+        assert!(!registry.has(CapabilityId::DOCKER_CONTAINER));
+        assert_eq!(registry.len(), 14);
     }
 
     #[test]

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -51,7 +51,7 @@ mod web_fetch;
 pub use current_time::{CurrentTimeCapability, GetCurrentTimeTool};
 pub use docker_container::{
     DockerContainerCapability, DockerContainerConfig, DockerExecTool, DockerReadFileTool,
-    DockerWriteFileTool,
+    DockerStopTool, DockerWriteFileTool,
 };
 pub use fake_aws::{
     AwsCreateEc2InstanceTool, AwsCreateIamUserTool, AwsCreateRdsDatabaseTool,

--- a/crates/core/src/capability_types.rs
+++ b/crates/core/src/capability_types.rs
@@ -55,6 +55,8 @@ impl CapabilityId {
     pub const FAKE_FINANCIAL: &'static str = "fake_financial";
     // Demo capability with mount points
     pub const SAMPLE_DATA: &'static str = "sample_data";
+    // Experimental capability ID constants
+    pub const DOCKER_CONTAINER: &'static str = "docker_container";
 
     /// Create the noop capability ID
     pub fn noop() -> Self {
@@ -124,6 +126,11 @@ impl CapabilityId {
     /// Create the sample_data capability ID
     pub fn sample_data() -> Self {
         Self::new(Self::SAMPLE_DATA)
+    }
+
+    /// Create the docker_container capability ID
+    pub fn docker_container() -> Self {
+        Self::new(Self::DOCKER_CONTAINER)
     }
 }
 

--- a/crates/core/src/deployment.rs
+++ b/crates/core/src/deployment.rs
@@ -99,19 +99,46 @@ mod tests {
 
     #[test]
     fn test_parse_grades() {
-        assert_eq!("dev".parse::<DeploymentGrade>().unwrap(), DeploymentGrade::Dev);
-        assert_eq!("development".parse::<DeploymentGrade>().unwrap(), DeploymentGrade::Dev);
-        assert_eq!("poc".parse::<DeploymentGrade>().unwrap(), DeploymentGrade::Poc);
-        assert_eq!("preview".parse::<DeploymentGrade>().unwrap(), DeploymentGrade::Preview);
-        assert_eq!("staging".parse::<DeploymentGrade>().unwrap(), DeploymentGrade::Preview);
-        assert_eq!("prod".parse::<DeploymentGrade>().unwrap(), DeploymentGrade::Prod);
-        assert_eq!("production".parse::<DeploymentGrade>().unwrap(), DeploymentGrade::Prod);
+        assert_eq!(
+            "dev".parse::<DeploymentGrade>().unwrap(),
+            DeploymentGrade::Dev
+        );
+        assert_eq!(
+            "development".parse::<DeploymentGrade>().unwrap(),
+            DeploymentGrade::Dev
+        );
+        assert_eq!(
+            "poc".parse::<DeploymentGrade>().unwrap(),
+            DeploymentGrade::Poc
+        );
+        assert_eq!(
+            "preview".parse::<DeploymentGrade>().unwrap(),
+            DeploymentGrade::Preview
+        );
+        assert_eq!(
+            "staging".parse::<DeploymentGrade>().unwrap(),
+            DeploymentGrade::Preview
+        );
+        assert_eq!(
+            "prod".parse::<DeploymentGrade>().unwrap(),
+            DeploymentGrade::Prod
+        );
+        assert_eq!(
+            "production".parse::<DeploymentGrade>().unwrap(),
+            DeploymentGrade::Prod
+        );
     }
 
     #[test]
     fn test_case_insensitive() {
-        assert_eq!("DEV".parse::<DeploymentGrade>().unwrap(), DeploymentGrade::Dev);
-        assert_eq!("PROD".parse::<DeploymentGrade>().unwrap(), DeploymentGrade::Prod);
+        assert_eq!(
+            "DEV".parse::<DeploymentGrade>().unwrap(),
+            DeploymentGrade::Dev
+        );
+        assert_eq!(
+            "PROD".parse::<DeploymentGrade>().unwrap(),
+            DeploymentGrade::Prod
+        );
     }
 
     #[test]

--- a/crates/core/src/deployment.rs
+++ b/crates/core/src/deployment.rs
@@ -1,0 +1,137 @@
+//! Deployment grade configuration
+//!
+//! This module defines the deployment grade (environment tier) which controls
+//! which features and capabilities are available in each environment.
+//!
+//! Grades:
+//! - `dev`: Development environment, all experimental features enabled
+//! - `poc`: Proof of concept / demo environment
+//! - `preview`: Preview/staging environment
+//! - `prod`: Production environment, only stable features
+
+use std::fmt;
+use std::str::FromStr;
+
+/// Deployment grade (environment tier)
+///
+/// Controls which features are available. More permissive grades include
+/// experimental features that may not be stable or secure for production.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DeploymentGrade {
+    /// Development environment - all experimental features enabled
+    Dev,
+    /// Proof of concept / demo environment
+    Poc,
+    /// Preview/staging environment
+    Preview,
+    /// Production environment - only stable features
+    #[default]
+    Prod,
+}
+
+impl DeploymentGrade {
+    /// Returns true if this is a development environment
+    pub fn is_dev(&self) -> bool {
+        matches!(self, DeploymentGrade::Dev)
+    }
+
+    /// Returns true if experimental features should be enabled
+    ///
+    /// Currently only enabled in dev environments
+    pub fn experimental_features_enabled(&self) -> bool {
+        matches!(self, DeploymentGrade::Dev)
+    }
+
+    /// Parse from environment variable
+    ///
+    /// Reads DEPLOYMENT_GRADE env var. Returns Dev if DEV_MODE=true,
+    /// otherwise defaults to Prod.
+    pub fn from_env() -> Self {
+        // Check explicit DEPLOYMENT_GRADE first
+        if let Ok(grade) = std::env::var("DEPLOYMENT_GRADE") {
+            return grade.parse().unwrap_or_default();
+        }
+
+        // Fall back to DEV_MODE for backwards compatibility
+        let dev_mode = std::env::var("DEV_MODE")
+            .map(|v| v == "true" || v == "1")
+            .unwrap_or(false);
+
+        if dev_mode {
+            DeploymentGrade::Dev
+        } else {
+            DeploymentGrade::Prod
+        }
+    }
+}
+
+impl fmt::Display for DeploymentGrade {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DeploymentGrade::Dev => write!(f, "dev"),
+            DeploymentGrade::Poc => write!(f, "poc"),
+            DeploymentGrade::Preview => write!(f, "preview"),
+            DeploymentGrade::Prod => write!(f, "prod"),
+        }
+    }
+}
+
+impl FromStr for DeploymentGrade {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "dev" | "development" => Ok(DeploymentGrade::Dev),
+            "poc" => Ok(DeploymentGrade::Poc),
+            "preview" | "staging" => Ok(DeploymentGrade::Preview),
+            "prod" | "production" => Ok(DeploymentGrade::Prod),
+            _ => Err(format!(
+                "Unknown deployment grade: '{}'. Valid values: dev, poc, preview, prod",
+                s
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_grades() {
+        assert_eq!("dev".parse::<DeploymentGrade>().unwrap(), DeploymentGrade::Dev);
+        assert_eq!("development".parse::<DeploymentGrade>().unwrap(), DeploymentGrade::Dev);
+        assert_eq!("poc".parse::<DeploymentGrade>().unwrap(), DeploymentGrade::Poc);
+        assert_eq!("preview".parse::<DeploymentGrade>().unwrap(), DeploymentGrade::Preview);
+        assert_eq!("staging".parse::<DeploymentGrade>().unwrap(), DeploymentGrade::Preview);
+        assert_eq!("prod".parse::<DeploymentGrade>().unwrap(), DeploymentGrade::Prod);
+        assert_eq!("production".parse::<DeploymentGrade>().unwrap(), DeploymentGrade::Prod);
+    }
+
+    #[test]
+    fn test_case_insensitive() {
+        assert_eq!("DEV".parse::<DeploymentGrade>().unwrap(), DeploymentGrade::Dev);
+        assert_eq!("PROD".parse::<DeploymentGrade>().unwrap(), DeploymentGrade::Prod);
+    }
+
+    #[test]
+    fn test_default() {
+        assert_eq!(DeploymentGrade::default(), DeploymentGrade::Prod);
+    }
+
+    #[test]
+    fn test_experimental_features() {
+        assert!(DeploymentGrade::Dev.experimental_features_enabled());
+        assert!(!DeploymentGrade::Poc.experimental_features_enabled());
+        assert!(!DeploymentGrade::Preview.experimental_features_enabled());
+        assert!(!DeploymentGrade::Prod.experimental_features_enabled());
+    }
+
+    #[test]
+    fn test_display() {
+        assert_eq!(DeploymentGrade::Dev.to_string(), "dev");
+        assert_eq!(DeploymentGrade::Poc.to_string(), "poc");
+        assert_eq!(DeploymentGrade::Preview.to_string(), "preview");
+        assert_eq!(DeploymentGrade::Prod.to_string(), "prod");
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -19,6 +19,9 @@
 pub mod capability_types;
 pub mod tool_types;
 
+// Deployment configuration
+pub mod deployment;
+
 // Telemetry (OpenTelemetry with gen-ai semantic conventions)
 pub mod telemetry;
 
@@ -150,6 +153,9 @@ pub use organization::{
 };
 pub use session::{Session, SessionStatus};
 pub use session_file::{FileInfo, FileStat, GrepMatch, GrepResult, SessionFile};
+
+// Deployment configuration
+pub use deployment::DeploymentGrade;
 
 // OTel event listener (observation backend)
 pub use observation::OtelEventListener;

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -15,7 +15,8 @@
 use anyhow::{Context, Result};
 use everruns_core::ToolRegistry;
 use everruns_core::atoms::{ActAtom, Atom, InputAtom, ReasonAtom};
-use everruns_core::capabilities::CapabilityRegistry;
+use everruns_core::capabilities::{CapabilityRegistry, collect_capabilities, is_mcp_capability};
+use everruns_core::traits::AgentStore;
 use std::sync::Arc;
 
 use crate::adapters::create_driver_registry;
@@ -253,8 +254,35 @@ pub async fn act_activity(
         "Executing act_activity"
     );
 
+    // Create tool registry with default built-in tools
+    let mut builtin_executor = ToolRegistry::with_defaults();
+
+    // Load agent capabilities and register their tools
+    let agent_store = GrpcAgentStore::new(grpc_client.clone(), org_id);
+    if let Ok(Some(agent)) = agent_store.get_agent(input.agent_id).await {
+        // Extract capability IDs, filtering out MCP capabilities (handled separately)
+        let builtin_cap_ids: Vec<String> = agent
+            .capabilities
+            .iter()
+            .map(|c| c.capability_id().to_string())
+            .filter(|id| !is_mcp_capability(id))
+            .collect();
+
+        if !builtin_cap_ids.is_empty() {
+            let capability_registry = CapabilityRegistry::with_builtins();
+            let collected = collect_capabilities(&builtin_cap_ids, &capability_registry);
+            for tool in collected.tools {
+                builtin_executor.register_boxed(tool);
+            }
+            tracing::debug!(
+                capability_count = builtin_cap_ids.len(),
+                tool_count = collected.tool_definitions.len(),
+                "Registered capability tools for act_activity"
+            );
+        }
+    }
+
     // Create composite tool executor that handles both built-in and MCP tools
-    let builtin_executor = ToolRegistry::with_defaults();
     let mcp_executor = Arc::new(crate::mcp_executor::McpToolExecutor::new(
         grpc_client.clone(),
         org_id,

--- a/docs/sre/environment-variables.md
+++ b/docs/sre/environment-variables.md
@@ -36,6 +36,41 @@ DEV_MODE=1 ./target/debug/everruns-control-plane
 - No distributed tracing of worker activities
 - Single-instance only
 
+## DEPLOYMENT_GRADE
+
+Deployment environment grade. Controls which features and capabilities are available.
+
+| Property | Value |
+|----------|-------|
+| **Required** | No |
+| **Default** | `prod` (or `dev` if `DEV_MODE=true`) |
+
+**Valid values:**
+
+| Grade | Description |
+|-------|-------------|
+| `dev` | Development - all experimental features enabled |
+| `poc` | Proof of concept / demo environment |
+| `preview` | Preview/staging environment |
+| `prod` | Production - only stable features |
+
+**Example:**
+
+```bash
+# Run in development mode with experimental features
+DEPLOYMENT_GRADE=dev ./target/debug/everruns-control-plane
+
+# Production mode (default)
+DEPLOYMENT_GRADE=prod ./target/debug/everruns-control-plane
+```
+
+**Notes:**
+- If not set, falls back to `DEV_MODE`: if `DEV_MODE=true`, uses `dev`; otherwise uses `prod`
+- Experimental capabilities (e.g., Docker Container) are only available in `dev` grade
+- Experimental seed agents (e.g., Python Coder) are only created in `dev` grade
+- Use `dev` for local development and testing experimental features
+- Use `prod` for production deployments
+
 ## API_PREFIX
 
 Optional prefix for all API routes.

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -326,6 +326,7 @@ case "$command" in
 
     # Enable dev mode
     export DEV_MODE=true
+    export DEPLOYMENT_GRADE=dev
     export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:9100}
     export RUST_LOG=${RUST_LOG:-info}
 
@@ -545,6 +546,7 @@ case "$command" in
     echo "4️⃣  Starting API server with auto-reload..."
     # Allow CORS from UI (localhost:9100) for SSE connections
     export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:9100}
+    export DEPLOYMENT_GRADE=dev
     export RUST_LOG=${RUST_LOG:-info}
     cargo watch -w crates -x 'run -p everruns-control-plane' &
     API_PID=$!


### PR DESCRIPTION
## Summary
- Add experimental Docker container capability that provides tools for running and interacting with Docker containers tied to session lifecycle
- Tools: `docker_exec`, `docker_read_file`, `docker_write_file`, `docker_stop`
- Add `DEPLOYMENT_GRADE` env variable to gate experimental features (dev, poc, preview, prod)
- Add "[Experimental] Python Coder" seed agent to demo the capability (dev-only)
- Fix capability tools not being registered in worker's `act_activity`

## Changes
- **Docker Container Capability**: Lazy container startup, host networking, per-session lifecycle
- **Deployment Grade**: Controls which features are available per environment
- **Seed Agent Gating**: `dev_only` field to restrict agents to dev environments
- **Documentation**: Added `DEPLOYMENT_GRADE` to environment variables docs

## Test plan
- [ ] Run `./scripts/dev.sh start-dev` and verify Docker capability is available
- [ ] Create session with Python Coder agent and execute docker tools
- [ ] Verify `DEPLOYMENT_GRADE=prod` excludes Docker capability and Python Coder agent
- [ ] Run `cargo test` to verify all tests pass