### PR TITLE
feat(ui): add capability settings editor for Docker custom image

### DIFF
--- a/apps/ui/e2e/screenshot-capability-settings.spec.ts
+++ b/apps/ui/e2e/screenshot-capability-settings.spec.ts
@@ -1,0 +1,43 @@
+import { test } from '@playwright/test';
+import { readFileSync } from 'fs';
+
+test('capability settings screenshots', async ({ page }) => {
+  const agentId = readFileSync('/tmp/test_agent_id.txt', 'utf-8').trim();
+  console.log('Agent ID:', agentId);
+
+  // 1. Go to agent edit page
+  console.log('Loading agent edit page...');
+  await page.goto(`/agents/${agentId}/edit`);
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(2000);
+
+  // Take screenshot of initial state (showing capability list with Docker selected)
+  await page.screenshot({ path: 'e2e/screenshots/capability-settings-1-initial.png' });
+  console.log('Screenshot 1: Agent edit page with Docker capability');
+
+  // 2. Click the settings gear icon to expand Docker capability settings
+  console.log('Expanding Docker capability settings...');
+  const settingsButton = page.locator('button[aria-label="Toggle settings"]');
+
+  if (await settingsButton.count() > 0) {
+    await settingsButton.click();
+    await page.waitForTimeout(500);
+
+    // Take screenshot with settings expanded
+    await page.screenshot({ path: 'e2e/screenshots/capability-settings-2-expanded.png' });
+    console.log('Screenshot 2: Docker capability settings expanded');
+
+    // 3. Enter a custom image
+    console.log('Entering custom Docker image...');
+    const imageInput = page.locator('input#docker-image');
+    await imageInput.fill('node:20-alpine');
+    await page.waitForTimeout(300);
+
+    // Take screenshot with custom image
+    await page.screenshot({ path: 'e2e/screenshots/capability-settings-3-custom-image.png' });
+    console.log('Screenshot 3: Custom Docker image entered');
+  } else {
+    console.log('Settings button not found');
+    await page.screenshot({ path: 'e2e/screenshots/capability-settings-debug.png', fullPage: true });
+  }
+});

--- a/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
@@ -21,7 +21,7 @@ import { CapabilitySelector } from "@/components/agents/capability-selector";
 import { AgentPreview } from "@/components/agents/agent-preview";
 import { ModelPicker } from "@/components/models/model-picker";
 import { ArrowLeft, Save, Trash2, Eye, Edit2 } from "lucide-react";
