### PR TITLE
feat(core): standardize ID schema with Stripe-style prefixed IDs

### DIFF
--- a/.claude/skills/smoke-test/scripts/tool-calling-tests.sh
+++ b/.claude/skills/smoke-test/scripts/tool-calling-tests.sh
@@ -23,6 +23,9 @@ VERBOSE="${VERBOSE:-false}"
 SKIP_CLEANUP="${SKIP_CLEANUP:-false}"
 WAIT_TIME=15
 
+# Default organization ID (for org-scoped endpoints)
+DEFAULT_ORG="org_00000000000000000000000000000001"
+
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -88,7 +91,7 @@ cleanup() {
     log_info "Cleaning up test agents..."
     for agent_id in "${AGENTS_TO_CLEANUP[@]}"; do
         log_verbose "Deleting agent: $agent_id"
-        curl -s -X DELETE "$API_URL/v1/agents/$agent_id" > /dev/null 2>&1 || true
+        curl -s -X DELETE "$API_URL/v1/orgs/$DEFAULT_ORG/agents/$agent_id" > /dev/null 2>&1 || true
     done
     log_info "Cleanup complete"
 }
@@ -100,13 +103,13 @@ setup_llm_provider() {
     log_info "Checking LLM provider configuration..."
 
     # Check if there's already a default model
-    local providers=$(curl -s "$API_URL/v1/llm-providers" | jq '.data // []')
+    local providers=$(curl -s "$API_URL/v1/orgs/$DEFAULT_ORG/llm-providers" | jq '.data // []')
     local provider_count=$(echo "$providers" | jq 'length')
 
     if [ "$provider_count" -gt 0 ]; then
         # Check if any provider has a default model
         for provider_id in $(echo "$providers" | jq -r '.[].id'); do
-            local models=$(curl -s "$API_URL/v1/llm-providers/$provider_id/models" | jq '.data // []')
+            local models=$(curl -s "$API_URL/v1/orgs/$DEFAULT_ORG/llm-providers/$provider_id/models" | jq '.data // []')
             local has_default=$(echo "$models" | jq '[.[] | select(.is_default == true)] | length')
             if [ "$has_default" -gt 0 ]; then
                 log_info "Found existing default model, skipping LLM setup"
@@ -140,7 +143,7 @@ setup_llm_provider() {
     fi
 
     # Create provider
-    local provider_response=$(curl -s -X POST "$API_URL/v1/llm-providers" \
+    local provider_response=$(curl -s -X POST "$API_URL/v1/orgs/$DEFAULT_ORG/llm-providers" \
         -H "Content-Type: application/json" \
         -d "{
             \"name\": \"Smoke Test Provider\",
@@ -158,7 +161,7 @@ setup_llm_provider() {
     log_verbose "Created LLM provider: $LLM_PROVIDER_ID"
 
     # Create default model
-    local model_response=$(curl -s -X POST "$API_URL/v1/llm-providers/$LLM_PROVIDER_ID/models" \
+    local model_response=$(curl -s -X POST "$API_URL/v1/orgs/$DEFAULT_ORG/llm-providers/$LLM_PROVIDER_ID/models" \
         -H "Content-Type: application/json" \
         -d "{
             \"model_id\": \"$model_id\",
@@ -207,10 +210,11 @@ create_agent() {
 
     local caps_json="[]"
     if [ ${#capabilities[@]} -gt 0 ]; then
-        caps_json=$(printf '%s\n' "${capabilities[@]}" | jq -R . | jq -s .)
+        # Format capabilities as [{"ref": "cap_id", "config": {}}, ...]
+        caps_json=$(printf '%s\n' "${capabilities[@]}" | jq -R '{ref: ., config: {}}' | jq -s .)
     fi
 
-    local response=$(curl -s -X POST "$API_URL/v1/agents" \
+    local response=$(curl -s -X POST "$API_URL/v1/orgs/$DEFAULT_ORG/agents" \
         -H "Content-Type: application/json" \
         -d "{
             \"name\": \"$name\",
@@ -235,7 +239,7 @@ create_session() {
     local agent_id="$1"
     local title="$2"
 
-    local response=$(curl -s -X POST "$API_URL/v1/agents/$agent_id/sessions" \
+    local response=$(curl -s -X POST "$API_URL/v1/orgs/$DEFAULT_ORG/agents/$agent_id/sessions" \
         -H "Content-Type: application/json" \
         -d "{\"title\": \"$title\"}")
 
@@ -249,7 +253,7 @@ send_message() {
     local message="$3"
     local wait_seconds="${4:-$WAIT_TIME}"
 
-    curl -s -X POST "$API_URL/v1/agents/$agent_id/sessions/$session_id/messages" \
+    curl -s -X POST "$API_URL/v1/orgs/$DEFAULT_ORG/agents/$agent_id/sessions/$session_id/messages" \
         -H "Content-Type: application/json" \
         -d "{\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"$message\"}]}}" > /dev/null
 
@@ -262,7 +266,7 @@ get_messages() {
     local agent_id="$1"
     local session_id="$2"
 
-    curl -s "$API_URL/v1/agents/$agent_id/sessions/$session_id/messages"
+    curl -s "$API_URL/v1/orgs/$DEFAULT_ORG/agents/$agent_id/sessions/$session_id/messages"
 }
 
 # Helper to get events
@@ -270,7 +274,7 @@ get_events() {
     local agent_id="$1"
     local session_id="$2"
 
-    curl -s "$API_URL/v1/agents/$agent_id/sessions/$session_id/events"
+    curl -s "$API_URL/v1/orgs/$DEFAULT_ORG/agents/$agent_id/sessions/$session_id/events"
 }
 
 # ============================================================================
@@ -310,12 +314,12 @@ test_single_tool() {
     local messages=$(get_messages "$agent_id" "$session_id")
 
     # Check for tool calls
-    local tool_calls=$(echo "$messages" | jq '[.data[] | select(.tool_calls != null) | .tool_calls[]] | length')
+    local tool_calls=$(echo "$messages" | jq '[.data[].content[]? | select(.type == "tool_call")] | length')
     log_verbose "Tool calls found: $tool_calls"
 
     if [ "$tool_calls" -ge 1 ]; then
         # Check for add tool
-        local add_called=$(echo "$messages" | jq '[.data[] | select(.tool_calls != null) | .tool_calls[] | select(.name == "add")] | length')
+        local add_called=$(echo "$messages" | jq '[.data[].content[]? | select(.type == "tool_call") | select(.name == "add")] | length')
         if [ "$add_called" -ge 1 ]; then
             return 0
         else
@@ -351,8 +355,8 @@ test_multiple_tools() {
     local messages=$(get_messages "$agent_id" "$session_id")
 
     # Should have called at least 2 different tools
-    local add_calls=$(echo "$messages" | jq '[.data[] | select(.tool_calls != null) | .tool_calls[] | select(.name == "add")] | length')
-    local multiply_calls=$(echo "$messages" | jq '[.data[] | select(.tool_calls != null) | .tool_calls[] | select(.name == "multiply")] | length')
+    local add_calls=$(echo "$messages" | jq '[.data[].content[]? | select(.type == "tool_call") | select(.name == "add")] | length')
+    local multiply_calls=$(echo "$messages" | jq '[.data[].content[]? | select(.type == "tool_call") | select(.name == "multiply")] | length')
 
     log_verbose "Add calls: $add_calls, Multiply calls: $multiply_calls"
 
@@ -387,8 +391,8 @@ test_weather_tools() {
     local messages=$(get_messages "$agent_id" "$session_id")
 
     # Should have called both get_weather and get_forecast
-    local weather_calls=$(echo "$messages" | jq '[.data[] | select(.tool_calls != null) | .tool_calls[] | select(.name == "get_weather")] | length')
-    local forecast_calls=$(echo "$messages" | jq '[.data[] | select(.tool_calls != null) | .tool_calls[] | select(.name == "get_forecast")] | length')
+    local weather_calls=$(echo "$messages" | jq '[.data[].content[]? | select(.type == "tool_call") | select(.name == "get_weather")] | length')
+    local forecast_calls=$(echo "$messages" | jq '[.data[].content[]? | select(.type == "tool_call") | select(.name == "get_forecast")] | length')
 
     log_verbose "Weather calls: $weather_calls, Forecast calls: $forecast_calls"
 
@@ -423,12 +427,12 @@ test_parallel_tools() {
     local messages=$(get_messages "$agent_id" "$session_id")
 
     # Should have made multiple weather calls
-    local weather_calls=$(echo "$messages" | jq '[.data[] | select(.tool_calls != null) | .tool_calls[] | select(.name == "get_weather")] | length')
+    local weather_calls=$(echo "$messages" | jq '[.data[].content[]? | select(.type == "tool_call") | select(.name == "get_weather")] | length')
 
     log_verbose "Weather calls: $weather_calls"
 
     # Check if there's an assistant message with multiple tool calls (parallel execution)
-    local parallel_msg=$(echo "$messages" | jq '[.data[] | select(.tool_calls != null) | select((.tool_calls | length) > 1)] | length')
+    local parallel_msg=$(echo "$messages" | jq '[.data[] | select(([.content[]? | select(.type == "tool_call")] | length) > 1)] | length')
 
     log_verbose "Messages with multiple parallel calls: $parallel_msg"
 
@@ -468,8 +472,8 @@ test_combined_capabilities() {
     local messages=$(get_messages "$agent_id" "$session_id")
 
     # Should have called both weather and math tools
-    local weather_calls=$(echo "$messages" | jq '[.data[] | select(.tool_calls != null) | .tool_calls[] | select(.name == "get_weather")] | length')
-    local add_calls=$(echo "$messages" | jq '[.data[] | select(.tool_calls != null) | .tool_calls[] | select(.name == "add")] | length')
+    local weather_calls=$(echo "$messages" | jq '[.data[].content[]? | select(.type == "tool_call") | select(.name == "get_weather")] | length')
+    local add_calls=$(echo "$messages" | jq '[.data[].content[]? | select(.type == "tool_call") | select(.name == "add")] | length')
 
     log_verbose "Weather calls: $weather_calls, Add calls: $add_calls"
 
@@ -504,13 +508,13 @@ test_tool_error_handling() {
     local messages=$(get_messages "$agent_id" "$session_id")
 
     # Check for divide tool call
-    local divide_calls=$(echo "$messages" | jq '[.data[] | select(.tool_calls != null) | .tool_calls[] | select(.name == "divide")] | length')
+    local divide_calls=$(echo "$messages" | jq '[.data[].content[]? | select(.type == "tool_call") | select(.name == "divide")] | length')
 
     log_verbose "Divide calls: $divide_calls"
 
     if [ "$divide_calls" -ge 1 ]; then
         # Check for error in tool results
-        local errors=$(echo "$messages" | jq '[.data[] | select(.tool_results != null) | .tool_results[] | select(.error != null)] | length')
+        local errors=$(echo "$messages" | jq '[.data[].content[]? | select(.type == "tool_result") | select(.error != null)] | length')
         log_verbose "Tool errors: $errors"
 
         if [ "$errors" -ge 1 ]; then
@@ -531,7 +535,7 @@ test_tool_error_handling() {
 test_webfetch_capability() {
     log_verbose "Checking WebFetch capability is available..."
 
-    local response=$(curl -s "$API_URL/v1/capabilities")
+    local response=$(curl -s "$API_URL/v1/orgs/$DEFAULT_ORG/capabilities")
     local web_fetch=$(echo "$response" | jq '.data[] | select(.id == "web_fetch")')
 
     if [ -z "$web_fetch" ] || [ "$web_fetch" = "null" ]; then
@@ -556,7 +560,7 @@ test_capability_detail() {
     log_verbose "Testing capability detail endpoint..."
 
     # Test with test_math capability which has system_prompt and tools
-    local response=$(curl -s "$API_URL/v1/capabilities/test_math")
+    local response=$(curl -s "$API_URL/v1/orgs/$DEFAULT_ORG/capabilities/test_math")
 
     local id=$(echo "$response" | jq -r '.id')
     if [ "$id" != "test_math" ]; then
@@ -636,7 +640,7 @@ test_webfetch_tool() {
     local messages=$(get_messages "$agent_id" "$session_id")
 
     # Check for tool calls
-    local tool_calls=$(echo "$messages" | jq '[.data[] | select(.tool_calls != null) | .tool_calls[] | select(.name == "web_fetch")] | length')
+    local tool_calls=$(echo "$messages" | jq '[.data[].content[]? | select(.type == "tool_call") | select(.name == "web_fetch")] | length')
     log_verbose "web_fetch tool calls found: $tool_calls"
 
     if [ "$tool_calls" -ge 1 ]; then
@@ -691,7 +695,7 @@ test_events_sync() {
     fi
 
     # Check for message.user event
-    local user_events=$(echo "$events" | jq '[.data[] | select(.event_type == "message.user")] | length')
+    local user_events=$(echo "$events" | jq '[.data[] | select(.type == "message.user")] | length')
     if [ "$user_events" -lt 1 ]; then
         log_error "Expected at least 1 message.user event"
         return 1
@@ -699,20 +703,20 @@ test_events_sync() {
     log_verbose "User events: $user_events"
 
     # Check for message.agent event
-    local agent_events=$(echo "$events" | jq '[.data[] | select(.event_type == "message.agent")] | length')
+    local agent_events=$(echo "$events" | jq '[.data[] | select(.type == "message.agent")] | length')
     if [ "$agent_events" -lt 1 ]; then
         log_error "Expected at least 1 message.agent event"
         return 1
     fi
     log_verbose "Agent events: $agent_events"
 
-    # Verify event data contains message info
-    local first_user_event=$(echo "$events" | jq '.data[] | select(.event_type == "message.user") | .data')
-    local has_message_id=$(echo "$first_user_event" | jq 'has("message_id")')
+    # Verify event data contains message info (nested under data.message)
+    local first_user_event=$(echo "$events" | jq '.data[] | select(.type == "message.user") | .data.message')
+    local has_message_id=$(echo "$first_user_event" | jq 'has("id")')
     local has_content=$(echo "$first_user_event" | jq 'has("content")')
 
     if [ "$has_message_id" != "true" ] || [ "$has_content" != "true" ]; then
-        log_error "Event data missing required fields (message_id, content)"
+        log_error "Event data missing required fields (message.id, message.content)"
         return 1
     fi
 
@@ -726,7 +730,7 @@ test_events_sync() {
 test_current_time_capability() {
     log_verbose "Checking CurrentTime capability is available..."
 
-    local response=$(curl -s "$API_URL/v1/capabilities")
+    local response=$(curl -s "$API_URL/v1/orgs/$DEFAULT_ORG/capabilities")
     local current_time=$(echo "$response" | jq '.data[] | select(.id == "current_time")')
 
     if [ -z "$current_time" ] || [ "$current_time" = "null" ]; then
@@ -773,22 +777,22 @@ test_dad_joke_agent() {
     local messages=$(get_messages "$agent_id" "$session_id")
 
     # Check for tool calls
-    local tool_calls=$(echo "$messages" | jq '[.data[] | select(.tool_calls != null) | .tool_calls[]] | length')
+    local tool_calls=$(echo "$messages" | jq '[.data[].content[]? | select(.type == "tool_call")] | length')
     log_verbose "Tool calls found: $tool_calls"
 
     if [ "$tool_calls" -ge 1 ]; then
         # Check for get_current_time tool
-        local time_called=$(echo "$messages" | jq '[.data[] | select(.tool_calls != null) | .tool_calls[] | select(.name == "get_current_time")] | length')
+        local time_called=$(echo "$messages" | jq '[.data[].content[]? | select(.type == "tool_call") | select(.name == "get_current_time")] | length')
         if [ "$time_called" -ge 1 ]; then
             log_verbose "get_current_time tool was called"
 
-            # Check for assistant response
-            local assistant_msgs=$(echo "$messages" | jq '[.data[] | select(.role == "assistant") | select(.content != null)] | length')
-            if [ "$assistant_msgs" -ge 1 ]; then
-                log_verbose "Assistant responded with message"
+            # Check for agent response (role is "agent" not "assistant" in our system)
+            local agent_msgs=$(echo "$messages" | jq '[.data[] | select(.role == "agent") | select(.content != null) | select(.content | any(.type == "text"))] | length')
+            if [ "$agent_msgs" -ge 1 ]; then
+                log_verbose "Agent responded with message"
                 return 0
             else
-                log_error "Expected assistant response after tool call"
+                log_error "Expected agent response after tool call"
                 return 1
             fi
         else

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ Available specs:
 - `specs/dismissed-options.md` - Technical options considered but dismissed
 - `specs/multitenancy.md` - Organization-based multitenancy and resource isolation
 - `specs/release-process.md` - Release workflow with CHANGELOG.md as source of truth
+- `specs/id-schema.md` - Standardized prefixed ID format for all entities
 
 Specification format: Abstract and Requirements sections.
 

--- a/crates/cli/src/commands/agents.rs
+++ b/crates/cli/src/commands/agents.rs
@@ -325,7 +325,12 @@ async fn create(
         capabilities: final_capabilities,
     };
 
-    let agent: Agent = client.post("/v1/orgs/org_00000000000000000000000000000001/agents", &request).await?;
+    let agent: Agent = client
+        .post(
+            "/v1/orgs/org_00000000000000000000000000000001/agents",
+            &request,
+        )
+        .await?;
 
     if output.is_text() {
         if quiet {
@@ -350,7 +355,9 @@ async fn create(
 }
 
 async fn list(client: &Client, output: OutputFormat) -> Result<()> {
-    let response: ListResponse<Agent> = client.get("/v1/orgs/org_00000000000000000000000000000001/agents").await?;
+    let response: ListResponse<Agent> = client
+        .get("/v1/orgs/org_00000000000000000000000000000001/agents")
+        .await?;
 
     if output.is_text() {
         if response.data.is_empty() {
@@ -392,7 +399,10 @@ async fn list(client: &Client, output: OutputFormat) -> Result<()> {
 
 async fn get(client: &Client, output: OutputFormat, agent_id: Uuid) -> Result<()> {
     let agent: Agent = client
-        .get(&format!("/v1/orgs/org_00000000000000000000000000000001/agents/{}", agent_id))
+        .get(&format!(
+            "/v1/orgs/org_00000000000000000000000000000001/agents/{}",
+            agent_id
+        ))
         .await
         .map_err(|e| match e {
             ClientError::NotFound => anyhow::anyhow!("Agent not found: {}", agent_id),
@@ -427,7 +437,10 @@ async fn get(client: &Client, output: OutputFormat, agent_id: Uuid) -> Result<()
 
 async fn delete(client: &Client, output: OutputFormat, quiet: bool, agent_id: Uuid) -> Result<()> {
     client
-        .delete(&format!("/v1/orgs/org_00000000000000000000000000000001/agents/{}", agent_id))
+        .delete(&format!(
+            "/v1/orgs/org_00000000000000000000000000000001/agents/{}",
+            agent_id
+        ))
         .await
         .map_err(|e| match e {
             ClientError::NotFound => anyhow::anyhow!("Agent not found: {}", agent_id),

--- a/crates/cli/src/commands/agents.rs
+++ b/crates/cli/src/commands/agents.rs
@@ -138,13 +138,13 @@ struct CreateAgentRequest {
 /// Agent response from API
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Agent {
-    pub id: Uuid,
+    pub id: String,
     pub name: String,
     #[serde(default)]
     pub description: Option<String>,
     pub system_prompt: String,
     #[serde(default)]
-    pub default_model_id: Option<Uuid>,
+    pub default_model_id: Option<String>,
     #[serde(default)]
     pub tags: Vec<String>,
     #[serde(default)]
@@ -325,7 +325,7 @@ async fn create(
         capabilities: final_capabilities,
     };
 
-    let agent: Agent = client.post("/v1/agents", &request).await?;
+    let agent: Agent = client.post("/v1/orgs/org_00000000000000000000000000000001/agents", &request).await?;
 
     if output.is_text() {
         if quiet {
@@ -350,7 +350,7 @@ async fn create(
 }
 
 async fn list(client: &Client, output: OutputFormat) -> Result<()> {
-    let response: ListResponse<Agent> = client.get("/v1/agents").await?;
+    let response: ListResponse<Agent> = client.get("/v1/orgs/org_00000000000000000000000000000001/agents").await?;
 
     if output.is_text() {
         if response.data.is_empty() {
@@ -392,7 +392,7 @@ async fn list(client: &Client, output: OutputFormat) -> Result<()> {
 
 async fn get(client: &Client, output: OutputFormat, agent_id: Uuid) -> Result<()> {
     let agent: Agent = client
-        .get(&format!("/v1/agents/{}", agent_id))
+        .get(&format!("/v1/orgs/org_00000000000000000000000000000001/agents/{}", agent_id))
         .await
         .map_err(|e| match e {
             ClientError::NotFound => anyhow::anyhow!("Agent not found: {}", agent_id),
@@ -427,7 +427,7 @@ async fn get(client: &Client, output: OutputFormat, agent_id: Uuid) -> Result<()
 
 async fn delete(client: &Client, output: OutputFormat, quiet: bool, agent_id: Uuid) -> Result<()> {
     client
-        .delete(&format!("/v1/agents/{}", agent_id))
+        .delete(&format!("/v1/orgs/org_00000000000000000000000000000001/agents/{}", agent_id))
         .await
         .map_err(|e| match e {
             ClientError::NotFound => anyhow::anyhow!("Agent not found: {}", agent_id),

--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -29,7 +29,7 @@ enum InputContentPart {
 /// Event from API
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct Event {
-    id: Uuid,
+    id: String,
     #[serde(rename = "type")]
     event_type: String,
     data: serde_json::Value,
@@ -74,7 +74,7 @@ pub async fn run(
 
     let _: serde_json::Value = client
         .post(
-            &format!("/v1/agents/{}/sessions/{}/messages", agent_id, session_id),
+            &format!("/v1/orgs/org_00000000000000000000000000000001/agents/{}/sessions/{}/messages", agent_id, session_id),
             &request,
         )
         .await?;
@@ -91,7 +91,7 @@ pub async fn run(
     let start = Instant::now();
     let timeout = Duration::from_secs(timeout_secs);
     let poll_interval = Duration::from_millis(500);
-    let mut last_event_id: Option<Uuid> = None;
+    let mut last_event_id: Option<String> = None;
     let mut agent_content = String::new();
 
     loop {
@@ -103,18 +103,18 @@ pub async fn run(
         }
 
         // Build URL with since_id parameter
-        let url = match last_event_id {
+        let url = match &last_event_id {
             Some(id) => format!(
-                "/v1/agents/{}/sessions/{}/events?since_id={}",
+                "/v1/orgs/org_00000000000000000000000000000001/agents/{}/sessions/{}/events?since_id={}",
                 agent_id, session_id, id
             ),
-            None => format!("/v1/agents/{}/sessions/{}/events", agent_id, session_id),
+            None => format!("/v1/orgs/org_00000000000000000000000000000001/agents/{}/sessions/{}/events", agent_id, session_id),
         };
 
         let response: ListResponse<Event> = client.get(&url).await?;
 
         for event in response.data {
-            last_event_id = Some(event.id);
+            last_event_id = Some(event.id.clone());
 
             if output.is_text() {
                 // Handle message.agent events

--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -74,7 +74,10 @@ pub async fn run(
 
     let _: serde_json::Value = client
         .post(
-            &format!("/v1/orgs/org_00000000000000000000000000000001/agents/{}/sessions/{}/messages", agent_id, session_id),
+            &format!(
+                "/v1/orgs/org_00000000000000000000000000000001/agents/{}/sessions/{}/messages",
+                agent_id, session_id
+            ),
             &request,
         )
         .await?;
@@ -108,7 +111,10 @@ pub async fn run(
                 "/v1/orgs/org_00000000000000000000000000000001/agents/{}/sessions/{}/events?since_id={}",
                 agent_id, session_id, id
             ),
-            None => format!("/v1/orgs/org_00000000000000000000000000000001/agents/{}/sessions/{}/events", agent_id, session_id),
+            None => format!(
+                "/v1/orgs/org_00000000000000000000000000000001/agents/{}/sessions/{}/events",
+                agent_id, session_id
+            ),
         };
 
         let response: ListResponse<Event> = client.get(&url).await?;

--- a/crates/cli/src/commands/sessions.rs
+++ b/crates/cli/src/commands/sessions.rs
@@ -116,7 +116,13 @@ async fn create(
     };
 
     let session: Session = client
-        .post(&format!("/v1/orgs/org_00000000000000000000000000000001/agents/{}/sessions", agent_id), &request)
+        .post(
+            &format!(
+                "/v1/orgs/org_00000000000000000000000000000001/agents/{}/sessions",
+                agent_id
+            ),
+            &request,
+        )
         .await?;
 
     if output.is_text() {
@@ -136,7 +142,10 @@ async fn create(
 
 async fn list(client: &Client, output: OutputFormat, agent_id: Uuid) -> Result<()> {
     let response: ListResponse<Session> = client
-        .get(&format!("/v1/orgs/org_00000000000000000000000000000001/agents/{}/sessions", agent_id))
+        .get(&format!(
+            "/v1/orgs/org_00000000000000000000000000000001/agents/{}/sessions",
+            agent_id
+        ))
         .await?;
 
     if output.is_text() {
@@ -170,7 +179,10 @@ async fn get(
     session_id: Uuid,
 ) -> Result<()> {
     let session: Session = client
-        .get(&format!("/v1/orgs/org_00000000000000000000000000000001/agents/{}/sessions/{}", agent_id, session_id))
+        .get(&format!(
+            "/v1/orgs/org_00000000000000000000000000000001/agents/{}/sessions/{}",
+            agent_id, session_id
+        ))
         .await
         .map_err(|e| match e {
             ClientError::NotFound => anyhow::anyhow!("Session not found: {}", session_id),

--- a/crates/cli/src/commands/sessions.rs
+++ b/crates/cli/src/commands/sessions.rs
@@ -61,14 +61,14 @@ struct CreateSessionRequest {
 /// Session response from API
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Session {
-    pub id: Uuid,
-    pub agent_id: Uuid,
+    pub id: String,
+    pub agent_id: String,
     #[serde(default)]
     pub title: Option<String>,
     #[serde(default)]
     pub tags: Vec<String>,
     #[serde(default)]
-    pub model_id: Option<Uuid>,
+    pub model_id: Option<String>,
     pub status: String,
     pub created_at: String,
     #[serde(default)]
@@ -116,7 +116,7 @@ async fn create(
     };
 
     let session: Session = client
-        .post(&format!("/v1/agents/{}/sessions", agent_id), &request)
+        .post(&format!("/v1/orgs/org_00000000000000000000000000000001/agents/{}/sessions", agent_id), &request)
         .await?;
 
     if output.is_text() {
@@ -136,7 +136,7 @@ async fn create(
 
 async fn list(client: &Client, output: OutputFormat, agent_id: Uuid) -> Result<()> {
     let response: ListResponse<Session> = client
-        .get(&format!("/v1/agents/{}/sessions", agent_id))
+        .get(&format!("/v1/orgs/org_00000000000000000000000000000001/agents/{}/sessions", agent_id))
         .await?;
 
     if output.is_text() {
@@ -170,7 +170,7 @@ async fn get(
     session_id: Uuid,
 ) -> Result<()> {
     let session: Session = client
-        .get(&format!("/v1/agents/{}/sessions/{}", agent_id, session_id))
+        .get(&format!("/v1/orgs/org_00000000000000000000000000000001/agents/{}/sessions/{}", agent_id, session_id))
         .await
         .map_err(|e| match e {
             ClientError::NotFound => anyhow::anyhow!("Session not found: {}", session_id),

--- a/crates/control-plane/src/api/agents.rs
+++ b/crates/control-plane/src/api/agents.rs
@@ -12,7 +12,7 @@ use axum::{
     routing::{get, post},
 };
 use chrono::Utc;
-use everruns_core::typed_id::AgentId;
+use everruns_core::typed_id::{AgentId, ModelId};
 use everruns_core::{Agent, AgentCapabilityConfig, AgentStatus, ToolDefinition};
 
 use super::common::{ApiOptionExt, ApiResultExt, ErrorResponse, ListResponse};
@@ -22,7 +22,6 @@ use super::validation::{
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
-use uuid::Uuid;
 
 /// Request to create a new agent
 #[derive(Debug, Clone, Deserialize, ToSchema)]
@@ -41,7 +40,8 @@ pub struct CreateAgentRequest {
     /// The ID of the default LLM model to use for this agent.
     /// If not specified, the system default model will be used.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_model_id: Option<Uuid>,
+    #[schema(value_type = Option<String>, example = "model_01933b5a00007000800000000000001")]
+    pub default_model_id: Option<ModelId>,
     /// Tags for organizing and filtering agents.
     #[serde(default)]
     #[schema(example = json!(["support", "customer-facing"]))]
@@ -70,7 +70,8 @@ pub struct UpdateAgentRequest {
     pub system_prompt: Option<String>,
     /// The ID of the default LLM model to use for this agent.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_model_id: Option<Uuid>,
+    #[schema(value_type = Option<String>, example = "model_01933b5a00007000800000000000001")]
+    pub default_model_id: Option<ModelId>,
     /// Tags for organizing and filtering agents.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(example = json!(["updated-tag"]))]
@@ -142,7 +143,7 @@ struct AgentFile {
     pub name: Option<String>,
     pub description: Option<String>,
     pub system_prompt: Option<String>,
-    pub default_model_id: Option<Uuid>,
+    pub default_model_id: Option<ModelId>,
     #[serde(default)]
     pub tags: Vec<String>,
     /// Capabilities - supports both string IDs and objects with ref/config

--- a/crates/control-plane/src/api/agents.rs
+++ b/crates/control-plane/src/api/agents.rs
@@ -12,6 +12,7 @@ use axum::{
     routing::{get, post},
 };
 use chrono::Utc;
+use everruns_core::typed_id::AgentId;
 use everruns_core::{Agent, AgentCapabilityConfig, AgentStatus, ToolDefinition};
 
 use super::common::{ApiOptionExt, ApiResultExt, ErrorResponse, ListResponse};
@@ -262,10 +263,11 @@ pub async fn list_agents(
     path = "/v1/orgs/{org}/agents/{agent_id}",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("agent_id" = Uuid, Path, description = "Agent ID")
+        ("agent_id" = String, Path, description = "Agent ID (prefixed, e.g., agt_...)")
     ),
     responses(
         (status = 200, description = "Agent found", body = Agent),
+        (status = 400, description = "Invalid agent ID"),
         (status = 404, description = "Agent not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -274,14 +276,23 @@ pub async fn list_agents(
 pub async fn get_agent(
     org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, agent_id)): Path<(String, Uuid)>,
-) -> Result<Json<Agent>, StatusCode> {
+    Path((_org_path, agent_id)): Path<(String, String)>,
+) -> Result<Json<Agent>, (StatusCode, Json<ErrorResponse>)> {
+    let agent_id: AgentId = agent_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid agent ID: {}", e),
+            }),
+        )
+    })?;
+
     let agent = state
         .service
-        .get(org.org_id, agent_id)
+        .get(org.org_id, agent_id.uuid())
         .await
-        .log_internal_error("get agent")?
-        .ok_or_not_found()?;
+        .log_internal_error_json("get agent")?
+        .ok_or_not_found_json("Agent")?;
 
     Ok(Json(agent))
 }
@@ -292,12 +303,12 @@ pub async fn get_agent(
     path = "/v1/orgs/{org}/agents/{agent_id}",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("agent_id" = Uuid, Path, description = "Agent ID")
+        ("agent_id" = String, Path, description = "Agent ID (prefixed, e.g., agt_...)")
     ),
     request_body = UpdateAgentRequest,
     responses(
         (status = 200, description = "Agent updated successfully", body = Agent),
-        (status = 400, description = "Input exceeds allowed limits", body = ErrorResponse),
+        (status = 400, description = "Invalid agent ID or input exceeds allowed limits", body = ErrorResponse),
         (status = 404, description = "Agent not found", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
@@ -306,9 +317,18 @@ pub async fn get_agent(
 pub async fn update_agent(
     org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, agent_id)): Path<(String, Uuid)>,
+    Path((_org_path, agent_id)): Path<(String, String)>,
     Json(req): Json<UpdateAgentRequest>,
 ) -> Result<Json<Agent>, (StatusCode, Json<ErrorResponse>)> {
+    let agent_id: AgentId = agent_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid agent ID: {}", e),
+            }),
+        )
+    })?;
+
     // Validate input sizes (last-resort protection against abuse)
     validate_update_agent_input(
         req.name.as_deref(),
@@ -319,7 +339,7 @@ pub async fn update_agent(
 
     let agent = state
         .service
-        .update(org.org_id, agent_id, req)
+        .update(org.org_id, agent_id.uuid(), req)
         .await
         .log_internal_error_json("update agent")?
         .ok_or_not_found_json("Agent")?;
@@ -333,10 +353,11 @@ pub async fn update_agent(
     path = "/v1/orgs/{org}/agents/{agent_id}",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("agent_id" = Uuid, Path, description = "Agent ID")
+        ("agent_id" = String, Path, description = "Agent ID (prefixed, e.g., agt_...)")
     ),
     responses(
         (status = 204, description = "Agent archived successfully"),
+        (status = 400, description = "Invalid agent ID"),
         (status = 404, description = "Agent not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -345,18 +366,32 @@ pub async fn update_agent(
 pub async fn delete_agent(
     org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, agent_id)): Path<(String, Uuid)>,
-) -> Result<StatusCode, StatusCode> {
+    Path((_org_path, agent_id)): Path<(String, String)>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let agent_id: AgentId = agent_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid agent ID: {}", e),
+            }),
+        )
+    })?;
+
     let deleted = state
         .service
-        .delete(org.org_id, agent_id)
+        .delete(org.org_id, agent_id.uuid())
         .await
-        .log_internal_error("delete agent")?;
+        .log_internal_error_json("delete agent")?;
 
     if deleted {
         Ok(StatusCode::NO_CONTENT)
     } else {
-        Err(StatusCode::NOT_FOUND)
+        Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: "Agent not found".to_string(),
+            }),
+        ))
     }
 }
 
@@ -366,10 +401,11 @@ pub async fn delete_agent(
     path = "/v1/orgs/{org}/agents/{agent_id}/export",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("agent_id" = Uuid, Path, description = "Agent ID")
+        ("agent_id" = String, Path, description = "Agent ID (prefixed, e.g., agt_...)")
     ),
     responses(
         (status = 200, description = "Agent exported as Markdown", content_type = "text/markdown"),
+        (status = 400, description = "Invalid agent ID"),
         (status = 404, description = "Agent not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -378,14 +414,23 @@ pub async fn delete_agent(
 pub async fn export_agent(
     org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, agent_id)): Path<(String, Uuid)>,
-) -> Result<Response, StatusCode> {
+    Path((_org_path, agent_id)): Path<(String, String)>,
+) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
+    let agent_id: AgentId = agent_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid agent ID: {}", e),
+            }),
+        )
+    })?;
+
     let agent = state
         .service
-        .get(org.org_id, agent_id)
+        .get(org.org_id, agent_id.uuid())
         .await
-        .log_internal_error("get agent for export")?
-        .ok_or_not_found()?;
+        .log_internal_error_json("get agent for export")?
+        .ok_or_not_found_json("Agent")?;
 
     let markdown = agent_to_markdown(&agent);
     let filename = format!("{}.md", slugify(&agent.name));

--- a/crates/control-plane/src/api/events.rs
+++ b/crates/control-plane/src/api/events.rs
@@ -11,10 +11,11 @@ use axum::{
     response::sse::{Event as SseEvent, KeepAlive, Sse},
     routing::get,
 };
+use everruns_core::typed_id::SessionId;
 use everruns_core::{Event, EventListener};
 use serde::Deserialize;
 
-use super::common::ListResponse;
+use super::common::{ErrorResponse, ListResponse};
 use super::sse::SseStreamConfig;
 use crate::services::EventService;
 use futures::{
@@ -101,12 +102,13 @@ pub fn routes(state: AppState) -> Router {
     path = "/v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}/sse",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("agent_id" = Uuid, Path, description = "Agent ID"),
-        ("session_id" = Uuid, Path, description = "Session ID"),
+        ("agent_id" = String, Path, description = "Agent ID (prefixed, e.g., agt_...)"),
+        ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)"),
         EventsQuery
     ),
     responses(
         (status = 200, description = "Event stream", content_type = "text/event-stream"),
+        (status = 400, description = "Invalid session ID"),
         (status = 404, description = "Session not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -115,20 +117,43 @@ pub fn routes(state: AppState) -> Router {
 pub async fn stream_sse(
     org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, _agent_id, session_id)): Path<(String, Uuid, Uuid)>,
+    Path((_org_path, _agent_id, session_id)): Path<(String, String, String)>,
     Query(query): Query<EventsQuery>,
-) -> Result<Sse<impl Stream<Item = Result<SseEvent, Infallible>>>, StatusCode> {
+) -> Result<Sse<impl Stream<Item = Result<SseEvent, Infallible>>>, (StatusCode, Json<ErrorResponse>)>
+{
+    let session_id: SessionId = session_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid session ID: {}", e),
+            }),
+        )
+    })?;
+
     // Verify session exists
     let _session = state
         .session_service
-        .get(org.org_id, session_id)
+        .get(org.org_id, session_id.uuid())
         .await
         .map_err(|e| {
             tracing::error!("Failed to get session: {}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "Internal server error".to_string(),
+                }),
+            )
         })?
-        .ok_or(StatusCode::NOT_FOUND)?;
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: "Session not found".to_string(),
+                }),
+            )
+        })?;
 
+    let session_id = session_id.uuid();
     tracing::info!(session_id = %session_id, since_id = ?query.since_id, "Starting event stream");
 
     let event_service = state.event_service.clone();
@@ -247,12 +272,13 @@ pub async fn stream_sse(
     path = "/v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}/events",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("agent_id" = Uuid, Path, description = "Agent ID"),
-        ("session_id" = Uuid, Path, description = "Session ID"),
+        ("agent_id" = String, Path, description = "Agent ID (prefixed, e.g., agt_...)"),
+        ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)"),
         EventsQuery
     ),
     responses(
         (status = 200, description = "Events list", body = ListResponse<Event>),
+        (status = 400, description = "Invalid session ID"),
         (status = 404, description = "Session not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -261,29 +287,55 @@ pub async fn stream_sse(
 pub async fn list_events(
     org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, _agent_id, session_id)): Path<(String, Uuid, Uuid)>,
+    Path((_org_path, _agent_id, session_id)): Path<(String, String, String)>,
     Query(query): Query<EventsQuery>,
-) -> Result<Json<ListResponse<Event>>, StatusCode> {
+) -> Result<Json<ListResponse<Event>>, (StatusCode, Json<ErrorResponse>)> {
+    let session_id: SessionId = session_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid session ID: {}", e),
+            }),
+        )
+    })?;
+
     // Verify session exists
     let _session = state
         .session_service
-        .get(org.org_id, session_id)
+        .get(org.org_id, session_id.uuid())
         .await
         .map_err(|e| {
             tracing::error!("Failed to get session: {}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "Internal server error".to_string(),
+                }),
+            )
         })?
-        .ok_or(StatusCode::NOT_FOUND)?;
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: "Session not found".to_string(),
+                }),
+            )
+        })?;
 
     // Fetch events using EventService (converts rows to core::Event)
     // Optional since_id filter for incremental fetching
     let events = state
         .event_service
-        .list(session_id, None, query.since_id)
+        .list(session_id.uuid(), None, query.since_id)
         .await
         .map_err(|e| {
             tracing::error!("Failed to list events: {}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "Internal server error".to_string(),
+                }),
+            )
         })?;
 
     Ok(Json(ListResponse { data: events }))

--- a/crates/control-plane/src/api/events.rs
+++ b/crates/control-plane/src/api/events.rs
@@ -202,8 +202,8 @@ pub async fn stream_sse(
             tracing::debug!(session_id = %session_id, last_id = ?state.last_id, "SSE: fetching events");
             match event_service.list(session_id, None, state.last_id).await {
                 Ok(events) if !events.is_empty() => {
-                    // Get the last event ID for next iteration
-                    let new_last_id = Some(events.last().unwrap().id);
+                    // Get the last event ID for next iteration (extract UUID for db query)
+                    let new_last_id = Some(events.last().unwrap().id.uuid());
 
                     tracing::debug!(
                         session_id = %session_id,

--- a/crates/control-plane/src/api/images.rs
+++ b/crates/control-plane/src/api/images.rs
@@ -17,6 +17,7 @@ use axum::{
 };
 use axum_extra::extract::Multipart;
 use chrono::{DateTime, Utc};
+use everruns_core::typed_id::ImageId;
 use image::ImageFormat;
 use serde::{Deserialize, Serialize};
 use std::io::Cursor;
@@ -344,10 +345,11 @@ pub async fn list_images(
     path = "/v1/orgs/{org}/images/{image_id}",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("image_id" = Uuid, Path, description = "Image ID")
+        ("image_id" = String, Path, description = "Image ID (prefixed, e.g., img_...)")
     ),
     responses(
         (status = 200, description = "Image binary data", content_type = "image/*"),
+        (status = 400, description = "Invalid image ID"),
         (status = 404, description = "Image not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -356,17 +358,24 @@ pub async fn list_images(
 pub async fn get_image(
     _org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, image_id)): Path<(String, Uuid)>,
-) -> Result<Response, StatusCode> {
+    Path((_org_path, image_id)): Path<(String, String)>,
+) -> Result<Response, (StatusCode, String)> {
+    let image_id: ImageId = image_id
+        .parse()
+        .map_err(|e| (StatusCode::BAD_REQUEST, format!("Invalid image ID: {}", e)))?;
+
     let row = state
         .db
-        .get_image(image_id)
+        .get_image(image_id.uuid())
         .await
         .map_err(|e| {
             tracing::error!("Failed to get image: {}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal server error".to_string(),
+            )
         })?
-        .ok_or(StatusCode::NOT_FOUND)?;
+        .ok_or((StatusCode::NOT_FOUND, "Image not found".to_string()))?;
 
     let response = Response::builder()
         .status(StatusCode::OK)
@@ -388,10 +397,11 @@ pub async fn get_image(
     path = "/v1/orgs/{org}/images/{image_id}/thumbnail",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("image_id" = Uuid, Path, description = "Image ID")
+        ("image_id" = String, Path, description = "Image ID (prefixed, e.g., img_...)")
     ),
     responses(
         (status = 200, description = "Thumbnail binary data", content_type = "image/jpeg"),
+        (status = 400, description = "Invalid image ID"),
         (status = 404, description = "Image not found or no thumbnail"),
         (status = 500, description = "Internal server error")
     ),
@@ -400,22 +410,29 @@ pub async fn get_image(
 pub async fn get_thumbnail(
     _org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, image_id)): Path<(String, Uuid)>,
-) -> Result<Response, StatusCode> {
+    Path((_org_path, image_id)): Path<(String, String)>,
+) -> Result<Response, (StatusCode, String)> {
+    let image_id: ImageId = image_id
+        .parse()
+        .map_err(|e| (StatusCode::BAD_REQUEST, format!("Invalid image ID: {}", e)))?;
+
     let row = state
         .db
-        .get_image(image_id)
+        .get_image(image_id.uuid())
         .await
         .map_err(|e| {
             tracing::error!("Failed to get image: {}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal server error".to_string(),
+            )
         })?
-        .ok_or(StatusCode::NOT_FOUND)?;
+        .ok_or((StatusCode::NOT_FOUND, "Image not found".to_string()))?;
 
     let (thumbnail_data, thumbnail_content_type) =
         match (row.thumbnail_data, row.thumbnail_content_type) {
             (Some(data), Some(ct)) => (data, ct),
-            _ => return Err(StatusCode::NOT_FOUND),
+            _ => return Err((StatusCode::NOT_FOUND, "No thumbnail available".to_string())),
         };
 
     let response = Response::builder()
@@ -434,10 +451,11 @@ pub async fn get_thumbnail(
     path = "/v1/orgs/{org}/images/{image_id}",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("image_id" = Uuid, Path, description = "Image ID")
+        ("image_id" = String, Path, description = "Image ID (prefixed, e.g., img_...)")
     ),
     responses(
         (status = 204, description = "Image deleted"),
+        (status = 400, description = "Invalid image ID"),
         (status = 404, description = "Image not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -446,17 +464,24 @@ pub async fn get_thumbnail(
 pub async fn delete_image(
     _org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, image_id)): Path<(String, Uuid)>,
-) -> Result<StatusCode, StatusCode> {
-    let deleted = state.db.delete_image(image_id).await.map_err(|e| {
+    Path((_org_path, image_id)): Path<(String, String)>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    let image_id: ImageId = image_id
+        .parse()
+        .map_err(|e| (StatusCode::BAD_REQUEST, format!("Invalid image ID: {}", e)))?;
+
+    let deleted = state.db.delete_image(image_id.uuid()).await.map_err(|e| {
         tracing::error!("Failed to delete image: {}", e);
-        StatusCode::INTERNAL_SERVER_ERROR
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Internal server error".to_string(),
+        )
     })?;
 
     if deleted {
         Ok(StatusCode::NO_CONTENT)
     } else {
-        Err(StatusCode::NOT_FOUND)
+        Err((StatusCode::NOT_FOUND, "Image not found".to_string()))
     }
 }
 

--- a/crates/control-plane/src/api/llm_models.rs
+++ b/crates/control-plane/src/api/llm_models.rs
@@ -10,11 +10,11 @@ use axum::{
     http::StatusCode,
     routing::{get, post},
 };
+use everruns_core::typed_id::{ModelId, ProviderId};
 use everruns_core::{LlmModel, LlmModelSource, LlmModelStatus, LlmModelWithProvider};
 use serde::Deserialize;
 use std::sync::Arc;
 use utoipa::{IntoParams, ToSchema};
-use uuid::Uuid;
 
 use crate::services::LlmModelService;
 
@@ -114,12 +114,12 @@ pub struct UpdateLlmModelRequest {
     path = "/v1/orgs/{org}/llm-providers/{provider_id}/models",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("provider_id" = Uuid, Path, description = "Provider ID")
+        ("provider_id" = String, Path, description = "Provider ID (prefixed, e.g., prov_...)")
     ),
     request_body = CreateLlmModelRequest,
     responses(
         (status = 201, description = "Model created", body = LlmModel),
-        (status = 400, description = "Invalid request"),
+        (status = 400, description = "Invalid provider ID"),
         (status = 500, description = "Internal error")
     ),
     tag = "llm-models"
@@ -127,18 +127,31 @@ pub struct UpdateLlmModelRequest {
 pub async fn create_model(
     _org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, provider_id)): Path<(String, Uuid)>,
+    Path((_org_path, provider_id)): Path<(String, String)>,
     Json(req): Json<CreateLlmModelRequest>,
 ) -> Result<(StatusCode, Json<LlmModel>), (StatusCode, Json<ErrorResponse>)> {
-    let model = state.service.create(provider_id, req).await.map_err(|e| {
-        tracing::error!("Failed to create LLM model: {}", e);
+    let provider_id: ProviderId = provider_id.parse().map_err(|e| {
         (
-            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::BAD_REQUEST,
             Json(ErrorResponse {
-                error: "Internal server error".to_string(),
+                error: format!("Invalid provider ID: {}", e),
             }),
         )
     })?;
+
+    let model = state
+        .service
+        .create(provider_id.uuid(), req)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to create LLM model: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "Internal server error".to_string(),
+                }),
+            )
+        })?;
 
     Ok((StatusCode::CREATED, Json(model)))
 }
@@ -149,21 +162,31 @@ pub async fn create_model(
     path = "/v1/orgs/{org}/llm-providers/{provider_id}/models",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("provider_id" = Uuid, Path, description = "Provider ID")
+        ("provider_id" = String, Path, description = "Provider ID (prefixed, e.g., prov_...)")
     ),
     responses(
-        (status = 200, description = "List of models", body = ListResponse<LlmModel>)
+        (status = 200, description = "List of models", body = ListResponse<LlmModel>),
+        (status = 400, description = "Invalid provider ID")
     ),
     tag = "llm-models"
 )]
 pub async fn list_provider_models(
     _org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, provider_id)): Path<(String, Uuid)>,
+    Path((_org_path, provider_id)): Path<(String, String)>,
 ) -> Result<Json<ListResponse<LlmModel>>, (StatusCode, Json<ErrorResponse>)> {
+    let provider_id: ProviderId = provider_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid provider ID: {}", e),
+            }),
+        )
+    })?;
+
     let models = state
         .service
-        .list_for_provider(provider_id)
+        .list_for_provider(provider_id.uuid())
         .await
         .map_err(|e| {
             tracing::error!("Failed to list LLM models for provider: {}", e);
@@ -219,10 +242,11 @@ pub async fn list_all_models(
     path = "/v1/orgs/{org}/llm-models/{id}",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("id" = Uuid, Path, description = "Model ID")
+        ("id" = String, Path, description = "Model ID (prefixed, e.g., mod_...)")
     ),
     responses(
         (status = 200, description = "Model found", body = LlmModelWithProvider),
+        (status = 400, description = "Invalid model ID"),
         (status = 404, description = "Model not found")
     ),
     tag = "llm-models"
@@ -230,11 +254,20 @@ pub async fn list_all_models(
 pub async fn get_model(
     _org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, id)): Path<(String, Uuid)>,
+    Path((_org_path, id)): Path<(String, String)>,
 ) -> Result<Json<LlmModelWithProvider>, (StatusCode, Json<ErrorResponse>)> {
+    let model_id: ModelId = id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid model ID: {}", e),
+            }),
+        )
+    })?;
+
     let model = state
         .service
-        .get_with_provider(id)
+        .get_with_provider(model_id.uuid())
         .await
         .map_err(|e| {
             tracing::error!("Failed to get LLM model: {}", e);
@@ -263,11 +296,12 @@ pub async fn get_model(
     path = "/v1/orgs/{org}/llm-models/{id}",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("id" = Uuid, Path, description = "Model ID")
+        ("id" = String, Path, description = "Model ID (prefixed, e.g., mod_...)")
     ),
     request_body = UpdateLlmModelRequest,
     responses(
         (status = 200, description = "Model updated", body = LlmModel),
+        (status = 400, description = "Invalid model ID"),
         (status = 404, description = "Model not found")
     ),
     tag = "llm-models"
@@ -275,12 +309,21 @@ pub async fn get_model(
 pub async fn update_model(
     _org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, id)): Path<(String, Uuid)>,
+    Path((_org_path, id)): Path<(String, String)>,
     Json(req): Json<UpdateLlmModelRequest>,
 ) -> Result<Json<LlmModel>, (StatusCode, Json<ErrorResponse>)> {
+    let model_id: ModelId = id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid model ID: {}", e),
+            }),
+        )
+    })?;
+
     let model = state
         .service
-        .update(id, req)
+        .update(model_id.uuid(), req)
         .await
         .map_err(|e| {
             tracing::error!("Failed to update LLM model: {}", e);
@@ -309,10 +352,11 @@ pub async fn update_model(
     path = "/v1/orgs/{org}/llm-models/{id}",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("id" = Uuid, Path, description = "Model ID")
+        ("id" = String, Path, description = "Model ID (prefixed, e.g., mod_...)")
     ),
     responses(
         (status = 204, description = "Model deleted"),
+        (status = 400, description = "Invalid model ID"),
         (status = 404, description = "Model not found")
     ),
     tag = "llm-models"
@@ -320,9 +364,18 @@ pub async fn update_model(
 pub async fn delete_model(
     _org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, id)): Path<(String, Uuid)>,
+    Path((_org_path, id)): Path<(String, String)>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let deleted = state.service.delete(id).await.map_err(|e| {
+    let model_id: ModelId = id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid model ID: {}", e),
+            }),
+        )
+    })?;
+
+    let deleted = state.service.delete(model_id.uuid()).await.map_err(|e| {
         tracing::error!("Failed to delete LLM model: {}", e);
         (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/control-plane/src/api/llm_providers.rs
+++ b/crates/control-plane/src/api/llm_providers.rs
@@ -11,11 +11,11 @@ use axum::{
     routing::{get, post},
 };
 use everruns_core::llm_models::LlmProvider;
+use everruns_core::typed_id::ProviderId;
 use everruns_core::{DriverRegistry, LlmProviderStatus, LlmProviderType};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
-use uuid::Uuid;
 
 use super::common::{ErrorResponse, ListResponse};
 
@@ -182,10 +182,11 @@ pub async fn list_providers(
     path = "/v1/orgs/{org}/llm-providers/{id}",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("id" = Uuid, Path, description = "Provider ID")
+        ("id" = String, Path, description = "Provider ID (prefixed, e.g., prov_...)")
     ),
     responses(
         (status = 200, description = "Provider found", body = LlmProvider),
+        (status = 400, description = "Invalid provider ID"),
         (status = 404, description = "Provider not found")
     ),
     tag = "llm-providers"
@@ -193,11 +194,20 @@ pub async fn list_providers(
 pub async fn get_provider(
     _org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, id)): Path<(String, Uuid)>,
+    Path((_org_path, id)): Path<(String, String)>,
 ) -> Result<Json<LlmProvider>, (StatusCode, Json<ErrorResponse>)> {
+    let provider_id: ProviderId = id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid provider ID: {}", e),
+            }),
+        )
+    })?;
+
     let provider = state
         .service
-        .get(id)
+        .get(provider_id.uuid())
         .await
         .map_err(|e| {
             tracing::error!("Failed to get LLM provider: {}", e);
@@ -226,11 +236,12 @@ pub async fn get_provider(
     path = "/v1/orgs/{org}/llm-providers/{id}",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("id" = Uuid, Path, description = "Provider ID")
+        ("id" = String, Path, description = "Provider ID (prefixed, e.g., prov_...)")
     ),
     request_body = UpdateLlmProviderRequest,
     responses(
         (status = 200, description = "Provider updated", body = LlmProvider),
+        (status = 400, description = "Invalid provider ID"),
         (status = 404, description = "Provider not found")
     ),
     tag = "llm-providers"
@@ -238,12 +249,21 @@ pub async fn get_provider(
 pub async fn update_provider(
     _org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, id)): Path<(String, Uuid)>,
+    Path((_org_path, id)): Path<(String, String)>,
     Json(req): Json<UpdateLlmProviderRequest>,
 ) -> Result<Json<LlmProvider>, (StatusCode, Json<ErrorResponse>)> {
+    let provider_id: ProviderId = id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid provider ID: {}", e),
+            }),
+        )
+    })?;
+
     let provider = state
         .service
-        .update(id, req)
+        .update(provider_id.uuid(), req)
         .await
         .map_err(|e| {
             let error_msg = e.to_string();
@@ -280,10 +300,11 @@ pub async fn update_provider(
     path = "/v1/orgs/{org}/llm-providers/{id}",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("id" = Uuid, Path, description = "Provider ID")
+        ("id" = String, Path, description = "Provider ID (prefixed, e.g., prov_...)")
     ),
     responses(
         (status = 204, description = "Provider deleted"),
+        (status = 400, description = "Invalid provider ID"),
         (status = 404, description = "Provider not found")
     ),
     tag = "llm-providers"
@@ -291,17 +312,30 @@ pub async fn update_provider(
 pub async fn delete_provider(
     _org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, id)): Path<(String, Uuid)>,
+    Path((_org_path, id)): Path<(String, String)>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let deleted = state.service.delete(id).await.map_err(|e| {
-        tracing::error!("Failed to delete LLM provider: {}", e);
+    let provider_id: ProviderId = id.parse().map_err(|e| {
         (
-            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::BAD_REQUEST,
             Json(ErrorResponse {
-                error: "Internal server error".to_string(),
+                error: format!("Invalid provider ID: {}", e),
             }),
         )
     })?;
+
+    let deleted = state
+        .service
+        .delete(provider_id.uuid())
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to delete LLM provider: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "Internal server error".to_string(),
+                }),
+            )
+        })?;
 
     if deleted {
         Ok(StatusCode::NO_CONTENT)
@@ -324,10 +358,11 @@ pub async fn delete_provider(
     path = "/v1/orgs/{org}/llm-providers/{id}/sync-models",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("id" = Uuid, Path, description = "Provider ID")
+        ("id" = String, Path, description = "Provider ID (prefixed, e.g., prov_...)")
     ),
     responses(
         (status = 200, description = "Models synced", body = SyncModelsResponse),
+        (status = 400, description = "Invalid provider ID"),
         (status = 404, description = "Provider not found"),
         (status = 500, description = "Sync failed")
     ),
@@ -336,27 +371,40 @@ pub async fn delete_provider(
 pub async fn sync_models(
     _org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, id)): Path<(String, Uuid)>,
+    Path((_org_path, id)): Path<(String, String)>,
 ) -> Result<Json<SyncModelsResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let result = state.sync_service.sync_provider(id).await.map_err(|e| {
-        let error_msg = e.to_string();
-        if error_msg.contains("Provider not found") {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse {
-                    error: "Provider not found".to_string(),
-                }),
-            )
-        } else {
-            tracing::error!("Failed to sync models for provider {}: {}", id, e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: "Internal server error".to_string(),
-                }),
-            )
-        }
+    let provider_id: ProviderId = id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid provider ID: {}", e),
+            }),
+        )
     })?;
+
+    let result = state
+        .sync_service
+        .sync_provider(provider_id.uuid())
+        .await
+        .map_err(|e| {
+            let error_msg = e.to_string();
+            if error_msg.contains("Provider not found") {
+                (
+                    StatusCode::NOT_FOUND,
+                    Json(ErrorResponse {
+                        error: "Provider not found".to_string(),
+                    }),
+                )
+            } else {
+                tracing::error!("Failed to sync models for provider {}: {}", provider_id, e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: "Internal server error".to_string(),
+                    }),
+                )
+            }
+        })?;
 
     let response = match result {
         SyncResult::Success {
@@ -370,7 +418,7 @@ pub async fn sync_models(
         },
         SyncResult::NotSupported => SyncModelsResponse::NotSupported,
         SyncResult::Failed { error } => {
-            tracing::error!("Model sync failed for provider {}: {}", id, error);
+            tracing::error!("Model sync failed for provider {}: {}", provider_id, error);
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse {

--- a/crates/control-plane/src/api/mcp_servers.rs
+++ b/crates/control-plane/src/api/mcp_servers.rs
@@ -10,6 +10,7 @@ use axum::{
     http::StatusCode,
     routing::{get, post},
 };
+use everruns_core::typed_id::McpServerId;
 use everruns_core::{McpServer, McpServerStatus, McpServerTransportType};
 
 use super::common::{ApiOptionExt, ApiResultExt, ErrorResponse, ListResponse};
@@ -17,7 +18,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 use utoipa::ToSchema;
-use uuid::Uuid;
 
 /// Request to create a new MCP server
 #[derive(Debug, Clone, Deserialize, ToSchema)]
@@ -208,10 +208,11 @@ pub async fn list_mcp_servers(
     path = "/v1/orgs/{org}/mcp-servers/{server_id}",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("server_id" = Uuid, Path, description = "MCP server ID")
+        ("server_id" = String, Path, description = "MCP server ID (prefixed, e.g., mcp_...)")
     ),
     responses(
         (status = 200, description = "MCP server found", body = McpServer),
+        (status = 400, description = "Invalid server ID"),
         (status = 404, description = "MCP server not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -220,14 +221,23 @@ pub async fn list_mcp_servers(
 pub async fn get_mcp_server(
     _org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, server_id)): Path<(String, Uuid)>,
-) -> Result<Json<McpServer>, StatusCode> {
+    Path((_org_path, server_id)): Path<(String, String)>,
+) -> Result<Json<McpServer>, (StatusCode, Json<ErrorResponse>)> {
+    let server_id: McpServerId = server_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid server ID: {}", e),
+            }),
+        )
+    })?;
+
     let server = state
         .service
-        .get(server_id)
+        .get(server_id.uuid())
         .await
-        .log_internal_error("get MCP server")?
-        .ok_or_not_found()?;
+        .log_internal_error_json("get MCP server")?
+        .ok_or_not_found_json("MCP server")?;
 
     Ok(Json(server))
 }
@@ -238,12 +248,12 @@ pub async fn get_mcp_server(
     path = "/v1/orgs/{org}/mcp-servers/{server_id}",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("server_id" = Uuid, Path, description = "MCP server ID")
+        ("server_id" = String, Path, description = "MCP server ID (prefixed, e.g., mcp_...)")
     ),
     request_body = UpdateMcpServerRequest,
     responses(
         (status = 200, description = "MCP server updated successfully", body = McpServer),
-        (status = 400, description = "Invalid input", body = ErrorResponse),
+        (status = 400, description = "Invalid server ID or input", body = ErrorResponse),
         (status = 404, description = "MCP server not found", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
@@ -252,9 +262,18 @@ pub async fn get_mcp_server(
 pub async fn update_mcp_server(
     _org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, server_id)): Path<(String, Uuid)>,
+    Path((_org_path, server_id)): Path<(String, String)>,
     Json(req): Json<UpdateMcpServerRequest>,
 ) -> Result<Json<McpServer>, (StatusCode, Json<ErrorResponse>)> {
+    let server_id: McpServerId = server_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid server ID: {}", e),
+            }),
+        )
+    })?;
+
     // Validate name if provided
     if let Some(ref name) = req.name
         && name.trim().is_empty()
@@ -275,7 +294,7 @@ pub async fn update_mcp_server(
 
     let server = state
         .service
-        .update(server_id, req)
+        .update(server_id.uuid(), req)
         .await
         .log_internal_error_json("update MCP server")?
         .ok_or_not_found_json("MCP server")?;
@@ -289,10 +308,11 @@ pub async fn update_mcp_server(
     path = "/v1/orgs/{org}/mcp-servers/{server_id}",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("server_id" = Uuid, Path, description = "MCP server ID")
+        ("server_id" = String, Path, description = "MCP server ID (prefixed, e.g., mcp_...)")
     ),
     responses(
         (status = 204, description = "MCP server deleted successfully"),
+        (status = 400, description = "Invalid server ID"),
         (status = 404, description = "MCP server not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -301,18 +321,32 @@ pub async fn update_mcp_server(
 pub async fn delete_mcp_server(
     _org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, server_id)): Path<(String, Uuid)>,
-) -> Result<StatusCode, StatusCode> {
+    Path((_org_path, server_id)): Path<(String, String)>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let server_id: McpServerId = server_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid server ID: {}", e),
+            }),
+        )
+    })?;
+
     let deleted = state
         .service
-        .delete(server_id)
+        .delete(server_id.uuid())
         .await
-        .log_internal_error("delete MCP server")?;
+        .log_internal_error_json("delete MCP server")?;
 
     if deleted {
         Ok(StatusCode::NO_CONTENT)
     } else {
-        Err(StatusCode::NOT_FOUND)
+        Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: "MCP server not found".to_string(),
+            }),
+        ))
     }
 }
 

