### PR TITLE
feat(session): add cancel turn functionality

### DIFF
--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/chat/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/chat/page.tsx
@@ -11,7 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Send, Bot, Loader2, Brain, ImagePlus } from "lucide-react";
+import { Send, Bot, Loader2, Brain, ImagePlus, StopCircle } from "lucide-react";
 import type { Controls, MessageUserData, MessageAgentData, ContentPart } from "@/lib/api/types";
 import { isImageFilePart } from "@/lib/api/types";
 import { ToolCallCardFromEvent } from "@/components/chat/tool-call-card-from-event";
@@ -37,12 +37,14 @@ export default function ChatPage() {
     chatEvents,
     toolResultsMap,
     eventsLoading,
+    isActive,
     reasoningEffort,
     setReasoningEffort,
     setIsWaitingForResponse,
     isThinking,
     streamingText,
     sendMessage,
+    cancelCurrentTurn,
     getMessageText,
     getToolCalls,
   } = useSessionContext();
@@ -437,21 +439,40 @@ export default function ChatPage() {
             />
           </div>
 
-          <Button
-            type="submit"
-            size="icon"
-            className="h-[60px] w-[60px]"
-            disabled={!canSubmit}
-            title={isUploading ? "Uploading images..." : undefined}
-          >
-            {sendMessage.isPending || sendMessageWithImages.isPending ? (
-              <Loader2 className="h-5 w-5 animate-spin" />
-            ) : isUploading ? (
-              <Loader2 className="h-5 w-5 animate-spin" />
-            ) : (
-              <Send className="h-5 w-5" />
-            )}
-          </Button>
+          {/* Show cancel button when turn is active and no input typed */}
+          {isActive && !inputValue.trim() && !hasImages ? (
+            <Button
+              type="button"
+              size="icon"
+              variant="destructive"
+              className="h-[60px] w-[60px]"
+              disabled={cancelCurrentTurn.isPending}
+              onClick={() => cancelCurrentTurn.mutate()}
+              title="Cancel current turn"
+            >
+              {cancelCurrentTurn.isPending ? (
+                <Loader2 className="h-5 w-5 animate-spin" />
+              ) : (
+                <StopCircle className="h-5 w-5" />
+              )}
+            </Button>
+          ) : (
+            <Button
+              type="submit"
+              size="icon"
+              className="h-[60px] w-[60px]"
+              disabled={!canSubmit}
+              title={isUploading ? "Uploading images..." : undefined}
+            >
+              {sendMessage.isPending || sendMessageWithImages.isPending ? (
+                <Loader2 className="h-5 w-5 animate-spin" />
+              ) : isUploading ? (
+                <Loader2 className="h-5 w-5 animate-spin" />
+              ) : (
+                <Send className="h-5 w-5" />
+              )}
+            </Button>
+          )}
         </form>
         <div className="flex flex-wrap items-center gap-4 mt-2">
           <div className="flex items-center gap-2">

--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/session-context.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/session-context.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useContext, useState, useMemo, useEffect, type ReactNode } from "react";
 import { useAgent, useSession, useEvents, useLlmModel } from "@/hooks";
-import { sendUserMessage } from "@/lib/api/sessions";
+import { sendUserMessage, cancelTurn } from "@/lib/api/sessions";
 import { useMutation } from "@tanstack/react-query";
 import { useOrg } from "@/providers/org-provider";
 import type {
@@ -65,6 +65,8 @@ interface SessionContextValue {
     { agentId: string; sessionId: string; content: string; controls?: Controls },
     { optimisticId: string; content: string }
   >;
+  // Turn cancellation
+  cancelCurrentTurn: UseMutationResult<void, Error, void, unknown>;
   // Utility functions
   getMessageText: (data: MessageUserData | MessageAgentData) => string;
   getToolCalls: (data: MessageAgentData) => Array<{ id: string; name: string; arguments: Record<string, unknown> }>;
@@ -154,6 +156,20 @@ export function SessionProvider({ agentId, sessionId, children }: SessionProvide
           prev.filter((e) => e.id !== context.optimisticId)
         );
       }
+    },
+  });
+
+  // Cancel turn mutation
+  const cancelCurrentTurn = useMutation({
+    mutationFn: async () => {
+      if (!org) throw new Error("Organization not found");
+      await cancelTurn(org, agentId, sessionId);
+    },
+    onSuccess: () => {
+      // Reset waiting state since turn is cancelled
+      setIsWaitingForResponse(false);
+      // Update local status to idle immediately
+      setLocalStatus("idle");
     },
   });
 
@@ -435,6 +451,7 @@ export function SessionProvider({ agentId, sessionId, children }: SessionProvide
     streamingText,
     streamingTurnId,
     sendMessage,
+    cancelCurrentTurn,
     getMessageText,
     getToolCalls,
   };

--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/session-context.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/session-context.tsx
@@ -195,6 +195,18 @@ export function SessionProvider({ agentId, sessionId, children }: SessionProvide
         setLocalStatus("idle");
         // When session becomes idle, user is no longer waiting for response
         setIsWaitingForResponse(false);
+        // Also clear thinking/streaming state - session is done
+        setIsThinking(false);
+        setStreamingText(null);
+        setStreamingTurnId(null);
+        break;
+      }
+      if (event.type === "turn.cancelled") {
+        // Turn was cancelled - clear thinking state immediately
+        setIsWaitingForResponse(false);
+        setIsThinking(false);
+        setStreamingText(null);
+        setStreamingTurnId(null);
         break;
       }
     }

