### PR TITLE
fix(core): isolate event listener errors to prevent crash propagation

### DIFF
--- a/crates/control-plane/src/services/event.rs
+++ b/crates/control-plane/src/services/event.rs
@@ -43,7 +43,11 @@ impl EventService {
         }
     }
 
-    /// Notify all registered listeners about an event
+    /// Notify all registered listeners about an event.
+    ///
+    /// Each listener is called in isolation - if a listener panics or fails,
+    /// other listeners are still notified. This ensures misbehaving listeners
+    /// cannot disrupt event processing.
     async fn notify_listeners(&self, event: &Event) {
         for listener in self.listeners.iter() {
             // Check if listener wants this event type
@@ -53,7 +57,23 @@ impl EventService {
                 .unwrap_or(true); // None means all events
 
             if should_notify {
-                listener.on_event(event).await;
+                let listener_name = listener.name();
+                let listener = listener.clone();
+                let event = event.clone();
+
+                // Spawn listener in isolated task to catch panics
+                let handle = tokio::spawn(async move {
+                    listener.on_event(&event).await;
+                });
+
+                // Wait for completion, log but don't propagate panics
+                if let Err(e) = handle.await {
+                    tracing::error!(
+                        listener = listener_name,
+                        error = %e,
+                        "EventListener panicked or was cancelled"
+                    );
+                }
             }
         }
     }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -20,7 +20,8 @@ thiserror.workspace = true
 async-trait.workspace = true
 
 # Async runtime
-tokio = { workspace = true, features = ["sync"] }
+# Note: "rt" is needed for tokio::spawn in event listener isolation
+tokio = { workspace = true, features = ["sync", "rt"] }
 tokio-stream.workspace = true
 futures.workspace = true
 

--- a/crates/core/src/event_listeners.rs
+++ b/crates/core/src/event_listeners.rs
@@ -124,6 +124,11 @@ impl CompositeEventListener {
 
 #[async_trait]
 impl EventListener for CompositeEventListener {
+    /// Forward event to all inner listeners with error isolation.
+    ///
+    /// Each listener is called in isolation - if a listener panics,
+    /// other listeners are still notified. This ensures misbehaving
+    /// listeners cannot disrupt event processing.
     async fn on_event(&self, event: &Event) {
         for listener in &self.listeners {
             // Check if listener wants this event type
@@ -132,7 +137,24 @@ impl EventListener for CompositeEventListener {
             {
                 continue;
             }
-            listener.on_event(event).await;
+
+            let listener_name = listener.name();
+            let listener = listener.clone();
+            let event = event.clone();
+
+            // Spawn listener in isolated task to catch panics
+            let handle = tokio::spawn(async move {
+                listener.on_event(&event).await;
+            });
+
+            // Wait for completion, log but don't propagate panics
+            if let Err(e) = handle.await {
+                tracing::error!(
+                    listener = listener_name,
+                    error = %e,
+                    "EventListener panicked or was cancelled"
+                );
+            }
         }
     }
 
@@ -321,5 +343,126 @@ mod tests {
                 message: Message::user("Hello"),
             }),
         )
+    }
+
+    #[tokio::test]
+    async fn test_composite_listener_isolates_panics() {
+        // A listener that always panics
+        struct PanickingListener;
+
+        #[async_trait]
+        impl EventListener for PanickingListener {
+            async fn on_event(&self, _event: &Event) {
+                panic!("This listener always panics!");
+            }
+
+            fn name(&self) -> &'static str {
+                "PanickingListener"
+            }
+        }
+
+        // A counter listener to verify it still gets called
+        struct CountingListener {
+            count: Arc<AtomicU32>,
+        }
+
+        #[async_trait]
+        impl EventListener for CountingListener {
+            async fn on_event(&self, _event: &Event) {
+                self.count.fetch_add(1, Ordering::SeqCst);
+            }
+
+            fn name(&self) -> &'static str {
+                "CountingListener"
+            }
+        }
+
+        let count = Arc::new(AtomicU32::new(0));
+
+        // Put panicking listener BEFORE counting listener
+        let panicking = Arc::new(PanickingListener) as Arc<dyn EventListener>;
+        let counting = Arc::new(CountingListener {
+            count: count.clone(),
+        }) as Arc<dyn EventListener>;
+
+        let composite = CompositeEventListener::new(vec![panicking, counting]);
+
+        let event = create_test_event();
+
+        // This should NOT panic - the panicking listener should be isolated
+        composite.on_event(&event).await;
+
+        // The counting listener should still have been called
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            1,
+            "Listener after panicking listener should still execute"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_composite_listener_continues_after_panic() {
+        // Multiple listeners with a panicking one in the middle
+        struct PanickingListener;
+
+        #[async_trait]
+        impl EventListener for PanickingListener {
+            async fn on_event(&self, _event: &Event) {
+                panic!("Middle listener panics!");
+            }
+
+            fn name(&self) -> &'static str {
+                "PanickingListener"
+            }
+        }
+
+        struct CountingListener {
+            count: Arc<AtomicU32>,
+            name: &'static str,
+        }
+
+        #[async_trait]
+        impl EventListener for CountingListener {
+            async fn on_event(&self, _event: &Event) {
+                self.count.fetch_add(1, Ordering::SeqCst);
+            }
+
+            fn name(&self) -> &'static str {
+                self.name
+            }
+        }
+
+        let count_before = Arc::new(AtomicU32::new(0));
+        let count_after = Arc::new(AtomicU32::new(0));
+
+        let listener_before = Arc::new(CountingListener {
+            count: count_before.clone(),
+            name: "BeforeListener",
+        }) as Arc<dyn EventListener>;
+
+        let panicking = Arc::new(PanickingListener) as Arc<dyn EventListener>;
+
+        let listener_after = Arc::new(CountingListener {
+            count: count_after.clone(),
+            name: "AfterListener",
+        }) as Arc<dyn EventListener>;
+
+        let composite =
+            CompositeEventListener::new(vec![listener_before, panicking, listener_after]);
+
+        let event = create_test_event();
+        composite.on_event(&event).await;
+
+        // Both before and after listeners should have been called
+        assert_eq!(
+            count_before.load(Ordering::SeqCst),
+            1,
+            "Listener before panicking listener should execute"
+        );
+        assert_eq!(
+            count_after.load(Ordering::SeqCst),
+            1,
+            "Listener after panicking listener should execute"
+        );
     }
 }

