### PR TITLE
feat(docker): add just example subcommand for docker-compose-full

### DIFF
--- a/example.just
+++ b/example.just
@@ -1,0 +1,26 @@
+# Example docker-compose commands
+
+# Start example docker-compose-full (checks local compose not running)
+start:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Check if local docker compose containers are running
+    if docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^everruns-postgres$\|^everruns-jaeger$'; then
+        echo "❌ Local docker compose appears to be running (found everruns-postgres or everruns-jaeger)."
+        echo "   Stop it first with: just stop-docker"
+        exit 1
+    fi
+    echo "✅ Local docker compose not running, starting example full stack..."
+    cd examples
+    docker compose -f docker-compose-full.yaml up -d
+    echo "✅ Example full stack started!"
+    echo "   - UI: http://localhost:8080"
+    echo "   - Jaeger UI: http://localhost:16686"
+
+# Stop example docker-compose-full
+stop:
+    cd examples && docker compose -f docker-compose-full.yaml down
+
+# Reset example docker-compose-full (removes volumes)
+reset:
+    cd examples && docker compose -f docker-compose-full.yaml down -v

--- a/justfile
+++ b/justfile
@@ -82,3 +82,30 @@ start-all *args:
 # Stop all services (API, UI, Docker)
 stop-all:
     ./scripts/lib/services.sh stop-all
+
+# === Example Docker Compose ===
+
+# Start example docker-compose-full (checks local compose not running)
+start-example-full:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Check if local docker compose containers are running
+    if docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^everruns-postgres$\|^everruns-jaeger$'; then
+        echo "❌ Local docker compose appears to be running (found everruns-postgres or everruns-jaeger)."
+        echo "   Stop it first with: just stop-docker"
+        exit 1
+    fi
+    echo "✅ Local docker compose not running, starting example full stack..."
+    cd examples
+    docker compose -f docker-compose-full.yaml up -d
+    echo "✅ Example full stack started!"
+    echo "   - UI: http://localhost:8080"
+    echo "   - Jaeger UI: http://localhost:16686"
+
+# Stop example docker-compose-full
+stop-example-full:
+    cd examples && docker compose -f docker-compose-full.yaml down
+
+# Reset example docker-compose-full (removes volumes)
+reset-example-full:
+    cd examples && docker compose -f docker-compose-full.yaml down -v

--- a/justfile
+++ b/justfile
@@ -5,6 +5,7 @@
 mod ui
 mod docs
 mod durable
+mod example
 
 # Default recipe: show available commands
 default:
@@ -82,30 +83,3 @@ start-all *args:
 # Stop all services (API, UI, Docker)
 stop-all:
     ./scripts/lib/services.sh stop-all
-
-# === Example Docker Compose ===
-
-# Start example docker-compose-full (checks local compose not running)
-start-example-full:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    # Check if local docker compose containers are running
-    if docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^everruns-postgres$\|^everruns-jaeger$'; then
-        echo "❌ Local docker compose appears to be running (found everruns-postgres or everruns-jaeger)."
-        echo "   Stop it first with: just stop-docker"
-        exit 1
-    fi
-    echo "✅ Local docker compose not running, starting example full stack..."
-    cd examples
-    docker compose -f docker-compose-full.yaml up -d
-    echo "✅ Example full stack started!"
-    echo "   - UI: http://localhost:8080"
-    echo "   - Jaeger UI: http://localhost:16686"
-
-# Stop example docker-compose-full
-stop-example-full:
-    cd examples && docker compose -f docker-compose-full.yaml down
-
-# Reset example docker-compose-full (removes volumes)
-reset-example-full:
-    cd examples && docker compose -f docker-compose-full.yaml down -v


### PR DESCRIPTION
## Summary
- Add `just example start` command that checks if local docker compose is running before starting `examples/docker-compose-full.yaml`
- Add `just example stop` and `just example reset` commands
- Prevents port conflicts between local dev and example full stack

## Test plan
- [ ] Run `just example start` with local compose running - should error
- [ ] Run `just example start` with local compose stopped - should start full stack
- [ ] Run `just example stop` - should stop containers