### PR TITLE
feat(core): add metadata to LLM API requests for tracking

### DIFF
--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -240,15 +240,6 @@ impl LlmDriver for AnthropicLlmDriver {
             .as_ref()
             .and_then(|e| AnthropicThinking::from_effort(e));
 
-        // Build metadata for request tracking
-        // Use session_id as the user_id for Anthropic's abuse detection
-        let metadata = config
-            .metadata
-            .get("session_id")
-            .map(|session_id| AnthropicMetadata {
-                user_id: Some(session_id.clone()),
-            });
-
         let mut request = AnthropicRequest {
             model: config.model.clone(),
             messages: anthropic_messages,
@@ -258,7 +249,6 @@ impl LlmDriver for AnthropicLlmDriver {
             stream: true,
             tools,
             thinking,
-            metadata,
         };
 
         // Ensure max_tokens is set (required by Anthropic)
@@ -604,19 +594,6 @@ struct AnthropicRequest {
     /// Extended thinking configuration (for Claude models that support it)
     #[serde(skip_serializing_if = "Option::is_none")]
     thinking: Option<AnthropicThinking>,
-    /// Metadata for tracking API usage.
-    /// Contains user_id for abuse detection and any additional tracking fields.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<AnthropicMetadata>,
-}
-
-/// Metadata for Anthropic API requests
-#[derive(Debug, Serialize)]
-struct AnthropicMetadata {
-    /// End-user identifier for abuse detection and rate limiting.
-    /// Anthropic recommends setting this to help with monitoring.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    user_id: Option<String>,
 }
 
 /// Extended thinking configuration for Claude
@@ -1062,25 +1039,5 @@ mod tests {
             reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             error
         ));
-    }
-
-    #[test]
-    fn test_request_includes_metadata() {
-        // Test that metadata with user_id is correctly serialized
-        let metadata = AnthropicMetadata {
-            user_id: Some("session_abc123".to_string()),
-        };
-
-        let json = serde_json::to_value(&metadata).unwrap();
-        assert_eq!(json["user_id"], "session_abc123");
-    }
-
-    #[test]
-    fn test_request_metadata_skips_none() {
-        // Test that None user_id is skipped in serialization
-        let metadata = AnthropicMetadata { user_id: None };
-
-        let json = serde_json::to_value(&metadata).unwrap();
-        assert!(json.get("user_id").is_none());
     }
 }

--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -240,6 +240,15 @@ impl LlmDriver for AnthropicLlmDriver {
             .as_ref()
             .and_then(|e| AnthropicThinking::from_effort(e));
 
+        // Build metadata for request tracking
+        // Use session_id as the user_id for Anthropic's abuse detection
+        let metadata = config
+            .metadata
+            .get("session_id")
+            .map(|session_id| AnthropicMetadata {
+                user_id: Some(session_id.clone()),
+            });
+
         let mut request = AnthropicRequest {
             model: config.model.clone(),
             messages: anthropic_messages,
@@ -249,6 +258,7 @@ impl LlmDriver for AnthropicLlmDriver {
             stream: true,
             tools,
             thinking,
+            metadata,
         };
 
         // Ensure max_tokens is set (required by Anthropic)
@@ -594,6 +604,19 @@ struct AnthropicRequest {
     /// Extended thinking configuration (for Claude models that support it)
     #[serde(skip_serializing_if = "Option::is_none")]
     thinking: Option<AnthropicThinking>,
+    /// Metadata for tracking API usage.
+    /// Contains user_id for abuse detection and any additional tracking fields.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata: Option<AnthropicMetadata>,
+}
+
+/// Metadata for Anthropic API requests
+#[derive(Debug, Serialize)]
+struct AnthropicMetadata {
+    /// End-user identifier for abuse detection and rate limiting.
+    /// Anthropic recommends setting this to help with monitoring.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    user_id: Option<String>,
 }
 
 /// Extended thinking configuration for Claude
@@ -1039,5 +1062,25 @@ mod tests {
             reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             error
         ));
+    }
+
+    #[test]
+    fn test_request_includes_metadata() {
+        // Test that metadata with user_id is correctly serialized
+        let metadata = AnthropicMetadata {
+            user_id: Some("session_abc123".to_string()),
+        };
+
+        let json = serde_json::to_value(&metadata).unwrap();
+        assert_eq!(json["user_id"], "session_abc123");
+    }
+
+    #[test]
+    fn test_request_metadata_skips_none() {
+        // Test that None user_id is skipped in serialization
+        let metadata = AnthropicMetadata { user_id: None };
+
+        let json = serde_json::to_value(&metadata).unwrap();
+        assert!(json.get("user_id").is_none());
     }
 }

