### PR TITLE
feat(ui): add organisation settings page

### DIFF
--- a/apps/ui/src/app/(main)/settings/layout.tsx
+++ b/apps/ui/src/app/(main)/settings/layout.tsx
@@ -4,9 +4,15 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { Header } from "@/components/layout/header";
-import { Server, Key, Users, Plug } from "lucide-react";
+import { Server, Key, Users, Plug, Building2 } from "lucide-react";
 
 const settingsNavigation = [
+  {
+    name: "Organisation",
+    href: "/settings/organisation",
+    icon: Building2,
+    description: "Manage organisation settings",
+  },
   {
     name: "LLM Providers",
     href: "/settings/providers",

--- a/apps/ui/src/app/(main)/settings/organisation/page.tsx
+++ b/apps/ui/src/app/(main)/settings/organisation/page.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { CopyButton } from "@/components/ui/copy-button";
+import { useOrganization, useUpdateOrganization } from "@/hooks/use-organizations";
+import { useOrg } from "@/providers/org-provider";
+import { Building2, Save, AlertCircle } from "lucide-react";
+
+export default function OrganisationPage() {
+  const { currentOrg } = useOrg();
+  const { data: organization, isLoading, error } = useOrganization();
+  const updateOrganization = useUpdateOrganization();
+
+  const [name, setName] = useState("");
+  const [hasChanges, setHasChanges] = useState(false);
+
+  // Sync name from fetched organization data
+  useEffect(() => {
+    if (organization?.name) {
+      setName(organization.name);
+      setHasChanges(false);
+    }
+  }, [organization?.name]);
+
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setName(e.target.value);
+    setHasChanges(e.target.value !== organization?.name);
+  };
+
+  const handleSave = async () => {
+    if (!hasChanges || !name.trim()) return;
+
+    await updateOrganization.mutateAsync({ name: name.trim() });
+    setHasChanges(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && hasChanges && name.trim()) {
+      handleSave();
+    }
+  };
+
+  if (error) {
+    return (
+      <div className="space-y-8">
+        <section>
+          <div className="mb-4">
+            <h2 className="text-xl font-semibold">Organisation</h2>
+            <p className="text-sm text-muted-foreground">
+              Manage organisation settings.
+            </p>
+          </div>
+          <Card className="p-8 text-center">
+            <AlertCircle className="h-12 w-12 mx-auto text-destructive mb-4" />
+            <h3 className="text-lg font-medium mb-2">Failed to load organisation</h3>
+            <p className="text-muted-foreground">{error.message}</p>
+          </Card>
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <section>
+        <div className="mb-6">
+          <h2 className="text-xl font-semibold">Organisation</h2>
+          <p className="text-sm text-muted-foreground">
+            Manage organisation settings.
+          </p>
+        </div>
+
+        {isLoading ? (
+          <Card className="p-6">
+            <div className="space-y-6">
+              <div className="space-y-2">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-10 w-full max-w-md" />
+              </div>
+              <div className="space-y-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-10 w-full max-w-md" />
+              </div>
+            </div>
+          </Card>
+        ) : (
+          <Card className="p-6">
+            <div className="flex items-center gap-3 mb-6">
+              <div className="p-2 rounded-lg bg-primary/10">
+                <Building2 className="h-5 w-5 text-primary" />
+              </div>
+              <div>
+                <h3 className="font-medium">{organization?.name || currentOrg?.name}</h3>
+                <p className="text-sm text-muted-foreground">Organisation settings</p>
+              </div>
+            </div>
+
+            <div className="space-y-6 max-w-md">
+              {/* Organisation Name */}
+              <div className="space-y-2">
+                <Label htmlFor="org-name">Organisation Name</Label>
+                <div className="flex gap-2">
+                  <Input
+                    id="org-name"
+                    value={name}
+                    onChange={handleNameChange}
+                    onKeyDown={handleKeyDown}
+                    placeholder="Organisation name"
+                    className="flex-1"
+                  />
+                  <Button
+                    onClick={handleSave}
+                    disabled={!hasChanges || !name.trim() || updateOrganization.isPending}
+                  >
+                    <Save className="h-4 w-4 mr-2" />
+                    {updateOrganization.isPending ? "Saving..." : "Save"}
+                  </Button>
+                </div>
+                {updateOrganization.isError && (
+                  <p className="text-sm text-destructive">
+                    Failed to update: {updateOrganization.error.message}
+                  </p>
+                )}
+                {updateOrganization.isSuccess && !hasChanges && (
+                  <p className="text-sm text-green-600">Saved successfully</p>
+                )}
+              </div>
+
+              {/* Organisation ID */}
+              <div className="space-y-2">
+                <Label htmlFor="org-id">Organisation ID</Label>
+                <div className="flex items-center gap-2">
+                  <Input
+                    id="org-id"
+                    value={organization?.id || currentOrg?.public_id || ""}
+                    readOnly
+                    className="font-mono text-sm bg-muted"
+                  />
+                  <CopyButton value={organization?.id || currentOrg?.public_id || ""} />
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  Use this ID when making API calls scoped to this organisation.
+                </p>
+              </div>
+            </div>
+          </Card>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/ui/src/app/(main)/settings/page.tsx
+++ b/apps/ui/src/app/(main)/settings/page.tsx
@@ -7,7 +7,7 @@ export default function SettingsPage() {
   const router = useRouter();
 
   useEffect(() => {
-    router.replace("/settings/providers");
+    router.replace("/settings/organisation");
   }, [router]);
 
   return null;

--- a/apps/ui/src/hooks/use-organizations.ts
+++ b/apps/ui/src/hooks/use-organizations.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { getOrganization, updateOrganization } from "@/lib/api/organizations";
+import { queryKeys } from "@/lib/query-keys";
+import type { UpdateOrganizationRequest } from "@/lib/api/types";
+import { useOrg } from "@/providers/org-provider";
+
+export function useOrganization() {
+  const { currentOrg } = useOrg();
+  const org = currentOrg?.public_id;
+
+  return useQuery({
+    queryKey: [...queryKeys.organizations.detail(org ?? ""), org],
+    queryFn: () => getOrganization(org!),
+    enabled: !!org,
+    staleTime: 30000,
+  });
+}
+
+export function useUpdateOrganization() {
+  const queryClient = useQueryClient();
+  const { currentOrg } = useOrg();
+  const org = currentOrg?.public_id;
+
+  return useMutation({
+    mutationFn: (data: UpdateOrganizationRequest) => updateOrganization(org!, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.organizations.all });
+      if (org) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.organizations.detail(org) });
+      }
+      // Also invalidate auth session to refresh user's org list
+      queryClient.invalidateQueries({ queryKey: queryKeys.users.me() });
+    },
+  });
+}

--- a/apps/ui/src/lib/api/index.ts
+++ b/apps/ui/src/lib/api/index.ts
@@ -7,5 +7,6 @@ export * from "./messages";
 export * from "./events";
 export * from "./llm-providers";
 export * from "./mcp-servers";
+export * from "./organizations";
 export * from "./auth";
 export * from "./durable";

--- a/apps/ui/src/lib/api/organizations.ts
+++ b/apps/ui/src/lib/api/organizations.ts
@@ -1,0 +1,18 @@
+// Organization API functions
+// Routes: GET/PATCH /v1/orgs/{org}
+
+import { api } from "./client";
+import type { Organization, UpdateOrganizationRequest } from "./types";
+
+export async function getOrganization(org: string): Promise<Organization> {
+  const response = await api.get<Organization>(`/v1/orgs/${org}`);
+  return response.data;
+}
+
+export async function updateOrganization(
+  org: string,
+  data: UpdateOrganizationRequest
+): Promise<Organization> {
+  const response = await api.patch<Organization>(`/v1/orgs/${org}`, data);
+  return response.data;
+}

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -584,6 +584,19 @@ export interface OrganizationMembership {
   name: string;
 }
 
+/** Full organization details (from API) */
+export interface Organization {
+  id: string;
+  name: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Request to update an organization */
+export interface UpdateOrganizationRequest {
+  name?: string;
+}
+
 export interface UserInfoResponse {
   id: string;
   email: string;

--- a/apps/ui/src/lib/query-keys.ts
+++ b/apps/ui/src/lib/query-keys.ts
@@ -105,4 +105,10 @@ export const queryKeys = {
     list: () => ["mcp-servers"] as const,
     detail: (serverId: string) => ["mcp-server", serverId] as const,
   },
+
+  // Organization queries
+  organizations: {
+    all: ["organizations"] as const,
+    detail: (orgId: string) => ["organization", orgId] as const,
+  },
 };


### PR DESCRIPTION
## Summary
- Add Organisation settings page under Settings that displays the organisation name (editable) and ID (with copy button)
- New page accessible at `/settings/organisation`
- Settings now defaults to the Organisation page

## Test plan
- [x] Page renders correctly with organisation details
- [x] Organisation name field is editable
- [x] Copy button copies Organisation ID to clipboard
- [x] UI build passes (`npm run build`)
- [x] Smoke tested with screenshot verification