### PR TITLE
fix(ui): shorten session ID display with copy button

### DIFF
--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/layout.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/layout.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/tooltip";
 import { ArrowLeft, Sparkles, MessageSquare, Folder, Activity, Zap, Database } from "lucide-react";
 import { cn, shortenId } from "@/lib/utils";
+import { CopyButton } from "@/components/ui/copy-button";
 import { SessionProvider, useSessionContext } from "./session-context";
 
 // Helper function to format token counts in a compact way
@@ -100,8 +101,9 @@ function SessionLayoutContent({ children, agentId, sessionId }: SessionLayoutCon
 
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-xl font-bold">
+            <h1 className="text-xl font-bold flex items-center gap-2">
               {session.title || `Session ${shortenId(session.id)}`}
+              <CopyButton value={session.id} />
             </h1>
             <p className="text-sm text-muted-foreground">
               {activeTab === "files"

--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/layout.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/layout.tsx
@@ -13,7 +13,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { ArrowLeft, Sparkles, MessageSquare, Folder, Activity, Zap, Database } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { cn, shortenId } from "@/lib/utils";
 import { SessionProvider, useSessionContext } from "./session-context";
 
 // Helper function to format token counts in a compact way
@@ -101,7 +101,7 @@ function SessionLayoutContent({ children, agentId, sessionId }: SessionLayoutCon
         <div className="flex items-center justify-between">
           <div>
             <h1 className="text-xl font-bold">
-              {session.title || `Session ${session.id.slice(0, 8)}`}
+              {session.title || `Session ${shortenId(session.id)}`}
             </h1>
             <p className="text-sm text-muted-foreground">
               {activeTab === "files"

--- a/apps/ui/src/components/dashboard/recent-sessions.tsx
+++ b/apps/ui/src/components/dashboard/recent-sessions.tsx
@@ -14,6 +14,7 @@ import { Badge } from "@/components/ui/badge";
 import { Sparkles } from "lucide-react";
 import { formatDate, formatDurationSeconds } from "@/lib/formatting";
 import { shortenId } from "@/lib/utils";
+import { CopyButton } from "@/components/ui/copy-button";
 import type { Session, Agent, LlmModelWithProvider } from "@/lib/api/types";
 
 interface RecentSessionsProps {
@@ -80,12 +81,15 @@ export function RecentSessions({ sessions, agents, models = [] }: RecentSessions
                 return (
                   <TableRow key={session.id}>
                     <TableCell>
-                      <Link
-                        href={`/agents/${session.agent_id}/sessions/${session.id}`}
-                        className="font-mono text-sm hover:underline"
-                      >
-                        {session.title || shortenId(session.id)}
-                      </Link>
+                      <div className="flex items-center gap-1">
+                        <Link
+                          href={`/agents/${session.agent_id}/sessions/${session.id}`}
+                          className="font-mono text-sm hover:underline"
+                        >
+                          {session.title || shortenId(session.id)}
+                        </Link>
+                        <CopyButton value={session.id} />
+                      </div>
                     </TableCell>
                     <TableCell>
                       <Link

--- a/apps/ui/src/components/dashboard/recent-sessions.tsx
+++ b/apps/ui/src/components/dashboard/recent-sessions.tsx
@@ -13,6 +13,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Sparkles } from "lucide-react";
 import { formatDate, formatDurationSeconds } from "@/lib/formatting";
+import { shortenId } from "@/lib/utils";
 import type { Session, Agent, LlmModelWithProvider } from "@/lib/api/types";
 
 interface RecentSessionsProps {
@@ -83,7 +84,7 @@ export function RecentSessions({ sessions, agents, models = [] }: RecentSessions
                         href={`/agents/${session.agent_id}/sessions/${session.id}`}
                         className="font-mono text-sm hover:underline"
                       >
-                        {session.title || session.id.slice(0, 8) + "..."}
+                        {session.title || shortenId(session.id)}
                       </Link>
                     </TableCell>
                     <TableCell>

--- a/apps/ui/src/components/session/session-card.tsx
+++ b/apps/ui/src/components/session/session-card.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/tooltip";
 import { cn, shortenId } from "@/lib/utils";
 import { formatRelativeTime, formatTokens } from "@/lib/formatting";
+import { CopyButton } from "@/components/ui/copy-button";
 import type { Session, SessionStatus, LlmModelWithProvider, TokenUsage } from "@/lib/api/types";
 
 /**
@@ -150,6 +151,7 @@ export function SessionCard({
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
             <p className="font-medium truncate">{displayTitle}</p>
+            <CopyButton value={session.id} />
             <Badge variant={statusInfo.variant} className="flex-shrink-0 text-xs">
               {statusInfo.label}
             </Badge>

--- a/apps/ui/src/components/session/session-card.tsx
+++ b/apps/ui/src/components/session/session-card.tsx
@@ -9,7 +9,7 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from "@/components/ui/tooltip";
-import { cn } from "@/lib/utils";
+import { cn, shortenId } from "@/lib/utils";
 import { formatRelativeTime, formatTokens } from "@/lib/formatting";
 import type { Session, SessionStatus, LlmModelWithProvider, TokenUsage } from "@/lib/api/types";
 
@@ -128,7 +128,7 @@ export function SessionCard({
   summary,
 }: SessionCardProps) {
   const statusInfo = getStatusInfo(session.status);
-  const displayTitle = session.title || `Session ${session.id.slice(0, 8)}`;
+  const displayTitle = session.title || `Session ${shortenId(session.id)}`;
   // Show preview from session (first user message), explicit summary prop, or nothing
   const inputPreview = summary ?? session.preview;
   // Show output preview from session (last assistant message)

--- a/apps/ui/src/components/ui/copy-button.tsx
+++ b/apps/ui/src/components/ui/copy-button.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useState } from "react";
+import { Copy, Check } from "lucide-react";
+import { Button } from "./button";
+import { cn } from "@/lib/utils";
+
+interface CopyButtonProps {
+  value: string;
+  className?: string;
+}
+
+export function CopyButton({ value, className }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    await navigator.clipboard.writeText(value);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className={cn("h-5 w-5 p-0", className)}
+      onClick={handleCopy}
+      title={copied ? "Copied!" : "Copy ID"}
+    >
+      {copied ? (
+        <Check className="h-3 w-3 text-green-500" />
+      ) : (
+        <Copy className="h-3 w-3 text-muted-foreground" />
+      )}
+    </Button>
+  );
+}

--- a/apps/ui/src/lib/utils.ts
+++ b/apps/ui/src/lib/utils.ts
@@ -6,23 +6,13 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 /**
- * Shorten a prefixed ID for display (like GitHub's short commit hashes).
- * Format: `{prefix}_{hex}` → `{prefix}_{first 7 hex chars}...`
- * Example: `session_01933b5a00007000...` → `session_01933b5...`
+ * Get the last N characters of an ID for compact display.
+ * Uses last chars because they contain the random bits (more unique).
+ * Example: `session_01933b5a00007000800000000000003` → `00000003`
  *
  * @param id The full prefixed ID
- * @param hexChars Number of hex characters to show after prefix (default: 7, like GitHub)
+ * @param chars Number of characters to show (default: 8)
  */
-export function shortenId(id: string, hexChars: number = 7): string {
-  const underscoreIndex = id.indexOf("_");
-  if (underscoreIndex === -1) {
-    // No prefix, just truncate
-    return id.length > hexChars ? id.slice(0, hexChars) + "..." : id;
-  }
-  const prefix = id.slice(0, underscoreIndex + 1); // includes underscore
-  const hex = id.slice(underscoreIndex + 1);
-  if (hex.length <= hexChars) {
-    return id; // Already short enough
-  }
-  return prefix + hex.slice(0, hexChars) + "...";
+export function shortenId(id: string, chars: number = 8): string {
+  return id.slice(-chars);
 }

--- a/apps/ui/src/lib/utils.ts
+++ b/apps/ui/src/lib/utils.ts
@@ -4,3 +4,25 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Shorten a prefixed ID for display (like GitHub's short commit hashes).
+ * Format: `{prefix}_{hex}` → `{prefix}_{first 7 hex chars}...`
+ * Example: `session_01933b5a00007000...` → `session_01933b5...`
+ *
+ * @param id The full prefixed ID
+ * @param hexChars Number of hex characters to show after prefix (default: 7, like GitHub)
+ */
+export function shortenId(id: string, hexChars: number = 7): string {
+  const underscoreIndex = id.indexOf("_");
+  if (underscoreIndex === -1) {
+    // No prefix, just truncate
+    return id.length > hexChars ? id.slice(0, hexChars) + "..." : id;
+  }
+  const prefix = id.slice(0, underscoreIndex + 1); // includes underscore
+  const hex = id.slice(underscoreIndex + 1);
+  if (hex.length <= hexChars) {
+    return id; // Already short enough
+  }
+  return prefix + hex.slice(0, hexChars) + "...";
+}


### PR DESCRIPTION
## Summary
- Changed session ID display to show last 8 characters (more unique - contains random bits from UUIDv7)
- Added copy button next to session titles to copy full ID to clipboard
- Example: "Session 00000003" with small copy icon

## Changes
- `apps/ui/src/lib/utils.ts` - Updated `shortenId()` to return last 8 chars
- `apps/ui/src/components/ui/copy-button.tsx` - New component with checkmark feedback
- Updated session display locations: detail header, session card, recent sessions table

## Test plan
- [ ] Navigate to a session detail page - verify short ID displays correctly
- [ ] Click copy button - verify full ID is copied to clipboard
- [ ] Verify checkmark appears after copying