### PR TITLE
fix(ui): reorder session tabs to Chat, Files, Storage, Events

### DIFF
--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/layout.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/[sessionId]/layout.tsx
@@ -185,19 +185,6 @@ function SessionLayoutContent({ children, agentId, sessionId }: SessionLayoutCon
             Files
           </Link>
           <Link
-            href={`${basePath}/events`}
-            className={cn(
-              buttonVariants({
-                variant: activeTab === "events" ? "default" : "ghost",
-                size: "sm",
-              }),
-              "gap-2"
-            )}
-          >
-            <Activity className="h-4 w-4" />
-            Events
-          </Link>
-          <Link
             href={`${basePath}/storage`}
             className={cn(
               buttonVariants({
@@ -209,6 +196,19 @@ function SessionLayoutContent({ children, agentId, sessionId }: SessionLayoutCon
           >
             <Database className="h-4 w-4" />
             Storage
+          </Link>
+          <Link
+            href={`${basePath}/events`}
+            className={cn(
+              buttonVariants({
+                variant: activeTab === "events" ? "default" : "ghost",
+                size: "sm",
+              }),
+              "gap-2"
+            )}
+          >
+            <Activity className="h-4 w-4" />
+            Events
           </Link>
         </div>
       </div>


### PR DESCRIPTION
## What
Reorder session tabs from Chat, Files, Events, Storage to Chat, Files, Storage, Events.

## Why
Better UX flow - Storage is more commonly accessed than Events.

## How
Swapped the tab Link components in the session layout.

## Risk
- Low
- Visual change only, no logic changes

## Checklist
- [x] Tests added or updated (N/A - visual change)
- [x] Backward compatibility considered (N/A)