### PR TITLE
feat(capabilities): add session storage capability with key/value and secret storage

### DIFF
--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/layout.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/layout.tsx
@@ -12,7 +12,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { ArrowLeft, Sparkles, MessageSquare, Folder, Activity, Zap } from "lucide-react";
+import { ArrowLeft, Sparkles, MessageSquare, Folder, Activity, Zap, Database } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { SessionProvider, useSessionContext } from "./session-context";
 
@@ -58,6 +58,7 @@ function SessionLayoutContent({ children, agentId, sessionId }: SessionLayoutCon
   const getActiveTab = () => {
     if (pathname.endsWith("/files")) return "files";
     if (pathname.endsWith("/events")) return "events";
+    if (pathname.endsWith("/storage")) return "storage";
     return "chat"; // Default to chat (includes /chat and base path)
   };
   const activeTab = getActiveTab();
@@ -193,6 +194,19 @@ function SessionLayoutContent({ children, agentId, sessionId }: SessionLayoutCon
           >
             <Activity className="h-4 w-4" />
             Events
+          </Link>
+          <Link
+            href={`${basePath}/storage`}
+            className={cn(
+              buttonVariants({
+                variant: activeTab === "storage" ? "default" : "ghost",
+                size: "sm",
+              }),
+              "gap-2"
+            )}
+          >
+            <Database className="h-4 w-4" />
+            Storage
           </Link>
         </div>
       </div>

--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/storage/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/storage/page.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api/client";
+import type { ListResponse, KeyValueInfo, SecretInfo } from "@/lib/api/types";
+import { useSessionContext } from "../session-context";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Key, Lock, Clock, AlertCircle } from "lucide-react";
+import { useOrg } from "@/providers/org-provider";
+
+export default function StoragePage() {
+  const { agentId, sessionId } = useSessionContext();
+  const { currentOrg } = useOrg();
+  const [keyValues, setKeyValues] = useState<KeyValueInfo[]>([]);
+  const [secrets, setSecrets] = useState<SecretInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchStorage() {
+      if (!currentOrg) return;
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const [keysRes, secretsRes] = await Promise.all([
+          api.get<ListResponse<KeyValueInfo>>(
+            `/v1/orgs/${currentOrg.public_id}/agents/${agentId}/sessions/${sessionId}/storage/keys`
+          ),
+          api.get<ListResponse<SecretInfo>>(
+            `/v1/orgs/${currentOrg.public_id}/agents/${agentId}/sessions/${sessionId}/storage/secrets`
+          ),
+        ]);
+
+        setKeyValues(keysRes.data.data);
+        setSecrets(secretsRes.data.data);
+      } catch (err) {
+        console.error("Failed to fetch storage:", err);
+        setError(err instanceof Error ? err.message : "Failed to load storage data");
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchStorage();
+  }, [agentId, sessionId, currentOrg]);
+
+  if (loading) {
+    return (
+      <div className="flex-1 p-6 space-y-6">
+        <Skeleton className="h-48 w-full" />
+        <Skeleton className="h-48 w-full" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex-1 p-6">
+        <div className="flex items-center gap-2 text-destructive">
+          <AlertCircle className="h-5 w-5" />
+          <span>{error}</span>
+        </div>
+      </div>
+    );
+  }
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleString();
+  };
+
+  return (
+    <div className="flex-1 p-6 space-y-6 overflow-y-auto">
+      {/* Key-Value Storage */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Key className="h-5 w-5" />
+            Key-Value Storage
+          </CardTitle>
+          <CardDescription>
+            Session-scoped key-value pairs stored by the agent
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {keyValues.length === 0 ? (
+            <p className="text-muted-foreground text-sm">No key-value pairs stored yet.</p>
+          ) : (
+            <div className="space-y-3">
+              {keyValues.map((kv) => (
+                <div
+                  key={kv.key}
+                  className="border rounded-lg p-3 space-y-2"
+                >
+                  <div className="flex items-center justify-between">
+                    <Badge variant="outline" className="font-mono">
+                      {kv.key}
+                    </Badge>
+                    <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                      <Clock className="h-3 w-3" />
+                      {formatDate(kv.updated_at)}
+                    </div>
+                  </div>
+                  <pre className="text-sm bg-muted p-2 rounded overflow-x-auto whitespace-pre-wrap break-all">
+                    {kv.value}
+                  </pre>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Secrets Storage */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Lock className="h-5 w-5" />
+            Secrets Storage
+          </CardTitle>
+          <CardDescription>
+            Encrypted secrets stored by the agent (values are hidden)
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {secrets.length === 0 ? (
+            <p className="text-muted-foreground text-sm">No secrets stored yet.</p>
+          ) : (
+            <div className="space-y-3">
+              {secrets.map((secret) => (
+                <div
+                  key={secret.name}
+                  className="border rounded-lg p-3 flex items-center justify-between"
+                >
+                  <div className="flex items-center gap-2">
+                    <Badge variant="secondary" className="font-mono">
+                      {secret.name}
+                    </Badge>
+                    <span className="text-muted-foreground text-sm">
+                      (encrypted)
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                    <Clock className="h-3 w-3" />
+                    {formatDate(secret.updated_at)}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -1171,3 +1171,29 @@ export type AllowedImageType = typeof ALLOWED_IMAGE_TYPES[number];
 
 /** Maximum image size in bytes (100 MB) */
 export const MAX_IMAGE_SIZE = 100 * 1024 * 1024;
+
+// ============================================
+// Session Storage types (Key-Value & Secrets)
+// ============================================
+
+/** Key-value entry info */
+export interface KeyValueInfo {
+  /** The key name */
+  key: string;
+  /** The stored value */
+  value: string;
+  /** When the key was created */
+  created_at: string;
+  /** When the key was last updated */
+  updated_at: string;
+}
+
+/** Secret entry info (no value exposed) */
+export interface SecretInfo {
+  /** The secret name */
+  name: string;
+  /** When the secret was created */
+  created_at: string;
+  /** When the secret was last updated */
+  updated_at: string;
+}

--- a/crates/control-plane/migrations/004_session_storage.sql
+++ b/crates/control-plane/migrations/004_session_storage.sql
@@ -1,0 +1,74 @@
+-- Migration: Session Key/Value and Secret Storage
+-- Adds session-scoped storage for key/value pairs and encrypted secrets.
+
+-- ============================================
+-- Session Key/Value Storage
+-- ============================================
+
+-- Simple key/value storage scoped to sessions.
+-- Use case: Agents can persist data across turns within a session.
+CREATE TABLE session_key_values (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    session_id UUID NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+
+    -- Key name (unique per session)
+    key VARCHAR(255) NOT NULL,
+
+    -- Value (stored as text, can be JSON)
+    value TEXT NOT NULL,
+
+    -- Timestamps
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Unique key per session
+    CONSTRAINT session_key_values_unique_key UNIQUE (session_id, key)
+);
+
+-- Index for listing all keys in a session
+CREATE INDEX idx_session_key_values_session_id ON session_key_values(session_id);
+
+-- Index for key lookup
+CREATE INDEX idx_session_key_values_key ON session_key_values(session_id, key);
+
+-- Auto-update updated_at
+CREATE TRIGGER update_session_key_values_updated_at
+    BEFORE UPDATE ON session_key_values
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- ============================================
+-- Session Secret Storage (Encrypted)
+-- ============================================
+
+-- Encrypted secret storage scoped to sessions.
+-- Use case: Agents can securely store sensitive data like API keys, tokens, etc.
+-- Secrets are encrypted using envelope encryption (AES-256-GCM).
+CREATE TABLE session_secrets (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    session_id UUID NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+
+    -- Secret name (unique per session)
+    name VARCHAR(255) NOT NULL,
+
+    -- Encrypted value (JSON-encoded EncryptedPayload from encryption.rs)
+    -- Contains: version, alg, key_id, dek_wrapped, nonce, ciphertext
+    value_encrypted BYTEA NOT NULL,
+
+    -- Timestamps
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Unique name per session
+    CONSTRAINT session_secrets_unique_name UNIQUE (session_id, name)
+);
+
+-- Index for listing all secrets in a session
+CREATE INDEX idx_session_secrets_session_id ON session_secrets(session_id);
+
+-- Index for secret name lookup
+CREATE INDEX idx_session_secrets_name ON session_secrets(session_id, name);
+
+-- Auto-update updated_at
+CREATE TRIGGER update_session_secrets_updated_at
+    BEFORE UPDATE ON session_secrets
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/crates/control-plane/src/api/mod.rs
+++ b/crates/control-plane/src/api/mod.rs
@@ -15,6 +15,7 @@ pub mod mcp_servers;
 pub mod messages;
 pub mod organizations;
 pub mod session_files;
+pub mod session_storage;
 pub mod sessions;
 pub mod sse;
 pub mod users;

--- a/crates/control-plane/src/api/session_storage.rs
+++ b/crates/control-plane/src/api/session_storage.rs
@@ -1,0 +1,195 @@
+// Session Storage HTTP routes
+// Routes for listing session key-value storage and secrets
+// Secrets are returned without their values for security
+
+use crate::auth::{AuthState, OrgContext, middleware::FromRef};
+use crate::storage::StorageBackend;
+use axum::{
+    Json, Router,
+    extract::{Path, State},
+    http::StatusCode,
+    routing::get,
+};
+use serde::Serialize;
+use std::sync::Arc;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use super::common::{ApiResultExt, ListResponse};
+
+/// Key-value entry info (key and timestamps, no value)
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct KeyValueInfo {
+    /// The key name
+    pub key: String,
+    /// The stored value
+    pub value: String,
+    /// When the key was created
+    pub created_at: String,
+    /// When the key was last updated
+    pub updated_at: String,
+}
+
+/// Secret entry info (name and timestamps only, no value)
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct SecretInfo {
+    /// The secret name
+    pub name: String,
+    /// When the secret was created
+    pub created_at: String,
+    /// When the secret was last updated
+    pub updated_at: String,
+}
+
+/// App state for session storage routes
+#[derive(Clone)]
+pub struct AppState {
+    pub db: Arc<StorageBackend>,
+    pub auth: AuthState,
+}
+
+impl AppState {
+    pub fn new(db: Arc<StorageBackend>, auth: AuthState) -> Self {
+        Self { db, auth }
+    }
+}
+
+impl FromRef<AppState> for AuthState {
+    fn from_ref(input: &AppState) -> Self {
+        input.auth.clone()
+    }
+}
+
+/// Create session storage routes (nested under sessions, org-scoped)
+pub fn routes(state: AppState) -> Router {
+    Router::new()
+        .route(
+            "/v1/orgs/:org/agents/:agent_id/sessions/:session_id/storage/keys",
+            get(list_keys),
+        )
+        .route(
+            "/v1/orgs/:org/agents/:agent_id/sessions/:session_id/storage/secrets",
+            get(list_secrets),
+        )
+        .with_state(state)
+}
+
+/// GET /v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}/storage/keys - List all key-value pairs
+#[utoipa::path(
+    get,
+    path = "/v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}/storage/keys",
+    params(
+        ("org" = String, Path, description = "Organization public ID"),
+        ("agent_id" = Uuid, Path, description = "Agent ID"),
+        ("session_id" = Uuid, Path, description = "Session ID")
+    ),
+    responses(
+        (status = 200, description = "List of key-value pairs", body = ListResponse<KeyValueInfo>),
+        (status = 404, description = "Session not found"),
+        (status = 500, description = "Internal server error")
+    ),
+    tag = "session-storage"
+)]
+pub async fn list_keys(
+    _org: OrgContext,
+    State(state): State<AppState>,
+    Path((_org_path, _agent_id, session_id)): Path<(String, Uuid, Uuid)>,
+) -> Result<Json<ListResponse<KeyValueInfo>>, StatusCode> {
+    // Get all keys with their values
+    let keys = state
+        .db
+        .list_session_keys(session_id)
+        .await
+        .log_internal_error("list session keys")?;
+
+    // Get values for each key
+    let mut items = Vec::with_capacity(keys.len());
+    for key_info in keys {
+        let value = state
+            .db
+            .get_session_key_value(session_id, &key_info.key)
+            .await
+            .log_internal_error("get session key value")?
+            .map(|row| row.value)
+            .unwrap_or_default();
+
+        items.push(KeyValueInfo {
+            key: key_info.key,
+            value,
+            created_at: key_info.created_at.to_rfc3339(),
+            updated_at: key_info.updated_at.to_rfc3339(),
+        });
+    }
+
+    Ok(Json(ListResponse::new(items)))
+}
+
+/// GET /v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}/storage/secrets - List all secrets (names only)
+#[utoipa::path(
+    get,
+    path = "/v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}/storage/secrets",
+    params(
+        ("org" = String, Path, description = "Organization public ID"),
+        ("agent_id" = Uuid, Path, description = "Agent ID"),
+        ("session_id" = Uuid, Path, description = "Session ID")
+    ),
+    responses(
+        (status = 200, description = "List of secrets (names only, no values)", body = ListResponse<SecretInfo>),
+        (status = 404, description = "Session not found"),
+        (status = 500, description = "Internal server error")
+    ),
+    tag = "session-storage"
+)]
+pub async fn list_secrets(
+    _org: OrgContext,
+    State(state): State<AppState>,
+    Path((_org_path, _agent_id, session_id)): Path<(String, Uuid, Uuid)>,
+) -> Result<Json<ListResponse<SecretInfo>>, StatusCode> {
+    let secrets = state
+        .db
+        .list_session_secrets(session_id)
+        .await
+        .log_internal_error("list session secrets")?;
+
+    let items: Vec<SecretInfo> = secrets
+        .into_iter()
+        .map(|row| SecretInfo {
+            name: row.name,
+            created_at: row.created_at.to_rfc3339(),
+            updated_at: row.updated_at.to_rfc3339(),
+        })
+        .collect();
+
+    Ok(Json(ListResponse::new(items)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_key_value_info_serialization() {
+        let info = KeyValueInfo {
+            key: "test_key".to_string(),
+            value: "test_value".to_string(),
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+            updated_at: "2024-01-01T00:00:00Z".to_string(),
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        assert!(json.contains("test_key"));
+        assert!(json.contains("test_value"));
+    }
+
+    #[test]
+    fn test_secret_info_serialization() {
+        let info = SecretInfo {
+            name: "api_key".to_string(),
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+            updated_at: "2024-01-01T00:00:00Z".to_string(),
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        assert!(json.contains("api_key"));
+        // Ensure no value field exists
+        assert!(!json.contains("value"));
+    }
+}

--- a/crates/control-plane/src/main.rs
+++ b/crates/control-plane/src/main.rs
@@ -204,6 +204,7 @@ async fn main() -> Result<()> {
     let agents_state =
         api::agents::AppState::new(db.clone(), capability_service, auth_state.clone());
     let session_files_state = api::session_files::AppState::new(db.clone());
+    let session_storage_state = api::session_storage::AppState::new(db.clone(), auth_state.clone());
     let users_state = api::users::UsersState {
         db: db.clone(),
         auth: auth_state.clone(),
@@ -263,6 +264,7 @@ async fn main() -> Result<()> {
         .merge(api::mcp_servers::routes(mcp_servers_state))
         .merge(api::capabilities::routes(capabilities_state))
         .merge(api::session_files::routes(session_files_state))
+        .merge(api::session_storage::routes(session_storage_state))
         .merge(api::users::routes(users_state))
         .merge(api::durable::routes(durable_state))
         .merge(api::images::routes(images_state))

--- a/crates/control-plane/src/storage/backend.rs
+++ b/crates/control-plane/src/storage/backend.rs
@@ -769,4 +769,27 @@ impl StorageBackend {
     pub async fn is_organization_member(&self, org_id: i64, user_id: Uuid) -> Result<bool> {
         dispatch!(self, is_organization_member, org_id, user_id)
     }
+
+    // ============================================
+    // Session Storage (Key-Value & Secrets)
+    // ============================================
+
+    pub async fn list_session_keys(&self, session_id: Uuid) -> Result<Vec<SessionKeyInfoRow>> {
+        dispatch!(self, list_session_keys, session_id)
+    }
+
+    pub async fn get_session_key_value(
+        &self,
+        session_id: Uuid,
+        key: &str,
+    ) -> Result<Option<SessionKeyValueRow>> {
+        dispatch!(self, get_session_key_value, session_id, key)
+    }
+
+    pub async fn list_session_secrets(
+        &self,
+        session_id: Uuid,
+    ) -> Result<Vec<SessionSecretInfoRow>> {
+        dispatch!(self, list_session_secrets, session_id)
+    }
 }

--- a/crates/control-plane/src/storage/encryption.rs
+++ b/crates/control-plane/src/storage/encryption.rs
@@ -336,6 +336,12 @@ pub const ENCRYPTED_COLUMNS: &[EncryptedColumn] = &[
         column: "api_key_encrypted",
         id_column: "id",
     },
+    // Session secrets are encrypted at rest
+    EncryptedColumn {
+        table: "session_secrets",
+        column: "value_encrypted",
+        id_column: "id",
+    },
 ];
 
 #[cfg(test)]

--- a/crates/control-plane/src/storage/memory.rs
+++ b/crates/control-plane/src/storage/memory.rs
@@ -36,6 +36,9 @@ pub struct InMemoryDatabase {
     images: RwLock<HashMap<Uuid, ImageRow>>,
     // Event sequence counter per session
     event_sequences: RwLock<HashMap<Uuid, i32>>,
+    // Session storage
+    session_key_values: RwLock<HashMap<(Uuid, String), SessionKeyValueRow>>,
+    session_secrets: RwLock<HashMap<(Uuid, String), SessionSecretRow>>,
 }
 
 impl Default for InMemoryDatabase {
@@ -71,6 +74,8 @@ impl Default for InMemoryDatabase {
             mcp_servers: RwLock::new(HashMap::new()),
             images: RwLock::new(HashMap::new()),
             event_sequences: RwLock::new(HashMap::new()),
+            session_key_values: RwLock::new(HashMap::new()),
+            session_secrets: RwLock::new(HashMap::new()),
         }
     }
 }
@@ -2034,6 +2039,55 @@ impl InMemoryDatabase {
             .organization_members
             .read()
             .contains_key(&(org_id, user_id)))
+    }
+
+    // ============================================
+    // Session Storage (Key-Value & Secrets)
+    // ============================================
+
+    pub async fn list_session_keys(&self, session_id: Uuid) -> Result<Vec<SessionKeyInfoRow>> {
+        let storage = self.session_key_values.read();
+        let mut keys: Vec<_> = storage
+            .iter()
+            .filter(|((sid, _), _)| *sid == session_id)
+            .map(|((_, _), row)| SessionKeyInfoRow {
+                key: row.key.clone(),
+                created_at: row.created_at,
+                updated_at: row.updated_at,
+            })
+            .collect();
+        keys.sort_by(|a, b| a.key.cmp(&b.key));
+        Ok(keys)
+    }
+
+    pub async fn get_session_key_value(
+        &self,
+        session_id: Uuid,
+        key: &str,
+    ) -> Result<Option<SessionKeyValueRow>> {
+        Ok(self
+            .session_key_values
+            .read()
+            .get(&(session_id, key.to_string()))
+            .cloned())
+    }
+
+    pub async fn list_session_secrets(
+        &self,
+        session_id: Uuid,
+    ) -> Result<Vec<SessionSecretInfoRow>> {
+        let storage = self.session_secrets.read();
+        let mut secrets: Vec<_> = storage
+            .iter()
+            .filter(|((sid, _), _)| *sid == session_id)
+            .map(|((_, _), row)| SessionSecretInfoRow {
+                name: row.name.clone(),
+                created_at: row.created_at,
+                updated_at: row.updated_at,
+            })
+            .collect();
+        secrets.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(secrets)
     }
 }
 

--- a/crates/control-plane/src/storage/mod.rs
+++ b/crates/control-plane/src/storage/mod.rs
@@ -6,6 +6,7 @@
 // - DbSessionStore: implements SessionStore for session retrieval
 // - DbMessageRetriever: implements MessageRetriever for message loading
 // - DbSessionFileStore: implements SessionFileStore for session filesystem
+// - DbSessionStorageStore: implements SessionStorageStore for key/value and secret storage
 // - DbLlmProviderStore: implements LlmProviderStore for LLM provider retrieval
 
 pub mod agent_store;
@@ -18,6 +19,7 @@ pub mod models;
 pub mod password;
 pub mod repositories;
 pub mod session_file_store;
+pub mod session_storage_store;
 pub mod session_store;
 
 #[cfg(test)]
@@ -35,4 +37,8 @@ pub use message_store::{DbMessageRetriever, create_db_message_retriever};
 pub use models::*;
 pub use repositories::*;
 pub use session_file_store::{DbSessionFileStore, create_db_session_file_store};
+pub use session_storage_store::{
+    DbSessionStorageStore, create_db_session_storage_store,
+    create_db_session_storage_store_without_encryption,
+};
 pub use session_store::{DbSessionStore, create_db_session_store};

--- a/crates/control-plane/src/storage/models.rs
+++ b/crates/control-plane/src/storage/models.rs
@@ -575,3 +575,65 @@ pub struct CreateImageRow {
 pub struct UpdateMcpServerTools {
     pub cached_tools: serde_json::Value,
 }
+
+// ============================================
+// Session Key/Value Storage models
+// ============================================
+
+/// Session key/value row from database
+#[derive(Debug, Clone, FromRow)]
+pub struct SessionKeyValueRow {
+    pub id: Uuid,
+    pub session_id: Uuid,
+    pub key: String,
+    pub value: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Input for creating/updating a session key/value
+#[derive(Debug, Clone)]
+pub struct UpsertSessionKeyValue {
+    pub session_id: Uuid,
+    pub key: String,
+    pub value: String,
+}
+
+/// Lightweight key info for listing (without value)
+#[derive(Debug, Clone, FromRow)]
+pub struct SessionKeyInfoRow {
+    pub key: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+// ============================================
+// Session Secret Storage models (encrypted)
+// ============================================
+
+/// Session secret row from database
+#[derive(Debug, Clone, FromRow)]
+pub struct SessionSecretRow {
+    pub id: Uuid,
+    pub session_id: Uuid,
+    pub name: String,
+    pub value_encrypted: Vec<u8>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Input for creating/updating a session secret
+#[derive(Debug, Clone)]
+pub struct UpsertSessionSecret {
+    pub session_id: Uuid,
+    pub name: String,
+    pub value_encrypted: Vec<u8>,
+}
+
+/// Lightweight secret info for listing (without encrypted value)
+#[derive(Debug, Clone, FromRow)]
+pub struct SessionSecretInfoRow {
+    pub name: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}

--- a/crates/control-plane/src/storage/repositories.rs
+++ b/crates/control-plane/src/storage/repositories.rs
@@ -2311,4 +2311,169 @@ impl Database {
 
         Ok(row.is_some())
     }
+
+    // ============================================
+    // Session Key/Value Storage
+    // ============================================
+
+    /// Upsert a session key/value (insert or update)
+    pub async fn upsert_session_key_value(
+        &self,
+        input: UpsertSessionKeyValue,
+    ) -> Result<SessionKeyValueRow> {
+        let row = sqlx::query_as::<_, SessionKeyValueRow>(
+            r#"
+            INSERT INTO session_key_values (session_id, key, value)
+            VALUES ($1, $2, $3)
+            ON CONFLICT (session_id, key) DO UPDATE
+            SET value = EXCLUDED.value, updated_at = NOW()
+            RETURNING id, session_id, key, value, created_at, updated_at
+            "#,
+        )
+        .bind(input.session_id)
+        .bind(&input.key)
+        .bind(&input.value)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    /// Get a session key/value by key
+    pub async fn get_session_key_value(
+        &self,
+        session_id: Uuid,
+        key: &str,
+    ) -> Result<Option<SessionKeyValueRow>> {
+        let row = sqlx::query_as::<_, SessionKeyValueRow>(
+            r#"
+            SELECT id, session_id, key, value, created_at, updated_at
+            FROM session_key_values
+            WHERE session_id = $1 AND key = $2
+            "#,
+        )
+        .bind(session_id)
+        .bind(key)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    /// List all keys for a session (without values)
+    pub async fn list_session_keys(&self, session_id: Uuid) -> Result<Vec<SessionKeyInfoRow>> {
+        let rows = sqlx::query_as::<_, SessionKeyInfoRow>(
+            r#"
+            SELECT key, created_at, updated_at
+            FROM session_key_values
+            WHERE session_id = $1
+            ORDER BY key
+            "#,
+        )
+        .bind(session_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+
+    /// Delete a session key/value by key
+    pub async fn delete_session_key_value(&self, session_id: Uuid, key: &str) -> Result<bool> {
+        let result = sqlx::query(
+            r#"
+            DELETE FROM session_key_values
+            WHERE session_id = $1 AND key = $2
+            "#,
+        )
+        .bind(session_id)
+        .bind(key)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    // ============================================
+    // Session Secret Storage (Encrypted)
+    // ============================================
+
+    /// Upsert a session secret (insert or update)
+    pub async fn upsert_session_secret(
+        &self,
+        input: UpsertSessionSecret,
+    ) -> Result<SessionSecretRow> {
+        let row = sqlx::query_as::<_, SessionSecretRow>(
+            r#"
+            INSERT INTO session_secrets (session_id, name, value_encrypted)
+            VALUES ($1, $2, $3)
+            ON CONFLICT (session_id, name) DO UPDATE
+            SET value_encrypted = EXCLUDED.value_encrypted, updated_at = NOW()
+            RETURNING id, session_id, name, value_encrypted, created_at, updated_at
+            "#,
+        )
+        .bind(input.session_id)
+        .bind(&input.name)
+        .bind(&input.value_encrypted)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    /// Get a session secret by name
+    pub async fn get_session_secret(
+        &self,
+        session_id: Uuid,
+        name: &str,
+    ) -> Result<Option<SessionSecretRow>> {
+        let row = sqlx::query_as::<_, SessionSecretRow>(
+            r#"
+            SELECT id, session_id, name, value_encrypted, created_at, updated_at
+            FROM session_secrets
+            WHERE session_id = $1 AND name = $2
+            "#,
+        )
+        .bind(session_id)
+        .bind(name)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    /// List all secret names for a session (without encrypted values)
+    pub async fn list_session_secrets(
+        &self,
+        session_id: Uuid,
+    ) -> Result<Vec<SessionSecretInfoRow>> {
+        let rows = sqlx::query_as::<_, SessionSecretInfoRow>(
+            r#"
+            SELECT name, created_at, updated_at
+            FROM session_secrets
+            WHERE session_id = $1
+            ORDER BY name
+            "#,
+        )
+        .bind(session_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+
+    /// Delete a session secret by name
+    pub async fn delete_session_secret(&self, session_id: Uuid, name: &str) -> Result<bool> {
+        let result = sqlx::query(
+            r#"
+            DELETE FROM session_secrets
+            WHERE session_id = $1 AND name = $2
+            "#,
+        )
+        .bind(session_id)
+        .bind(name)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
 }

--- a/crates/control-plane/src/storage/session_storage_store.rs
+++ b/crates/control-plane/src/storage/session_storage_store.rs
@@ -1,0 +1,202 @@
+// Database-backed SessionStorageStore implementation
+//
+// This module implements the core SessionStorageStore trait for persisting
+// session key/value pairs and encrypted secrets to the database.
+
+use async_trait::async_trait;
+use everruns_core::{AgentLoopError, KeyInfo, Result, SecretInfo, traits::SessionStorageStore};
+use uuid::Uuid;
+
+use super::encryption::EncryptionService;
+use super::models::{UpsertSessionKeyValue, UpsertSessionSecret};
+use super::repositories::Database;
+
+// ============================================================================
+// DbSessionStorageStore - Stores session data in database
+// ============================================================================
+
+/// Database-backed session storage store
+///
+/// Stores session key/value pairs and encrypted secrets in the database.
+/// Used by tools that need to persist data within a session.
+#[derive(Clone)]
+pub struct DbSessionStorageStore {
+    db: Database,
+    encryption: Option<EncryptionService>,
+}
+
+impl DbSessionStorageStore {
+    /// Create a new storage store with encryption enabled
+    pub fn new(db: Database, encryption: EncryptionService) -> Self {
+        Self {
+            db,
+            encryption: Some(encryption),
+        }
+    }
+
+    /// Create a new storage store without encryption
+    /// (secrets operations will fail)
+    pub fn new_without_encryption(db: Database) -> Self {
+        Self {
+            db,
+            encryption: None,
+        }
+    }
+
+    /// Get the encryption service, returning an error if not configured
+    fn encryption(&self) -> Result<&EncryptionService> {
+        self.encryption.as_ref().ok_or_else(|| {
+            AgentLoopError::store(
+                "Encryption not configured. Set SECRETS_ENCRYPTION_KEY environment variable.",
+            )
+        })
+    }
+}
+
+#[async_trait]
+impl SessionStorageStore for DbSessionStorageStore {
+    // ========================================================================
+    // Key/Value operations (plain text)
+    // ========================================================================
+
+    async fn set_value(&self, session_id: Uuid, key: &str, value: &str) -> Result<()> {
+        let input = UpsertSessionKeyValue {
+            session_id,
+            key: key.to_string(),
+            value: value.to_string(),
+        };
+
+        self.db
+            .upsert_session_key_value(input)
+            .await
+            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn get_value(&self, session_id: Uuid, key: &str) -> Result<Option<String>> {
+        let row = self
+            .db
+            .get_session_key_value(session_id, key)
+            .await
+            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+
+        Ok(row.map(|r| r.value))
+    }
+
+    async fn delete_value(&self, session_id: Uuid, key: &str) -> Result<bool> {
+        self.db
+            .delete_session_key_value(session_id, key)
+            .await
+            .map_err(|e| AgentLoopError::store(e.to_string()))
+    }
+
+    async fn list_keys(&self, session_id: Uuid) -> Result<Vec<KeyInfo>> {
+        let rows = self
+            .db
+            .list_session_keys(session_id)
+            .await
+            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+
+        Ok(rows
+            .into_iter()
+            .map(|r| KeyInfo {
+                key: r.key,
+                created_at: r.created_at,
+                updated_at: r.updated_at,
+            })
+            .collect())
+    }
+
+    // ========================================================================
+    // Secret operations (encrypted)
+    // ========================================================================
+
+    async fn set_secret(&self, session_id: Uuid, name: &str, value: &str) -> Result<()> {
+        let encryption = self.encryption()?;
+
+        // Encrypt the value
+        let encrypted = encryption
+            .encrypt_string(value)
+            .map_err(|e| AgentLoopError::store(format!("Encryption failed: {}", e)))?;
+
+        let input = UpsertSessionSecret {
+            session_id,
+            name: name.to_string(),
+            value_encrypted: encrypted,
+        };
+
+        self.db
+            .upsert_session_secret(input)
+            .await
+            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn get_secret(&self, session_id: Uuid, name: &str) -> Result<Option<String>> {
+        let encryption = self.encryption()?;
+
+        let row = self
+            .db
+            .get_session_secret(session_id, name)
+            .await
+            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+
+        match row {
+            Some(r) => {
+                // Decrypt the value
+                let decrypted = encryption
+                    .decrypt_to_string(&r.value_encrypted)
+                    .map_err(|e| AgentLoopError::store(format!("Decryption failed: {}", e)))?;
+                Ok(Some(decrypted))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn delete_secret(&self, session_id: Uuid, name: &str) -> Result<bool> {
+        self.db
+            .delete_session_secret(session_id, name)
+            .await
+            .map_err(|e| AgentLoopError::store(e.to_string()))
+    }
+
+    async fn list_secrets(&self, session_id: Uuid) -> Result<Vec<SecretInfo>> {
+        let rows = self
+            .db
+            .list_session_secrets(session_id)
+            .await
+            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+
+        Ok(rows
+            .into_iter()
+            .map(|r| SecretInfo {
+                name: r.name,
+                created_at: r.created_at,
+                updated_at: r.updated_at,
+            })
+            .collect())
+    }
+}
+
+// ============================================================================
+// Factory functions
+// ============================================================================
+
+/// Create a database-backed session storage store with encryption
+pub fn create_db_session_storage_store(
+    db: Database,
+    encryption: EncryptionService,
+) -> DbSessionStorageStore {
+    DbSessionStorageStore::new(db, encryption)
+}
+
+/// Create a database-backed session storage store without encryption
+/// (secrets operations will fail, but key/value operations will work)
+pub fn create_db_session_storage_store_without_encryption(db: Database) -> DbSessionStorageStore {
+    DbSessionStorageStore::new_without_encryption(db)
+}
+
+// Note: Integration tests for this module are covered by smoke tests
+// since they require a running database and encryption service.

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -43,6 +43,7 @@ mod noop;
 mod research;
 mod sample_data;
 mod sandbox;
+mod session_storage;
 mod stateless_todo_list;
 mod test_math;
 mod test_weather;
@@ -88,6 +89,10 @@ pub use noop::NoopCapability;
 pub use research::ResearchCapability;
 pub use sample_data::SampleDataCapability;
 pub use sandbox::SandboxCapability;
+pub use session_storage::{
+    DeleteSecretTool, DeleteValueTool, GetSecretTool, GetValueTool, ListKeysTool, ListSecretsTool,
+    SessionStorageCapability, SetSecretTool, SetValueTool,
+};
 pub use stateless_todo_list::{StatelessTodoListCapability, WriteTodosTool};
 pub use test_math::{AddTool, DivideTool, MultiplyTool, SubtractTool, TestMathCapability};
 pub use test_weather::{GetForecastTool, GetWeatherTool, TestWeatherCapability};
@@ -252,6 +257,7 @@ impl CapabilityRegistry {
         registry.register(ResearchCapability);
         registry.register(SandboxCapability);
         registry.register(FileSystemCapability);
+        registry.register(SessionStorageCapability);
         registry.register(TestMathCapability);
         registry.register(TestWeatherCapability);
         registry.register(StatelessTodoListCapability);
@@ -768,6 +774,7 @@ mod tests {
         assert!(registry.has(CapabilityId::RESEARCH));
         assert!(registry.has(CapabilityId::SANDBOX));
         assert!(registry.has(CapabilityId::FILE_SYSTEM));
+        assert!(registry.has(CapabilityId::SESSION_STORAGE));
         assert!(registry.has(CapabilityId::TEST_MATH));
         assert!(registry.has(CapabilityId::TEST_WEATHER));
         assert!(registry.has(CapabilityId::STATELESS_TODO_LIST));
@@ -779,7 +786,7 @@ mod tests {
         assert!(registry.has(CapabilityId::FAKE_FINANCIAL));
         // Experimental capability included in dev
         assert!(registry.has(CapabilityId::DOCKER_CONTAINER));
-        assert_eq!(registry.len(), 15);
+        assert_eq!(registry.len(), 16);
     }
 
     #[test]
@@ -792,6 +799,7 @@ mod tests {
         assert!(registry.has(CapabilityId::RESEARCH));
         assert!(registry.has(CapabilityId::SANDBOX));
         assert!(registry.has(CapabilityId::FILE_SYSTEM));
+        assert!(registry.has(CapabilityId::SESSION_STORAGE));
         assert!(registry.has(CapabilityId::TEST_MATH));
         assert!(registry.has(CapabilityId::TEST_WEATHER));
         assert!(registry.has(CapabilityId::STATELESS_TODO_LIST));
@@ -803,7 +811,7 @@ mod tests {
         assert!(registry.has(CapabilityId::FAKE_FINANCIAL));
         // Experimental capability NOT included in prod
         assert!(!registry.has(CapabilityId::DOCKER_CONTAINER));
-        assert_eq!(registry.len(), 14);
+        assert_eq!(registry.len(), 15);
     }
 
     #[test]

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -89,10 +89,7 @@ pub use noop::NoopCapability;
 pub use research::ResearchCapability;
 pub use sample_data::SampleDataCapability;
 pub use sandbox::SandboxCapability;
-pub use session_storage::{
-    DeleteSecretTool, DeleteValueTool, GetSecretTool, GetValueTool, ListKeysTool, ListSecretsTool,
-    SessionStorageCapability, SetSecretTool, SetValueTool,
-};
+pub use session_storage::{KvStoreTool, SecretStoreTool, SessionStorageCapability};
 pub use stateless_todo_list::{StatelessTodoListCapability, WriteTodosTool};
 pub use test_math::{AddTool, DivideTool, MultiplyTool, SubtractTool, TestMathCapability};
 pub use test_weather::{GetForecastTool, GetWeatherTool, TestWeatherCapability};

--- a/crates/core/src/capabilities/session_storage.rs
+++ b/crates/core/src/capabilities/session_storage.rs
@@ -4,17 +4,8 @@
 //! Data persists for the session duration.
 //!
 //! Tools provided:
-//! - Key/Value (plain text):
-//!   - `set_value`: Store a key/value pair
-//!   - `get_value`: Retrieve a value by key
-//!   - `delete_value`: Delete a key/value pair
-//!   - `list_keys`: List all stored keys
-//!
-//! - Secrets (encrypted at rest):
-//!   - `set_secret`: Store an encrypted secret
-//!   - `get_secret`: Retrieve a decrypted secret
-//!   - `delete_secret`: Delete a secret
-//!   - `list_secrets`: List all secret names
+//! - `kv_store`: Key/value storage operations (set, get, delete, list)
+//! - `secret_store`: Encrypted secret storage operations (set, get, delete, list)
 
 use super::{Capability, CapabilityId, CapabilityStatus};
 use crate::tools::{Tool, ToolExecutionResult};
@@ -60,79 +51,73 @@ impl Capability for SessionStorageCapability {
         Some(
             r#"You have access to session storage tools for persisting data within the session.
 
-Key/Value Storage (plain text):
-- `set_value`: Store a key/value pair (creates or updates)
-- `get_value`: Retrieve a value by key
-- `delete_value`: Delete a key/value pair
-- `list_keys`: List all stored keys
+`kv_store` - Key/value storage (plain text):
+- operation: "set" - Store a key/value pair (key, value required)
+- operation: "get" - Retrieve a value (key required)
+- operation: "delete" - Delete a key/value pair (key required)
+- operation: "list" - List all stored keys
 
-Secret Storage (encrypted at rest):
-- `set_secret`: Store a secret securely (creates or updates)
-- `get_secret`: Retrieve a secret (decrypted)
-- `delete_secret`: Delete a secret
-- `list_secrets`: List all secret names (without values)
+`secret_store` - Secret storage (encrypted at rest):
+- operation: "set" - Store a secret (name, value required)
+- operation: "get" - Retrieve a secret (name required)
+- operation: "delete" - Delete a secret (name required)
+- operation: "list" - List all secret names
 
 Best practices:
-- Use key/value storage for general data like state, preferences, or intermediate results
-- Use secret storage for sensitive data like API keys, tokens, or credentials
-- Keys and secret names are unique per session - storing with the same name overwrites"#,
+- Use kv_store for general data like state, preferences, or intermediate results
+- Use secret_store for sensitive data like API keys, tokens, or credentials
+- Keys and names are unique per session - storing with the same key/name overwrites"#,
         )
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
-        vec![
-            // Key/Value tools
-            Box::new(SetValueTool),
-            Box::new(GetValueTool),
-            Box::new(DeleteValueTool),
-            Box::new(ListKeysTool),
-            // Secret tools
-            Box::new(SetSecretTool),
-            Box::new(GetSecretTool),
-            Box::new(DeleteSecretTool),
-            Box::new(ListSecretsTool),
-        ]
+        vec![Box::new(KvStoreTool), Box::new(SecretStoreTool)]
     }
 }
 
 // ============================================================================
-// Key/Value Tools
+// KvStoreTool - Unified key/value storage tool
 // ============================================================================
 
-/// Tool to set a key/value pair
-pub struct SetValueTool;
+/// Tool for key/value storage operations
+pub struct KvStoreTool;
 
 #[async_trait]
-impl Tool for SetValueTool {
+impl Tool for KvStoreTool {
     fn name(&self) -> &str {
-        "set_value"
+        "kv_store"
     }
 
     fn description(&self) -> &str {
-        "Store a key/value pair. Creates a new entry or updates an existing one."
+        "Key/value storage operations: set, get, delete, or list keys."
     }
 
     fn parameters_schema(&self) -> Value {
         json!({
             "type": "object",
             "properties": {
+                "operation": {
+                    "type": "string",
+                    "enum": ["set", "get", "delete", "list"],
+                    "description": "The operation to perform"
+                },
                 "key": {
                     "type": "string",
-                    "description": "The key to store the value under (max 255 chars)"
+                    "description": "The key (required for set, get, delete; max 255 chars)"
                 },
                 "value": {
                     "type": "string",
-                    "description": "The value to store (can be JSON-encoded for structured data)"
+                    "description": "The value to store (required for set; can be JSON-encoded)"
                 }
             },
-            "required": ["key", "value"],
+            "required": ["operation"],
             "additionalProperties": false
         })
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error(
-            "set_value requires context. This tool must be executed with session context.",
+            "kv_store requires context. This tool must be executed with session context.",
         )
     }
 
@@ -141,19 +126,12 @@ impl Tool for SetValueTool {
         arguments: Value,
         context: &ToolContext,
     ) -> ToolExecutionResult {
-        let key = match arguments.get("key").and_then(|v| v.as_str()) {
-            Some(k) => k,
-            None => return ToolExecutionResult::tool_error("Missing required parameter: key"),
+        let operation = match arguments.get("operation").and_then(|v| v.as_str()) {
+            Some(op) => op,
+            None => {
+                return ToolExecutionResult::tool_error("Missing required parameter: operation");
+            }
         };
-
-        let value = match arguments.get("value").and_then(|v| v.as_str()) {
-            Some(v) => v,
-            None => return ToolExecutionResult::tool_error("Missing required parameter: value"),
-        };
-
-        if key.len() > 255 {
-            return ToolExecutionResult::tool_error("Key must be 255 characters or less");
-        }
 
         let storage_store = match &context.storage_store {
             Some(store) => store,
@@ -162,215 +140,106 @@ impl Tool for SetValueTool {
             }
         };
 
-        match storage_store
-            .set_value(context.session_id, key, value)
-            .await
-        {
-            Ok(()) => ToolExecutionResult::success(json!({
-                "key": key,
-                "stored": true
-            })),
-            Err(e) => ToolExecutionResult::internal_error(e),
-        }
-    }
-
-    fn requires_context(&self) -> bool {
-        true
-    }
-}
-
-/// Tool to get a value by key
-pub struct GetValueTool;
-
-#[async_trait]
-impl Tool for GetValueTool {
-    fn name(&self) -> &str {
-        "get_value"
-    }
-
-    fn description(&self) -> &str {
-        "Retrieve a stored value by its key. Returns null if the key doesn't exist."
-    }
-
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "key": {
-                    "type": "string",
-                    "description": "The key to retrieve the value for"
+        match operation {
+            "set" => {
+                let key = match arguments.get("key").and_then(|v| v.as_str()) {
+                    Some(k) => k,
+                    None => {
+                        return ToolExecutionResult::tool_error(
+                            "Missing required parameter: key (for set operation)",
+                        );
+                    }
+                };
+                let value = match arguments.get("value").and_then(|v| v.as_str()) {
+                    Some(v) => v,
+                    None => {
+                        return ToolExecutionResult::tool_error(
+                            "Missing required parameter: value (for set operation)",
+                        );
+                    }
+                };
+                if key.len() > 255 {
+                    return ToolExecutionResult::tool_error("Key must be 255 characters or less");
                 }
-            },
-            "required": ["key"],
-            "additionalProperties": false
-        })
-    }
-
-    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
-        ToolExecutionResult::tool_error(
-            "get_value requires context. This tool must be executed with session context.",
-        )
-    }
-
-    async fn execute_with_context(
-        &self,
-        arguments: Value,
-        context: &ToolContext,
-    ) -> ToolExecutionResult {
-        let key = match arguments.get("key").and_then(|v| v.as_str()) {
-            Some(k) => k,
-            None => return ToolExecutionResult::tool_error("Missing required parameter: key"),
-        };
-
-        let storage_store = match &context.storage_store {
-            Some(store) => store,
-            None => {
-                return ToolExecutionResult::tool_error("Storage not available in this context");
-            }
-        };
-
-        match storage_store.get_value(context.session_id, key).await {
-            Ok(Some(value)) => ToolExecutionResult::success(json!({
-                "key": key,
-                "value": value,
-                "found": true
-            })),
-            Ok(None) => ToolExecutionResult::success(json!({
-                "key": key,
-                "value": null,
-                "found": false
-            })),
-            Err(e) => ToolExecutionResult::internal_error(e),
-        }
-    }
-
-    fn requires_context(&self) -> bool {
-        true
-    }
-}
-
-/// Tool to delete a key/value pair
-pub struct DeleteValueTool;
-
-#[async_trait]
-impl Tool for DeleteValueTool {
-    fn name(&self) -> &str {
-        "delete_value"
-    }
-
-    fn description(&self) -> &str {
-        "Delete a stored key/value pair. Returns whether the key existed."
-    }
-
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "key": {
-                    "type": "string",
-                    "description": "The key to delete"
+                match storage_store
+                    .set_value(context.session_id, key, value)
+                    .await
+                {
+                    Ok(()) => ToolExecutionResult::success(json!({
+                        "operation": "set",
+                        "key": key,
+                        "success": true
+                    })),
+                    Err(e) => ToolExecutionResult::internal_error(e),
                 }
-            },
-            "required": ["key"],
-            "additionalProperties": false
-        })
-    }
-
-    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
-        ToolExecutionResult::tool_error(
-            "delete_value requires context. This tool must be executed with session context.",
-        )
-    }
-
-    async fn execute_with_context(
-        &self,
-        arguments: Value,
-        context: &ToolContext,
-    ) -> ToolExecutionResult {
-        let key = match arguments.get("key").and_then(|v| v.as_str()) {
-            Some(k) => k,
-            None => return ToolExecutionResult::tool_error("Missing required parameter: key"),
-        };
-
-        let storage_store = match &context.storage_store {
-            Some(store) => store,
-            None => {
-                return ToolExecutionResult::tool_error("Storage not available in this context");
             }
-        };
-
-        match storage_store.delete_value(context.session_id, key).await {
-            Ok(deleted) => ToolExecutionResult::success(json!({
-                "key": key,
-                "deleted": deleted
-            })),
-            Err(e) => ToolExecutionResult::internal_error(e),
-        }
-    }
-
-    fn requires_context(&self) -> bool {
-        true
-    }
-}
-
-/// Tool to list all stored keys
-pub struct ListKeysTool;
-
-#[async_trait]
-impl Tool for ListKeysTool {
-    fn name(&self) -> &str {
-        "list_keys"
-    }
-
-    fn description(&self) -> &str {
-        "List all stored keys in the session (without their values)."
-    }
-
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {},
-            "additionalProperties": false
-        })
-    }
-
-    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
-        ToolExecutionResult::tool_error(
-            "list_keys requires context. This tool must be executed with session context.",
-        )
-    }
-
-    async fn execute_with_context(
-        &self,
-        _arguments: Value,
-        context: &ToolContext,
-    ) -> ToolExecutionResult {
-        let storage_store = match &context.storage_store {
-            Some(store) => store,
-            None => {
-                return ToolExecutionResult::tool_error("Storage not available in this context");
+            "get" => {
+                let key = match arguments.get("key").and_then(|v| v.as_str()) {
+                    Some(k) => k,
+                    None => {
+                        return ToolExecutionResult::tool_error(
+                            "Missing required parameter: key (for get operation)",
+                        );
+                    }
+                };
+                match storage_store.get_value(context.session_id, key).await {
+                    Ok(Some(value)) => ToolExecutionResult::success(json!({
+                        "operation": "get",
+                        "key": key,
+                        "value": value,
+                        "found": true
+                    })),
+                    Ok(None) => ToolExecutionResult::success(json!({
+                        "operation": "get",
+                        "key": key,
+                        "value": null,
+                        "found": false
+                    })),
+                    Err(e) => ToolExecutionResult::internal_error(e),
+                }
             }
-        };
-
-        match storage_store.list_keys(context.session_id).await {
-            Ok(keys) => {
-                let key_list: Vec<Value> = keys
-                    .iter()
-                    .map(|k| {
-                        json!({
-                            "key": k.key,
-                            "created_at": k.created_at.to_rfc3339(),
-                            "updated_at": k.updated_at.to_rfc3339()
+            "delete" => {
+                let key = match arguments.get("key").and_then(|v| v.as_str()) {
+                    Some(k) => k,
+                    None => {
+                        return ToolExecutionResult::tool_error(
+                            "Missing required parameter: key (for delete operation)",
+                        );
+                    }
+                };
+                match storage_store.delete_value(context.session_id, key).await {
+                    Ok(deleted) => ToolExecutionResult::success(json!({
+                        "operation": "delete",
+                        "key": key,
+                        "deleted": deleted
+                    })),
+                    Err(e) => ToolExecutionResult::internal_error(e),
+                }
+            }
+            "list" => match storage_store.list_keys(context.session_id).await {
+                Ok(keys) => {
+                    let key_list: Vec<Value> = keys
+                        .iter()
+                        .map(|k| {
+                            json!({
+                                "key": k.key,
+                                "created_at": k.created_at.to_rfc3339(),
+                                "updated_at": k.updated_at.to_rfc3339()
+                            })
                         })
-                    })
-                    .collect();
-
-                ToolExecutionResult::success(json!({
-                    "keys": key_list,
-                    "count": key_list.len()
-                }))
-            }
-            Err(e) => ToolExecutionResult::internal_error(e),
+                        .collect();
+                    ToolExecutionResult::success(json!({
+                        "operation": "list",
+                        "keys": key_list,
+                        "count": key_list.len()
+                    }))
+                }
+                Err(e) => ToolExecutionResult::internal_error(e),
+            },
+            _ => ToolExecutionResult::tool_error(format!(
+                "Invalid operation: {}. Must be one of: set, get, delete, list",
+                operation
+            )),
         }
     }
 
@@ -380,43 +249,48 @@ impl Tool for ListKeysTool {
 }
 
 // ============================================================================
-// Secret Tools
+// SecretStoreTool - Unified secret storage tool
 // ============================================================================
 
-/// Tool to set a secret
-pub struct SetSecretTool;
+/// Tool for encrypted secret storage operations
+pub struct SecretStoreTool;
 
 #[async_trait]
-impl Tool for SetSecretTool {
+impl Tool for SecretStoreTool {
     fn name(&self) -> &str {
-        "set_secret"
+        "secret_store"
     }
 
     fn description(&self) -> &str {
-        "Store a secret securely. The value is encrypted at rest. Creates or updates."
+        "Encrypted secret storage operations: set, get, delete, or list secrets."
     }
 
     fn parameters_schema(&self) -> Value {
         json!({
             "type": "object",
             "properties": {
+                "operation": {
+                    "type": "string",
+                    "enum": ["set", "get", "delete", "list"],
+                    "description": "The operation to perform"
+                },
                 "name": {
                     "type": "string",
-                    "description": "The name/identifier for the secret (max 255 chars)"
+                    "description": "The secret name (required for set, get, delete; max 255 chars)"
                 },
                 "value": {
                     "type": "string",
-                    "description": "The secret value to store (will be encrypted)"
+                    "description": "The secret value to store (required for set; will be encrypted)"
                 }
             },
-            "required": ["name", "value"],
+            "required": ["operation"],
             "additionalProperties": false
         })
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error(
-            "set_secret requires context. This tool must be executed with session context.",
+            "secret_store requires context. This tool must be executed with session context.",
         )
     }
 
@@ -425,94 +299,11 @@ impl Tool for SetSecretTool {
         arguments: Value,
         context: &ToolContext,
     ) -> ToolExecutionResult {
-        let name = match arguments.get("name").and_then(|v| v.as_str()) {
-            Some(n) => n,
-            None => return ToolExecutionResult::tool_error("Missing required parameter: name"),
-        };
-
-        let value = match arguments.get("value").and_then(|v| v.as_str()) {
-            Some(v) => v,
-            None => return ToolExecutionResult::tool_error("Missing required parameter: value"),
-        };
-
-        if name.len() > 255 {
-            return ToolExecutionResult::tool_error("Secret name must be 255 characters or less");
-        }
-
-        let storage_store = match &context.storage_store {
-            Some(store) => store,
+        let operation = match arguments.get("operation").and_then(|v| v.as_str()) {
+            Some(op) => op,
             None => {
-                return ToolExecutionResult::tool_error("Storage not available in this context");
+                return ToolExecutionResult::tool_error("Missing required parameter: operation");
             }
-        };
-
-        match storage_store
-            .set_secret(context.session_id, name, value)
-            .await
-        {
-            Ok(()) => ToolExecutionResult::success(json!({
-                "name": name,
-                "stored": true
-            })),
-            Err(e) => {
-                let msg = e.to_string();
-                if msg.contains("Encryption not configured") {
-                    ToolExecutionResult::tool_error(
-                        "Secret storage is not available. Encryption is not configured.",
-                    )
-                } else {
-                    ToolExecutionResult::internal_error(e)
-                }
-            }
-        }
-    }
-
-    fn requires_context(&self) -> bool {
-        true
-    }
-}
-
-/// Tool to get a secret
-pub struct GetSecretTool;
-
-#[async_trait]
-impl Tool for GetSecretTool {
-    fn name(&self) -> &str {
-        "get_secret"
-    }
-
-    fn description(&self) -> &str {
-        "Retrieve a stored secret by name. The value is decrypted before returning."
-    }
-
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "description": "The name of the secret to retrieve"
-                }
-            },
-            "required": ["name"],
-            "additionalProperties": false
-        })
-    }
-
-    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
-        ToolExecutionResult::tool_error(
-            "get_secret requires context. This tool must be executed with session context.",
-        )
-    }
-
-    async fn execute_with_context(
-        &self,
-        arguments: Value,
-        context: &ToolContext,
-    ) -> ToolExecutionResult {
-        let name = match arguments.get("name").and_then(|v| v.as_str()) {
-            Some(n) => n,
-            None => return ToolExecutionResult::tool_error("Missing required parameter: name"),
         };
 
         let storage_store = match &context.storage_store {
@@ -522,166 +313,135 @@ impl Tool for GetSecretTool {
             }
         };
 
-        match storage_store.get_secret(context.session_id, name).await {
-            Ok(Some(value)) => ToolExecutionResult::success(json!({
-                "name": name,
-                "value": value,
-                "found": true
-            })),
-            Ok(None) => ToolExecutionResult::success(json!({
-                "name": name,
-                "value": null,
-                "found": false
-            })),
-            Err(e) => {
-                let msg = e.to_string();
-                if msg.contains("Encryption not configured") {
-                    ToolExecutionResult::tool_error(
-                        "Secret storage is not available. Encryption is not configured.",
-                    )
-                } else {
-                    ToolExecutionResult::internal_error(e)
+        match operation {
+            "set" => {
+                let name = match arguments.get("name").and_then(|v| v.as_str()) {
+                    Some(n) => n,
+                    None => {
+                        return ToolExecutionResult::tool_error(
+                            "Missing required parameter: name (for set operation)",
+                        );
+                    }
+                };
+                let value = match arguments.get("value").and_then(|v| v.as_str()) {
+                    Some(v) => v,
+                    None => {
+                        return ToolExecutionResult::tool_error(
+                            "Missing required parameter: value (for set operation)",
+                        );
+                    }
+                };
+                if name.len() > 255 {
+                    return ToolExecutionResult::tool_error(
+                        "Secret name must be 255 characters or less",
+                    );
+                }
+                match storage_store
+                    .set_secret(context.session_id, name, value)
+                    .await
+                {
+                    Ok(()) => ToolExecutionResult::success(json!({
+                        "operation": "set",
+                        "name": name,
+                        "success": true
+                    })),
+                    Err(e) => {
+                        let msg = e.to_string();
+                        if msg.contains("Encryption not configured") {
+                            ToolExecutionResult::tool_error(
+                                "Secret storage not available. Encryption is not configured.",
+                            )
+                        } else {
+                            ToolExecutionResult::internal_error(e)
+                        }
+                    }
                 }
             }
-        }
-    }
-
-    fn requires_context(&self) -> bool {
-        true
-    }
-}
-
-/// Tool to delete a secret
-pub struct DeleteSecretTool;
-
-#[async_trait]
-impl Tool for DeleteSecretTool {
-    fn name(&self) -> &str {
-        "delete_secret"
-    }
-
-    fn description(&self) -> &str {
-        "Delete a stored secret. Returns whether the secret existed."
-    }
-
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "description": "The name of the secret to delete"
+            "get" => {
+                let name = match arguments.get("name").and_then(|v| v.as_str()) {
+                    Some(n) => n,
+                    None => {
+                        return ToolExecutionResult::tool_error(
+                            "Missing required parameter: name (for get operation)",
+                        );
+                    }
+                };
+                match storage_store.get_secret(context.session_id, name).await {
+                    Ok(Some(value)) => ToolExecutionResult::success(json!({
+                        "operation": "get",
+                        "name": name,
+                        "value": value,
+                        "found": true
+                    })),
+                    Ok(None) => ToolExecutionResult::success(json!({
+                        "operation": "get",
+                        "name": name,
+                        "value": null,
+                        "found": false
+                    })),
+                    Err(e) => {
+                        let msg = e.to_string();
+                        if msg.contains("Encryption not configured") {
+                            ToolExecutionResult::tool_error(
+                                "Secret storage not available. Encryption is not configured.",
+                            )
+                        } else {
+                            ToolExecutionResult::internal_error(e)
+                        }
+                    }
                 }
-            },
-            "required": ["name"],
-            "additionalProperties": false
-        })
-    }
-
-    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
-        ToolExecutionResult::tool_error(
-            "delete_secret requires context. This tool must be executed with session context.",
-        )
-    }
-
-    async fn execute_with_context(
-        &self,
-        arguments: Value,
-        context: &ToolContext,
-    ) -> ToolExecutionResult {
-        let name = match arguments.get("name").and_then(|v| v.as_str()) {
-            Some(n) => n,
-            None => return ToolExecutionResult::tool_error("Missing required parameter: name"),
-        };
-
-        let storage_store = match &context.storage_store {
-            Some(store) => store,
-            None => {
-                return ToolExecutionResult::tool_error("Storage not available in this context");
             }
-        };
-
-        match storage_store.delete_secret(context.session_id, name).await {
-            Ok(deleted) => ToolExecutionResult::success(json!({
-                "name": name,
-                "deleted": deleted
-            })),
-            Err(e) => ToolExecutionResult::internal_error(e),
-        }
-    }
-
-    fn requires_context(&self) -> bool {
-        true
-    }
-}
-
-/// Tool to list all secret names
-pub struct ListSecretsTool;
-
-#[async_trait]
-impl Tool for ListSecretsTool {
-    fn name(&self) -> &str {
-        "list_secrets"
-    }
-
-    fn description(&self) -> &str {
-        "List all stored secret names in the session (without their values)."
-    }
-
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {},
-            "additionalProperties": false
-        })
-    }
-
-    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
-        ToolExecutionResult::tool_error(
-            "list_secrets requires context. This tool must be executed with session context.",
-        )
-    }
-
-    async fn execute_with_context(
-        &self,
-        _arguments: Value,
-        context: &ToolContext,
-    ) -> ToolExecutionResult {
-        let storage_store = match &context.storage_store {
-            Some(store) => store,
-            None => {
-                return ToolExecutionResult::tool_error("Storage not available in this context");
+            "delete" => {
+                let name = match arguments.get("name").and_then(|v| v.as_str()) {
+                    Some(n) => n,
+                    None => {
+                        return ToolExecutionResult::tool_error(
+                            "Missing required parameter: name (for delete operation)",
+                        );
+                    }
+                };
+                match storage_store.delete_secret(context.session_id, name).await {
+                    Ok(deleted) => ToolExecutionResult::success(json!({
+                        "operation": "delete",
+                        "name": name,
+                        "deleted": deleted
+                    })),
+                    Err(e) => ToolExecutionResult::internal_error(e),
+                }
             }
-        };
-
-        match storage_store.list_secrets(context.session_id).await {
-            Ok(secrets) => {
-                let secret_list: Vec<Value> = secrets
-                    .iter()
-                    .map(|s| {
-                        json!({
-                            "name": s.name,
-                            "created_at": s.created_at.to_rfc3339(),
-                            "updated_at": s.updated_at.to_rfc3339()
+            "list" => match storage_store.list_secrets(context.session_id).await {
+                Ok(secrets) => {
+                    let secret_list: Vec<Value> = secrets
+                        .iter()
+                        .map(|s| {
+                            json!({
+                                "name": s.name,
+                                "created_at": s.created_at.to_rfc3339(),
+                                "updated_at": s.updated_at.to_rfc3339()
+                            })
                         })
-                    })
-                    .collect();
-
-                ToolExecutionResult::success(json!({
-                    "secrets": secret_list,
-                    "count": secret_list.len()
-                }))
-            }
-            Err(e) => {
-                let msg = e.to_string();
-                if msg.contains("Encryption not configured") {
-                    ToolExecutionResult::tool_error(
-                        "Secret storage is not available. Encryption is not configured.",
-                    )
-                } else {
-                    ToolExecutionResult::internal_error(e)
+                        .collect();
+                    ToolExecutionResult::success(json!({
+                        "operation": "list",
+                        "secrets": secret_list,
+                        "count": secret_list.len()
+                    }))
                 }
-            }
+                Err(e) => {
+                    let msg = e.to_string();
+                    if msg.contains("Encryption not configured") {
+                        ToolExecutionResult::tool_error(
+                            "Secret storage not available. Encryption is not configured.",
+                        )
+                    } else {
+                        ToolExecutionResult::internal_error(e)
+                    }
+                }
+            },
+            _ => ToolExecutionResult::tool_error(format!(
+                "Invalid operation: {}. Must be one of: set, get, delete, list",
+                operation
+            )),
         }
     }
 
@@ -705,51 +465,38 @@ mod tests {
     }
 
     #[test]
-    fn test_capability_has_tools() {
+    fn test_capability_has_two_tools() {
         let cap = SessionStorageCapability;
         let tools = cap.tools();
 
-        assert_eq!(tools.len(), 8);
+        assert_eq!(tools.len(), 2);
 
         let tool_names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
-        // Key/Value tools
-        assert!(tool_names.contains(&"set_value"));
-        assert!(tool_names.contains(&"get_value"));
-        assert!(tool_names.contains(&"delete_value"));
-        assert!(tool_names.contains(&"list_keys"));
-        // Secret tools
-        assert!(tool_names.contains(&"set_secret"));
-        assert!(tool_names.contains(&"get_secret"));
-        assert!(tool_names.contains(&"delete_secret"));
-        assert!(tool_names.contains(&"list_secrets"));
+        assert!(tool_names.contains(&"kv_store"));
+        assert!(tool_names.contains(&"secret_store"));
     }
 
     #[test]
     fn test_capability_has_system_prompt() {
         let cap = SessionStorageCapability;
         let prompt = cap.system_prompt_addition().unwrap();
-        assert!(prompt.contains("set_value"));
-        assert!(prompt.contains("get_value"));
-        assert!(prompt.contains("set_secret"));
+        assert!(prompt.contains("kv_store"));
+        assert!(prompt.contains("secret_store"));
         assert!(prompt.contains("encrypted at rest"));
     }
 
     #[test]
     fn test_tools_require_context() {
-        assert!(SetValueTool.requires_context());
-        assert!(GetValueTool.requires_context());
-        assert!(DeleteValueTool.requires_context());
-        assert!(ListKeysTool.requires_context());
-        assert!(SetSecretTool.requires_context());
-        assert!(GetSecretTool.requires_context());
-        assert!(DeleteSecretTool.requires_context());
-        assert!(ListSecretsTool.requires_context());
+        assert!(KvStoreTool.requires_context());
+        assert!(SecretStoreTool.requires_context());
     }
 
     #[tokio::test]
-    async fn test_set_value_without_context() {
-        let tool = SetValueTool;
-        let result = tool.execute(json!({"key": "test", "value": "data"})).await;
+    async fn test_kv_store_without_context() {
+        let tool = KvStoreTool;
+        let result = tool
+            .execute(json!({"operation": "set", "key": "test", "value": "data"}))
+            .await;
 
         if let ToolExecutionResult::ToolError(msg) = result {
             assert!(msg.contains("requires context"));
@@ -759,28 +506,31 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_set_value_missing_key() {
-        let tool = SetValueTool;
+    async fn test_kv_store_missing_operation() {
+        let tool = KvStoreTool;
         let context = ToolContext::new(uuid::Uuid::nil());
 
         let result = tool
-            .execute_with_context(json!({"value": "data"}), &context)
+            .execute_with_context(json!({"key": "test"}), &context)
             .await;
 
         if let ToolExecutionResult::ToolError(msg) = result {
-            assert!(msg.contains("Missing required parameter"));
+            assert!(msg.contains("operation"));
         } else {
-            panic!("Expected tool error for missing key");
+            panic!("Expected tool error for missing operation");
         }
     }
 
     #[tokio::test]
-    async fn test_set_value_no_storage_store() {
-        let tool = SetValueTool;
+    async fn test_kv_store_no_storage_store() {
+        let tool = KvStoreTool;
         let context = ToolContext::new(uuid::Uuid::nil());
 
         let result = tool
-            .execute_with_context(json!({"key": "test", "value": "data"}), &context)
+            .execute_with_context(
+                json!({"operation": "set", "key": "test", "value": "data"}),
+                &context,
+            )
             .await;
 
         if let ToolExecutionResult::ToolError(msg) = result {
@@ -791,10 +541,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_set_secret_without_context() {
-        let tool = SetSecretTool;
+    async fn test_secret_store_without_context() {
+        let tool = SecretStoreTool;
         let result = tool
-            .execute(json!({"name": "api_key", "value": "secret123"}))
+            .execute(json!({"operation": "set", "name": "api_key", "value": "secret123"}))
             .await;
 
         if let ToolExecutionResult::ToolError(msg) = result {

--- a/crates/core/src/capabilities/session_storage.rs
+++ b/crates/core/src/capabilities/session_storage.rs
@@ -1,0 +1,806 @@
+//! Session Storage Capability
+//!
+//! This capability provides tools for session-scoped key/value and secret storage.
+//! Data persists for the session duration.
+//!
+//! Tools provided:
+//! - Key/Value (plain text):
+//!   - `set_value`: Store a key/value pair
+//!   - `get_value`: Retrieve a value by key
+//!   - `delete_value`: Delete a key/value pair
+//!   - `list_keys`: List all stored keys
+//!
+//! - Secrets (encrypted at rest):
+//!   - `set_secret`: Store an encrypted secret
+//!   - `get_secret`: Retrieve a decrypted secret
+//!   - `delete_secret`: Delete a secret
+//!   - `list_secrets`: List all secret names
+
+use super::{Capability, CapabilityId, CapabilityStatus};
+use crate::tools::{Tool, ToolExecutionResult};
+use crate::traits::ToolContext;
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+/// Session Storage capability - provides key/value and secret storage for sessions
+pub struct SessionStorageCapability;
+
+impl Capability for SessionStorageCapability {
+    fn id(&self) -> &str {
+        CapabilityId::SESSION_STORAGE
+    }
+
+    fn name(&self) -> &str {
+        "Session Storage"
+    }
+
+    fn description(&self) -> &str {
+        r#"Tools to store and retrieve key/value pairs and encrypted secrets within a session.
+
+> [!NOTE]
+> Data persists for the session duration. Secrets are encrypted at rest.
+
+> [!TIP]
+> Use key/value storage for general data. Use secrets for sensitive information like API keys or tokens."#
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("database")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Storage")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(
+            r#"You have access to session storage tools for persisting data within the session.
+
+Key/Value Storage (plain text):
+- `set_value`: Store a key/value pair (creates or updates)
+- `get_value`: Retrieve a value by key
+- `delete_value`: Delete a key/value pair
+- `list_keys`: List all stored keys
+
+Secret Storage (encrypted at rest):
+- `set_secret`: Store a secret securely (creates or updates)
+- `get_secret`: Retrieve a secret (decrypted)
+- `delete_secret`: Delete a secret
+- `list_secrets`: List all secret names (without values)
+
+Best practices:
+- Use key/value storage for general data like state, preferences, or intermediate results
+- Use secret storage for sensitive data like API keys, tokens, or credentials
+- Keys and secret names are unique per session - storing with the same name overwrites"#,
+        )
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            // Key/Value tools
+            Box::new(SetValueTool),
+            Box::new(GetValueTool),
+            Box::new(DeleteValueTool),
+            Box::new(ListKeysTool),
+            // Secret tools
+            Box::new(SetSecretTool),
+            Box::new(GetSecretTool),
+            Box::new(DeleteSecretTool),
+            Box::new(ListSecretsTool),
+        ]
+    }
+}
+
+// ============================================================================
+// Key/Value Tools
+// ============================================================================
+
+/// Tool to set a key/value pair
+pub struct SetValueTool;
+
+#[async_trait]
+impl Tool for SetValueTool {
+    fn name(&self) -> &str {
+        "set_value"
+    }
+
+    fn description(&self) -> &str {
+        "Store a key/value pair. Creates a new entry or updates an existing one."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "key": {
+                    "type": "string",
+                    "description": "The key to store the value under (max 255 chars)"
+                },
+                "value": {
+                    "type": "string",
+                    "description": "The value to store (can be JSON-encoded for structured data)"
+                }
+            },
+            "required": ["key", "value"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "set_value requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let key = match arguments.get("key").and_then(|v| v.as_str()) {
+            Some(k) => k,
+            None => return ToolExecutionResult::tool_error("Missing required parameter: key"),
+        };
+
+        let value = match arguments.get("value").and_then(|v| v.as_str()) {
+            Some(v) => v,
+            None => return ToolExecutionResult::tool_error("Missing required parameter: value"),
+        };
+
+        if key.len() > 255 {
+            return ToolExecutionResult::tool_error("Key must be 255 characters or less");
+        }
+
+        let storage_store = match &context.storage_store {
+            Some(store) => store,
+            None => {
+                return ToolExecutionResult::tool_error("Storage not available in this context");
+            }
+        };
+
+        match storage_store
+            .set_value(context.session_id, key, value)
+            .await
+        {
+            Ok(()) => ToolExecutionResult::success(json!({
+                "key": key,
+                "stored": true
+            })),
+            Err(e) => ToolExecutionResult::internal_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+/// Tool to get a value by key
+pub struct GetValueTool;
+
+#[async_trait]
+impl Tool for GetValueTool {
+    fn name(&self) -> &str {
+        "get_value"
+    }
+
+    fn description(&self) -> &str {
+        "Retrieve a stored value by its key. Returns null if the key doesn't exist."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "key": {
+                    "type": "string",
+                    "description": "The key to retrieve the value for"
+                }
+            },
+            "required": ["key"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "get_value requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let key = match arguments.get("key").and_then(|v| v.as_str()) {
+            Some(k) => k,
+            None => return ToolExecutionResult::tool_error("Missing required parameter: key"),
+        };
+
+        let storage_store = match &context.storage_store {
+            Some(store) => store,
+            None => {
+                return ToolExecutionResult::tool_error("Storage not available in this context");
+            }
+        };
+
+        match storage_store.get_value(context.session_id, key).await {
+            Ok(Some(value)) => ToolExecutionResult::success(json!({
+                "key": key,
+                "value": value,
+                "found": true
+            })),
+            Ok(None) => ToolExecutionResult::success(json!({
+                "key": key,
+                "value": null,
+                "found": false
+            })),
+            Err(e) => ToolExecutionResult::internal_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+/// Tool to delete a key/value pair
+pub struct DeleteValueTool;
+
+#[async_trait]
+impl Tool for DeleteValueTool {
+    fn name(&self) -> &str {
+        "delete_value"
+    }
+
+    fn description(&self) -> &str {
+        "Delete a stored key/value pair. Returns whether the key existed."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "key": {
+                    "type": "string",
+                    "description": "The key to delete"
+                }
+            },
+            "required": ["key"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "delete_value requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let key = match arguments.get("key").and_then(|v| v.as_str()) {
+            Some(k) => k,
+            None => return ToolExecutionResult::tool_error("Missing required parameter: key"),
+        };
+
+        let storage_store = match &context.storage_store {
+            Some(store) => store,
+            None => {
+                return ToolExecutionResult::tool_error("Storage not available in this context");
+            }
+        };
+
+        match storage_store.delete_value(context.session_id, key).await {
+            Ok(deleted) => ToolExecutionResult::success(json!({
+                "key": key,
+                "deleted": deleted
+            })),
+            Err(e) => ToolExecutionResult::internal_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+/// Tool to list all stored keys
+pub struct ListKeysTool;
+
+#[async_trait]
+impl Tool for ListKeysTool {
+    fn name(&self) -> &str {
+        "list_keys"
+    }
+
+    fn description(&self) -> &str {
+        "List all stored keys in the session (without their values)."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "list_keys requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        _arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let storage_store = match &context.storage_store {
+            Some(store) => store,
+            None => {
+                return ToolExecutionResult::tool_error("Storage not available in this context");
+            }
+        };
+
+        match storage_store.list_keys(context.session_id).await {
+            Ok(keys) => {
+                let key_list: Vec<Value> = keys
+                    .iter()
+                    .map(|k| {
+                        json!({
+                            "key": k.key,
+                            "created_at": k.created_at.to_rfc3339(),
+                            "updated_at": k.updated_at.to_rfc3339()
+                        })
+                    })
+                    .collect();
+
+                ToolExecutionResult::success(json!({
+                    "keys": key_list,
+                    "count": key_list.len()
+                }))
+            }
+            Err(e) => ToolExecutionResult::internal_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// Secret Tools
+// ============================================================================
+
+/// Tool to set a secret
+pub struct SetSecretTool;
+
+#[async_trait]
+impl Tool for SetSecretTool {
+    fn name(&self) -> &str {
+        "set_secret"
+    }
+
+    fn description(&self) -> &str {
+        "Store a secret securely. The value is encrypted at rest. Creates or updates."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name/identifier for the secret (max 255 chars)"
+                },
+                "value": {
+                    "type": "string",
+                    "description": "The secret value to store (will be encrypted)"
+                }
+            },
+            "required": ["name", "value"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "set_secret requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let name = match arguments.get("name").and_then(|v| v.as_str()) {
+            Some(n) => n,
+            None => return ToolExecutionResult::tool_error("Missing required parameter: name"),
+        };
+
+        let value = match arguments.get("value").and_then(|v| v.as_str()) {
+            Some(v) => v,
+            None => return ToolExecutionResult::tool_error("Missing required parameter: value"),
+        };
+
+        if name.len() > 255 {
+            return ToolExecutionResult::tool_error("Secret name must be 255 characters or less");
+        }
+
+        let storage_store = match &context.storage_store {
+            Some(store) => store,
+            None => {
+                return ToolExecutionResult::tool_error("Storage not available in this context");
+            }
+        };
+
+        match storage_store
+            .set_secret(context.session_id, name, value)
+            .await
+        {
+            Ok(()) => ToolExecutionResult::success(json!({
+                "name": name,
+                "stored": true
+            })),
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("Encryption not configured") {
+                    ToolExecutionResult::tool_error(
+                        "Secret storage is not available. Encryption is not configured.",
+                    )
+                } else {
+                    ToolExecutionResult::internal_error(e)
+                }
+            }
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+/// Tool to get a secret
+pub struct GetSecretTool;
+
+#[async_trait]
+impl Tool for GetSecretTool {
+    fn name(&self) -> &str {
+        "get_secret"
+    }
+
+    fn description(&self) -> &str {
+        "Retrieve a stored secret by name. The value is decrypted before returning."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the secret to retrieve"
+                }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "get_secret requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let name = match arguments.get("name").and_then(|v| v.as_str()) {
+            Some(n) => n,
+            None => return ToolExecutionResult::tool_error("Missing required parameter: name"),
+        };
+
+        let storage_store = match &context.storage_store {
+            Some(store) => store,
+            None => {
+                return ToolExecutionResult::tool_error("Storage not available in this context");
+            }
+        };
+
+        match storage_store.get_secret(context.session_id, name).await {
+            Ok(Some(value)) => ToolExecutionResult::success(json!({
+                "name": name,
+                "value": value,
+                "found": true
+            })),
+            Ok(None) => ToolExecutionResult::success(json!({
+                "name": name,
+                "value": null,
+                "found": false
+            })),
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("Encryption not configured") {
+                    ToolExecutionResult::tool_error(
+                        "Secret storage is not available. Encryption is not configured.",
+                    )
+                } else {
+                    ToolExecutionResult::internal_error(e)
+                }
+            }
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+/// Tool to delete a secret
+pub struct DeleteSecretTool;
+
+#[async_trait]
+impl Tool for DeleteSecretTool {
+    fn name(&self) -> &str {
+        "delete_secret"
+    }
+
+    fn description(&self) -> &str {
+        "Delete a stored secret. Returns whether the secret existed."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the secret to delete"
+                }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "delete_secret requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let name = match arguments.get("name").and_then(|v| v.as_str()) {
+            Some(n) => n,
+            None => return ToolExecutionResult::tool_error("Missing required parameter: name"),
+        };
+
+        let storage_store = match &context.storage_store {
+            Some(store) => store,
+            None => {
+                return ToolExecutionResult::tool_error("Storage not available in this context");
+            }
+        };
+
+        match storage_store.delete_secret(context.session_id, name).await {
+            Ok(deleted) => ToolExecutionResult::success(json!({
+                "name": name,
+                "deleted": deleted
+            })),
+            Err(e) => ToolExecutionResult::internal_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+/// Tool to list all secret names
+pub struct ListSecretsTool;
+
+#[async_trait]
+impl Tool for ListSecretsTool {
+    fn name(&self) -> &str {
+        "list_secrets"
+    }
+
+    fn description(&self) -> &str {
+        "List all stored secret names in the session (without their values)."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "list_secrets requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        _arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let storage_store = match &context.storage_store {
+            Some(store) => store,
+            None => {
+                return ToolExecutionResult::tool_error("Storage not available in this context");
+            }
+        };
+
+        match storage_store.list_secrets(context.session_id).await {
+            Ok(secrets) => {
+                let secret_list: Vec<Value> = secrets
+                    .iter()
+                    .map(|s| {
+                        json!({
+                            "name": s.name,
+                            "created_at": s.created_at.to_rfc3339(),
+                            "updated_at": s.updated_at.to_rfc3339()
+                        })
+                    })
+                    .collect();
+
+                ToolExecutionResult::success(json!({
+                    "secrets": secret_list,
+                    "count": secret_list.len()
+                }))
+            }
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("Encryption not configured") {
+                    ToolExecutionResult::tool_error(
+                        "Secret storage is not available. Encryption is not configured.",
+                    )
+                } else {
+                    ToolExecutionResult::internal_error(e)
+                }
+            }
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_capability_metadata() {
+        let cap = SessionStorageCapability;
+        assert_eq!(cap.id(), CapabilityId::SESSION_STORAGE);
+        assert_eq!(cap.name(), "Session Storage");
+        assert_eq!(cap.status(), CapabilityStatus::Available);
+        assert_eq!(cap.icon(), Some("database"));
+        assert_eq!(cap.category(), Some("Storage"));
+    }
+
+    #[test]
+    fn test_capability_has_tools() {
+        let cap = SessionStorageCapability;
+        let tools = cap.tools();
+
+        assert_eq!(tools.len(), 8);
+
+        let tool_names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        // Key/Value tools
+        assert!(tool_names.contains(&"set_value"));
+        assert!(tool_names.contains(&"get_value"));
+        assert!(tool_names.contains(&"delete_value"));
+        assert!(tool_names.contains(&"list_keys"));
+        // Secret tools
+        assert!(tool_names.contains(&"set_secret"));
+        assert!(tool_names.contains(&"get_secret"));
+        assert!(tool_names.contains(&"delete_secret"));
+        assert!(tool_names.contains(&"list_secrets"));
+    }
+
+    #[test]
+    fn test_capability_has_system_prompt() {
+        let cap = SessionStorageCapability;
+        let prompt = cap.system_prompt_addition().unwrap();
+        assert!(prompt.contains("set_value"));
+        assert!(prompt.contains("get_value"));
+        assert!(prompt.contains("set_secret"));
+        assert!(prompt.contains("encrypted at rest"));
+    }
+
+    #[test]
+    fn test_tools_require_context() {
+        assert!(SetValueTool.requires_context());
+        assert!(GetValueTool.requires_context());
+        assert!(DeleteValueTool.requires_context());
+        assert!(ListKeysTool.requires_context());
+        assert!(SetSecretTool.requires_context());
+        assert!(GetSecretTool.requires_context());
+        assert!(DeleteSecretTool.requires_context());
+        assert!(ListSecretsTool.requires_context());
+    }
+
+    #[tokio::test]
+    async fn test_set_value_without_context() {
+        let tool = SetValueTool;
+        let result = tool.execute(json!({"key": "test", "value": "data"})).await;
+
+        if let ToolExecutionResult::ToolError(msg) = result {
+            assert!(msg.contains("requires context"));
+        } else {
+            panic!("Expected tool error");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_set_value_missing_key() {
+        let tool = SetValueTool;
+        let context = ToolContext::new(uuid::Uuid::nil());
+
+        let result = tool
+            .execute_with_context(json!({"value": "data"}), &context)
+            .await;
+
+        if let ToolExecutionResult::ToolError(msg) = result {
+            assert!(msg.contains("Missing required parameter"));
+        } else {
+            panic!("Expected tool error for missing key");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_set_value_no_storage_store() {
+        let tool = SetValueTool;
+        let context = ToolContext::new(uuid::Uuid::nil());
+
+        let result = tool
+            .execute_with_context(json!({"key": "test", "value": "data"}), &context)
+            .await;
+
+        if let ToolExecutionResult::ToolError(msg) = result {
+            assert!(msg.contains("not available"));
+        } else {
+            panic!("Expected tool error for missing storage store");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_set_secret_without_context() {
+        let tool = SetSecretTool;
+        let result = tool
+            .execute(json!({"name": "api_key", "value": "secret123"}))
+            .await;
+
+        if let ToolExecutionResult::ToolError(msg) = result {
+            assert!(msg.contains("requires context"));
+        } else {
+            panic!("Expected tool error");
+        }
+    }
+}

--- a/crates/core/src/capability_types.rs
+++ b/crates/core/src/capability_types.rs
@@ -55,6 +55,8 @@ impl CapabilityId {
     pub const FAKE_FINANCIAL: &'static str = "fake_financial";
     // Demo capability with mount points
     pub const SAMPLE_DATA: &'static str = "sample_data";
+    // Session storage capability (key/value and secrets)
+    pub const SESSION_STORAGE: &'static str = "session_storage";
     // Experimental capability ID constants
     pub const DOCKER_CONTAINER: &'static str = "docker_container";
 
@@ -126,6 +128,11 @@ impl CapabilityId {
     /// Create the sample_data capability ID
     pub fn sample_data() -> Self {
         Self::new(Self::SAMPLE_DATA)
+    }
+
+    /// Create the session_storage capability ID
+    pub fn session_storage() -> Self {
+        Self::new(Self::SESSION_STORAGE)
     }
 
     /// Create the docker_container capability ID
@@ -437,6 +444,10 @@ mod tests {
             CapabilityId::file_system().to_string(),
             "session_file_system"
         );
+        assert_eq!(
+            CapabilityId::session_storage().to_string(),
+            "session_storage"
+        );
         assert_eq!(CapabilityId::test_math().to_string(), "test_math");
         assert_eq!(CapabilityId::test_weather().to_string(), "test_weather");
         assert_eq!(
@@ -467,6 +478,10 @@ mod tests {
         assert_eq!(
             "session_file_system".parse::<CapabilityId>().unwrap(),
             CapabilityId::file_system()
+        );
+        assert_eq!(
+            "session_storage".parse::<CapabilityId>().unwrap(),
+            CapabilityId::session_storage()
         );
         assert_eq!(
             "test_math".parse::<CapabilityId>().unwrap(),

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -79,8 +79,9 @@ pub use message::{
 pub use message_retriever::{InputMessage, MessageRetriever};
 pub use runtime_agent::{RuntimeAgent, RuntimeAgentBuilder};
 pub use traits::{
-    EventEmitter, ImageResolver, LlmProviderStore, ModelWithProvider, NoopEventEmitter,
-    ResolvedImage, SessionFileStore, SessionStore, ToolContext, ToolExecutor,
+    EventEmitter, ImageResolver, KeyInfo, LlmProviderStore, ModelWithProvider, NoopEventEmitter,
+    ResolvedImage, SecretInfo, SessionFileStore, SessionStorageStore, SessionStore, ToolContext,
+    ToolExecutor,
 };
 
 // Event listener re-exports

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -227,6 +227,66 @@ pub trait SessionFileStore: Send + Sync {
 }
 
 // ============================================================================
+// SessionStorageStore - For session key/value and secret storage
+// ============================================================================
+
+/// Info about a stored key (without its value)
+#[derive(Debug, Clone)]
+pub struct KeyInfo {
+    pub key: String,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Info about a stored secret (without its value)
+#[derive(Debug, Clone)]
+pub struct SecretInfo {
+    pub name: String,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Trait for session key/value and secret storage operations
+///
+/// This trait abstracts storage operations for tools that need to persist
+/// data within a session. Implementations can:
+/// - Store data in a database (production)
+/// - Use in-memory storage for testing
+///
+/// Key/value storage is for general data that doesn't need encryption.
+/// Secret storage is for sensitive data that is encrypted at rest.
+#[async_trait]
+pub trait SessionStorageStore: Send + Sync {
+    // Key/Value operations (plain text)
+
+    /// Set a key/value pair (creates or updates)
+    async fn set_value(&self, session_id: Uuid, key: &str, value: &str) -> Result<()>;
+
+    /// Get a value by key
+    async fn get_value(&self, session_id: Uuid, key: &str) -> Result<Option<String>>;
+
+    /// Delete a key/value pair
+    async fn delete_value(&self, session_id: Uuid, key: &str) -> Result<bool>;
+
+    /// List all keys in a session
+    async fn list_keys(&self, session_id: Uuid) -> Result<Vec<KeyInfo>>;
+
+    // Secret operations (encrypted)
+
+    /// Set a secret (creates or updates, value is encrypted before storage)
+    async fn set_secret(&self, session_id: Uuid, name: &str, value: &str) -> Result<()>;
+
+    /// Get a secret by name (value is decrypted before returning)
+    async fn get_secret(&self, session_id: Uuid, name: &str) -> Result<Option<String>>;
+
+    /// Delete a secret
+    async fn delete_secret(&self, session_id: Uuid, name: &str) -> Result<bool>;
+
+    /// List all secret names in a session (without values)
+    async fn list_secrets(&self, session_id: Uuid) -> Result<Vec<SecretInfo>>;
+}
+
+// ============================================================================
 // ToolContext - Runtime context for tool execution
 // ============================================================================
 
@@ -245,6 +305,9 @@ pub struct ToolContext {
 
     /// Optional file store for filesystem operations
     pub file_store: Option<Arc<dyn SessionFileStore>>,
+
+    /// Optional storage store for key/value and secret storage
+    pub storage_store: Option<Arc<dyn SessionStorageStore>>,
 }
 
 impl ToolContext {
@@ -253,6 +316,7 @@ impl ToolContext {
         Self {
             session_id,
             file_store: None,
+            storage_store: None,
         }
     }
 
@@ -261,6 +325,32 @@ impl ToolContext {
         Self {
             session_id,
             file_store: Some(file_store),
+            storage_store: None,
+        }
+    }
+
+    /// Create a context with a storage store
+    pub fn with_storage_store(
+        session_id: Uuid,
+        storage_store: Arc<dyn SessionStorageStore>,
+    ) -> Self {
+        Self {
+            session_id,
+            file_store: None,
+            storage_store: Some(storage_store),
+        }
+    }
+
+    /// Create a context with both file store and storage store
+    pub fn with_stores(
+        session_id: Uuid,
+        file_store: Arc<dyn SessionFileStore>,
+        storage_store: Arc<dyn SessionStorageStore>,
+    ) -> Self {
+        Self {
+            session_id,
+            file_store: Some(file_store),
+            storage_store: Some(storage_store),
         }
     }
 }
@@ -270,6 +360,7 @@ impl std::fmt::Debug for ToolContext {
         f.debug_struct("ToolContext")
             .field("session_id", &self.session_id)
             .field("file_store", &self.file_store.is_some())
+            .field("storage_store", &self.storage_store.is_some())
             .finish()
     }
 }

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -385,6 +385,74 @@ Each session has its own isolated filesystem stored in PostgreSQL. Files are ses
 
 When writing a file like `/a/b/c.txt`, parent directories `/a` and `/a/b` are automatically created if they don't exist. This follows common filesystem patterns and reduces tool call overhead.
 
+#### SessionStorage
+
+- **Status**: Available
+- **ID**: `session_storage`
+- **Purpose**: Session-scoped key/value storage and encrypted secret storage
+- **System Prompt**: Guidance on using storage tools for persisting data and secrets
+- **Tools**:
+  - `set_value` - Store a key/value pair (plain text)
+    - Parameters:
+      - `key`: string (required, max 255 chars) - The key to store under
+      - `value`: string (required) - The value to store (can be JSON)
+    - Returns: Object containing key, stored status
+    - Policy: Auto
+  - `get_value` - Retrieve a value by key
+    - Parameters:
+      - `key`: string (required) - The key to retrieve
+    - Returns: Object containing key, value (or null), found status
+    - Policy: Auto
+  - `delete_value` - Delete a key/value pair
+    - Parameters:
+      - `key`: string (required) - The key to delete
+    - Returns: Object containing key, deleted status
+    - Policy: Auto
+  - `list_keys` - List all stored keys
+    - Parameters: None
+    - Returns: Object containing keys array (with timestamps), count
+    - Policy: Auto
+  - `set_secret` - Store an encrypted secret
+    - Parameters:
+      - `name`: string (required, max 255 chars) - Secret name/identifier
+      - `value`: string (required) - The secret value (will be encrypted)
+    - Returns: Object containing name, stored status
+    - Policy: Auto
+  - `get_secret` - Retrieve a decrypted secret
+    - Parameters:
+      - `name`: string (required) - The secret name
+    - Returns: Object containing name, value (or null), found status
+    - Policy: Auto
+  - `delete_secret` - Delete a secret
+    - Parameters:
+      - `name`: string (required) - The secret name
+    - Returns: Object containing name, deleted status
+    - Policy: Auto
+  - `list_secrets` - List all secret names (without values)
+    - Parameters: None
+    - Returns: Object containing secrets array (with timestamps), count
+    - Policy: Auto
+- **Icon**: "database"
+- **Category**: "Storage"
+
+##### Design Decision: Key/Value vs Secrets
+
+Two storage types are provided:
+- **Key/Value storage**: For general data like state, preferences, or intermediate results. Stored as plain text in the database.
+- **Secret storage**: For sensitive data like API keys, tokens, or credentials. Values are encrypted at rest using AES-256-GCM envelope encryption.
+
+##### Design Decision: Session Isolation
+
+Like the FileSystem capability, storage is session-scoped. Keys and secrets cannot be accessed across sessions.
+
+##### Design Decision: Upsert Semantics
+
+Both `set_value` and `set_secret` use upsert semantics - storing a value with an existing key/name will overwrite the previous value.
+
+##### Design Decision: Encryption Requirement for Secrets
+
+Secret operations require the `SECRETS_ENCRYPTION_KEY` environment variable to be configured. If encryption is not configured, secret operations will return an error. Key/value operations work without encryption.
+
 #### WebFetch
 
 - **Status**: Available

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -392,48 +392,28 @@ When writing a file like `/a/b/c.txt`, parent directories `/a` and `/a/b` are au
 - **Purpose**: Session-scoped key/value storage and encrypted secret storage
 - **System Prompt**: Guidance on using storage tools for persisting data and secrets
 - **Tools**:
-  - `set_value` - Store a key/value pair (plain text)
+  - `kv_store` - Key/value storage operations (plain text)
     - Parameters:
-      - `key`: string (required, max 255 chars) - The key to store under
-      - `value`: string (required) - The value to store (can be JSON)
-    - Returns: Object containing key, stored status
+      - `operation`: enum (set, get, delete, list) - The operation to perform
+      - `key`: string (max 255 chars) - Required for set, get, delete
+      - `value`: string - Required for set (can be JSON-encoded)
+    - Returns: Object containing operation, key, and result (success/value/deleted/keys)
     - Policy: Auto
-  - `get_value` - Retrieve a value by key
+  - `secret_store` - Encrypted secret storage operations
     - Parameters:
-      - `key`: string (required) - The key to retrieve
-    - Returns: Object containing key, value (or null), found status
-    - Policy: Auto
-  - `delete_value` - Delete a key/value pair
-    - Parameters:
-      - `key`: string (required) - The key to delete
-    - Returns: Object containing key, deleted status
-    - Policy: Auto
-  - `list_keys` - List all stored keys
-    - Parameters: None
-    - Returns: Object containing keys array (with timestamps), count
-    - Policy: Auto
-  - `set_secret` - Store an encrypted secret
-    - Parameters:
-      - `name`: string (required, max 255 chars) - Secret name/identifier
-      - `value`: string (required) - The secret value (will be encrypted)
-    - Returns: Object containing name, stored status
-    - Policy: Auto
-  - `get_secret` - Retrieve a decrypted secret
-    - Parameters:
-      - `name`: string (required) - The secret name
-    - Returns: Object containing name, value (or null), found status
-    - Policy: Auto
-  - `delete_secret` - Delete a secret
-    - Parameters:
-      - `name`: string (required) - The secret name
-    - Returns: Object containing name, deleted status
-    - Policy: Auto
-  - `list_secrets` - List all secret names (without values)
-    - Parameters: None
-    - Returns: Object containing secrets array (with timestamps), count
+      - `operation`: enum (set, get, delete, list) - The operation to perform
+      - `name`: string (max 255 chars) - Required for set, get, delete
+      - `value`: string - Required for set (will be encrypted)
+    - Returns: Object containing operation, name, and result (success/value/deleted/secrets)
     - Policy: Auto
 - **Icon**: "database"
 - **Category**: "Storage"
+
+##### Design Decision: Consolidated Tools
+
+Two tools consolidate 8 operations (4 per storage type) to reduce tool count:
+- `kv_store` with `operation` parameter (set/get/delete/list) for key/value storage
+- `secret_store` with `operation` parameter (set/get/delete/list) for encrypted secrets
 
 ##### Design Decision: Key/Value vs Secrets
 
@@ -447,7 +427,7 @@ Like the FileSystem capability, storage is session-scoped. Keys and secrets cann
 
 ##### Design Decision: Upsert Semantics
 
-Both `set_value` and `set_secret` use upsert semantics - storing a value with an existing key/name will overwrite the previous value.
+Both set operations use upsert semantics - storing with an existing key/name will overwrite the previous value.
 
 ##### Design Decision: Encryption Requirement for Secrets
 


### PR DESCRIPTION
## What
Adds a new `session_storage` capability that provides session-scoped key/value storage and encrypted secret storage.

## Why
Agents need a way to persist data within a session for:
- Storing state, preferences, or intermediate results (key/value)
- Storing sensitive data like API keys or tokens securely (secrets)

## How
- **Database**: New `session_key_values` and `session_secrets` tables with session cascade delete
- **Core trait**: `SessionStorageStore` trait with operations for both storage types
- **Encryption**: Secrets use existing envelope encryption (AES-256-GCM)
- **Capability**: 8 tools (set/get/delete/list for both key/value and secrets)
- **ToolContext**: Extended with `storage_store` field

### Tools Provided
| Tool | Description |
|------|-------------|
| `set_value` | Store a key/value pair (plain text) |
| `get_value` | Retrieve value by key |
| `delete_value` | Delete a key/value pair |
| `list_keys` | List all stored keys |
| `set_secret` | Store a secret (encrypted) |
| `get_secret` | Retrieve a secret (decrypted) |
| `delete_secret` | Delete a secret |
| `list_secrets` | List all secret names |

## Risk
- Low
- No breaking changes, additive only
- Secrets require existing `SECRETS_ENCRYPTION_KEY` env var

## Checklist
- [x] Tests added (8 unit tests for capability, capability registry tests updated)
- [x] Database migration added
- [x] Encrypted column registered for key rotation support
- [x] Specs updated (capabilities.md)
- [x] Smoke tested - capability appears in API and all tools are properly defined