### PR TITLE
feat(core): add in-memory LLM integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,8 @@ jobs:
 
     env:
       DATABASE_URL: postgres://everruns:everruns@localhost:5432/everruns_test
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
     steps:
       - uses: actions/checkout@v4

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -70,9 +70,10 @@ eventsource-stream = "0.2"
 llmsim = "0.2.0"
 
 [features]
-default = []
+default = ["llm-tests"]
 openapi = ["utoipa"]
 sqlx = ["dep:sqlx"]
+llm-tests = []  # LLM integration tests (requires API keys)
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/core/src/in_memory_loop.rs
+++ b/crates/core/src/in_memory_loop.rs
@@ -18,7 +18,7 @@ use crate::agent::{Agent, AgentStatus};
 use crate::atoms::{
     ActAtom, ActInput, Atom, AtomContext, InputAtom, InputAtomInput, ReasonAtom, ReasonInput,
 };
-use crate::capabilities::{Capability, CapabilityRegistry};
+use crate::capabilities::{AgentCapabilityConfig, Capability, CapabilityRegistry};
 use crate::error::Result;
 use crate::events::{Event, EventData, EventRequest, OUTPUT_MESSAGE_COMPLETED};
 use crate::llm_driver_registry::{DriverRegistry, ProviderType};
