### PR TITLE
refactor(core): use typed IDs throughout codebase for type safety

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,6 +1179,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sqlx",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",

--- a/crates/control-plane/Cargo.toml
+++ b/crates/control-plane/Cargo.toml
@@ -51,7 +51,7 @@ aes-gcm.workspace = true
 argon2.workspace = true
 parking_lot.workspace = true
 
-everruns-core = { path = "../core", features = ["openapi"] }
+everruns-core = { path = "../core", features = ["openapi", "sqlx"] }
 everruns-worker = { path = "../worker" }  # For AgentRunner trait
 everruns-internal-protocol = { path = "../internal-protocol" }
 everruns-durable = { path = "../durable" }  # For durable execution gRPC service

--- a/crates/control-plane/src/api/images.rs
+++ b/crates/control-plane/src/api/images.rs
@@ -286,7 +286,7 @@ pub async fn upload_image(
     Ok((
         StatusCode::CREATED,
         Json(ImageUploadResponse {
-            id: row.id,
+            id: row.id.uuid(),
             filename: row.filename,
             content_type: row.content_type,
             size_bytes: row.size_bytes,
@@ -327,7 +327,7 @@ pub async fn list_images(
     let images: Vec<ImageInfo> = rows
         .into_iter()
         .map(|row| ImageInfo {
-            id: row.id,
+            id: row.id.uuid(),
             filename: row.filename,
             content_type: row.content_type,
             size_bytes: row.size_bytes,

--- a/crates/control-plane/src/api/sessions.rs
+++ b/crates/control-plane/src/api/sessions.rs
@@ -11,7 +11,7 @@ use axum::{
     routing::{get, post},
 };
 use everruns_core::events::{EventContext, EventRequest, MessageUserData, TurnCancelledData};
-use everruns_core::typed_id::{AgentId, ModelId, SessionId, TurnId};
+use everruns_core::typed_id::{AgentId, MessageId, ModelId, SessionId, TurnId};
 use everruns_core::{Message, Session};
 use everruns_worker::AgentRunner;
 
@@ -19,7 +19,6 @@ use super::common::{ApiOptionExt, ApiResultExt, ErrorResponse, PaginatedResponse
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::{IntoParams, ToSchema};
-use uuid::Uuid;
 
 /// Request to create a session
 #[derive(Debug, Clone, Deserialize, ToSchema)]
@@ -385,8 +384,6 @@ pub async fn cancel_turn(
     State(state): State<AppState>,
     Path((_org_path, _agent_id, session_id)): Path<(String, String, String)>,
 ) -> Result<Json<CancelTurnResponse>, StatusCode> {
-    use everruns_core::typed_id::SessionId;
-
     let session_id: SessionId = session_id.parse().map_err(|_| StatusCode::BAD_REQUEST)?;
 
     // Verify session exists
@@ -406,20 +403,19 @@ pub async fn cancel_turn(
     }
 
     // Cancel the workflow
-    let session_uuid = session_id.uuid();
-    if let Err(e) = state.runner.cancel_run(session_uuid).await {
+    if let Err(e) = state.runner.cancel_run(session_id).await {
         tracing::error!(session_id = %session_id, error = %e, "Failed to cancel workflow");
         // Continue anyway - workflow may have already completed
     }
 
     // Generate IDs for the turn context
     // Use session_id as turn_id since workflow_id = session_id in durable runner
-    let turn_id = TurnId::from_uuid(session_uuid);
-    let input_message_id = Uuid::now_v7(); // Placeholder since we don't have the original
+    let turn_id = TurnId::from_uuid(session_id.uuid());
+    let input_message_id = MessageId::new(); // Placeholder since we don't have the original
 
     // Emit turn.cancelled event
     let cancelled_event = EventRequest::new(
-        session_uuid,
+        session_id,
         EventContext::turn(turn_id, input_message_id),
         TurnCancelledData {
             turn_id,
@@ -434,7 +430,7 @@ pub async fn cancel_turn(
     // Insert user message indicating cancellation request
     let user_cancel_message = Message::user("User requested to cancel the work.");
     let user_message_event = EventRequest::new(
-        session_uuid,
+        session_id,
         EventContext::turn(turn_id, input_message_id),
         MessageUserData::new(user_cancel_message),
     );

--- a/crates/control-plane/src/dev_worker/direct_adapters.rs
+++ b/crates/control-plane/src/dev_worker/direct_adapters.rs
@@ -15,8 +15,8 @@ use everruns_core::traits::{
 };
 use everruns_core::typed_id::MessageId;
 use everruns_core::{
-    Agent, AgentStatus, ContentPart, DEFAULT_ORG_ID, LlmProviderType, Message, MessageRole,
-    Session, SessionStatus, ToolResultContentPart,
+    Agent, AgentId, AgentStatus, ContentPart, DEFAULT_ORG_ID, LlmProviderType, Message,
+    MessageRole, ModelId, Session, SessionId, SessionStatus, ToolResultContentPart,
 };
 use everruns_core::{InputMessage, MessageRetriever};
 use std::sync::Arc;
@@ -60,7 +60,7 @@ impl DirectAgentStore {
 
 #[async_trait]
 impl AgentStore for DirectAgentStore {
-    async fn get_agent(&self, agent_id: Uuid) -> Result<Option<Agent>> {
+    async fn get_agent(&self, agent_id: AgentId) -> Result<Option<Agent>> {
         // TODO: Get org_id from context after Phase 3
         let row = self
             .db
@@ -74,7 +74,7 @@ impl AgentStore for DirectAgentStore {
         // Also get capabilities for the agent
         let capabilities = if let Some(ref _r) = row {
             self.db
-                .get_agent_capabilities(agent_id)
+                .get_agent_capabilities(agent_id.uuid())
                 .await
                 .unwrap_or_default()
         } else {
@@ -82,11 +82,11 @@ impl AgentStore for DirectAgentStore {
         };
 
         Ok(row.map(|r| Agent {
-            id: r.id.into(),
+            id: r.id,
             name: r.name,
             description: r.description,
             system_prompt: r.system_prompt,
-            default_model_id: r.default_model_id.map(|id| id.into()),
+            default_model_id: r.default_model_id,
             tags: r.tags,
             capabilities: capabilities
                 .into_iter()
@@ -121,7 +121,7 @@ impl DirectSessionStore {
 
 #[async_trait]
 impl SessionStore for DirectSessionStore {
-    async fn get_session(&self, session_id: Uuid) -> Result<Option<Session>> {
+    async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>> {
         // TODO: Get org_id from context after Phase 3
         let row = self
             .db
@@ -133,13 +133,13 @@ impl SessionStore for DirectSessionStore {
             })?;
 
         Ok(row.map(|r| Session {
-            id: r.id.into(),
-            agent_id: r.agent_id.into(),
+            id: r.id,
+            agent_id: r.agent_id,
             title: r.title,
             preview: None,
             output_preview: None,
             tags: r.tags,
-            model_id: r.model_id.map(|id| id.into()),
+            model_id: r.model_id,
             status: match r.status.as_str() {
                 "started" => SessionStatus::Started,
                 "active" => SessionStatus::Active,
@@ -211,7 +211,7 @@ impl DirectMessageRetriever {
             .as_ref()
             .and_then(|m| serde_json::to_value(m).ok());
         let request = EventRequest {
-            session_id,
+            session_id: session_id.into(),
             event_type: event_type.to_string(),
             ts: message.created_at,
             context: EventContext::default(),
@@ -231,15 +231,15 @@ impl DirectMessageRetriever {
 
 #[async_trait]
 impl MessageRetriever for DirectMessageRetriever {
-    async fn get(&self, session_id: Uuid, message_id: Uuid) -> Result<Option<Message>> {
+    async fn get(&self, session_id: SessionId, message_id: MessageId) -> Result<Option<Message>> {
         let messages = self.load(session_id).await?;
         Ok(messages.into_iter().find(|m| m.id == message_id))
     }
 
-    async fn load(&self, session_id: Uuid) -> Result<Vec<Message>> {
+    async fn load(&self, session_id: SessionId) -> Result<Vec<Message>> {
         let events = self
             .event_service
-            .list_message_events(session_id)
+            .list_message_events(session_id.uuid())
             .await
             .map_err(|e| {
                 tracing::error!("Failed to load message events: {}", e);
@@ -301,11 +301,18 @@ impl DirectLlmProviderStore {
 
 #[async_trait]
 impl LlmProviderStore for DirectLlmProviderStore {
-    async fn get_model_with_provider(&self, model_id: Uuid) -> Result<Option<ModelWithProvider>> {
-        let resolved = self.resolver.resolve_model(model_id).await.map_err(|e| {
-            tracing::error!("Failed to resolve model: {}", e);
-            store_error("Failed to resolve model")
-        })?;
+    async fn get_model_with_provider(
+        &self,
+        model_id: ModelId,
+    ) -> Result<Option<ModelWithProvider>> {
+        let resolved = self
+            .resolver
+            .resolve_model(model_id.uuid())
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to resolve model: {}", e);
+                store_error("Failed to resolve model")
+            })?;
 
         Ok(resolved.map(|r| ModelWithProvider {
             model: r.model_id,
@@ -382,10 +389,10 @@ impl DirectSessionFileStore {
 
 #[async_trait]
 impl SessionFileStore for DirectSessionFileStore {
-    async fn read_file(&self, session_id: Uuid, path: &str) -> Result<Option<SessionFile>> {
+    async fn read_file(&self, session_id: SessionId, path: &str) -> Result<Option<SessionFile>> {
         let row = self
             .db
-            .get_session_file(session_id, path)
+            .get_session_file(session_id.uuid(), path)
             .await
             .map_err(|e| {
                 tracing::error!("Failed to read file: {}", e);
@@ -411,7 +418,7 @@ impl SessionFileStore for DirectSessionFileStore {
 
             SessionFile {
                 id: r.id,
-                session_id: r.session_id,
+                session_id: r.session_id.uuid(),
                 path: r.path.clone(),
                 name: name_from_path(&r.path),
                 content,
@@ -427,7 +434,7 @@ impl SessionFileStore for DirectSessionFileStore {
 
     async fn write_file(
         &self,
-        session_id: Uuid,
+        session_id: SessionId,
         path: &str,
         content: &str,
         encoding: &str,
@@ -447,7 +454,7 @@ impl SessionFileStore for DirectSessionFileStore {
         // Check if file exists
         let existing = self
             .db
-            .get_session_file(session_id, path)
+            .get_session_file(session_id.uuid(), path)
             .await
             .map_err(|e| {
                 tracing::error!("Failed to check existing file: {}", e);
@@ -461,7 +468,7 @@ impl SessionFileStore for DirectSessionFileStore {
                 ..Default::default()
             };
             self.db
-                .update_session_file(session_id, path, update)
+                .update_session_file(session_id.uuid(), path, update)
                 .await
                 .map_err(|e| {
                     tracing::error!("Failed to update file: {}", e);
@@ -485,7 +492,7 @@ impl SessionFileStore for DirectSessionFileStore {
 
         Ok(SessionFile {
             id: row.id,
-            session_id: row.session_id,
+            session_id: row.session_id.uuid(),
             path: row.path.clone(),
             name: name_from_path(&row.path),
             content: Some(content.to_string()),
@@ -498,11 +505,16 @@ impl SessionFileStore for DirectSessionFileStore {
         })
     }
 
-    async fn delete_file(&self, session_id: Uuid, path: &str, recursive: bool) -> Result<bool> {
+    async fn delete_file(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        recursive: bool,
+    ) -> Result<bool> {
         if recursive {
             let count = self
                 .db
-                .delete_session_file_recursive(session_id, path)
+                .delete_session_file_recursive(session_id.uuid(), path)
                 .await
                 .map_err(|e| {
                     tracing::error!("Failed to delete file recursively: {}", e);
@@ -511,7 +523,7 @@ impl SessionFileStore for DirectSessionFileStore {
             Ok(count > 0)
         } else {
             self.db
-                .delete_session_file(session_id, path)
+                .delete_session_file(session_id.uuid(), path)
                 .await
                 .map_err(|e| {
                     tracing::error!("Failed to delete file: {}", e);
@@ -520,10 +532,10 @@ impl SessionFileStore for DirectSessionFileStore {
         }
     }
 
-    async fn list_directory(&self, session_id: Uuid, path: &str) -> Result<Vec<FileInfo>> {
+    async fn list_directory(&self, session_id: SessionId, path: &str) -> Result<Vec<FileInfo>> {
         let rows = self
             .db
-            .list_session_files(session_id, path)
+            .list_session_files(session_id.uuid(), path)
             .await
             .map_err(|e| {
                 tracing::error!("Failed to list directory: {}", e);
@@ -534,7 +546,7 @@ impl SessionFileStore for DirectSessionFileStore {
             .into_iter()
             .map(|r| FileInfo {
                 id: r.id,
-                session_id: r.session_id,
+                session_id: r.session_id.uuid(),
                 path: r.path.clone(),
                 name: name_from_path(&r.path),
                 is_directory: r.is_directory,
@@ -546,10 +558,10 @@ impl SessionFileStore for DirectSessionFileStore {
             .collect())
     }
 
-    async fn stat_file(&self, session_id: Uuid, path: &str) -> Result<Option<FileStat>> {
+    async fn stat_file(&self, session_id: SessionId, path: &str) -> Result<Option<FileStat>> {
         let row = self
             .db
-            .get_session_file(session_id, path)
+            .get_session_file(session_id.uuid(), path)
             .await
             .map_err(|e| {
                 tracing::error!("Failed to stat file: {}", e);
@@ -569,13 +581,13 @@ impl SessionFileStore for DirectSessionFileStore {
 
     async fn grep_files(
         &self,
-        session_id: Uuid,
+        session_id: SessionId,
         pattern: &str,
         path_pattern: Option<&str>,
     ) -> Result<Vec<GrepMatch>> {
         let _rows = self
             .db
-            .grep_session_files(session_id, pattern, path_pattern)
+            .grep_session_files(session_id.uuid(), pattern, path_pattern)
             .await
             .map_err(|e| {
                 tracing::error!("Failed to grep files: {}", e);
@@ -588,7 +600,7 @@ impl SessionFileStore for DirectSessionFileStore {
         Ok(vec![])
     }
 
-    async fn create_directory(&self, session_id: Uuid, path: &str) -> Result<FileInfo> {
+    async fn create_directory(&self, session_id: SessionId, path: &str) -> Result<FileInfo> {
         use crate::storage::models::CreateSessionFileRow;
 
         let create = CreateSessionFileRow {
@@ -606,7 +618,7 @@ impl SessionFileStore for DirectSessionFileStore {
 
         Ok(FileInfo {
             id: row.id,
-            session_id: row.session_id,
+            session_id: row.session_id.uuid(),
             path: row.path.clone(),
             name: name_from_path(&row.path),
             is_directory: row.is_directory,
@@ -632,7 +644,7 @@ impl SessionStatusUpdater {
         Self { db }
     }
 
-    pub async fn set_status(&self, session_id: Uuid, status: &str) -> Result<()> {
+    pub async fn set_status(&self, session_id: SessionId, status: &str) -> Result<()> {
         let update = UpdateSession {
             status: Some(status.to_string()),
             ..Default::default()

--- a/crates/control-plane/src/dev_worker/worker.rs
+++ b/crates/control-plane/src/dev_worker/worker.rs
@@ -10,7 +10,7 @@ use anyhow::Result;
 use everruns_core::ToolRegistry;
 use everruns_core::atoms::{ActAtom, Atom, AtomContext, InputAtom, ReasonAtom};
 use everruns_core::capabilities::{CapabilityRegistry, collect_capabilities, is_mcp_capability};
-use everruns_core::typed_id::{MessageId, TurnId};
+use everruns_core::typed_id::{ExecId, TurnId};
 use everruns_core::{
     ActInput, DEFAULT_ORG_ID, InputAtomInput, ReasonInput, ReasonResult, TokenUsage,
 };
@@ -375,7 +375,7 @@ impl InProcessWorker {
             session_id: input.session_id,
             turn_id: TurnId::new(),
             input_message_id: input.input_message_id,
-            exec_id: Uuid::now_v7(),
+            exec_id: ExecId::new(),
         };
 
         // Set session status to "active"
@@ -391,7 +391,7 @@ impl InProcessWorker {
             EventContext::turn(context.turn_id, input.input_message_id),
             SessionActivatedData {
                 turn_id: context.turn_id,
-                input_message_id: MessageId::from_uuid(input.input_message_id),
+                input_message_id: input.input_message_id,
             },
         );
         if let Err(e) = event_emitter.emit(activated_event).await {
@@ -404,7 +404,7 @@ impl InProcessWorker {
             EventContext::turn(context.turn_id, input.input_message_id),
             TurnStartedData {
                 turn_id: context.turn_id,
-                input_message_id: MessageId::from_uuid(input.input_message_id),
+                input_message_id: input.input_message_id,
             },
         );
         if let Err(e) = event_emitter.emit(turn_started_event).await {
@@ -451,7 +451,7 @@ impl InProcessWorker {
             session_id: input.session_id,
             turn_id,
             input_message_id: input.input_message_id,
-            exec_id: Uuid::now_v7(),
+            exec_id: ExecId::new(),
         };
 
         let session_id = input.session_id;
@@ -481,7 +481,7 @@ impl InProcessWorker {
 
         // Fetch MCP tool definitions for agent's MCP capabilities
         let mcp_tool_definitions = self
-            .build_mcp_tool_definitions(input.agent_id)
+            .build_mcp_tool_definitions(input.agent_id.uuid())
             .await
             .unwrap_or_default();
 
@@ -592,7 +592,10 @@ impl InProcessWorker {
         let mut tool_registry = ToolRegistry::with_defaults();
 
         // Get agent's capabilities and add their tools to the registry
-        let capability_rows = self.db.get_agent_capabilities(input.agent_id).await?;
+        let capability_rows = self
+            .db
+            .get_agent_capabilities(input.agent_id.uuid())
+            .await?;
         let builtin_cap_ids: Vec<String> = capability_rows
             .iter()
             .map(|r| r.capability_id.clone())
@@ -693,7 +696,7 @@ impl InProcessWorker {
                             session_id: input.session_id,
                             turn_id,
                             input_message_id: input.input_message_id,
-                            exec_id: Uuid::now_v7(),
+                            exec_id: ExecId::new(),
                         },
                         agent_id: input.agent_id,
                         tool_calls: reason_result.tool_calls,

--- a/crates/control-plane/src/grpc_service.rs
+++ b/crates/control-plane/src/grpc_service.rs
@@ -649,12 +649,12 @@ impl WorkerService for WorkerServiceImpl {
         // Create typed event request based on role
         let event_request = match role {
             MessageRole::User => EventRequest::new(
-                session_id,
+                session_id.into(),
                 EventContext::empty(),
                 MessageUserData::new(message.clone()),
             ),
             MessageRole::Assistant => EventRequest::new(
-                session_id,
+                session_id.into(),
                 EventContext::empty(),
                 MessageAgentData::new(message.clone()),
             ),

--- a/crates/control-plane/src/seed.rs
+++ b/crates/control-plane/src/seed.rs
@@ -353,7 +353,7 @@ async fn seed_agents(db: &StorageBackend, grade: DeploymentGrade) -> anyhow::Res
         };
 
         match db
-            .create_agent_with_id(DEFAULT_ORG_ID, seed.id, input)
+            .create_agent_with_id(DEFAULT_ORG_ID, seed.id.into(), input)
             .await?
         {
             Some(row) => {
@@ -371,7 +371,7 @@ async fn seed_agents(db: &StorageBackend, grade: DeploymentGrade) -> anyhow::Res
                             )
                         })
                         .collect();
-                    db.set_agent_capabilities(row.id, cap_tuples).await?;
+                    db.set_agent_capabilities(row.id.uuid(), cap_tuples).await?;
                 }
                 tracing::info!(name = seed.name, id = %seed.id, "Created seed agent");
                 result.created += 1;
@@ -794,7 +794,7 @@ async fn seed_models(db: &StorageBackend) -> anyhow::Result<SeedResult> {
 
     for seed in SEED_MODELS {
         let input = CreateLlmModelRow {
-            provider_id: seed.provider_id,
+            provider_id: seed.provider_id.into(),
             model_id: seed.model_id.to_string(),
             display_name: seed.display_name.to_string(),
             capabilities: vec![], // Empty capabilities for now

--- a/crates/control-plane/src/services/agent.rs
+++ b/crates/control-plane/src/services/agent.rs
@@ -9,7 +9,7 @@ use crate::storage::{
     models::{CreateAgentRow, UpdateAgent},
 };
 use anyhow::Result;
-use everruns_core::{Agent, AgentCapabilityConfig, AgentStatus, TokenUsage};
+use everruns_core::{Agent, AgentCapabilityConfig, AgentId, AgentStatus, TokenUsage};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -31,7 +31,7 @@ impl AgentService {
             name: req.name,
             description: req.description,
             system_prompt: req.system_prompt,
-            default_model_id: req.default_model_id.map(|id| id.uuid()),
+            default_model_id: req.default_model_id,
             tags: req.tags,
         };
         let row = self.db.create_agent(org_id, input).await?;
@@ -51,7 +51,9 @@ impl AgentService {
                     )
                 })
                 .collect();
-            self.db.set_agent_capabilities(agent_id, cap_tuples).await?;
+            self.db
+                .set_agent_capabilities(agent_id.uuid(), cap_tuples)
+                .await?;
             req.capabilities
         } else {
             vec![]
@@ -61,7 +63,7 @@ impl AgentService {
     }
 
     pub async fn get(&self, org_id: i64, id: Uuid) -> Result<Option<Agent>> {
-        let row = self.db.get_agent(org_id, id).await?;
+        let row = self.db.get_agent(org_id, AgentId::from_uuid(id)).await?;
         match row {
             Some(row) => {
                 let capabilities = self.get_capabilities(id).await?;
@@ -77,7 +79,7 @@ impl AgentService {
         // Fetch capabilities for each agent
         let mut agents = Vec::with_capacity(rows.len());
         for row in rows {
-            let capabilities = self.get_capabilities(row.id).await?;
+            let capabilities = self.get_capabilities(row.id.uuid()).await?;
             agents.push(Self::row_to_agent(row, capabilities));
         }
 
@@ -94,11 +96,14 @@ impl AgentService {
             name: req.name,
             description: req.description,
             system_prompt: req.system_prompt,
-            default_model_id: req.default_model_id.map(|id| id.uuid()),
+            default_model_id: req.default_model_id,
             tags: req.tags,
             status: req.status.map(|s| s.to_string()),
         };
-        let row = self.db.update_agent(org_id, id, input).await?;
+        let row = self
+            .db
+            .update_agent(org_id, AgentId::from_uuid(id), input)
+            .await?;
 
         match row {
             Some(row) => {
@@ -128,7 +133,7 @@ impl AgentService {
     }
 
     pub async fn delete(&self, org_id: i64, id: Uuid) -> Result<bool> {
-        self.db.delete_agent(org_id, id).await
+        self.db.delete_agent(org_id, AgentId::from_uuid(id)).await
     }
 
     async fn get_capabilities(&self, agent_id: Uuid) -> Result<Vec<AgentCapabilityConfig>> {
@@ -161,11 +166,11 @@ impl AgentService {
         };
 
         Agent {
-            id: row.id.into(),
+            id: row.id,
             name: row.name,
             description: row.description,
             system_prompt: row.system_prompt,
-            default_model_id: row.default_model_id.map(|id| id.into()),
+            default_model_id: row.default_model_id,
             tags: row.tags,
             capabilities,
             status: AgentStatus::from(row.status.as_str()),

--- a/crates/control-plane/src/services/braintrust.rs
+++ b/crates/control-plane/src/services/braintrust.rs
@@ -1027,7 +1027,7 @@ mod tests {
         ReasonCompletedData, TokenUsage, ToolCallCompletedData, TurnCompletedData, TurnStartedData,
     };
     use everruns_core::message::Message;
-    use everruns_core::typed_id::{MessageId, TurnId};
+    use everruns_core::typed_id::{AgentId, MessageId, SessionId, TurnId};
     use uuid::Uuid;
 
     fn test_config() -> BraintrustConfig {
@@ -1080,7 +1080,7 @@ mod tests {
         };
 
         let event = Event::new(
-            Uuid::now_v7(),
+            SessionId::new(),
             EventContext::empty(),
             EventData::TurnStarted(data.clone()),
         );
@@ -1131,7 +1131,7 @@ mod tests {
         context.turn_id = Some(turn_id);
 
         let event = Event::new(
-            Uuid::now_v7(),
+            SessionId::new(),
             context,
             EventData::LlmGeneration(data.clone()),
         );
@@ -1163,7 +1163,7 @@ mod tests {
         };
 
         let event = Event::new(
-            Uuid::now_v7(),
+            SessionId::new(),
             EventContext::empty(),
             EventData::TurnCompleted(data.clone()),
         );
@@ -1203,7 +1203,7 @@ mod tests {
             input_message_id,
         };
         let started_event = Event::new(
-            Uuid::now_v7(),
+            SessionId::new(),
             EventContext::empty(),
             EventData::TurnStarted(started_data.clone()),
         );
@@ -1238,7 +1238,7 @@ mod tests {
             usage: None,
         };
         let completed_event = Event::new(
-            Uuid::now_v7(),
+            SessionId::new(),
             EventContext::empty(),
             EventData::TurnCompleted(completed_data.clone()),
         );
@@ -1272,11 +1272,11 @@ mod tests {
         context.parent_span_id = Some(turn_id.to_string());
 
         let data = ReasonStartedData {
-            agent_id: Uuid::now_v7(),
+            agent_id: AgentId::new(),
             metadata: None,
         };
         let event = Event::new(
-            Uuid::now_v7(),
+            SessionId::new(),
             context,
             EventData::ReasonStarted(data.clone()),
         );
@@ -1335,7 +1335,7 @@ mod tests {
             },
         };
         let event = Event::new(
-            Uuid::now_v7(),
+            SessionId::new(),
             context,
             EventData::LlmGeneration(data.clone()),
         );
@@ -1387,7 +1387,11 @@ mod tests {
                 },
             ],
         };
-        let event = Event::new(Uuid::now_v7(), context, EventData::ActStarted(data.clone()));
+        let event = Event::new(
+            SessionId::new(),
+            context,
+            EventData::ActStarted(data.clone()),
+        );
 
         let bt_event = listener.convert_act_started(&event, &data);
 
@@ -1432,7 +1436,7 @@ mod tests {
             error: None,
         };
         let event = Event::new(
-            Uuid::now_v7(),
+            SessionId::new(),
             context,
             EventData::ToolCallCompleted(data.clone()),
         );
@@ -1472,11 +1476,11 @@ mod tests {
 
         // reason.started
         let started_data = ReasonStartedData {
-            agent_id: Uuid::now_v7(),
+            agent_id: AgentId::new(),
             metadata: None,
         };
         let started_event = Event::new(
-            Uuid::now_v7(),
+            SessionId::new(),
             context.clone(),
             EventData::ReasonStarted(started_data.clone()),
         );
@@ -1491,7 +1495,7 @@ mod tests {
             error: None,
         };
         let completed_event = Event::new(
-            Uuid::now_v7(),
+            SessionId::new(),
             context.clone(),
             EventData::ReasonCompleted(completed_data.clone()),
         );
@@ -1529,7 +1533,7 @@ mod tests {
             input_message_id,
         };
         let turn_event = Event::new(
-            Uuid::now_v7(),
+            SessionId::new(),
             EventContext::empty(),
             EventData::TurnStarted(turn_data.clone()),
         );
@@ -1547,11 +1551,11 @@ mod tests {
         reason_ctx.span_id = Some(reason_span_id.clone());
         reason_ctx.parent_span_id = Some(turn_id.to_string());
         let reason_data = ReasonStartedData {
-            agent_id: Uuid::now_v7(),
+            agent_id: AgentId::new(),
             metadata: None,
         };
         let reason_event = Event::new(
-            Uuid::now_v7(),
+            SessionId::new(),
             reason_ctx,
             EventData::ReasonStarted(reason_data.clone()),
         );
@@ -1588,7 +1592,7 @@ mod tests {
             },
         };
         let llm_event = Event::new(
-            Uuid::now_v7(),
+            SessionId::new(),
             llm_ctx,
             EventData::LlmGeneration(llm_data.clone()),
         );
@@ -1612,7 +1616,7 @@ mod tests {
             }],
         };
         let act_event = Event::new(
-            Uuid::now_v7(),
+            SessionId::new(),
             act_ctx,
             EventData::ActStarted(act_data.clone()),
         );
@@ -1638,7 +1642,7 @@ mod tests {
             error: None,
         };
         let tool_event = Event::new(
-            Uuid::now_v7(),
+            SessionId::new(),
             tool_ctx,
             EventData::ToolCallCompleted(tool_data.clone()),
         );

--- a/crates/control-plane/src/services/event.rs
+++ b/crates/control-plane/src/services/event.rs
@@ -205,7 +205,11 @@ impl EventService {
     ) -> Result<Vec<Event>> {
         let rows = self
             .db
-            .list_events(session_id, since_sequence, since_id)
+            .list_events(
+                SessionId::from_uuid(session_id),
+                since_sequence,
+                since_id.map(EventId::from_uuid),
+            )
             .await?;
         Ok(rows.into_iter().map(Self::row_to_event).collect())
     }
@@ -213,7 +217,10 @@ impl EventService {
     /// List events that represent messages (user, agent, tool results)
     /// Used by gRPC service to load conversation history for workers.
     pub async fn list_message_events(&self, session_id: Uuid) -> Result<Vec<Event>> {
-        let rows = self.db.list_message_events(session_id).await?;
+        let rows = self
+            .db
+            .list_message_events(SessionId::from_uuid(session_id))
+            .await?;
         Ok(rows.into_iter().map(Self::row_to_event).collect())
     }
 
@@ -222,10 +229,10 @@ impl EventService {
         let data =
             serde_json::from_value(row.data.clone()).unwrap_or_else(|_| EventData::raw(row.data));
         Event {
-            id: EventId::from_uuid(row.id),
+            id: row.id,
             event_type: row.event_type,
             ts: row.ts,
-            session_id: SessionId::from_uuid(row.session_id),
+            session_id: row.session_id,
             context: serde_json::from_value(row.context).unwrap_or_default(),
             data,
             metadata: row.metadata,

--- a/crates/control-plane/src/services/llm_model.rs
+++ b/crates/control-plane/src/services/llm_model.rs
@@ -31,7 +31,7 @@ impl LlmModelService {
         }
 
         let input = CreateLlmModelRow {
-            provider_id,
+            provider_id: provider_id.into(),
             model_id: req.model_id,
             display_name: req.display_name,
             capabilities: req.capabilities,
@@ -76,7 +76,10 @@ impl LlmModelService {
         let provider_sync_times: std::collections::HashMap<
             Uuid,
             Option<chrono::DateTime<chrono::Utc>>,
-        > = providers.iter().map(|p| (p.id, p.last_synced_at)).collect();
+        > = providers
+            .iter()
+            .map(|p| (p.id.uuid(), p.last_synced_at))
+            .collect();
 
         let models: Vec<LlmModelWithProvider> = rows
             .iter()
@@ -99,7 +102,8 @@ impl LlmModelService {
                 // Only discovered models can be stale
                 if !include_stale
                     && row.source == "discovered"
-                    && let Some(Some(last_synced)) = provider_sync_times.get(&row.provider_id)
+                    && let Some(Some(last_synced)) =
+                        provider_sync_times.get(&row.provider_id.uuid())
                 {
                     // Model is stale if last_seen_at < provider.last_synced_at
                     if let Some(last_seen) = row.last_seen_at {
@@ -160,8 +164,8 @@ impl LlmModelService {
         let capabilities: Vec<String> =
             serde_json::from_value(row.capabilities.clone()).unwrap_or_default();
         LlmModel {
-            id: row.id.into(),
-            provider_id: row.provider_id.into(),
+            id: row.id,
+            provider_id: row.provider_id,
             model_id: row.model_id.clone(),
             display_name: row.display_name.clone(),
             capabilities,
@@ -187,8 +191,8 @@ impl LlmModelService {
         let profile = get_model_profile(&provider_type, &row.model_id);
 
         LlmModelWithProvider {
-            id: row.id.into(),
-            provider_id: row.provider_id.into(),
+            id: row.id,
+            provider_id: row.provider_id,
             model_id: row.model_id.clone(),
             display_name: row.display_name.clone(),
             capabilities,

--- a/crates/control-plane/src/services/llm_provider.rs
+++ b/crates/control-plane/src/services/llm_provider.rs
@@ -100,7 +100,7 @@ impl LlmProviderService {
         let api_key_set = row.api_key_set || has_default_api_key_from_env(&row.provider_type);
 
         LlmProvider {
-            id: row.id.into(),
+            id: row.id,
             name: row.name.clone(),
             provider_type,
             base_url: row.base_url.clone(),

--- a/crates/control-plane/src/services/llm_resolver.rs
+++ b/crates/control-plane/src/services/llm_resolver.rs
@@ -77,7 +77,10 @@ impl LlmResolverService {
         };
 
         // Look up the provider
-        let provider_row = self.db.get_llm_provider(model_row.provider_id).await?;
+        let provider_row = self
+            .db
+            .get_llm_provider(model_row.provider_id.uuid())
+            .await?;
 
         let provider_row = match provider_row {
             Some(row) => row,
@@ -107,7 +110,10 @@ impl LlmResolverService {
         };
 
         // Look up the provider
-        let provider_row = self.db.get_llm_provider(model_row.provider_id).await?;
+        let provider_row = self
+            .db
+            .get_llm_provider(model_row.provider_id.uuid())
+            .await?;
 
         let provider_row = match provider_row {
             Some(row) => row,

--- a/crates/control-plane/src/services/mcp_server.rs
+++ b/crates/control-plane/src/services/mcp_server.rs
@@ -202,7 +202,7 @@ impl McpServerService {
             serde_json::from_value(row.headers.clone()).unwrap_or_default();
 
         McpServer {
-            id: row.id.into(),
+            id: row.id,
             name: row.name.clone(),
             description: row.description.clone(),
             url: row.url.clone(),

--- a/crates/control-plane/src/services/message.rs
+++ b/crates/control-plane/src/services/message.rs
@@ -12,7 +12,7 @@ use anyhow::Result;
 use chrono::Utc;
 use everruns_core::Event;
 use everruns_core::events::{EventContext, EventRequest, MessageUserData};
-use everruns_core::typed_id::{MessageId, SessionId};
+use everruns_core::typed_id::{AgentId, MessageId, SessionId};
 use everruns_worker::AgentRunner;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -73,11 +73,16 @@ impl MessageService {
             created_at: now,
         };
 
+        // Convert to typed IDs for emit/runner
+        let session_id_typed = SessionId::from_uuid(session_id);
+        let agent_id_typed = AgentId::from_uuid(agent_id);
+        let message_id_typed = MessageId::from_uuid(message_id);
+
         // Emit as typed event using EventService
         let stored_event = self
             .event_service
             .emit(EventRequest::new(
-                session_id,
+                session_id_typed,
                 EventContext::empty(),
                 MessageUserData::new(core_message),
             ))
@@ -85,8 +90,8 @@ impl MessageService {
 
         // Construct API Message
         let message = Message {
-            id: MessageId::from_uuid(message_id),
-            session_id: SessionId::from_uuid(session_id),
+            id: message_id_typed,
+            session_id: session_id_typed,
             sequence: stored_event.sequence.unwrap_or(0),
             role: MessageRole::User,
             content,
@@ -100,7 +105,7 @@ impl MessageService {
         let runner = self.runner.clone();
         tokio::spawn(async move {
             if let Err(e) = runner
-                .start_run(org_id, session_id, agent_id, message_id)
+                .start_run(org_id, session_id_typed, agent_id_typed, message_id_typed)
                 .await
             {
                 tracing::error!(
@@ -122,7 +127,10 @@ impl MessageService {
     }
 
     pub async fn list(&self, session_id: Uuid) -> Result<Vec<Message>> {
-        let events = self.db.list_message_events(session_id).await?;
+        let events = self
+            .db
+            .list_message_events(SessionId::from_uuid(session_id))
+            .await?;
         let mut messages = Vec::with_capacity(events.len());
 
         for event_row in events {

--- a/crates/control-plane/src/services/model_sync.rs
+++ b/crates/control-plane/src/services/model_sync.rs
@@ -10,7 +10,7 @@ use crate::storage::{
 use anyhow::{Context, Result};
 use chrono::Utc;
 use everruns_core::{
-    DiscoveredModel, DriverRegistry, LlmProviderType, ProviderConfig, ProviderType,
+    DiscoveredModel, DriverRegistry, LlmProviderType, ProviderConfig, ProviderId, ProviderType,
     get_model_profile,
 };
 use serde::{Deserialize, Serialize};
@@ -143,17 +143,17 @@ impl ModelSyncService {
     }
 
     /// Sync all providers (called by background job)
-    pub async fn sync_all(&self) -> Result<Vec<(Uuid, SyncResult)>> {
+    pub async fn sync_all(&self) -> Result<Vec<(ProviderId, SyncResult)>> {
         let providers = self.db.list_llm_providers().await?;
         let mut results = Vec::with_capacity(providers.len());
 
         for provider in providers {
-            let result =
-                self.sync_provider(provider.id)
-                    .await
-                    .unwrap_or_else(|e| SyncResult::Failed {
-                        error: e.to_string(),
-                    });
+            let result = self
+                .sync_provider(provider.id.uuid())
+                .await
+                .unwrap_or_else(|e| SyncResult::Failed {
+                    error: e.to_string(),
+                });
             results.push((provider.id, result));
         }
 
@@ -177,7 +177,10 @@ impl ModelSyncService {
             .unwrap_or(LlmProviderType::Openai);
 
         // Get existing models for this provider
-        let existing = self.db.list_llm_models_for_provider(provider.id).await?;
+        let existing = self
+            .db
+            .list_llm_models_for_provider(provider.id.uuid())
+            .await?;
         let existing_ids: std::collections::HashSet<_> =
             existing.iter().map(|m| m.model_id.as_str()).collect();
 
@@ -204,7 +207,9 @@ impl ModelSyncService {
                         provider_metadata: Some(metadata),
                         ..Default::default()
                     };
-                    self.db.update_llm_model(existing_model.id, update).await?;
+                    self.db
+                        .update_llm_model(existing_model.id.uuid(), update)
+                        .await?;
                     updated += 1;
                 }
             } else {

--- a/crates/control-plane/src/services/session.rs
+++ b/crates/control-plane/src/services/session.rs
@@ -13,7 +13,8 @@ use crate::storage::{
 };
 use anyhow::Result;
 use everruns_core::{
-    CapabilityRegistry, Session, SessionStatus, TokenUsage, capabilities::collect_capabilities,
+    AgentId, CapabilityRegistry, ModelId, Session, SessionId, SessionStatus, TokenUsage,
+    capabilities::collect_capabilities,
 };
 use std::sync::Arc;
 use uuid::Uuid;
@@ -50,9 +51,11 @@ impl SessionService {
         agent_id: Uuid,
         req: CreateSessionRequest,
     ) -> Result<Session> {
+        let agent_id = AgentId::from_uuid(agent_id);
+
         // If model_id not provided, use the agent's default_model_id
-        let model_id = match req.model_id {
-            Some(id) => Some(id.uuid()),
+        let model_id: Option<ModelId> = match req.model_id {
+            Some(id) => Some(id),
             None => {
                 // Look up the agent to get its default_model_id
                 let agent = self.db.get_agent(org_id, agent_id).await?;
@@ -70,7 +73,7 @@ impl SessionService {
         let session = Self::row_to_session(row);
 
         // Apply capability mounts to the session filesystem
-        self.apply_capability_mounts(agent_id, session.id.uuid())
+        self.apply_capability_mounts(agent_id.uuid(), session.id.uuid())
             .await?;
 
         Ok(session)
@@ -134,7 +137,10 @@ impl SessionService {
     }
 
     pub async fn get(&self, org_id: i64, id: Uuid) -> Result<Option<Session>> {
-        let row = self.db.get_session(org_id, id).await?;
+        let row = self
+            .db
+            .get_session(org_id, SessionId::from_uuid(id))
+            .await?;
         Ok(row.map(Self::row_to_session))
     }
 
@@ -147,7 +153,10 @@ impl SessionService {
         agent_id: Uuid,
         pagination: Pagination,
     ) -> Result<(Vec<Session>, u32)> {
-        let (rows, total) = self.db.list_sessions(org_id, agent_id, pagination).await?;
+        let (rows, total) = self
+            .db
+            .list_sessions(org_id, AgentId::from_uuid(agent_id), pagination)
+            .await?;
         let mut sessions: Vec<Session> = rows.into_iter().map(Self::row_to_session).collect();
 
         // Fetch previews for all sessions in batch queries
@@ -179,7 +188,10 @@ impl SessionService {
             tags: req.tags,
             ..Default::default()
         };
-        let row = self.db.update_session(org_id, id, input).await?;
+        let row = self
+            .db
+            .update_session(org_id, SessionId::from_uuid(id), input)
+            .await?;
         Ok(row.map(Self::row_to_session))
     }
 
@@ -194,12 +206,17 @@ impl SessionService {
             status: Some(status),
             ..Default::default()
         };
-        let row = self.db.update_session(org_id, id, input).await?;
+        let row = self
+            .db
+            .update_session(org_id, SessionId::from_uuid(id), input)
+            .await?;
         Ok(row.map(Self::row_to_session))
     }
 
     pub async fn delete(&self, org_id: i64, id: Uuid) -> Result<bool> {
-        self.db.delete_session(org_id, id).await
+        self.db
+            .delete_session(org_id, SessionId::from_uuid(id))
+            .await
     }
 
     fn row_to_session(row: crate::storage::SessionRow) -> Session {
@@ -224,13 +241,13 @@ impl SessionService {
         };
 
         Session {
-            id: row.id.into(),
-            agent_id: row.agent_id.into(),
+            id: row.id,
+            agent_id: row.agent_id,
             title: row.title,
             preview: None,        // Populated separately in list()
             output_preview: None, // Populated separately in list()
             tags: row.tags,
-            model_id: row.model_id.map(|id| id.into()),
+            model_id: row.model_id,
             status: SessionStatus::from(row.status.as_str()),
             created_at: row.created_at,
             updated_at: row.updated_at,

--- a/crates/control-plane/src/services/session_file.rs
+++ b/crates/control-plane/src/services/session_file.rs
@@ -12,6 +12,7 @@ use crate::storage::{
 use anyhow::{Result, anyhow};
 use everruns_core::{
     FileInfo, FileStat, GrepMatch, GrepResult, MountEntry, MountPoint, MountSource, SessionFile,
+    SessionId,
 };
 use regex::Regex;
 use std::sync::Arc;
@@ -133,7 +134,7 @@ impl SessionFileService {
         }
 
         let input = CreateSessionFileRow {
-            session_id,
+            session_id: SessionId::from_uuid(session_id),
             path: path.clone(),
             content,
             is_directory: false,
@@ -168,7 +169,7 @@ impl SessionFileService {
         }
 
         let input = CreateSessionFileRow {
-            session_id,
+            session_id: SessionId::from_uuid(session_id),
             path: path.clone(),
             content: None,
             is_directory: true,
@@ -201,7 +202,7 @@ impl SessionFileService {
 
         // Create this directory
         let input = CreateSessionFileRow {
-            session_id,
+            session_id: SessionId::from_uuid(session_id),
             path: path.to_string(),
             content: None,
             is_directory: true,
@@ -496,7 +497,7 @@ impl SessionFileService {
 
         SessionFile {
             id: row.id,
-            session_id: row.session_id,
+            session_id: row.session_id.uuid(),
             path: row.path.clone(),
             name: FileInfo::name_from_path(&row.path),
             content,
@@ -512,7 +513,7 @@ impl SessionFileService {
     fn row_to_file_info(row: SessionFileRow) -> FileInfo {
         FileInfo {
             id: row.id,
-            session_id: row.session_id,
+            session_id: row.session_id.uuid(),
             path: row.path.clone(),
             name: FileInfo::name_from_path(&row.path),
             is_directory: row.is_directory,
@@ -526,7 +527,7 @@ impl SessionFileService {
     fn row_to_file_info_from_info(row: SessionFileInfoRow) -> FileInfo {
         FileInfo {
             id: row.id,
-            session_id: row.session_id,
+            session_id: row.session_id.uuid(),
             path: row.path.clone(),
             name: FileInfo::name_from_path(&row.path),
             is_directory: row.is_directory,
@@ -669,7 +670,7 @@ impl SessionFileService {
         let content_bytes = SessionFile::decode_content(content, encoding)?;
 
         let input = CreateSessionFileRow {
-            session_id,
+            session_id: SessionId::from_uuid(session_id),
             path: path.to_string(),
             content: Some(content_bytes),
             is_directory: false,
@@ -708,7 +709,7 @@ impl SessionFileService {
         }
 
         let input = CreateSessionFileRow {
-            session_id,
+            session_id: SessionId::from_uuid(session_id),
             path: path.to_string(),
             content: None,
             is_directory: true,

--- a/crates/control-plane/src/services/usage_tracking.rs
+++ b/crates/control-plane/src/services/usage_tracking.rs
@@ -54,11 +54,7 @@ impl EventListener for UsageTrackingListener {
         let cache_creation_tokens = usage.cache_creation_tokens.unwrap_or(0) as i64;
 
         // Get session to determine org_id
-        let session = match self
-            .db
-            .get_session(DEFAULT_ORG_ID, event.session_id.uuid())
-            .await
-        {
+        let session = match self.db.get_session(DEFAULT_ORG_ID, event.session_id).await {
             Ok(Some(s)) => s,
             Ok(None) => {
                 error!("Session not found for usage tracking: {}", event.session_id);
@@ -129,7 +125,7 @@ impl EventListener for UsageTrackingListener {
         if let Err(e) = self
             .db
             .increment_agent_usage(
-                session.agent_id,
+                session.agent_id.uuid(),
                 input_tokens,
                 output_tokens,
                 cache_read_tokens,

--- a/crates/control-plane/src/storage/agent_store.rs
+++ b/crates/control-plane/src/storage/agent_store.rs
@@ -5,11 +5,10 @@
 
 use async_trait::async_trait;
 use everruns_core::{
-    AgentCapabilityConfig, AgentLoopError, DEFAULT_ORG_ID, Result,
+    AgentCapabilityConfig, AgentId, AgentLoopError, DEFAULT_ORG_ID, Result,
     agent::{Agent, AgentStatus},
     traits::AgentStore,
 };
-use uuid::Uuid;
 
 use super::repositories::Database;
 
@@ -34,7 +33,7 @@ impl DbAgentStore {
 
 #[async_trait]
 impl AgentStore for DbAgentStore {
-    async fn get_agent(&self, agent_id: Uuid) -> Result<Option<Agent>> {
+    async fn get_agent(&self, agent_id: AgentId) -> Result<Option<Agent>> {
         // TODO: Get org_id from context after Phase 3
         let agent_row = self
             .db
@@ -47,7 +46,7 @@ impl AgentStore for DbAgentStore {
                 // Load capabilities for this agent
                 let capability_rows = self
                     .db
-                    .get_agent_capabilities(agent_id)
+                    .get_agent_capabilities(agent_id.uuid())
                     .await
                     .map_err(|e| AgentLoopError::store(e.to_string()))?;
 
@@ -57,11 +56,11 @@ impl AgentStore for DbAgentStore {
                     .collect();
 
                 Ok(Some(Agent {
-                    id: row.id.into(),
+                    id: row.id,
                     name: row.name,
                     description: row.description,
                     system_prompt: row.system_prompt,
-                    default_model_id: row.default_model_id.map(|id| id.into()),
+                    default_model_id: row.default_model_id,
                     tags: row.tags,
                     capabilities,
                     status: AgentStatus::from(row.status.as_str()),

--- a/crates/control-plane/src/storage/backend.rs
+++ b/crates/control-plane/src/storage/backend.rs
@@ -6,6 +6,7 @@
 
 use anyhow::Result;
 use everruns_core::message_filter::MessageQuery;
+use everruns_core::typed_id::{AgentId, EventId, SessionId};
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -166,13 +167,13 @@ impl StorageBackend {
     pub async fn create_agent_with_id(
         &self,
         org_id: i64,
-        id: Uuid,
+        id: AgentId,
         input: CreateAgentRow,
     ) -> Result<Option<AgentRow>> {
         dispatch!(self, create_agent_with_id, org_id, id, input)
     }
 
-    pub async fn get_agent(&self, org_id: i64, id: Uuid) -> Result<Option<AgentRow>> {
+    pub async fn get_agent(&self, org_id: i64, id: AgentId) -> Result<Option<AgentRow>> {
         dispatch!(self, get_agent, org_id, id)
     }
 
@@ -187,13 +188,13 @@ impl StorageBackend {
     pub async fn update_agent(
         &self,
         org_id: i64,
-        id: Uuid,
+        id: AgentId,
         input: UpdateAgent,
     ) -> Result<Option<AgentRow>> {
         dispatch!(self, update_agent, org_id, id, input)
     }
 
-    pub async fn delete_agent(&self, org_id: i64, id: Uuid) -> Result<bool> {
+    pub async fn delete_agent(&self, org_id: i64, id: AgentId) -> Result<bool> {
         dispatch!(self, delete_agent, org_id, id)
     }
 
@@ -205,7 +206,7 @@ impl StorageBackend {
         dispatch!(self, create_session, input)
     }
 
-    pub async fn get_session(&self, org_id: i64, id: Uuid) -> Result<Option<SessionRow>> {
+    pub async fn get_session(&self, org_id: i64, id: SessionId) -> Result<Option<SessionRow>> {
         dispatch!(self, get_session, org_id, id)
     }
 
@@ -214,7 +215,7 @@ impl StorageBackend {
     pub async fn list_sessions(
         &self,
         org_id: i64,
-        agent_id: Uuid,
+        agent_id: AgentId,
         pagination: Pagination,
     ) -> Result<(Vec<SessionRow>, u32)> {
         dispatch!(self, list_sessions, org_id, agent_id, pagination)
@@ -223,13 +224,13 @@ impl StorageBackend {
     pub async fn update_session(
         &self,
         org_id: i64,
-        id: Uuid,
+        id: SessionId,
         input: UpdateSession,
     ) -> Result<Option<SessionRow>> {
         dispatch!(self, update_session, org_id, id, input)
     }
 
-    pub async fn delete_session(&self, org_id: i64, id: Uuid) -> Result<bool> {
+    pub async fn delete_session(&self, org_id: i64, id: SessionId) -> Result<bool> {
         dispatch!(self, delete_session, org_id, id)
     }
 
@@ -243,14 +244,14 @@ impl StorageBackend {
 
     pub async fn list_events(
         &self,
-        session_id: Uuid,
+        session_id: SessionId,
         since_sequence: Option<i32>,
-        since_id: Option<Uuid>,
+        since_id: Option<EventId>,
     ) -> Result<Vec<EventRow>> {
         dispatch!(self, list_events, session_id, since_sequence, since_id)
     }
 
-    pub async fn list_message_events(&self, session_id: Uuid) -> Result<Vec<EventRow>> {
+    pub async fn list_message_events(&self, session_id: SessionId) -> Result<Vec<EventRow>> {
         dispatch!(self, list_message_events, session_id)
     }
 

--- a/crates/control-plane/src/storage/event_tests.rs
+++ b/crates/control-plane/src/storage/event_tests.rs
@@ -5,12 +5,13 @@
 
 use everruns_core::events::{EventContext, InputReceivedData, ToolCallCompletedData};
 use everruns_core::message::Message;
+use everruns_core::typed_id::SessionId;
 use everruns_core::{ContentPart, Event};
 use uuid::Uuid;
 
 #[test]
 fn test_event_serialization() {
-    let session_id = Uuid::now_v7();
+    let session_id = SessionId::new();
     let event_context = EventContext::empty();
     let event = Event::new(
         session_id,
@@ -23,14 +24,14 @@ fn test_event_serialization() {
     assert!(json.is_object());
     assert_eq!(json["type"], "input.received");
     // session_id now uses prefixed format (session_{hex})
-    let expected_session_id = format!("session_{}", session_id.simple());
+    let expected_session_id = format!("session_{}", session_id.uuid().simple());
     assert_eq!(json["session_id"], expected_session_id);
     assert!(json["context"].is_object());
 }
 
 #[test]
 fn test_event_type() {
-    let session_id = Uuid::now_v7();
+    let session_id = SessionId::new();
     let event_context = EventContext::empty();
     let event = Event::new(
         session_id,
@@ -43,7 +44,8 @@ fn test_event_type() {
 
 #[test]
 fn test_event_session_id() {
-    let session_id = Uuid::now_v7();
+    let raw_uuid = Uuid::now_v7();
+    let session_id = SessionId::from_uuid(raw_uuid);
     let event_context = EventContext::empty();
     let event = Event::new(
         session_id,
@@ -51,13 +53,13 @@ fn test_event_session_id() {
         InputReceivedData::new(Message::user("test")),
     );
 
-    assert_eq!(event.session_uuid(), session_id);
+    assert_eq!(event.session_uuid(), raw_uuid);
 }
 
 #[test]
 fn test_tool_call_completed_event_serialization() {
     // This test verifies the exact JSON structure that the UI expects
-    let session_id = Uuid::now_v7();
+    let session_id = SessionId::new();
     let completed = ToolCallCompletedData::success(
         "call_abc123".to_string(),
         "get_weather".to_string(),
@@ -74,7 +76,7 @@ fn test_tool_call_completed_event_serialization() {
     // Verify top-level structure
     assert_eq!(json["type"], "tool.call_completed");
     // session_id now uses prefixed format (session_{hex})
-    let expected_session_id = format!("session_{}", session_id.simple());
+    let expected_session_id = format!("session_{}", session_id.uuid().simple());
     assert_eq!(json["session_id"], expected_session_id);
 
     // Verify data field contains the payload directly (untagged)
@@ -93,7 +95,7 @@ fn test_tool_call_completed_event_serialization() {
 
 #[test]
 fn test_tool_call_completed_error_serialization() {
-    let session_id = Uuid::now_v7();
+    let session_id = SessionId::new();
     let completed = ToolCallCompletedData::failure(
         "call_xyz789".to_string(),
         "read_file".to_string(),

--- a/crates/control-plane/src/storage/llm_provider_store.rs
+++ b/crates/control-plane/src/storage/llm_provider_store.rs
@@ -5,11 +5,10 @@
 
 use async_trait::async_trait;
 use everruns_core::{
-    AgentLoopError, DEFAULT_ORG_ID, Result,
+    AgentLoopError, DEFAULT_ORG_ID, ModelId, Result,
     llm_models::LlmProviderType,
     traits::{LlmProviderStore, ModelWithProvider},
 };
-use uuid::Uuid;
 
 use super::{encryption::EncryptionService, repositories::Database};
 
@@ -37,11 +36,14 @@ impl DbLlmProviderStore {
 
 #[async_trait]
 impl LlmProviderStore for DbLlmProviderStore {
-    async fn get_model_with_provider(&self, model_id: Uuid) -> Result<Option<ModelWithProvider>> {
+    async fn get_model_with_provider(
+        &self,
+        model_id: ModelId,
+    ) -> Result<Option<ModelWithProvider>> {
         // Look up the model
         let model_row = self
             .db
-            .get_llm_model(model_id)
+            .get_llm_model(model_id.uuid())
             .await
             .map_err(|e| AgentLoopError::store(e.to_string()))?;
 
@@ -53,7 +55,7 @@ impl LlmProviderStore for DbLlmProviderStore {
         // Look up the provider
         let provider_row = self
             .db
-            .get_llm_provider(model_row.provider_id)
+            .get_llm_provider(model_row.provider_id.uuid())
             .await
             .map_err(|e| AgentLoopError::store(e.to_string()))?;
 
@@ -96,7 +98,7 @@ impl LlmProviderStore for DbLlmProviderStore {
         // Look up the provider
         let provider_row = self
             .db
-            .get_llm_provider(model_row.provider_id)
+            .get_llm_provider(model_row.provider_id.uuid())
             .await
             .map_err(|e| AgentLoopError::store(e.to_string()))?;
 

--- a/crates/control-plane/src/storage/memory.rs
+++ b/crates/control-plane/src/storage/memory.rs
@@ -8,7 +8,10 @@
 use anyhow::{Result, anyhow};
 use chrono::{DateTime, Utc};
 use everruns_core::message_filter::{MessageFilter, MessageQuery};
-use everruns_core::{DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID};
+use everruns_core::{
+    AgentId, DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, EventId, ImageId, McpServerId, ModelId,
+    ProviderId, SessionId,
+};
 use parking_lot::RwLock;
 use std::collections::HashMap;
 use uuid::Uuid;
@@ -26,20 +29,20 @@ pub struct InMemoryDatabase {
     users: RwLock<HashMap<Uuid, UserRow>>,
     api_keys: RwLock<HashMap<Uuid, ApiKeyRow>>,
     refresh_tokens: RwLock<HashMap<Uuid, RefreshTokenRow>>,
-    agents: RwLock<HashMap<Uuid, AgentRow>>,
-    sessions: RwLock<HashMap<Uuid, SessionRow>>,
-    events: RwLock<HashMap<Uuid, EventRow>>,
-    llm_providers: RwLock<HashMap<Uuid, LlmProviderRow>>,
-    llm_models: RwLock<HashMap<Uuid, LlmModelRow>>,
-    agent_capabilities: RwLock<HashMap<(Uuid, String), AgentCapabilityRow>>,
+    agents: RwLock<HashMap<AgentId, AgentRow>>,
+    sessions: RwLock<HashMap<SessionId, SessionRow>>,
+    events: RwLock<HashMap<EventId, EventRow>>,
+    llm_providers: RwLock<HashMap<ProviderId, LlmProviderRow>>,
+    llm_models: RwLock<HashMap<ModelId, LlmModelRow>>,
+    agent_capabilities: RwLock<HashMap<(AgentId, String), AgentCapabilityRow>>,
     session_files: RwLock<HashMap<Uuid, SessionFileRow>>,
-    mcp_servers: RwLock<HashMap<Uuid, McpServerRow>>,
-    images: RwLock<HashMap<Uuid, ImageRow>>,
+    mcp_servers: RwLock<HashMap<McpServerId, McpServerRow>>,
+    images: RwLock<HashMap<ImageId, ImageRow>>,
     // Event sequence counter per session
-    event_sequences: RwLock<HashMap<Uuid, i32>>,
+    event_sequences: RwLock<HashMap<SessionId, i32>>,
     // Session storage
-    session_key_values: RwLock<HashMap<(Uuid, String), SessionKeyValueRow>>,
-    session_secrets: RwLock<HashMap<(Uuid, String), SessionSecretRow>>,
+    session_key_values: RwLock<HashMap<(SessionId, String), SessionKeyValueRow>>,
+    session_secrets: RwLock<HashMap<(SessionId, String), SessionSecretRow>>,
 }
 
 impl Default for InMemoryDatabase {
@@ -320,7 +323,7 @@ impl InMemoryDatabase {
 
     pub async fn create_agent(&self, org_id: i64, input: CreateAgentRow) -> Result<AgentRow> {
         let now = Self::now();
-        let id = Uuid::now_v7();
+        let id = AgentId::new();
         let row = AgentRow {
             id,
             org_id,
@@ -345,7 +348,7 @@ impl InMemoryDatabase {
     pub async fn create_agent_with_id(
         &self,
         org_id: i64,
-        id: Uuid,
+        id: AgentId,
         input: CreateAgentRow,
     ) -> Result<Option<AgentRow>> {
         let mut agents = self.agents.write();
@@ -373,7 +376,7 @@ impl InMemoryDatabase {
         Ok(Some(row))
     }
 
-    pub async fn get_agent(&self, org_id: i64, id: Uuid) -> Result<Option<AgentRow>> {
+    pub async fn get_agent(&self, org_id: i64, id: AgentId) -> Result<Option<AgentRow>> {
         Ok(self
             .agents
             .read()
@@ -405,7 +408,7 @@ impl InMemoryDatabase {
     pub async fn update_agent(
         &self,
         org_id: i64,
-        id: Uuid,
+        id: AgentId,
         input: UpdateAgent,
     ) -> Result<Option<AgentRow>> {
         let mut agents = self.agents.write();
@@ -434,7 +437,7 @@ impl InMemoryDatabase {
         Ok(None)
     }
 
-    pub async fn delete_agent(&self, org_id: i64, id: Uuid) -> Result<bool> {
+    pub async fn delete_agent(&self, org_id: i64, id: AgentId) -> Result<bool> {
         // Delete capabilities first
         {
             let mut caps = self.agent_capabilities.write();
@@ -457,7 +460,7 @@ impl InMemoryDatabase {
 
     pub async fn create_session(&self, input: CreateSessionRow) -> Result<SessionRow> {
         let now = Self::now();
-        let id = Uuid::now_v7();
+        let id = SessionId::new();
         let row = SessionRow {
             id,
             agent_id: input.agent_id,
@@ -479,7 +482,7 @@ impl InMemoryDatabase {
     }
 
     /// Get session, validating org ownership via agent lookup
-    pub async fn get_session(&self, org_id: i64, id: Uuid) -> Result<Option<SessionRow>> {
+    pub async fn get_session(&self, org_id: i64, id: SessionId) -> Result<Option<SessionRow>> {
         let sessions = self.sessions.read();
         let agents = self.agents.read();
         if let Some(session) = sessions.get(&id) {
@@ -498,7 +501,7 @@ impl InMemoryDatabase {
     pub async fn list_sessions(
         &self,
         org_id: i64,
-        agent_id: Uuid,
+        agent_id: AgentId,
         pagination: crate::api::common::Pagination,
     ) -> Result<(Vec<SessionRow>, u32)> {
         // First validate the agent belongs to the org
@@ -535,7 +538,7 @@ impl InMemoryDatabase {
     pub async fn update_session(
         &self,
         org_id: i64,
-        id: Uuid,
+        id: SessionId,
         input: UpdateSession,
     ) -> Result<Option<SessionRow>> {
         // First validate org ownership
@@ -580,7 +583,7 @@ impl InMemoryDatabase {
     }
 
     /// Delete session, validating org ownership via agent lookup
-    pub async fn delete_session(&self, org_id: i64, id: Uuid) -> Result<bool> {
+    pub async fn delete_session(&self, org_id: i64, id: SessionId) -> Result<bool> {
         // First validate org ownership
         {
             let sessions = self.sessions.read();
@@ -601,7 +604,7 @@ impl InMemoryDatabase {
         // Delete events first
         {
             let mut events = self.events.write();
-            let to_remove: Vec<Uuid> = events
+            let to_remove: Vec<EventId> = events
                 .iter()
                 .filter(|(_, e)| e.session_id == id)
                 .map(|(eid, _)| *eid)
@@ -631,7 +634,7 @@ impl InMemoryDatabase {
 
     pub async fn create_event(&self, input: CreateEventRow) -> Result<EventRow> {
         let now = Self::now();
-        let id = Uuid::now_v7();
+        let id = EventId::new();
 
         // Get next sequence for this session
         let sequence = {
@@ -659,9 +662,9 @@ impl InMemoryDatabase {
 
     pub async fn list_events(
         &self,
-        session_id: Uuid,
+        session_id: SessionId,
         since_sequence: Option<i32>,
-        since_id: Option<Uuid>,
+        since_id: Option<EventId>,
     ) -> Result<Vec<EventRow>> {
         let events = self.events.read();
         let mut result: Vec<_> = events
@@ -672,7 +675,8 @@ impl InMemoryDatabase {
                 }
                 // Prefer since_id (UUID v7 monotonically increasing) over sequence
                 if let Some(id) = since_id {
-                    if e.id <= id {
+                    // Compare UUIDs directly for monotonic ordering
+                    if e.id.uuid() <= id.uuid() {
                         return false;
                     }
                 } else if let Some(seq) = since_sequence
@@ -689,7 +693,7 @@ impl InMemoryDatabase {
         Ok(result)
     }
 
-    pub async fn list_message_events(&self, session_id: Uuid) -> Result<Vec<EventRow>> {
+    pub async fn list_message_events(&self, session_id: SessionId) -> Result<Vec<EventRow>> {
         let message_types = [
             "message.user",
             "message.assistant",
@@ -903,7 +907,7 @@ impl InMemoryDatabase {
         input: CreateLlmProviderRow,
     ) -> Result<LlmProviderRow> {
         let now = Self::now();
-        let id = Uuid::now_v7();
+        let id = ProviderId::new();
         let api_key_set = input.api_key_encrypted.is_some();
         let row = LlmProviderRow {
             id,
@@ -931,6 +935,7 @@ impl InMemoryDatabase {
         id: Uuid,
         input: CreateLlmProviderRow,
     ) -> Result<Option<LlmProviderRow>> {
+        let id = ProviderId::from_uuid(id);
         let mut providers = self.llm_providers.write();
         if providers.contains_key(&id) {
             return Ok(None); // Already exists
@@ -956,7 +961,11 @@ impl InMemoryDatabase {
     }
 
     pub async fn get_llm_provider(&self, id: Uuid) -> Result<Option<LlmProviderRow>> {
-        Ok(self.llm_providers.read().get(&id).cloned())
+        Ok(self
+            .llm_providers
+            .read()
+            .get(&ProviderId::from_uuid(id))
+            .cloned())
     }
 
     pub async fn list_llm_providers(&self) -> Result<Vec<LlmProviderRow>> {
@@ -971,6 +980,7 @@ impl InMemoryDatabase {
         id: Uuid,
         input: UpdateLlmProvider,
     ) -> Result<Option<LlmProviderRow>> {
+        let id = ProviderId::from_uuid(id);
         let mut providers = self.llm_providers.write();
         if let Some(provider) = providers.get_mut(&id) {
             if let Some(name) = input.name {
@@ -996,10 +1006,11 @@ impl InMemoryDatabase {
     }
 
     pub async fn delete_llm_provider(&self, id: Uuid) -> Result<bool> {
+        let id = ProviderId::from_uuid(id);
         // Delete models first
         {
             let mut models = self.llm_models.write();
-            let to_remove: Vec<Uuid> = models
+            let to_remove: Vec<ModelId> = models
                 .iter()
                 .filter(|(_, m)| m.provider_id == id)
                 .map(|(mid, _)| *mid)
@@ -1017,6 +1028,7 @@ impl InMemoryDatabase {
         id: Uuid,
         last_synced_at: chrono::DateTime<chrono::Utc>,
     ) -> Result<()> {
+        let id = ProviderId::from_uuid(id);
         if let Some(provider) = self.llm_providers.write().get_mut(&id) {
             provider.last_synced_at = Some(last_synced_at);
             provider.updated_at = Self::now();
@@ -1104,7 +1116,7 @@ impl InMemoryDatabase {
         input: CreateLlmModelRow,
     ) -> Result<LlmModelRow> {
         let now = Self::now();
-        let id = Uuid::now_v7();
+        let id = ModelId::new();
         let row = LlmModelRow {
             id,
             org_id,
@@ -1133,6 +1145,7 @@ impl InMemoryDatabase {
         id: Uuid,
         input: CreateLlmModelRow,
     ) -> Result<Option<LlmModelRow>> {
+        let id = ModelId::from_uuid(id);
         let mut models = self.llm_models.write();
         let now = Self::now();
 
@@ -1179,6 +1192,7 @@ impl InMemoryDatabase {
     }
 
     pub async fn get_llm_model(&self, id: Uuid) -> Result<Option<LlmModelRow>> {
+        let id = ModelId::from_uuid(id);
         Ok(self.llm_models.read().get(&id).cloned())
     }
 
@@ -1186,6 +1200,7 @@ impl InMemoryDatabase {
         &self,
         id: Uuid,
     ) -> Result<Option<LlmModelWithProviderRow>> {
+        let id = ModelId::from_uuid(id);
         let models = self.llm_models.read();
         let providers = self.llm_providers.read();
 
@@ -1218,6 +1233,7 @@ impl InMemoryDatabase {
         &self,
         provider_id: Uuid,
     ) -> Result<Vec<LlmModelRow>> {
+        let provider_id = ProviderId::from_uuid(provider_id);
         let models = self.llm_models.read();
         let mut result: Vec<_> = models
             .values()
@@ -1272,6 +1288,7 @@ impl InMemoryDatabase {
         id: Uuid,
         input: UpdateLlmModel,
     ) -> Result<Option<LlmModelRow>> {
+        let id = ModelId::from_uuid(id);
         let mut models = self.llm_models.write();
         if let Some(model) = models.get_mut(&id) {
             if let Some(display_name) = input.display_name {
@@ -1296,6 +1313,7 @@ impl InMemoryDatabase {
     }
 
     pub async fn delete_llm_model(&self, id: Uuid) -> Result<bool> {
+        let id = ModelId::from_uuid(id);
         Ok(self.llm_models.write().remove(&id).is_some())
     }
 
@@ -1340,6 +1358,7 @@ impl InMemoryDatabase {
     // ============================================
 
     pub async fn get_agent_capabilities(&self, agent_id: Uuid) -> Result<Vec<AgentCapabilityRow>> {
+        let agent_id = AgentId::from_uuid(agent_id);
         let caps = self.agent_capabilities.read();
         let mut result: Vec<_> = caps
             .iter()
@@ -1355,6 +1374,7 @@ impl InMemoryDatabase {
         agent_id: Uuid,
         capabilities: Vec<(String, i32, serde_json::Value)>,
     ) -> Result<Vec<AgentCapabilityRow>> {
+        let agent_id = AgentId::from_uuid(agent_id);
         let now = Self::now();
         let mut caps = self.agent_capabilities.write();
 
@@ -1410,6 +1430,7 @@ impl InMemoryDatabase {
         agent_id: Uuid,
         capability_id: &str,
     ) -> Result<bool> {
+        let agent_id = AgentId::from_uuid(agent_id);
         Ok(self
             .agent_capabilities
             .write()
@@ -1542,6 +1563,7 @@ impl InMemoryDatabase {
     }
 
     pub async fn delete_session_file(&self, session_id: Uuid, path: &str) -> Result<bool> {
+        let session_id = SessionId::from_uuid(session_id);
         let mut files = self.session_files.write();
         let to_remove: Option<Uuid> = files
             .iter()
@@ -1556,6 +1578,7 @@ impl InMemoryDatabase {
     }
 
     pub async fn delete_session_file_recursive(&self, session_id: Uuid, path: &str) -> Result<u64> {
+        let session_id = SessionId::from_uuid(session_id);
         let mut files = self.session_files.write();
         let prefix = format!("{}/", path.trim_end_matches('/'));
 
@@ -1580,6 +1603,7 @@ impl InMemoryDatabase {
         source_path: &str,
         dest_path: &str,
     ) -> Result<Option<SessionFileRow>> {
+        let session_id = SessionId::from_uuid(session_id);
         // Check if destination exists
         {
             let files = self.session_files.read();
@@ -1609,6 +1633,7 @@ impl InMemoryDatabase {
         source_path: &str,
         dest_path: &str,
     ) -> Result<Option<SessionFileRow>> {
+        let session_id = SessionId::from_uuid(session_id);
         // Check if destination exists
         {
             let files = self.session_files.read();
@@ -1654,6 +1679,7 @@ impl InMemoryDatabase {
         pattern: &str,
         path_prefix: Option<&str>,
     ) -> Result<Vec<SessionFileInfoRow>> {
+        let session_id = SessionId::from_uuid(session_id);
         let regex = regex::Regex::new(pattern)?;
         let files = self.session_files.read();
 
@@ -1682,6 +1708,7 @@ impl InMemoryDatabase {
     }
 
     pub async fn session_file_exists(&self, session_id: Uuid, path: &str) -> Result<bool> {
+        let session_id = SessionId::from_uuid(session_id);
         Ok(self
             .session_files
             .read()
@@ -1694,6 +1721,7 @@ impl InMemoryDatabase {
         session_id: Uuid,
         path: &str,
     ) -> Result<bool> {
+        let session_id = SessionId::from_uuid(session_id);
         let prefix = format!("{}/", path.trim_end_matches('/'));
         Ok(self
             .session_files
@@ -1725,7 +1753,7 @@ impl InMemoryDatabase {
         }
 
         let now = Self::now();
-        let id = Uuid::now_v7();
+        let id = McpServerId::new();
         let api_key_set = input.api_key_encrypted.is_some();
 
         let row = McpServerRow {
@@ -1758,6 +1786,7 @@ impl InMemoryDatabase {
         id: Uuid,
         input: CreateMcpServerRow,
     ) -> Result<Option<McpServerRow>> {
+        let id = McpServerId::from_uuid(id);
         // Check if already exists
         if self.mcp_servers.read().contains_key(&id) {
             return Ok(None);
@@ -1789,6 +1818,7 @@ impl InMemoryDatabase {
     }
 
     pub async fn get_mcp_server(&self, id: Uuid) -> Result<Option<McpServerRow>> {
+        let id = McpServerId::from_uuid(id);
         Ok(self.mcp_servers.read().get(&id).cloned())
     }
 
@@ -1935,7 +1965,7 @@ impl InMemoryDatabase {
 
     pub async fn create_image(&self, input: CreateImageRow) -> Result<ImageRow> {
         let now = Self::now();
-        let id = Uuid::now_v7();
+        let id = ImageId::new();
         let row = ImageRow {
             id,
             filename: input.filename,
@@ -1952,10 +1982,12 @@ impl InMemoryDatabase {
     }
 
     pub async fn get_image(&self, id: Uuid) -> Result<Option<ImageRow>> {
+        let id = ImageId::from_uuid(id);
         Ok(self.images.read().get(&id).cloned())
     }
 
     pub async fn get_image_info(&self, id: Uuid) -> Result<Option<ImageInfoRow>> {
+        let id = ImageId::from_uuid(id);
         Ok(self.images.read().get(&id).map(|img| ImageInfoRow {
             id: img.id,
             filename: img.filename.clone(),
@@ -1967,6 +1999,7 @@ impl InMemoryDatabase {
     }
 
     pub async fn delete_image(&self, id: Uuid) -> Result<bool> {
+        let id = ImageId::from_uuid(id);
         Ok(self.images.write().remove(&id).is_some())
     }
 
@@ -1997,6 +2030,7 @@ impl InMemoryDatabase {
         id: Uuid,
         input: UpdateMcpServerTools,
     ) -> Result<Option<McpServerRow>> {
+        let id = McpServerId::from_uuid(id);
         let mut servers = self.mcp_servers.write();
         if let Some(server) = servers.get_mut(&id) {
             server.cached_tools = input.cached_tools;
@@ -2167,6 +2201,7 @@ impl InMemoryDatabase {
     // ============================================
 
     pub async fn list_session_keys(&self, session_id: Uuid) -> Result<Vec<SessionKeyInfoRow>> {
+        let session_id = SessionId::from_uuid(session_id);
         let storage = self.session_key_values.read();
         let mut keys: Vec<_> = storage
             .iter()
@@ -2186,6 +2221,7 @@ impl InMemoryDatabase {
         session_id: Uuid,
         key: &str,
     ) -> Result<Option<SessionKeyValueRow>> {
+        let session_id = SessionId::from_uuid(session_id);
         Ok(self
             .session_key_values
             .read()
@@ -2197,6 +2233,7 @@ impl InMemoryDatabase {
         &self,
         session_id: Uuid,
     ) -> Result<Vec<SessionSecretInfoRow>> {
+        let session_id = SessionId::from_uuid(session_id);
         let storage = self.session_secrets.read();
         let mut secrets: Vec<_> = storage
             .iter()

--- a/crates/control-plane/src/storage/message_store.rs
+++ b/crates/control-plane/src/storage/message_store.rs
@@ -12,8 +12,8 @@
 use async_trait::async_trait;
 use chrono::Utc;
 use everruns_core::{
-    AgentLoopError, ContentPart, Event, EventData, InputMessage, Message, MessageFilter,
-    MessageQuery, MessageRetriever, MessageRole, Result,
+    AgentLoopError, ContentPart, Event, EventData, InputMessage, Message, MessageFilter, MessageId,
+    MessageQuery, MessageRetriever, MessageRole, Result, SessionId,
     events::{
         EventContext, EventRequest, MessageAgentData, MessageUserData, ToolCallCompletedData,
     },
@@ -63,6 +63,7 @@ impl DbMessageRetriever {
         };
 
         // Emit as typed event based on role
+        let session_id: SessionId = session_id.into();
         let event_request = match message.role {
             MessageRole::User => EventRequest::new(
                 session_id,
@@ -91,12 +92,12 @@ impl DbMessageRetriever {
 
 #[async_trait]
 impl MessageRetriever for DbMessageRetriever {
-    async fn get(&self, session_id: Uuid, message_id: Uuid) -> Result<Option<Message>> {
+    async fn get(&self, session_id: SessionId, message_id: MessageId) -> Result<Option<Message>> {
         let messages = self.load(session_id).await?;
         Ok(messages.into_iter().find(|m| m.id == message_id))
     }
 
-    async fn load(&self, session_id: Uuid) -> Result<Vec<Message>> {
+    async fn load(&self, session_id: SessionId) -> Result<Vec<Message>> {
         let events = self
             .db
             .list_message_events(session_id)
@@ -157,7 +158,7 @@ impl MessageRetriever for DbMessageRetriever {
         Ok(messages)
     }
 
-    async fn count(&self, session_id: Uuid) -> Result<usize> {
+    async fn count(&self, session_id: SessionId) -> Result<usize> {
         let events = self
             .db
             .list_message_events(session_id)
@@ -250,6 +251,7 @@ pub fn create_db_message_retriever(db: Arc<StorageBackend>) -> DbMessageRetrieve
 #[cfg(test)]
 mod tests {
     use everruns_core::events::EventContext;
+    use everruns_core::typed_id::SessionId;
     use everruns_core::{ContentPart, Event, ToolCall, ToolCallCompletedData};
     use serde_json::json;
 
@@ -371,7 +373,7 @@ mod tests {
 
     #[test]
     fn test_parse_message_user_event() {
-        let session_id = Uuid::now_v7();
+        let session_id = SessionId::new();
         let message = Message::user("Hello from user!");
         let event = Event::new(
             session_id,
@@ -390,7 +392,7 @@ mod tests {
 
     #[test]
     fn test_parse_message_agent_event() {
-        let session_id = Uuid::now_v7();
+        let session_id = SessionId::new();
         let message = Message::assistant("Hello from agent!");
         let event = Event::new(
             session_id,
@@ -409,7 +411,7 @@ mod tests {
 
     #[test]
     fn test_parse_tool_call_completed_event() {
-        let session_id = Uuid::now_v7();
+        let session_id = SessionId::new();
         let completed = ToolCallCompletedData::success(
             "call_123".to_string(),
             "get_weather".to_string(),
@@ -428,7 +430,7 @@ mod tests {
 
     #[test]
     fn test_parse_tool_call_completed_error() {
-        let session_id = Uuid::now_v7();
+        let session_id = SessionId::new();
         let completed = ToolCallCompletedData::failure(
             "call_456".to_string(),
             "read_file".to_string(),
@@ -453,7 +455,7 @@ mod tests {
 
     #[test]
     fn test_parse_agent_message_with_tool_calls() {
-        let session_id = Uuid::now_v7();
+        let session_id = SessionId::new();
         let message = Message::assistant_with_tools(
             "Let me search for that",
             vec![ToolCall {

--- a/crates/control-plane/src/storage/models.rs
+++ b/crates/control-plane/src/storage/models.rs
@@ -1,6 +1,7 @@
 // Database models (internal, may differ from public DTOs)
 
 use chrono::{DateTime, Utc};
+use everruns_core::{AgentId, EventId, ImageId, McpServerId, ModelId, ProviderId, SessionId};
 use sqlx::FromRow;
 use uuid::Uuid;
 
@@ -158,12 +159,12 @@ pub struct CreateRefreshTokenRow {
 
 #[derive(Debug, Clone, FromRow)]
 pub struct AgentRow {
-    pub id: Uuid,
+    pub id: AgentId,
     pub org_id: i64,
     pub name: String,
     pub description: Option<String>,
     pub system_prompt: String,
-    pub default_model_id: Option<Uuid>,
+    pub default_model_id: Option<ModelId>,
     pub tags: Vec<String>,
     pub status: String,
     pub created_at: DateTime<Utc>,
@@ -187,7 +188,7 @@ pub struct CreateAgentRow {
     pub name: String,
     pub description: Option<String>,
     pub system_prompt: String,
-    pub default_model_id: Option<Uuid>,
+    pub default_model_id: Option<ModelId>,
     pub tags: Vec<String>,
 }
 
@@ -196,7 +197,7 @@ pub struct UpdateAgent {
     pub name: Option<String>,
     pub description: Option<String>,
     pub system_prompt: Option<String>,
-    pub default_model_id: Option<Uuid>,
+    pub default_model_id: Option<ModelId>,
     pub tags: Option<Vec<String>>,
     pub status: Option<String>,
 }
@@ -207,11 +208,11 @@ pub struct UpdateAgent {
 
 #[derive(Debug, Clone, FromRow)]
 pub struct SessionRow {
-    pub id: Uuid,
-    pub agent_id: Uuid,
+    pub id: SessionId,
+    pub agent_id: AgentId,
     pub title: Option<String>,
     pub tags: Vec<String>,
-    pub model_id: Option<Uuid>,
+    pub model_id: Option<ModelId>,
     pub status: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
@@ -233,17 +234,17 @@ pub struct SessionRow {
 
 #[derive(Debug, Clone, Default)]
 pub struct CreateSessionRow {
-    pub agent_id: Uuid,
+    pub agent_id: AgentId,
     pub title: Option<String>,
     pub tags: Vec<String>,
-    pub model_id: Option<Uuid>,
+    pub model_id: Option<ModelId>,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct UpdateSession {
     pub title: Option<String>,
     pub tags: Option<Vec<String>>,
-    pub model_id: Option<Uuid>,
+    pub model_id: Option<ModelId>,
     pub status: Option<String>,
     pub started_at: Option<DateTime<Utc>>,
     pub finished_at: Option<DateTime<Utc>>,
@@ -258,8 +259,8 @@ pub struct UpdateSession {
 
 #[derive(Debug, Clone, FromRow)]
 pub struct EventRow {
-    pub id: Uuid,
-    pub session_id: Uuid,
+    pub id: EventId,
+    pub session_id: SessionId,
     pub sequence: i32,
     pub event_type: String,
     pub ts: DateTime<Utc>,
@@ -272,7 +273,7 @@ pub struct EventRow {
 
 #[derive(Debug, Clone)]
 pub struct CreateEventRow {
-    pub session_id: Uuid,
+    pub session_id: SessionId,
     pub event_type: String,
     pub ts: DateTime<Utc>,
     pub context: serde_json::Value,
@@ -287,7 +288,7 @@ pub struct CreateEventRow {
 
 #[derive(Debug, Clone, FromRow)]
 pub struct LlmProviderRow {
-    pub id: Uuid,
+    pub id: ProviderId,
     pub org_id: i64,
     pub name: String,
     pub provider_type: String,
@@ -304,9 +305,9 @@ pub struct LlmProviderRow {
 
 #[derive(Debug, Clone, FromRow)]
 pub struct LlmModelRow {
-    pub id: Uuid,
+    pub id: ModelId,
     pub org_id: i64,
-    pub provider_id: Uuid,
+    pub provider_id: ProviderId,
     pub model_id: String,
     pub display_name: String,
     pub capabilities: sqlx::types::JsonValue,
@@ -326,9 +327,9 @@ pub struct LlmModelRow {
 /// Model with provider info joined
 #[derive(Debug, Clone, FromRow)]
 pub struct LlmModelWithProviderRow {
-    pub id: Uuid,
+    pub id: ModelId,
     pub org_id: i64,
-    pub provider_id: Uuid,
+    pub provider_id: ProviderId,
     pub model_id: String,
     pub display_name: String,
     pub capabilities: sqlx::types::JsonValue,
@@ -350,7 +351,7 @@ pub struct LlmModelWithProviderRow {
 /// LLM Provider with decrypted API key (used by worker activities)
 #[derive(Debug, Clone)]
 pub struct LlmProviderWithApiKey {
-    pub id: Uuid,
+    pub id: ProviderId,
     pub name: String,
     pub provider_type: String,
     pub base_url: Option<String>,
@@ -380,7 +381,7 @@ pub struct UpdateLlmProvider {
 
 #[derive(Debug, Clone)]
 pub struct CreateLlmModelRow {
-    pub provider_id: Uuid,
+    pub provider_id: ProviderId,
     pub model_id: String,
     pub display_name: String,
     pub capabilities: Vec<String>,
@@ -413,7 +414,7 @@ pub struct UpdateLlmModel {
 #[derive(Debug, Clone, FromRow)]
 pub struct AgentCapabilityRow {
     pub id: Uuid,
-    pub agent_id: Uuid,
+    pub agent_id: AgentId,
     pub capability_id: String,
     pub position: i32,
     /// Per-agent capability configuration (JSON)
@@ -423,7 +424,7 @@ pub struct AgentCapabilityRow {
 
 #[derive(Debug, Clone)]
 pub struct CreateAgentCapabilityRow {
-    pub agent_id: Uuid,
+    pub agent_id: AgentId,
     pub capability_id: String,
     pub position: i32,
     /// Per-agent capability configuration (JSON)
@@ -439,7 +440,7 @@ pub struct CreateAgentCapabilityRow {
 #[derive(Debug, Clone, FromRow)]
 pub struct SessionFileRow {
     pub id: Uuid,
-    pub session_id: Uuid,
+    pub session_id: SessionId,
     pub path: String,
     pub content: Option<Vec<u8>>,
     pub is_directory: bool,
@@ -452,7 +453,7 @@ pub struct SessionFileRow {
 /// Input for creating a session file
 #[derive(Debug, Clone)]
 pub struct CreateSessionFileRow {
-    pub session_id: Uuid,
+    pub session_id: SessionId,
     pub path: String,
     pub content: Option<Vec<u8>>,
     pub is_directory: bool,
@@ -470,7 +471,7 @@ pub struct UpdateSessionFile {
 #[derive(Debug, Clone, FromRow)]
 pub struct SessionFileInfoRow {
     pub id: Uuid,
-    pub session_id: Uuid,
+    pub session_id: SessionId,
     pub path: String,
     pub is_directory: bool,
     pub is_readonly: bool,
@@ -486,7 +487,7 @@ pub struct SessionFileInfoRow {
 /// MCP Server row from database
 #[derive(Debug, Clone, FromRow)]
 pub struct McpServerRow {
-    pub id: Uuid,
+    pub id: McpServerId,
     pub org_id: i64,
     pub name: String,
     pub description: Option<String>,
@@ -537,7 +538,7 @@ pub struct UpdateMcpServer {
 /// Image row from database
 #[derive(Debug, Clone, FromRow)]
 pub struct ImageRow {
-    pub id: Uuid,
+    pub id: ImageId,
     pub filename: String,
     pub content_type: String,
     pub size_bytes: i64,
@@ -551,7 +552,7 @@ pub struct ImageRow {
 /// Image info without binary data (for listing)
 #[derive(Debug, Clone, FromRow)]
 pub struct ImageInfoRow {
-    pub id: Uuid,
+    pub id: ImageId,
     pub filename: String,
     pub content_type: String,
     pub size_bytes: i64,
@@ -585,7 +586,7 @@ pub struct UpdateMcpServerTools {
 #[derive(Debug, Clone, FromRow)]
 pub struct SessionKeyValueRow {
     pub id: Uuid,
-    pub session_id: Uuid,
+    pub session_id: SessionId,
     pub key: String,
     pub value: String,
     pub created_at: DateTime<Utc>,
@@ -595,7 +596,7 @@ pub struct SessionKeyValueRow {
 /// Input for creating/updating a session key/value
 #[derive(Debug, Clone)]
 pub struct UpsertSessionKeyValue {
-    pub session_id: Uuid,
+    pub session_id: SessionId,
     pub key: String,
     pub value: String,
 }
@@ -616,7 +617,7 @@ pub struct SessionKeyInfoRow {
 #[derive(Debug, Clone, FromRow)]
 pub struct SessionSecretRow {
     pub id: Uuid,
-    pub session_id: Uuid,
+    pub session_id: SessionId,
     pub name: String,
     pub value_encrypted: Vec<u8>,
     pub created_at: DateTime<Utc>,
@@ -626,7 +627,7 @@ pub struct SessionSecretRow {
 /// Input for creating/updating a session secret
 #[derive(Debug, Clone)]
 pub struct UpsertSessionSecret {
-    pub session_id: Uuid,
+    pub session_id: SessionId,
     pub name: String,
     pub value_encrypted: Vec<u8>,
 }

--- a/crates/control-plane/src/storage/repositories.rs
+++ b/crates/control-plane/src/storage/repositories.rs
@@ -4,6 +4,7 @@
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use everruns_core::message_filter::{MessageFilter, MessageQuery};
+use everruns_core::typed_id::{AgentId, EventId, SessionId};
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -344,7 +345,7 @@ impl Database {
     pub async fn create_agent_with_id(
         &self,
         org_id: i64,
-        id: Uuid,
+        id: AgentId,
         input: CreateAgentRow,
     ) -> Result<Option<AgentRow>> {
         let row = sqlx::query_as::<_, AgentRow>(
@@ -356,12 +357,12 @@ impl Database {
                       total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens
             "#,
         )
-        .bind(id)
+        .bind(id.uuid())
         .bind(org_id)
         .bind(&input.name)
         .bind(&input.description)
         .bind(&input.system_prompt)
-        .bind(input.default_model_id)
+        .bind(input.default_model_id.map(|m| m.uuid()))
         .bind(&input.tags)
         .fetch_optional(&self.pool)
         .await?;
@@ -369,7 +370,7 @@ impl Database {
         Ok(row)
     }
 
-    pub async fn get_agent(&self, org_id: i64, id: Uuid) -> Result<Option<AgentRow>> {
+    pub async fn get_agent(&self, org_id: i64, id: AgentId) -> Result<Option<AgentRow>> {
         let row = sqlx::query_as::<_, AgentRow>(
             r#"
             SELECT id, org_id, name, description, system_prompt, default_model_id, tags, status, created_at, updated_at,
@@ -379,7 +380,7 @@ impl Database {
             "#,
         )
         .bind(org_id)
-        .bind(id)
+        .bind(id.uuid())
         .fetch_optional(&self.pool)
         .await?;
 
@@ -423,7 +424,7 @@ impl Database {
     pub async fn update_agent(
         &self,
         org_id: i64,
-        id: Uuid,
+        id: AgentId,
         input: UpdateAgent,
     ) -> Result<Option<AgentRow>> {
         let row = sqlx::query_as::<_, AgentRow>(
@@ -443,11 +444,11 @@ impl Database {
             "#,
         )
         .bind(org_id)
-        .bind(id)
+        .bind(id.uuid())
         .bind(&input.name)
         .bind(&input.description)
         .bind(&input.system_prompt)
-        .bind(input.default_model_id)
+        .bind(input.default_model_id.map(|m| m.uuid()))
         .bind(&input.tags)
         .bind(&input.status)
         .fetch_optional(&self.pool)
@@ -456,7 +457,7 @@ impl Database {
         Ok(row)
     }
 
-    pub async fn delete_agent(&self, org_id: i64, id: Uuid) -> Result<bool> {
+    pub async fn delete_agent(&self, org_id: i64, id: AgentId) -> Result<bool> {
         // Archive instead of hard delete
         let result = sqlx::query(
             r#"
@@ -466,7 +467,7 @@ impl Database {
             "#,
         )
         .bind(org_id)
-        .bind(id)
+        .bind(id.uuid())
         .execute(&self.pool)
         .await?;
 
@@ -497,7 +498,7 @@ impl Database {
     }
 
     /// Get session, validating org ownership via agent join
-    pub async fn get_session(&self, org_id: i64, id: Uuid) -> Result<Option<SessionRow>> {
+    pub async fn get_session(&self, org_id: i64, id: SessionId) -> Result<Option<SessionRow>> {
         let row = sqlx::query_as::<_, SessionRow>(
             r#"
             SELECT s.id, s.agent_id, s.title, s.tags, s.model_id, s.status, s.created_at, s.updated_at, s.started_at, s.finished_at,
@@ -508,7 +509,7 @@ impl Database {
             "#,
         )
         .bind(org_id)
-        .bind(id)
+        .bind(id.uuid())
         .fetch_optional(&self.pool)
         .await?;
 
@@ -520,7 +521,7 @@ impl Database {
     pub async fn list_sessions(
         &self,
         org_id: i64,
-        agent_id: Uuid,
+        agent_id: AgentId,
         pagination: crate::api::common::Pagination,
     ) -> Result<(Vec<SessionRow>, u32)> {
         // Get total count (validates agent belongs to org)
@@ -533,7 +534,7 @@ impl Database {
             "#,
         )
         .bind(org_id)
-        .bind(agent_id)
+        .bind(agent_id.uuid())
         .fetch_one(&self.pool)
         .await?;
 
@@ -550,7 +551,7 @@ impl Database {
             "#,
         )
         .bind(org_id)
-        .bind(agent_id)
+        .bind(agent_id.uuid())
         .bind(pagination.limit as i64)
         .bind(pagination.offset as i64)
         .fetch_all(&self.pool)
@@ -563,7 +564,7 @@ impl Database {
     pub async fn update_session(
         &self,
         org_id: i64,
-        id: Uuid,
+        id: SessionId,
         input: UpdateSession,
     ) -> Result<Option<SessionRow>> {
         // Update only if session belongs to an agent in the org
@@ -585,10 +586,10 @@ impl Database {
             "#,
         )
         .bind(org_id)
-        .bind(id)
+        .bind(id.uuid())
         .bind(&input.title)
         .bind(&input.tags)
-        .bind(input.model_id)
+        .bind(input.model_id.map(|m| m.uuid()))
         .bind(&input.status)
         .bind(input.started_at)
         .bind(input.finished_at)
@@ -599,7 +600,7 @@ impl Database {
     }
 
     /// Delete session, validating org ownership via agent join
-    pub async fn delete_session(&self, org_id: i64, id: Uuid) -> Result<bool> {
+    pub async fn delete_session(&self, org_id: i64, id: SessionId) -> Result<bool> {
         let result = sqlx::query(
             r#"
             DELETE FROM sessions s
@@ -608,7 +609,7 @@ impl Database {
             "#,
         )
         .bind(org_id)
-        .bind(id)
+        .bind(id.uuid())
         .execute(&self.pool)
         .await?;
 
@@ -647,9 +648,9 @@ impl Database {
 
     pub async fn list_events(
         &self,
-        session_id: Uuid,
+        session_id: SessionId,
         since_sequence: Option<i32>,
-        since_id: Option<Uuid>,
+        since_id: Option<EventId>,
     ) -> Result<Vec<EventRow>> {
         // Prefer since_id (UUID v7 monotonically increasing) over sequence for filtering
         let rows = match (since_id, since_sequence) {
@@ -662,8 +663,8 @@ impl Database {
                     ORDER BY id ASC
                     "#,
                 )
-                .bind(session_id)
-                .bind(id)
+                .bind(session_id.uuid())
+                .bind(id.uuid())
                 .fetch_all(&self.pool)
                 .await?
             }
@@ -676,7 +677,7 @@ impl Database {
                     ORDER BY sequence ASC
                     "#,
                 )
-                .bind(session_id)
+                .bind(session_id.uuid())
                 .bind(seq)
                 .fetch_all(&self.pool)
                 .await?
@@ -690,7 +691,7 @@ impl Database {
                     ORDER BY sequence ASC
                     "#,
                 )
-                .bind(session_id)
+                .bind(session_id.uuid())
                 .fetch_all(&self.pool)
                 .await?
             }
@@ -705,7 +706,7 @@ impl Database {
     /// Ordered by sequence for conversation reconstruction.
     /// Note: Tool calls are embedded in message.agent events via ContentPart::ToolCall.
     /// Note: Tool results come from tool.call_completed events (not message.tool_result).
-    pub async fn list_message_events(&self, session_id: Uuid) -> Result<Vec<EventRow>> {
+    pub async fn list_message_events(&self, session_id: SessionId) -> Result<Vec<EventRow>> {
         let rows = sqlx::query_as::<_, EventRow>(
             r#"
             SELECT id, session_id, sequence, event_type, ts, context, data, metadata, tags, created_at
@@ -715,7 +716,7 @@ impl Database {
             ORDER BY sequence ASC
             "#,
         )
-        .bind(session_id)
+        .bind(session_id.uuid())
         .fetch_all(&self.pool)
         .await?;
 
@@ -807,12 +808,12 @@ impl Database {
                 }
                 MessageFilter::ExcludeIds(ids) => {
                     sql.push_str(&format!(" AND id != ALL(${})", param_idx));
-                    exclude_ids = Some(ids.clone());
+                    exclude_ids = Some(ids.iter().map(|id| id.uuid()).collect());
                     param_idx += 1;
                 }
                 MessageFilter::IncludeIds(ids) => {
                     sql.push_str(&format!(" AND id = ANY(${})", param_idx));
-                    include_ids = Some(ids.clone());
+                    include_ids = Some(ids.iter().map(|id| id.uuid()).collect());
                     param_idx += 1;
                 }
                 MessageFilter::Custom(_) => {
@@ -835,7 +836,7 @@ impl Database {
         // sqlx doesn't support truly dynamic queries, so we need to use raw SQL
         // with all possible parameters, binding None for unused ones
         let mut db_query = sqlx::query_as::<_, EventRow>(&sql)
-            .bind(query.session_id)
+            .bind(query.session_id.uuid())
             .bind(&types);
 
         // Bind parameters in order they were added to SQL

--- a/crates/control-plane/src/storage/session_file_store.rs
+++ b/crates/control-plane/src/storage/session_file_store.rs
@@ -5,10 +5,10 @@
 
 use async_trait::async_trait;
 use everruns_core::{
-    AgentLoopError, FileInfo, FileStat, GrepMatch, Result, SessionFile, traits::SessionFileStore,
+    AgentLoopError, FileInfo, FileStat, GrepMatch, Result, SessionFile, SessionId,
+    traits::SessionFileStore,
 };
 use regex::Regex;
-use uuid::Uuid;
 
 use super::models::{CreateSessionFileRow, UpdateSessionFile};
 use super::repositories::Database;
@@ -54,13 +54,13 @@ impl DbSessionFileStore {
     }
 
     /// Ensure a directory exists, creating it and parents if needed
-    async fn ensure_directory_exists(&self, session_id: Uuid, path: &str) -> Result<()> {
+    async fn ensure_directory_exists(&self, session_id: SessionId, path: &str) -> Result<()> {
         if path == "/" {
             return Ok(()); // Root always exists
         }
 
         // Check if directory exists
-        if let Some(existing) = self.db.get_session_file(session_id, path).await? {
+        if let Some(existing) = self.db.get_session_file(session_id.uuid(), path).await? {
             if existing.is_directory {
                 return Ok(());
             } else {
@@ -92,11 +92,11 @@ impl DbSessionFileStore {
 
 #[async_trait]
 impl SessionFileStore for DbSessionFileStore {
-    async fn read_file(&self, session_id: Uuid, path: &str) -> Result<Option<SessionFile>> {
+    async fn read_file(&self, session_id: SessionId, path: &str) -> Result<Option<SessionFile>> {
         let path = Self::normalize_path(path);
         let row = self
             .db
-            .get_session_file(session_id, &path)
+            .get_session_file(session_id.uuid(), &path)
             .await
             .map_err(|e| AgentLoopError::store(e.to_string()))?;
 
@@ -110,7 +110,7 @@ impl SessionFileStore for DbSessionFileStore {
 
             SessionFile {
                 id: r.id,
-                session_id: r.session_id,
+                session_id: r.session_id.uuid(),
                 path: r.path.clone(),
                 name: FileInfo::name_from_path(&r.path),
                 content,
@@ -126,7 +126,7 @@ impl SessionFileStore for DbSessionFileStore {
 
     async fn write_file(
         &self,
-        session_id: Uuid,
+        session_id: SessionId,
         path: &str,
         content: &str,
         encoding: &str,
@@ -145,7 +145,7 @@ impl SessionFileStore for DbSessionFileStore {
         // Check if file exists
         let existing = self
             .db
-            .get_session_file(session_id, &path)
+            .get_session_file(session_id.uuid(), &path)
             .await
             .map_err(|e| AgentLoopError::store(e.to_string()))?;
 
@@ -166,7 +166,7 @@ impl SessionFileStore for DbSessionFileStore {
 
             self.db
                 .update_session_file(
-                    session_id,
+                    session_id.uuid(),
                     &path,
                     UpdateSessionFile {
                         content: Some(bytes),
@@ -202,7 +202,7 @@ impl SessionFileStore for DbSessionFileStore {
 
         Ok(SessionFile {
             id: row.id,
-            session_id: row.session_id,
+            session_id: row.session_id.uuid(),
             path: row.path.clone(),
             name: FileInfo::name_from_path(&row.path),
             content,
@@ -215,14 +215,19 @@ impl SessionFileStore for DbSessionFileStore {
         })
     }
 
-    async fn delete_file(&self, session_id: Uuid, path: &str, recursive: bool) -> Result<bool> {
+    async fn delete_file(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        recursive: bool,
+    ) -> Result<bool> {
         let path = Self::normalize_path(path);
 
         if path == "/" {
             if recursive {
                 // Delete all files in session
                 self.db
-                    .delete_session_file_recursive(session_id, "/")
+                    .delete_session_file_recursive(session_id.uuid(), "/")
                     .await
                     .map_err(|e| AgentLoopError::store(e.to_string()))?;
                 return Ok(true);
@@ -236,7 +241,7 @@ impl SessionFileStore for DbSessionFileStore {
         // Check if it's a directory with children
         let file = self
             .db
-            .get_session_file(session_id, &path)
+            .get_session_file(session_id.uuid(), &path)
             .await
             .map_err(|e| AgentLoopError::store(e.to_string()))?;
 
@@ -246,7 +251,7 @@ impl SessionFileStore for DbSessionFileStore {
         {
             let has_children = self
                 .db
-                .session_directory_has_children(session_id, &path)
+                .session_directory_has_children(session_id.uuid(), &path)
                 .await
                 .map_err(|e| AgentLoopError::store(e.to_string()))?;
             if has_children {
@@ -259,26 +264,26 @@ impl SessionFileStore for DbSessionFileStore {
         if recursive {
             let deleted = self
                 .db
-                .delete_session_file_recursive(session_id, &path)
+                .delete_session_file_recursive(session_id.uuid(), &path)
                 .await
                 .map_err(|e| AgentLoopError::store(e.to_string()))?;
             Ok(deleted > 0)
         } else {
             self.db
-                .delete_session_file(session_id, &path)
+                .delete_session_file(session_id.uuid(), &path)
                 .await
                 .map_err(|e| AgentLoopError::store(e.to_string()))
         }
     }
 
-    async fn list_directory(&self, session_id: Uuid, path: &str) -> Result<Vec<FileInfo>> {
+    async fn list_directory(&self, session_id: SessionId, path: &str) -> Result<Vec<FileInfo>> {
         let path = Self::normalize_path(path);
 
         // Verify directory exists (root always exists)
         if path != "/" {
             let dir = self
                 .db
-                .get_session_file(session_id, &path)
+                .get_session_file(session_id.uuid(), &path)
                 .await
                 .map_err(|e| AgentLoopError::store(e.to_string()))?;
             match dir {
@@ -300,7 +305,7 @@ impl SessionFileStore for DbSessionFileStore {
 
         let rows = self
             .db
-            .list_session_files(session_id, &path)
+            .list_session_files(session_id.uuid(), &path)
             .await
             .map_err(|e| AgentLoopError::store(e.to_string()))?;
 
@@ -308,7 +313,7 @@ impl SessionFileStore for DbSessionFileStore {
             .into_iter()
             .map(|r| FileInfo {
                 id: r.id,
-                session_id: r.session_id,
+                session_id: r.session_id.uuid(),
                 path: r.path.clone(),
                 name: FileInfo::name_from_path(&r.path),
                 is_directory: r.is_directory,
@@ -320,7 +325,7 @@ impl SessionFileStore for DbSessionFileStore {
             .collect())
     }
 
-    async fn stat_file(&self, session_id: Uuid, path: &str) -> Result<Option<FileStat>> {
+    async fn stat_file(&self, session_id: SessionId, path: &str) -> Result<Option<FileStat>> {
         let path = Self::normalize_path(path);
 
         // Handle root directory specially
@@ -338,7 +343,7 @@ impl SessionFileStore for DbSessionFileStore {
 
         let row = self
             .db
-            .get_session_file(session_id, &path)
+            .get_session_file(session_id.uuid(), &path)
             .await
             .map_err(|e| AgentLoopError::store(e.to_string()))?;
 
@@ -355,7 +360,7 @@ impl SessionFileStore for DbSessionFileStore {
 
     async fn grep_files(
         &self,
-        session_id: Uuid,
+        session_id: SessionId,
         pattern: &str,
         path_pattern: Option<&str>,
     ) -> Result<Vec<GrepMatch>> {
@@ -366,7 +371,7 @@ impl SessionFileStore for DbSessionFileStore {
         // Get matching files from database
         let files = self
             .db
-            .grep_session_files(session_id, pattern, path_pattern)
+            .grep_session_files(session_id.uuid(), pattern, path_pattern)
             .await
             .map_err(|e| AgentLoopError::store(e.to_string()))?;
 
@@ -377,7 +382,7 @@ impl SessionFileStore for DbSessionFileStore {
             // Read full file content
             let file = self
                 .db
-                .get_session_file(session_id, &file_info.path)
+                .get_session_file(session_id.uuid(), &file_info.path)
                 .await
                 .map_err(|e| AgentLoopError::store(e.to_string()))?;
 
@@ -402,20 +407,20 @@ impl SessionFileStore for DbSessionFileStore {
         Ok(results)
     }
 
-    async fn create_directory(&self, session_id: Uuid, path: &str) -> Result<FileInfo> {
+    async fn create_directory(&self, session_id: SessionId, path: &str) -> Result<FileInfo> {
         let path = Self::normalize_path(path);
 
         // Check if already exists
         if let Some(existing) = self
             .db
-            .get_session_file(session_id, &path)
+            .get_session_file(session_id.uuid(), &path)
             .await
             .map_err(|e| AgentLoopError::store(e.to_string()))?
         {
             if existing.is_directory {
                 return Ok(FileInfo {
                     id: existing.id,
-                    session_id: existing.session_id,
+                    session_id: existing.session_id.uuid(),
                     path: existing.path.clone(),
                     name: FileInfo::name_from_path(&existing.path),
                     is_directory: existing.is_directory,
@@ -453,7 +458,7 @@ impl SessionFileStore for DbSessionFileStore {
 
         Ok(FileInfo {
             id: row.id,
-            session_id: row.session_id,
+            session_id: row.session_id.uuid(),
             path: row.path.clone(),
             name: FileInfo::name_from_path(&row.path),
             is_directory: row.is_directory,

--- a/crates/control-plane/src/storage/session_storage_store.rs
+++ b/crates/control-plane/src/storage/session_storage_store.rs
@@ -4,8 +4,9 @@
 // session key/value pairs and encrypted secrets to the database.
 
 use async_trait::async_trait;
-use everruns_core::{AgentLoopError, KeyInfo, Result, SecretInfo, traits::SessionStorageStore};
-use uuid::Uuid;
+use everruns_core::{
+    AgentLoopError, KeyInfo, Result, SecretInfo, SessionId, traits::SessionStorageStore,
+};
 
 use super::encryption::EncryptionService;
 use super::models::{UpsertSessionKeyValue, UpsertSessionSecret};
@@ -59,7 +60,7 @@ impl SessionStorageStore for DbSessionStorageStore {
     // Key/Value operations (plain text)
     // ========================================================================
 
-    async fn set_value(&self, session_id: Uuid, key: &str, value: &str) -> Result<()> {
+    async fn set_value(&self, session_id: SessionId, key: &str, value: &str) -> Result<()> {
         let input = UpsertSessionKeyValue {
             session_id,
             key: key.to_string(),
@@ -74,27 +75,27 @@ impl SessionStorageStore for DbSessionStorageStore {
         Ok(())
     }
 
-    async fn get_value(&self, session_id: Uuid, key: &str) -> Result<Option<String>> {
+    async fn get_value(&self, session_id: SessionId, key: &str) -> Result<Option<String>> {
         let row = self
             .db
-            .get_session_key_value(session_id, key)
+            .get_session_key_value(session_id.uuid(), key)
             .await
             .map_err(|e| AgentLoopError::store(e.to_string()))?;
 
         Ok(row.map(|r| r.value))
     }
 
-    async fn delete_value(&self, session_id: Uuid, key: &str) -> Result<bool> {
+    async fn delete_value(&self, session_id: SessionId, key: &str) -> Result<bool> {
         self.db
-            .delete_session_key_value(session_id, key)
+            .delete_session_key_value(session_id.uuid(), key)
             .await
             .map_err(|e| AgentLoopError::store(e.to_string()))
     }
 
-    async fn list_keys(&self, session_id: Uuid) -> Result<Vec<KeyInfo>> {
+    async fn list_keys(&self, session_id: SessionId) -> Result<Vec<KeyInfo>> {
         let rows = self
             .db
-            .list_session_keys(session_id)
+            .list_session_keys(session_id.uuid())
             .await
             .map_err(|e| AgentLoopError::store(e.to_string()))?;
 
@@ -112,7 +113,7 @@ impl SessionStorageStore for DbSessionStorageStore {
     // Secret operations (encrypted)
     // ========================================================================
 
-    async fn set_secret(&self, session_id: Uuid, name: &str, value: &str) -> Result<()> {
+    async fn set_secret(&self, session_id: SessionId, name: &str, value: &str) -> Result<()> {
         let encryption = self.encryption()?;
 
         // Encrypt the value
@@ -134,12 +135,12 @@ impl SessionStorageStore for DbSessionStorageStore {
         Ok(())
     }
 
-    async fn get_secret(&self, session_id: Uuid, name: &str) -> Result<Option<String>> {
+    async fn get_secret(&self, session_id: SessionId, name: &str) -> Result<Option<String>> {
         let encryption = self.encryption()?;
 
         let row = self
             .db
-            .get_session_secret(session_id, name)
+            .get_session_secret(session_id.uuid(), name)
             .await
             .map_err(|e| AgentLoopError::store(e.to_string()))?;
 
@@ -155,17 +156,17 @@ impl SessionStorageStore for DbSessionStorageStore {
         }
     }
 
-    async fn delete_secret(&self, session_id: Uuid, name: &str) -> Result<bool> {
+    async fn delete_secret(&self, session_id: SessionId, name: &str) -> Result<bool> {
         self.db
-            .delete_session_secret(session_id, name)
+            .delete_session_secret(session_id.uuid(), name)
             .await
             .map_err(|e| AgentLoopError::store(e.to_string()))
     }
 
-    async fn list_secrets(&self, session_id: Uuid) -> Result<Vec<SecretInfo>> {
+    async fn list_secrets(&self, session_id: SessionId) -> Result<Vec<SecretInfo>> {
         let rows = self
             .db
-            .list_session_secrets(session_id)
+            .list_session_secrets(session_id.uuid())
             .await
             .map_err(|e| AgentLoopError::store(e.to_string()))?;
 

--- a/crates/control-plane/src/storage/session_store.rs
+++ b/crates/control-plane/src/storage/session_store.rs
@@ -5,11 +5,10 @@
 
 use async_trait::async_trait;
 use everruns_core::{
-    AgentLoopError, DEFAULT_ORG_ID, Result, TokenUsage,
+    AgentLoopError, DEFAULT_ORG_ID, Result, SessionId, TokenUsage,
     session::{Session, SessionStatus},
     traits::SessionStore,
 };
-use uuid::Uuid;
 
 use super::repositories::Database;
 
@@ -34,7 +33,7 @@ impl DbSessionStore {
 
 #[async_trait]
 impl SessionStore for DbSessionStore {
-    async fn get_session(&self, session_id: Uuid) -> Result<Option<Session>> {
+    async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>> {
         // TODO: Get org_id from context after Phase 3
         let session_row = self
             .db
@@ -65,13 +64,13 @@ impl SessionStore for DbSessionStore {
                 };
 
                 Ok(Some(Session {
-                    id: row.id.into(),
-                    agent_id: row.agent_id.into(),
+                    id: row.id,
+                    agent_id: row.agent_id,
                     title: row.title,
                     preview: None, // Preview populated separately when listing sessions
                     output_preview: None, // Output preview populated separately when listing sessions
                     tags: row.tags,
-                    model_id: row.model_id.map(|id| id.into()),
+                    model_id: row.model_id,
                     status: SessionStatus::from(row.status.as_str()),
                     created_at: row.created_at,
                     updated_at: row.updated_at,

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -55,6 +55,9 @@ fetchkit = { git = "https://github.com/everruns/fetchkit" }
 # OpenAPI schema generation (optional, enabled by everruns-control-plane)
 utoipa = { workspace = true, optional = true }
 
+# Database (optional, for TypedId sqlx support)
+sqlx = { workspace = true, optional = true }
+
 # Note: This crate has NO dependency on storage/contracts - it's purely runtime abstractions
 # Tool types are defined locally in this crate
 
@@ -69,6 +72,7 @@ llmsim = "0.2.0"
 [features]
 default = []
 openapi = ["utoipa"]
+sqlx = ["dep:sqlx"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/core/examples/turn_based_execution.rs
+++ b/crates/core/examples/turn_based_execution.rs
@@ -169,7 +169,7 @@ async fn main() -> anyhow::Result<()> {
     // Create Turn Context
     // =========================================================================
     let turn_id = TurnId::new();
-    let base_context = AtomContext::new(session_id, turn_id, user_message.id.into());
+    let base_context = AtomContext::new(session_id.into(), turn_id, user_message.id);
 
     println!("Turn ID: {}", turn_id);
     println!("Input Message ID: {}\n", user_message.id);
@@ -229,7 +229,7 @@ async fn main() -> anyhow::Result<()> {
         let reason_result = reason_atom
             .execute(ReasonInput {
                 context: reason_context,
-                agent_id,
+                agent_id: agent_id.into(),
                 org_id: 0,
                 mcp_tool_definitions: vec![],
             })
@@ -270,7 +270,7 @@ async fn main() -> anyhow::Result<()> {
         let act_result = act_atom
             .execute(ActInput {
                 context: act_context,
-                agent_id,
+                agent_id: agent_id.into(),
                 tool_calls: reason_result.tool_calls.clone(),
                 tool_definitions: reason_result.tool_definitions.clone(),
             })
@@ -313,7 +313,7 @@ async fn main() -> anyhow::Result<()> {
     // Conversation History
     // =========================================================================
     println!("\n━━━ Conversation History ━━━");
-    let messages = message_retriever.load(session_id).await?;
+    let messages = message_retriever.load(session_id.into()).await?;
     for (i, msg) in messages.iter().enumerate() {
         println!(
             "  {}. [{:?}] {}",

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -36,6 +36,7 @@ use crate::events::{
 use crate::message::ContentPart;
 use crate::tool_types::{ToolCall, ToolDefinition, ToolResult};
 use crate::traits::{EventEmitter, SessionFileStore, ToolContext, ToolExecutor};
+use crate::typed_id::AgentId;
 use uuid::Uuid;
 
 // ============================================================================
@@ -48,7 +49,7 @@ pub struct ActInput {
     /// Atom execution context
     pub context: AtomContext,
     /// Agent ID (needed for scheduling follow-up reason activity)
-    pub agent_id: uuid::Uuid,
+    pub agent_id: AgentId,
     /// Tool calls to execute
     pub tool_calls: Vec<ToolCall>,
     /// Available tool definitions for resolution
@@ -505,9 +506,8 @@ mod tests {
     use super::*;
     use crate::tools::ToolRegistry;
     use crate::traits::NoopEventEmitter;
-    use crate::typed_id::TurnId;
+    use crate::typed_id::{AgentId, MessageId, SessionId, TurnId};
     use serde_json::json;
-    use uuid::Uuid;
 
     #[tokio::test]
     async fn test_act_atom_empty_tool_calls() {
@@ -515,10 +515,10 @@ mod tests {
         let event_emitter = NoopEventEmitter;
         let atom = ActAtom::new(executor, event_emitter);
 
-        let context = AtomContext::new(Uuid::now_v7(), TurnId::new(), Uuid::now_v7());
+        let context = AtomContext::new(SessionId::new(), TurnId::new(), MessageId::new());
         let input = ActInput {
             context,
-            agent_id: Uuid::now_v7(),
+            agent_id: AgentId::new(),
             tool_calls: vec![],
             tool_definitions: vec![],
         };
@@ -537,10 +537,10 @@ mod tests {
         let event_emitter = NoopEventEmitter;
         let atom = ActAtom::new(executor, event_emitter);
 
-        let context = AtomContext::new(Uuid::now_v7(), TurnId::new(), Uuid::now_v7());
+        let context = AtomContext::new(SessionId::new(), TurnId::new(), MessageId::new());
         let input = ActInput {
             context,
-            agent_id: Uuid::now_v7(),
+            agent_id: AgentId::new(),
             tool_calls: vec![ToolCall {
                 id: "call_1".to_string(),
                 name: "nonexistent_tool".to_string(),

--- a/crates/core/src/atoms/input.rs
+++ b/crates/core/src/atoms/input.rs
@@ -146,23 +146,22 @@ mod tests {
     use crate::memory::InMemoryMessageRetriever;
     use crate::message_retriever::InputMessage;
     use crate::traits::NoopEventEmitter;
-    use crate::typed_id::TurnId;
-    use uuid::Uuid;
+    use crate::typed_id::{MessageId, SessionId, TurnId};
 
     #[tokio::test]
     async fn test_input_atom_retrieves_message() {
         let retriever = InMemoryMessageRetriever::new();
         let event_emitter = NoopEventEmitter;
-        let session_id = Uuid::now_v7();
+        let session_id = SessionId::new();
         let turn_id = TurnId::new();
 
         // Add a user message to the retriever
         let user_message = retriever
-            .add(session_id.into(), InputMessage::user("Hello, world!"))
+            .add(session_id, InputMessage::user("Hello, world!"))
             .await
             .unwrap();
 
-        let context = AtomContext::new(session_id, turn_id, user_message.id.into());
+        let context = AtomContext::new(session_id, turn_id, user_message.id);
         let atom = InputAtom::new(retriever, event_emitter);
 
         let result = atom.execute(InputAtomInput { context }).await.unwrap();
@@ -175,9 +174,9 @@ mod tests {
     async fn test_input_atom_not_found() {
         let retriever = InMemoryMessageRetriever::new();
         let event_emitter = NoopEventEmitter;
-        let session_id = Uuid::now_v7();
+        let session_id = SessionId::new();
         let turn_id = TurnId::new();
-        let missing_id = Uuid::now_v7();
+        let missing_id = MessageId::new();
 
         let context = AtomContext::new(session_id, turn_id, missing_id);
         let atom = InputAtom::new(retriever, event_emitter);

--- a/crates/core/src/atoms/mod.rs
+++ b/crates/core/src/atoms/mod.rs
@@ -13,10 +13,9 @@
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 use crate::error::Result;
-use crate::typed_id::TurnId;
+use crate::typed_id::{ExecId, MessageId, SessionId, TurnId};
 
 // ============================================================================
 // Atom Modules
@@ -51,28 +50,28 @@ pub use reason::{ReasonAtom, ReasonInput, ReasonResult};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AtomContext {
     /// Session ID - the conversation session
-    pub session_id: Uuid,
+    pub session_id: SessionId,
 
     /// Turn ID - unique identifier for the current turn (user input → final response)
     /// Uses typed TurnId for type safety and consistent prefixed format.
     pub turn_id: TurnId,
 
     /// Input message ID - the user message that triggered this turn
-    pub input_message_id: Uuid,
+    pub input_message_id: MessageId,
 
     /// Execution ID - unique identifier for this specific atom execution
     /// Also serves as a version identifier for the execution
-    pub exec_id: Uuid,
+    pub exec_id: ExecId,
 }
 
 impl AtomContext {
     /// Create a new AtomContext
-    pub fn new(session_id: Uuid, turn_id: TurnId, input_message_id: Uuid) -> Self {
+    pub fn new(session_id: SessionId, turn_id: TurnId, input_message_id: MessageId) -> Self {
         Self {
             session_id,
             turn_id,
             input_message_id,
-            exec_id: Uuid::now_v7(),
+            exec_id: ExecId::new(),
         }
     }
 
@@ -82,7 +81,7 @@ impl AtomContext {
             session_id: self.session_id,
             turn_id: self.turn_id,
             input_message_id: self.input_message_id,
-            exec_id: Uuid::now_v7(),
+            exec_id: ExecId::new(),
         }
     }
 }
@@ -127,9 +126,9 @@ mod tests {
 
     #[test]
     fn test_atom_context_new() {
-        let session_id = Uuid::now_v7();
+        let session_id = SessionId::new();
         let turn_id = TurnId::new();
-        let input_message_id = Uuid::now_v7();
+        let input_message_id = MessageId::new();
 
         let context = AtomContext::new(session_id, turn_id, input_message_id);
 
@@ -137,14 +136,14 @@ mod tests {
         assert_eq!(context.turn_id, turn_id);
         assert_eq!(context.input_message_id, input_message_id);
         // exec_id should be auto-generated
-        assert!(!context.exec_id.is_nil());
+        assert!(!context.exec_id.uuid().is_nil());
     }
 
     #[test]
     fn test_atom_context_next_exec() {
-        let session_id = Uuid::now_v7();
+        let session_id = SessionId::new();
         let turn_id = TurnId::new();
-        let input_message_id = Uuid::now_v7();
+        let input_message_id = MessageId::new();
 
         let context1 = AtomContext::new(session_id, turn_id, input_message_id);
         let context2 = context1.next_exec();
@@ -159,7 +158,7 @@ mod tests {
 
     #[test]
     fn test_atom_context_serialization() {
-        let context = AtomContext::new(Uuid::now_v7(), TurnId::new(), Uuid::now_v7());
+        let context = AtomContext::new(SessionId::new(), TurnId::new(), MessageId::new());
 
         let json = serde_json::to_string(&context).unwrap();
         let parsed: AtomContext = serde_json::from_str(&json).unwrap();

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -43,6 +43,7 @@ use crate::traits::{
     AgentStore, EventEmitter, ImageResolver, LlmProviderStore, ModelWithProvider, ResolvedImage,
     SessionStore,
 };
+use crate::typed_id::{AgentId, SessionId};
 
 // ============================================================================
 // Helper Functions
@@ -93,7 +94,7 @@ pub struct ReasonInput {
     /// Atom execution context
     pub context: AtomContext,
     /// Agent ID for loading configuration
-    pub agent_id: Uuid,
+    pub agent_id: AgentId,
     /// Organization ID for multi-tenancy tracking
     #[serde(default)]
     pub org_id: i64,
@@ -431,8 +432,8 @@ where
     #[allow(clippy::too_many_arguments)]
     async fn execute_llm_call(
         &self,
-        session_id: Uuid,
-        agent_id: Uuid,
+        session_id: SessionId,
+        agent_id: AgentId,
         org_id: i64,
         context: &AtomContext,
         mcp_tool_definitions: &[ToolDefinition],
@@ -538,11 +539,12 @@ where
 
         // Add metadata for API tracking and debugging
         // These IDs help correlate API requests with Everruns entities
+        // TypedId::to_string() produces prefixed format (e.g., "session_abc123")
         llm_config_builder = llm_config_builder
-            .with_metadata("session_id", format!("session_{}", session_id.as_simple()))
-            .with_metadata("agent_id", format!("agent_{}", agent_id.as_simple()))
-            .with_metadata("turn_id", context.turn_id.to_string()) // TurnId.to_string() is already prefixed
-            .with_metadata("exec_id", format!("exec_{}", context.exec_id.as_simple()))
+            .with_metadata("session_id", session_id.to_string())
+            .with_metadata("agent_id", agent_id.to_string())
+            .with_metadata("turn_id", context.turn_id.to_string())
+            .with_metadata("exec_id", context.exec_id.to_string())
             .with_metadata("org_id", format!("org_{:032x}", org_id));
 
         // Add model_id if we have one (not available for system default model)
@@ -841,7 +843,7 @@ where
         if let Some(model_id) = controls_model_id
             && let Some(model_with_provider) = self
                 .provider_store
-                .get_model_with_provider(model_id.uuid())
+                .get_model_with_provider(model_id)
                 .await?
         {
             return Ok((model_with_provider, Some(model_id)));
@@ -851,7 +853,7 @@ where
         if let Some(model_id) = session_model_id
             && let Some(model_with_provider) = self
                 .provider_store
-                .get_model_with_provider(model_id.uuid())
+                .get_model_with_provider(model_id)
                 .await?
         {
             return Ok((model_with_provider, Some(model_id)));
@@ -861,7 +863,7 @@ where
         if let Some(model_id) = agent_model_id
             && let Some(model_with_provider) = self
                 .provider_store
-                .get_model_with_provider(model_id.uuid())
+                .get_model_with_provider(model_id)
                 .await?
         {
             return Ok((model_with_provider, Some(model_id)));

--- a/crates/core/src/capabilities/docker_container.rs
+++ b/crates/core/src/capabilities/docker_container.rs
@@ -140,8 +140,8 @@ Best practices:
 // ============================================================================
 
 /// Generate container name from session ID
-fn container_name(session_id: &uuid::Uuid) -> String {
-    format!("{}-{}", CONTAINER_PREFIX, session_id)
+fn container_name(session_id: &crate::typed_id::SessionId) -> String {
+    format!("{}-{}", CONTAINER_PREFIX, session_id.uuid())
 }
 
 /// Check if Docker is available on the system
@@ -972,7 +972,8 @@ mod tests {
 
     #[test]
     fn test_container_name() {
-        let session_id = uuid::Uuid::parse_str("12345678-1234-1234-1234-123456789012").unwrap();
+        let uuid = uuid::Uuid::parse_str("12345678-1234-1234-1234-123456789012").unwrap();
+        let session_id = crate::typed_id::SessionId::from_uuid(uuid);
         let name = container_name(&session_id);
         assert_eq!(name, "everruns-12345678-1234-1234-1234-123456789012");
     }
@@ -1018,7 +1019,7 @@ mod tests {
     #[tokio::test]
     async fn test_docker_exec_missing_command() {
         let tool = DockerExecTool;
-        let context = ToolContext::new(uuid::Uuid::nil());
+        let context = ToolContext::new(crate::typed_id::SessionId::from_uuid(uuid::Uuid::nil()));
 
         let result = tool.execute_with_context(json!({}), &context).await;
 
@@ -1032,7 +1033,7 @@ mod tests {
     #[tokio::test]
     async fn test_docker_read_file_missing_path() {
         let tool = DockerReadFileTool;
-        let context = ToolContext::new(uuid::Uuid::nil());
+        let context = ToolContext::new(crate::typed_id::SessionId::from_uuid(uuid::Uuid::nil()));
 
         let result = tool.execute_with_context(json!({}), &context).await;
 
@@ -1046,7 +1047,7 @@ mod tests {
     #[tokio::test]
     async fn test_docker_write_file_missing_params() {
         let tool = DockerWriteFileTool;
-        let context = ToolContext::new(uuid::Uuid::nil());
+        let context = ToolContext::new(crate::typed_id::SessionId::from_uuid(uuid::Uuid::nil()));
 
         // Missing path
         let result = tool

--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -640,6 +640,7 @@ impl Tool for StatFileTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::typed_id::SessionId;
 
     #[test]
     fn test_capability_metadata() {
@@ -715,7 +716,7 @@ mod tests {
     #[tokio::test]
     async fn test_read_file_missing_path() {
         let tool = ReadFileTool;
-        let context = ToolContext::new(uuid::Uuid::nil());
+        let context = ToolContext::new(SessionId::new());
 
         let result = tool.execute_with_context(json!({}), &context).await;
 
@@ -729,7 +730,7 @@ mod tests {
     #[tokio::test]
     async fn test_read_file_no_file_store() {
         let tool = ReadFileTool;
-        let context = ToolContext::new(uuid::Uuid::nil());
+        let context = ToolContext::new(SessionId::new());
 
         let result = tool
             .execute_with_context(json!({"path": "/test.txt"}), &context)

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -831,6 +831,8 @@ pub fn apply_capabilities(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::typed_id::SessionId;
+    use uuid::Uuid;
 
     // =========================================================================
     // CapabilityRegistry tests
@@ -1537,7 +1539,7 @@ mod tests {
         let collected = collect_capabilities_with_configs(&configs, &registry);
 
         // Apply filters to a query
-        let session_id = uuid::Uuid::now_v7();
+        let session_id: SessionId = Uuid::now_v7().into();
         let mut query = MessageQuery::new(session_id);
 
         collected.apply_message_filters(&mut query);
@@ -1624,7 +1626,7 @@ mod tests {
 
         let collected = collect_capabilities_with_configs(&configs, &registry);
 
-        let session_id = uuid::Uuid::now_v7();
+        let session_id: SessionId = Uuid::now_v7().into();
         let mut query = MessageQuery::new(session_id);
 
         collected.apply_message_filters(&mut query);

--- a/crates/core/src/capabilities/session_storage.rs
+++ b/crates/core/src/capabilities/session_storage.rs
@@ -453,6 +453,7 @@ impl Tool for SecretStoreTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::typed_id::SessionId;
 
     #[test]
     fn test_capability_metadata() {
@@ -508,7 +509,7 @@ mod tests {
     #[tokio::test]
     async fn test_kv_store_missing_operation() {
         let tool = KvStoreTool;
-        let context = ToolContext::new(uuid::Uuid::nil());
+        let context = ToolContext::new(SessionId::new());
 
         let result = tool
             .execute_with_context(json!({"key": "test"}), &context)
@@ -524,7 +525,7 @@ mod tests {
     #[tokio::test]
     async fn test_kv_store_no_storage_store() {
         let tool = KvStoreTool;
-        let context = ToolContext::new(uuid::Uuid::nil());
+        let context = ToolContext::new(SessionId::new());
 
         let result = tool
             .execute_with_context(

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -1,7 +1,7 @@
 // Error types for the agent loop
 
+use crate::typed_id::{AgentId, SessionId};
 use thiserror::Error;
-use uuid::Uuid;
 
 /// Result type alias for agent loop operations
 pub type Result<T> = std::result::Result<T, AgentLoopError>;
@@ -48,11 +48,11 @@ pub enum AgentLoopError {
 
     /// Agent not found
     #[error("Agent not found: {0}")]
-    AgentNotFound(Uuid),
+    AgentNotFound(AgentId),
 
     /// Session not found
     #[error("Session not found: {0}")]
-    SessionNotFound(Uuid),
+    SessionNotFound(SessionId),
 
     /// Internal error
     #[error("Internal error: {0}")]
@@ -92,12 +92,12 @@ impl AgentLoopError {
     }
 
     /// Create an agent not found error
-    pub fn agent_not_found(agent_id: Uuid) -> Self {
+    pub fn agent_not_found(agent_id: AgentId) -> Self {
         AgentLoopError::AgentNotFound(agent_id)
     }
 
     /// Create a session not found error
-    pub fn session_not_found(session_id: Uuid) -> Self {
+    pub fn session_not_found(session_id: SessionId) -> Self {
         AgentLoopError::SessionNotFound(session_id)
     }
 

--- a/crates/core/src/event_listeners.rs
+++ b/crates/core/src/event_listeners.rs
@@ -172,6 +172,7 @@ mod tests {
     use super::*;
     use crate::events::{EventContext, EventData, MessageUserData};
     use crate::message::Message;
+    use crate::typed_id::SessionId;
     use std::sync::atomic::{AtomicU32, Ordering};
     use uuid::Uuid;
 
@@ -337,7 +338,7 @@ mod tests {
 
     fn create_test_event() -> Event {
         Event::new(
-            Uuid::now_v7(),
+            SessionId::from_uuid(Uuid::now_v7()),
             EventContext::empty(),
             EventData::MessageUser(MessageUserData {
                 message: Message::user("Hello"),

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -105,8 +105,8 @@ impl EventContext {
     pub fn from_atom_context(ctx: &AtomContext) -> Self {
         Self {
             turn_id: Some(ctx.turn_id),
-            input_message_id: Some(MessageId::from_uuid(ctx.input_message_id)),
-            exec_id: Some(ExecId::from_uuid(ctx.exec_id)),
+            input_message_id: Some(ctx.input_message_id),
+            exec_id: Some(ctx.exec_id),
             trace_id: None,
             span_id: None,
             parent_span_id: None,
@@ -114,10 +114,10 @@ impl EventContext {
     }
 
     /// Create a context for turn-scoped events (without exec_id)
-    pub fn turn(turn_id: TurnId, input_message_id: Uuid) -> Self {
+    pub fn turn(turn_id: TurnId, input_message_id: MessageId) -> Self {
         Self {
             turn_id: Some(turn_id),
-            input_message_id: Some(MessageId::from_uuid(input_message_id)),
+            input_message_id: Some(input_message_id),
             exec_id: None,
             trace_id: None,
             span_id: None,
@@ -196,14 +196,14 @@ impl Event {
     /// Create a new event with the given session_id, context, and typed data
     ///
     /// The event type is automatically inferred from the data type.
-    pub fn new(session_id: Uuid, context: EventContext, data: impl Into<EventData>) -> Self {
+    pub fn new(session_id: SessionId, context: EventContext, data: impl Into<EventData>) -> Self {
         let data = data.into();
         let event_type = data.event_type().to_string();
         Self {
             id: EventId::new(),
             event_type,
             ts: Utc::now(),
-            session_id: SessionId::from_uuid(session_id),
+            session_id,
             context,
             data,
             metadata: None,
@@ -214,18 +214,18 @@ impl Event {
 
     /// Create an event with a specific ID (for testing or replay)
     pub fn with_id(
-        id: Uuid,
-        session_id: Uuid,
+        id: EventId,
+        session_id: SessionId,
         context: EventContext,
         data: impl Into<EventData>,
     ) -> Self {
         let data = data.into();
         let event_type = data.event_type().to_string();
         Self {
-            id: EventId::from_uuid(id),
+            id,
             event_type,
             ts: Utc::now(),
-            session_id: SessionId::from_uuid(session_id),
+            session_id,
             context,
             data,
             metadata: None,
@@ -450,7 +450,7 @@ impl InputReceivedData {
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct ReasonStartedData {
     /// Agent ID being used
-    pub agent_id: Uuid,
+    pub agent_id: AgentId,
 
     /// Metadata about the model being used
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1149,7 +1149,7 @@ pub struct EventRequest {
     pub ts: DateTime<Utc>,
 
     /// Session this event belongs to
-    pub session_id: Uuid,
+    pub session_id: SessionId,
 
     /// Correlation context
     pub context: EventContext,
@@ -1170,7 +1170,7 @@ impl EventRequest {
     /// Create a new event request with the given session_id, context, and typed data
     ///
     /// The event type is automatically inferred from the data type.
-    pub fn new(session_id: Uuid, context: EventContext, data: impl Into<EventData>) -> Self {
+    pub fn new(session_id: SessionId, context: EventContext, data: impl Into<EventData>) -> Self {
         let data = data.into();
         let event_type = data.event_type().to_string();
         Self {
@@ -1197,12 +1197,12 @@ impl EventRequest {
     }
 
     /// Convert to an Event with the given id and sequence
-    pub fn into_event(self, id: Uuid, sequence: i32) -> Event {
+    pub fn into_event(self, id: EventId, sequence: i32) -> Event {
         Event {
-            id: EventId::from_uuid(id),
+            id,
             event_type: self.event_type,
             ts: self.ts,
-            session_id: SessionId::from_uuid(self.session_id),
+            session_id: self.session_id,
             context: self.context,
             data: self.data,
             metadata: self.metadata,
@@ -1218,26 +1218,26 @@ impl EventRequest {
 
 /// Builder for creating events with fluent API
 pub struct EventBuilder {
-    session_id: Uuid,
+    session_id: SessionId,
     context: EventContext,
 }
 
 impl EventBuilder {
-    pub fn new(session_id: Uuid) -> Self {
+    pub fn new(session_id: SessionId) -> Self {
         Self {
             session_id,
             context: EventContext::empty(),
         }
     }
 
-    pub fn with_turn(mut self, turn_id: Uuid, input_message_id: Uuid) -> Self {
-        self.context.turn_id = Some(TurnId::from_uuid(turn_id));
-        self.context.input_message_id = Some(MessageId::from_uuid(input_message_id));
+    pub fn with_turn(mut self, turn_id: TurnId, input_message_id: MessageId) -> Self {
+        self.context.turn_id = Some(turn_id);
+        self.context.input_message_id = Some(input_message_id);
         self
     }
 
-    pub fn with_exec(mut self, exec_id: Uuid) -> Self {
-        self.context.exec_id = Some(ExecId::from_uuid(exec_id));
+    pub fn with_exec(mut self, exec_id: ExecId) -> Self {
+        self.context.exec_id = Some(exec_id);
         self
     }
 
@@ -1256,38 +1256,35 @@ mod tests {
 
     #[test]
     fn test_event_creation() {
-        let session_id = Uuid::now_v7();
+        let session_id = SessionId::new();
         let context = EventContext::empty();
         let data = InputReceivedData::new(Message::user("test"));
 
         let event = Event::new(session_id, context, data);
 
         assert_eq!(event.event_type, "input.received");
-        assert_eq!(event.session_uuid(), session_id);
+        assert_eq!(event.session_uuid(), session_id.uuid());
         assert!(event.is_atom_event());
         assert!(!event.is_message_event());
     }
 
     #[test]
     fn test_event_context_from_atom_context() {
-        let session_id = Uuid::now_v7();
+        let session_id = SessionId::new();
         let turn_id = TurnId::new();
-        let input_message_id = Uuid::now_v7();
+        let input_message_id = MessageId::new();
 
         let atom_ctx = AtomContext::new(session_id, turn_id, input_message_id);
         let context = EventContext::from_atom_context(&atom_ctx);
 
         assert_eq!(context.turn_id, Some(turn_id));
-        assert_eq!(
-            context.input_message_id,
-            Some(MessageId::from_uuid(input_message_id))
-        );
-        assert_eq!(context.exec_id, Some(ExecId::from_uuid(atom_ctx.exec_id)));
+        assert_eq!(context.input_message_id, Some(input_message_id));
+        assert_eq!(context.exec_id, Some(atom_ctx.exec_id));
     }
 
     #[test]
     fn test_event_serialization() {
-        let session_id = Uuid::now_v7();
+        let session_id = SessionId::new();
         let context = EventContext::empty();
         let event = Event::new(
             session_id,
@@ -1305,16 +1302,16 @@ mod tests {
 
     #[test]
     fn test_event_builder() {
-        let session_id = Uuid::now_v7();
-        let turn_id = Uuid::now_v7();
-        let input_message_id = Uuid::now_v7();
-        let exec_id = Uuid::now_v7();
+        let session_id = SessionId::new();
+        let turn_id = TurnId::new();
+        let input_message_id = MessageId::new();
+        let exec_id = ExecId::new();
 
         let event = EventBuilder::new(session_id)
             .with_turn(turn_id, input_message_id)
             .with_exec(exec_id)
             .build(ReasonStartedData {
-                agent_id: Uuid::now_v7(),
+                agent_id: AgentId::new(),
                 metadata: Some(ModelMetadata {
                     model: "gpt-4o".to_string(),
                     model_id: None,
@@ -1323,9 +1320,9 @@ mod tests {
             });
 
         assert_eq!(event.event_type, "reason.started");
-        assert_eq!(event.session_id, SessionId::from_uuid(session_id));
-        assert_eq!(event.context.turn_id, Some(TurnId::from_uuid(turn_id)));
-        assert_eq!(event.context.exec_id, Some(ExecId::from_uuid(exec_id)));
+        assert_eq!(event.session_id, session_id);
+        assert_eq!(event.context.turn_id, Some(turn_id));
+        assert_eq!(event.context.exec_id, Some(exec_id));
     }
 
     #[test]

--- a/crates/core/src/memory.rs
+++ b/crates/core/src/memory.rs
@@ -10,7 +10,7 @@ use crate::llm_models::LlmProviderType;
 use crate::session::Session;
 use crate::tool_types::{ToolCall, ToolDefinition, ToolResult};
 use crate::traits::ModelWithProvider;
-use crate::typed_id::{MessageId, SessionId};
+use crate::typed_id::{AgentId, EventId, MessageId, ModelId, SessionId};
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -36,7 +36,7 @@ use chrono::Utc;
 /// for testing purposes. In production, messages are stored via EventEmitter.
 #[derive(Debug, Default, Clone)]
 pub struct InMemoryMessageRetriever {
-    messages: Arc<RwLock<HashMap<Uuid, Vec<Message>>>>,
+    messages: Arc<RwLock<HashMap<SessionId, Vec<Message>>>>,
 }
 
 impl InMemoryMessageRetriever {
@@ -48,7 +48,7 @@ impl InMemoryMessageRetriever {
     }
 
     /// Get all sessions
-    pub async fn sessions(&self) -> Vec<Uuid> {
+    pub async fn sessions(&self) -> Vec<SessionId> {
         self.messages.read().await.keys().copied().collect()
     }
 
@@ -58,12 +58,12 @@ impl InMemoryMessageRetriever {
     }
 
     /// Clear messages for a specific session
-    pub async fn clear_session(&self, session_id: Uuid) {
+    pub async fn clear_session(&self, session_id: SessionId) {
         self.messages.write().await.remove(&session_id);
     }
 
     /// Pre-populate with messages (useful for testing)
-    pub async fn seed(&self, session_id: Uuid, messages: Vec<Message>) {
+    pub async fn seed(&self, session_id: SessionId, messages: Vec<Message>) {
         self.messages.write().await.insert(session_id, messages);
     }
 
@@ -84,7 +84,7 @@ impl InMemoryMessageRetriever {
         self.messages
             .write()
             .await
-            .entry(session_id.uuid())
+            .entry(session_id)
             .or_default()
             .push(message.clone());
 
@@ -95,7 +95,7 @@ impl InMemoryMessageRetriever {
     ///
     /// Note: In production, messages are stored via EventEmitter.
     /// This method is provided for test setup and in-memory usage.
-    pub async fn store(&self, session_id: Uuid, message: Message) -> Result<()> {
+    pub async fn store(&self, session_id: SessionId, message: Message) -> Result<()> {
         self.messages
             .write()
             .await
@@ -108,7 +108,7 @@ impl InMemoryMessageRetriever {
 
 #[async_trait]
 impl MessageRetriever for InMemoryMessageRetriever {
-    async fn get(&self, session_id: Uuid, message_id: Uuid) -> Result<Option<Message>> {
+    async fn get(&self, session_id: SessionId, message_id: MessageId) -> Result<Option<Message>> {
         Ok(self
             .messages
             .read()
@@ -117,7 +117,7 @@ impl MessageRetriever for InMemoryMessageRetriever {
             .and_then(|messages| messages.iter().find(|m| m.id == message_id).cloned()))
     }
 
-    async fn load(&self, session_id: Uuid) -> Result<Vec<Message>> {
+    async fn load(&self, session_id: SessionId) -> Result<Vec<Message>> {
         Ok(self
             .messages
             .read()
@@ -127,7 +127,7 @@ impl MessageRetriever for InMemoryMessageRetriever {
             .unwrap_or_default())
     }
 
-    async fn count(&self, session_id: Uuid) -> Result<usize> {
+    async fn count(&self, session_id: SessionId) -> Result<usize> {
         Ok(self
             .messages
             .read()
@@ -148,7 +148,7 @@ impl MessageRetriever for InMemoryMessageRetriever {
 /// Useful for testing and examples where you want to configure agents without a database.
 #[derive(Debug, Default, Clone)]
 pub struct InMemoryAgentStore {
-    agents: Arc<RwLock<HashMap<Uuid, Agent>>>,
+    agents: Arc<RwLock<HashMap<AgentId, Agent>>>,
 }
 
 impl InMemoryAgentStore {
@@ -161,11 +161,11 @@ impl InMemoryAgentStore {
 
     /// Add an agent to the store
     pub async fn add_agent(&self, agent: Agent) {
-        self.agents.write().await.insert(agent.id.uuid(), agent);
+        self.agents.write().await.insert(agent.id, agent);
     }
 
     /// Get all agent IDs
-    pub async fn agent_ids(&self) -> Vec<Uuid> {
+    pub async fn agent_ids(&self) -> Vec<AgentId> {
         self.agents.read().await.keys().copied().collect()
     }
 
@@ -177,7 +177,7 @@ impl InMemoryAgentStore {
 
 #[async_trait]
 impl AgentStore for InMemoryAgentStore {
-    async fn get_agent(&self, agent_id: Uuid) -> Result<Option<Agent>> {
+    async fn get_agent(&self, agent_id: AgentId) -> Result<Option<Agent>> {
         Ok(self.agents.read().await.get(&agent_id).cloned())
     }
 }
@@ -192,7 +192,7 @@ impl AgentStore for InMemoryAgentStore {
 /// Useful for testing and examples where you want to configure sessions without a database.
 #[derive(Debug, Default, Clone)]
 pub struct InMemorySessionStore {
-    sessions: Arc<RwLock<HashMap<Uuid, Session>>>,
+    sessions: Arc<RwLock<HashMap<SessionId, Session>>>,
 }
 
 impl InMemorySessionStore {
@@ -205,14 +205,11 @@ impl InMemorySessionStore {
 
     /// Add a session to the store
     pub async fn add_session(&self, session: Session) {
-        self.sessions
-            .write()
-            .await
-            .insert(session.id.uuid(), session);
+        self.sessions.write().await.insert(session.id, session);
     }
 
     /// Get all session IDs
-    pub async fn session_ids(&self) -> Vec<Uuid> {
+    pub async fn session_ids(&self) -> Vec<SessionId> {
         self.sessions.read().await.keys().copied().collect()
     }
 
@@ -224,7 +221,7 @@ impl InMemorySessionStore {
 
 #[async_trait]
 impl SessionStore for InMemorySessionStore {
-    async fn get_session(&self, session_id: Uuid) -> Result<Option<Session>> {
+    async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>> {
         Ok(self.sessions.read().await.get(&session_id).cloned())
     }
 }
@@ -249,7 +246,7 @@ impl SessionStore for InMemorySessionStore {
 /// ```
 #[derive(Debug, Default, Clone)]
 pub struct InMemoryLlmProviderStore {
-    models: Arc<RwLock<HashMap<Uuid, ModelWithProvider>>>,
+    models: Arc<RwLock<HashMap<ModelId, ModelWithProvider>>>,
     default_model: Arc<RwLock<Option<ModelWithProvider>>>,
 }
 
@@ -299,8 +296,8 @@ impl InMemoryLlmProviderStore {
     }
 
     /// Add a model to the store
-    pub async fn add_model(&self, model_uuid: Uuid, model: ModelWithProvider) {
-        self.models.write().await.insert(model_uuid, model);
+    pub async fn add_model(&self, model_id: ModelId, model: ModelWithProvider) {
+        self.models.write().await.insert(model_id, model);
     }
 
     /// Set the default model
@@ -317,7 +314,10 @@ impl InMemoryLlmProviderStore {
 
 #[async_trait]
 impl LlmProviderStore for InMemoryLlmProviderStore {
-    async fn get_model_with_provider(&self, model_id: Uuid) -> Result<Option<ModelWithProvider>> {
+    async fn get_model_with_provider(
+        &self,
+        model_id: ModelId,
+    ) -> Result<Option<ModelWithProvider>> {
         Ok(self.models.read().await.get(&model_id).cloned())
     }
 
@@ -668,7 +668,7 @@ impl EventEmitter for InMemoryEventEmitter {
         drop(sequence);
 
         // Convert EventRequest to Event with generated id and sequence
-        let event = request.into_event(Uuid::now_v7(), seq);
+        let event = request.into_event(EventId::new(), seq);
         self.events.write().await.push(event.clone());
         Ok(event)
     }
@@ -677,11 +677,12 @@ impl EventEmitter for InMemoryEventEmitter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use uuid::Uuid;
 
     #[tokio::test]
     async fn test_in_memory_message_retriever() {
         let store = InMemoryMessageRetriever::new();
-        let session_id = Uuid::now_v7();
+        let session_id: SessionId = Uuid::now_v7().into();
 
         store
             .store(session_id, Message::user("Hello"))
@@ -696,21 +697,21 @@ mod tests {
     #[tokio::test]
     async fn test_in_memory_message_retriever_add_and_get() {
         let store = InMemoryMessageRetriever::new();
-        let session_id = Uuid::now_v7();
+        let session_id: SessionId = Uuid::now_v7().into();
 
         // Add a message using the add method
         let message = store
-            .add(session_id.into(), InputMessage::user("Hello via add"))
+            .add(session_id, InputMessage::user("Hello via add"))
             .await
             .unwrap();
 
         // Get the message by ID
-        let retrieved = store.get(session_id, message.id.into()).await.unwrap();
+        let retrieved = store.get(session_id, message.id).await.unwrap();
         assert!(retrieved.is_some());
         assert_eq!(retrieved.unwrap().text(), Some("Hello via add"));
 
         // Get non-existent message
-        let missing = store.get(session_id, Uuid::now_v7()).await.unwrap();
+        let missing = store.get(session_id, MessageId::new()).await.unwrap();
         assert!(missing.is_none());
     }
 
@@ -721,16 +722,16 @@ mod tests {
     #[tokio::test]
     async fn test_message_retriever_add_returns_consistent_id() {
         let store = InMemoryMessageRetriever::new();
-        let session_id = Uuid::now_v7();
+        let session_id: SessionId = Uuid::now_v7().into();
 
         // Add a message
         let added = store
-            .add(session_id.into(), InputMessage::user("Test consistency"))
+            .add(session_id, InputMessage::user("Test consistency"))
             .await
             .unwrap();
 
         // The returned message ID must be retrievable
-        let retrieved = store.get(session_id, added.id.into()).await.unwrap();
+        let retrieved = store.get(session_id, added.id).await.unwrap();
         assert!(
             retrieved.is_some(),
             "Message must be retrievable by the ID returned from add()"
@@ -783,7 +784,7 @@ mod tests {
         use crate::events::{EventContext, EventRequest, InputReceivedData};
 
         let emitter = InMemoryEventEmitter::new();
-        let session_id = Uuid::now_v7();
+        let session_id: SessionId = Uuid::now_v7().into();
         let event_context = EventContext::empty();
 
         // Emit an event
@@ -822,7 +823,7 @@ mod tests {
         };
 
         let emitter = InMemoryEventEmitter::new();
-        let session_id = Uuid::now_v7();
+        let session_id: SessionId = Uuid::now_v7().into();
         let event_context = EventContext::empty();
 
         // Emit different event types
@@ -840,7 +841,7 @@ mod tests {
                 session_id,
                 event_context,
                 ReasonStartedData {
-                    agent_id: Uuid::now_v7(),
+                    agent_id: AgentId::new(),
                     metadata: None,
                 },
             ))
@@ -860,8 +861,8 @@ mod tests {
         use crate::events::{EventContext, EventRequest, InputReceivedData};
 
         let emitter = InMemoryEventEmitter::new();
-        let session1 = Uuid::now_v7();
-        let session2 = Uuid::now_v7();
+        let session1: SessionId = Uuid::now_v7().into();
+        let session2: SessionId = Uuid::now_v7().into();
 
         // Emit events for different sessions
         let context = EventContext::empty();
@@ -884,10 +885,10 @@ mod tests {
             .unwrap();
 
         // Filter by session
-        let session1_events = emitter.events_for_session(session1).await;
+        let session1_events = emitter.events_for_session(session1.uuid()).await;
         assert_eq!(session1_events.len(), 1);
 
-        let session2_events = emitter.events_for_session(session2).await;
+        let session2_events = emitter.events_for_session(session2.uuid()).await;
         assert_eq!(session2_events.len(), 1);
     }
 
@@ -896,7 +897,7 @@ mod tests {
         use crate::events::{EventContext, EventRequest, InputReceivedData};
 
         let emitter = InMemoryEventEmitter::new();
-        let session_id = Uuid::now_v7();
+        let session_id: SessionId = Uuid::now_v7().into();
         let event_context = EventContext::empty();
 
         emitter

--- a/crates/core/src/message_filter.rs
+++ b/crates/core/src/message_filter.rs
@@ -19,9 +19,9 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::sync::Arc;
-use uuid::Uuid;
 
 use crate::message::Message;
+use crate::typed_id::{EventId, SessionId};
 
 // ============================================================================
 // MessageFilter - Filter specifications for message queries
@@ -61,15 +61,15 @@ pub enum MessageFilter {
     /// For production, consider using pg_trgm or tsvector for better performance.
     Search(String),
 
-    /// Exclude specific message IDs
+    /// Exclude specific event IDs
     ///
     /// Maps to: `WHERE id != ALL($ids)`
-    ExcludeIds(Vec<Uuid>),
+    ExcludeIds(Vec<EventId>),
 
-    /// Include only specific message IDs
+    /// Include only specific event IDs
     ///
     /// Maps to: `WHERE id = ANY($ids)`
-    IncludeIds(Vec<Uuid>),
+    IncludeIds(Vec<EventId>),
 
     /// Custom predicate (in-memory only)
     ///
@@ -183,10 +183,10 @@ impl InjectedMessage {
 ///     })
 ///     .with_limit(100);
 /// ```
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct MessageQuery {
     /// Session to load messages from
-    pub session_id: Uuid,
+    pub session_id: SessionId,
 
     /// Filters to apply (combined with AND)
     pub filters: Vec<MessageFilter>,
@@ -201,9 +201,21 @@ pub struct MessageQuery {
     pub offset: Option<i64>,
 }
 
+impl Default for MessageQuery {
+    fn default() -> Self {
+        Self {
+            session_id: SessionId::from_seed(0),
+            filters: Vec::new(),
+            injections: Vec::new(),
+            limit: None,
+            offset: None,
+        }
+    }
+}
+
 impl MessageQuery {
     /// Create a new query for a session
-    pub fn new(session_id: Uuid) -> Self {
+    pub fn new(session_id: SessionId) -> Self {
         Self {
             session_id,
             filters: Vec::new(),
@@ -370,10 +382,11 @@ pub trait MessageFilterProvider: Send + Sync {
 mod tests {
     use super::*;
     use crate::message::Message;
+    use uuid::Uuid;
 
     #[test]
     fn test_message_query_builder() {
-        let session_id = Uuid::now_v7();
+        let session_id: SessionId = Uuid::now_v7().into();
         let query = MessageQuery::new(session_id)
             .with_filter(MessageFilter::EventTypes(vec!["message.user".to_string()]))
             .with_limit(50)
@@ -387,7 +400,7 @@ mod tests {
 
     #[test]
     fn test_message_query_has_filters() {
-        let session_id = Uuid::now_v7();
+        let session_id: SessionId = Uuid::now_v7().into();
 
         let query_with_db_filter =
             MessageQuery::new(session_id).with_filter(MessageFilter::Search("hello".to_string()));
@@ -402,7 +415,7 @@ mod tests {
 
     #[test]
     fn test_injection_at_start() {
-        let session_id = Uuid::now_v7();
+        let session_id: SessionId = Uuid::now_v7().into();
         let injected = Message::system("Injected at start");
 
         let query = MessageQuery::new(session_id)
@@ -419,7 +432,7 @@ mod tests {
 
     #[test]
     fn test_injection_at_end() {
-        let session_id = Uuid::now_v7();
+        let session_id: SessionId = Uuid::now_v7().into();
         let injected = Message::system("Injected at end");
 
         let query =
@@ -435,7 +448,7 @@ mod tests {
 
     #[test]
     fn test_injection_before_index() {
-        let session_id = Uuid::now_v7();
+        let session_id: SessionId = Uuid::now_v7().into();
         let injected = Message::system("Injected before index 1");
 
         let query = MessageQuery::new(session_id)
@@ -457,7 +470,7 @@ mod tests {
 
     #[test]
     fn test_multiple_injections() {
-        let session_id = Uuid::now_v7();
+        let session_id: SessionId = Uuid::now_v7().into();
 
         let query = MessageQuery::new(session_id)
             .with_injection(InjectedMessage::at_start(Message::system("Start")))
@@ -494,7 +507,7 @@ mod tests {
 
     #[test]
     fn test_with_filters_multiple() {
-        let session_id = Uuid::now_v7();
+        let session_id: SessionId = Uuid::now_v7().into();
         let query = MessageQuery::new(session_id).with_filters([
             MessageFilter::EventTypes(vec!["message.user".to_string()]),
             MessageFilter::Search("hello".to_string()),
@@ -507,7 +520,7 @@ mod tests {
 
     #[test]
     fn test_with_injections_multiple() {
-        let session_id = Uuid::now_v7();
+        let session_id: SessionId = Uuid::now_v7().into();
         let query = MessageQuery::new(session_id).with_injections([
             InjectedMessage::at_start(Message::system("First")),
             InjectedMessage::at_end(Message::system("Last")),
@@ -519,7 +532,7 @@ mod tests {
 
     #[test]
     fn test_injection_after_index() {
-        let session_id = Uuid::now_v7();
+        let session_id: SessionId = Uuid::now_v7().into();
         let injected = Message::system("Injected after index 0");
 
         let query = MessageQuery::new(session_id)
@@ -542,7 +555,7 @@ mod tests {
 
     #[test]
     fn test_injection_into_empty_list() {
-        let session_id = Uuid::now_v7();
+        let session_id: SessionId = Uuid::now_v7().into();
 
         let query = MessageQuery::new(session_id)
             .with_injection(InjectedMessage::at_start(Message::system("Start")))
@@ -559,7 +572,7 @@ mod tests {
 
     #[test]
     fn test_injection_before_index_out_of_bounds() {
-        let session_id = Uuid::now_v7();
+        let session_id: SessionId = Uuid::now_v7().into();
         let injected = Message::system("Injected before index 10");
 
         // Index 10 is out of bounds for a 2-element list
@@ -577,7 +590,7 @@ mod tests {
 
     #[test]
     fn test_injection_after_index_out_of_bounds() {
-        let session_id = Uuid::now_v7();
+        let session_id: SessionId = Uuid::now_v7().into();
         let injected = Message::system("Injected after index 10");
 
         // Index 10 is out of bounds for a 2-element list
@@ -595,7 +608,7 @@ mod tests {
 
     #[test]
     fn test_multiple_start_injections_preserve_order() {
-        let session_id = Uuid::now_v7();
+        let session_id: SessionId = Uuid::now_v7().into();
 
         // Multiple start injections should maintain their order
         let query = MessageQuery::new(session_id)
@@ -617,7 +630,7 @@ mod tests {
 
     #[test]
     fn test_combined_db_and_custom_filters() {
-        let session_id = Uuid::now_v7();
+        let session_id: SessionId = Uuid::now_v7().into();
 
         let query = MessageQuery::new(session_id)
             .with_filter(MessageFilter::Search("hello".to_string()))
@@ -632,8 +645,8 @@ mod tests {
 
     #[test]
     fn test_filter_exclude_ids() {
-        let id1 = Uuid::now_v7();
-        let id2 = Uuid::now_v7();
+        let id1 = EventId::new();
+        let id2 = EventId::new();
 
         let filter = MessageFilter::ExcludeIds(vec![id1, id2]);
         let debug_str = format!("{:?}", filter);
@@ -642,8 +655,8 @@ mod tests {
 
     #[test]
     fn test_filter_include_ids() {
-        let id1 = Uuid::now_v7();
-        let id2 = Uuid::now_v7();
+        let id1 = EventId::new();
+        let id2 = EventId::new();
 
         let filter = MessageFilter::IncludeIds(vec![id1, id2]);
         let debug_str = format!("{:?}", filter);
@@ -694,7 +707,7 @@ mod tests {
     #[test]
     fn test_filter_provider_apply() {
         let provider = TestFilterProvider { priority: 0 };
-        let session_id = Uuid::now_v7();
+        let session_id: SessionId = Uuid::now_v7().into();
         let mut query = MessageQuery::new(session_id);
 
         let config = serde_json::json!({ "search": "hello" });

--- a/crates/core/src/message_retriever.rs
+++ b/crates/core/src/message_retriever.rs
@@ -5,11 +5,11 @@
 // This trait provides read access for building LLM context.
 
 use async_trait::async_trait;
-use uuid::Uuid;
 
 use crate::error::Result;
 use crate::message::{ContentPart, Controls, Message, MessageRole};
 use crate::message_filter::MessageQuery;
+use crate::typed_id::{MessageId, SessionId};
 
 // ============================================================================
 // InputMessage - Input structure for message creation
@@ -77,10 +77,10 @@ impl InputMessage {
 #[async_trait]
 pub trait MessageRetriever: Send + Sync {
     /// Get a specific message by ID
-    async fn get(&self, session_id: Uuid, message_id: Uuid) -> Result<Option<Message>>;
+    async fn get(&self, session_id: SessionId, message_id: MessageId) -> Result<Option<Message>>;
 
     /// Load all messages for a session
-    async fn load(&self, session_id: Uuid) -> Result<Vec<Message>>;
+    async fn load(&self, session_id: SessionId) -> Result<Vec<Message>>;
 
     /// Load messages with filters and injections applied.
     ///
@@ -99,7 +99,7 @@ pub trait MessageRetriever: Send + Sync {
     /// Load messages with pagination
     async fn load_page(
         &self,
-        session_id: Uuid,
+        session_id: SessionId,
         offset: usize,
         limit: usize,
     ) -> Result<Vec<Message>> {
@@ -108,7 +108,7 @@ pub trait MessageRetriever: Send + Sync {
     }
 
     /// Count messages in a session
-    async fn count(&self, session_id: Uuid) -> Result<usize> {
+    async fn count(&self, session_id: SessionId) -> Result<usize> {
         Ok(self.load(session_id).await?.len())
     }
 }

--- a/crates/core/src/observation/otel.rs
+++ b/crates/core/src/observation/otel.rs
@@ -343,8 +343,9 @@ mod tests {
     use crate::events::{EventContext, LlmGenerationMetadata, LlmGenerationOutput, TokenUsage};
     use crate::message::Message;
     use crate::tool_types::ToolCall;
-    use crate::typed_id::{MessageId, TurnId};
+    use crate::typed_id::{MessageId, SessionId, TurnId};
     use serde_json::json;
+    use uuid::Uuid;
 
     #[tokio::test]
     async fn test_otel_listener_creation() {
@@ -400,7 +401,7 @@ mod tests {
         };
 
         let event = Event::new(
-            Uuid::now_v7(),
+            SessionId::from_uuid(Uuid::now_v7()),
             EventContext::empty(),
             EventData::LlmGeneration(data),
         );
@@ -445,7 +446,7 @@ mod tests {
         };
 
         let event = Event::new(
-            Uuid::now_v7(),
+            SessionId::from_uuid(Uuid::now_v7()),
             EventContext::empty(),
             EventData::LlmGeneration(data),
         );
@@ -478,7 +479,7 @@ mod tests {
         };
 
         let event = Event::new(
-            Uuid::now_v7(),
+            SessionId::from_uuid(Uuid::now_v7()),
             EventContext::empty(),
             EventData::LlmGeneration(data),
         );
@@ -501,7 +502,7 @@ mod tests {
         };
 
         let start_event = Event::new(
-            Uuid::now_v7(),
+            SessionId::from_uuid(Uuid::now_v7()),
             EventContext::empty(),
             EventData::ToolCallStarted(started_data),
         );
@@ -520,7 +521,7 @@ mod tests {
         };
 
         let complete_event = Event::new(
-            Uuid::now_v7(),
+            SessionId::from_uuid(Uuid::now_v7()),
             EventContext::empty(),
             EventData::ToolCallCompleted(completed_data),
         );
@@ -544,7 +545,7 @@ mod tests {
         };
 
         let event = Event::new(
-            Uuid::now_v7(),
+            SessionId::from_uuid(Uuid::now_v7()),
             EventContext::empty(),
             EventData::ToolCallCompleted(completed_data),
         );
@@ -557,7 +558,7 @@ mod tests {
     async fn test_handle_turn_lifecycle() {
         let listener = OtelEventListener::new();
         let turn_id = TurnId::from_uuid(Uuid::now_v7());
-        let session_id = Uuid::now_v7();
+        let session_id = SessionId::from_uuid(Uuid::now_v7());
 
         // Start a turn
         let started_data = TurnStartedData {
@@ -605,7 +606,7 @@ mod tests {
         };
 
         let event = Event::new(
-            Uuid::now_v7(),
+            SessionId::from_uuid(Uuid::now_v7()),
             EventContext::empty(),
             EventData::TurnCompleted(completed_data),
         );
@@ -622,7 +623,7 @@ mod tests {
 
         // Send an event type that OtelEventListener doesn't handle
         let event = Event::new(
-            Uuid::now_v7(),
+            SessionId::from_uuid(Uuid::now_v7()),
             EventContext::empty(),
             EventData::MessageUser(MessageUserData {
                 message: Message::user("Hello"),
@@ -648,7 +649,7 @@ mod tests {
             };
 
             let event = Event::new(
-                Uuid::now_v7(),
+                SessionId::from_uuid(Uuid::now_v7()),
                 EventContext::empty(),
                 EventData::ToolCallStarted(started_data),
             );
@@ -670,7 +671,7 @@ mod tests {
             };
 
             let event = Event::new(
-                Uuid::now_v7(),
+                SessionId::from_uuid(Uuid::now_v7()),
                 EventContext::empty(),
                 EventData::ToolCallCompleted(completed_data),
             );

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -9,6 +9,7 @@ use crate::agent::Agent;
 use crate::llm_models::LlmProviderType;
 use crate::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
 use crate::tool_types::{ToolCall, ToolDefinition, ToolResult};
+use crate::typed_id::{AgentId, ModelId, SessionId};
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -34,7 +35,7 @@ use crate::error::Result;
 #[async_trait]
 pub trait AgentStore: Send + Sync {
     /// Get an agent by ID
-    async fn get_agent(&self, agent_id: Uuid) -> Result<Option<Agent>>;
+    async fn get_agent(&self, agent_id: AgentId) -> Result<Option<Agent>>;
 }
 
 // ============================================================================
@@ -51,7 +52,7 @@ use crate::session::Session;
 #[async_trait]
 pub trait SessionStore: Send + Sync {
     /// Get a session by ID
-    async fn get_session(&self, session_id: Uuid) -> Result<Option<Session>>;
+    async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>>;
 }
 
 // ============================================================================
@@ -82,11 +83,12 @@ pub struct ModelWithProvider {
 /// - Load from environment variables for development
 #[async_trait]
 pub trait LlmProviderStore: Send + Sync {
-    /// Get model with provider info by model UUID
+    /// Get model with provider info by model ID
     ///
     /// Returns the model string ID, provider type, decrypted API key, and base URL
     /// needed to create an LLM provider via the factory.
-    async fn get_model_with_provider(&self, model_id: Uuid) -> Result<Option<ModelWithProvider>>;
+    async fn get_model_with_provider(&self, model_id: ModelId)
+    -> Result<Option<ModelWithProvider>>;
 
     /// Get the default model with provider info
     ///
@@ -194,36 +196,37 @@ pub trait ToolExecutor: Send + Sync {
 #[async_trait]
 pub trait SessionFileStore: Send + Sync {
     /// Read a file by path
-    async fn read_file(&self, session_id: Uuid, path: &str) -> Result<Option<SessionFile>>;
+    async fn read_file(&self, session_id: SessionId, path: &str) -> Result<Option<SessionFile>>;
 
     /// Write/create a file
     async fn write_file(
         &self,
-        session_id: Uuid,
+        session_id: SessionId,
         path: &str,
         content: &str,
         encoding: &str,
     ) -> Result<SessionFile>;
 
     /// Delete a file or directory
-    async fn delete_file(&self, session_id: Uuid, path: &str, recursive: bool) -> Result<bool>;
+    async fn delete_file(&self, session_id: SessionId, path: &str, recursive: bool)
+    -> Result<bool>;
 
     /// List files in a directory
-    async fn list_directory(&self, session_id: Uuid, path: &str) -> Result<Vec<FileInfo>>;
+    async fn list_directory(&self, session_id: SessionId, path: &str) -> Result<Vec<FileInfo>>;
 
     /// Get file metadata
-    async fn stat_file(&self, session_id: Uuid, path: &str) -> Result<Option<FileStat>>;
+    async fn stat_file(&self, session_id: SessionId, path: &str) -> Result<Option<FileStat>>;
 
     /// Search files by pattern (grep)
     async fn grep_files(
         &self,
-        session_id: Uuid,
+        session_id: SessionId,
         pattern: &str,
         path_pattern: Option<&str>,
     ) -> Result<Vec<GrepMatch>>;
 
     /// Create a directory
-    async fn create_directory(&self, session_id: Uuid, path: &str) -> Result<FileInfo>;
+    async fn create_directory(&self, session_id: SessionId, path: &str) -> Result<FileInfo>;
 }
 
 // ============================================================================
@@ -260,30 +263,30 @@ pub trait SessionStorageStore: Send + Sync {
     // Key/Value operations (plain text)
 
     /// Set a key/value pair (creates or updates)
-    async fn set_value(&self, session_id: Uuid, key: &str, value: &str) -> Result<()>;
+    async fn set_value(&self, session_id: SessionId, key: &str, value: &str) -> Result<()>;
 
     /// Get a value by key
-    async fn get_value(&self, session_id: Uuid, key: &str) -> Result<Option<String>>;
+    async fn get_value(&self, session_id: SessionId, key: &str) -> Result<Option<String>>;
 
     /// Delete a key/value pair
-    async fn delete_value(&self, session_id: Uuid, key: &str) -> Result<bool>;
+    async fn delete_value(&self, session_id: SessionId, key: &str) -> Result<bool>;
 
     /// List all keys in a session
-    async fn list_keys(&self, session_id: Uuid) -> Result<Vec<KeyInfo>>;
+    async fn list_keys(&self, session_id: SessionId) -> Result<Vec<KeyInfo>>;
 
     // Secret operations (encrypted)
 
     /// Set a secret (creates or updates, value is encrypted before storage)
-    async fn set_secret(&self, session_id: Uuid, name: &str, value: &str) -> Result<()>;
+    async fn set_secret(&self, session_id: SessionId, name: &str, value: &str) -> Result<()>;
 
     /// Get a secret by name (value is decrypted before returning)
-    async fn get_secret(&self, session_id: Uuid, name: &str) -> Result<Option<String>>;
+    async fn get_secret(&self, session_id: SessionId, name: &str) -> Result<Option<String>>;
 
     /// Delete a secret
-    async fn delete_secret(&self, session_id: Uuid, name: &str) -> Result<bool>;
+    async fn delete_secret(&self, session_id: SessionId, name: &str) -> Result<bool>;
 
     /// List all secret names in a session (without values)
-    async fn list_secrets(&self, session_id: Uuid) -> Result<Vec<SecretInfo>>;
+    async fn list_secrets(&self, session_id: SessionId) -> Result<Vec<SecretInfo>>;
 }
 
 // ============================================================================
@@ -301,7 +304,7 @@ pub trait SessionStorageStore: Send + Sync {
 #[derive(Clone)]
 pub struct ToolContext {
     /// The session ID for the current execution
-    pub session_id: Uuid,
+    pub session_id: SessionId,
 
     /// Optional file store for filesystem operations
     pub file_store: Option<Arc<dyn SessionFileStore>>,
@@ -312,7 +315,7 @@ pub struct ToolContext {
 
 impl ToolContext {
     /// Create a new tool context with just a session ID
-    pub fn new(session_id: Uuid) -> Self {
+    pub fn new(session_id: SessionId) -> Self {
         Self {
             session_id,
             file_store: None,
@@ -321,7 +324,7 @@ impl ToolContext {
     }
 
     /// Create a context with a file store
-    pub fn with_file_store(session_id: Uuid, file_store: Arc<dyn SessionFileStore>) -> Self {
+    pub fn with_file_store(session_id: SessionId, file_store: Arc<dyn SessionFileStore>) -> Self {
         Self {
             session_id,
             file_store: Some(file_store),
@@ -331,7 +334,7 @@ impl ToolContext {
 
     /// Create a context with a storage store
     pub fn with_storage_store(
-        session_id: Uuid,
+        session_id: SessionId,
         storage_store: Arc<dyn SessionStorageStore>,
     ) -> Self {
         Self {
@@ -343,7 +346,7 @@ impl ToolContext {
 
     /// Create a context with both file store and storage store
     pub fn with_stores(
-        session_id: Uuid,
+        session_id: SessionId,
         file_store: Arc<dyn SessionFileStore>,
         storage_store: Arc<dyn SessionStorageStore>,
     ) -> Self {
@@ -400,7 +403,7 @@ pub struct NoopEventEmitter;
 impl EventEmitter for NoopEventEmitter {
     async fn emit(&self, request: EventRequest) -> Result<Event> {
         // Return a dummy event with sequence 0
-        Ok(request.into_event(uuid::Uuid::now_v7(), 0))
+        Ok(request.into_event(crate::typed_id::EventId::new(), 0))
     }
 }
 

--- a/crates/core/src/typed_id.rs
+++ b/crates/core/src/typed_id.rs
@@ -251,6 +251,38 @@ impl<T: IdMarker> utoipa::PartialSchema for TypedId<T> {
     }
 }
 
+// sqlx support - maps TypedId to/from UUID in database
+#[cfg(feature = "sqlx")]
+impl<T: IdMarker> sqlx::Type<sqlx::Postgres> for TypedId<T> {
+    fn type_info() -> sqlx::postgres::PgTypeInfo {
+        <Uuid as sqlx::Type<sqlx::Postgres>>::type_info()
+    }
+
+    fn compatible(ty: &sqlx::postgres::PgTypeInfo) -> bool {
+        <Uuid as sqlx::Type<sqlx::Postgres>>::compatible(ty)
+    }
+}
+
+#[cfg(feature = "sqlx")]
+impl<T: IdMarker> sqlx::Encode<'_, sqlx::Postgres> for TypedId<T> {
+    fn encode_by_ref(
+        &self,
+        buf: &mut sqlx::postgres::PgArgumentBuffer,
+    ) -> Result<sqlx::encode::IsNull, Box<dyn std::error::Error + Send + Sync>> {
+        <Uuid as sqlx::Encode<sqlx::Postgres>>::encode_by_ref(&self.uuid, buf)
+    }
+}
+
+#[cfg(feature = "sqlx")]
+impl<T: IdMarker> sqlx::Decode<'_, sqlx::Postgres> for TypedId<T> {
+    fn decode(
+        value: sqlx::postgres::PgValueRef<'_>,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let uuid = <Uuid as sqlx::Decode<sqlx::Postgres>>::decode(value)?;
+        Ok(Self::from_uuid(uuid))
+    }
+}
+
 // ============================================================================
 // Marker types for each entity
 // ============================================================================

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -17,7 +17,7 @@ use everruns_core::memory::{
 };
 use everruns_core::session::{Session, SessionStatus};
 use everruns_core::traits::{ModelWithProvider, NoopEventEmitter};
-use everruns_core::typed_id::TurnId;
+use everruns_core::typed_id::{MessageId, SessionId, TurnId};
 use everruns_core::{Message, ToolCall};
 use serde_json::json;
 use uuid::Uuid;
@@ -104,8 +104,8 @@ fn create_custom_driver_registry(config: LlmSimConfig) -> DriverRegistry {
 /// Create an AtomContext for testing
 fn create_context(session_id: Uuid) -> AtomContext {
     let turn_id = TurnId::new();
-    let input_message_id = Uuid::now_v7();
-    AtomContext::new(session_id, turn_id, input_message_id)
+    let input_message_id = MessageId::new();
+    AtomContext::new(SessionId::from_uuid(session_id), turn_id, input_message_id)
 }
 
 #[tokio::test]
@@ -116,7 +116,7 @@ async fn test_reason_atom_with_fixed_response() {
     // Add a user message
     message_retriever
         .seed(
-            session_id,
+            session_id.into(),
             vec![Message::user("What is the capital of France?")],
         )
         .await;
@@ -138,7 +138,7 @@ async fn test_reason_atom_with_fixed_response() {
     let context = create_context(session_id);
     let input = ReasonInput {
         context,
-        agent_id,
+        agent_id: agent_id.into(),
         org_id: 0,
         mcp_tool_definitions: vec![],
     };
@@ -154,7 +154,7 @@ async fn test_reason_atom_with_fixed_response() {
     assert!(result.tool_calls.is_empty());
 
     // Verify the assistant message was stored
-    let messages = message_retriever.load(session_id).await.unwrap();
+    let messages = message_retriever.load(session_id.into()).await.unwrap();
     assert_eq!(messages.len(), 2); // user + assistant
     assert_eq!(messages[1].text(), Some("The capital of France is Paris."));
 }
@@ -167,7 +167,7 @@ async fn test_reason_atom_with_tool_calls() {
     // Add a user message
     message_retriever
         .seed(
-            session_id,
+            session_id.into(),
             vec![Message::user("What's the weather in Tokyo?")],
         )
         .await;
@@ -197,7 +197,7 @@ async fn test_reason_atom_with_tool_calls() {
     let context = create_context(session_id);
     let input = ReasonInput {
         context,
-        agent_id,
+        agent_id: agent_id.into(),
         org_id: 0,
         mcp_tool_definitions: vec![],
     };
@@ -222,7 +222,10 @@ async fn test_reason_atom_with_echo_response() {
 
     // Add a user message
     message_retriever
-        .seed(session_id, vec![Message::user("Hello, how are you?")])
+        .seed(
+            session_id.into(),
+            vec![Message::user("Hello, how are you?")],
+        )
         .await;
 
     // Create a driver that echoes the user input
@@ -241,7 +244,7 @@ async fn test_reason_atom_with_echo_response() {
     let context = create_context(session_id);
     let input = ReasonInput {
         context,
-        agent_id,
+        agent_id: agent_id.into(),
         org_id: 0,
         mcp_tool_definitions: vec![],
     };
@@ -267,7 +270,7 @@ async fn test_reason_atom_with_different_configs() {
 
     // First test with one configuration
     message_retriever
-        .seed(session_id, vec![Message::user("Question 1")])
+        .seed(session_id.into(), vec![Message::user("Question 1")])
         .await;
 
     let driver_registry1 = create_custom_driver_registry(LlmSimConfig::fixed("Response A"));
@@ -286,7 +289,7 @@ async fn test_reason_atom_with_different_configs() {
     let result1 = atom1
         .execute(ReasonInput {
             context: context1,
-            agent_id,
+            agent_id: agent_id.into(),
             org_id: 0,
             mcp_tool_definitions: vec![],
         })
@@ -315,7 +318,7 @@ async fn test_reason_atom_with_different_configs() {
     };
     session_store.add_session(session2).await;
     message_retriever
-        .seed(session_id2, vec![Message::user("Question 2")])
+        .seed(session_id2.into(), vec![Message::user("Question 2")])
         .await;
 
     let driver_registry2 = create_custom_driver_registry(LlmSimConfig::fixed("Response B"));
@@ -334,7 +337,7 @@ async fn test_reason_atom_with_different_configs() {
     let result2 = atom2
         .execute(ReasonInput {
             context: context2,
-            agent_id,
+            agent_id: agent_id.into(),
             org_id: 0,
             mcp_tool_definitions: vec![],
         })
@@ -352,7 +355,7 @@ async fn test_reason_atom_with_multi_turn_conversation() {
     // Seed a multi-turn conversation
     message_retriever
         .seed(
-            session_id,
+            session_id.into(),
             vec![
                 Message::user("Hi, I'm Bob."),
                 Message::assistant("Hello Bob! How can I help you today?"),
@@ -378,7 +381,7 @@ async fn test_reason_atom_with_multi_turn_conversation() {
     let context = create_context(session_id);
     let input = ReasonInput {
         context,
-        agent_id,
+        agent_id: agent_id.into(),
         org_id: 0,
         mcp_tool_definitions: vec![],
     };
@@ -392,7 +395,7 @@ async fn test_reason_atom_with_multi_turn_conversation() {
     assert!(result.text.contains("Bob"));
 
     // Verify all messages are preserved
-    let messages = message_retriever.load(session_id).await.unwrap();
+    let messages = message_retriever.load(session_id.into()).await.unwrap();
     assert_eq!(messages.len(), 4); // 3 original + 1 new assistant response
 }
 
@@ -410,7 +413,7 @@ async fn test_reason_atom_with_tool_result_continuation() {
 
     message_retriever
         .seed(
-            session_id,
+            session_id.into(),
             vec![
                 Message::user("What's the weather in Tokyo?"),
                 Message::assistant_with_tools("Let me check that.", vec![tool_call]),
@@ -440,7 +443,7 @@ async fn test_reason_atom_with_tool_result_continuation() {
     let context = create_context(session_id);
     let input = ReasonInput {
         context,
-        agent_id,
+        agent_id: agent_id.into(),
         org_id: 0,
         mcp_tool_definitions: vec![],
     };
@@ -461,7 +464,10 @@ async fn test_reason_atom_with_lorem_response() {
         setup_test_environment().await;
 
     message_retriever
-        .seed(session_id, vec![Message::user("Tell me a long story")])
+        .seed(
+            session_id.into(),
+            vec![Message::user("Tell me a long story")],
+        )
         .await;
 
     // Use lorem ipsum generator
@@ -480,7 +486,7 @@ async fn test_reason_atom_with_lorem_response() {
     let context = create_context(session_id);
     let input = ReasonInput {
         context,
-        agent_id,
+        agent_id: agent_id.into(),
         org_id: 0,
         mcp_tool_definitions: vec![],
     };
@@ -505,7 +511,7 @@ async fn test_reason_atom_handles_llm_error() {
 
     // Add a user message
     message_retriever
-        .seed(session_id, vec![Message::user("Hello!")])
+        .seed(session_id.into(), vec![Message::user("Hello!")])
         .await;
 
     // Create a driver that returns an error (simulating API key missing, rate limit, etc.)
@@ -527,7 +533,7 @@ async fn test_reason_atom_handles_llm_error() {
     let context = create_context(session_id);
     let input = ReasonInput {
         context,
-        agent_id,
+        agent_id: agent_id.into(),
         org_id: 0,
         mcp_tool_definitions: vec![],
     };
@@ -563,7 +569,7 @@ async fn test_reason_atom_handles_llm_error() {
     assert!(result.tool_calls.is_empty());
 
     // Verify an error message was stored for the user
-    let messages = message_retriever.load(session_id).await.unwrap();
+    let messages = message_retriever.load(session_id.into()).await.unwrap();
     assert_eq!(messages.len(), 2, "Should have user + error message");
     assert_eq!(messages[1].role, everruns_core::MessageRole::Assistant);
     assert!(

--- a/crates/core/tests/tool_calling_test.rs
+++ b/crates/core/tests/tool_calling_test.rs
@@ -6,7 +6,7 @@
 use async_trait::async_trait;
 use everruns_core::{BuiltinTool, ToolCall, ToolDefinition, ToolPolicy};
 use everruns_core::{
-    GetCurrentTimeTool, Message, MessageRetriever, MessageRole,
+    GetCurrentTimeTool, Message, MessageRetriever, MessageRole, SessionId,
     memory::InMemoryMessageRetriever,
     tools::{EchoTool, FailingTool, Tool, ToolExecutionResult, ToolRegistry},
     traits::ToolExecutor,
@@ -286,7 +286,7 @@ async fn test_multiple_tools_in_registry() {
 #[tokio::test]
 async fn test_message_retriever_preserves_tool_calls() {
     let store = InMemoryMessageRetriever::new();
-    let session_id = Uuid::now_v7();
+    let session_id: SessionId = Uuid::now_v7().into();
 
     // Create an assistant message with tool calls (the critical case)
     let tool_calls = vec![
@@ -325,7 +325,7 @@ async fn test_message_retriever_preserves_tool_calls() {
 #[tokio::test]
 async fn test_message_retriever_full_tool_conversation() {
     let store = InMemoryMessageRetriever::new();
-    let session_id = Uuid::now_v7();
+    let session_id: SessionId = Uuid::now_v7().into();
 
     // Simulate a full tool-calling conversation:
     // 1. User message
@@ -395,7 +395,7 @@ async fn test_message_retriever_full_tool_conversation() {
 #[tokio::test]
 async fn test_message_retriever_parallel_tool_calls() {
     let store = InMemoryMessageRetriever::new();
-    let session_id = Uuid::now_v7();
+    let session_id: SessionId = Uuid::now_v7().into();
 
     // Create an assistant message with multiple parallel tool calls
     let tool_calls = vec![

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -678,7 +678,7 @@ pub fn proto_event_request_to_schema(
     Ok(everruns_core::EventRequest {
         event_type: value.event_type,
         ts,
-        session_id,
+        session_id: SessionId::from_uuid(session_id),
         context,
         data,
         metadata,
@@ -700,7 +700,7 @@ pub fn schema_event_request_to_proto(value: &everruns_core::EventRequest) -> pro
         event_type: value.event_type.clone(),
         ts: Some(datetime_to_proto_timestamp(value.ts)),
         context: Some(proto::EventContext {
-            session_id: Some(uuid_to_proto_uuid(value.session_id)),
+            session_id: Some(uuid_to_proto_uuid(value.session_id.uuid())),
             turn_id: value
                 .context
                 .turn_id

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -17,7 +17,6 @@ use everruns_core::ToolRegistry;
 use everruns_core::atoms::{ActAtom, Atom, InputAtom, ReasonAtom};
 use everruns_core::capabilities::{CapabilityRegistry, collect_capabilities, is_mcp_capability};
 use everruns_core::traits::AgentStore;
-use everruns_core::typed_id::MessageId;
 use std::sync::Arc;
 
 use crate::adapters::create_driver_registry;
@@ -75,7 +74,7 @@ pub async fn input_activity(
         EventContext::turn(input.context.turn_id, input.context.input_message_id),
         SessionActivatedData {
             turn_id: input.context.turn_id,
-            input_message_id: MessageId::from_uuid(input.context.input_message_id),
+            input_message_id: input.context.input_message_id,
         },
     );
     if let Err(e) = event_emitter.emit(activated_event).await {
@@ -88,7 +87,7 @@ pub async fn input_activity(
         EventContext::turn(input.context.turn_id, input.context.input_message_id),
         TurnStartedData {
             turn_id: input.context.turn_id,
-            input_message_id: MessageId::from_uuid(input.context.input_message_id),
+            input_message_id: input.context.input_message_id,
         },
     );
     if let Err(e) = event_emitter.emit(turn_started_event).await {
@@ -320,7 +319,7 @@ pub mod activity_types {
 mod tests {
     use super::*;
     use everruns_core::atoms::AtomContext;
-    use everruns_core::typed_id::TurnId;
+    use everruns_core::typed_id::{AgentId, MessageId, SessionId, TurnId};
     use everruns_core::{BuiltinTool, ToolCall, ToolDefinition, ToolPolicy};
     use serde_json::json;
     use uuid::Uuid;
@@ -328,9 +327,9 @@ mod tests {
     #[test]
     fn test_input_atom_input_serialization() {
         let context = AtomContext::new(
-            Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap(),
+            SessionId::from_uuid(Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap()),
             TurnId::from_uuid(Uuid::parse_str("660e8400-e29b-41d4-a716-446655440000").unwrap()),
-            Uuid::parse_str("770e8400-e29b-41d4-a716-446655440000").unwrap(),
+            MessageId::from_uuid(Uuid::parse_str("770e8400-e29b-41d4-a716-446655440000").unwrap()),
         );
 
         let input = InputAtomInput { context };
@@ -338,18 +337,20 @@ mod tests {
         let json = serde_json::to_string(&input).unwrap();
         let parsed: InputAtomInput = serde_json::from_str(&json).unwrap();
         assert_eq!(
-            parsed.context.session_id,
+            parsed.context.session_id.uuid(),
             Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap()
         );
     }
 
     #[test]
     fn test_reason_input_serialization() {
-        let context = AtomContext::new(Uuid::now_v7(), TurnId::new(), Uuid::now_v7());
+        let context = AtomContext::new(SessionId::new(), TurnId::new(), MessageId::new());
 
         let input = ReasonInput {
             context: context.clone(),
-            agent_id: Uuid::parse_str("880e8400-e29b-41d4-a716-446655440000").unwrap(),
+            agent_id: AgentId::from_uuid(
+                Uuid::parse_str("880e8400-e29b-41d4-a716-446655440000").unwrap(),
+            ),
             org_id: 1,
             mcp_tool_definitions: vec![],
         };
@@ -357,18 +358,18 @@ mod tests {
         let json = serde_json::to_string(&input).unwrap();
         let parsed: ReasonInput = serde_json::from_str(&json).unwrap();
         assert_eq!(
-            parsed.agent_id,
+            parsed.agent_id.uuid(),
             Uuid::parse_str("880e8400-e29b-41d4-a716-446655440000").unwrap()
         );
     }
 
     #[test]
     fn test_act_input_serialization() {
-        let context = AtomContext::new(Uuid::now_v7(), TurnId::new(), Uuid::now_v7());
+        let context = AtomContext::new(SessionId::new(), TurnId::new(), MessageId::new());
 
         let input = ActInput {
             context: context.clone(),
-            agent_id: Uuid::now_v7(),
+            agent_id: AgentId::new(),
             tool_calls: vec![ToolCall {
                 id: "call_1".to_string(),
                 name: "get_weather".to_string(),

--- a/crates/worker/src/durable_runner.rs
+++ b/crates/worker/src/durable_runner.rs
@@ -6,7 +6,7 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use everruns_core::TurnId;
+use everruns_core::typed_id::{AgentId, MessageId, SessionId, TurnId};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -32,9 +32,9 @@ use everruns_durable::{
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DurableTurnInput {
     pub org_id: i64,
-    pub session_id: Uuid,
-    pub agent_id: Uuid,
-    pub input_message_id: Uuid,
+    pub session_id: SessionId,
+    pub agent_id: AgentId,
+    pub input_message_id: MessageId,
     /// Turn ID for trace correlation. Created by input activity, propagated to reason/act.
     /// Uses typed TurnId for type safety and consistent prefixed format.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -44,7 +44,7 @@ pub struct DurableTurnInput {
 /// Output from the turn workflow
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DurableTurnOutput {
-    pub session_id: Uuid,
+    pub session_id: SessionId,
     pub success: bool,
     pub error: Option<String>,
 }
@@ -465,9 +465,9 @@ impl AgentRunner for DurableRunner {
     async fn start_run(
         &self,
         org_id: i64,
-        session_id: Uuid,
-        agent_id: Uuid,
-        input_message_id: Uuid,
+        session_id: SessionId,
+        agent_id: AgentId,
+        input_message_id: MessageId,
     ) -> Result<()> {
         info!(
             org_id = org_id,
@@ -489,7 +489,7 @@ impl AgentRunner for DurableRunner {
 
         // Create workflow instance
         // Use session_id as workflow_id for consistency
-        let workflow_id = session_id;
+        let workflow_id = session_id.uuid();
         let input_json = serde_json::to_value(&input)?;
 
         let mut store = self.store.lock().await;
@@ -595,10 +595,10 @@ impl AgentRunner for DurableRunner {
         Ok(())
     }
 
-    async fn cancel_run(&self, session_id: Uuid) -> Result<()> {
+    async fn cancel_run(&self, session_id: SessionId) -> Result<()> {
         info!(session_id = %session_id, "Cancelling durable workflow");
 
-        let workflow_id = session_id;
+        let workflow_id = session_id.uuid();
         let mut store = self.store.lock().await;
 
         // Update workflow status to cancelled
@@ -621,8 +621,8 @@ impl AgentRunner for DurableRunner {
         Ok(())
     }
 
-    async fn is_running(&self, session_id: Uuid) -> bool {
-        let workflow_id = session_id;
+    async fn is_running(&self, session_id: SessionId) -> bool {
+        let workflow_id = session_id.uuid();
         let mut store = self.store.lock().await;
 
         match store.get_workflow_status(workflow_id).await {
@@ -640,6 +640,7 @@ impl AgentRunner for DurableRunner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use everruns_core::typed_id::{AgentId, MessageId, SessionId};
 
     #[test]
     fn test_durable_turn_input_serialization() {
@@ -647,9 +648,9 @@ mod tests {
 
         let input = DurableTurnInput {
             org_id: DEFAULT_ORG_ID,
-            session_id: Uuid::now_v7(),
-            agent_id: Uuid::now_v7(),
-            input_message_id: Uuid::now_v7(),
+            session_id: SessionId::new(),
+            agent_id: AgentId::new(),
+            input_message_id: MessageId::new(),
             turn_id: None,
         };
 
@@ -670,9 +671,9 @@ mod tests {
 
         let runner = DurableRunner::new_in_memory();
 
-        let session_id = Uuid::now_v7();
-        let agent_id = Uuid::now_v7();
-        let message_id = Uuid::now_v7();
+        let session_id = SessionId::new();
+        let agent_id = AgentId::new();
+        let message_id = MessageId::new();
 
         // First call should create a new workflow
         runner
@@ -691,10 +692,10 @@ mod tests {
 
         let runner = DurableRunner::new_in_memory();
 
-        let session_id = Uuid::now_v7();
-        let agent_id = Uuid::now_v7();
-        let message_id1 = Uuid::now_v7();
-        let message_id2 = Uuid::now_v7();
+        let session_id = SessionId::new();
+        let agent_id = AgentId::new();
+        let message_id1 = MessageId::new();
+        let message_id2 = MessageId::new();
 
         // First message
         runner
@@ -725,10 +726,10 @@ mod tests {
 
         let runner = DurableRunner::new_in_memory();
 
-        let session_id = Uuid::now_v7();
-        let agent_id = Uuid::now_v7();
-        let message_id1 = Uuid::now_v7();
-        let message_id2 = Uuid::now_v7();
+        let session_id = SessionId::new();
+        let agent_id = AgentId::new();
+        let message_id1 = MessageId::new();
+        let message_id2 = MessageId::new();
 
         // First message - creates workflow
         runner
@@ -742,7 +743,7 @@ mod tests {
         {
             let mut store = runner.store.lock().await;
             store
-                .update_workflow_status(session_id, WorkflowStatus::Completed, None, None)
+                .update_workflow_status(session_id.uuid(), WorkflowStatus::Completed, None, None)
                 .await
                 .expect("Should update workflow status");
         }
@@ -775,10 +776,10 @@ mod tests {
 
         let runner = DurableRunner::new_in_memory();
 
-        let session_id = Uuid::now_v7();
-        let agent_id = Uuid::now_v7();
-        let message_id1 = Uuid::now_v7();
-        let message_id2 = Uuid::now_v7();
+        let session_id = SessionId::new();
+        let agent_id = AgentId::new();
+        let message_id1 = MessageId::new();
+        let message_id2 = MessageId::new();
 
         // First message
         runner
@@ -791,7 +792,7 @@ mod tests {
             let mut store = runner.store.lock().await;
             store
                 .update_workflow_status(
-                    session_id,
+                    session_id.uuid(),
                     WorkflowStatus::Failed,
                     None,
                     Some("Test error".to_string()),

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -7,7 +7,7 @@ use everruns_core::Message;
 use everruns_core::atoms::AtomContext;
 use everruns_core::events::{EventContext, EventRequest, MessageAgentData, SessionIdledData};
 use everruns_core::traits::EventEmitter;
-use everruns_core::typed_id::TurnId;
+use everruns_core::typed_id::{ExecId, MessageId, SessionId, TurnId};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
@@ -48,9 +48,9 @@ struct ActTaskInput {
 async fn emit_cancellation_events(
     grpc_address: &str,
     org_id: i64,
-    session_id: Uuid,
+    session_id: SessionId,
     turn_id: TurnId,
-    input_message_id: Uuid,
+    input_message_id: MessageId,
 ) {
     // Connect to gRPC for event emission
     let grpc_client = match GrpcClient::connect(grpc_address).await {
@@ -573,7 +573,11 @@ impl DurableWorker {
                                 turn_input.input_message_id,
                             )
                         } else {
-                            (0, task.workflow_id, Uuid::nil())
+                            (
+                                0,
+                                SessionId::from_uuid(task.workflow_id),
+                                MessageId::from_uuid(Uuid::nil()),
+                            )
                         }
                     }
                     "act" => {
@@ -586,10 +590,18 @@ impl DurableWorker {
                                 act_input.act_input.context.input_message_id,
                             )
                         } else {
-                            (0, task.workflow_id, Uuid::nil())
+                            (
+                                0,
+                                SessionId::from_uuid(task.workflow_id),
+                                MessageId::from_uuid(Uuid::nil()),
+                            )
                         }
                     }
-                    _ => (0, task.workflow_id, Uuid::nil()),
+                    _ => (
+                        0,
+                        SessionId::from_uuid(task.workflow_id),
+                        MessageId::from_uuid(Uuid::nil()),
+                    ),
                 };
 
                 // Emit cancellation events (agent message + session.idled)
@@ -776,7 +788,7 @@ impl DurableWorker {
             session_id: input.session_id,
             turn_id: TurnId::new(),
             input_message_id: input.input_message_id,
-            exec_id: Uuid::now_v7(),
+            exec_id: ExecId::new(),
         };
 
         let atom_input = InputAtomInput {
@@ -856,7 +868,7 @@ impl DurableWorker {
             session_id: input.session_id,
             turn_id,
             input_message_id: input.input_message_id,
-            exec_id: Uuid::now_v7(),
+            exec_id: ExecId::new(),
         };
 
         let reason_input = ReasonInput {
@@ -1013,7 +1025,7 @@ impl DurableWorker {
                                 session_id: input.session_id,
                                 turn_id,
                                 input_message_id: input.input_message_id,
-                                exec_id: Uuid::now_v7(),
+                                exec_id: ExecId::new(),
                             },
                             agent_id: input.agent_id, // Pass through for follow-up reason activity
                             tool_calls: reason_result.tool_calls,

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -14,6 +14,7 @@ use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
 use everruns_core::traits::{
     AgentStore, EventEmitter, LlmProviderStore, ModelWithProvider, SessionFileStore, SessionStore,
 };
+use everruns_core::typed_id::{AgentId, MessageId, ModelId, SessionId};
 use everruns_core::{Agent, Message, Session};
 use everruns_internal_protocol::proto;
 use everruns_internal_protocol::{
@@ -78,11 +79,11 @@ impl GrpcClient {
     pub async fn set_session_status(
         &self,
         org_id: i64,
-        session_id: Uuid,
+        session_id: SessionId,
         status: &str,
     ) -> Result<Session> {
         let request = proto::SetSessionStatusRequest {
-            session_id: Some(uuid_to_proto(session_id)),
+            session_id: Some(uuid_to_proto(session_id.uuid())),
             status: status.to_string(),
             org_id,
         };
@@ -239,18 +240,18 @@ impl GrpcMessageRetriever {
 
 #[async_trait]
 impl MessageRetriever for GrpcMessageRetriever {
-    async fn get(&self, session_id: Uuid, message_id: Uuid) -> Result<Option<Message>> {
+    async fn get(&self, session_id: SessionId, message_id: MessageId) -> Result<Option<Message>> {
         // Load all messages and find the one we want
         // TODO: Add a specific get_message RPC
         let messages = self.load(session_id).await?;
         Ok(messages.into_iter().find(|m| m.id == message_id))
     }
 
-    async fn load(&self, session_id: Uuid) -> Result<Vec<Message>> {
+    async fn load(&self, session_id: SessionId) -> Result<Vec<Message>> {
         let mut client = self.client.inner.lock().await;
 
         let request = proto::LoadMessagesRequest {
-            session_id: Some(uuid_to_proto(session_id)),
+            session_id: Some(uuid_to_proto(session_id.uuid())),
         };
 
         let response = client
@@ -333,11 +334,11 @@ impl GrpcAgentStore {
 
 #[async_trait]
 impl AgentStore for GrpcAgentStore {
-    async fn get_agent(&self, agent_id: Uuid) -> Result<Option<Agent>> {
+    async fn get_agent(&self, agent_id: AgentId) -> Result<Option<Agent>> {
         let mut client = self.client.inner.lock().await;
 
         let request = proto::GetAgentRequest {
-            agent_id: Some(uuid_to_proto(agent_id)),
+            agent_id: Some(uuid_to_proto(agent_id.uuid())),
             org_id: self.org_id,
         };
 
@@ -407,11 +408,11 @@ impl GrpcSessionStore {
 
 #[async_trait]
 impl SessionStore for GrpcSessionStore {
-    async fn get_session(&self, session_id: Uuid) -> Result<Option<Session>> {
+    async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>> {
         let mut client = self.client.inner.lock().await;
 
         let request = proto::GetSessionRequest {
-            session_id: Some(uuid_to_proto(session_id)),
+            session_id: Some(uuid_to_proto(session_id.uuid())),
             org_id: self.org_id,
         };
 
@@ -487,11 +488,14 @@ impl GrpcLlmProviderStore {
 
 #[async_trait]
 impl LlmProviderStore for GrpcLlmProviderStore {
-    async fn get_model_with_provider(&self, model_id: Uuid) -> Result<Option<ModelWithProvider>> {
+    async fn get_model_with_provider(
+        &self,
+        model_id: ModelId,
+    ) -> Result<Option<ModelWithProvider>> {
         let mut client = self.client.inner.lock().await;
 
         let request = proto::GetModelWithProviderRequest {
-            model_id: Some(uuid_to_proto(model_id)),
+            model_id: Some(uuid_to_proto(model_id.uuid())),
             org_id: self.org_id,
         };
 
@@ -570,11 +574,11 @@ impl GrpcSessionFileStore {
 
 #[async_trait]
 impl SessionFileStore for GrpcSessionFileStore {
-    async fn read_file(&self, session_id: Uuid, path: &str) -> Result<Option<SessionFile>> {
+    async fn read_file(&self, session_id: SessionId, path: &str) -> Result<Option<SessionFile>> {
         let mut client = self.client.inner.lock().await;
 
         let request = proto::SessionReadFileRequest {
-            session_id: Some(uuid_to_proto(session_id)),
+            session_id: Some(uuid_to_proto(session_id.uuid())),
             path: path.to_string(),
         };
 
@@ -594,7 +598,7 @@ impl SessionFileStore for GrpcSessionFileStore {
 
     async fn write_file(
         &self,
-        session_id: Uuid,
+        session_id: SessionId,
         path: &str,
         content: &str,
         encoding: &str,
@@ -602,7 +606,7 @@ impl SessionFileStore for GrpcSessionFileStore {
         let mut client = self.client.inner.lock().await;
 
         let request = proto::SessionWriteFileRequest {
-            session_id: Some(uuid_to_proto(session_id)),
+            session_id: Some(uuid_to_proto(session_id.uuid())),
             path: path.to_string(),
             content: content.to_string(),
             encoding: encoding.to_string(),
@@ -621,11 +625,16 @@ impl SessionFileStore for GrpcSessionFileStore {
         proto_session_file_to_file(proto_file)
     }
 
-    async fn delete_file(&self, session_id: Uuid, path: &str, recursive: bool) -> Result<bool> {
+    async fn delete_file(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        recursive: bool,
+    ) -> Result<bool> {
         let mut client = self.client.inner.lock().await;
 
         let request = proto::SessionDeleteFileRequest {
-            session_id: Some(uuid_to_proto(session_id)),
+            session_id: Some(uuid_to_proto(session_id.uuid())),
             path: path.to_string(),
             recursive,
         };
@@ -638,11 +647,11 @@ impl SessionFileStore for GrpcSessionFileStore {
         Ok(response.into_inner().deleted)
     }
 
-    async fn list_directory(&self, session_id: Uuid, path: &str) -> Result<Vec<FileInfo>> {
+    async fn list_directory(&self, session_id: SessionId, path: &str) -> Result<Vec<FileInfo>> {
         let mut client = self.client.inner.lock().await;
 
         let request = proto::SessionListDirectoryRequest {
-            session_id: Some(uuid_to_proto(session_id)),
+            session_id: Some(uuid_to_proto(session_id.uuid())),
             path: path.to_string(),
         };
 
@@ -659,11 +668,11 @@ impl SessionFileStore for GrpcSessionFileStore {
             .collect()
     }
 
-    async fn stat_file(&self, session_id: Uuid, path: &str) -> Result<Option<FileStat>> {
+    async fn stat_file(&self, session_id: SessionId, path: &str) -> Result<Option<FileStat>> {
         let mut client = self.client.inner.lock().await;
 
         let request = proto::SessionStatFileRequest {
-            session_id: Some(uuid_to_proto(session_id)),
+            session_id: Some(uuid_to_proto(session_id.uuid())),
             path: path.to_string(),
         };
 
@@ -683,14 +692,14 @@ impl SessionFileStore for GrpcSessionFileStore {
 
     async fn grep_files(
         &self,
-        session_id: Uuid,
+        session_id: SessionId,
         pattern: &str,
         path_pattern: Option<&str>,
     ) -> Result<Vec<GrepMatch>> {
         let mut client = self.client.inner.lock().await;
 
         let request = proto::SessionGrepFilesRequest {
-            session_id: Some(uuid_to_proto(session_id)),
+            session_id: Some(uuid_to_proto(session_id.uuid())),
             pattern: pattern.to_string(),
             path_pattern: path_pattern.map(|s| s.to_string()),
         };
@@ -712,11 +721,11 @@ impl SessionFileStore for GrpcSessionFileStore {
             .collect())
     }
 
-    async fn create_directory(&self, session_id: Uuid, path: &str) -> Result<FileInfo> {
+    async fn create_directory(&self, session_id: SessionId, path: &str) -> Result<FileInfo> {
         let mut client = self.client.inner.lock().await;
 
         let request = proto::SessionCreateDirectoryRequest {
-            session_id: Some(uuid_to_proto(session_id)),
+            session_id: Some(uuid_to_proto(session_id.uuid())),
             path: path.to_string(),
         };
 
@@ -852,12 +861,12 @@ pub struct TurnContext {
 pub async fn load_turn_context(
     client: &GrpcClient,
     org_id: i64,
-    session_id: Uuid,
+    session_id: SessionId,
 ) -> Result<TurnContext> {
     let mut grpc_client = client.inner.lock().await;
 
     let request = proto::GetTurnContextRequest {
-        session_id: Some(uuid_to_proto(session_id)),
+        session_id: Some(uuid_to_proto(session_id.uuid())),
         org_id,
     };
 

--- a/crates/worker/src/runner.rs
+++ b/crates/worker/src/runner.rs
@@ -15,9 +15,9 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
+use everruns_core::typed_id::{AgentId, MessageId, SessionId};
 use everruns_durable::InMemoryWorkflowEventStore;
 use std::sync::Arc;
-use uuid::Uuid;
 
 use crate::durable_runner::DurableRunner;
 
@@ -39,16 +39,16 @@ pub trait AgentRunner: Send + Sync {
     async fn start_run(
         &self,
         org_id: i64,
-        session_id: Uuid,
-        agent_id: Uuid,
-        input_message_id: Uuid,
+        session_id: SessionId,
+        agent_id: AgentId,
+        input_message_id: MessageId,
     ) -> Result<()>;
 
     /// Cancel a running workflow
-    async fn cancel_run(&self, run_id: Uuid) -> Result<()>;
+    async fn cancel_run(&self, run_id: SessionId) -> Result<()>;
 
     /// Check if a workflow is still running
-    async fn is_running(&self, run_id: Uuid) -> bool;
+    async fn is_running(&self, run_id: SessionId) -> bool;
 
     /// Get count of active workflows (for monitoring)
     async fn active_count(&self) -> usize;

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -5615,8 +5615,7 @@
         ],
         "properties": {
           "agent_id": {
-            "type": "string",
-            "format": "uuid",
+            "$ref": "#/components/schemas/TypedId",
             "description": "Agent ID being used"
           },
           "metadata": {
@@ -6301,6 +6300,12 @@
             "example": "turn_01933b5a00007000800000000000001"
           }
         }
+      },
+      "TypedId": {
+        "type": "string",
+        "description": "Prefixed identifier with 'agent' prefix",
+        "example": "agent_01933b5a00007000800000000000001",
+        "pattern": "^agent_[0-9a-f]{32}$"
       },
       "UpdateAgentRequest": {
         "type": "object",

--- a/specs/id-schema.md
+++ b/specs/id-schema.md
@@ -131,11 +131,89 @@ The `TypedId<T>` generic type provides:
 - Automatic serialization/deserialization
 - Validation on construction
 - Display and Debug implementations
+- Database compatibility via sqlx `Type`/`Encode`/`Decode` implementations
 
 ```rust
 // Type aliases for each entity
 pub type AgentId = TypedId<AgentIdMarker>;
 pub type SessionId = TypedId<SessionIdMarker>;
 pub type MessageId = TypedId<MessageIdMarker>;
-// etc.
+pub type EventId = TypedId<EventIdMarker>;
+pub type TurnId = TypedId<TurnIdMarker>;
+pub type ExecId = TypedId<ExecIdMarker>;
+pub type ProviderId = TypedId<ProviderIdMarker>;
+pub type ModelId = TypedId<ModelIdMarker>;
+pub type ImageId = TypedId<ImageIdMarker>;
+pub type McpServerId = TypedId<McpServerIdMarker>;
+```
+
+### Usage Requirements
+
+**IMPORTANT: Typed IDs are mandatory throughout the codebase.**
+
+All code MUST use typed IDs instead of raw `Uuid` for entity identifiers:
+
+```rust
+// ✅ Correct: Use typed IDs
+fn get_session(session_id: SessionId) -> Option<Session>;
+fn create_event(session_id: SessionId, agent_id: AgentId) -> Event;
+
+// ❌ Wrong: Raw UUIDs lose type safety
+fn get_session(session_id: Uuid) -> Option<Session>;
+fn create_event(session_id: Uuid, agent_id: Uuid) -> Event;
+```
+
+### Common Patterns
+
+```rust
+// Create new ID (uses UUIDv7 internally)
+let session_id = SessionId::new();
+
+// Convert from existing UUID
+let session_id = SessionId::from_uuid(uuid);
+let session_id: SessionId = uuid.into();
+
+// Extract underlying UUID (for database queries, external APIs)
+let uuid = session_id.uuid();
+let uuid: Uuid = session_id.into();
+
+// String formatting (produces prefixed format)
+let s = session_id.to_string(); // "session_01933b5a..."
+
+// Parse from string
+let session_id: SessionId = "session_01933b5a...".parse()?;
+```
+
+### Trait Implementations
+
+All core traits use typed IDs:
+
+```rust
+// MessageRetriever uses SessionId and MessageId
+async fn get(&self, session_id: SessionId, message_id: MessageId) -> Result<Option<Message>>;
+async fn load(&self, session_id: SessionId) -> Result<Vec<Message>>;
+
+// AgentStore uses AgentId
+async fn get_agent(&self, agent_id: AgentId) -> Result<Option<Agent>>;
+
+// SessionStore uses SessionId
+async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>>;
+
+// LlmProviderStore uses ModelId
+async fn get_model_with_provider(&self, model_id: ModelId) -> Result<Option<ModelWithProvider>>;
+```
+
+### Database Integration
+
+TypedId implements sqlx traits for direct database usage:
+
+```rust
+// Direct use in queries - stored as UUID in database
+let row = sqlx::query_as!(
+    AgentRow,
+    "SELECT * FROM agents WHERE id = $1",
+    agent_id  // AgentId works directly
+)
+.fetch_one(&pool)
+.await?;
 ```

--- a/specs/models.md
+++ b/specs/models.md
@@ -12,16 +12,18 @@ Configuration for an agentic loop. An agent can have many concurrent sessions.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `id` | UUID v7 | Unique identifier |
+| `id` | AgentId | Typed ID with `agent_` prefix (UUIDv7) |
 | `name` | string | Display name |
 | `description` | string? | Optional description (supports markdown) |
 | `system_prompt` | string | System prompt for the LLM |
-| `default_model_id` | UUID? | Reference to llm_models table |
+| `default_model_id` | ModelId? | Reference to llm_models table |
 | `tags` | string[] | Tags for organization/filtering |
 | `capabilities` | CapabilityId[] | Enabled capabilities |
 | `status` | enum | `active` or `archived` |
 | `created_at` | timestamp | Creation time |
 | `updated_at` | timestamp | Last modification time |
+
+**Note:** All entity IDs use typed wrappers (AgentId, SessionId, etc.) for compile-time type safety. See `specs/id-schema.md` for details.
 
 **Input Validation Limits:**
 
@@ -41,11 +43,11 @@ An instance of agentic loop execution. Multiple sessions can exist concurrently 
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `id` | UUID v7 | Unique identifier |
-| `agent_id` | UUID v7 | Parent agent reference |
+| `id` | SessionId | Typed ID with `session_` prefix (UUIDv7) |
+| `agent_id` | AgentId | Parent agent reference |
 | `title` | string? | Session title (user-provided or auto-generated) |
 | `tags` | string[] | Tags for organization/filtering |
-| `model_id` | UUID? | Override model (null = use agent default) |
+| `model_id` | ModelId? | Override model (null = use agent default) |
 | `status` | enum | `started`, `active`, `idle` |
 | `created_at` | timestamp | Creation time |
 | `updated_at` | timestamp | Last modification time (auto-updated on any change) |
@@ -62,8 +64,8 @@ Conversation data stored as events in the `events` table with `event_type` prefi
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `id` | UUID v7 | Unique identifier (stored in event.data.message_id) |
-| `session_id` | UUID v7 | Parent session reference (from event.session_id) |
+| `id` | MessageId | Typed ID with `message_` prefix (stored in event.data.message_id) |
+| `session_id` | SessionId | Parent session reference (from event.session_id) |
 | `sequence` | integer | Order within session (from event.sequence) |
 | `role` | enum | `user`, `assistant`, `tool_result` |
 | `content` | ContentPart[] | Array of content parts (see below) |


### PR DESCRIPTION
## Summary
- Replace raw `Uuid` fields with strongly-typed ID wrappers throughout the codebase
- All entity IDs now use compile-time type safety to prevent mixing up different ID types
- Add sqlx database integration for TypedId

## Changes

### Core crate
- Add sqlx `Type`/`Encode`/`Decode` implementations for database compatibility
- Update `AtomContext`, `Event`, `EventRequest`, `EventContext`, `EventBuilder`
- Update traits: `MessageRetriever`, `AgentStore`, `SessionStore`, `LlmProviderStore`, `SessionFileStore`, `SessionStorageStore`
- Update error types to use typed IDs

### Control-plane crate
- Update all storage Row models to use typed IDs
- Update all trait implementations
- Update API and service layers

### Worker crate
- Update `AgentRunner` trait and implementations
- Update `DurableTurnInput`, `DurableTurnOutput`
- Update gRPC adapters

### Specs
- Update `specs/id-schema.md` with mandatory usage requirements
- Update `specs/models.md` to use typed ID types

## Available Typed IDs
- `AgentId`, `SessionId`, `MessageId`, `ModelId`, `EventId`
- `ProviderId`, `ImageId`, `McpServerId`, `TurnId`, `ExecId`

## Test plan
- [x] All unit tests pass (782+)
- [x] `cargo check --all` passes
- [x] CI should pass

https://claude.ai/code/session_019HLhux3Hj9yyFeUn6PTxEA