### PR TITLE
feat(core): add composable message filter abstraction

### DIFF
--- a/crates/control-plane/src/storage/backend.rs
+++ b/crates/control-plane/src/storage/backend.rs
@@ -5,6 +5,7 @@
 // either PostgreSQL (production) or in-memory (dev mode) storage.
 
 use anyhow::Result;
+use everruns_core::message_filter::MessageQuery;
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -251,6 +252,21 @@ impl StorageBackend {
 
     pub async fn list_message_events(&self, session_id: Uuid) -> Result<Vec<EventRow>> {
         dispatch!(self, list_message_events, session_id)
+    }
+
+    /// List message events with filters applied
+    ///
+    /// This method applies the filters from the MessageQuery to efficiently
+    /// retrieve messages. DB-mappable filters are pushed to the database,
+    /// while custom filters are applied in-memory.
+    ///
+    /// Note: Injections are NOT applied here - they should be applied at the
+    /// MessageRetriever layer after converting events to messages.
+    pub async fn list_message_events_filtered(
+        &self,
+        query: &MessageQuery,
+    ) -> Result<Vec<EventRow>> {
+        dispatch!(self, list_message_events_filtered, query)
     }
 
     /// Get preview text for multiple sessions (first user message)

--- a/crates/control-plane/src/storage/memory.rs
+++ b/crates/control-plane/src/storage/memory.rs
@@ -7,6 +7,7 @@
 
 use anyhow::{Result, anyhow};
 use chrono::{DateTime, Utc};
+use everruns_core::message_filter::{MessageFilter, MessageQuery};
 use everruns_core::{DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID};
 use parking_lot::RwLock;
 use std::collections::HashMap;
@@ -701,6 +702,121 @@ impl InMemoryDatabase {
             .cloned()
             .collect();
         result.sort_by_key(|e| e.sequence);
+        Ok(result)
+    }
+
+    /// List message events for a session with filters applied.
+    ///
+    /// This method applies filters in-memory, mirroring the behavior of the
+    /// PostgreSQL implementation but using Rust predicates instead of SQL.
+    ///
+    /// Note: Injections are NOT applied here - they should be applied at the
+    /// MessageRetriever layer after converting events to messages.
+    pub async fn list_message_events_filtered(
+        &self,
+        query: &MessageQuery,
+    ) -> Result<Vec<EventRow>> {
+        // Default event types if not specified
+        let default_types = vec![
+            "message.user".to_string(),
+            "message.agent".to_string(),
+            "tool.call_completed".to_string(),
+        ];
+
+        // Check for EventTypes filter, else use defaults
+        let event_types = query
+            .filters
+            .iter()
+            .find_map(|f| match f {
+                MessageFilter::EventTypes(types) => Some(types.clone()),
+                _ => None,
+            })
+            .unwrap_or(default_types);
+
+        let events = self.events.read();
+        let mut result: Vec<_> = events
+            .values()
+            .filter(|e| {
+                // Session filter
+                if e.session_id != query.session_id {
+                    return false;
+                }
+
+                // Event type filter
+                if !event_types.iter().any(|t| t == &e.event_type) {
+                    return false;
+                }
+
+                // Apply all filters
+                for filter in &query.filters {
+                    match filter {
+                        MessageFilter::EventTypes(_) => {
+                            // Already handled above
+                        }
+                        MessageFilter::TimeRange { from, to } => {
+                            if let Some(f) = from
+                                && e.created_at < *f
+                            {
+                                return false;
+                            }
+                            if let Some(t) = to
+                                && e.created_at > *t
+                            {
+                                return false;
+                            }
+                        }
+                        MessageFilter::ToolName(name) => {
+                            if e.event_type != "tool.call_completed" {
+                                return false;
+                            }
+                            let tool_match = e
+                                .data
+                                .get("tool_name")
+                                .and_then(|v| v.as_str())
+                                .map(|n| n == name)
+                                .unwrap_or(false);
+                            if !tool_match {
+                                return false;
+                            }
+                        }
+                        MessageFilter::Search(search_query) => {
+                            let data_str = e.data.to_string().to_lowercase();
+                            if !data_str.contains(&search_query.to_lowercase()) {
+                                return false;
+                            }
+                        }
+                        MessageFilter::ExcludeIds(ids) => {
+                            if ids.contains(&e.id) {
+                                return false;
+                            }
+                        }
+                        MessageFilter::IncludeIds(ids) => {
+                            if !ids.contains(&e.id) {
+                                return false;
+                            }
+                        }
+                        MessageFilter::Custom(_) => {
+                            // Custom filters are applied at the Message level,
+                            // not the EventRow level. Skip here.
+                        }
+                    }
+                }
+
+                true
+            })
+            .cloned()
+            .collect();
+
+        result.sort_by_key(|e| e.sequence);
+
+        // Apply offset and limit
+        if let Some(offset) = query.offset {
+            result = result.into_iter().skip(offset as usize).collect();
+        }
+        if let Some(limit) = query.limit {
+            result.truncate(limit as usize);
+        }
+
         Ok(result)
     }
 

--- a/crates/control-plane/src/storage/message_store.rs
+++ b/crates/control-plane/src/storage/message_store.rs
@@ -12,8 +12,8 @@
 use async_trait::async_trait;
 use chrono::Utc;
 use everruns_core::{
-    AgentLoopError, ContentPart, Event, EventData, InputMessage, Message, MessageRetriever,
-    MessageRole, Result,
+    AgentLoopError, ContentPart, Event, EventData, InputMessage, Message, MessageFilter,
+    MessageQuery, MessageRetriever, MessageRole, Result,
     events::{
         EventContext, EventRequest, MessageAgentData, MessageUserData, ToolCallCompletedData,
     },
@@ -112,6 +112,46 @@ impl MessageRetriever for DbMessageRetriever {
                     tracing::warn!("Failed to parse message from event {}: {}", event_row.id, e);
                 }
             }
+        }
+
+        Ok(messages)
+    }
+
+    async fn load_filtered(&self, query: MessageQuery) -> Result<Vec<Message>> {
+        // Check if we have any custom filters that need in-memory processing
+        let has_custom_filters = query.has_custom_filters();
+
+        // Load events using the filtered query
+        let events = self
+            .db
+            .list_message_events_filtered(&query)
+            .await
+            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+
+        // Convert events to messages
+        let mut messages = Vec::with_capacity(events.len());
+        for event_row in events {
+            match event_to_message(&event_row.data, &event_row.event_type) {
+                Ok(message) => messages.push(message),
+                Err(e) => {
+                    tracing::warn!("Failed to parse message from event {}: {}", event_row.id, e);
+                }
+            }
+        }
+
+        // Apply custom filters in-memory if any
+        if has_custom_filters {
+            messages.retain(|msg| {
+                query.filters.iter().all(|filter| match filter {
+                    MessageFilter::Custom(predicate) => predicate(msg),
+                    _ => true, // DB filters already applied
+                })
+            });
+        }
+
+        // Apply injections
+        if query.has_injections() {
+            query.apply_injections(&mut messages);
         }
 
         Ok(messages)

--- a/crates/control-plane/src/storage/repositories.rs
+++ b/crates/control-plane/src/storage/repositories.rs
@@ -2,6 +2,8 @@
 // M2 Revised: Agent/Session/Messages/Events model
 
 use anyhow::Result;
+use chrono::{DateTime, Utc};
+use everruns_core::message_filter::{MessageFilter, MessageQuery};
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -715,6 +717,147 @@ impl Database {
         .bind(session_id)
         .fetch_all(&self.pool)
         .await?;
+
+        Ok(rows)
+    }
+
+    /// List message events for a session with filters applied.
+    ///
+    /// This method builds a dynamic SQL query based on the provided filters.
+    /// DB-mappable filters (TimeRange, EventTypes, ToolName, Search, etc.) are
+    /// pushed to the database for efficient filtering. Custom filters are applied
+    /// in-memory after loading.
+    ///
+    /// Note: Injections are NOT applied here - they should be applied at the
+    /// MessageRetriever layer after converting events to messages.
+    pub async fn list_message_events_filtered(
+        &self,
+        query: &MessageQuery,
+    ) -> Result<Vec<EventRow>> {
+        // Build dynamic SQL query
+        let mut sql = String::from(
+            "SELECT id, session_id, sequence, event_type, ts, context, data, metadata, tags, created_at FROM events WHERE session_id = $1",
+        );
+
+        // Collect bound values for later binding
+        // We track types separately since sqlx needs typed bindings
+        let mut time_from: Option<DateTime<Utc>> = None;
+        let mut time_to: Option<DateTime<Utc>> = None;
+        let mut event_types: Option<Vec<String>> = None;
+        let mut tool_name: Option<String> = None;
+        let mut search_query: Option<String> = None;
+        let mut exclude_ids: Option<Vec<Uuid>> = None;
+        let mut include_ids: Option<Vec<Uuid>> = None;
+
+        // Check for EventTypes filter, else use defaults
+        for filter in &query.filters {
+            if let MessageFilter::EventTypes(types) = filter {
+                event_types = Some(types.clone());
+                break;
+            }
+        }
+
+        // Default event types if not specified
+        let types = event_types.unwrap_or_else(|| {
+            vec![
+                "message.user".to_string(),
+                "message.agent".to_string(),
+                "tool.call_completed".to_string(),
+            ]
+        });
+        sql.push_str(" AND event_type = ANY($2)");
+
+        // Build parameter index tracker (starting at 3 since $1=session_id, $2=event_types)
+        let mut param_idx = 3;
+
+        // Process filters
+        for filter in &query.filters {
+            match filter {
+                MessageFilter::EventTypes(_) => {
+                    // Already handled above
+                }
+                MessageFilter::TimeRange { from, to } => {
+                    if let Some(f) = from {
+                        sql.push_str(&format!(" AND created_at >= ${}", param_idx));
+                        time_from = Some(*f);
+                        param_idx += 1;
+                    }
+                    if let Some(t) = to {
+                        sql.push_str(&format!(" AND created_at <= ${}", param_idx));
+                        time_to = Some(*t);
+                        param_idx += 1;
+                    }
+                }
+                MessageFilter::ToolName(name) => {
+                    sql.push_str(&format!(
+                        " AND (event_type = 'tool.call_completed' AND data->>'tool_name' = ${})",
+                        param_idx
+                    ));
+                    tool_name = Some(name.clone());
+                    param_idx += 1;
+                }
+                MessageFilter::Search(q) => {
+                    sql.push_str(&format!(
+                        " AND data::text ILIKE '%' || ${} || '%'",
+                        param_idx
+                    ));
+                    search_query = Some(q.clone());
+                    param_idx += 1;
+                }
+                MessageFilter::ExcludeIds(ids) => {
+                    sql.push_str(&format!(" AND id != ALL(${})", param_idx));
+                    exclude_ids = Some(ids.clone());
+                    param_idx += 1;
+                }
+                MessageFilter::IncludeIds(ids) => {
+                    sql.push_str(&format!(" AND id = ANY(${})", param_idx));
+                    include_ids = Some(ids.clone());
+                    param_idx += 1;
+                }
+                MessageFilter::Custom(_) => {
+                    // Custom filters are applied in-memory, not in SQL
+                }
+            }
+        }
+
+        sql.push_str(" ORDER BY sequence ASC");
+
+        // Apply limit/offset
+        if let Some(limit) = query.limit {
+            sql.push_str(&format!(" LIMIT {}", limit));
+        }
+        if let Some(offset) = query.offset {
+            sql.push_str(&format!(" OFFSET {}", offset));
+        }
+
+        // Build and execute query with dynamic bindings
+        // sqlx doesn't support truly dynamic queries, so we need to use raw SQL
+        // with all possible parameters, binding None for unused ones
+        let mut db_query = sqlx::query_as::<_, EventRow>(&sql)
+            .bind(query.session_id)
+            .bind(&types);
+
+        // Bind parameters in order they were added to SQL
+        if time_from.is_some() {
+            db_query = db_query.bind(time_from);
+        }
+        if time_to.is_some() {
+            db_query = db_query.bind(time_to);
+        }
+        if tool_name.is_some() {
+            db_query = db_query.bind(tool_name);
+        }
+        if search_query.is_some() {
+            db_query = db_query.bind(search_query);
+        }
+        if exclude_ids.is_some() {
+            db_query = db_query.bind(exclude_ids);
+        }
+        if include_ids.is_some() {
+            db_query = db_query.bind(include_ids);
+        }
+
+        let rows = db_query.fetch_all(&self.pool).await?;
 
         Ok(rows)
     }

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -1423,4 +1423,287 @@ mod tests {
         // This test verifies the constant is set correctly
         assert_eq!(MAX_RESOLVED_CAPABILITIES, 100);
     }
+
+    // =========================================================================
+    // Message filter provider tests
+    // =========================================================================
+
+    use crate::message_filter::{MessageFilter, MessageFilterProvider, MessageQuery};
+
+    /// Test capability that provides a message filter
+    struct FilterTestCapability {
+        priority: i32,
+    }
+
+    impl Capability for FilterTestCapability {
+        fn id(&self) -> &str {
+            "filter_test"
+        }
+        fn name(&self) -> &str {
+            "Filter Test"
+        }
+        fn description(&self) -> &str {
+            "Test capability with message filter"
+        }
+        fn message_filter_provider(&self) -> Option<Arc<dyn MessageFilterProvider>> {
+            Some(Arc::new(FilterTestProvider {
+                priority: self.priority,
+            }))
+        }
+    }
+
+    struct FilterTestProvider {
+        priority: i32,
+    }
+
+    impl MessageFilterProvider for FilterTestProvider {
+        fn apply_filters(&self, query: &mut MessageQuery, config: &serde_json::Value) {
+            // Add a search filter based on config
+            if let Some(search) = config.get("search").and_then(|v| v.as_str()) {
+                query
+                    .filters
+                    .push(MessageFilter::Search(search.to_string()));
+            }
+        }
+
+        fn priority(&self) -> i32 {
+            self.priority
+        }
+    }
+
+    #[test]
+    fn test_collect_capabilities_with_configs_no_filter_providers() {
+        let registry = CapabilityRegistry::with_builtins();
+        let configs = vec![AgentCapabilityConfig {
+            capability_ref: CapabilityId::new(CapabilityId::CURRENT_TIME),
+            config: serde_json::json!({}),
+        }];
+
+        let collected = collect_capabilities_with_configs(&configs, &registry);
+
+        assert!(collected.message_filter_providers.is_empty());
+        assert!(!collected.has_message_filters());
+    }
+
+    #[test]
+    fn test_collect_capabilities_with_configs_with_filter_provider() {
+        let mut registry = CapabilityRegistry::new();
+        registry.register(FilterTestCapability { priority: 0 });
+
+        let configs = vec![AgentCapabilityConfig {
+            capability_ref: CapabilityId::new("filter_test"),
+            config: serde_json::json!({ "search": "hello" }),
+        }];
+
+        let collected = collect_capabilities_with_configs(&configs, &registry);
+
+        assert_eq!(collected.message_filter_providers.len(), 1);
+        assert!(collected.has_message_filters());
+    }
+
+    #[test]
+    fn test_collect_capabilities_with_configs_filter_priority_order() {
+        // Create capabilities with different priorities
+        struct HighPriorityCapability;
+        struct LowPriorityCapability;
+
+        impl Capability for HighPriorityCapability {
+            fn id(&self) -> &str {
+                "high_priority"
+            }
+            fn name(&self) -> &str {
+                "High Priority"
+            }
+            fn description(&self) -> &str {
+                "Test"
+            }
+            fn message_filter_provider(&self) -> Option<Arc<dyn MessageFilterProvider>> {
+                Some(Arc::new(FilterTestProvider { priority: 10 }))
+            }
+        }
+
+        impl Capability for LowPriorityCapability {
+            fn id(&self) -> &str {
+                "low_priority"
+            }
+            fn name(&self) -> &str {
+                "Low Priority"
+            }
+            fn description(&self) -> &str {
+                "Test"
+            }
+            fn message_filter_provider(&self) -> Option<Arc<dyn MessageFilterProvider>> {
+                Some(Arc::new(FilterTestProvider { priority: -5 }))
+            }
+        }
+
+        let mut registry = CapabilityRegistry::new();
+        registry.register(HighPriorityCapability);
+        registry.register(LowPriorityCapability);
+
+        // Add in order: high priority first, low priority second
+        let configs = vec![
+            AgentCapabilityConfig {
+                capability_ref: CapabilityId::new("high_priority"),
+                config: serde_json::json!({}),
+            },
+            AgentCapabilityConfig {
+                capability_ref: CapabilityId::new("low_priority"),
+                config: serde_json::json!({}),
+            },
+        ];
+
+        let collected = collect_capabilities_with_configs(&configs, &registry);
+
+        // Should be sorted by priority (lower first)
+        assert_eq!(collected.message_filter_providers.len(), 2);
+        assert_eq!(collected.message_filter_providers[0].0.priority(), -5);
+        assert_eq!(collected.message_filter_providers[1].0.priority(), 10);
+    }
+
+    #[test]
+    fn test_collected_capabilities_apply_message_filters() {
+        let mut registry = CapabilityRegistry::new();
+        registry.register(FilterTestCapability { priority: 0 });
+
+        let configs = vec![AgentCapabilityConfig {
+            capability_ref: CapabilityId::new("filter_test"),
+            config: serde_json::json!({ "search": "test_query" }),
+        }];
+
+        let collected = collect_capabilities_with_configs(&configs, &registry);
+
+        // Apply filters to a query
+        let session_id = uuid::Uuid::now_v7();
+        let mut query = MessageQuery::new(session_id);
+
+        collected.apply_message_filters(&mut query);
+
+        // Should have added the search filter
+        assert_eq!(query.filters.len(), 1);
+        assert!(matches!(&query.filters[0], MessageFilter::Search(s) if s == "test_query"));
+    }
+
+    #[test]
+    fn test_collected_capabilities_apply_multiple_filters_in_priority_order() {
+        struct SearchCapability {
+            id: &'static str,
+            search_term: &'static str,
+            priority: i32,
+        }
+
+        struct SearchProvider {
+            search_term: &'static str,
+            priority: i32,
+        }
+
+        impl MessageFilterProvider for SearchProvider {
+            fn apply_filters(&self, query: &mut MessageQuery, _config: &serde_json::Value) {
+                query
+                    .filters
+                    .push(MessageFilter::Search(self.search_term.to_string()));
+            }
+
+            fn priority(&self) -> i32 {
+                self.priority
+            }
+        }
+
+        impl Capability for SearchCapability {
+            fn id(&self) -> &str {
+                self.id
+            }
+            fn name(&self) -> &str {
+                "Search"
+            }
+            fn description(&self) -> &str {
+                "Test"
+            }
+            fn message_filter_provider(&self) -> Option<Arc<dyn MessageFilterProvider>> {
+                Some(Arc::new(SearchProvider {
+                    search_term: self.search_term,
+                    priority: self.priority,
+                }))
+            }
+        }
+
+        let mut registry = CapabilityRegistry::new();
+        registry.register(SearchCapability {
+            id: "cap_a",
+            search_term: "alpha",
+            priority: 5,
+        });
+        registry.register(SearchCapability {
+            id: "cap_b",
+            search_term: "beta",
+            priority: 1,
+        });
+        registry.register(SearchCapability {
+            id: "cap_c",
+            search_term: "gamma",
+            priority: 10,
+        });
+
+        let configs = vec![
+            AgentCapabilityConfig {
+                capability_ref: CapabilityId::new("cap_a"),
+                config: serde_json::json!({}),
+            },
+            AgentCapabilityConfig {
+                capability_ref: CapabilityId::new("cap_b"),
+                config: serde_json::json!({}),
+            },
+            AgentCapabilityConfig {
+                capability_ref: CapabilityId::new("cap_c"),
+                config: serde_json::json!({}),
+            },
+        ];
+
+        let collected = collect_capabilities_with_configs(&configs, &registry);
+
+        let session_id = uuid::Uuid::now_v7();
+        let mut query = MessageQuery::new(session_id);
+
+        collected.apply_message_filters(&mut query);
+
+        // Filters should be applied in priority order: beta (1), alpha (5), gamma (10)
+        assert_eq!(query.filters.len(), 3);
+        assert!(matches!(&query.filters[0], MessageFilter::Search(s) if s == "beta"));
+        assert!(matches!(&query.filters[1], MessageFilter::Search(s) if s == "alpha"));
+        assert!(matches!(&query.filters[2], MessageFilter::Search(s) if s == "gamma"));
+    }
+
+    #[test]
+    fn test_capability_without_message_filter_returns_none() {
+        let registry = CapabilityRegistry::with_builtins();
+
+        let noop = registry.get(CapabilityId::NOOP).unwrap();
+        assert!(noop.message_filter_provider().is_none());
+
+        let current_time = registry.get(CapabilityId::CURRENT_TIME).unwrap();
+        assert!(current_time.message_filter_provider().is_none());
+    }
+
+    #[test]
+    fn test_collect_capabilities_preserves_config_for_filter_provider() {
+        let mut registry = CapabilityRegistry::new();
+        registry.register(FilterTestCapability { priority: 0 });
+
+        let test_config = serde_json::json!({
+            "search": "custom_search",
+            "extra_field": 42
+        });
+
+        let configs = vec![AgentCapabilityConfig {
+            capability_ref: CapabilityId::new("filter_test"),
+            config: test_config.clone(),
+        }];
+
+        let collected = collect_capabilities_with_configs(&configs, &registry);
+
+        // Verify the config is preserved
+        assert_eq!(collected.message_filter_providers.len(), 1);
+        let (_, stored_config) = &collected.message_filter_providers[0];
+        assert_eq!(*stored_config, test_config);
+    }
 }

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -15,6 +15,7 @@
 //! Each capability is in its own file with collocated tools.
 
 use crate::deployment::DeploymentGrade;
