### PR TITLE
fix(scripts): improve PostgreSQL detection with /dev/tcp

### DIFF
--- a/scripts/lib/bench.sh
+++ b/scripts/lib/bench.sh
@@ -84,7 +84,7 @@ case "$cmd" in
         sleep 1
       done
       echo "   ✅ PostgreSQL is ready"
-    elif pg_isready -h "$DB_HOST" -p "$DB_PORT" > /dev/null 2>&1; then
+    elif check_port_open "$DB_HOST" "$DB_PORT"; then
       echo "   ✅ Local PostgreSQL is ready"
       DB_USER="${DB_USER:-postgres}"
       DB_PASS="${DB_PASS:-postgres}"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -78,6 +78,13 @@ check_npm_deps() {
   return 0
 }
 
+# Check if something is listening on a port (no external tools needed)
+check_port_open() {
+  local host="${1:-localhost}"
+  local port="${2:-5432}"
+  (echo > "/dev/tcp/$host/$port") 2>/dev/null
+}
+
 # Backward-compatible wrappers
 check_ui_deps() {
   check_npm_deps "UI" "just ui-install"

--- a/scripts/lib/services.sh
+++ b/scripts/lib/services.sh
@@ -275,7 +275,7 @@ case "$cmd" in
     echo "1️⃣  Checking PostgreSQL..."
     if [ "$NO_DOCKER" = true ]; then
       # No Docker mode - require local PostgreSQL
-      if pg_isready -h localhost -p 5432 > /dev/null 2>&1; then
+      if check_port_open localhost 5432; then
         echo "   ✅ Local PostgreSQL is ready"
         export DATABASE_URL=${DATABASE_URL:-postgres://everruns:everruns@localhost:5432/everruns}
       else
@@ -285,7 +285,7 @@ case "$cmd" in
       fi
       export OTEL_SDK_DISABLED=true
       echo "   ℹ️  OpenTelemetry disabled (--no-docker)"
-    elif pg_isready -h localhost -p 5432 > /dev/null 2>&1; then
+    elif check_port_open localhost 5432; then
       echo "   ✅ Local PostgreSQL is ready"
       export DATABASE_URL=${DATABASE_URL:-postgres://postgres:postgres@localhost/everruns}
       if resolve_docker_compose 2>/dev/null; then


### PR DESCRIPTION
## What
Replace `pg_isready` with bash built-in `/dev/tcp` for PostgreSQL detection.

## Why
`pg_isready` may not be installed when:
- PostgreSQL runs in Docker (no client tools on host)
- Server-only install without client tools
- Homebrew PostgreSQL not in PATH

## How
Added `check_port_open()` function using `/dev/tcp/$host/$port` - works without any external tools.

## Risk
- Low
- Fallback is simpler but equally reliable for port detection

## Checklist
- [x] Tests: Script syntax validated
- [x] Backward compatibility: N/A (internal scripts)