@@ -316,6 +316,13 @@ impl InMemoryAgenticLoopBuilder {
         let message_retriever = InMemoryMessageRetriever::new();
         let event_emitter = BridgingEventEmitter::new(message_retriever.clone());
 
+        // Build capability configs for the agent from capabilities
+        let agent_capability_configs: Vec<AgentCapabilityConfig> = self
+            .capabilities
+            .iter()
+            .map(|cap| AgentCapabilityConfig::new(cap.id()))
+            .collect();
+
         // Create agent
         let agent_id = AgentId::new();
         let now = Utc::now();
@@ -326,7 +333,7 @@ impl InMemoryAgenticLoopBuilder {
             system_prompt: self.system_prompt,
             default_model_id: None,
             tags: vec![],
-            capabilities: vec![],
+            capabilities: agent_capability_configs,
             status: AgentStatus::Active,
             created_at: now,
             updated_at: now,
@@ -398,8 +405,11 @@ impl InMemoryAgenticLoopBuilder {
         }
         let tool_registry = tool_builder.build();
 
-        // Create atoms
-        let capability_registry = CapabilityRegistry::new();
+        // Create capability registry with added capabilities
+        let mut capability_registry = CapabilityRegistry::new();
+        for capability in self.capabilities {
+            capability_registry.register_boxed(capability);
+        }
 
         let input_atom = InputAtom::new(message_retriever.clone());
         let reason_atom = ReasonAtom::new(
@@ -504,7 +514,10 @@ impl InMemoryAgenticLoop {
         self.session_id
     }
 
-    /// Run a turn with the given user message
+    /// Run a turn with the given user input
+    ///
+    /// Accepts either a string or an `InputMessage` for full control over
+    /// message options like reasoning effort.
     ///
     /// This executes the full agentic loop using the TurnStateMachine:
     /// 1. Add user message
@@ -513,11 +526,31 @@ impl InMemoryAgenticLoop {
     ///
     /// The TurnStateMachine ensures consistent orchestration logic,
     /// proper error handling (checking success flag), and turn ID management.
-    pub async fn run_turn(&self, user_message: &str) -> Result<TurnResult> {
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// // Simple string input
+    /// let result = runner.run_turn("Hello").await?;
+    ///
+    /// // Full InputMessage with controls
+    /// let input = InputMessage {
+    ///     role: MessageRole::User,
+    ///     content: vec![ContentPart::text("What is 2+2?")],
+    ///     controls: Some(Controls {
+    ///         model_id: None,
+    ///         reasoning: Some(ReasoningConfig { effort: Some("medium".into()) }),
+    ///     }),
+    ///     metadata: None,
+    ///     tags: vec![],
+    /// };
+    /// let result = runner.run_turn(input).await?;
+    /// ```
+    pub async fn run_turn(&self, input: impl Into<InputMessage>) -> Result<TurnResult> {
         // Add user message
         let message = self
             .message_retriever
-            .add(self.session_id, InputMessage::user(user_message))
+            .add(self.session_id, input.into())
             .await?;
 
         // Create turn context and state machine
@@ -609,7 +642,7 @@ impl InMemoryAgenticLoop {
     pub async fn run_conversation(&self, messages: &[&str]) -> Result<Vec<TurnResult>> {
         let mut results = Vec::with_capacity(messages.len());
         for msg in messages {
-            results.push(self.run_turn(msg).await?);
+            results.push(self.run_turn(*msg).await?);
         }
         Ok(results)
     }

--- a/crates/core/src/message_retriever.rs
+++ b/crates/core/src/message_retriever.rs
@@ -60,6 +60,18 @@ impl InputMessage {
     }
 }
 
+impl From<&str> for InputMessage {
+    fn from(text: &str) -> Self {
+        InputMessage::user(text)
+    }
+}
+
+impl From<String> for InputMessage {
+    fn from(text: String) -> Self {
+        InputMessage::user(text)
+    }
+}
+
 // ============================================================================
 // MessageRetriever trait
 // ============================================================================

--- a/crates/core/tests/agent_run_basic.rs
+++ b/crates/core/tests/agent_run_basic.rs
@@ -1,0 +1,172 @@
+//! Basic agent run tests against real LLM endpoints (Anthropic + OpenAI).
+//!
+//! These tests verify the InMemoryAgenticLoop works with real LLM providers.
+//! Tests skip gracefully if API keys are not set.
+//!
+//! Run with:
+//!   cargo test -p everruns-core --test agent_run_basic
+//!
+//! Required environment variables:
+//!   - ANTHROPIC_API_KEY: For Anthropic tests
+//!   - OPENAI_API_KEY: For OpenAI tests
+#![cfg(feature = "llm-tests")]
+
+use everruns_core::capabilities::CurrentTimeCapability;
+use everruns_core::in_memory_loop::InMemoryAgenticLoop;
+use everruns_core::llm_driver_registry::DriverRegistry;
+use everruns_core::llm_models::LlmProviderType;
+use everruns_core::traits::ModelWithProvider;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn anthropic_model(model_name: &str) -> Option<ModelWithProvider> {
+    let api_key = std::env::var("ANTHROPIC_API_KEY").ok()?;
+    Some(ModelWithProvider {
+        model: model_name.to_string(),
+        provider_type: LlmProviderType::Anthropic,
+        api_key: Some(api_key),
+        base_url: None,
+    })
+}
+
+fn openai_model(model_name: &str) -> Option<ModelWithProvider> {
+    let api_key = std::env::var("OPENAI_API_KEY").ok()?;
+    Some(ModelWithProvider {
+        model: model_name.to_string(),
+        provider_type: LlmProviderType::Openai,
+        api_key: Some(api_key),
+        base_url: None,
+    })
+}
+
+fn anthropic_registry() -> DriverRegistry {
+    let mut registry = DriverRegistry::new();
+    everruns_anthropic::register_driver(&mut registry);
+    registry
+}
+
+fn openai_registry() -> DriverRegistry {
+    let mut registry = DriverRegistry::new();
+    everruns_openai::register_driver(&mut registry);
+    registry
+}
+
+// ============================================================================
+// Anthropic Tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_anthropic_basic_completion() {
+    let Some(model) = anthropic_model("claude-3-5-haiku-20241022") else {
+        eprintln!("Skipping test: ANTHROPIC_API_KEY not set");
+        return;
+    };
+
+    let runner = InMemoryAgenticLoop::builder()
+        .agent_name("Dad Joke Agent")
+        .system_prompt("Tell short dad jokes. Just the joke, no explanation.")
+        .model(model)
+        .driver_registry(anthropic_registry())
+        .max_iterations(3)
+        .build()
+        .await
+        .unwrap();
+
+    let result = runner.run_turn("Tell me a dad joke").await.unwrap();
+
+    assert!(result.success, "Turn should succeed: {:?}", result.error);
+    assert!(!result.response.is_empty(), "Response should not be empty");
+    assert_eq!(result.tool_calls_count, 0, "No tools should be called");
+}
+
+#[tokio::test]
+async fn test_anthropic_tool_call() {
+    let Some(model) = anthropic_model("claude-3-5-haiku-20241022") else {
+        eprintln!("Skipping test: ANTHROPIC_API_KEY not set");
+        return;
+    };
+
+    let runner = InMemoryAgenticLoop::builder()
+        .agent_name("Time Agent")
+        .system_prompt("When asked about time, use get_current_time tool first.")
+        .model(model)
+        .driver_registry(anthropic_registry())
+        .capability(CurrentTimeCapability)
+        .max_iterations(5)
+        .build()
+        .await
+        .unwrap();
+
+    let result = runner.run_turn("What time is it?").await.unwrap();
+
+    assert!(result.success, "Turn should succeed: {:?}", result.error);
+    assert!(
+        result.tool_calls_count > 0,
+        "Should have called get_current_time"
+    );
+    assert!(
+        result.iterations > 1,
+        "Should have multiple iterations (reason -> act -> reason)"
+    );
+}
+
+// ============================================================================
+// OpenAI Tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_openai_basic_completion() {
+    let Some(model) = openai_model("gpt-4o-mini") else {
+        eprintln!("Skipping test: OPENAI_API_KEY not set");
+        return;
+    };
+
+    let runner = InMemoryAgenticLoop::builder()
+        .agent_name("Dad Joke Agent")
+        .system_prompt("Tell short dad jokes. Just the joke, no explanation.")
+        .model(model)
+        .driver_registry(openai_registry())
+        .max_iterations(3)
+        .build()
+        .await
+        .unwrap();
+
+    let result = runner.run_turn("Tell me a dad joke").await.unwrap();
+
+    assert!(result.success, "Turn should succeed: {:?}", result.error);
+    assert!(!result.response.is_empty(), "Response should not be empty");
+    assert_eq!(result.tool_calls_count, 0, "No tools should be called");
+}
+
+#[tokio::test]
+async fn test_openai_tool_call() {
+    let Some(model) = openai_model("gpt-4o-mini") else {
+        eprintln!("Skipping test: OPENAI_API_KEY not set");
+        return;
+    };
+
+    let runner = InMemoryAgenticLoop::builder()
+        .agent_name("Time Agent")
+        .system_prompt("When asked about time, use get_current_time tool first.")
+        .model(model)
+        .driver_registry(openai_registry())
+        .capability(CurrentTimeCapability)
+        .max_iterations(5)
+        .build()
+        .await
+        .unwrap();
+
+    let result = runner.run_turn("What time is it?").await.unwrap();
+
+    assert!(result.success, "Turn should succeed: {:?}", result.error);
+    assert!(
+        result.tool_calls_count > 0,
+        "Should have called get_current_time"
+    );
+    assert!(
+        result.iterations > 1,
+        "Should have multiple iterations (reason -> act -> reason)"
+    );
+}

--- a/crates/core/tests/agent_run_with_thinking.rs
+++ b/crates/core/tests/agent_run_with_thinking.rs
@@ -1,0 +1,123 @@
+//! Extended thinking tests against real LLM endpoints (Anthropic only).
+//!
+//! These tests verify extended thinking (reasoning) works with the InMemoryAgenticLoop.
+//! Extended thinking is an Anthropic-specific feature.
+//!
+//! Run with:
+//!   cargo test -p everruns-core --test agent_run_with_thinking
+//!
+//! Required environment variables:
+//!   - ANTHROPIC_API_KEY: For Anthropic tests
+#![cfg(feature = "llm-tests")]
+
+use everruns_core::capabilities::CurrentTimeCapability;
+use everruns_core::in_memory_loop::InMemoryAgenticLoop;
+use everruns_core::llm_driver_registry::DriverRegistry;
+use everruns_core::llm_models::LlmProviderType;
+use everruns_core::message::{ContentPart, Controls, MessageRole, ReasoningConfig};
+use everruns_core::message_retriever::InputMessage;
+use everruns_core::traits::ModelWithProvider;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn anthropic_model(model_name: &str) -> Option<ModelWithProvider> {
+    let api_key = std::env::var("ANTHROPIC_API_KEY").ok()?;
+    Some(ModelWithProvider {
+        model: model_name.to_string(),
+        provider_type: LlmProviderType::Anthropic,
+        api_key: Some(api_key),
+        base_url: None,
+    })
+}
+
+fn anthropic_registry() -> DriverRegistry {
+    let mut registry = DriverRegistry::new();
+    everruns_anthropic::register_driver(&mut registry);
+    registry
+}
+
+// ============================================================================
+// Extended Thinking Tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_extended_thinking() {
+    let Some(model) = anthropic_model("claude-sonnet-4-20250514") else {
+        eprintln!("Skipping test: ANTHROPIC_API_KEY not set");
+        return;
+    };
+
+    let runner = InMemoryAgenticLoop::builder()
+        .agent_name("Thinking Agent")
+        .system_prompt("You are a helpful assistant.")
+        .model(model)
+        .driver_registry(anthropic_registry())
+        .max_iterations(3)
+        .build()
+        .await
+        .unwrap();
+
+    let input = InputMessage {
+        role: MessageRole::User,
+        content: vec![ContentPart::text("What is 17 * 23?")],
+        controls: Some(Controls {
+            model_id: None,
+            reasoning: Some(ReasoningConfig {
+                effort: Some("medium".into()),
+            }),
+        }),
+        metadata: None,
+        tags: vec![],
+    };
+
+    let result = runner.run_turn(input).await.unwrap();
+
+    assert!(result.success, "Turn should succeed: {:?}", result.error);
+    assert!(
+        result.response.contains("391"),
+        "Response should contain the correct answer 391, got: {}",
+        result.response
+    );
+}
+
+#[tokio::test]
+async fn test_thinking_with_tool_call() {
+    let Some(model) = anthropic_model("claude-sonnet-4-20250514") else {
+        eprintln!("Skipping test: ANTHROPIC_API_KEY not set");
+        return;
+    };
+
+    let runner = InMemoryAgenticLoop::builder()
+        .agent_name("Thinking Time Agent")
+        .system_prompt("Use get_current_time tool when asked about time.")
+        .model(model)
+        .driver_registry(anthropic_registry())
+        .capability(CurrentTimeCapability)
+        .max_iterations(5)
+        .build()
+        .await
+        .unwrap();
+
+    let input = InputMessage {
+        role: MessageRole::User,
+        content: vec![ContentPart::text("What's the current time in UTC?")],
+        controls: Some(Controls {
+            model_id: None,
+            reasoning: Some(ReasoningConfig {
+                effort: Some("low".into()),
+            }),
+        }),
+        metadata: None,
+        tags: vec![],
+    };
+
+    let result = runner.run_turn(input).await.unwrap();
+
+    assert!(result.success, "Turn should succeed: {:?}", result.error);
+    assert!(
+        result.tool_calls_count > 0,
+        "Should have called get_current_time"
+    );
+}

--- a/specs/code-organization.md
+++ b/specs/code-organization.md
@@ -60,6 +60,14 @@ let result = db.operation().await.map_err(|e| {
 
 ## Testing
 
+### Test Categories
+
+| Category | Location | Dependencies | Run Command |
+|----------|----------|--------------|-------------|
+| Unit Tests | Inline `#[cfg(test)]` modules | None | `cargo test --lib` |
+| Integration Tests | `tests/integration_test.rs` | PostgreSQL, workers | `cargo test --test integration_test` |
+| LLM Tests | `tests/agent_run_*.rs` | Real LLM API keys | `cargo test --test agent_run_basic` |
+
 ### Unit Tests
 
 Inline `#[cfg(test)]` modules for:
@@ -72,6 +80,23 @@ Inline `#[cfg(test)]` modules for:
 `tests/integration_test.rs` for:
 - API endpoints
 - Multi-service workflows
+- Requires infrastructure (PostgreSQL, workers)
+
+### LLM Tests
+
+`crates/core/tests/agent_run_*.rs` for testing against real LLM endpoints:
+- `agent_run_basic.rs` - Basic completion + tool calls (Anthropic + OpenAI)
+- `agent_run_with_thinking.rs` - Extended thinking tests (Anthropic only)
+
+**Requirements:**
+- `ANTHROPIC_API_KEY` and/or `OPENAI_API_KEY` environment variables
+- Tests skip gracefully if API keys are not set
+- Feature flag: `llm-tests` (enabled by default)
+
+```bash
+# Run LLM tests
+ANTHROPIC_API_KEY=key OPENAI_API_KEY=key cargo test -p everruns-core --test agent_run_basic
+```
 
 ### When to Add
 


### PR DESCRIPTION
## Summary

- Add integration tests that run against real LLM endpoints (Anthropic + OpenAI) using `InMemoryAgenticLoop`
- Tests require no infrastructure (no Postgres, no workers) - fully in-memory
- Fix bug where `InMemoryAgenticLoop` wasn't properly registering capabilities with the agent
- Update specs to document test categories (unit, integration, LLM)

## Test plan

- [x] All 6 LLM tests pass locally with API keys
- [x] Tests skip gracefully when API keys are not set
- [x] 498 existing unit tests still pass
- [x] `cargo clippy` passes
- [ ] CI passes (requires ANTHROPIC_API_KEY and OPENAI_API_KEY secrets)