+use crate::message_filter::MessageFilterProvider;
 use crate::runtime_agent::RuntimeAgent;
 use crate::tool_types::ToolDefinition;
 use crate::tools::{Tool, ToolRegistry};
@@ -192,6 +193,22 @@ pub trait Capability: Send + Sync {
     /// By default, returns an empty vector (no dependencies).
     fn dependencies(&self) -> Vec<&'static str> {
         vec![]
+    }
+
+    /// Returns a message filter provider if this capability modifies message retrieval.
+    ///
+    /// Capabilities can contribute filters that modify how messages are loaded
+    /// from the database. This enables features like:
+    /// - Time-based filtering (recent messages only)
+    /// - Event type filtering
+    /// - Tool result filtering by tool name
+    /// - Ephemeral message injection (summaries, reminders)
+    ///
+    /// Filters are applied in capability priority order (by `MessageFilterProvider::priority()`).
+    ///
+    /// By default, returns None (no message filtering).
+    fn message_filter_provider(&self) -> Option<Arc<dyn MessageFilterProvider>> {
+        None
     }
 }
 
@@ -396,6 +413,8 @@ pub struct CollectedCapabilities {
     pub tool_definitions: Vec<ToolDefinition>,
     /// Mount points from capabilities
     pub mounts: Vec<MountPoint>,
+    /// Message filter providers with their configs (in priority order)
+    pub message_filter_providers: Vec<(Arc<dyn MessageFilterProvider>, serde_json::Value)>,
     /// IDs of capabilities that were collected
     pub applied_ids: Vec<String>,
 }
