### PR TITLE
feat(metrics): add time-to-first-token tracking for LLM calls

### DIFF
--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -385,6 +385,7 @@ export interface LlmGenerationMetadata {
   provider?: string;
   usage?: TokenUsage;
   duration_ms?: number;
+  time_to_first_token_ms?: number;
   success: boolean;
   error?: string;
 }

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -555,8 +555,8 @@ where
         while let Some(event) = stream.next().await {
             match event? {
                 LlmStreamEvent::TextDelta(delta) => {
-                    // Track time-to-first-token on first delta
-                    if time_to_first_token_ms.is_none() {
+                    // Track time-to-first-token on first non-empty delta
+                    if time_to_first_token_ms.is_none() && !delta.is_empty() {
                         let ttft = llm_start.elapsed().as_millis() as u64;
                         time_to_first_token_ms = Some(ttft);
                         tracing::info!(
@@ -641,6 +641,7 @@ where
                                 Some(model_with_provider.provider_type.to_string()),
                                 err.clone(),
                                 Some(llm_duration_ms),
+                                time_to_first_token_ms,
                             ),
                         ))
                         .await;

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -675,6 +675,7 @@ impl LlmGenerationData {
         provider: Option<String>,
         usage: Option<TokenUsage>,
         duration_ms: Option<u64>,
+        time_to_first_token_ms: Option<u64>,
     ) -> Self {
         // Infer finish reasons from content
         let finish_reasons = if !tool_calls.is_empty() {
@@ -692,7 +693,7 @@ impl LlmGenerationData {
                 provider,
                 usage,
                 duration_ms,
-                time_to_first_token_ms: None,
+                time_to_first_token_ms,
                 success: true,
                 error: None,
                 finish_reasons,
@@ -742,6 +743,7 @@ impl LlmGenerationData {
         provider: Option<String>,
         error: String,
         duration_ms: Option<u64>,
+        time_to_first_token_ms: Option<u64>,
     ) -> Self {
         Self {
             messages,
@@ -755,7 +757,7 @@ impl LlmGenerationData {
                 provider,
                 usage: None,
                 duration_ms,
-                time_to_first_token_ms: None,
+                time_to_first_token_ms,
                 success: false,
                 error: Some(error),
                 finish_reasons: Some(vec!["error".to_string()]),
@@ -1336,6 +1338,7 @@ mod tests {
                 cache_creation_tokens: None,
             }),
             Some(100),
+            Some(25), // time_to_first_token_ms
         );
 
         assert_eq!(data.messages.len(), 2);
@@ -1395,6 +1398,7 @@ mod tests {
             Some("openai".to_string()),
             "Rate limit exceeded".to_string(),
             Some(50),
+            None, // time_to_first_token_ms
         );
 
         assert!(!data.metadata.success);
@@ -1414,6 +1418,7 @@ mod tests {
             None,
             None,
             None,
+            None, // time_to_first_token_ms
         );
 
         let event_data: EventData = data.into();
@@ -1588,9 +1593,10 @@ mod tests {
             None,
             None,
             None,
+            None, // time_to_first_token_ms
         );
 
-        // TTFT should be None by default in success()
+        // TTFT should be None when passed as None
         assert!(data.metadata.time_to_first_token_ms.is_none());
 
         // Should not appear in JSON when None

--- a/crates/core/src/observation/otel.rs
+++ b/crates/core/src/observation/otel.rs
@@ -129,6 +129,8 @@ impl OtelEventListener {
             "gen_ai.conversation.id" = %event.session_id,
             // Duration
             "duration_ms" = data.metadata.duration_ms.unwrap_or(0),
+            // Time to first token (streaming latency)
+            "time_to_first_token_ms" = data.metadata.time_to_first_token_ms.unwrap_or(0),
         );
 
         // Enter and immediately exit the span (event is a point-in-time record)


### PR DESCRIPTION
## Summary
- Track streaming latency by measuring time from LLM request start to first text delta received
- Add `time_to_first_token_ms` field to `LlmGenerationMetadata`
- Include TTFT in OpenTelemetry spans for observability via Jaeger
- This metric is valuable for monitoring LLM provider performance and identifying latency regressions

## Test plan
- [x] Unit tests pass (`cargo test -p everruns-core --lib`)
- [x] Clippy and fmt checks pass
- [ ] CI passes