### PR TITLE
refactor(ui): rename File System tab to Files with subtitle

### DIFF
--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/layout.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/layout.tsx
@@ -103,7 +103,9 @@ function SessionLayoutContent({ children, agentId, sessionId }: SessionLayoutCon
               {session.title || `Session ${session.id.slice(0, 8)}`}
             </h1>
             <p className="text-sm text-muted-foreground">
-              Started {new Date(session.created_at).toLocaleString()}
+              {activeTab === "files"
+                ? "Session file system"
+                : `Started ${new Date(session.created_at).toLocaleString()}`}
             </p>
           </div>
           <div className="flex items-center gap-2">
@@ -177,7 +179,7 @@ function SessionLayoutContent({ children, agentId, sessionId }: SessionLayoutCon
             )}
           >
             <Folder className="h-4 w-4" />
-            File System
+            Files
           </Link>
           <Link
             href={`${basePath}/events`}


### PR DESCRIPTION
## What
Rename the "File System" tab to "Files" in the Session UI and add a contextual subtitle.

## Why
Shorter tab name is cleaner, and the subtitle provides context about what the tab shows.

## How
- Renamed tab label from "File System" to "Files"
- When Files tab is active, subtitle shows "Session file system" instead of session start time

## Risk
- Low - UI text change only