### PR TITLE
feat(db): add updated_at column to sessions table

### DIFF
--- a/crates/control-plane/migrations/005_session_updated_at.sql
+++ b/crates/control-plane/migrations/005_session_updated_at.sql
@@ -1,0 +1,13 @@
+-- Add updated_at column to sessions table
+--
+-- Sessions need updated_at to track when they were last modified.
+-- Uses the existing update_updated_at_column() trigger function.
+
+ALTER TABLE sessions ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+-- Backfill: Set updated_at to created_at for existing sessions
+UPDATE sessions SET updated_at = created_at;
+
+-- Create trigger to auto-update updated_at on row updates
+CREATE TRIGGER update_sessions_updated_at BEFORE UPDATE ON sessions
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/crates/control-plane/src/dev_worker/direct_adapters.rs
+++ b/crates/control-plane/src/dev_worker/direct_adapters.rs
@@ -148,6 +148,7 @@ impl SessionStore for DirectSessionStore {
                 _ => SessionStatus::Started,
             },
             created_at: r.created_at,
+            updated_at: r.updated_at,
             started_at: r.started_at,
             finished_at: r.finished_at,
             usage: None, // Usage not tracked in direct adapter context

--- a/crates/control-plane/src/grpc_service.rs
+++ b/crates/control-plane/src/grpc_service.rs
@@ -292,7 +292,7 @@ impl WorkerService for WorkerServiceImpl {
             title: session.title.clone().unwrap_or_default(),
             status: session.status.to_string(),
             created_at: Some(datetime_to_proto_timestamp(session.created_at)),
-            updated_at: Some(datetime_to_proto_timestamp(session.created_at)),
+            updated_at: Some(datetime_to_proto_timestamp(session.updated_at)),
             default_model_id: session.model_id.map(|id| uuid_to_proto_uuid(id.uuid())),
         };
 
@@ -476,7 +476,7 @@ impl WorkerService for WorkerServiceImpl {
             title: s.title.clone().unwrap_or_default(),
             status: s.status.to_string(),
             created_at: Some(datetime_to_proto_timestamp(s.created_at)),
-            updated_at: Some(datetime_to_proto_timestamp(s.created_at)),
+            updated_at: Some(datetime_to_proto_timestamp(s.updated_at)),
             default_model_id: s.model_id.map(|id| uuid_to_proto_uuid(id.uuid())),
         });
 
@@ -519,7 +519,7 @@ impl WorkerService for WorkerServiceImpl {
             title: session.title.clone().unwrap_or_default(),
             status: session.status.to_string(),
             created_at: Some(datetime_to_proto_timestamp(session.created_at)),
-            updated_at: Some(datetime_to_proto_timestamp(session.created_at)),
+            updated_at: Some(datetime_to_proto_timestamp(session.updated_at)),
             default_model_id: session.model_id.map(|id| uuid_to_proto_uuid(id.uuid())),
         };
 