--- a/apps/ui/src/lib/api/sessions.ts
+++ b/apps/ui/src/lib/api/sessions.ts
@@ -79,3 +79,22 @@ export async function deleteSession(
 ): Promise<void> {
   await api.delete(`/v1/orgs/${org}/agents/${agentId}/sessions/${sessionId}`);
 }
+
+/**
+ * Cancel the currently running turn in a session.
+ *
+ * This will:
+ * 1. Cancel the underlying workflow execution
+ * 2. Emit a turn.cancelled event
+ * 3. Insert an agent message indicating the turn was cancelled
+ * 4. Set the session status back to idle
+ *
+ * @throws Error if no turn is currently running (409 Conflict)
+ */
+export async function cancelTurn(
+  org: string,
+  agentId: string,
+  sessionId: string
+): Promise<void> {
+  await api.post(`/v1/orgs/${org}/agents/${agentId}/sessions/${sessionId}/cancel`);
+}

--- a/crates/control-plane/src/api/sessions.rs
+++ b/crates/control-plane/src/api/sessions.rs
@@ -11,7 +11,8 @@ use axum::{
     routing::{get, post},
 };
 use everruns_core::events::{
-    EventContext, EventRequest, MessageAgentData, SessionIdledData, TurnCancelledData,
+    EventContext, EventRequest, MessageAgentData, MessageUserData, SessionIdledData,
+    TurnCancelledData,
 };
 use everruns_core::{Message, Session};
 use everruns_worker::AgentRunner;
@@ -346,15 +347,26 @@ pub async fn cancel_turn(
         tracing::warn!(session_id = %session_id, error = %e, "Failed to emit turn.cancelled event");
     }
 