--- a/specs/events.md
+++ b/specs/events.md
@@ -844,9 +844,33 @@ let event_service = EventService::with_listeners(db, vec![otel_listener]);
 ### Execution Model
 
 1. Event is persisted to database
-2. All registered listeners are notified synchronously
+2. All registered listeners are notified sequentially
 3. Listeners should not block; spawn background tasks for heavy processing
 4. Listener failures do not affect event persistence
+
+### Error Isolation
+
+Listeners are executed in isolation to ensure misbehaving listeners cannot disrupt event processing:
+
+- **Panic isolation**: Each listener runs in a separate tokio task. If a listener panics, the panic is caught and logged, but other listeners continue to execute.
+- **No error propagation**: Listener errors/panics never propagate to the event emitter or affect event persistence.
+- **Logging**: Panics are logged with `tracing::error!` including the listener name for debugging.
+- **Sequential execution**: Despite isolation, listeners are awaited sequentially to preserve ordering semantics.
+
+**Rationale:** Event listeners are pluggable integrations (OTel, metrics, audit logs) that should not affect core event processing. A bug in an observability integration should never break the application.
+
+**Implementation:**
+```rust
+// Each listener is spawned in isolation
+let handle = tokio::spawn(async move {
+    listener.on_event(&event).await;
+});
+
+// Panics are caught and logged, not propagated
+if let Err(e) = handle.await {
+    tracing::error!(listener = name, error = %e, "EventListener panicked");
+}
+```
 
 ### Custom Listeners
 


### PR DESCRIPTION
## What
Wrap each EventListener call in `tokio::spawn` to isolate panics. If a listener panics, the error is logged but other listeners continue to execute normally.

## Why
Event listeners are pluggable integrations (OTel, metrics, audit logs) that should not affect core event processing. A bug in an observability integration should never crash the application or prevent other listeners from being notified.

## How
- `EventService::notify_listeners()` now spawns each listener in a separate tokio task
- `CompositeEventListener::on_event()` uses the same isolation pattern
- Panics are caught via `JoinHandle::await` and logged with `tracing::error!`
- Added `tokio "rt"` feature to core crate for `tokio::spawn`

## Changes
- `crates/control-plane/src/services/event.rs` - isolated listener calls
- `crates/core/src/event_listeners.rs` - isolated listener calls + 2 new tests
- `crates/core/Cargo.toml` - added tokio `rt` feature
- `specs/events.md` - documented error isolation behavior

## Risk
- Low
- Only affects error handling path - normal execution unchanged
- Added tests verify isolation works correctly

## Checklist
- [x] Tests added (2 tests verifying listeners execute after a panicking listener)
- [x] Specs updated (`specs/events.md`)
- [x] Rust tests pass
- [x] Clippy passes