### PR TITLE
fix(ui): bypass Next.js proxy for image uploads

### DIFF
--- a/apps/ui/src/lib/api/images.ts
+++ b/apps/ui/src/lib/api/images.ts
@@ -4,7 +4,7 @@
 // API functions for uploading, retrieving, and deleting images.
 // Images can be attached to messages as image_file content parts.
 
-import { getApiBaseUrl } from "./client";
+import { getApiBaseUrl, getDirectBackendUrl } from "./client";
 import type { ImageUploadResponse, ImageInfo } from "./types";
 import { ALLOWED_IMAGE_TYPES, MAX_IMAGE_SIZE } from "./types";
 
@@ -42,6 +42,9 @@ function formatBytes(bytes: number): string {
 
 /**
  * Upload an image file
+ * @param org - Organization public ID
+ * @param file - Image file to upload
+ * @param sessionId - Optional: session ID stored as metadata for tracking (not required)
  */
 export async function uploadImage(
   org: string,
@@ -51,14 +54,16 @@ export async function uploadImage(
   const formData = new FormData();
   formData.append("file", file);
 
-  let url = `${getApiBaseUrl()}/v1/orgs/${org}/images`;
-  if (sessionId) {
-    url += `?session_id=${sessionId}`;
-  }
+  // Use direct backend URL for multipart uploads
+  // Next.js rewrites don't handle streaming/multipart properly (causes EPIPE errors)
+  const baseUrl = getDirectBackendUrl();
+  const params = sessionId ? `?session_id=${sessionId}` : "";
+  const url = `${baseUrl}/v1/orgs/${org}/images${params}`;
 
   const response = await fetch(url, {
     method: "POST",
     body: formData,
+    credentials: "include", // Include cookies for auth
   });
 
   if (!response.ok) {
@@ -141,6 +146,9 @@ export interface PendingImage {
 
 /**
  * Create a pending image from a file
+ * @param org - Organization public ID
+ * @param file - Image file to upload
+ * @param sessionId - Optional: session ID stored as metadata for tracking (not required)
  */
 export function createPendingImage(org: string, file: File, sessionId?: string): PendingImage {
   const tempId = crypto.randomUUID();

--- a/crates/control-plane/src/api/images.rs
+++ b/crates/control-plane/src/api/images.rs
@@ -79,7 +79,7 @@ fn default_limit() -> i64 {
 /// Query parameters for image upload
 #[derive(Debug, Deserialize)]
 pub struct UploadImageQuery {
-    /// Optional session ID for metadata tracking
+    /// Optional session ID stored as metadata for tracking (not required for upload)
     pub session_id: Option<Uuid>,
 }
 
@@ -174,7 +174,7 @@ fn generate_thumbnail(data: &[u8], content_type: &str) -> Option<(Vec<u8>, Strin
     path = "/v1/orgs/{org}/images",
     params(
         ("org" = String, Path, description = "Organization public ID"),
-        ("session_id" = Option<Uuid>, Query, description = "Optional session ID for tracking")
+        ("session_id" = Option<Uuid>, Query, description = "Optional: session ID stored as metadata for tracking (not required for upload)")
     ),
     request_body(content = String, description = "Multipart form data with 'file' field", content_type = "multipart/form-data"),
     responses(


### PR DESCRIPTION
## What
Fix image upload EPIPE errors by bypassing Next.js proxy for multipart uploads.

## Why
Next.js rewrites don't handle multipart form data streaming properly, causing EPIPE errors when uploading images. The same issue was already fixed for SSE/durable event streaming.

## How
- Use `getDirectBackendUrl()` instead of `getApiBaseUrl()` for image uploads
- Added `credentials: "include"` for auth cookies
- Clarified `session_id` parameter is optional (metadata only, not required for upload)

## Risk
- Low
- Only affects image upload path in development mode (production uses reverse proxy which handles multipart correctly)

## Checklist
- [x] Smoke tested image upload without session_id
- [x] Smoke tested image upload with session_id
- [x] Backend compiles and unit tests pass