--- a/crates/control-plane/src/api/messages.rs
+++ b/crates/control-plane/src/api/messages.rs
@@ -17,8 +17,9 @@ use axum::{
     routing::post,
 };
 use chrono::{DateTime, Utc};
+use everruns_core::typed_id::SessionId;
 
-use super::common::ListResponse;
+use super::common::{ErrorResponse, ListResponse};
 use everruns_worker::AgentRunner;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, sync::Arc};
@@ -186,12 +187,13 @@ pub fn routes(state: AppState) -> Router {
     path = "/v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}/messages",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("agent_id" = Uuid, Path, description = "Agent ID"),
-        ("session_id" = Uuid, Path, description = "Session ID")
+        ("agent_id" = String, Path, description = "Agent ID (prefixed, e.g., agt_...)"),
+        ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)")
     ),
     request_body = CreateMessageRequest,
     responses(
         (status = 201, description = "Message created successfully", body = Message),
+        (status = 400, description = "Invalid ID format"),
         (status = 500, description = "Internal server error")
     ),
     tag = "messages"
@@ -199,19 +201,50 @@ pub fn routes(state: AppState) -> Router {
 pub async fn create_message(
     org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, agent_id, session_id)): Path<(String, Uuid, Uuid)>,
+    Path((_org_path, agent_id, session_id)): Path<(String, String, String)>,
     Json(req): Json<CreateMessageRequest>,
