### PR TITLE
docs: rebrand from platform to agentic harness engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 > **Note:** This repository is in **Heavy Vibecoding PoC Mode**. Expect rapid changes, experimental features, and unconventional approaches as we explore ideas quickly.
 
-Headless durable AI agent execution platform. Run long-running LLM agents reliably and scalably.
+Headless durable agentic harness engine. Run durable AI agents reliably and scalably.
 
 ## Overview
 

--- a/docs/getting-started/architecture.md
+++ b/docs/getting-started/architecture.md
@@ -1,9 +1,9 @@
 ---
 title: Architecture
-description: System architecture overview for Everruns - A durable AI agent execution platform
+description: System architecture overview for Everruns - A durable agentic harness engine
 ---
 
-Everruns is a **headless AI agent execution platform** built for reliability and scale. It provides a REST API for managing agents, sessions, and runs with real-time event streaming via SSE.
+Everruns is a **headless durable agentic harness engine** built for reliability and scale. It provides a REST API for managing agents, sessions, and runs with real-time event streaming via SSE.
 
 ## Platform Overview
 

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -1,9 +1,9 @@
 ---
 title: Introduction
-description: Get started with Everruns - A durable AI agent execution platform
+description: Get started with Everruns - A durable agentic harness engine
 ---
 
-Everruns is a durable AI agent execution platform built on Rust with a PostgreSQL-backed durable execution engine. It provides APIs for managing agents, sessions, and runs with streaming event output via SSE.
+Everruns is a durable agentic harness engine built on Rust with a PostgreSQL-backed durable execution engine. It provides APIs for managing agents, sessions, and runs with streaming event output via SSE.
 
 ## Overview
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: Everruns Documentation
-description: Documentation for Everruns - A durable AI agent execution platform
+description: Documentation for Everruns - A durable agentic harness engine
 ---
 
 Welcome to the Everruns documentation.

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Abstract
 
-Everruns is a durable AI agent execution platform built on Rust with a PostgreSQL-backed durable execution engine. It provides APIs for managing agents, threads, and runs with streaming event output via SSE. The architecture prioritizes durability, observability, and developer experience.
+Everruns is a durable agentic harness engine built on Rust with a PostgreSQL-backed durable execution engine. It provides APIs for managing agents, threads, and runs with streaming event output via SSE. The architecture prioritizes durability, observability, and developer experience.
 
 ## System Architecture
 

--- a/specs/brand.md
+++ b/specs/brand.md
@@ -9,8 +9,8 @@ Brand guidelines for the Everruns project ensuring visual and verbal consistency
 ### Name & Tagline
 
 1. **Name**: Everruns
-2. **Tagline**: "Durable AI. Unstoppable agents."
-3. **Meaning**: AI agents that **ever run** — continuous, uninterrupted, eternal execution
+2. **Tagline**: "Durable Agentic Harness. Unstoppable agents."
+3. **Meaning**: A harness engine where AI agents **ever run** — continuous, uninterrupted, eternal execution
 
 ### Logo
 

--- a/specs/models.md
+++ b/specs/models.md
@@ -2,7 +2,7 @@
 
 ## Abstract
 
-This document defines the core data models for Everruns - a durable AI agent execution platform.
+This document defines the core data models for Everruns - a durable agentic harness engine.
 
 ## Requirements
 


### PR DESCRIPTION
## What
Rebrand Everruns from "durable AI agent platform" to "durable agentic harness engine" across documentation and specs.

## Why
Positioning shift to emphasize the harness concept — infrastructure that holds/manages agents — rather than just a platform.

## How
Updated branding in 7 files:

| Element | Before | After |
|---------|--------|-------|
| Tagline | "Durable AI. Unstoppable agents." | "Durable Agentic Harness. Unstoppable agents." |
| Meaning | "AI agents that ever run" | "A harness engine where AI agents ever run" |
| Summary | "durable AI agent execution platform" | "durable agentic harness engine" |
| Terminology | "long-running LLM agents" | "durable AI agents" |

## Risk
- Low
- Documentation-only changes, no code affected

## Checklist
- [x] Tests added or updated (N/A - docs only)
- [x] Backward compatibility considered (N/A)