### PR TITLE
refactor(proto): make ResolveImageResponse and TaskNotification fields required

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1230,6 +1230,7 @@ dependencies = [
  "chrono",
  "everruns-core",
  "prost",
+ "prost-build",
  "prost-types",
  "protox",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ tonic-build = "0.12"
 
 # Protocol Buffers (used by tonic/gRPC)
 prost = "0.13"
+prost-build = "0.13"
 prost-types = "0.13"
 
 # Image processing (for thumbnail generation)

--- a/crates/control-plane/src/grpc_service.rs
+++ b/crates/control-plane/src/grpc_service.rs
@@ -1698,7 +1698,7 @@ impl WorkerService for WorkerServiceImpl {
                                 if activity_types_set.contains(&payload.activity_type) {
                                     let proto_notification = TaskNotification {
                                         notification_type: TaskNotificationType::TaskAvailable.into(),
-                                        activity_type: Some(payload.activity_type),
+                                        activity_type: payload.activity_type,
                                         pending_count: payload.pending_count,
                                         timestamp: Some(everruns_internal_protocol::datetime_to_proto_timestamp(
                                             chrono::Utc::now(),
@@ -1738,8 +1738,8 @@ impl WorkerService for WorkerServiceImpl {
                     _ = heartbeat_interval.tick() => {
                         let heartbeat = TaskNotification {
                             notification_type: TaskNotificationType::Heartbeat.into(),
-                            activity_type: None,
-                            pending_count: None,
+                            activity_type: String::new(),
+                            pending_count: 0,
                             timestamp: Some(everruns_internal_protocol::datetime_to_proto_timestamp(
                                 chrono::Utc::now(),
                             )),
@@ -1790,8 +1790,8 @@ impl WorkerService for WorkerServiceImpl {
             Ok(None) => {
                 return Ok(Response::new(ResolveImageResponse {
                     found: false,
-                    base64: None,
-                    media_type: None,
+                    base64: String::new(),
+                    media_type: String::new(),
                 }));
             }
             Err(e) => {
@@ -1805,8 +1805,8 @@ impl WorkerService for WorkerServiceImpl {
 
         Ok(Response::new(ResolveImageResponse {
             found: true,
-            base64: Some(base64_data),
-            media_type: Some(image_row.content_type),
+            base64: base64_data,
+            media_type: image_row.content_type,
         }))
     }
 

--- a/crates/control-plane/src/task_notifications.rs
+++ b/crates/control-plane/src/task_notifications.rs
@@ -12,7 +12,7 @@ use tracing::{debug, error, info, warn};
 #[derive(Debug, Clone)]
 pub struct TaskNotificationPayload {
     pub activity_type: String,
-    pub pending_count: Option<i32>,
+    pub pending_count: i32,
 }
 
 /// Handle for a worker subscription
@@ -152,7 +152,7 @@ impl TaskNotificationBroadcaster {
                                 // Broadcast to all subscribers
                                 let payload = TaskNotificationPayload {
                                     activity_type,
-                                    pending_count: None, // Could query count, but adds latency
+                                    pending_count: 0, // Could query count, but adds latency
                                 };
 
                                 // Ignore send errors (no receivers is fine)
@@ -190,7 +190,7 @@ mod tests {
     fn test_notification_payload_debug() {
         let payload = TaskNotificationPayload {
             activity_type: "reason".to_string(),
-            pending_count: Some(5),
+            pending_count: 5,
         };
         let debug_str = format!("{:?}", payload);
         assert!(debug_str.contains("reason"));

--- a/crates/internal-protocol/Cargo.toml
+++ b/crates/internal-protocol/Cargo.toml
@@ -37,4 +37,5 @@ chrono.workspace = true
 
 [build-dependencies]
 tonic-build.workspace = true
+prost-build.workspace = true
 protox = "0.7"

--- a/crates/internal-protocol/build.rs
+++ b/crates/internal-protocol/build.rs
@@ -1,4 +1,8 @@
 // Uses protox (pure Rust protobuf compiler) to avoid requiring external protoc binary
+//
+// Note: In proto3, message-type fields (like Uuid, Timestamp) are always optional
+// at the wire level, so prost generates them as Option<T>. The conversion code in
+// lib.rs handles validation for fields that must be present.
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Ensure rebuild triggers when proto files change (protox doesn't emit these automatically)
     println!("cargo:rerun-if-changed=proto/worker.proto");

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -689,9 +689,11 @@ message ResolveImageResponse {
     // True if image was found
     bool found = 1;
     // Base64-encoded image data (without data URL prefix)
-    optional string base64 = 2;
+    // Empty string when found=false
+    string base64 = 2;
     // MIME type (e.g., "image/png", "image/jpeg")
-    optional string media_type = 3;
+    // Empty string when found=false
+    string media_type = 3;
 }
 
 // Batch request to resolve multiple images
@@ -756,10 +758,12 @@ enum TaskNotificationType {
 
 message TaskNotification {
     TaskNotificationType notification_type = 1;
-    // Set for TASK_AVAILABLE notifications - the activity type of the available task
-    optional string activity_type = 2;
+    // The activity type of the available task
+    // Empty string for HEARTBEAT notifications
+    string activity_type = 2;
     // Approximate number of pending tasks for this activity type (hint for batch claiming)
-    optional int32 pending_count = 3;
+    // Zero for HEARTBEAT notifications
+    int32 pending_count = 3;
     // Server timestamp when notification was generated
     Timestamp timestamp = 4;
 }

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -996,12 +996,7 @@ impl ImageResolver for GrpcImageResolver {
         let inner = response.into_inner();
 
         if inner.found {
-            match (inner.base64, inner.media_type) {
-                (Some(base64), Some(media_type)) => {
-                    Ok(Some(ResolvedImage::new(base64, media_type)))
-                }
-                _ => Ok(None),
-            }
+            Ok(Some(ResolvedImage::new(inner.base64, inner.media_type)))
         } else {
             Ok(None)
         }

--- a/crates/worker/src/grpc_durable_store.rs
+++ b/crates/worker/src/grpc_durable_store.rs
@@ -412,9 +412,9 @@ pub enum TaskNotificationEvent {
     /// A task is available for claiming
     TaskAvailable {
         /// The activity type of the available task
-        activity_type: Option<String>,
+        activity_type: String,
         /// Approximate number of pending tasks (hint for batch claiming)
-        pending_count: Option<i32>,
+        pending_count: i32,
     },
     /// Heartbeat to keep the connection alive
     Heartbeat,


### PR DESCRIPTION
## What
Make optional fields required in internal protocol proto for `ResolveImageResponse` and `TaskNotification` messages.

## Why
These fields are always present in practice:
- `ResolveImageResponse.base64` and `media_type` - always set (empty string when not found)
- `TaskNotification.activity_type` and `pending_count` - always set (empty/0 for heartbeats)

Making them required simplifies conversion code by removing unnecessary `Option` wrappers.

## How
- Removed `optional` keyword from proto fields
- Updated Rust code to use non-Option values directly
- Simplified `grpc_adapters.rs` resolve_image handling

## Risk
- Low - Internal protocol only (worker ↔ control-plane)
- Breaking change but no external consumers

## Checklist
- [x] Tests pass (`cargo test --all-features --lib`)
- [x] Clippy clean (`cargo clippy --all-targets --all-features -- -D warnings`)
- [x] Rebased on latest main