-) -> Result<(StatusCode, Json<Message>), StatusCode> {
+) -> Result<(StatusCode, Json<Message>), (StatusCode, Json<ErrorResponse>)> {
+    let session_id: SessionId = session_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid session ID: {}", e),
+            }),
+        )
+    })?;
+
+    // Parse agent_id for validation but use the raw UUID for the service
+    let agent_uuid = agent_id_to_uuid(&agent_id)?;
+
     let message = state
         .message_service
-        .create(org.org_id, agent_id, session_id, req)
+        .create(org.org_id, agent_uuid, session_id.uuid(), req)
         .await
         .map_err(|e| {
             tracing::error!("Failed to create message: {}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "Internal server error".to_string(),
+                }),
+            )
         })?;
 
     Ok((StatusCode::CREATED, Json(message)))
+}
+
+// Helper function to parse agent ID and return UUID
+fn agent_id_to_uuid(id: &str) -> Result<Uuid, (StatusCode, Json<ErrorResponse>)> {
+    use everruns_core::typed_id::AgentId;
+    let agent_id: AgentId = id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid agent ID: {}", e),
+            }),
+        )
+    })?;
+    Ok(agent_id.uuid())
 }
 
 /// GET /v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}/messages - List messages (PRIMARY data)
@@ -220,11 +253,12 @@ pub async fn create_message(
     path = "/v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}/messages",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("agent_id" = Uuid, Path, description = "Agent ID"),
-        ("session_id" = Uuid, Path, description = "Session ID")
+        ("agent_id" = String, Path, description = "Agent ID (prefixed, e.g., agt_...)"),
+        ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)")
     ),
     responses(
         (status = 200, description = "List of messages", body = ListResponse<Message>),
+        (status = 400, description = "Invalid ID format"),
         (status = 404, description = "Session not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -233,23 +267,53 @@ pub async fn create_message(
 pub async fn list_messages(
     org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, _agent_id, session_id)): Path<(String, Uuid, Uuid)>,
-) -> Result<Json<ListResponse<Message>>, StatusCode> {
+    Path((_org_path, _agent_id, session_id)): Path<(String, String, String)>,
+) -> Result<Json<ListResponse<Message>>, (StatusCode, Json<ErrorResponse>)> {
+    let session_id: SessionId = session_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid session ID: {}", e),
+            }),
+        )
+    })?;
+
     // Verify session exists
     let _session = state
         .session_service
-        .get(org.org_id, session_id)
+        .get(org.org_id, session_id.uuid())
         .await
         .map_err(|e| {
             tracing::error!("Failed to get session: {}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "Internal server error".to_string(),
+                }),
+            )
         })?
-        .ok_or(StatusCode::NOT_FOUND)?;
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: "Session not found".to_string(),
+                }),
+            )
+        })?;
 
-    let messages = state.message_service.list(session_id).await.map_err(|e| {
-        tracing::error!("Failed to list messages: {}", e);
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    let messages = state
+        .message_service
+        .list(session_id.uuid())
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to list messages: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "Internal server error".to_string(),
+                }),
+            )
+        })?;
 
     Ok(Json(ListResponse::new(messages)))
 }

--- a/crates/control-plane/src/api/messages.rs
+++ b/crates/control-plane/src/api/messages.rs
@@ -17,7 +17,7 @@ use axum::{
     routing::post,
 };
 use chrono::{DateTime, Utc};
-use everruns_core::typed_id::SessionId;
+use everruns_core::typed_id::{MessageId, SessionId};
 
 use super::common::{ErrorResponse, ListResponse};
 use everruns_worker::AgentRunner;
@@ -75,8 +75,12 @@ impl From<&str> for MessageRole {
 /// Message - primary conversation data (API response)
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct Message {
-    pub id: Uuid,
-    pub session_id: Uuid,
+    /// Unique message ID (format: message_{32-hex})
+    #[schema(value_type = String, example = "message_01933b5a00007000800000000000001")]
+    pub id: MessageId,
+    /// Session ID this message belongs to (format: session_{32-hex})
+    #[schema(value_type = String, example = "session_01933b5a00007000800000000000001")]
+    pub session_id: SessionId,
     pub sequence: i32,
     pub role: MessageRole,
     /// Array of content parts

--- a/crates/control-plane/src/api/session_files.rs
+++ b/crates/control-plane/src/api/session_files.rs
@@ -20,6 +20,7 @@ use axum::{
     http::StatusCode,
     routing::{get, post},
 };
+use everruns_core::typed_id::SessionId;
 use everruns_core::{FileInfo, FileStat, GrepResult, SessionFile};
 
 use super::common::ListResponse;
@@ -200,22 +201,29 @@ fn is_reserved_path(path: &str) -> bool {
     path = "/v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}/fs",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("agent_id" = Uuid, Path, description = "Agent ID"),
-        ("session_id" = Uuid, Path, description = "Session ID"),
+        ("agent_id" = String, Path, description = "Agent ID (prefixed, e.g., agt_...)"),
+        ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)"),
         ("recursive" = Option<bool>, Query, description = "List recursively")
     ),
     responses(
         (status = 200, description = "Directory listing"),
+        (status = 400, description = "Invalid session ID"),
         (status = 500, description = "Internal server error")
     ),
     tag = "filesystem"
 )]
 pub async fn get_root(
     State(state): State<AppState>,
-    Path((_org_path, _agent_id, session_id)): Path<(String, Uuid, Uuid)>,
+    Path((_org_path, _agent_id, session_id)): Path<(String, String, String)>,
     Query(query): Query<GetQuery>,
-) -> Result<Json<GetResponse>, StatusCode> {
-    get_path_impl(state, session_id, "/", query).await
+) -> Result<Json<GetResponse>, (StatusCode, String)> {
+    let session_id: SessionId = session_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("Invalid session ID: {}", e),
+        )
+    })?;
+    get_path_impl(state, session_id.uuid(), "/", query).await
 }
 
 /// GET /fs/*path - Get file content or directory listing
@@ -224,13 +232,14 @@ pub async fn get_root(
     path = "/v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}/fs/{path}",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("agent_id" = Uuid, Path, description = "Agent ID"),
-        ("session_id" = Uuid, Path, description = "Session ID"),
+        ("agent_id" = String, Path, description = "Agent ID (prefixed, e.g., agt_...)"),
+        ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)"),
         ("path" = String, Path, description = "File or directory path"),
         ("recursive" = Option<bool>, Query, description = "List recursively")
     ),
     responses(
         (status = 200, description = "File content or directory listing"),
+        (status = 400, description = "Invalid session ID"),
         (status = 404, description = "Not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -238,11 +247,17 @@ pub async fn get_root(
 )]
 pub async fn get_path(
     State(state): State<AppState>,
-    Path((_org_path, _agent_id, session_id, path)): Path<(String, Uuid, Uuid, String)>,
+    Path((_org_path, _agent_id, session_id, path)): Path<(String, String, String, String)>,
     Query(query): Query<GetQuery>,
-) -> Result<Json<GetResponse>, StatusCode> {
+) -> Result<Json<GetResponse>, (StatusCode, String)> {
+    let session_id: SessionId = session_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("Invalid session ID: {}", e),
+        )
+    })?;
     let normalized = normalize_path(&path);
-    get_path_impl(state, session_id, &normalized, query).await
+    get_path_impl(state, session_id.uuid(), &normalized, query).await
 }
 
 async fn get_path_impl(
@@ -250,7 +265,7 @@ async fn get_path_impl(
     session_id: Uuid,
     path: &str,
     query: GetQuery,
-) -> Result<Json<GetResponse>, StatusCode> {
+) -> Result<Json<GetResponse>, (StatusCode, String)> {
     // Check if path is a directory or file
     let stat = state
         .file_service
@@ -258,7 +273,10 @@ async fn get_path_impl(
         .await
         .map_err(|e| {
             tracing::error!("Failed to stat: {}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal server error".to_string(),
+            )
         })?;
 
     match stat {
@@ -271,7 +289,10 @@ async fn get_path_impl(
             }
             .map_err(|e| {
                 tracing::error!("Failed to list: {}", e);
-                StatusCode::INTERNAL_SERVER_ERROR
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Internal server error".to_string(),
+                )
             })?;
             Ok(Json(GetResponse::Listing(ListResponse::new(files))))
         }
@@ -283,9 +304,12 @@ async fn get_path_impl(
                 .await
                 .map_err(|e| {
                     tracing::error!("Failed to read file: {}", e);
-                    StatusCode::INTERNAL_SERVER_ERROR
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "Internal server error".to_string(),
+                    )
                 })?
-                .ok_or(StatusCode::NOT_FOUND)?;
+                .ok_or((StatusCode::NOT_FOUND, "File not found".to_string()))?;
             Ok(Json(GetResponse::File(file)))
         }
         None => {
@@ -293,7 +317,7 @@ async fn get_path_impl(
             if path == "/" {
                 Ok(Json(GetResponse::Listing(ListResponse::new(vec![]))))
             } else {
-                Err(StatusCode::NOT_FOUND)
+                Err((StatusCode::NOT_FOUND, "Path not found".to_string()))
             }
         }
     }
@@ -313,14 +337,14 @@ pub async fn create_root() -> (StatusCode, String) {
     path = "/v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}/fs/{path}",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("agent_id" = Uuid, Path, description = "Agent ID"),
-        ("session_id" = Uuid, Path, description = "Session ID"),
+        ("agent_id" = String, Path, description = "Agent ID (prefixed, e.g., agt_...)"),
+        ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)"),
         ("path" = String, Path, description = "File or directory path")
     ),
     request_body = CreateFileRequest,
     responses(
         (status = 201, description = "Created successfully", body = SessionFile),
-        (status = 400, description = "Invalid request"),
+        (status = 400, description = "Invalid session ID or request"),
         (status = 409, description = "Already exists"),
         (status = 500, description = "Internal server error")
     ),
@@ -328,9 +352,16 @@ pub async fn create_root() -> (StatusCode, String) {
 )]
 pub async fn create_path(
     State(state): State<AppState>,
-    Path((_org_path, _agent_id, session_id, path)): Path<(String, Uuid, Uuid, String)>,
+    Path((_org_path, _agent_id, session_id, path)): Path<(String, String, String, String)>,
     Json(req): Json<CreateFileRequest>,
 ) -> Result<(StatusCode, Json<SessionFile>), (StatusCode, String)> {
+    let session_id: SessionId = session_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("Invalid session ID: {}", e),
+        )
+    })?;
+    let session_id = session_id.uuid();
     let normalized = normalize_path(&path);
 
     // Paths starting with _ are reserved for actions
@@ -416,14 +447,14 @@ pub async fn create_path(
     path = "/v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}/fs/{path}",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("agent_id" = Uuid, Path, description = "Agent ID"),
-        ("session_id" = Uuid, Path, description = "Session ID"),
+        ("agent_id" = String, Path, description = "Agent ID (prefixed, e.g., agt_...)"),
+        ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)"),
         ("path" = String, Path, description = "File path")
     ),
     request_body = UpdateFileRequest,
     responses(
         (status = 200, description = "Updated successfully", body = SessionFile),
-        (status = 400, description = "Cannot modify readonly file or directory"),
+        (status = 400, description = "Invalid session ID or cannot modify readonly file or directory"),
         (status = 404, description = "Not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -431,9 +462,16 @@ pub async fn create_path(
 )]
 pub async fn update_path(
     State(state): State<AppState>,
-    Path((_org_path, _agent_id, session_id, path)): Path<(String, Uuid, Uuid, String)>,
+    Path((_org_path, _agent_id, session_id, path)): Path<(String, String, String, String)>,
     Json(req): Json<UpdateFileRequest>,
 ) -> Result<Json<SessionFile>, (StatusCode, String)> {
+    let session_id: SessionId = session_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("Invalid session ID: {}", e),
+        )
+    })?;
+    let session_id = session_id.uuid();
     let normalized = normalize_path(&path);
 
     // Paths starting with _ are reserved for actions
@@ -485,23 +523,30 @@ pub async fn delete_root() -> (StatusCode, String) {
     path = "/v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}/fs/{path}",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("agent_id" = Uuid, Path, description = "Agent ID"),
-        ("session_id" = Uuid, Path, description = "Session ID"),
+        ("agent_id" = String, Path, description = "Agent ID (prefixed, e.g., agt_...)"),
+        ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)"),
         ("path" = String, Path, description = "File or directory path"),
         ("recursive" = Option<bool>, Query, description = "Delete recursively")
     ),
     responses(
         (status = 200, description = "Deleted", body = DeleteResponse),
-        (status = 400, description = "Directory not empty"),
+        (status = 400, description = "Invalid session ID or directory not empty"),
         (status = 500, description = "Internal server error")
     ),
     tag = "filesystem"
 )]
 pub async fn delete_path(
     State(state): State<AppState>,
-    Path((_org_path, _agent_id, session_id, path)): Path<(String, Uuid, Uuid, String)>,
+    Path((_org_path, _agent_id, session_id, path)): Path<(String, String, String, String)>,
     Query(query): Query<DeleteQuery>,
 ) -> Result<Json<DeleteResponse>, (StatusCode, String)> {
+    let session_id: SessionId = session_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("Invalid session ID: {}", e),
+        )
+    })?;
+    let session_id = session_id.uuid();
     let normalized = normalize_path(&path);
 
     let deleted = state
@@ -530,13 +575,13 @@ pub async fn delete_path(
     path = "/v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}/fs/_/move",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("agent_id" = Uuid, Path, description = "Agent ID"),
-        ("session_id" = Uuid, Path, description = "Session ID")
+        ("agent_id" = String, Path, description = "Agent ID (prefixed, e.g., agt_...)"),
+        ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)")
     ),
     request_body = MoveFileRequest,
     responses(
         (status = 200, description = "Moved successfully", body = SessionFile),
-        (status = 400, description = "Invalid path"),
+        (status = 400, description = "Invalid session ID or path"),
         (status = 404, description = "Source not found"),
         (status = 409, description = "Destination exists"),
         (status = 500, description = "Internal server error")
@@ -545,9 +590,16 @@ pub async fn delete_path(
 )]
 pub async fn move_file(
     State(state): State<AppState>,
-    Path((_org_path, _agent_id, session_id)): Path<(String, Uuid, Uuid)>,
+    Path((_org_path, _agent_id, session_id)): Path<(String, String, String)>,
     Json(req): Json<MoveFileRequest>,
 ) -> Result<Json<SessionFile>, (StatusCode, String)> {
+    let session_id: SessionId = session_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("Invalid session ID: {}", e),
+        )
+    })?;
+    let session_id = session_id.uuid();
     let input = MoveFileInput {
         src_path: req.src_path,
         dst_path: req.dst_path,
@@ -584,13 +636,13 @@ pub async fn move_file(
     path = "/v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}/fs/_/copy",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("agent_id" = Uuid, Path, description = "Agent ID"),
-        ("session_id" = Uuid, Path, description = "Session ID")
+        ("agent_id" = String, Path, description = "Agent ID (prefixed, e.g., agt_...)"),
+        ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)")
     ),
     request_body = CopyFileRequest,
     responses(
         (status = 201, description = "Copied successfully", body = SessionFile),
-        (status = 400, description = "Cannot copy directories"),
+        (status = 400, description = "Invalid session ID or cannot copy directories"),
         (status = 404, description = "Source not found"),
         (status = 409, description = "Destination exists"),
         (status = 500, description = "Internal server error")
@@ -599,9 +651,16 @@ pub async fn move_file(
 )]
 pub async fn copy_file(
     State(state): State<AppState>,
-    Path((_org_path, _agent_id, session_id)): Path<(String, Uuid, Uuid)>,
+    Path((_org_path, _agent_id, session_id)): Path<(String, String, String)>,
     Json(req): Json<CopyFileRequest>,
 ) -> Result<(StatusCode, Json<SessionFile>), (StatusCode, String)> {
+    let session_id: SessionId = session_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("Invalid session ID: {}", e),
+        )
+    })?;
+    let session_id = session_id.uuid();
     let input = CopyFileInput {
         src_path: req.src_path,
         dst_path: req.dst_path,
@@ -638,22 +697,29 @@ pub async fn copy_file(
     path = "/v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}/fs/_/grep",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("agent_id" = Uuid, Path, description = "Agent ID"),
-        ("session_id" = Uuid, Path, description = "Session ID")
+        ("agent_id" = String, Path, description = "Agent ID (prefixed, e.g., agt_...)"),
+        ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)")
     ),
     request_body = GrepRequest,
     responses(
         (status = 200, description = "Search results", body = ListResponse<GrepResult>),
-        (status = 400, description = "Invalid regex pattern"),
+        (status = 400, description = "Invalid session ID or regex pattern"),
         (status = 500, description = "Internal server error")
     ),
     tag = "filesystem"
 )]
 pub async fn grep_files(
     State(state): State<AppState>,
-    Path((_org_path, _agent_id, session_id)): Path<(String, Uuid, Uuid)>,
+    Path((_org_path, _agent_id, session_id)): Path<(String, String, String)>,
     Json(req): Json<GrepRequest>,
 ) -> Result<Json<ListResponse<GrepResult>>, (StatusCode, String)> {
+    let session_id: SessionId = session_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("Invalid session ID: {}", e),
+        )
+    })?;
+    let session_id = session_id.uuid();
     let input = GrepInput {
         pattern: req.pattern,
         path_pattern: req.path_pattern,
@@ -685,12 +751,13 @@ pub async fn grep_files(
     path = "/v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}/fs/_/stat",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("agent_id" = Uuid, Path, description = "Agent ID"),
-        ("session_id" = Uuid, Path, description = "Session ID")
+        ("agent_id" = String, Path, description = "Agent ID (prefixed, e.g., agt_...)"),
+        ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)")
     ),
     request_body = StatRequest,
     responses(
         (status = 200, description = "Stat info", body = FileStat),
+        (status = 400, description = "Invalid session ID"),
         (status = 404, description = "Not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -698,9 +765,16 @@ pub async fn grep_files(
 )]
 pub async fn stat_file(
     State(state): State<AppState>,
-    Path((_org_path, _agent_id, session_id)): Path<(String, Uuid, Uuid)>,
+    Path((_org_path, _agent_id, session_id)): Path<(String, String, String)>,
     Json(req): Json<StatRequest>,
 ) -> Result<Json<FileStat>, (StatusCode, String)> {
+    let session_id: SessionId = session_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("Invalid session ID: {}", e),
+        )
+    })?;
+    let session_id = session_id.uuid();
     let normalized = normalize_path(&req.path);
 
     let stat = state

--- a/crates/control-plane/src/api/sessions.rs
+++ b/crates/control-plane/src/api/sessions.rs
@@ -387,9 +387,7 @@ pub async fn cancel_turn(
 ) -> Result<Json<CancelTurnResponse>, StatusCode> {
     use everruns_core::typed_id::SessionId;
 
-    let session_id: SessionId = session_id
-        .parse()
-        .map_err(|_| StatusCode::BAD_REQUEST)?;
+    let session_id: SessionId = session_id.parse().map_err(|_| StatusCode::BAD_REQUEST)?;
 
     // Verify session exists
     let session = state

--- a/crates/control-plane/src/api/sessions.rs
+++ b/crates/control-plane/src/api/sessions.rs
@@ -11,7 +11,7 @@ use axum::{
     routing::{get, post},
 };
 use everruns_core::events::{EventContext, EventRequest, MessageUserData, TurnCancelledData};
-use everruns_core::typed_id::{AgentId, SessionId, TurnId};
+use everruns_core::typed_id::{AgentId, ModelId, SessionId, TurnId};
 use everruns_core::{Message, Session};
 use everruns_worker::AgentRunner;
 
@@ -35,7 +35,8 @@ pub struct CreateSessionRequest {
     /// The ID of the LLM model to use for this session.
     /// Overrides the agent's default model if specified.
     #[serde(default)]
-    pub model_id: Option<Uuid>,
+    #[schema(value_type = Option<String>, example = "model_01933b5a00007000800000000000001")]
+    pub model_id: Option<ModelId>,
 }
 
 /// Response from cancel turn endpoint
@@ -368,11 +369,12 @@ pub async fn delete_session(
     path = "/v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}/cancel",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("agent_id" = Uuid, Path, description = "Agent ID"),
-        ("session_id" = Uuid, Path, description = "Session ID")
+        ("agent_id" = String, Path, description = "Agent ID (prefixed, e.g., agent_...)"),
+        ("session_id" = String, Path, description = "Session ID (prefixed, e.g., session_...)")
     ),
     responses(
         (status = 200, description = "Turn cancelled successfully (or no-op if idle)", body = CancelTurnResponse),
+        (status = 400, description = "Invalid session ID"),
         (status = 404, description = "Session not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -381,12 +383,18 @@ pub async fn delete_session(
 pub async fn cancel_turn(
     org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, _agent_id, session_id)): Path<(String, Uuid, Uuid)>,
+    Path((_org_path, _agent_id, session_id)): Path<(String, String, String)>,
 ) -> Result<Json<CancelTurnResponse>, StatusCode> {
+    use everruns_core::typed_id::SessionId;
+
+    let session_id: SessionId = session_id
+        .parse()
+        .map_err(|_| StatusCode::BAD_REQUEST)?;
+
     // Verify session exists
     let session = state
         .session_service
-        .get(org.org_id, session_id)
+        .get(org.org_id, session_id.uuid())
         .await
         .log_internal_error("get session for cancel")?
         .ok_or_not_found()?;
@@ -400,19 +408,20 @@ pub async fn cancel_turn(
     }
 
     // Cancel the workflow
-    if let Err(e) = state.runner.cancel_run(session_id).await {
+    let session_uuid = session_id.uuid();
+    if let Err(e) = state.runner.cancel_run(session_uuid).await {
         tracing::error!(session_id = %session_id, error = %e, "Failed to cancel workflow");
         // Continue anyway - workflow may have already completed
     }
 
     // Generate IDs for the turn context
     // Use session_id as turn_id since workflow_id = session_id in durable runner
-    let turn_id = session_id;
+    let turn_id = session_uuid;
     let input_message_id = Uuid::now_v7(); // Placeholder since we don't have the original
 
     // Emit turn.cancelled event
     let cancelled_event = EventRequest::new(
-        session_id,
+        session_uuid,
         EventContext::turn(turn_id, input_message_id),
         TurnCancelledData {
             turn_id: TurnId::from_uuid(turn_id),
@@ -427,7 +436,7 @@ pub async fn cancel_turn(
     // Insert user message indicating cancellation request
     let user_cancel_message = Message::user("User requested to cancel the work.");
     let user_message_event = EventRequest::new(
-        session_id,
+        session_uuid,
         EventContext::turn(turn_id, input_message_id),
         MessageUserData::new(user_cancel_message),
     );
@@ -470,23 +479,23 @@ mod tests {
 
     #[test]
     fn test_create_session_request_with_model_id() {
-        let model_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
-        let json = format!(r#"{{"model_id": "{}"}}"#, model_uuid);
+        let model_id: ModelId = "model_550e8400e29b41d4a716446655440000".parse().unwrap();
+        let json = format!(r#"{{"model_id": "{}"}}"#, model_id);
         let req: CreateSessionRequest = serde_json::from_str(&json).unwrap();
-        assert_eq!(req.model_id, Some(model_uuid));
+        assert_eq!(req.model_id, Some(model_id));
     }
 
     #[test]
     fn test_create_session_request_full() {
-        let model_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440001").unwrap();
+        let model_id: ModelId = "model_550e8400e29b41d4a716446655440001".parse().unwrap();
         let json = format!(
             r#"{{"title": "Full Session", "tags": ["tag1", "tag2"], "model_id": "{}"}}"#,
-            model_uuid
+            model_id
         );
         let req: CreateSessionRequest = serde_json::from_str(&json).unwrap();
         assert_eq!(req.title, Some("Full Session".to_string()));
         assert_eq!(req.tags, vec!["tag1", "tag2"]);
-        assert_eq!(req.model_id, Some(model_uuid));
+        assert_eq!(req.model_id, Some(model_id));
     }
 
     #[test]

--- a/crates/control-plane/src/api/sessions.rs
+++ b/crates/control-plane/src/api/sessions.rs
@@ -11,7 +11,7 @@ use axum::{
     routing::{get, post},
 };
 use everruns_core::events::{EventContext, EventRequest, MessageUserData, TurnCancelledData};
-use everruns_core::typed_id::{AgentId, SessionId};
+use everruns_core::typed_id::{AgentId, SessionId, TurnId};
 use everruns_core::{Message, Session};
 use everruns_worker::AgentRunner;
 
@@ -415,7 +415,7 @@ pub async fn cancel_turn(
         session_id,
         EventContext::turn(turn_id, input_message_id),
         TurnCancelledData {
-            turn_id,
+            turn_id: TurnId::from_uuid(turn_id),
             reason: Some("User requested cancellation".to_string()),
             usage: None, // Usage not available at cancellation time
         },

--- a/crates/control-plane/src/api/sessions.rs
+++ b/crates/control-plane/src/api/sessions.rs
@@ -11,10 +11,11 @@ use axum::{
     routing::{get, post},
 };
 use everruns_core::events::{EventContext, EventRequest, MessageUserData, TurnCancelledData};
+use everruns_core::typed_id::{AgentId, SessionId};
 use everruns_core::{Message, Session};
 use everruns_worker::AgentRunner;
 
-use super::common::{ApiOptionExt, ApiResultExt, PaginatedResponse, Pagination};
+use super::common::{ApiOptionExt, ApiResultExt, ErrorResponse, PaginatedResponse, Pagination};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::{IntoParams, ToSchema};
@@ -143,11 +144,12 @@ pub fn routes(state: AppState) -> Router {
     path = "/v1/orgs/{org}/agents/{agent_id}/sessions",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("agent_id" = Uuid, Path, description = "Agent ID")
+        ("agent_id" = String, Path, description = "Agent ID (prefixed, e.g., agt_...)")
     ),
     request_body = CreateSessionRequest,
     responses(
         (status = 201, description = "Session created successfully", body = Session),
+        (status = 400, description = "Invalid agent ID"),
         (status = 500, description = "Internal server error")
     ),
     tag = "sessions"
@@ -155,14 +157,23 @@ pub fn routes(state: AppState) -> Router {
 pub async fn create_session(
     org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, agent_id)): Path<(String, Uuid)>,
+    Path((_org_path, agent_id)): Path<(String, String)>,
     Json(req): Json<CreateSessionRequest>,
-) -> Result<(StatusCode, Json<Session>), StatusCode> {
+) -> Result<(StatusCode, Json<Session>), (StatusCode, Json<ErrorResponse>)> {
+    let agent_id: AgentId = agent_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid agent ID: {}", e),
+            }),
+        )
+    })?;
+
     let session = state
         .session_service
-        .create(org.org_id, agent_id, req)
+        .create(org.org_id, agent_id.uuid(), req)
         .await
-        .log_internal_error("create session")?;
+        .log_internal_error_json("create session")?;
 
     Ok((StatusCode::CREATED, Json(session)))
 }
@@ -173,11 +184,12 @@ pub async fn create_session(
     path = "/v1/orgs/{org}/agents/{agent_id}/sessions",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("agent_id" = Uuid, Path, description = "Agent ID"),
+        ("agent_id" = String, Path, description = "Agent ID (prefixed, e.g., agt_...)"),
         ListSessionsQuery
     ),
     responses(
         (status = 200, description = "Paginated list of sessions", body = PaginatedResponse<Session>),
+        (status = 400, description = "Invalid agent ID"),
         (status = 500, description = "Internal server error")
     ),
     tag = "sessions"
@@ -185,18 +197,27 @@ pub async fn create_session(
 pub async fn list_sessions(
     org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, agent_id)): Path<(String, Uuid)>,
+    Path((_org_path, agent_id)): Path<(String, String)>,
     Query(query): Query<ListSessionsQuery>,
-) -> Result<Json<PaginatedResponse<Session>>, StatusCode> {
+) -> Result<Json<PaginatedResponse<Session>>, (StatusCode, Json<ErrorResponse>)> {
+    let agent_id: AgentId = agent_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid agent ID: {}", e),
+            }),
+        )
+    })?;
+
     let offset = query.offset.unwrap_or(0);
     let limit = query.limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT);
     let pagination = Pagination::new(offset, limit);
 
     let (sessions, total) = state
         .session_service
-        .list(org.org_id, agent_id, pagination)
+        .list(org.org_id, agent_id.uuid(), pagination)
         .await
-        .log_internal_error("list sessions")?;
+        .log_internal_error_json("list sessions")?;
 
     Ok(Json(PaginatedResponse::new(sessions, total, offset, limit)))
 }
@@ -207,11 +228,12 @@ pub async fn list_sessions(
     path = "/v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("agent_id" = Uuid, Path, description = "Agent ID"),
-        ("session_id" = Uuid, Path, description = "Session ID")
+        ("agent_id" = String, Path, description = "Agent ID (prefixed, e.g., agt_...)"),
+        ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)")
     ),
     responses(
         (status = 200, description = "Session found", body = Session),
+        (status = 400, description = "Invalid session ID"),
         (status = 404, description = "Session not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -220,14 +242,23 @@ pub async fn list_sessions(
 pub async fn get_session(
     org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, _agent_id, session_id)): Path<(String, Uuid, Uuid)>,
-) -> Result<Json<Session>, StatusCode> {
+    Path((_org_path, _agent_id, session_id)): Path<(String, String, String)>,
+) -> Result<Json<Session>, (StatusCode, Json<ErrorResponse>)> {
+    let session_id: SessionId = session_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid session ID: {}", e),
+            }),
+        )
+    })?;
+
     let session = state
         .session_service
-        .get(org.org_id, session_id)
+        .get(org.org_id, session_id.uuid())
         .await
-        .log_internal_error("get session")?
-        .ok_or_not_found()?;
+        .log_internal_error_json("get session")?
+        .ok_or_not_found_json("Session")?;
 
     Ok(Json(session))
 }
@@ -238,12 +269,13 @@ pub async fn get_session(
     path = "/v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("agent_id" = Uuid, Path, description = "Agent ID"),
-        ("session_id" = Uuid, Path, description = "Session ID")
+        ("agent_id" = String, Path, description = "Agent ID (prefixed, e.g., agt_...)"),
+        ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)")
     ),
     request_body = UpdateSessionRequest,
     responses(
         (status = 200, description = "Session updated successfully", body = Session),
+        (status = 400, description = "Invalid session ID"),
         (status = 404, description = "Session not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -252,15 +284,24 @@ pub async fn get_session(
 pub async fn update_session(
     org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, _agent_id, session_id)): Path<(String, Uuid, Uuid)>,
+    Path((_org_path, _agent_id, session_id)): Path<(String, String, String)>,
     Json(req): Json<UpdateSessionRequest>,
-) -> Result<Json<Session>, StatusCode> {
+) -> Result<Json<Session>, (StatusCode, Json<ErrorResponse>)> {
+    let session_id: SessionId = session_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid session ID: {}", e),
+            }),
+        )
+    })?;
+
     let session = state
         .session_service