-import type { CapabilityId, AgentCapabilityConfig } from "@/lib/api/types";
+import type { AgentCapabilityConfig } from "@/lib/api/types";
 
 interface FormData {
   name: string;
@@ -82,28 +82,20 @@ export default function EditAgentPage({
   );
 
   // Capabilities state - now included directly in agent response
-  // Extract just the capability IDs for the selector
+  // Use full AgentCapabilityConfig objects to preserve per-agent config
   const initialCapabilities = useMemo(() => {
-    return (agent?.capabilities ?? []).map((c) => c.ref);
+    return agent?.capabilities ?? [];
   }, [agent?.capabilities]);
 
   const [localCapabilities, setLocalCapabilities] = useState<
-    CapabilityId[] | null
+    AgentCapabilityConfig[] | null
   >(null);
   const selectedCapabilities = localCapabilities ?? initialCapabilities;
 
   // Capabilities change handler
-  const handleCapabilitiesChange = useCallback((newCapabilities: CapabilityId[]) => {
+  const handleCapabilitiesChange = useCallback((newCapabilities: AgentCapabilityConfig[]) => {
     setLocalCapabilities(newCapabilities);
   }, []);
-
-  // Convert selected capability IDs to AgentCapabilityConfig format for preview
-  const capabilityConfigs: AgentCapabilityConfig[] = useMemo(() => {
-    return selectedCapabilities.map(id => ({
-      ref: id,
-      config: {},
-    }));
-  }, [selectedCapabilities]);
 
   // Submit handler
   const handleSubmit = async (e: React.FormEvent) => {
@@ -116,16 +108,10 @@ export default function EditAgentPage({
         .map((t) => t.trim())
         .filter((t) => t.length > 0);
 
-      // Get capabilities to save (convert IDs to AgentCapabilityConfig format)
-      const capabilityIdsToSave = localCapabilities ?? initialCapabilities;
+      // Get capabilities to save (already full AgentCapabilityConfig format)
+      const capabilitiesToSave = localCapabilities ?? initialCapabilities;
       const capabilitiesChanged =
-        JSON.stringify(capabilityIdsToSave) !== JSON.stringify(initialCapabilities);
-
-      // Convert capability IDs to AgentCapabilityConfig format
-      const capabilityConfigsToSave: AgentCapabilityConfig[] = capabilityIdsToSave.map(id => ({
-        ref: id,
-        config: {},
-      }));
+        JSON.stringify(capabilitiesToSave) !== JSON.stringify(initialCapabilities);
 
       // Update agent (capabilities are now part of the agent resource)
       await updateAgent.mutateAsync({
@@ -137,7 +123,7 @@ export default function EditAgentPage({
           tags,
           default_model_id: formData.default_model_id || undefined,
           // Only include capabilities if they changed
-          ...(capabilitiesChanged && { capabilities: capabilityConfigsToSave }),
+          ...(capabilitiesChanged && { capabilities: capabilitiesToSave }),
         },
       });
 
@@ -373,7 +359,7 @@ export default function EditAgentPage({
             <div className="lg:col-span-2">
               <AgentPreview
                 systemPrompt={formData.system_prompt}
-                capabilities={capabilityConfigs}
+                capabilities={selectedCapabilities}
               />
             </div>
 
@@ -398,7 +384,7 @@ export default function EditAgentPage({
                   <div>
                     <p className="text-sm font-medium">Capabilities</p>
                     <p className="text-sm text-muted-foreground">
-                      {selectedCapabilities.length} capability{selectedCapabilities.length !== 1 ? "ies" : ""} enabled
+                      {selectedCapabilities.length} capabilit{selectedCapabilities.length !== 1 ? "ies" : "y"} enabled
                     </p>
                   </div>
                 </CardContent>

--- a/apps/ui/src/app/(main)/agents/new/page.tsx
+++ b/apps/ui/src/app/(main)/agents/new/page.tsx
@@ -20,7 +20,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { ProviderIcon } from "@/components/providers/provider-icon";
 import { CapabilitySelector } from "@/components/agents/capability-selector";
-import type { CapabilityId, AgentCapabilityConfig } from "@/lib/api/types";
+import type { AgentCapabilityConfig } from "@/lib/api/types";
 
 export default function NewAgentPage() {
   const router = useRouter();
@@ -35,9 +35,9 @@ export default function NewAgentPage() {
     default_model_id: "",
   });
 
-  const [selectedCapabilities, setSelectedCapabilities] = useState<CapabilityId[]>([]);
+  const [selectedCapabilities, setSelectedCapabilities] = useState<AgentCapabilityConfig[]>([]);
 
-  const handleCapabilitiesChange = useCallback((capabilities: CapabilityId[]) => {
+  const handleCapabilitiesChange = useCallback((capabilities: AgentCapabilityConfig[]) => {
     setSelectedCapabilities(capabilities);
   }, []);
 
@@ -45,18 +45,12 @@ export default function NewAgentPage() {
     e.preventDefault();
 
     try {
-      // Convert capability IDs to AgentCapabilityConfig format
-      const capabilityConfigs: AgentCapabilityConfig[] = selectedCapabilities.map(id => ({
-        ref: id,
-        config: {},
-      }));
-
       const agent = await createAgent.mutateAsync({
         name: formData.name,
         description: formData.description || undefined,
         system_prompt: formData.system_prompt,
         default_model_id: formData.default_model_id || undefined,
-        capabilities: capabilityConfigs.length > 0 ? capabilityConfigs : undefined,
+        capabilities: selectedCapabilities.length > 0 ? selectedCapabilities : undefined,
       });
 
       router.push(`/agents/${agent.id}`);

--- a/apps/ui/src/components/agents/capability-selector.tsx
+++ b/apps/ui/src/components/agents/capability-selector.tsx
@@ -19,6 +19,11 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import {
   Plus,
   Search,
   ChevronUp,
@@ -28,19 +33,21 @@ import {
   Plug,
   Link,
   Lock,
+  Settings,
 } from "lucide-react";
-import type { Capability, CapabilityId } from "@/lib/api/types";
+import type { Capability, CapabilityId, AgentCapabilityConfig } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
 import { cn } from "@/lib/utils";
 import { InlineMarkdown } from "@/components/ui/markdown";
+import { CapabilitySettingsEditor, hasCapabilitySettings } from "./capability-settings-editor";
 
 interface CapabilitySelectorProps {
   /** All available capabilities */
   capabilities: Capability[];
-  /** Currently selected capability IDs (order matters) */
-  selected: CapabilityId[];
+  /** Currently selected capabilities with configs (order matters) */
+  selected: AgentCapabilityConfig[];
   /** Callback when selection changes */
-  onChange: (selected: CapabilityId[]) => void;
+  onChange: (selected: AgentCapabilityConfig[]) => void;
   /** Whether the selector is disabled */
   disabled?: boolean;
   /** Label for the component */
@@ -63,6 +70,16 @@ export function CapabilitySelector({
   const [searchQuery, setSearchQuery] = useState("");
   const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(
     new Set()
+  );
+  // Track which capability settings are expanded in the selected list
+  const [expandedSettings, setExpandedSettings] = useState<Set<CapabilityId>>(
+    new Set()
+  );
+
+  // Get selected capability IDs for quick lookup
+  const selectedIds = useMemo(() =>
+    new Set(selected.map((c) => c.ref)),
+    [selected]
   );
 
   // Create a map of capability ID to capability for fast lookup
@@ -111,11 +128,11 @@ export function CapabilitySelector({
   const getDependents = useCallback(
     (capId: CapabilityId): CapabilityId[] => {
       const dependents: CapabilityId[] = [];
-      for (const selectedId of selected) {
-        if (selectedId === capId) continue;
-        const deps = getAllDependencies(selectedId);
+      for (const selectedCap of selected) {
+        if (selectedCap.ref === capId) continue;
+        const deps = getAllDependencies(selectedCap.ref);
         if (deps.includes(capId)) {
-          dependents.push(selectedId);
+          dependents.push(selectedCap.ref);
         }
       }
       return dependents;
@@ -175,14 +192,33 @@ export function CapabilitySelector({
   const handleToggle = useCallback(
     (capabilityId: CapabilityId, checked: boolean) => {
       if (checked) {
-        // Add capability and its dependencies
+        // Add capability and its dependencies with empty configs
         const deps = getAllDependencies(capabilityId);
-        const toAdd = [...deps.filter((d) => !selected.includes(d)), capabilityId];
-        onChange([...selected, ...toAdd.filter((id) => !selected.includes(id))]);
+        const existingIds = new Set(selected.map((c) => c.ref));
+        const toAdd: AgentCapabilityConfig[] = [];
+
+        // Add dependencies first
+        for (const depId of deps) {
+          if (!existingIds.has(depId)) {
+            toAdd.push({ ref: depId, config: {} });
+          }
+        }
+        // Add the capability itself
+        if (!existingIds.has(capabilityId)) {
+          toAdd.push({ ref: capabilityId, config: {} });
+        }
+
+        onChange([...selected, ...toAdd]);
       } else {
         // Remove capability if no dependents require it
         if (canRemove(capabilityId)) {
-          onChange(selected.filter((id) => id !== capabilityId));
+          onChange(selected.filter((c) => c.ref !== capabilityId));
+          // Also collapse settings if removing
+          setExpandedSettings((prev) => {
+            const next = new Set(prev);
+            next.delete(capabilityId);
+            return next;
+          });
         }
       }
     },
@@ -192,11 +228,39 @@ export function CapabilitySelector({
   const handleRemove = useCallback(
     (capabilityId: CapabilityId) => {
       if (canRemove(capabilityId)) {
-        onChange(selected.filter((id) => id !== capabilityId));
+        onChange(selected.filter((c) => c.ref !== capabilityId));
+        setExpandedSettings((prev) => {
+          const next = new Set(prev);
+          next.delete(capabilityId);
+          return next;
+        });
       }
     },
     [selected, onChange, canRemove]
   );
+
+  const handleConfigChange = useCallback(
+    (capabilityId: CapabilityId, newConfig: Record<string, unknown>) => {
+      onChange(
+        selected.map((c) =>
+          c.ref === capabilityId ? { ...c, config: newConfig } : c
+        )
+      );
+    },
+    [selected, onChange]
+  );
+
+  const toggleSettings = useCallback((capabilityId: CapabilityId) => {
+    setExpandedSettings((prev) => {
+      const next = new Set(prev);
+      if (next.has(capabilityId)) {
+        next.delete(capabilityId);
+      } else {
+        next.add(capabilityId);
+      }
+      return next;
+    });
+  }, []);
 
   const moveUp = useCallback(
     (index: number) => {
@@ -236,7 +300,7 @@ export function CapabilitySelector({
     });
   }, []);
 
-  const selectedCount = selected.length;
+  const selectedCount = selectedIds.size;
   const availableCount = availableCapabilities.length;
 
   return (
@@ -290,7 +354,7 @@ export function CapabilitySelector({
                   {groupedCapabilities.map(({ category, capabilities: caps }) => {
                     const isCollapsed = collapsedCategories.has(category);
                     const selectedInCategory = caps.filter((c) =>
-                      selected.includes(c.id)
+                      selectedIds.has(c.id)
                     ).length;
 
                     return (
@@ -318,7 +382,7 @@ export function CapabilitySelector({
                           <div className="ml-6 space-y-1 mt-1">
                             {caps.map((cap) => {
                               const IconComponent = getCapabilityIcon(cap.icon);
-                              const isSelected = selected.includes(cap.id);
+                              const isSelected = selectedIds.has(cap.id);
                               const dependents = getDependents(cap.id);
                               const isRequired = dependents.length > 0;
                               const hasDependencies = (cap.dependencies?.length ?? 0) > 0;
@@ -411,94 +475,134 @@ export function CapabilitySelector({
         </div>
       ) : (
         <div className="space-y-1">
-          {selected.map((capId, index) => {
-            const cap = getCapability(capId);
+          {selected.map((capConfig, index) => {
+            const cap = getCapability(capConfig.ref);
             if (!cap) return null;
             const IconComponent = getCapabilityIcon(cap.icon);
-            const dependents = getDependents(capId);
+            const hasSettings = hasCapabilitySettings(capConfig.ref);
+            const isSettingsExpanded = expandedSettings.has(capConfig.ref);
+            const hasConfigValues = Object.keys(capConfig.config).length > 0;
+            const dependents = getDependents(capConfig.ref);
             const isRequired = dependents.length > 0;
 
             return (
-              <div
-                key={capId}
-                className="flex items-center gap-2 p-2 rounded-md border group bg-muted/30"
+              <Collapsible
+                key={capConfig.ref}
+                open={isSettingsExpanded}
+                onOpenChange={() => hasSettings && toggleSettings(capConfig.ref)}
               >
-                {/* Reorder controls */}
-                <div className="flex flex-col gap-0.5">
-                  <button
-                    type="button"
-                    onClick={() => moveUp(index)}
-                    disabled={index === 0 || disabled}
-                    className="text-muted-foreground hover:text-foreground disabled:opacity-30 p-0.5"
-                    aria-label="Move up"
-                  >
-                    <ChevronUp className="w-3 h-3" />
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => moveDown(index)}
-                    disabled={index === selected.length - 1 || disabled}
-                    className="text-muted-foreground hover:text-foreground disabled:opacity-30 p-0.5"
-                    aria-label="Move down"
-                  >
-                    <ChevronDown className="w-3 h-3" />
-                  </button>
-                </div>
+                <div className="rounded-md border bg-muted/30 group">
+                  <div className="flex items-center gap-2 p-2">
+                    {/* Reorder controls */}
+                    <div className="flex flex-col gap-0.5">
+                      <button
+                        type="button"
+                        onClick={() => moveUp(index)}
+                        disabled={index === 0 || disabled}
+                        className="text-muted-foreground hover:text-foreground disabled:opacity-30 p-0.5"
+                        aria-label="Move up"
+                      >
+                        <ChevronUp className="w-3 h-3" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => moveDown(index)}
+                        disabled={index === selected.length - 1 || disabled}
+                        className="text-muted-foreground hover:text-foreground disabled:opacity-30 p-0.5"
+                        aria-label="Move down"
+                      >
+                        <ChevronDown className="w-3 h-3" />
+                      </button>
+                    </div>
 
-                {/* Position indicator */}
-                <span className="text-xs text-muted-foreground w-4 text-center">
-                  {index + 1}
-                </span>
+                    {/* Position indicator */}
+                    <span className="text-xs text-muted-foreground w-4 text-center">
+                      {index + 1}
+                    </span>
 
-                {/* Icon and name */}
-                <IconComponent className="w-4 h-4 shrink-0" />
-                <span className="flex-1 text-sm truncate flex items-center gap-2">
-                  {cap.name}
-                  {cap.is_mcp && (
-                    <Badge variant="outline" className="text-xs px-1 py-0 h-4 gap-0.5 shrink-0">
-                      <Plug className="w-2.5 h-2.5" />
-                      MCP
-                    </Badge>
-                  )}
-                  {isRequired && (
-                    <Tooltip>
-                      <TooltipTrigger>
-                        <Badge variant="secondary" className="text-xs px-1 py-0 h-4 gap-0.5 shrink-0">
-                          <Lock className="w-2.5 h-2.5" />
-                          Required
+                    {/* Icon and name */}
+                    <IconComponent className="w-4 h-4 shrink-0" />
+                    <span className="flex-1 text-sm truncate flex items-center gap-2">
+                      {cap.name}
+                      {cap.is_mcp && (
+                        <Badge variant="outline" className="text-xs px-1 py-0 h-4 gap-0.5 shrink-0">
+                          <Plug className="w-2.5 h-2.5" />
+                          MCP
                         </Badge>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <p>Required by: {dependents.map(d => getCapability(d)?.name ?? d).join(", ")}</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  )}
-                </span>
+                      )}
+                      {isRequired && (
+                        <Tooltip>
+                          <TooltipTrigger>
+                            <Badge variant="secondary" className="text-xs px-1 py-0 h-4 gap-0.5 shrink-0">
+                              <Lock className="w-2.5 h-2.5" />
+                              Required
+                            </Badge>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p>Required by: {dependents.map(d => getCapability(d)?.name ?? d).join(", ")}</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      )}
+                    </span>
 
-                {/* Remove button */}
-                {isRequired ? (
-                  <Tooltip>
-                    <TooltipTrigger>
-                      <span className="text-muted-foreground/50 p-1 cursor-not-allowed">
-                        <Lock className="w-3 h-3" />
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>Cannot remove: required by {dependents.map(d => getCapability(d)?.name ?? d).join(", ")}</p>
-                    </TooltipContent>
-                  </Tooltip>
-                ) : (
-                  <button
-                    type="button"
-                    onClick={() => handleRemove(capId)}
-                    disabled={disabled}
-                    className="opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive p-1 transition-opacity"
-                    aria-label="Remove capability"
-                  >
-                    <X className="w-3 h-3" />
-                  </button>
-                )}
-              </div>
+                    {/* Settings button (if capability has configurable settings) */}
+                    {hasSettings && (
+                      <CollapsibleTrigger asChild>
+                        <button
+                          type="button"
+                          disabled={disabled}
+                          className={cn(
+                            "text-muted-foreground hover:text-foreground p-1 transition-colors",
+                            isSettingsExpanded && "text-foreground",
+                            hasConfigValues && !isSettingsExpanded && "text-primary"
+                          )}
+                          aria-label="Toggle settings"
+                        >
+                          <Settings className="w-3.5 h-3.5" />
+                        </button>
+                      </CollapsibleTrigger>
+                    )}
+
+                    {/* Remove button */}
+                    {isRequired ? (
+                      <Tooltip>
+                        <TooltipTrigger>
+                          <span className="text-muted-foreground/50 p-1 cursor-not-allowed">
+                            <Lock className="w-3 h-3" />
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>Cannot remove: required by {dependents.map(d => getCapability(d)?.name ?? d).join(", ")}</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => handleRemove(capConfig.ref)}
+                        disabled={disabled}
+                        className="opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive p-1 transition-opacity"
+                        aria-label="Remove capability"
+                      >
+                        <X className="w-3 h-3" />
+                      </button>
+                    )}
+                  </div>
+
+                  {/* Settings editor (collapsible) */}
+                  {hasSettings && (
+                    <CollapsibleContent>
+                      <div className="px-2 pb-2 border-t border-border/50 mx-2 pt-2">
+                        <CapabilitySettingsEditor
+                          capabilityId={capConfig.ref}
+                          config={capConfig.config}
+                          onChange={(newConfig) => handleConfigChange(capConfig.ref, newConfig)}
+                          disabled={disabled}
+                        />
+                      </div>
+                    </CollapsibleContent>
+                  )}
+                </div>
+              </Collapsible>
             );
           })}
         </div>

--- a/apps/ui/src/components/agents/capability-settings-editor.tsx
+++ b/apps/ui/src/components/agents/capability-settings-editor.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { CapabilityId } from "@/lib/api/types";
+
+// Known capability IDs that have configurable settings
+const DOCKER_CONTAINER_ID = "docker_container";
+
+// Type definitions for capability-specific configs
+export interface DockerContainerConfig {
+  image?: string;
+  working_dir?: string;
+}
+
+export type CapabilityConfig = DockerContainerConfig | Record<string, unknown>;
+
+interface CapabilitySettingsEditorProps {
+  /** The capability ID */
+  capabilityId: CapabilityId;
+  /** Current config value */
+  config: Record<string, unknown>;
+  /** Callback when config changes */
+  onChange: (config: Record<string, unknown>) => void;
+  /** Whether editing is disabled */
+  disabled?: boolean;
+}
+
+/**
+ * Editor for capability-specific configuration.
+ * Renders appropriate form fields based on the capability type.
+ */
+export function CapabilitySettingsEditor({
+  capabilityId,
+  config,
+  onChange,
+  disabled,
+}: CapabilitySettingsEditorProps) {
+  // Render appropriate editor based on capability type
+  switch (capabilityId) {
+    case DOCKER_CONTAINER_ID:
+      return (
+        <DockerContainerEditor
+          config={config as DockerContainerConfig}
+          onChange={onChange}
+          disabled={disabled}
+        />
+      );
+    default:
+      // No settings editor for this capability
+      return null;
+  }
+}
+
+/**
+ * Check if a capability has configurable settings
+ */
+export function hasCapabilitySettings(capabilityId: CapabilityId): boolean {
+  return capabilityId === DOCKER_CONTAINER_ID;
+}
+
+// ============================================================================
+// Docker Container Config Editor
+// ============================================================================
+
+const DEFAULT_DOCKER_IMAGE = "mcr.microsoft.com/devcontainers/python:3.11";
+const DEFAULT_WORKING_DIR = "/workspace";
+
+interface DockerContainerEditorProps {
+  config: DockerContainerConfig;
+  onChange: (config: Record<string, unknown>) => void;
+  disabled?: boolean;
+}
+
+function DockerContainerEditor({
+  config,
+  onChange,
+  disabled,
+}: DockerContainerEditorProps) {
+  const handleImageChange = (value: string) => {
+    // Only set the value if it's different from default, to keep config clean
+    const newConfig = { ...config };
+    if (value && value !== DEFAULT_DOCKER_IMAGE) {
+      newConfig.image = value;
+    } else {
+      delete newConfig.image;
+    }
+    onChange(newConfig);
+  };
+
+  const handleWorkingDirChange = (value: string) => {
+    const newConfig = { ...config };
+    if (value && value !== DEFAULT_WORKING_DIR) {
+      newConfig.working_dir = value;
+    } else {
+      delete newConfig.working_dir;
+    }
+    onChange(newConfig);
+  };
+
+  return (
+    <div className="space-y-3 pt-2">
+      <div className="space-y-1.5">
+        <Label htmlFor="docker-image" className="text-xs font-normal text-muted-foreground">
+          Docker Image
+        </Label>
+        <Input
+          id="docker-image"
+          placeholder={DEFAULT_DOCKER_IMAGE}
+          value={config.image || ""}
+          onChange={(e) => handleImageChange(e.target.value)}
+          disabled={disabled}
+          className="h-8 text-sm"
+        />
+        <p className="text-xs text-muted-foreground">
+          Custom base image for the container
+        </p>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="docker-working-dir" className="text-xs font-normal text-muted-foreground">
+          Working Directory
+        </Label>
+        <Input
+          id="docker-working-dir"
+          placeholder={DEFAULT_WORKING_DIR}
+          value={config.working_dir || ""}
+          onChange={(e) => handleWorkingDirChange(e.target.value)}
+          disabled={disabled}
+          className="h-8 text-sm"
+        />
+        <p className="text-xs text-muted-foreground">
+          Default working directory inside the container
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/ui/collapsible.tsx
+++ b/apps/ui/src/components/ui/collapsible.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface CollapsibleContextValue {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const CollapsibleContext = React.createContext<CollapsibleContextValue | null>(null);
+
+function useCollapsibleContext() {
+  const context = React.useContext(CollapsibleContext);
+  if (!context) {
+    throw new Error("Collapsible components must be used within a Collapsible");
+  }
+  return context;
+}
+
+interface CollapsibleProps {
+  children: React.ReactNode;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  className?: string;
+}
+
+function Collapsible({
+  children,
+  open: controlledOpen,
+  defaultOpen = false,
+  onOpenChange,
+  className,
+}: CollapsibleProps) {
+  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
+
+  const isControlled = controlledOpen !== undefined;
+  const open = isControlled ? controlledOpen : uncontrolledOpen;
+
+  const handleOpenChange = React.useCallback(
+    (newOpen: boolean) => {
+      if (!isControlled) {
+        setUncontrolledOpen(newOpen);
+      }
+      onOpenChange?.(newOpen);
+    },
+    [isControlled, onOpenChange]
+  );
+
+  return (
+    <CollapsibleContext.Provider value={{ open, onOpenChange: handleOpenChange }}>
+      <div data-slot="collapsible" data-state={open ? "open" : "closed"} className={className}>
+        {children}
+      </div>
+    </CollapsibleContext.Provider>
+  );
+}
+
+interface CollapsibleTriggerProps {
+  children: React.ReactNode;
+  asChild?: boolean;
+  className?: string;
+}
+
+function CollapsibleTrigger({ children, asChild, className }: CollapsibleTriggerProps) {
+  const { open, onOpenChange } = useCollapsibleContext();
+
+  if (asChild && React.isValidElement(children)) {
+    return React.cloneElement(children as React.ReactElement<{ onClick?: () => void }>, {
+      onClick: () => onOpenChange(!open),
+    });
+  }
+
+  return (
+    <button
+      type="button"
+      data-slot="collapsible-trigger"
+      data-state={open ? "open" : "closed"}
+      className={className}
+      onClick={() => onOpenChange(!open)}
+    >
+      {children}
+    </button>
+  );
+}
+
+interface CollapsibleContentProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+function CollapsibleContent({ children, className }: CollapsibleContentProps) {
+  const { open } = useCollapsibleContext();
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      data-slot="collapsible-content"
+      data-state={open ? "open" : "closed"}
+      className={cn("overflow-hidden", className)}
+    >
+      {children}
+    </div>
+  );
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent };


### PR DESCRIPTION
## Summary

- Add capability settings editor for Docker capability custom base image configuration
- Create `CapabilitySettingsEditor` component for editing capability-specific config
- Update `CapabilitySelector` to work with full `AgentCapabilityConfig` objects
- Add `Collapsible` UI component for expandable settings sections

## Changes

- **New Components:**
  - `capability-settings-editor.tsx` - Editor for capability-specific configuration (Docker config: image, working_dir)
  - `collapsible.tsx` - Simple collapsible component for expandable sections

- **Updated Components:**
  - `capability-selector.tsx` - Now works with full `AgentCapabilityConfig[]` instead of just capability IDs
  - Agent Edit and New Agent pages updated to pass full capability configs

## Screenshots

### 1. Agent Edit page with Docker capability selected
![Agent Edit with Docker capability](https://res.cloudinary.com/chalyi/image/upload/v1768876661/everruns/pr-screenshots/e9zc1r4y7ckdd4gckimt.png)

### 2. Docker capability settings expanded (click gear icon)
![Settings expanded](https://res.cloudinary.com/chalyi/image/upload/v1768876662/everruns/pr-screenshots/wgji7h90kz8174gpgyl6.png)

### 3. Custom Docker image entered
![Custom image entered](https://res.cloudinary.com/chalyi/image/upload/v1768876663/everruns/pr-screenshots/lfluz2fb1vim4dxe0jxz.png)

## Test Plan

- [x] API correctly stores capability config with custom image/working_dir
- [x] Settings gear icon appears on Docker capability in selected list
- [x] Clicking gear expands settings editor
- [x] Custom image/working_dir values are saved to capability config
- [x] Settings icon turns blue when config has values
- [x] Lint and build pass

## Risk

- Low - UI-only changes with backward compatible API