### PR TITLE
fix(scripts): use robust PostgreSQL check instead of port-only check

### DIFF
--- a/scripts/lib/bench.sh
+++ b/scripts/lib/bench.sh
@@ -84,7 +84,7 @@ case "$cmd" in
         sleep 1
       done
       echo "   ✅ PostgreSQL is ready"
-    elif check_port_open "$DB_HOST" "$DB_PORT"; then
+    elif check_postgres_ready "$DB_HOST" "$DB_PORT" "${DB_USER:-postgres}"; then
       echo "   ✅ Local PostgreSQL is ready"
       DB_USER="${DB_USER:-postgres}"
       DB_PASS="${DB_PASS:-postgres}"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -87,6 +87,34 @@ check_port_open() {
   (echo > "/dev/tcp/$host/$port") 2>/dev/null
 }
 
+# Check if PostgreSQL is actually responding (not just port open)
+# Uses pg_isready if available, falls back to psql connection test
+check_postgres_ready() {
+  local host="${1:-localhost}"
+  local port="${2:-5432}"
+  local user="${3:-postgres}"
+
+  # First check if port is open
+  if ! check_port_open "$host" "$port"; then
+    return 1
+  fi
+
+  # Try pg_isready if available (preferred)
+  if command -v pg_isready &> /dev/null; then
+    pg_isready -h "$host" -p "$port" -U "$user" -q -t 2 2>/dev/null
+    return $?
+  fi
+
+  # Fall back to psql connection test
+  if command -v psql &> /dev/null; then
+    PGCONNECT_TIMEOUT=2 psql -h "$host" -p "$port" -U "$user" -c "SELECT 1" &>/dev/null
+    return $?
+  fi
+
+  # If no tools available, just rely on port check (less reliable)
+  return 0
+}
+
 # Backward-compatible wrappers
 check_ui_deps() {
   check_npm_deps "UI" "just ui-install"

--- a/scripts/lib/services.sh
+++ b/scripts/lib/services.sh
@@ -275,17 +275,17 @@ case "$cmd" in
     echo "1️⃣  Checking PostgreSQL..."
     if [ "$NO_DOCKER" = true ]; then
       # No Docker mode - require local PostgreSQL
-      if check_port_open localhost 5432; then
+      if check_postgres_ready localhost 5432 everruns; then
         echo "   ✅ Local PostgreSQL is ready"
         export DATABASE_URL=${DATABASE_URL:-postgres://everruns:everruns@localhost:5432/everruns}
       else
-        echo "   ❌ PostgreSQL not running on localhost:5432"
+        echo "   ❌ PostgreSQL not running or not responding on localhost:5432"
         echo "   Start PostgreSQL or remove --no-docker flag"
         exit 1
       fi
       export OTEL_SDK_DISABLED=true
       echo "   ℹ️  OpenTelemetry disabled (--no-docker)"
-    elif check_port_open localhost 5432; then
+    elif check_postgres_ready localhost 5432 postgres; then
       echo "   ✅ Local PostgreSQL is ready"
       export DATABASE_URL=${DATABASE_URL:-postgres://postgres:postgres@localhost/everruns}
       if resolve_docker_compose 2>/dev/null; then


### PR DESCRIPTION
## Summary

- Fixed false positive PostgreSQL detection in `start-all` that caused migrations to fail
- Added `check_postgres_ready()` function that verifies PostgreSQL actually responds, not just that port 5432 is open
- Updated `services.sh` and `bench.sh` to use the robust check

## Test plan

- [ ] Run `just start-all` with no PostgreSQL running - should start Docker Compose automatically
- [ ] Run `just start-all` with local PostgreSQL running - should detect and use it
- [ ] Run `just start-all --no-docker` without PostgreSQL - should fail with clear error

https://claude.ai/code/session_01WqUNPnisLBgLLCiFN2amLv