### PR TITLE
feat(ui): unify ID handling with copy buttons

### DIFF
--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -33,6 +33,7 @@
         "jest": "^30.2.0",
         "jest-environment-jsdom": "^30.2.0",
         "oxlint": "^1.39.0",
+        "playwright": "^1.58.0",
         "tailwindcss": "^4",
         "ts-jest": "^29.4.6",
         "typescript": "^5"
@@ -2084,6 +2085,53 @@
       },
       "bin": {
         "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
+      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright-core": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
+      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
       },
       "engines": {
         "node": ">=18"
@@ -7412,13 +7460,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
-      "devOptional": true,
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
+      "integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.58.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -7431,10 +7479,10 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
-      "devOptional": true,
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
+      "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -40,6 +40,7 @@
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",
     "oxlint": "^1.39.0",
+    "playwright": "^1.58.0",
     "tailwindcss": "^4",
     "ts-jest": "^29.4.6",
     "typescript": "^5"

--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -23,6 +23,7 @@ import {
   Eye,
   LayoutDashboard,
 } from "lucide-react";
+import { CopyButton } from "@/components/ui/copy-button";
 import type { Capability, LlmModelWithProvider, TokenUsage } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
 
@@ -141,15 +142,13 @@ export default function AgentDetailPage({
         <div>
           <h1 className="text-2xl font-bold flex items-center gap-2">
             {agent.name}
+            <CopyButton value={agent.id} />
             <Badge
               variant={agent.status === "active" ? "default" : "secondary"}
             >
               {agent.status}
             </Badge>
           </h1>
-          <p className="text-muted-foreground font-mono text-sm">
-            ID: {agent.id}
-          </p>
         </div>
         <div className="flex gap-2">
           <Button

--- a/apps/ui/src/app/(main)/capabilities/[capabilityId]/page.tsx
+++ b/apps/ui/src/app/(main)/capabilities/[capabilityId]/page.tsx
@@ -16,6 +16,7 @@ import {
   Code,
   Link as LinkIcon,
 } from "lucide-react";
+import { CopyButton } from "@/components/ui/copy-button";
 import type { CapabilityStatus, ToolDefinition } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
 
@@ -145,13 +146,11 @@ export default function CapabilityDetailPage({
           <div>
             <h1 className="text-2xl font-bold flex items-center gap-3">
               {capability.name}
+              <CopyButton value={capability.id} />
               <Badge variant={getStatusBadgeVariant(capability.status)}>
                 {getStatusLabel(capability.status)}
               </Badge>
             </h1>
-            <p className="text-muted-foreground font-mono text-sm">
-              {capability.id}
-            </p>
           </div>
         </div>
       </div>
@@ -261,13 +260,6 @@ export default function CapabilityDetailPage({
                   </div>
                 </div>
               )}
-
-              <div>
-                <p className="text-sm font-medium">ID</p>
-                <p className="text-sm text-muted-foreground font-mono">
-                  {capability.id}
-                </p>
-              </div>
             </CardContent>
           </Card>
 

--- a/apps/ui/src/app/(main)/capabilities/page.tsx
+++ b/apps/ui/src/app/(main)/capabilities/page.tsx
@@ -13,6 +13,7 @@ import {
   AlertCircle,
   Info,
 } from "lucide-react";
+import { CopyButton } from "@/components/ui/copy-button";
 import type { Capability, CapabilityStatus } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
 import { InlineMarkdown } from "@/components/ui/markdown";
@@ -52,11 +53,9 @@ function CapabilityCard({ capability }: { capability: Capability }) {
             <div className="p-2 bg-muted rounded-lg">
               <IconComponent className="w-5 h-5" />
             </div>
-            <div>
+            <div className="flex items-center gap-2">
               <CardTitle className="text-lg">{capability.name}</CardTitle>
-              <p className="text-sm text-muted-foreground font-mono">
-                {capability.id}
-              </p>
+              <CopyButton value={capability.id} />
             </div>
           </div>
           <Badge variant={getStatusBadgeVariant(capability.status)}>

--- a/apps/ui/src/app/(main)/durable/workflows/[workflowId]/page.tsx
+++ b/apps/ui/src/app/(main)/durable/workflows/[workflowId]/page.tsx
@@ -25,6 +25,7 @@ import {
   Zap,
   MessageSquare,
 } from "lucide-react";
+import { CopyButton } from "@/components/ui/copy-button";
 import Link from "next/link";
 
 function formatDistanceToNow(date: Date, options?: { addSuffix?: boolean }): string {
@@ -248,9 +249,9 @@ export default function WorkflowDetailPage({ params }: { params: Promise<{ workf
         <div className="flex items-start justify-between">
           <div className="flex items-center gap-4">
             {getStatusIcon(workflow.status, "lg")}
-            <div>
+            <div className="flex items-center gap-2">
               <h2 className="text-2xl font-bold">{workflow.workflow_type}</h2>
-              <p className="text-sm text-muted-foreground font-mono">{workflow.id}</p>
+              <CopyButton value={workflow.id} />
             </div>
           </div>
           <div className="flex items-center gap-2">

--- a/apps/ui/src/app/(main)/durable/workflows/page.tsx
+++ b/apps/ui/src/app/(main)/durable/workflows/page.tsx
@@ -46,6 +46,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
+import { CopyButton } from "@/components/ui/copy-button";
 
 type TabValue = "workflows" | "tasks" | "dlq";
 
@@ -108,10 +109,8 @@ function WorkflowRow({ workflow, onCancel }: { workflow: DurableWorkflow; onCanc
       <TableCell>
         <div className="flex items-center gap-2">
           {getStatusIcon(workflow.status)}
-          <div>
-            <p className="font-medium">{workflow.workflow_type}</p>
-            <p className="text-xs text-muted-foreground font-mono">{workflow.id.slice(0, 16)}...</p>
-          </div>
+          <p className="font-medium">{workflow.workflow_type}</p>
+          <CopyButton value={workflow.id} />
         </div>
       </TableCell>
       <TableCell>

--- a/apps/ui/src/components/agents/agent-card.tsx
+++ b/apps/ui/src/components/agents/agent-card.tsx
@@ -11,6 +11,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Pencil } from "lucide-react";
+import { CopyButton } from "@/components/ui/copy-button";
 import type { Agent, Capability, CapabilityId } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
 import { InlineMarkdown } from "@/components/ui/markdown";
@@ -38,15 +39,13 @@ export function AgentCard({
   return (
     <Card className="hover:shadow-md transition-shadow">
       <CardHeader className="flex flex-row items-start justify-between space-y-0">
-        <div className="space-y-1">
+        <div className="flex items-center gap-2">
           <CardTitle className="text-lg">
             <Link href={`/agents/${agent.id}`} className="hover:underline">
               {agent.name}
             </Link>
           </CardTitle>
-          <p className="text-sm text-muted-foreground font-mono">
-            {agent.id}
-          </p>
+          <CopyButton value={agent.id} />
         </div>
         <Badge variant={agent.status === "active" ? "default" : "secondary"}>
           {agent.status}

--- a/apps/ui/src/components/dashboard/agent-list-widget.tsx
+++ b/apps/ui/src/components/dashboard/agent-list-widget.tsx
@@ -11,6 +11,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Boxes, Plus } from "lucide-react";
+import { CopyButton } from "@/components/ui/copy-button";
 import type { Agent, Capability, CapabilityId } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
 
@@ -63,11 +64,11 @@ export function AgentListWidget({
                   <div className="flex items-center gap-3">
                     <Boxes className="h-5 w-5 text-muted-foreground" />
                     <div>
-                      <p className="font-medium">{agent.name}</p>
+                      <div className="flex items-center gap-1">
+                        <p className="font-medium">{agent.name}</p>
+                        <CopyButton value={agent.id} />
+                      </div>
                       <div className="flex items-center gap-2">
-                        <p className="text-xs text-muted-foreground font-mono">
-                          {agent.id}
-                        </p>
                         {/* Capabilities icons */}
                         {agentCapabilities.length > 0 && (
                           <TooltipProvider>

--- a/specs/code-organization.md
+++ b/specs/code-organization.md
@@ -233,6 +233,42 @@ export function AgentFilterMenu({ value, onValueChange, className }) {
 **Existing components:**
 - `AgentFilterMenu` - `components/agent/agent-filter-menu.tsx`
 
+### Entity ID Display
+
+**Rule:** Never show entity IDs as visible text. Provide a copy button for ID access.
+
+**Pattern:**
+- Display entity name/title prominently
+- Add `CopyButton` next to title for ID copying
+- Tooltips may show full ID for reference
+- If entity has no name, show `"{EntityType} {shortenId(id)}"` as fallback
+
+**Implementation:**
+```tsx
+// In headers/titles
+<h1 className="text-2xl font-bold flex items-center gap-2">
+  {entity.name}
+  <CopyButton value={entity.id} />
+</h1>
+
+// In cards (within Link)
+<div className="flex items-center gap-2">
+  <CardTitle>{entity.name}</CardTitle>
+  <CopyButton value={entity.id} />
+</div>
+
+// Fallback when no name
+<h1 className="text-2xl font-bold flex items-center gap-2">
+  {entity.name || `Agent ${shortenId(entity.id)}`}
+  <CopyButton value={entity.id} />
+</h1>
+```
+
+**Why:** IDs are for programmatic use (API calls, debugging). Users need to copy them occasionally but don't need to see them constantly. This keeps the UI clean while maintaining accessibility.
+
+**Components:**
+- `CopyButton` - `components/ui/copy-button.tsx` - Icon button that copies value to clipboard
+
 ### List Page Structure
 
 For pages listing entities with filters:


### PR DESCRIPTION
## Summary

- Unify ID handling across all entity views in the UI
- Replace visible ID displays with copy buttons next to entity titles
- Document the pattern in `specs/code-organization.md`

**Changes:**
- Agent detail page: Remove ID display, add CopyButton to title
- Agent card: Remove ID display, add CopyButton to title
- Agent list widget (dashboard): Remove ID, add CopyButton
- Capability detail page: Remove ID display from header and sidebar, add CopyButton
- Capability list cards: Remove ID display, add CopyButton
- Workflow detail page: Remove ID display, add CopyButton
- Workflow list table: Remove truncated ID, add CopyButton

**Pattern documented in spec:**
- Never show entity IDs as visible text
- Provide copy button next to title for ID access
- Tooltips may show full ID for reference

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes (1 pre-existing warning unrelated to this PR)
- [ ] Verify copy buttons appear next to entity titles
- [ ] Verify clicking copy button copies full ID to clipboard
- [ ] Verify no visible IDs in entity headers/cards