-    // Insert agent message indicating cancellation
-    let cancel_message = Message::assistant("Work was cancelled by user.");
-    let message_event = EventRequest::new(
+    // Insert user message indicating cancellation request
+    let user_cancel_message = Message::user("User requested to cancel the work.");
+    let user_message_event = EventRequest::new(
         session_id,
         EventContext::turn(turn_id, input_message_id),
-        MessageAgentData::new(cancel_message),
+        MessageUserData::new(user_cancel_message),
     );
-    if let Err(e) = state.event_service.emit(message_event).await {
-        tracing::warn!(session_id = %session_id, error = %e, "Failed to emit cancellation message");
+    if let Err(e) = state.event_service.emit(user_message_event).await {
+        tracing::warn!(session_id = %session_id, error = %e, "Failed to emit user cancellation message");
+    }
+
+    // Insert agent message indicating cancellation completed
+    let agent_cancel_message = Message::assistant("Work was cancelled by user.");
+    let agent_message_event = EventRequest::new(
+        session_id,
+        EventContext::turn(turn_id, input_message_id),
+        MessageAgentData::new(agent_cancel_message),
+    );
+    if let Err(e) = state.event_service.emit(agent_message_event).await {
+        tracing::warn!(session_id = %session_id, error = %e, "Failed to emit agent cancellation message");
     }
 
     // Emit session.idled event

--- a/crates/control-plane/src/api/sessions.rs
+++ b/crates/control-plane/src/api/sessions.rs
@@ -10,10 +10,7 @@ use axum::{
     http::StatusCode,
     routing::{get, post},
 };
-use everruns_core::events::{
-    EventContext, EventRequest, MessageAgentData, MessageUserData, SessionIdledData,
-    TurnCancelledData,
-};
+use everruns_core::events::{EventContext, EventRequest, MessageUserData, TurnCancelledData};
 use everruns_core::{Message, Session};
 use everruns_worker::AgentRunner;
 
@@ -358,39 +355,9 @@ pub async fn cancel_turn(
         tracing::warn!(session_id = %session_id, error = %e, "Failed to emit user cancellation message");
     }
 
-    // Insert agent message indicating cancellation completed
-    let agent_cancel_message = Message::assistant("Work was cancelled by user.");
-    let agent_message_event = EventRequest::new(
-        session_id,
-        EventContext::turn(turn_id, input_message_id),
-        MessageAgentData::new(agent_cancel_message),
-    );
-    if let Err(e) = state.event_service.emit(agent_message_event).await {
-        tracing::warn!(session_id = %session_id, error = %e, "Failed to emit agent cancellation message");
-    }
-
-    // Emit session.idled event
-    let idled_event = EventRequest::new(
-        session_id,
-        EventContext::turn(turn_id, input_message_id),
-        SessionIdledData {
-            turn_id,
-            iterations: None,
-            usage: None,
-        },
-    );
-    if let Err(e) = state.event_service.emit(idled_event).await {
-        tracing::warn!(session_id = %session_id, error = %e, "Failed to emit session.idled event");
-    }
-
-    // Update session status to idle
-    if let Err(e) = state
-        .session_service
-        .update_status(org.org_id, session_id, "idle".to_string())
-        .await
-    {
-        tracing::warn!(session_id = %session_id, error = %e, "Failed to update session status to idle");
-    }
+    // Note: Agent message "Work was cancelled by user." and session.idled event
+    // are emitted by the worker when it detects the cancellation and stops.
+    // This ensures the agent message appears AFTER any in-flight events.
 
     Ok(StatusCode::OK)
 }

--- a/crates/control-plane/src/api/sessions.rs
+++ b/crates/control-plane/src/api/sessions.rs
@@ -347,7 +347,7 @@ pub async fn cancel_turn(
     }
 
     // Insert agent message indicating cancellation
-    let cancel_message = Message::assistant("Turn cancelled by user.");
+    let cancel_message = Message::assistant("Work was cancelled by user.");
     let message_event = EventRequest::new(
         session_id,
         EventContext::turn(turn_id, input_message_id),

--- a/crates/control-plane/src/api/sessions.rs
+++ b/crates/control-plane/src/api/sessions.rs
@@ -2,7 +2,7 @@
 // Routes are org-scoped: /v1/orgs/:org/agents/:agent_id/sessions/...
 
 use crate::auth::{AuthState, OrgContext, middleware::FromRef};
-use crate::services::SessionService;
+use crate::services::{EventService, SessionService};
 use crate::storage::StorageBackend;
 use axum::{
     Json, Router,
@@ -10,7 +10,11 @@ use axum::{
     http::StatusCode,
     routing::{get, post},
 };
-use everruns_core::Session;
+use everruns_core::events::{
+    EventContext, EventRequest, MessageAgentData, SessionIdledData, TurnCancelledData,
+};
+use everruns_core::{Message, Session};
+use everruns_worker::AgentRunner;
 
 use super::common::{ApiOptionExt, ApiResultExt, PaginatedResponse, Pagination};
 use serde::Deserialize;
@@ -67,14 +71,20 @@ const MAX_LIMIT: u32 = 100;
 /// App state for sessions routes
 #[derive(Clone)]
 pub struct AppState {
+    pub db: Arc<StorageBackend>,
     pub session_service: Arc<SessionService>,
+    pub event_service: EventService,
+    pub runner: Arc<dyn AgentRunner>,
     pub auth: AuthState,
 }
 
 impl AppState {
-    pub fn new(db: Arc<StorageBackend>, auth: AuthState) -> Self {
+    pub fn new(db: Arc<StorageBackend>, runner: Arc<dyn AgentRunner>, auth: AuthState) -> Self {
         Self {
-            session_service: Arc::new(SessionService::new(db)),
+            session_service: Arc::new(SessionService::new(db.clone())),
+            event_service: EventService::new(db.clone()),
+            db,
+            runner,
             auth,
         }
     }
@@ -99,6 +109,11 @@ pub fn routes(state: AppState) -> Router {
             get(get_session)
                 .patch(update_session)
                 .delete(delete_session),
+        )
+        // Cancel turn endpoint
+        .route(
+            "/v1/orgs/:org/agents/:agent_id/sessions/:session_id/cancel",
+            post(cancel_turn),
         )
         .with_state(state)
 }
@@ -263,6 +278,109 @@ pub async fn delete_session(
     } else {
         Err(StatusCode::NOT_FOUND)
     }
+}
+
+/// POST /v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}/cancel - Cancel current turn
+///
+/// Cancels the currently running turn in the session. This will:
+/// 1. Cancel the underlying workflow execution
+/// 2. Emit a turn.cancelled event
+/// 3. Insert an agent message indicating the turn was cancelled
+/// 4. Set the session status back to idle
+#[utoipa::path(
+    post,
+    path = "/v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}/cancel",
+    params(
+        ("org" = String, Path, description = "Organization public ID"),
+        ("agent_id" = Uuid, Path, description = "Agent ID"),
+        ("session_id" = Uuid, Path, description = "Session ID")
+    ),
+    responses(
+        (status = 200, description = "Turn cancelled successfully"),
+        (status = 404, description = "Session not found"),
+        (status = 409, description = "No turn currently running"),
+        (status = 500, description = "Internal server error")
+    ),
+    tag = "sessions"
+)]
+pub async fn cancel_turn(
+    org: OrgContext,
+    State(state): State<AppState>,
+    Path((_org_path, _agent_id, session_id)): Path<(String, Uuid, Uuid)>,
+) -> Result<StatusCode, StatusCode> {
+    // Verify session exists
+    let session = state
+        .session_service
+        .get(org.org_id, session_id)
+        .await
+        .log_internal_error("get session for cancel")?
+        .ok_or_not_found()?;
+
+    // Check if session is active (turn running)
+    if session.status != everruns_core::SessionStatus::Active {
+        return Err(StatusCode::CONFLICT);
+    }
+
+    // Cancel the workflow
+    if let Err(e) = state.runner.cancel_run(session_id).await {
+        tracing::error!(session_id = %session_id, error = %e, "Failed to cancel workflow");
+        // Continue anyway - workflow may have already completed
+    }
+
+    // Generate IDs for the turn context
+    // Use session_id as turn_id since workflow_id = session_id in durable runner
+    let turn_id = session_id;
+    let input_message_id = Uuid::now_v7(); // Placeholder since we don't have the original
+
+    // Emit turn.cancelled event
+    let cancelled_event = EventRequest::new(
+        session_id,
+        EventContext::turn(turn_id, input_message_id),
+        TurnCancelledData {
+            turn_id,
+            reason: Some("User requested cancellation".to_string()),
+            usage: None, // Usage not available at cancellation time
+        },
+    );
+    if let Err(e) = state.event_service.emit(cancelled_event).await {
+        tracing::warn!(session_id = %session_id, error = %e, "Failed to emit turn.cancelled event");
+    }
+
+    // Insert agent message indicating cancellation
+    let cancel_message = Message::assistant("Turn cancelled by user.");
+    let message_event = EventRequest::new(
+        session_id,
+        EventContext::turn(turn_id, input_message_id),
+        MessageAgentData::new(cancel_message),
+    );
+    if let Err(e) = state.event_service.emit(message_event).await {
+        tracing::warn!(session_id = %session_id, error = %e, "Failed to emit cancellation message");
+    }
+
+    // Emit session.idled event
+    let idled_event = EventRequest::new(
+        session_id,
+        EventContext::turn(turn_id, input_message_id),
+        SessionIdledData {
+            turn_id,
+            iterations: None,
+            usage: None,
+        },
+    );
+    if let Err(e) = state.event_service.emit(idled_event).await {
+        tracing::warn!(session_id = %session_id, error = %e, "Failed to emit session.idled event");
+    }
+
+    // Update session status to idle
+    if let Err(e) = state
+        .session_service
+        .update_status(org.org_id, session_id, "idle".to_string())
+        .await
+    {
+        tracing::warn!(session_id = %session_id, error = %e, "Failed to update session status to idle");
+    }
+
+    Ok(StatusCode::OK)
 }
 
 #[cfg(test)]

--- a/crates/control-plane/src/main.rs
+++ b/crates/control-plane/src/main.rs
@@ -161,7 +161,8 @@ async fn main() -> Result<()> {
     let auth_state = auth::AuthState::new(auth_config.clone(), db.clone());
 
     // Create module-specific states
-    let sessions_state = api::sessions::AppState::new(db.clone(), auth_state.clone());
+    let sessions_state =
+        api::sessions::AppState::new(db.clone(), runner.clone(), auth_state.clone());
     let messages_state =
         api::messages::AppState::new(db.clone(), runner.clone(), auth_state.clone());
 

--- a/crates/control-plane/tests/integration_test.rs
+++ b/crates/control-plane/tests/integration_test.rs
@@ -3854,7 +3854,10 @@ async fn test_cancel_turn_endpoint() {
         .expect("Failed to create session");
 
     assert_eq!(session_response.status(), 201);
-    let session: Session = session_response.json().await.expect("Failed to parse session");
+    let session: Session = session_response
+        .json()
+        .await
+        .expect("Failed to parse session");
     println!("Created session: {}", session.id);
 
     // Test 1: Cancel on idle session should return 400

--- a/crates/control-plane/tests/integration_test.rs
+++ b/crates/control-plane/tests/integration_test.rs
@@ -3818,3 +3818,74 @@ async fn test_streaming_events_emitted() {
 
     println!("Streaming events test passed!");
 }
+
+#[tokio::test]
+async fn test_cancel_turn_endpoint() {
+    let client = reqwest::Client::new();
+
+    println!("Testing cancel turn endpoint...");
+
+    // Create an agent
+    let agent_response = client
+        .post(format!("{}/v1/orgs/{}/agents", API_BASE_URL, DEFAULT_ORG))
+        .json(&json!({
+            "name": "Cancel Test Agent",
+            "system_prompt": "You are a helpful assistant"
+        }))
+        .send()
+        .await
+        .expect("Failed to create agent");
+
+    assert_eq!(agent_response.status(), 201);
+    let agent: Agent = agent_response.json().await.expect("Failed to parse agent");
+    println!("Created agent: {}", agent.id);
+
+    // Create a session
+    let session_response = client
+        .post(format!(
+            "{}/v1/orgs/{}/agents/{}/sessions",
+            API_BASE_URL, DEFAULT_ORG, agent.id
+        ))
+        .json(&json!({
+            "title": "Cancel Test Session"
+        }))
+        .send()
+        .await
+        .expect("Failed to create session");
+
+    assert_eq!(session_response.status(), 201);
+    let session: Session = session_response.json().await.expect("Failed to parse session");
+    println!("Created session: {}", session.id);
+
+    // Test 1: Cancel on idle session should return 400
+    println!("\nTest 1: Cancel on idle session (should return 400)...");
+    let cancel_response = client
+        .post(format!(
+            "{}/v1/orgs/{}/agents/{}/sessions/{}/cancel",
+            API_BASE_URL, DEFAULT_ORG, agent.id, session.id
+        ))
+        .send()
+        .await
+        .expect("Failed to call cancel endpoint");
+
+    assert_eq!(
+        cancel_response.status(),
+        400,
+        "Expected 400 for cancelling idle session, got {}",
+        cancel_response.status()
+    );
+    println!("Correctly returned 400 for idle session");
+
+    // Cleanup
+    println!("\nCleaning up...");
+    client
+        .delete(format!(
+            "{}/v1/orgs/{}/agents/{}",
+            API_BASE_URL, DEFAULT_ORG, agent.id
+        ))
+        .send()
+        .await
+        .expect("Failed to delete agent");
+
+    println!("Cancel turn endpoint test passed!");
+}

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -957,7 +957,7 @@ pub enum EventData {
     TurnStarted(TurnStartedData),
     TurnCompleted(TurnCompletedData),
     TurnFailed(TurnFailedData),
-    TurnCancelled(TurnCancelledData),
+    // NOTE: TurnCancelled is placed after streaming events (see below)
 
     // Atom lifecycle events
     InputReceived(InputReceivedData),
@@ -978,6 +978,11 @@ pub enum EventData {
     // comes first, it will match TextDelta JSON and discard delta/accumulated fields.
     TextDelta(TextDeltaData),
     AgentThinking(AgentThinkingData),
+
+    // NOTE: TurnCancelled is placed here (after streaming events) because it only
+    // requires turn_id. If placed before TextDelta/AgentThinking, it would greedily
+    // match their JSON and discard their specific fields.
+    TurnCancelled(TurnCancelledData),
 
     // Session events
     SessionStarted(SessionStartedData),

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -24,6 +24,7 @@ pub const MESSAGE_AGENT: &str = "message.agent";
 pub const TURN_STARTED: &str = "turn.started";
 pub const TURN_COMPLETED: &str = "turn.completed";
 pub const TURN_FAILED: &str = "turn.failed";
+pub const TURN_CANCELLED: &str = "turn.cancelled";
 
 // Atom lifecycle events
 pub const INPUT_RECEIVED: &str = "input.received";
@@ -850,6 +851,22 @@ pub struct TurnFailedData {
     pub error_code: Option<String>,
 }
 
+/// Data for turn.cancelled event
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct TurnCancelledData {
+    /// Turn identifier
+    pub turn_id: Uuid,
+
+    /// Reason for cancellation
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+
+    /// Token usage before cancellation (if available)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<TokenUsage>,
+}
+
 // ============================================================================
 // Session Event Data Types
 // ============================================================================
@@ -940,6 +957,7 @@ pub enum EventData {
     TurnStarted(TurnStartedData),
     TurnCompleted(TurnCompletedData),
     TurnFailed(TurnFailedData),
+    TurnCancelled(TurnCancelledData),
 
     // Atom lifecycle events
     InputReceived(InputReceivedData),
@@ -983,6 +1001,7 @@ impl EventData {
             EventData::TurnStarted(_) => TURN_STARTED,
             EventData::TurnCompleted(_) => TURN_COMPLETED,
             EventData::TurnFailed(_) => TURN_FAILED,
+            EventData::TurnCancelled(_) => TURN_CANCELLED,
             EventData::InputReceived(_) => INPUT_RECEIVED,
             EventData::ReasonStarted(_) => REASON_STARTED,
             EventData::ReasonCompleted(_) => REASON_COMPLETED,
@@ -1028,6 +1047,7 @@ impl_from_event_data! {
     TurnStartedData => TurnStarted,
     TurnCompletedData => TurnCompleted,
     TurnFailedData => TurnFailed,
+    TurnCancelledData => TurnCancelled,
     InputReceivedData => InputReceived,
     ReasonStartedData => ReasonStarted,
     ReasonCompletedData => ReasonCompleted,
@@ -1264,6 +1284,19 @@ mod tests {
         assert_eq!(TURN_STARTED, "turn.started");
         assert_eq!(TURN_COMPLETED, "turn.completed");
         assert_eq!(TURN_FAILED, "turn.failed");
+        assert_eq!(TURN_CANCELLED, "turn.cancelled");
+    }
+
+    #[test]
+    fn test_turn_cancelled_data() {
+        let data = TurnCancelledData {
+            turn_id: Uuid::now_v7(),
+            reason: Some("User requested cancellation".to_string()),
+            usage: Some(TokenUsage::new(100, 50)),
+        };
+
+        let event_data: EventData = data.into();
+        assert_eq!(event_data.event_type(), TURN_CANCELLED);
     }
 
     #[test]

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -291,6 +291,7 @@ fn serialize_event_data(data: &everruns_core::EventData) -> serde_json::Value {
         EventData::TurnStarted(d) => serde_json::to_value(d).unwrap_or_default(),
         EventData::TurnCompleted(d) => serde_json::to_value(d).unwrap_or_default(),
         EventData::TurnFailed(d) => serde_json::to_value(d).unwrap_or_default(),
+        EventData::TurnCancelled(d) => serde_json::to_value(d).unwrap_or_default(),
         EventData::InputReceived(d) => serde_json::to_value(d).unwrap_or_default(),
         EventData::ReasonStarted(d) => serde_json::to_value(d).unwrap_or_default(),
         EventData::ReasonCompleted(d) => serde_json::to_value(d).unwrap_or_default(),

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -3,10 +3,10 @@
 // Decision: Uses gRPC adapters for control-plane communication (no direct DB access)
 
 use anyhow::Result;
+use everruns_core::Message;
 use everruns_core::atoms::AtomContext;
 use everruns_core::events::{EventContext, EventRequest, MessageAgentData, SessionIdledData};
 use everruns_core::traits::EventEmitter;
-use everruns_core::Message;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
@@ -88,7 +88,10 @@ async fn emit_cancellation_events(
     }
 
     // Set session status to idle
-    if let Err(e) = grpc_client.set_session_status(org_id, session_id, "idle").await {
+    if let Err(e) = grpc_client
+        .set_session_status(org_id, session_id, "idle")
+        .await
+    {
         warn!(session_id = %session_id, error = %e, "Failed to set session status to idle");
     }
 
@@ -558,36 +561,35 @@ impl DurableWorker {
                 );
 
                 // Parse task input to get session context for cancellation events
-                let (org_id, session_id, input_message_id) =
-                    match task.activity_type.as_str() {
-                        "process_input" | "reason" => {
-                            if let Ok(turn_input) =
-                                serde_json::from_value::<DurableTurnInput>(task.input.clone())
-                            {
-                                (
-                                    turn_input.org_id,
-                                    turn_input.session_id,
-                                    turn_input.input_message_id,
-                                )
-                            } else {
-                                (0, task.workflow_id, Uuid::nil())
-                            }
+                let (org_id, session_id, input_message_id) = match task.activity_type.as_str() {
+                    "process_input" | "reason" => {
+                        if let Ok(turn_input) =
+                            serde_json::from_value::<DurableTurnInput>(task.input.clone())
+                        {
+                            (
+                                turn_input.org_id,
+                                turn_input.session_id,
+                                turn_input.input_message_id,
+                            )
+                        } else {
+                            (0, task.workflow_id, Uuid::nil())
                         }
-                        "act" => {
-                            if let Ok(act_input) =
-                                serde_json::from_value::<ActTaskInput>(task.input.clone())
-                            {
-                                (
-                                    act_input.org_id,
-                                    act_input.act_input.context.session_id,
-                                    act_input.act_input.context.input_message_id,
-                                )
-                            } else {
-                                (0, task.workflow_id, Uuid::nil())
-                            }
+                    }
+                    "act" => {
+                        if let Ok(act_input) =
+                            serde_json::from_value::<ActTaskInput>(task.input.clone())
+                        {
+                            (
+                                act_input.org_id,
+                                act_input.act_input.context.session_id,
+                                act_input.act_input.context.input_message_id,
+                            )
+                        } else {
+                            (0, task.workflow_id, Uuid::nil())
                         }
-                        _ => (0, task.workflow_id, Uuid::nil()),
-                    };
+                    }
+                    _ => (0, task.workflow_id, Uuid::nil()),
+                };
 
                 // Emit cancellation events (agent message + session.idled)
                 let turn_id = Uuid::now_v7(); // Generate turn_id for cancellation context

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -485,6 +485,23 @@ impl DurableWorker {
             "Executing task"
         );
 
+        // Check if workflow is cancelled before executing
+        {
+            let mut store = self.store.lock().await;
+            if let Ok((status, _, _)) = store.get_workflow_status(task.workflow_id).await
+                && status == WorkflowStatus::Cancelled
+            {
+                info!(
+                    task_id = %task.id,
+                    workflow_id = %task.workflow_id,
+                    "Workflow cancelled, skipping task execution"
+                );
+                // Mark task as failed due to cancellation
+                let _ = store.fail_task(task.id, "Workflow cancelled").await;
+                return Ok(());
+            }
+        }
+
         // Create a new gRPC client for this task execution
         let grpc_client = GrpcClient::connect(&self.grpc_address).await?;
 
@@ -794,6 +811,18 @@ impl DurableWorker {
     ) -> Result<()> {
         let input_json = serde_json::to_value(input)?;
         let mut store = self.store.lock().await;
+
+        // Check if workflow is cancelled before scheduling next activity
+        if let Ok((status, _, _)) = store.get_workflow_status(workflow_id).await
+            && status == WorkflowStatus::Cancelled
+        {
+            info!(
+                workflow_id = %workflow_id,
+                completed_activity = %completed_activity,
+                "Workflow cancelled, not scheduling next activity"
+            );
+            return Ok(());
+        }
 
         match completed_activity {
             "process_input" => {

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -4,6 +4,9 @@
 
 use anyhow::Result;
 use everruns_core::atoms::AtomContext;
+use everruns_core::events::{EventContext, EventRequest, MessageAgentData, SessionIdledData};
+use everruns_core::traits::EventEmitter;
+use everruns_core::Message;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
@@ -16,7 +19,7 @@ use crate::activities::{
     reason_activity,
 };
 use crate::durable_runner::DurableTurnInput;
-use crate::grpc_adapters::{GrpcClient, load_turn_context};
+use crate::grpc_adapters::{GrpcClient, GrpcEventEmitter, load_turn_context};
 use crate::grpc_durable_store::{
     ClaimedTask, GrpcDurableStore, TaskNotificationEvent, TaskNotificationStream, WorkflowStatus,
 };
@@ -33,6 +36,63 @@ struct ActTaskInput {
     org_id: i64,
     #[serde(flatten)]
     act_input: ActInput,
+}
+
+// =============================================================================
+// Cancellation Helper
+// =============================================================================
+
+/// Emit cancellation events when workflow is cancelled
+/// This emits the agent message and session.idled event
+async fn emit_cancellation_events(
+    grpc_address: &str,
+    org_id: i64,
+    session_id: Uuid,
+    turn_id: Uuid,
+    input_message_id: Uuid,
+) {
+    // Connect to gRPC for event emission
+    let grpc_client = match GrpcClient::connect(grpc_address).await {
+        Ok(client) => client,
+        Err(e) => {
+            warn!(error = %e, "Failed to connect to gRPC for cancellation events");
+            return;
+        }
+    };
+
+    let event_emitter = GrpcEventEmitter::new(grpc_client.clone());
+
+    // Emit agent message indicating cancellation completed
+    let cancel_message = Message::assistant("Work was cancelled by user.");
+    let message_event = EventRequest::new(
+        session_id,
+        EventContext::turn(turn_id, input_message_id),
+        MessageAgentData::new(cancel_message),
+    );
+    if let Err(e) = event_emitter.emit(message_event).await {
+        warn!(session_id = %session_id, error = %e, "Failed to emit cancellation message");
+    }
+
+    // Emit session.idled event
+    let idled_event = EventRequest::new(
+        session_id,
+        EventContext::turn(turn_id, input_message_id),
+        SessionIdledData {
+            turn_id,
+            iterations: None,
+            usage: None,
+        },
+    );
+    if let Err(e) = event_emitter.emit(idled_event).await {
+        warn!(session_id = %session_id, error = %e, "Failed to emit session.idled event");
+    }
+
+    // Set session status to idle
+    if let Err(e) = grpc_client.set_session_status(org_id, session_id, "idle").await {
+        warn!(session_id = %session_id, error = %e, "Failed to set session status to idle");
+    }
+
+    info!(session_id = %session_id, "Cancellation events emitted");
 }
 
 // =============================================================================
@@ -496,7 +556,53 @@ impl DurableWorker {
                     workflow_id = %task.workflow_id,
                     "Workflow cancelled, skipping task execution"
                 );
+
+                // Parse task input to get session context for cancellation events
+                let (org_id, session_id, input_message_id) =
+                    match task.activity_type.as_str() {
+                        "process_input" | "reason" => {
+                            if let Ok(turn_input) =
+                                serde_json::from_value::<DurableTurnInput>(task.input.clone())
+                            {
+                                (
+                                    turn_input.org_id,
+                                    turn_input.session_id,
+                                    turn_input.input_message_id,
+                                )
+                            } else {
+                                (0, task.workflow_id, Uuid::nil())
+                            }
+                        }
+                        "act" => {
+                            if let Ok(act_input) =
+                                serde_json::from_value::<ActTaskInput>(task.input.clone())
+                            {
+                                (
+                                    act_input.org_id,
+                                    act_input.act_input.context.session_id,
+                                    act_input.act_input.context.input_message_id,
+                                )
+                            } else {
+                                (0, task.workflow_id, Uuid::nil())
+                            }
+                        }
+                        _ => (0, task.workflow_id, Uuid::nil()),
+                    };
+
+                // Emit cancellation events (agent message + session.idled)
+                let turn_id = Uuid::now_v7(); // Generate turn_id for cancellation context
+                drop(store); // Release lock before async call
+                emit_cancellation_events(
+                    &self.grpc_address,
+                    org_id,
+                    session_id,
+                    turn_id,
+                    input_message_id,
+                )
+                .await;
+
                 // Mark task as failed due to cancellation
+                let mut store = self.store.lock().await;
                 let _ = store.fail_task(task.id, "Workflow cancelled").await;
                 return Ok(());
             }
@@ -821,6 +927,19 @@ impl DurableWorker {
                 completed_activity = %completed_activity,
                 "Workflow cancelled, not scheduling next activity"
             );
+
+            // Emit cancellation events (agent message + session.idled)
+            let turn_id = Uuid::now_v7(); // Generate turn_id for cancellation context
+            drop(store); // Release lock before async call
+            emit_cancellation_events(
+                &self.grpc_address,
+                input.org_id,
+                input.session_id,
+                turn_id,
+                input.input_message_id,
+            )
+            .await;
+
             return Ok(());
         }
 

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3317,9 +3317,6 @@
             "$ref": "#/components/schemas/TurnFailedData"
           },
           {
-            "$ref": "#/components/schemas/TurnCancelledData"
-          },
-          {
             "$ref": "#/components/schemas/InputReceivedData"
           },
           {
@@ -3348,6 +3345,9 @@
           },
           {
             "$ref": "#/components/schemas/AgentThinkingData"
+          },
+          {
+            "$ref": "#/components/schemas/TurnCancelledData"
           },
           {
             "$ref": "#/components/schemas/SessionStartedData"

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3317,6 +3317,9 @@
             "$ref": "#/components/schemas/TurnFailedData"
           },
           {
+            "$ref": "#/components/schemas/TurnCancelledData"
+          },
+          {
             "$ref": "#/components/schemas/InputReceivedData"
           },
           {
@@ -6018,6 +6021,38 @@
           "tool_call_id": {
             "type": "string",
             "description": "ID of the tool call this result corresponds to"
+          }
+        }
+      },
+      "TurnCancelledData": {
+        "type": "object",
+        "description": "Data for turn.cancelled event",
+        "required": [
+          "turn_id"
+        ],
+        "properties": {
+          "reason": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Reason for cancellation"
+          },
+          "turn_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Turn identifier"
+          },
+          "usage": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/TokenUsage",
+                "description": "Token usage before cancellation (if available)"
+              }
+            ]
           }
         }
       },

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -96,6 +96,23 @@ Sessions are instances of agentic loop execution tied to an agent.
 | GET | `/v1/agents/{agent_id}/sessions/{session_id}` | Get session |
 | PATCH | `/v1/agents/{agent_id}/sessions/{session_id}` | Update session |
 | DELETE | `/v1/agents/{agent_id}/sessions/{session_id}` | Delete session |
+| POST | `/v1/agents/{agent_id}/sessions/{session_id}/cancel` | Cancel current turn |
+
+#### Cancel Turn
+
+Cancels the currently executing turn in a session. This stops the workflow execution and emits appropriate events.
+
+**Request:** No body required.
+
+**Response:** `200 OK` on success, `400 Bad Request` if session is not active.
+
+**Events emitted:**
+1. `turn.cancelled` - Immediately when cancel is requested
+2. `message.user` - "User requested to cancel the work."
+3. `message.agent` - "Work was cancelled by user." (emitted by worker when it stops)
+4. `session.idled` - When the session transitions to idle (emitted by worker)
+
+The user message is emitted immediately by the API, while the agent message and session.idled events are emitted by the worker after it detects the cancellation and stops execution. This ensures the agent message appears after any in-flight events.
 
 ### Messages
 

--- a/specs/events.md
+++ b/specs/events.md
@@ -189,6 +189,43 @@ When a turn fails, a `message.agent` event with a user-friendly error message is
 | `llm_error` | LLM call failed (API key missing, rate limit, network error) |
 | `max_iterations` | Maximum iterations exceeded |
 
+#### `turn.cancelled`
+
+Turn execution was cancelled by user request. This event is emitted immediately when the cancel endpoint is called.
+
+```json
+{
+  "type": "turn.cancelled",
+  "session_id": "...",
+  "context": {
+    "turn_id": "..."
+  },
+  "data": {
+    "turn_id": "...",
+    "reason": "User requested cancellation",
+    "usage": {
+      "input_tokens": 150,
+      "output_tokens": 30
+    }
+  }
+}
+```
+
+**Fields:**
+| Field | Type | Description |
+|-------|------|-------------|
+| `turn_id` | UUID | The cancelled turn identifier |
+| `reason` | string | Optional reason for cancellation |
+| `usage` | TokenUsage | Optional token usage up to cancellation point |
+
+**Cancellation Flow:**
+1. User clicks cancel in UI
+2. API emits `turn.cancelled` event immediately
+3. API emits `message.user` with "User requested to cancel the work."
+4. Worker detects cancellation and stops execution
+5. Worker emits `message.agent` with "Work was cancelled by user."
+6. Worker emits `session.idled` event
+
 ### Atom Lifecycle Events
 
 Atom events provide observability into the execution pipeline.
@@ -595,6 +632,7 @@ This approach provides real-time feedback as tokens are consumed during LLM call
 | `turn.started` | Turn | Turn execution started |
 | `turn.completed` | Turn | Turn completed |
 | `turn.failed` | Turn | Turn failed |
+| `turn.cancelled` | Turn | Turn cancelled by user |
 | `input.received` | Atom | User input received |
 | `reason.started` | Atom | ReasonAtom started |
 | `reason.completed` | Atom | ReasonAtom completed |


### PR DESCRIPTION
## What
Add ability to cancel the currently executing turn in a session via a new API endpoint and UI button.

## Why
Users need to be able to stop a long-running turn (e.g., when the agent is executing slow tools or making many LLM calls) without having to refresh the page or close the session.

## How

### API Changes
- Added `POST /v1/agents/{agent_id}/sessions/{session_id}/cancel` endpoint
- Cancels the workflow via the durable execution engine
- Emits `turn.cancelled` event immediately
- Emits `message.user` with "User requested to cancel the work."
- Worker emits `message.agent` with "Work was cancelled by user." after stopping
- Worker emits `session.idled` and sets session status to idle

### Worker Changes
- Added cancellation checks in `execute_task` (before executing) and `schedule_next_activity` (after completing)
- Worker emits cancellation events when it detects the workflow is cancelled
- This ensures the agent message appears AFTER any in-flight events

### UI Changes
- Message input shows cancel button (StopCircle icon) when session is active
- Cancel button triggers `cancelCurrentTurn` mutation
- Added handling for `turn.cancelled` and `session.idled` events to clear thinking state

### Spec Updates
- Documented cancel endpoint in `specs/apis.md`
- Documented `turn.cancelled` event in `specs/events.md`

## Risk
- Low
- Cancellation is a new feature that doesn't affect existing functionality
- Worker gracefully handles cancelled workflows by checking status before execution

## Checklist
- [x] Tests added (integration test for cancel endpoint)
- [x] Specs updated
- [x] UI changes tested manually