--- a/crates/control-plane/src/services/session.rs
+++ b/crates/control-plane/src/services/session.rs
@@ -233,6 +233,7 @@ impl SessionService {
             model_id: row.model_id.map(|id| id.into()),
             status: SessionStatus::from(row.status.as_str()),
             created_at: row.created_at,
+            updated_at: row.updated_at,
             started_at: row.started_at,
             finished_at: row.finished_at,
             usage,

--- a/crates/control-plane/src/storage/memory.rs
+++ b/crates/control-plane/src/storage/memory.rs
@@ -2281,6 +2281,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_session_updated_at() {
+        let db = InMemoryDatabase::new();
+
+        let agent = db
+            .create_agent(
+                DEFAULT_ORG_ID,
+                CreateAgentRow {
+                    name: "Test Agent".to_string(),
+                    description: None,
+                    system_prompt: String::new(),
+                    default_model_id: None,
+                    tags: vec![],
+                },
+            )
+            .await
+            .unwrap();
+
+        // Create session - updated_at should equal created_at
+        let session = db
+            .create_session(CreateSessionRow {
+                agent_id: agent.id,
+                title: Some("Test Session".to_string()),
+                tags: vec![],
+                model_id: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(session.created_at, session.updated_at);
+        let original_updated_at = session.updated_at;
+
+        // Small delay to ensure different timestamp
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        // Update session - updated_at should change
+        let updated = db
+            .update_session(
+                DEFAULT_ORG_ID,
+                session.id,
+                UpdateSession {
+                    title: Some("Updated Title".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(updated.updated_at > original_updated_at);
+        assert_eq!(updated.title, Some("Updated Title".to_string()));
+    }
+
+    #[tokio::test]
     async fn test_events_sequence() {
         use chrono::Utc;
 

--- a/crates/control-plane/src/storage/memory.rs
+++ b/crates/control-plane/src/storage/memory.rs
@@ -466,6 +466,7 @@ impl InMemoryDatabase {
             model_id: input.model_id,
             status: "pending".to_string(), // Default status for new sessions
             created_at: now,
+            updated_at: now,
             started_at: None,
             finished_at: None,
             total_input_tokens: 0,
@@ -571,6 +572,8 @@ impl InMemoryDatabase {
             if input.finished_at.is_some() {
                 session.finished_at = input.finished_at;
             }
+            // Update updated_at on every update (mimics DB trigger)
+            session.updated_at = Self::now();
             return Ok(Some(session.clone()));
         }
         Ok(None)
@@ -1902,6 +1905,8 @@ impl InMemoryDatabase {
             session.total_output_tokens += output_tokens;
             session.total_cache_read_tokens += cache_read_tokens;
             session.total_cache_creation_tokens += cache_creation_tokens;
+            // Update updated_at on every update (mimics DB trigger)
+            session.updated_at = Self::now();
         }
         Ok(())
     }

--- a/crates/control-plane/src/storage/models.rs
+++ b/crates/control-plane/src/storage/models.rs
@@ -214,6 +214,7 @@ pub struct SessionRow {
     pub model_id: Option<Uuid>,
     pub status: String,
     pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
     pub started_at: Option<DateTime<Utc>>,
     pub finished_at: Option<DateTime<Utc>>,
     /// Cumulative input tokens for all LLM calls in this session

--- a/crates/control-plane/src/storage/repositories.rs
+++ b/crates/control-plane/src/storage/repositories.rs
@@ -482,7 +482,7 @@ impl Database {
             r#"
             INSERT INTO sessions (agent_id, title, tags, model_id, status)
             VALUES ($1, $2, $3, $4, 'started')
-            RETURNING id, agent_id, title, tags, model_id, status, created_at, started_at, finished_at,
+            RETURNING id, agent_id, title, tags, model_id, status, created_at, updated_at, started_at, finished_at,
                       total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens
             "#,
         )
@@ -500,7 +500,7 @@ impl Database {
     pub async fn get_session(&self, org_id: i64, id: Uuid) -> Result<Option<SessionRow>> {
         let row = sqlx::query_as::<_, SessionRow>(
             r#"
-            SELECT s.id, s.agent_id, s.title, s.tags, s.model_id, s.status, s.created_at, s.started_at, s.finished_at,
+            SELECT s.id, s.agent_id, s.title, s.tags, s.model_id, s.status, s.created_at, s.updated_at, s.started_at, s.finished_at,
                    s.total_input_tokens, s.total_output_tokens, s.total_cache_read_tokens, s.total_cache_creation_tokens
             FROM sessions s
             JOIN agents a ON s.agent_id = a.id
@@ -540,7 +540,7 @@ impl Database {
         // Get paginated results
         let rows = sqlx::query_as::<_, SessionRow>(
             r#"
-            SELECT s.id, s.agent_id, s.title, s.tags, s.model_id, s.status, s.created_at, s.started_at, s.finished_at,
+            SELECT s.id, s.agent_id, s.title, s.tags, s.model_id, s.status, s.created_at, s.updated_at, s.started_at, s.finished_at,
                    s.total_input_tokens, s.total_output_tokens, s.total_cache_read_tokens, s.total_cache_creation_tokens
             FROM sessions s
             JOIN agents a ON s.agent_id = a.id
@@ -567,6 +567,7 @@ impl Database {
         input: UpdateSession,
     ) -> Result<Option<SessionRow>> {
         // Update only if session belongs to an agent in the org
+        // Note: updated_at is automatically set by the update_sessions_updated_at trigger
         let row = sqlx::query_as::<_, SessionRow>(
             r#"
             UPDATE sessions s
@@ -579,7 +580,7 @@ impl Database {
                 finished_at = COALESCE($8, s.finished_at)
             FROM agents a
             WHERE s.agent_id = a.id AND a.org_id = $1 AND s.id = $2
-            RETURNING s.id, s.agent_id, s.title, s.tags, s.model_id, s.status, s.created_at, s.started_at, s.finished_at,
+            RETURNING s.id, s.agent_id, s.title, s.tags, s.model_id, s.status, s.created_at, s.updated_at, s.started_at, s.finished_at,
                       s.total_input_tokens, s.total_output_tokens, s.total_cache_read_tokens, s.total_cache_creation_tokens
             "#,
         )

--- a/crates/control-plane/src/storage/session_store.rs
+++ b/crates/control-plane/src/storage/session_store.rs
@@ -74,6 +74,7 @@ impl SessionStore for DbSessionStore {
                     model_id: row.model_id.map(|id| id.into()),
                     status: SessionStatus::from(row.status.as_str()),
                     created_at: row.created_at,
+                    updated_at: row.updated_at,
                     started_at: row.started_at,
                     finished_at: row.finished_at,
                     usage,

--- a/crates/core/examples/turn_based_execution.rs
+++ b/crates/core/examples/turn_based_execution.rs
@@ -136,6 +136,7 @@ async fn main() -> anyhow::Result<()> {
         model_id: None,
         status: SessionStatus::Started,
         created_at: now,
+        updated_at: now,
         started_at: None,
         finished_at: None,
         usage: None,

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -83,6 +83,8 @@ pub struct Session {
     pub status: SessionStatus,
     /// Timestamp when the session was created.
     pub created_at: DateTime<Utc>,
+    /// Timestamp when the session was last updated.
+    pub updated_at: DateTime<Utc>,
     /// Timestamp when the session started executing.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub started_at: Option<DateTime<Utc>>,

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -54,6 +54,7 @@ async fn setup_test_environment() -> (
 
     // Create a test session
     let session_id = Uuid::now_v7();
+    let now = chrono::Utc::now();
     let session = Session {
         id: session_id.into(),
         agent_id: agent_id.into(),
@@ -63,7 +64,8 @@ async fn setup_test_environment() -> (
         tags: vec![],
         status: SessionStatus::Started,
         model_id: None,
-        created_at: chrono::Utc::now(),
+        created_at: now,
+        updated_at: now,
         started_at: None,
         finished_at: None,
         usage: None,
@@ -294,6 +296,7 @@ async fn test_reason_atom_with_different_configs() {
 
     // Second test with a different configuration
     let session_id2 = Uuid::now_v7();
+    let now2 = chrono::Utc::now();
     let session2 = Session {
         id: session_id2.into(),
         agent_id: agent_id.into(),
@@ -303,7 +306,8 @@ async fn test_reason_atom_with_different_configs() {
         tags: vec![],
         status: SessionStatus::Started,
         model_id: None,
-        created_at: chrono::Utc::now(),
+        created_at: now2,
+        updated_at: now2,
         started_at: None,
         finished_at: None,
         usage: None,

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -422,7 +422,7 @@ pub fn schema_session_to_proto(value: &everruns_core::Session) -> proto::Session
         title: value.title.clone().unwrap_or_default(),
         status: value.status.to_string(),
         created_at: Some(datetime_to_proto_timestamp(value.created_at)),
-        updated_at: Some(datetime_to_proto_timestamp(value.created_at)), // Use created_at as fallback
+        updated_at: Some(datetime_to_proto_timestamp(value.updated_at)),
         default_model_id: value.model_id.map(|id| uuid_to_proto_uuid(id.uuid())),
     }
 }

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -449,6 +449,9 @@ fn proto_session_to_session(proto_session: proto::Session) -> Result<Session> {
         _ => everruns_core::SessionStatus::Started,
     };
 
+    let created_at = proto_timestamp_or_now(proto_session.created_at.as_ref());
+    let updated_at = proto_timestamp_or_now(proto_session.updated_at.as_ref());
+
     Ok(Session {
         id: id.into(),
         agent_id: agent_id.into(),
@@ -458,7 +461,8 @@ fn proto_session_to_session(proto_session: proto::Session) -> Result<Session> {
         tags: vec![],
         model_id: model_id.map(|u| u.into()),
         status,
-        created_at: proto_timestamp_or_now(proto_session.created_at.as_ref()),
+        created_at,
+        updated_at,
         started_at: None,
         finished_at: None,
         usage: None, // Usage not tracked in worker context

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -5432,7 +5432,8 @@
                 "id",
                 "agent_id",
                 "status",
-                "created_at"
+                "created_at",
+                "updated_at"
               ],
               "properties": {
                 "agent_id": {
@@ -5505,6 +5506,11 @@
                     "null"
                   ],
                   "description": "Human-readable title for the session."
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Timestamp when the session was last updated."
                 },
                 "usage": {
                   "oneOf": [
@@ -5676,7 +5682,8 @@
           "id",
           "agent_id",
           "status",
-          "created_at"
+          "created_at",
+          "updated_at"
         ],
         "properties": {
           "agent_id": {
@@ -5749,6 +5756,11 @@
               "null"
             ],
             "description": "Human-readable title for the session."
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the session was last updated."
           },
           "usage": {
             "oneOf": [

--- a/specs/models.md
+++ b/specs/models.md
@@ -46,14 +46,15 @@ An instance of agentic loop execution. Multiple sessions can exist concurrently 
 | `title` | string? | Session title (user-provided or auto-generated) |
 | `tags` | string[] | Tags for organization/filtering |
 | `model_id` | UUID? | Override model (null = use agent default) |
-| `status` | enum | `pending`, `running`, `failed` |
+| `status` | enum | `started`, `active`, `idle` |
 | `created_at` | timestamp | Creation time |
+| `updated_at` | timestamp | Last modification time (auto-updated on any change) |
 | `started_at` | timestamp? | Execution start time |
-| `finished_at` | timestamp? | Completion time (only set on failure) |
+| `finished_at` | timestamp? | Completion time |
 
-Status transitions: `pending` → `running` → `pending` (cycles indefinitely) | `failed`
+Status transitions: `started` → `active` (processing) → `idle` (waiting for input)
 
-Sessions work indefinitely - after processing a message, status returns to `pending` (ready for more messages). Only `failed` is a terminal state.
+Sessions work indefinitely - after processing a message, status returns to `idle` (ready for more messages).
 
 ### Message
 


### PR DESCRIPTION
## What
Add `updated_at` timestamp to the sessions table to track when sessions are last modified.

## Why
Sessions need an `updated_at` field to track modification time, which is useful for:
- Sorting sessions by recent activity
- Cache invalidation
- Audit trails

## How
- Add migration `005_session_updated_at.sql` with column and database trigger
- Update `SessionRow` and `Session` structs to include `updated_at`
- Update all SQL queries to select `updated_at`
- Update all `Session` struct instantiations across crates
- Update gRPC proto conversion to use `updated_at`
- Update in-memory storage to set `updated_at` on create/update
- Fix `schema_session_to_proto` to use `updated_at` instead of `created_at` fallback
- Add test for `updated_at` behavior
- Update specs/models.md to document the field

## Risk
- Low
- Database migration adds a NOT NULL column with default, backfills existing rows

## Checklist
- [x] Tests added or updated
- [x] Specs updated
- [x] Backward compatibility considered (migration handles existing data)