-        .update(org.org_id, session_id, req)
+        .update(org.org_id, session_id.uuid(), req)
         .await
-        .log_internal_error("update session")?
-        .ok_or_not_found()?;
+        .log_internal_error_json("update session")?
+        .ok_or_not_found_json("Session")?;
 
     Ok(Json(session))
 }
@@ -271,11 +312,12 @@ pub async fn update_session(
     path = "/v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("agent_id" = Uuid, Path, description = "Agent ID"),
-        ("session_id" = Uuid, Path, description = "Session ID")
+        ("agent_id" = String, Path, description = "Agent ID (prefixed, e.g., agt_...)"),
+        ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)")
     ),
     responses(
         (status = 204, description = "Session deleted successfully"),
+        (status = 400, description = "Invalid session ID"),
         (status = 404, description = "Session not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -284,18 +326,32 @@ pub async fn update_session(
 pub async fn delete_session(
     org: OrgContext,
     State(state): State<AppState>,
-    Path((_org_path, _agent_id, session_id)): Path<(String, Uuid, Uuid)>,
-) -> Result<StatusCode, StatusCode> {
+    Path((_org_path, _agent_id, session_id)): Path<(String, String, String)>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let session_id: SessionId = session_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid session ID: {}", e),
+            }),
+        )
+    })?;
+
     let deleted = state
         .session_service
-        .delete(org.org_id, session_id)
+        .delete(org.org_id, session_id.uuid())
         .await
-        .log_internal_error("delete session")?;
+        .log_internal_error_json("delete session")?;
 
     if deleted {
         Ok(StatusCode::NO_CONTENT)
     } else {
-        Err(StatusCode::NOT_FOUND)
+        Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: "Session not found".to_string(),
+            }),
+        ))
     }
 }
 

--- a/crates/control-plane/src/dev_worker/direct_adapters.rs
+++ b/crates/control-plane/src/dev_worker/direct_adapters.rs
@@ -13,6 +13,7 @@ use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
 use everruns_core::traits::{
     AgentStore, EventEmitter, LlmProviderStore, ModelWithProvider, SessionFileStore, SessionStore,
 };
