### PR TITLE
feat(ui): show full agent_id instead of truncated version

### DIFF
--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -149,7 +149,7 @@ export default function AgentDetailPage({
             </Badge>
           </h1>
           <p className="text-muted-foreground font-mono text-sm">
-            ID: {agent.id.slice(0, 8)}...
+            ID: {agent.id}
           </p>
         </div>
         <div className="flex gap-2">

--- a/apps/ui/src/components/agents/agent-card.tsx
+++ b/apps/ui/src/components/agents/agent-card.tsx
@@ -45,7 +45,7 @@ export function AgentCard({
             </Link>
           </CardTitle>
           <p className="text-sm text-muted-foreground font-mono">
-            {agent.id.slice(0, 8)}...
+            {agent.id}
           </p>
         </div>
         <Badge variant={agent.status === "active" ? "default" : "secondary"}>

--- a/apps/ui/src/components/dashboard/agent-list-widget.tsx
+++ b/apps/ui/src/components/dashboard/agent-list-widget.tsx
@@ -66,7 +66,7 @@ export function AgentListWidget({
                       <p className="font-medium">{agent.name}</p>
                       <div className="flex items-center gap-2">
                         <p className="text-xs text-muted-foreground font-mono">
-                          {agent.id.slice(0, 8)}...
+                          {agent.id}
                         </p>
                         {/* Capabilities icons */}
                         {agentCapabilities.length > 0 && (


### PR DESCRIPTION
## What
Display the full agent_id in the Agent UI instead of truncating to first 8 characters.

## Why
Users need to see and potentially copy the full agent ID for API calls, debugging, and reference purposes.

## How
Removed `.slice(0, 8)` truncation from agent ID display in:
- Agent card component
- Agent detail page
- Agent list widget (dashboard)

## Risk
- Low
- No functional changes, only display changes

## Checklist
- [x] Tests added or updated (N/A - display only change)
- [x] Backward compatibility considered (no breaking changes)