### PR TITLE
feat(events): add event filtering with exclude parameter

### DIFF
--- a/apps/ui/src/app/(main)/sessions/[sessionId]/events/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/events/page.tsx
@@ -14,6 +14,8 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { useSessionContext } from "../session-context";
+import { EventFilter } from "@/components/events/event-filter";
+import { DEFAULT_EXCLUDED_EVENTS } from "@/lib/api/events";
 
 const EVENTS_PER_PAGE = 50;
 
@@ -51,13 +53,20 @@ export default function EventsPage() {
   const { events, eventsLoading, sessionId } = useSessionContext();
   const [currentPage, setCurrentPage] = useState(1);
   const [hasNewEvents, setHasNewEvents] = useState(false);
+  const [hideDeltaEvents, setHideDeltaEvents] = useState(true);
   const lastKnownCountRef = useRef(0);
+
+  // Filter out delta events if hideDeltaEvents is enabled
+  const filteredEvents = useMemo(() => {
+    if (!events) return [];
+    if (!hideDeltaEvents) return events;
+    return events.filter((e) => !DEFAULT_EXCLUDED_EVENTS.includes(e.type));
+  }, [events, hideDeltaEvents]);
 
   // Sort events by sequence descending (newest first)
   const sortedEvents = useMemo(() => {
-    if (!events) return [];
-    return [...events].sort((a, b) => (b.sequence ?? 0) - (a.sequence ?? 0));
-  }, [events]);
+    return [...filteredEvents].sort((a, b) => (b.sequence ?? 0) - (a.sequence ?? 0));
+  }, [filteredEvents]);
 
   // Calculate pagination
   const totalEvents = sortedEvents.length;