@@ -409,6 +428,21 @@ impl CollectedCapabilities {
         } else {
             Some(self.system_prompt_parts.join("\n\n"))
         }
+    }
+
+    /// Apply all collected message filter providers to a query.
+    ///
+    /// Providers are applied in priority order (lower priority first).
+    pub fn apply_message_filters(&self, query: &mut crate::message_filter::MessageQuery) {
+        // Providers are already sorted by priority during collection
+        for (provider, config) in &self.message_filter_providers {
+            provider.apply_filters(query, config);
+        }
+    }
+
+    /// Check if any capabilities contribute message filters.
+    pub fn has_message_filters(&self) -> bool {
+        !self.message_filter_providers.is_empty()
     }
 }
 
@@ -617,6 +651,10 @@ pub fn get_dependencies(cap_id: &str, registry: &CapabilityRegistry) -> Vec<Stri
 /// points from the given capabilities. Use this when you need the raw capability
 /// data before applying it to a config or builder.
 ///
+/// Note: This function does not collect message filter providers since it doesn't
+/// have access to per-agent capability configs. Use `collect_capabilities_with_configs`
+/// if you need message filter providers.
+///
 /// # Arguments
 ///
 /// * `capability_ids` - Ordered list of capability IDs to collect
@@ -625,13 +663,41 @@ pub fn collect_capabilities(
     capability_ids: &[String],
     registry: &CapabilityRegistry,
 ) -> CollectedCapabilities {
+    // Convert to AgentCapabilityConfig with empty configs
+    let configs: Vec<AgentCapabilityConfig> = capability_ids
+        .iter()
+        .map(|id| AgentCapabilityConfig {
+            capability_ref: CapabilityId::new(id),
+            config: serde_json::Value::Object(serde_json::Map::new()),
+        })
+        .collect();
+
+    collect_capabilities_with_configs(&configs, registry)
+}
+
+/// Collect contributions from capabilities with their per-agent configurations.
+///
+/// This extracts system prompt additions, tools, tool definitions, mount points,
+/// and message filter providers from the given capabilities.
+///
+/// # Arguments
+///
+/// * `capability_configs` - Ordered list of capability configs (ID + per-agent config)
+/// * `registry` - The capability registry containing implementations
+pub fn collect_capabilities_with_configs(
+    capability_configs: &[AgentCapabilityConfig],
+    registry: &CapabilityRegistry,
+) -> CollectedCapabilities {
     let mut system_prompt_parts: Vec<String> = Vec::new();
     let mut tools: Vec<Box<dyn Tool>> = Vec::new();
     let mut tool_definitions: Vec<ToolDefinition> = Vec::new();
     let mut mounts: Vec<MountPoint> = Vec::new();
+    let mut message_filter_providers: Vec<(Arc<dyn MessageFilterProvider>, serde_json::Value)> =
+        Vec::new();
     let mut applied_ids: Vec<String> = Vec::new();
 
-    for cap_id in capability_ids {
+    for cap_config in capability_configs {
+        let cap_id = cap_config.capability_ref.as_str();
         if let Some(capability) = registry.get(cap_id) {
             // Only collect from available capabilities
             if capability.status() != CapabilityStatus::Available {
@@ -652,15 +718,24 @@ pub fn collect_capabilities(
             // Collect mount points
             mounts.extend(capability.mounts());
 
-            applied_ids.push(cap_id.clone());
+            // Collect message filter provider
+            if let Some(provider) = capability.message_filter_provider() {
+                message_filter_providers.push((provider, cap_config.config.clone()));
+            }
+
+            applied_ids.push(cap_id.to_string());
         }
     }
+
+    // Sort message filter providers by priority (lower = earlier)
+    message_filter_providers.sort_by_key(|(p, _)| p.priority());
 
     CollectedCapabilities {
         system_prompt_parts,
         tools,
         tool_definitions,
         mounts,
+        message_filter_providers,
         applied_ids,
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -52,6 +52,7 @@ pub mod capabilities;
 pub mod error;
 pub mod llm_driver_registry;
 pub mod message;
+pub mod message_filter;
 pub mod message_retriever;
 pub mod openai_protocol;
 pub mod openresponses_protocol;
@@ -75,6 +76,9 @@ pub use message::{
     ContentPart, ContentType, Controls, ImageContentPart, ImageFileContentPart, InputContentPart,
     Message, MessageRole, ReasoningConfig, TextContentPart, ToolCallContentPart,
     ToolResultContentPart,
+};
+pub use message_filter::{
+    InjectedMessage, InjectionPosition, MessageFilter, MessageFilterProvider, MessageQuery,
 };
 pub use message_retriever::{InputMessage, MessageRetriever};
 pub use runtime_agent::{RuntimeAgent, RuntimeAgentBuilder};
@@ -111,15 +115,16 @@ pub use tools::{
 // Capability re-exports
 pub use capabilities::{
     AddTool, AgentCapabilityConfig, AppliedCapabilities, Capability, CapabilityId,
-    CapabilityRegistry, CapabilityRegistryBuilder, CapabilityStatus, CurrentTimeCapability,
-    DeleteFileTool, DependencyError, DivideTool, FileSystemCapability, GetCurrentTimeTool,
-    GetForecastTool, GetWeatherTool, GrepFilesTool, ListDirectoryTool, MAX_RESOLVED_CAPABILITIES,
-    MCP_CAPABILITY_PREFIX, McpCapability, MountAccess, MountDirectoryBuilder, MountEntry,
-    MountPoint, MountSource, MultiplyTool, NoopCapability, ReadFileTool, ResearchCapability,
-    ResolvedCapabilities, SampleDataCapability, SandboxCapability, StatFileTool,
-    StatelessTodoListCapability, SubtractTool, TestMathCapability, TestWeatherCapability,
-    WriteFileTool, WriteTodosTool, apply_capabilities, collect_capabilities, get_dependencies,
-    is_mcp_capability, mcp_capability_id, parse_mcp_capability_id, resolve_dependencies,
+    CapabilityRegistry, CapabilityRegistryBuilder, CapabilityStatus, CollectedCapabilities,
+    CurrentTimeCapability, DeleteFileTool, DependencyError, DivideTool, FileSystemCapability,
+    GetCurrentTimeTool, GetForecastTool, GetWeatherTool, GrepFilesTool, ListDirectoryTool,
+    MAX_RESOLVED_CAPABILITIES, MCP_CAPABILITY_PREFIX, McpCapability, MountAccess,
+    MountDirectoryBuilder, MountEntry, MountPoint, MountSource, MultiplyTool, NoopCapability,
+    ReadFileTool, ResearchCapability, ResolvedCapabilities, SampleDataCapability,
+    SandboxCapability, StatFileTool, StatelessTodoListCapability, SubtractTool, TestMathCapability,
+    TestWeatherCapability, WriteFileTool, WriteTodosTool, apply_capabilities,
+    collect_capabilities_with_configs, get_dependencies, is_mcp_capability, mcp_capability_id,
+    parse_mcp_capability_id, resolve_dependencies,
 };
 
 // Atoms re-exports (stateless atomic operations)

--- a/crates/core/src/message_filter.rs
+++ b/crates/core/src/message_filter.rs
@@ -1,0 +1,490 @@
+//! Message Filter Abstraction
+//!
+//! This module provides a composable filter system for message retrieval.
+//! Capabilities can contribute filters that modify how messages are loaded,
+//! enabling features like:
+//! - Time-based filtering (from/to timestamps)
+//! - Event type filtering
+//! - Tool name filtering (for tool results)
+//! - Full-text search
+//! - Ephemeral message injection
+//!
+//! Design decisions:
+//! - Filters are stackable: capabilities apply filters in priority order
+//! - DB-mapped where possible: most filters translate to SQL for efficiency
+//! - In-memory fallback: custom filters use Rust predicates
+//! - Injection support: ephemeral messages can be added without persistence
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::message::Message;
+
+// ============================================================================
+// MessageFilter - Filter specifications for message queries
+// ============================================================================
+
+/// Filter specification for message queries.
+///
+/// Each variant can be mapped to either:
+/// - SQL WHERE clause (for PostgreSQL)
+/// - Rust predicate (for in-memory filtering)
+///
+/// Filters are applied in order and combined with AND semantics.
+#[derive(Clone)]
+pub enum MessageFilter {
+    /// Filter by time range (inclusive bounds)
+    ///
+    /// Maps to: `WHERE created_at >= $from AND created_at <= $to`
+    TimeRange {
+        from: Option<DateTime<Utc>>,
+        to: Option<DateTime<Utc>>,
+    },
+
+    /// Filter by event types (whitelist)
+    ///
+    /// Maps to: `WHERE event_type = ANY($types)`
+    /// Default types if not specified: message.user, message.agent, tool.call_completed
+    EventTypes(Vec<String>),
+
+    /// Filter tool results by tool name
+    ///
+    /// Maps to: `WHERE event_type = 'tool.call_completed' AND data->>'tool_name' = $name`
+    ToolName(String),
+
+    /// Full-text search in message content
+    ///
+    /// Maps to: `WHERE data::text ILIKE '%' || $query || '%'`
+    /// For production, consider using pg_trgm or tsvector for better performance.
+    Search(String),
+
+    /// Exclude specific message IDs
+    ///
+    /// Maps to: `WHERE id != ALL($ids)`
+    ExcludeIds(Vec<Uuid>),
+
+    /// Include only specific message IDs
+    ///
+    /// Maps to: `WHERE id = ANY($ids)`
+    IncludeIds(Vec<Uuid>),
+
+    /// Custom predicate (in-memory only)
+    ///
+    /// Use sparingly - this filter cannot be pushed to the database.
+    /// For complex filtering that can't be expressed in SQL.
+    Custom(Arc<dyn Fn(&Message) -> bool + Send + Sync>),
+}
+
+impl fmt::Debug for MessageFilter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TimeRange { from, to } => f
+                .debug_struct("TimeRange")
+                .field("from", from)
+                .field("to", to)
+                .finish(),
+            Self::EventTypes(types) => f.debug_tuple("EventTypes").field(types).finish(),
+            Self::ToolName(name) => f.debug_tuple("ToolName").field(name).finish(),
+            Self::Search(query) => f.debug_tuple("Search").field(query).finish(),
+            Self::ExcludeIds(ids) => f.debug_tuple("ExcludeIds").field(ids).finish(),
+            Self::IncludeIds(ids) => f.debug_tuple("IncludeIds").field(ids).finish(),
+            Self::Custom(_) => f.debug_tuple("Custom").field(&"<fn>").finish(),
+        }
+    }
+}
+
+// ============================================================================
+// InjectedMessage - Ephemeral messages to add to results
+// ============================================================================
+
+/// Position for injecting ephemeral messages.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum InjectionPosition {
+    /// Insert at the beginning (before all messages)
+    Start,
+    /// Insert at the end (after all messages)
+    End,
+    /// Insert before the message at the given index
+    BeforeIndex(usize),
+    /// Insert after the message at the given index
+    AfterIndex(usize),
+}
+
+/// An ephemeral message to inject into the result set.
+///
+/// Injected messages are not persisted - they're added during retrieval
+/// for context augmentation purposes (e.g., summaries, system reminders).
+#[derive(Debug, Clone)]
+pub struct InjectedMessage {
+    /// Where to insert this message
+    pub position: InjectionPosition,
+    /// The message to inject
+    pub message: Message,
+}
+
+impl InjectedMessage {
+    /// Create an injection at the start of the message list
+    pub fn at_start(message: Message) -> Self {
+        Self {
+            position: InjectionPosition::Start,
+            message,
+        }
+    }
+
+    /// Create an injection at the end of the message list
+    pub fn at_end(message: Message) -> Self {
+        Self {
+            position: InjectionPosition::End,
+            message,
+        }
+    }
+
+    /// Create an injection before a specific index
+    pub fn before_index(index: usize, message: Message) -> Self {
+        Self {
+            position: InjectionPosition::BeforeIndex(index),
+            message,
+        }
+    }
+
+    /// Create an injection after a specific index
+    pub fn after_index(index: usize, message: Message) -> Self {
+        Self {
+            position: InjectionPosition::AfterIndex(index),
+            message,
+        }
+    }
+}
+
+// ============================================================================
+// MessageQuery - Query specification for message retrieval
+// ============================================================================
+
+/// Query specification for message retrieval with filters and injections.
+///
+/// This is the main interface for filtered message retrieval. Capabilities
+/// contribute to this query through `MessageFilterProvider`.
+///
+/// # Example
+///
+/// ```
+/// use everruns_core::message_filter::{MessageQuery, MessageFilter};
+/// use uuid::Uuid;
+/// use chrono::Utc;
+///
+/// let query = MessageQuery::new(Uuid::now_v7())
+///     .with_filter(MessageFilter::TimeRange {
+///         from: Some(Utc::now() - chrono::Duration::hours(24)),
+///         to: None,
+///     })
+///     .with_limit(100);
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct MessageQuery {
+    /// Session to load messages from
+    pub session_id: Uuid,
+
+    /// Filters to apply (combined with AND)
+    pub filters: Vec<MessageFilter>,
+
+    /// Ephemeral messages to inject after loading
+    pub injections: Vec<InjectedMessage>,
+
+    /// Maximum number of messages to return
+    pub limit: Option<i64>,
+
+    /// Number of messages to skip
+    pub offset: Option<i64>,
+}
+
+impl MessageQuery {
+    /// Create a new query for a session
+    pub fn new(session_id: Uuid) -> Self {
+        Self {
+            session_id,
+            filters: Vec::new(),
+            injections: Vec::new(),
+            limit: None,
+            offset: None,
+        }
+    }
+
+    /// Add a filter to the query
+    pub fn with_filter(mut self, filter: MessageFilter) -> Self {
+        self.filters.push(filter);
+        self
+    }
+
+    /// Add multiple filters to the query
+    pub fn with_filters(mut self, filters: impl IntoIterator<Item = MessageFilter>) -> Self {
+        self.filters.extend(filters);
+        self
+    }
+
+    /// Add an injection to the query
+    pub fn with_injection(mut self, injection: InjectedMessage) -> Self {
+        self.injections.push(injection);
+        self
+    }
+
+    /// Add multiple injections to the query
+    pub fn with_injections(
+        mut self,
+        injections: impl IntoIterator<Item = InjectedMessage>,
+    ) -> Self {
+        self.injections.extend(injections);
+        self
+    }
+
+    /// Set the maximum number of messages to return
+    pub fn with_limit(mut self, limit: i64) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    /// Set the number of messages to skip
+    pub fn with_offset(mut self, offset: i64) -> Self {
+        self.offset = Some(offset);
+        self
+    }
+
+    /// Check if this query has any DB-mappable filters
+    pub fn has_db_filters(&self) -> bool {
+        self.filters
+            .iter()
+            .any(|f| !matches!(f, MessageFilter::Custom(_)))
+    }
+
+    /// Check if this query has any in-memory-only filters
+    pub fn has_custom_filters(&self) -> bool {
+        self.filters
+            .iter()
+            .any(|f| matches!(f, MessageFilter::Custom(_)))
+    }
+
+    /// Check if this query has any injections
+    pub fn has_injections(&self) -> bool {
+        !self.injections.is_empty()
+    }
+
+    /// Apply injections to a message list (in-place)
+    ///
+    /// Injections are applied in order. Note that indices may shift
+    /// as messages are inserted.
+    pub fn apply_injections(&self, messages: &mut Vec<Message>) {
+        // Sort injections by position to handle index shifts correctly
+        // Process End injections last, Start first, then indices in reverse order
+        let mut start_injections = Vec::new();
+        let mut end_injections = Vec::new();
+        let mut index_injections: Vec<_> = Vec::new();
+
+        for inj in &self.injections {
+            match &inj.position {
+                InjectionPosition::Start => start_injections.push(inj.message.clone()),
+                InjectionPosition::End => end_injections.push(inj.message.clone()),
+                InjectionPosition::BeforeIndex(idx) => {
+                    index_injections.push((*idx, true, inj.message.clone()))
+                }
+                InjectionPosition::AfterIndex(idx) => {
+                    index_injections.push((*idx, false, inj.message.clone()))
+                }
+            }
+        }
+
+        // Insert start injections (in reverse order to maintain original order)
+        for msg in start_injections.into_iter().rev() {
+            messages.insert(0, msg);
+        }
+
+        // Sort index injections by index (descending) to avoid index shifts affecting later insertions
+        index_injections.sort_by(|a, b| b.0.cmp(&a.0));
+
+        for (idx, is_before, msg) in index_injections {
+            let insert_idx = if is_before {
+                idx.min(messages.len())
+            } else {
+                (idx + 1).min(messages.len())
+            };
+            messages.insert(insert_idx, msg);
+        }
+
+        // Insert end injections
+        messages.extend(end_injections);
+    }
+}
+
+// ============================================================================
+// MessageFilterProvider - Trait for capabilities to contribute filters
+// ============================================================================
+
+/// Trait for capabilities to contribute message filters.
+///
+/// Implement this trait to modify how messages are retrieved for sessions
+/// using your capability. Filters are applied in capability priority order.
+///
+/// # Example
+///
+/// ```ignore
+/// use everruns_core::message_filter::{MessageFilterProvider, MessageQuery, MessageFilter};
+///
+/// struct RecentMessagesProvider;
+///
+/// impl MessageFilterProvider for RecentMessagesProvider {
+///     fn apply_filters(&self, query: &mut MessageQuery, config: &serde_json::Value) {
+///         // Only load messages from the last 24 hours
+///         let cutoff = chrono::Utc::now() - chrono::Duration::hours(24);
+///         query.filters.push(MessageFilter::TimeRange {
+///             from: Some(cutoff),
+///             to: None,
+///         });
+///     }
+/// }
+/// ```
+pub trait MessageFilterProvider: Send + Sync {
+    /// Modify the message query by adding filters and/or injections.
+    ///
+    /// # Arguments
+    ///
+    /// * `query` - The query to modify (add filters, injections, etc.)
+    /// * `config` - Per-agent capability configuration from the database
+    fn apply_filters(&self, query: &mut MessageQuery, config: &serde_json::Value);
+
+    /// Priority for filter application (lower = earlier).
+    ///
+    /// Filters from lower-priority providers are applied first.
+    /// Default is 0.
+    fn priority(&self) -> i32 {
+        0
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::Message;
+
+    #[test]
+    fn test_message_query_builder() {
+        let session_id = Uuid::now_v7();
+        let query = MessageQuery::new(session_id)
+            .with_filter(MessageFilter::EventTypes(vec!["message.user".to_string()]))
+            .with_limit(50)
+            .with_offset(10);
+
+        assert_eq!(query.session_id, session_id);
+        assert_eq!(query.filters.len(), 1);
+        assert_eq!(query.limit, Some(50));
+        assert_eq!(query.offset, Some(10));
+    }
+
+    #[test]
+    fn test_message_query_has_filters() {
+        let session_id = Uuid::now_v7();
+
+        let query_with_db_filter =
+            MessageQuery::new(session_id).with_filter(MessageFilter::Search("hello".to_string()));
+        assert!(query_with_db_filter.has_db_filters());
+        assert!(!query_with_db_filter.has_custom_filters());
+
+        let query_with_custom =
+            MessageQuery::new(session_id).with_filter(MessageFilter::Custom(Arc::new(|_| true)));
+        assert!(!query_with_custom.has_db_filters());
+        assert!(query_with_custom.has_custom_filters());
+    }
+
+    #[test]
+    fn test_injection_at_start() {
+        let session_id = Uuid::now_v7();
+        let injected = Message::system("Injected at start");
+
+        let query = MessageQuery::new(session_id)
+            .with_injection(InjectedMessage::at_start(injected.clone()));
+
+        let mut messages = vec![Message::user("First"), Message::user("Second")];
+
+        query.apply_injections(&mut messages);
+
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[0].text(), Some("Injected at start"));
+        assert_eq!(messages[1].text(), Some("First"));
+    }
+
+    #[test]
+    fn test_injection_at_end() {
+        let session_id = Uuid::now_v7();
+        let injected = Message::system("Injected at end");
+
+        let query =
+            MessageQuery::new(session_id).with_injection(InjectedMessage::at_end(injected.clone()));
+
+        let mut messages = vec![Message::user("First"), Message::user("Second")];
+
+        query.apply_injections(&mut messages);
+
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[2].text(), Some("Injected at end"));
+    }
+
+    #[test]
+    fn test_injection_before_index() {
+        let session_id = Uuid::now_v7();
+        let injected = Message::system("Injected before index 1");
+
+        let query = MessageQuery::new(session_id)
+            .with_injection(InjectedMessage::before_index(1, injected.clone()));
+
+        let mut messages = vec![
+            Message::user("First"),
+            Message::user("Second"),
+            Message::user("Third"),
+        ];
+
+        query.apply_injections(&mut messages);
+
+        assert_eq!(messages.len(), 4);
+        assert_eq!(messages[0].text(), Some("First"));
+        assert_eq!(messages[1].text(), Some("Injected before index 1"));
+        assert_eq!(messages[2].text(), Some("Second"));
+    }
+
+    #[test]
+    fn test_multiple_injections() {
+        let session_id = Uuid::now_v7();
+
+        let query = MessageQuery::new(session_id)
+            .with_injection(InjectedMessage::at_start(Message::system("Start")))
+            .with_injection(InjectedMessage::at_end(Message::system("End")));
+
+        let mut messages = vec![Message::user("Middle")];
+
+        query.apply_injections(&mut messages);
+
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[0].text(), Some("Start"));
+        assert_eq!(messages[1].text(), Some("Middle"));
+        assert_eq!(messages[2].text(), Some("End"));
+    }
+
+    #[test]
+    fn test_filter_debug() {
+        let filter = MessageFilter::TimeRange {
+            from: None,
+            to: None,
+        };
+        let debug_str = format!("{:?}", filter);
+        assert!(debug_str.contains("TimeRange"));
+
+        let custom = MessageFilter::Custom(Arc::new(|_| true));
+        let debug_str = format!("{:?}", custom);
+        assert!(debug_str.contains("Custom"));
+        assert!(debug_str.contains("<fn>"));
+    }
+}