+use everruns_core::typed_id::MessageId;
 use everruns_core::{
     Agent, AgentStatus, ContentPart, DEFAULT_ORG_ID, LlmProviderType, Message, MessageRole,
     Session, SessionStatus, ToolResultContentPart,
@@ -270,7 +271,7 @@ fn event_to_message(event: Event) -> Option<Message> {
                 error: data.error.clone(),
             })];
             Some(Message {
-                id: event.id.into(),
+                id: MessageId::from_uuid(event.id.uuid()),
                 role: MessageRole::ToolResult,
                 content,
                 controls: None,

--- a/crates/control-plane/src/dev_worker/direct_adapters.rs
+++ b/crates/control-plane/src/dev_worker/direct_adapters.rs
@@ -81,11 +81,11 @@ impl AgentStore for DirectAgentStore {
         };
 
         Ok(row.map(|r| Agent {
-            id: r.id,
+            id: r.id.into(),
             name: r.name,
             description: r.description,
             system_prompt: r.system_prompt,
-            default_model_id: r.default_model_id,
+            default_model_id: r.default_model_id.map(|id| id.into()),
             tags: r.tags,
             capabilities: capabilities
                 .into_iter()
@@ -132,13 +132,13 @@ impl SessionStore for DirectSessionStore {
             })?;
 
         Ok(row.map(|r| Session {
-            id: r.id,
-            agent_id: r.agent_id,
+            id: r.id.into(),
+            agent_id: r.agent_id.into(),
             title: r.title,
             preview: None,
             output_preview: None,
             tags: r.tags,
-            model_id: r.model_id,
+            model_id: r.model_id.map(|id| id.into()),
             status: match r.status.as_str() {
                 "started" => SessionStatus::Started,
                 "active" => SessionStatus::Active,
@@ -181,7 +181,7 @@ impl DirectMessageRetriever {
 
         // Create a Message from the input
         let message = Message {
-            id: Uuid::now_v7(),
+            id: Uuid::now_v7().into(),
             role: input.role.clone(),
             content: input.content.clone(),
             controls: input.controls.clone(),
@@ -270,7 +270,7 @@ fn event_to_message(event: Event) -> Option<Message> {
                 error: data.error.clone(),
             })];
             Some(Message {
-                id: event.id,
+                id: event.id.into(),
                 role: MessageRole::ToolResult,
                 content,
                 controls: None,

--- a/crates/control-plane/src/dev_worker/worker.rs
+++ b/crates/control-plane/src/dev_worker/worker.rs
@@ -10,6 +10,7 @@ use anyhow::Result;
 use everruns_core::ToolRegistry;
 use everruns_core::atoms::{ActAtom, Atom, AtomContext, InputAtom, ReasonAtom};
 use everruns_core::capabilities::{CapabilityRegistry, collect_capabilities, is_mcp_capability};
+use everruns_core::typed_id::{MessageId, TurnId};
 use everruns_core::{
     ActInput, DEFAULT_ORG_ID, InputAtomInput, ReasonInput, ReasonResult, TokenUsage,
 };
@@ -387,8 +388,8 @@ impl InProcessWorker {
             input.session_id,
             EventContext::turn(context.turn_id, input.input_message_id),
             SessionActivatedData {
-                turn_id: context.turn_id,
-                input_message_id: input.input_message_id,
+                turn_id: TurnId::from_uuid(context.turn_id),
+                input_message_id: MessageId::from_uuid(input.input_message_id),
             },
         );
         if let Err(e) = event_emitter.emit(activated_event).await {
@@ -400,8 +401,8 @@ impl InProcessWorker {
             input.session_id,
             EventContext::turn(context.turn_id, input.input_message_id),
             TurnStartedData {
-                turn_id: context.turn_id,
-                input_message_id: input.input_message_id,
+                turn_id: TurnId::from_uuid(context.turn_id),
+                input_message_id: MessageId::from_uuid(input.input_message_id),
             },
         );
         if let Err(e) = event_emitter.emit(turn_started_event).await {
@@ -495,7 +496,7 @@ impl InProcessWorker {
                     session_id,
                     EventContext::turn(turn_id, input_message_id),
                     TurnFailedData {
-                        turn_id,
+                        turn_id: TurnId::from_uuid(turn_id),
                         error: "An error occurred while processing your request.".to_string(),
                         error_code: Some("llm_error".to_string()),
                     },
@@ -508,7 +509,7 @@ impl InProcessWorker {
                     session_id,
                     EventContext::turn(turn_id, input_message_id),
                     TurnCompletedData {
-                        turn_id,
+                        turn_id: TurnId::from_uuid(turn_id),
                         iterations: 1,
                         duration_ms: None,
                         usage: result.usage.clone(),
@@ -551,7 +552,7 @@ impl InProcessWorker {
                 session_id,
                 EventContext::turn(turn_id, input_message_id),
                 SessionIdledData {
-                    turn_id,
+                    turn_id: TurnId::from_uuid(turn_id),
                     iterations: None,
                     usage: session_usage,
                 },

--- a/crates/control-plane/src/grpc_service.rs
+++ b/crates/control-plane/src/grpc_service.rs
@@ -273,7 +273,7 @@ impl WorkerService for WorkerServiceImpl {
         // Get agent with capabilities via AgentService
         let agent = self
             .agent_service
-            .get(req.org_id, session.agent_id)
+            .get(req.org_id, session.agent_id.uuid())
             .await
             .map_err(|e| {
                 tracing::error!("Failed to get agent: {}", e);
@@ -287,13 +287,13 @@ impl WorkerService for WorkerServiceImpl {
         let proto_agent = schema_agent_to_proto(&agent);
 
         let proto_session = proto::Session {
-            id: Some(uuid_to_proto_uuid(session.id)),
-            agent_id: Some(uuid_to_proto_uuid(session.agent_id)),
+            id: Some(uuid_to_proto_uuid(session.id.uuid())),
+            agent_id: Some(uuid_to_proto_uuid(session.agent_id.uuid())),
             title: session.title.clone().unwrap_or_default(),
             status: session.status.to_string(),
             created_at: Some(datetime_to_proto_timestamp(session.created_at)),
             updated_at: Some(datetime_to_proto_timestamp(session.created_at)),
-            default_model_id: session.model_id.map(uuid_to_proto_uuid),
+            default_model_id: session.model_id.map(|id| uuid_to_proto_uuid(id.uuid())),
         };
 
         // Load messages from events using EventService
@@ -339,7 +339,7 @@ impl WorkerService for WorkerServiceImpl {
             });
 
             proto_messages.push(proto::Message {
-                id: Some(uuid_to_proto_uuid(message.id)),
+                id: Some(uuid_to_proto_uuid(message.id.uuid())),
                 role: message.role.to_string(),
                 content,
                 controls,
@@ -354,7 +354,7 @@ impl WorkerService for WorkerServiceImpl {
 
         let model: Option<proto::ModelWithProvider> = if let Some(mid) = model_id {
             self.llm_resolver_service
-                .resolve_model(mid)
+                .resolve_model(mid.uuid())
                 .await
                 .map_err(|e| {
                     tracing::error!("Failed to resolve model: {}", e);
@@ -471,13 +471,13 @@ impl WorkerService for WorkerServiceImpl {
         use everruns_internal_protocol::{datetime_to_proto_timestamp, uuid_to_proto_uuid};
 
         let proto_session = session.map(|s| proto::Session {
-            id: Some(uuid_to_proto_uuid(s.id)),
-            agent_id: Some(uuid_to_proto_uuid(s.agent_id)),
+            id: Some(uuid_to_proto_uuid(s.id.uuid())),
+            agent_id: Some(uuid_to_proto_uuid(s.agent_id.uuid())),
             title: s.title.clone().unwrap_or_default(),
             status: s.status.to_string(),
             created_at: Some(datetime_to_proto_timestamp(s.created_at)),
             updated_at: Some(datetime_to_proto_timestamp(s.created_at)),
-            default_model_id: s.model_id.map(uuid_to_proto_uuid),
+            default_model_id: s.model_id.map(|id| uuid_to_proto_uuid(id.uuid())),
         });
 
         Ok(Response::new(GetSessionResponse {
@@ -514,13 +514,13 @@ impl WorkerService for WorkerServiceImpl {
             .ok_or_else(|| Status::not_found("Session not found"))?;
 
         let proto_session = proto::Session {
-            id: Some(uuid_to_proto_uuid(session.id)),
-            agent_id: Some(uuid_to_proto_uuid(session.agent_id)),
+            id: Some(uuid_to_proto_uuid(session.id.uuid())),
+            agent_id: Some(uuid_to_proto_uuid(session.agent_id.uuid())),
             title: session.title.clone().unwrap_or_default(),
             status: session.status.to_string(),
             created_at: Some(datetime_to_proto_timestamp(session.created_at)),
             updated_at: Some(datetime_to_proto_timestamp(session.created_at)),
-            default_model_id: session.model_id.map(uuid_to_proto_uuid),
+            default_model_id: session.model_id.map(|id| uuid_to_proto_uuid(id.uuid())),
         };
 
         Ok(Response::new(SetSessionStatusResponse {
@@ -577,7 +577,7 @@ impl WorkerService for WorkerServiceImpl {
             });
 
             proto_messages.push(proto::Message {
-                id: Some(uuid_to_proto_uuid(message.id)),
+                id: Some(uuid_to_proto_uuid(message.id.uuid())),
                 role: message.role.to_string(),
                 content,
                 controls,
@@ -638,7 +638,7 @@ impl WorkerService for WorkerServiceImpl {
 
         // Create the message
         let message = Message {
-            id: uuid::Uuid::now_v7(),
+            id: uuid::Uuid::now_v7().into(),
             role: role.clone(),
             content,
             controls,
@@ -687,7 +687,7 @@ impl WorkerService for WorkerServiceImpl {
         });
 
         let proto_message = proto::Message {
-            id: Some(uuid_to_proto_uuid(message.id)),
+            id: Some(uuid_to_proto_uuid(message.id.uuid())),
             role: message.role.to_string(),
             content,
             controls,

--- a/crates/control-plane/src/services/agent.rs
+++ b/crates/control-plane/src/services/agent.rs
@@ -31,7 +31,7 @@ impl AgentService {
             name: req.name,
             description: req.description,
             system_prompt: req.system_prompt,
-            default_model_id: req.default_model_id,
+            default_model_id: req.default_model_id.map(|id| id.uuid()),
             tags: req.tags,
         };
         let row = self.db.create_agent(org_id, input).await?;
@@ -94,7 +94,7 @@ impl AgentService {
             name: req.name,
             description: req.description,
             system_prompt: req.system_prompt,
-            default_model_id: req.default_model_id,
+            default_model_id: req.default_model_id.map(|id| id.uuid()),
             tags: req.tags,
             status: req.status.map(|s| s.to_string()),
         };

--- a/crates/control-plane/src/services/agent.rs
+++ b/crates/control-plane/src/services/agent.rs
@@ -161,11 +161,11 @@ impl AgentService {
         };
 
         Agent {
-            id: row.id,
+            id: row.id.into(),
             name: row.name,
             description: row.description,
             system_prompt: row.system_prompt,
-            default_model_id: row.default_model_id,
+            default_model_id: row.default_model_id.map(|id| id.into()),
             tags: row.tags,
             capabilities,
             status: AgentStatus::from(row.status.as_str()),

--- a/crates/control-plane/src/services/capability.rs
+++ b/crates/control-plane/src/services/capability.rs
@@ -47,7 +47,7 @@ impl CapabilityService {
         let mcp_servers = self.mcp_service.list_active_with_tools().await?;
         for server_with_tools in mcp_servers {
             let mcp_cap = McpCapability::new(
-                server_with_tools.server.id,
+                server_with_tools.server.id.uuid(),
                 server_with_tools.server.name.clone(),
                 server_with_tools.server.description.clone(),
                 server_with_tools.cached_tools.clone(),
@@ -62,7 +62,7 @@ impl CapabilityService {
                 .unwrap_or_else(|| format!("MCP Server with {} tool(s)", tool_count));
 
             capabilities.push(CapabilityInfo {
-                id: CapabilityId::new(mcp_capability_id(server_with_tools.server.id)),
+                id: CapabilityId::new(mcp_capability_id(server_with_tools.server.id.uuid())),
                 name: server_with_tools.server.name.clone(),
                 description,
                 status: CapabilityStatus::Available,
@@ -92,7 +92,7 @@ impl CapabilityService {
 
             if let Some(server) = server {
                 let mcp_cap = McpCapability::new(
-                    server.id,
+                    server.id.uuid(),
                     server.name.clone(),
                     server.description.clone(),
                     tools.clone(),
@@ -105,7 +105,7 @@ impl CapabilityService {
                     .unwrap_or_else(|| format!("MCP Server with {} tool(s)", tool_count));
 
                 return Ok(Some(CapabilityInfo {
-                    id: CapabilityId::new(mcp_capability_id(server.id)),
+                    id: CapabilityId::new(mcp_capability_id(server.id.uuid())),
                     name: server.name,
                     description,
                     status: CapabilityStatus::Available,
@@ -215,7 +215,7 @@ impl CapabilityService {
 
             if let Some(server) = server {
                 let mcp_cap = McpCapability::new(
-                    server.id,
+                    server.id.uuid(),
                     server.name.clone(),
                     server.description.clone(),
                     tools,

--- a/crates/control-plane/src/services/event.rs
+++ b/crates/control-plane/src/services/event.rs
@@ -15,6 +15,7 @@
 
 use crate::storage::{EventRow, StorageBackend, models::CreateEventRow};
 use anyhow::{Result, bail};
+use everruns_core::typed_id::{EventId, SessionId};
 use everruns_core::{Event, EventData, EventListener, EventRequest, UNKNOWN};
 use std::sync::Arc;
 use uuid::Uuid;
@@ -201,10 +202,10 @@ impl EventService {
         let data =
             serde_json::from_value(row.data.clone()).unwrap_or_else(|_| EventData::raw(row.data));
         Event {
-            id: row.id,
+            id: EventId::from_uuid(row.id),
             event_type: row.event_type,
             ts: row.ts,
-            session_id: row.session_id,
+            session_id: SessionId::from_uuid(row.session_id),
             context: serde_json::from_value(row.context).unwrap_or_default(),
             data,
             metadata: row.metadata,

--- a/crates/control-plane/src/services/llm_model.rs
+++ b/crates/control-plane/src/services/llm_model.rs
@@ -160,8 +160,8 @@ impl LlmModelService {
         let capabilities: Vec<String> =
             serde_json::from_value(row.capabilities.clone()).unwrap_or_default();
         LlmModel {
-            id: row.id,
-            provider_id: row.provider_id,
+            id: row.id.into(),
+            provider_id: row.provider_id.into(),
             model_id: row.model_id.clone(),
             display_name: row.display_name.clone(),
             capabilities,
@@ -187,8 +187,8 @@ impl LlmModelService {
         let profile = get_model_profile(&provider_type, &row.model_id);
 
         LlmModelWithProvider {
-            id: row.id,
-            provider_id: row.provider_id,
+            id: row.id.into(),
+            provider_id: row.provider_id.into(),
             model_id: row.model_id.clone(),
             display_name: row.display_name.clone(),
             capabilities,

--- a/crates/control-plane/src/services/llm_provider.rs
+++ b/crates/control-plane/src/services/llm_provider.rs
@@ -100,7 +100,7 @@ impl LlmProviderService {
         let api_key_set = row.api_key_set || has_default_api_key_from_env(&row.provider_type);
 
         LlmProvider {
-            id: row.id,
+            id: row.id.into(),
             name: row.name.clone(),
             provider_type,
             base_url: row.base_url.clone(),

--- a/crates/control-plane/src/services/mcp_server.rs
+++ b/crates/control-plane/src/services/mcp_server.rs
@@ -202,7 +202,7 @@ impl McpServerService {
             serde_json::from_value(row.headers.clone()).unwrap_or_default();
 
         McpServer {
-            id: row.id,
+            id: row.id.into(),
             name: row.name.clone(),
             description: row.description.clone(),
             url: row.url.clone(),

--- a/crates/control-plane/src/services/message.rs
+++ b/crates/control-plane/src/services/message.rs
@@ -64,7 +64,7 @@ impl MessageService {
 
         // Build the core message
         let core_message = everruns_core::Message {
-            id: message_id,
+            id: message_id.into(),
             role: everruns_core::MessageRole::User,
             content: content.clone(),
             controls: req.controls.clone(),
@@ -174,7 +174,7 @@ impl MessageService {
                             data.error.clone(),
                         );
                         return Ok(Message {
-                            id: msg.id,
+                            id: msg.id.uuid(),
                             session_id,
                             sequence,
                             role: MessageRole::from(msg.role.to_string().as_str()),
@@ -188,7 +188,7 @@ impl MessageService {
                 };
 
                 Ok(Message {
-                    id: core_message.id,
+                    id: core_message.id.uuid(),
                     session_id,
                     sequence,
                     role: MessageRole::from(core_message.role.to_string().as_str()),

--- a/crates/control-plane/src/services/message.rs
+++ b/crates/control-plane/src/services/message.rs
@@ -189,7 +189,7 @@ impl MessageService {
                 };
 
                 Ok(Message {
-                    id: core_message.id.clone(),
+                    id: core_message.id,
                     session_id: SessionId::from_uuid(session_id),
                     sequence,
                     role: MessageRole::from(core_message.role.to_string().as_str()),

--- a/crates/control-plane/src/services/message.rs
+++ b/crates/control-plane/src/services/message.rs
@@ -12,6 +12,7 @@ use anyhow::Result;
 use chrono::Utc;
 use everruns_core::Event;
 use everruns_core::events::{EventContext, EventRequest, MessageUserData};
+use everruns_core::typed_id::{MessageId, SessionId};
 use everruns_worker::AgentRunner;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -84,8 +85,8 @@ impl MessageService {
 
         // Construct API Message
         let message = Message {
-            id: message_id,
-            session_id,
+            id: MessageId::from_uuid(message_id),
+            session_id: SessionId::from_uuid(session_id),
             sequence: stored_event.sequence.unwrap_or(0),
             role: MessageRole::User,
             content,
@@ -174,8 +175,8 @@ impl MessageService {
                             data.error.clone(),
                         );
                         return Ok(Message {
-                            id: msg.id.uuid(),
-                            session_id,
+                            id: msg.id,
+                            session_id: SessionId::from_uuid(session_id),
                             sequence,
                             role: MessageRole::from(msg.role.to_string().as_str()),
                             content: msg.content,
@@ -188,8 +189,8 @@ impl MessageService {
                 };
 
                 Ok(Message {
-                    id: core_message.id.uuid(),
-                    session_id,
+                    id: core_message.id.clone(),
+                    session_id: SessionId::from_uuid(session_id),
                     sequence,
                     role: MessageRole::from(core_message.role.to_string().as_str()),
                     content: core_message.content.clone(),

--- a/crates/control-plane/src/services/session.rs
+++ b/crates/control-plane/src/services/session.rs
@@ -70,7 +70,8 @@ impl SessionService {
         let session = Self::row_to_session(row);
 
         // Apply capability mounts to the session filesystem
-        self.apply_capability_mounts(agent_id, session.id).await?;
+        self.apply_capability_mounts(agent_id, session.id.uuid())
+            .await?;
 
         Ok(session)
     }
@@ -81,7 +82,12 @@ impl SessionService {
     /// 1. Gets the agent's enabled capabilities
     /// 2. Collects mount points from those capabilities
     /// 3. Creates the mounted files/directories in the session filesystem
-    async fn apply_capability_mounts(&self, agent_id: Uuid, session_id: Uuid) -> Result<()> {
+    async fn apply_capability_mounts(
+        &self,
+        agent_id: Uuid,
+        session_id: impl Into<uuid::Uuid> + Copy,
+    ) -> Result<()> {
+        let session_id = session_id.into();
         // Get agent's capability IDs
         let capability_rows = self.db.get_agent_capabilities(agent_id).await?;
         let capability_ids: Vec<String> = capability_rows
@@ -145,16 +151,16 @@ impl SessionService {
         let mut sessions: Vec<Session> = rows.into_iter().map(Self::row_to_session).collect();
 
         // Fetch previews for all sessions in batch queries
-        let session_ids: Vec<Uuid> = sessions.iter().map(|s| s.id).collect();
+        let session_ids: Vec<Uuid> = sessions.iter().map(|s| s.id.uuid()).collect();
         let input_previews = self.db.get_session_previews(&session_ids).await?;
         let output_previews = self.db.get_session_output_previews(&session_ids).await?;
 
         // Populate previews for each session
         for session in &mut sessions {
-            if let Some(preview) = input_previews.get(&session.id) {
+            if let Some(preview) = input_previews.get(&session.id.uuid()) {
                 session.preview = Some(preview.clone());
             }
-            if let Some(preview) = output_previews.get(&session.id) {
+            if let Some(preview) = output_previews.get(&session.id.uuid()) {
                 session.output_preview = Some(preview.clone());
             }
         }
@@ -218,13 +224,13 @@ impl SessionService {
         };
 
         Session {
-            id: row.id,
-            agent_id: row.agent_id,
+            id: row.id.into(),
+            agent_id: row.agent_id.into(),
             title: row.title,
             preview: None,        // Populated separately in list()
             output_preview: None, // Populated separately in list()
             tags: row.tags,
-            model_id: row.model_id,
+            model_id: row.model_id.map(|id| id.into()),
             status: SessionStatus::from(row.status.as_str()),
             created_at: row.created_at,
             started_at: row.started_at,

--- a/crates/control-plane/src/services/session.rs
+++ b/crates/control-plane/src/services/session.rs
@@ -52,7 +52,7 @@ impl SessionService {
     ) -> Result<Session> {
         // If model_id not provided, use the agent's default_model_id
         let model_id = match req.model_id {
-            Some(id) => Some(id),
+            Some(id) => Some(id.uuid()),
             None => {
                 // Look up the agent to get its default_model_id
                 let agent = self.db.get_agent(org_id, agent_id).await?;

--- a/crates/control-plane/src/services/usage_tracking.rs
+++ b/crates/control-plane/src/services/usage_tracking.rs
@@ -54,7 +54,11 @@ impl EventListener for UsageTrackingListener {
         let cache_creation_tokens = usage.cache_creation_tokens.unwrap_or(0) as i64;
 
         // Get session to determine org_id
-        let session = match self.db.get_session(DEFAULT_ORG_ID, event.session_id).await {
+        let session = match self
+            .db
+            .get_session(DEFAULT_ORG_ID, event.session_id.uuid())
+            .await
+        {
             Ok(Some(s)) => s,
             Ok(None) => {
                 error!("Session not found for usage tracking: {}", event.session_id);
@@ -84,9 +88,9 @@ impl EventListener for UsageTrackingListener {
             .db
             .create_llm_generation(
                 org_id,
-                event.session_id,
-                event.context.turn_id,
-                Some(event.id),
+                event.session_id.uuid(),
+                event.context.turn_id.as_ref().map(|id| id.uuid()),
+                Some(event.id.uuid()),
                 data.metadata.model.clone(),
                 data.metadata.provider.clone(),
                 input_tokens,
@@ -110,7 +114,7 @@ impl EventListener for UsageTrackingListener {
         if let Err(e) = self
             .db
             .increment_session_usage(
-                event.session_id,
+                event.session_id.uuid(),
                 input_tokens,
                 output_tokens,
                 cache_read_tokens,

--- a/crates/control-plane/src/storage/agent_store.rs
+++ b/crates/control-plane/src/storage/agent_store.rs
@@ -57,11 +57,11 @@ impl AgentStore for DbAgentStore {
                     .collect();
 
                 Ok(Some(Agent {
-                    id: row.id,
+                    id: row.id.into(),
                     name: row.name,
                     description: row.description,
                     system_prompt: row.system_prompt,
-                    default_model_id: row.default_model_id,
+                    default_model_id: row.default_model_id.map(|id| id.into()),
                     tags: row.tags,
                     capabilities,
                     status: AgentStatus::from(row.status.as_str()),

--- a/crates/control-plane/src/storage/event_tests.rs
+++ b/crates/control-plane/src/storage/event_tests.rs
@@ -22,7 +22,9 @@ fn test_event_serialization() {
 
     assert!(json.is_object());
     assert_eq!(json["type"], "input.received");
-    assert_eq!(json["session_id"], session_id.to_string());
+    // session_id now uses prefixed format (session_{hex})
+    let expected_session_id = format!("session_{}", session_id.simple());
+    assert_eq!(json["session_id"], expected_session_id);
     assert!(json["context"].is_object());
 }
 
@@ -49,7 +51,7 @@ fn test_event_session_id() {
         InputReceivedData::new(Message::user("test")),
     );
 
-    assert_eq!(event.session_id(), session_id);
+    assert_eq!(event.session_uuid(), session_id);
 }
 
 #[test]
@@ -71,7 +73,9 @@ fn test_tool_call_completed_event_serialization() {
 
     // Verify top-level structure
     assert_eq!(json["type"], "tool.call_completed");
-    assert_eq!(json["session_id"], session_id.to_string());
+    // session_id now uses prefixed format (session_{hex})
+    let expected_session_id = format!("session_{}", session_id.simple());
+    assert_eq!(json["session_id"], expected_session_id);
 
     // Verify data field contains the payload directly (untagged)
     let data = &json["data"];

--- a/crates/control-plane/src/storage/message_store.rs
+++ b/crates/control-plane/src/storage/message_store.rs
@@ -54,7 +54,7 @@ impl DbMessageRetriever {
     pub async fn add(&self, session_id: Uuid, input: InputMessage) -> Result<Message> {
         // Create the message
         let message = Message {
-            id: Uuid::now_v7(),
+            id: Uuid::now_v7().into(),
             role: input.role,
             content: input.content,
             controls: input.controls,

--- a/crates/control-plane/src/storage/session_store.rs
+++ b/crates/control-plane/src/storage/session_store.rs
@@ -65,13 +65,13 @@ impl SessionStore for DbSessionStore {
                 };
 
                 Ok(Some(Session {
-                    id: row.id,
-                    agent_id: row.agent_id,
+                    id: row.id.into(),
+                    agent_id: row.agent_id.into(),
                     title: row.title,
                     preview: None, // Preview populated separately when listing sessions
                     output_preview: None, // Output preview populated separately when listing sessions
                     tags: row.tags,
-                    model_id: row.model_id,
+                    model_id: row.model_id.map(|id| id.into()),
                     status: SessionStatus::from(row.status.as_str()),
                     created_at: row.created_at,
                     started_at: row.started_at,

--- a/crates/control-plane/tests/integration_test.rs
+++ b/crates/control-plane/tests/integration_test.rs
@@ -2467,7 +2467,7 @@ async fn test_mcp_server_crud() {
     println!("\nStep 10: Testing 404 for non-existent server...");
     let not_found_response = client
         .get(format!(
-            "{}/v1/orgs/{}/mcp-servers/00000000-0000-0000-0000-000000000000",
+            "{}/v1/orgs/{}/mcp-servers/mcp_00000000000000000000000000000000",
             API_BASE_URL, DEFAULT_ORG
         ))
         .send()

--- a/crates/core/examples/turn_based_execution.rs
+++ b/crates/core/examples/turn_based_execution.rs
@@ -111,7 +111,7 @@ async fn main() -> anyhow::Result<()> {
     let session_id = Uuid::now_v7();
     let now = Utc::now();
     let agent = Agent {
-        id: agent_id,
+        id: agent_id.into(),
         name: "Weather Assistant".to_string(),
         description: Some("A helpful weather assistant".to_string()),
         system_prompt: "You are a helpful weather assistant. Use the get_weather tool to answer weather questions.".to_string(),
@@ -127,8 +127,8 @@ async fn main() -> anyhow::Result<()> {
 
     // Create a session in the store
     let session = Session {
-        id: session_id,
-        agent_id,
+        id: session_id.into(),
+        agent_id: agent_id.into(),
         title: Some("Weather Query".to_string()),
         preview: None,
         output_preview: None,
@@ -160,14 +160,14 @@ async fn main() -> anyhow::Result<()> {
 
     // Add user message to store (this would be done by the API layer)
     let user_message = message_retriever
-        .add(session_id, InputMessage::user(user_question))
+        .add(session_id.into(), InputMessage::user(user_question))
         .await?;
 
     // =========================================================================
     // Create Turn Context
     // =========================================================================
     let turn_id = Uuid::now_v7();
-    let base_context = AtomContext::new(session_id, turn_id, user_message.id);
+    let base_context = AtomContext::new(session_id, turn_id, user_message.id.into());
 
     println!("Turn ID: {}", turn_id);
     println!("Input Message ID: {}\n", user_message.id);

--- a/crates/core/src/agent.rs
+++ b/crates/core/src/agent.rs
@@ -49,8 +49,8 @@ impl From<&str> for AgentStatus {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct Agent {
-    /// Unique identifier for the agent (format: agt_{32-hex}).
-    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "agt_01933b5a00007000800000000000001"))]
+    /// Unique identifier for the agent (format: agent_{32-hex}).
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "agent_01933b5a00007000800000000000001"))]
     pub id: AgentId,
     /// Display name of the agent.
     pub name: String,
@@ -63,7 +63,7 @@ pub struct Agent {
     /// Default LLM model ID for this agent.
     /// Can be overridden at the session level.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = "mod_01933b5a00007000800000000000001"))]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = "model_01933b5a00007000800000000000001"))]
     pub default_model_id: Option<ModelId>,
     /// Tags for organizing and filtering agents.
     #[serde(default)]

--- a/crates/core/src/agent.rs
+++ b/crates/core/src/agent.rs
@@ -5,10 +5,10 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 use crate::capability_types::AgentCapabilityConfig;
 use crate::events::TokenUsage;
+use crate::typed_id::{AgentId, ModelId};
 
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
@@ -49,8 +49,9 @@ impl From<&str> for AgentStatus {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct Agent {
-    /// Unique identifier for the agent.
-    pub id: Uuid,
+    /// Unique identifier for the agent (format: agt_{32-hex}).
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "agt_01933b5a00007000800000000000001"))]
+    pub id: AgentId,
     /// Display name of the agent.
     pub name: String,
     /// Human-readable description of what the agent does.
@@ -62,7 +63,8 @@ pub struct Agent {
     /// Default LLM model ID for this agent.
     /// Can be overridden at the session level.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_model_id: Option<Uuid>,
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = "mod_01933b5a00007000800000000000001"))]
+    pub default_model_id: Option<ModelId>,
     /// Tags for organizing and filtering agents.
     #[serde(default)]
     pub tags: Vec<String>,

--- a/crates/core/src/atoms/input.rs
+++ b/crates/core/src/atoms/input.rs
@@ -157,11 +157,11 @@ mod tests {
 
         // Add a user message to the retriever
         let user_message = retriever
-            .add(session_id, InputMessage::user("Hello, world!"))
+            .add(session_id.into(), InputMessage::user("Hello, world!"))
             .await
             .unwrap();
 
-        let context = AtomContext::new(session_id, turn_id, user_message.id);
+        let context = AtomContext::new(session_id, turn_id, user_message.id.into());
         let atom = InputAtom::new(retriever, event_emitter);
 
         let result = atom.execute(InputAtomInput { context }).await.unwrap();

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -763,15 +763,15 @@ where
     /// Resolve model using priority chain
     async fn resolve_model(
         &self,
-        controls_model_id: Option<Uuid>,
-        session_model_id: Option<Uuid>,
-        agent_model_id: Option<Uuid>,
+        controls_model_id: Option<crate::typed_id::ModelId>,
+        session_model_id: Option<crate::typed_id::ModelId>,
+        agent_model_id: Option<crate::typed_id::ModelId>,
     ) -> Result<ModelWithProvider> {
         // Try controls.model_id first (highest priority)
         if let Some(model_id) = controls_model_id
             && let Some(model_with_provider) = self
                 .provider_store
-                .get_model_with_provider(model_id)
+                .get_model_with_provider(model_id.uuid())
                 .await?
         {
             return Ok(model_with_provider);
@@ -781,7 +781,7 @@ where
         if let Some(model_id) = session_model_id
             && let Some(model_with_provider) = self
                 .provider_store
-                .get_model_with_provider(model_id)
+                .get_model_with_provider(model_id.uuid())
                 .await?
         {
             return Ok(model_with_provider);
@@ -791,7 +791,7 @@ where
         if let Some(model_id) = agent_model_id
             && let Some(model_with_provider) = self
                 .provider_store
-                .get_model_with_provider(model_id)
+                .get_model_with_provider(model_id.uuid())
                 .await?
         {
             return Ok(model_with_provider);

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -31,7 +31,6 @@ use crate::events::{
     AgentThinkingData, EventContext, EventRequest, LlmGenerationData, MessageAgentData,
     ReasonCompletedData, ReasonStartedData, TextDeltaData, TokenUsage, ToolDefinitionSummary,
 };
-use crate::typed_id::TurnId;
 use crate::llm_driver_registry::{
     DriverRegistry, LlmCallConfigBuilder, LlmCompletionMetadata, LlmMessage, LlmMessageContent,
     LlmMessageRole, LlmStreamEvent, ProviderConfig, ProviderType,
@@ -44,6 +43,7 @@ use crate::traits::{
     AgentStore, EventEmitter, ImageResolver, LlmProviderStore, ModelWithProvider, ResolvedImage,
     SessionStore,
 };
+use crate::typed_id::TurnId;
 
 // ============================================================================
 // Helper Functions

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -31,6 +31,7 @@ use crate::events::{
     AgentThinkingData, EventContext, EventRequest, LlmGenerationData, MessageAgentData,
     ReasonCompletedData, ReasonStartedData, TextDeltaData, TokenUsage, ToolDefinitionSummary,
 };
+use crate::typed_id::TurnId;
 use crate::llm_driver_registry::{
     DriverRegistry, LlmCallConfigBuilder, LlmCompletionMetadata, LlmMessage, LlmMessageContent,
     LlmMessageRole, LlmStreamEvent, ProviderConfig, ProviderType,
@@ -517,7 +518,7 @@ where
                 session_id,
                 streaming_event_context.clone(),
                 AgentThinkingData {
-                    turn_id: context.turn_id,
+                    turn_id: TurnId::from_uuid(context.turn_id),
                     model: Some(runtime_agent.model.clone()),
                 },
             ))
@@ -578,7 +579,7 @@ where
                                 session_id,
                                 streaming_event_context.clone(),
                                 TextDeltaData {
-                                    turn_id: context.turn_id,
+                                    turn_id: TurnId::from_uuid(context.turn_id),
                                     delta: pending_delta.clone(),
                                     accumulated: text.clone(),
                                 },
@@ -607,7 +608,7 @@ where
                                 session_id,
                                 streaming_event_context.clone(),
                                 TextDeltaData {
-                                    turn_id: context.turn_id,
+                                    turn_id: TurnId::from_uuid(context.turn_id),
                                     delta: pending_delta.clone(),
                                     accumulated: text.clone(),
                                 },

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -12,6 +12,8 @@ use uuid::Uuid;
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
 
+use crate::typed_id::{EventId, ExecId, MessageId, SessionId, TurnId};
+
 // ============================================================================
 // Event Type Constants
 // ============================================================================
@@ -59,15 +61,18 @@ use crate::atoms::AtomContext;
 pub struct EventContext {
     /// Turn identifier (for turn-scoped events)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub turn_id: Option<Uuid>,
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = "turn_01933b5a00007000800000000000001"))]
+    pub turn_id: Option<TurnId>,
 
     /// User message that triggered this turn
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub input_message_id: Option<Uuid>,
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = "message_01933b5a00007000800000000000001"))]
+    pub input_message_id: Option<MessageId>,
 
     /// Atom execution identifier
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub exec_id: Option<Uuid>,
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = "exec_01933b5a00007000800000000000001"))]
+    pub exec_id: Option<ExecId>,
 }
 
 impl EventContext {
@@ -79,17 +84,17 @@ impl EventContext {
     /// Create a full context from an AtomContext
     pub fn from_atom_context(ctx: &AtomContext) -> Self {
         Self {
-            turn_id: Some(ctx.turn_id),
-            input_message_id: Some(ctx.input_message_id),
-            exec_id: Some(ctx.exec_id),
+            turn_id: Some(TurnId::from_uuid(ctx.turn_id)),
+            input_message_id: Some(MessageId::from_uuid(ctx.input_message_id)),
+            exec_id: Some(ExecId::from_uuid(ctx.exec_id)),
         }
     }
 
     /// Create a context for turn-scoped events (without exec_id)
     pub fn turn(turn_id: Uuid, input_message_id: Uuid) -> Self {
         Self {
-            turn_id: Some(turn_id),
-            input_message_id: Some(input_message_id),
+            turn_id: Some(TurnId::from_uuid(turn_id)),
+            input_message_id: Some(MessageId::from_uuid(input_message_id)),
             exec_id: None,
         }
     }
@@ -102,10 +107,10 @@ impl EventContext {
 /// Standard event following the Everruns event protocol.
 ///
 /// All events have a consistent structure:
-/// - `id`: Unique UUID v7 identifier (monotonically increasing)
+/// - `id`: Unique event identifier (format: event_{32-hex})
 /// - `type`: Event type in dot notation (e.g., "message.user", "reason.started")
 /// - `ts`: ISO 8601 timestamp with millisecond precision
-/// - `session_id`: Session this event belongs to
+/// - `session_id`: Session this event belongs to (format: session_{32-hex})
 /// - `context`: Correlation context for tracing
 /// - `data`: Event-specific payload (typed via EventData enum)
 /// - `metadata`: Optional arbitrary metadata
@@ -113,8 +118,9 @@ impl EventContext {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct Event {
-    /// Unique event identifier (UUID v7, monotonically increasing)
-    pub id: Uuid,
+    /// Unique event identifier (format: event_{32-hex})
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "event_01933b5a00007000800000000000001"))]
+    pub id: EventId,
 
     /// Event type in dot notation
     #[serde(rename = "type")]
@@ -123,8 +129,9 @@ pub struct Event {
     /// Event timestamp
     pub ts: DateTime<Utc>,
 
-    /// Session this event belongs to
-    pub session_id: Uuid,
+    /// Session this event belongs to (format: session_{32-hex})
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "session_01933b5a00007000800000000000001"))]
+    pub session_id: SessionId,
 
     /// Correlation context
     pub context: EventContext,
@@ -154,10 +161,10 @@ impl Event {
         let data = data.into();
         let event_type = data.event_type().to_string();
         Self {
-            id: Uuid::now_v7(),
+            id: EventId::new(),
             event_type,
             ts: Utc::now(),
-            session_id,
+            session_id: SessionId::from_uuid(session_id),
             context,
             data,
             metadata: None,
@@ -176,10 +183,10 @@ impl Event {
         let data = data.into();
         let event_type = data.event_type().to_string();
         Self {
-            id,
+            id: EventId::from_uuid(id),
             event_type,
             ts: Utc::now(),
-            session_id,
+            session_id: SessionId::from_uuid(session_id),
             context,
             data,
             metadata: None,
@@ -206,9 +213,9 @@ impl Event {
         self
     }
 
-    /// Get the session_id
-    pub fn session_id(&self) -> Uuid {
-        self.session_id
+    /// Get the session_id as raw UUID
+    pub fn session_uuid(&self) -> Uuid {
+        self.session_id.uuid()
     }
 
     /// Check if this is a message event
@@ -1141,10 +1148,10 @@ impl EventRequest {
     /// Convert to an Event with the given id and sequence
     pub fn into_event(self, id: Uuid, sequence: i32) -> Event {
         Event {
-            id,
+            id: EventId::from_uuid(id),
             event_type: self.event_type,
             ts: self.ts,
-            session_id: self.session_id,
+            session_id: SessionId::from_uuid(self.session_id),
             context: self.context,
             data: self.data,
             metadata: self.metadata,
@@ -1173,13 +1180,13 @@ impl EventBuilder {
     }
 
     pub fn with_turn(mut self, turn_id: Uuid, input_message_id: Uuid) -> Self {
-        self.context.turn_id = Some(turn_id);
-        self.context.input_message_id = Some(input_message_id);
+        self.context.turn_id = Some(TurnId::from_uuid(turn_id));
+        self.context.input_message_id = Some(MessageId::from_uuid(input_message_id));
         self
     }
 
     pub fn with_exec(mut self, exec_id: Uuid) -> Self {
-        self.context.exec_id = Some(exec_id);
+        self.context.exec_id = Some(ExecId::from_uuid(exec_id));
         self
     }
 
@@ -1205,7 +1212,7 @@ mod tests {
         let event = Event::new(session_id, context, data);
 
         assert_eq!(event.event_type, "input.received");
-        assert_eq!(event.session_id(), session_id);
+        assert_eq!(event.session_uuid(), session_id);
         assert!(event.is_atom_event());
         assert!(!event.is_message_event());
     }
@@ -1219,9 +1226,12 @@ mod tests {
         let atom_ctx = AtomContext::new(session_id, turn_id, input_message_id);
         let context = EventContext::from_atom_context(&atom_ctx);
 
-        assert_eq!(context.turn_id, Some(turn_id));
-        assert_eq!(context.input_message_id, Some(input_message_id));
-        assert_eq!(context.exec_id, Some(atom_ctx.exec_id));
+        assert_eq!(context.turn_id, Some(TurnId::from_uuid(turn_id)));
+        assert_eq!(
+            context.input_message_id,
+            Some(MessageId::from_uuid(input_message_id))
+        );
+        assert_eq!(context.exec_id, Some(ExecId::from_uuid(atom_ctx.exec_id)));
     }
 
     #[test]
@@ -1262,9 +1272,9 @@ mod tests {
             });
 
         assert_eq!(event.event_type, "reason.started");
-        assert_eq!(event.session_id, session_id);
-        assert_eq!(event.context.turn_id, Some(turn_id));
-        assert_eq!(event.context.exec_id, Some(exec_id));
+        assert_eq!(event.session_id, SessionId::from_uuid(session_id));
+        assert_eq!(event.context.turn_id, Some(TurnId::from_uuid(turn_id)));
+        assert_eq!(event.context.exec_id, Some(ExecId::from_uuid(exec_id)));
     }
 
     #[test]

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
 
-use crate::typed_id::{EventId, ExecId, MessageId, SessionId, TurnId};
+use crate::typed_id::{AgentId, EventId, ExecId, MessageId, ModelId, SessionId, TurnId};
 
 // ============================================================================
 // Event Type Constants
@@ -786,7 +786,8 @@ impl LlmGenerationData {
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct AgentThinkingData {
     /// Turn ID this thinking indicator belongs to
-    pub turn_id: Uuid,
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "turn_01933b5a00007000800000000000001"))]
+    pub turn_id: TurnId,
 
     /// Optional model name being used
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -802,7 +803,8 @@ pub struct AgentThinkingData {
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct TextDeltaData {
     /// Turn ID this delta belongs to (for correlation)
-    pub turn_id: Uuid,
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "turn_01933b5a00007000800000000000001"))]
+    pub turn_id: TurnId,
 
     /// The text delta (new text since last delta)
     pub delta: String,
@@ -820,10 +822,12 @@ pub struct TextDeltaData {
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct TurnStartedData {
     /// Turn identifier
-    pub turn_id: Uuid,
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "turn_01933b5a00007000800000000000001"))]
+    pub turn_id: TurnId,
 
     /// Input message ID that triggered this turn
-    pub input_message_id: Uuid,
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "message_01933b5a00007000800000000000001"))]
+    pub input_message_id: MessageId,
 }
 
 /// Data for turn.completed event
@@ -831,7 +835,8 @@ pub struct TurnStartedData {
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct TurnCompletedData {
     /// Turn identifier
-    pub turn_id: Uuid,
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "turn_01933b5a00007000800000000000001"))]
+    pub turn_id: TurnId,
 
     /// Number of iterations in this turn
     pub iterations: u32,
@@ -850,7 +855,8 @@ pub struct TurnCompletedData {
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct TurnFailedData {
     /// Turn identifier
-    pub turn_id: Uuid,
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "turn_01933b5a00007000800000000000001"))]
+    pub turn_id: TurnId,
 
     /// Error message
     pub error: String,
@@ -865,7 +871,8 @@ pub struct TurnFailedData {
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct TurnCancelledData {
     /// Turn identifier
-    pub turn_id: Uuid,
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "turn_01933b5a00007000800000000000001"))]
+    pub turn_id: TurnId,
 
     /// Reason for cancellation
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -885,11 +892,13 @@ pub struct TurnCancelledData {
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct SessionStartedData {
     /// Agent ID
-    pub agent_id: Uuid,
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "agent_01933b5a00007000800000000000001"))]
+    pub agent_id: AgentId,
 
     /// Model ID if specified
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub model_id: Option<Uuid>,
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = "model_01933b5a00007000800000000000001"))]
+    pub model_id: Option<ModelId>,
 }
 
 /// Data for session.activated event (turn started, session now active)
@@ -897,10 +906,12 @@ pub struct SessionStartedData {
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct SessionActivatedData {
     /// Turn ID that activated the session
-    pub turn_id: Uuid,
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "turn_01933b5a00007000800000000000001"))]
+    pub turn_id: TurnId,
 
     /// Input message ID that triggered the turn
-    pub input_message_id: Uuid,
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "message_01933b5a00007000800000000000001"))]
+    pub input_message_id: MessageId,
 }
 
 /// Data for session.idled event (turn completed, session now idle)
@@ -908,7 +919,8 @@ pub struct SessionActivatedData {
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct SessionIdledData {
     /// Turn ID that just completed
-    pub turn_id: Uuid,
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "turn_01933b5a00007000800000000000001"))]
+    pub turn_id: TurnId,
 
     /// Number of iterations in the completed turn
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1307,7 +1319,7 @@ mod tests {
     #[test]
     fn test_turn_cancelled_data() {
         let data = TurnCancelledData {
-            turn_id: Uuid::now_v7(),
+            turn_id: TurnId::from_uuid(Uuid::now_v7()),
             reason: Some("User requested cancellation".to_string()),
             usage: Some(TokenUsage::new(100, 50)),
         };
@@ -1443,7 +1455,7 @@ mod tests {
 
     #[test]
     fn test_agent_thinking_data() {
-        let turn_id = Uuid::now_v7();
+        let turn_id = TurnId::from_uuid(Uuid::now_v7());
         let data = AgentThinkingData {
             turn_id,
             model: Some("gpt-4o".to_string()),
@@ -1460,7 +1472,7 @@ mod tests {
 
     #[test]
     fn test_agent_thinking_data_without_model() {
-        let turn_id = Uuid::now_v7();
+        let turn_id = TurnId::from_uuid(Uuid::now_v7());
         let data = AgentThinkingData {
             turn_id,
             model: None,
@@ -1473,7 +1485,7 @@ mod tests {
 
     #[test]
     fn test_text_delta_data() {
-        let turn_id = Uuid::now_v7();
+        let turn_id = TurnId::from_uuid(Uuid::now_v7());
         let data = TextDeltaData {
             turn_id,
             delta: "Hello".to_string(),
@@ -1494,7 +1506,7 @@ mod tests {
     fn test_text_delta_deserialization_preserves_fields() {
         // This test verifies that TextDelta deserializes correctly with all fields
         // (regression test for the untagged enum ordering fix)
-        let turn_id = Uuid::now_v7();
+        let turn_id = TurnId::from_uuid(Uuid::now_v7());
         let data = TextDeltaData {
             turn_id,
             delta: "Hello world".to_string(),
@@ -1520,7 +1532,7 @@ mod tests {
 
     #[test]
     fn test_agent_thinking_deserialization() {
-        let turn_id = Uuid::now_v7();
+        let turn_id = TurnId::from_uuid(Uuid::now_v7());
         let data = AgentThinkingData {
             turn_id,
             model: Some("claude-3".to_string()),

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -31,6 +31,10 @@ pub mod event_listeners;
 // Observation backends (OTel, etc.)
 pub mod observation;
 
+// Typed ID system (type-safe prefixed identifiers)
+// See specs/id-schema.md for specification
+pub mod typed_id;
+
 // Domain entity types
 // These are DB-agnostic entity types used by both API and worker
 pub mod agent;
@@ -160,6 +164,10 @@ pub use organization::{
 };
 pub use session::{Session, SessionStatus};
 pub use session_file::{FileInfo, FileStat, GrepMatch, GrepResult, SessionFile};
+pub use typed_id::{
+    AgentId, EventId, ExecId, IdMarker, IdParseError, ImageId, McpServerId, MessageId, ModelId,
+    OrgId, ProviderId, SessionId, TurnId, TypedId,
+};
 
 // Deployment configuration
 pub use deployment::DeploymentGrade;

--- a/crates/core/src/llm_driver_registry.rs
+++ b/crates/core/src/llm_driver_registry.rs
@@ -498,7 +498,7 @@ impl LlmMessage {
                 }
                 ContentPart::ImageFile(img_file) => {
                     // Resolve image_file to actual image data
-                    if let Some(resolved) = resolved_images.get(&img_file.image_id) {
+                    if let Some(resolved) = resolved_images.get(&img_file.image_id.uuid()) {
                         parts.push(LlmContentPart::Image {
                             url: resolved.to_data_url(),
                         });
@@ -569,7 +569,7 @@ impl LlmMessage {
         msg.content
             .iter()
             .filter_map(|p| match p {
-                crate::message::ContentPart::ImageFile(f) => Some(f.image_id),
+                crate::message::ContentPart::ImageFile(f) => Some(f.image_id.uuid()),
                 _ => None,
             })
             .collect()
@@ -913,14 +913,14 @@ mod tests {
     #[test]
     fn test_message_has_image_files_with_image_file() {
         let message = Message {
-            id: uuid::Uuid::new_v4(),
+            id: uuid::Uuid::new_v4().into(),
             role: MessageRole::User,
             content: vec![
                 ContentPart::Text(TextContentPart {
                     text: "Look at this image".to_string(),
                 }),
                 ContentPart::ImageFile(ImageFileContentPart {
-                    image_id: uuid::Uuid::new_v4(),
+                    image_id: uuid::Uuid::new_v4().into(),
                     filename: Some("test.png".to_string()),
                 }),
             ],
@@ -935,7 +935,7 @@ mod tests {
     #[test]
     fn test_message_has_image_files_without_image_file() {
         let message = Message {
-            id: uuid::Uuid::new_v4(),
+            id: uuid::Uuid::new_v4().into(),
             role: MessageRole::User,
             content: vec![ContentPart::Text(TextContentPart {
                 text: "Just text".to_string(),
@@ -954,18 +954,18 @@ mod tests {
         let id2 = uuid::Uuid::new_v4();
 
         let message = Message {
-            id: uuid::Uuid::new_v4(),
+            id: uuid::Uuid::new_v4().into(),
             role: MessageRole::User,
             content: vec![
                 ContentPart::Text(TextContentPart {
                     text: "Look at these images".to_string(),
                 }),
                 ContentPart::ImageFile(ImageFileContentPart {
-                    image_id: id1,
+                    image_id: id1.into(),
                     filename: Some("test1.png".to_string()),
                 }),
                 ContentPart::ImageFile(ImageFileContentPart {
-                    image_id: id2,
+                    image_id: id2.into(),
                     filename: Some("test2.png".to_string()),
                 }),
             ],
@@ -983,7 +983,7 @@ mod tests {
     #[test]
     fn test_from_message_with_images_text_only() {
         let message = Message {
-            id: uuid::Uuid::new_v4(),
+            id: uuid::Uuid::new_v4().into(),
             role: MessageRole::User,
             content: vec![ContentPart::Text(TextContentPart {
                 text: "Hello".to_string(),
@@ -1007,14 +1007,14 @@ mod tests {
     fn test_from_message_with_images_resolved_image() {
         let image_id = uuid::Uuid::new_v4();
         let message = Message {
-            id: uuid::Uuid::new_v4(),
+            id: uuid::Uuid::new_v4().into(),
             role: MessageRole::User,
             content: vec![
                 ContentPart::Text(TextContentPart {
                     text: "Look at this".to_string(),
                 }),
                 ContentPart::ImageFile(ImageFileContentPart {
-                    image_id,
+                    image_id: image_id.into(),
                     filename: Some("test.png".to_string()),
                 }),
             ],
@@ -1051,10 +1051,10 @@ mod tests {
     fn test_from_message_with_images_unresolved_image() {
         let image_id = uuid::Uuid::new_v4();
         let message = Message {
-            id: uuid::Uuid::new_v4(),
+            id: uuid::Uuid::new_v4().into(),
             role: MessageRole::User,
             content: vec![ContentPart::ImageFile(ImageFileContentPart {
-                image_id,
+                image_id: image_id.into(),
                 filename: Some("missing.png".to_string()),
             })],
             controls: None,

--- a/crates/core/src/llm_models.rs
+++ b/crates/core/src/llm_models.rs
@@ -112,7 +112,7 @@ impl std::str::FromStr for LlmModelSource {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct LlmProvider {
-    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "prov_01933b5a00007000800000000000001"))]
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "provider_01933b5a00007000800000000000001"))]
     pub id: ProviderId,
     pub name: String,
     pub provider_type: LlmProviderType,
@@ -132,9 +132,9 @@ pub struct LlmProvider {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct LlmModel {
-    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "mod_01933b5a00007000800000000000001"))]
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "model_01933b5a00007000800000000000001"))]
     pub id: ModelId,
-    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "prov_01933b5a00007000800000000000001"))]
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "provider_01933b5a00007000800000000000001"))]
     pub provider_id: ProviderId,
     pub model_id: String,
     pub display_name: String,
@@ -152,9 +152,9 @@ pub struct LlmModel {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct LlmModelWithProvider {
-    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "mod_01933b5a00007000800000000000001"))]
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "model_01933b5a00007000800000000000001"))]
     pub id: ModelId,
-    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "prov_01933b5a00007000800000000000001"))]
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "provider_01933b5a00007000800000000000001"))]
     pub provider_id: ProviderId,
     pub model_id: String,
     pub display_name: String,

--- a/crates/core/src/llm_models.rs
+++ b/crates/core/src/llm_models.rs
@@ -5,7 +5,8 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
+
+use crate::typed_id::{ModelId, ProviderId};
 
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
@@ -111,7 +112,8 @@ impl std::str::FromStr for LlmModelSource {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct LlmProvider {
-    pub id: Uuid,
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "prov_01933b5a00007000800000000000001"))]
+    pub id: ProviderId,
     pub name: String,
     pub provider_type: LlmProviderType,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -130,8 +132,10 @@ pub struct LlmProvider {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct LlmModel {
-    pub id: Uuid,
-    pub provider_id: Uuid,
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "mod_01933b5a00007000800000000000001"))]
+    pub id: ModelId,
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "prov_01933b5a00007000800000000000001"))]
+    pub provider_id: ProviderId,
     pub model_id: String,
     pub display_name: String,
     pub capabilities: Vec<String>,
@@ -148,8 +152,10 @@ pub struct LlmModel {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct LlmModelWithProvider {
-    pub id: Uuid,
-    pub provider_id: Uuid,
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "mod_01933b5a00007000800000000000001"))]
+    pub id: ModelId,
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "prov_01933b5a00007000800000000000001"))]
+    pub provider_id: ProviderId,
     pub model_id: String,
     pub display_name: String,
     pub capabilities: Vec<String>,

--- a/crates/core/src/mcp_server.rs
+++ b/crates/core/src/mcp_server.rs
@@ -10,7 +10,8 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
-use uuid::Uuid;
+
+use crate::typed_id::McpServerId;
 
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
@@ -79,7 +80,8 @@ impl From<&str> for McpServerStatus {
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct McpServer {
     /// Unique identifier for the MCP server.
-    pub id: Uuid,
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "mcp_01933b5a00007000800000000000001"))]
+    pub id: McpServerId,
     /// Display name of the MCP server.
     #[cfg_attr(feature = "openapi", schema(example = "atlassian-mcp-server"))]
     pub name: String,

--- a/crates/core/src/memory.rs
+++ b/crates/core/src/memory.rs
@@ -10,6 +10,7 @@ use crate::llm_models::LlmProviderType;
 use crate::session::Session;
 use crate::tool_types::{ToolCall, ToolDefinition, ToolResult};
 use crate::traits::ModelWithProvider;
+use crate::typed_id::{MessageId, SessionId};
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -70,9 +71,9 @@ impl InMemoryMessageRetriever {
     ///
     /// Note: In production, messages are stored via EventService.
     /// This method is provided for test setup and in-memory usage.
-    pub async fn add(&self, session_id: Uuid, input: InputMessage) -> Result<Message> {
+    pub async fn add(&self, session_id: SessionId, input: InputMessage) -> Result<Message> {
         let message = Message {
-            id: Uuid::now_v7(),
+            id: MessageId::new(),
             role: input.role,
             content: input.content,
             controls: input.controls,
@@ -83,7 +84,7 @@ impl InMemoryMessageRetriever {
         self.messages
             .write()
             .await
-            .entry(session_id)
+            .entry(session_id.uuid())
             .or_default()
             .push(message.clone());
 
@@ -160,7 +161,7 @@ impl InMemoryAgentStore {
 
     /// Add an agent to the store
     pub async fn add_agent(&self, agent: Agent) {
-        self.agents.write().await.insert(agent.id, agent);
+        self.agents.write().await.insert(agent.id.uuid(), agent);
     }
 
     /// Get all agent IDs
@@ -204,7 +205,10 @@ impl InMemorySessionStore {
 
     /// Add a session to the store
     pub async fn add_session(&self, session: Session) {
-        self.sessions.write().await.insert(session.id, session);
+        self.sessions
+            .write()
+            .await
+            .insert(session.id.uuid(), session);
     }
 
     /// Get all session IDs
@@ -696,12 +700,12 @@ mod tests {
 
         // Add a message using the add method
         let message = store
-            .add(session_id, InputMessage::user("Hello via add"))
+            .add(session_id.into(), InputMessage::user("Hello via add"))
             .await
             .unwrap();
 
         // Get the message by ID
-        let retrieved = store.get(session_id, message.id).await.unwrap();
+        let retrieved = store.get(session_id, message.id.into()).await.unwrap();
         assert!(retrieved.is_some());
         assert_eq!(retrieved.unwrap().text(), Some("Hello via add"));
 
@@ -721,12 +725,12 @@ mod tests {
 
         // Add a message
         let added = store
-            .add(session_id, InputMessage::user("Test consistency"))
+            .add(session_id.into(), InputMessage::user("Test consistency"))
             .await
             .unwrap();
 
         // The returned message ID must be retrievable
-        let retrieved = store.get(session_id, added.id).await.unwrap();
+        let retrieved = store.get(session_id, added.id.into()).await.unwrap();
         assert!(
             retrieved.is_some(),
             "Message must be retrievable by the ID returned from add()"

--- a/crates/core/src/memory.rs
+++ b/crates/core/src/memory.rs
@@ -653,7 +653,7 @@ impl InMemoryEventEmitter {
             .read()
             .await
             .iter()
-            .filter(|e| e.session_id() == session_id)
+            .filter(|e| e.session_uuid() == session_id)
             .cloned()
             .collect()
     }

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -8,7 +8,8 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
+
+use crate::typed_id::{ImageId, MessageId, ModelId};
 
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
@@ -71,10 +72,11 @@ pub struct ReasoningConfig {
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct Controls {
-    /// Model ID (UUID) to use for this message.
+    /// Model ID to use for this message (format: mod_{32-hex}).
     /// Overrides session and agent model settings.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub model_id: Option<Uuid>,
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = "mod_01933b5a00007000800000000000001"))]
+    pub model_id: Option<ModelId>,
 
     /// Reasoning configuration
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -85,8 +87,9 @@ pub struct Controls {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct Message {
-    /// Unique message ID
-    pub id: Uuid,
+    /// Unique message ID (format: msg_{32-hex})
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "msg_01933b5a00007000800000000000001"))]
+    pub id: MessageId,
 
     /// Message role
     pub role: MessageRole,
@@ -202,22 +205,23 @@ impl ImageContentPart {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct ImageFileContentPart {
-    /// ID of the uploaded image
-    pub image_id: Uuid,
+    /// ID of the uploaded image (format: img_{32-hex})
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "img_01933b5a00007000800000000000001"))]
+    pub image_id: ImageId,
     /// Original filename (for display)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filename: Option<String>,
 }
 
 impl ImageFileContentPart {
-    pub fn new(image_id: Uuid) -> Self {
+    pub fn new(image_id: ImageId) -> Self {
         Self {
             image_id,
             filename: None,
         }
     }
 
-    pub fn with_filename(image_id: Uuid, filename: impl Into<String>) -> Self {
+    pub fn with_filename(image_id: ImageId, filename: impl Into<String>) -> Self {
         Self {
             image_id,
             filename: Some(filename.into()),
@@ -326,7 +330,7 @@ impl ContentPart {
     }
 
     /// Create an image file content part (reference to uploaded image)
-    pub fn image_file(image_id: Uuid) -> Self {
+    pub fn image_file(image_id: ImageId) -> Self {
         ContentPart::ImageFile(ImageFileContentPart::new(image_id))
     }
 
@@ -411,7 +415,7 @@ impl InputContentPart {
     }
 
     /// Create an image file content part (reference to uploaded image)
-    pub fn image_file(image_id: Uuid) -> Self {
+    pub fn image_file(image_id: ImageId) -> Self {
         InputContentPart::ImageFile(ImageFileContentPart::new(image_id))
     }
 
@@ -437,7 +441,7 @@ impl Message {
     /// Create a new user message
     pub fn user(content: impl Into<String>) -> Self {
         Self {
-            id: Uuid::now_v7(),
+            id: MessageId::new(),
             role: MessageRole::User,
             content: vec![ContentPart::text(content)],
             controls: None,
@@ -449,7 +453,7 @@ impl Message {
     /// Create a new assistant message
     pub fn assistant(content: impl Into<String>) -> Self {
         Self {
-            id: Uuid::now_v7(),
+            id: MessageId::new(),
             role: MessageRole::Assistant,
             content: vec![ContentPart::text(content)],
             controls: None,
@@ -481,7 +485,7 @@ impl Message {
             }));
         }
         Self {
-            id: Uuid::now_v7(),
+            id: MessageId::new(),
             role: MessageRole::Assistant,
             content: parts,
             controls: None,
@@ -493,7 +497,7 @@ impl Message {
     /// Create a new system message
     pub fn system(content: impl Into<String>) -> Self {
         Self {
-            id: Uuid::now_v7(),
+            id: MessageId::new(),
             role: MessageRole::System,
             content: vec![ContentPart::text(content)],
             controls: None,
@@ -510,7 +514,7 @@ impl Message {
     ) -> Self {
         let tool_call_id = tool_call_id.into();
         Self {
-            id: Uuid::now_v7(),
+            id: MessageId::new(),
             role: MessageRole::ToolResult,
             content: vec![ContentPart::ToolResult(ToolResultContentPart::new(
                 tool_call_id,

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -72,10 +72,10 @@ pub struct ReasoningConfig {
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct Controls {
-    /// Model ID to use for this message (format: mod_{32-hex}).
+    /// Model ID to use for this message (format: model_{32-hex}).
     /// Overrides session and agent model settings.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = "mod_01933b5a00007000800000000000001"))]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = "model_01933b5a00007000800000000000001"))]
     pub model_id: Option<ModelId>,
 
     /// Reasoning configuration
@@ -87,8 +87,8 @@ pub struct Controls {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct Message {
-    /// Unique message ID (format: msg_{32-hex})
-    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "msg_01933b5a00007000800000000000001"))]
+    /// Unique message ID (format: message_{32-hex})
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "message_01933b5a00007000800000000000001"))]
     pub id: MessageId,
 
     /// Message role

--- a/crates/core/src/observation/otel.rs
+++ b/crates/core/src/observation/otel.rs
@@ -215,7 +215,7 @@ impl OtelEventListener {
     fn handle_turn_started(&self, event: &Event, data: &TurnStartedData) {
         let mut spans = self.turn_spans.lock().unwrap();
         spans.insert(
-            data.turn_id,
+            data.turn_id.uuid(),
             TurnSpanInfo {
                 session_id: event.session_id.uuid(),
                 agent_id: None, // Will be filled from context if available
@@ -229,7 +229,7 @@ impl OtelEventListener {
         // Get start info if available
         let start_info = {
             let mut spans = self.turn_spans.lock().unwrap();
-            spans.remove(&data.turn_id)
+            spans.remove(&data.turn_id.uuid())
         };
 
         let duration_ms = data.duration_ms.or_else(|| {
@@ -343,6 +343,7 @@ mod tests {
     use crate::events::{EventContext, LlmGenerationMetadata, LlmGenerationOutput, TokenUsage};
     use crate::message::Message;
     use crate::tool_types::ToolCall;
+    use crate::typed_id::{MessageId, TurnId};
     use serde_json::json;
 
     #[tokio::test]
@@ -555,13 +556,13 @@ mod tests {
     #[tokio::test]
     async fn test_handle_turn_lifecycle() {
         let listener = OtelEventListener::new();
-        let turn_id = Uuid::now_v7();
+        let turn_id = TurnId::from_uuid(Uuid::now_v7());
         let session_id = Uuid::now_v7();
 
         // Start a turn
         let started_data = TurnStartedData {
             turn_id,
-            input_message_id: Uuid::now_v7(),
+            input_message_id: MessageId::from_uuid(Uuid::now_v7()),
         };
 
         let start_event = Event::new(
@@ -597,7 +598,7 @@ mod tests {
 
         // Complete a turn that was never started
         let completed_data = TurnCompletedData {
-            turn_id: Uuid::now_v7(),
+            turn_id: TurnId::from_uuid(Uuid::now_v7()),
             iterations: 1,
             duration_ms: None, // No duration provided
             usage: None,

--- a/crates/core/src/observation/otel.rs
+++ b/crates/core/src/observation/otel.rs
@@ -217,7 +217,7 @@ impl OtelEventListener {
         spans.insert(
             data.turn_id,
             TurnSpanInfo {
-                session_id: event.session_id,
+                session_id: event.session_id.uuid(),
                 agent_id: None, // Will be filled from context if available
                 started_at: std::time::Instant::now(),
             },

--- a/crates/core/src/runtime_agent.rs
+++ b/crates/core/src/runtime_agent.rs
@@ -347,7 +347,7 @@ mod tests {
         let registry = CapabilityRegistry::with_builtins();
         let ts = Timestamp::now(NoContext);
         let agent = Agent {
-            id: Uuid::new_v7(ts),
+            id: Uuid::new_v7(ts).into(),
             name: "Test Agent".to_string(),
             description: None,
             system_prompt: "Agent prompt.".to_string(),

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -56,11 +56,11 @@ impl From<&str> for SessionStatus {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct Session {
-    /// Unique identifier for the session (format: sess_{32-hex}).
-    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "sess_01933b5a00007000800000000000001"))]
+    /// Unique identifier for the session (format: session_{32-hex}).
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "session_01933b5a00007000800000000000001"))]
     pub id: SessionId,
-    /// ID of the agent this session belongs to (format: agt_{32-hex}).
-    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "agt_01933b5a00007000800000000000001"))]
+    /// ID of the agent this session belongs to (format: agent_{32-hex}).
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "agent_01933b5a00007000800000000000001"))]
     pub agent_id: AgentId,
     /// Human-readable title for the session.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -74,10 +74,10 @@ pub struct Session {
     /// Tags for organizing and filtering sessions.
     #[serde(default)]
     pub tags: Vec<String>,
-    /// LLM model ID to use for this session (format: mod_{32-hex}).
+    /// LLM model ID to use for this session (format: model_{32-hex}).
     /// Overrides the agent's default model if set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = "mod_01933b5a00007000800000000000001"))]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = "model_01933b5a00007000800000000000001"))]
     pub model_id: Option<ModelId>,
     /// Current execution status of the session.
     pub status: SessionStatus,

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -5,9 +5,9 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 use crate::events::TokenUsage;
+use crate::typed_id::{AgentId, ModelId, SessionId};
 
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
@@ -56,10 +56,12 @@ impl From<&str> for SessionStatus {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct Session {
-    /// Unique identifier for the session.
-    pub id: Uuid,
-    /// ID of the agent this session belongs to.
-    pub agent_id: Uuid,
+    /// Unique identifier for the session (format: sess_{32-hex}).
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "sess_01933b5a00007000800000000000001"))]
+    pub id: SessionId,
+    /// ID of the agent this session belongs to (format: agt_{32-hex}).
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "agt_01933b5a00007000800000000000001"))]
+    pub agent_id: AgentId,
     /// Human-readable title for the session.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
@@ -72,10 +74,11 @@ pub struct Session {
     /// Tags for organizing and filtering sessions.
     #[serde(default)]
     pub tags: Vec<String>,
-    /// LLM model ID to use for this session.
+    /// LLM model ID to use for this session (format: mod_{32-hex}).
     /// Overrides the agent's default model if set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub model_id: Option<Uuid>,
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = "mod_01933b5a00007000800000000000001"))]
+    pub model_id: Option<ModelId>,
     /// Current execution status of the session.
     pub status: SessionStatus,
     /// Timestamp when the session was created.

--- a/crates/core/src/typed_id.rs
+++ b/crates/core/src/typed_id.rs
@@ -1,0 +1,506 @@
+// Typed ID module - provides type-safe, prefixed identifiers
+// See specs/id-schema.md for the full specification
+//
+// Design decisions:
+// - Uses marker traits to differentiate ID types at compile time
+// - Stores IDs as prefixed strings (e.g., "agt_01933b5a...")
+// - Uses UUIDv7 for time-ordering benefits
+// - Supports serde, sqlx, and utoipa for full integration
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+use std::hash::Hash;
+use std::marker::PhantomData;
+use std::str::FromStr;
+use uuid::Uuid;
+
+/// Error type for ID parsing failures
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IdParseError {
+    /// ID doesn't start with the expected prefix
+    InvalidPrefix { expected: &'static str, got: String },
+    /// Suffix is not valid hex
+    InvalidHex(String),
+    /// Suffix has wrong length
+    InvalidLength { expected: usize, got: usize },
+}
+
+impl std::fmt::Display for IdParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IdParseError::InvalidPrefix { expected, got } => {
+                write!(f, "invalid prefix: expected '{}', got '{}'", expected, got)
+            }
+            IdParseError::InvalidHex(s) => write!(f, "invalid hex in ID: {}", s),
+            IdParseError::InvalidLength { expected, got } => {
+                write!(f, "invalid length: expected {}, got {}", expected, got)
+            }
+        }
+    }
+}
+
+impl std::error::Error for IdParseError {}
+
+/// Marker trait for typed ID types
+pub trait IdMarker: Clone + Copy + Send + Sync + 'static {
+    /// The prefix for this ID type (e.g., "agt" for agents)
+    const PREFIX: &'static str;
+}
+
+/// A type-safe identifier with a specific prefix
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TypedId<T: IdMarker> {
+    uuid: Uuid,
+    _marker: PhantomData<T>,
+}
+
+impl<T: IdMarker> TypedId<T> {
+    /// Create a new ID with a random UUIDv7
+    pub fn new() -> Self {
+        Self {
+            uuid: Uuid::now_v7(),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Create an ID from an existing UUID
+    pub fn from_uuid(uuid: Uuid) -> Self {
+        Self {
+            uuid,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Get the underlying UUID
+    pub fn uuid(&self) -> Uuid {
+        self.uuid
+    }
+
+    /// Get the prefix for this ID type
+    pub fn prefix() -> &'static str {
+        T::PREFIX
+    }
+
+    /// Parse an ID from a prefixed string
+    pub fn parse(s: &str) -> Result<Self, IdParseError> {
+        let expected_prefix = format!("{}_", T::PREFIX);
+
+        if !s.starts_with(&expected_prefix) {
+            let got_prefix = s.split('_').next().unwrap_or("").to_string();
+            return Err(IdParseError::InvalidPrefix {
+                expected: T::PREFIX,
+                got: got_prefix,
+            });
+        }
+
+        let suffix = &s[expected_prefix.len()..];
+
+        if suffix.len() != 32 {
+            return Err(IdParseError::InvalidLength {
+                expected: 32,
+                got: suffix.len(),
+            });
+        }
+
+        // Validate hex characters (lowercase only)
+        if !suffix
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+        {
+            return Err(IdParseError::InvalidHex(suffix.to_string()));
+        }
+
+        // Parse the UUID
+        let uuid =
+            Uuid::parse_str(suffix).map_err(|_| IdParseError::InvalidHex(suffix.to_string()))?;
+
+        Ok(Self {
+            uuid,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Create an ID from a well-known integer value (for seeding)
+    /// Produces IDs like "agt_00000000000000000000000000000001"
+    pub fn from_seed(value: u128) -> Self {
+        let uuid = Uuid::from_u128(value);
+        Self {
+            uuid,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T: IdMarker> Default for TypedId<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// Conversion from TypedId to Uuid
+impl<T: IdMarker> From<TypedId<T>> for Uuid {
+    fn from(id: TypedId<T>) -> Self {
+        id.uuid
+    }
+}
+
+// Conversion from Uuid to TypedId
+impl<T: IdMarker> From<Uuid> for TypedId<T> {
+    fn from(uuid: Uuid) -> Self {
+        Self::from_uuid(uuid)
+    }
+}
+
+// Allow using TypedId as a key in HashMap/HashSet that expects Uuid
+impl<T: IdMarker> std::borrow::Borrow<Uuid> for TypedId<T> {
+    fn borrow(&self) -> &Uuid {
+        &self.uuid
+    }
+}
+
+// AsRef<Uuid> for TypedId
+impl<T: IdMarker> AsRef<Uuid> for TypedId<T> {
+    fn as_ref(&self) -> &Uuid {
+        &self.uuid
+    }
+}
+
+// PartialEq<Uuid> for TypedId (allows comparing TypedId == Uuid)
+impl<T: IdMarker> PartialEq<Uuid> for TypedId<T> {
+    fn eq(&self, other: &Uuid) -> bool {
+        self.uuid == *other
+    }
+}
+
+// PartialEq<TypedId> for Uuid (allows comparing Uuid == TypedId)
+impl<T: IdMarker> PartialEq<TypedId<T>> for Uuid {
+    fn eq(&self, other: &TypedId<T>) -> bool {
+        *self == other.uuid
+    }
+}
+
+impl<T: IdMarker> fmt::Display for TypedId<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}_{}", T::PREFIX, self.uuid.simple())
+    }
+}
+
+impl<T: IdMarker> fmt::Debug for TypedId<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}({})",
+            std::any::type_name::<T>()
+                .split("::")
+                .last()
+                .unwrap_or("Id"),
+            self
+        )
+    }
+}
+
+impl<T: IdMarker> FromStr for TypedId<T> {
+    type Err = IdParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
+
+impl<T: IdMarker> Serialize for TypedId<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de, T: IdMarker> Deserialize<'de> for TypedId<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Self::parse(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+// OpenAPI schema support
+#[cfg(feature = "openapi")]
+impl<T: IdMarker> utoipa::ToSchema for TypedId<T> {
+    fn name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("TypedId")
+    }
+}
+
+#[cfg(feature = "openapi")]
+impl<T: IdMarker> utoipa::PartialSchema for TypedId<T> {
+    #[allow(deprecated)]
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        let example_value = format!("{}_{}", T::PREFIX, "01933b5a00007000800000000000001");
+        utoipa::openapi::ObjectBuilder::new()
+            .schema_type(utoipa::openapi::schema::Type::String)
+            .description(Some(format!(
+                "Prefixed identifier with '{}' prefix",
+                T::PREFIX
+            )))
+            .example(Some(serde_json::json!(example_value)))
+            .pattern(Some(format!("^{}_[0-9a-f]{{32}}$", T::PREFIX)))
+            .into()
+    }
+}
+
+// ============================================================================
+// Marker types for each entity
+// ============================================================================
+
+/// Marker for Organization IDs
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct OrgIdMarker;
+impl IdMarker for OrgIdMarker {
+    const PREFIX: &'static str = "org";
+}
+
+/// Marker for Agent IDs
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct AgentIdMarker;
+impl IdMarker for AgentIdMarker {
+    const PREFIX: &'static str = "agt";
+}
+
+/// Marker for Session IDs
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct SessionIdMarker;
+impl IdMarker for SessionIdMarker {
+    const PREFIX: &'static str = "sess";
+}
+
+/// Marker for Message IDs
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct MessageIdMarker;
+impl IdMarker for MessageIdMarker {
+    const PREFIX: &'static str = "msg";
+}
+
+/// Marker for Event IDs
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct EventIdMarker;
+impl IdMarker for EventIdMarker {
+    const PREFIX: &'static str = "evt";
+}
+
+/// Marker for LLM Provider IDs
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ProviderIdMarker;
+impl IdMarker for ProviderIdMarker {
+    const PREFIX: &'static str = "prov";
+}
+
+/// Marker for LLM Model IDs
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ModelIdMarker;
+impl IdMarker for ModelIdMarker {
+    const PREFIX: &'static str = "mod";
+}
+
+/// Marker for Image IDs
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ImageIdMarker;
+impl IdMarker for ImageIdMarker {
+    const PREFIX: &'static str = "img";
+}
+
+/// Marker for MCP Server IDs
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct McpServerIdMarker;
+impl IdMarker for McpServerIdMarker {
+    const PREFIX: &'static str = "mcp";
+}
+
+/// Marker for Turn IDs (used in workflow execution)
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct TurnIdMarker;
+impl IdMarker for TurnIdMarker {
+    const PREFIX: &'static str = "turn";
+}
+
+/// Marker for Execution IDs (workflow execution instance)
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ExecIdMarker;
+impl IdMarker for ExecIdMarker {
+    const PREFIX: &'static str = "exec";
+}
+
+// ============================================================================
+// Type aliases for convenience
+// ============================================================================
+
+/// Organization ID
+pub type OrgId = TypedId<OrgIdMarker>;
+/// Agent ID
+pub type AgentId = TypedId<AgentIdMarker>;
+/// Session ID
+pub type SessionId = TypedId<SessionIdMarker>;
+/// Message ID
+pub type MessageId = TypedId<MessageIdMarker>;
+/// Event ID
+pub type EventId = TypedId<EventIdMarker>;
+/// LLM Provider ID
+pub type ProviderId = TypedId<ProviderIdMarker>;
+/// LLM Model ID
+pub type ModelId = TypedId<ModelIdMarker>;
+/// Image ID
+pub type ImageId = TypedId<ImageIdMarker>;
+/// MCP Server ID
+pub type McpServerId = TypedId<McpServerIdMarker>;
+/// Turn ID
+pub type TurnId = TypedId<TurnIdMarker>;
+/// Execution ID
+pub type ExecId = TypedId<ExecIdMarker>;
+
+// ============================================================================
+// Well-known IDs (for seeding and defaults)
+// ============================================================================
+
+/// Default organization ID
+pub const DEFAULT_ORG_ID: OrgId = TypedId {
+    uuid: Uuid::from_u128(1),
+    _marker: PhantomData,
+};
+
+/// Well-known provider IDs
+pub mod well_known {
+    use super::*;
+
+    /// OpenAI provider ID
+    pub const OPENAI_PROVIDER_ID: ProviderId = TypedId {
+        uuid: Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000001),
+        _marker: PhantomData,
+    };
+
+    /// Anthropic provider ID
+    pub const ANTHROPIC_PROVIDER_ID: ProviderId = TypedId {
+        uuid: Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000002),
+        _marker: PhantomData,
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_agent_id() {
+        let id = AgentId::new();
+        let s = id.to_string();
+        assert!(s.starts_with("agt_"));
+        assert_eq!(s.len(), 36); // "agt_" + 32 hex chars
+    }
+
+    #[test]
+    fn test_parse_agent_id() {
+        let id = AgentId::new();
+        let s = id.to_string();
+        let parsed = AgentId::parse(&s).unwrap();
+        assert_eq!(id, parsed);
+    }
+
+    #[test]
+    fn test_parse_invalid_prefix() {
+        let result = AgentId::parse("sess_01933b5a00007000800000000000001");
+        assert!(matches!(result, Err(IdParseError::InvalidPrefix { .. })));
+    }
+
+    #[test]
+    fn test_parse_invalid_length() {
+        let result = AgentId::parse("agt_123");
+        assert!(matches!(result, Err(IdParseError::InvalidLength { .. })));
+    }
+
+    #[test]
+    fn test_parse_invalid_hex() {
+        let result = AgentId::parse("agt_GHIJKLMNOPQRSTUVWXYZ123456789012");
+        assert!(matches!(result, Err(IdParseError::InvalidHex(_))));
+    }
+
+    #[test]
+    fn test_from_seed() {
+        let id = AgentId::from_seed(1);
+        assert_eq!(id.to_string(), "agt_00000000000000000000000000000001");
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        let id = AgentId::new();
+        let json = serde_json::to_string(&id).unwrap();
+        let parsed: AgentId = serde_json::from_str(&json).unwrap();
+        assert_eq!(id, parsed);
+    }
+
+    #[test]
+    fn test_different_id_types_not_mixable() {
+        // This test verifies type safety at compile time
+        // AgentId and SessionId are different types
+        let agent_id = AgentId::new();
+        let session_id = SessionId::new();
+
+        // These would not compile:
+        // let _: AgentId = session_id;
+        // assert_eq!(agent_id, session_id);
+
+        // But we can compare their string representations
+        assert_ne!(
+            agent_id.to_string().chars().take(4).collect::<String>(),
+            session_id.to_string().chars().take(4).collect::<String>()
+        );
+    }
+
+    #[test]
+    fn test_default_org_id() {
+        assert_eq!(
+            DEFAULT_ORG_ID.to_string(),
+            "org_00000000000000000000000000000001"
+        );
+    }
+
+    #[test]
+    fn test_well_known_provider_ids() {
+        assert_eq!(
+            well_known::OPENAI_PROVIDER_ID.to_string(),
+            "prov_01933b5a000070008000000000000001"
+        );
+        assert_eq!(
+            well_known::ANTHROPIC_PROVIDER_ID.to_string(),
+            "prov_01933b5a000070008000000000000002"
+        );
+    }
+
+    #[test]
+    fn test_from_uuid() {
+        let uuid = Uuid::now_v7();
+        let id = AgentId::from_uuid(uuid);
+        assert_eq!(id.uuid(), uuid);
+    }
+
+    #[test]
+    fn test_hash() {
+        use std::collections::HashSet;
+        let id1 = AgentId::new();
+        let id2 = AgentId::new();
+        let mut set = HashSet::new();
+        set.insert(id1);
+        set.insert(id2);
+        assert_eq!(set.len(), 2);
+        set.insert(id1);
+        assert_eq!(set.len(), 2); // No duplicate
+    }
+
+    #[test]
+    fn test_debug_format() {
+        let id = AgentId::from_seed(42);
+        let debug = format!("{:?}", id);
+        assert!(debug.contains("AgentIdMarker"));
+        assert!(debug.contains("agt_"));
+    }
+}

--- a/crates/core/src/typed_id.rs
+++ b/crates/core/src/typed_id.rs
@@ -3,7 +3,7 @@
 //
 // Design decisions:
 // - Uses marker traits to differentiate ID types at compile time
-// - Stores IDs as prefixed strings (e.g., "agt_01933b5a...")
+// - Stores IDs as prefixed strings (e.g., "agent_01933b5a...")
 // - Uses UUIDv7 for time-ordering benefits
 // - Supports serde, sqlx, and utoipa for full integration
 
@@ -121,7 +121,7 @@ impl<T: IdMarker> TypedId<T> {
     }
 
     /// Create an ID from a well-known integer value (for seeding)
-    /// Produces IDs like "agt_00000000000000000000000000000001"
+    /// Produces IDs like "agent_00000000000000000000000000000001"
     pub fn from_seed(value: u128) -> Self {
         let uuid = Uuid::from_u128(value);
         Self {
@@ -266,42 +266,42 @@ impl IdMarker for OrgIdMarker {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct AgentIdMarker;
 impl IdMarker for AgentIdMarker {
-    const PREFIX: &'static str = "agt";
+    const PREFIX: &'static str = "agent";
 }
 
 /// Marker for Session IDs
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct SessionIdMarker;
 impl IdMarker for SessionIdMarker {
-    const PREFIX: &'static str = "sess";
+    const PREFIX: &'static str = "session";
 }
 
 /// Marker for Message IDs
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct MessageIdMarker;
 impl IdMarker for MessageIdMarker {
-    const PREFIX: &'static str = "msg";
+    const PREFIX: &'static str = "message";
 }
 
 /// Marker for Event IDs
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct EventIdMarker;
 impl IdMarker for EventIdMarker {
-    const PREFIX: &'static str = "evt";
+    const PREFIX: &'static str = "event";
 }
 
 /// Marker for LLM Provider IDs
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct ProviderIdMarker;
 impl IdMarker for ProviderIdMarker {
-    const PREFIX: &'static str = "prov";
+    const PREFIX: &'static str = "provider";
 }
 
 /// Marker for LLM Model IDs
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct ModelIdMarker;
 impl IdMarker for ModelIdMarker {
-    const PREFIX: &'static str = "mod";
+    const PREFIX: &'static str = "model";
 }
 
 /// Marker for Image IDs
@@ -394,8 +394,8 @@ mod tests {
     fn test_new_agent_id() {
         let id = AgentId::new();
         let s = id.to_string();
-        assert!(s.starts_with("agt_"));
-        assert_eq!(s.len(), 36); // "agt_" + 32 hex chars
+        assert!(s.starts_with("agent_"));
+        assert_eq!(s.len(), 38); // "agent_" + 32 hex chars
     }
 
     #[test]
@@ -408,26 +408,26 @@ mod tests {
 
     #[test]
     fn test_parse_invalid_prefix() {
-        let result = AgentId::parse("sess_01933b5a00007000800000000000001");
+        let result = AgentId::parse("session_01933b5a00007000800000000000001");
         assert!(matches!(result, Err(IdParseError::InvalidPrefix { .. })));
     }
 
     #[test]
     fn test_parse_invalid_length() {
-        let result = AgentId::parse("agt_123");
+        let result = AgentId::parse("agent_123");
         assert!(matches!(result, Err(IdParseError::InvalidLength { .. })));
     }
 
     #[test]
     fn test_parse_invalid_hex() {
-        let result = AgentId::parse("agt_GHIJKLMNOPQRSTUVWXYZ123456789012");
+        let result = AgentId::parse("agent_GHIJKLMNOPQRSTUVWXYZ123456789012");
         assert!(matches!(result, Err(IdParseError::InvalidHex(_))));
     }
 
     #[test]
     fn test_from_seed() {
         let id = AgentId::from_seed(1);
-        assert_eq!(id.to_string(), "agt_00000000000000000000000000000001");
+        assert_eq!(id.to_string(), "agent_00000000000000000000000000000001");
     }
 
     #[test]
@@ -468,11 +468,11 @@ mod tests {
     fn test_well_known_provider_ids() {
         assert_eq!(
             well_known::OPENAI_PROVIDER_ID.to_string(),
-            "prov_01933b5a000070008000000000000001"
+            "provider_01933b5a000070008000000000000001"
         );
         assert_eq!(
             well_known::ANTHROPIC_PROVIDER_ID.to_string(),
-            "prov_01933b5a000070008000000000000002"
+            "provider_01933b5a000070008000000000000002"
         );
     }
 
@@ -501,6 +501,6 @@ mod tests {
         let id = AgentId::from_seed(42);
         let debug = format!("{:?}", id);
         assert!(debug.contains("AgentIdMarker"));
-        assert!(debug.contains("agt_"));
+        assert!(debug.contains("agent_"));
     }
 }

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -38,7 +38,7 @@ async fn setup_test_environment() -> (
     // Create a test agent
     let agent_id = Uuid::now_v7();
     let agent = Agent {
-        id: agent_id,
+        id: agent_id.into(),
         name: "Test Agent".to_string(),
         description: None,
         system_prompt: "You are a helpful assistant.".to_string(),
@@ -55,8 +55,8 @@ async fn setup_test_environment() -> (
     // Create a test session
     let session_id = Uuid::now_v7();
     let session = Session {
-        id: session_id,
-        agent_id,
+        id: session_id.into(),
+        agent_id: agent_id.into(),
         title: Some("Test Session".to_string()),
         preview: None,
         output_preview: None,
@@ -291,8 +291,8 @@ async fn test_reason_atom_with_different_configs() {
     // Second test with a different configuration
     let session_id2 = Uuid::now_v7();
     let session2 = Session {
-        id: session_id2,
-        agent_id,
+        id: session_id2.into(),
+        agent_id: agent_id.into(),
         title: Some("Test Session 2".to_string()),
         preview: None,
         output_preview: None,

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -329,12 +329,12 @@ pub fn proto_agent_to_schema(value: proto::Agent) -> Result<everruns_core::Agent
     let id_str = value
         .id
         .as_ref()
-        .map(|u| format!("agt_{}", u.value.replace("-", "")))
+        .map(|u| format!("agent_{}", u.value.replace("-", "")))
         .unwrap_or_default();
     let model_id_str = value
         .default_model_id
         .as_ref()
-        .map(|u| format!("mod_{}", u.value.replace("-", "")));
+        .map(|u| format!("model_{}", u.value.replace("-", "")));
 
     let json = serde_json::json!({
         "id": id_str,
@@ -387,17 +387,17 @@ pub fn proto_session_to_schema(
     let id_str = value
         .id
         .as_ref()
-        .map(|u| format!("sess_{}", u.value.replace("-", "")))
+        .map(|u| format!("session_{}", u.value.replace("-", "")))
         .unwrap_or_default();
     let agent_id_str = value
         .agent_id
         .as_ref()
-        .map(|u| format!("agt_{}", u.value.replace("-", "")))
+        .map(|u| format!("agent_{}", u.value.replace("-", "")))
         .unwrap_or_default();
     let model_id_str = value
         .default_model_id
         .as_ref()
-        .map(|u| format!("mod_{}", u.value.replace("-", "")));
+        .map(|u| format!("model_{}", u.value.replace("-", "")));
 
     let json = serde_json::json!({
         "id": id_str,

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -5,6 +5,7 @@
 // Decision: Proto is transport layer, Rust schemas remain source of truth
 
 use chrono::{DateTime, TimeZone, Utc};
+use everruns_core::typed_id::{EventId, ExecId, MessageId, SessionId, TurnId};
 use prost_types::{ListValue, Struct, Value, value::Kind};
 
 // Generated protobuf code
@@ -531,17 +532,20 @@ pub fn proto_event_to_schema(value: proto::Event) -> Result<everruns_core::Event
             .turn_id
             .as_ref()
             .map(proto_uuid_to_uuid)
-            .transpose()?,
+            .transpose()?
+            .map(TurnId::from_uuid),
         input_message_id: proto_context
             .input_message_id
             .as_ref()
             .map(proto_uuid_to_uuid)
-            .transpose()?,
+            .transpose()?
+            .map(MessageId::from_uuid),
         exec_id: proto_context
             .exec_id
             .as_ref()
             .map(proto_uuid_to_uuid)
-            .transpose()?,
+            .transpose()?
+            .map(ExecId::from_uuid),
     };
 
     // Convert Struct data to EventData based on event_type
@@ -556,10 +560,10 @@ pub fn proto_event_to_schema(value: proto::Event) -> Result<everruns_core::Event
     let metadata: Option<serde_json::Value> = value.metadata.as_ref().map(proto_struct_to_json);
 
     Ok(everruns_core::Event {
-        id,
+        id: EventId::from_uuid(id),
         event_type: value.event_type,
         ts,
-        session_id,
+        session_id: SessionId::from_uuid(session_id),
         context,
         data,
         metadata,
@@ -579,14 +583,26 @@ pub fn schema_event_to_proto(value: &everruns_core::Event) -> proto::Event {
     let data_struct = json_to_proto_struct(&data_json);
 
     proto::Event {
-        id: Some(uuid_to_proto_uuid(value.id)),
+        id: Some(uuid_to_proto_uuid(value.id.uuid())),
         event_type: value.event_type.clone(),
         ts: Some(datetime_to_proto_timestamp(value.ts)),
         context: Some(proto::EventContext {
-            session_id: Some(uuid_to_proto_uuid(value.session_id)),
-            turn_id: value.context.turn_id.map(uuid_to_proto_uuid),
-            input_message_id: value.context.input_message_id.map(uuid_to_proto_uuid),
-            exec_id: value.context.exec_id.map(uuid_to_proto_uuid),
+            session_id: Some(uuid_to_proto_uuid(value.session_id.uuid())),
+            turn_id: value
+                .context
+                .turn_id
+                .as_ref()
+                .map(|id| uuid_to_proto_uuid(id.uuid())),
+            input_message_id: value
+                .context
+                .input_message_id
+                .as_ref()
+                .map(|id| uuid_to_proto_uuid(id.uuid())),
+            exec_id: value
+                .context
+                .exec_id
+                .as_ref()
+                .map(|id| uuid_to_proto_uuid(id.uuid())),
         }),
         data: Some(data_struct),
         metadata: value.metadata.as_ref().map(json_to_proto_struct),
@@ -620,17 +636,20 @@ pub fn proto_event_request_to_schema(
             .turn_id
             .as_ref()
             .map(proto_uuid_to_uuid)
-            .transpose()?,
+            .transpose()?
+            .map(TurnId::from_uuid),
         input_message_id: proto_context
             .input_message_id
             .as_ref()
             .map(proto_uuid_to_uuid)
-            .transpose()?,
+            .transpose()?
+            .map(MessageId::from_uuid),
         exec_id: proto_context
             .exec_id
             .as_ref()
             .map(proto_uuid_to_uuid)
-            .transpose()?,
+            .transpose()?
+            .map(ExecId::from_uuid),
     };
 
     // Convert Struct data to EventData based on event_type
@@ -670,9 +689,21 @@ pub fn schema_event_request_to_proto(value: &everruns_core::EventRequest) -> pro
         ts: Some(datetime_to_proto_timestamp(value.ts)),
         context: Some(proto::EventContext {
             session_id: Some(uuid_to_proto_uuid(value.session_id)),
-            turn_id: value.context.turn_id.map(uuid_to_proto_uuid),
-            input_message_id: value.context.input_message_id.map(uuid_to_proto_uuid),
-            exec_id: value.context.exec_id.map(uuid_to_proto_uuid),
+            turn_id: value
+                .context
+                .turn_id
+                .as_ref()
+                .map(|id| uuid_to_proto_uuid(id.uuid())),
+            input_message_id: value
+                .context
+                .input_message_id
+                .as_ref()
+                .map(|id| uuid_to_proto_uuid(id.uuid())),
+            exec_id: value
+                .context
+                .exec_id
+                .as_ref()
+                .map(|id| uuid_to_proto_uuid(id.uuid())),
         }),
         data: Some(data_struct),
         metadata: value.metadata.as_ref().map(json_to_proto_struct),

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -324,12 +324,24 @@ pub fn proto_agent_to_schema(value: proto::Agent) -> Result<everruns_core::Agent
         .iter()
         .map(|id| serde_json::json!({"ref": id, "config": {}}))
         .collect();
+
+    // Convert UUID string to prefixed format for typed IDs
+    let id_str = value
+        .id
+        .as_ref()
+        .map(|u| format!("agt_{}", u.value.replace("-", "")))
+        .unwrap_or_default();
+    let model_id_str = value
+        .default_model_id
+        .as_ref()
+        .map(|u| format!("mod_{}", u.value.replace("-", "")));
+
     let json = serde_json::json!({
-        "id": value.id.as_ref().map(|u| &u.value).unwrap_or(&String::new()),
+        "id": id_str,
         "name": value.name,
         "description": if value.description.is_empty() { None } else { Some(&value.description) },
         "system_prompt": value.system_prompt,
-        "default_model_id": value.default_model_id.as_ref().map(|u| &u.value),
+        "default_model_id": model_id_str,
         "tags": tags,
         "capabilities": capabilities,
         "status": value.status,
@@ -342,11 +354,13 @@ pub fn proto_agent_to_schema(value: proto::Agent) -> Result<everruns_core::Agent
 /// Convert schemas Agent to proto Agent
 pub fn schema_agent_to_proto(value: &everruns_core::Agent) -> proto::Agent {
     proto::Agent {
-        id: Some(uuid_to_proto_uuid(value.id)),
+        id: Some(uuid_to_proto_uuid(value.id.uuid())),
         name: value.name.clone(),
         description: value.description.clone().unwrap_or_default(),
         system_prompt: value.system_prompt.clone(),
-        default_model_id: value.default_model_id.map(uuid_to_proto_uuid),
+        default_model_id: value
+            .default_model_id
+            .map(|id| uuid_to_proto_uuid(id.uuid())),
         temperature: None,
         max_tokens: None,
         status: value.status.to_string(),
@@ -368,12 +382,29 @@ pub fn proto_session_to_schema(
     let tags: Vec<String> = vec![];
     let started_at: Option<String> = None;
     let finished_at: Option<String> = None;
+
+    // Convert UUID string to prefixed format for typed IDs
+    let id_str = value
+        .id
+        .as_ref()
+        .map(|u| format!("sess_{}", u.value.replace("-", "")))
+        .unwrap_or_default();
+    let agent_id_str = value
+        .agent_id
+        .as_ref()
+        .map(|u| format!("agt_{}", u.value.replace("-", "")))
+        .unwrap_or_default();
+    let model_id_str = value
+        .default_model_id
+        .as_ref()
+        .map(|u| format!("mod_{}", u.value.replace("-", "")));
+
     let json = serde_json::json!({
-        "id": value.id.as_ref().map(|u| &u.value).unwrap_or(&String::new()),
-        "agent_id": value.agent_id.as_ref().map(|u| &u.value).unwrap_or(&String::new()),
+        "id": id_str,
+        "agent_id": agent_id_str,
         "title": if value.title.is_empty() { None } else { Some(&value.title) },
         "tags": tags,
-        "model_id": value.default_model_id.as_ref().map(|u| &u.value),
+        "model_id": model_id_str,
         "status": value.status,
         "created_at": value.created_at.as_ref().map(|t| proto_timestamp_to_datetime(t).to_rfc3339()),
         "started_at": started_at,
@@ -385,13 +416,13 @@ pub fn proto_session_to_schema(
 /// Convert schemas Session to proto Session
 pub fn schema_session_to_proto(value: &everruns_core::Session) -> proto::Session {
     proto::Session {
-        id: Some(uuid_to_proto_uuid(value.id)),
-        agent_id: Some(uuid_to_proto_uuid(value.agent_id)),
+        id: Some(uuid_to_proto_uuid(value.id.uuid())),
+        agent_id: Some(uuid_to_proto_uuid(value.agent_id.uuid())),
         title: value.title.clone().unwrap_or_default(),
         status: value.status.to_string(),
         created_at: Some(datetime_to_proto_timestamp(value.created_at)),
         updated_at: Some(datetime_to_proto_timestamp(value.created_at)), // Use created_at as fallback
-        default_model_id: value.model_id.map(uuid_to_proto_uuid),
+        default_model_id: value.model_id.map(|id| uuid_to_proto_uuid(id.uuid())),
     }
 }
 
@@ -435,7 +466,7 @@ pub fn proto_message_to_schema(
     let role = parse_message_role(&value.role);
 
     Ok(everruns_core::Message {
-        id,
+        id: id.into(),
         role,
         content,
         controls,
@@ -463,7 +494,7 @@ pub fn schema_message_to_proto(value: &everruns_core::Message) -> proto::Message
     });
 
     proto::Message {
-        id: Some(uuid_to_proto_uuid(value.id)),
+        id: Some(uuid_to_proto_uuid(value.id.uuid())),
         role: value.role.to_string(),
         content,
         controls,
@@ -958,7 +989,7 @@ mod tests {
 
         // Create an Agent with capabilities
         let agent = everruns_core::Agent {
-            id: Uuid::now_v7(),
+            id: Uuid::now_v7().into(),
             name: "Test Agent".to_string(),
             description: Some("Test description".to_string()),
             system_prompt: "You are a helpful assistant".to_string(),
@@ -1012,7 +1043,7 @@ mod tests {
 
         // Create an Agent without capabilities
         let agent = everruns_core::Agent {
-            id: Uuid::now_v7(),
+            id: Uuid::now_v7().into(),
             name: "Test Agent".to_string(),
             description: None,
             system_prompt: "You are a helpful assistant".to_string(),

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -17,6 +17,7 @@ use everruns_core::ToolRegistry;
 use everruns_core::atoms::{ActAtom, Atom, InputAtom, ReasonAtom};
 use everruns_core::capabilities::{CapabilityRegistry, collect_capabilities, is_mcp_capability};
 use everruns_core::traits::AgentStore;
+use everruns_core::typed_id::{MessageId, TurnId};
 use std::sync::Arc;
 
 use crate::adapters::create_driver_registry;
@@ -73,8 +74,8 @@ pub async fn input_activity(
         input.context.session_id,
         EventContext::turn(input.context.turn_id, input.context.input_message_id),
         SessionActivatedData {
-            turn_id: input.context.turn_id,
-            input_message_id: input.context.input_message_id,
+            turn_id: TurnId::from_uuid(input.context.turn_id),
+            input_message_id: MessageId::from_uuid(input.context.input_message_id),
         },
     );
     if let Err(e) = event_emitter.emit(activated_event).await {
@@ -86,8 +87,8 @@ pub async fn input_activity(
         input.context.session_id,
         EventContext::turn(input.context.turn_id, input.context.input_message_id),
         TurnStartedData {
-            turn_id: input.context.turn_id,
-            input_message_id: input.context.input_message_id,
+            turn_id: TurnId::from_uuid(input.context.turn_id),
+            input_message_id: MessageId::from_uuid(input.context.input_message_id),
         },
     );
     if let Err(e) = event_emitter.emit(turn_started_event).await {
@@ -185,7 +186,7 @@ pub async fn reason_activity(
                 session_id,
                 EventContext::turn(turn_id, input_message_id),
                 TurnFailedData {
-                    turn_id,
+                    turn_id: TurnId::from_uuid(turn_id),
                     error: "An error occurred while processing your request.".to_string(),
                     error_code: Some("llm_error".to_string()),
                 },
@@ -199,7 +200,7 @@ pub async fn reason_activity(
                 session_id,
                 EventContext::turn(turn_id, input_message_id),
                 TurnCompletedData {
-                    turn_id,
+                    turn_id: TurnId::from_uuid(turn_id),
                     iterations: 1, // TODO: Track actual iterations when workflow supports it
                     duration_ms: None,
                     usage: result.usage.clone(),
@@ -217,7 +218,7 @@ pub async fn reason_activity(
             session_id,
             EventContext::turn(turn_id, input_message_id),
             SessionIdledData {
-                turn_id,
+                turn_id: TurnId::from_uuid(turn_id),
                 iterations: None, // We don't track iterations in the activity
                 usage: result.usage.clone(),
             },

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -7,6 +7,7 @@ use everruns_core::Message;
 use everruns_core::atoms::AtomContext;
 use everruns_core::events::{EventContext, EventRequest, MessageAgentData, SessionIdledData};
 use everruns_core::traits::EventEmitter;
+use everruns_core::typed_id::TurnId;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
@@ -78,7 +79,7 @@ async fn emit_cancellation_events(
         session_id,
         EventContext::turn(turn_id, input_message_id),
         SessionIdledData {
-            turn_id,
+            turn_id: TurnId::from_uuid(turn_id),
             iterations: None,
             usage: None,
         },

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -306,7 +306,7 @@ fn proto_message_to_message(proto_msg: proto::Message) -> Result<Message> {
     };
 
     Ok(Message {
-        id,
+        id: id.into(),
         role,
         content,
         controls,
@@ -371,11 +371,11 @@ fn proto_agent_to_agent(proto_agent: proto::Agent) -> Result<Agent> {
     };
 
     Ok(Agent {
-        id,
+        id: id.into(),
         name: proto_agent.name,
         description: non_empty_string(proto_agent.description),
         system_prompt: proto_agent.system_prompt,
-        default_model_id,
+        default_model_id: default_model_id.map(|u| u.into()),
         tags: vec![],
         capabilities: proto_agent
             .capability_ids
@@ -450,13 +450,13 @@ fn proto_session_to_session(proto_session: proto::Session) -> Result<Session> {
     };
 
     Ok(Session {
-        id,
-        agent_id,
+        id: id.into(),
+        agent_id: agent_id.into(),
         title: non_empty_string(proto_session.title),
         preview: None,
         output_preview: None,
         tags: vec![],
-        model_id,
+        model_id: model_id.map(|u| u.into()),
         status,
         created_at: proto_timestamp_or_now(proto_session.created_at.as_ref()),
         started_at: None,

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2631,7 +2631,7 @@
               "null"
             ],
             "description": "Default LLM model ID for this agent.\nCan be overridden at the session level.",
-            "example": "mod_01933b5a00007000800000000000001"
+            "example": "model_01933b5a00007000800000000000001"
           },
           "description": {
             "type": [
@@ -2642,8 +2642,8 @@
           },
           "id": {
             "type": "string",
-            "description": "Unique identifier for the agent (format: agt_{32-hex}).",
-            "example": "agt_01933b5a00007000800000000000001"
+            "description": "Unique identifier for the agent (format: agent_{32-hex}).",
+            "example": "agent_01933b5a00007000800000000000001"
           },
           "name": {
             "type": "string",
@@ -2950,8 +2950,8 @@
               "string",
               "null"
             ],
-            "description": "Model ID to use for this message (format: mod_{32-hex}).\nOverrides session and agent model settings.",
-            "example": "mod_01933b5a00007000800000000000001"
+            "description": "Model ID to use for this message (format: model_{32-hex}).\nOverrides session and agent model settings.",
+            "example": "model_01933b5a00007000800000000000001"
           },
           "reasoning": {
             "oneOf": [
@@ -3849,7 +3849,7 @@
                     "null"
                   ],
                   "description": "Default LLM model ID for this agent.\nCan be overridden at the session level.",
-                  "example": "mod_01933b5a00007000800000000000001"
+                  "example": "model_01933b5a00007000800000000000001"
                 },
                 "description": {
                   "type": [
@@ -3860,8 +3860,8 @@
                 },
                 "id": {
                   "type": "string",
-                  "description": "Unique identifier for the agent (format: agt_{32-hex}).",
-                  "example": "agt_01933b5a00007000800000000000001"
+                  "description": "Unique identifier for the agent (format: agent_{32-hex}).",
+                  "example": "agent_01933b5a00007000800000000000001"
                 },
                 "name": {
                   "type": "string",
@@ -4194,7 +4194,7 @@
                 },
                 "id": {
                   "type": "string",
-                  "example": "mod_01933b5a00007000800000000000001"
+                  "example": "model_01933b5a00007000800000000000001"
                 },
                 "is_default": {
                   "type": "boolean"
@@ -4207,7 +4207,7 @@
                 },
                 "provider_id": {
                   "type": "string",
-                  "example": "prov_01933b5a00007000800000000000001"
+                  "example": "provider_01933b5a00007000800000000000001"
                 },
                 "source": {
                   "$ref": "#/components/schemas/LlmModelSource",
@@ -4269,7 +4269,7 @@
                 },
                 "id": {
                   "type": "string",
-                  "example": "mod_01933b5a00007000800000000000001"
+                  "example": "model_01933b5a00007000800000000000001"
                 },
                 "is_default": {
                   "type": "boolean"
@@ -4293,7 +4293,7 @@
                 },
                 "provider_id": {
                   "type": "string",
-                  "example": "prov_01933b5a00007000800000000000001"
+                  "example": "provider_01933b5a00007000800000000000001"
                 },
                 "provider_name": {
                   "type": "string"
@@ -4356,7 +4356,7 @@
                 },
                 "id": {
                   "type": "string",
-                  "example": "prov_01933b5a00007000800000000000001"
+                  "example": "provider_01933b5a00007000800000000000001"
                 },
                 "last_synced_at": {
                   "type": [
@@ -4777,7 +4777,7 @@
           },
           "id": {
             "type": "string",
-            "example": "mod_01933b5a00007000800000000000001"
+            "example": "model_01933b5a00007000800000000000001"
           },
           "is_default": {
             "type": "boolean"
@@ -4790,7 +4790,7 @@
           },
           "provider_id": {
             "type": "string",
-            "example": "prov_01933b5a00007000800000000000001"
+            "example": "provider_01933b5a00007000800000000000001"
           },
           "source": {
             "$ref": "#/components/schemas/LlmModelSource",
@@ -5041,7 +5041,7 @@
           },
           "id": {
             "type": "string",
-            "example": "mod_01933b5a00007000800000000000001"
+            "example": "model_01933b5a00007000800000000000001"
           },
           "is_default": {
             "type": "boolean"
@@ -5065,7 +5065,7 @@
           },
           "provider_id": {
             "type": "string",
-            "example": "prov_01933b5a00007000800000000000001"
+            "example": "provider_01933b5a00007000800000000000001"
           },
           "provider_name": {
             "type": "string"
@@ -5115,7 +5115,7 @@
           },
           "id": {
             "type": "string",
-            "example": "prov_01933b5a00007000800000000000001"
+            "example": "provider_01933b5a00007000800000000000001"
           },
           "last_synced_at": {
             "type": [
@@ -5279,8 +5279,8 @@
           },
           "id": {
             "type": "string",
-            "description": "Unique message ID (format: msg_{32-hex})",
-            "example": "msg_01933b5a00007000800000000000001"
+            "description": "Unique message ID (format: message_{32-hex})",
+            "example": "message_01933b5a00007000800000000000001"
           },
           "metadata": {
             "type": [
@@ -5434,8 +5434,8 @@
               "properties": {
                 "agent_id": {
                   "type": "string",
-                  "description": "ID of the agent this session belongs to (format: agt_{32-hex}).",
-                  "example": "agt_01933b5a00007000800000000000001"
+                  "description": "ID of the agent this session belongs to (format: agent_{32-hex}).",
+                  "example": "agent_01933b5a00007000800000000000001"
                 },
                 "created_at": {
                   "type": "string",
@@ -5452,16 +5452,16 @@
                 },
                 "id": {
                   "type": "string",
-                  "description": "Unique identifier for the session (format: sess_{32-hex}).",
-                  "example": "sess_01933b5a00007000800000000000001"
+                  "description": "Unique identifier for the session (format: session_{32-hex}).",
+                  "example": "session_01933b5a00007000800000000000001"
                 },
                 "model_id": {
                   "type": [
                     "string",
                     "null"
                   ],
-                  "description": "LLM model ID to use for this session (format: mod_{32-hex}).\nOverrides the agent's default model if set.",
-                  "example": "mod_01933b5a00007000800000000000001"
+                  "description": "LLM model ID to use for this session (format: model_{32-hex}).\nOverrides the agent's default model if set.",
+                  "example": "model_01933b5a00007000800000000000001"
                 },
                 "output_preview": {
                   "type": [
@@ -5678,8 +5678,8 @@
         "properties": {
           "agent_id": {
             "type": "string",
-            "description": "ID of the agent this session belongs to (format: agt_{32-hex}).",
-            "example": "agt_01933b5a00007000800000000000001"
+            "description": "ID of the agent this session belongs to (format: agent_{32-hex}).",
+            "example": "agent_01933b5a00007000800000000000001"
           },
           "created_at": {
             "type": "string",
@@ -5696,16 +5696,16 @@
           },
           "id": {
             "type": "string",
-            "description": "Unique identifier for the session (format: sess_{32-hex}).",
-            "example": "sess_01933b5a00007000800000000000001"
+            "description": "Unique identifier for the session (format: session_{32-hex}).",
+            "example": "session_01933b5a00007000800000000000001"
           },
           "model_id": {
             "type": [
               "string",
               "null"
             ],
-            "description": "LLM model ID to use for this session (format: mod_{32-hex}).\nOverrides the agent's default model if set.",
-            "example": "mod_01933b5a00007000800000000000001"
+            "description": "LLM model ID to use for this session (format: model_{32-hex}).\nOverrides the agent's default model if set.",
+            "example": "model_01933b5a00007000800000000000001"
           },
           "output_preview": {
             "type": [

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -720,21 +720,19 @@
           {
             "name": "agent_id",
             "in": "path",
-            "description": "Agent ID",
+            "description": "Agent ID (prefixed, e.g., agent_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           },
           {
             "name": "session_id",
             "in": "path",
-            "description": "Session ID",
+            "description": "Session ID (prefixed, e.g., session_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           }
         ],
@@ -748,6 +746,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid session ID"
           },
           "404": {
             "description": "Session not found"
@@ -3264,8 +3265,8 @@
               "string",
               "null"
             ],
-            "format": "uuid",
-            "description": "The ID of the LLM model to use for this session.\nOverrides the agent's default model if specified."
+            "description": "The ID of the LLM model to use for this session.\nOverrides the agent's default model if specified.",
+            "example": "model_01933b5a00007000800000000000001"
           },
           "tags": {
             "type": "array",

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3014,8 +3014,8 @@
               "string",
               "null"
             ],
-            "format": "uuid",
-            "description": "The ID of the default LLM model to use for this agent.\nIf not specified, the system default model will be used."
+            "description": "The ID of the default LLM model to use for this agent.\nIf not specified, the system default model will be used.",
+            "example": "model_01933b5a00007000800000000000001"
           },
           "description": {
             "type": [
@@ -6297,8 +6297,8 @@
               "string",
               "null"
             ],
-            "format": "uuid",
-            "description": "The ID of the default LLM model to use for this agent."
+            "description": "The ID of the default LLM model to use for this agent.",
+            "example": "model_01933b5a00007000800000000000001"
           },
           "description": {
             "type": [

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -4437,8 +4437,8 @@
                 },
                 "id": {
                   "type": "string",
-                  "format": "uuid",
-                  "description": "Unique identifier for the MCP server."
+                  "description": "Unique identifier for the MCP server.",
+                  "example": "mcp_01933b5a00007000800000000000001"
                 },
                 "name": {
                   "type": "string",
@@ -5203,8 +5203,8 @@
           },
           "id": {
             "type": "string",
-            "format": "uuid",
-            "description": "Unique identifier for the MCP server."
+            "description": "Unique identifier for the MCP server.",
+            "example": "mcp_01933b5a00007000800000000000001"
           },
           "name": {
             "type": "string",

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2722,8 +2722,8 @@
           },
           "turn_id": {
             "type": "string",
-            "format": "uuid",
-            "description": "Turn ID this thinking indicator belongs to"
+            "description": "Turn ID this thinking indicator belongs to",
+            "example": "turn_01933b5a00007000800000000000001"
           }
         }
       },
@@ -5772,13 +5772,13 @@
         "properties": {
           "input_message_id": {
             "type": "string",
-            "format": "uuid",
-            "description": "Input message ID that triggered the turn"
+            "description": "Input message ID that triggered the turn",
+            "example": "message_01933b5a00007000800000000000001"
           },
           "turn_id": {
             "type": "string",
-            "format": "uuid",
-            "description": "Turn ID that activated the session"
+            "description": "Turn ID that activated the session",
+            "example": "turn_01933b5a00007000800000000000001"
           }
         }
       },
@@ -5860,8 +5860,8 @@
           },
           "turn_id": {
             "type": "string",
-            "format": "uuid",
-            "description": "Turn ID that just completed"
+            "description": "Turn ID that just completed",
+            "example": "turn_01933b5a00007000800000000000001"
           },
           "usage": {
             "oneOf": [
@@ -5885,16 +5885,16 @@
         "properties": {
           "agent_id": {
             "type": "string",
-            "format": "uuid",
-            "description": "Agent ID"
+            "description": "Agent ID",
+            "example": "agent_01933b5a00007000800000000000001"
           },
           "model_id": {
             "type": [
               "string",
               "null"
             ],
-            "format": "uuid",
-            "description": "Model ID if specified"
+            "description": "Model ID if specified",
+            "example": "model_01933b5a00007000800000000000001"
           }
         }
       },
@@ -5951,8 +5951,8 @@
           },
           "turn_id": {
             "type": "string",
-            "format": "uuid",
-            "description": "Turn ID this delta belongs to (for correlation)"
+            "description": "Turn ID this delta belongs to (for correlation)",
+            "example": "turn_01933b5a00007000800000000000001"
           }
         }
       },
@@ -6165,8 +6165,8 @@
           },
           "turn_id": {
             "type": "string",
-            "format": "uuid",
-            "description": "Turn identifier"
+            "description": "Turn identifier",
+            "example": "turn_01933b5a00007000800000000000001"
           },
           "usage": {
             "oneOf": [
@@ -6206,8 +6206,8 @@
           },
           "turn_id": {
             "type": "string",
-            "format": "uuid",
-            "description": "Turn identifier"
+            "description": "Turn identifier",
+            "example": "turn_01933b5a00007000800000000000001"
           },
           "usage": {
             "oneOf": [
@@ -6243,8 +6243,8 @@
           },
           "turn_id": {
             "type": "string",
-            "format": "uuid",
-            "description": "Turn identifier"
+            "description": "Turn identifier",
+            "example": "turn_01933b5a00007000800000000000001"
           }
         }
       },
@@ -6258,13 +6258,13 @@
         "properties": {
           "input_message_id": {
             "type": "string",
-            "format": "uuid",
-            "description": "Input message ID that triggered this turn"
+            "description": "Input message ID that triggered this turn",
+            "example": "message_01933b5a00007000800000000000001"
           },
           "turn_id": {
             "type": "string",
-            "format": "uuid",
-            "description": "Turn identifier"
+            "description": "Turn identifier",
+            "example": "turn_01933b5a00007000800000000000001"
           }
         }
       },

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -194,11 +194,10 @@
           {
             "name": "agent_id",
             "in": "path",
-            "description": "Agent ID",
+            "description": "Agent ID (prefixed, e.g., agt_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           }
         ],
@@ -212,6 +211,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid agent ID"
           },
           "404": {
             "description": "Agent not found"
@@ -240,17 +242,19 @@
           {
             "name": "agent_id",
             "in": "path",
-            "description": "Agent ID",
+            "description": "Agent ID (prefixed, e.g., agt_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           }
         ],
         "responses": {
           "204": {
             "description": "Agent archived successfully"
+          },
+          "400": {
+            "description": "Invalid agent ID"
           },
           "404": {
             "description": "Agent not found"
@@ -279,11 +283,10 @@
           {
             "name": "agent_id",
             "in": "path",
-            "description": "Agent ID",
+            "description": "Agent ID (prefixed, e.g., agt_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           }
         ],
@@ -309,7 +312,7 @@
             }
           },
           "400": {
-            "description": "Input exceeds allowed limits",
+            "description": "Invalid agent ID or input exceeds allowed limits",
             "content": {
               "application/json": {
                 "schema": {
@@ -361,11 +364,10 @@
           {
             "name": "agent_id",
             "in": "path",
-            "description": "Agent ID",
+            "description": "Agent ID (prefixed, e.g., agt_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           }
         ],
@@ -375,6 +377,9 @@
             "content": {
               "text/markdown": {}
             }
+          },
+          "400": {
+            "description": "Invalid agent ID"
           },
           "404": {
             "description": "Agent not found"
@@ -405,11 +410,10 @@
           {
             "name": "agent_id",
             "in": "path",
-            "description": "Agent ID",
+            "description": "Agent ID (prefixed, e.g., agt_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           },
           {
@@ -455,6 +459,9 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid agent ID"
+          },
           "500": {
             "description": "Internal server error"
           }
@@ -479,11 +486,10 @@
           {
             "name": "agent_id",
             "in": "path",
-            "description": "Agent ID",
+            "description": "Agent ID (prefixed, e.g., agt_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           }
         ],
@@ -507,6 +513,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid agent ID"
           },
           "500": {
             "description": "Internal server error"
@@ -534,21 +543,19 @@
           {
             "name": "agent_id",
             "in": "path",
-            "description": "Agent ID",
+            "description": "Agent ID (prefixed, e.g., agt_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           },
           {
             "name": "session_id",
             "in": "path",
-            "description": "Session ID",
+            "description": "Session ID (prefixed, e.g., sess_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           }
         ],
@@ -562,6 +569,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid session ID"
           },
           "404": {
             "description": "Session not found"
@@ -590,27 +600,28 @@
           {
             "name": "agent_id",
             "in": "path",
-            "description": "Agent ID",
+            "description": "Agent ID (prefixed, e.g., agt_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           },
           {
             "name": "session_id",
             "in": "path",
-            "description": "Session ID",
+            "description": "Session ID (prefixed, e.g., sess_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           }
         ],
         "responses": {
           "204": {
             "description": "Session deleted successfully"
+          },
+          "400": {
+            "description": "Invalid session ID"
           },
           "404": {
             "description": "Session not found"
@@ -639,21 +650,19 @@
           {
             "name": "agent_id",
             "in": "path",
-            "description": "Agent ID",
+            "description": "Agent ID (prefixed, e.g., agt_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           },
           {
             "name": "session_id",
             "in": "path",
-            "description": "Session ID",
+            "description": "Session ID (prefixed, e.g., sess_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           }
         ],
@@ -677,6 +686,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid session ID"
           },
           "404": {
             "description": "Session not found"
@@ -766,21 +778,19 @@
           {
             "name": "agent_id",
             "in": "path",
-            "description": "Agent ID",
+            "description": "Agent ID (prefixed, e.g., agt_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           },
           {
             "name": "session_id",
             "in": "path",
-            "description": "Session ID",
+            "description": "Session ID (prefixed, e.g., sess_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           },
           {
@@ -807,6 +817,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid session ID"
           },
           "404": {
             "description": "Session not found"
@@ -837,21 +850,19 @@
           {
             "name": "agent_id",
             "in": "path",
-            "description": "Agent ID",
+            "description": "Agent ID (prefixed, e.g., agt_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           },
           {
             "name": "session_id",
             "in": "path",
-            "description": "Session ID",
+            "description": "Session ID (prefixed, e.g., sess_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           },
           {
@@ -867,6 +878,9 @@
         "responses": {
           "200": {
             "description": "Directory listing"
+          },
+          "400": {
+            "description": "Invalid session ID"
           },
           "500": {
             "description": "Internal server error"
@@ -894,21 +908,19 @@
           {
             "name": "agent_id",
             "in": "path",
-            "description": "Agent ID",
+            "description": "Agent ID (prefixed, e.g., agt_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           },
           {
             "name": "session_id",
             "in": "path",
-            "description": "Session ID",
+            "description": "Session ID (prefixed, e.g., sess_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           }
         ],
@@ -934,7 +946,7 @@
             }
           },
           "400": {
-            "description": "Cannot copy directories"
+            "description": "Invalid session ID or cannot copy directories"
           },
           "404": {
             "description": "Source not found"
@@ -968,21 +980,19 @@
           {
             "name": "agent_id",
             "in": "path",
-            "description": "Agent ID",
+            "description": "Agent ID (prefixed, e.g., agt_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           },
           {
             "name": "session_id",
             "in": "path",
-            "description": "Session ID",
+            "description": "Session ID (prefixed, e.g., sess_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           }
         ],
@@ -1008,7 +1018,7 @@
             }
           },
           "400": {
-            "description": "Invalid regex pattern"
+            "description": "Invalid session ID or regex pattern"
           },
           "500": {
             "description": "Internal server error"
@@ -1036,21 +1046,19 @@
           {
             "name": "agent_id",
             "in": "path",
-            "description": "Agent ID",
+            "description": "Agent ID (prefixed, e.g., agt_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           },
           {
             "name": "session_id",
             "in": "path",
-            "description": "Session ID",
+            "description": "Session ID (prefixed, e.g., sess_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           }
         ],
@@ -1076,7 +1084,7 @@
             }
           },
           "400": {
-            "description": "Invalid path"
+            "description": "Invalid session ID or path"
           },
           "404": {
             "description": "Source not found"
@@ -1110,21 +1118,19 @@
           {
             "name": "agent_id",
             "in": "path",
-            "description": "Agent ID",
+            "description": "Agent ID (prefixed, e.g., agt_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           },
           {
             "name": "session_id",
             "in": "path",
-            "description": "Session ID",
+            "description": "Session ID (prefixed, e.g., sess_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           }
         ],
@@ -1148,6 +1154,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid session ID"
           },
           "404": {
             "description": "Not found"
@@ -1178,21 +1187,19 @@
           {
             "name": "agent_id",
             "in": "path",
-            "description": "Agent ID",
+            "description": "Agent ID (prefixed, e.g., agt_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           },
           {
             "name": "session_id",
             "in": "path",
-            "description": "Session ID",
+            "description": "Session ID (prefixed, e.g., sess_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           },
           {
@@ -1217,6 +1224,9 @@
         "responses": {
           "200": {
             "description": "File content or directory listing"
+          },
+          "400": {
+            "description": "Invalid session ID"
           },
           "404": {
             "description": "Not found"
@@ -1245,21 +1255,19 @@
           {
             "name": "agent_id",
             "in": "path",
-            "description": "Agent ID",
+            "description": "Agent ID (prefixed, e.g., agt_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           },
           {
             "name": "session_id",
             "in": "path",
-            "description": "Session ID",
+            "description": "Session ID (prefixed, e.g., sess_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           },
           {
@@ -1294,7 +1302,7 @@
             }
           },
           "400": {
-            "description": "Cannot modify readonly file or directory"
+            "description": "Invalid session ID or cannot modify readonly file or directory"
           },
           "404": {
             "description": "Not found"
@@ -1323,21 +1331,19 @@
           {
             "name": "agent_id",
             "in": "path",
-            "description": "Agent ID",
+            "description": "Agent ID (prefixed, e.g., agt_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           },
           {
             "name": "session_id",
             "in": "path",
-            "description": "Session ID",
+            "description": "Session ID (prefixed, e.g., sess_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           },
           {
@@ -1372,7 +1378,7 @@
             }
           },
           "400": {
-            "description": "Invalid request"
+            "description": "Invalid session ID or request"
           },
           "409": {
             "description": "Already exists"
@@ -1401,21 +1407,19 @@
           {
             "name": "agent_id",
             "in": "path",
-            "description": "Agent ID",
+            "description": "Agent ID (prefixed, e.g., agt_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           },
           {
             "name": "session_id",
             "in": "path",
-            "description": "Session ID",
+            "description": "Session ID (prefixed, e.g., sess_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           },
           {
@@ -1449,7 +1453,7 @@
             }
           },
           "400": {
-            "description": "Directory not empty"
+            "description": "Invalid session ID or directory not empty"
           },
           "500": {
             "description": "Internal server error"
@@ -1477,21 +1481,19 @@
           {
             "name": "agent_id",
             "in": "path",
-            "description": "Agent ID",
+            "description": "Agent ID (prefixed, e.g., agt_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           },
           {
             "name": "session_id",
             "in": "path",
-            "description": "Session ID",
+            "description": "Session ID (prefixed, e.g., sess_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           }
         ],
@@ -1505,6 +1507,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid ID format"
           },
           "404": {
             "description": "Session not found"
@@ -1533,21 +1538,19 @@
           {
             "name": "agent_id",
             "in": "path",
-            "description": "Agent ID",
+            "description": "Agent ID (prefixed, e.g., agt_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           },
           {
             "name": "session_id",
             "in": "path",
-            "description": "Session ID",
+            "description": "Session ID (prefixed, e.g., sess_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           }
         ],
@@ -1571,6 +1574,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid ID format"
           },
           "500": {
             "description": "Internal server error"
@@ -1598,21 +1604,19 @@
           {
             "name": "agent_id",
             "in": "path",
-            "description": "Agent ID",
+            "description": "Agent ID (prefixed, e.g., agt_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           },
           {
             "name": "session_id",
             "in": "path",
-            "description": "Session ID",
+            "description": "Session ID (prefixed, e.g., sess_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           },
           {
@@ -1635,6 +1639,9 @@
             "content": {
               "text/event-stream": {}
             }
+          },
+          "400": {
+            "description": "Invalid session ID"
           },
           "404": {
             "description": "Session not found"
@@ -1807,11 +1814,10 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Model ID",
+            "description": "Model ID (prefixed, e.g., mod_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           }
         ],
@@ -1825,6 +1831,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid model ID"
           },
           "404": {
             "description": "Model not found"
@@ -1850,17 +1859,19 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Model ID",
+            "description": "Model ID (prefixed, e.g., mod_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           }
         ],
         "responses": {
           "204": {
             "description": "Model deleted"
+          },
+          "400": {
+            "description": "Invalid model ID"
           },
           "404": {
             "description": "Model not found"
@@ -1886,11 +1897,10 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Model ID",
+            "description": "Model ID (prefixed, e.g., mod_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           }
         ],
@@ -1914,6 +1924,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid model ID"
           },
           "404": {
             "description": "Model not found"
@@ -2019,11 +2032,10 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Provider ID",
+            "description": "Provider ID (prefixed, e.g., prov_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           }
         ],
@@ -2037,6 +2049,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid provider ID"
           },
           "404": {
             "description": "Provider not found"
@@ -2062,17 +2077,19 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Provider ID",
+            "description": "Provider ID (prefixed, e.g., prov_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           }
         ],
         "responses": {
           "204": {
             "description": "Provider deleted"
+          },
+          "400": {
+            "description": "Invalid provider ID"
           },
           "404": {
             "description": "Provider not found"
@@ -2098,11 +2115,10 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Provider ID",
+            "description": "Provider ID (prefixed, e.g., prov_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           }
         ],
@@ -2126,6 +2142,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid provider ID"
           },
           "404": {
             "description": "Provider not found"
@@ -2153,11 +2172,10 @@
           {
             "name": "provider_id",
             "in": "path",
-            "description": "Provider ID",
+            "description": "Provider ID (prefixed, e.g., prov_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           }
         ],
@@ -2171,6 +2189,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid provider ID"
           }
         }
       },
@@ -2193,11 +2214,10 @@
           {
             "name": "provider_id",
             "in": "path",
-            "description": "Provider ID",
+            "description": "Provider ID (prefixed, e.g., prov_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           }
         ],
@@ -2223,7 +2243,7 @@
             }
           },
           "400": {
-            "description": "Invalid request"
+            "description": "Invalid provider ID"
           },
           "500": {
             "description": "Internal error"
@@ -2346,11 +2366,10 @@
           {
             "name": "server_id",
             "in": "path",
-            "description": "MCP server ID",
+            "description": "MCP server ID (prefixed, e.g., mcp_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           }
         ],
@@ -2364,6 +2383,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid server ID"
           },
           "404": {
             "description": "MCP server not found"
@@ -2392,17 +2414,19 @@
           {
             "name": "server_id",
             "in": "path",
-            "description": "MCP server ID",
+            "description": "MCP server ID (prefixed, e.g., mcp_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           }
         ],
         "responses": {
           "204": {
             "description": "MCP server deleted successfully"
+          },
+          "400": {
+            "description": "Invalid server ID"
           },
           "404": {
             "description": "MCP server not found"
@@ -2431,11 +2455,10 @@
           {
             "name": "server_id",
             "in": "path",
-            "description": "MCP server ID",
+            "description": "MCP server ID (prefixed, e.g., mcp_...)",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           }
         ],
@@ -2461,7 +2484,7 @@
             }
           },
           "400": {
-            "description": "Invalid input",
+            "description": "Invalid server ID or input",
             "content": {
               "application/json": {
                 "schema": {
@@ -2607,8 +2630,8 @@
               "string",
               "null"
             ],
-            "format": "uuid",
-            "description": "Default LLM model ID for this agent.\nCan be overridden at the session level."
+            "description": "Default LLM model ID for this agent.\nCan be overridden at the session level.",
+            "example": "mod_01933b5a00007000800000000000001"
           },
           "description": {
             "type": [
@@ -2619,8 +2642,8 @@
           },
           "id": {
             "type": "string",
-            "format": "uuid",
-            "description": "Unique identifier for the agent."
+            "description": "Unique identifier for the agent (format: agt_{32-hex}).",
+            "example": "agt_01933b5a00007000800000000000001"
           },
           "name": {
             "type": "string",
@@ -2927,8 +2950,8 @@
               "string",
               "null"
             ],
-            "format": "uuid",
-            "description": "Model ID (UUID) to use for this message.\nOverrides session and agent model settings."
+            "description": "Model ID to use for this message (format: mod_{32-hex}).\nOverrides session and agent model settings.",
+            "example": "mod_01933b5a00007000800000000000001"
           },
           "reasoning": {
             "oneOf": [
@@ -3675,8 +3698,8 @@
           },
           "image_id": {
             "type": "string",
-            "format": "uuid",
-            "description": "ID of the uploaded image"
+            "description": "ID of the uploaded image (format: img_{32-hex})",
+            "example": "img_01933b5a00007000800000000000001"
           }
         }
       },
@@ -3825,8 +3848,8 @@
                     "string",
                     "null"
                   ],
-                  "format": "uuid",
-                  "description": "Default LLM model ID for this agent.\nCan be overridden at the session level."
+                  "description": "Default LLM model ID for this agent.\nCan be overridden at the session level.",
+                  "example": "mod_01933b5a00007000800000000000001"
                 },
                 "description": {
                   "type": [
@@ -3837,8 +3860,8 @@
                 },
                 "id": {
                   "type": "string",
-                  "format": "uuid",
-                  "description": "Unique identifier for the agent."
+                  "description": "Unique identifier for the agent (format: agt_{32-hex}).",
+                  "example": "agt_01933b5a00007000800000000000001"
                 },
                 "name": {
                   "type": "string",
@@ -4171,7 +4194,7 @@
                 },
                 "id": {
                   "type": "string",
-                  "format": "uuid"
+                  "example": "mod_01933b5a00007000800000000000001"
                 },
                 "is_default": {
                   "type": "boolean"
@@ -4184,7 +4207,7 @@
                 },
                 "provider_id": {
                   "type": "string",
-                  "format": "uuid"
+                  "example": "prov_01933b5a00007000800000000000001"
                 },
                 "source": {
                   "$ref": "#/components/schemas/LlmModelSource",
@@ -4246,7 +4269,7 @@
                 },
                 "id": {
                   "type": "string",
-                  "format": "uuid"
+                  "example": "mod_01933b5a00007000800000000000001"
                 },
                 "is_default": {
                   "type": "boolean"
@@ -4270,7 +4293,7 @@
                 },
                 "provider_id": {
                   "type": "string",
-                  "format": "uuid"
+                  "example": "prov_01933b5a00007000800000000000001"
                 },
                 "provider_name": {
                   "type": "string"
@@ -4333,7 +4356,7 @@
                 },
                 "id": {
                   "type": "string",
-                  "format": "uuid"
+                  "example": "prov_01933b5a00007000800000000000001"
                 },
                 "last_synced_at": {
                   "type": [
@@ -4754,7 +4777,7 @@
           },
           "id": {
             "type": "string",
-            "format": "uuid"
+            "example": "mod_01933b5a00007000800000000000001"
           },
           "is_default": {
             "type": "boolean"
@@ -4767,7 +4790,7 @@
           },
           "provider_id": {
             "type": "string",
-            "format": "uuid"
+            "example": "prov_01933b5a00007000800000000000001"
           },
           "source": {
             "$ref": "#/components/schemas/LlmModelSource",
@@ -5018,7 +5041,7 @@
           },
           "id": {
             "type": "string",
-            "format": "uuid"
+            "example": "mod_01933b5a00007000800000000000001"
           },
           "is_default": {
             "type": "boolean"
@@ -5042,7 +5065,7 @@
           },
           "provider_id": {
             "type": "string",
-            "format": "uuid"
+            "example": "prov_01933b5a00007000800000000000001"
           },
           "provider_name": {
             "type": "string"
@@ -5092,7 +5115,7 @@
           },
           "id": {
             "type": "string",
-            "format": "uuid"
+            "example": "prov_01933b5a00007000800000000000001"
           },
           "last_synced_at": {
             "type": [
@@ -5256,8 +5279,8 @@
           },
           "id": {
             "type": "string",
-            "format": "uuid",
-            "description": "Unique message ID"
+            "description": "Unique message ID (format: msg_{32-hex})",
+            "example": "msg_01933b5a00007000800000000000001"
           },
           "metadata": {
             "type": [
@@ -5411,8 +5434,8 @@
               "properties": {
                 "agent_id": {
                   "type": "string",
-                  "format": "uuid",
-                  "description": "ID of the agent this session belongs to."
+                  "description": "ID of the agent this session belongs to (format: agt_{32-hex}).",
+                  "example": "agt_01933b5a00007000800000000000001"
                 },
                 "created_at": {
                   "type": "string",
@@ -5429,16 +5452,16 @@
                 },
                 "id": {
                   "type": "string",
-                  "format": "uuid",
-                  "description": "Unique identifier for the session."
+                  "description": "Unique identifier for the session (format: sess_{32-hex}).",
+                  "example": "sess_01933b5a00007000800000000000001"
                 },
                 "model_id": {
                   "type": [
                     "string",
                     "null"
                   ],
-                  "format": "uuid",
-                  "description": "LLM model ID to use for this session.\nOverrides the agent's default model if set."
+                  "description": "LLM model ID to use for this session (format: mod_{32-hex}).\nOverrides the agent's default model if set.",
+                  "example": "mod_01933b5a00007000800000000000001"
                 },
                 "output_preview": {
                   "type": [
@@ -5655,8 +5678,8 @@
         "properties": {
           "agent_id": {
             "type": "string",
-            "format": "uuid",
-            "description": "ID of the agent this session belongs to."
+            "description": "ID of the agent this session belongs to (format: agt_{32-hex}).",
+            "example": "agt_01933b5a00007000800000000000001"
           },
           "created_at": {
             "type": "string",
@@ -5673,16 +5696,16 @@
           },
           "id": {
             "type": "string",
-            "format": "uuid",
-            "description": "Unique identifier for the session."
+            "description": "Unique identifier for the session (format: sess_{32-hex}).",
+            "example": "sess_01933b5a00007000800000000000001"
           },
           "model_id": {
             "type": [
               "string",
               "null"
             ],
-            "format": "uuid",
-            "description": "LLM model ID to use for this session.\nOverrides the agent's default model if set."
+            "description": "LLM model ID to use for this session (format: mod_{32-hex}).\nOverrides the agent's default model if set.",
+            "example": "mod_01933b5a00007000800000000000001"
           },
           "output_preview": {
             "type": [

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3325,7 +3325,7 @@
       },
       "Event": {
         "type": "object",
-        "description": "Standard event following the Everruns event protocol.\n\nAll events have a consistent structure:\n- `id`: Unique UUID v7 identifier (monotonically increasing)\n- `type`: Event type in dot notation (e.g., \"message.user\", \"reason.started\")\n- `ts`: ISO 8601 timestamp with millisecond precision\n- `session_id`: Session this event belongs to\n- `context`: Correlation context for tracing\n- `data`: Event-specific payload (typed via EventData enum)\n- `metadata`: Optional arbitrary metadata\n- `tags`: Optional list of tags for filtering",
+        "description": "Standard event following the Everruns event protocol.\n\nAll events have a consistent structure:\n- `id`: Unique event identifier (format: event_{32-hex})\n- `type`: Event type in dot notation (e.g., \"message.user\", \"reason.started\")\n- `ts`: ISO 8601 timestamp with millisecond precision\n- `session_id`: Session this event belongs to (format: session_{32-hex})\n- `context`: Correlation context for tracing\n- `data`: Event-specific payload (typed via EventData enum)\n- `metadata`: Optional arbitrary metadata\n- `tags`: Optional list of tags for filtering",
         "required": [
           "id",
           "type",
@@ -3345,8 +3345,8 @@
           },
           "id": {
             "type": "string",
-            "format": "uuid",
-            "description": "Unique event identifier (UUID v7, monotonically increasing)"
+            "description": "Unique event identifier (format: event_{32-hex})",
+            "example": "event_01933b5a00007000800000000000001"
           },
           "metadata": {
             "description": "Arbitrary metadata for the event"
@@ -3361,8 +3361,8 @@
           },
           "session_id": {
             "type": "string",
-            "format": "uuid",
-            "description": "Session this event belongs to"
+            "description": "Session this event belongs to (format: session_{32-hex})",
+            "example": "session_01933b5a00007000800000000000001"
           },
           "tags": {
             "type": [
@@ -3394,24 +3394,24 @@
               "string",
               "null"
             ],
-            "format": "uuid",
-            "description": "Atom execution identifier"
+            "description": "Atom execution identifier",
+            "example": "exec_01933b5a00007000800000000000001"
           },
           "input_message_id": {
             "type": [
               "string",
               "null"
             ],
-            "format": "uuid",
-            "description": "User message that triggered this turn"
+            "description": "User message that triggered this turn",
+            "example": "message_01933b5a00007000800000000000001"
           },
           "turn_id": {
             "type": [
               "string",
               "null"
             ],
-            "format": "uuid",
-            "description": "Turn identifier (for turn-scoped events)"
+            "description": "Turn identifier (for turn-scoped events)",
+            "example": "turn_01933b5a00007000800000000000001"
           }
         }
       },
@@ -3995,7 +3995,7 @@
             "type": "array",
             "items": {
               "type": "object",
-              "description": "Standard event following the Everruns event protocol.\n\nAll events have a consistent structure:\n- `id`: Unique UUID v7 identifier (monotonically increasing)\n- `type`: Event type in dot notation (e.g., \"message.user\", \"reason.started\")\n- `ts`: ISO 8601 timestamp with millisecond precision\n- `session_id`: Session this event belongs to\n- `context`: Correlation context for tracing\n- `data`: Event-specific payload (typed via EventData enum)\n- `metadata`: Optional arbitrary metadata\n- `tags`: Optional list of tags for filtering",
+              "description": "Standard event following the Everruns event protocol.\n\nAll events have a consistent structure:\n- `id`: Unique event identifier (format: event_{32-hex})\n- `type`: Event type in dot notation (e.g., \"message.user\", \"reason.started\")\n- `ts`: ISO 8601 timestamp with millisecond precision\n- `session_id`: Session this event belongs to (format: session_{32-hex})\n- `context`: Correlation context for tracing\n- `data`: Event-specific payload (typed via EventData enum)\n- `metadata`: Optional arbitrary metadata\n- `tags`: Optional list of tags for filtering",
               "required": [
                 "id",
                 "type",
@@ -4015,8 +4015,8 @@
                 },
                 "id": {
                   "type": "string",
-                  "format": "uuid",
-                  "description": "Unique event identifier (UUID v7, monotonically increasing)"
+                  "description": "Unique event identifier (format: event_{32-hex})",
+                  "example": "event_01933b5a00007000800000000000001"
                 },
                 "metadata": {
                   "description": "Arbitrary metadata for the event"
@@ -4031,8 +4031,8 @@
                 },
                 "session_id": {
                   "type": "string",
-                  "format": "uuid",
-                  "description": "Session this event belongs to"
+                  "description": "Session this event belongs to (format: session_{32-hex})",
+                  "example": "session_01933b5a00007000800000000000001"
                 },
                 "tags": {
                   "type": [
@@ -4514,7 +4514,8 @@
                 },
                 "id": {
                   "type": "string",
-                  "format": "uuid"
+                  "description": "Unique message ID (format: message_{32-hex})",
+                  "example": "message_01933b5a00007000800000000000001"
                 },
                 "metadata": {
                   "type": [
@@ -4536,7 +4537,8 @@
                 },
                 "session_id": {
                   "type": "string",
-                  "format": "uuid"
+                  "description": "Session ID this message belongs to (format: session_{32-hex})",
+                  "example": "session_01933b5a00007000800000000000001"
                 }
               }
             },

--- a/specs/id-schema.md
+++ b/specs/id-schema.md
@@ -15,23 +15,23 @@ All entity identifiers follow a consistent prefixed format:
 ```
 
 Where:
-- `{prefix}` - A short, lowercase string identifying the entity type (2-4 chars)
+- `{prefix}` - A descriptive lowercase string identifying the entity type
 - `_` - Underscore separator
 - `{32-hex-chars}` - UUIDv7 in simple format (lowercase hex, no dashes)
 
-**Example:** `agt_01933b5a00007000800000000000001`
+**Example:** `agent_01933b5a00007000800000000000001`
 
 ### Entity Prefixes
 
 | Entity | Prefix | Example |
 |--------|--------|---------|
 | Organization | `org_` | `org_01933b5a00007000800000000000001` |
-| Agent | `agt_` | `agt_01933b5a00007000800000000000002` |
-| Session | `sess_` | `sess_01933b5a00007000800000000000003` |
-| Message | `msg_` | `msg_01933b5a00007000800000000000004` |
-| Event | `evt_` | `evt_01933b5a00007000800000000000005` |
-| LLM Provider | `prov_` | `prov_01933b5a00007000800000000000006` |
-| LLM Model | `mod_` | `mod_01933b5a00007000800000000000007` |
+| Agent | `agent_` | `agent_01933b5a00007000800000000000002` |
+| Session | `session_` | `session_01933b5a00007000800000000000003` |
+| Message | `message_` | `message_01933b5a00007000800000000000004` |
+| Event | `event_` | `event_01933b5a00007000800000000000005` |
+| LLM Provider | `provider_` | `provider_01933b5a00007000800000000000006` |
+| LLM Model | `model_` | `model_01933b5a00007000800000000000007` |
 | Image | `img_` | `img_01933b5a00007000800000000000008` |
 | MCP Server | `mcp_` | `mcp_01933b5a00007000800000000000009` |
 
@@ -44,7 +44,7 @@ Where:
 ```rust
 // Example generation
 let uuid = Uuid::now_v7();
-let id = format!("agt_{}", uuid.simple()); // agt_0193...
+let id = format!("agent_{}", uuid.simple()); // agent_0193...
 ```
 
 ### ID Validation
@@ -57,7 +57,7 @@ IDs must pass validation:
 
 ```rust
 // Validation pattern (example for agent_id)
-// ^agt_[0-9a-f]{32}$
+// ^agent_[0-9a-f]{32}$
 ```
 
 ### Database Storage
@@ -77,8 +77,8 @@ IDs are serialized as strings in JSON:
 
 ```json
 {
-  "id": "agt_01933b5a00007000800000000000001",
-  "session_id": "sess_01933b5a00007000800000000000003"
+  "id": "agent_01933b5a00007000800000000000001",
+  "session_id": "session_01933b5a00007000800000000000003"
 }
 ```
 
@@ -94,8 +94,8 @@ org_00000000000000000000000000000001
 **Seeded Providers:**
 | Provider | ID |
 |----------|-----|
-| OpenAI | `prov_01933b5a00007000800000000001` |
-| Anthropic | `prov_01933b5a00007000800000000002` |
+| OpenAI | `provider_01933b5a00007000800000000001` |
+| Anthropic | `provider_01933b5a00007000800000000002` |
 
 **Seeded Models (range allocation):**
 - `0x001-0x0FF`: LLM Providers

--- a/specs/id-schema.md
+++ b/specs/id-schema.md
@@ -1,0 +1,137 @@
+# ID Schema Specification
+
+## Abstract
+
+This document defines the standardized identifier schema for all entity types in Everruns. All external-facing identifiers use a prefixed format for type safety, debuggability, and consistency.
+
+## Requirements
+
+### ID Format
+
+All entity identifiers follow a consistent prefixed format:
+
+```
+{prefix}_{32-hex-chars}
+```
+
+Where:
+- `{prefix}` - A short, lowercase string identifying the entity type (2-4 chars)
+- `_` - Underscore separator
+- `{32-hex-chars}` - UUIDv7 in simple format (lowercase hex, no dashes)
+
+**Example:** `agt_01933b5a00007000800000000000001`
+
+### Entity Prefixes
+
+| Entity | Prefix | Example |
+|--------|--------|---------|
+| Organization | `org_` | `org_01933b5a00007000800000000000001` |
+| Agent | `agt_` | `agt_01933b5a00007000800000000000002` |
+| Session | `sess_` | `sess_01933b5a00007000800000000000003` |
+| Message | `msg_` | `msg_01933b5a00007000800000000000004` |
+| Event | `evt_` | `evt_01933b5a00007000800000000000005` |
+| LLM Provider | `prov_` | `prov_01933b5a00007000800000000000006` |
+| LLM Model | `mod_` | `mod_01933b5a00007000800000000000007` |
+| Image | `img_` | `img_01933b5a00007000800000000000008` |
+| MCP Server | `mcp_` | `mcp_01933b5a00007000800000000000009` |
+
+### ID Generation
+
+- IDs are generated using UUIDv7 for time-ordering benefits
+- The UUID is formatted as lowercase hex without dashes (32 chars)
+- The prefix is prepended with an underscore separator
+
+```rust
+// Example generation
+let uuid = Uuid::now_v7();
+let id = format!("agt_{}", uuid.simple()); // agt_0193...
+```
+
+### ID Validation
+
+IDs must pass validation:
+1. Must start with the correct prefix for the entity type
+2. Must have exactly 32 hex characters after the prefix
+3. Hex characters must be lowercase
+4. No non-hex characters allowed in the suffix
+
+```rust
+// Validation pattern (example for agent_id)
+// ^agt_[0-9a-f]{32}$
+```
+
+### Database Storage
+
+IDs are stored as:
+- **Primary Key Column:** `TEXT` (the full prefixed string)
+- **Index:** B-tree index on ID columns for efficient lookups
+
+This approach:
+- Preserves type information in the database
+- Makes debugging easier (can identify entity type from ID)
+- Maintains compatibility with external systems expecting string IDs
+
+### API Serialization
+
+IDs are serialized as strings in JSON:
+
+```json
+{
+  "id": "agt_01933b5a00007000800000000000001",
+  "session_id": "sess_01933b5a00007000800000000000003"
+}
+```
+
+### Well-Known IDs
+
+Certain entities have well-known IDs for seeding and testing:
+
+**Default Organization:**
+```
+org_00000000000000000000000000000001
+```
+
+**Seeded Providers:**
+| Provider | ID |
+|----------|-----|
+| OpenAI | `prov_01933b5a00007000800000000001` |
+| Anthropic | `prov_01933b5a00007000800000000002` |
+
+**Seeded Models (range allocation):**
+- `0x001-0x0FF`: LLM Providers
+- `0x100-0x1FF`: Seed Agents
+- `0x200-0x2FF`: OpenAI Models
+- `0x300-0x3FF`: Anthropic Models
+
+## Design Decisions
+
+| Question | Decision |
+|----------|----------|
+| Why prefixed IDs? | Type safety, debuggability, prevents mixing ID types |
+| Why UUIDv7? | Time-ordering benefits, sortable, globally unique |
+| Why TEXT storage? | Preserves type info, debuggable, no conversion needed |
+| Why lowercase hex? | Consistency, case-insensitive matching, URL-safe |
+
+## Migration Strategy
+
+Existing UUIDs are migrated to prefixed format:
+1. Add new TEXT column with prefixed IDs
+2. Migrate data: `{prefix}_{uuid_without_dashes}`
+3. Drop old UUID column
+4. Rename new column to original name
+
+## Type Implementation
+
+The `TypedId<T>` generic type provides:
+- Type-safe ID handling (prevents mixing agent IDs with session IDs)
+- Automatic serialization/deserialization
+- Validation on construction
+- Display and Debug implementations
+
+```rust
+// Type aliases for each entity
+pub type AgentId = TypedId<AgentIdMarker>;
+pub type SessionId = TypedId<SessionIdMarker>;
+pub type MessageId = TypedId<MessageIdMarker>;
+// etc.
+```

--- a/specs/id-schema.md
+++ b/specs/id-schema.md
@@ -2,7 +2,9 @@
 
 ## Abstract
 
-This document defines the standardized identifier schema for all entity types in Everruns. All external-facing identifiers use a prefixed format for type safety, debuggability, and consistency.
+This document defines the standardized identifier schema for all entity types in Everruns. All external-facing identifiers use **Stripe-style prefixed IDs with UUIDv7** for type safety, debuggability, and consistency.
+
+This pattern was popularized by Stripe (`cus_`, `sub_`, `pi_`) and formalized by the [TypeID spec](https://github.com/jetpack-io/typeid). Our implementation uses hex encoding (32 chars) rather than TypeID's base32 (26 chars) for simpler debugging and UUID compatibility.
 
 ## Requirements
 

--- a/specs/id-schema.md
+++ b/specs/id-schema.md
@@ -32,10 +32,12 @@ Where:
 | Session | `session_` | `session_01933b5a00007000800000000000003` |
 | Message | `message_` | `message_01933b5a00007000800000000000004` |
 | Event | `event_` | `event_01933b5a00007000800000000000005` |
-| LLM Provider | `provider_` | `provider_01933b5a00007000800000000000006` |
-| LLM Model | `model_` | `model_01933b5a00007000800000000000007` |
-| Image | `img_` | `img_01933b5a00007000800000000000008` |
-| MCP Server | `mcp_` | `mcp_01933b5a00007000800000000000009` |
+| Turn | `turn_` | `turn_01933b5a00007000800000000000006` |
+| Execution | `exec_` | `exec_01933b5a00007000800000000000007` |
+| LLM Provider | `provider_` | `provider_01933b5a00007000800000000000008` |
+| LLM Model | `model_` | `model_01933b5a00007000800000000000009` |
+| Image | `img_` | `img_01933b5a0000700080000000000000a` |
+| MCP Server | `mcp_` | `mcp_01933b5a0000700080000000000000b` |
 
 ### ID Generation
 


### PR DESCRIPTION
## What

Standardize all entity identifiers to use Stripe-style prefixed IDs with UUIDv7 for type safety, debuggability, and consistency.

**Format:** `{prefix}_{32-hex-chars}` (e.g., `agent_01933b5a00007000800000000000001`)

## Why

- **Type safety**: Prevents mixing agent IDs with session IDs at compile time
- **Debuggability**: Can identify entity type just by looking at the ID
- **Consistency**: All APIs now use the same prefixed format
- **Industry standard**: Follows the pattern popularized by Stripe

## Changes

### Core (`everruns-core`)
- Add `TypedId<T>` generic type with marker traits for each entity
- Type aliases: `AgentId`, `SessionId`, `MessageId`, `EventId`, `TurnId`, `ExecId`, etc.
- Automatic serialization to prefixed format
- OpenAPI schema annotations for proper documentation

### API Responses
- All entity IDs in responses use prefixed format
- Event data structs (`TurnStartedData`, `TurnCompletedData`, etc.) use typed IDs
- Event context uses typed IDs for `turn_id`, `input_message_id`, `exec_id`

### CLI
- Updated to use org-scoped routes
- Uses String instead of Uuid for ID fields (handles prefixed format)

### Documentation
- Added `specs/id-schema.md` specification
- Updated OpenAPI spec with typed ID examples

## Entity Prefixes

| Entity | Prefix | Example |
|--------|--------|---------|
| Organization | `org_` | `org_01933b5a00007000800000000000001` |
| Agent | `agent_` | `agent_01933b5a00007000800000000000002` |
| Session | `session_` | `session_01933b5a00007000800000000000003` |
| Message | `message_` | `message_01933b5a00007000800000000000004` |
| Event | `event_` | `event_01933b5a00007000800000000000005` |
| Turn | `turn_` | `turn_01933b5a00007000800000000000006` |
| Execution | `exec_` | `exec_01933b5a00007000800000000000007` |
| LLM Provider | `provider_` | `provider_01933b5a00007000800000000000008` |
| LLM Model | `model_` | `model_01933b5a00007000800000000000009` |

## Risk
- **Medium**: API response format change (IDs now have prefixes)
- Breaking change for clients expecting raw UUIDs
- Database storage unchanged (still uses UUIDs internally)

## Checklist
- [x] Tests pass
- [x] Clippy passes
- [x] Smoke tested with DEV_MODE
- [x] Spec updated (`specs/id-schema.md`)
- [x] OpenAPI spec updated