@@ -68,9 +77,9 @@ export default function EventsPage() {
 
   // Track new events arriving while viewing the list
   useEffect(() => {
-    if (!events) return;
+    if (!filteredEvents) return;
 
-    const currentCount = events.length;
+    const currentCount = filteredEvents.length;
 
     // Initialize on first load
     if (lastKnownCountRef.current === 0) {
@@ -86,7 +95,7 @@ export default function EventsPage() {
       // If on a different page, show refresh button
       setHasNewEvents(true);
     }
-  }, [events, currentPage]);
+  }, [filteredEvents, currentPage]);
 
   // Reset to page 1 when session changes
   useEffect(() => {
@@ -95,10 +104,16 @@ export default function EventsPage() {
     lastKnownCountRef.current = 0;
   }, [sessionId]);
 
+  // Reset to page 1 when filter changes
+  useEffect(() => {
+    setCurrentPage(1);
+    lastKnownCountRef.current = filteredEvents.length;
+  }, [hideDeltaEvents, filteredEvents.length]);
+
   const handleRefresh = () => {
     setCurrentPage(1);
     setHasNewEvents(false);
-    lastKnownCountRef.current = events?.length ?? 0;
+    lastKnownCountRef.current = filteredEvents.length;
   };
 
   const handlePageChange = (page: number) => {
@@ -121,9 +136,13 @@ export default function EventsPage() {
         </div>
       ) : (
         <div className="space-y-4">
-          {/* Header with refresh button and pagination info */}
+          {/* Header with filter, refresh button and pagination info */}
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
+              <EventFilter
+                hideDeltaEvents={hideDeltaEvents}
+                onHideDeltaEventsChange={setHideDeltaEvents}
+              />
               {hasNewEvents && (
                 <Button
                   variant="outline"

--- a/apps/ui/src/components/events/event-filter.tsx
+++ b/apps/ui/src/components/events/event-filter.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Filter } from "lucide-react";
+import { buttonVariants } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuPositioner,
+  DropdownMenuContent,
+  DropdownMenuCheckboxItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+interface EventFilterProps {
+  hideDeltaEvents: boolean;
+  onHideDeltaEventsChange: (hide: boolean) => void;
+}
+
+export function EventFilter({
+  hideDeltaEvents,
+  onHideDeltaEventsChange,
+}: EventFilterProps) {
+  const activeFilterCount = hideDeltaEvents ? 1 : 0;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        className={cn(buttonVariants({ variant: "outline", size: "sm" }), "gap-1.5")}
+      >
+        <Filter className="size-3.5" />
+        Filter
+        {activeFilterCount > 0 && (
+          <span className="bg-primary text-primary-foreground rounded-full px-1.5 text-xs">
+            {activeFilterCount}
+          </span>
+        )}
+      </DropdownMenuTrigger>
+      <DropdownMenuPositioner align="end">
+        <DropdownMenuContent className="w-56">
+          <DropdownMenuLabel>Event Filters</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuCheckboxItem
+            checked={hideDeltaEvents}
+            onCheckedChange={onHideDeltaEventsChange}
+          >
+            Hide streaming events
+          </DropdownMenuCheckboxItem>
+        </DropdownMenuContent>
+      </DropdownMenuPositioner>
+    </DropdownMenu>
+  );
+}

--- a/apps/ui/src/lib/api/events.ts
+++ b/apps/ui/src/lib/api/events.ts
@@ -5,13 +5,28 @@
 import { api, getDirectBackendUrl } from "./client";
 import type { Event, ListResponse } from "./types";
 
+// Default event types to exclude in UI contexts (streaming delta events are noise)
+export const DEFAULT_EXCLUDED_EVENTS = [
+  "output.message.delta",
+  "reason.thinking.delta",
+];
+
 // List events for a session (polling alternative to SSE)
+// Optional exclude parameter to filter out event types (e.g., delta events)
 export async function listEvents(
   org: string,
-  sessionId: string
+  sessionId: string,
+  exclude?: string[]
 ): Promise<Event[]> {
+  const params = new URLSearchParams();
+  if (exclude) {
+    for (const type of exclude) {
+      params.append("exclude", type);
+    }
+  }
+  const queryString = params.toString();
   const response = await api.get<ListResponse<Event>>(
-    `/v1/orgs/${org}/sessions/${sessionId}/events`
+    `/v1/orgs/${org}/sessions/${sessionId}/events${queryString ? `?${queryString}` : ""}`
   );
   return response.data.data;
 }
@@ -19,8 +34,23 @@ export async function listEvents(
 // Get SSE URL for real-time event streaming
 // Uses direct backend URL to bypass Next.js proxy (proxies buffer SSE)
 // Uses since_id for incremental updates (UUID v7 monotonically increasing)
-export function getSseUrl(org: string, sessionId: string, sinceId?: string): string {
+// Optional exclude parameter to filter out event types (e.g., delta events)
+export function getSseUrl(
+  org: string,
+  sessionId: string,
+  sinceId?: string,
+  exclude?: string[]
+): string {
   const baseUrl = getDirectBackendUrl();
-  const params = sinceId ? `?since_id=${sinceId}` : "";
-  return `${baseUrl}/v1/orgs/${org}/sessions/${sessionId}/sse${params}`;
+  const params = new URLSearchParams();
+  if (sinceId) {
+    params.set("since_id", sinceId);
+  }
+  if (exclude) {
+    for (const type of exclude) {
+      params.append("exclude", type);
+    }
+  }
+  const queryString = params.toString();
+  return `${baseUrl}/v1/orgs/${org}/sessions/${sessionId}/sse${queryString ? `?${queryString}` : ""}`;
 }

--- a/crates/control-plane/src/api/events.rs
+++ b/crates/control-plane/src/api/events.rs
@@ -33,6 +33,11 @@ use utoipa::{IntoParams, ToSchema};
 pub struct EventsQuery {
     /// Filter events with ID greater than this UUID v7 (monotonically increasing)
     pub since_id: Option<Uuid>,
+    /// Event types to exclude from the response (can be specified multiple times).
+    /// Common delta events to exclude: output.message.delta, reason.thinking.delta
+    #[serde(default)]
+    #[param(style = Form, explode = true)]
+    pub exclude: Vec<String>,
 }
 
 // ============================================
@@ -150,21 +155,23 @@ pub async fn stream_sse(
         })?;
 
     let session_id = session_id.uuid();
-    tracing::info!(session_id = %session_id, since_id = ?query.since_id, "Starting event stream");
+    tracing::info!(session_id = %session_id, since_id = ?query.since_id, exclude = ?query.exclude, "Starting event stream");
 
     let event_service = state.event_service.clone();
     let initial_since_id = query.since_id;
+    let exclude_types = query.exclude;
 
     // Use realtime config for session events (fast updates for interactive UX)
     let config = SseStreamConfig::realtime();
 
-    // State for stream: (last_id, backoff_ms, sent_connected)
+    // State for stream: (last_id, backoff_ms, sent_connected, exclude_types)
     #[derive(Clone)]
     struct StreamState {
         last_id: Option<Uuid>,
         backoff_ms: u64,
         sent_connected: bool,
         config: SseStreamConfig,
+        exclude_types: Vec<String>,
     }
 
     let initial_state = StreamState {
@@ -172,6 +179,7 @@ pub async fn stream_sse(
         backoff_ms: config.min_backoff_ms,
         sent_connected: false,
         config,
+        exclude_types,
     };
 
     // Create stream that replays events from database
@@ -196,7 +204,7 @@ pub async fn stream_sse(
 
             // Fetch events since last ID
             tracing::debug!(session_id = %session_id, last_id = ?state.last_id, "SSE: fetching events");
-            match event_service.list(session_id, None, state.last_id).await {
+            match event_service.list(session_id, None, state.last_id, &state.exclude_types).await {
                 Ok(events) if !events.is_empty() => {
                     // Get the last event ID for next iteration (extract UUID for db query)
                     let new_last_id = Some(events.last().unwrap().id.uuid());
@@ -231,6 +239,7 @@ pub async fn stream_sse(
                         backoff_ms: state.config.min_backoff_ms,
                         sent_connected: true,
                         config: state.config,
+                        exclude_types: state.exclude_types,
                     };
                     Some((stream::iter(sse_events), new_state))
                 }
@@ -319,9 +328,10 @@ pub async fn list_events(
 
     // Fetch events using EventService (converts rows to core::Event)
     // Optional since_id filter for incremental fetching
+    // Optional exclude filter for filtering out event types (e.g., delta events)
     let events = state
         .event_service
-        .list(session_id.uuid(), None, query.since_id)
+        .list(session_id.uuid(), None, query.since_id, &query.exclude)
         .await
         .map_err(|e| {
             tracing::error!("Failed to list events: {}", e);

--- a/crates/control-plane/src/services/event.rs
+++ b/crates/control-plane/src/services/event.rs
@@ -202,6 +202,7 @@ impl EventService {
         session_id: Uuid,
         since_sequence: Option<i32>,
         since_id: Option<Uuid>,
+        exclude_types: &[String],
     ) -> Result<Vec<Event>> {
         let rows = self
             .db
@@ -209,6 +210,7 @@ impl EventService {
                 SessionId::from_uuid(session_id),
                 since_sequence,
                 since_id.map(EventId::from_uuid),
+                exclude_types,
             )
             .await?;
         Ok(rows.into_iter().map(Self::row_to_event).collect())

--- a/crates/control-plane/src/storage/backend.rs
+++ b/crates/control-plane/src/storage/backend.rs
@@ -247,8 +247,16 @@ impl StorageBackend {
         session_id: SessionId,
         since_sequence: Option<i32>,
         since_id: Option<EventId>,
+        exclude_types: &[String],
     ) -> Result<Vec<EventRow>> {
-        dispatch!(self, list_events, session_id, since_sequence, since_id)
+        dispatch!(
+            self,
+            list_events,
+            session_id,
+            since_sequence,
+            since_id,
+            exclude_types
+        )
     }
 
     pub async fn list_message_events(&self, session_id: SessionId) -> Result<Vec<EventRow>> {

--- a/crates/control-plane/src/storage/memory.rs
+++ b/crates/control-plane/src/storage/memory.rs
@@ -658,12 +658,17 @@ impl InMemoryDatabase {
         session_id: SessionId,
         since_sequence: Option<i32>,
         since_id: Option<EventId>,
+        exclude_types: &[String],
     ) -> Result<Vec<EventRow>> {
         let events = self.events.read();
         let mut result: Vec<_> = events
             .values()
             .filter(|e| {
                 if e.session_id != session_id {
+                    return false;
+                }
+                // Filter out excluded event types
+                if !exclude_types.is_empty() && exclude_types.contains(&e.event_type) {
                     return false;
                 }
                 // Prefer since_id (UUID v7 monotonically increasing) over sequence
@@ -2412,7 +2417,7 @@ mod tests {
             .unwrap();
         }
 
-        let events = db.list_events(session.id, None, None).await.unwrap();
+        let events = db.list_events(session.id, None, None, &[]).await.unwrap();
         assert_eq!(events.len(), 3);
         assert_eq!(events[0].sequence, 1);
         assert_eq!(events[1].sequence, 2);

--- a/crates/control-plane/src/storage/repositories.rs
+++ b/crates/control-plane/src/storage/repositories.rs
@@ -677,8 +677,10 @@ impl Database {
         session_id: SessionId,
         since_sequence: Option<i32>,
         since_id: Option<EventId>,
+        exclude_types: &[String],
     ) -> Result<Vec<EventRow>> {
         // Prefer since_id (UUID v7 monotonically increasing) over sequence for filtering
+        // exclude_types filters out unwanted event types (e.g., delta events)
         let rows = match (since_id, since_sequence) {
             (Some(id), _) => {
                 sqlx::query_as::<_, EventRow>(
@@ -686,11 +688,13 @@ impl Database {
                     SELECT id, session_id, sequence, event_type, ts, context, data, metadata, tags, created_at
                     FROM events
                     WHERE session_id = $1 AND id > $2
+                      AND (cardinality($3::text[]) = 0 OR event_type <> ALL($3))
                     ORDER BY id ASC
                     "#,
                 )
                 .bind(session_id.uuid())
                 .bind(id.uuid())
+                .bind(exclude_types)
                 .fetch_all(&self.pool)
                 .await?
             }
@@ -700,11 +704,13 @@ impl Database {
                     SELECT id, session_id, sequence, event_type, ts, context, data, metadata, tags, created_at
                     FROM events
                     WHERE session_id = $1 AND sequence > $2
+                      AND (cardinality($3::text[]) = 0 OR event_type <> ALL($3))
                     ORDER BY sequence ASC
                     "#,
                 )
                 .bind(session_id.uuid())
                 .bind(seq)
+                .bind(exclude_types)
                 .fetch_all(&self.pool)
                 .await?
             }
@@ -714,10 +720,12 @@ impl Database {
                     SELECT id, session_id, sequence, event_type, ts, context, data, metadata, tags, created_at
                     FROM events
                     WHERE session_id = $1
+                      AND (cardinality($2::text[]) = 0 OR event_type <> ALL($2))
                     ORDER BY sequence ASC
                     "#,
                 )
                 .bind(session_id.uuid())
+                .bind(exclude_types)
                 .fetch_all(&self.pool)
                 .await?
             }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1617,6 +1617,20 @@
               ],
               "format": "uuid"
             }
+          },
+          {
+            "name": "exclude",
+            "in": "query",
+            "description": "Event types to exclude from the response (can be specified multiple times).\nCommon delta events to exclude: output.message.delta, reason.thinking.delta",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "style": "form",
+            "explode": true
           }
         ],
         "responses": {
@@ -2338,6 +2352,20 @@
               ],
               "format": "uuid"
             }
+          },
+          {
+            "name": "exclude",
+            "in": "query",
+            "description": "Event types to exclude from the response (can be specified multiple times).\nCommon delta events to exclude: output.message.delta, reason.thinking.delta",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "style": "form",
+            "explode": true
           }
         ],
         "responses": {


### PR DESCRIPTION
## Summary
- Add `exclude` query parameter to events API endpoints for filtering out event types
- Database-level filtering using PostgreSQL array operators for efficient queries
- New EventFilter dropdown in Sessions > Events tab with "Hide streaming events" option
- Delta events (`output.message.delta`, `reason.thinking.delta`) filtered by default in UI

## Test plan
- [ ] Navigate to Sessions > Events tab
- [ ] Verify delta events are hidden by default (Filter button shows "1" badge)
- [ ] Click Filter, uncheck "Hide streaming events"
- [ ] Verify delta events now appear in list
- [ ] Test API: `GET /v1/orgs/{org}/sessions/{id}/events?exclude=output.message.delta` returns no delta events
- [ ] Test SSE: `GET /v1/orgs/{org}/sessions/{id}/sse?exclude=output.message.delta` streams without delta events