### PR TITLE
fix(scripts): improve Ctrl+C signal handling in start-all/start-dev

### DIFF
--- a/scripts/lib/services.sh
+++ b/scripts/lib/services.sh
@@ -56,19 +56,50 @@ case "$cmd" in
 
     # Track child PIDs for cleanup
     CHILD_PIDS=()
+    CLEANUP_DONE=false
 
     cleanup() {
+      # Prevent multiple cleanup runs
+      if [ "$CLEANUP_DONE" = true ]; then
+        return
+      fi
+      CLEANUP_DONE=true
+
+      # Ignore signals during cleanup to prevent interruption
+      trap '' SIGINT SIGTERM
+
       stty sane 2>/dev/null || true
       echo ""
       echo "🛑 Stopping services..."
+
+      # Send SIGTERM to tracked PIDs first
       for pid in "${CHILD_PIDS[@]}"; do
         if kill -0 "$pid" 2>/dev/null; then
-          kill "$pid" 2>/dev/null || true
+          kill -TERM "$pid" 2>/dev/null || true
         fi
       done
-      pkill -f "cargo-watch" 2>/dev/null || true
-      pkill -f "everruns-control-plane" 2>/dev/null || true
-      pkill -f "next dev" 2>/dev/null || true
+
+      # Kill by name (catches any child processes we didn't track directly)
+      pkill -TERM -f "cargo-watch" 2>/dev/null || true
+      pkill -TERM -f "everruns-control-plane" 2>/dev/null || true
+      pkill -TERM -f "next dev" 2>/dev/null || true
+      pkill -TERM -f "next-router-worker" 2>/dev/null || true
+
+      # Give processes time to terminate gracefully
+      sleep 1
+
+      # Force kill any remaining processes
+      for pid in "${CHILD_PIDS[@]}"; do
+        if kill -0 "$pid" 2>/dev/null; then
+          kill -KILL "$pid" 2>/dev/null || true
+        fi
+      done
+      pkill -KILL -f "cargo-watch" 2>/dev/null || true
+      pkill -KILL -f "everruns-control-plane" 2>/dev/null || true
+      pkill -KILL -f "next dev" 2>/dev/null || true
+      pkill -KILL -f "next-router-worker" 2>/dev/null || true
+
+      # Restore terminal state
       stty sane 2>/dev/null || true
       echo "✅ Services stopped"
       exit 0
@@ -187,20 +218,52 @@ case "$cmd" in
 
     CHILD_PIDS=()
     JAEGER_STARTED=false
+    CLEANUP_DONE=false
 
     cleanup() {
+      # Prevent multiple cleanup runs
+      if [ "$CLEANUP_DONE" = true ]; then
+        return
+      fi
+      CLEANUP_DONE=true
+
+      # Ignore signals during cleanup to prevent interruption
+      trap '' SIGINT SIGTERM
+
       stty sane 2>/dev/null || true
       echo ""
       echo "🛑 Stopping services..."
+
+      # Send SIGTERM to tracked PIDs first
       for pid in "${CHILD_PIDS[@]}"; do
         if kill -0 "$pid" 2>/dev/null; then
-          kill "$pid" 2>/dev/null || true
+          kill -TERM "$pid" 2>/dev/null || true
         fi
       done
-      pkill -f "cargo-watch" 2>/dev/null || true
-      pkill -f "everruns-control-plane" 2>/dev/null || true
-      pkill -f "everruns-worker" 2>/dev/null || true
-      pkill -f "next dev" 2>/dev/null || true
+
+      # Kill by name (catches any child processes we didn't track directly)
+      pkill -TERM -f "cargo-watch" 2>/dev/null || true
+      pkill -TERM -f "everruns-control-plane" 2>/dev/null || true
+      pkill -TERM -f "everruns-worker" 2>/dev/null || true
+      pkill -TERM -f "next dev" 2>/dev/null || true
+      pkill -TERM -f "next-router-worker" 2>/dev/null || true
+
+      # Give processes time to terminate gracefully
+      sleep 1
+
+      # Force kill any remaining processes
+      for pid in "${CHILD_PIDS[@]}"; do
+        if kill -0 "$pid" 2>/dev/null; then
+          kill -KILL "$pid" 2>/dev/null || true
+        fi
+      done
+      pkill -KILL -f "cargo-watch" 2>/dev/null || true
+      pkill -KILL -f "everruns-control-plane" 2>/dev/null || true
+      pkill -KILL -f "everruns-worker" 2>/dev/null || true
+      pkill -KILL -f "next dev" 2>/dev/null || true
+      pkill -KILL -f "next-router-worker" 2>/dev/null || true
+
+      # Restore terminal state
       stty sane 2>/dev/null || true
       echo "✅ Services stopped (Docker still running if started)"
       exit 0


### PR DESCRIPTION
## What
Fixes Ctrl+C handling in `just start-all` and `just start-dev` scripts to cleanly terminate on first press.

## Why
Previously, pressing Ctrl+C would leave the terminal in a strange state and require a second Ctrl+C to fully exit. This happened due to race conditions in signal handling and incomplete process cleanup.

## How
- Add `CLEANUP_DONE` flag to prevent re-entering cleanup on repeated Ctrl+C
- Ignore SIGINT/SIGTERM during cleanup (`trap ''`) so it completes uninterrupted
- Use two-phase termination: SIGTERM for graceful shutdown, wait 1s, then SIGKILL for stubborn processes
- Add `next-router-worker` to pkill targets (Next.js spawns worker processes)
- Use explicit signal types (`-TERM`/`-KILL`) instead of defaults

## Risk
- Low
- Only affects dev scripts, not production code

## Checklist
- [x] Scripts tested locally
- [x] No production code affected