### PR TITLE
fix(worker): add startup retry for control-plane connection

### DIFF
--- a/crates/worker/src/grpc_durable_store.rs
+++ b/crates/worker/src/grpc_durable_store.rs
@@ -29,11 +29,60 @@ pub struct GrpcDurableStore {
 }
 
 impl GrpcDurableStore {
-    /// Connect to the control-plane gRPC service
+    /// Connect to the control-plane gRPC service with retry logic.
+    /// Retries with exponential backoff for up to 5 seconds total.
     pub async fn connect(address: &str) -> Result<Self> {
+        use std::time::Duration;
+        use tokio::time::sleep;
+
         let endpoint = format!("http://{}", address);
-        let client = WorkerServiceClient::connect(endpoint).await?;
-        Ok(Self { client })
+        let max_duration = Duration::from_secs(5);
+        let initial_backoff = Duration::from_millis(100);
+        let max_backoff = Duration::from_secs(1);
+
+        let start = std::time::Instant::now();
+        let mut backoff = initial_backoff;
+        let mut attempt = 0;
+
+        loop {
+            attempt += 1;
+            match WorkerServiceClient::connect(endpoint.clone()).await {
+                Ok(client) => {
+                    if attempt > 1 {
+                        tracing::info!(
+                            address = %address,
+                            attempts = attempt,
+                            elapsed_ms = start.elapsed().as_millis(),
+                            "Connected to control-plane gRPC"
+                        );
+                    }
+                    return Ok(Self { client });
+                }
+                Err(e) => {
+                    let elapsed = start.elapsed();
+                    if elapsed >= max_duration {
+                        return Err(anyhow::anyhow!(
+                            "Failed to connect to control-plane at {} after {:.1}s ({} attempts): {}",
+                            address,
+                            elapsed.as_secs_f32(),
+                            attempt,
+                            e
+                        ));
+                    }
+
+                    tracing::debug!(
+                        address = %address,
+                        attempt = attempt,
+                        backoff_ms = backoff.as_millis(),
+                        error = %e,
+                        "Control-plane not available, retrying..."
+                    );
+
+                    sleep(backoff).await;
+                    backoff = std::cmp::min(backoff * 2, max_backoff);
+                }
+            }
+        }
     }
 
     /// Create a new durable workflow

--- a/crates/worker/src/grpc_durable_store.rs
+++ b/crates/worker/src/grpc_durable_store.rs
@@ -576,4 +576,40 @@ mod tests {
         assert!(WorkflowStatus::Failed.is_terminal());
         assert!(WorkflowStatus::Cancelled.is_terminal());
     }
+
+    #[tokio::test]
+    async fn test_connect_fails_after_timeout_on_unavailable_server() {
+        // Verify connection fails with clear error after retry timeout
+        // when control-plane is unavailable
+        let start = std::time::Instant::now();
+        let result = GrpcDurableStore::connect("127.0.0.1:19999").await;
+
+        assert!(result.is_err());
+        let elapsed = start.elapsed();
+
+        // Should take ~5 seconds (the retry timeout)
+        assert!(
+            elapsed.as_secs() >= 4,
+            "Should retry for at least 4 seconds, got {:?}",
+            elapsed
+        );
+        assert!(
+            elapsed.as_secs() <= 7,
+            "Should not take more than 7 seconds, got {:?}",
+            elapsed
+        );
+
+        // Error message should be helpful
+        let err_msg = result.err().expect("Expected error").to_string();
+        assert!(
+            err_msg.contains("127.0.0.1:19999"),
+            "Error should contain address: {}",
+            err_msg
+        );
+        assert!(
+            err_msg.contains("5") || err_msg.contains("attempts"),
+            "Error should mention timeout or attempts: {}",
+            err_msg
+        );
+    }
 }

--- a/specs/durable-execution-engine.md
+++ b/specs/durable-execution-engine.md
@@ -174,6 +174,8 @@ Latency improvement:
 
 **Task Distribution**: Push-based via gRPC streaming. Workers subscribe to `SubscribeTaskNotifications` and receive immediate notifications when tasks are enqueued. Falls back to polling (10s interval) if stream disconnects.
 
+**Startup**: Workers retry connecting to control-plane for up to 5 seconds with exponential backoff (100ms → 1s). This handles startup race conditions when both services restart simultaneously.
+
 ## Benchmarks
 
 Load tests for validating performance and scalability. Located in `crates/durable/benches/`.


### PR DESCRIPTION
## What
Add retry logic for worker startup connection to control-plane gRPC server.

## Why
When using `just start-all` with cargo-watch, the worker might restart before the control-plane is ready. This causes immediate failure instead of waiting for the control-plane to become available.

## How
- `GrpcDurableStore::connect()` now retries with exponential backoff (100ms → 1s) for up to 5 seconds
- Silent on immediate success, logs info if retries were needed
- Clear error message after timeout with attempt count

## Risk
- Low
- Only affects startup behavior; no impact on running worker

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Specs updated