### PR TITLE
refactor: rename MessageRole::Assistant to MessageRole::Agent

### DIFF
--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -62,7 +62,7 @@ fn patch_dangling_tool_calls(messages: &[Message]) -> Vec<Message> {
         result.push(msg.clone());
 
         // After an assistant message with tool calls, add cancelled results for any missing ones
-        if msg.role == MessageRole::Assistant && msg.has_tool_calls() {
+        if msg.role == MessageRole::Agent && msg.has_tool_calls() {
             for tc in msg.tool_calls() {
                 // Look for a matching tool result in ALL subsequent messages
                 let has_result = messages[(i + 1)..]

--- a/crates/core/src/in_memory_loop.rs
+++ b/crates/core/src/in_memory_loop.rs
@@ -925,7 +925,7 @@ mod tests {
 
         let conv = runner.conversation_string().await.unwrap();
         assert!(conv.contains("[User]"));
-        assert!(conv.contains("[Assistant]"));
+        assert!(conv.contains("[Agent]"));
         assert!(conv.contains("Hi"));
         assert!(conv.contains("Hello!"));
     }

--- a/crates/core/src/llm_driver_registry.rs
+++ b/crates/core/src/llm_driver_registry.rs
@@ -456,7 +456,7 @@ impl From<&crate::message::Message> for LlmMessage {
         let role = match msg.role {
             crate::message::MessageRole::System => LlmMessageRole::System,
             crate::message::MessageRole::User => LlmMessageRole::User,
-            crate::message::MessageRole::Assistant => LlmMessageRole::Assistant,
+            crate::message::MessageRole::Agent => LlmMessageRole::Assistant,
             crate::message::MessageRole::ToolResult => LlmMessageRole::Tool,
         };
 
@@ -522,7 +522,7 @@ impl LlmMessage {
         let role = match msg.role {
             MessageRole::System => LlmMessageRole::System,
             MessageRole::User => LlmMessageRole::User,
-            MessageRole::Assistant => LlmMessageRole::Assistant,
+            MessageRole::Agent => LlmMessageRole::Assistant,
             MessageRole::ToolResult => LlmMessageRole::Tool,
         };
 

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -24,9 +24,7 @@ pub enum MessageRole {
     /// User message
     User,
     /// Agent response (may contain tool calls in content)
-    /// Note: Serializes as "agent" for API consistency
-    #[serde(rename = "agent")]
-    Assistant,
+    Agent,
     /// Tool execution result
     ToolResult,
 }
@@ -36,7 +34,7 @@ impl std::fmt::Display for MessageRole {
         match self {
             MessageRole::System => write!(f, "system"),
             MessageRole::User => write!(f, "user"),
-            MessageRole::Assistant => write!(f, "agent"),
+            MessageRole::Agent => write!(f, "agent"),
             MessageRole::ToolResult => write!(f, "tool_result"),
         }
     }
@@ -48,7 +46,7 @@ impl From<&str> for MessageRole {
             "system" => MessageRole::System,
             "user" => MessageRole::User,
             // Accept both "agent" and legacy "assistant"
-            "agent" | "assistant" => MessageRole::Assistant,
+            "agent" | "assistant" => MessageRole::Agent,
             "tool_result" => MessageRole::ToolResult,
             _ => MessageRole::User,
         }
@@ -498,7 +496,7 @@ impl Message {
     pub fn assistant(content: impl Into<String>) -> Self {
         Self {
             id: MessageId::new(),
-            role: MessageRole::Assistant,
+            role: MessageRole::Agent,
             content: vec![ContentPart::text(content)],
             thinking: None,
             thinking_signature: None,
@@ -532,7 +530,7 @@ impl Message {
         }
         Self {
             id: MessageId::new(),
-            role: MessageRole::Assistant,
+            role: MessageRole::Agent,
             content: parts,
             thinking: None,
             thinking_signature: None,
@@ -661,7 +659,7 @@ impl Message {
         let role = match self.role {
             MessageRole::System => "system",
             MessageRole::User => "user",
-            MessageRole::Assistant => "assistant",
+            MessageRole::Agent => "assistant",
             MessageRole::ToolResult => "tool",
         };
 
@@ -693,7 +691,7 @@ impl Message {
         }
 
         // Handle assistant messages with tool calls
-        if self.role == MessageRole::Assistant {
+        if self.role == MessageRole::Agent {
             let tool_calls: Vec<serde_json::Value> = self
                 .content
                 .iter()
@@ -791,7 +789,7 @@ mod tests {
     #[test]
     fn test_assistant_message() {
         let msg = Message::assistant("Hi there!");
-        assert_eq!(msg.role, MessageRole::Assistant);
+        assert_eq!(msg.role, MessageRole::Agent);
         assert_eq!(msg.text(), Some("Hi there!"));
     }
 
@@ -815,7 +813,7 @@ mod tests {
         };
         let msg = Message::assistant_with_tools("Let me check the weather.", vec![tool_call]);
 
-        assert_eq!(msg.role, MessageRole::Assistant);
+        assert_eq!(msg.role, MessageRole::Agent);
         assert_eq!(msg.text(), Some("Let me check the weather."));
         assert_eq!(msg.tool_calls().len(), 1);
         assert_eq!(msg.tool_calls()[0].name, "get_weather");
@@ -832,7 +830,7 @@ mod tests {
         };
         let msg = Message::assistant_with_tools("", vec![tool_call]);
 
-        assert_eq!(msg.role, MessageRole::Assistant);
+        assert_eq!(msg.role, MessageRole::Agent);
         // Empty text should result in None, not Some("")
         assert_eq!(msg.text(), None);
         // But tool calls should still be present

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -601,6 +601,108 @@ async fn test_reason_atom_handles_llm_error() {
 }
 
 #[tokio::test]
+async fn test_reason_atom_emits_output_message_completed_on_success() {
+    use everruns_core::memory::InMemoryEventEmitter;
+
+    let (agent_store, session_store, message_retriever, provider_store, agent_id, session_id) =
+        setup_test_environment().await;
+
+    // Add a user message
+    message_retriever
+        .seed(
+            session_id.into(),
+            vec![Message::user("What is the capital of France?")],
+        )
+        .await;
+
+    // Create a driver with a fixed response
+    let driver_registry =
+        create_custom_driver_registry(LlmSimConfig::fixed("The capital of France is Paris."));
+
+    // Use an in-memory event emitter to capture events
+    let event_emitter = InMemoryEventEmitter::new();
+
+    let atom = ReasonAtom::new(
+        agent_store,
+        session_store,
+        message_retriever.clone(),
+        provider_store,
+        CapabilityRegistry::new(),
+        driver_registry,
+        event_emitter.clone(),
+    );
+
+    let context = create_context(session_id);
+    let input = ReasonInput {
+        context,
+        agent_id: agent_id.into(),
+        org_id: 0,
+        mcp_tool_definitions: vec![],
+    };
+
+    let result = atom
+        .execute(input)
+        .await
+        .expect("ReasonAtom should succeed");
+
+    assert!(result.success);
+    assert_eq!(result.text, "The capital of France is Paris.");
+
+    // Verify events were emitted
+    let events = event_emitter.events().await;
+    assert!(!events.is_empty(), "Events should have been emitted");
+
+    // Check for output.message.started event
+    let has_output_started = events
+        .iter()
+        .any(|e| e.event_type == "output.message.started");
+    assert!(
+        has_output_started,
+        "Should emit output.message.started event"
+    );
+
+    // Check for output.message.completed event (the final message)
+    let output_completed = events
+        .iter()
+        .find(|e| e.event_type == "output.message.completed");
+    assert!(
+        output_completed.is_some(),
+        "Should emit output.message.completed event on success"
+    );
+
+    // Verify the completed event has the correct message
+    if let Some(event) = output_completed {
+        if let everruns_core::EventData::OutputMessageCompleted(data) = &event.data {
+            assert_eq!(data.message.text(), Some("The capital of France is Paris."));
+            assert_eq!(data.message.role, everruns_core::MessageRole::Assistant);
+        } else {
+            panic!("Expected OutputMessageCompleted data");
+        }
+    }
+
+    // Check for reason.started and reason.completed events
+    let has_reason_started = events.iter().any(|e| e.event_type == "reason.started");
+    assert!(has_reason_started, "Should emit reason.started event");
+
+    let reason_completed = events.iter().find(|e| e.event_type == "reason.completed");
+    assert!(
+        reason_completed.is_some(),
+        "Should emit reason.completed event"
+    );
+
+    // Verify reason.completed shows success
+    if let Some(event) = reason_completed
+        && let everruns_core::EventData::ReasonCompleted(data) = &event.data
+    {
+        assert!(data.success, "reason.completed should indicate success");
+    }
+
+    // Check for llm.generation event
+    let has_llm_generation = events.iter().any(|e| e.event_type == "llm.generation");
+    assert!(has_llm_generation, "Should emit llm.generation event");
+}
+
+#[tokio::test]
 async fn test_driver_registry_integration() {
     // Verify that register_driver works with the standard DriverRegistry flow
     let mut registry = DriverRegistry::new();

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -573,7 +573,7 @@ async fn test_reason_atom_handles_llm_error() {
     // Verify an error message was stored for the user
     let messages = message_retriever.load(session_id.into()).await.unwrap();
     assert_eq!(messages.len(), 2, "Should have user + error message");
-    assert_eq!(messages[1].role, everruns_core::MessageRole::Assistant);
+    assert_eq!(messages[1].role, everruns_core::MessageRole::Agent);
     assert!(
         messages[1].text().unwrap().contains("error"),
         "Stored message should be an error message"
@@ -674,7 +674,7 @@ async fn test_reason_atom_emits_output_message_completed_on_success() {
     if let Some(event) = output_completed {
         if let everruns_core::EventData::OutputMessageCompleted(data) = &event.data {
             assert_eq!(data.message.text(), Some("The capital of France is Paris."));
-            assert_eq!(data.message.role, everruns_core::MessageRole::Assistant);
+            assert_eq!(data.message.role, everruns_core::MessageRole::Agent);
         } else {
             panic!("Expected OutputMessageCompleted data");
         }

--- a/crates/core/tests/tool_calling_test.rs
+++ b/crates/core/tests/tool_calling_test.rs
@@ -310,7 +310,7 @@ async fn test_message_retriever_preserves_tool_calls() {
     assert_eq!(loaded.len(), 1);
 
     let loaded_msg = &loaded[0];
-    assert_eq!(loaded_msg.role, MessageRole::Assistant);
+    assert_eq!(loaded_msg.role, MessageRole::Agent);
     assert_eq!(loaded_msg.text(), Some("Let me check that for you."));
 
     // Verify tool_calls are preserved - this is the key assertion
@@ -371,9 +371,9 @@ async fn test_message_retriever_full_tool_conversation() {
 
     // Verify message order and content
     assert_eq!(messages[0].role, MessageRole::User);
-    assert_eq!(messages[1].role, MessageRole::Assistant);
+    assert_eq!(messages[1].role, MessageRole::Agent);
     assert_eq!(messages[2].role, MessageRole::ToolResult);
-    assert_eq!(messages[3].role, MessageRole::Assistant);
+    assert_eq!(messages[3].role, MessageRole::Agent);
 
     // Verify the assistant message with tool calls has them preserved
     let assistant_msg = &messages[1];

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -830,7 +830,7 @@ fn parse_message_role(s: &str) -> everruns_core::MessageRole {
     match s.to_lowercase().as_str() {
         "system" => everruns_core::MessageRole::System,
         "user" => everruns_core::MessageRole::User,
-        "assistant" | "agent" => everruns_core::MessageRole::Assistant,
+        "assistant" | "agent" => everruns_core::MessageRole::Agent,
         "tool_result" => everruns_core::MessageRole::ToolResult,
         _ => everruns_core::MessageRole::User,
     }
@@ -1054,7 +1054,7 @@ mod tests {
         let thinking_content = "Let me analyze this step by step...\n\n1. First, I need to understand the problem.\n2. Then, I'll formulate a solution.".to_string();
         let message = Message {
             id: Uuid::now_v7().into(),
-            role: MessageRole::Assistant,
+            role: MessageRole::Agent,
             content: vec![ContentPart::text(
                 "Here is my response based on my analysis.",
             )],
@@ -1080,7 +1080,7 @@ mod tests {
 
         // Verify thinking field survives roundtrip
         assert_eq!(schema_message.thinking, Some(thinking_content));
-        assert_eq!(schema_message.role, MessageRole::Assistant);
+        assert_eq!(schema_message.role, MessageRole::Agent);
     }
 
     #[test]
@@ -1092,7 +1092,7 @@ mod tests {
         // Create a Message without thinking content (normal model output)
         let message = Message {
             id: Uuid::now_v7().into(),
-            role: MessageRole::Assistant,
+            role: MessageRole::Agent,
             content: vec![ContentPart::text("A simple response without thinking.")],
             thinking: None,
             thinking_signature: None,

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -679,7 +679,7 @@ impl WorkerService for WorkerServiceImpl {
                 EventContext::empty(),
                 InputMessageData::new(message.clone()),
             ),
-            MessageRole::Assistant => EventRequest::new(
+            MessageRole::Agent => EventRequest::new(
                 session_id.into(),
                 EventContext::empty(),
                 OutputMessageCompletedData::new(message.clone()),

--- a/crates/server/src/storage/message_store.rs
+++ b/crates/server/src/storage/message_store.rs
@@ -72,7 +72,7 @@ impl DbMessageRetriever {
                 EventContext::empty(),
                 InputMessageData::new(message.clone()),
             ),
-            MessageRole::Assistant => EventRequest::new(
+            MessageRole::Agent => EventRequest::new(
                 session_id,
                 EventContext::empty(),
                 OutputMessageCompletedData::new(message.clone()),
@@ -407,7 +407,7 @@ mod tests {
 
         assert!(result.is_ok());
         let parsed = result.unwrap();
-        assert_eq!(parsed.role, MessageRole::Assistant);
+        assert_eq!(parsed.role, MessageRole::Agent);
         assert_eq!(parsed.text(), Some("Hello from agent!"));
     }
 

--- a/crates/server/tests/integration_test.rs
+++ b/crates/server/tests/integration_test.rs
@@ -3745,6 +3745,41 @@ async fn test_streaming_events_emitted() {
         delta_event["data"]["accumulated"].as_str().unwrap_or("")
     );
 
+    // Check for output.message.completed event
+    let completed_events: Vec<_> = events
+        .iter()
+        .filter(|e| e["type"] == "output.message.completed")
+        .collect();
+    println!(
+        "Found {} output.message.completed events",
+        completed_events.len()
+    );
+    assert!(
+        !completed_events.is_empty(),
+        "Expected at least one output.message.completed event"
+    );
+
+    // Verify output.message.completed has required fields (message)
+    let completed_event = &completed_events[0];
+    assert!(
+        completed_event["data"]["message"].is_object(),
+        "output.message.completed should have message object"
+    );
+    assert!(
+        completed_event["data"]["message"]["role"] == "agent",
+        "output.message.completed message should have role=agent"
+    );
+    assert!(
+        completed_event["data"]["message"]["content"].is_array(),
+        "output.message.completed message should have content array"
+    );
+    println!(
+        "output.message.completed event: message_id={}",
+        completed_event["data"]["message"]["id"]
+            .as_str()
+            .unwrap_or("unknown")
+    );
+
     // Check for llm.generation event with time_to_first_token_ms
     let llm_events: Vec<_> = events
         .iter()

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -299,9 +299,8 @@ fn proto_message_to_message(proto_msg: proto::Message) -> Result<Message> {
     let role = match proto_msg.role.to_lowercase().as_str() {
         "system" => everruns_core::MessageRole::System,
         "user" => everruns_core::MessageRole::User,
-        // Map both "assistant" and "agent" to Assistant role
-        // Events store messages with role "agent" from MessageAgentData
-        "assistant" | "agent" => everruns_core::MessageRole::Assistant,
+        // Map both "assistant" (legacy) and "agent" to Agent role
+        "assistant" | "agent" => everruns_core::MessageRole::Agent,
         "tool_result" => everruns_core::MessageRole::ToolResult,
         _ => everruns_core::MessageRole::User,
     };

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -141,7 +141,7 @@ The user message is emitted immediately by the API, while the agent message and 
 
 ### Messages
 
-Messages store all conversation content (user, assistant, tool calls, tool results).
+Messages store all conversation content (user, agent, tool calls, tool results).
 
 | Method | Path | Description |
 |--------|------|-------------|

--- a/specs/braintrust-integration.md
+++ b/specs/braintrust-integration.md
@@ -233,7 +233,7 @@ Messages are converted to OpenAI-compatible format before sending to Braintrust:
 
 | Internal Role | OpenAI Role | Notes |
 |--------------|-------------|-------|
-| `agent` | `assistant` | Assistant responses |
+| `agent` | `assistant` | Agent responses (mapped to OpenAI "assistant" role) |
 | `tool_result` | `tool` | Includes `tool_call_id` at message level |
 | `system` | `system` | No change |
 | `user` | `user` | No change |

--- a/specs/events.md
+++ b/specs/events.md
@@ -266,7 +266,7 @@ Agent response message. Emitted when LLM generation completes.
   "data": {
     "message": {
       "id": "01937abc-...",
-      "role": "assistant",
+      "role": "agent",
       "content": [
         { "type": "text", "text": "Hello! How can I help?" }
       ],
@@ -960,7 +960,7 @@ Messages are reconstructed from events for the conversation view. The following 
 | Event Type | Role | Content Source |
 |------------|------|----------------|
 | `input.message` | `user` | `data.message.content` |
-| `output.message.completed` | `assistant` | `data.message.content` (may include tool calls) |
+| `output.message.completed` | `agent` | `data.message.content` (may include tool calls) |
 | `tool.completed` | `tool` | `data.result` (tool execution results) |
 
 **Note:** Tool calls are embedded in `output.message.completed` events via `ContentPart::ToolCall`. Tool results come from `tool.completed` events, not a separate message type.

--- a/specs/models.md
+++ b/specs/models.md
@@ -70,7 +70,7 @@ Conversation data stored as events in the `events` table with `event_type` prefi
 | `id` | MessageId | Typed ID with `message_` prefix (stored in event.data.message_id) |
 | `session_id` | SessionId | Parent session reference (from event.session_id) |
 | `sequence` | integer | Order within session (from event.sequence) |
-| `role` | enum | `user`, `assistant`, `tool_result` |
+| `role` | enum | `user`, `agent`, `tool_result` |
 | `content` | ContentPart[] | Array of content parts (see below) |
 | `thinking` | string? | Extended thinking content from reasoning models (Anthropic Claude) |
 | `thinking_signature` | string? | Cryptographic signature for thinking (required for multi-turn with Anthropic) |
@@ -95,7 +95,7 @@ Conversation data stored as events in the `events` table with `event_type` prefi
 // type=image_file (reference to uploaded image)
 { "type": "image_file", "image_id": "01933b5a-...", "filename": "photo.png" }
 
-// type=tool_call (assistant requesting tool execution)
+// type=tool_call (agent requesting tool execution)
 {
   "type": "tool_call",
   "id": "call_abc123",
@@ -129,7 +129,7 @@ Controls are optional and allow per-message overrides for model selection and re
 
 **Extended Thinking:**
 
-When `controls.reasoning.effort` is set, models that support extended thinking (e.g., Anthropic Claude) will generate internal reasoning before producing a response. This thinking content is stored in the `thinking` field of assistant messages.
+When `controls.reasoning.effort` is set, models that support extended thinking (e.g., Anthropic Claude) will generate internal reasoning before producing a response. This thinking content is stored in the `thinking` field of agent messages.
 
 - `thinking`: The model's chain-of-thought reasoning (can be lengthy)
 - `thinking_signature`: Cryptographic signature required by Anthropic for multi-turn conversations
@@ -169,7 +169,7 @@ Each level references a UUID that points to a configured model in the `llm_model
 }
 ```
 
-**Note:** The `message.role` field defaults to `"user"` and can be omitted. Only `user` messages can be created via the API; `assistant`, `tool_result`, and `system` messages are created internally by the system.
+**Note:** The `message.role` field defaults to `"user"` and can be omitted. Only `user` messages can be created via the API; `agent`, `tool_result`, and `system` messages are created internally by the system.
 
 **InputContentPart types (allowed in user messages):**
 
@@ -198,7 +198,7 @@ Messages are stored in the `events` table with the full content in the `data` JS
 // Event for an agent message with tool calls (event_type: "output.message.completed")
 {
   "message_id": "...",
-  "role": "assistant",
+  "role": "agent",
   "content": [
     {"type": "text", "text": "Let me search for that."},
     {"type": "tool_call", "id": "call_abc123", "name": "search", "arguments": {"query": "test"}}
@@ -380,7 +380,7 @@ User sends: "How much is 2+2?"
    → Emits Event(output.message.started)
    → LLM streams response
    → Emits Event(output.message.delta) (batched)
-   → Creates Message(role=assistant, content: { text: "The answer is 4" })
+   → Creates Message(role=agent, content: { text: "The answer is 4" })
    → Emits Event(reason.completed)
    → Emits Event(llm.generation)
    → Emits Event(output.message.completed)


### PR DESCRIPTION
## Summary

- Rename `MessageRole::Assistant` to `MessageRole::Agent` for clearer domain terminology
- Add tests for `output.message.completed` event to verify it's properly emitted during LLM generation
- Update specs to use "agent" role consistently

## Changes

**Refactoring:**
- `MessageRole::Assistant` → `MessageRole::Agent` (serializes as `"agent"` in API/events)
- Mapping preserved: `MessageRole::Agent` → `LlmMessageRole::Assistant` for LLM driver layer

**Tests:**
- Add `test_reason_atom_emits_output_message_completed_on_success` in core crate
- Add assertions for `output.message.completed` in integration test

**Docs:**
- Update specs/events.md, specs/models.md, specs/apis.md, specs/braintrust-integration.md

## Architecture

| Layer | Type | Serialized |
|-------|------|------------|
| API/Events | `MessageRole::Agent` | `"agent"` |
| LLM Drivers | `LlmMessageRole::Assistant` | `"assistant"` |

## Test plan

- [x] `cargo test -p everruns-core --test reason_atom_test test_reason_atom_emits_output_message_completed_on_success`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`