### PR TITLE
chore(ci): add workflow permissions blocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 env:
   REGISTRY: ghcr.io
   # Repository name for image naming

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_DENY_VERSION: "0.16"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` blocks to all GitHub Actions workflows
- Follows principle of least privilege for GITHUB_TOKEN
- Jobs requiring elevated permissions (packages: write, contents: write) already have job-level overrides

## Test plan
- [ ] CI workflows run successfully with restricted permissions

https://claude.ai/code/session_01RYNAnMMAC49tZ9JfLKN3P7