### PR TITLE
fix(observability): fix Braintrust timeline view for reason and act spans

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,11 @@ GRPC_ADDRESS=127.0.0.1:9001
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 # OTEL_SERVICE_NAME=everruns
 # OTEL_ENVIRONMENT=development
+
+# Braintrust (optional - for LLM observability)
+# Set BRAINTRUST_API_KEY to enable Braintrust integration
+# BRAINTRUST_API_KEY=your-braintrust-api-key
+# BRAINTRUST_PROJECT_NAME=My Project
+# Or use project ID directly (skips name resolution API call):
+# BRAINTRUST_PROJECT_ID=your-project-uuid
+# BRAINTRUST_API_URL=https://api.braintrust.dev

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -295,6 +295,8 @@ export interface MessageAgentData {
 export interface TurnStartedData {
   turn_id: string;
   input_message_id: string;
+  /** Input message content (for observability) */
+  input_content?: string;
 }
 
 /** Data for turn.completed event */

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -374,6 +374,7 @@ export interface ToolCallCompletedData {
   status: "success" | "error" | "timeout" | "cancelled";
   result?: ContentPart[];
   error?: string;
+  duration_ms?: number;
 }
 
 /** LLM generation output */

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -331,6 +331,8 @@ export interface ReasonCompletedData {
   has_tool_calls: boolean;
   tool_call_count: number;
   error?: string;
+  duration_ms?: number;
+  usage?: TokenUsage;
 }
 
 /** Tool call summary (compact form) */
@@ -349,6 +351,7 @@ export interface ActCompletedData {
   completed: boolean;
   success_count: number;
   error_count: number;
+  duration_ms?: number;
 }
 
 /** Tool call from LLM response */

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -306,6 +306,8 @@ export interface TurnCompletedData {
   duration_ms?: number;
   /** Aggregated token usage for all LLM calls in this turn */
   usage?: TokenUsage;
+  /** Input message content (for observability, passed through from turn.started) */
+  input_content?: string;
 }
 
 /** Data for turn.failed event */

--- a/crates/control-plane/src/dev_worker/worker.rs
+++ b/crates/control-plane/src/dev_worker/worker.rs
@@ -360,11 +360,11 @@ impl InProcessWorker {
 
     /// Execute input processing activity
     async fn execute_input_activity(&self, input: &DurableTurnInput) -> Result<serde_json::Value> {
+        use everruns_core::MessageRetriever;
         use everruns_core::events::{
             EventContext, EventRequest, SessionActivatedData, TurnStartedData,
         };
         use everruns_core::traits::EventEmitter;
-        use everruns_core::MessageRetriever;
 
         debug!(
             session_id = %input.session_id,
@@ -454,11 +454,11 @@ impl InProcessWorker {
 
     /// Execute reasoning activity (LLM call)
     async fn execute_reason_activity(&self, input: &DurableTurnInput) -> Result<serde_json::Value> {
+        use everruns_core::MessageRetriever;
         use everruns_core::events::{
             EventContext, EventRequest, SessionIdledData, TurnCompletedData, TurnFailedData,
         };
         use everruns_core::traits::EventEmitter;
-        use everruns_core::MessageRetriever;
 
         debug!(
             session_id = %input.session_id,

--- a/crates/control-plane/src/dev_worker/worker.rs
+++ b/crates/control-plane/src/dev_worker/worker.rs
@@ -364,6 +364,7 @@ impl InProcessWorker {
             EventContext, EventRequest, SessionActivatedData, TurnStartedData,
         };
         use everruns_core::traits::EventEmitter;
+        use everruns_core::MessageRetriever;
 
         debug!(
             session_id = %input.session_id,
@@ -384,6 +385,26 @@ impl InProcessWorker {
             warn!(error = %e, "Failed to set session status to active");
         }
 
+        // Create message retriever early to fetch input content for observability
+        let message_retriever =
+            DirectMessageRetriever::new(self.db.clone(), self.event_service.clone());
+
+        // Fetch input message content for turn.started event (for Braintrust observability)
+        let input_content = match message_retriever
+            .get(input.session_id, input.input_message_id)
+            .await
+        {
+            Ok(Some(msg)) => Some(msg.content_to_llm_string()),
+            Ok(None) => {
+                warn!("Input message not found for turn.started event");
+                None
+            }
+            Err(e) => {
+                warn!(error = %e, "Failed to fetch input message for turn.started event");
+                None
+            }
+        };
+
         // Emit session.activated event
         let event_emitter = DirectEventEmitter::new(self.event_service.clone());
         let activated_event = EventRequest::new(
@@ -398,13 +419,14 @@ impl InProcessWorker {
             warn!(error = %e, "Failed to emit session.activated event");
         }
 
-        // Emit turn.started event
+        // Emit turn.started event with input content for observability
         let turn_started_event = EventRequest::new(
             input.session_id,
             EventContext::turn(context.turn_id, input.input_message_id),
             TurnStartedData {
                 turn_id: context.turn_id,
                 input_message_id: input.input_message_id,
+                input_content,
             },
         );
         if let Err(e) = event_emitter.emit(turn_started_event).await {
@@ -412,8 +434,6 @@ impl InProcessWorker {
         }
 
         // Execute InputAtom
-        let message_retriever =
-            DirectMessageRetriever::new(self.db.clone(), self.event_service.clone());
         let atom = InputAtom::new(message_retriever, event_emitter);
 
         let atom_input = InputAtomInput {

--- a/crates/control-plane/src/dev_worker/worker.rs
+++ b/crates/control-plane/src/dev_worker/worker.rs
@@ -458,6 +458,7 @@ impl InProcessWorker {
             EventContext, EventRequest, SessionIdledData, TurnCompletedData, TurnFailedData,
         };
         use everruns_core::traits::EventEmitter;
+        use everruns_core::MessageRetriever;
 
         debug!(
             session_id = %input.session_id,
@@ -540,6 +541,19 @@ impl InProcessWorker {
                     warn!(error = %e, "Failed to emit turn.failed event");
                 }
             } else {
+                // Fetch input message content for turn.completed (for Braintrust observability)
+                let message_retriever =
+                    DirectMessageRetriever::new(self.db.clone(), self.event_service.clone());
+                let input_content = match message_retriever.get(session_id, input_message_id).await
+                {
+                    Ok(Some(msg)) => Some(msg.content_to_llm_string()),
+                    Ok(None) => None,
+                    Err(e) => {
+                        warn!(error = %e, "Failed to fetch input message for turn.completed");
+                        None
+                    }
+                };
+
                 let turn_completed_event = EventRequest::new(
                     session_id,
                     EventContext::turn(turn_id, input_message_id),
@@ -548,6 +562,7 @@ impl InProcessWorker {
                         iterations: 1,
                         duration_ms: None,
                         usage: result.usage.clone(),
+                        input_content,
                     },
                 );
                 if let Err(e) = event_emitter.emit(turn_completed_event).await {

--- a/crates/control-plane/src/services/braintrust.rs
+++ b/crates/control-plane/src/services/braintrust.rs
@@ -335,12 +335,19 @@ impl BraintrustListener {
         // This allows child spans to link to the root via root_span_id
         let turn_id_str = data.turn_id.to_string();
 
+        // Use input_content if available, otherwise fall back to message ID
+        let input = if let Some(content) = &data.input_content {
+            Some(serde_json::json!(content))
+        } else {
+            Some(serde_json::json!({
+                "input_message_id": data.input_message_id.to_string(),
+            }))
+        };
+
         BraintrustLogEvent {
             id: turn_id_str.clone(), // Use turn_id as span ID for parent linking
             created: event.ts,
-            input: Some(serde_json::json!({
-                "input_message_id": data.input_message_id.to_string(),
-            })),
+            input,
             output: None,
             error: None,
             metadata,
@@ -1130,6 +1137,7 @@ mod tests {
         let data = TurnStartedData {
             turn_id,
             input_message_id: message_id,
+            input_content: Some("Hello, how are you?".to_string()),
         };
 
         let event = Event::new(
@@ -1254,6 +1262,7 @@ mod tests {
         let started_data = TurnStartedData {
             turn_id,
             input_message_id,
+            input_content: Some("Test input content".to_string()),
         };
         let started_event = Event::new(
             SessionId::new(),
@@ -1587,6 +1596,7 @@ mod tests {
         let turn_data = TurnStartedData {
             turn_id,
             input_message_id,
+            input_content: Some("Test message".to_string()),
         };
         let turn_event = Event::new(
             SessionId::new(),

--- a/crates/control-plane/src/services/braintrust.rs
+++ b/crates/control-plane/src/services/braintrust.rs
@@ -401,10 +401,16 @@ impl BraintrustListener {
         // Root span: span_id and root_span_id both reference self (turn_id)
         let turn_id_str = data.turn_id.to_string();
 
+        // Use input_content if available (to preserve it during span merge)
+        let input = data
+            .input_content
+            .as_ref()
+            .map(|content| serde_json::json!(content));
+
         BraintrustLogEvent {
             id: turn_id_str.clone(), // Same ID as started to update the span
             created: event.ts,
-            input: None,
+            input,
             output: Some(serde_json::json!({
                 "iterations": data.iterations,
                 "status": "completed",
@@ -1221,6 +1227,7 @@ mod tests {
                 cache_read_tokens: None,
                 cache_creation_tokens: None,
             }),
+            input_content: Some("Hello, how are you?".to_string()),
         };
 
         let event = Event::new(
@@ -1298,6 +1305,7 @@ mod tests {
             iterations: 1,
             duration_ms: Some(1000),
             usage: None,
+            input_content: Some("Test input content".to_string()),
         };
         let completed_event = Event::new(
             SessionId::new(),

--- a/crates/control-plane/src/services/braintrust.rs
+++ b/crates/control-plane/src/services/braintrust.rs
@@ -720,6 +720,25 @@ impl BraintrustListener {
             "text_preview": data.text_preview,
         });
 
+        // Build metrics if we have duration/usage for timeline display
+        let metrics = if data.duration_ms.is_some() || data.usage.is_some() {
+            let end_time = event.ts.timestamp_millis() as f64 / 1000.0;
+            let start_time = data.duration_ms.map(|d| end_time - (d as f64 / 1000.0));
+
+            Some(BraintrustMetrics {
+                start: start_time,
+                end: Some(end_time),
+                prompt_tokens: data.usage.as_ref().map(|u| u.input_tokens),
+                completion_tokens: data.usage.as_ref().map(|u| u.output_tokens),
+                tokens: data.usage.as_ref().map(|u| u.total_tokens()),
+                time_to_first_token: None,
+                cache_read_tokens: data.usage.as_ref().and_then(|u| u.cache_read_tokens),
+                cache_creation_tokens: data.usage.as_ref().and_then(|u| u.cache_creation_tokens),
+            })
+        } else {
+            None
+        };
+
         // Parent-child linking using OTel-style span fields from context
         let (span_id, root_span_id, span_parents) = Self::compute_child_span_linkage(event);
 
@@ -740,7 +759,7 @@ impl BraintrustListener {
             output: Some(output),
             error: data.error.clone(),
             metadata,
-            metrics: None,
+            metrics,
             span_attributes: BraintrustSpanAttributes {
                 name: "reason".to_string(),
                 span_type: "task".to_string(),
@@ -817,6 +836,23 @@ impl BraintrustListener {
             "error_count": data.error_count,
         });
 
+        // Build metrics if we have duration for timeline display
+        let metrics = data.duration_ms.map(|duration_ms| {
+            let end_time = event.ts.timestamp_millis() as f64 / 1000.0;
+            let start_time = end_time - (duration_ms as f64 / 1000.0);
+
+            BraintrustMetrics {
+                start: Some(start_time),
+                end: Some(end_time),
+                prompt_tokens: None,
+                completion_tokens: None,
+                tokens: None,
+                time_to_first_token: None,
+                cache_read_tokens: None,
+                cache_creation_tokens: None,
+            }
+        });
+
         // Parent-child linking using OTel-style span fields from context
         let (span_id, root_span_id, span_parents) = Self::compute_child_span_linkage(event);
 
@@ -837,7 +873,7 @@ impl BraintrustListener {
             output: Some(output),
             error: None,
             metadata,
-            metrics: None,
+            metrics,
             span_attributes: BraintrustSpanAttributes {
                 name: "act".to_string(),
                 span_type: "task".to_string(),
@@ -1493,6 +1529,8 @@ mod tests {
             has_tool_calls: false,
             tool_call_count: 0,
             error: None,
+            duration_ms: Some(1500),
+            usage: None,
         };
         let completed_event = Event::new(
             SessionId::new(),

--- a/crates/control-plane/src/services/braintrust.rs
+++ b/crates/control-plane/src/services/braintrust.rs
@@ -453,7 +453,7 @@ impl BraintrustListener {
             span_id: Some(turn_id_str.clone()), // Root span self-references
             root_span_id: Some(turn_id_str.clone()), // Root span self-references
             span_parents: None,
-            is_merge: Some(true),               // Merge with turn.started event
+            is_merge: Some(true), // Merge with turn.started event
         }
     }
 
@@ -536,7 +536,7 @@ impl BraintrustListener {
             span_id,
             root_span_id,
             span_parents,
-            is_merge: None,                     // Single event, no merge needed
+            is_merge: None, // Single event, no merge needed
         }
     }
 
@@ -615,7 +615,7 @@ impl BraintrustListener {
             span_id,
             root_span_id,
             span_parents,
-            is_merge: Some(true),               // Merge with tool_call.started event
+            is_merge: Some(true), // Merge with tool_call.started event
         }
     }
 
@@ -651,7 +651,7 @@ impl BraintrustListener {
             span_id: Some(turn_id_str.clone()), // Root span self-references
             root_span_id: Some(turn_id_str.clone()), // Root span self-references
             span_parents: None,
-            is_merge: Some(true),               // Merge with turn.started event
+            is_merge: Some(true), // Merge with turn.started event
         }
     }
 
@@ -703,7 +703,7 @@ impl BraintrustListener {
             span_id: Some(turn_id_str.clone()), // Root span self-references
             root_span_id: Some(turn_id_str.clone()), // Root span self-references
             span_parents: None,
-            is_merge: Some(true),               // Merge with turn.started event
+            is_merge: Some(true), // Merge with turn.started event
         }
     }
 
@@ -771,7 +771,7 @@ impl BraintrustListener {
             span_id,
             root_span_id,
             span_parents,
-            is_merge: None,                     // First event creates the span
+            is_merge: None, // First event creates the span
         }
     }
 
@@ -844,7 +844,7 @@ impl BraintrustListener {
             span_id,
             root_span_id,
             span_parents,
-            is_merge: Some(true),               // Merge with reason.started event
+            is_merge: Some(true), // Merge with reason.started event
         }
     }
 
@@ -907,7 +907,7 @@ impl BraintrustListener {
             span_id,
             root_span_id,
             span_parents,
-            is_merge: None,                     // First event creates the span
+            is_merge: None, // First event creates the span
         }
     }
 
@@ -973,7 +973,7 @@ impl BraintrustListener {
             span_id,
             root_span_id,
             span_parents,
-            is_merge: Some(true),               // Merge with act.started event
+            is_merge: Some(true), // Merge with act.started event
         }
     }
 
@@ -1035,7 +1035,7 @@ impl BraintrustListener {
             span_id,
             root_span_id,
             span_parents,
-            is_merge: None,                     // First event creates the span
+            is_merge: None, // First event creates the span
         }
     }
 }

--- a/crates/control-plane/src/services/braintrust.rs
+++ b/crates/control-plane/src/services/braintrust.rs
@@ -216,6 +216,10 @@ struct BraintrustLogEvent {
     /// Parent span IDs
     #[serde(skip_serializing_if = "Option::is_none")]
     span_parents: Option<Vec<String>>,
+    /// When true, merge with existing event instead of replacing
+    /// Required for started/completed event pairs to combine properly
+    #[serde(rename = "_is_merge", skip_serializing_if = "Option::is_none")]
+    is_merge: Option<bool>,
 }
 
 /// Request body for Braintrust insert endpoint
@@ -373,6 +377,7 @@ impl BraintrustListener {
             span_id: Some(turn_id_str.clone()), // Root span self-references
             root_span_id: Some(turn_id_str.clone()), // Root span self-references
             span_parents: None,                 // Root has no parents
+            is_merge: None,                     // First event creates the span
         }
     }
 
@@ -439,6 +444,7 @@ impl BraintrustListener {
             span_id: Some(turn_id_str.clone()), // Root span self-references
             root_span_id: Some(turn_id_str.clone()), // Root span self-references
             span_parents: None,
+            is_merge: Some(true),               // Merge with turn.started event
         }
     }
 
@@ -521,6 +527,7 @@ impl BraintrustListener {
             span_id,
             root_span_id,
             span_parents,
+            is_merge: None,                     // Single event, no merge needed
         }
     }
 
@@ -599,6 +606,7 @@ impl BraintrustListener {
             span_id,
             root_span_id,
             span_parents,
+            is_merge: Some(true),               // Merge with tool_call.started event
         }
     }
 
@@ -634,6 +642,7 @@ impl BraintrustListener {
             span_id: Some(turn_id_str.clone()), // Root span self-references
             root_span_id: Some(turn_id_str.clone()), // Root span self-references
             span_parents: None,
+            is_merge: Some(true),               // Merge with turn.started event
         }
     }
 
@@ -685,6 +694,7 @@ impl BraintrustListener {
             span_id: Some(turn_id_str.clone()), // Root span self-references
             root_span_id: Some(turn_id_str.clone()), // Root span self-references
             span_parents: None,
+            is_merge: Some(true),               // Merge with turn.started event
         }
     }
 
@@ -752,6 +762,7 @@ impl BraintrustListener {
             span_id,
             root_span_id,
             span_parents,
+            is_merge: None,                     // First event creates the span
         }
     }
 
@@ -824,6 +835,7 @@ impl BraintrustListener {
             span_id,
             root_span_id,
             span_parents,
+            is_merge: Some(true),               // Merge with reason.started event
         }
     }
 
@@ -886,6 +898,7 @@ impl BraintrustListener {
             span_id,
             root_span_id,
             span_parents,
+            is_merge: None,                     // First event creates the span
         }
     }
 
@@ -951,6 +964,7 @@ impl BraintrustListener {
             span_id,
             root_span_id,
             span_parents,
+            is_merge: Some(true),               // Merge with act.started event
         }
     }
 
@@ -1012,6 +1026,7 @@ impl BraintrustListener {
             span_id,
             root_span_id,
             span_parents,
+            is_merge: None,                     // First event creates the span
         }
     }
 }

--- a/crates/control-plane/src/services/braintrust.rs
+++ b/crates/control-plane/src/services/braintrust.rs
@@ -344,6 +344,19 @@ impl BraintrustListener {
             }))
         };
 
+        // Set start time in metrics for proper timeline ordering
+        let start_time = event.ts.timestamp_micros() as f64 / 1_000_000.0;
+        let metrics = Some(BraintrustMetrics {
+            start: Some(start_time),
+            end: None, // Will be set by completed event
+            prompt_tokens: None,
+            completion_tokens: None,
+            tokens: None,
+            time_to_first_token: None,
+            cache_read_tokens: None,
+            cache_creation_tokens: None,
+        });
+
         BraintrustLogEvent {
             id: turn_id_str.clone(), // Use turn_id as span ID for parent linking
             created: event.ts,
@@ -351,7 +364,7 @@ impl BraintrustListener {
             output: None,
             error: None,
             metadata,
-            metrics: None,
+            metrics,
             span_attributes: BraintrustSpanAttributes {
                 name: "agent turn".to_string(),
                 span_type: "task".to_string(),
@@ -377,7 +390,7 @@ impl BraintrustListener {
 
         // Build metrics if we have usage/duration (with prompt caching support)
         let metrics = if data.usage.is_some() || data.duration_ms.is_some() {
-            let end_time = event.ts.timestamp_millis() as f64 / 1000.0;
+            let end_time = event.ts.timestamp_micros() as f64 / 1_000_000.0;
             let start_time = data.duration_ms.map(|d| end_time - (d as f64 / 1000.0));
 
             Some(BraintrustMetrics {
@@ -468,7 +481,7 @@ impl BraintrustListener {
 
         // Build metrics with prompt caching support
         let metrics = data.metadata.usage.as_ref().map(|usage| {
-            let end_time = event.ts.timestamp_millis() as f64 / 1000.0;
+            let end_time = event.ts.timestamp_micros() as f64 / 1_000_000.0;
             let start_time = data
                 .metadata
                 .duration_ms
@@ -549,7 +562,7 @@ impl BraintrustListener {
 
         // Build metrics if we have duration for timeline display
         let metrics = data.duration_ms.map(|duration_ms| {
-            let end_time = event.ts.timestamp_millis() as f64 / 1000.0;
+            let end_time = event.ts.timestamp_micros() as f64 / 1_000_000.0;
             let start_time = end_time - (duration_ms as f64 / 1000.0);
 
             BraintrustMetrics {
@@ -638,7 +651,7 @@ impl BraintrustListener {
         // Build metrics if we have usage
         let metrics = data.usage.as_ref().map(|usage| BraintrustMetrics {
             start: None,
-            end: Some(event.ts.timestamp_millis() as f64 / 1000.0),
+            end: Some(event.ts.timestamp_micros() as f64 / 1_000_000.0),
             prompt_tokens: Some(usage.input_tokens),
             completion_tokens: Some(usage.output_tokens),
             tokens: Some(usage.total_tokens()),
@@ -710,6 +723,19 @@ impl BraintrustListener {
         // Use span_id as log ID so started/completed merge into one span
         let log_id = span_id.clone().unwrap_or_else(|| event.id.to_string());
 
+        // Set start time in metrics for proper timeline ordering
+        let start_time = event.ts.timestamp_micros() as f64 / 1_000_000.0;
+        let metrics = Some(BraintrustMetrics {
+            start: Some(start_time),
+            end: None, // Will be set by completed event
+            prompt_tokens: None,
+            completion_tokens: None,
+            tokens: None,
+            time_to_first_token: None,
+            cache_read_tokens: None,
+            cache_creation_tokens: None,
+        });
+
         BraintrustLogEvent {
             id: log_id,
             created: event.ts,
@@ -717,7 +743,7 @@ impl BraintrustListener {
             output: None,
             error: None,
             metadata,
-            metrics: None,
+            metrics,
             span_attributes: BraintrustSpanAttributes {
                 name: "reason".to_string(),
                 span_type: "task".to_string(),
@@ -752,7 +778,7 @@ impl BraintrustListener {
 
         // Build metrics if we have duration/usage for timeline display
         let metrics = if data.duration_ms.is_some() || data.usage.is_some() {
-            let end_time = event.ts.timestamp_millis() as f64 / 1000.0;
+            let end_time = event.ts.timestamp_micros() as f64 / 1_000_000.0;
             let start_time = data.duration_ms.map(|d| end_time - (d as f64 / 1000.0));
 
             Some(BraintrustMetrics {
@@ -831,6 +857,19 @@ impl BraintrustListener {
         // Use span_id as log ID so started/completed merge into one span
         let log_id = span_id.clone().unwrap_or_else(|| event.id.to_string());
 
+        // Set start time in metrics for proper timeline ordering
+        let start_time = event.ts.timestamp_micros() as f64 / 1_000_000.0;
+        let metrics = Some(BraintrustMetrics {
+            start: Some(start_time),
+            end: None, // Will be set by completed event
+            prompt_tokens: None,
+            completion_tokens: None,
+            tokens: None,
+            time_to_first_token: None,
+            cache_read_tokens: None,
+            cache_creation_tokens: None,
+        });
+
         BraintrustLogEvent {
             id: log_id,
             created: event.ts,
@@ -838,7 +877,7 @@ impl BraintrustListener {
             output: None,
             error: None,
             metadata,
-            metrics: None,
+            metrics,
             span_attributes: BraintrustSpanAttributes {
                 name: "act".to_string(),
                 span_type: "task".to_string(),
@@ -868,7 +907,7 @@ impl BraintrustListener {
 
         // Build metrics if we have duration for timeline display
         let metrics = data.duration_ms.map(|duration_ms| {
-            let end_time = event.ts.timestamp_millis() as f64 / 1000.0;
+            let end_time = event.ts.timestamp_micros() as f64 / 1_000_000.0;
             let start_time = end_time - (duration_ms as f64 / 1000.0);
 
             BraintrustMetrics {
@@ -944,6 +983,19 @@ impl BraintrustListener {
         // Use span_id as log ID so started/completed merge into one span
         let log_id = span_id.clone().unwrap_or_else(|| event.id.to_string());
 
+        // Set start time in metrics for proper timeline ordering
+        let start_time = event.ts.timestamp_micros() as f64 / 1_000_000.0;
+        let metrics = Some(BraintrustMetrics {
+            start: Some(start_time),
+            end: None, // Will be set by completed event
+            prompt_tokens: None,
+            completion_tokens: None,
+            tokens: None,
+            time_to_first_token: None,
+            cache_read_tokens: None,
+            cache_creation_tokens: None,
+        });
+
         BraintrustLogEvent {
             id: log_id,
             created: event.ts,
@@ -951,7 +1003,7 @@ impl BraintrustListener {
             output: None,
             error: None,
             metadata,
-            metrics: None,
+            metrics,
             span_attributes: BraintrustSpanAttributes {
                 name: format!("tool {}", data.tool_call.name),
                 span_type: "tool".to_string(),

--- a/crates/control-plane/src/services/braintrust.rs
+++ b/crates/control-plane/src/services/braintrust.rs
@@ -534,6 +534,23 @@ impl BraintrustListener {
             metadata["turn_id"] = serde_json::json!(turn_id.to_string());
         }
 
+        // Build metrics if we have duration for timeline display
+        let metrics = data.duration_ms.map(|duration_ms| {
+            let end_time = event.ts.timestamp_millis() as f64 / 1000.0;
+            let start_time = end_time - (duration_ms as f64 / 1000.0);
+
+            BraintrustMetrics {
+                start: Some(start_time),
+                end: Some(end_time),
+                prompt_tokens: None,
+                completion_tokens: None,
+                tokens: None,
+                time_to_first_token: None,
+                cache_read_tokens: None,
+                cache_creation_tokens: None,
+            }
+        });
+
         // Parent-child linking using OTel-style span fields from context
         let (span_id, root_span_id, span_parents) = Self::compute_child_span_linkage(event);
 
@@ -547,7 +564,7 @@ impl BraintrustListener {
             output: Some(output),
             error: data.error.clone(),
             metadata,
-            metrics: None,
+            metrics,
             span_attributes: BraintrustSpanAttributes {
                 name: format!("tool {}", data.tool_name),
                 span_type: "tool".to_string(),
@@ -1470,6 +1487,7 @@ mod tests {
             status: "success".to_string(),
             result: None,
             error: None,
+            duration_ms: Some(200),
         };
         let event = Event::new(
             SessionId::new(),
@@ -1678,6 +1696,7 @@ mod tests {
             status: "success".to_string(),
             result: None,
             error: None,
+            duration_ms: Some(75),
         };
         let tool_event = Event::new(
             SessionId::new(),

--- a/crates/control-plane/src/services/braintrust.rs
+++ b/crates/control-plane/src/services/braintrust.rs
@@ -260,6 +260,15 @@ impl BraintrustListener {
 
         let request = BraintrustInsertRequest { events };
 
+        // Log the request payload for debugging
+        if let Ok(payload) = serde_json::to_string_pretty(&request) {
+            debug!(
+                url = %url,
+                payload = %payload,
+                "Sending events to Braintrust"
+            );
+        }
+
         let result = self
             .client
             .post(&url)
@@ -1793,6 +1802,253 @@ mod tests {
             bt_tool.root_span_id,
             Some(expected_root.clone()),
             "tool should have root_span_id = turn_id"
+        );
+    }
+
+    // =============================================================================
+    // _is_merge Serialization Tests
+    // =============================================================================
+    //
+    // These tests verify that the _is_merge field is correctly serialized:
+    // - Started events: is_merge = None (creates new span)
+    // - Completed events: is_merge = Some(true) (merges with existing span)
+
+    #[test]
+    fn test_is_merge_serialization_started_events() {
+        let listener = BraintrustListener::new(test_config());
+        let turn_id = TurnId::new();
+        let input_message_id = MessageId::new();
+
+        // turn.started should have is_merge = None
+        let turn_data = TurnStartedData {
+            turn_id,
+            input_message_id,
+            input_content: Some("Test".to_string()),
+        };
+        let event = Event::new(
+            SessionId::new(),
+            EventContext::empty(),
+            EventData::TurnStarted(turn_data.clone()),
+        );
+        let bt_event = listener.convert_turn_started(&event, &turn_data);
+
+        // is_merge should be None for started events
+        assert!(
+            bt_event.is_merge.is_none(),
+            "turn.started should have is_merge = None"
+        );
+
+        // Serialize to JSON and verify _is_merge is not present
+        let json = serde_json::to_string(&bt_event).unwrap();
+        assert!(
+            !json.contains("_is_merge"),
+            "turn.started JSON should not contain _is_merge: {}",
+            json
+        );
+    }
+
+    #[test]
+    fn test_is_merge_serialization_completed_events() {
+        let listener = BraintrustListener::new(test_config());
+        let turn_id = TurnId::new();
+
+        // turn.completed should have is_merge = Some(true)
+        let turn_data = TurnCompletedData {
+            turn_id,
+            iterations: 1,
+            duration_ms: Some(1000),
+            usage: None,
+            input_content: Some("Test".to_string()),
+        };
+        let event = Event::new(
+            SessionId::new(),
+            EventContext::empty(),
+            EventData::TurnCompleted(turn_data.clone()),
+        );
+        let bt_event = listener.convert_turn_completed(&event, &turn_data);
+
+        // is_merge should be Some(true) for completed events
+        assert_eq!(
+            bt_event.is_merge,
+            Some(true),
+            "turn.completed should have is_merge = Some(true)"
+        );
+
+        // Serialize to JSON and verify _is_merge is present and true
+        let json = serde_json::to_string(&bt_event).unwrap();
+        assert!(
+            json.contains("\"_is_merge\":true"),
+            "turn.completed JSON should contain _is_merge:true: {}",
+            json
+        );
+    }
+
+    #[test]
+    fn test_is_merge_serialization_reason_events() {
+        let listener = BraintrustListener::new(test_config());
+        let turn_id = TurnId::new();
+        let reason_span_id = Uuid::now_v7().to_string();
+
+        let mut context = EventContext::empty();
+        context.turn_id = Some(turn_id);
+        context.trace_id = Some(turn_id.to_string());
+        context.span_id = Some(reason_span_id.clone());
+        context.parent_span_id = Some(turn_id.to_string());
+
+        // reason.started - should NOT have _is_merge
+        let started_data = ReasonStartedData {
+            agent_id: AgentId::new(),
+            metadata: None,
+        };
+        let started_event = Event::new(
+            SessionId::new(),
+            context.clone(),
+            EventData::ReasonStarted(started_data.clone()),
+        );
+        let bt_started = listener.convert_reason_started(&started_event, &started_data);
+        let started_json = serde_json::to_string(&bt_started).unwrap();
+        assert!(
+            !started_json.contains("_is_merge"),
+            "reason.started should not have _is_merge: {}",
+            started_json
+        );
+
+        // reason.completed - should have _is_merge: true
+        let completed_data = ReasonCompletedData {
+            success: true,
+            text_preview: None,
+            has_tool_calls: false,
+            tool_call_count: 0,
+            error: None,
+            duration_ms: Some(500),
+            usage: None,
+        };
+        let completed_event = Event::new(
+            SessionId::new(),
+            context.clone(),
+            EventData::ReasonCompleted(completed_data.clone()),
+        );
+        let bt_completed = listener.convert_reason_completed(&completed_event, &completed_data);
+        let completed_json = serde_json::to_string(&bt_completed).unwrap();
+        assert!(
+            completed_json.contains("\"_is_merge\":true"),
+            "reason.completed should have _is_merge:true: {}",
+            completed_json
+        );
+    }
+
+    #[test]
+    fn test_is_merge_serialization_act_events() {
+        use everruns_core::events::ToolCallSummary;
+
+        let listener = BraintrustListener::new(test_config());
+        let turn_id = TurnId::new();
+        let act_span_id = Uuid::now_v7().to_string();
+
+        let mut context = EventContext::empty();
+        context.turn_id = Some(turn_id);
+        context.trace_id = Some(turn_id.to_string());
+        context.span_id = Some(act_span_id.clone());
+        context.parent_span_id = Some(turn_id.to_string());
+
+        // act.started - should NOT have _is_merge
+        let started_data = ActStartedData {
+            tool_calls: vec![ToolCallSummary {
+                id: "call_1".to_string(),
+                name: "search".to_string(),
+            }],
+        };
+        let started_event = Event::new(
+            SessionId::new(),
+            context.clone(),
+            EventData::ActStarted(started_data.clone()),
+        );
+        let bt_started = listener.convert_act_started(&started_event, &started_data);
+        let started_json = serde_json::to_string(&bt_started).unwrap();
+        assert!(
+            !started_json.contains("_is_merge"),
+            "act.started should not have _is_merge: {}",
+            started_json
+        );
+
+        // act.completed - should have _is_merge: true
+        let completed_data = ActCompletedData {
+            completed: true,
+            success_count: 1,
+            error_count: 0,
+            duration_ms: Some(200),
+        };
+        let completed_event = Event::new(
+            SessionId::new(),
+            context.clone(),
+            EventData::ActCompleted(completed_data.clone()),
+        );
+        let bt_completed = listener.convert_act_completed(&completed_event, &completed_data);
+        let completed_json = serde_json::to_string(&bt_completed).unwrap();
+        assert!(
+            completed_json.contains("\"_is_merge\":true"),
+            "act.completed should have _is_merge:true: {}",
+            completed_json
+        );
+    }
+
+    #[test]
+    fn test_is_merge_serialization_tool_events() {
+        use everruns_core::tool_types::ToolCall;
+
+        let listener = BraintrustListener::new(test_config());
+        let turn_id = TurnId::new();
+        let tool_span_id = Uuid::now_v7().to_string();
+        let act_span_id = Uuid::now_v7().to_string();
+
+        let mut context = EventContext::empty();
+        context.turn_id = Some(turn_id);
+        context.trace_id = Some(turn_id.to_string());
+        context.span_id = Some(tool_span_id.clone());
+        context.parent_span_id = Some(act_span_id.clone());
+
+        // tool.call_started - should NOT have _is_merge
+        let started_data = ToolCallStartedData {
+            tool_call: ToolCall {
+                id: "call_1".to_string(),
+                name: "search".to_string(),
+                arguments: serde_json::json!({"query": "test"}),
+            },
+        };
+        let started_event = Event::new(
+            SessionId::new(),
+            context.clone(),
+            EventData::ToolCallStarted(started_data.clone()),
+        );
+        let bt_started = listener.convert_tool_call_started(&started_event, &started_data);
+        let started_json = serde_json::to_string(&bt_started).unwrap();
+        assert!(
+            !started_json.contains("_is_merge"),
+            "tool.call_started should not have _is_merge: {}",
+            started_json
+        );
+
+        // tool.call_completed - should have _is_merge: true
+        let completed_data = ToolCallCompletedData {
+            tool_call_id: "call_1".to_string(),
+            tool_name: "search".to_string(),
+            success: true,
+            status: "success".to_string(),
+            result: None,
+            error: None,
+            duration_ms: Some(100),
+        };
+        let completed_event = Event::new(
+            SessionId::new(),
+            context.clone(),
+            EventData::ToolCallCompleted(completed_data.clone()),
+        );
+        let bt_completed = listener.convert_tool_call_completed(&completed_event, &completed_data);
+        let completed_json = serde_json::to_string(&bt_completed).unwrap();
+        assert!(
+            completed_json.contains("\"_is_merge\":true"),
+            "tool.call_completed should have _is_merge:true: {}",
+            completed_json
         );
     }
 }

--- a/crates/control-plane/src/storage/event_tests.rs
+++ b/crates/control-plane/src/storage/event_tests.rs
@@ -64,6 +64,7 @@ fn test_tool_call_completed_event_serialization() {
         "call_abc123".to_string(),
         "get_weather".to_string(),
         vec![ContentPart::text("Sunny, 72°F")],
+        Some(150),
     );
     let event = Event::new(session_id, EventContext::empty(), completed);
 
@@ -101,6 +102,7 @@ fn test_tool_call_completed_error_serialization() {
         "read_file".to_string(),
         "error".to_string(),
         "File not found".to_string(),
+        Some(50),
     );
     let event = Event::new(session_id, EventContext::empty(), completed);
 

--- a/crates/control-plane/src/storage/message_store.rs
+++ b/crates/control-plane/src/storage/message_store.rs
@@ -416,6 +416,7 @@ mod tests {
             "call_123".to_string(),
             "get_weather".to_string(),
             vec![ContentPart::text("Sunny, 72°F")],
+            Some(100),
         );
         let event = Event::new(session_id, EventContext::empty(), completed);
 
@@ -436,6 +437,7 @@ mod tests {
             "read_file".to_string(),
             "error".to_string(),
             "File not found".to_string(),
+            Some(25),
         );
         let event = Event::new(session_id, EventContext::empty(), completed);
 

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -328,6 +328,9 @@ where
             Some(act_span_id.to_string()),
         );
 
+        // Track tool call timing for Braintrust observability
+        let tool_start = Instant::now();
+
         // Emit tool.call_started event (child of act.started)
         if let Err(e) = self
             .event_emitter
@@ -351,6 +354,7 @@ where
         // If tool definition not found, return error result
         let Some(tool_def) = tool_def else {
             let error_msg = format!("Tool definition not found: {}", tool_call.name);
+            let tool_duration_ms = tool_start.elapsed().as_millis() as u64;
 
             // Emit tool.call_completed event for error (child of act.started)
             if let Err(e) = self
@@ -363,6 +367,7 @@ where
                         tool_call.name.clone(),
                         "error".to_string(),
                         error_msg.clone(),
+                        Some(tool_duration_ms),
                     ),
                 ))
                 .await
@@ -399,6 +404,7 @@ where
 
         match result {
             Ok(tool_result) => {
+                let tool_duration_ms = tool_start.elapsed().as_millis() as u64;
                 let success = tool_result.error.is_none();
                 let status = if success { "success" } else { "error" };
 
@@ -414,6 +420,7 @@ where
                         tool_call.id.clone(),
                         tool_call.name.clone(),
                         result_content,
+                        Some(tool_duration_ms),
                     )
                 } else {
                     ToolCallCompletedData::failure(
@@ -421,6 +428,7 @@ where
                         tool_call.name.clone(),
                         status.to_string(),
                         tool_result.error.clone().unwrap_or_default(),
+                        Some(tool_duration_ms),
                     )
                 };
 
@@ -457,6 +465,7 @@ where
                 }
             }
             Err(e) => {
+                let tool_duration_ms = tool_start.elapsed().as_millis() as u64;
                 let error_msg = e.to_string();
 
                 // Emit tool.call_completed event for error
@@ -470,6 +479,7 @@ where
                             tool_call.name.clone(),
                             "error".to_string(),
                             error_msg.clone(),
+                            Some(tool_duration_ms),
                         ),
                     ))
                     .await

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -26,6 +26,7 @@ use async_trait::async_trait;
 use futures::future::join_all;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use std::time::Instant;
 
 use super::{Atom, AtomContext};
 use crate::error::Result;
@@ -192,6 +193,9 @@ where
             Some(parent_span_id.clone()),
         );
 
+        // Track act phase timing for Braintrust observability
+        let act_start = Instant::now();
+
         // Emit act.started event
         if let Err(e) = self
             .event_emitter
@@ -241,6 +245,9 @@ where
         let success_count = results.iter().filter(|r| r.success).count() as u32;
         let error_count = results.iter().filter(|r| !r.success).count() as u32;
 
+        // Calculate act phase duration
+        let act_duration_ms = act_start.elapsed().as_millis() as u64;
+
         // Emit act.completed event (same span as act.started, parent is turn)
         let completed_context = EventContext::from_atom_context(&context).with_span(
             trace_id.clone(),
@@ -256,6 +263,7 @@ where
                     completed: true,
                     success_count,
                     error_count,
+                    duration_ms: Some(act_duration_ms),
                 },
             ))
             .await

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -271,6 +271,9 @@ where
             Some(parent_span_id.clone()),
         );
 
+        // Track reason phase timing for Braintrust observability
+        let reason_start = Instant::now();
+
         // Emit reason.started event
         if let Err(e) = self
             .event_emitter
@@ -305,6 +308,9 @@ where
             .await
         {
             Ok(result) => {
+                // Calculate reason phase duration
+                let reason_duration_ms = reason_start.elapsed().as_millis() as u64;
+
                 // Emit reason.completed event (same span as reason.started, parent is turn)
                 let completed_context = EventContext::from_atom_context(&context).with_span(
                     trace_id.clone(),
@@ -320,6 +326,8 @@ where
                             &result.text,
                             result.has_tool_calls,
                             result.tool_calls.len() as u32,
+                            Some(reason_duration_ms),
+                            result.usage.clone(),
                         ),
                     ))
                     .await
@@ -333,6 +341,9 @@ where
                 result
             }
             Err(e) => {
+                // Calculate reason phase duration even for failures
+                let reason_duration_ms = reason_start.elapsed().as_millis() as u64;
+
                 // LLM call failure is a "normal" result per the spec
                 // Return a result indicating failure with the error message
                 tracing::warn!(
@@ -392,7 +403,7 @@ where
                     .emit(EventRequest::new(
                         context.session_id,
                         completed_context,
-                        ReasonCompletedData::failure(error_msg.clone()),
+                        ReasonCompletedData::failure(error_msg.clone(), Some(reason_duration_ms)),
                     ))
                     .await
                 {

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -477,10 +477,24 @@ pub struct ReasonCompletedData {
     /// Error message if failed
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+
+    /// Duration of the reason phase in milliseconds
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+
+    /// Token usage from the LLM call
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<TokenUsage>,
 }
 
 impl ReasonCompletedData {
-    pub fn success(text: &str, has_tool_calls: bool, tool_call_count: u32) -> Self {
+    pub fn success(
+        text: &str,
+        has_tool_calls: bool,
+        tool_call_count: u32,
+        duration_ms: Option<u64>,
+        usage: Option<TokenUsage>,
+    ) -> Self {
         let text_preview = if text.is_empty() {
             None
         } else {
@@ -493,16 +507,20 @@ impl ReasonCompletedData {
             has_tool_calls,
             tool_call_count,
             error: None,
+            duration_ms,
+            usage,
         }
     }
 
-    pub fn failure(error: String) -> Self {
+    pub fn failure(error: String, duration_ms: Option<u64>) -> Self {
         Self {
             success: false,
             text_preview: None,
             has_tool_calls: false,
             tool_call_count: 0,
             error: Some(error),
+            duration_ms,
+            usage: None,
         }
     }
 }
@@ -571,6 +589,10 @@ pub struct ActCompletedData {
 
     /// Number of failed tool calls
     pub error_count: u32,
+
+    /// Duration of the act phase in milliseconds
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
 }
 
 /// Data for tool.call_started event
@@ -1327,15 +1349,18 @@ mod tests {
 
     #[test]
     fn test_reason_completed_data() {
-        let data = ReasonCompletedData::success("Hello world", true, 2);
+        let data = ReasonCompletedData::success("Hello world", true, 2, Some(1000), None);
         assert!(data.success);
         assert_eq!(data.text_preview, Some("Hello world".to_string()));
         assert!(data.has_tool_calls);
         assert_eq!(data.tool_call_count, 2);
+        assert_eq!(data.duration_ms, Some(1000));
+        assert!(data.usage.is_none());
 
-        let data = ReasonCompletedData::failure("Network error".to_string());
+        let data = ReasonCompletedData::failure("Network error".to_string(), Some(500));
         assert!(!data.success);
         assert_eq!(data.error, Some("Network error".to_string()));
+        assert_eq!(data.duration_ms, Some(500));
     }
 
     #[test]

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -906,6 +906,10 @@ pub struct TurnStartedData {
     /// Input message ID that triggered this turn
     #[cfg_attr(feature = "openapi", schema(value_type = String, example = "message_01933b5a00007000800000000000001"))]
     pub input_message_id: MessageId,
+
+    /// Input message content (for observability)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_content: Option<String>,
 }
 
 /// Data for turn.completed event

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -930,6 +930,10 @@ pub struct TurnCompletedData {
     /// Aggregated token usage for all LLM calls in this turn
     #[serde(skip_serializing_if = "Option::is_none")]
     pub usage: Option<TokenUsage>,
+
+    /// Input message content (for observability, passed through from turn.started)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_content: Option<String>,
 }
 
 /// Data for turn.failed event

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -626,10 +626,19 @@ pub struct ToolCallCompletedData {
     /// Error message if failed
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+
+    /// Duration of the tool call in milliseconds
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
 }
 
 impl ToolCallCompletedData {
-    pub fn success(tool_call_id: String, tool_name: String, result: Vec<ContentPart>) -> Self {
+    pub fn success(
+        tool_call_id: String,
+        tool_name: String,
+        result: Vec<ContentPart>,
+        duration_ms: Option<u64>,
+    ) -> Self {
         Self {
             tool_call_id,
             tool_name,
@@ -637,10 +646,17 @@ impl ToolCallCompletedData {
             status: "success".to_string(),
             result: Some(result),
             error: None,
+            duration_ms,
         }
     }
 
-    pub fn failure(tool_call_id: String, tool_name: String, status: String, error: String) -> Self {
+    pub fn failure(
+        tool_call_id: String,
+        tool_name: String,
+        status: String,
+        error: String,
+        duration_ms: Option<u64>,
+    ) -> Self {
         Self {
             tool_call_id,
             tool_name,
@@ -648,6 +664,7 @@ impl ToolCallCompletedData {
             status,
             result: None,
             error: Some(error),
+            duration_ms,
         }
     }
 }

--- a/crates/core/src/observation/otel.rs
+++ b/crates/core/src/observation/otel.rs
@@ -566,6 +566,7 @@ mod tests {
         let started_data = TurnStartedData {
             turn_id,
             input_message_id: MessageId::from_uuid(Uuid::now_v7()),
+            input_content: Some("Test message".to_string()),
         };
 
         let start_event = Event::new(

--- a/crates/core/src/observation/otel.rs
+++ b/crates/core/src/observation/otel.rs
@@ -518,6 +518,7 @@ mod tests {
             status: "success".to_string(),
             result: None,
             error: None,
+            duration_ms: Some(100),
         };
 
         let complete_event = Event::new(
@@ -542,6 +543,7 @@ mod tests {
             status: "error".to_string(),
             result: None,
             error: Some("Connection timeout".to_string()),
+            duration_ms: None,
         };
 
         let event = Event::new(
@@ -668,6 +670,7 @@ mod tests {
                 status: "success".to_string(),
                 result: None,
                 error: None,
+                duration_ms: Some(50),
             };
 
             let event = Event::new(

--- a/crates/core/src/observation/otel.rs
+++ b/crates/core/src/observation/otel.rs
@@ -584,6 +584,7 @@ mod tests {
             iterations: 3,
             duration_ms: Some(1500),
             usage: None,
+            input_content: Some("Test message".to_string()),
         };
 
         let complete_event = Event::new(
@@ -606,6 +607,7 @@ mod tests {
             iterations: 1,
             duration_ms: None, // No duration provided
             usage: None,
+            input_content: None,
         };
 
         let event = Event::new(

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -1011,7 +1011,7 @@ mod tests {
         use everruns_core::events::ReasonCompletedData;
 
         // Create test data
-        let data = ReasonCompletedData::success("Test response", true, 3);
+        let data = ReasonCompletedData::success("Test response", true, 3, Some(2000), None);
 
         // Serialize to JSON
         let json = serde_json::to_value(&data).unwrap();

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -144,6 +144,7 @@ pub async fn reason_activity(
         EventContext, EventRequest, SessionIdledData, TurnCompletedData, TurnFailedData,
     };
     use everruns_core::traits::EventEmitter;
+    use everruns_core::MessageRetriever;
 
     tracing::info!(
         org_id = org_id,
@@ -214,6 +215,17 @@ pub async fn reason_activity(
                 tracing::warn!(error = %e, "Failed to emit turn.failed event");
             }
         } else {
+            // Fetch input message content for turn.completed (for Braintrust observability)
+            let message_retriever = GrpcMessageRetriever::new(grpc_client.clone());
+            let input_content = match message_retriever.get(session_id, input_message_id).await {
+                Ok(Some(msg)) => Some(msg.content_to_llm_string()),
+                Ok(None) => None,
+                Err(e) => {
+                    tracing::warn!(error = %e, "Failed to fetch input message for turn.completed");
+                    None
+                }
+            };
+
             // Emit turn.completed event with usage
             let turn_completed_event = EventRequest::new(
                 session_id,
@@ -223,6 +235,7 @@ pub async fn reason_activity(
                     iterations: 1, // TODO: Track actual iterations when workflow supports it
                     duration_ms: None,
                     usage: result.usage.clone(),
+                    input_content,
                 },
             );
             if let Err(e) = event_emitter.emit(turn_completed_event).await {

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -46,11 +46,11 @@ pub async fn input_activity(
     org_id: i64,
     input: InputAtomInput,
 ) -> Result<InputAtomResult> {
+    use everruns_core::MessageRetriever;
     use everruns_core::events::{
         EventContext, EventRequest, SessionActivatedData, TurnStartedData,
     };
     use everruns_core::traits::EventEmitter;
-    use everruns_core::MessageRetriever;
 
     tracing::info!(
         org_id = org_id,
@@ -140,11 +140,11 @@ pub async fn reason_activity(
     org_id: i64,
     input: ReasonInput,
 ) -> Result<ReasonResult> {
+    use everruns_core::MessageRetriever;
     use everruns_core::events::{
         EventContext, EventRequest, SessionIdledData, TurnCompletedData, TurnFailedData,
     };
     use everruns_core::traits::EventEmitter;
-    use everruns_core::MessageRetriever;
 
     tracing::info!(
         org_id = org_id,

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -50,6 +50,7 @@ pub async fn input_activity(
         EventContext, EventRequest, SessionActivatedData, TurnStartedData,
     };
     use everruns_core::traits::EventEmitter;
+    use everruns_core::MessageRetriever;
 
     tracing::info!(
         org_id = org_id,
@@ -67,6 +68,25 @@ pub async fn input_activity(
         tracing::warn!(error = %e, "Failed to set session status to active");
     }
 
+    // Create message retriever early to fetch input content for observability
+    let message_retriever = GrpcMessageRetriever::new(grpc_client.clone());
+
+    // Fetch input message content for turn.started event (for Braintrust observability)
+    let input_content = match message_retriever
+        .get(input.context.session_id, input.context.input_message_id)
+        .await
+    {
+        Ok(Some(msg)) => Some(msg.content_to_llm_string()),
+        Ok(None) => {
+            tracing::warn!("Input message not found for turn.started event");
+            None
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to fetch input message for turn.started event");
+            None
+        }
+    };
+
     // Emit session.activated event
     let event_emitter = GrpcEventEmitter::new(grpc_client.clone());
     let activated_event = EventRequest::new(
@@ -81,20 +101,20 @@ pub async fn input_activity(
         tracing::warn!(error = %e, "Failed to emit session.activated event");
     }
 
-    // Emit turn.started event
+    // Emit turn.started event with input content for observability
     let turn_started_event = EventRequest::new(
         input.context.session_id,
         EventContext::turn(input.context.turn_id, input.context.input_message_id),
         TurnStartedData {
             turn_id: input.context.turn_id,
             input_message_id: input.context.input_message_id,
+            input_content,
         },
     );
     if let Err(e) = event_emitter.emit(turn_started_event).await {
         tracing::warn!(error = %e, "Failed to emit turn.started event");
     }
 
-    let message_retriever = GrpcMessageRetriever::new(grpc_client.clone());
     let atom = InputAtom::new(message_retriever, event_emitter);
 
     atom.execute(input)

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2572,6 +2572,15 @@
             "type": "boolean",
             "description": "Whether all tool calls completed"
           },
+          "duration_ms": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Duration of the act phase in milliseconds",
+            "minimum": 0
+          },
           "error_count": {
             "type": "integer",
             "format": "int32",
@@ -5577,6 +5586,15 @@
           "tool_call_count"
         ],
         "properties": {
+          "duration_ms": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Duration of the reason phase in milliseconds",
+            "minimum": 0
+          },
           "error": {
             "type": [
               "string",
@@ -5604,6 +5622,17 @@
             "format": "int32",
             "description": "Number of tool calls requested",
             "minimum": 0
+          },
+          "usage": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/TokenUsage",
+                "description": "Token usage from the LLM call"
+              }
+            ]
           }
         }
       },
@@ -6062,6 +6091,15 @@
           "status"
         ],
         "properties": {
+          "duration_ms": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Duration of the tool call in milliseconds",
+            "minimum": 0
+          },
           "error": {
             "type": [
               "string",
@@ -6231,6 +6269,13 @@
             "description": "Duration in milliseconds",
             "minimum": 0
           },
+          "input_content": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Input message content (for observability, passed through from turn.started)"
+          },
           "iterations": {
             "type": "integer",
             "format": "int32",
@@ -6289,6 +6334,13 @@
           "input_message_id"
         ],
         "properties": {
+          "input_content": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Input message content (for observability)"
+          },
           "input_message_id": {
             "type": "string",
             "description": "Input message ID that triggered this turn",


### PR DESCRIPTION
## Summary

- Fix Braintrust Timeline view not showing timeline bars for "reason" and "act" spans
- Add `metrics.start` to all started events for proper timeline positioning
- Add `_is_merge` flag to completed events so Braintrust merges instead of replaces spans
- Add `input_content` field to turn events so input is visible in Braintrust UI
- Upgrade timestamp precision from milliseconds to microseconds for better ordering
- Add debug logging for Braintrust payloads to aid troubleshooting

## Changes

**Core events (`crates/core/src/events.rs`):**
- Add `input_content: Option<String>` to `TurnStartedData` and `TurnCompletedData`
- Add `duration_ms` and `start_time` fields to reason/act atoms for timing metrics

**Braintrust integration (`crates/control-plane/src/services/braintrust.rs`):**
- Add `_is_merge` field to `BraintrustLogEvent` for proper span merging
- Set `is_merge: None` for started events (creates span)
- Set `is_merge: Some(true)` for completed events (merges with existing)
- Add `metrics.start` to all started events for timeline ordering
- Use microsecond precision timestamps (`timestamp_micros()`)
- Add debug logging to `send_events` for payload inspection
- Add 5 new tests verifying `_is_merge` serialization

**Worker activities:**
- Fetch input message content before emitting turn.started/turn.completed events
- Pass timing metrics through reason/act atoms

## Test plan

- [x] All 17 Braintrust tests pass
- [x] Verified timeline bars appear correctly in Braintrust UI
- [x] Verified span ordering is correct (reason → act → reason pattern)
- [x] Verified input content persists after turn completes

https://claude.ai/code/session_01D7g9uYYEY1JBQVkU4F1Lut