### PR TITLE
refactor(core): remove CapabilityId constants and factory methods

### DIFF
--- a/crates/core/src/capabilities/current_time.rs
+++ b/crates/core/src/capabilities/current_time.rs
@@ -1,6 +1,6 @@
 //! CurrentTime Capability - provides tools to get current date and time
 
-use super::{Capability, CapabilityId, CapabilityStatus};
+use super::{Capability, CapabilityStatus};
 use crate::tools::{Tool, ToolExecutionResult};
 use async_trait::async_trait;
 use serde_json::Value;
@@ -10,7 +10,7 @@ pub struct CurrentTimeCapability;
 
 impl Capability for CurrentTimeCapability {
     fn id(&self) -> &str {
-        CapabilityId::CURRENT_TIME
+        "current_time"
     }
 
     fn name(&self) -> &str {

--- a/crates/core/src/capabilities/docker_container.rs
+++ b/crates/core/src/capabilities/docker_container.rs
@@ -21,7 +21,7 @@
 //! - `docker_logs`: Get logs from the container
 //! - `docker_stop`: Stop and remove the container
 
-use super::{Capability, CapabilityId, CapabilityStatus};
+use super::{Capability, CapabilityStatus};
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
@@ -74,7 +74,7 @@ pub struct DockerContainerCapability;
 
 impl Capability for DockerContainerCapability {
     fn id(&self) -> &str {
-        CapabilityId::DOCKER_CONTAINER
+        "docker_container"
     }
 
     fn name(&self) -> &str {
@@ -899,7 +899,7 @@ mod tests {
     #[test]
     fn test_capability_metadata() {
         let cap = DockerContainerCapability;
-        assert_eq!(cap.id(), CapabilityId::DOCKER_CONTAINER);
+        assert_eq!(cap.id(), "docker_container");
         assert_eq!(cap.name(), "[Experimental] Docker Container");
         assert_eq!(cap.status(), CapabilityStatus::Available);
         assert_eq!(cap.icon(), Some("container"));

--- a/crates/core/src/capabilities/fake_aws.rs
+++ b/crates/core/src/capabilities/fake_aws.rs
@@ -16,7 +16,7 @@
 //! - `aws_list_security_groups`: List security groups
 //! - `aws_get_cloudwatch_metrics`: Get CloudWatch metrics
 
-use super::{Capability, CapabilityId, CapabilityStatus};
+use super::{Capability, CapabilityStatus};
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
@@ -28,7 +28,7 @@ pub struct FakeAwsCapability;
 
 impl Capability for FakeAwsCapability {
     fn id(&self) -> &str {
-        CapabilityId::FAKE_AWS
+        "fake_aws"
     }
 
     fn name(&self) -> &str {

--- a/crates/core/src/capabilities/fake_crm.rs
+++ b/crates/core/src/capabilities/fake_crm.rs
@@ -13,7 +13,7 @@
 //! - `crm_add_interaction`: Add customer interaction note
 //! - `crm_search_customers`: Search customers by criteria
 
-use super::{Capability, CapabilityId, CapabilityStatus};
+use super::{Capability, CapabilityStatus};
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
@@ -25,7 +25,7 @@ pub struct FakeCrmCapability;
 
 impl Capability for FakeCrmCapability {
     fn id(&self) -> &str {
-        CapabilityId::FAKE_CRM
+        "fake_crm"
     }
 
     fn name(&self) -> &str {

--- a/crates/core/src/capabilities/fake_financial.rs
+++ b/crates/core/src/capabilities/fake_financial.rs
@@ -13,7 +13,7 @@
 //! - `finance_get_revenue_report`: Generate revenue report
 //! - `finance_forecast_cash_flow`: Forecast cash flow
 
-use super::{Capability, CapabilityId, CapabilityStatus};
+use super::{Capability, CapabilityStatus};
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
@@ -25,7 +25,7 @@ pub struct FakeFinancialCapability;
 
 impl Capability for FakeFinancialCapability {
     fn id(&self) -> &str {
-        CapabilityId::FAKE_FINANCIAL
+        "fake_financial"
     }
 
     fn name(&self) -> &str {

--- a/crates/core/src/capabilities/fake_warehouse.rs
+++ b/crates/core/src/capabilities/fake_warehouse.rs
@@ -15,7 +15,7 @@
 //! - `warehouse_process_return`: Process a product return
 //! - `warehouse_inventory_report`: Generate inventory report
 
-use super::{Capability, CapabilityId, CapabilityStatus};
+use super::{Capability, CapabilityStatus};
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
@@ -27,7 +27,7 @@ pub struct FakeWarehouseCapability;
 
 impl Capability for FakeWarehouseCapability {
     fn id(&self) -> &str {
-        CapabilityId::FAKE_WAREHOUSE
+        "fake_warehouse"
     }
 
     fn name(&self) -> &str {

--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -11,7 +11,7 @@
 //! - `delete_file`: Delete a file or directory
 //! - `stat_file`: Get file metadata
 
-use super::{Capability, CapabilityId, CapabilityStatus};
+use super::{Capability, CapabilityStatus};
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
@@ -22,7 +22,7 @@ pub struct FileSystemCapability;
 
 impl Capability for FileSystemCapability {
     fn id(&self) -> &str {
-        CapabilityId::FILE_SYSTEM
+        "session_file_system"
     }
 
     fn name(&self) -> &str {
@@ -644,7 +644,7 @@ mod tests {
     #[test]
     fn test_capability_metadata() {
         let cap = FileSystemCapability;
-        assert_eq!(cap.id(), CapabilityId::FILE_SYSTEM);
+        assert_eq!(cap.id(), "session_file_system");
         assert_eq!(cap.name(), "File System");
         assert_eq!(cap.status(), CapabilityStatus::Available);
         assert_eq!(cap.icon(), Some("hard-drive"));

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -109,13 +109,13 @@ pub use web_fetch::{WebFetchCapability, WebFetchTool};
 /// # Example
 ///
 /// ```ignore
-/// use everruns_core::capabilities::{Capability, CapabilityId};
+/// use everruns_core::capabilities::Capability;
 ///
 /// struct CurrentTimeCapability;
 ///
 /// impl Capability for CurrentTimeCapability {
 ///     fn id(&self) -> &str {
-///         CapabilityId::CURRENT_TIME
+///         "current_time"
 ///     }
 ///
 ///     fn name(&self) -> &str {
@@ -224,12 +224,12 @@ pub trait Capability: Send + Sync {
 /// # Example
 ///
 /// ```
-/// use everruns_core::capabilities::{CapabilityRegistry, CapabilityId};
+/// use everruns_core::capabilities::CapabilityRegistry;
 ///
 /// let registry = CapabilityRegistry::with_builtins();
 ///
 /// // Get a capability by ID
-/// if let Some(cap) = registry.get(CapabilityId::CURRENT_TIME) {
+/// if let Some(cap) = registry.get("current_time") {
 ///     println!("Capability: {}", cap.name());
 /// }
 ///
@@ -776,13 +776,13 @@ pub struct AppliedCapabilities {
 /// # Example
 ///
 /// ```
-/// use everruns_core::capabilities::{apply_capabilities, CapabilityRegistry, CapabilityId};
+/// use everruns_core::capabilities::{apply_capabilities, CapabilityRegistry};
 /// use everruns_core::runtime_agent::RuntimeAgent;
 ///
 /// let registry = CapabilityRegistry::with_builtins();
 /// let base_runtime_agent = RuntimeAgent::new("You are a helpful assistant.", "gpt-5.2");
 ///
-/// let capability_ids = vec![CapabilityId::CURRENT_TIME.to_string()];
+/// let capability_ids = vec!["current_time".to_string()];
 /// let applied = apply_capabilities(base_runtime_agent, &capability_ids, &registry);
 ///
 /// // The runtime agent now includes CurrentTime tool
@@ -841,23 +841,23 @@ mod tests {
         // Dev mode includes all capabilities including experimental
         let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
 
-        assert!(registry.has(CapabilityId::NOOP));
-        assert!(registry.has(CapabilityId::CURRENT_TIME));
-        assert!(registry.has(CapabilityId::RESEARCH));
-        assert!(registry.has(CapabilityId::SANDBOX));
-        assert!(registry.has(CapabilityId::FILE_SYSTEM));
-        assert!(registry.has(CapabilityId::SESSION_STORAGE));
-        assert!(registry.has(CapabilityId::TEST_MATH));
-        assert!(registry.has(CapabilityId::TEST_WEATHER));
-        assert!(registry.has(CapabilityId::STATELESS_TODO_LIST));
-        assert!(registry.has(CapabilityId::WEB_FETCH));
-        assert!(registry.has(CapabilityId::SAMPLE_DATA));
-        assert!(registry.has(CapabilityId::FAKE_WAREHOUSE));
-        assert!(registry.has(CapabilityId::FAKE_AWS));
-        assert!(registry.has(CapabilityId::FAKE_CRM));
-        assert!(registry.has(CapabilityId::FAKE_FINANCIAL));
+        assert!(registry.has("noop"));
+        assert!(registry.has("current_time"));
+        assert!(registry.has("research"));
+        assert!(registry.has("sandbox"));
+        assert!(registry.has("session_file_system"));
+        assert!(registry.has("session_storage"));
+        assert!(registry.has("test_math"));
+        assert!(registry.has("test_weather"));
+        assert!(registry.has("stateless_todo_list"));
+        assert!(registry.has("web_fetch"));
+        assert!(registry.has("sample_data"));
+        assert!(registry.has("fake_warehouse"));
+        assert!(registry.has("fake_aws"));
+        assert!(registry.has("fake_crm"));
+        assert!(registry.has("fake_financial"));
         // Experimental capability included in dev
-        assert!(registry.has(CapabilityId::DOCKER_CONTAINER));
+        assert!(registry.has("docker_container"));
         assert_eq!(registry.len(), 16);
     }
 
@@ -866,23 +866,23 @@ mod tests {
         // Prod mode excludes experimental capabilities
         let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Prod);
 
-        assert!(registry.has(CapabilityId::NOOP));
-        assert!(registry.has(CapabilityId::CURRENT_TIME));
-        assert!(registry.has(CapabilityId::RESEARCH));
-        assert!(registry.has(CapabilityId::SANDBOX));
-        assert!(registry.has(CapabilityId::FILE_SYSTEM));
-        assert!(registry.has(CapabilityId::SESSION_STORAGE));
-        assert!(registry.has(CapabilityId::TEST_MATH));
-        assert!(registry.has(CapabilityId::TEST_WEATHER));
-        assert!(registry.has(CapabilityId::STATELESS_TODO_LIST));
-        assert!(registry.has(CapabilityId::WEB_FETCH));
-        assert!(registry.has(CapabilityId::SAMPLE_DATA));
-        assert!(registry.has(CapabilityId::FAKE_WAREHOUSE));
-        assert!(registry.has(CapabilityId::FAKE_AWS));
-        assert!(registry.has(CapabilityId::FAKE_CRM));
-        assert!(registry.has(CapabilityId::FAKE_FINANCIAL));
+        assert!(registry.has("noop"));
+        assert!(registry.has("current_time"));
+        assert!(registry.has("research"));
+        assert!(registry.has("sandbox"));
+        assert!(registry.has("session_file_system"));
+        assert!(registry.has("session_storage"));
+        assert!(registry.has("test_math"));
+        assert!(registry.has("test_weather"));
+        assert!(registry.has("stateless_todo_list"));
+        assert!(registry.has("web_fetch"));
+        assert!(registry.has("sample_data"));
+        assert!(registry.has("fake_warehouse"));
+        assert!(registry.has("fake_aws"));
+        assert!(registry.has("fake_crm"));
+        assert!(registry.has("fake_financial"));
         // Experimental capability NOT included in prod
-        assert!(!registry.has(CapabilityId::DOCKER_CONTAINER));
+        assert!(!registry.has("docker_container"));
         assert_eq!(registry.len(), 15);
     }
 
@@ -890,8 +890,8 @@ mod tests {
     fn test_capability_registry_get() {
         let registry = CapabilityRegistry::with_builtins();
 
-        let noop = registry.get(CapabilityId::NOOP).unwrap();
-        assert_eq!(noop.id(), CapabilityId::NOOP);
+        let noop = registry.get("noop").unwrap();
+        assert_eq!(noop.id(), "noop");
         assert_eq!(noop.name(), "No-Op");
         assert_eq!(noop.status(), CapabilityStatus::Available);
     }
@@ -903,8 +903,8 @@ mod tests {
             .capability(CurrentTimeCapability)
             .build();
 
-        assert!(registry.has(CapabilityId::NOOP));
-        assert!(registry.has(CapabilityId::CURRENT_TIME));
+        assert!(registry.has("noop"));
+        assert!(registry.has("current_time"));
         assert_eq!(registry.len(), 2);
     }
 
@@ -912,10 +912,10 @@ mod tests {
     fn test_capability_status() {
         let registry = CapabilityRegistry::with_builtins();
 
-        let current_time = registry.get(CapabilityId::CURRENT_TIME).unwrap();
+        let current_time = registry.get("current_time").unwrap();
         assert_eq!(current_time.status(), CapabilityStatus::Available);
 
-        let research = registry.get(CapabilityId::RESEARCH).unwrap();
+        let research = registry.get("research").unwrap();
         assert_eq!(research.status(), CapabilityStatus::ComingSoon);
     }
 
@@ -923,11 +923,11 @@ mod tests {
     fn test_capability_icons_and_categories() {
         let registry = CapabilityRegistry::with_builtins();
 
-        let noop = registry.get(CapabilityId::NOOP).unwrap();
+        let noop = registry.get("noop").unwrap();
         assert_eq!(noop.icon(), Some("circle-off"));
         assert_eq!(noop.category(), Some("Testing"));
 
-        let current_time = registry.get(CapabilityId::CURRENT_TIME).unwrap();
+        let current_time = registry.get("current_time").unwrap();
         assert_eq!(current_time.icon(), Some("clock"));
         assert_eq!(current_time.category(), Some("Utilities"));
     }
@@ -956,11 +956,8 @@ mod tests {
         let registry = CapabilityRegistry::with_builtins();
         let base_runtime_agent = RuntimeAgent::new("You are a helpful assistant.", "gpt-5.2");
 
-        let applied = apply_capabilities(
-            base_runtime_agent.clone(),
-            &[CapabilityId::NOOP.to_string()],
-            &registry,
-        );
+        let applied =
+            apply_capabilities(base_runtime_agent.clone(), &["noop".to_string()], &registry);
 
         // Noop has no system prompt addition or tools
         assert_eq!(
@@ -968,7 +965,7 @@ mod tests {
             base_runtime_agent.system_prompt
         );
         assert!(applied.tool_registry.is_empty());
-        assert_eq!(applied.applied_ids, vec![CapabilityId::NOOP]);
+        assert_eq!(applied.applied_ids, vec!["noop"]);
     }
 
     #[test]
@@ -978,7 +975,7 @@ mod tests {
 
         let applied = apply_capabilities(
             base_runtime_agent.clone(),
-            &[CapabilityId::CURRENT_TIME.to_string()],
+            &["current_time".to_string()],
             &registry,
         );
 
@@ -989,7 +986,7 @@ mod tests {
         );
         assert!(applied.tool_registry.has("get_current_time"));
         assert_eq!(applied.tool_registry.len(), 1);
-        assert_eq!(applied.applied_ids, vec![CapabilityId::CURRENT_TIME]);
+        assert_eq!(applied.applied_ids, vec!["current_time"]);
     }
 
     #[test]
@@ -1000,7 +997,7 @@ mod tests {
         // Research is ComingSoon, so it should be skipped
         let applied = apply_capabilities(
             base_runtime_agent.clone(),
-            &[CapabilityId::RESEARCH.to_string()],
+            &["research".to_string()],
             &registry,
         );
 
@@ -1019,18 +1016,12 @@ mod tests {
 
         let applied = apply_capabilities(
             base_runtime_agent.clone(),
-            &[
-                CapabilityId::NOOP.to_string(),
-                CapabilityId::CURRENT_TIME.to_string(),
-            ],
+            &["noop".to_string(), "current_time".to_string()],
             &registry,
         );
 
         assert!(applied.tool_registry.has("get_current_time"));
-        assert_eq!(
-            applied.applied_ids,
-            vec![CapabilityId::NOOP, CapabilityId::CURRENT_TIME]
-        );
+        assert_eq!(applied.applied_ids, vec!["noop", "current_time"]);
     }
 
     #[test]
@@ -1041,17 +1032,11 @@ mod tests {
         // Order should be preserved in applied_ids
         let applied = apply_capabilities(
             base_runtime_agent,
-            &[
-                CapabilityId::CURRENT_TIME.to_string(),
-                CapabilityId::NOOP.to_string(),
-            ],
+            &["current_time".to_string(), "noop".to_string()],
             &registry,
         );
 
-        assert_eq!(
-            applied.applied_ids,
-            vec![CapabilityId::CURRENT_TIME, CapabilityId::NOOP]
-        );
+        assert_eq!(applied.applied_ids, vec!["current_time", "noop"]);
     }
 
     #[test]
@@ -1061,7 +1046,7 @@ mod tests {
 
         let applied = apply_capabilities(
             base_runtime_agent.clone(),
-            &[CapabilityId::TEST_MATH.to_string()],
+            &["test_math".to_string()],
             &registry,
         );
 
@@ -1081,7 +1066,7 @@ mod tests {
 
         let applied = apply_capabilities(
             base_runtime_agent.clone(),
-            &[CapabilityId::TEST_WEATHER.to_string()],
+            &["test_weather".to_string()],
             &registry,
         );
 
@@ -1104,10 +1089,7 @@ mod tests {
 
         let applied = apply_capabilities(
             base_runtime_agent.clone(),
-            &[
-                CapabilityId::TEST_MATH.to_string(),
-                CapabilityId::TEST_WEATHER.to_string(),
-            ],
+            &["test_math".to_string(), "test_weather".to_string()],
             &registry,
         );
 
@@ -1124,7 +1106,7 @@ mod tests {
 
         let applied = apply_capabilities(
             base_runtime_agent.clone(),
-            &[CapabilityId::STATELESS_TODO_LIST.to_string()],
+            &["stateless_todo_list".to_string()],
             &registry,
         );
 
@@ -1147,7 +1129,7 @@ mod tests {
 
         let applied = apply_capabilities(
             base_runtime_agent.clone(),
-            &[CapabilityId::WEB_FETCH.to_string()],
+            &["web_fetch".to_string()],
             &registry,
         );
 
@@ -1171,7 +1153,7 @@ mod tests {
     fn test_collect_capabilities_includes_mounts() {
         let registry = CapabilityRegistry::with_builtins();
 
-        let collected = collect_capabilities(&[CapabilityId::SAMPLE_DATA.to_string()], &registry);
+        let collected = collect_capabilities(&["sample_data".to_string()], &registry);
 
         assert!(!collected.mounts.is_empty());
         assert_eq!(collected.mounts.len(), 1);
@@ -1184,7 +1166,7 @@ mod tests {
         let registry = CapabilityRegistry::with_builtins();
 
         // Most capabilities don't have mounts
-        let collected = collect_capabilities(&[CapabilityId::CURRENT_TIME.to_string()], &registry);
+        let collected = collect_capabilities(&["current_time".to_string()], &registry);
 
         assert!(collected.mounts.is_empty());
     }
@@ -1195,10 +1177,7 @@ mod tests {
 
         // Collect from multiple capabilities - only sample_data has mounts
         let collected = collect_capabilities(
-            &[
-                CapabilityId::SAMPLE_DATA.to_string(),
-                CapabilityId::CURRENT_TIME.to_string(),
-            ],
+            &["sample_data".to_string(), "current_time".to_string()],
             &registry,
         );
 
@@ -1209,9 +1188,9 @@ mod tests {
     #[test]
     fn test_sample_data_capability() {
         let registry = CapabilityRegistry::with_builtins();
-        let cap = registry.get(CapabilityId::SAMPLE_DATA).unwrap();
+        let cap = registry.get("sample_data").unwrap();
 
-        assert_eq!(cap.id(), CapabilityId::SAMPLE_DATA);
+        assert_eq!(cap.id(), "sample_data");
         assert_eq!(cap.name(), "Sample Data");
         assert_eq!(cap.status(), CapabilityStatus::Available);
 
@@ -1243,10 +1222,9 @@ mod tests {
         let registry = CapabilityRegistry::with_builtins();
 
         // CurrentTime has no dependencies
-        let resolved =
-            resolve_dependencies(&[CapabilityId::CURRENT_TIME.to_string()], &registry).unwrap();
+        let resolved = resolve_dependencies(&["current_time".to_string()], &registry).unwrap();
 
-        assert_eq!(resolved.resolved_ids, vec![CapabilityId::CURRENT_TIME]);
+        assert_eq!(resolved.resolved_ids, vec!["current_time"]);
         assert!(resolved.added_as_dependencies.is_empty());
     }
 
@@ -1255,28 +1233,24 @@ mod tests {
         let registry = CapabilityRegistry::with_builtins();
 
         // SampleData depends on FileSystem
-        let resolved =
-            resolve_dependencies(&[CapabilityId::SAMPLE_DATA.to_string()], &registry).unwrap();
+        let resolved = resolve_dependencies(&["sample_data".to_string()], &registry).unwrap();
 
         // FileSystem should be resolved before SampleData
         assert_eq!(resolved.resolved_ids.len(), 2);
         let fs_pos = resolved
             .resolved_ids
             .iter()
-            .position(|id| id == CapabilityId::FILE_SYSTEM)
+            .position(|id| id == "session_file_system")
             .unwrap();
         let sd_pos = resolved
             .resolved_ids
             .iter()
-            .position(|id| id == CapabilityId::SAMPLE_DATA)
+            .position(|id| id == "sample_data")
             .unwrap();
         assert!(fs_pos < sd_pos, "FileSystem should come before SampleData");
 
         // FileSystem was added as a dependency
-        assert_eq!(
-            resolved.added_as_dependencies,
-            vec![CapabilityId::FILE_SYSTEM]
-        );
+        assert_eq!(resolved.added_as_dependencies, vec!["session_file_system"]);
     }
 
     #[test]
@@ -1285,10 +1259,7 @@ mod tests {
 
         // If dependency is already selected, it shouldn't be duplicated
         let resolved = resolve_dependencies(
-            &[
-                CapabilityId::FILE_SYSTEM.to_string(),
-                CapabilityId::SAMPLE_DATA.to_string(),
-            ],
+            &["session_file_system".to_string(), "sample_data".to_string()],
             &registry,
         )
         .unwrap();
@@ -1303,19 +1274,11 @@ mod tests {
         let registry = CapabilityRegistry::with_builtins();
 
         // Multiple independent capabilities should maintain their relative order
-        let resolved = resolve_dependencies(
-            &[
-                CapabilityId::CURRENT_TIME.to_string(),
-                CapabilityId::NOOP.to_string(),
-            ],
-            &registry,
-        )
-        .unwrap();
+        let resolved =
+            resolve_dependencies(&["current_time".to_string(), "noop".to_string()], &registry)
+                .unwrap();
 
-        assert_eq!(
-            resolved.resolved_ids,
-            vec![CapabilityId::CURRENT_TIME, CapabilityId::NOOP]
-        );
+        assert_eq!(resolved.resolved_ids, vec!["current_time", "noop"]);
     }
 
     #[test]
@@ -1334,11 +1297,11 @@ mod tests {
         let registry = CapabilityRegistry::with_builtins();
 
         // SampleData depends on FileSystem
-        let deps = get_dependencies(CapabilityId::SAMPLE_DATA, &registry);
-        assert_eq!(deps, vec![CapabilityId::FILE_SYSTEM]);
+        let deps = get_dependencies("sample_data", &registry);
+        assert_eq!(deps, vec!["session_file_system"]);
 
         // CurrentTime has no dependencies
-        let deps = get_dependencies(CapabilityId::CURRENT_TIME, &registry);
+        let deps = get_dependencies("current_time", &registry);
         assert!(deps.is_empty());
 
         // Unknown capability
@@ -1349,17 +1312,17 @@ mod tests {
     #[test]
     fn test_sample_data_has_dependency() {
         let registry = CapabilityRegistry::with_builtins();
-        let cap = registry.get(CapabilityId::SAMPLE_DATA).unwrap();
+        let cap = registry.get("sample_data").unwrap();
 
         let deps = cap.dependencies();
         assert_eq!(deps.len(), 1);
-        assert_eq!(deps[0], CapabilityId::FILE_SYSTEM);
+        assert_eq!(deps[0], "session_file_system");
     }
 
     #[test]
     fn test_noop_has_no_dependencies() {
         let registry = CapabilityRegistry::with_builtins();
-        let cap = registry.get(CapabilityId::NOOP).unwrap();
+        let cap = registry.get("noop").unwrap();
 
         assert!(cap.dependencies().is_empty());
     }
@@ -1475,7 +1438,7 @@ mod tests {
     fn test_collect_capabilities_with_configs_no_filter_providers() {
         let registry = CapabilityRegistry::with_builtins();
         let configs = vec![AgentCapabilityConfig {
-            capability_ref: CapabilityId::new(CapabilityId::CURRENT_TIME),
+            capability_ref: CapabilityId::new("current_time"),
             config: serde_json::json!({}),
         }];
 
@@ -1677,10 +1640,10 @@ mod tests {
     fn test_capability_without_message_filter_returns_none() {
         let registry = CapabilityRegistry::with_builtins();
 
-        let noop = registry.get(CapabilityId::NOOP).unwrap();
+        let noop = registry.get("noop").unwrap();
         assert!(noop.message_filter_provider().is_none());
 
-        let current_time = registry.get(CapabilityId::CURRENT_TIME).unwrap();
+        let current_time = registry.get("current_time").unwrap();
         assert!(current_time.message_filter_provider().is_none());
     }
 

--- a/crates/core/src/capabilities/noop.rs
+++ b/crates/core/src/capabilities/noop.rs
@@ -1,13 +1,13 @@
 //! Noop Capability - for testing and demonstration purposes
 
-use super::{Capability, CapabilityId, CapabilityStatus};
+use super::{Capability, CapabilityStatus};
 
 /// Noop capability - for testing and demonstration purposes
 pub struct NoopCapability;
 
 impl Capability for NoopCapability {
     fn id(&self) -> &str {
-        CapabilityId::NOOP
+        "noop"
     }
 
     fn name(&self) -> &str {

--- a/crates/core/src/capabilities/research.rs
+++ b/crates/core/src/capabilities/research.rs
@@ -1,13 +1,13 @@
 //! Research Capability - for deep research with organized findings (coming soon)
 
-use super::{Capability, CapabilityId, CapabilityStatus};
+use super::{Capability, CapabilityStatus};
 
 /// Research capability - for deep research with organized findings (coming soon)
 pub struct ResearchCapability;
 
 impl Capability for ResearchCapability {
     fn id(&self) -> &str {
-        CapabilityId::RESEARCH
+        "research"
     }
 
     fn name(&self) -> &str {

--- a/crates/core/src/capabilities/sample_data.rs
+++ b/crates/core/src/capabilities/sample_data.rs
@@ -9,7 +9,7 @@
 //! - `/samples/config.yaml` - Sample configuration
 //! - `/samples/README.md` - Documentation about the sample files
 
-use super::{Capability, CapabilityId, CapabilityStatus, MountDirectoryBuilder, MountPoint};
+use super::{Capability, CapabilityStatus, MountDirectoryBuilder, MountPoint};
 
 /// Sample Data capability - demonstrates capability mounting
 pub struct SampleDataCapability;
@@ -99,7 +99,7 @@ data formats commonly used in applications.
 
 impl Capability for SampleDataCapability {
     fn id(&self) -> &str {
-        CapabilityId::SAMPLE_DATA
+        "sample_data"
     }
 
     fn name(&self) -> &str {
@@ -145,7 +145,7 @@ These files are read-only and can be used for learning, testing, or as templates
 
     fn dependencies(&self) -> Vec<&'static str> {
         // Sample Data depends on Session File System for file operations
-        vec![CapabilityId::FILE_SYSTEM]
+        vec!["session_file_system"]
     }
 }
 
@@ -157,7 +157,7 @@ mod tests {
     #[test]
     fn test_capability_metadata() {
         let cap = SampleDataCapability;
-        assert_eq!(cap.id(), CapabilityId::SAMPLE_DATA);
+        assert_eq!(cap.id(), "sample_data");
         assert_eq!(cap.name(), "Sample Data");
         assert_eq!(cap.status(), CapabilityStatus::Available);
         assert_eq!(cap.icon(), Some("database"));
@@ -224,6 +224,6 @@ mod tests {
         let cap = SampleDataCapability;
         let deps = cap.dependencies();
         assert_eq!(deps.len(), 1);
-        assert_eq!(deps[0], CapabilityId::FILE_SYSTEM);
+        assert_eq!(deps[0], "session_file_system");
     }
 }

--- a/crates/core/src/capabilities/sandbox.rs
+++ b/crates/core/src/capabilities/sandbox.rs
@@ -1,13 +1,13 @@
 //! Sandbox Capability - for sandboxed code execution (coming soon)
 
-use super::{Capability, CapabilityId, CapabilityStatus};
+use super::{Capability, CapabilityStatus};
 
 /// Sandbox capability - for sandboxed code execution (coming soon)
 pub struct SandboxCapability;
 
 impl Capability for SandboxCapability {
     fn id(&self) -> &str {
-        CapabilityId::SANDBOX
+        "sandbox"
     }
 
     fn name(&self) -> &str {

--- a/crates/core/src/capabilities/session_storage.rs
+++ b/crates/core/src/capabilities/session_storage.rs
@@ -7,7 +7,7 @@
 //! - `kv_store`: Key/value storage operations (set, get, delete, list)
 //! - `secret_store`: Encrypted secret storage operations (set, get, delete, list)
 
-use super::{Capability, CapabilityId, CapabilityStatus};
+use super::{Capability, CapabilityStatus};
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
@@ -18,7 +18,7 @@ pub struct SessionStorageCapability;
 
 impl Capability for SessionStorageCapability {
     fn id(&self) -> &str {
-        CapabilityId::SESSION_STORAGE
+        "session_storage"
     }
 
     fn name(&self) -> &str {
@@ -457,7 +457,7 @@ mod tests {
     #[test]
     fn test_capability_metadata() {
         let cap = SessionStorageCapability;
-        assert_eq!(cap.id(), CapabilityId::SESSION_STORAGE);
+        assert_eq!(cap.id(), "session_storage");
         assert_eq!(cap.name(), "Session Storage");
         assert_eq!(cap.status(), CapabilityStatus::Available);
         assert_eq!(cap.icon(), Some("database"));

--- a/crates/core/src/capabilities/stateless_todo_list.rs
+++ b/crates/core/src/capabilities/stateless_todo_list.rs
@@ -38,7 +38,7 @@
 //! Consider adding context compaction (prune old write_todos calls) if context
 //! growth becomes an issue in long-running sessions.
 
-use super::{Capability, CapabilityId, CapabilityStatus};
+use super::{Capability, CapabilityStatus};
 use crate::tools::{Tool, ToolExecutionResult};
 use async_trait::async_trait;
 use serde_json::Value;
@@ -49,7 +49,7 @@ pub struct StatelessTodoListCapability;
 
 impl Capability for StatelessTodoListCapability {
     fn id(&self) -> &str {
-        CapabilityId::STATELESS_TODO_LIST
+        "stateless_todo_list"
     }
 
     fn name(&self) -> &str {
@@ -304,7 +304,7 @@ mod tests {
     fn test_capability_metadata() {
         let capability = StatelessTodoListCapability;
 
-        assert_eq!(capability.id(), CapabilityId::STATELESS_TODO_LIST);
+        assert_eq!(capability.id(), "stateless_todo_list");
         assert_eq!(capability.name(), "Task Management");
         assert_eq!(capability.icon(), Some("list-checks"));
         assert_eq!(capability.category(), Some("Productivity"));

--- a/crates/core/src/capabilities/test_math.rs
+++ b/crates/core/src/capabilities/test_math.rs
@@ -1,6 +1,6 @@
 //! TestMath Capability - calculator tools for testing tool calling
 
-use super::{Capability, CapabilityId, CapabilityStatus};
+use super::{Capability, CapabilityStatus};
 use crate::tools::{Tool, ToolExecutionResult};
 use async_trait::async_trait;
 use serde_json::Value;
@@ -10,7 +10,7 @@ pub struct TestMathCapability;
 
 impl Capability for TestMathCapability {
     fn id(&self) -> &str {
-        CapabilityId::TEST_MATH
+        "test_math"
     }
 
     fn name(&self) -> &str {

--- a/crates/core/src/capabilities/test_weather.rs
+++ b/crates/core/src/capabilities/test_weather.rs
@@ -1,6 +1,6 @@
 //! TestWeather Capability - mock weather tools for testing tool calling
 
-use super::{Capability, CapabilityId, CapabilityStatus};
+use super::{Capability, CapabilityStatus};
 use crate::tools::{Tool, ToolExecutionResult};
 use async_trait::async_trait;
 use serde_json::Value;
@@ -10,7 +10,7 @@ pub struct TestWeatherCapability;
 
 impl Capability for TestWeatherCapability {
     fn id(&self) -> &str {
-        CapabilityId::TEST_WEATHER
+        "test_weather"
     }
 
     fn name(&self) -> &str {

--- a/crates/core/src/capabilities/web_fetch.rs
+++ b/crates/core/src/capabilities/web_fetch.rs
@@ -9,7 +9,7 @@
 //! - Timeout for first byte: 1 second (connect + time to first response byte)
 //! - Timeout for body: 30 seconds total, partial content returned if exceeded
 
-use super::{Capability, CapabilityId, CapabilityStatus};
+use super::{Capability, CapabilityStatus};
 use crate::tools::{Tool, ToolExecutionResult};
 use async_trait::async_trait;
 use fetchkit::{FetchError, FetchRequest, TOOL_DESCRIPTION, TOOL_LLMTXT, fetch};
@@ -20,7 +20,7 @@ pub struct WebFetchCapability;
 
 impl Capability for WebFetchCapability {
     fn id(&self) -> &str {
-        CapabilityId::WEB_FETCH
+        "web_fetch"
     }
 
     fn name(&self) -> &str {

--- a/crates/core/src/capability_dto.rs
+++ b/crates/core/src/capability_dto.rs
@@ -89,7 +89,7 @@ mod tests {
     #[test]
     fn test_capability_info_serialization() {
         let cap = CapabilityInfo {
-            id: CapabilityId::research(),
+            id: CapabilityId::new("research"),
             name: "Research".to_string(),
             description: "Deep research capability".to_string(),
             status: CapabilityStatus::Available,
@@ -152,7 +152,7 @@ mod tests {
     #[test]
     fn test_agent_capability_serialization() {
         let agent_cap = AgentCapability {
-            capability_id: CapabilityId::sandbox(),
+            capability_id: CapabilityId::new("sandbox"),
             position: 1,
         };
 
@@ -164,8 +164,11 @@ mod tests {
     #[test]
     fn test_test_capabilities() {
         // Verify test math and weather capabilities are available
-        assert_eq!(CapabilityId::test_math().to_string(), "test_math");
-        assert_eq!(CapabilityId::test_weather().to_string(), "test_weather");
+        assert_eq!(CapabilityId::new("test_math").to_string(), "test_math");
+        assert_eq!(
+            CapabilityId::new("test_weather").to_string(),
+            "test_weather"
+        );
     }
 
     #[test]

--- a/crates/core/src/capability_types.rs
+++ b/crates/core/src/capability_types.rs
@@ -1,8 +1,9 @@
 // Capability type definitions
 //
-// Design Decision: Capability IDs are now String-based to allow adding new capabilities
-// without requiring database migrations or code changes to enums.
-// Validation happens at the registry level rather than the type level.
+// Design Decision: Capability IDs are String-based to allow adding new capabilities
+// without requiring database migrations or code changes. Each capability defines its
+// own ID via the Capability trait's id() method - no central registry of IDs needed.
+// Validation happens at the registry level (capability must be registered).
 //
 // Design Decision: AgentCapabilityConfig uses `ref` for the capability ID to avoid
 // confusion with `id` which typically refers to primary keys. The config field stores
@@ -23,6 +24,7 @@ use utoipa::ToSchema;
 ///
 /// This allows new capabilities to be added without database changes.
 /// The ID is validated at runtime against the capability registry.
+/// Capabilities define their own IDs via the Capability trait's id() method.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct CapabilityId(String);
@@ -36,108 +38,6 @@ impl CapabilityId {
     /// Get the ID as a string slice
     pub fn as_str(&self) -> &str {
         &self.0
-    }
-
-    // Built-in capability ID constants for convenience
-    pub const NOOP: &'static str = "noop";
-    pub const CURRENT_TIME: &'static str = "current_time";
-    pub const RESEARCH: &'static str = "research";
-    pub const SANDBOX: &'static str = "sandbox";
-    pub const FILE_SYSTEM: &'static str = "session_file_system";
-    pub const TEST_MATH: &'static str = "test_math";
-    pub const TEST_WEATHER: &'static str = "test_weather";
-    pub const STATELESS_TODO_LIST: &'static str = "stateless_todo_list";
-    pub const WEB_FETCH: &'static str = "web_fetch";
-    // Fake demo capability ID constants
-    pub const FAKE_WAREHOUSE: &'static str = "fake_warehouse";
-    pub const FAKE_AWS: &'static str = "fake_aws";
-    pub const FAKE_CRM: &'static str = "fake_crm";
-    pub const FAKE_FINANCIAL: &'static str = "fake_financial";
-    // Demo capability with mount points
-    pub const SAMPLE_DATA: &'static str = "sample_data";
-    // Session storage capability (key/value and secrets)
-    pub const SESSION_STORAGE: &'static str = "session_storage";
-    // Experimental capability ID constants
-    pub const DOCKER_CONTAINER: &'static str = "docker_container";
-
-    /// Create the noop capability ID
-    pub fn noop() -> Self {
-        Self::new(Self::NOOP)
-    }
-
-    /// Create the current_time capability ID
-    pub fn current_time() -> Self {
-        Self::new(Self::CURRENT_TIME)
-    }
-
-    /// Create the research capability ID
-    pub fn research() -> Self {
-        Self::new(Self::RESEARCH)
-    }
-
-    /// Create the sandbox capability ID
-    pub fn sandbox() -> Self {
-        Self::new(Self::SANDBOX)
-    }
-
-    /// Create the file_system capability ID
-    pub fn file_system() -> Self {
-        Self::new(Self::FILE_SYSTEM)
-    }
-
-    /// Create the test_math capability ID
-    pub fn test_math() -> Self {
-        Self::new(Self::TEST_MATH)
-    }
-
-    /// Create the test_weather capability ID
-    pub fn test_weather() -> Self {
-        Self::new(Self::TEST_WEATHER)
-    }
-
-    /// Create the stateless_todo_list capability ID
-    pub fn stateless_todo_list() -> Self {
-        Self::new(Self::STATELESS_TODO_LIST)
-    }
-
-    /// Create the web_fetch capability ID
-    pub fn web_fetch() -> Self {
-        Self::new(Self::WEB_FETCH)
-    }
-
-    /// Create the fake_warehouse capability ID
-    pub fn fake_warehouse() -> Self {
-        Self::new(Self::FAKE_WAREHOUSE)
-    }
-
-    /// Create the fake_aws capability ID
-    pub fn fake_aws() -> Self {
-        Self::new(Self::FAKE_AWS)
-    }
-
-    /// Create the fake_crm capability ID
-    pub fn fake_crm() -> Self {
-        Self::new(Self::FAKE_CRM)
-    }
-
-    /// Create the fake_financial capability ID
-    pub fn fake_financial() -> Self {
-        Self::new(Self::FAKE_FINANCIAL)
-    }
-
-    /// Create the sample_data capability ID
-    pub fn sample_data() -> Self {
-        Self::new(Self::SAMPLE_DATA)
-    }
-
-    /// Create the session_storage capability ID
-    pub fn session_storage() -> Self {
-        Self::new(Self::SESSION_STORAGE)
-    }
-
-    /// Create the docker_container capability ID
-    pub fn docker_container() -> Self {
-        Self::new(Self::DOCKER_CONTAINER)
     }
 }
 
@@ -436,74 +336,27 @@ mod tests {
 
     #[test]
     fn test_capability_id_display() {
-        assert_eq!(CapabilityId::noop().to_string(), "noop");
-        assert_eq!(CapabilityId::current_time().to_string(), "current_time");
-        assert_eq!(CapabilityId::research().to_string(), "research");
-        assert_eq!(CapabilityId::sandbox().to_string(), "sandbox");
+        assert_eq!(CapabilityId::new("noop").to_string(), "noop");
         assert_eq!(
-            CapabilityId::file_system().to_string(),
-            "session_file_system"
+            CapabilityId::new("current_time").to_string(),
+            "current_time"
         );
-        assert_eq!(
-            CapabilityId::session_storage().to_string(),
-            "session_storage"
-        );
-        assert_eq!(CapabilityId::test_math().to_string(), "test_math");
-        assert_eq!(CapabilityId::test_weather().to_string(), "test_weather");
-        assert_eq!(
-            CapabilityId::stateless_todo_list().to_string(),
-            "stateless_todo_list"
-        );
-        assert_eq!(CapabilityId::web_fetch().to_string(), "web_fetch");
     }
 
     #[test]
     fn test_capability_id_from_str() {
         assert_eq!(
             "noop".parse::<CapabilityId>().unwrap(),
-            CapabilityId::noop()
+            CapabilityId::new("noop")
         );
         assert_eq!(
             "current_time".parse::<CapabilityId>().unwrap(),
-            CapabilityId::current_time()
-        );
-        assert_eq!(
-            "research".parse::<CapabilityId>().unwrap(),
-            CapabilityId::research()
-        );
-        assert_eq!(
-            "sandbox".parse::<CapabilityId>().unwrap(),
-            CapabilityId::sandbox()
-        );
-        assert_eq!(
-            "session_file_system".parse::<CapabilityId>().unwrap(),
-            CapabilityId::file_system()
-        );
-        assert_eq!(
-            "session_storage".parse::<CapabilityId>().unwrap(),
-            CapabilityId::session_storage()
-        );
-        assert_eq!(
-            "test_math".parse::<CapabilityId>().unwrap(),
-            CapabilityId::test_math()
-        );
-        assert_eq!(
-            "test_weather".parse::<CapabilityId>().unwrap(),
-            CapabilityId::test_weather()
-        );
-        assert_eq!(
-            "stateless_todo_list".parse::<CapabilityId>().unwrap(),
-            CapabilityId::stateless_todo_list()
-        );
-        assert_eq!(
-            "web_fetch".parse::<CapabilityId>().unwrap(),
-            CapabilityId::web_fetch()
+            CapabilityId::new("current_time")
         );
     }
 
     #[test]
     fn test_capability_id_from_custom_string() {
-        // Custom capability IDs should work
         let custom = CapabilityId::new("my_custom_capability");
         assert_eq!(custom.to_string(), "my_custom_capability");
         assert_eq!(custom.as_str(), "my_custom_capability");
@@ -511,7 +364,7 @@ mod tests {
 
     #[test]
     fn test_capability_id_serialization() {
-        let id = CapabilityId::current_time();
+        let id = CapabilityId::new("current_time");
         let json = serde_json::to_string(&id).unwrap();
         assert_eq!(json, "\"current_time\"");
 
@@ -523,8 +376,8 @@ mod tests {
     fn test_capability_id_hash() {
         use std::collections::HashSet;
         let mut set = HashSet::new();
-        set.insert(CapabilityId::noop());
-        set.insert(CapabilityId::current_time());
+        set.insert(CapabilityId::new("noop"));
+        set.insert(CapabilityId::new("current_time"));
         set.insert(CapabilityId::new("noop")); // Should not add a duplicate
 
         assert_eq!(set.len(), 2);
@@ -551,7 +404,7 @@ mod tests {
 
     #[test]
     fn test_agent_capability_config_from_capability_id() {
-        let config: AgentCapabilityConfig = CapabilityId::current_time().into();
+        let config: AgentCapabilityConfig = CapabilityId::new("current_time").into();
         assert_eq!(config.capability_id(), "current_time");
         assert_eq!(config.config, serde_json::json!({}));
     }

--- a/crates/core/src/runtime_agent.rs
+++ b/crates/core/src/runtime_agent.rs
@@ -225,7 +225,7 @@ impl Default for RuntimeAgentBuilder {
 mod tests {
     use super::*;
     use crate::agent::AgentStatus;
-    use crate::capabilities::{AgentCapabilityConfig, CapabilityId};
+    use crate::capabilities::AgentCapabilityConfig;
 
     #[test]
     fn test_runtime_agent_new() {
@@ -316,7 +316,7 @@ mod tests {
         let registry = CapabilityRegistry::with_builtins();
         let runtime_agent = RuntimeAgentBuilder::new()
             .system_prompt("Base prompt.")
-            .with_capabilities(&[CapabilityId::CURRENT_TIME.to_string()], &registry)
+            .with_capabilities(&["current_time".to_string()], &registry)
             .build();
 
         assert_eq!(runtime_agent.tools.len(), 1);
@@ -332,7 +332,7 @@ mod tests {
         let registry = CapabilityRegistry::with_builtins();
         let runtime_agent = RuntimeAgentBuilder::new()
             .system_prompt("Base prompt.")
-            .with_capabilities(&[CapabilityId::TEST_MATH.to_string()], &registry)
+            .with_capabilities(&["test_math".to_string()], &registry)
             .build();
 
         assert!(runtime_agent.system_prompt.contains("math tools"));
@@ -351,7 +351,7 @@ mod tests {
             name: "Test Agent".to_string(),
             description: None,
             system_prompt: "Agent prompt.".to_string(),
-            capabilities: vec![AgentCapabilityConfig::new(CapabilityId::CURRENT_TIME)],
+            capabilities: vec![AgentCapabilityConfig::new("current_time")],
             status: AgentStatus::Active,
             default_model_id: None,
             tags: vec![],
@@ -390,7 +390,7 @@ mod tests {
         let registry = CapabilityRegistry::with_builtins();
         let runtime_agent = RuntimeAgentBuilder::new()
             .system_prompt("Base prompt.")
-            .with_capabilities(&[CapabilityId::SAMPLE_DATA.to_string()], &registry)
+            .with_capabilities(&["sample_data".to_string()], &registry)
             .build();
 
         // System prompt should include File System's contribution (the dependency)

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -111,7 +111,7 @@ Capability IDs are string-based for extensibility. New capabilities can be added
 | Built-in | `snake_case` identifier | `current_time`, `web_fetch` |
 | MCP | `mcp:{server_uuid}` | `mcp:01933b5a-0000-7000-8000-000000000501` |
 
-**Built-in IDs** are static constants defined in code. They use `snake_case` naming and are validated against the `CapabilityRegistry`.
+**Built-in IDs** use `snake_case` naming and are validated against the `CapabilityRegistry`. Each capability defines its own ID via the `Capability` trait's `id()` method.
 
 **MCP IDs** use the `mcp:` prefix followed by the MCP server's UUID. These are dynamic—they exist only when the corresponding MCP server exists. See `specs/mcp-servers.md` for details.
 
@@ -133,28 +133,15 @@ Capability IDs are string-based for extensibility. New capabilities can be added
 | `sandbox` | Sandbox | Execution | Coming Soon |
 
 ```rust
+/// Simple string wrapper - capabilities define their own IDs via id() method
 pub struct CapabilityId(String);
 
 impl CapabilityId {
-    // Built-in capability ID constants
-    pub const NOOP: &'static str = "noop";
-    pub const CURRENT_TIME: &'static str = "current_time";
-    pub const RESEARCH: &'static str = "research";
-    pub const SANDBOX: &'static str = "sandbox";
-    pub const FILE_SYSTEM: &'static str = "session_file_system";
-    pub const TEST_MATH: &'static str = "test_math";
-    pub const TEST_WEATHER: &'static str = "test_weather";
-    pub const STATELESS_TODO_LIST: &'static str = "stateless_todo_list";
-    pub const WEB_FETCH: &'static str = "web_fetch";
-    pub const DOCKER_CONTAINER: &'static str = "docker_container"; // Experimental
-
-    // Factory methods
+    /// Create a new capability ID from a string
     pub fn new(id: impl Into<String>) -> Self;
-    pub fn noop() -> Self;
-    pub fn current_time() -> Self;
-    pub fn stateless_todo_list() -> Self;
-    pub fn web_fetch() -> Self;
-    // ... etc
+
+    /// Get the ID as a string slice
+    pub fn as_str(&self) -> &str;
 }
 ```
 
@@ -831,7 +818,7 @@ CREATE INDEX idx_agent_capabilities_position ON agent_capabilities(agent_id, pos
 | Order of application? | By `position` field (lower = earlier) |
 | Can capabilities conflict? | Currently no conflict resolution; later capabilities add to earlier ones |
 | Can users create custom capabilities? | Not in current version (built-in only) |
-| How are new capabilities added? | Implement `Capability` trait and register in `CapabilityRegistry` - no database changes needed |
+| How are new capabilities added? | Implement `Capability` trait with unique `id()` and register in `CapabilityRegistry` - no database changes or central ID definitions needed |
 
 ### Adding New Capabilities
 


### PR DESCRIPTION
## What

Remove CapabilityId constants and factory methods. Each capability now defines its own ID via the Capability trait's `id()` method as a simple string literal.

## Why

Capabilities should be addable/removable without changes to central factories or fixed ID lists. The distinction between "capability type" and "capability id" was unclear - now there's just capability IDs defined by each capability.

## How

- Removed `CapabilityId` constants (`NOOP`, `CURRENT_TIME`, etc.)
- Removed `CapabilityId` factory methods (`noop()`, `current_time()`, etc.)
- Kept `CapabilityId` as simple String wrapper with `new()` and `as_str()`
- Updated all capability implementations to return string literals in `id()`
- Updated all tests to use string literals directly
- Updated `specs/capabilities.md` to reflect simplified design

## Risk

- Low
- Only refactoring internal types; no API changes
- Existing stored capability IDs (strings) remain unchanged

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (no breaking changes)