### PR TITLE
fix(api): make cancel turn endpoint idempotent with response body

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,6 +242,7 @@ Message content uses unified `Vec<ContentPart>` across all layers:
 ### CI expectations
 
 - CI is implemented using GitHub Actions, status is available via `gh` tool
+- **NEVER merge when CI is red.** This is a hard requirement with no exceptions. Even if the failure appears unrelated to your changes, do not merge. Fix the issue or get help first.
 
 ### Pre-PR checklist
 

--- a/crates/control-plane/src/api/sessions.rs
+++ b/crates/control-plane/src/api/sessions.rs
@@ -280,7 +280,8 @@ pub async fn delete_session(
 
 /// POST /v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}/cancel - Cancel current turn
 ///
-/// Cancels the currently running turn in the session. This will:
+/// Cancels the currently running turn in the session. If no turn is running,
+/// this is a no-op and returns success (idempotent). When a turn is active:
 /// 1. Cancel the underlying workflow execution
 /// 2. Emit a turn.cancelled event
 /// 3. Insert an agent message indicating the turn was cancelled
@@ -294,9 +295,8 @@ pub async fn delete_session(
         ("session_id" = Uuid, Path, description = "Session ID")
     ),
     responses(
-        (status = 200, description = "Turn cancelled successfully"),
+        (status = 200, description = "Turn cancelled successfully (or no-op if idle)"),
         (status = 404, description = "Session not found"),
-        (status = 409, description = "No turn currently running"),
         (status = 500, description = "Internal server error")
     ),
     tag = "sessions"
@@ -314,9 +314,9 @@ pub async fn cancel_turn(
         .log_internal_error("get session for cancel")?
         .ok_or_not_found()?;
 
-    // Check if session is active (turn running)
+    // If session is not active, cancel is a no-op (idempotent)
     if session.status != everruns_core::SessionStatus::Active {
-        return Err(StatusCode::CONFLICT);
+        return Ok(StatusCode::OK);
     }
 
     // Cancel the workflow

--- a/crates/control-plane/src/api/sessions.rs
+++ b/crates/control-plane/src/api/sessions.rs
@@ -15,7 +15,7 @@ use everruns_core::{Message, Session};
 use everruns_worker::AgentRunner;
 
 use super::common::{ApiOptionExt, ApiResultExt, PaginatedResponse, Pagination};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
@@ -35,6 +35,27 @@ pub struct CreateSessionRequest {
     /// Overrides the agent's default model if specified.
     #[serde(default)]
     pub model_id: Option<Uuid>,
+}
+
+/// Response from cancel turn endpoint
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct CancelTurnResponse {
+    /// Whether the cancellation was performed or was a no-op
+    #[schema(example = "cancelled")]
+    pub status: CancelStatus,
+    /// Human-readable message
+    #[schema(example = "Turn cancelled successfully")]
+    pub message: String,
+}
+
+/// Status of the cancel operation
+#[derive(Debug, Clone, Serialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum CancelStatus {
+    /// Turn was actively cancelled
+    Cancelled,
+    /// No turn was running, cancel was a no-op
+    NoOp,
 }
 
 /// Request to update a session. Only provided fields will be updated.
@@ -295,7 +316,7 @@ pub async fn delete_session(
         ("session_id" = Uuid, Path, description = "Session ID")
     ),
     responses(
-        (status = 200, description = "Turn cancelled successfully (or no-op if idle)"),
+        (status = 200, description = "Turn cancelled successfully (or no-op if idle)", body = CancelTurnResponse),
         (status = 404, description = "Session not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -305,7 +326,7 @@ pub async fn cancel_turn(
     org: OrgContext,
     State(state): State<AppState>,
     Path((_org_path, _agent_id, session_id)): Path<(String, Uuid, Uuid)>,
-) -> Result<StatusCode, StatusCode> {
+) -> Result<Json<CancelTurnResponse>, StatusCode> {
     // Verify session exists
     let session = state
         .session_service
@@ -316,7 +337,10 @@ pub async fn cancel_turn(
 
     // If session is not active, cancel is a no-op (idempotent)
     if session.status != everruns_core::SessionStatus::Active {
-        return Ok(StatusCode::OK);
+        return Ok(Json(CancelTurnResponse {
+            status: CancelStatus::NoOp,
+            message: "No turn currently running".to_string(),
+        }));
     }
 
     // Cancel the workflow
@@ -359,7 +383,10 @@ pub async fn cancel_turn(
     // are emitted by the worker when it detects the cancellation and stops.
     // This ensures the agent message appears AFTER any in-flight events.
 
-    Ok(StatusCode::OK)
+    Ok(Json(CancelTurnResponse {
+        status: CancelStatus::Cancelled,
+        message: "Turn cancelled successfully".to_string(),
+    }))
 }
 
 #[cfg(test)]

--- a/crates/control-plane/src/openapi.rs
+++ b/crates/control-plane/src/openapi.rs
@@ -41,6 +41,7 @@ use utoipa::OpenApi;
         api::sessions::get_session,
         api::sessions::update_session,
         api::sessions::delete_session,
+        api::sessions::cancel_turn,
         api::messages::create_message,
         api::messages::list_messages,
         api::events::stream_sse,
@@ -89,6 +90,7 @@ use utoipa::OpenApi;
             // Agent/Session types
             api::agents::CreateAgentRequest, api::agents::UpdateAgentRequest,
             api::sessions::CreateSessionRequest, api::sessions::UpdateSessionRequest,
+            api::sessions::CancelTurnResponse, api::sessions::CancelStatus,
             api::messages::Message, api::messages::MessageRole, api::messages::ContentPart, api::messages::InputContentPart,
             api::messages::CreateMessageRequest, api::messages::InputMessage,
             api::messages::Controls, api::messages::ReasoningConfig,

--- a/crates/control-plane/tests/integration_test.rs
+++ b/crates/control-plane/tests/integration_test.rs
@@ -3819,18 +3819,79 @@ async fn test_streaming_events_emitted() {
     println!("Streaming events test passed!");
 }
 
+/// Test cancel turn endpoint behavior.
+///
+/// Requirements: API + Worker running (uses LlmSim, no real API keys needed)
 #[tokio::test]
 async fn test_cancel_turn_endpoint() {
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(tokio::time::Duration::from_secs(30))
+        .build()
+        .expect("Failed to create client");
 
     println!("Testing cancel turn endpoint...");
 
-    // Create an agent
+    // Step 1: Create LlmSim provider and model
+    println!("\nStep 1: Creating LlmSim provider and model...");
+    let provider_response = client
+        .post(format!(
+            "{}/v1/orgs/{}/llm-providers",
+            API_BASE_URL, DEFAULT_ORG
+        ))
+        .json(&json!({
+            "name": "Cancel Test Provider",
+            "provider_type": "llmsim"
+        }))
+        .send()
+        .await
+        .expect("Failed to create provider");
+
+    if provider_response.status() != 201 {
+        let status = provider_response.status();
+        let body = provider_response.text().await.unwrap_or_default();
+        panic!(
+            "Failed to create LlmSim provider: status={}, body={}",
+            status, body
+        );
+    }
+    let provider: LlmProvider = provider_response
+        .json()
+        .await
+        .expect("Failed to parse provider");
+    println!("Created LlmSim provider: {}", provider.id);
+
+    let model_response = client
+        .post(format!(
+            "{}/v1/orgs/{}/llm-providers/{}/models",
+            API_BASE_URL, DEFAULT_ORG, provider.id
+        ))
+        .json(&json!({
+            "model_id": "llmsim-cancel-test",
+            "display_name": "LlmSim Cancel Test Model"
+        }))
+        .send()
+        .await
+        .expect("Failed to create model");
+
+    if model_response.status() != 201 {
+        let status = model_response.status();
+        let body = model_response.text().await.unwrap_or_default();
+        panic!(
+            "Failed to create LlmSim model: status={}, body={}",
+            status, body
+        );
+    }
+    let model: LlmModel = model_response.json().await.expect("Failed to parse model");
+    println!("Created LlmSim model: {}", model.id);
+
+    // Step 2: Create agent with LlmSim model
+    println!("\nStep 2: Creating agent...");
     let agent_response = client
         .post(format!("{}/v1/orgs/{}/agents", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({
             "name": "Cancel Test Agent",
-            "system_prompt": "You are a helpful assistant"
+            "system_prompt": "You are a helpful assistant. Write a very long response.",
+            "default_model_id": model.id.to_string()
         }))
         .send()
         .await
@@ -3840,7 +3901,8 @@ async fn test_cancel_turn_endpoint() {
     let agent: Agent = agent_response.json().await.expect("Failed to parse agent");
     println!("Created agent: {}", agent.id);
 
-    // Create a session
+    // Step 3: Create session
+    println!("\nStep 3: Creating session...");
     let session_response = client
         .post(format!(
             "{}/v1/orgs/{}/agents/{}/sessions",
@@ -3860,8 +3922,8 @@ async fn test_cancel_turn_endpoint() {
         .expect("Failed to parse session");
     println!("Created session: {}", session.id);
 
-    // Test 1: Cancel on idle session should return 409 Conflict (no turn running)
-    println!("\nTest 1: Cancel on idle session (should return 409 Conflict)...");
+    // Test 1: Cancel on idle session should return 200 (no-op, idempotent)
+    println!("\nTest 1: Cancel on idle session (should return 200, no-op)...");
     let cancel_response = client
         .post(format!(
             "{}/v1/orgs/{}/agents/{}/sessions/{}/cancel",
@@ -3873,11 +3935,80 @@ async fn test_cancel_turn_endpoint() {
 
     assert_eq!(
         cancel_response.status(),
-        409,
-        "Expected 409 Conflict for cancelling idle session, got {}",
+        200,
+        "Expected 200 for cancelling idle session (no-op), got {}",
         cancel_response.status()
     );
-    println!("Correctly returned 409 Conflict for idle session");
+    println!("Correctly returned 200 for idle session (no-op)");
+
+    // Test 2: Start a turn and cancel it
+    println!("\nTest 2: Start a turn and cancel it...");
+
+    // Send a message to start the turn
+    let message_response = client
+        .post(format!(
+            "{}/v1/orgs/{}/agents/{}/sessions/{}/messages",
+            API_BASE_URL, DEFAULT_ORG, agent.id, session.id
+        ))
+        .json(&json!({
+            "role": "user",
+            "content": "Write a very detailed 1000-word essay about the history of computing."
+        }))
+        .send()
+        .await
+        .expect("Failed to send message");
+
+    assert_eq!(message_response.status(), 201, "Failed to create message");
+    println!("Message sent, turn should be starting...");
+
+    // Small delay to let the turn start
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    // Try to cancel - may succeed (200) or be no-op if turn already completed
+    let cancel_response = client
+        .post(format!(
+            "{}/v1/orgs/{}/agents/{}/sessions/{}/cancel",
+            API_BASE_URL, DEFAULT_ORG, agent.id, session.id
+        ))
+        .send()
+        .await
+        .expect("Failed to call cancel endpoint");
+
+    assert_eq!(
+        cancel_response.status(),
+        200,
+        "Expected 200 for cancel, got {}",
+        cancel_response.status()
+    );
+    println!("Cancel returned 200");
+
+    // Wait for session to return to idle
+    println!("Waiting for session to return to idle...");
+    let mut attempts = 0;
+    loop {
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        attempts += 1;
+
+        let session_response = client
+            .get(format!(
+                "{}/v1/orgs/{}/agents/{}/sessions/{}",
+                API_BASE_URL, DEFAULT_ORG, agent.id, session.id
+            ))
+            .send()
+            .await
+            .expect("Failed to get session");
+
+        let session: Session = session_response.json().await.expect("Failed to parse session");
+
+        if session.status == everruns_core::SessionStatus::Idle {
+            println!("Session returned to idle after {} attempts", attempts);
+            break;
+        }
+
+        if attempts > 50 {
+            panic!("Session did not return to idle after cancel");
+        }
+    }
 
     // Cleanup
     println!("\nCleaning up...");

--- a/crates/control-plane/tests/integration_test.rs
+++ b/crates/control-plane/tests/integration_test.rs
@@ -3860,8 +3860,8 @@ async fn test_cancel_turn_endpoint() {
         .expect("Failed to parse session");
     println!("Created session: {}", session.id);
 
-    // Test 1: Cancel on idle session should return 400
-    println!("\nTest 1: Cancel on idle session (should return 400)...");
+    // Test 1: Cancel on idle session should return 409 Conflict (no turn running)
+    println!("\nTest 1: Cancel on idle session (should return 409 Conflict)...");
     let cancel_response = client
         .post(format!(
             "{}/v1/orgs/{}/agents/{}/sessions/{}/cancel",
@@ -3873,11 +3873,11 @@ async fn test_cancel_turn_endpoint() {
 
     assert_eq!(
         cancel_response.status(),
-        400,
-        "Expected 400 for cancelling idle session, got {}",
+        409,
+        "Expected 409 Conflict for cancelling idle session, got {}",
         cancel_response.status()
     );
-    println!("Correctly returned 400 for idle session");
+    println!("Correctly returned 409 Conflict for idle session");
 
     // Cleanup
     println!("\nCleaning up...");

--- a/crates/control-plane/tests/integration_test.rs
+++ b/crates/control-plane/tests/integration_test.rs
@@ -3939,7 +3939,10 @@ async fn test_cancel_turn_endpoint() {
         "Expected 200 for cancelling idle session (no-op), got {}",
         cancel_response.status()
     );
-    let cancel_body: Value = cancel_response.json().await.expect("Failed to parse cancel response");
+    let cancel_body: Value = cancel_response
+        .json()
+        .await
+        .expect("Failed to parse cancel response");
     assert_eq!(
         cancel_body["status"], "no_op",
         "Expected no_op status for idle session, got {:?}",
@@ -3986,9 +3989,14 @@ async fn test_cancel_turn_endpoint() {
         "Expected 200 for cancel, got {}",
         cancel_response.status()
     );
-    let cancel_body: Value = cancel_response.json().await.expect("Failed to parse cancel response");
+    let cancel_body: Value = cancel_response
+        .json()
+        .await
+        .expect("Failed to parse cancel response");
     // Status can be "cancelled" (if we caught active turn) or "no_op" (if turn completed)
-    let status = cancel_body["status"].as_str().expect("status should be string");
+    let status = cancel_body["status"]
+        .as_str()
+        .expect("status should be string");
     assert!(
         status == "cancelled" || status == "no_op",
         "Expected cancelled or no_op status, got {}",
@@ -4012,7 +4020,10 @@ async fn test_cancel_turn_endpoint() {
             .await
             .expect("Failed to get session");
 
-        let session: Session = session_response.json().await.expect("Failed to parse session");
+        let session: Session = session_response
+            .json()
+            .await
+            .expect("Failed to parse session");
 
         if session.status == everruns_core::SessionStatus::Idle {
             println!("Session returned to idle after {} attempts", attempts);

--- a/crates/control-plane/tests/integration_test.rs
+++ b/crates/control-plane/tests/integration_test.rs
@@ -3922,7 +3922,7 @@ async fn test_cancel_turn_endpoint() {
         .expect("Failed to parse session");
     println!("Created session: {}", session.id);
 
-    // Test 1: Cancel on idle session should return 200 (no-op, idempotent)
+    // Test 1: Cancel on idle session should return 200 with no_op status
     println!("\nTest 1: Cancel on idle session (should return 200, no-op)...");
     let cancel_response = client
         .post(format!(
@@ -3939,7 +3939,13 @@ async fn test_cancel_turn_endpoint() {
         "Expected 200 for cancelling idle session (no-op), got {}",
         cancel_response.status()
     );
-    println!("Correctly returned 200 for idle session (no-op)");
+    let cancel_body: Value = cancel_response.json().await.expect("Failed to parse cancel response");
+    assert_eq!(
+        cancel_body["status"], "no_op",
+        "Expected no_op status for idle session, got {:?}",
+        cancel_body["status"]
+    );
+    println!("Correctly returned no_op: {}", cancel_body["message"]);
 
     // Test 2: Start a turn and cancel it
     println!("\nTest 2: Start a turn and cancel it...");
@@ -3964,7 +3970,7 @@ async fn test_cancel_turn_endpoint() {
     // Small delay to let the turn start
     tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
 
-    // Try to cancel - may succeed (200) or be no-op if turn already completed
+    // Try to cancel - may succeed (cancelled) or be no-op if turn already completed
     let cancel_response = client
         .post(format!(
             "{}/v1/orgs/{}/agents/{}/sessions/{}/cancel",
@@ -3980,7 +3986,15 @@ async fn test_cancel_turn_endpoint() {
         "Expected 200 for cancel, got {}",
         cancel_response.status()
     );
-    println!("Cancel returned 200");
+    let cancel_body: Value = cancel_response.json().await.expect("Failed to parse cancel response");
+    // Status can be "cancelled" (if we caught active turn) or "no_op" (if turn completed)
+    let status = cancel_body["status"].as_str().expect("status should be string");
+    assert!(
+        status == "cancelled" || status == "no_op",
+        "Expected cancelled or no_op status, got {}",
+        status
+    );
+    println!("Cancel returned {}: {}", status, cancel_body["message"]);
 
     // Wait for session to return to idle
     println!("Waiting for session to return to idle...");

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -687,6 +687,65 @@
         }
       }
     },
+    "/v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}/cancel": {
+      "post": {
+        "tags": [
+          "sessions"
+        ],
+        "summary": "POST /v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}/cancel - Cancel current turn",
+        "description": "Cancels the currently running turn in the session. If no turn is running,\nthis is a no-op and returns success (idempotent). When a turn is active:\n1. Cancel the underlying workflow execution\n2. Emit a turn.cancelled event\n3. Insert an agent message indicating the turn was cancelled\n4. Set the session status back to idle",
+        "operationId": "cancel_turn",
+        "parameters": [
+          {
+            "name": "org",
+            "in": "path",
+            "description": "Organization public ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "agent_id",
+            "in": "path",
+            "description": "Agent ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "path",
+            "description": "Session ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Turn cancelled successfully (or no-op if idle)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CancelTurnResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Session not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
     "/v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}/events": {
       "get": {
         "tags": [
@@ -2642,6 +2701,33 @@
             "type": "string",
             "format": "uuid",
             "description": "Turn ID this thinking indicator belongs to"
+          }
+        }
+      },
+      "CancelStatus": {
+        "type": "string",
+        "description": "Status of the cancel operation",
+        "enum": [
+          "cancelled",
+          "no_op"
+        ]
+      },
+      "CancelTurnResponse": {
+        "type": "object",
+        "description": "Response from cancel turn endpoint",
+        "required": [
+          "status",
+          "message"
+        ],
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Human-readable message",
+            "example": "Turn cancelled successfully"
+          },
+          "status": {
+            "$ref": "#/components/schemas/CancelStatus",
+            "description": "Whether the cancellation was performed or was a no-op"
           }
         }
       },


### PR DESCRIPTION
## What
- Make cancel turn endpoint idempotent (return 200 for idle sessions instead of 409)
- Add JSON response body with status (`cancelled`/`no_op`) and message
- Add missing `cancel_turn` endpoint to OpenAPI spec
- Improve integration test coverage

## Why
- Idempotent cancel is better UX - calling cancel multiple times or on idle session should be safe
- Response body provides clear feedback on what happened
- OpenAPI spec was missing the cancel endpoint

## How
- Changed `cancel_turn` return type from `StatusCode` to `Json<CancelTurnResponse>`
- Added `CancelTurnResponse` struct with `status` and `message` fields
- Added `CancelStatus` enum: `Cancelled` | `NoOp`
- Registered endpoint in `openapi.rs` paths

## Response examples
```json
// Idle session (no-op)
{"status": "no_op", "message": "No turn currently running"}

// Active turn cancelled
{"status": "cancelled", "message": "Turn cancelled successfully"}
```

## Risk
- Low
- Backward compatible (200 status unchanged, adds response body)

## Checklist
- [x] Tests added or updated
- [x] OpenAPI spec updated
- [x] Backward compatibility considered