--- a/crates/control-plane/src/dev_worker/worker.rs
+++ b/crates/control-plane/src/dev_worker/worker.rs
@@ -474,6 +474,7 @@ impl InProcessWorker {
         let reason_input = ReasonInput {
             context,
             agent_id: input.agent_id,
+            org_id: DEFAULT_ORG_ID,
             mcp_tool_definitions,
         };
 

--- a/crates/core/examples/turn_based_execution.rs
+++ b/crates/core/examples/turn_based_execution.rs
@@ -228,6 +228,7 @@ async fn main() -> anyhow::Result<()> {
             .execute(ReasonInput {
                 context: reason_context,
                 agent_id,
+                org_id: 0,
                 mcp_tool_definitions: vec![],
             })
             .await?;

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -489,11 +489,20 @@ where
             llm_messages.push(LlmMessage::from_message_with_images(msg, &resolved_images));
         }
 
-        // 12. Build LLM call config with reasoning effort
+        // 12. Build LLM call config with reasoning effort and metadata
         let mut llm_config_builder = LlmCallConfigBuilder::from(&runtime_agent);
         if let Some(effort) = reasoning_effort.clone() {
             llm_config_builder = llm_config_builder.reasoning_effort(effort);
         }
+
+        // Add metadata for API tracking and debugging
+        // These IDs help correlate API requests with Everruns entities
+        llm_config_builder = llm_config_builder
+            .with_metadata("session_id", format!("session_{}", session_id.as_simple()))
+            .with_metadata("agent_id", format!("agent_{}", agent_id.as_simple()))
+            .with_metadata("turn_id", format!("turn_{}", context.turn_id.as_simple()))
+            .with_metadata("exec_id", format!("exec_{}", context.exec_id.as_simple()));
+
         let llm_config = llm_config_builder.build();
 
         tracing::debug!(

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -95,6 +95,9 @@ pub struct ReasonInput {
     pub context: AtomContext,
     /// Agent ID for loading configuration
     pub agent_id: Uuid,
+    /// Organization ID for multi-tenancy tracking
+    #[serde(default)]
+    pub org_id: i64,
     /// MCP tool definitions from agent's MCP capabilities (pre-resolved)
     /// These are passed from the control-plane since MCP capabilities
     /// are not in the CapabilityRegistry.
@@ -237,6 +240,7 @@ where
         let ReasonInput {
             context,
             agent_id,
+            org_id,
             mcp_tool_definitions,
         } = input;
 
@@ -277,6 +281,7 @@ where
             .execute_llm_call(
                 context.session_id,
                 agent_id,
+                org_id,
                 &context,
                 &mcp_tool_definitions,
             )
@@ -395,6 +400,7 @@ where
         &self,
         session_id: Uuid,
         agent_id: Uuid,
+        org_id: i64,
         context: &AtomContext,
         mcp_tool_definitions: &[ToolDefinition],
     ) -> Result<ReasonResult> {
@@ -428,7 +434,7 @@ where
             .and_then(|c| c.model_id);
 
         // 5. Resolve model using chain: controls.model_id > session.model_id > agent.default_model_id
-        let model_with_provider = self
+        let (model_with_provider, resolved_model_id) = self
             .resolve_model(controls_model_id, session.model_id, agent.default_model_id)
             .await?;
 
@@ -501,7 +507,13 @@ where
             .with_metadata("session_id", format!("session_{}", session_id.as_simple()))
             .with_metadata("agent_id", format!("agent_{}", agent_id.as_simple()))
             .with_metadata("turn_id", format!("turn_{}", context.turn_id.as_simple()))
-            .with_metadata("exec_id", format!("exec_{}", context.exec_id.as_simple()));
+            .with_metadata("exec_id", format!("exec_{}", context.exec_id.as_simple()))
+            .with_metadata("org_id", format!("org_{:032x}", org_id));
+
+        // Add model_id if we have one (not available for system default model)
+        if let Some(model_id) = &resolved_model_id {
+            llm_config_builder = llm_config_builder.with_metadata("model_id", model_id.to_string());
+        }
 
         let llm_config = llm_config_builder.build();
 
@@ -771,12 +783,13 @@ where
     }
 
     /// Resolve model using priority chain
+    /// Resolve model and return both the ModelWithProvider and the resolved model_id (if known)
     async fn resolve_model(
         &self,
         controls_model_id: Option<crate::typed_id::ModelId>,
         session_model_id: Option<crate::typed_id::ModelId>,
         agent_model_id: Option<crate::typed_id::ModelId>,
-    ) -> Result<ModelWithProvider> {
+    ) -> Result<(ModelWithProvider, Option<crate::typed_id::ModelId>)> {
         // Try controls.model_id first (highest priority)
         if let Some(model_id) = controls_model_id
             && let Some(model_with_provider) = self
@@ -784,7 +797,7 @@ where
                 .get_model_with_provider(model_id.uuid())
                 .await?
         {
-            return Ok(model_with_provider);
+            return Ok((model_with_provider, Some(model_id)));
         }
 
         // Try session.model_id second
@@ -794,7 +807,7 @@ where
                 .get_model_with_provider(model_id.uuid())
                 .await?
         {
-            return Ok(model_with_provider);
+            return Ok((model_with_provider, Some(model_id)));
         }
 
         // Try agent.default_model_id third
@@ -804,18 +817,20 @@ where
                 .get_model_with_provider(model_id.uuid())
                 .await?
         {
-            return Ok(model_with_provider);
+            return Ok((model_with_provider, Some(model_id)));
         }
 
-        // Fall back to system default model
-        self.provider_store
+        // Fall back to system default model (no model_id available)
+        let model = self
+            .provider_store
             .get_default_model()
             .await?
             .ok_or_else(|| {
                 AgentLoopError::llm(
                     "No model configured: no model_id in controls, session, or agent, and no system default model is set"
                 )
-            })
+            })?;
+        Ok((model, None))
     }
 
     /// Create LLM driver using the driver registry

