### PR TITLE
fix(ui): use TooltipPrimitive.Provider for tooltips to work

### DIFF
--- a/apps/ui/src/components/ui/tooltip.tsx
+++ b/apps/ui/src/components/ui/tooltip.tsx
@@ -4,7 +4,7 @@ import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
 import { cn } from "@/lib/utils";
 
 function TooltipProvider({ children }: { children: React.ReactNode }) {
-  return <>{children}</>;
+  return <TooltipPrimitive.Provider>{children}</TooltipPrimitive.Provider>;
 }
 
 function Tooltip({ ...props }: TooltipPrimitive.Root.Props) {


### PR DESCRIPTION
## Summary
- Fixed tooltips not appearing in the UI by properly initializing the @base-ui/react tooltip context
- The `TooltipProvider` component was returning children without context setup, causing tooltips to show the "?" cursor but not display content

## What
The `TooltipProvider` in `apps/ui/src/components/ui/tooltip.tsx` was just returning children as a fragment (`<>{children}</>`) without initializing the @base-ui/react tooltip context.

**Before:**
```tsx
function TooltipProvider({ children }: { children: React.ReactNode }) {
  return <>{children}</>;
}
```

**After:**
```tsx
function TooltipProvider({ children }: { children: React.ReactNode }) {
  return <TooltipPrimitive.Provider>{children}</TooltipPrimitive.Provider>;
}
```

## Why
According to Base UI documentation, tooltips must be wrapped in a `<Tooltip.Provider>` for proper context initialization and shared delay timing.

## Test plan
- [x] UI build passes
- [x] Smoke test: API health check passes
- [x] Smoke test: Tooltip appears on hover (verified with Playwright)
- [x] Screenshot shows tooltip working on agents page