### PR TITLE
fix(scripts): fetch github remote main branch for gh pr merge

### DIFF
--- a/scripts/init-cloud-env.sh
+++ b/scripts/init-cloud-env.sh
@@ -140,6 +140,12 @@ configure_gh_repo() {
             info "Adding 'github' remote: $github_url"
             git remote add github "$github_url"
         fi
+        # Fetch main branch so github/main ref exists (needed for gh pr merge)
+        # Always fetch in case remote exists but was never fetched
+        if ! git rev-parse --verify github/main &>/dev/null; then
+            info "Fetching main branch from github remote..."
+            git fetch github main 2>/dev/null || warn "Failed to fetch github/main"
+        fi
         # Use the github remote for set-default
         gh repo set-default github 2>/dev/null && info "gh default repo set: $repo" || warn "Failed to set default repo"
     else


### PR DESCRIPTION
## What
Fetch the `main` branch from the `github` remote after adding it in `init-cloud-env.sh`.

## Why
When `gh pr merge --delete-branch` completes, it tries to update the local `main` branch using `github/main` as reference. If the remote was never fetched, this fails with:

```
fatal: 'github/main' is not a commit and a branch 'main' cannot be created from it
```

## How
After adding the `github` remote, fetch the main branch so `github/main` ref exists. Only fetches if the ref doesn't already exist to avoid unnecessary network calls.

## Risk
- Low
- Only affects cloud/proxy environments where origin isn't github.com