--- a/crates/core/src/message_filter.rs
+++ b/crates/core/src/message_filter.rs
@@ -487,4 +487,253 @@ mod tests {
         assert!(debug_str.contains("Custom"));
         assert!(debug_str.contains("<fn>"));
     }
+
+    // ========================================================================
+    // Additional edge case tests
+    // ========================================================================
+
+    #[test]
+    fn test_with_filters_multiple() {
+        let session_id = Uuid::now_v7();
+        let query = MessageQuery::new(session_id).with_filters([
+            MessageFilter::EventTypes(vec!["message.user".to_string()]),
+            MessageFilter::Search("hello".to_string()),
+        ]);
+
+        assert_eq!(query.filters.len(), 2);
+        assert!(query.has_db_filters());
+        assert!(!query.has_custom_filters());
+    }
+
+    #[test]
+    fn test_with_injections_multiple() {
+        let session_id = Uuid::now_v7();
+        let query = MessageQuery::new(session_id).with_injections([
+            InjectedMessage::at_start(Message::system("First")),
+            InjectedMessage::at_end(Message::system("Last")),
+        ]);
+
+        assert_eq!(query.injections.len(), 2);
+        assert!(query.has_injections());
+    }
+
+    #[test]
+    fn test_injection_after_index() {
+        let session_id = Uuid::now_v7();
+        let injected = Message::system("Injected after index 0");
+
+        let query = MessageQuery::new(session_id)
+            .with_injection(InjectedMessage::after_index(0, injected.clone()));
+
+        let mut messages = vec![
+            Message::user("First"),
+            Message::user("Second"),
+            Message::user("Third"),
+        ];
+
+        query.apply_injections(&mut messages);
+
+        assert_eq!(messages.len(), 4);
+        assert_eq!(messages[0].text(), Some("First"));
+        assert_eq!(messages[1].text(), Some("Injected after index 0"));
+        assert_eq!(messages[2].text(), Some("Second"));
+        assert_eq!(messages[3].text(), Some("Third"));
+    }
+
+    #[test]
+    fn test_injection_into_empty_list() {
+        let session_id = Uuid::now_v7();
+
+        let query = MessageQuery::new(session_id)
+            .with_injection(InjectedMessage::at_start(Message::system("Start")))
+            .with_injection(InjectedMessage::at_end(Message::system("End")));
+
+        let mut messages: Vec<Message> = vec![];
+
+        query.apply_injections(&mut messages);
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].text(), Some("Start"));
+        assert_eq!(messages[1].text(), Some("End"));
+    }
+
+    #[test]
+    fn test_injection_before_index_out_of_bounds() {
+        let session_id = Uuid::now_v7();
+        let injected = Message::system("Injected before index 10");
+
+        // Index 10 is out of bounds for a 2-element list
+        let query = MessageQuery::new(session_id)
+            .with_injection(InjectedMessage::before_index(10, injected.clone()));
+
+        let mut messages = vec![Message::user("First"), Message::user("Second")];
+
+        query.apply_injections(&mut messages);
+
+        // Should insert at the end (min(10, 2) = 2)
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[2].text(), Some("Injected before index 10"));
+    }
+
+    #[test]
+    fn test_injection_after_index_out_of_bounds() {
+        let session_id = Uuid::now_v7();
+        let injected = Message::system("Injected after index 10");
+
+        // Index 10 is out of bounds for a 2-element list
+        let query = MessageQuery::new(session_id)
+            .with_injection(InjectedMessage::after_index(10, injected.clone()));
+
+        let mut messages = vec![Message::user("First"), Message::user("Second")];
+
+        query.apply_injections(&mut messages);
+
+        // Should insert at the end (min(11, 2) = 2)
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[2].text(), Some("Injected after index 10"));
+    }
+
+    #[test]
+    fn test_multiple_start_injections_preserve_order() {
+        let session_id = Uuid::now_v7();
+
+        // Multiple start injections should maintain their order
+        let query = MessageQuery::new(session_id)
+            .with_injection(InjectedMessage::at_start(Message::system("First injected")))
+            .with_injection(InjectedMessage::at_start(Message::system(
+                "Second injected",
+            )));
+
+        let mut messages = vec![Message::user("Original")];
+
+        query.apply_injections(&mut messages);
+
+        assert_eq!(messages.len(), 3);
+        // Both should be at the start, first one should come first
+        assert_eq!(messages[0].text(), Some("First injected"));
+        assert_eq!(messages[1].text(), Some("Second injected"));
+        assert_eq!(messages[2].text(), Some("Original"));
+    }
+
+    #[test]
+    fn test_combined_db_and_custom_filters() {
+        let session_id = Uuid::now_v7();
+
+        let query = MessageQuery::new(session_id)
+            .with_filter(MessageFilter::Search("hello".to_string()))
+            .with_filter(MessageFilter::Custom(Arc::new(|msg| {
+                msg.role == crate::MessageRole::User
+            })));
+
+        assert!(query.has_db_filters());
+        assert!(query.has_custom_filters());
+        assert_eq!(query.filters.len(), 2);
+    }
+
+    #[test]
+    fn test_filter_exclude_ids() {
+        let id1 = Uuid::now_v7();
+        let id2 = Uuid::now_v7();
+
+        let filter = MessageFilter::ExcludeIds(vec![id1, id2]);
+        let debug_str = format!("{:?}", filter);
+        assert!(debug_str.contains("ExcludeIds"));
+    }
+
+    #[test]
+    fn test_filter_include_ids() {
+        let id1 = Uuid::now_v7();
+        let id2 = Uuid::now_v7();
+
+        let filter = MessageFilter::IncludeIds(vec![id1, id2]);
+        let debug_str = format!("{:?}", filter);
+        assert!(debug_str.contains("IncludeIds"));
+    }
+
+    #[test]
+    fn test_filter_tool_name() {
+        let filter = MessageFilter::ToolName("get_weather".to_string());
+        let debug_str = format!("{:?}", filter);
+        assert!(debug_str.contains("ToolName"));
+        assert!(debug_str.contains("get_weather"));
+    }
+
+    #[test]
+    fn test_query_default() {
+        let query = MessageQuery::default();
+        assert_eq!(query.session_id, Uuid::nil());
+        assert!(query.filters.is_empty());
+        assert!(query.injections.is_empty());
+        assert_eq!(query.limit, None);
+        assert_eq!(query.offset, None);
+    }
+
+    // ========================================================================
+    // MessageFilterProvider tests
+    // ========================================================================
+
+    struct TestFilterProvider {
+        priority: i32,
+    }
+
+    impl MessageFilterProvider for TestFilterProvider {
+        fn apply_filters(&self, query: &mut MessageQuery, config: &serde_json::Value) {
+            // Add a filter based on config
+            if let Some(search) = config.get("search").and_then(|v| v.as_str()) {
+                query
+                    .filters
+                    .push(MessageFilter::Search(search.to_string()));
+            }
+        }
+
+        fn priority(&self) -> i32 {
+            self.priority
+        }
+    }
+
+    #[test]
+    fn test_filter_provider_apply() {
+        let provider = TestFilterProvider { priority: 0 };
+        let session_id = Uuid::now_v7();
+        let mut query = MessageQuery::new(session_id);
+
+        let config = serde_json::json!({ "search": "hello" });
+        provider.apply_filters(&mut query, &config);
+
+        assert_eq!(query.filters.len(), 1);
+        assert!(matches!(&query.filters[0], MessageFilter::Search(s) if s == "hello"));
+    }
+
+    #[test]
+    fn test_filter_provider_priority() {
+        let low_priority = TestFilterProvider { priority: -10 };
+        let high_priority = TestFilterProvider { priority: 10 };
+        let default_priority = TestFilterProvider { priority: 0 };
+
+        assert_eq!(low_priority.priority(), -10);
+        assert_eq!(high_priority.priority(), 10);
+        assert_eq!(default_priority.priority(), 0);
+    }
+
+    #[test]
+    fn test_injection_position_debug() {
+        // Test debug representation of InjectionPosition variants
+        let start = InjectionPosition::Start;
+        let debug = format!("{:?}", start);
+        assert!(debug.contains("Start"));
+
+        let end = InjectionPosition::End;
+        let debug = format!("{:?}", end);
+        assert!(debug.contains("End"));
+
+        let before = InjectionPosition::BeforeIndex(5);
+        let debug = format!("{:?}", before);
+        assert!(debug.contains("BeforeIndex"));
+        assert!(debug.contains("5"));
+
+        let after = InjectionPosition::AfterIndex(3);
+        let debug = format!("{:?}", after);
+        assert!(debug.contains("AfterIndex"));
+        assert!(debug.contains("3"));
+    }
 }