--- a/crates/core/src/llm_driver_registry.rs
+++ b/crates/core/src/llm_driver_registry.rs
@@ -305,6 +305,10 @@ pub struct LlmCallConfig {
     pub tools: Vec<ToolDefinition>,
     /// Reasoning effort level (for models that support it: low, medium, high)
     pub reasoning_effort: Option<String>,
+    /// Metadata to send with the API request for tracking and debugging.
+    /// Keys and values are strings. Both OpenAI and Anthropic support metadata fields.
+    /// Typically includes: session_id, agent_id, org_id, turn_id, exec_id.
+    pub metadata: HashMap<String, String>,
 }
 
 impl From<&RuntimeAgent> for LlmCallConfig {
@@ -315,6 +319,7 @@ impl From<&RuntimeAgent> for LlmCallConfig {
             max_tokens: runtime_agent.max_tokens,
             tools: runtime_agent.tools.clone(),
             reasoning_effort: None, // Set by ReasonAtom from user message controls
+            metadata: HashMap::new(), // Set by ReasonAtom with session/agent context
         }
     }
 }
@@ -384,6 +389,21 @@ impl LlmCallConfigBuilder {
     /// Set tools
     pub fn tools(mut self, tools: Vec<ToolDefinition>) -> Self {
         self.config.tools = tools;
+        self
+    }
+
+    /// Set metadata for API tracking
+    ///
+    /// This metadata is sent to the LLM provider for tracking and debugging.
+    /// Typically includes session_id, agent_id, org_id, turn_id, exec_id.
+    pub fn metadata(mut self, metadata: HashMap<String, String>) -> Self {
+        self.config.metadata = metadata;
+        self
+    }
+
+    /// Add a single metadata key-value pair
+    pub fn with_metadata(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.config.metadata.insert(key.into(), value.into());
         self
     }
 
@@ -763,6 +783,40 @@ mod tests {
         assert!(llm_config.temperature.is_none());
         assert!(llm_config.max_tokens.is_none());
         assert!(llm_config.tools.is_empty());
+        assert!(llm_config.metadata.is_empty());
+    }
+
+    #[test]
+    fn test_llm_call_config_builder_with_metadata() {
+        let runtime_agent = RuntimeAgent::new("You are helpful", "gpt-4o");
+        let llm_config = LlmCallConfigBuilder::from(&runtime_agent)
+            .with_metadata("session_id", "session_abc123")
+            .with_metadata("agent_id", "agent_xyz789")
+            .build();
+
+        assert_eq!(
+            llm_config.metadata.get("session_id"),
+            Some(&"session_abc123".to_string())
+        );
+        assert_eq!(
+            llm_config.metadata.get("agent_id"),
+            Some(&"agent_xyz789".to_string())
+        );
+    }
+
+    #[test]
+    fn test_llm_call_config_builder_with_metadata_hashmap() {
+        let runtime_agent = RuntimeAgent::new("You are helpful", "gpt-4o");
+        let mut metadata = HashMap::new();
+        metadata.insert("key1".to_string(), "value1".to_string());
+        metadata.insert("key2".to_string(), "value2".to_string());
+
+        let llm_config = LlmCallConfigBuilder::from(&runtime_agent)
+            .metadata(metadata)
+            .build();
+
+        assert_eq!(llm_config.metadata.get("key1"), Some(&"value1".to_string()));
+        assert_eq!(llm_config.metadata.get("key2"), Some(&"value2".to_string()));
     }
 
     #[test]

--- a/crates/core/src/llmsim_driver.rs
+++ b/crates/core/src/llmsim_driver.rs
@@ -553,6 +553,7 @@ mod tests {
             max_tokens: None,
             tools: vec![],
             reasoning_effort: None,
+            metadata: std::collections::HashMap::new(),
         }
     }
 

