### PR TITLE
refactor(ui): split components and consolidate utilities

### DIFF
--- a/apps/ui/src/components/agents/capability-dialog.tsx
+++ b/apps/ui/src/components/agents/capability-dialog.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { useState, useMemo, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Badge } from "@/components/ui/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  Plus,
+  Search,
+  ChevronRight,
+  Plug,
+  Link,
+  Lock,
+} from "lucide-react";
+import type { Capability, CapabilityId } from "@/lib/api/types";
+import { getCapabilityIcon } from "@/lib/capability-icons";
+import { cn } from "@/lib/utils";
+import { InlineMarkdown } from "@/components/ui/markdown";
+
+interface CapabilityDialogProps {
+  capabilities: Capability[];
+  selectedIds: Set<CapabilityId>;
+  disabled?: boolean;
+  getCapability: (id: CapabilityId) => Capability | undefined;
+  getDependents: (capId: CapabilityId) => CapabilityId[];
+  onToggle: (capabilityId: CapabilityId, checked: boolean) => void;
+}
+
+export function CapabilityDialog({
+  capabilities,
+  selectedIds,
+  disabled,
+  getCapability,
+  getDependents,
+  onToggle,
+}: CapabilityDialogProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(
+    new Set()
+  );
+
+  // Filter and group capabilities
+  const { availableCapabilities, groupedCapabilities } = useMemo(() => {
+    const available = capabilities.filter((c) => c.status === "available");
+    const query = searchQuery.toLowerCase().trim();
+
+    // Filter by search query
+    const filtered = query
+      ? available.filter(
+          (c) =>
+            c.name.toLowerCase().includes(query) ||
+            c.description.toLowerCase().includes(query) ||
+            c.id.toLowerCase().includes(query) ||
+            (c.category && c.category.toLowerCase().includes(query))
+        )
+      : available;
+
+    // Group by category
+    const grouped = new Map<string, Capability[]>();
+    for (const cap of filtered) {
+      const category = cap.category || "General";
+      const existing = grouped.get(category) || [];
+      grouped.set(category, [...existing, cap]);
+    }
+
+    // Sort categories alphabetically, but put "General" last
+    const sortedCategories = Array.from(grouped.keys()).sort((a, b) => {
+      if (a === "General") return 1;
+      if (b === "General") return -1;
+      return a.localeCompare(b);
+    });
+
+    return {
+      availableCapabilities: available,
+      groupedCapabilities: sortedCategories.map((category) => ({
+        category,
+        capabilities: grouped.get(category)!,
+      })),
+    };
+  }, [capabilities, searchQuery]);
+
+  const toggleCategory = useCallback((category: string) => {
+    setCollapsedCategories((prev) => {
+      const next = new Set(prev);
+      if (next.has(category)) {
+        next.delete(category);
+      } else {
+        next.add(category);
+      }
+      return next;
+    });
+  }, []);
+
+  const selectedCount = selectedIds.size;
+  const availableCount = availableCapabilities.length;
+
+  return (
+    <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+      <DialogTrigger
+        render={
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={disabled}
+          >
+            <Plus className="w-4 h-4 mr-1" />
+            Add
+          </Button>
+        }
+      />
+      <DialogContent className="max-w-2xl max-h-[80vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle>Select Capabilities</DialogTitle>
+          <DialogDescription>
+            {selectedCount} of {availableCount} capabilities selected
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Search input */}
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+          <Input
+            placeholder="Search capabilities..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="pl-9"
+            autoFocus
+          />
+        </div>
+
+        {/* Capability list */}
+        <div className="flex-1 overflow-y-auto min-h-0 -mx-6 px-6">
+          {groupedCapabilities.length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground">
+              {searchQuery
+                ? "No capabilities match your search"
+                : "No capabilities available"}
+            </div>
+          ) : (
+            <div className="space-y-4 py-2">
+              {groupedCapabilities.map(({ category, capabilities: caps }) => {
+                const isCollapsed = collapsedCategories.has(category);
+                const selectedInCategory = caps.filter((c) =>
+                  selectedIds.has(c.id)
+                ).length;
+
+                return (
+                  <div key={category}>
+                    {/* Category header */}
+                    <button
+                      type="button"
+                      onClick={() => toggleCategory(category)}
+                      className="flex items-center gap-2 w-full py-1 text-sm font-medium text-muted-foreground hover:text-foreground"
+                    >
+                      <ChevronRight
+                        className={cn(
+                          "w-4 h-4 transition-transform",
+                          !isCollapsed && "rotate-90"
+                        )}
+                      />
+                      {category}
+                      <Badge variant="secondary" className="ml-auto">
+                        {selectedInCategory}/{caps.length}
+                      </Badge>
+                    </button>
+
+                    {/* Category items */}
+                    {!isCollapsed && (
+                      <div className="ml-6 space-y-1 mt-1">
+                        {caps.map((cap) => {
+                          const IconComponent = getCapabilityIcon(cap.icon);
+                          const isSelected = selectedIds.has(cap.id);
+                          const dependents = getDependents(cap.id);
+                          const isRequired = dependents.length > 0;
+                          const hasDependencies = (cap.dependencies?.length ?? 0) > 0;
+
+                          return (
+                            <label
+                              key={cap.id}
+                              className={cn(
+                                "flex items-start gap-3 p-2 rounded-md cursor-pointer transition-colors",
+                                isSelected
+                                  ? "bg-primary/10 border border-primary/20"
+                                  : "hover:bg-muted/50"
+                              )}
+                            >
+                              <Checkbox
+                                checked={isSelected}
+                                onCheckedChange={(checked) =>
+                                  onToggle(cap.id, checked as boolean)
+                                }
+                                disabled={isSelected && isRequired}
+                                className="mt-0.5"
+                              />
+                              <IconComponent className="w-4 h-4 mt-0.5 shrink-0" />
+                              <div className="flex-1 min-w-0">
+                                <div className="flex items-center gap-2 text-sm font-medium">
+                                  {cap.name}
+                                  {cap.is_mcp && (
+                                    <Badge variant="outline" className="text-xs px-1.5 py-0 h-5 gap-1">
+                                      <Plug className="w-3 h-3" />
+                                      MCP
+                                    </Badge>
+                                  )}
+                                  {hasDependencies && (
+                                    <Tooltip>
+                                      <TooltipTrigger>
+                                        <Badge variant="secondary" className="text-xs px-1.5 py-0 h-5 gap-1">
+                                          <Link className="w-3 h-3" />
+                                          Requires
+                                        </Badge>
+                                      </TooltipTrigger>
+                                      <TooltipContent>
+                                        <p>Depends on: {cap.dependencies?.map(d => getCapability(d)?.name ?? d).join(", ")}</p>
+                                      </TooltipContent>
+                                    </Tooltip>
+                                  )}
+                                  {isRequired && (
+                                    <Tooltip>
+                                      <TooltipTrigger>
+                                        <Badge variant="secondary" className="text-xs px-1.5 py-0 h-5 gap-1">
+                                          <Lock className="w-3 h-3" />
+                                          Required
+                                        </Badge>
+                                      </TooltipTrigger>
+                                      <TooltipContent>
+                                        <p>Required by: {dependents.map(d => getCapability(d)?.name ?? d).join(", ")}</p>
+                                      </TooltipContent>
+                                    </Tooltip>
+                                  )}
+                                </div>
+                                <div className="text-xs text-muted-foreground line-clamp-2">
+                                  <InlineMarkdown content={cap.description} />
+                                </div>
+                              </div>
+                            </label>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* Footer with done button */}
+        <div className="flex justify-end pt-4 border-t">
+          <Button type="button" onClick={() => setDialogOpen(false)}>
+            Done
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/ui/src/components/agents/capability-selector.tsx
+++ b/apps/ui/src/components/agents/capability-selector.tsx
@@ -1,45 +1,10 @@
 "use client";
 
-import { useState, useMemo, useCallback } from "react";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Checkbox } from "@/components/ui/checkbox";
-import { Badge } from "@/components/ui/badge";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-  DialogDescription,
-} from "@/components/ui/dialog";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
-import {
-  Plus,
-  Search,
-  ChevronUp,
-  ChevronDown,
-  X,
-  ChevronRight,
-  Plug,
-  Link,
-  Lock,
-  Settings,
-} from "lucide-react";
+import { useCallback } from "react";
 import type { Capability, CapabilityId, AgentCapabilityConfig } from "@/lib/api/types";
-import { getCapabilityIcon } from "@/lib/capability-icons";
-import { cn } from "@/lib/utils";
-import { InlineMarkdown } from "@/components/ui/markdown";
-import { CapabilitySettingsEditor, hasCapabilitySettings } from "./capability-settings-editor";
+import { useCapabilityDependencies } from "./use-capability-dependencies";
+import { CapabilityDialog } from "./capability-dialog";
+import { SelectedCapabilityList } from "./selected-capability-list";
 
 interface CapabilitySelectorProps {
   /** All available capabilities */
@@ -66,127 +31,13 @@ export function CapabilitySelector({
   disabled,
   label = "Capabilities",
 }: CapabilitySelectorProps) {
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [searchQuery, setSearchQuery] = useState("");
-  const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(
-    new Set()
-  );
-  // Track which capability settings are expanded in the selected list
-  const [expandedSettings, setExpandedSettings] = useState<Set<CapabilityId>>(
-    new Set()
-  );
-
-  // Get selected capability IDs for quick lookup
-  const selectedIds = useMemo(() =>
-    new Set(selected.map((c) => c.ref)),
-    [selected]
-  );
-
-  // Create a map of capability ID to capability for fast lookup
-  const capabilityMap = useMemo(() => {
-    const map = new Map<CapabilityId, Capability>();
-    for (const cap of capabilities) {
-      map.set(cap.id, cap);
-    }
-    return map;
-  }, [capabilities]);
-
-  // Get capability info by ID
-  const getCapability = useCallback(
-    (id: CapabilityId): Capability | undefined => capabilityMap.get(id),
-    [capabilityMap]
-  );
-
-  // Get all dependencies for a capability (recursively)
-  const getAllDependencies = useCallback(
-    (capId: CapabilityId, visited: Set<CapabilityId> = new Set()): CapabilityId[] => {
-      if (visited.has(capId)) return []; // Prevent cycles
-      visited.add(capId);
-
-      const cap = getCapability(capId);
-      if (!cap?.dependencies?.length) return [];
-
-      const deps: CapabilityId[] = [];
-      for (const depId of cap.dependencies) {
-        // Add direct dependency
-        if (!deps.includes(depId)) {
-          deps.push(depId);
-        }
-        // Add transitive dependencies
-        for (const transitiveDep of getAllDependencies(depId, visited)) {
-          if (!deps.includes(transitiveDep)) {
-            deps.push(transitiveDep);
-          }
-        }
-      }
-      return deps;
-    },
-    [getCapability]
-  );
-
-  // Check which selected capabilities depend on a given capability
-  const getDependents = useCallback(
-    (capId: CapabilityId): CapabilityId[] => {
-      const dependents: CapabilityId[] = [];
-      for (const selectedCap of selected) {
-        if (selectedCap.ref === capId) continue;
-        const deps = getAllDependencies(selectedCap.ref);
-        if (deps.includes(capId)) {
-          dependents.push(selectedCap.ref);
-        }
-      }
-      return dependents;
-    },
-    [selected, getAllDependencies]
-  );
-
-  // Check if a capability can be removed (no dependents require it)
-  const canRemove = useCallback(
-    (capId: CapabilityId): boolean => {
-      return getDependents(capId).length === 0;
-    },
-    [getDependents]
-  );
-
-  // Filter and group capabilities
-  const { availableCapabilities, groupedCapabilities } = useMemo(() => {
-    const available = capabilities.filter((c) => c.status === "available");
-    const query = searchQuery.toLowerCase().trim();
-
-    // Filter by search query
-    const filtered = query
-      ? available.filter(
-          (c) =>
-            c.name.toLowerCase().includes(query) ||
-            c.description.toLowerCase().includes(query) ||
-            c.id.toLowerCase().includes(query) ||
-            (c.category && c.category.toLowerCase().includes(query))
-        )
-      : available;
-
-    // Group by category
-    const grouped = new Map<string, Capability[]>();
-    for (const cap of filtered) {
-      const category = cap.category || "General";
-      const existing = grouped.get(category) || [];
-      grouped.set(category, [...existing, cap]);
-    }
-
-    // Sort categories alphabetically, but put "General" last
-    const sortedCategories = Array.from(grouped.keys()).sort((a, b) => {
-      if (a === "General") return 1;
-      if (b === "General") return -1;
-      return a.localeCompare(b);
-    });
-
-    return {
-      availableCapabilities: available,
-      groupedCapabilities: sortedCategories.map((category) => ({
-        category,
-        capabilities: grouped.get(category)!,
-      })),
-    };
-  }, [capabilities, searchQuery]);
+  const {
+    selectedIds,
+    getCapability,
+    getAllDependencies,
+    getDependents,
+    canRemove,
+  } = useCapabilityDependencies({ capabilities, selected });
 
   // Handle toggling a capability (with automatic dependency handling)
   const handleToggle = useCallback(
@@ -213,12 +64,6 @@ export function CapabilitySelector({
         // Remove capability if no dependents require it
         if (canRemove(capabilityId)) {
           onChange(selected.filter((c) => c.ref !== capabilityId));
-          // Also collapse settings if removing
-          setExpandedSettings((prev) => {
-            const next = new Set(prev);
-            next.delete(capabilityId);
-            return next;
-          });
         }
       }
     },
@@ -229,11 +74,6 @@ export function CapabilitySelector({
     (capabilityId: CapabilityId) => {
       if (canRemove(capabilityId)) {
         onChange(selected.filter((c) => c.ref !== capabilityId));
-        setExpandedSettings((prev) => {
-          const next = new Set(prev);
-          next.delete(capabilityId);
-          return next;
-        });
       }
     },
     [selected, onChange, canRemove]
@@ -249,18 +89,6 @@ export function CapabilitySelector({
     },
     [selected, onChange]
   );
-
-  const toggleSettings = useCallback((capabilityId: CapabilityId) => {
-    setExpandedSettings((prev) => {
-      const next = new Set(prev);
-      if (next.has(capabilityId)) {
-        next.delete(capabilityId);
-      } else {
-        next.add(capabilityId);
-      }
-      return next;
-    });
-  }, []);
 
   const moveUp = useCallback(
     (index: number) => {
@@ -288,325 +116,30 @@ export function CapabilitySelector({
     [selected, onChange]
   );
 
-  const toggleCategory = useCallback((category: string) => {
-    setCollapsedCategories((prev) => {
-      const next = new Set(prev);
-      if (next.has(category)) {
-        next.delete(category);
-      } else {
-        next.add(category);
-      }
-      return next;
-    });
-  }, []);
-
-  const selectedCount = selectedIds.size;
-  const availableCount = availableCapabilities.length;
-
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
         <span className="text-sm font-medium">{label}</span>
-        <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-          <DialogTrigger
-            render={
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                disabled={disabled}
-              >
-                <Plus className="w-4 h-4 mr-1" />
-                Add
-              </Button>
-            }
-          />
-          <DialogContent className="max-w-2xl max-h-[80vh] flex flex-col">
-            <DialogHeader>
-              <DialogTitle>Select Capabilities</DialogTitle>
-              <DialogDescription>
-                {selectedCount} of {availableCount} capabilities selected
-              </DialogDescription>
-            </DialogHeader>
-
-            {/* Search input */}
-            <div className="relative">
-              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-              <Input
-                placeholder="Search capabilities..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className="pl-9"
-                autoFocus
-              />
-            </div>
-
-            {/* Capability list */}
-            <div className="flex-1 overflow-y-auto min-h-0 -mx-6 px-6">
-              {groupedCapabilities.length === 0 ? (
-                <div className="text-center py-8 text-muted-foreground">
-                  {searchQuery
-                    ? "No capabilities match your search"
-                    : "No capabilities available"}
-                </div>
-              ) : (
-                <div className="space-y-4 py-2">
-                  {groupedCapabilities.map(({ category, capabilities: caps }) => {
-                    const isCollapsed = collapsedCategories.has(category);
-                    const selectedInCategory = caps.filter((c) =>
-                      selectedIds.has(c.id)
-                    ).length;
-
-                    return (
-                      <div key={category}>
-                        {/* Category header */}
-                        <button
-                          type="button"
-                          onClick={() => toggleCategory(category)}
-                          className="flex items-center gap-2 w-full py-1 text-sm font-medium text-muted-foreground hover:text-foreground"
-                        >
-                          <ChevronRight
-                            className={cn(
-                              "w-4 h-4 transition-transform",
-                              !isCollapsed && "rotate-90"
-                            )}
-                          />
-                          {category}
-                          <Badge variant="secondary" className="ml-auto">
-                            {selectedInCategory}/{caps.length}
-                          </Badge>
-                        </button>
-
-                        {/* Category items */}
-                        {!isCollapsed && (
-                          <div className="ml-6 space-y-1 mt-1">
-                            {caps.map((cap) => {
-                              const IconComponent = getCapabilityIcon(cap.icon);
-                              const isSelected = selectedIds.has(cap.id);
-                              const dependents = getDependents(cap.id);
-                              const isRequired = dependents.length > 0;
-                              const hasDependencies = (cap.dependencies?.length ?? 0) > 0;
-
-                              return (
-                                <label
-                                  key={cap.id}
-                                  className={cn(
-                                    "flex items-start gap-3 p-2 rounded-md cursor-pointer transition-colors",
-                                    isSelected
-                                      ? "bg-primary/10 border border-primary/20"
-                                      : "hover:bg-muted/50"
-                                  )}
-                                >
-                                  <Checkbox
-                                    checked={isSelected}
-                                    onCheckedChange={(checked) =>
-                                      handleToggle(cap.id, checked as boolean)
-                                    }
-                                    disabled={isSelected && isRequired}
-                                    className="mt-0.5"
-                                  />
-                                  <IconComponent className="w-4 h-4 mt-0.5 shrink-0" />
-                                  <div className="flex-1 min-w-0">
-                                    <div className="flex items-center gap-2 text-sm font-medium">
-                                      {cap.name}
-                                      {cap.is_mcp && (
-                                        <Badge variant="outline" className="text-xs px-1.5 py-0 h-5 gap-1">
-                                          <Plug className="w-3 h-3" />
-                                          MCP
-                                        </Badge>
-                                      )}
-                                      {hasDependencies && (
-                                        <Tooltip>
-                                          <TooltipTrigger>
-                                            <Badge variant="secondary" className="text-xs px-1.5 py-0 h-5 gap-1">
-                                              <Link className="w-3 h-3" />
-                                              Requires
-                                            </Badge>
-                                          </TooltipTrigger>
-                                          <TooltipContent>
-                                            <p>Depends on: {cap.dependencies?.map(d => getCapability(d)?.name ?? d).join(", ")}</p>
-                                          </TooltipContent>
-                                        </Tooltip>
-                                      )}
-                                      {isRequired && (
-                                        <Tooltip>
-                                          <TooltipTrigger>
-                                            <Badge variant="secondary" className="text-xs px-1.5 py-0 h-5 gap-1">
-                                              <Lock className="w-3 h-3" />
-                                              Required
-                                            </Badge>
-                                          </TooltipTrigger>
-                                          <TooltipContent>
-                                            <p>Required by: {dependents.map(d => getCapability(d)?.name ?? d).join(", ")}</p>
-                                          </TooltipContent>
-                                        </Tooltip>
-                                      )}
-                                    </div>
-                                    <div className="text-xs text-muted-foreground line-clamp-2">
-                                      <InlineMarkdown content={cap.description} />
-                                    </div>
-                                  </div>
-                                </label>
-                              );
-                            })}
-                          </div>
-                        )}
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
-            </div>
-
-            {/* Footer with done button */}
-            <div className="flex justify-end pt-4 border-t">
-              <Button type="button" onClick={() => setDialogOpen(false)}>
-                Done
-              </Button>
-            </div>
-          </DialogContent>
-        </Dialog>
+        <CapabilityDialog
+          capabilities={capabilities}
+          selectedIds={selectedIds}
+          disabled={disabled}
+          getCapability={getCapability}
+          getDependents={getDependents}
+          onToggle={handleToggle}
+        />
       </div>
 
-      {/* Selected capabilities list */}
-      {selectedCount === 0 ? (
-        <div className="text-sm text-muted-foreground py-4 text-center border rounded-md border-dashed">
-          No capabilities selected
-        </div>
-      ) : (
-        <div className="space-y-1">
-          {selected.map((capConfig, index) => {
-            const cap = getCapability(capConfig.ref);
-            if (!cap) return null;
-            const IconComponent = getCapabilityIcon(cap.icon);
-            const hasSettings = hasCapabilitySettings(capConfig.ref);
-            const isSettingsExpanded = expandedSettings.has(capConfig.ref);
-            const hasConfigValues = Object.keys(capConfig.config).length > 0;
-            const dependents = getDependents(capConfig.ref);
-            const isRequired = dependents.length > 0;
-
-            return (
-              <Collapsible
-                key={capConfig.ref}
-                open={isSettingsExpanded}
-                onOpenChange={() => hasSettings && toggleSettings(capConfig.ref)}
-              >
-                <div className="rounded-md border bg-muted/30 group">
-                  <div className="flex items-center gap-2 p-2">
-                    {/* Reorder controls */}
-                    <div className="flex flex-col gap-0.5">
-                      <button
-                        type="button"
-                        onClick={() => moveUp(index)}
-                        disabled={index === 0 || disabled}
-                        className="text-muted-foreground hover:text-foreground disabled:opacity-30 p-0.5"
-                        aria-label="Move up"
-                      >
-                        <ChevronUp className="w-3 h-3" />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => moveDown(index)}
-                        disabled={index === selected.length - 1 || disabled}
-                        className="text-muted-foreground hover:text-foreground disabled:opacity-30 p-0.5"
-                        aria-label="Move down"
-                      >
-                        <ChevronDown className="w-3 h-3" />
-                      </button>
-                    </div>
-
-                    {/* Position indicator */}
-                    <span className="text-xs text-muted-foreground w-4 text-center">
-                      {index + 1}
-                    </span>
-
-                    {/* Icon and name */}
-                    <IconComponent className="w-4 h-4 shrink-0" />
-                    <span className="flex-1 text-sm truncate flex items-center gap-2">
-                      {cap.name}
-                      {cap.is_mcp && (
-                        <Badge variant="outline" className="text-xs px-1 py-0 h-4 gap-0.5 shrink-0">
-                          <Plug className="w-2.5 h-2.5" />
-                          MCP
-                        </Badge>
-                      )}
-                      {isRequired && (
-                        <Tooltip>
-                          <TooltipTrigger>
-                            <Badge variant="secondary" className="text-xs px-1 py-0 h-4 gap-0.5 shrink-0">
-                              <Lock className="w-2.5 h-2.5" />
-                              Required
-                            </Badge>
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            <p>Required by: {dependents.map(d => getCapability(d)?.name ?? d).join(", ")}</p>
-                          </TooltipContent>
-                        </Tooltip>
-                      )}
-                    </span>
-
-                    {/* Settings button (if capability has configurable settings) */}
-                    {hasSettings && (
-                      <CollapsibleTrigger asChild>
-                        <button
-                          type="button"
-                          disabled={disabled}
-                          className={cn(
-                            "text-muted-foreground hover:text-foreground p-1 transition-colors",
-                            isSettingsExpanded && "text-foreground",
-                            hasConfigValues && !isSettingsExpanded && "text-primary"
-                          )}
-                          aria-label="Toggle settings"
-                        >
-                          <Settings className="w-3.5 h-3.5" />
-                        </button>
-                      </CollapsibleTrigger>
-                    )}
-
-                    {/* Remove button */}
-                    {isRequired ? (
-                      <Tooltip>
-                        <TooltipTrigger>
-                          <span className="text-muted-foreground/50 p-1 cursor-not-allowed">
-                            <Lock className="w-3 h-3" />
-                          </span>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p>Cannot remove: required by {dependents.map(d => getCapability(d)?.name ?? d).join(", ")}</p>
-                        </TooltipContent>
-                      </Tooltip>
-                    ) : (
-                      <button
-                        type="button"
-                        onClick={() => handleRemove(capConfig.ref)}
-                        disabled={disabled}
-                        className="opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive p-1 transition-opacity"
-                        aria-label="Remove capability"
-                      >
-                        <X className="w-3 h-3" />
-                      </button>
-                    )}
-                  </div>
-
-                  {/* Settings editor (collapsible) */}
-                  {hasSettings && (
-                    <CollapsibleContent>
-                      <div className="px-2 pb-2 border-t border-border/50 mx-2 pt-2">
-                        <CapabilitySettingsEditor
-                          capabilityId={capConfig.ref}
-                          config={capConfig.config}
-                          onChange={(newConfig) => handleConfigChange(capConfig.ref, newConfig)}
-                          disabled={disabled}
-                        />
-                      </div>
-                    </CollapsibleContent>
-                  )}
-                </div>
-              </Collapsible>
-            );
-          })}
-        </div>
-      )}
+      <SelectedCapabilityList
+        selected={selected}
+        disabled={disabled}
+        getCapability={getCapability}
+        getDependents={getDependents}
+        onRemove={handleRemove}
+        onConfigChange={handleConfigChange}
+        onMoveUp={moveUp}
+        onMoveDown={moveDown}
+      />
 
       {/* Coming soon indicator */}
       {capabilities.some((c) => c.status === "coming_soon") && (

--- a/apps/ui/src/components/agents/selected-capability-list.tsx
+++ b/apps/ui/src/components/agents/selected-capability-list.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import {
+  ChevronUp,
+  ChevronDown,
+  X,
+  Plug,
+  Lock,
+  Settings,
+} from "lucide-react";
+import type { Capability, CapabilityId, AgentCapabilityConfig } from "@/lib/api/types";
+import { getCapabilityIcon } from "@/lib/capability-icons";
+import { cn } from "@/lib/utils";
+import { CapabilitySettingsEditor, hasCapabilitySettings } from "./capability-settings-editor";
+
+interface SelectedCapabilityListProps {
+  selected: AgentCapabilityConfig[];
+  disabled?: boolean;
+  getCapability: (id: CapabilityId) => Capability | undefined;
+  getDependents: (capId: CapabilityId) => CapabilityId[];
+  onRemove: (capabilityId: CapabilityId) => void;
+  onConfigChange: (capabilityId: CapabilityId, newConfig: Record<string, unknown>) => void;
+  onMoveUp: (index: number) => void;
+  onMoveDown: (index: number) => void;
+}
+
+export function SelectedCapabilityList({
+  selected,
+  disabled,
+  getCapability,
+  getDependents,
+  onRemove,
+  onConfigChange,
+  onMoveUp,
+  onMoveDown,
+}: SelectedCapabilityListProps) {
+  // Track which capability settings are expanded
+  const [expandedSettings, setExpandedSettings] = useState<Set<CapabilityId>>(
+    new Set()
+  );
+
+  const toggleSettings = useCallback((capabilityId: CapabilityId) => {
+    setExpandedSettings((prev) => {
+      const next = new Set(prev);
+      if (next.has(capabilityId)) {
+        next.delete(capabilityId);
+      } else {
+        next.add(capabilityId);
+      }
+      return next;
+    });
+  }, []);
+
+  if (selected.length === 0) {
+    return (
+      <div className="text-sm text-muted-foreground py-4 text-center border rounded-md border-dashed">
+        No capabilities selected
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      {selected.map((capConfig, index) => {
+        const cap = getCapability(capConfig.ref);
+        if (!cap) return null;
+        const IconComponent = getCapabilityIcon(cap.icon);
+        const hasSettings = hasCapabilitySettings(capConfig.ref);
+        const isSettingsExpanded = expandedSettings.has(capConfig.ref);
+        const hasConfigValues = Object.keys(capConfig.config).length > 0;
+        const dependents = getDependents(capConfig.ref);
+        const isRequired = dependents.length > 0;
+
+        return (
+          <Collapsible
+            key={capConfig.ref}
+            open={isSettingsExpanded}
+            onOpenChange={() => hasSettings && toggleSettings(capConfig.ref)}
+          >
+            <div className="rounded-md border bg-muted/30 group">
+              <div className="flex items-center gap-2 p-2">
+                {/* Reorder controls */}
+                <div className="flex flex-col gap-0.5">
+                  <button
+                    type="button"
+                    onClick={() => onMoveUp(index)}
+                    disabled={index === 0 || disabled}
+                    className="text-muted-foreground hover:text-foreground disabled:opacity-30 p-0.5"
+                    aria-label="Move up"
+                  >
+                    <ChevronUp className="w-3 h-3" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onMoveDown(index)}
+                    disabled={index === selected.length - 1 || disabled}
+                    className="text-muted-foreground hover:text-foreground disabled:opacity-30 p-0.5"
+                    aria-label="Move down"
+                  >
+                    <ChevronDown className="w-3 h-3" />
+                  </button>
+                </div>
+
+                {/* Position indicator */}
+                <span className="text-xs text-muted-foreground w-4 text-center">
+                  {index + 1}
+                </span>
+
+                {/* Icon and name */}
+                <IconComponent className="w-4 h-4 shrink-0" />
+                <span className="flex-1 text-sm truncate flex items-center gap-2">
+                  {cap.name}
+                  {cap.is_mcp && (
+                    <Badge variant="outline" className="text-xs px-1 py-0 h-4 gap-0.5 shrink-0">
+                      <Plug className="w-2.5 h-2.5" />
+                      MCP
+                    </Badge>
+                  )}
+                  {isRequired && (
+                    <Tooltip>
+                      <TooltipTrigger>
+                        <Badge variant="secondary" className="text-xs px-1 py-0 h-4 gap-0.5 shrink-0">
+                          <Lock className="w-2.5 h-2.5" />
+                          Required
+                        </Badge>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>Required by: {dependents.map(d => getCapability(d)?.name ?? d).join(", ")}</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                </span>
+
+                {/* Settings button (if capability has configurable settings) */}
+                {hasSettings && (
+                  <CollapsibleTrigger asChild>
+                    <button
+                      type="button"
+                      disabled={disabled}
+                      className={cn(
+                        "text-muted-foreground hover:text-foreground p-1 transition-colors",
+                        isSettingsExpanded && "text-foreground",
+                        hasConfigValues && !isSettingsExpanded && "text-primary"
+                      )}
+                      aria-label="Toggle settings"
+                    >
+                      <Settings className="w-3.5 h-3.5" />
+                    </button>
+                  </CollapsibleTrigger>
+                )}
+
+                {/* Remove button */}
+                {isRequired ? (
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <span className="text-muted-foreground/50 p-1 cursor-not-allowed">
+                        <Lock className="w-3 h-3" />
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Cannot remove: required by {dependents.map(d => getCapability(d)?.name ?? d).join(", ")}</p>
+                    </TooltipContent>
+                  </Tooltip>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => onRemove(capConfig.ref)}
+                    disabled={disabled}
+                    className="opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive p-1 transition-opacity"
+                    aria-label="Remove capability"
+                  >
+                    <X className="w-3 h-3" />
+                  </button>
+                )}
+              </div>
+
+              {/* Settings editor (collapsible) */}
+              {hasSettings && (
+                <CollapsibleContent>
+                  <div className="px-2 pb-2 border-t border-border/50 mx-2 pt-2">
+                    <CapabilitySettingsEditor
+                      capabilityId={capConfig.ref}
+                      config={capConfig.config}
+                      onChange={(newConfig) => onConfigChange(capConfig.ref, newConfig)}
+                      disabled={disabled}
+                    />
+                  </div>
+                </CollapsibleContent>
+              )}
+            </div>
+          </Collapsible>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/ui/src/components/agents/use-capability-dependencies.ts
+++ b/apps/ui/src/components/agents/use-capability-dependencies.ts
@@ -1,0 +1,112 @@
+/**
+ * Hook for managing capability dependencies
+ */
+
+import { useMemo, useCallback } from "react";
+import type { Capability, CapabilityId, AgentCapabilityConfig } from "@/lib/api/types";
+
+interface UseCapabilityDependenciesProps {
+  capabilities: Capability[];
+  selected: AgentCapabilityConfig[];
+}
+
+interface UseCapabilityDependenciesReturn {
+  /** Set of selected capability IDs */
+  selectedIds: Set<CapabilityId>;
+  /** Map of capability ID to Capability */
+  capabilityMap: Map<CapabilityId, Capability>;
+  /** Get capability by ID */
+  getCapability: (id: CapabilityId) => Capability | undefined;
+  /** Get all dependencies for a capability (recursively) */
+  getAllDependencies: (capId: CapabilityId) => CapabilityId[];
+  /** Get which selected capabilities depend on a given capability */
+  getDependents: (capId: CapabilityId) => CapabilityId[];
+  /** Check if a capability can be removed (no dependents) */
+  canRemove: (capId: CapabilityId) => boolean;
+}
+
+export function useCapabilityDependencies({
+  capabilities,
+  selected,
+}: UseCapabilityDependenciesProps): UseCapabilityDependenciesReturn {
+  // Get selected capability IDs for quick lookup
+  const selectedIds = useMemo(
+    () => new Set(selected.map((c) => c.ref)),
+    [selected]
+  );
+
+  // Create a map of capability ID to capability for fast lookup
+  const capabilityMap = useMemo(() => {
+    const map = new Map<CapabilityId, Capability>();
+    for (const cap of capabilities) {
+      map.set(cap.id, cap);
+    }
+    return map;
+  }, [capabilities]);
+
+  // Get capability info by ID
+  const getCapability = useCallback(
+    (id: CapabilityId): Capability | undefined => capabilityMap.get(id),
+    [capabilityMap]
+  );
+
+  // Get all dependencies for a capability (recursively)
+  const getAllDependencies = useCallback(
+    (capId: CapabilityId, visited: Set<CapabilityId> = new Set()): CapabilityId[] => {
+      if (visited.has(capId)) return []; // Prevent cycles
+      visited.add(capId);
+
+      const cap = getCapability(capId);
+      if (!cap?.dependencies?.length) return [];
+
+      const deps: CapabilityId[] = [];
+      for (const depId of cap.dependencies) {
+        // Add direct dependency
+        if (!deps.includes(depId)) {
+          deps.push(depId);
+        }
+        // Add transitive dependencies
+        for (const transitiveDep of getAllDependencies(depId, visited)) {
+          if (!deps.includes(transitiveDep)) {
+            deps.push(transitiveDep);
+          }
+        }
+      }
+      return deps;
+    },
+    [getCapability]
+  );
+
+  // Check which selected capabilities depend on a given capability
+  const getDependents = useCallback(
+    (capId: CapabilityId): CapabilityId[] => {
+      const dependents: CapabilityId[] = [];
+      for (const selectedCap of selected) {
+        if (selectedCap.ref === capId) continue;
+        const deps = getAllDependencies(selectedCap.ref);
+        if (deps.includes(capId)) {
+          dependents.push(selectedCap.ref);
+        }
+      }
+      return dependents;
+    },
+    [selected, getAllDependencies]
+  );
+
+  // Check if a capability can be removed (no dependents require it)
+  const canRemove = useCallback(
+    (capId: CapabilityId): boolean => {
+      return getDependents(capId).length === 0;
+    },
+    [getDependents]
+  );
+
+  return {
+    selectedIds,
+    capabilityMap,
+    getCapability,
+    getAllDependencies,
+    getDependents,
+    canRemove,
+  };
+}

--- a/apps/ui/src/components/chat/tool-call-card-from-event.tsx
+++ b/apps/ui/src/components/chat/tool-call-card-from-event.tsx
@@ -2,40 +2,16 @@
 
 import { useState } from "react";
 import { Check, Loader2, ChevronDown, ChevronRight } from "lucide-react";
-import type { ToolCallCompletedData, ContentPart } from "@/lib/api/types";
+import type { ToolCallCompletedData } from "@/lib/api/types";
 import { TodoListRenderer, isWriteTodosTool } from "./todo-list-renderer";
-
-interface ToolCallInfo {
-  id: string;
-  name: string;
-  arguments: Record<string, unknown>;
-}
-
-// Format arguments as "arg1: value, arg2: value..." with truncation
-function formatArguments(args: Record<string, unknown>): string {
-  const entries = Object.entries(args);
-  if (entries.length === 0) return "";
-
-  const formatted = entries.map(([key, value]) => {
-    const strValue = typeof value === "string" ? value : JSON.stringify(value);
-    const truncated = strValue.length > 30 ? strValue.substring(0, 30) + "..." : strValue;
-    return `${key}: ${truncated}`;
-  }).join(", ");
-
-  return formatted.length > 80 ? formatted.substring(0, 80) + "..." : formatted;
-}
-
-// Get full text from ContentPart array
-function getFullText(result: ContentPart[] | undefined): string {
-  if (!result || result.length === 0) return "";
-  return result
-    .filter((part): part is { type: "text"; text: string } => part.type === "text")
-    .map(part => part.text)
-    .join("\n");
-}
+import {
+  formatArguments,
+  getFullText,
+  type ToolCallContent,
+} from "./tool-call-utils";
 
 interface ToolCallCardFromEventProps {
-  toolCall: ToolCallInfo;
+  toolCall: ToolCallContent;
   toolResult?: ToolCallCompletedData;
 }
 

--- a/apps/ui/src/components/chat/tool-call-card.tsx
+++ b/apps/ui/src/components/chat/tool-call-card.tsx
@@ -1,78 +1,17 @@
 "use client";
 
 import { useState } from "react";
-import type { Message, ContentPart } from "@/lib/api/types";
-import { isToolCallPart, isToolResultPart } from "@/lib/api/types";
+import type { Message } from "@/lib/api/types";
 import { TodoListRenderer, isWriteTodosTool } from "./todo-list-renderer";
-
-interface ToolCallContent {
-  id: string;
-  name: string;
-  arguments: Record<string, unknown>;
-}
-
-interface ToolResultContent {
-  tool_call_id: string;
-  result?: unknown;
-  error?: string;
-}
-
-// Extract tool call content from ContentPart array
-function extractToolCallContent(content: ContentPart[]): ToolCallContent | null {
-  for (const part of content) {
-    if (isToolCallPart(part)) {
-      return {
-        id: part.id,
-        name: part.name,
-        arguments: part.arguments,
-      };
-    }
-  }
-  return null;
-}
-
-// Extract tool result content from ContentPart array
-function extractToolResultContent(content: ContentPart[]): ToolResultContent | null {
-  for (const part of content) {
-    if (isToolResultPart(part)) {
-      return {
-        tool_call_id: part.tool_call_id,
-        result: part.result,
-        error: part.error,
-      };
-    }
-  }
-  return null;
-}
-
-// Format arguments as "arg1: value, arg2: value..." with truncation
-function formatArguments(args: Record<string, unknown>): string {
-  const entries = Object.entries(args);
-  if (entries.length === 0) return "";
-
-  const formatted = entries.map(([key, value]) => {
-    const strValue = typeof value === "string" ? value : JSON.stringify(value);
-    const truncated = strValue.length > 30 ? strValue.substring(0, 30) + "..." : strValue;
-    return `${key}: ${truncated}`;
-  }).join(", ");
-
-  return formatted.length > 80 ? formatted.substring(0, 80) + "..." : formatted;
-}
-
-// Get first N lines of result text, limited to maxChars
-function getResultPreview(result: unknown, maxLines: number = 2, maxChars: number = 360): { preview: string; hasMore: boolean } {
-  const text = typeof result === "string" ? result : JSON.stringify(result, null, 2);
-  const lines = text.split("\n");
-  let preview = lines.slice(0, maxLines).join("\n");
-  const truncatedByLines = lines.length > maxLines;
-  const truncatedByChars = preview.length > maxChars;
-
-  if (truncatedByChars) {
-    preview = preview.substring(0, maxChars) + "...";
-  }
-
-  return { preview, hasMore: truncatedByLines || truncatedByChars || text.length > preview.length };
-}
+import {
+  extractToolCallContent,
+  extractToolResultContent,
+  formatArguments,
+  getResultPreview,
+  formatResult,
+  type ToolCallContent,
+  type ToolResultContent,
+} from "./tool-call-utils";
 
 interface ToolCallCardProps {
   toolCall: Message;
@@ -147,9 +86,7 @@ export function ToolCallCard({ toolCall, toolResult }: ToolCallCardProps) {
             )}
             {isExpanded && resultContent?.result !== undefined && (
               <pre className="text-xs bg-muted/50 p-2 rounded mt-1 overflow-x-auto max-h-60">
-                {typeof resultContent.result === "string"
-                  ? resultContent.result
-                  : JSON.stringify(resultContent.result, null, 2)}
+                {formatResult(resultContent.result)}
               </pre>
             )}
           </div>

--- a/apps/ui/src/components/chat/tool-call-utils.ts
+++ b/apps/ui/src/components/chat/tool-call-utils.ts
@@ -1,0 +1,111 @@
+/**
+ * Shared utilities for tool-call card components
+ */
+
+import type { ContentPart } from "@/lib/api/types";
+import { isToolCallPart, isToolResultPart } from "@/lib/api/types";
+
+/**
+ * Common tool call content structure
+ */
+export interface ToolCallContent {
+  id: string;
+  name: string;
+  arguments: Record<string, unknown>;
+}
+
+/**
+ * Common tool result content structure
+ */
+export interface ToolResultContent {
+  tool_call_id: string;
+  result?: unknown;
+  error?: string;
+}
+
+/**
+ * Extract tool call content from ContentPart array
+ */
+export function extractToolCallContent(content: ContentPart[]): ToolCallContent | null {
+  for (const part of content) {
+    if (isToolCallPart(part)) {
+      return {
+        id: part.id,
+        name: part.name,
+        arguments: part.arguments,
+      };
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract tool result content from ContentPart array
+ */
+export function extractToolResultContent(content: ContentPart[]): ToolResultContent | null {
+  for (const part of content) {
+    if (isToolResultPart(part)) {
+      return {
+        tool_call_id: part.tool_call_id,
+        result: part.result,
+        error: part.error,
+      };
+    }
+  }
+  return null;
+}
+
+/**
+ * Format arguments as "arg1: value, arg2: value..." with truncation
+ */
+export function formatArguments(args: Record<string, unknown>): string {
+  const entries = Object.entries(args);
+  if (entries.length === 0) return "";
+
+  const formatted = entries.map(([key, value]) => {
+    const strValue = typeof value === "string" ? value : JSON.stringify(value);
+    const truncated = strValue.length > 30 ? strValue.substring(0, 30) + "..." : strValue;
+    return `${key}: ${truncated}`;
+  }).join(", ");
+
+  return formatted.length > 80 ? formatted.substring(0, 80) + "..." : formatted;
+}
+
+/**
+ * Get first N lines of result text, limited to maxChars
+ */
+export function getResultPreview(
+  result: unknown,
+  maxLines: number = 2,
+  maxChars: number = 360
+): { preview: string; hasMore: boolean } {
+  const text = typeof result === "string" ? result : JSON.stringify(result, null, 2);
+  const lines = text.split("\n");
+  let preview = lines.slice(0, maxLines).join("\n");
+  const truncatedByLines = lines.length > maxLines;
+  const truncatedByChars = preview.length > maxChars;
+
+  if (truncatedByChars) {
+    preview = preview.substring(0, maxChars) + "...";
+  }
+
+  return { preview, hasMore: truncatedByLines || truncatedByChars || text.length > preview.length };
+}
+
+/**
+ * Get full text from ContentPart array (for tool results)
+ */
+export function getFullText(result: ContentPart[] | undefined): string {
+  if (!result || result.length === 0) return "";
+  return result
+    .filter((part): part is { type: "text"; text: string } => part.type === "text")
+    .map(part => part.text)
+    .join("\n");
+}
+
+/**
+ * Format result content for display
+ */
+export function formatResult(result: unknown): string {
+  return typeof result === "string" ? result : JSON.stringify(result, null, 2);
+}

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -102,7 +102,35 @@ Fetch content from URLs and convert HTML to markdown.
 
 #### CapabilityId (String wrapper)
 
-Capability IDs are now string-based for extensibility. New capabilities can be added without database migrations.
+Capability IDs are string-based for extensibility. New capabilities can be added without database migrations.
+
+##### ID Format
+
+| Type | Format | Example |
+|------|--------|---------|
+| Built-in | `snake_case` identifier | `current_time`, `web_fetch` |
+| MCP | `mcp:{server_uuid}` | `mcp:01933b5a-0000-7000-8000-000000000501` |
+
+**Built-in IDs** are static constants defined in code. They use `snake_case` naming and are validated against the `CapabilityRegistry`.
+
+**MCP IDs** use the `mcp:` prefix followed by the MCP server's UUID. These are dynamic—they exist only when the corresponding MCP server exists. See `specs/mcp-servers.md` for details.
+
+##### Quick Reference: Built-in Capabilities
+
+| ID | Name | Category | Status |
+|----|------|----------|--------|
+| `noop` | No-Op | Testing | Available |
+| `current_time` | Current Time | Utilities | Available |
+| `test_math` | Test Math | Testing | Available |
+| `test_weather` | Test Weather | Testing | Available |
+| `session_file_system` | File System | File Operations | Available |
+| `session_storage` | Session Storage | Storage | Available |
+| `web_fetch` | Web Fetch | Network | Available |
+| `stateless_todo_list` | Task Management | Productivity | Available |
+| `sample_data` | Sample Data | Data | Available |
+| `docker_container` | Docker Container | Development | Available (Dev only) |
+| `research` | Research | AI | Coming Soon |
+| `sandbox` | Sandbox | Execution | Coming Soon |
 
 ```rust
 pub struct CapabilityId(String);
@@ -580,23 +608,64 @@ mcp:{server_uuid}
 
 Example: `mcp:01933b5a-0000-7000-8000-000000000501`
 
+The UUID portion is the MCP server's unique identifier (UUID v7).
+
 #### How MCP Capabilities Work
 
 1. **Discovery**: When listing capabilities, active MCP servers are included with their cached tools
 2. **Selection**: Agents can select MCP capabilities just like built-in capabilities
-3. **Tool Execution**: MCP tools are prefixed with `mcp_{server_name}_` to avoid conflicts
+3. **Tool Execution**: MCP tools are prefixed with `mcp_{server_name}__` (double underscore) to avoid conflicts
 4. **UI Badge**: MCP capabilities display an "MCP" badge in the capability selector
+
+#### MCP Tool Name Format
+
+MCP tools use a double-underscore separator to distinguish server name from tool name:
+
+```
+mcp_{server_name}__{tool_name}
+```
+
+**Why double underscore?** Server names can contain underscores (e.g., `microsoft_learn`), so a single underscore would be ambiguous. The double underscore provides unambiguous parsing.
+
+**Examples:**
+| Server | Tool | Full Tool Name |
+|--------|------|----------------|
+| `github` | `search_repos` | `mcp_github__search_repos` |
+| `microsoft_learn` | `search` | `mcp_microsoft_learn__search` |
+| `atlassian_jira` | `create_issue` | `mcp_atlassian_jira__create_issue` |
+
+#### MCP Capability Properties
+
+When an MCP server is converted to a capability:
+
+| Property | Source |
+|----------|--------|
+| `id` | `mcp:{server.id}` |
+| `name` | Server name (display name) |
+| `description` | Server description |
+| `is_mcp` | `true` |
+| `icon` | `plug` (hardcoded) |
+| `category` | `MCP Servers` |
+| `status` | `available` if server active, else excluded |
 
 #### Key Differences from Built-in Capabilities
 
 | Aspect | Built-in | MCP |
 |--------|----------|-----|
 | Source | Rust code | Remote server |
-| Tool discovery | Compile-time | Runtime (cached) |
-| Execution | In-process | HTTP call |
+| ID format | `snake_case` | `mcp:{uuid}` |
+| Tool prefix | None | `mcp_{server}__` |
+| Tool discovery | Compile-time | Runtime (cached, 24h TTL) |
+| Execution | In-process | HTTP JSON-RPC |
 | Availability | Always | Depends on server status |
+| System prompt | Optional per-capability | None |
+| Dependencies | Supported | Not supported |
 
-See `specs/mcp-servers.md` for full MCP integration details.
+See `specs/mcp-servers.md` for full MCP integration details including:
+- Server configuration and authentication
+- Tool discovery protocol
+- Tool execution flow
+- Error handling
 
 ### Capability Application Flow
 


### PR DESCRIPTION
## What
Refactors large UI components and consolidates duplicated code:

1. **Tool-call-card consolidation** - Extract shared utilities from duplicated tool-call-card components
2. **CapabilitySelector split** - Break down 619-line component into focused sub-components
3. **Spec docs updates** - Add mapping tables and clarify capability ID formats

## Why
- Reduce code duplication between `tool-call-card.tsx` and `tool-call-card-from-event.tsx`
- Improve maintainability by splitting the large `CapabilitySelector` component
- Improve documentation with quick reference tables for capability IDs

## How

### Tool-call utilities
- New `tool-call-utils.ts` with shared functions: `formatArguments`, `getResultPreview`, `extractToolCallContent`, etc.
- Both card components now import from the shared module

### CapabilitySelector split (619 → 153 lines)
- `use-capability-dependencies.ts` - Hook for dependency logic
- `capability-dialog.tsx` - Selection dialog with search/categories  
- `selected-capability-list.tsx` - Ordered list with controls
- `capability-selector.tsx` - Main orchestrating component

### Spec updates
- Quick reference table mapping capability IDs to names/categories/status
- ID format section clarifying built-in vs MCP formats
- Enhanced MCP section with tool naming details

## Risk
- Low
- UI components maintain same behavior, just reorganized

## Checklist
- [x] Lint passes
- [x] Build passes
- [x] No new dependencies