--- a/crates/core/src/message_retriever.rs
+++ b/crates/core/src/message_retriever.rs
@@ -9,6 +9,7 @@ use uuid::Uuid;
 
 use crate::error::Result;
 use crate::message::{ContentPart, Controls, Message, MessageRole};
+use crate::message_filter::MessageQuery;
 
 // ============================================================================
 // InputMessage - Input structure for message creation
@@ -80,6 +81,20 @@ pub trait MessageRetriever: Send + Sync {
 
     /// Load all messages for a session
     async fn load(&self, session_id: Uuid) -> Result<Vec<Message>>;
+
+    /// Load messages with filters and injections applied.
+    ///
+    /// This method supports the composable filter system where capabilities
+    /// can contribute filters that modify how messages are loaded.
+    ///
+    /// Default implementation calls `load()` and ignores the query filters,
+    /// maintaining backward compatibility for implementations that don't
+    /// support filtering.
+    async fn load_filtered(&self, query: MessageQuery) -> Result<Vec<Message>> {
+        // Default: load all messages for the session, ignoring filters
+        // Implementations should override this to support filtering
+        self.load(query.session_id).await
+    }
 
     /// Load messages with pagination
     async fn load_page(

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -195,10 +195,13 @@ pub trait Capability: Send + Sync {
     fn category(&self) -> Option<&str> { None }
     fn mounts(&self) -> Vec<MountPoint> { vec![] }
     fn dependencies(&self) -> Vec<&'static str> { vec![] }
+    fn message_filter_provider(&self) -> Option<Arc<dyn MessageFilterProvider>> { None }
 }
 ```
 
 The `CapabilityRegistry` in core holds all registered capability implementations. The API layer converts trait objects to DTOs using `Capability::from_core()`.
+
+**Note**: The `message_filter_provider()` method returns an optional filter provider that can modify how messages are retrieved for sessions using this capability. See the [Message Filters](#message-filters) section for details.
 
 ### Capability Dependencies
 
@@ -954,9 +957,143 @@ This capability is experimental and only available in development environments d
 - Resource management considerations
 - API stability concerns
 
+### Message Filters
+
+Capabilities can contribute message filters that modify how messages are retrieved from the database. This enables features like:
+
+- **Time-based filtering**: Load messages from a specific time range
+- **Event type filtering**: Filter by message type (user, agent, tool result)
+- **Tool name filtering**: Filter tool results by specific tool names
+- **Full-text search**: Search message content
+- **Ephemeral message injection**: Add system reminders or summaries without persistence
+
+#### How Message Filters Work
+
+1. **Filter Contribution**: Capabilities implement `message_filter_provider()` returning a `MessageFilterProvider`
+2. **Priority Ordering**: Providers are sorted by priority (lower = earlier)
+3. **Query Building**: Filters are combined into a `MessageQuery` and applied to message retrieval
+4. **DB Mapping**: Most filters map directly to SQL WHERE clauses for efficiency
+5. **In-Memory Fallback**: Custom predicates use Rust closures for complex filtering
+
+#### MessageFilter Types
+
+| Filter | Description | SQL Mapping |
+|--------|-------------|-------------|
+| `TimeRange { from, to }` | Filter by timestamp range | `WHERE created_at >= $from AND created_at <= $to` |
+| `EventTypes(Vec<String>)` | Whitelist event types | `WHERE event_type = ANY($types)` |
+| `ToolName(String)` | Filter tool results by name | `WHERE event_type = 'tool.call_completed' AND data->>'tool_name' = $name` |
+| `Search(String)` | Full-text search in content | `WHERE data::text ILIKE '%' || $query || '%'` |
+| `ExcludeIds(Vec<Uuid>)` | Exclude specific message IDs | `WHERE id != ALL($ids)` |
+| `IncludeIds(Vec<Uuid>)` | Include only specific IDs | `WHERE id = ANY($ids)` |
+| `Custom(Arc<dyn Fn(&Message) -> bool>)` | In-memory predicate | Applied after DB query |
+
+#### MessageFilterProvider Trait
+
+```rust
+pub trait MessageFilterProvider: Send + Sync {
+    /// Modify the message query by adding filters and/or injections.
+    fn apply_filters(&self, query: &mut MessageQuery, config: &serde_json::Value);
+
+    /// Priority for filter application (lower = earlier). Default is 0.
+    fn priority(&self) -> i32 { 0 }
+}
+```
+
+#### Message Injection
+
+Ephemeral messages can be injected into the result set without persistence:
+
+```rust
+pub enum InjectionPosition {
+    Start,           // Before all messages
+    End,             // After all messages
+    BeforeIndex(usize),
+    AfterIndex(usize),
+}
+
+pub struct InjectedMessage {
+    pub position: InjectionPosition,
+    pub message: Message,
+}
+```
+
+Injections are applied after filtering and are useful for:
+- Adding conversation summaries at the start
+- Inserting system reminders before recent context
+- Appending instructions or context
+
+#### MessageQuery Builder
+
+```rust
+let query = MessageQuery::new(session_id)
+    .with_filter(MessageFilter::TimeRange {
+        from: Some(Utc::now() - Duration::hours(24)),
+        to: None,
+    })
+    .with_filter(MessageFilter::EventTypes(vec!["message.user".to_string()]))
+    .with_injection(InjectedMessage::at_start(Message::system("Summary: ...")))
+    .with_limit(100);
+```
+
+#### Example Capability with Message Filter
+
+```rust
+impl Capability for RecentMessagesCapability {
+    fn id(&self) -> &str { "recent_messages" }
+    fn name(&self) -> &str { "Recent Messages" }
+    fn description(&self) -> &str { "Only load messages from the last 24 hours" }
+
+    fn message_filter_provider(&self) -> Option<Arc<dyn MessageFilterProvider>> {
+        Some(Arc::new(RecentMessagesProvider))
+    }
+}
+
+struct RecentMessagesProvider;
+
+impl MessageFilterProvider for RecentMessagesProvider {
+    fn apply_filters(&self, query: &mut MessageQuery, config: &serde_json::Value) {
+        // Check config for custom hours setting
+        let hours = config.get("hours")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(24);
+
+        let cutoff = Utc::now() - Duration::hours(hours as i64);
+        query.filters.push(MessageFilter::TimeRange {
+            from: Some(cutoff),
+            to: None,
+        });
+    }
+
+    fn priority(&self) -> i32 {
+        -10  // Run early to reduce data loaded
+    }
+}
+```
+
+#### Filter Application Flow
+
+1. **Collect Providers**: During capability resolution, filter providers are collected from enabled capabilities
+2. **Sort by Priority**: Providers are sorted (lower priority values first)
+3. **Build Query**: Each provider modifies the `MessageQuery` in priority order
+4. **Execute Query**: The query is executed against the message store
+5. **Apply Custom Filters**: In-memory predicates filter the results
+6. **Apply Injections**: Ephemeral messages are inserted at their specified positions
+
+#### Design Decisions
+
+| Question | Decision |
+|----------|----------|
+| Where are filters defined? | Capabilities implement `message_filter_provider()` |
+| How are they combined? | AND semantics - all filters must match |
+| Order of application? | By `priority()` value (lower = earlier) |
+| Can filters be stacked? | Yes - multiple capabilities can each contribute filters |
+| Database efficiency? | Most filters map to SQL; only `Custom` requires in-memory filtering |
+| DEV_MODE parity? | In-memory storage implements the same filter semantics |
+
 ### Extension Points (Future)
 
 1. **Custom Capabilities**: User-defined capabilities with custom tools
 2. **Conflict Resolution**: Handle tool name conflicts between capabilities
 3. **Capability Versioning**: Track capability API versions for compatibility
 4. **Dynamic Mount Sources**: External file sources (URLs, S3, etc.)
+5. **OR Filter Semantics**: Support for OR combinations of filters


### PR DESCRIPTION
## What

Adds a composable filter system for message retrieval that allows capabilities to modify how messages are loaded from the database.

## Why

To support features like:
- Time-based filtering (recent messages only)
- Event/message type filtering
- Tool-specific filtering (only results from specific tools like `todo_list`)
- Full-text search across messages
- Ephemeral message injection (summaries, context reminders)

These modifications need to be stackable (capability A adds filters, then capability B adds more) and mapped to the DB layer where possible for efficiency.

## How

### New Types (in `everruns-core`)

- **MessageFilter enum**: DB-mappable filter specifications
  - `TimeRange { from, to }` - Filter by timestamp
  - `EventTypes(Vec<String>)` - Whitelist event types
  - `ToolName(String)` - Filter tool results by name
  - `Search(String)` - Full-text search in message content
  - `ExcludeIds(Vec<Uuid>)` / `IncludeIds(Vec<Uuid>)` - ID filtering
  - `Custom(Arc<dyn Fn(&Message) -> bool>)` - In-memory predicate fallback

- **MessageQuery**: Builder for filtered queries with limit/offset/injections

- **InjectedMessage**: Ephemeral messages to inject at Start/End/BeforeIndex/AfterIndex

- **MessageFilterProvider trait**: Capabilities implement to contribute filters

### Capability Integration

- New `Capability::message_filter_provider()` method returns an optional filter provider
- `collect_capabilities_with_configs()` collects filter providers with per-agent configs
- `CollectedCapabilities::apply_message_filters()` applies all providers to a query

### Storage Layer

- `list_message_events_filtered(MessageQuery)` in both PostgreSQL and in-memory backends
- PostgreSQL: Dynamic SQL query building with type-safe bindings
- In-memory: Rust predicates for DEV_MODE parity

### MessageRetriever

- New `load_filtered(MessageQuery)` method with default fallback to `load()`
- `DbMessageRetriever` implementation applies DB filters, then custom filters, then injections

## Risk

- **Low** - Additive API changes, no breaking changes to existing code
- Filter providers default to None, so existing capabilities work unchanged
- `load_filtered` has a default implementation that falls back to `load`

## Checklist

- [x] Unit tests for MessageQuery and injection logic
- [x] Clippy passes
- [x] Format check passes
- [ ] Integration tests (require running API server)
- [x] Backward compatibility maintained