--- a/crates/core/src/openai_protocol.rs
+++ b/crates/core/src/openai_protocol.rs
@@ -192,6 +192,15 @@ impl LlmDriver for OpenAIProtocolLlmDriver {
             Some(Self::convert_tools(&config.tools))
         };
 
+        // Build metadata for request tracking
+        // Use session_id as the user identifier for OpenAI's abuse detection
+        let metadata = if config.metadata.is_empty() {
+            None
+        } else {
+            Some(config.metadata.clone())
+        };
+        let user = config.metadata.get("session_id").cloned();
+
         let request = OpenAiRequest {
             model: config.model.clone(),
             messages: openai_messages,
@@ -203,6 +212,8 @@ impl LlmDriver for OpenAIProtocolLlmDriver {
             }),
             tools,
             reasoning_effort: config.reasoning_effort.clone(),
+            metadata,
+            user,
         };
 
         let response = self
@@ -450,6 +461,14 @@ struct OpenAiRequest {
     tools: Option<Vec<OpenAiTool>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     reasoning_effort: Option<String>,
+    /// Metadata for tracking API usage (up to 16 key-value pairs).
+    /// Useful for correlating requests with session_id, agent_id, org_id, etc.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata: Option<std::collections::HashMap<String, String>>,
+    /// End-user identifier for abuse detection and monitoring.
+    /// OpenAI recommends setting this for per-user tracking.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    user: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -631,11 +650,44 @@ mod tests {
             }),
             tools: None,
             reasoning_effort: None,
+            metadata: None,
+            user: None,
         };
 
         let json = serde_json::to_value(&request).unwrap();
         assert_eq!(json["stream"], true);
         assert_eq!(json["stream_options"]["include_usage"], true);
+    }
+
+    #[test]
+    fn test_request_includes_metadata() {
+        // Metadata should be included when provided
+        let mut metadata = std::collections::HashMap::new();
+        metadata.insert("session_id".to_string(), "session_abc123".to_string());
+        metadata.insert("agent_id".to_string(), "agent_xyz789".to_string());
+
+        let request = OpenAiRequest {
+            model: "gpt-4o".to_string(),
+            messages: vec![OpenAiMessage {
+                role: "user".to_string(),
+                content: Some(OpenAiContent::Text("Hello".to_string())),
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            temperature: None,
+            max_tokens: None,
+            stream: true,
+            stream_options: None,
+            tools: None,
+            reasoning_effort: None,
+            metadata: Some(metadata),
+            user: Some("session_abc123".to_string()),
+        };
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(json["metadata"]["session_id"], "session_abc123");
+        assert_eq!(json["metadata"]["agent_id"], "agent_xyz789");
+        assert_eq!(json["user"], "session_abc123");
     }
 
     #[test]

--- a/crates/core/src/openai_protocol.rs
+++ b/crates/core/src/openai_protocol.rs
@@ -193,13 +193,11 @@ impl LlmDriver for OpenAIProtocolLlmDriver {
         };
 
         // Build metadata for request tracking
-        // Use session_id as the user identifier for OpenAI's abuse detection
         let metadata = if config.metadata.is_empty() {
             None
         } else {
             Some(config.metadata.clone())
         };
-        let user = config.metadata.get("session_id").cloned();
 
         let request = OpenAiRequest {
             model: config.model.clone(),
@@ -213,7 +211,6 @@ impl LlmDriver for OpenAIProtocolLlmDriver {
             tools,
             reasoning_effort: config.reasoning_effort.clone(),
             metadata,
-            user,
         };
 
         let response = self
@@ -465,10 +462,6 @@ struct OpenAiRequest {
     /// Useful for correlating requests with session_id, agent_id, org_id, etc.
     #[serde(skip_serializing_if = "Option::is_none")]
     metadata: Option<std::collections::HashMap<String, String>>,
-    /// End-user identifier for abuse detection and monitoring.
-    /// OpenAI recommends setting this for per-user tracking.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    user: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -651,7 +644,6 @@ mod tests {
             tools: None,
             reasoning_effort: None,
             metadata: None,
-            user: None,
         };
 
         let json = serde_json::to_value(&request).unwrap();
@@ -681,13 +673,11 @@ mod tests {
             tools: None,
             reasoning_effort: None,
             metadata: Some(metadata),
-            user: Some("session_abc123".to_string()),
         };
 
         let json = serde_json::to_value(&request).unwrap();
         assert_eq!(json["metadata"]["session_id"], "session_abc123");
         assert_eq!(json["metadata"]["agent_id"], "agent_xyz789");
-        assert_eq!(json["user"], "session_abc123");
     }
 
     #[test]

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -259,13 +259,11 @@ impl LlmDriver for OpenResponsesProtocolLlmDriver {
             });
 
         // Build metadata for request tracking
-        // Use session_id as the user identifier for OpenAI's abuse detection
         let metadata = if config.metadata.is_empty() {
             None
         } else {
             Some(config.metadata.clone())
         };
-        let user = config.metadata.get("session_id").cloned();
 
         let request = ResponsesRequest {
             model: config.model.clone(),
@@ -277,7 +275,6 @@ impl LlmDriver for OpenResponsesProtocolLlmDriver {
             tools,
             reasoning,
             metadata,
-            user,
         };
 
         let response = self
@@ -570,9 +567,6 @@ struct ResponsesRequest {
     /// Useful for correlating requests with session_id, agent_id, org_id, etc.
     #[serde(skip_serializing_if = "Option::is_none")]
     metadata: Option<std::collections::HashMap<String, String>>,
-    /// End-user identifier for abuse detection and monitoring.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    user: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -684,7 +678,6 @@ mod tests {
             tools: None,
             reasoning: None,
             metadata: None,
-            user: None,
         };
 
         let json = serde_json::to_value(&request).unwrap();
@@ -712,7 +705,6 @@ mod tests {
                 effort: "high".to_string(),
             }),
             metadata: None,
-            user: None,
         };
 
         let json = serde_json::to_value(&request).unwrap();
@@ -739,13 +731,11 @@ mod tests {
             tools: None,
             reasoning: None,
             metadata: Some(metadata),
-            user: Some("session_abc123".to_string()),
         };
 
         let json = serde_json::to_value(&request).unwrap();
         assert_eq!(json["metadata"]["session_id"], "session_abc123");
         assert_eq!(json["metadata"]["agent_id"], "agent_xyz789");
-        assert_eq!(json["user"], "session_abc123");
     }
 
     #[test]

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -258,6 +258,15 @@ impl LlmDriver for OpenResponsesProtocolLlmDriver {
                 effort: effort.clone(),
             });
 
+        // Build metadata for request tracking
+        // Use session_id as the user identifier for OpenAI's abuse detection
+        let metadata = if config.metadata.is_empty() {
+            None
+        } else {
+            Some(config.metadata.clone())
+        };
+        let user = config.metadata.get("session_id").cloned();
+
         let request = ResponsesRequest {
             model: config.model.clone(),
             input: input_items,
@@ -267,6 +276,8 @@ impl LlmDriver for OpenResponsesProtocolLlmDriver {
             stream: true,
             tools,
             reasoning,
+            metadata,
+            user,
         };
 
         let response = self
@@ -555,6 +566,13 @@ struct ResponsesRequest {
     tools: Option<Vec<ResponsesTool>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     reasoning: Option<ResponsesReasoning>,
+    /// Metadata for tracking API usage (up to 16 key-value pairs).
+    /// Useful for correlating requests with session_id, agent_id, org_id, etc.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata: Option<std::collections::HashMap<String, String>>,
+    /// End-user identifier for abuse detection and monitoring.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    user: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -665,6 +683,8 @@ mod tests {
             stream: true,
             tools: None,
             reasoning: None,
+            metadata: None,
+            user: None,
         };
 
         let json = serde_json::to_value(&request).unwrap();
@@ -691,10 +711,41 @@ mod tests {
             reasoning: Some(ResponsesReasoning {
                 effort: "high".to_string(),
             }),
+            metadata: None,
+            user: None,
         };
 
         let json = serde_json::to_value(&request).unwrap();
         assert_eq!(json["reasoning"]["effort"], "high");
+    }
+
+    #[test]
+    fn test_request_with_metadata() {
+        let mut metadata = std::collections::HashMap::new();
+        metadata.insert("session_id".to_string(), "session_abc123".to_string());
+        metadata.insert("agent_id".to_string(), "agent_xyz789".to_string());
+
+        let request = ResponsesRequest {
+            model: "gpt-4o".to_string(),
+            input: vec![ResponsesInputItem::Message {
+                r#type: "message".to_string(),
+                role: "user".to_string(),
+                content: ResponsesContent::Text("Hello".to_string()),
+            }],
+            instructions: None,
+            temperature: None,
+            max_output_tokens: None,
+            stream: true,
+            tools: None,
+            reasoning: None,
+            metadata: Some(metadata),
+            user: Some("session_abc123".to_string()),
+        };
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(json["metadata"]["session_id"], "session_abc123");
+        assert_eq!(json["metadata"]["agent_id"], "agent_xyz789");
+        assert_eq!(json["user"], "session_abc123");
     }
 
     #[test]

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -604,6 +604,7 @@ async fn test_driver_registry_integration() {
         max_tokens: None,
         tools: vec![],
         reasoning_effort: None,
+        metadata: std::collections::HashMap::new(),
     };
 
     let response = driver

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -136,6 +136,7 @@ async fn test_reason_atom_with_fixed_response() {
     let input = ReasonInput {
         context,
         agent_id,
+        org_id: 0,
         mcp_tool_definitions: vec![],
     };
 
@@ -194,6 +195,7 @@ async fn test_reason_atom_with_tool_calls() {
     let input = ReasonInput {
         context,
         agent_id,
+        org_id: 0,
         mcp_tool_definitions: vec![],
     };
 
@@ -237,6 +239,7 @@ async fn test_reason_atom_with_echo_response() {
     let input = ReasonInput {
         context,
         agent_id,
+        org_id: 0,
         mcp_tool_definitions: vec![],
     };
 
@@ -281,6 +284,7 @@ async fn test_reason_atom_with_different_configs() {
         .execute(ReasonInput {
             context: context1,
             agent_id,
+            org_id: 0,
             mcp_tool_definitions: vec![],
         })
         .await
@@ -326,6 +330,7 @@ async fn test_reason_atom_with_different_configs() {
         .execute(ReasonInput {
             context: context2,
             agent_id,
+            org_id: 0,
             mcp_tool_definitions: vec![],
         })
         .await
@@ -369,6 +374,7 @@ async fn test_reason_atom_with_multi_turn_conversation() {
     let input = ReasonInput {
         context,
         agent_id,
+        org_id: 0,
         mcp_tool_definitions: vec![],
     };
 
@@ -430,6 +436,7 @@ async fn test_reason_atom_with_tool_result_continuation() {
     let input = ReasonInput {
         context,
         agent_id,
+        org_id: 0,
         mcp_tool_definitions: vec![],
     };
 
@@ -469,6 +476,7 @@ async fn test_reason_atom_with_lorem_response() {
     let input = ReasonInput {
         context,
         agent_id,
+        org_id: 0,
         mcp_tool_definitions: vec![],
     };
 
@@ -515,6 +523,7 @@ async fn test_reason_atom_handles_llm_error() {
     let input = ReasonInput {
         context,
         agent_id,
+        org_id: 0,
         mcp_tool_definitions: vec![],
     };
 

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -349,6 +349,7 @@ mod tests {
         let input = ReasonInput {
             context: context.clone(),
             agent_id: Uuid::parse_str("880e8400-e29b-41d4-a716-446655440000").unwrap(),
+            org_id: 1,
             mcp_tool_definitions: vec![],
         };
 

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -847,6 +847,7 @@ impl DurableWorker {
         let reason_input = ReasonInput {
             context,
             agent_id: input.agent_id,
+            org_id: input.org_id,
             mcp_tool_definitions: turn_context.mcp_tool_definitions,
         };
 


### PR DESCRIPTION
## Summary
- Add session_id, agent_id, turn_id, exec_id, org_id, and model_id metadata to OpenAI API requests
- Add metadata field to LlmCallConfig with builder methods for easy population
- Pass org_id through ReasonInput for organization tracking

## What
Adds tracking metadata to LLM API requests to enable correlation between API calls and Everruns entities.

## Why
This enables:
- Debugging and tracing of LLM calls back to specific sessions/agents
- Usage tracking per organization
- Model usage analytics

## How
- Added `metadata: HashMap<String, String>` field to `LlmCallConfig`
- Added `org_id` field to `ReasonInput`
- Modified `resolve_model` to return both `ModelWithProvider` and the resolved `model_id`
- Populated metadata in `ReasonAtom` before LLM calls
- Included metadata in OpenAI Chat Completions and Responses API requests

## Metadata fields sent to OpenAI
```json
{
  "metadata": {
    "session_id": "session_...",
    "agent_id": "agent_...",
    "turn_id": "turn_...",
    "exec_id": "exec_...",
    "org_id": "org_...",
    "model_id": "model_..."
  }
}
```

Note: Anthropic API doesn't support arbitrary metadata fields, so only OpenAI providers receive this data.

## Risk
- Low
- Additive change, no breaking changes
- Metadata is optional and skipped if empty

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (no breaking changes)