### PR TITLE
refactor(api): remove org from API paths, derive from auth context

### DIFF
--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -61,7 +61,7 @@ curl -s -o /dev/null -w "%{http_code}" http://localhost:9100
 ORG="org_00000000000000000000000000000001"
 
 # Create agent
-curl -s -X POST "http://localhost:9000/v1/orgs/$ORG/agents" \
+curl -s -X POST "http://localhost:9000/v1/agents" \
   -H "Content-Type: application/json" \
   -d '{"name": "Test", "system_prompt": "You are helpful."}' | jq '.id'
 ```

--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ curl -X POST http://localhost:8080/api/v1/agents \
   -d '{"name": "Assistant", "system_prompt": "You are a helpful assistant."}'
 
 # Create a session (agent_id in request body)
-curl -X POST http://localhost:8080/api/v1/orgs/default/sessions \
+curl -X POST http://localhost:8080/api/v1/sessions \
   -H "Content-Type: application/json" \
   -d '{"agent_id": "{agent_id}"}'
 
 # Send a message
-curl -X POST http://localhost:8080/api/v1/orgs/default/sessions/{session_id}/messages \
+curl -X POST http://localhost:8080/api/v1/sessions/{session_id}/messages \
   -H "Content-Type: application/json" \
   -d '{"message": {"role": "user", "content": [{"type": "text", "text": "Hello!"}]}}'
 ```

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/chat/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/chat/page.tsx
@@ -141,7 +141,7 @@ export default function ChatPage() {
       images: Array<{ imageId: string; filename?: string }>;
       controls?: Controls;
     }) => {
-      return sendUserMessageWithImages(org!, sessionId, text, images, controls);
+      return sendUserMessageWithImages(sessionId, text, images, controls);
     },
   });
 

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/chat/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/chat/page.tsx
@@ -24,12 +24,7 @@ import { useLlmModels, useImageAttachments } from "@/hooks";
 import { sendUserMessageWithImages } from "@/lib/api/messages";
 import { useMutation } from "@tanstack/react-query";
 import { ALLOWED_IMAGE_TYPES } from "@/lib/api/types";
-import { useOrg } from "@/providers/org-provider";
-
 export default function ChatPage() {
-  const { currentOrg } = useOrg();
-  const org = currentOrg?.public_id;
-
   const {
     agentId,
     sessionId,

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
@@ -124,7 +124,7 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
       sessionId: string;
       content: string;
       controls?: Controls;
-    }) => sendUserMessage(org!, sessionId, content, controls),
+    }) => sendUserMessage(sessionId, content, controls),
     onMutate: async ({ sessionId, content }) => {
       // Create optimistic event immediately
       const optimisticId = `optimistic-${Date.now()}`;
@@ -164,7 +164,7 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
   const cancelCurrentTurn = useMutation({
     mutationFn: async () => {
       if (!org) throw new Error("Organization not found");
-      await cancelTurn(org, sessionId);
+      await cancelTurn(sessionId);
     },
     onSuccess: () => {
       // Reset waiting state since turn is cancelled

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/storage/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/storage/page.tsx
@@ -28,10 +28,10 @@ export default function StoragePage() {
       try {
         const [keysRes, secretsRes] = await Promise.all([
           api.get<ListResponse<KeyValueInfo>>(
-            `/v1/orgs/${currentOrg.public_id}/sessions/${sessionId}/storage/keys`
+            `/v1/sessions/${sessionId}/storage/keys`
           ),
           api.get<ListResponse<SecretInfo>>(
-            `/v1/orgs/${currentOrg.public_id}/sessions/${sessionId}/storage/secrets`
+            `/v1/sessions/${sessionId}/storage/secrets`
           ),
         ]);
 

--- a/apps/ui/src/components/chat/image-attachments.tsx
+++ b/apps/ui/src/components/chat/image-attachments.tsx
@@ -10,7 +10,6 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { useOrg } from "@/providers/org-provider";
 
 interface ImageAttachmentsProps {
   images: PendingImage[];
@@ -21,15 +20,12 @@ interface ImageAttachmentsProps {
  * Component to display pending image attachments in the chat input area
  */
 export function ImageAttachments({ images, onRemove }: ImageAttachmentsProps) {
-  const { currentOrg } = useOrg();
-  const org = currentOrg?.public_id;
-
   if (images.length === 0) return null;
 
   return (
     <div className="flex flex-wrap gap-2 p-2 bg-muted/30 rounded-lg">
       {images.map((img) => (
-        <ImageAttachmentItem key={img.tempId} image={img} onRemove={onRemove} org={org} />
+        <ImageAttachmentItem key={img.tempId} image={img} onRemove={onRemove} />
       ))}
     </div>
   );
@@ -38,10 +34,9 @@ export function ImageAttachments({ images, onRemove }: ImageAttachmentsProps) {
 interface ImageAttachmentItemProps {
   image: PendingImage;
   onRemove: (tempId: string) => void;
-  org: string | undefined;
 }
 
-function ImageAttachmentItem({ image, onRemove, org }: ImageAttachmentItemProps) {
+function ImageAttachmentItem({ image, onRemove }: ImageAttachmentItemProps) {
   // Use thumbnail URL if uploaded, otherwise use object URL preview
   const displayUrl = image.imageId
     ? getThumbnailUrl(image.imageId)
@@ -96,9 +91,6 @@ interface MessageImageProps {
 }
 
 export function MessageImage({ imageId, filename }: MessageImageProps) {
-  const { currentOrg } = useOrg();
-  const org = currentOrg?.public_id;
-
   const [isOpen, setIsOpen] = useState(false);
   const thumbnailUrl = getThumbnailUrl(imageId);
   const fullImageUrl = getImageUrl(imageId);

--- a/apps/ui/src/components/chat/image-attachments.tsx
+++ b/apps/ui/src/components/chat/image-attachments.tsx
@@ -43,8 +43,8 @@ interface ImageAttachmentItemProps {
 
 function ImageAttachmentItem({ image, onRemove, org }: ImageAttachmentItemProps) {
   // Use thumbnail URL if uploaded, otherwise use object URL preview
-  const displayUrl = image.imageId && org
-    ? getThumbnailUrl(org, image.imageId)
+  const displayUrl = image.imageId
+    ? getThumbnailUrl(image.imageId)
     : image.previewUrl;
 
   return (
@@ -100,8 +100,8 @@ export function MessageImage({ imageId, filename }: MessageImageProps) {
   const org = currentOrg?.public_id;
 
   const [isOpen, setIsOpen] = useState(false);
-  const thumbnailUrl = org ? getThumbnailUrl(org, imageId) : "";
-  const fullImageUrl = org ? getImageUrl(org, imageId) : "";
+  const thumbnailUrl = getThumbnailUrl(imageId);
+  const fullImageUrl = getImageUrl(imageId);
 
   const handleDownload = () => {
     const link = document.createElement("a");

--- a/apps/ui/src/hooks/use-agents.ts
+++ b/apps/ui/src/hooks/use-agents.ts
@@ -22,7 +22,7 @@ export function useAgents() {
 
   return useQuery({
     queryKey: [...queryKeys.agents.list(), org],
-    queryFn: () => listAgents(org!),
+    queryFn: () => listAgents(),
     enabled: !!org,
   });
 }
@@ -33,7 +33,7 @@ export function useAgent(agentId: string | undefined) {
 
   return useQuery({
     queryKey: [...queryKeys.agents.detail(agentId!), org],
-    queryFn: () => getAgent(org!, agentId!),
+    queryFn: () => getAgent(agentId!),
     enabled: !!org && !!agentId,
   });
 }
@@ -44,7 +44,7 @@ export function useCreateAgent() {
   const org = currentOrg?.public_id;
 
   return useMutation({
-    mutationFn: (request: CreateAgentRequest) => createAgent(org!, request),
+    mutationFn: (request: CreateAgentRequest) => createAgent(request),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.all });
     },
@@ -53,8 +53,6 @@ export function useCreateAgent() {
 
 export function useUpdateAgent() {
   const queryClient = useQueryClient();
-  const { currentOrg } = useOrg();
-  const org = currentOrg?.public_id;
 
   return useMutation({
     mutationFn: ({
@@ -63,7 +61,7 @@ export function useUpdateAgent() {
     }: {
       agentId: string;
       request: UpdateAgentRequest;
-    }) => updateAgent(org!, agentId, request),
+    }) => updateAgent(agentId, request),
     onSuccess: (_, { agentId }) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.all });
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(agentId) });
@@ -73,11 +71,9 @@ export function useUpdateAgent() {
 
 export function useDeleteAgent() {
   const queryClient = useQueryClient();
-  const { currentOrg } = useOrg();
-  const org = currentOrg?.public_id;
 
   return useMutation({
-    mutationFn: (agentId: string) => deleteAgent(org!, agentId),
+    mutationFn: (agentId: string) => deleteAgent(agentId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.all });
     },
@@ -85,21 +81,16 @@ export function useDeleteAgent() {
 }
 
 export function useExportAgent() {
-  const { currentOrg } = useOrg();
-  const org = currentOrg?.public_id;
-
   return useMutation({
-    mutationFn: (agentId: string) => exportAgent(org!, agentId),
+    mutationFn: (agentId: string) => exportAgent(agentId),
   });
 }
 
 export function useImportAgent() {
   const queryClient = useQueryClient();
-  const { currentOrg } = useOrg();
-  const org = currentOrg?.public_id;
 
   return useMutation({
-    mutationFn: (markdown: string) => importAgent(org!, markdown),
+    mutationFn: (markdown: string) => importAgent(markdown),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.all });
     },
@@ -107,10 +98,7 @@ export function useImportAgent() {
 }
 
 export function usePreviewAgent() {
-  const { currentOrg } = useOrg();
-  const org = currentOrg?.public_id;
-
   return useMutation({
-    mutationFn: (request: PreviewAgentRequest) => previewAgent(org!, request),
+    mutationFn: (request: PreviewAgentRequest) => previewAgent(request),
   });
 }

--- a/apps/ui/src/hooks/use-agents.ts
+++ b/apps/ui/src/hooks/use-agents.ts
@@ -40,8 +40,6 @@ export function useAgent(agentId: string | undefined) {
 
 export function useCreateAgent() {
   const queryClient = useQueryClient();
-  const { currentOrg } = useOrg();
-  const org = currentOrg?.public_id;
 
   return useMutation({
     mutationFn: (request: CreateAgentRequest) => createAgent(request),

--- a/apps/ui/src/hooks/use-capabilities.ts
+++ b/apps/ui/src/hooks/use-capabilities.ts
@@ -18,7 +18,7 @@ export function useCapabilities() {
 
   return useQuery({
     queryKey: ["capabilities", org],
-    queryFn: () => listCapabilities(org!),
+    queryFn: () => listCapabilities(),
     enabled: !!org,
   });
 }
@@ -29,7 +29,7 @@ export function useCapability(capabilityId: CapabilityId | undefined) {
 
   return useQuery({
     queryKey: ["capability", capabilityId, org],
-    queryFn: () => getCapability(org!, capabilityId!),
+    queryFn: () => getCapability(capabilityId!),
     enabled: !!org && !!capabilityId,
   });
 }

--- a/apps/ui/src/hooks/use-image-attachments.ts
+++ b/apps/ui/src/hooks/use-image-attachments.ts
@@ -7,7 +7,6 @@ import {
   cleanupPendingImages,
   validateImageFile,
 } from "@/lib/api/images";
-import { useOrg } from "@/providers/org-provider";
 
 interface UseImageAttachmentsOptions {
   sessionId?: string;
@@ -26,8 +25,6 @@ interface UseImageAttachmentsOptions {
  */
 export function useImageAttachments(options: UseImageAttachmentsOptions = {}) {
   const { sessionId, maxImages = 10 } = options;
-  const { currentOrg } = useOrg();
-  const org = currentOrg?.public_id;
 
   const [pendingImages, setPendingImages] = useState<PendingImage[]>([]);
 
@@ -54,8 +51,6 @@ export function useImageAttachments(options: UseImageAttachmentsOptions = {}) {
    */
   const addFiles = useCallback(
     async (files: File[]) => {
-      if (!org) return;
-
       // Filter to only valid files
       const validFiles: File[] = [];
       const errors: string[] = [];
@@ -86,7 +81,7 @@ export function useImageAttachments(options: UseImageAttachmentsOptions = {}) {
 
       // Create pending images and start uploads
       const newPendingImages = filesToAdd.map((file) =>
-        createPendingImage(org, file, sessionId)
+        createPendingImage(file, sessionId)
       );
 
       // Add to state
@@ -127,7 +122,7 @@ export function useImageAttachments(options: UseImageAttachmentsOptions = {}) {
           });
       }
     },
-    [org, pendingImages.length, maxImages, sessionId]
+    [pendingImages.length, maxImages, sessionId]
   );
 
   /**

--- a/apps/ui/src/hooks/use-llm-providers.ts
+++ b/apps/ui/src/hooks/use-llm-providers.ts
@@ -31,7 +31,7 @@ export function useLlmProviders() {
 
   return useQuery({
     queryKey: [...queryKeys.llmProviders.list(), org],
-    queryFn: () => getLlmProviders(org!),
+    queryFn: () => getLlmProviders(),
     enabled: !!org,
     staleTime: 30000,
   });
@@ -43,18 +43,16 @@ export function useLlmProvider(providerId: string) {
 
   return useQuery({
     queryKey: [...queryKeys.llmProviders.detail(providerId), org],
-    queryFn: () => getLlmProvider(org!, providerId),
+    queryFn: () => getLlmProvider(providerId),
     enabled: !!org && !!providerId,
   });
 }
 
 export function useCreateLlmProvider() {
   const queryClient = useQueryClient();
-  const { currentOrg } = useOrg();
-  const org = currentOrg?.public_id;
 
   return useMutation({
-    mutationFn: (data: CreateLlmProviderRequest) => createLlmProvider(org!, data),
+    mutationFn: (data: CreateLlmProviderRequest) => createLlmProvider(data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.llmProviders.all });
     },
@@ -63,12 +61,10 @@ export function useCreateLlmProvider() {
 
 export function useUpdateLlmProvider(providerId: string) {
   const queryClient = useQueryClient();
-  const { currentOrg } = useOrg();
-  const org = currentOrg?.public_id;
 
   return useMutation({
     mutationFn: (data: UpdateLlmProviderRequest) =>
-      updateLlmProvider(org!, providerId, data),
+      updateLlmProvider(providerId, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.llmProviders.all });
       queryClient.invalidateQueries({ queryKey: queryKeys.llmProviders.detail(providerId) });
@@ -78,11 +74,9 @@ export function useUpdateLlmProvider(providerId: string) {
 
 export function useDeleteLlmProvider() {
   const queryClient = useQueryClient();
-  const { currentOrg } = useOrg();
-  const org = currentOrg?.public_id;
 
   return useMutation({
-    mutationFn: (providerId: string) => deleteLlmProvider(org!, providerId),
+    mutationFn: (providerId: string) => deleteLlmProvider(providerId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.llmProviders.all });
       queryClient.invalidateQueries({ queryKey: queryKeys.llmModels.all });
@@ -92,11 +86,9 @@ export function useDeleteLlmProvider() {
 
 export function useSyncProviderModels() {
   const queryClient = useQueryClient();
-  const { currentOrg } = useOrg();
-  const org = currentOrg?.public_id;
 
   return useMutation({
-    mutationFn: (providerId: string) => syncProviderModels(org!, providerId),
+    mutationFn: (providerId: string) => syncProviderModels(providerId),
     onSuccess: () => {
       // Refresh models list after sync
       queryClient.invalidateQueries({ queryKey: queryKeys.llmModels.all });
@@ -112,7 +104,7 @@ export function useLlmModels() {
 
   return useQuery({
     queryKey: [...queryKeys.llmModels.list(), org],
-    queryFn: () => getLlmModels(org!),
+    queryFn: () => getLlmModels(),
     enabled: !!org,
     staleTime: 30000,
   });
@@ -124,7 +116,7 @@ export function useLlmProviderModels(providerId: string) {
 
   return useQuery({
     queryKey: [...queryKeys.llmProviders.models(providerId), org],
-    queryFn: () => getLlmProviderModels(org!, providerId),
+    queryFn: () => getLlmProviderModels(providerId),
     enabled: !!org && !!providerId,
   });
 }
@@ -135,18 +127,16 @@ export function useLlmModel(modelId: string) {
 
   return useQuery({
     queryKey: [...queryKeys.llmModels.detail(modelId), org],
-    queryFn: () => getLlmModel(org!, modelId),
+    queryFn: () => getLlmModel(modelId),
     enabled: !!org && !!modelId,
   });
 }
 
 export function useCreateLlmModel(providerId: string) {
   const queryClient = useQueryClient();
-  const { currentOrg } = useOrg();
-  const org = currentOrg?.public_id;
 
   return useMutation({
-    mutationFn: (data: CreateLlmModelRequest) => createLlmModel(org!, providerId, data),
+    mutationFn: (data: CreateLlmModelRequest) => createLlmModel(providerId, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.llmModels.all });
       queryClient.invalidateQueries({ queryKey: queryKeys.llmProviders.models(providerId) });
@@ -156,11 +146,9 @@ export function useCreateLlmModel(providerId: string) {
 
 export function useUpdateLlmModel(modelId: string) {
   const queryClient = useQueryClient();
-  const { currentOrg } = useOrg();
-  const org = currentOrg?.public_id;
 
   return useMutation({
-    mutationFn: (data: UpdateLlmModelRequest) => updateLlmModel(org!, modelId, data),
+    mutationFn: (data: UpdateLlmModelRequest) => updateLlmModel(modelId, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.llmModels.all });
     },
@@ -169,11 +157,9 @@ export function useUpdateLlmModel(modelId: string) {
 
 export function useDeleteLlmModel() {
   const queryClient = useQueryClient();
-  const { currentOrg } = useOrg();
-  const org = currentOrg?.public_id;
 
   return useMutation({
-    mutationFn: (modelId: string) => deleteLlmModel(org!, modelId),
+    mutationFn: (modelId: string) => deleteLlmModel(modelId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.llmModels.all });
       queryClient.invalidateQueries({ queryKey: queryKeys.llmProviders.all });

--- a/apps/ui/src/hooks/use-mcp-servers.ts
+++ b/apps/ui/src/hooks/use-mcp-servers.ts
@@ -23,7 +23,7 @@ export function useMcpServers() {
 
   return useQuery({
     queryKey: [...queryKeys.mcpServers.list(), org],
-    queryFn: () => getMcpServers(org!),
+    queryFn: () => getMcpServers(),
     enabled: !!org,
     staleTime: 30000,
   });
@@ -35,18 +35,16 @@ export function useMcpServer(serverId: string) {
 
   return useQuery({
     queryKey: [...queryKeys.mcpServers.detail(serverId), org],
-    queryFn: () => getMcpServer(org!, serverId),
+    queryFn: () => getMcpServer(serverId),
     enabled: !!org && !!serverId,
   });
 }
 
 export function useCreateMcpServer() {
   const queryClient = useQueryClient();
-  const { currentOrg } = useOrg();
-  const org = currentOrg?.public_id;
 
   return useMutation({
-    mutationFn: (data: CreateMcpServerRequest) => createMcpServer(org!, data),
+    mutationFn: (data: CreateMcpServerRequest) => createMcpServer(data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.mcpServers.all });
     },
@@ -55,12 +53,10 @@ export function useCreateMcpServer() {
 
 export function useUpdateMcpServer(serverId: string) {
   const queryClient = useQueryClient();
-  const { currentOrg } = useOrg();
-  const org = currentOrg?.public_id;
 
   return useMutation({
     mutationFn: (data: UpdateMcpServerRequest) =>
-      updateMcpServer(org!, serverId, data),
+      updateMcpServer(serverId, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.mcpServers.all });
       queryClient.invalidateQueries({ queryKey: queryKeys.mcpServers.detail(serverId) });
@@ -70,11 +66,9 @@ export function useUpdateMcpServer(serverId: string) {
 
 export function useDeleteMcpServer() {
   const queryClient = useQueryClient();
-  const { currentOrg } = useOrg();
-  const org = currentOrg?.public_id;
 
   return useMutation({
-    mutationFn: (serverId: string) => deleteMcpServer(org!, serverId),
+    mutationFn: (serverId: string) => deleteMcpServer(serverId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.mcpServers.all });
     },

--- a/apps/ui/src/hooks/use-session-files.ts
+++ b/apps/ui/src/hooks/use-session-files.ts
@@ -49,7 +49,7 @@ export function useFiles(
 
   return useQuery({
     queryKey: fileKeys.list(org!, sessionId!, path, recursive),
-    queryFn: () => listFiles(org!, sessionId!, path, recursive),
+    queryFn: () => listFiles(sessionId!, path, recursive),
     enabled: !!org && !!sessionId,
   });
 }
@@ -64,7 +64,7 @@ export function useFile(
 
   return useQuery({
     queryKey: fileKeys.file(org!, sessionId!, path!),
-    queryFn: () => readFile(org!, sessionId!, path!),
+    queryFn: () => readFile(sessionId!, path!),
     enabled: !!org && !!sessionId && !!path,
   });
 }
@@ -79,7 +79,7 @@ export function useFileStat(
 
   return useQuery({
     queryKey: fileKeys.stat(org!, sessionId!, path!),
-    queryFn: () => statFile(org!, sessionId!, path!),
+    queryFn: () => statFile(sessionId!, path!),
     enabled: !!org && !!sessionId && !!path,
   });
 }
@@ -101,7 +101,7 @@ export function useCreateFile() {
     }: {
       sessionId: string;
       request: CreateFileRequest;
-    }) => createFile(org!, sessionId, request),
+    }) => createFile(sessionId, request),
     onSuccess: (_, { sessionId }) => {
       queryClient.invalidateQueries({
         queryKey: fileKeys.all(org!, sessionId),
@@ -123,7 +123,7 @@ export function useCreateDirectory() {
     }: {
       sessionId: string;
       path: string;
-    }) => mkdir(org!, sessionId, path),
+    }) => mkdir(sessionId, path),
     onSuccess: (_, { sessionId }) => {
       queryClient.invalidateQueries({
         queryKey: fileKeys.all(org!, sessionId),
@@ -147,7 +147,7 @@ export function useUpdateFile() {
       sessionId: string;
       path: string;
       request: UpdateFileRequest;
-    }) => updateFile(org!, sessionId, path, request),
+    }) => updateFile(sessionId, path, request),
     onSuccess: (_, { sessionId, path }) => {
       queryClient.invalidateQueries({
         queryKey: fileKeys.all(org!, sessionId),
@@ -174,7 +174,7 @@ export function useDeleteFile() {
       sessionId: string;
       path: string;
       recursive?: boolean;
-    }) => deleteFile(org!, sessionId, path, recursive),
+    }) => deleteFile(sessionId, path, recursive),
     onSuccess: (_, { sessionId }) => {
       queryClient.invalidateQueries({
         queryKey: fileKeys.all(org!, sessionId),
@@ -196,7 +196,7 @@ export function useMoveFile() {
     }: {
       sessionId: string;
       request: MoveFileRequest;
-    }) => moveFile(org!, sessionId, request),
+    }) => moveFile(sessionId, request),
     onSuccess: (_, { sessionId }) => {
       queryClient.invalidateQueries({
         queryKey: fileKeys.all(org!, sessionId),
@@ -218,7 +218,7 @@ export function useCopyFile() {
     }: {
       sessionId: string;
       request: CopyFileRequest;
-    }) => copyFile(org!, sessionId, request),
+    }) => copyFile(sessionId, request),
     onSuccess: (_, { sessionId }) => {
       queryClient.invalidateQueries({
         queryKey: fileKeys.all(org!, sessionId),
@@ -229,9 +229,6 @@ export function useCopyFile() {
 
 /** Search files using grep */
 export function useGrepFiles() {
-  const { currentOrg } = useOrg();
-  const org = currentOrg?.public_id;
-
   return useMutation({
     mutationFn: ({
       sessionId,
@@ -239,6 +236,6 @@ export function useGrepFiles() {
     }: {
       sessionId: string;
       request: GrepRequest;
-    }) => grepFiles(org!, sessionId, request),
+    }) => grepFiles(sessionId, request),
   });
 }

--- a/apps/ui/src/hooks/use-sessions.ts
+++ b/apps/ui/src/hooks/use-sessions.ts
@@ -52,8 +52,6 @@ export function useSession(
 
 export function useCreateSession() {
   const queryClient = useQueryClient();
-  const { currentOrg } = useOrg();
-  const org = currentOrg?.public_id;
 
   return useMutation({
     mutationFn: ({

--- a/apps/ui/src/hooks/use-sessions.ts
+++ b/apps/ui/src/hooks/use-sessions.ts
@@ -30,7 +30,7 @@ export function useSessions(
 
   return useQuery({
     queryKey: queryKeys.sessions.list(org, agentId, params?.offset ?? 0, params?.limit ?? 20),
-    queryFn: () => listSessions(org!, { ...params, agentId }),
+    queryFn: () => listSessions({ ...params, agentId }),
     enabled: !!org,
   });
 }
@@ -44,7 +44,7 @@ export function useSession(
 
   return useQuery({
     queryKey: queryKeys.sessions.detail(org, sessionId!),
-    queryFn: () => getSession(org!, sessionId!),
+    queryFn: () => getSession(sessionId!),
     enabled: !!org && !!sessionId,
     refetchInterval: options?.refetchInterval,
   });
@@ -60,7 +60,7 @@ export function useCreateSession() {
       request,
     }: {
       request: CreateSessionRequest;
-    }) => createSession(org!, request),
+    }) => createSession(request),
     onSuccess: (_, { request }) => {
       // Invalidate sessions list - both all sessions and agent-specific
       queryClient.invalidateQueries({ queryKey: queryKeys.sessions.all() });
@@ -83,7 +83,7 @@ export function useUpdateSession() {
     }: {
       sessionId: string;
       request: UpdateSessionRequest;
-    }) => updateSession(org!, sessionId, request),
+    }) => updateSession(sessionId, request),
     onSuccess: (_, { sessionId }) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.sessions.all() });
       queryClient.invalidateQueries({
@@ -95,15 +95,13 @@ export function useUpdateSession() {
 
 export function useDeleteSession() {
   const queryClient = useQueryClient();
-  const { currentOrg } = useOrg();
-  const org = currentOrg?.public_id;
 
   return useMutation({
     mutationFn: ({
       sessionId,
     }: {
       sessionId: string;
-    }) => deleteSession(org!, sessionId),
+    }) => deleteSession(sessionId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.sessions.all() });
     },
@@ -112,8 +110,6 @@ export function useDeleteSession() {
 
 export function useSendMessage() {
   const queryClient = useQueryClient();
-  const { currentOrg } = useOrg();
-  const org = currentOrg?.public_id;
 
   return useMutation({
     mutationFn: ({
@@ -124,7 +120,7 @@ export function useSendMessage() {
       sessionId: string;
       content: string;
       controls?: Controls;
-    }) => sendUserMessage(org!, sessionId, content, controls),
+    }) => sendUserMessage(sessionId, content, controls),
     onSuccess: (_, { sessionId }) => {
       // Invalidate events query to refresh the message list
       queryClient.invalidateQueries({
@@ -190,7 +186,7 @@ export function useEvents(
       // Close existing connection
       cleanup();
 
-      const sseUrl = getSseUrl(org, sessionId, lastEventIdRef.current ?? undefined);
+      const sseUrl = getSseUrl(sessionId, lastEventIdRef.current ?? undefined);
       const eventSource = new EventSource(sseUrl, { withCredentials: true });
       eventSourceRef.current = eventSource;
 

--- a/apps/ui/src/lib/api/agents.ts
+++ b/apps/ui/src/lib/api/agents.ts
@@ -1,7 +1,7 @@
 // Agent API functions (M2)
-// Org is sent via X-Org-Id header (set by OrgProvider)
+// Org is sent via everruns_org cookie (set by OrgProvider via /v1/users/me/switch-org)
 
-import { api, getCurrentOrgId } from "./client";
+import { api } from "./client";
 import type {
   Agent,
   AgentPreviewResponse,
@@ -40,15 +40,9 @@ export async function deleteAgent(agentId: string): Promise<void> {
 
 export async function exportAgent(agentId: string): Promise<string> {
   // Use fetch directly since we need to return text, not JSON
-  const headers: Record<string, string> = {};
-  const orgId = getCurrentOrgId();
-  if (orgId) {
-    headers["X-Org-Id"] = orgId;
-  }
-
+  // Org is sent via cookie automatically (credentials: "include")
   const response = await fetch(`/api/v1/agents/${agentId}/export`, {
     credentials: "include",
-    headers,
   });
   if (!response.ok) {
     throw new Error(`Export failed: ${response.statusText}`);
@@ -58,18 +52,13 @@ export async function exportAgent(agentId: string): Promise<string> {
 
 export async function importAgent(markdown: string): Promise<Agent> {
   // Use fetch directly since we need to send text/markdown content type
-  const headers: Record<string, string> = {
-    "Content-Type": "text/markdown",
-  };
-  const orgId = getCurrentOrgId();
-  if (orgId) {
-    headers["X-Org-Id"] = orgId;
-  }
-
+  // Org is sent via cookie automatically (credentials: "include")
   const response = await fetch("/api/v1/agents/import", {
     method: "POST",
     credentials: "include",
-    headers,
+    headers: {
+      "Content-Type": "text/markdown",
+    },
     body: markdown,
   });
   if (!response.ok) {

--- a/apps/ui/src/lib/api/agents.ts
+++ b/apps/ui/src/lib/api/agents.ts
@@ -1,7 +1,7 @@
 // Agent API functions (M2)
-// All routes are org-scoped: /v1/orgs/{org}/agents/...
+// Org is sent via X-Org-Id header (set by OrgProvider)
 
-import { api } from "./client";
+import { api, getCurrentOrgId } from "./client";
 import type {
   Agent,
   AgentPreviewResponse,
@@ -11,44 +11,44 @@ import type {
   ListResponse,
 } from "./types";
 
-export async function createAgent(
-  org: string,
-  request: CreateAgentRequest
-): Promise<Agent> {
-  const response = await api.post<Agent>(`/v1/orgs/${org}/agents`, request);
+export async function createAgent(request: CreateAgentRequest): Promise<Agent> {
+  const response = await api.post<Agent>("/v1/agents", request);
   return response.data;
 }
 
-export async function listAgents(org: string): Promise<Agent[]> {
-  const response = await api.get<ListResponse<Agent>>(`/v1/orgs/${org}/agents`);
+export async function listAgents(): Promise<Agent[]> {
+  const response = await api.get<ListResponse<Agent>>("/v1/agents");
   return response.data.data;
 }
 
-export async function getAgent(org: string, agentId: string): Promise<Agent> {
-  const response = await api.get<Agent>(`/v1/orgs/${org}/agents/${agentId}`);
+export async function getAgent(agentId: string): Promise<Agent> {
+  const response = await api.get<Agent>(`/v1/agents/${agentId}`);
   return response.data;
 }
 
 export async function updateAgent(
-  org: string,
   agentId: string,
   request: UpdateAgentRequest
 ): Promise<Agent> {
-  const response = await api.patch<Agent>(
-    `/v1/orgs/${org}/agents/${agentId}`,
-    request
-  );
+  const response = await api.patch<Agent>(`/v1/agents/${agentId}`, request);
   return response.data;
 }
 
-export async function deleteAgent(org: string, agentId: string): Promise<void> {
-  await api.delete(`/v1/orgs/${org}/agents/${agentId}`);
+export async function deleteAgent(agentId: string): Promise<void> {
+  await api.delete(`/v1/agents/${agentId}`);
 }
 
-export async function exportAgent(org: string, agentId: string): Promise<string> {
+export async function exportAgent(agentId: string): Promise<string> {
   // Use fetch directly since we need to return text, not JSON
-  const response = await fetch(`/api/v1/orgs/${org}/agents/${agentId}/export`, {
+  const headers: Record<string, string> = {};
+  const orgId = getCurrentOrgId();
+  if (orgId) {
+    headers["X-Org-Id"] = orgId;
+  }
+
+  const response = await fetch(`/api/v1/agents/${agentId}/export`, {
     credentials: "include",
+    headers,
   });
   if (!response.ok) {
     throw new Error(`Export failed: ${response.statusText}`);
@@ -56,14 +56,20 @@ export async function exportAgent(org: string, agentId: string): Promise<string>
   return response.text();
 }
 
-export async function importAgent(org: string, markdown: string): Promise<Agent> {
+export async function importAgent(markdown: string): Promise<Agent> {
   // Use fetch directly since we need to send text/markdown content type
-  const response = await fetch(`/api/v1/orgs/${org}/agents/import`, {
+  const headers: Record<string, string> = {
+    "Content-Type": "text/markdown",
+  };
+  const orgId = getCurrentOrgId();
+  if (orgId) {
+    headers["X-Org-Id"] = orgId;
+  }
+
+  const response = await fetch("/api/v1/agents/import", {
     method: "POST",
     credentials: "include",
-    headers: {
-      "Content-Type": "text/markdown",
-    },
+    headers,
     body: markdown,
   });
   if (!response.ok) {
@@ -74,11 +80,10 @@ export async function importAgent(org: string, markdown: string): Promise<Agent>
 }
 
 export async function previewAgent(
-  org: string,
   request: PreviewAgentRequest
 ): Promise<AgentPreviewResponse> {
   const response = await api.post<AgentPreviewResponse>(
-    `/v1/orgs/${org}/agents/preview`,
+    "/v1/agents/preview",
     request
   );
   return response.data;

--- a/apps/ui/src/lib/api/capabilities.ts
+++ b/apps/ui/src/lib/api/capabilities.ts
@@ -1,5 +1,5 @@
 // Capability API functions
-// Org is sent via X-Org-Id header (set by OrgProvider)
+// Org is sent via everruns_org cookie (set by OrgProvider via /v1/users/me/switch-org)
 //
 // Note: Agent-specific capabilities are managed through the agents API.
 // See agents.ts for createAgent/updateAgent with capabilities.

--- a/apps/ui/src/lib/api/capabilities.ts
+++ b/apps/ui/src/lib/api/capabilities.ts
@@ -1,5 +1,5 @@
 // Capability API functions
-// All routes are org-scoped: /v1/orgs/{org}/capabilities/...
+// Org is sent via X-Org-Id header (set by OrgProvider)
 //
 // Note: Agent-specific capabilities are managed through the agents API.
 // See agents.ts for createAgent/updateAgent with capabilities.
@@ -11,17 +11,16 @@ import type {
   ListResponse,
 } from "./types";
 
-export async function listCapabilities(org: string): Promise<Capability[]> {
-  const response = await api.get<ListResponse<Capability>>(`/v1/orgs/${org}/capabilities`);
+export async function listCapabilities(): Promise<Capability[]> {
+  const response = await api.get<ListResponse<Capability>>("/v1/capabilities");
   return response.data.data;
 }
 
 export async function getCapability(
-  org: string,
   capabilityId: CapabilityId
 ): Promise<Capability> {
   const response = await api.get<Capability>(
-    `/v1/orgs/${org}/capabilities/${capabilityId}`
+    `/v1/capabilities/${capabilityId}`
   );
   return response.data;
 }

--- a/apps/ui/src/lib/api/client.ts
+++ b/apps/ui/src/lib/api/client.ts
@@ -4,6 +4,24 @@
 // - Handled by reverse proxy in production (strips /api, forwards to backend)
 const API_BASE = "/api";
 
+// Current organization ID for X-Org-Id header injection
+let currentOrgId: string | null = null;
+
+/**
+ * Set the current organization ID for API requests.
+ * All subsequent API requests will include X-Org-Id header with this value.
+ */
+export function setCurrentOrgId(orgId: string | null): void {
+  currentOrgId = orgId;
+}
+
+/**
+ * Get the current organization ID.
+ */
+export function getCurrentOrgId(): string | null {
+  return currentOrgId;
+}
+
 export class ApiError extends Error {
   constructor(
     public status: number,
@@ -19,13 +37,21 @@ async function request<T>(
   endpoint: string,
   options: RequestInit = {}
 ): Promise<{ data: T }> {
+  // Build headers with optional X-Org-Id
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...(options.headers as Record<string, string>),
+  };
+
+  // Inject X-Org-Id header if org is set
+  if (currentOrgId) {
+    headers["X-Org-Id"] = currentOrgId;
+  }
+
   const response = await fetch(`${API_BASE}${endpoint}`, {
     ...options,
     credentials: "include", // Include cookies for auth
-    headers: {
-      "Content-Type": "application/json",
-      ...options.headers,
-    },
+    headers,
   });
 
   if (!response.ok) {

--- a/apps/ui/src/lib/api/client.ts
+++ b/apps/ui/src/lib/api/client.ts
@@ -4,23 +4,9 @@
 // - Handled by reverse proxy in production (strips /api, forwards to backend)
 const API_BASE = "/api";
 
-// Current organization ID for X-Org-Id header injection
-let currentOrgId: string | null = null;
-
-/**
- * Set the current organization ID for API requests.
- * All subsequent API requests will include X-Org-Id header with this value.
- */
-export function setCurrentOrgId(orgId: string | null): void {
-  currentOrgId = orgId;
-}
-
-/**
- * Get the current organization ID.
- */
-export function getCurrentOrgId(): string | null {
-  return currentOrgId;
-}
+// Org selection is handled via server-side cookie (everruns_org), set by
+// POST /v1/users/me/switch-org. This works automatically with all requests
+// including SSE (EventSource) because cookies are sent automatically.
 
 export class ApiError extends Error {
   constructor(
@@ -37,20 +23,14 @@ async function request<T>(
   endpoint: string,
   options: RequestInit = {}
 ): Promise<{ data: T }> {
-  // Build headers with optional X-Org-Id
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     ...(options.headers as Record<string, string>),
   };
 
-  // Inject X-Org-Id header if org is set
-  if (currentOrgId) {
-    headers["X-Org-Id"] = currentOrgId;
-  }
-
   const response = await fetch(`${API_BASE}${endpoint}`, {
     ...options,
-    credentials: "include", // Include cookies for auth
+    credentials: "include", // Include cookies for auth (access_token, everruns_org)
     headers,
   });
 

--- a/apps/ui/src/lib/api/events.ts
+++ b/apps/ui/src/lib/api/events.ts
@@ -1,8 +1,8 @@
 // Event API functions
 // Events are SSE notifications for real-time updates
-// Org is sent via X-Org-Id header (set by OrgProvider)
+// Org is sent via everruns_org cookie (set by OrgProvider via /v1/users/me/switch-org)
 
-import { api, getDirectBackendUrl, getCurrentOrgId } from "./client";
+import { api, getDirectBackendUrl } from "./client";
 import type { Event, ListResponse } from "./types";
 
 // Default event types to exclude in UI contexts (streaming delta events are noise)
@@ -34,7 +34,7 @@ export async function listEvents(
 // Uses direct backend URL to bypass Next.js proxy (proxies buffer SSE)
 // Uses since_id for incremental updates (UUID v7 monotonically increasing)
 // Optional exclude parameter to filter out event types (e.g., delta events)
-// Note: X-Org-Id header must be set via EventSource headers or query param
+// Note: Org is sent via everruns_org cookie (EventSource sends cookies automatically)
 export function getSseUrl(
   sessionId: string,
   sinceId?: string,
@@ -49,11 +49,6 @@ export function getSseUrl(
     for (const type of exclude) {
       params.append("exclude", type);
     }
-  }
-  // Include org ID as query param for SSE (EventSource doesn't support custom headers)
-  const orgId = getCurrentOrgId();
-  if (orgId) {
-    params.set("org_id", orgId);
   }
   const queryString = params.toString();
   return `${baseUrl}/v1/sessions/${sessionId}/sse${queryString ? `?${queryString}` : ""}`;

--- a/apps/ui/src/lib/api/events.ts
+++ b/apps/ui/src/lib/api/events.ts
@@ -1,8 +1,8 @@
 // Event API functions
 // Events are SSE notifications for real-time updates
-// All routes are org-scoped: /v1/orgs/{org}/sessions/{sessionId}/events
+// Org is sent via X-Org-Id header (set by OrgProvider)
 
-import { api, getDirectBackendUrl } from "./client";
+import { api, getDirectBackendUrl, getCurrentOrgId } from "./client";
 import type { Event, ListResponse } from "./types";
 
 // Default event types to exclude in UI contexts (streaming delta events are noise)
@@ -14,7 +14,6 @@ export const DEFAULT_EXCLUDED_EVENTS = [
 // List events for a session (polling alternative to SSE)
 // Optional exclude parameter to filter out event types (e.g., delta events)
 export async function listEvents(
-  org: string,
   sessionId: string,
   exclude?: string[]
 ): Promise<Event[]> {
@@ -26,7 +25,7 @@ export async function listEvents(
   }
   const queryString = params.toString();
   const response = await api.get<ListResponse<Event>>(
-    `/v1/orgs/${org}/sessions/${sessionId}/events${queryString ? `?${queryString}` : ""}`
+    `/v1/sessions/${sessionId}/events${queryString ? `?${queryString}` : ""}`
   );
   return response.data.data;
 }
@@ -35,8 +34,8 @@ export async function listEvents(
 // Uses direct backend URL to bypass Next.js proxy (proxies buffer SSE)
 // Uses since_id for incremental updates (UUID v7 monotonically increasing)
 // Optional exclude parameter to filter out event types (e.g., delta events)
+// Note: X-Org-Id header must be set via EventSource headers or query param
 export function getSseUrl(
-  org: string,
   sessionId: string,
   sinceId?: string,
   exclude?: string[]
@@ -51,6 +50,11 @@ export function getSseUrl(
       params.append("exclude", type);
     }
   }
+  // Include org ID as query param for SSE (EventSource doesn't support custom headers)
+  const orgId = getCurrentOrgId();
+  if (orgId) {
+    params.set("org_id", orgId);
+  }
   const queryString = params.toString();
-  return `${baseUrl}/v1/orgs/${org}/sessions/${sessionId}/sse${queryString ? `?${queryString}` : ""}`;
+  return `${baseUrl}/v1/sessions/${sessionId}/sse${queryString ? `?${queryString}` : ""}`;
 }

--- a/apps/ui/src/lib/api/images.ts
+++ b/apps/ui/src/lib/api/images.ts
@@ -1,10 +1,10 @@
 // Image upload API
-// Org is sent via X-Org-Id header (set by OrgProvider)
+// Org is sent via everruns_org cookie (set by OrgProvider via /v1/users/me/switch-org)
 //
 // API functions for uploading, retrieving, and deleting images.
 // Images can be attached to messages as image_file content parts.
 
-import { getApiBaseUrl, getDirectBackendUrl, getCurrentOrgId } from "./client";
+import { getApiBaseUrl, getDirectBackendUrl } from "./client";
 import type { ImageUploadResponse, ImageInfo } from "./types";
 import { ALLOWED_IMAGE_TYPES, MAX_IMAGE_SIZE } from "./types";
 
@@ -58,18 +58,11 @@ export async function uploadImage(
   const params = sessionId ? `?session_id=${sessionId}` : "";
   const url = `${baseUrl}/v1/images${params}`;
 
-  // Build headers with X-Org-Id
-  const headers: Record<string, string> = {};
-  const orgId = getCurrentOrgId();
-  if (orgId) {
-    headers["X-Org-Id"] = orgId;
-  }
-
+  // Org is sent via cookie automatically (credentials: "include")
   const response = await fetch(url, {
     method: "POST",
     body: formData,
-    headers,
-    credentials: "include", // Include cookies for auth
+    credentials: "include", // Include cookies for auth (access_token, everruns_org)
   });
 
   if (!response.ok) {
@@ -98,17 +91,10 @@ export function getThumbnailUrl(imageId: string): string {
  * Delete an image
  */
 export async function deleteImage(imageId: string): Promise<void> {
-  // Build headers with X-Org-Id
-  const headers: Record<string, string> = {};
-  const orgId = getCurrentOrgId();
-  if (orgId) {
-    headers["X-Org-Id"] = orgId;
-  }
-
+  // Org is sent via cookie automatically (credentials: "include")
   const response = await fetch(`${getApiBaseUrl()}/v1/images/${imageId}`, {
     method: "DELETE",
-    headers,
-    credentials: "include",
+    credentials: "include", // Include cookies for auth (access_token, everruns_org)
   });
 
   if (!response.ok) {
@@ -124,16 +110,10 @@ export async function listImages(
   limit: number = 50,
   offset: number = 0
 ): Promise<ImageInfo[]> {
-  // Build headers with X-Org-Id
-  const headers: Record<string, string> = {};
-  const orgId = getCurrentOrgId();
-  if (orgId) {
-    headers["X-Org-Id"] = orgId;
-  }
-
+  // Org is sent via cookie automatically (credentials: "include")
   const response = await fetch(
     `${getApiBaseUrl()}/v1/images?limit=${limit}&offset=${offset}`,
-    { headers, credentials: "include" }
+    { credentials: "include" } // Include cookies for auth (access_token, everruns_org)
   );
 
   if (!response.ok) {

--- a/apps/ui/src/lib/api/images.ts
+++ b/apps/ui/src/lib/api/images.ts
@@ -1,10 +1,10 @@
 // Image upload API
-// All routes are org-scoped: /v1/orgs/{org}/images/...
+// Org is sent via X-Org-Id header (set by OrgProvider)
 //
 // API functions for uploading, retrieving, and deleting images.
 // Images can be attached to messages as image_file content parts.
 
-import { getApiBaseUrl, getDirectBackendUrl } from "./client";
+import { getApiBaseUrl, getDirectBackendUrl, getCurrentOrgId } from "./client";
 import type { ImageUploadResponse, ImageInfo } from "./types";
 import { ALLOWED_IMAGE_TYPES, MAX_IMAGE_SIZE } from "./types";
 
@@ -42,12 +42,10 @@ function formatBytes(bytes: number): string {
 
 /**
  * Upload an image file
- * @param org - Organization public ID
  * @param file - Image file to upload
  * @param sessionId - Optional: session ID stored as metadata for tracking (not required)
  */
 export async function uploadImage(
-  org: string,
   file: File,
   sessionId?: string
 ): Promise<ImageUploadResponse> {
@@ -58,11 +56,19 @@ export async function uploadImage(
   // Next.js rewrites don't handle streaming/multipart properly (causes EPIPE errors)
   const baseUrl = getDirectBackendUrl();
   const params = sessionId ? `?session_id=${sessionId}` : "";
-  const url = `${baseUrl}/v1/orgs/${org}/images${params}`;
+  const url = `${baseUrl}/v1/images${params}`;
+
+  // Build headers with X-Org-Id
+  const headers: Record<string, string> = {};
+  const orgId = getCurrentOrgId();
+  if (orgId) {
+    headers["X-Org-Id"] = orgId;
+  }
 
   const response = await fetch(url, {
     method: "POST",
     body: formData,
+    headers,
     credentials: "include", // Include cookies for auth
   });
 
@@ -77,23 +83,32 @@ export async function uploadImage(
 /**
  * Get image URL for display (original size)
  */
-export function getImageUrl(org: string, imageId: string): string {
-  return `${getApiBaseUrl()}/v1/orgs/${org}/images/${imageId}`;
+export function getImageUrl(imageId: string): string {
+  return `${getApiBaseUrl()}/v1/images/${imageId}`;
 }
 
 /**
  * Get thumbnail URL for display
  */
-export function getThumbnailUrl(org: string, imageId: string): string {
-  return `${getApiBaseUrl()}/v1/orgs/${org}/images/${imageId}/thumbnail`;
+export function getThumbnailUrl(imageId: string): string {
+  return `${getApiBaseUrl()}/v1/images/${imageId}/thumbnail`;
 }
 
 /**
  * Delete an image
  */
-export async function deleteImage(org: string, imageId: string): Promise<void> {
-  const response = await fetch(`${getApiBaseUrl()}/v1/orgs/${org}/images/${imageId}`, {
+export async function deleteImage(imageId: string): Promise<void> {
+  // Build headers with X-Org-Id
+  const headers: Record<string, string> = {};
+  const orgId = getCurrentOrgId();
+  if (orgId) {
+    headers["X-Org-Id"] = orgId;
+  }
+
+  const response = await fetch(`${getApiBaseUrl()}/v1/images/${imageId}`, {
     method: "DELETE",
+    headers,
+    credentials: "include",
   });
 
   if (!response.ok) {
@@ -106,12 +121,19 @@ export async function deleteImage(org: string, imageId: string): Promise<void> {
  * List images
  */
 export async function listImages(
-  org: string,
   limit: number = 50,
   offset: number = 0
 ): Promise<ImageInfo[]> {
+  // Build headers with X-Org-Id
+  const headers: Record<string, string> = {};
+  const orgId = getCurrentOrgId();
+  if (orgId) {
+    headers["X-Org-Id"] = orgId;
+  }
+
   const response = await fetch(
-    `${getApiBaseUrl()}/v1/orgs/${org}/images?limit=${limit}&offset=${offset}`
+    `${getApiBaseUrl()}/v1/images?limit=${limit}&offset=${offset}`,
+    { headers, credentials: "include" }
   );
 
   if (!response.ok) {
@@ -146,15 +168,14 @@ export interface PendingImage {
 
 /**
  * Create a pending image from a file
- * @param org - Organization public ID
  * @param file - Image file to upload
  * @param sessionId - Optional: session ID stored as metadata for tracking (not required)
  */
-export function createPendingImage(org: string, file: File, sessionId?: string): PendingImage {
+export function createPendingImage(file: File, sessionId?: string): PendingImage {
   const tempId = crypto.randomUUID();
   const previewUrl = URL.createObjectURL(file);
 
-  const uploadPromise = uploadImage(org, file, sessionId);
+  const uploadPromise = uploadImage(file, sessionId);
 
   return {
     tempId,

--- a/apps/ui/src/lib/api/llm-providers.ts
+++ b/apps/ui/src/lib/api/llm-providers.ts
@@ -1,5 +1,5 @@
 // LLM Provider and Model API functions
-// All routes are org-scoped: /v1/orgs/{org}/llm-providers/... and /v1/orgs/{org}/llm-models/...
+// Org is sent via X-Org-Id header (set by OrgProvider)
 
 import { api } from "./client";
 import type {
@@ -15,84 +15,78 @@ import type {
 } from "./types";
 
 // Provider CRUD
-export async function getLlmProviders(org: string): Promise<LlmProvider[]> {
-  const response = await api.get<ListResponse<LlmProvider>>(`/v1/orgs/${org}/llm-providers`);
+export async function getLlmProviders(): Promise<LlmProvider[]> {
+  const response = await api.get<ListResponse<LlmProvider>>("/v1/llm-providers");
   return response.data.data;
 }
 
-export async function getLlmProvider(org: string, providerId: string): Promise<LlmProvider> {
-  const response = await api.get<LlmProvider>(`/v1/orgs/${org}/llm-providers/${providerId}`);
+export async function getLlmProvider(providerId: string): Promise<LlmProvider> {
+  const response = await api.get<LlmProvider>(`/v1/llm-providers/${providerId}`);
   return response.data;
 }
 
 export async function createLlmProvider(
-  org: string,
   data: CreateLlmProviderRequest
 ): Promise<LlmProvider> {
-  const response = await api.post<LlmProvider>(`/v1/orgs/${org}/llm-providers`, data);
+  const response = await api.post<LlmProvider>("/v1/llm-providers", data);
   return response.data;
 }
 
 export async function updateLlmProvider(
-  org: string,
   providerId: string,
   data: UpdateLlmProviderRequest
 ): Promise<LlmProvider> {
-  const response = await api.patch<LlmProvider>(`/v1/orgs/${org}/llm-providers/${providerId}`, data);
+  const response = await api.patch<LlmProvider>(`/v1/llm-providers/${providerId}`, data);
   return response.data;
 }
 
-export async function deleteLlmProvider(org: string, providerId: string): Promise<void> {
-  await api.delete(`/v1/orgs/${org}/llm-providers/${providerId}`);
+export async function deleteLlmProvider(providerId: string): Promise<void> {
+  await api.delete(`/v1/llm-providers/${providerId}`);
 }
 
 export async function syncProviderModels(
-  org: string,
   providerId: string
 ): Promise<SyncModelsResponse> {
   const response = await api.post<SyncModelsResponse>(
-    `/v1/orgs/${org}/llm-providers/${providerId}/sync-models`
+    `/v1/llm-providers/${providerId}/sync-models`
   );
   return response.data;
 }
 
 // Model CRUD
-export async function getLlmModels(org: string): Promise<LlmModelWithProvider[]> {
-  const response = await api.get<ListResponse<LlmModelWithProvider>>(`/v1/orgs/${org}/llm-models`);
+export async function getLlmModels(): Promise<LlmModelWithProvider[]> {
+  const response = await api.get<ListResponse<LlmModelWithProvider>>("/v1/llm-models");
   return response.data.data;
 }
 
 export async function getLlmProviderModels(
-  org: string,
   providerId: string
 ): Promise<LlmModel[]> {
-  const response = await api.get<ListResponse<LlmModel>>(`/v1/orgs/${org}/llm-providers/${providerId}/models`);
+  const response = await api.get<ListResponse<LlmModel>>(`/v1/llm-providers/${providerId}/models`);
   return response.data.data;
 }
 
-export async function getLlmModel(org: string, modelId: string): Promise<LlmModelWithProvider> {
-  const response = await api.get<LlmModelWithProvider>(`/v1/orgs/${org}/llm-models/${modelId}`);
+export async function getLlmModel(modelId: string): Promise<LlmModelWithProvider> {
+  const response = await api.get<LlmModelWithProvider>(`/v1/llm-models/${modelId}`);
   return response.data;
 }
 
 export async function createLlmModel(
-  org: string,
   providerId: string,
   data: CreateLlmModelRequest
 ): Promise<LlmModel> {
-  const response = await api.post<LlmModel>(`/v1/orgs/${org}/llm-providers/${providerId}/models`, data);
+  const response = await api.post<LlmModel>(`/v1/llm-providers/${providerId}/models`, data);
   return response.data;
 }
 
 export async function updateLlmModel(
-  org: string,
   modelId: string,
   data: UpdateLlmModelRequest
 ): Promise<LlmModel> {
-  const response = await api.patch<LlmModel>(`/v1/orgs/${org}/llm-models/${modelId}`, data);
+  const response = await api.patch<LlmModel>(`/v1/llm-models/${modelId}`, data);
   return response.data;
 }
 
-export async function deleteLlmModel(org: string, modelId: string): Promise<void> {
-  await api.delete(`/v1/orgs/${org}/llm-models/${modelId}`);
+export async function deleteLlmModel(modelId: string): Promise<void> {
+  await api.delete(`/v1/llm-models/${modelId}`);
 }

--- a/apps/ui/src/lib/api/llm-providers.ts
+++ b/apps/ui/src/lib/api/llm-providers.ts
@@ -1,5 +1,5 @@
 // LLM Provider and Model API functions
-// Org is sent via X-Org-Id header (set by OrgProvider)
+// Org is sent via everruns_org cookie (set by OrgProvider via /v1/users/me/switch-org)
 
 import { api } from "./client";
 import type {

--- a/apps/ui/src/lib/api/mcp-servers.ts
+++ b/apps/ui/src/lib/api/mcp-servers.ts
@@ -1,5 +1,5 @@
 // MCP Server API functions
-// All routes are org-scoped: /v1/orgs/{org}/mcp-servers/...
+// Org is sent via X-Org-Id header (set by OrgProvider)
 
 import { api } from "./client";
 import type {
@@ -11,33 +11,31 @@ import type {
 
 // MCP Server CRUD
 
-export async function getMcpServers(org: string): Promise<McpServer[]> {
-  const response = await api.get<ListResponse<McpServer>>(`/v1/orgs/${org}/mcp-servers`);
+export async function getMcpServers(): Promise<McpServer[]> {
+  const response = await api.get<ListResponse<McpServer>>("/v1/mcp-servers");
   return response.data.data;
 }
 
-export async function getMcpServer(org: string, serverId: string): Promise<McpServer> {
-  const response = await api.get<McpServer>(`/v1/orgs/${org}/mcp-servers/${serverId}`);
+export async function getMcpServer(serverId: string): Promise<McpServer> {
+  const response = await api.get<McpServer>(`/v1/mcp-servers/${serverId}`);
   return response.data;
 }
 
 export async function createMcpServer(
-  org: string,
   data: CreateMcpServerRequest
 ): Promise<McpServer> {
-  const response = await api.post<McpServer>(`/v1/orgs/${org}/mcp-servers`, data);
+  const response = await api.post<McpServer>("/v1/mcp-servers", data);
   return response.data;
 }
 
 export async function updateMcpServer(
-  org: string,
   serverId: string,
   data: UpdateMcpServerRequest
 ): Promise<McpServer> {
-  const response = await api.patch<McpServer>(`/v1/orgs/${org}/mcp-servers/${serverId}`, data);
+  const response = await api.patch<McpServer>(`/v1/mcp-servers/${serverId}`, data);
   return response.data;
 }
 
-export async function deleteMcpServer(org: string, serverId: string): Promise<void> {
-  await api.delete(`/v1/orgs/${org}/mcp-servers/${serverId}`);
+export async function deleteMcpServer(serverId: string): Promise<void> {
+  await api.delete(`/v1/mcp-servers/${serverId}`);
 }

--- a/apps/ui/src/lib/api/mcp-servers.ts
+++ b/apps/ui/src/lib/api/mcp-servers.ts
@@ -1,5 +1,5 @@
 // MCP Server API functions
-// Org is sent via X-Org-Id header (set by OrgProvider)
+// Org is sent via everruns_org cookie (set by OrgProvider via /v1/users/me/switch-org)
 
 import { api } from "./client";
 import type {

--- a/apps/ui/src/lib/api/messages.ts
+++ b/apps/ui/src/lib/api/messages.ts
@@ -1,5 +1,5 @@
 // Message API functions
-// Org is sent via X-Org-Id header (set by OrgProvider)
+// Org is sent via everruns_org cookie (set by OrgProvider via /v1/users/me/switch-org)
 
 import { api } from "./client";
 import type {

--- a/apps/ui/src/lib/api/messages.ts
+++ b/apps/ui/src/lib/api/messages.ts
@@ -1,5 +1,5 @@
 // Message API functions
-// All routes are org-scoped: /v1/orgs/{org}/sessions/{sessionId}/messages
+// Org is sent via X-Org-Id header (set by OrgProvider)
 
 import { api } from "./client";
 import type {
@@ -10,35 +10,30 @@ import type {
 } from "./types";
 
 export async function createMessage(
-  org: string,
   sessionId: string,
   request: CreateMessageRequest
 ): Promise<Message> {
   const response = await api.post<Message>(
-    `/v1/orgs/${org}/sessions/${sessionId}/messages`,
+    `/v1/sessions/${sessionId}/messages`,
     request
   );
   return response.data;
 }
 
-export async function listMessages(
-  org: string,
-  sessionId: string
-): Promise<Message[]> {
+export async function listMessages(sessionId: string): Promise<Message[]> {
   const response = await api.get<ListResponse<Message>>(
-    `/v1/orgs/${org}/sessions/${sessionId}/messages`
+    `/v1/sessions/${sessionId}/messages`
   );
   return response.data.data;
 }
 
 // Send a user message to a session (triggers workflow)
 export async function sendUserMessage(
-  org: string,
   sessionId: string,
   content: string,
   controls?: Controls
 ): Promise<Message> {
-  return createMessage(org, sessionId, {
+  return createMessage(sessionId, {
     message: {
       role: "user",
       content: [{ type: "text", text: content }],
@@ -57,7 +52,6 @@ export interface ImageAttachment {
  * Send a user message with optional image attachments
  */
 export async function sendUserMessageWithImages(
-  org: string,
   sessionId: string,
   text: string,
   images: ImageAttachment[],
@@ -79,7 +73,7 @@ export async function sendUserMessageWithImages(
     });
   }
 
-  return createMessage(org, sessionId, {
+  return createMessage(sessionId, {
     message: {
       role: "user",
       content,

--- a/apps/ui/src/lib/api/session-files.ts
+++ b/apps/ui/src/lib/api/session-files.ts
@@ -1,5 +1,5 @@
 // Session Files (Virtual Filesystem) API functions
-// Org is sent via X-Org-Id header (set by OrgProvider)
+// Org is sent via everruns_org cookie (set by OrgProvider via /v1/users/me/switch-org)
 //
 // RESTful API design:
 // - GET    /fs/{path}  - Read file or list directory

--- a/apps/ui/src/lib/api/session-files.ts
+++ b/apps/ui/src/lib/api/session-files.ts
@@ -1,5 +1,5 @@
 // Session Files (Virtual Filesystem) API functions
-// All routes are org-scoped: /v1/orgs/{org}/sessions/{sessionId}/fs/...
+// Org is sent via X-Org-Id header (set by OrgProvider)
 //
 // RESTful API design:
 // - GET    /fs/{path}  - Read file or list directory
@@ -27,8 +27,8 @@ import type {
 } from "./types";
 
 // Base path for filesystem
-function fsPath(org: string, sessionId: string, path?: string): string {
-  const base = `/v1/orgs/${org}/sessions/${sessionId}/fs`;
+function fsPath(sessionId: string, path?: string): string {
+  const base = `/v1/sessions/${sessionId}/fs`;
   if (!path || path === "/") return base;
   // Ensure path doesn't have double slashes
   const normalizedPath = path.startsWith("/") ? path.slice(1) : path;
@@ -41,27 +41,25 @@ function fsPath(org: string, sessionId: string, path?: string): string {
 
 /** List files in a directory */
 export async function listFiles(
-  org: string,
   sessionId: string,
   path: string = "/",
   recursive: boolean = false
 ): Promise<FileInfo[]> {
   const url = recursive
-    ? `${fsPath(org, sessionId, path)}?recursive=true`
-    : fsPath(org, sessionId, path);
+    ? `${fsPath(sessionId, path)}?recursive=true`
+    : fsPath(sessionId, path);
   const response = await api.get<ListResponse<FileInfo>>(url);
   return response.data.data;
 }
 
 /** Create a new file */
 export async function createFile(
-  org: string,
   sessionId: string,
   request: CreateFileRequest
 ): Promise<SessionFile> {
   const { path, ...body } = request;
   const response = await api.post<SessionFile>(
-    fsPath(org, sessionId, path),
+    fsPath(sessionId, path),
     body
   );
   return response.data;
@@ -69,25 +67,23 @@ export async function createFile(
 
 /** Read a file */
 export async function readFile(
-  org: string,
   sessionId: string,
   path: string
 ): Promise<SessionFile> {
   const response = await api.get<SessionFile>(
-    fsPath(org, sessionId, path)
+    fsPath(sessionId, path)
   );
   return response.data;
 }
 
 /** Update a file */
 export async function updateFile(
-  org: string,
   sessionId: string,
   path: string,
   request: UpdateFileRequest
 ): Promise<SessionFile> {
   const response = await api.put<SessionFile>(
-    fsPath(org, sessionId, path),
+    fsPath(sessionId, path),
     request
   );
   return response.data;
@@ -95,12 +91,11 @@ export async function updateFile(
 
 /** Get file stat (metadata) */
 export async function statFile(
-  org: string,
   sessionId: string,
   path: string
 ): Promise<FileStat> {
   const response = await api.post<FileStat>(
-    `/v1/orgs/${org}/sessions/${sessionId}/fs/_/stat`,
+    `/v1/sessions/${sessionId}/fs/_/stat`,
     { path }
   );
   return response.data;
@@ -108,14 +103,13 @@ export async function statFile(
 
 /** Delete a file or directory */
 export async function deleteFile(
-  org: string,
   sessionId: string,
   path: string,
   recursive: boolean = false
 ): Promise<boolean> {
   const url = recursive
-    ? `${fsPath(org, sessionId, path)}?recursive=true`
-    : fsPath(org, sessionId, path);
+    ? `${fsPath(sessionId, path)}?recursive=true`
+    : fsPath(sessionId, path);
   const response = await api.delete<DeleteFileResponse>(url);
   return response.data.deleted;
 }
@@ -126,12 +120,11 @@ export async function deleteFile(
 
 /** Create a directory */
 export async function mkdir(
-  org: string,
   sessionId: string,
   path: string
 ): Promise<SessionFile> {
   const response = await api.post<SessionFile>(
-    fsPath(org, sessionId, path),
+    fsPath(sessionId, path),
     { is_directory: true }
   );
   return response.data;
@@ -143,12 +136,11 @@ export async function mkdir(
 
 /** Move/rename a file or directory */
 export async function moveFile(
-  org: string,
   sessionId: string,
   request: MoveFileRequest
 ): Promise<SessionFile> {
   const response = await api.post<SessionFile>(
-    `/v1/orgs/${org}/sessions/${sessionId}/fs/_/move`,
+    `/v1/sessions/${sessionId}/fs/_/move`,
     request
   );
   return response.data;
@@ -156,12 +148,11 @@ export async function moveFile(
 
 /** Copy a file */
 export async function copyFile(
-  org: string,
   sessionId: string,
   request: CopyFileRequest
 ): Promise<SessionFile> {
   const response = await api.post<SessionFile>(
-    `/v1/orgs/${org}/sessions/${sessionId}/fs/_/copy`,
+    `/v1/sessions/${sessionId}/fs/_/copy`,
     request
   );
   return response.data;
@@ -173,12 +164,11 @@ export async function copyFile(
 
 /** Search files using grep-like pattern matching */
 export async function grepFiles(
-  org: string,
   sessionId: string,
   request: GrepRequest
 ): Promise<GrepResult[]> {
   const response = await api.post<ListResponse<GrepResult>>(
-    `/v1/orgs/${org}/sessions/${sessionId}/fs/_/grep`,
+    `/v1/sessions/${sessionId}/fs/_/grep`,
     request
   );
   return response.data.data;

--- a/apps/ui/src/lib/api/sessions.ts
+++ b/apps/ui/src/lib/api/sessions.ts
@@ -1,5 +1,5 @@
 // Session API functions
-// All routes are org-scoped: /v1/orgs/{org}/sessions/...
+// Org is sent via X-Org-Id header (set by OrgProvider)
 
 import { api } from "./client";
 import type {
@@ -23,10 +23,9 @@ export { listEvents } from "./events";
  * Sessions are direct children of organizations, with agent_id specifying which agent works in the session.
  */
 export async function createSession(
-  org: string,
   request: CreateSessionRequest
 ): Promise<Session> {
-  const response = await api.post<Session>(`/v1/orgs/${org}/sessions`, request);
+  const response = await api.post<Session>("/v1/sessions", request);
   return response.data;
 }
 
@@ -35,7 +34,6 @@ export async function createSession(
  * @param agentId - Optional filter by agent ID
  */
 export async function listSessions(
-  org: string,
   params?: PaginationParams & { agentId?: string }
 ): Promise<PaginatedResponse<Session>> {
   const searchParams = new URLSearchParams();
@@ -49,38 +47,29 @@ export async function listSessions(
     searchParams.set("limit", String(params.limit));
   }
   const query = searchParams.toString();
-  const url = `/v1/orgs/${org}/sessions${query ? `?${query}` : ""}`;
+  const url = `/v1/sessions${query ? `?${query}` : ""}`;
   const response = await api.get<PaginatedResponse<Session>>(url);
   return response.data;
 }
 
-export async function getSession(
-  org: string,
-  sessionId: string
-): Promise<Session> {
-  const response = await api.get<Session>(
-    `/v1/orgs/${org}/sessions/${sessionId}`
-  );
+export async function getSession(sessionId: string): Promise<Session> {
+  const response = await api.get<Session>(`/v1/sessions/${sessionId}`);
   return response.data;
 }
 
 export async function updateSession(
-  org: string,
   sessionId: string,
   request: UpdateSessionRequest
 ): Promise<Session> {
   const response = await api.patch<Session>(
-    `/v1/orgs/${org}/sessions/${sessionId}`,
+    `/v1/sessions/${sessionId}`,
     request
   );
   return response.data;
 }
 
-export async function deleteSession(
-  org: string,
-  sessionId: string
-): Promise<void> {
-  await api.delete(`/v1/orgs/${org}/sessions/${sessionId}`);
+export async function deleteSession(sessionId: string): Promise<void> {
+  await api.delete(`/v1/sessions/${sessionId}`);
 }
 
 /**
@@ -94,9 +83,6 @@ export async function deleteSession(
  *
  * @throws Error if no turn is currently running (409 Conflict)
  */
-export async function cancelTurn(
-  org: string,
-  sessionId: string
-): Promise<void> {
-  await api.post(`/v1/orgs/${org}/sessions/${sessionId}/cancel`);
+export async function cancelTurn(sessionId: string): Promise<void> {
+  await api.post(`/v1/sessions/${sessionId}/cancel`);
 }

--- a/apps/ui/src/lib/api/sessions.ts
+++ b/apps/ui/src/lib/api/sessions.ts
@@ -1,5 +1,5 @@
 // Session API functions
-// Org is sent via X-Org-Id header (set by OrgProvider)
+// Org is sent via everruns_org cookie (set by OrgProvider via /v1/users/me/switch-org)
 
 import { api } from "./client";
 import type {

--- a/apps/ui/src/lib/api/users.ts
+++ b/apps/ui/src/lib/api/users.ts
@@ -18,3 +18,20 @@ export async function listUsers(query?: ListUsersQuery): Promise<User[]> {
   const response = await api.get<ListResponse<User>>(url);
   return response.data.data;
 }
+
+interface SwitchOrgResponse {
+  success: boolean;
+  org_id: string;
+}
+
+/**
+ * Switch the current organization.
+ * Sets a server-side cookie (everruns_org) that will be sent with all subsequent requests.
+ * This is the preferred method for org selection as cookies work with SSE (EventSource).
+ */
+export async function switchOrg(orgId: string): Promise<SwitchOrgResponse> {
+  const response = await api.post<SwitchOrgResponse>("/v1/users/me/switch-org", {
+    org_id: orgId,
+  });
+  return response.data;
+}

--- a/apps/ui/src/providers/org-provider.tsx
+++ b/apps/ui/src/providers/org-provider.tsx
@@ -4,6 +4,7 @@
 // Decision: Current org stored in localStorage for persistence across sessions
 // Decision: Default org ID used as fallback
 // Decision: When AUTH_MODE=none, use default org directly
+// Decision: Org selection via server-side cookie (everruns_org) for SSE compatibility
 
 import {
   createContext,
@@ -11,10 +12,11 @@ import {
   useState,
   useEffect,
   useMemo,
+  useCallback,
   type ReactNode,
 } from "react";
 import { useAuth } from "./auth-provider";
-import { setCurrentOrgId } from "@/lib/api/client";
+import { switchOrg as switchOrgApi } from "@/lib/api/users";
 import type { OrganizationMembership } from "@/lib/api/types";
 
 // Default organization public ID (matches backend DEFAULT_ORG_PUBLIC_ID)
@@ -99,18 +101,29 @@ export function OrgProvider({ children }: OrgProviderProps) {
     }
   }, [organizations, currentOrg, isInitialized]);
 
-  const setCurrentOrg = (org: OrganizationMembership) => {
-    setCurrentOrgState(org);
-    setCurrentOrgId(org.public_id); // Update API client header
-    localStorage.setItem(STORAGE_KEY, org.public_id);
-  };
-
-  // Sync currentOrg changes to API client header
-  useEffect(() => {
-    if (currentOrg) {
-      setCurrentOrgId(currentOrg.public_id);
+  // Call API to switch org (sets server-side cookie)
+  const syncOrgCookie = useCallback(async (orgId: string) => {
+    try {
+      await switchOrgApi(orgId);
+    } catch (error) {
+      // Log but don't throw - org switching should be resilient
+      console.warn("Failed to sync org cookie:", error);
     }
-  }, [currentOrg]);
+  }, []);
+
+  const setCurrentOrg = useCallback((org: OrganizationMembership) => {
+    setCurrentOrgState(org);
+    localStorage.setItem(STORAGE_KEY, org.public_id);
+    // Set server-side cookie via API
+    void syncOrgCookie(org.public_id);
+  }, [syncOrgCookie]);
+
+  // Sync currentOrg to server cookie on mount/change
+  useEffect(() => {
+    if (currentOrg && isInitialized) {
+      void syncOrgCookie(currentOrg.public_id);
+    }
+  }, [currentOrg, isInitialized, syncOrgCookie]);
 
   const value: OrgContextValue = {
     currentOrg,

--- a/apps/ui/src/providers/org-provider.tsx
+++ b/apps/ui/src/providers/org-provider.tsx
@@ -14,6 +14,7 @@ import {
   type ReactNode,
 } from "react";
 import { useAuth } from "./auth-provider";
+import { setCurrentOrgId } from "@/lib/api/client";
 import type { OrganizationMembership } from "@/lib/api/types";
 
 // Default organization public ID (matches backend DEFAULT_ORG_PUBLIC_ID)
@@ -100,8 +101,16 @@ export function OrgProvider({ children }: OrgProviderProps) {
 
   const setCurrentOrg = (org: OrganizationMembership) => {
     setCurrentOrgState(org);
+    setCurrentOrgId(org.public_id); // Update API client header
     localStorage.setItem(STORAGE_KEY, org.public_id);
   };
+
+  // Sync currentOrg changes to API client header
+  useEffect(() => {
+    if (currentOrg) {
+      setCurrentOrgId(currentOrg.public_id);
+    }
+  }, [currentOrg]);
 
   const value: OrgContextValue = {
     currentOrg,

--- a/crates/cli/src/commands/agents.rs
+++ b/crates/cli/src/commands/agents.rs
@@ -325,12 +325,7 @@ async fn create(
         capabilities: final_capabilities,
     };
 
-    let agent: Agent = client
-        .post(
-            "/v1/agents",
-            &request,
-        )
-        .await?;
+    let agent: Agent = client.post("/v1/agents", &request).await?;
 
     if output.is_text() {
         if quiet {
@@ -355,9 +350,7 @@ async fn create(
 }
 
 async fn list(client: &Client, output: OutputFormat) -> Result<()> {
-    let response: ListResponse<Agent> = client
-        .get("/v1/agents")
-        .await?;
+    let response: ListResponse<Agent> = client.get("/v1/agents").await?;
 
     if output.is_text() {
         if response.data.is_empty() {
@@ -399,10 +392,7 @@ async fn list(client: &Client, output: OutputFormat) -> Result<()> {
 
 async fn get(client: &Client, output: OutputFormat, agent_id: Uuid) -> Result<()> {
     let agent: Agent = client
-        .get(&format!(
-            "/v1/agents/{}",
-            agent_id
-        ))
+        .get(&format!("/v1/agents/{}", agent_id))
         .await
         .map_err(|e| match e {
             ClientError::NotFound => anyhow::anyhow!("Agent not found: {}", agent_id),
@@ -437,10 +427,7 @@ async fn get(client: &Client, output: OutputFormat, agent_id: Uuid) -> Result<()
 
 async fn delete(client: &Client, output: OutputFormat, quiet: bool, agent_id: Uuid) -> Result<()> {
     client
-        .delete(&format!(
-            "/v1/agents/{}",
-            agent_id
-        ))
+        .delete(&format!("/v1/agents/{}", agent_id))
         .await
         .map_err(|e| match e {
             ClientError::NotFound => anyhow::anyhow!("Agent not found: {}", agent_id),

--- a/crates/cli/src/commands/agents.rs
+++ b/crates/cli/src/commands/agents.rs
@@ -327,7 +327,7 @@ async fn create(
 
     let agent: Agent = client
         .post(
-            "/v1/orgs/org_00000000000000000000000000000001/agents",
+            "/v1/agents",
             &request,
         )
         .await?;
@@ -356,7 +356,7 @@ async fn create(
 
 async fn list(client: &Client, output: OutputFormat) -> Result<()> {
     let response: ListResponse<Agent> = client
-        .get("/v1/orgs/org_00000000000000000000000000000001/agents")
+        .get("/v1/agents")
         .await?;
 
     if output.is_text() {
@@ -400,7 +400,7 @@ async fn list(client: &Client, output: OutputFormat) -> Result<()> {
 async fn get(client: &Client, output: OutputFormat, agent_id: Uuid) -> Result<()> {
     let agent: Agent = client
         .get(&format!(
-            "/v1/orgs/org_00000000000000000000000000000001/agents/{}",
+            "/v1/agents/{}",
             agent_id
         ))
         .await
@@ -438,7 +438,7 @@ async fn get(client: &Client, output: OutputFormat, agent_id: Uuid) -> Result<()
 async fn delete(client: &Client, output: OutputFormat, quiet: bool, agent_id: Uuid) -> Result<()> {
     client
         .delete(&format!(
-            "/v1/orgs/org_00000000000000000000000000000001/agents/{}",
+            "/v1/agents/{}",
             agent_id
         ))
         .await

--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -63,10 +63,7 @@ pub async fn run(
 
     let _: serde_json::Value = client
         .post(
-            &format!(
-                "/v1/sessions/ses_{}/messages",
-                session_id.as_hyphenated()
-            ),
+            &format!("/v1/sessions/ses_{}/messages", session_id.as_hyphenated()),
             &request,
         )
         .await?;
@@ -101,10 +98,7 @@ pub async fn run(
                 session_id.as_hyphenated(),
                 id
             ),
-            None => format!(
-                "/v1/sessions/ses_{}/events",
-                session_id.as_hyphenated()
-            ),
+            None => format!("/v1/sessions/ses_{}/events", session_id.as_hyphenated()),
         };
 
         let response: ListResponse<Event> = client.get(&url).await?;

--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -64,7 +64,7 @@ pub async fn run(
     let _: serde_json::Value = client
         .post(
             &format!(
-                "/v1/orgs/org_00000000000000000000000000000001/sessions/ses_{}/messages",
+                "/v1/sessions/ses_{}/messages",
                 session_id.as_hyphenated()
             ),
             &request,
@@ -97,12 +97,12 @@ pub async fn run(
         // Build URL with since_id parameter
         let url = match &last_event_id {
             Some(id) => format!(
-                "/v1/orgs/org_00000000000000000000000000000001/sessions/ses_{}/events?since_id={}",
+                "/v1/sessions/ses_{}/events?since_id={}",
                 session_id.as_hyphenated(),
                 id
             ),
             None => format!(
-                "/v1/orgs/org_00000000000000000000000000000001/sessions/ses_{}/events",
+                "/v1/sessions/ses_{}/events",
                 session_id.as_hyphenated()
             ),
         };

--- a/crates/cli/src/commands/sessions.rs
+++ b/crates/cli/src/commands/sessions.rs
@@ -120,7 +120,7 @@ async fn create(
 
     let session: Session = client
         .post(
-            "/v1/orgs/org_00000000000000000000000000000001/sessions",
+            "/v1/sessions",
             &request,
         )
         .await?;
@@ -143,7 +143,7 @@ async fn create(
 async fn list(client: &Client, output: OutputFormat, agent_id: Uuid) -> Result<()> {
     let response: ListResponse<Session> = client
         .get(&format!(
-            "/v1/orgs/org_00000000000000000000000000000001/sessions?agent_id=agt_{}",
+            "/v1/sessions?agent_id=agt_{}",
             agent_id.as_hyphenated()
         ))
         .await?;
@@ -180,7 +180,7 @@ async fn get(
 ) -> Result<()> {
     let session: Session = client
         .get(&format!(
-            "/v1/orgs/org_00000000000000000000000000000001/sessions/ses_{}",
+            "/v1/sessions/ses_{}",
             session_id.as_hyphenated()
         ))
         .await

--- a/crates/cli/src/commands/sessions.rs
+++ b/crates/cli/src/commands/sessions.rs
@@ -118,12 +118,7 @@ async fn create(
         model_id,
     };
 
-    let session: Session = client
-        .post(
-            "/v1/sessions",
-            &request,
-        )
-        .await?;
+    let session: Session = client.post("/v1/sessions", &request).await?;
 
     if output.is_text() {
         if quiet {
@@ -179,10 +174,7 @@ async fn get(
     session_id: Uuid,
 ) -> Result<()> {
     let session: Session = client
-        .get(&format!(
-            "/v1/sessions/ses_{}",
-            session_id.as_hyphenated()
-        ))
+        .get(&format!("/v1/sessions/ses_{}", session_id.as_hyphenated()))
         .await
         .map_err(|e| match e {
             ClientError::NotFound => anyhow::anyhow!("Session not found: {}", session_id),

--- a/crates/server/examples/create_agent.rs
+++ b/crates/server/examples/create_agent.rs
@@ -72,8 +72,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("\nExample completed successfully!");
     println!("\nNext steps:");
-    println!("   - Create a session: POST /v1/orgs/default/sessions (with agent_id in body)");
-    println!("   - Send a message: POST /v1/orgs/default/sessions/<session_id>/messages");
+    println!("   - Create a session: POST /v1/sessions (with agent_id in body)");
+    println!("   - Send a message: POST /v1/sessions/<session_id>/messages");
     println!("   - View API docs: http://localhost:9000/swagger-ui/");
 
     Ok(())

--- a/crates/server/examples/dad_joke_agent.rs
+++ b/crates/server/examples/dad_joke_agent.rs
@@ -93,7 +93,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Step 2: Create a session
     println!("\nCreating session...");
     let session_response = client
-        .post(format!("{}/v1/orgs/default/sessions", API_BASE_URL))
+        .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({
             "agent_id": agent.id,
             "title": "Dad Joke Time"
@@ -114,7 +114,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\nSending message: \"Tell me a joke about the current time!\"");
     let message_response = client
         .post(format!(
-            "{}/v1/orgs/default/sessions/{}/messages",
+            "{}/v1/sessions/{}/messages",
             API_BASE_URL, session.id
         ))
         .json(&json!({
@@ -142,7 +142,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("-------------------------------------------");
 
     let sse_url = format!(
-        "{}/v1/orgs/default/sessions/{}/sse",
+        "{}/v1/sessions/{}/sse",
         API_BASE_URL, session.id
     );
 

--- a/crates/server/examples/dad_joke_agent.rs
+++ b/crates/server/examples/dad_joke_agent.rs
@@ -141,10 +141,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\nListening to SSE events...");
     println!("-------------------------------------------");
 
-    let sse_url = format!(
-        "{}/v1/sessions/{}/sse",
-        API_BASE_URL, session.id
-    );
+    let sse_url = format!("{}/v1/sessions/{}/sse", API_BASE_URL, session.id);
 
     // Use blocking client for SSE streaming (reqwest-eventsource alternative)
     let result = listen_to_sse(&sse_url).await;

--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -1,5 +1,5 @@
 // Agent CRUD HTTP routes (M2)
-// Routes use ResolvedOrg: org derived from auth context (API key or X-Org-Id header)
+// Routes use ResolvedOrg: org derived from auth context (API key or cookie)
 
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::storage::StorageBackend;

--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -1,8 +1,9 @@
 // Agent CRUD HTTP routes (M2)
-// Routes are org-scoped: /v1/orgs/:org/agents/...
+// Routes use ResolvedOrg: org derived from auth context (API key or X-Org-Id header)
 
-use crate::auth::{AuthState, OrgContext, middleware::FromRef};
+use crate::auth::{AuthState, ResolvedOrg};
 use crate::storage::StorageBackend;
+use axum::extract::FromRef;
 use axum::{
     Json, Router,
     body::Body,
@@ -181,27 +182,24 @@ impl FromRef<AppState> for AuthState {
     }
 }
 
-/// Create agent routes (org-scoped)
+/// Create agent routes
 pub fn routes(state: AppState) -> Router {
     Router::new()
-        .route("/v1/orgs/:org/agents", post(create_agent).get(list_agents))
-        .route("/v1/orgs/:org/agents/import", post(import_agent))
-        .route("/v1/orgs/:org/agents/preview", post(preview_agent))
+        .route("/v1/agents", post(create_agent).get(list_agents))
+        .route("/v1/agents/import", post(import_agent))
+        .route("/v1/agents/preview", post(preview_agent))
         .route(
-            "/v1/orgs/:org/agents/:agent_id",
+            "/v1/agents/:agent_id",
             get(get_agent).patch(update_agent).delete(delete_agent),
         )
-        .route("/v1/orgs/:org/agents/:agent_id/export", get(export_agent))
+        .route("/v1/agents/:agent_id/export", get(export_agent))
         .with_state(state)
 }
 
-/// POST /v1/orgs/{org}/agents - Create a new agent
+/// POST /v1/agents - Create a new agent
 #[utoipa::path(
     post,
-    path = "/v1/orgs/{org}/agents",
-    params(
-        ("org" = String, Path, description = "Organization public ID")
-    ),
+    path = "/v1/agents",
     request_body = CreateAgentRequest,
     responses(
         (status = 201, description = "Agent created successfully", body = Agent),
@@ -211,7 +209,7 @@ pub fn routes(state: AppState) -> Router {
     tag = "agents"
 )]
 pub async fn create_agent(
-    org: OrgContext,
+    org: ResolvedOrg,
     State(state): State<AppState>,
     Json(req): Json<CreateAgentRequest>,
 ) -> Result<(StatusCode, Json<Agent>), (StatusCode, Json<ErrorResponse>)> {
@@ -232,13 +230,10 @@ pub async fn create_agent(
     Ok((StatusCode::CREATED, Json(agent)))
 }
 
-/// GET /v1/orgs/{org}/agents - List all active agents
+/// GET /v1/agents - List all active agents
 #[utoipa::path(
     get,
-    path = "/v1/orgs/{org}/agents",
-    params(
-        ("org" = String, Path, description = "Organization public ID")
-    ),
+    path = "/v1/agents",
     responses(
         (status = 200, description = "List of agents", body = ListResponse<Agent>),
         (status = 500, description = "Internal server error")
@@ -246,7 +241,7 @@ pub async fn create_agent(
     tag = "agents"
 )]
 pub async fn list_agents(
-    org: OrgContext,
+    org: ResolvedOrg,
     State(state): State<AppState>,
 ) -> Result<Json<ListResponse<Agent>>, StatusCode> {
     let agents = state
@@ -258,12 +253,11 @@ pub async fn list_agents(
     Ok(Json(ListResponse::new(agents)))
 }
 
-/// GET /v1/orgs/{org}/agents/{agent_id} - Get agent by ID
+/// GET /v1/agents/{agent_id} - Get agent by ID
 #[utoipa::path(
     get,
-    path = "/v1/orgs/{org}/agents/{agent_id}",
+    path = "/v1/agents/{agent_id}",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("agent_id" = String, Path, description = "Agent ID (prefixed, e.g., agt_...)")
     ),
     responses(
@@ -275,9 +269,9 @@ pub async fn list_agents(
     tag = "agents"
 )]
 pub async fn get_agent(
-    org: OrgContext,
+    org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, agent_id)): Path<(String, String)>,
+    Path(agent_id): Path<String>,
 ) -> Result<Json<Agent>, (StatusCode, Json<ErrorResponse>)> {
     let agent_id: AgentId = agent_id.parse().map_err(|e| {
         (
@@ -298,12 +292,11 @@ pub async fn get_agent(
     Ok(Json(agent))
 }
 
-/// PATCH /v1/orgs/{org}/agents/{agent_id} - Update agent
+/// PATCH /v1/agents/{agent_id} - Update agent
 #[utoipa::path(
     patch,
-    path = "/v1/orgs/{org}/agents/{agent_id}",
+    path = "/v1/agents/{agent_id}",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("agent_id" = String, Path, description = "Agent ID (prefixed, e.g., agt_...)")
     ),
     request_body = UpdateAgentRequest,
@@ -316,9 +309,9 @@ pub async fn get_agent(
     tag = "agents"
 )]
 pub async fn update_agent(
-    org: OrgContext,
+    org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, agent_id)): Path<(String, String)>,
+    Path(agent_id): Path<String>,
     Json(req): Json<UpdateAgentRequest>,
 ) -> Result<Json<Agent>, (StatusCode, Json<ErrorResponse>)> {
     let agent_id: AgentId = agent_id.parse().map_err(|e| {
@@ -348,12 +341,11 @@ pub async fn update_agent(
     Ok(Json(agent))
 }
 
-/// DELETE /v1/orgs/{org}/agents/{agent_id} - Archive agent
+/// DELETE /v1/agents/{agent_id} - Archive agent
 #[utoipa::path(
     delete,
-    path = "/v1/orgs/{org}/agents/{agent_id}",
+    path = "/v1/agents/{agent_id}",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("agent_id" = String, Path, description = "Agent ID (prefixed, e.g., agt_...)")
     ),
     responses(
@@ -365,9 +357,9 @@ pub async fn update_agent(
     tag = "agents"
 )]
 pub async fn delete_agent(
-    org: OrgContext,
+    org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, agent_id)): Path<(String, String)>,
+    Path(agent_id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     let agent_id: AgentId = agent_id.parse().map_err(|e| {
         (
@@ -396,12 +388,11 @@ pub async fn delete_agent(
     }
 }
 
-/// GET /v1/orgs/{org}/agents/{agent_id}/export - Export agent in Markdown format with YAML front matter
+/// GET /v1/agents/{agent_id}/export - Export agent in Markdown format with YAML front matter
 #[utoipa::path(
     get,
-    path = "/v1/orgs/{org}/agents/{agent_id}/export",
+    path = "/v1/agents/{agent_id}/export",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("agent_id" = String, Path, description = "Agent ID (prefixed, e.g., agt_...)")
     ),
     responses(
@@ -413,9 +404,9 @@ pub async fn delete_agent(
     tag = "agents"
 )]
 pub async fn export_agent(
-    org: OrgContext,
+    org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, agent_id)): Path<(String, String)>,
+    Path(agent_id): Path<String>,
 ) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
     let agent_id: AgentId = agent_id.parse().map_err(|e| {
         (
@@ -447,7 +438,7 @@ pub async fn export_agent(
         .unwrap())
 }
 
-/// POST /v1/orgs/{org}/agents/import - Import agent from Markdown, YAML, or JSON
+/// POST /v1/agents/import - Import agent from Markdown, YAML, or JSON
 ///
 /// Accepts agent definition in multiple formats:
 /// - Markdown with YAML front matter (if starts with ---)
@@ -456,10 +447,7 @@ pub async fn export_agent(
 /// - Plain text (treated as system prompt, name auto-generated)
 #[utoipa::path(
     post,
-    path = "/v1/orgs/{org}/agents/import",
-    params(
-        ("org" = String, Path, description = "Organization public ID")
-    ),
+    path = "/v1/agents/import",
     request_body(content = String, content_type = "text/plain"),
     responses(
         (status = 201, description = "Agent imported successfully", body = Agent),
@@ -469,7 +457,7 @@ pub async fn export_agent(
     tag = "agents"
 )]
 pub async fn import_agent(
-    org: OrgContext,
+    org: ResolvedOrg,
     State(state): State<AppState>,
     body: String,
 ) -> Result<(StatusCode, Json<Agent>), (StatusCode, Json<ErrorResponse>)> {
@@ -640,16 +628,13 @@ fn slugify(s: &str) -> String {
         .join("-")
 }
 
-/// POST /v1/orgs/{org}/agents/preview - Preview the final agent shape with capabilities applied
+/// POST /v1/agents/preview - Preview the final agent shape with capabilities applied
 ///
 /// Returns the merged system prompt and all tools that would be available to the agent.
 /// This is useful for previewing what the agent will look like before saving.
 #[utoipa::path(
     post,
-    path = "/v1/orgs/{org}/agents/preview",
-    params(
-        ("org" = String, Path, description = "Organization public ID")
-    ),
+    path = "/v1/agents/preview",
     request_body = PreviewAgentRequest,
     responses(
         (status = 200, description = "Agent preview generated", body = AgentPreviewResponse),
@@ -658,7 +643,7 @@ fn slugify(s: &str) -> String {
     tag = "agents"
 )]
 pub async fn preview_agent(
-    _org: OrgContext,
+    _org: ResolvedOrg,
     State(state): State<AppState>,
     Json(req): Json<PreviewAgentRequest>,
 ) -> Result<Json<AgentPreviewResponse>, (StatusCode, Json<ErrorResponse>)> {

--- a/crates/server/src/api/capabilities.rs
+++ b/crates/server/src/api/capabilities.rs
@@ -1,13 +1,14 @@
 // Capability HTTP routes
-// Routes are org-scoped: /v1/orgs/:org/capabilities/...
+// Routes: /v1/capabilities/...
 //
 // Design Decision: Capabilities are defined in everruns-core via the Capability trait.
 // This module provides HTTP endpoints that expose capability information from the
 // CapabilityRegistry in everruns-core.
 //
-// Agent capabilities are managed through the agents API (POST/PATCH /v1/orgs/{org}/agents).
+// Agent capabilities are managed through the agents API (POST/PATCH /v1/agents).
 
-use crate::auth::{AuthState, OrgContext, middleware::FromRef};
+use crate::auth::{AuthState, ResolvedOrg};
+use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, State},
@@ -40,31 +41,25 @@ impl FromRef<AppState> for AuthState {
     }
 }
 
-/// Create capability routes (org-scoped)
+/// Create capability routes
 pub fn routes(state: AppState) -> Router {
     Router::new()
-        .route("/v1/orgs/:org/capabilities", get(list_capabilities))
-        .route(
-            "/v1/orgs/:org/capabilities/:capability_id",
-            get(get_capability),
-        )
+        .route("/v1/capabilities", get(list_capabilities))
+        .route("/v1/capabilities/:capability_id", get(get_capability))
         .with_state(state)
 }
 
-/// GET /v1/orgs/{org}/capabilities - List all available capabilities
+/// GET /v1/capabilities - List all available capabilities
 #[utoipa::path(
     get,
-    path = "/v1/orgs/{org}/capabilities",
-    params(
-        ("org" = String, Path, description = "Organization public ID")
-    ),
+    path = "/v1/capabilities",
     responses(
         (status = 200, description = "List of available capabilities", body = ListResponse<CapabilityInfo>),
     ),
     tag = "capabilities"
 )]
 pub async fn list_capabilities(
-    _org: OrgContext,
+    _org: ResolvedOrg,
     State(state): State<AppState>,
 ) -> Result<Json<ListResponse<CapabilityInfo>>, StatusCode> {
     let capabilities = state.service.list_all().await.map_err(|e| {
@@ -74,12 +69,11 @@ pub async fn list_capabilities(
     Ok(Json(ListResponse::new(capabilities)))
 }
 
-/// GET /v1/orgs/{org}/capabilities/{capability_id} - Get a specific capability
+/// GET /v1/capabilities/{capability_id} - Get a specific capability
 #[utoipa::path(
     get,
-    path = "/v1/orgs/{org}/capabilities/{capability_id}",
+    path = "/v1/capabilities/{capability_id}",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("capability_id" = String, Path, description = "Capability ID")
     ),
     responses(
@@ -89,9 +83,9 @@ pub async fn list_capabilities(
     tag = "capabilities"
 )]
 pub async fn get_capability(
-    _org: OrgContext,
+    _org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, capability_id)): Path<(String, String)>,
+    Path(capability_id): Path<String>,
 ) -> Result<Json<CapabilityInfo>, StatusCode> {
     let cap_id = CapabilityId::new(&capability_id);
 

--- a/crates/server/src/api/events.rs
+++ b/crates/server/src/api/events.rs
@@ -1,6 +1,6 @@
 // Event streaming HTTP routes (SSE)
 // Events are notifications streamed to clients, NOT primary data storage
-// Routes use ResolvedOrg: org derived from auth context (API key or X-Org-Id header)
+// Routes use ResolvedOrg: org derived from auth context (API key or cookie)
 
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::storage::StorageBackend;

--- a/crates/server/src/api/events.rs
+++ b/crates/server/src/api/events.rs
@@ -1,9 +1,10 @@
 // Event streaming HTTP routes (SSE)
 // Events are notifications streamed to clients, NOT primary data storage
-// Routes are org-scoped: /v1/orgs/:org/sessions/:session_id/...
+// Routes use ResolvedOrg: org derived from auth context (API key or X-Org-Id header)
 
-use crate::auth::{AuthState, OrgContext, middleware::FromRef};
+use crate::auth::{AuthState, ResolvedOrg};
 use crate::storage::StorageBackend;
+use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, Query, State},
@@ -83,14 +84,11 @@ impl FromRef<AppState> for AuthState {
     }
 }
 
-/// Create event routes (nested under sessions, org-scoped)
+/// Create event routes (nested under sessions)
 pub fn routes(state: AppState) -> Router {
     Router::new()
-        .route("/v1/orgs/:org/sessions/:session_id/sse", get(stream_sse))
-        .route(
-            "/v1/orgs/:org/sessions/:session_id/events",
-            get(list_events),
-        )
+        .route("/v1/sessions/:session_id/sse", get(stream_sse))
+        .route("/v1/sessions/:session_id/events", get(list_events))
         .with_state(state)
 }
 
@@ -98,12 +96,11 @@ pub fn routes(state: AppState) -> Router {
 // HTTP Handlers
 // ============================================
 
-/// GET /v1/orgs/{org}/sessions/{session_id}/sse - Stream events (SSE notifications)
+/// GET /v1/sessions/{session_id}/sse - Stream events (SSE notifications)
 #[utoipa::path(
     get,
-    path = "/v1/orgs/{org}/sessions/{session_id}/sse",
+    path = "/v1/sessions/{session_id}/sse",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)"),
         EventsQuery
     ),
@@ -116,9 +113,9 @@ pub fn routes(state: AppState) -> Router {
     tag = "events"
 )]
 pub async fn stream_sse(
-    org: OrgContext,
+    org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, session_id)): Path<(String, String)>,
+    Path(session_id): Path<String>,
     Query(query): Query<EventsQuery>,
 ) -> Result<Sse<impl Stream<Item = Result<SseEvent, Infallible>>>, (StatusCode, Json<ErrorResponse>)>
 {
@@ -271,12 +268,11 @@ pub async fn stream_sse(
 // List Events (JSON response for polling)
 // ============================================
 
-/// GET /v1/orgs/{org}/sessions/{session_id}/events - List events (JSON)
+/// GET /v1/sessions/{session_id}/events - List events (JSON)
 #[utoipa::path(
     get,
-    path = "/v1/orgs/{org}/sessions/{session_id}/events",
+    path = "/v1/sessions/{session_id}/events",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)"),
         EventsQuery
     ),
@@ -289,9 +285,9 @@ pub async fn stream_sse(
     tag = "events"
 )]
 pub async fn list_events(
-    org: OrgContext,
+    org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, session_id)): Path<(String, String)>,
+    Path(session_id): Path<String>,
     Query(query): Query<EventsQuery>,
 ) -> Result<Json<ListResponse<Event>>, (StatusCode, Json<ErrorResponse>)> {
     let session_id: SessionId = session_id.parse().map_err(|e| {

--- a/crates/server/src/api/images.rs
+++ b/crates/server/src/api/images.rs
@@ -1,12 +1,13 @@
 // Image upload HTTP routes
-// Routes are org-scoped: /v1/orgs/:org/images/...
+// Routes: /v1/images/...
 //
 // Organization image storage for message attachments.
 // Supports PNG, JPEG, GIF, WebP (OpenAI Vision compatible formats).
 // Generates thumbnails on upload for efficient display.
 
-use crate::auth::{AuthState, OrgContext, middleware::FromRef};
+use crate::auth::{AuthState, ResolvedOrg};
 use crate::storage::{StorageBackend, models::CreateImageRow};
+use axum::extract::FromRef;
 use axum::{
     Json, Router,
     body::Body,
@@ -106,24 +107,18 @@ impl FromRef<AppState> for AuthState {
     }
 }
 
-/// Create images routes (org-scoped)
+/// Create images routes
 pub fn routes(state: AppState) -> Router {
     Router::new()
         // Upload needs larger body limit (100MB + some overhead for multipart encoding)
         .route(
-            "/v1/orgs/:org/images",
+            "/v1/images",
             post(upload_image)
                 .layer(DefaultBodyLimit::max(MAX_IMAGE_SIZE + 1024 * 1024))
                 .get(list_images),
         )
-        .route(
-            "/v1/orgs/:org/images/:image_id",
-            get(get_image).delete(delete_image),
-        )
-        .route(
-            "/v1/orgs/:org/images/:image_id/thumbnail",
-            get(get_thumbnail),
-        )
+        .route("/v1/images/:image_id", get(get_image).delete(delete_image))
+        .route("/v1/images/:image_id/thumbnail", get(get_thumbnail))
         .with_state(state)
 }
 
@@ -168,12 +163,11 @@ fn generate_thumbnail(data: &[u8], content_type: &str) -> Option<(Vec<u8>, Strin
 // HTTP Handlers
 // ============================================
 
-/// POST /v1/orgs/{org}/images - Upload an image
+/// POST /v1/images - Upload an image
 #[utoipa::path(
     post,
-    path = "/v1/orgs/{org}/images",
+    path = "/v1/images",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("session_id" = Option<Uuid>, Query, description = "Optional: session ID stored as metadata for tracking (not required for upload)")
     ),
     request_body(content = String, description = "Multipart form data with 'file' field", content_type = "multipart/form-data"),
@@ -185,7 +179,7 @@ fn generate_thumbnail(data: &[u8], content_type: &str) -> Option<(Vec<u8>, Strin
     tag = "images"
 )]
 pub async fn upload_image(
-    _org: OrgContext,
+    _org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<UploadImageQuery>,
     mut multipart: Multipart,
@@ -295,12 +289,11 @@ pub async fn upload_image(
     ))
 }
 
-/// GET /v1/orgs/{org}/images - List images
+/// GET /v1/images - List images
 #[utoipa::path(
     get,
-    path = "/v1/orgs/{org}/images",
+    path = "/v1/images",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("limit" = Option<i64>, Query, description = "Max items to return (default 50)"),
         ("offset" = Option<i64>, Query, description = "Items to skip")
     ),
@@ -311,7 +304,7 @@ pub async fn upload_image(
     tag = "images"
 )]
 pub async fn list_images(
-    _org: OrgContext,
+    _org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListImagesQuery>,
 ) -> Result<Json<Vec<ImageInfo>>, StatusCode> {
@@ -339,12 +332,11 @@ pub async fn list_images(
     Ok(Json(images))
 }
 
-/// GET /v1/orgs/{org}/images/{image_id} - Get image (returns binary data)
+/// GET /v1/images/{image_id} - Get image (returns binary data)
 #[utoipa::path(
     get,
-    path = "/v1/orgs/{org}/images/{image_id}",
+    path = "/v1/images/{image_id}",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("image_id" = String, Path, description = "Image ID (prefixed, e.g., img_...)")
     ),
     responses(
@@ -356,9 +348,9 @@ pub async fn list_images(
     tag = "images"
 )]
 pub async fn get_image(
-    _org: OrgContext,
+    _org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, image_id)): Path<(String, String)>,
+    Path(image_id): Path<String>,
 ) -> Result<Response, (StatusCode, String)> {
     let image_id: ImageId = image_id
         .parse()
@@ -391,12 +383,11 @@ pub async fn get_image(
     Ok(response)
 }
 
-/// GET /v1/orgs/{org}/images/{image_id}/thumbnail - Get image thumbnail
+/// GET /v1/images/{image_id}/thumbnail - Get image thumbnail
 #[utoipa::path(
     get,
-    path = "/v1/orgs/{org}/images/{image_id}/thumbnail",
+    path = "/v1/images/{image_id}/thumbnail",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("image_id" = String, Path, description = "Image ID (prefixed, e.g., img_...)")
     ),
     responses(
@@ -408,9 +399,9 @@ pub async fn get_image(
     tag = "images"
 )]
 pub async fn get_thumbnail(
-    _org: OrgContext,
+    _org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, image_id)): Path<(String, String)>,
+    Path(image_id): Path<String>,
 ) -> Result<Response, (StatusCode, String)> {
     let image_id: ImageId = image_id
         .parse()
@@ -445,12 +436,11 @@ pub async fn get_thumbnail(
     Ok(response)
 }
 
-/// DELETE /v1/orgs/{org}/images/{image_id} - Delete an image
+/// DELETE /v1/images/{image_id} - Delete an image
 #[utoipa::path(
     delete,
-    path = "/v1/orgs/{org}/images/{image_id}",
+    path = "/v1/images/{image_id}",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("image_id" = String, Path, description = "Image ID (prefixed, e.g., img_...)")
     ),
     responses(
@@ -462,9 +452,9 @@ pub async fn get_thumbnail(
     tag = "images"
 )]
 pub async fn delete_image(
-    _org: OrgContext,
+    _org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, image_id)): Path<(String, String)>,
+    Path(image_id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, String)> {
     let image_id: ImageId = image_id
         .parse()

--- a/crates/server/src/api/llm_models.rs
+++ b/crates/server/src/api/llm_models.rs
@@ -1,9 +1,10 @@
 // LLM Model API endpoints
-// Routes are org-scoped: /v1/orgs/:org/llm-providers/:provider_id/models/...
+// Routes: /v1/llm-providers/:provider_id/models/... and /v1/llm-models/...
 
 use crate::api::common::{ErrorResponse, ListResponse};
-use crate::auth::{AuthState, OrgContext, middleware::FromRef};
+use crate::auth::{AuthState, ResolvedOrg};
 use crate::storage::StorageBackend;
+use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, Query, State},
@@ -111,9 +112,8 @@ pub struct UpdateLlmModelRequest {
 /// Create a new model for a provider
 #[utoipa::path(
     post,
-    path = "/v1/orgs/{org}/llm-providers/{provider_id}/models",
+    path = "/v1/llm-providers/{provider_id}/models",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("provider_id" = String, Path, description = "Provider ID (prefixed, e.g., prov_...)")
     ),
     request_body = CreateLlmModelRequest,
@@ -125,9 +125,9 @@ pub struct UpdateLlmModelRequest {
     tag = "llm-models"
 )]
 pub async fn create_model(
-    _org: OrgContext,
+    _org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, provider_id)): Path<(String, String)>,
+    Path(provider_id): Path<String>,
     Json(req): Json<CreateLlmModelRequest>,
 ) -> Result<(StatusCode, Json<LlmModel>), (StatusCode, Json<ErrorResponse>)> {
     let provider_id: ProviderId = provider_id.parse().map_err(|e| {
@@ -159,9 +159,8 @@ pub async fn create_model(
 /// List models for a specific provider
 #[utoipa::path(
     get,
-    path = "/v1/orgs/{org}/llm-providers/{provider_id}/models",
+    path = "/v1/llm-providers/{provider_id}/models",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("provider_id" = String, Path, description = "Provider ID (prefixed, e.g., prov_...)")
     ),
     responses(
@@ -171,9 +170,9 @@ pub async fn create_model(
     tag = "llm-models"
 )]
 pub async fn list_provider_models(
-    _org: OrgContext,
+    _org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, provider_id)): Path<(String, String)>,
+    Path(provider_id): Path<String>,
 ) -> Result<Json<ListResponse<LlmModel>>, (StatusCode, Json<ErrorResponse>)> {
     let provider_id: ProviderId = provider_id.parse().map_err(|e| {
         (
@@ -204,9 +203,8 @@ pub async fn list_provider_models(
 /// List all models across all providers
 #[utoipa::path(
     get,
-    path = "/v1/orgs/{org}/llm-models",
+    path = "/v1/llm-models",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ListModelsQuery
     ),
     responses(
@@ -215,7 +213,7 @@ pub async fn list_provider_models(
     tag = "llm-models"
 )]
 pub async fn list_all_models(
-    _org: OrgContext,
+    _org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListModelsQuery>,
 ) -> Result<Json<ListResponse<LlmModelWithProvider>>, (StatusCode, Json<ErrorResponse>)> {
@@ -239,9 +237,8 @@ pub async fn list_all_models(
 /// Get a specific model with provider info and profile
 #[utoipa::path(
     get,
-    path = "/v1/orgs/{org}/llm-models/{id}",
+    path = "/v1/llm-models/{id}",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("id" = String, Path, description = "Model ID (prefixed, e.g., mod_...)")
     ),
     responses(
@@ -252,9 +249,9 @@ pub async fn list_all_models(
     tag = "llm-models"
 )]
 pub async fn get_model(
-    _org: OrgContext,
+    _org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, id)): Path<(String, String)>,
+    Path(id): Path<String>,
 ) -> Result<Json<LlmModelWithProvider>, (StatusCode, Json<ErrorResponse>)> {
     let model_id: ModelId = id.parse().map_err(|e| {
         (
@@ -293,9 +290,8 @@ pub async fn get_model(
 /// Update a model
 #[utoipa::path(
     patch,
-    path = "/v1/orgs/{org}/llm-models/{id}",
+    path = "/v1/llm-models/{id}",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("id" = String, Path, description = "Model ID (prefixed, e.g., mod_...)")
     ),
     request_body = UpdateLlmModelRequest,
@@ -307,9 +303,9 @@ pub async fn get_model(
     tag = "llm-models"
 )]
 pub async fn update_model(
-    _org: OrgContext,
+    _org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, id)): Path<(String, String)>,
+    Path(id): Path<String>,
     Json(req): Json<UpdateLlmModelRequest>,
 ) -> Result<Json<LlmModel>, (StatusCode, Json<ErrorResponse>)> {
     let model_id: ModelId = id.parse().map_err(|e| {
@@ -349,9 +345,8 @@ pub async fn update_model(
 /// Delete a model
 #[utoipa::path(
     delete,
-    path = "/v1/orgs/{org}/llm-models/{id}",
+    path = "/v1/llm-models/{id}",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("id" = String, Path, description = "Model ID (prefixed, e.g., mod_...)")
     ),
     responses(
@@ -362,9 +357,9 @@ pub async fn update_model(
     tag = "llm-models"
 )]
 pub async fn delete_model(
-    _org: OrgContext,
+    _org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, id)): Path<(String, String)>,
+    Path(id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     let model_id: ModelId = id.parse().map_err(|e| {
         (
@@ -400,12 +395,12 @@ pub async fn delete_model(
 pub fn routes(state: AppState) -> Router {
     Router::new()
         .route(
-            "/v1/orgs/:org/llm-providers/:provider_id/models",
+            "/v1/llm-providers/:provider_id/models",
             post(create_model).get(list_provider_models),
         )
-        .route("/v1/orgs/:org/llm-models", get(list_all_models))
+        .route("/v1/llm-models", get(list_all_models))
         .route(
-            "/v1/orgs/:org/llm-models/:id",
+            "/v1/llm-models/:id",
             get(get_model).patch(update_model).delete(delete_model),
         )
         .with_state(state)

--- a/crates/server/src/api/llm_providers.rs
+++ b/crates/server/src/api/llm_providers.rs
@@ -1,9 +1,10 @@
 // LLM Provider API endpoints
-// Routes are org-scoped: /v1/orgs/:org/llm-providers/...
+// Routes: /v1/llm-providers/...
 
-use crate::auth::{AuthState, OrgContext, middleware::FromRef};
+use crate::auth::{AuthState, ResolvedOrg};
 use crate::services::{LlmProviderService, ModelSyncService, SyncResult};
 use crate::storage::{EncryptionService, StorageBackend};
+use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, State},
@@ -109,10 +110,7 @@ pub struct UpdateLlmProviderRequest {
 /// Create a new LLM provider
 #[utoipa::path(
     post,
-    path = "/v1/orgs/{org}/llm-providers",
-    params(
-        ("org" = String, Path, description = "Organization public ID")
-    ),
+    path = "/v1/llm-providers",
     request_body = CreateLlmProviderRequest,
     responses(
         (status = 201, description = "Provider created", body = LlmProvider),
@@ -122,7 +120,7 @@ pub struct UpdateLlmProviderRequest {
     tag = "llm-providers"
 )]
 pub async fn create_provider(
-    _org: OrgContext,
+    _org: ResolvedOrg,
     State(state): State<AppState>,
     Json(req): Json<CreateLlmProviderRequest>,
 ) -> Result<(StatusCode, Json<LlmProvider>), (StatusCode, Json<ErrorResponse>)> {
@@ -150,17 +148,14 @@ pub async fn create_provider(
 /// List all LLM providers
 #[utoipa::path(
     get,
-    path = "/v1/orgs/{org}/llm-providers",
-    params(
-        ("org" = String, Path, description = "Organization public ID")
-    ),
+    path = "/v1/llm-providers",
     responses(
         (status = 200, description = "List of providers", body = ListResponse<LlmProvider>)
     ),
     tag = "llm-providers"
 )]
 pub async fn list_providers(
-    _org: OrgContext,
+    _org: ResolvedOrg,
     State(state): State<AppState>,
 ) -> Result<Json<ListResponse<LlmProvider>>, (StatusCode, Json<ErrorResponse>)> {
     let providers = state.service.list().await.map_err(|e| {
@@ -179,9 +174,8 @@ pub async fn list_providers(
 /// Get a specific LLM provider
 #[utoipa::path(
     get,
-    path = "/v1/orgs/{org}/llm-providers/{id}",
+    path = "/v1/llm-providers/{id}",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("id" = String, Path, description = "Provider ID (prefixed, e.g., prov_...)")
     ),
     responses(
@@ -192,9 +186,9 @@ pub async fn list_providers(
     tag = "llm-providers"
 )]
 pub async fn get_provider(
-    _org: OrgContext,
+    _org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, id)): Path<(String, String)>,
+    Path(id): Path<String>,
 ) -> Result<Json<LlmProvider>, (StatusCode, Json<ErrorResponse>)> {
     let provider_id: ProviderId = id.parse().map_err(|e| {
         (
@@ -233,9 +227,8 @@ pub async fn get_provider(
 /// Update an LLM provider
 #[utoipa::path(
     patch,
-    path = "/v1/orgs/{org}/llm-providers/{id}",
+    path = "/v1/llm-providers/{id}",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("id" = String, Path, description = "Provider ID (prefixed, e.g., prov_...)")
     ),
     request_body = UpdateLlmProviderRequest,
@@ -247,9 +240,9 @@ pub async fn get_provider(
     tag = "llm-providers"
 )]
 pub async fn update_provider(
-    _org: OrgContext,
+    _org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, id)): Path<(String, String)>,
+    Path(id): Path<String>,
     Json(req): Json<UpdateLlmProviderRequest>,
 ) -> Result<Json<LlmProvider>, (StatusCode, Json<ErrorResponse>)> {
     let provider_id: ProviderId = id.parse().map_err(|e| {
@@ -297,9 +290,8 @@ pub async fn update_provider(
 /// Delete an LLM provider
 #[utoipa::path(
     delete,
-    path = "/v1/orgs/{org}/llm-providers/{id}",
+    path = "/v1/llm-providers/{id}",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("id" = String, Path, description = "Provider ID (prefixed, e.g., prov_...)")
     ),
     responses(
@@ -310,9 +302,9 @@ pub async fn update_provider(
     tag = "llm-providers"
 )]
 pub async fn delete_provider(
-    _org: OrgContext,
+    _org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, id)): Path<(String, String)>,
+    Path(id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     let provider_id: ProviderId = id.parse().map_err(|e| {
         (
@@ -355,9 +347,8 @@ pub async fn delete_provider(
 /// the database. Only works for providers with standard base URLs (not custom).
 #[utoipa::path(
     post,
-    path = "/v1/orgs/{org}/llm-providers/{id}/sync-models",
+    path = "/v1/llm-providers/{id}/sync-models",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("id" = String, Path, description = "Provider ID (prefixed, e.g., prov_...)")
     ),
     responses(
@@ -369,9 +360,9 @@ pub async fn delete_provider(
     tag = "llm-providers"
 )]
 pub async fn sync_models(
-    _org: OrgContext,
+    _org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, id)): Path<(String, String)>,
+    Path(id): Path<String>,
 ) -> Result<Json<SyncModelsResponse>, (StatusCode, Json<ErrorResponse>)> {
     let provider_id: ProviderId = id.parse().map_err(|e| {
         (
@@ -434,19 +425,16 @@ pub async fn sync_models(
 pub fn routes(state: AppState) -> Router {
     Router::new()
         .route(
-            "/v1/orgs/:org/llm-providers",
+            "/v1/llm-providers",
             post(create_provider).get(list_providers),
         )
         .route(
-            "/v1/orgs/:org/llm-providers/:id",
+            "/v1/llm-providers/:id",
             get(get_provider)
                 .patch(update_provider)
                 .delete(delete_provider),
         )
-        .route(
-            "/v1/orgs/:org/llm-providers/:id/sync-models",
-            post(sync_models),
-        )
+        .route("/v1/llm-providers/:id/sync-models", post(sync_models))
         .with_state(state)
 }
 

--- a/crates/server/src/api/mcp_servers.rs
+++ b/crates/server/src/api/mcp_servers.rs
@@ -1,9 +1,10 @@
 // MCP Server CRUD HTTP routes
-// Routes are org-scoped: /v1/orgs/:org/mcp-servers/...
+// Routes: /v1/mcp-servers/...
 
-use crate::auth::{AuthState, OrgContext, middleware::FromRef};
+use crate::auth::{AuthState, ResolvedOrg};
 use crate::services::McpServerService;
 use crate::storage::{EncryptionService, StorageBackend};
+use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, State},
@@ -112,15 +113,15 @@ impl FromRef<AppState> for AuthState {
     }
 }
 
-/// Create MCP server routes (org-scoped)
+/// Create MCP server routes
 pub fn routes(state: AppState) -> Router {
     Router::new()
         .route(
-            "/v1/orgs/:org/mcp-servers",
+            "/v1/mcp-servers",
             post(create_mcp_server).get(list_mcp_servers),
         )
         .route(
-            "/v1/orgs/:org/mcp-servers/:server_id",
+            "/v1/mcp-servers/:server_id",
             get(get_mcp_server)
                 .patch(update_mcp_server)
                 .delete(delete_mcp_server),
@@ -128,13 +129,10 @@ pub fn routes(state: AppState) -> Router {
         .with_state(state)
 }
 
-/// POST /v1/orgs/{org}/mcp-servers - Create a new MCP server
+/// POST /v1/mcp-servers - Create a new MCP server
 #[utoipa::path(
     post,
-    path = "/v1/orgs/{org}/mcp-servers",
-    params(
-        ("org" = String, Path, description = "Organization public ID")
-    ),
+    path = "/v1/mcp-servers",
     request_body = CreateMcpServerRequest,
     responses(
         (status = 201, description = "MCP server created successfully", body = McpServer),
@@ -144,7 +142,7 @@ pub fn routes(state: AppState) -> Router {
     tag = "mcp-servers"
 )]
 pub async fn create_mcp_server(
-    _org: OrgContext,
+    _org: ResolvedOrg,
     State(state): State<AppState>,
     Json(req): Json<CreateMcpServerRequest>,
 ) -> Result<(StatusCode, Json<McpServer>), (StatusCode, Json<ErrorResponse>)> {
@@ -176,13 +174,10 @@ pub async fn create_mcp_server(
     Ok((StatusCode::CREATED, Json(server)))
 }
 
-/// GET /v1/orgs/{org}/mcp-servers - List all MCP servers
+/// GET /v1/mcp-servers - List all MCP servers
 #[utoipa::path(
     get,
-    path = "/v1/orgs/{org}/mcp-servers",
-    params(
-        ("org" = String, Path, description = "Organization public ID")
-    ),
+    path = "/v1/mcp-servers",
     responses(
         (status = 200, description = "List of MCP servers", body = ListResponse<McpServer>),
         (status = 500, description = "Internal server error")
@@ -190,7 +185,7 @@ pub async fn create_mcp_server(
     tag = "mcp-servers"
 )]
 pub async fn list_mcp_servers(
-    _org: OrgContext,
+    _org: ResolvedOrg,
     State(state): State<AppState>,
 ) -> Result<Json<ListResponse<McpServer>>, StatusCode> {
     let servers = state
@@ -202,12 +197,11 @@ pub async fn list_mcp_servers(
     Ok(Json(ListResponse::new(servers)))
 }
 
-/// GET /v1/orgs/{org}/mcp-servers/{server_id} - Get MCP server by ID
+/// GET /v1/mcp-servers/{server_id} - Get MCP server by ID
 #[utoipa::path(
     get,
-    path = "/v1/orgs/{org}/mcp-servers/{server_id}",
+    path = "/v1/mcp-servers/{server_id}",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("server_id" = String, Path, description = "MCP server ID (prefixed, e.g., mcp_...)")
     ),
     responses(
@@ -219,9 +213,9 @@ pub async fn list_mcp_servers(
     tag = "mcp-servers"
 )]
 pub async fn get_mcp_server(
-    _org: OrgContext,
+    _org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, server_id)): Path<(String, String)>,
+    Path(server_id): Path<String>,
 ) -> Result<Json<McpServer>, (StatusCode, Json<ErrorResponse>)> {
     let server_id: McpServerId = server_id.parse().map_err(|e| {
         (
@@ -242,12 +236,11 @@ pub async fn get_mcp_server(
     Ok(Json(server))
 }
 
-/// PATCH /v1/orgs/{org}/mcp-servers/{server_id} - Update MCP server
+/// PATCH /v1/mcp-servers/{server_id} - Update MCP server
 #[utoipa::path(
     patch,
-    path = "/v1/orgs/{org}/mcp-servers/{server_id}",
+    path = "/v1/mcp-servers/{server_id}",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("server_id" = String, Path, description = "MCP server ID (prefixed, e.g., mcp_...)")
     ),
     request_body = UpdateMcpServerRequest,
@@ -260,9 +253,9 @@ pub async fn get_mcp_server(
     tag = "mcp-servers"
 )]
 pub async fn update_mcp_server(
-    _org: OrgContext,
+    _org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, server_id)): Path<(String, String)>,
+    Path(server_id): Path<String>,
     Json(req): Json<UpdateMcpServerRequest>,
 ) -> Result<Json<McpServer>, (StatusCode, Json<ErrorResponse>)> {
     let server_id: McpServerId = server_id.parse().map_err(|e| {
@@ -302,12 +295,11 @@ pub async fn update_mcp_server(
     Ok(Json(server))
 }
 
-/// DELETE /v1/orgs/{org}/mcp-servers/{server_id} - Delete MCP server
+/// DELETE /v1/mcp-servers/{server_id} - Delete MCP server
 #[utoipa::path(
     delete,
-    path = "/v1/orgs/{org}/mcp-servers/{server_id}",
+    path = "/v1/mcp-servers/{server_id}",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("server_id" = String, Path, description = "MCP server ID (prefixed, e.g., mcp_...)")
     ),
     responses(
@@ -319,9 +311,9 @@ pub async fn update_mcp_server(
     tag = "mcp-servers"
 )]
 pub async fn delete_mcp_server(
-    _org: OrgContext,
+    _org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, server_id)): Path<(String, String)>,
+    Path(server_id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     let server_id: McpServerId = server_id.parse().map_err(|e| {
         (

--- a/crates/server/src/api/messages.rs
+++ b/crates/server/src/api/messages.rs
@@ -1,5 +1,5 @@
 // Message HTTP routes and API contracts
-// Routes use ResolvedOrg: org derived from auth context (API key or X-Org-Id header)
+// Routes use ResolvedOrg: org derived from auth context (API key or cookie)
 //
 // BREAKING CHANGE: Simplified message roles to just `user` and `agent`.
 // - Tool results are conveyed via `tool.completed` events

--- a/crates/server/src/api/messages.rs
+++ b/crates/server/src/api/messages.rs
@@ -1,5 +1,5 @@
 // Message HTTP routes and API contracts
-// Routes are org-scoped: /v1/orgs/:org/sessions/:session_id/messages
+// Routes use ResolvedOrg: org derived from auth context (API key or X-Org-Id header)
 //
 // BREAKING CHANGE: Simplified message roles to just `user` and `agent`.
 // - Tool results are conveyed via `tool.completed` events
@@ -8,8 +8,9 @@
 // ContentPart and InputContentPart are defined in everruns-core.
 // We re-export them here with ToSchema for OpenAPI documentation.
 
-use crate::auth::{AuthState, OrgContext, middleware::FromRef};
+use crate::auth::{AuthState, ResolvedOrg};
 use crate::storage::StorageBackend;
+use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, State},
@@ -170,11 +171,11 @@ impl FromRef<AppState> for AuthState {
     }
 }
 
-/// Create message routes (nested under sessions, org-scoped)
+/// Create message routes (nested under sessions)
 pub fn routes(state: AppState) -> Router {
     Router::new()
         .route(
-            "/v1/orgs/:org/sessions/:session_id/messages",
+            "/v1/sessions/:session_id/messages",
             post(create_message).get(list_messages),
         )
         .with_state(state)
@@ -184,12 +185,11 @@ pub fn routes(state: AppState) -> Router {
 // HTTP Handlers
 // ============================================
 
-/// POST /v1/orgs/{org}/sessions/{session_id}/messages - Create message (user message triggers workflow)
+/// POST /v1/sessions/{session_id}/messages - Create message (user message triggers workflow)
 #[utoipa::path(
     post,
-    path = "/v1/orgs/{org}/sessions/{session_id}/messages",
+    path = "/v1/sessions/{session_id}/messages",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)")
     ),
     request_body = CreateMessageRequest,
@@ -202,9 +202,9 @@ pub fn routes(state: AppState) -> Router {
     tag = "messages"
 )]
 pub async fn create_message(
-    org: OrgContext,
+    org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, session_id)): Path<(String, String)>,
+    Path(session_id): Path<String>,
     Json(req): Json<CreateMessageRequest>,
 ) -> Result<(StatusCode, Json<Message>), (StatusCode, Json<ErrorResponse>)> {
     let session_id: SessionId = session_id.parse().map_err(|e| {
@@ -256,12 +256,11 @@ pub async fn create_message(
     Ok((StatusCode::CREATED, Json(message)))
 }
 
-/// GET /v1/orgs/{org}/sessions/{session_id}/messages - List messages (PRIMARY data)
+/// GET /v1/sessions/{session_id}/messages - List messages (PRIMARY data)
 #[utoipa::path(
     get,
-    path = "/v1/orgs/{org}/sessions/{session_id}/messages",
+    path = "/v1/sessions/{session_id}/messages",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)")
     ),
     responses(
@@ -273,9 +272,9 @@ pub async fn create_message(
     tag = "messages"
 )]
 pub async fn list_messages(
-    org: OrgContext,
+    org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, session_id)): Path<(String, String)>,
+    Path(session_id): Path<String>,
 ) -> Result<Json<ListResponse<Message>>, (StatusCode, Json<ErrorResponse>)> {
     let session_id: SessionId = session_id.parse().map_err(|e| {
         (

--- a/crates/server/src/api/organizations.rs
+++ b/crates/server/src/api/organizations.rs
@@ -3,8 +3,9 @@
 // Note: Organization routes are NOT org-scoped (they are at the root level)
 // because they manage organizations themselves.
 
-use crate::auth::middleware::{AuthState, AuthUser, FromRef};
+use crate::auth::middleware::{AuthState, AuthUser};
 use crate::storage::StorageBackend;
+use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, State},

--- a/crates/server/src/api/session_files.rs
+++ b/crates/server/src/api/session_files.rs
@@ -13,7 +13,9 @@
 // Note: Paths starting with "_" are reserved for actions and cannot be
 // used for file creation or updates.
 
+use crate::auth::{AuthState, ResolvedOrg};
 use crate::storage::StorageBackend;
+use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, Query, State},
@@ -134,43 +136,39 @@ pub enum GetResponse {
 #[derive(Clone)]
 pub struct AppState {
     pub file_service: Arc<SessionFileService>,
+    pub auth: AuthState,
 }
 
 impl AppState {
-    pub fn new(db: Arc<StorageBackend>) -> Self {
+    pub fn new(db: Arc<StorageBackend>, auth: AuthState) -> Self {
         Self {
             file_service: Arc::new(SessionFileService::new(db)),
+            auth,
         }
     }
 }
 
-/// Create session files routes (org-scoped)
+impl FromRef<AppState> for AuthState {
+    fn from_ref(input: &AppState) -> Self {
+        input.auth.clone()
+    }
+}
+
+/// Create session files routes
 pub fn routes(state: AppState) -> Router {
     Router::new()
         // Actions (must be before wildcard to take precedence)
-        .route(
-            "/v1/orgs/:org/sessions/:session_id/fs/_/move",
-            post(move_file),
-        )
-        .route(
-            "/v1/orgs/:org/sessions/:session_id/fs/_/copy",
-            post(copy_file),
-        )
-        .route(
-            "/v1/orgs/:org/sessions/:session_id/fs/_/grep",
-            post(grep_files),
-        )
-        .route(
-            "/v1/orgs/:org/sessions/:session_id/fs/_/stat",
-            post(stat_file),
-        )
+        .route("/v1/sessions/:session_id/fs/_/move", post(move_file))
+        .route("/v1/sessions/:session_id/fs/_/copy", post(copy_file))
+        .route("/v1/sessions/:session_id/fs/_/grep", post(grep_files))
+        .route("/v1/sessions/:session_id/fs/_/stat", post(stat_file))
         // File operations with path
         .route(
-            "/v1/orgs/:org/sessions/:session_id/fs",
+            "/v1/sessions/:session_id/fs",
             get(get_root).post(create_root).delete(delete_root),
         )
         .route(
-            "/v1/orgs/:org/sessions/:session_id/fs/*path",
+            "/v1/sessions/:session_id/fs/*path",
             get(get_path)
                 .post(create_path)
                 .put(update_path)
@@ -198,9 +196,8 @@ fn is_reserved_path(path: &str) -> bool {
 /// GET /fs - Get root directory listing
 #[utoipa::path(
     get,
-    path = "/v1/orgs/{org}/sessions/{session_id}/fs",
+    path = "/v1/sessions/{session_id}/fs",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)"),
         ("recursive" = Option<bool>, Query, description = "List recursively")
     ),
@@ -212,8 +209,9 @@ fn is_reserved_path(path: &str) -> bool {
     tag = "filesystem"
 )]
 pub async fn get_root(
+    _org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, session_id)): Path<(String, String)>,
+    Path(session_id): Path<String>,
     Query(query): Query<GetQuery>,
 ) -> Result<Json<GetResponse>, (StatusCode, String)> {
     let session_id: SessionId = session_id.parse().map_err(|e| {
@@ -228,9 +226,8 @@ pub async fn get_root(
 /// GET /fs/*path - Get file content or directory listing
 #[utoipa::path(
     get,
-    path = "/v1/orgs/{org}/sessions/{session_id}/fs/{path}",
+    path = "/v1/sessions/{session_id}/fs/{path}",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)"),
         ("path" = String, Path, description = "File or directory path"),
         ("recursive" = Option<bool>, Query, description = "List recursively")
@@ -244,8 +241,9 @@ pub async fn get_root(
     tag = "filesystem"
 )]
 pub async fn get_path(
+    _org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, session_id, path)): Path<(String, String, String)>,
+    Path((session_id, path)): Path<(String, String)>,
     Query(query): Query<GetQuery>,
 ) -> Result<Json<GetResponse>, (StatusCode, String)> {
     let session_id: SessionId = session_id.parse().map_err(|e| {
@@ -322,7 +320,7 @@ async fn get_path_impl(
 }
 
 /// POST /fs - Create at root (not allowed)
-pub async fn create_root() -> (StatusCode, String) {
+pub async fn create_root(_org: ResolvedOrg) -> (StatusCode, String) {
     (
         StatusCode::BAD_REQUEST,
         "Cannot create at root path, specify a path".to_string(),
@@ -332,9 +330,8 @@ pub async fn create_root() -> (StatusCode, String) {
 /// POST /fs/*path - Create file or directory
 #[utoipa::path(
     post,
-    path = "/v1/orgs/{org}/sessions/{session_id}/fs/{path}",
+    path = "/v1/sessions/{session_id}/fs/{path}",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)"),
         ("path" = String, Path, description = "File or directory path")
     ),
@@ -348,8 +345,9 @@ pub async fn create_root() -> (StatusCode, String) {
     tag = "filesystem"
 )]
 pub async fn create_path(
+    _org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, session_id, path)): Path<(String, String, String)>,
+    Path((session_id, path)): Path<(String, String)>,
     Json(req): Json<CreateFileRequest>,
 ) -> Result<(StatusCode, Json<SessionFile>), (StatusCode, String)> {
     let session_id: SessionId = session_id.parse().map_err(|e| {
@@ -441,9 +439,8 @@ pub async fn create_path(
 /// PUT /fs/*path - Update file content
 #[utoipa::path(
     put,
-    path = "/v1/orgs/{org}/sessions/{session_id}/fs/{path}",
+    path = "/v1/sessions/{session_id}/fs/{path}",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)"),
         ("path" = String, Path, description = "File path")
     ),
@@ -457,8 +454,9 @@ pub async fn create_path(
     tag = "filesystem"
 )]
 pub async fn update_path(
+    _org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, session_id, path)): Path<(String, String, String)>,
+    Path((session_id, path)): Path<(String, String)>,
     Json(req): Json<UpdateFileRequest>,
 ) -> Result<Json<SessionFile>, (StatusCode, String)> {
     let session_id: SessionId = session_id.parse().map_err(|e| {
@@ -506,7 +504,7 @@ pub async fn update_path(
 }
 
 /// DELETE /fs - Delete root (not allowed)
-pub async fn delete_root() -> (StatusCode, String) {
+pub async fn delete_root(_org: ResolvedOrg) -> (StatusCode, String) {
     (
         StatusCode::BAD_REQUEST,
         "Cannot delete root directory".to_string(),
@@ -516,9 +514,8 @@ pub async fn delete_root() -> (StatusCode, String) {
 /// DELETE /fs/*path - Delete file or directory
 #[utoipa::path(
     delete,
-    path = "/v1/orgs/{org}/sessions/{session_id}/fs/{path}",
+    path = "/v1/sessions/{session_id}/fs/{path}",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)"),
         ("path" = String, Path, description = "File or directory path"),
         ("recursive" = Option<bool>, Query, description = "Delete recursively")
@@ -531,8 +528,9 @@ pub async fn delete_root() -> (StatusCode, String) {
     tag = "filesystem"
 )]
 pub async fn delete_path(
+    _org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, session_id, path)): Path<(String, String, String)>,
+    Path((session_id, path)): Path<(String, String)>,
     Query(query): Query<DeleteQuery>,
 ) -> Result<Json<DeleteResponse>, (StatusCode, String)> {
     let session_id: SessionId = session_id.parse().map_err(|e| {
@@ -567,9 +565,8 @@ pub async fn delete_path(
 /// POST /fs/_/move - Move/rename file
 #[utoipa::path(
     post,
-    path = "/v1/orgs/{org}/sessions/{session_id}/fs/_/move",
+    path = "/v1/sessions/{session_id}/fs/_/move",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)")
     ),
     request_body = MoveFileRequest,
@@ -583,8 +580,9 @@ pub async fn delete_path(
     tag = "filesystem"
 )]
 pub async fn move_file(
+    _org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, session_id)): Path<(String, String)>,
+    Path(session_id): Path<String>,
     Json(req): Json<MoveFileRequest>,
 ) -> Result<Json<SessionFile>, (StatusCode, String)> {
     let session_id: SessionId = session_id.parse().map_err(|e| {
@@ -627,9 +625,8 @@ pub async fn move_file(
 /// POST /fs/_/copy - Copy file
 #[utoipa::path(
     post,
-    path = "/v1/orgs/{org}/sessions/{session_id}/fs/_/copy",
+    path = "/v1/sessions/{session_id}/fs/_/copy",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)")
     ),
     request_body = CopyFileRequest,
@@ -643,8 +640,9 @@ pub async fn move_file(
     tag = "filesystem"
 )]
 pub async fn copy_file(
+    _org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, session_id)): Path<(String, String)>,
+    Path(session_id): Path<String>,
     Json(req): Json<CopyFileRequest>,
 ) -> Result<(StatusCode, Json<SessionFile>), (StatusCode, String)> {
     let session_id: SessionId = session_id.parse().map_err(|e| {
@@ -687,9 +685,8 @@ pub async fn copy_file(
 /// POST /fs/_/grep - Search files
 #[utoipa::path(
     post,
-    path = "/v1/orgs/{org}/sessions/{session_id}/fs/_/grep",
+    path = "/v1/sessions/{session_id}/fs/_/grep",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)")
     ),
     request_body = GrepRequest,
@@ -701,8 +698,9 @@ pub async fn copy_file(
     tag = "filesystem"
 )]
 pub async fn grep_files(
+    _org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, session_id)): Path<(String, String)>,
+    Path(session_id): Path<String>,
     Json(req): Json<GrepRequest>,
 ) -> Result<Json<ListResponse<GrepResult>>, (StatusCode, String)> {
     let session_id: SessionId = session_id.parse().map_err(|e| {
@@ -740,9 +738,8 @@ pub async fn grep_files(
 /// POST /fs/_/stat - Get file or directory stat
 #[utoipa::path(
     post,
-    path = "/v1/orgs/{org}/sessions/{session_id}/fs/_/stat",
+    path = "/v1/sessions/{session_id}/fs/_/stat",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)")
     ),
     request_body = StatRequest,
@@ -755,8 +752,9 @@ pub async fn grep_files(
     tag = "filesystem"
 )]
 pub async fn stat_file(
+    _org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, session_id)): Path<(String, String)>,
+    Path(session_id): Path<String>,
     Json(req): Json<StatRequest>,
 ) -> Result<Json<FileStat>, (StatusCode, String)> {
     let session_id: SessionId = session_id.parse().map_err(|e| {

--- a/crates/server/src/api/session_storage.rs
+++ b/crates/server/src/api/session_storage.rs
@@ -2,8 +2,9 @@
 // Routes for listing session key-value storage and secrets
 // Secrets are returned without their values for security
 
-use crate::auth::{AuthState, OrgContext, middleware::FromRef};
+use crate::auth::{AuthState, ResolvedOrg};
 use crate::storage::StorageBackend;
+use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, State},
@@ -60,26 +61,22 @@ impl FromRef<AppState> for AuthState {
     }
 }
 
-/// Create session storage routes (nested under sessions, org-scoped)
+/// Create session storage routes (nested under sessions)
 pub fn routes(state: AppState) -> Router {
     Router::new()
+        .route("/v1/sessions/:session_id/storage/keys", get(list_keys))
         .route(
-            "/v1/orgs/:org/sessions/:session_id/storage/keys",
-            get(list_keys),
-        )
-        .route(
-            "/v1/orgs/:org/sessions/:session_id/storage/secrets",
+            "/v1/sessions/:session_id/storage/secrets",
             get(list_secrets),
         )
         .with_state(state)
 }
 
-/// GET /v1/orgs/{org}/sessions/{session_id}/storage/keys - List all key-value pairs
+/// GET /v1/sessions/{session_id}/storage/keys - List all key-value pairs
 #[utoipa::path(
     get,
-    path = "/v1/orgs/{org}/sessions/{session_id}/storage/keys",
+    path = "/v1/sessions/{session_id}/storage/keys",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("session_id" = String, Path, description = "Session ID")
     ),
     responses(
@@ -90,9 +87,9 @@ pub fn routes(state: AppState) -> Router {
     tag = "session-storage"
 )]
 pub async fn list_keys(
-    _org: OrgContext,
+    _org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, session_id)): Path<(String, String)>,
+    Path(session_id): Path<String>,
 ) -> Result<Json<ListResponse<KeyValueInfo>>, StatusCode> {
     let session_id: SessionId = session_id.parse().map_err(|_| StatusCode::BAD_REQUEST)?;
 
@@ -125,12 +122,11 @@ pub async fn list_keys(
     Ok(Json(ListResponse::new(items)))
 }
 
-/// GET /v1/orgs/{org}/sessions/{session_id}/storage/secrets - List all secrets (names only)
+/// GET /v1/sessions/{session_id}/storage/secrets - List all secrets (names only)
 #[utoipa::path(
     get,
-    path = "/v1/orgs/{org}/sessions/{session_id}/storage/secrets",
+    path = "/v1/sessions/{session_id}/storage/secrets",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("session_id" = String, Path, description = "Session ID")
     ),
     responses(
@@ -141,9 +137,9 @@ pub async fn list_keys(
     tag = "session-storage"
 )]
 pub async fn list_secrets(
-    _org: OrgContext,
+    _org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, session_id)): Path<(String, String)>,
+    Path(session_id): Path<String>,
 ) -> Result<Json<ListResponse<SecretInfo>>, StatusCode> {
     let session_id: SessionId = session_id.parse().map_err(|_| StatusCode::BAD_REQUEST)?;
 

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -1,5 +1,5 @@
 // Session CRUD HTTP routes
-// Routes use ResolvedOrg: org derived from auth context (API key or X-Org-Id header)
+// Routes use ResolvedOrg: org derived from auth context (API key or cookie)
 
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::services::{EventService, SessionService};

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -1,9 +1,10 @@
 // Session CRUD HTTP routes
-// Routes are org-scoped: /v1/orgs/:org/sessions/...
+// Routes use ResolvedOrg: org derived from auth context (API key or X-Org-Id header)
 
-use crate::auth::{AuthState, OrgContext, middleware::FromRef};
+use crate::auth::{AuthState, ResolvedOrg};
 use crate::services::{EventService, SessionService};
 use crate::storage::StorageBackend;
+use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, Query, State},
@@ -122,35 +123,26 @@ impl FromRef<AppState> for AuthState {
     }
 }
 
-/// Create session routes (org-scoped)
+/// Create session routes
 pub fn routes(state: AppState) -> Router {
     Router::new()
-        // Session CRUD at org level
+        // Session CRUD
+        .route("/v1/sessions", post(create_session).get(list_sessions))
         .route(
-            "/v1/orgs/:org/sessions",
-            post(create_session).get(list_sessions),
-        )
-        .route(
-            "/v1/orgs/:org/sessions/:session_id",
+            "/v1/sessions/:session_id",
             get(get_session)
                 .patch(update_session)
                 .delete(delete_session),
         )
         // Cancel turn endpoint
-        .route(
-            "/v1/orgs/:org/sessions/:session_id/cancel",
-            post(cancel_turn),
-        )
+        .route("/v1/sessions/:session_id/cancel", post(cancel_turn))
         .with_state(state)
 }
 
-/// POST /v1/orgs/{org}/sessions - Create a new session
+/// POST /v1/sessions - Create a new session
 #[utoipa::path(
     post,
-    path = "/v1/orgs/{org}/sessions",
-    params(
-        ("org" = String, Path, description = "Organization public ID"),
-    ),
+    path = "/v1/sessions",
     request_body = CreateSessionRequest,
     responses(
         (status = 201, description = "Session created successfully", body = Session),
@@ -160,7 +152,7 @@ pub fn routes(state: AppState) -> Router {
     tag = "sessions"
 )]
 pub async fn create_session(
-    org: OrgContext,
+    org: ResolvedOrg,
     State(state): State<AppState>,
     Json(req): Json<CreateSessionRequest>,
 ) -> Result<(StatusCode, Json<Session>), (StatusCode, Json<ErrorResponse>)> {
@@ -173,14 +165,11 @@ pub async fn create_session(
     Ok((StatusCode::CREATED, Json(session)))
 }
 
-/// GET /v1/orgs/{org}/sessions - List sessions in organization
+/// GET /v1/sessions - List sessions in organization
 #[utoipa::path(
     get,
-    path = "/v1/orgs/{org}/sessions",
-    params(
-        ("org" = String, Path, description = "Organization public ID"),
-        ListSessionsQuery
-    ),
+    path = "/v1/sessions",
+    params(ListSessionsQuery),
     responses(
         (status = 200, description = "Paginated list of sessions", body = PaginatedResponse<Session>),
         (status = 500, description = "Internal server error")
@@ -188,7 +177,7 @@ pub async fn create_session(
     tag = "sessions"
 )]
 pub async fn list_sessions(
-    org: OrgContext,
+    org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListSessionsQuery>,
 ) -> Result<Json<PaginatedResponse<Session>>, (StatusCode, Json<ErrorResponse>)> {
@@ -210,12 +199,11 @@ pub async fn list_sessions(
     Ok(Json(PaginatedResponse::new(sessions, total, offset, limit)))
 }
 
-/// GET /v1/orgs/{org}/sessions/{session_id} - Get session
+/// GET /v1/sessions/{session_id} - Get session
 #[utoipa::path(
     get,
-    path = "/v1/orgs/{org}/sessions/{session_id}",
+    path = "/v1/sessions/{session_id}",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("session_id" = String, Path, description = "Session ID (prefixed, e.g., session_...)")
     ),
     responses(
@@ -227,9 +215,9 @@ pub async fn list_sessions(
     tag = "sessions"
 )]
 pub async fn get_session(
-    org: OrgContext,
+    org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, session_id)): Path<(String, String)>,
+    Path(session_id): Path<String>,
 ) -> Result<Json<Session>, (StatusCode, Json<ErrorResponse>)> {
     let session_id: SessionId = session_id.parse().map_err(|e| {
         (
@@ -250,12 +238,11 @@ pub async fn get_session(
     Ok(Json(session))
 }
 
-/// PATCH /v1/orgs/{org}/sessions/{session_id} - Update session
+/// PATCH /v1/sessions/{session_id} - Update session
 #[utoipa::path(
     patch,
-    path = "/v1/orgs/{org}/sessions/{session_id}",
+    path = "/v1/sessions/{session_id}",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("session_id" = String, Path, description = "Session ID (prefixed, e.g., session_...)")
     ),
     request_body = UpdateSessionRequest,
@@ -268,9 +255,9 @@ pub async fn get_session(
     tag = "sessions"
 )]
 pub async fn update_session(
-    org: OrgContext,
+    org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, session_id)): Path<(String, String)>,
+    Path(session_id): Path<String>,
     Json(req): Json<UpdateSessionRequest>,
 ) -> Result<Json<Session>, (StatusCode, Json<ErrorResponse>)> {
     let session_id: SessionId = session_id.parse().map_err(|e| {
@@ -292,12 +279,11 @@ pub async fn update_session(
     Ok(Json(session))
 }
 
-/// DELETE /v1/orgs/{org}/sessions/{session_id} - Delete session
+/// DELETE /v1/sessions/{session_id} - Delete session
 #[utoipa::path(
     delete,
-    path = "/v1/orgs/{org}/sessions/{session_id}",
+    path = "/v1/sessions/{session_id}",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("session_id" = String, Path, description = "Session ID (prefixed, e.g., session_...)")
     ),
     responses(
@@ -309,9 +295,9 @@ pub async fn update_session(
     tag = "sessions"
 )]
 pub async fn delete_session(
-    org: OrgContext,
+    org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, session_id)): Path<(String, String)>,
+    Path(session_id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     let session_id: SessionId = session_id.parse().map_err(|e| {
         (
@@ -340,7 +326,7 @@ pub async fn delete_session(
     }
 }
 
-/// POST /v1/orgs/{org}/sessions/{session_id}/cancel - Cancel current turn
+/// POST /v1/sessions/{session_id}/cancel - Cancel current turn
 ///
 /// Cancels the currently running turn in the session. If no turn is running,
 /// this is a no-op and returns success (idempotent). When a turn is active:
@@ -350,9 +336,8 @@ pub async fn delete_session(
 /// 4. Set the session status back to idle
 #[utoipa::path(
     post,
-    path = "/v1/orgs/{org}/sessions/{session_id}/cancel",
+    path = "/v1/sessions/{session_id}/cancel",
     params(
-        ("org" = String, Path, description = "Organization public ID"),
         ("session_id" = String, Path, description = "Session ID (prefixed, e.g., session_...)")
     ),
     responses(
@@ -364,9 +349,9 @@ pub async fn delete_session(
     tag = "sessions"
 )]
 pub async fn cancel_turn(
-    org: OrgContext,
+    org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_org_path, session_id)): Path<(String, String)>,
+    Path(session_id): Path<String>,
 ) -> Result<Json<CancelTurnResponse>, StatusCode> {
     let session_id: SessionId = session_id.parse().map_err(|_| StatusCode::BAD_REQUEST)?;
 

--- a/crates/server/src/api/users.rs
+++ b/crates/server/src/api/users.rs
@@ -1,14 +1,17 @@
 // Users API routes
 // Decision: Expose user listing for admin settings page (member management)
+// Decision: Cookie-based org selection for consistent auth across all requests (including SSE)
 
 use crate::storage::StorageBackend;
 use axum::{
     Json, Router,
     extract::{Query, State},
     http::StatusCode,
-    routing::get,
+    routing::{get, post},
 };
+use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 use chrono::{DateTime, Utc};
+use everruns_core::validate_org_public_id;
 
 use super::common::ListResponse;
 use serde::{Deserialize, Serialize};
@@ -17,6 +20,9 @@ use utoipa::ToSchema;
 
 use crate::auth::middleware::{AuthState, AuthUser};
 use axum::extract::FromRef;
+
+/// Cookie name for storing selected organization
+pub const ORG_COOKIE_NAME: &str = "everruns_org";
 
 /// App state for users routes
 #[derive(Clone)]
@@ -53,10 +59,28 @@ pub struct ListUsersQuery {
     pub search: Option<String>,
 }
 
+/// Request to switch organization
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct SwitchOrgRequest {
+    /// Organization public ID to switch to
+    #[schema(example = "org_2f3c1b3e6a9d4c6f8a1d4e9c9b7f21a0")]
+    pub org_id: String,
+}
+
+/// Response from switch org endpoint
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct SwitchOrgResponse {
+    /// Whether the switch was successful
+    pub success: bool,
+    /// The organization ID that was switched to
+    pub org_id: String,
+}
+
 /// Create users routes
 pub fn routes(state: UsersState) -> Router {
     Router::new()
         .route("/v1/users", get(list_users))
+        .route("/v1/users/me/switch-org", post(switch_org))
         .with_state(state)
 }
 
@@ -108,6 +132,69 @@ pub async fn list_users(
         .collect();
 
     Ok(Json(ListResponse::new(users)))
+}
+
+/// POST /v1/users/me/switch-org - Switch current organization
+///
+/// Sets a cookie with the selected organization. This org will be used for all
+/// subsequent requests (including SSE connections via EventSource).
+/// The user must be a member of the requested organization.
+#[utoipa::path(
+    post,
+    path = "/v1/users/me/switch-org",
+    request_body = SwitchOrgRequest,
+    responses(
+        (status = 200, description = "Organization switched successfully", body = SwitchOrgResponse),
+        (status = 400, description = "Invalid organization ID format"),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Organization not found or user is not a member")
+    ),
+    tag = "users"
+)]
+pub async fn switch_org(
+    auth: AuthUser,
+    jar: CookieJar,
+    Json(req): Json<SwitchOrgRequest>,
+) -> Result<(CookieJar, Json<SwitchOrgResponse>), StatusCode> {
+    // Validate org ID format
+    if !validate_org_public_id(&req.org_id) {
+        tracing::warn!("Invalid org ID format: {}", req.org_id);
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    // Verify user is a member of this org
+    let is_member = auth
+        .organizations
+        .iter()
+        .any(|org| org.public_id == req.org_id);
+
+    if !is_member {
+        tracing::warn!(
+            "User {} attempted to switch to org {} but is not a member",
+            auth.id,
+            req.org_id
+        );
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    // Build the org cookie
+    let org_cookie = Cookie::build((ORG_COOKIE_NAME, req.org_id.clone()))
+        .path("/")
+        .http_only(true)
+        .same_site(SameSite::Lax)
+        .build();
+
+    let jar = jar.add(org_cookie);
+
+    tracing::info!("User {} switched to org {}", auth.id, req.org_id);
+
+    Ok((
+        jar,
+        Json(SwitchOrgResponse {
+            success: true,
+            org_id: req.org_id,
+        }),
+    ))
 }
 
 #[cfg(test)]

--- a/crates/server/src/api/users.rs
+++ b/crates/server/src/api/users.rs
@@ -15,7 +15,8 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
 
-use crate::auth::middleware::{AuthState, AuthUser, FromRef};
+use crate::auth::middleware::{AuthState, AuthUser};
+use axum::extract::FromRef;
 
 /// App state for users routes
 #[derive(Clone)]

--- a/crates/server/src/auth/api_key.rs
+++ b/crates/server/src/auth/api_key.rs
@@ -74,6 +74,7 @@ pub fn is_valid_api_key_format(key: &str) -> bool {
 pub struct ValidatedApiKey {
     pub key_id: Uuid,
     pub user_id: Uuid,
+    pub org_id: i64,
     pub name: String,
     pub scopes: Vec<String>,
     pub expires_at: Option<DateTime<Utc>>,
@@ -170,6 +171,7 @@ mod tests {
         let key = ValidatedApiKey {
             key_id: Uuid::nil(),
             user_id: Uuid::nil(),
+            org_id: 1,
             name: "test".to_string(),
             scopes: vec!["*".to_string()],
             expires_at: Some(Utc::now() + Duration::days(1)),
@@ -180,6 +182,7 @@ mod tests {
         let expired_key = ValidatedApiKey {
             key_id: Uuid::nil(),
             user_id: Uuid::nil(),
+            org_id: 1,
             name: "test".to_string(),
             scopes: vec!["*".to_string()],
             expires_at: Some(Utc::now() - Duration::days(1)),
@@ -190,6 +193,7 @@ mod tests {
         let no_expiry_key = ValidatedApiKey {
             key_id: Uuid::nil(),
             user_id: Uuid::nil(),
+            org_id: 1,
             name: "test".to_string(),
             scopes: vec!["*".to_string()],
             expires_at: None,
@@ -202,6 +206,7 @@ mod tests {
         let key = ValidatedApiKey {
             key_id: Uuid::nil(),
             user_id: Uuid::nil(),
+            org_id: 1,
             name: "test".to_string(),
             scopes: vec!["read".to_string(), "write".to_string()],
             expires_at: None,
@@ -215,6 +220,7 @@ mod tests {
         let admin_key = ValidatedApiKey {
             key_id: Uuid::nil(),
             user_id: Uuid::nil(),
+            org_id: 1,
             name: "admin".to_string(),
             scopes: vec!["*".to_string()],
             expires_at: None,

--- a/crates/server/src/auth/middleware.rs
+++ b/crates/server/src/auth/middleware.rs
@@ -461,15 +461,19 @@ where
 // ResolvedOrg - Organization context from auth (not URL path)
 // ============================================================================
 
-/// Header name for org selection in session auth
-pub const ORG_HEADER: &str = "X-Org-Id";
+/// Cookie name for org selection in session auth
+/// Note: Also defined in api/users.rs - keep in sync
+pub const ORG_COOKIE_NAME: &str = "everruns_org";
 
 /// Organization context resolved from authentication
 ///
 /// Unlike OrgContext which extracts org from URL path, ResolvedOrg derives
 /// the organization from the authentication context:
 /// - API key auth: org comes from API key (single org in AuthUser.organizations)
-/// - Session auth (JWT): org from X-Org-Id header, validated against user membership
+/// - Session auth (JWT/None): org from everruns_org cookie, validated against user membership
+///
+/// The cookie is set via POST /v1/users/me/switch-org endpoint.
+/// Cookies work automatically with SSE (EventSource) unlike headers.
 ///
 /// Usage:
 /// ```rust,ignore
@@ -502,37 +506,32 @@ where
         let user = AuthUser::from_request_parts(parts, state).await?;
 
         match user.auth_method {
-            AuthMethod::ApiKey => {
+            AuthMethod::ApiKey | AuthMethod::None => {
                 // API key auth: user has exactly one org (from API key)
+                // None (anonymous): user has exactly one org (default org)
+                // In both cases, just use the single org - no cookie needed
                 let org = user
                     .organizations
                     .first()
-                    .ok_or_else(|| AuthError::unauthorized("API key has no organization"))?;
+                    .ok_or_else(|| AuthError::unauthorized("No organization available"))?;
                 Ok(ResolvedOrg {
                     org_id: org.org_id,
                     public_id: org.public_id.clone(),
                     name: org.name.clone(),
                 })
             }
-            AuthMethod::Jwt | AuthMethod::None => {
-                // Session auth: get org from X-Org-Id header or org_id query param
-                // Query param fallback is needed for SSE (EventSource doesn't support headers)
-                let org_public_id = parts
-                    .headers
-                    .get(ORG_HEADER)
-                    .and_then(|v| v.to_str().ok())
-                    .map(|s| s.to_string())
-                    .or_else(|| {
-                        // Fallback to query param for SSE (EventSource doesn't support headers)
-                        parts.uri.query().and_then(|q| {
-                            q.split('&')
-                                .filter_map(|part| part.split_once('='))
-                                .find(|(k, _)| *k == "org_id")
-                                .map(|(_, v)| v.to_string())
-                        })
-                    })
+            AuthMethod::Jwt => {
+                // Session auth: get org from everruns_org cookie
+                // Cookie is set via POST /v1/users/me/switch-org
+                // Cookies work automatically with SSE (EventSource) unlike headers
+                let jar = CookieJar::from_headers(&parts.headers);
+                let org_public_id = jar
+                    .get(ORG_COOKIE_NAME)
+                    .map(|c| c.value().to_string())
                     .ok_or_else(|| {
-                        AuthError::unauthorized("Missing X-Org-Id header or org_id query param")
+                        AuthError::unauthorized(
+                            "Missing organization cookie. Call POST /v1/users/me/switch-org first.",
+                        )
                     })?;
                 let org_public_id = org_public_id.as_str();
 

--- a/crates/server/src/auth/middleware.rs
+++ b/crates/server/src/auth/middleware.rs
@@ -4,7 +4,7 @@
 
 use axum::{
     Json,
-    extract::FromRequestParts,
+    extract::{FromRef, FromRequestParts},
     http::{StatusCode, header, request::Parts},
     response::{IntoResponse, Response},
 };
@@ -161,17 +161,6 @@ where
     }
 }
 
-/// Helper trait for extracting AuthState from application state
-pub trait FromRef<T> {
-    fn from_ref(input: &T) -> Self;
-}
-
-impl FromRef<AuthState> for AuthState {
-    fn from_ref(input: &AuthState) -> Self {
-        input.clone()
-    }
-}
-
 /// Extract authenticated user from request
 async fn extract_auth_user(
     parts: &mut Parts,
@@ -258,6 +247,7 @@ async fn validate_api_key(key: &str, auth_state: &AuthState) -> Result<AuthUser,
     let validated_key = ValidatedApiKey {
         key_id: api_key_row.id,
         user_id: api_key_row.user_id,
+        org_id: api_key_row.org_id,
         name: api_key_row.name.clone(),
         scopes: serde_json::from_value(api_key_row.scopes.clone()).unwrap_or_default(),
         expires_at: api_key_row.expires_at,
@@ -287,8 +277,16 @@ async fn validate_api_key(key: &str, auth_state: &AuthState) -> Result<AuthUser,
 
     let roles: Vec<String> = serde_json::from_value(user.roles.clone()).unwrap_or_default();
 
-    // Fetch organization memberships for the user
-    let organizations = fetch_user_organizations(&auth_state.db, user.id).await?;
+    // Fetch org for the API key (API key is scoped to single org)
+    let org = auth_state
+        .db
+        .get_organization(api_key_row.org_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to fetch org for API key: {}", e);
+            AuthError::unauthorized("Failed to validate API key")
+        })?
+        .ok_or_else(|| AuthError::unauthorized("Organization not found for API key"))?;
 
     Ok(AuthUser {
         id: user.id,
@@ -296,7 +294,11 @@ async fn validate_api_key(key: &str, auth_state: &AuthState) -> Result<AuthUser,
         name: user.name,
         roles,
         auth_method: AuthMethod::ApiKey,
-        organizations,
+        organizations: vec![OrgMembership {
+            org_id: org.org_id,
+            public_id: org.public_id,
+            name: org.name,
+        }],
     })
 }
 
@@ -452,6 +454,109 @@ where
             public_id: org.public_id.clone(),
             name: org.name.clone(),
         })
+    }
+}
+
+// ============================================================================
+// ResolvedOrg - Organization context from auth (not URL path)
+// ============================================================================
+
+/// Header name for org selection in session auth
+pub const ORG_HEADER: &str = "X-Org-Id";
+
+/// Organization context resolved from authentication
+///
+/// Unlike OrgContext which extracts org from URL path, ResolvedOrg derives
+/// the organization from the authentication context:
+/// - API key auth: org comes from API key (single org in AuthUser.organizations)
+/// - Session auth (JWT): org from X-Org-Id header, validated against user membership
+///
+/// Usage:
+/// ```rust,ignore
+/// async fn handler(
+///     ResolvedOrg { org_id, public_id, .. }: ResolvedOrg,
+/// ) -> impl IntoResponse {
+///     // org_id is the internal i64 ID for database queries
+/// }
+/// ```
+#[derive(Debug, Clone)]
+pub struct ResolvedOrg {
+    /// Internal organization ID (for database queries)
+    pub org_id: i64,
+    /// External organization public ID
+    pub public_id: String,
+    /// Organization name
+    pub name: String,
+}
+
+#[axum::async_trait]
+impl<S> FromRequestParts<S> for ResolvedOrg
+where
+    S: Send + Sync,
+    AuthState: axum::extract::FromRef<S>,
+{
+    type Rejection = AuthError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        // First extract the authenticated user
+        let user = AuthUser::from_request_parts(parts, state).await?;
+
+        match user.auth_method {
+            AuthMethod::ApiKey => {
+                // API key auth: user has exactly one org (from API key)
+                let org = user
+                    .organizations
+                    .first()
+                    .ok_or_else(|| AuthError::unauthorized("API key has no organization"))?;
+                Ok(ResolvedOrg {
+                    org_id: org.org_id,
+                    public_id: org.public_id.clone(),
+                    name: org.name.clone(),
+                })
+            }
+            AuthMethod::Jwt | AuthMethod::None => {
+                // Session auth: get org from X-Org-Id header or org_id query param
+                // Query param fallback is needed for SSE (EventSource doesn't support headers)
+                let org_public_id = parts
+                    .headers
+                    .get(ORG_HEADER)
+                    .and_then(|v| v.to_str().ok())
+                    .map(|s| s.to_string())
+                    .or_else(|| {
+                        // Fallback to query param for SSE (EventSource doesn't support headers)
+                        parts.uri.query().and_then(|q| {
+                            q.split('&')
+                                .filter_map(|part| part.split_once('='))
+                                .find(|(k, _)| *k == "org_id")
+                                .map(|(_, v)| v.to_string())
+                        })
+                    })
+                    .ok_or_else(|| {
+                        AuthError::unauthorized("Missing X-Org-Id header or org_id query param")
+                    })?;
+                let org_public_id = org_public_id.as_str();
+
+                // Validate format
+                if !validate_org_public_id(org_public_id) {
+                    return Err(AuthError::unauthorized("Invalid organization ID format"));
+                }
+
+                // Check user membership
+                let org = user.get_org(org_public_id).ok_or_else(|| {
+                    // Return 404 to prevent enumeration
+                    AuthError {
+                        error: "Organization not found".to_string(),
+                        status: StatusCode::NOT_FOUND,
+                    }
+                })?;
+
+                Ok(ResolvedOrg {
+                    org_id: org.org_id,
+                    public_id: org.public_id.clone(),
+                    name: org.name.clone(),
+                })
+            }
+        }
     }
 }
 

--- a/crates/server/src/auth/mod.rs
+++ b/crates/server/src/auth/mod.rs
@@ -10,5 +10,5 @@ pub mod oauth;
 pub mod routes;
 
 pub use config::AuthConfig;
-pub use middleware::{AuthState, AuthUser, ORG_HEADER, OrgContext, ResolvedOrg};
+pub use middleware::{AuthState, AuthUser, OrgContext, ResolvedOrg};
 pub use routes::routes;

--- a/crates/server/src/auth/mod.rs
+++ b/crates/server/src/auth/mod.rs
@@ -10,5 +10,5 @@ pub mod oauth;
 pub mod routes;
 
 pub use config::AuthConfig;
-pub use middleware::{AuthState, AuthUser, OrgContext};
+pub use middleware::{AuthState, AuthUser, ORG_HEADER, OrgContext, ResolvedOrg};
 pub use routes::routes;

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -21,7 +21,7 @@ use super::{
     api_key::generate_api_key,
     config::AuthMode,
     jwt::hash_token,
-    middleware::{AuthError, AuthState, AuthUser},
+    middleware::{AuthError, AuthMethod, AuthState, AuthUser, ResolvedOrg},
     oauth::{GitHubOAuthService, GoogleOAuthService, OAuthProvider},
 };
 use crate::api::common::ListResponse;
@@ -644,11 +644,22 @@ pub async fn list_api_keys(
 }
 
 /// POST /v1/auth/api-keys - Create a new API key
+///
+/// Requires X-Org-Id header to specify which organization the API key is for.
+/// Cannot be called with API key authentication (must use session auth).
 pub async fn create_api_key_route(
     State(state): State<AuthState>,
     user: AuthUser,
+    org: ResolvedOrg,
     Json(req): Json<CreateApiKeyRequest>,
 ) -> Result<(StatusCode, Json<ApiKeyResponse>), AuthError> {
+    // Cannot create API key using API key auth
+    if user.auth_method == AuthMethod::ApiKey {
+        return Err(AuthError::forbidden(
+            "Cannot create API key using API key authentication",
+        ));
+    }
+
     let generated = generate_api_key();
 
     let scopes = if req.scopes.is_empty() {
@@ -664,7 +675,7 @@ pub async fn create_api_key_route(
     let key_row = state
         .db
         .create_api_key(CreateApiKeyRow {
-            org_id: DEFAULT_ORG_ID, // TODO: Get from request context after Phase 3
+            org_id: org.org_id,
             user_id: user.id,
             name: req.name.clone(),
             key_hash: generated.key_hash.clone(),

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -645,7 +645,7 @@ pub async fn list_api_keys(
 
 /// POST /v1/auth/api-keys - Create a new API key
 ///
-/// Requires X-Org-Id header to specify which organization the API key is for.
+/// Organization is derived from the everruns_org cookie (set via /v1/users/me/switch-org).
 /// Cannot be called with API key authentication (must use session auth).
 pub async fn create_api_key_route(
     State(state): State<AuthState>,

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -242,7 +242,7 @@ async fn main() -> Result<()> {
         api::capabilities::AppState::new(capability_service.clone(), auth_state.clone());
     let agents_state =
         api::agents::AppState::new(db.clone(), capability_service, auth_state.clone());
-    let session_files_state = api::session_files::AppState::new(db.clone());
+    let session_files_state = api::session_files::AppState::new(db.clone(), auth_state.clone());
     let session_storage_state = api::session_storage::AppState::new(db.clone(), auth_state.clone());
     let users_state = api::users::UsersState {
         db: db.clone(),

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -200,7 +200,7 @@ impl Database {
     pub async fn get_api_key_by_hash(&self, key_hash: &str) -> Result<Option<ApiKeyRow>> {
         let row = sqlx::query_as::<_, ApiKeyRow>(
             r#"
-            SELECT id, user_id, name, key_hash, key_prefix, scopes, expires_at, last_used_at, created_at
+            SELECT id, org_id, user_id, name, key_hash, key_prefix, scopes, expires_at, last_used_at, created_at
             FROM api_keys
             WHERE key_hash = $1
             "#,
@@ -215,7 +215,7 @@ impl Database {
     pub async fn list_api_keys_for_user(&self, user_id: Uuid) -> Result<Vec<ApiKeyRow>> {
         let rows = sqlx::query_as::<_, ApiKeyRow>(
             r#"
-            SELECT id, user_id, name, key_hash, key_prefix, scopes, expires_at, last_used_at, created_at
+            SELECT id, org_id, user_id, name, key_hash, key_prefix, scopes, expires_at, last_used_at, created_at
             FROM api_keys
             WHERE user_id = $1
             ORDER BY created_at DESC

--- a/crates/server/tests/integration_test.rs
+++ b/crates/server/tests/integration_test.rs
@@ -19,7 +19,7 @@ async fn test_full_agent_session_workflow() {
     // Step 1: Create an agent
     println!("\nStep 1: Creating agent...");
     let create_agent_response = client
-        .post(format!("{}/v1/orgs/{}/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({
             "name": "Test Agent",
             "description": "An agent for testing",
@@ -48,7 +48,7 @@ async fn test_full_agent_session_workflow() {
     // Step 2: List agents
     println!("\nStep 2: Listing agents...");
     let list_response = client
-        .get(format!("{}/v1/orgs/{}/agents", API_BASE_URL, DEFAULT_ORG))
+        .get(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
         .send()
         .await
         .expect("Failed to list agents");
@@ -65,7 +65,7 @@ async fn test_full_agent_session_workflow() {
     println!("\nStep 3: Getting agent by ID...");
     let get_response = client
         .get(format!(
-            "{}/v1/orgs/{}/agents/{}",
+            "{}/v1/agents/{}",
             API_BASE_URL, DEFAULT_ORG, agent.id
         ))
         .send()
@@ -81,7 +81,7 @@ async fn test_full_agent_session_workflow() {
     println!("\nStep 4: Updating agent...");
     let update_response = client
         .patch(format!(
-            "{}/v1/orgs/{}/agents/{}",
+            "{}/v1/agents/{}",
             API_BASE_URL, DEFAULT_ORG, agent.id
         ))
         .json(&json!({
@@ -100,7 +100,7 @@ async fn test_full_agent_session_workflow() {
     // Step 5: Create a session
     println!("\nStep 5: Creating session...");
     let session_response = client
-        .post(format!("{}/v1/orgs/{}/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({
             "agent_id": agent.id,
             "title": "Test Session"
@@ -121,7 +121,7 @@ async fn test_full_agent_session_workflow() {
     println!("\nStep 6: Adding user message...");
     let message_response = client
         .post(format!(
-            "{}/v1/orgs/{}/sessions/{}/messages",
+            "{}/v1/sessions/{}/messages",
             API_BASE_URL, DEFAULT_ORG, session.id
         ))
         .json(&json!({
@@ -146,7 +146,7 @@ async fn test_full_agent_session_workflow() {
     println!("\nStep 7: Listing messages...");
     let messages_response = client
         .get(format!(
-            "{}/v1/orgs/{}/sessions/{}/messages",
+            "{}/v1/sessions/{}/messages",
             API_BASE_URL, DEFAULT_ORG, session.id
         ))
         .send()
@@ -165,7 +165,7 @@ async fn test_full_agent_session_workflow() {
     println!("\nStep 8: Getting session...");
     let get_session_response = client
         .get(format!(
-            "{}/v1/orgs/{}/sessions/{}",
+            "{}/v1/sessions/{}",
             API_BASE_URL, DEFAULT_ORG, session.id
         ))
         .send()
@@ -184,7 +184,7 @@ async fn test_full_agent_session_workflow() {
     println!("\nStep 9: Listing events...");
     let events_response = client
         .get(format!(
-            "{}/v1/orgs/{}/sessions/{}/events",
+            "{}/v1/sessions/{}/events",
             API_BASE_URL, DEFAULT_ORG, session.id
         ))
         .send()
@@ -250,7 +250,7 @@ async fn test_llm_provider_and_model_workflow() {
     println!("\nStep 1: Creating LLM provider...");
     let create_provider_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers",
+            "{}/v1/llm-providers",
             API_BASE_URL, DEFAULT_ORG
         ))
         .json(&json!({
@@ -278,7 +278,7 @@ async fn test_llm_provider_and_model_workflow() {
     println!("\nStep 2: Creating model for provider...");
     let create_model_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers/{}/models",
+            "{}/v1/llm-providers/{}/models",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .json(&json!({
@@ -307,7 +307,7 @@ async fn test_llm_provider_and_model_workflow() {
 
     client
         .delete(format!(
-            "{}/v1/orgs/{}/llm-models/{}",
+            "{}/v1/llm-models/{}",
             API_BASE_URL, DEFAULT_ORG, model.id
         ))
         .send()
@@ -316,7 +316,7 @@ async fn test_llm_provider_and_model_workflow() {
 
     client
         .delete(format!(
-            "{}/v1/orgs/{}/llm-providers/{}",
+            "{}/v1/llm-providers/{}",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .send()
@@ -336,7 +336,7 @@ async fn test_llm_model_profile() {
     println!("\nStep 1: Creating OpenAI provider...");
     let create_provider_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers",
+            "{}/v1/llm-providers",
             API_BASE_URL, DEFAULT_ORG
         ))
         .json(&json!({
@@ -359,7 +359,7 @@ async fn test_llm_model_profile() {
     println!("\nStep 2: Creating gpt-4o model...");
     let create_model_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers/{}/models",
+            "{}/v1/llm-providers/{}/models",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .json(&json!({
@@ -384,7 +384,7 @@ async fn test_llm_model_profile() {
     println!("\nStep 3: Getting model with profile via list endpoint...");
     let list_models_response = client
         .get(format!(
-            "{}/v1/orgs/{}/llm-models",
+            "{}/v1/llm-models",
             API_BASE_URL, DEFAULT_ORG
         ))
         .send()
@@ -430,7 +430,7 @@ async fn test_llm_model_profile() {
     println!("\nCleaning up...");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/llm-models/{}",
+            "{}/v1/llm-models/{}",
             API_BASE_URL, DEFAULT_ORG, model_id
         ))
         .send()
@@ -439,7 +439,7 @@ async fn test_llm_model_profile() {
 
     client
         .delete(format!(
-            "{}/v1/orgs/{}/llm-providers/{}",
+            "{}/v1/llm-providers/{}",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .send()
@@ -459,7 +459,7 @@ async fn test_session_inherits_agent_default_model() {
     println!("\nStep 1: Creating LLM provider...");
     let provider_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers",
+            "{}/v1/llm-providers",
             API_BASE_URL, DEFAULT_ORG
         ))
         .json(&json!({
@@ -481,7 +481,7 @@ async fn test_session_inherits_agent_default_model() {
     println!("\nStep 2: Creating model...");
     let model_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers/{}/models",
+            "{}/v1/llm-providers/{}/models",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .json(&json!({
@@ -499,7 +499,7 @@ async fn test_session_inherits_agent_default_model() {
     // Step 3: Create an agent with default_model_id
     println!("\nStep 3: Creating agent with default_model_id...");
     let agent_response = client
-        .post(format!("{}/v1/orgs/{}/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({
             "name": "Agent with Default Model",
             "system_prompt": "Test agent",
@@ -520,7 +520,7 @@ async fn test_session_inherits_agent_default_model() {
     // Step 4: Create a session WITHOUT specifying model_id
     println!("\nStep 4: Creating session without model_id...");
     let session_response = client
-        .post(format!("{}/v1/orgs/{}/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({
             "agent_id": agent.id,
             "title": "Test Session"
@@ -552,7 +552,7 @@ async fn test_session_inherits_agent_default_model() {
     // Create another model
     let model2_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers/{}/models",
+            "{}/v1/llm-providers/{}/models",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .json(&json!({
@@ -570,7 +570,7 @@ async fn test_session_inherits_agent_default_model() {
         .expect("Failed to parse second model");
 
     let session2_response = client
-        .post(format!("{}/v1/orgs/{}/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({
             "agent_id": agent.id,
             "title": "Test Session 2",
@@ -601,7 +601,7 @@ async fn test_session_inherits_agent_default_model() {
     println!("\nCleaning up...");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/agents/{}",
+            "{}/v1/agents/{}",
             API_BASE_URL, DEFAULT_ORG, agent.id
         ))
         .send()
@@ -609,7 +609,7 @@ async fn test_session_inherits_agent_default_model() {
         .expect("Failed to delete agent");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/llm-models/{}",
+            "{}/v1/llm-models/{}",
             API_BASE_URL, DEFAULT_ORG, model.id
         ))
         .send()
@@ -617,7 +617,7 @@ async fn test_session_inherits_agent_default_model() {
         .expect("Failed to delete model");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/llm-models/{}",
+            "{}/v1/llm-models/{}",
             API_BASE_URL, DEFAULT_ORG, model2.id
         ))
         .send()
@@ -625,7 +625,7 @@ async fn test_session_inherits_agent_default_model() {
         .expect("Failed to delete model2");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/llm-providers/{}",
+            "{}/v1/llm-providers/{}",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .send()
@@ -644,7 +644,7 @@ async fn test_session_filesystem() {
     // Step 1: Create an agent
     println!("\nStep 1: Creating agent...");
     let agent_response = client
-        .post(format!("{}/v1/orgs/{}/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({
             "name": "Filesystem Test Agent",
             "system_prompt": "Test agent for filesystem"
@@ -659,7 +659,7 @@ async fn test_session_filesystem() {
     // Step 2: Create a session
     println!("\nStep 2: Creating session...");
     let session_response = client
-        .post(format!("{}/v1/orgs/{}/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({
             "agent_id": agent.id,
             "title": "Filesystem Test Session"
@@ -675,7 +675,7 @@ async fn test_session_filesystem() {
     println!("Created session: {}", session.id);
 
     let fs_url = format!(
-        "{}/v1/orgs/{}/sessions/{}/fs",
+        "{}/v1/sessions/{}/fs",
         API_BASE_URL, DEFAULT_ORG, session.id
     );
 
@@ -877,7 +877,7 @@ async fn test_session_filesystem() {
     println!("\nCleaning up...");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/agents/{}",
+            "{}/v1/agents/{}",
             API_BASE_URL, DEFAULT_ORG, agent.id
         ))
         .send()
@@ -909,7 +909,7 @@ async fn test_message_triggers_agent_workflow() {
     println!("\nStep 0: Creating LlmSim provider and model...");
     let provider_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers",
+            "{}/v1/llm-providers",
             API_BASE_URL, DEFAULT_ORG
         ))
         .json(&json!({
@@ -936,7 +936,7 @@ async fn test_message_triggers_agent_workflow() {
 
     let model_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers/{}/models",
+            "{}/v1/llm-providers/{}/models",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .json(&json!({
@@ -961,7 +961,7 @@ async fn test_message_triggers_agent_workflow() {
     // Step 1: Create agent with LlmSim model
     println!("\nStep 1: Creating agent with LlmSim model...");
     let agent_response = client
-        .post(format!("{}/v1/orgs/{}/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({
             "name": "Workflow Test Agent",
             "system_prompt": "You are a helpful assistant. Respond briefly.",
@@ -981,7 +981,7 @@ async fn test_message_triggers_agent_workflow() {
     // Step 2: Create session
     println!("\nStep 2: Creating session...");
     let session_response = client
-        .post(format!("{}/v1/orgs/{}/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({"agent_id": agent.id, "title": "Workflow Test Session"}))
         .send()
         .await
@@ -999,7 +999,7 @@ async fn test_message_triggers_agent_workflow() {
     let start = Instant::now();
     let message_response = client
         .post(format!(
-            "{}/v1/orgs/{}/sessions/{}/messages",
+            "{}/v1/sessions/{}/messages",
             API_BASE_URL, DEFAULT_ORG, session.id
         ))
         .json(&json!({
@@ -1039,7 +1039,7 @@ async fn test_message_triggers_agent_workflow() {
 
         let messages_response = client
             .get(format!(
-                "{}/v1/orgs/{}/sessions/{}/messages",
+                "{}/v1/sessions/{}/messages",
                 API_BASE_URL, DEFAULT_ORG, session.id
             ))
             .send()
@@ -1090,7 +1090,7 @@ async fn test_message_triggers_agent_workflow() {
         println!("\nDebug: Checking events for session...");
         if let Ok(resp) = client
             .get(format!(
-                "{}/v1/orgs/{}/sessions/{}/events",
+                "{}/v1/sessions/{}/events",
                 API_BASE_URL, DEFAULT_ORG, session.id
             ))
             .send()
@@ -1127,7 +1127,7 @@ async fn test_message_triggers_agent_workflow() {
     println!("\nStep 5: Verifying events...");
     let events_response = client
         .get(format!(
-            "{}/v1/orgs/{}/sessions/{}/events",
+            "{}/v1/sessions/{}/events",
             API_BASE_URL, DEFAULT_ORG, session.id
         ))
         .send()
@@ -1152,7 +1152,7 @@ async fn test_message_triggers_agent_workflow() {
     println!("\nCleaning up...");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/agents/{}",
+            "{}/v1/agents/{}",
             API_BASE_URL, DEFAULT_ORG, agent.id
         ))
         .send()
@@ -1160,7 +1160,7 @@ async fn test_message_triggers_agent_workflow() {
         .expect("Failed to delete agent");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/llm-models/{}",
+            "{}/v1/llm-models/{}",
             API_BASE_URL, DEFAULT_ORG, model.id
         ))
         .send()
@@ -1168,7 +1168,7 @@ async fn test_message_triggers_agent_workflow() {
         .expect("Failed to delete model");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/llm-providers/{}",
+            "{}/v1/llm-providers/{}",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .send()
@@ -1206,7 +1206,7 @@ async fn test_no_duplicate_tool_calls() {
 
     let provider_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers",
+            "{}/v1/llm-providers",
             API_BASE_URL, DEFAULT_ORG
         ))
         .json(&json!({
@@ -1229,7 +1229,7 @@ async fn test_no_duplicate_tool_calls() {
     println!("\nStep 2: Creating model...");
     let model_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers/{}/models",
+            "{}/v1/llm-providers/{}/models",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .json(&json!({
@@ -1251,7 +1251,7 @@ async fn test_no_duplicate_tool_calls() {
     // Step 3: Create an agent with current_time capability
     println!("\nStep 3: Creating agent with current_time capability...");
     let agent_response = client
-        .post(format!("{}/v1/orgs/{}/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({
             "name": "Time Tool Test Agent",
             "system_prompt": "You are a helpful time assistant. When asked about the current time, use the get_current_time tool.",
@@ -1271,7 +1271,7 @@ async fn test_no_duplicate_tool_calls() {
     // Step 4: Create a session
     println!("\nStep 4: Creating session...");
     let session_response = client
-        .post(format!("{}/v1/orgs/{}/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({"agent_id": agent.id}))
         .send()
         .await
@@ -1287,7 +1287,7 @@ async fn test_no_duplicate_tool_calls() {
     println!("\nStep 5: Sending message to trigger tool use...");
     let message_response = client
         .post(format!(
-            "{}/v1/orgs/{}/sessions/{}/messages",
+            "{}/v1/sessions/{}/messages",
             API_BASE_URL, DEFAULT_ORG, session.id
         ))
         .json(&json!({
@@ -1313,7 +1313,7 @@ async fn test_no_duplicate_tool_calls() {
 
         let messages_response = client
             .get(format!(
-                "{}/v1/orgs/{}/sessions/{}/messages",
+                "{}/v1/sessions/{}/messages",
                 API_BASE_URL, DEFAULT_ORG, session.id
             ))
             .send()
@@ -1358,7 +1358,7 @@ async fn test_no_duplicate_tool_calls() {
     println!("\nStep 7: Checking for duplicate tool calls...");
     let messages_response = client
         .get(format!(
-            "{}/v1/orgs/{}/sessions/{}/messages",
+            "{}/v1/sessions/{}/messages",
             API_BASE_URL, DEFAULT_ORG, session.id
         ))
         .send()
@@ -1428,7 +1428,7 @@ async fn test_no_duplicate_tool_calls() {
     println!("\nCleaning up...");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/agents/{}",
+            "{}/v1/agents/{}",
             API_BASE_URL, DEFAULT_ORG, agent.id
         ))
         .send()
@@ -1436,7 +1436,7 @@ async fn test_no_duplicate_tool_calls() {
         .expect("Failed to delete agent");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/llm-models/{}",
+            "{}/v1/llm-models/{}",
             API_BASE_URL, DEFAULT_ORG, model.id
         ))
         .send()
@@ -1444,7 +1444,7 @@ async fn test_no_duplicate_tool_calls() {
         .expect("Failed to delete model");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/llm-providers/{}",
+            "{}/v1/llm-providers/{}",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .send()
@@ -1462,7 +1462,7 @@ async fn test_sessions_pagination() {
 
     // Create an agent for the test
     let agent_response = client
-        .post(format!("{}/v1/orgs/{}/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({
             "name": "Pagination Test Agent",
             "system_prompt": "Test agent"
@@ -1479,7 +1479,7 @@ async fn test_sessions_pagination() {
     println!("Creating 15 sessions...");
     for i in 1..=15 {
         let response = client
-            .post(format!("{}/v1/orgs/{}/sessions", API_BASE_URL, DEFAULT_ORG))
+            .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
             .json(&json!({ "agent_id": agent.id, "title": format!("Session {}", i) }))
             .send()
             .await
@@ -1492,7 +1492,7 @@ async fn test_sessions_pagination() {
     println!("\nTest 1: Default pagination...");
     let response = client
         .get(format!(
-            "{}/v1/orgs/{}/sessions?agent_id={}",
+            "{}/v1/sessions?agent_id={}",
             API_BASE_URL, DEFAULT_ORG, agent.id
         ))
         .send()
@@ -1516,7 +1516,7 @@ async fn test_sessions_pagination() {
     println!("\nTest 2: Custom limit=5...");
     let response = client
         .get(format!(
-            "{}/v1/orgs/{}/sessions?agent_id={}&limit=5",
+            "{}/v1/sessions?agent_id={}&limit=5",
             API_BASE_URL, DEFAULT_ORG, agent.id
         ))
         .send()
@@ -1539,7 +1539,7 @@ async fn test_sessions_pagination() {
     println!("\nTest 3: Offset=5, limit=5...");
     let response = client
         .get(format!(
-            "{}/v1/orgs/{}/sessions?agent_id={}&offset=5&limit=5",
+            "{}/v1/sessions?agent_id={}&offset=5&limit=5",
             API_BASE_URL, DEFAULT_ORG, agent.id
         ))
         .send()
@@ -1559,7 +1559,7 @@ async fn test_sessions_pagination() {
     println!("\nTest 4: Last partial page (offset=10, limit=10)...");
     let response = client
         .get(format!(
-            "{}/v1/orgs/{}/sessions?agent_id={}&offset=10&limit=10",
+            "{}/v1/sessions?agent_id={}&offset=10&limit=10",
             API_BASE_URL, DEFAULT_ORG, agent.id
         ))
         .send()
@@ -1581,7 +1581,7 @@ async fn test_sessions_pagination() {
     println!("\nTest 5: Beyond range (offset=20)...");
     let response = client
         .get(format!(
-            "{}/v1/orgs/{}/sessions?agent_id={}&offset=20",
+            "{}/v1/sessions?agent_id={}&offset=20",
             API_BASE_URL, DEFAULT_ORG, agent.id
         ))
         .send()
@@ -1603,7 +1603,7 @@ async fn test_sessions_pagination() {
     println!("\nTest 6: Max limit enforcement (limit=200 should cap to 100)...");
     let response = client
         .get(format!(
-            "{}/v1/orgs/{}/sessions?agent_id={}&limit=200",
+            "{}/v1/sessions?agent_id={}&limit=200",
             API_BASE_URL, DEFAULT_ORG, agent.id
         ))
         .send()
@@ -1620,7 +1620,7 @@ async fn test_sessions_pagination() {
     println!("\nCleaning up...");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/agents/{}",
+            "{}/v1/agents/{}",
             API_BASE_URL, DEFAULT_ORG, agent.id
         ))
         .send()
@@ -1656,7 +1656,7 @@ async fn test_second_message_triggers_workflow() {
     println!("\nStep 0: Creating LlmSim provider and model...");
     let provider_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers",
+            "{}/v1/llm-providers",
             API_BASE_URL, DEFAULT_ORG
         ))
         .json(&json!({
@@ -1683,7 +1683,7 @@ async fn test_second_message_triggers_workflow() {
 
     let model_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers/{}/models",
+            "{}/v1/llm-providers/{}/models",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .json(&json!({
@@ -1708,7 +1708,7 @@ async fn test_second_message_triggers_workflow() {
     // Step 1: Create agent with LlmSim model
     println!("\nStep 1: Creating agent with LlmSim model...");
     let agent_response = client
-        .post(format!("{}/v1/orgs/{}/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({
             "name": "Second Message Test Agent",
             "system_prompt": "You are a helpful assistant. Respond briefly.",
@@ -1728,7 +1728,7 @@ async fn test_second_message_triggers_workflow() {
     // Step 2: Create session
     println!("\nStep 2: Creating session...");
     let session_response = client
-        .post(format!("{}/v1/orgs/{}/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({"agent_id": agent.id, "title": "Second Message Test Session"}))
         .send()
         .await
@@ -1745,7 +1745,7 @@ async fn test_second_message_triggers_workflow() {
     println!("\nStep 3: Sending FIRST message...");
     let first_message_response = client
         .post(format!(
-            "{}/v1/orgs/{}/sessions/{}/messages",
+            "{}/v1/sessions/{}/messages",
             API_BASE_URL, DEFAULT_ORG, session.id
         ))
         .json(&json!({
@@ -1772,7 +1772,7 @@ async fn test_second_message_triggers_workflow() {
 
         let messages_response = client
             .get(format!(
-                "{}/v1/orgs/{}/sessions/{}/messages",
+                "{}/v1/sessions/{}/messages",
                 API_BASE_URL, DEFAULT_ORG, session.id
             ))
             .send()
@@ -1812,7 +1812,7 @@ async fn test_second_message_triggers_workflow() {
     let second_message_start = Instant::now();
     let second_message_response = client
         .post(format!(
-            "{}/v1/orgs/{}/sessions/{}/messages",
+            "{}/v1/sessions/{}/messages",
             API_BASE_URL, DEFAULT_ORG, session.id
         ))
         .json(&json!({
@@ -1842,7 +1842,7 @@ async fn test_second_message_triggers_workflow() {
 
         let messages_response = client
             .get(format!(
-                "{}/v1/orgs/{}/sessions/{}/messages",
+                "{}/v1/sessions/{}/messages",
                 API_BASE_URL, DEFAULT_ORG, session.id
             ))
             .send()
@@ -1880,7 +1880,7 @@ async fn test_second_message_triggers_workflow() {
         println!("\nDebug: Final message state:");
         if let Ok(resp) = client
             .get(format!(
-                "{}/v1/orgs/{}/sessions/{}/messages",
+                "{}/v1/sessions/{}/messages",
                 API_BASE_URL, DEFAULT_ORG, session.id
             ))
             .send()
@@ -1910,7 +1910,7 @@ async fn test_second_message_triggers_workflow() {
     println!("\nStep 5: Verifying message counts...");
     let final_messages_response = client
         .get(format!(
-            "{}/v1/orgs/{}/sessions/{}/messages",
+            "{}/v1/sessions/{}/messages",
             API_BASE_URL, DEFAULT_ORG, session.id
         ))
         .send()
@@ -1945,7 +1945,7 @@ async fn test_second_message_triggers_workflow() {
     println!("\nCleaning up...");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/agents/{}",
+            "{}/v1/agents/{}",
             API_BASE_URL, DEFAULT_ORG, agent.id
         ))
         .send()
@@ -1953,7 +1953,7 @@ async fn test_second_message_triggers_workflow() {
         .expect("Failed to delete agent");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/llm-models/{}",
+            "{}/v1/llm-models/{}",
             API_BASE_URL, DEFAULT_ORG, model.id
         ))
         .send()
@@ -1961,7 +1961,7 @@ async fn test_second_message_triggers_workflow() {
         .expect("Failed to delete model");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/llm-providers/{}",
+            "{}/v1/llm-providers/{}",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .send()
@@ -1987,7 +1987,7 @@ async fn test_capability_mounts_applied_on_session_creation() {
     // Step 1: Create an agent with sample_data capability
     println!("\nStep 1: Creating agent with sample_data capability...");
     let agent_response = client
-        .post(format!("{}/v1/orgs/{}/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({
             "name": "Mount Test Agent",
             "system_prompt": "Test agent for capability mounts",
@@ -2020,7 +2020,7 @@ async fn test_capability_mounts_applied_on_session_creation() {
     // Step 2: Create a session (this should trigger mount application)
     println!("\nStep 2: Creating session...");
     let session_response = client
-        .post(format!("{}/v1/orgs/{}/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({
             "agent_id": agent.id,
             "title": "Mount Test Session"
@@ -2037,7 +2037,7 @@ async fn test_capability_mounts_applied_on_session_creation() {
     println!("Created session: {}", session.id);
 
     let fs_url = format!(
-        "{}/v1/orgs/{}/sessions/{}/fs",
+        "{}/v1/sessions/{}/fs",
         API_BASE_URL, DEFAULT_ORG, session.id
     );
 
@@ -2143,7 +2143,7 @@ async fn test_capability_mounts_applied_on_session_creation() {
     // Step 8: Create a second session - verify mounts are independent
     println!("\nStep 8: Creating second session...");
     let session2_response = client
-        .post(format!("{}/v1/orgs/{}/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({
             "agent_id": agent.id,
             "title": "Second Mount Test Session"
@@ -2161,7 +2161,7 @@ async fn test_capability_mounts_applied_on_session_creation() {
 
     // Verify second session also has mounts
     let fs_url2 = format!(
-        "{}/v1/orgs/{}/sessions/{}/fs",
+        "{}/v1/sessions/{}/fs",
         API_BASE_URL, DEFAULT_ORG, session2.id
     );
     let stat2_response = client
@@ -2183,7 +2183,7 @@ async fn test_capability_mounts_applied_on_session_creation() {
     println!("\nCleaning up...");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/agents/{}",
+            "{}/v1/agents/{}",
             API_BASE_URL, DEFAULT_ORG, agent.id
         ))
         .send()
@@ -2213,7 +2213,7 @@ async fn test_mcp_server_crud() {
     println!("\nStep 1: Creating MCP server...");
     let create_response = client
         .post(format!(
-            "{}/v1/orgs/{}/mcp-servers",
+            "{}/v1/mcp-servers",
             API_BASE_URL, DEFAULT_ORG
         ))
         .json(&json!({
@@ -2247,7 +2247,7 @@ async fn test_mcp_server_crud() {
     println!("\nStep 2: Listing MCP servers...");
     let list_response = client
         .get(format!(
-            "{}/v1/orgs/{}/mcp-servers",
+            "{}/v1/mcp-servers",
             API_BASE_URL, DEFAULT_ORG
         ))
         .send()
@@ -2266,7 +2266,7 @@ async fn test_mcp_server_crud() {
     println!("\nStep 3: Getting MCP server by ID...");
     let get_response = client
         .get(format!(
-            "{}/v1/orgs/{}/mcp-servers/{}",
+            "{}/v1/mcp-servers/{}",
             API_BASE_URL, DEFAULT_ORG, server.id
         ))
         .send()
@@ -2286,7 +2286,7 @@ async fn test_mcp_server_crud() {
     println!("\nStep 4: Updating MCP server...");
     let update_response = client
         .patch(format!(
-            "{}/v1/orgs/{}/mcp-servers/{}",
+            "{}/v1/mcp-servers/{}",
             API_BASE_URL, DEFAULT_ORG, server.id
         ))
         .json(&json!({
@@ -2315,7 +2315,7 @@ async fn test_mcp_server_crud() {
     println!("\nStep 5: Disabling MCP server...");
     let disable_response = client
         .patch(format!(
-            "{}/v1/orgs/{}/mcp-servers/{}",
+            "{}/v1/mcp-servers/{}",
             API_BASE_URL, DEFAULT_ORG, server.id
         ))
         .json(&json!({
@@ -2337,7 +2337,7 @@ async fn test_mcp_server_crud() {
     println!("\nStep 6: Creating MCP server with API key...");
     let create_with_key_response = client
         .post(format!(
-            "{}/v1/orgs/{}/mcp-servers",
+            "{}/v1/mcp-servers",
             API_BASE_URL, DEFAULT_ORG
         ))
         .json(&json!({
@@ -2364,7 +2364,7 @@ async fn test_mcp_server_crud() {
     println!("\nStep 7: Creating MCP server with custom headers...");
     let create_with_headers_response = client
         .post(format!(
-            "{}/v1/orgs/{}/mcp-servers",
+            "{}/v1/mcp-servers",
             API_BASE_URL, DEFAULT_ORG
         ))
         .json(&json!({
@@ -2399,7 +2399,7 @@ async fn test_mcp_server_crud() {
     println!("\nStep 8: Testing validation - empty name...");
     let empty_name_response = client
         .post(format!(
-            "{}/v1/orgs/{}/mcp-servers",
+            "{}/v1/mcp-servers",
             API_BASE_URL, DEFAULT_ORG
         ))
         .json(&json!({
@@ -2421,7 +2421,7 @@ async fn test_mcp_server_crud() {
     println!("\nStep 9: Testing validation - empty URL...");
     let empty_url_response = client
         .post(format!(
-            "{}/v1/orgs/{}/mcp-servers",
+            "{}/v1/mcp-servers",
             API_BASE_URL, DEFAULT_ORG
         ))
         .json(&json!({
@@ -2443,7 +2443,7 @@ async fn test_mcp_server_crud() {
     println!("\nStep 10: Testing 404 for non-existent server...");
     let not_found_response = client
         .get(format!(
-            "{}/v1/orgs/{}/mcp-servers/mcp_00000000000000000000000000000000",
+            "{}/v1/mcp-servers/mcp_00000000000000000000000000000000",
             API_BASE_URL, DEFAULT_ORG
         ))
         .send()
@@ -2461,7 +2461,7 @@ async fn test_mcp_server_crud() {
     println!("\nCleaning up...");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/mcp-servers/{}",
+            "{}/v1/mcp-servers/{}",
             API_BASE_URL, DEFAULT_ORG, server.id
         ))
         .send()
@@ -2469,7 +2469,7 @@ async fn test_mcp_server_crud() {
         .expect("Failed to delete MCP server");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/mcp-servers/{}",
+            "{}/v1/mcp-servers/{}",
             API_BASE_URL, DEFAULT_ORG, server_with_key.id
         ))
         .send()
@@ -2477,7 +2477,7 @@ async fn test_mcp_server_crud() {
         .expect("Failed to delete MCP server with key");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/mcp-servers/{}",
+            "{}/v1/mcp-servers/{}",
             API_BASE_URL, DEFAULT_ORG, server_with_headers.id
         ))
         .send()
@@ -2487,7 +2487,7 @@ async fn test_mcp_server_crud() {
     // Verify deletion
     let verify_deleted = client
         .get(format!(
-            "{}/v1/orgs/{}/mcp-servers/{}",
+            "{}/v1/mcp-servers/{}",
             API_BASE_URL, DEFAULT_ORG, server.id
         ))
         .send()
@@ -2528,7 +2528,7 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
     println!("\nStep 1: Creating LlmSim provider and model...");
     let provider_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers",
+            "{}/v1/llm-providers",
             API_BASE_URL, DEFAULT_ORG
         ))
         .json(&json!({
@@ -2555,7 +2555,7 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
 
     let model_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers/{}/models",
+            "{}/v1/llm-providers/{}/models",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .json(&json!({
@@ -2580,7 +2580,7 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
     // Step 2: Create a dad jokes agent with current_time capability
     println!("\nStep 2: Creating dad jokes agent with current_time capability...");
     let agent_response = client
-        .post(format!("{}/v1/orgs/{}/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({
             "name": "Dad Jokes Time Agent",
             "system_prompt": "You are a dad jokes comedian. When asked for a joke about the time, first use the get_current_time tool to get the current time, then tell a dad joke that incorporates the time. Your jokes should be punny and family-friendly.",
@@ -2601,7 +2601,7 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
     // Step 3: Create a session
     println!("\nStep 3: Creating session...");
     let session_response = client
-        .post(format!("{}/v1/orgs/{}/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({"agent_id": agent.id, "title": "Dad Jokes Session"}))
         .send()
         .await
@@ -2618,7 +2618,7 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
     println!("\nStep 4: Sending message asking for time-based joke...");
     let message_response = client
         .post(format!(
-            "{}/v1/orgs/{}/sessions/{}/messages",
+            "{}/v1/sessions/{}/messages",
             API_BASE_URL, DEFAULT_ORG, session.id
         ))
         .json(&json!({
@@ -2644,7 +2644,7 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
 
         let messages_response = client
             .get(format!(
-                "{}/v1/orgs/{}/sessions/{}/messages",
+                "{}/v1/sessions/{}/messages",
                 API_BASE_URL, DEFAULT_ORG, session.id
             ))
             .send()
@@ -2715,7 +2715,7 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
     // Get final messages
     let final_messages_response = client
         .get(format!(
-            "{}/v1/orgs/{}/sessions/{}/messages",
+            "{}/v1/sessions/{}/messages",
             API_BASE_URL, DEFAULT_ORG, session.id
         ))
         .send()
@@ -2770,7 +2770,7 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
     println!("\nCleaning up...");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/agents/{}",
+            "{}/v1/agents/{}",
             API_BASE_URL, DEFAULT_ORG, agent.id
         ))
         .send()
@@ -2778,7 +2778,7 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
         .expect("Failed to delete agent");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/llm-providers/{}/models/{}",
+            "{}/v1/llm-providers/{}/models/{}",
             API_BASE_URL, DEFAULT_ORG, provider.id, model.id
         ))
         .send()
@@ -2786,7 +2786,7 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
         .expect("Failed to delete model");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/llm-providers/{}",
+            "{}/v1/llm-providers/{}",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .send()
@@ -2831,7 +2831,7 @@ async fn test_agent_execution_openai_with_tool_calls() {
 
     let provider_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers",
+            "{}/v1/llm-providers",
             API_BASE_URL, DEFAULT_ORG
         ))
         .json(&json!({
@@ -2861,7 +2861,7 @@ async fn test_agent_execution_openai_with_tool_calls() {
     // Create model (gpt-4o-mini for cost-effectiveness)
     let model_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers/{}/models",
+            "{}/v1/llm-providers/{}/models",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .json(&json!({
@@ -2883,7 +2883,7 @@ async fn test_agent_execution_openai_with_tool_calls() {
     // Step 2: Create dad jokes agent with current_time capability
     println!("\nStep 2: Creating dad jokes agent with current_time capability...");
     let agent_response = client
-        .post(format!("{}/v1/orgs/{}/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({
             "name": "OpenAI Dad Jokes Agent",
             "system_prompt": "You are a dad jokes comedian. When the user asks for a joke about the time, you MUST first use the get_current_time tool to get the current time, then tell a short dad joke that somehow references the time you received. Keep your response brief.",
@@ -2901,7 +2901,7 @@ async fn test_agent_execution_openai_with_tool_calls() {
     // Step 3: Create session
     println!("\nStep 3: Creating session...");
     let session_response = client
-        .post(format!("{}/v1/orgs/{}/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({"agent_id": agent.id, "title": "OpenAI Dad Jokes Session"}))
         .send()
         .await
@@ -2918,7 +2918,7 @@ async fn test_agent_execution_openai_with_tool_calls() {
     println!("\nStep 4: Sending message...");
     let message_response = client
         .post(format!(
-            "{}/v1/orgs/{}/sessions/{}/messages",
+            "{}/v1/sessions/{}/messages",
             API_BASE_URL, DEFAULT_ORG, session.id
         ))
         .json(&json!({
@@ -2943,7 +2943,7 @@ async fn test_agent_execution_openai_with_tool_calls() {
 
         let messages_response = client
             .get(format!(
-                "{}/v1/orgs/{}/sessions/{}/messages",
+                "{}/v1/sessions/{}/messages",
                 API_BASE_URL, DEFAULT_ORG, session.id
             ))
             .send()
@@ -3011,7 +3011,7 @@ async fn test_agent_execution_openai_with_tool_calls() {
     println!("\nCleaning up...");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/agents/{}",
+            "{}/v1/agents/{}",
             API_BASE_URL, DEFAULT_ORG, agent.id
         ))
         .send()
@@ -3019,7 +3019,7 @@ async fn test_agent_execution_openai_with_tool_calls() {
         .expect("Failed to delete agent");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/llm-providers/{}/models/{}",
+            "{}/v1/llm-providers/{}/models/{}",
             API_BASE_URL, DEFAULT_ORG, provider.id, model.id
         ))
         .send()
@@ -3027,7 +3027,7 @@ async fn test_agent_execution_openai_with_tool_calls() {
         .expect("Failed to delete model");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/llm-providers/{}",
+            "{}/v1/llm-providers/{}",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .send()
@@ -3088,7 +3088,7 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
 
     let provider_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers",
+            "{}/v1/llm-providers",
             API_BASE_URL, DEFAULT_ORG
         ))
         .json(&json!({
@@ -3118,7 +3118,7 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
     // Create model (claude-3-5-haiku for cost-effectiveness)
     let model_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers/{}/models",
+            "{}/v1/llm-providers/{}/models",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .json(&json!({
@@ -3140,7 +3140,7 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
     // Step 2: Create dad jokes agent with current_time capability
     println!("\nStep 2: Creating dad jokes agent with current_time capability...");
     let agent_response = client
-        .post(format!("{}/v1/orgs/{}/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({
             "name": "Anthropic Dad Jokes Agent",
             "system_prompt": "You are a dad jokes comedian. When the user asks for a joke about the time, you MUST first use the get_current_time tool to get the current time, then tell a short dad joke that somehow references the time you received. Keep your response brief.",
@@ -3158,7 +3158,7 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
     // Step 3: Create session
     println!("\nStep 3: Creating session...");
     let session_response = client
-        .post(format!("{}/v1/orgs/{}/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({"agent_id": agent.id, "title": "Anthropic Dad Jokes Session"}))
         .send()
         .await
@@ -3175,7 +3175,7 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
     println!("\nStep 4: Sending message...");
     let message_response = client
         .post(format!(
-            "{}/v1/orgs/{}/sessions/{}/messages",
+            "{}/v1/sessions/{}/messages",
             API_BASE_URL, DEFAULT_ORG, session.id
         ))
         .json(&json!({
@@ -3200,7 +3200,7 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
 
         let messages_response = client
             .get(format!(
-                "{}/v1/orgs/{}/sessions/{}/messages",
+                "{}/v1/sessions/{}/messages",
                 API_BASE_URL, DEFAULT_ORG, session.id
             ))
             .send()
@@ -3268,7 +3268,7 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
     println!("\nCleaning up...");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/agents/{}",
+            "{}/v1/agents/{}",
             API_BASE_URL, DEFAULT_ORG, agent.id
         ))
         .send()
@@ -3276,7 +3276,7 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
         .expect("Failed to delete agent");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/llm-providers/{}/models/{}",
+            "{}/v1/llm-providers/{}/models/{}",
             API_BASE_URL, DEFAULT_ORG, provider.id, model.id
         ))
         .send()
@@ -3284,7 +3284,7 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
         .expect("Failed to delete model");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/llm-providers/{}",
+            "{}/v1/llm-providers/{}",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .send()
@@ -3332,7 +3332,7 @@ async fn test_agent_execution_multiple_tool_calls() {
     println!("\nStep 1: Creating LlmSim provider and model...");
     let provider_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers",
+            "{}/v1/llm-providers",
             API_BASE_URL, DEFAULT_ORG
         ))
         .json(&json!({
@@ -3358,7 +3358,7 @@ async fn test_agent_execution_multiple_tool_calls() {
 
     let model_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers/{}/models",
+            "{}/v1/llm-providers/{}/models",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .json(&json!({
@@ -3375,7 +3375,7 @@ async fn test_agent_execution_multiple_tool_calls() {
     // Step 2: Create agent with test_math capability
     println!("\nStep 2: Creating math agent with test_math capability...");
     let agent_response = client
-        .post(format!("{}/v1/orgs/{}/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({
             "name": "Math Calculator Agent",
             "system_prompt": "You are a math calculator. Use the available math tools (add, subtract, multiply, divide) to solve problems. Show your work step by step.",
@@ -3393,7 +3393,7 @@ async fn test_agent_execution_multiple_tool_calls() {
     // Step 3: Create session and send message
     println!("\nStep 3: Creating session and sending message...");
     let session_response = client
-        .post(format!("{}/v1/orgs/{}/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({"agent_id": agent.id}))
         .send()
         .await
@@ -3406,7 +3406,7 @@ async fn test_agent_execution_multiple_tool_calls() {
 
     let message_response = client
         .post(format!(
-            "{}/v1/orgs/{}/sessions/{}/messages",
+            "{}/v1/sessions/{}/messages",
             API_BASE_URL, DEFAULT_ORG, session.id
         ))
         .json(&json!({
@@ -3429,7 +3429,7 @@ async fn test_agent_execution_multiple_tool_calls() {
 
         let messages_response = client
             .get(format!(
-                "{}/v1/orgs/{}/sessions/{}/messages",
+                "{}/v1/sessions/{}/messages",
                 API_BASE_URL, DEFAULT_ORG, session.id
             ))
             .send()
@@ -3464,7 +3464,7 @@ async fn test_agent_execution_multiple_tool_calls() {
     println!("\nCleaning up...");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/agents/{}",
+            "{}/v1/agents/{}",
             API_BASE_URL, DEFAULT_ORG, agent.id
         ))
         .send()
@@ -3472,7 +3472,7 @@ async fn test_agent_execution_multiple_tool_calls() {
         .expect("Failed to delete agent");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/llm-providers/{}/models/{}",
+            "{}/v1/llm-providers/{}/models/{}",
             API_BASE_URL, DEFAULT_ORG, provider.id, model.id
         ))
         .send()
@@ -3480,7 +3480,7 @@ async fn test_agent_execution_multiple_tool_calls() {
         .expect("Failed to delete model");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/llm-providers/{}",
+            "{}/v1/llm-providers/{}",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .send()
@@ -3515,7 +3515,7 @@ async fn test_streaming_events_emitted() {
     println!("\nStep 1: Creating LlmSim provider and model...");
     let provider_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers",
+            "{}/v1/llm-providers",
             API_BASE_URL, DEFAULT_ORG
         ))
         .json(&json!({
@@ -3542,7 +3542,7 @@ async fn test_streaming_events_emitted() {
 
     let model_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers/{}/models",
+            "{}/v1/llm-providers/{}/models",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .json(&json!({
@@ -3564,7 +3564,7 @@ async fn test_streaming_events_emitted() {
     // Step 2: Create agent
     println!("\nStep 2: Creating agent...");
     let agent_response = client
-        .post(format!("{}/v1/orgs/{}/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({
             "name": "Streaming Test Agent",
             "system_prompt": "You are a helpful assistant. Respond briefly.",
@@ -3581,7 +3581,7 @@ async fn test_streaming_events_emitted() {
     // Step 3: Create session
     println!("\nStep 3: Creating session...");
     let session_response = client
-        .post(format!("{}/v1/orgs/{}/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({"agent_id": agent.id, "title": "Streaming Test Session"}))
         .send()
         .await
@@ -3598,7 +3598,7 @@ async fn test_streaming_events_emitted() {
     println!("\nStep 4: Sending message...");
     let message_response = client
         .post(format!(
-            "{}/v1/orgs/{}/sessions/{}/messages",
+            "{}/v1/sessions/{}/messages",
             API_BASE_URL, DEFAULT_ORG, session.id
         ))
         .json(&json!({
@@ -3622,7 +3622,7 @@ async fn test_streaming_events_emitted() {
 
         let messages_response = client
             .get(format!(
-                "{}/v1/orgs/{}/sessions/{}/messages",
+                "{}/v1/sessions/{}/messages",
                 API_BASE_URL, DEFAULT_ORG, session.id
             ))
             .send()
@@ -3662,7 +3662,7 @@ async fn test_streaming_events_emitted() {
     println!("\nStep 6: Verifying streaming events...");
     let events_response = client
         .get(format!(
-            "{}/v1/orgs/{}/sessions/{}/events",
+            "{}/v1/sessions/{}/events",
             API_BASE_URL, DEFAULT_ORG, session.id
         ))
         .send()
@@ -3772,7 +3772,7 @@ async fn test_streaming_events_emitted() {
     println!("\nCleaning up...");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/agents/{}",
+            "{}/v1/agents/{}",
             API_BASE_URL, DEFAULT_ORG, agent.id
         ))
         .send()
@@ -3780,7 +3780,7 @@ async fn test_streaming_events_emitted() {
         .expect("Failed to delete agent");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/llm-models/{}",
+            "{}/v1/llm-models/{}",
             API_BASE_URL, DEFAULT_ORG, model.id
         ))
         .send()
@@ -3788,7 +3788,7 @@ async fn test_streaming_events_emitted() {
         .expect("Failed to delete model");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/llm-providers/{}",
+            "{}/v1/llm-providers/{}",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .send()
@@ -3814,7 +3814,7 @@ async fn test_cancel_turn_endpoint() {
     println!("\nStep 1: Creating LlmSim provider...");
     let provider_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers",
+            "{}/v1/llm-providers",
             API_BASE_URL, DEFAULT_ORG
         ))
         .json(&json!({
@@ -3843,7 +3843,7 @@ async fn test_cancel_turn_endpoint() {
     println!("\nStep 2: Creating model...");
     let model_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers/{}/models",
+            "{}/v1/llm-providers/{}/models",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .json(&json!({
@@ -3865,7 +3865,7 @@ async fn test_cancel_turn_endpoint() {
     // Step 3: Create agent with LlmSim model
     println!("\nStep 3: Creating agent...");
     let agent_response = client
-        .post(format!("{}/v1/orgs/{}/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({
             "name": "Cancel Test Agent",
             "system_prompt": "You are a helpful assistant.",
@@ -3882,7 +3882,7 @@ async fn test_cancel_turn_endpoint() {
     // Step 4: Create session
     println!("\nStep 4: Creating session...");
     let session_response = client
-        .post(format!("{}/v1/orgs/{}/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({
             "agent_id": agent.id,
             "title": "Cancel Test Session"
@@ -3902,7 +3902,7 @@ async fn test_cancel_turn_endpoint() {
     println!("\nStep 5: Testing cancel on idle session...");
     let cancel_response = client
         .post(format!(
-            "{}/v1/orgs/{}/sessions/{}/cancel",
+            "{}/v1/sessions/{}/cancel",
             API_BASE_URL, DEFAULT_ORG, session.id
         ))
         .send()
@@ -3930,7 +3930,7 @@ async fn test_cancel_turn_endpoint() {
     println!("\nCleaning up...");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/agents/{}",
+            "{}/v1/agents/{}",
             API_BASE_URL, DEFAULT_ORG, agent.id
         ))
         .send()
@@ -3939,7 +3939,7 @@ async fn test_cancel_turn_endpoint() {
 
     client
         .delete(format!(
-            "{}/v1/orgs/{}/llm-providers/{}",
+            "{}/v1/llm-providers/{}",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .send()
@@ -3981,7 +3981,7 @@ async fn test_anthropic_extended_thinking() {
 
     let provider_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers",
+            "{}/v1/llm-providers",
             API_BASE_URL, DEFAULT_ORG
         ))
         .json(&json!({
@@ -4011,7 +4011,7 @@ async fn test_anthropic_extended_thinking() {
     // Create model (claude-sonnet-4 supports extended thinking)
     let model_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers/{}/models",
+            "{}/v1/llm-providers/{}/models",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .json(&json!({
@@ -4033,7 +4033,7 @@ async fn test_anthropic_extended_thinking() {
     // Step 2: Create agent (no tool calls - tests basic thinking flow)
     println!("\nStep 2: Creating agent...");
     let agent_response = client
-        .post(format!("{}/v1/orgs/{}/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({
             "name": "Thinking Test Agent",
             "system_prompt": "You are a helpful assistant. Think through problems step by step.",
@@ -4051,7 +4051,7 @@ async fn test_anthropic_extended_thinking() {
     println!("\nStep 3: Creating session...");
     let session_response = client
         .post(format!(
-            "{}/v1/orgs/{}/agents/{}/sessions",
+            "{}/v1/agents/{}/sessions",
             API_BASE_URL, DEFAULT_ORG, agent.id
         ))
         .json(&json!({"title": "Extended Thinking Test Session"}))
@@ -4071,7 +4071,7 @@ async fn test_anthropic_extended_thinking() {
     println!("\nStep 4: Sending message with reasoning effort=low...");
     let message_response = client
         .post(format!(
-            "{}/v1/orgs/{}/agents/{}/sessions/{}/messages",
+            "{}/v1/agents/{}/sessions/{}/messages",
             API_BASE_URL, DEFAULT_ORG, agent.id, session.id
         ))
         .json(&json!({
@@ -4106,7 +4106,7 @@ async fn test_anthropic_extended_thinking() {
         // Check session status
         let session_response = client
             .get(format!(
-                "{}/v1/orgs/{}/agents/{}/sessions/{}",
+                "{}/v1/agents/{}/sessions/{}",
                 API_BASE_URL, DEFAULT_ORG, agent.id, session.id
             ))
             .send()
@@ -4132,7 +4132,7 @@ async fn test_anthropic_extended_thinking() {
     // Fetch all events (requires agent_id in path)
     let events_response = client
         .get(format!(
-            "{}/v1/orgs/{}/agents/{}/sessions/{}/events",
+            "{}/v1/agents/{}/sessions/{}/events",
             API_BASE_URL, DEFAULT_ORG, agent.id, session.id
         ))
         .send()
@@ -4208,7 +4208,7 @@ async fn test_anthropic_extended_thinking() {
     println!("\nStep 6: Sending follow-up message to test multi-turn with thinking...");
     let followup_response = client
         .post(format!(
-            "{}/v1/orgs/{}/agents/{}/sessions/{}/messages",
+            "{}/v1/agents/{}/sessions/{}/messages",
             API_BASE_URL, DEFAULT_ORG, agent.id, session.id
         ))
         .json(&json!({
@@ -4235,7 +4235,7 @@ async fn test_anthropic_extended_thinking() {
 
         let session_response = client
             .get(format!(
-                "{}/v1/orgs/{}/agents/{}/sessions/{}",
+                "{}/v1/agents/{}/sessions/{}",
                 API_BASE_URL, DEFAULT_ORG, agent.id, session.id
             ))
             .send()
@@ -4267,7 +4267,7 @@ async fn test_anthropic_extended_thinking() {
     println!("\nCleaning up...");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/agents/{}",
+            "{}/v1/agents/{}",
             API_BASE_URL, DEFAULT_ORG, agent.id
         ))
         .send()
@@ -4275,7 +4275,7 @@ async fn test_anthropic_extended_thinking() {
         .expect("Failed to delete agent");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/llm-providers/{}/models/{}",
+            "{}/v1/llm-providers/{}/models/{}",
             API_BASE_URL, DEFAULT_ORG, provider.id, model.id
         ))
         .send()
@@ -4283,7 +4283,7 @@ async fn test_anthropic_extended_thinking() {
         .expect("Failed to delete model");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/llm-providers/{}",
+            "{}/v1/llm-providers/{}",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .send()
@@ -4348,7 +4348,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
 
     let provider_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers",
+            "{}/v1/llm-providers",
             API_BASE_URL, DEFAULT_ORG
         ))
         .json(&json!({
@@ -4378,7 +4378,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
     // Create model (claude-sonnet-4 supports extended thinking)
     let model_response = client
         .post(format!(
-            "{}/v1/orgs/{}/llm-providers/{}/models",
+            "{}/v1/llm-providers/{}/models",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .json(&json!({
@@ -4400,7 +4400,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
     // Step 2: Create agent WITH current_time tool
     println!("\nStep 2: Creating agent with current_time tool...");
     let agent_response = client
-        .post(format!("{}/v1/orgs/{}/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({
             "name": "Time Reporter Agent",
             "system_prompt": "You help users with simple requests. When asked for the time, call the current_time tool once and report the result.",
@@ -4421,7 +4421,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
     println!("\nStep 3: Creating session...");
     let session_response = client
         .post(format!(
-            "{}/v1/orgs/{}/agents/{}/sessions",
+            "{}/v1/agents/{}/sessions",
             API_BASE_URL, DEFAULT_ORG, agent.id
         ))
         .json(&json!({"title": "Time Reporting with Thinking Test"}))
@@ -4441,7 +4441,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
     println!("\nStep 4: Sending message (expecting thinking + tool use)...");
     let message_response = client
         .post(format!(
-            "{}/v1/orgs/{}/agents/{}/sessions/{}/messages",
+            "{}/v1/agents/{}/sessions/{}/messages",
             API_BASE_URL, DEFAULT_ORG, agent.id, session.id
         ))
         .json(&json!({
@@ -4474,7 +4474,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
 
         let session_response = client
             .get(format!(
-                "{}/v1/orgs/{}/agents/{}/sessions/{}",
+                "{}/v1/agents/{}/sessions/{}",
                 API_BASE_URL, DEFAULT_ORG, agent.id, session.id
             ))
             .send()
@@ -4507,7 +4507,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
     // Fetch all events
     let events_response = client
         .get(format!(
-            "{}/v1/orgs/{}/agents/{}/sessions/{}/events",
+            "{}/v1/agents/{}/sessions/{}/events",
             API_BASE_URL, DEFAULT_ORG, agent.id, session.id
         ))
         .send()
@@ -4559,7 +4559,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
     println!("\nStep 6: Sending follow-up message (multi-turn with thinking+tools)...");
     let followup_response = client
         .post(format!(
-            "{}/v1/orgs/{}/agents/{}/sessions/{}/messages",
+            "{}/v1/agents/{}/sessions/{}/messages",
             API_BASE_URL, DEFAULT_ORG, agent.id, session.id
         ))
         .json(&json!({
@@ -4586,7 +4586,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
 
         let session_response = client
             .get(format!(
-                "{}/v1/orgs/{}/agents/{}/sessions/{}",
+                "{}/v1/agents/{}/sessions/{}",
                 API_BASE_URL, DEFAULT_ORG, agent.id, session.id
             ))
             .send()
@@ -4624,7 +4624,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
     println!("\nCleaning up...");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/agents/{}",
+            "{}/v1/agents/{}",
             API_BASE_URL, DEFAULT_ORG, agent.id
         ))
         .send()
@@ -4632,7 +4632,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
         .expect("Failed to delete agent");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/llm-providers/{}/models/{}",
+            "{}/v1/llm-providers/{}/models/{}",
             API_BASE_URL, DEFAULT_ORG, provider.id, model.id
         ))
         .send()
@@ -4640,7 +4640,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
         .expect("Failed to delete model");
     client
         .delete(format!(
-            "{}/v1/orgs/{}/llm-providers/{}",
+            "{}/v1/llm-providers/{}",
             API_BASE_URL, DEFAULT_ORG, provider.id
         ))
         .send()
@@ -4690,7 +4690,7 @@ async fn test_events_api_contract() {
 
     // Step 1: Create agent and session
     let agent: Agent = client
-        .post(format!("{}/v1/orgs/{}/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({
             "name": "Events Contract Test Agent",
             "system_prompt": "You are helpful"
@@ -4703,7 +4703,7 @@ async fn test_events_api_contract() {
         .expect("Failed to parse agent");
 
     let session: Session = client
-        .post(format!("{}/v1/orgs/{}/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({"agent_id": agent.id, "title": "Events Contract Test"}))
         .send()
         .await
@@ -4718,7 +4718,7 @@ async fn test_events_api_contract() {
     println!("\nVerifying events list API contract...");
     let events_response = client
         .get(format!(
-            "{}/v1/orgs/{}/sessions/{}/events",
+            "{}/v1/sessions/{}/events",
             API_BASE_URL, DEFAULT_ORG, session.id
         ))
         .send()
@@ -4783,7 +4783,7 @@ async fn test_events_api_contract() {
     // Cleanup
     client
         .delete(format!(
-            "{}/v1/orgs/{}/agents/{}",
+            "{}/v1/agents/{}",
             API_BASE_URL, DEFAULT_ORG, agent.id
         ))
         .send()
@@ -4804,7 +4804,7 @@ async fn test_events_sse_contract() {
 
     // Step 1: Create agent and session
     let agent: Agent = client
-        .post(format!("{}/v1/orgs/{}/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({
             "name": "SSE Contract Test Agent",
             "system_prompt": "You are helpful"
@@ -4817,7 +4817,7 @@ async fn test_events_sse_contract() {
         .expect("Failed to parse agent");
 
     let session: Session = client
-        .post(format!("{}/v1/orgs/{}/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
         .json(&json!({"agent_id": agent.id, "title": "SSE Contract Test"}))
         .send()
         .await
@@ -4831,7 +4831,7 @@ async fn test_events_sse_contract() {
     // Step 2: Connect to SSE stream and verify headers and initial data
     println!("\nConnecting to SSE stream...");
     let sse_url = format!(
-        "{}/v1/orgs/{}/sessions/{}/sse",
+        "{}/v1/sessions/{}/sse",
         API_BASE_URL, DEFAULT_ORG, session.id
     );
 
@@ -4877,7 +4877,7 @@ async fn test_events_sse_contract() {
     // Cleanup
     client
         .delete(format!(
-            "{}/v1/orgs/{}/agents/{}",
+            "{}/v1/agents/{}",
             API_BASE_URL, DEFAULT_ORG, agent.id
         ))
         .send()

--- a/crates/server/tests/integration_test.rs
+++ b/crates/server/tests/integration_test.rs
@@ -7,6 +7,8 @@ use everruns_core::{Agent, LlmModel, Session, SessionFile};
 use serde_json::{Value, json};
 
 const API_BASE_URL: &str = "http://localhost:9000";
+const ORG_HEADER: &str = "X-Org-Id";
+const DEFAULT_ORG: &str = "org_00000000000000000000000000000001";
 
 #[tokio::test]
 async fn test_full_agent_session_workflow() {
@@ -23,6 +25,7 @@ async fn test_full_agent_session_workflow() {
             "description": "An agent for testing",
             "system_prompt": "You are a helpful assistant"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create agent");
@@ -47,6 +50,7 @@ async fn test_full_agent_session_workflow() {
     println!("\nStep 2: Listing agents...");
     let list_response = client
         .get(format!("{}/v1/agents", API_BASE_URL))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list agents");
@@ -63,6 +67,7 @@ async fn test_full_agent_session_workflow() {
     println!("\nStep 3: Getting agent by ID...");
     let get_response = client
         .get(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to get agent");
@@ -80,6 +85,7 @@ async fn test_full_agent_session_workflow() {
             "name": "Updated Test Agent",
             "description": "Updated description"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to update agent");
@@ -97,6 +103,7 @@ async fn test_full_agent_session_workflow() {
             "agent_id": agent.id,
             "title": "Test Session"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -122,6 +129,7 @@ async fn test_full_agent_session_workflow() {
                 "content": [{"type": "text", "text": "Hello!"}]
             }
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create message");
@@ -141,6 +149,7 @@ async fn test_full_agent_session_workflow() {
             "{}/v1/sessions/{}/messages",
             API_BASE_URL, session.id
         ))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list messages");
@@ -157,6 +166,7 @@ async fn test_full_agent_session_workflow() {
     println!("\nStep 8: Getting session...");
     let get_session_response = client
         .get(format!("{}/v1/sessions/{}", API_BASE_URL, session.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to get session");
@@ -176,6 +186,7 @@ async fn test_full_agent_session_workflow() {
             "{}/v1/sessions/{}/events",
             API_BASE_URL, session.id
         ))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list events");
@@ -202,6 +213,7 @@ async fn test_health_endpoint() {
     println!("Testing health endpoint...");
     let response = client
         .get(format!("{}/health", API_BASE_URL))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to call health endpoint");
@@ -219,6 +231,7 @@ async fn test_openapi_spec() {
     println!("Testing OpenAPI spec endpoint...");
     let response = client
         .get(format!("{}/api-doc/openapi.json", API_BASE_URL))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to get OpenAPI spec");
@@ -245,6 +258,7 @@ async fn test_llm_provider_and_model_workflow() {
             "base_url": "https://api.openai.com/v1",
             "is_default": true
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create LLM provider");
@@ -273,6 +287,7 @@ async fn test_llm_provider_and_model_workflow() {
             "capabilities": ["chat", "vision"],
             "is_default": true
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create model");
@@ -293,12 +308,14 @@ async fn test_llm_provider_and_model_workflow() {
 
     client
         .delete(format!("{}/v1/llm-models/{}", API_BASE_URL, model.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete model");
 
     client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete provider");
@@ -321,6 +338,7 @@ async fn test_llm_model_profile() {
             "provider_type": "openai",
             "is_default": false
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create LLM provider");
@@ -345,6 +363,7 @@ async fn test_llm_model_profile() {
             "capabilities": ["chat", "vision"],
             "is_default": false
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create model");
@@ -361,6 +380,7 @@ async fn test_llm_model_profile() {
     println!("\nStep 3: Getting model with profile via list endpoint...");
     let list_models_response = client
         .get(format!("{}/v1/llm-models", API_BASE_URL))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list models");
@@ -404,12 +424,14 @@ async fn test_llm_model_profile() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/llm-models/{}", API_BASE_URL, model_id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete model");
 
     client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete provider");
@@ -432,6 +454,7 @@ async fn test_session_inherits_agent_default_model() {
             "provider_type": "openai",
             "is_default": false
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create provider");
@@ -454,6 +477,7 @@ async fn test_session_inherits_agent_default_model() {
             "display_name": "Test Model",
             "is_default": false
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create model");
@@ -470,6 +494,7 @@ async fn test_session_inherits_agent_default_model() {
             "system_prompt": "Test agent",
             "default_model_id": model.id.to_string()
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create agent");
@@ -490,6 +515,7 @@ async fn test_session_inherits_agent_default_model() {
             "agent_id": agent.id,
             "title": "Test Session"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -525,6 +551,7 @@ async fn test_session_inherits_agent_default_model() {
             "display_name": "Test Model 2",
             "is_default": false
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create second model");
@@ -541,6 +568,7 @@ async fn test_session_inherits_agent_default_model() {
             "title": "Test Session 2",
             "model_id": model2.id.to_string()
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session with explicit model");
@@ -566,21 +594,25 @@ async fn test_session_inherits_agent_default_model() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
     client
         .delete(format!("{}/v1/llm-models/{}", API_BASE_URL, model.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete model");
     client
         .delete(format!("{}/v1/llm-models/{}", API_BASE_URL, model2.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete model2");
     client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete provider");
@@ -602,6 +634,7 @@ async fn test_session_filesystem() {
             "name": "Filesystem Test Agent",
             "system_prompt": "Test agent for filesystem"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create agent");
@@ -617,6 +650,7 @@ async fn test_session_filesystem() {
             "agent_id": agent.id,
             "title": "Filesystem Test Session"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -633,6 +667,7 @@ async fn test_session_filesystem() {
     println!("\nStep 3: Listing root directory...");
     let list_response = client
         .get(&fs_url)
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list files");
@@ -650,6 +685,7 @@ async fn test_session_filesystem() {
             "content": "Hello, World!",
             "encoding": "text"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create file");
@@ -664,6 +700,7 @@ async fn test_session_filesystem() {
     println!("\nStep 5: Reading file...");
     let read_response = client
         .get(format!("{}/hello.txt", fs_url))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to read file");
@@ -680,6 +717,7 @@ async fn test_session_filesystem() {
         .json(&json!({
             "path": "/hello.txt"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to get stat");
@@ -697,6 +735,7 @@ async fn test_session_filesystem() {
         .json(&json!({
             "content": "Updated content"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to update file");
@@ -713,6 +752,7 @@ async fn test_session_filesystem() {
         .json(&json!({
             "is_directory": true
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create directory");
@@ -729,6 +769,7 @@ async fn test_session_filesystem() {
         .json(&json!({
             "content": "fn main() {}"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create nested file");
@@ -742,6 +783,7 @@ async fn test_session_filesystem() {
     println!("\nStep 10: Listing all files...");
     let list_all_response = client
         .get(format!("{}?recursive=true", fs_url))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list all files");
@@ -760,6 +802,7 @@ async fn test_session_filesystem() {
             "src_path": "/hello.txt",
             "dst_path": "/hello-copy.txt"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to copy file");
@@ -775,6 +818,7 @@ async fn test_session_filesystem() {
             "src_path": "/hello-copy.txt",
             "dst_path": "/renamed.txt"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to move file");
@@ -789,6 +833,7 @@ async fn test_session_filesystem() {
         .json(&json!({
             "pattern": "main"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to grep");
@@ -803,6 +848,7 @@ async fn test_session_filesystem() {
     println!("\nStep 14: Deleting file...");
     let delete_response = client
         .delete(format!("{}/renamed.txt", fs_url))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete file");
@@ -816,6 +862,7 @@ async fn test_session_filesystem() {
     println!("\nStep 15: Deleting directory recursively...");
     let delete_dir_response = client
         .delete(format!("{}/src?recursive=true", fs_url))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete directory");
@@ -827,6 +874,7 @@ async fn test_session_filesystem() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
@@ -860,6 +908,7 @@ async fn test_message_triggers_agent_workflow() {
             "name": "LlmSim Test Provider",
             "provider_type": "llmsim"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create provider");
@@ -887,6 +936,7 @@ async fn test_message_triggers_agent_workflow() {
             "model_id": "llmsim-test",
             "display_name": "LlmSim Test Model"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create model");
@@ -911,6 +961,7 @@ async fn test_message_triggers_agent_workflow() {
             "system_prompt": "You are a helpful assistant. Respond briefly.",
             "default_model_id": model.id.to_string()
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create agent");
@@ -927,6 +978,7 @@ async fn test_message_triggers_agent_workflow() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id, "title": "Workflow Test Session"}))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -951,6 +1003,7 @@ async fn test_message_triggers_agent_workflow() {
                 "content": [{"type": "text", "text": "Say hello in one word."}]
             }
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create message");
@@ -986,6 +1039,7 @@ async fn test_message_triggers_agent_workflow() {
                 "{}/v1/sessions/{}/messages",
                 API_BASE_URL, session.id
             ))
+            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await;
 
@@ -1037,6 +1091,7 @@ async fn test_message_triggers_agent_workflow() {
                 "{}/v1/sessions/{}/events",
                 API_BASE_URL, session.id
             ))
+            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await
             && resp.status() == 200
@@ -1074,6 +1129,7 @@ async fn test_message_triggers_agent_workflow() {
             "{}/v1/sessions/{}/events",
             API_BASE_URL, session.id
         ))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list events");
@@ -1096,16 +1152,19 @@ async fn test_message_triggers_agent_workflow() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
     client
         .delete(format!("{}/v1/llm-models/{}", API_BASE_URL, model.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete model");
     client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete provider");
@@ -1147,6 +1206,7 @@ async fn test_no_duplicate_tool_calls() {
             "api_key": api_key,
             "is_default": false
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create provider");
@@ -1168,6 +1228,7 @@ async fn test_no_duplicate_tool_calls() {
             "model_id": "gpt-4o-mini",
             "display_name": "GPT-4o Mini Test"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create model");
@@ -1190,7 +1251,7 @@ async fn test_no_duplicate_tool_calls() {
             "capabilities": [{"ref": "current_time", "config": {}}],
             "default_model_id": model.id
         }))
-        .send()
+        .header(ORG_HEADER, DEFAULT_ORG).send()
         .await
         .expect("Failed to create agent");
 
@@ -1205,6 +1266,7 @@ async fn test_no_duplicate_tool_calls() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id}))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -1227,6 +1289,7 @@ async fn test_no_duplicate_tool_calls() {
                 "content": [{"type": "text", "text": "What time is it right now?"}]
             }
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to send message");
@@ -1248,6 +1311,7 @@ async fn test_no_duplicate_tool_calls() {
                 "{}/v1/sessions/{}/messages",
                 API_BASE_URL, session.id
             ))
+            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await;
 
@@ -1293,6 +1357,7 @@ async fn test_no_duplicate_tool_calls() {
             "{}/v1/sessions/{}/messages",
             API_BASE_URL, session.id
         ))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list messages");
@@ -1360,16 +1425,19 @@ async fn test_no_duplicate_tool_calls() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
     client
         .delete(format!("{}/v1/llm-models/{}", API_BASE_URL, model.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete model");
     client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete provider");
@@ -1390,6 +1458,7 @@ async fn test_sessions_pagination() {
             "name": "Pagination Test Agent",
             "system_prompt": "Test agent"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create agent");
@@ -1404,6 +1473,7 @@ async fn test_sessions_pagination() {
         let response = client
             .post(format!("{}/v1/sessions", API_BASE_URL))
             .json(&json!({ "agent_id": agent.id, "title": format!("Session {}", i) }))
+            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await
             .expect("Failed to create session");
@@ -1418,6 +1488,7 @@ async fn test_sessions_pagination() {
             "{}/v1/sessions?agent_id={}",
             API_BASE_URL, agent.id
         ))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list sessions");
@@ -1442,6 +1513,7 @@ async fn test_sessions_pagination() {
             "{}/v1/sessions?agent_id={}&limit=5",
             API_BASE_URL, agent.id
         ))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list sessions with limit");
@@ -1465,6 +1537,7 @@ async fn test_sessions_pagination() {
             "{}/v1/sessions?agent_id={}&offset=5&limit=5",
             API_BASE_URL, agent.id
         ))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list sessions with offset");
@@ -1485,6 +1558,7 @@ async fn test_sessions_pagination() {
             "{}/v1/sessions?agent_id={}&offset=10&limit=10",
             API_BASE_URL, agent.id
         ))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list sessions");
@@ -1507,6 +1581,7 @@ async fn test_sessions_pagination() {
             "{}/v1/sessions?agent_id={}&offset=20",
             API_BASE_URL, agent.id
         ))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list sessions");
@@ -1529,6 +1604,7 @@ async fn test_sessions_pagination() {
             "{}/v1/sessions?agent_id={}&limit=200",
             API_BASE_URL, agent.id
         ))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list sessions");
@@ -1543,6 +1619,7 @@ async fn test_sessions_pagination() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
@@ -1580,6 +1657,7 @@ async fn test_second_message_triggers_workflow() {
             "name": "LlmSim Second Message Test",
             "provider_type": "llmsim"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create provider");
@@ -1607,6 +1685,7 @@ async fn test_second_message_triggers_workflow() {
             "model_id": "llmsim-second-msg-test",
             "display_name": "LlmSim Second Message Test Model"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create model");
@@ -1631,6 +1710,7 @@ async fn test_second_message_triggers_workflow() {
             "system_prompt": "You are a helpful assistant. Respond briefly.",
             "default_model_id": model.id.to_string()
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create agent");
@@ -1647,6 +1727,7 @@ async fn test_second_message_triggers_workflow() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id, "title": "Second Message Test Session"}))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -1670,6 +1751,7 @@ async fn test_second_message_triggers_workflow() {
                 "content": [{"type": "text", "text": "Hello, this is the first message."}]
             }
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create first message");
@@ -1692,6 +1774,7 @@ async fn test_second_message_triggers_workflow() {
                 "{}/v1/sessions/{}/messages",
                 API_BASE_URL, session.id
             ))
+            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await;
 
@@ -1737,7 +1820,7 @@ async fn test_second_message_triggers_workflow() {
                 "content": [{"type": "text", "text": "Hello, this is the SECOND message. Please respond."}]
             }
         }))
-        .send()
+        .header(ORG_HEADER, DEFAULT_ORG).send()
         .await
         .expect("Failed to create second message");
 
@@ -1762,6 +1845,7 @@ async fn test_second_message_triggers_workflow() {
                 "{}/v1/sessions/{}/messages",
                 API_BASE_URL, session.id
             ))
+            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await;
 
@@ -1800,6 +1884,7 @@ async fn test_second_message_triggers_workflow() {
                 "{}/v1/sessions/{}/messages",
                 API_BASE_URL, session.id
             ))
+            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await
             && resp.status() == 200
@@ -1830,6 +1915,7 @@ async fn test_second_message_triggers_workflow() {
             "{}/v1/sessions/{}/messages",
             API_BASE_URL, session.id
         ))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to get final messages");
@@ -1862,16 +1948,19 @@ async fn test_second_message_triggers_workflow() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
     client
         .delete(format!("{}/v1/llm-models/{}", API_BASE_URL, model.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete model");
     client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete provider");
@@ -1904,6 +1993,7 @@ async fn test_capability_mounts_applied_on_session_creation() {
                 {"ref": "session_file_system", "config": {}}
             ]
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create agent");
@@ -1933,6 +2023,7 @@ async fn test_capability_mounts_applied_on_session_creation() {
             "agent_id": agent.id,
             "title": "Mount Test Session"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -1951,6 +2042,7 @@ async fn test_capability_mounts_applied_on_session_creation() {
     let stat_response = client
         .post(format!("{}/_/stat", fs_url))
         .json(&json!({"path": "/samples"}))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to stat /samples");
@@ -1964,6 +2056,7 @@ async fn test_capability_mounts_applied_on_session_creation() {
     println!("\nStep 4: Listing /samples directory...");
     let list_response = client
         .get(format!("{}/samples", fs_url))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list /samples");
@@ -1993,6 +2086,7 @@ async fn test_capability_mounts_applied_on_session_creation() {
     println!("\nStep 5: Reading /samples/users.json...");
     let read_response = client
         .get(format!("{}/samples/users.json", fs_url))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to read users.json");
@@ -2012,6 +2106,7 @@ async fn test_capability_mounts_applied_on_session_creation() {
         .json(&json!({
             "content": "modified content"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to send update request");
@@ -2028,6 +2123,7 @@ async fn test_capability_mounts_applied_on_session_creation() {
     println!("\nStep 7: Reading /samples/config.yaml...");
     let config_response = client
         .get(format!("{}/samples/config.yaml", fs_url))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to read config.yaml");
@@ -2053,6 +2149,7 @@ async fn test_capability_mounts_applied_on_session_creation() {
             "agent_id": agent.id,
             "title": "Second Mount Test Session"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create second session");
@@ -2069,6 +2166,7 @@ async fn test_capability_mounts_applied_on_session_creation() {
     let stat2_response = client
         .post(format!("{}/_/stat", fs_url2))
         .json(&json!({"path": "/samples"}))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to stat /samples in session2");
@@ -2085,6 +2183,7 @@ async fn test_capability_mounts_applied_on_session_creation() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
@@ -2117,6 +2216,7 @@ async fn test_mcp_server_crud() {
             "description": "A test MCP server for integration testing",
             "url": "https://mcp.example.com/v1/mcp"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create MCP server");
@@ -2143,6 +2243,7 @@ async fn test_mcp_server_crud() {
     println!("\nStep 2: Listing MCP servers...");
     let list_response = client
         .get(format!("{}/v1/mcp-servers", API_BASE_URL))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list MCP servers");
@@ -2159,6 +2260,7 @@ async fn test_mcp_server_crud() {
     println!("\nStep 3: Getting MCP server by ID...");
     let get_response = client
         .get(format!("{}/v1/mcp-servers/{}", API_BASE_URL, server.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to get MCP server");
@@ -2181,6 +2283,7 @@ async fn test_mcp_server_crud() {
             "description": "Updated description",
             "url": "https://mcp.updated.com/v1/mcp"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to update MCP server");
@@ -2205,6 +2308,7 @@ async fn test_mcp_server_crud() {
         .json(&json!({
             "status": "disabled"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to disable MCP server");
@@ -2226,6 +2330,7 @@ async fn test_mcp_server_crud() {
             "url": "https://secure.mcp.com/v1/mcp",
             "api_key": "test-api-key-12345"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create MCP server with API key");
@@ -2253,6 +2358,7 @@ async fn test_mcp_server_crud() {
                 "X-Another-Header": "another-value"
             }
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create MCP server with headers");
@@ -2281,6 +2387,7 @@ async fn test_mcp_server_crud() {
             "name": "",
             "url": "https://mcp.example.com/v1/mcp"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to send request");
@@ -2300,6 +2407,7 @@ async fn test_mcp_server_crud() {
             "name": "test-server",
             "url": ""
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to send request");
@@ -2318,6 +2426,7 @@ async fn test_mcp_server_crud() {
             "{}/v1/mcp-servers/mcp_00000000000000000000000000000000",
             API_BASE_URL
         ))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to get non-existent server");
@@ -2333,6 +2442,7 @@ async fn test_mcp_server_crud() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/mcp-servers/{}", API_BASE_URL, server.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete MCP server");
@@ -2341,6 +2451,7 @@ async fn test_mcp_server_crud() {
             "{}/v1/mcp-servers/{}",
             API_BASE_URL, server_with_key.id
         ))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete MCP server with key");
@@ -2349,6 +2460,7 @@ async fn test_mcp_server_crud() {
             "{}/v1/mcp-servers/{}",
             API_BASE_URL, server_with_headers.id
         ))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete MCP server with headers");
@@ -2356,6 +2468,7 @@ async fn test_mcp_server_crud() {
     // Verify deletion
     let verify_deleted = client
         .get(format!("{}/v1/mcp-servers/{}", API_BASE_URL, server.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to verify deletion");
@@ -2398,6 +2511,7 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
             "name": "LlmSim Tool Test Provider",
             "provider_type": "llmsim"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create provider");
@@ -2425,6 +2539,7 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
             "model_id": "llmsim-tool-test",
             "display_name": "LlmSim Tool Test Model"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create model");
@@ -2450,7 +2565,7 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
             "capabilities": [{"ref": "current_time", "config": {}}],
             "default_model_id": model.id
         }))
-        .send()
+        .header(ORG_HEADER, DEFAULT_ORG).send()
         .await
         .expect("Failed to create agent");
 
@@ -2466,6 +2581,7 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id, "title": "Dad Jokes Session"}))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -2489,6 +2605,7 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
                 "content": [{"type": "text", "text": "Tell me a dad joke about the current time!"}]
             }
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to send message");
@@ -2510,6 +2627,7 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
                 "{}/v1/sessions/{}/messages",
                 API_BASE_URL, session.id
             ))
+            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await;
 
@@ -2581,6 +2699,7 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
             "{}/v1/sessions/{}/messages",
             API_BASE_URL, session.id
         ))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to get final messages");
@@ -2633,6 +2752,7 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
@@ -2641,11 +2761,13 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
             "{}/v1/llm-providers/{}/models/{}",
             API_BASE_URL, provider.id, model.id
         ))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete model");
     client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete provider");
@@ -2694,6 +2816,7 @@ async fn test_agent_execution_openai_with_tool_calls() {
             "api_key": api_key,
             "is_default": false
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create provider");
@@ -2722,6 +2845,7 @@ async fn test_agent_execution_openai_with_tool_calls() {
             "model_id": "gpt-4o-mini",
             "display_name": "GPT-4o Mini (Tool Test)"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create model");
@@ -2744,7 +2868,7 @@ async fn test_agent_execution_openai_with_tool_calls() {
             "capabilities": [{"ref": "current_time", "config": {}}],
             "default_model_id": model.id
         }))
-        .send()
+        .header(ORG_HEADER, DEFAULT_ORG).send()
         .await
         .expect("Failed to create agent");
 
@@ -2757,6 +2881,7 @@ async fn test_agent_execution_openai_with_tool_calls() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id, "title": "OpenAI Dad Jokes Session"}))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -2780,6 +2905,7 @@ async fn test_agent_execution_openai_with_tool_calls() {
                 "content": [{"type": "text", "text": "Tell me a dad joke about the current time!"}]
             }
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to send message");
@@ -2800,6 +2926,7 @@ async fn test_agent_execution_openai_with_tool_calls() {
                 "{}/v1/sessions/{}/messages",
                 API_BASE_URL, session.id
             ))
+            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await;
 
@@ -2865,6 +2992,7 @@ async fn test_agent_execution_openai_with_tool_calls() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
@@ -2873,11 +3001,13 @@ async fn test_agent_execution_openai_with_tool_calls() {
             "{}/v1/llm-providers/{}/models/{}",
             API_BASE_URL, provider.id, model.id
         ))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete model");
     client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete provider");
@@ -2942,6 +3072,7 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
             "api_key": api_key,
             "is_default": false
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create provider");
@@ -2970,6 +3101,7 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
             "model_id": "claude-3-5-haiku-latest",
             "display_name": "Claude 3.5 Haiku (Tool Test)"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create model");
@@ -2992,7 +3124,7 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
             "capabilities": [{"ref": "current_time", "config": {}}],
             "default_model_id": model.id
         }))
-        .send()
+        .header(ORG_HEADER, DEFAULT_ORG).send()
         .await
         .expect("Failed to create agent");
 
@@ -3005,6 +3137,7 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id, "title": "Anthropic Dad Jokes Session"}))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -3028,6 +3161,7 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
                 "content": [{"type": "text", "text": "Tell me a dad joke about the current time!"}]
             }
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to send message");
@@ -3048,6 +3182,7 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
                 "{}/v1/sessions/{}/messages",
                 API_BASE_URL, session.id
             ))
+            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await;
 
@@ -3113,6 +3248,7 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
@@ -3121,11 +3257,13 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
             "{}/v1/llm-providers/{}/models/{}",
             API_BASE_URL, provider.id, model.id
         ))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete model");
     client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete provider");
@@ -3175,6 +3313,7 @@ async fn test_agent_execution_multiple_tool_calls() {
             "name": "LlmSim Multi-Tool Test",
             "provider_type": "llmsim"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create provider");
@@ -3201,6 +3340,7 @@ async fn test_agent_execution_multiple_tool_calls() {
             "model_id": "llmsim-multi-tool",
             "display_name": "LlmSim Multi-Tool Model"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create model");
@@ -3218,7 +3358,7 @@ async fn test_agent_execution_multiple_tool_calls() {
             "capabilities": [{"ref": "test_math", "config": {}}],
             "default_model_id": model.id
         }))
-        .send()
+        .header(ORG_HEADER, DEFAULT_ORG).send()
         .await
         .expect("Failed to create agent");
 
@@ -3231,6 +3371,7 @@ async fn test_agent_execution_multiple_tool_calls() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id}))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -3250,7 +3391,7 @@ async fn test_agent_execution_multiple_tool_calls() {
                 "content": [{"type": "text", "text": "Calculate 5 + 3, then multiply the result by 2"}]
             }
         }))
-        .send()
+        .header(ORG_HEADER, DEFAULT_ORG).send()
         .await
         .expect("Failed to send message");
 
@@ -3268,6 +3409,7 @@ async fn test_agent_execution_multiple_tool_calls() {
                 "{}/v1/sessions/{}/messages",
                 API_BASE_URL, session.id
             ))
+            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await;
 
@@ -3300,6 +3442,7 @@ async fn test_agent_execution_multiple_tool_calls() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
@@ -3308,11 +3451,13 @@ async fn test_agent_execution_multiple_tool_calls() {
             "{}/v1/llm-providers/{}/models/{}",
             API_BASE_URL, provider.id, model.id
         ))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete model");
     client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete provider");
@@ -3349,6 +3494,7 @@ async fn test_streaming_events_emitted() {
             "name": "Streaming Test Provider",
             "provider_type": "llmsim"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create provider");
@@ -3376,6 +3522,7 @@ async fn test_streaming_events_emitted() {
             "model_id": "llmsim-streaming",
             "display_name": "LlmSim Streaming Model"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create model");
@@ -3397,6 +3544,7 @@ async fn test_streaming_events_emitted() {
             "system_prompt": "You are a helpful assistant. Respond briefly.",
             "default_model_id": model.id.to_string()
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create agent");
@@ -3410,6 +3558,7 @@ async fn test_streaming_events_emitted() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id, "title": "Streaming Test Session"}))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -3433,6 +3582,7 @@ async fn test_streaming_events_emitted() {
                 "content": [{"type": "text", "text": "Hello, how are you?"}]
             }
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create message");
@@ -3452,6 +3602,7 @@ async fn test_streaming_events_emitted() {
                 "{}/v1/sessions/{}/messages",
                 API_BASE_URL, session.id
             ))
+            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await;
 
@@ -3492,6 +3643,7 @@ async fn test_streaming_events_emitted() {
             "{}/v1/sessions/{}/events",
             API_BASE_URL, session.id
         ))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list events");
@@ -3599,16 +3751,19 @@ async fn test_streaming_events_emitted() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
     client
         .delete(format!("{}/v1/llm-models/{}", API_BASE_URL, model.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete model");
     client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete provider");
@@ -3636,6 +3791,7 @@ async fn test_cancel_turn_endpoint() {
             "name": "LlmSim Cancel Test",
             "provider_type": "llmsim"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create provider");
@@ -3665,6 +3821,7 @@ async fn test_cancel_turn_endpoint() {
             "model_id": "llmsim-cancel-test",
             "display_name": "LlmSim Cancel Test Model"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create model");
@@ -3686,6 +3843,7 @@ async fn test_cancel_turn_endpoint() {
             "system_prompt": "You are a helpful assistant.",
             "default_model_id": model.id.to_string()
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create agent");
@@ -3702,6 +3860,7 @@ async fn test_cancel_turn_endpoint() {
             "agent_id": agent.id,
             "title": "Cancel Test Session"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -3720,6 +3879,7 @@ async fn test_cancel_turn_endpoint() {
             "{}/v1/sessions/{}/cancel",
             API_BASE_URL, session.id
         ))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to call cancel endpoint");
@@ -3745,12 +3905,14 @@ async fn test_cancel_turn_endpoint() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
 
     client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete provider");
@@ -3796,6 +3958,7 @@ async fn test_anthropic_extended_thinking() {
             "api_key": api_key,
             "is_default": false
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create provider");
@@ -3824,6 +3987,7 @@ async fn test_anthropic_extended_thinking() {
             "model_id": "claude-sonnet-4-20250514",
             "display_name": "Claude Sonnet 4 (Thinking Test)"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create model");
@@ -3845,6 +4009,7 @@ async fn test_anthropic_extended_thinking() {
             "system_prompt": "You are a helpful assistant. Think through problems step by step.",
             "default_model_id": model.id
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create agent");
@@ -3858,6 +4023,7 @@ async fn test_anthropic_extended_thinking() {
     let session_response = client
         .post(format!("{}/v1/agents/{}/sessions", API_BASE_URL, agent.id))
         .json(&json!({"title": "Extended Thinking Test Session"}))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -3887,6 +4053,7 @@ async fn test_anthropic_extended_thinking() {
                 }
             }
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to send message");
@@ -3912,6 +4079,7 @@ async fn test_anthropic_extended_thinking() {
                 "{}/v1/agents/{}/sessions/{}",
                 API_BASE_URL, agent.id, session.id
             ))
+            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await;
 
@@ -3938,6 +4106,7 @@ async fn test_anthropic_extended_thinking() {
             "{}/v1/agents/{}/sessions/{}/events",
             API_BASE_URL, agent.id, session.id
         ))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to get events");
@@ -4024,6 +4193,7 @@ async fn test_anthropic_extended_thinking() {
                 }
             }
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to send follow-up message");
@@ -4041,6 +4211,7 @@ async fn test_anthropic_extended_thinking() {
                 "{}/v1/agents/{}/sessions/{}",
                 API_BASE_URL, agent.id, session.id
             ))
+            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await;
 
@@ -4070,6 +4241,7 @@ async fn test_anthropic_extended_thinking() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
@@ -4078,11 +4250,13 @@ async fn test_anthropic_extended_thinking() {
             "{}/v1/llm-providers/{}/models/{}",
             API_BASE_URL, provider.id, model.id
         ))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete model");
     client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete provider");
@@ -4151,6 +4325,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
             "api_key": api_key,
             "is_default": false
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create provider");
@@ -4179,6 +4354,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
             "model_id": "claude-sonnet-4-20250514",
             "display_name": "Claude Sonnet 4 (Thinking+Tools Test)"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create model");
@@ -4203,7 +4379,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
                 {"ref": "current_time"}
             ]
         }))
-        .send()
+        .header(ORG_HEADER, DEFAULT_ORG).send()
         .await
         .expect("Failed to create agent");
 
@@ -4216,6 +4392,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
     let session_response = client
         .post(format!("{}/v1/agents/{}/sessions", API_BASE_URL, agent.id))
         .json(&json!({"title": "Time Reporting with Thinking Test"}))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -4245,6 +4422,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
                 }
             }
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to send message");
@@ -4268,6 +4446,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
                 "{}/v1/agents/{}/sessions/{}",
                 API_BASE_URL, agent.id, session.id
             ))
+            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await;
 
@@ -4301,6 +4480,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
             "{}/v1/agents/{}/sessions/{}/events",
             API_BASE_URL, agent.id, session.id
         ))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to get events");
@@ -4363,6 +4543,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
                 }
             }
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to send follow-up message");
@@ -4380,6 +4561,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
                 "{}/v1/agents/{}/sessions/{}",
                 API_BASE_URL, agent.id, session.id
             ))
+            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await;
 
@@ -4415,6 +4597,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
@@ -4423,11 +4606,13 @@ async fn test_anthropic_extended_thinking_with_tools() {
             "{}/v1/llm-providers/{}/models/{}",
             API_BASE_URL, provider.id, model.id
         ))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete model");
     client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete provider");
@@ -4480,6 +4665,7 @@ async fn test_events_api_contract() {
             "name": "Events Contract Test Agent",
             "system_prompt": "You are helpful"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create agent")
@@ -4490,6 +4676,7 @@ async fn test_events_api_contract() {
     let session: Session = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id, "title": "Events Contract Test"}))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session")
@@ -4506,6 +4693,7 @@ async fn test_events_api_contract() {
             "{}/v1/sessions/{}/events",
             API_BASE_URL, session.id
         ))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list events");
@@ -4568,6 +4756,7 @@ async fn test_events_api_contract() {
     // Cleanup
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
@@ -4591,6 +4780,7 @@ async fn test_events_sse_contract() {
             "name": "SSE Contract Test Agent",
             "system_prompt": "You are helpful"
         }))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create agent")
@@ -4601,6 +4791,7 @@ async fn test_events_sse_contract() {
     let session: Session = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id, "title": "SSE Contract Test"}))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session")
@@ -4617,6 +4808,7 @@ async fn test_events_sse_contract() {
     let sse_response = client
         .get(&sse_url)
         .header("Accept", "text/event-stream")
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to connect to SSE");
@@ -4656,6 +4848,7 @@ async fn test_events_sse_contract() {
     // Cleanup
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
+        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");

--- a/crates/server/tests/integration_test.rs
+++ b/crates/server/tests/integration_test.rs
@@ -7,8 +7,8 @@ use everruns_core::{Agent, LlmModel, Session, SessionFile};
 use serde_json::{Value, json};
 
 const API_BASE_URL: &str = "http://localhost:9000";
-const ORG_HEADER: &str = "X-Org-Id";
-const DEFAULT_ORG: &str = "org_00000000000000000000000000000001";
+// Note: With AUTH_MODE=none, org is derived from the anonymous user's default org.
+// No cookie or header needed for integration tests.
 
 #[tokio::test]
 async fn test_full_agent_session_workflow() {
@@ -25,7 +25,6 @@ async fn test_full_agent_session_workflow() {
             "description": "An agent for testing",
             "system_prompt": "You are a helpful assistant"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create agent");
@@ -50,7 +49,6 @@ async fn test_full_agent_session_workflow() {
     println!("\nStep 2: Listing agents...");
     let list_response = client
         .get(format!("{}/v1/agents", API_BASE_URL))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list agents");
@@ -67,7 +65,6 @@ async fn test_full_agent_session_workflow() {
     println!("\nStep 3: Getting agent by ID...");
     let get_response = client
         .get(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to get agent");
@@ -85,7 +82,6 @@ async fn test_full_agent_session_workflow() {
             "name": "Updated Test Agent",
             "description": "Updated description"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to update agent");
@@ -103,7 +99,6 @@ async fn test_full_agent_session_workflow() {
             "agent_id": agent.id,
             "title": "Test Session"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -129,7 +124,6 @@ async fn test_full_agent_session_workflow() {
                 "content": [{"type": "text", "text": "Hello!"}]
             }
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create message");
@@ -149,7 +143,6 @@ async fn test_full_agent_session_workflow() {
             "{}/v1/sessions/{}/messages",
             API_BASE_URL, session.id
         ))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list messages");
@@ -166,7 +159,6 @@ async fn test_full_agent_session_workflow() {
     println!("\nStep 8: Getting session...");
     let get_session_response = client
         .get(format!("{}/v1/sessions/{}", API_BASE_URL, session.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to get session");
@@ -186,7 +178,6 @@ async fn test_full_agent_session_workflow() {
             "{}/v1/sessions/{}/events",
             API_BASE_URL, session.id
         ))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list events");
@@ -213,7 +204,6 @@ async fn test_health_endpoint() {
     println!("Testing health endpoint...");
     let response = client
         .get(format!("{}/health", API_BASE_URL))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to call health endpoint");
@@ -231,7 +221,6 @@ async fn test_openapi_spec() {
     println!("Testing OpenAPI spec endpoint...");
     let response = client
         .get(format!("{}/api-doc/openapi.json", API_BASE_URL))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to get OpenAPI spec");
@@ -258,7 +247,6 @@ async fn test_llm_provider_and_model_workflow() {
             "base_url": "https://api.openai.com/v1",
             "is_default": true
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create LLM provider");
@@ -287,7 +275,6 @@ async fn test_llm_provider_and_model_workflow() {
             "capabilities": ["chat", "vision"],
             "is_default": true
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create model");
@@ -308,14 +295,12 @@ async fn test_llm_provider_and_model_workflow() {
 
     client
         .delete(format!("{}/v1/llm-models/{}", API_BASE_URL, model.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete model");
 
     client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete provider");
@@ -338,7 +323,6 @@ async fn test_llm_model_profile() {
             "provider_type": "openai",
             "is_default": false
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create LLM provider");
@@ -363,7 +347,6 @@ async fn test_llm_model_profile() {
             "capabilities": ["chat", "vision"],
             "is_default": false
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create model");
@@ -380,7 +363,6 @@ async fn test_llm_model_profile() {
     println!("\nStep 3: Getting model with profile via list endpoint...");
     let list_models_response = client
         .get(format!("{}/v1/llm-models", API_BASE_URL))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list models");
@@ -424,14 +406,12 @@ async fn test_llm_model_profile() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/llm-models/{}", API_BASE_URL, model_id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete model");
 
     client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete provider");
@@ -454,7 +434,6 @@ async fn test_session_inherits_agent_default_model() {
             "provider_type": "openai",
             "is_default": false
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create provider");
@@ -477,7 +456,6 @@ async fn test_session_inherits_agent_default_model() {
             "display_name": "Test Model",
             "is_default": false
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create model");
@@ -494,7 +472,6 @@ async fn test_session_inherits_agent_default_model() {
             "system_prompt": "Test agent",
             "default_model_id": model.id.to_string()
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create agent");
@@ -515,7 +492,6 @@ async fn test_session_inherits_agent_default_model() {
             "agent_id": agent.id,
             "title": "Test Session"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -551,7 +527,6 @@ async fn test_session_inherits_agent_default_model() {
             "display_name": "Test Model 2",
             "is_default": false
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create second model");
@@ -568,7 +543,6 @@ async fn test_session_inherits_agent_default_model() {
             "title": "Test Session 2",
             "model_id": model2.id.to_string()
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session with explicit model");
@@ -594,25 +568,21 @@ async fn test_session_inherits_agent_default_model() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
     client
         .delete(format!("{}/v1/llm-models/{}", API_BASE_URL, model.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete model");
     client
         .delete(format!("{}/v1/llm-models/{}", API_BASE_URL, model2.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete model2");
     client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete provider");
@@ -634,7 +604,6 @@ async fn test_session_filesystem() {
             "name": "Filesystem Test Agent",
             "system_prompt": "Test agent for filesystem"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create agent");
@@ -650,7 +619,6 @@ async fn test_session_filesystem() {
             "agent_id": agent.id,
             "title": "Filesystem Test Session"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -667,7 +635,6 @@ async fn test_session_filesystem() {
     println!("\nStep 3: Listing root directory...");
     let list_response = client
         .get(&fs_url)
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list files");
@@ -685,7 +652,6 @@ async fn test_session_filesystem() {
             "content": "Hello, World!",
             "encoding": "text"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create file");
@@ -700,7 +666,6 @@ async fn test_session_filesystem() {
     println!("\nStep 5: Reading file...");
     let read_response = client
         .get(format!("{}/hello.txt", fs_url))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to read file");
@@ -717,7 +682,6 @@ async fn test_session_filesystem() {
         .json(&json!({
             "path": "/hello.txt"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to get stat");
@@ -735,7 +699,6 @@ async fn test_session_filesystem() {
         .json(&json!({
             "content": "Updated content"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to update file");
@@ -752,7 +715,6 @@ async fn test_session_filesystem() {
         .json(&json!({
             "is_directory": true
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create directory");
@@ -769,7 +731,6 @@ async fn test_session_filesystem() {
         .json(&json!({
             "content": "fn main() {}"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create nested file");
@@ -783,7 +744,6 @@ async fn test_session_filesystem() {
     println!("\nStep 10: Listing all files...");
     let list_all_response = client
         .get(format!("{}?recursive=true", fs_url))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list all files");
@@ -802,7 +762,6 @@ async fn test_session_filesystem() {
             "src_path": "/hello.txt",
             "dst_path": "/hello-copy.txt"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to copy file");
@@ -818,7 +777,6 @@ async fn test_session_filesystem() {
             "src_path": "/hello-copy.txt",
             "dst_path": "/renamed.txt"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to move file");
@@ -833,7 +791,6 @@ async fn test_session_filesystem() {
         .json(&json!({
             "pattern": "main"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to grep");
@@ -848,7 +805,6 @@ async fn test_session_filesystem() {
     println!("\nStep 14: Deleting file...");
     let delete_response = client
         .delete(format!("{}/renamed.txt", fs_url))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete file");
@@ -862,7 +818,6 @@ async fn test_session_filesystem() {
     println!("\nStep 15: Deleting directory recursively...");
     let delete_dir_response = client
         .delete(format!("{}/src?recursive=true", fs_url))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete directory");
@@ -874,7 +829,6 @@ async fn test_session_filesystem() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
@@ -908,7 +862,6 @@ async fn test_message_triggers_agent_workflow() {
             "name": "LlmSim Test Provider",
             "provider_type": "llmsim"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create provider");
@@ -936,7 +889,6 @@ async fn test_message_triggers_agent_workflow() {
             "model_id": "llmsim-test",
             "display_name": "LlmSim Test Model"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create model");
@@ -961,7 +913,6 @@ async fn test_message_triggers_agent_workflow() {
             "system_prompt": "You are a helpful assistant. Respond briefly.",
             "default_model_id": model.id.to_string()
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create agent");
@@ -978,7 +929,6 @@ async fn test_message_triggers_agent_workflow() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id, "title": "Workflow Test Session"}))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -1003,7 +953,6 @@ async fn test_message_triggers_agent_workflow() {
                 "content": [{"type": "text", "text": "Say hello in one word."}]
             }
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create message");
@@ -1039,7 +988,6 @@ async fn test_message_triggers_agent_workflow() {
                 "{}/v1/sessions/{}/messages",
                 API_BASE_URL, session.id
             ))
-            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await;
 
@@ -1091,7 +1039,6 @@ async fn test_message_triggers_agent_workflow() {
                 "{}/v1/sessions/{}/events",
                 API_BASE_URL, session.id
             ))
-            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await
             && resp.status() == 200
@@ -1129,7 +1076,6 @@ async fn test_message_triggers_agent_workflow() {
             "{}/v1/sessions/{}/events",
             API_BASE_URL, session.id
         ))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list events");
@@ -1152,19 +1098,16 @@ async fn test_message_triggers_agent_workflow() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
     client
         .delete(format!("{}/v1/llm-models/{}", API_BASE_URL, model.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete model");
     client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete provider");
@@ -1206,7 +1149,6 @@ async fn test_no_duplicate_tool_calls() {
             "api_key": api_key,
             "is_default": false
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create provider");
@@ -1228,7 +1170,6 @@ async fn test_no_duplicate_tool_calls() {
             "model_id": "gpt-4o-mini",
             "display_name": "GPT-4o Mini Test"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create model");
@@ -1251,7 +1192,7 @@ async fn test_no_duplicate_tool_calls() {
             "capabilities": [{"ref": "current_time", "config": {}}],
             "default_model_id": model.id
         }))
-        .header(ORG_HEADER, DEFAULT_ORG).send()
+        .send()
         .await
         .expect("Failed to create agent");
 
@@ -1266,7 +1207,6 @@ async fn test_no_duplicate_tool_calls() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id}))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -1289,7 +1229,6 @@ async fn test_no_duplicate_tool_calls() {
                 "content": [{"type": "text", "text": "What time is it right now?"}]
             }
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to send message");
@@ -1311,7 +1250,6 @@ async fn test_no_duplicate_tool_calls() {
                 "{}/v1/sessions/{}/messages",
                 API_BASE_URL, session.id
             ))
-            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await;
 
@@ -1357,7 +1295,6 @@ async fn test_no_duplicate_tool_calls() {
             "{}/v1/sessions/{}/messages",
             API_BASE_URL, session.id
         ))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list messages");
@@ -1425,19 +1362,16 @@ async fn test_no_duplicate_tool_calls() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
     client
         .delete(format!("{}/v1/llm-models/{}", API_BASE_URL, model.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete model");
     client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete provider");
@@ -1458,7 +1392,6 @@ async fn test_sessions_pagination() {
             "name": "Pagination Test Agent",
             "system_prompt": "Test agent"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create agent");
@@ -1473,7 +1406,6 @@ async fn test_sessions_pagination() {
         let response = client
             .post(format!("{}/v1/sessions", API_BASE_URL))
             .json(&json!({ "agent_id": agent.id, "title": format!("Session {}", i) }))
-            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await
             .expect("Failed to create session");
@@ -1488,7 +1420,6 @@ async fn test_sessions_pagination() {
             "{}/v1/sessions?agent_id={}",
             API_BASE_URL, agent.id
         ))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list sessions");
@@ -1513,7 +1444,6 @@ async fn test_sessions_pagination() {
             "{}/v1/sessions?agent_id={}&limit=5",
             API_BASE_URL, agent.id
         ))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list sessions with limit");
@@ -1537,7 +1467,6 @@ async fn test_sessions_pagination() {
             "{}/v1/sessions?agent_id={}&offset=5&limit=5",
             API_BASE_URL, agent.id
         ))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list sessions with offset");
@@ -1558,7 +1487,6 @@ async fn test_sessions_pagination() {
             "{}/v1/sessions?agent_id={}&offset=10&limit=10",
             API_BASE_URL, agent.id
         ))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list sessions");
@@ -1581,7 +1509,6 @@ async fn test_sessions_pagination() {
             "{}/v1/sessions?agent_id={}&offset=20",
             API_BASE_URL, agent.id
         ))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list sessions");
@@ -1604,7 +1531,6 @@ async fn test_sessions_pagination() {
             "{}/v1/sessions?agent_id={}&limit=200",
             API_BASE_URL, agent.id
         ))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list sessions");
@@ -1619,7 +1545,6 @@ async fn test_sessions_pagination() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
@@ -1657,7 +1582,6 @@ async fn test_second_message_triggers_workflow() {
             "name": "LlmSim Second Message Test",
             "provider_type": "llmsim"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create provider");
@@ -1685,7 +1609,6 @@ async fn test_second_message_triggers_workflow() {
             "model_id": "llmsim-second-msg-test",
             "display_name": "LlmSim Second Message Test Model"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create model");
@@ -1710,7 +1633,6 @@ async fn test_second_message_triggers_workflow() {
             "system_prompt": "You are a helpful assistant. Respond briefly.",
             "default_model_id": model.id.to_string()
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create agent");
@@ -1727,7 +1649,6 @@ async fn test_second_message_triggers_workflow() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id, "title": "Second Message Test Session"}))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -1751,7 +1672,6 @@ async fn test_second_message_triggers_workflow() {
                 "content": [{"type": "text", "text": "Hello, this is the first message."}]
             }
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create first message");
@@ -1774,7 +1694,6 @@ async fn test_second_message_triggers_workflow() {
                 "{}/v1/sessions/{}/messages",
                 API_BASE_URL, session.id
             ))
-            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await;
 
@@ -1820,7 +1739,7 @@ async fn test_second_message_triggers_workflow() {
                 "content": [{"type": "text", "text": "Hello, this is the SECOND message. Please respond."}]
             }
         }))
-        .header(ORG_HEADER, DEFAULT_ORG).send()
+        .send()
         .await
         .expect("Failed to create second message");
 
@@ -1845,7 +1764,6 @@ async fn test_second_message_triggers_workflow() {
                 "{}/v1/sessions/{}/messages",
                 API_BASE_URL, session.id
             ))
-            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await;
 
@@ -1884,7 +1802,6 @@ async fn test_second_message_triggers_workflow() {
                 "{}/v1/sessions/{}/messages",
                 API_BASE_URL, session.id
             ))
-            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await
             && resp.status() == 200
@@ -1915,7 +1832,6 @@ async fn test_second_message_triggers_workflow() {
             "{}/v1/sessions/{}/messages",
             API_BASE_URL, session.id
         ))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to get final messages");
@@ -1948,19 +1864,16 @@ async fn test_second_message_triggers_workflow() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
     client
         .delete(format!("{}/v1/llm-models/{}", API_BASE_URL, model.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete model");
     client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete provider");
@@ -1993,7 +1906,6 @@ async fn test_capability_mounts_applied_on_session_creation() {
                 {"ref": "session_file_system", "config": {}}
             ]
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create agent");
@@ -2023,7 +1935,6 @@ async fn test_capability_mounts_applied_on_session_creation() {
             "agent_id": agent.id,
             "title": "Mount Test Session"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -2042,7 +1953,6 @@ async fn test_capability_mounts_applied_on_session_creation() {
     let stat_response = client
         .post(format!("{}/_/stat", fs_url))
         .json(&json!({"path": "/samples"}))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to stat /samples");
@@ -2056,7 +1966,6 @@ async fn test_capability_mounts_applied_on_session_creation() {
     println!("\nStep 4: Listing /samples directory...");
     let list_response = client
         .get(format!("{}/samples", fs_url))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list /samples");
@@ -2086,7 +1995,6 @@ async fn test_capability_mounts_applied_on_session_creation() {
     println!("\nStep 5: Reading /samples/users.json...");
     let read_response = client
         .get(format!("{}/samples/users.json", fs_url))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to read users.json");
@@ -2106,7 +2014,6 @@ async fn test_capability_mounts_applied_on_session_creation() {
         .json(&json!({
             "content": "modified content"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to send update request");
@@ -2123,7 +2030,6 @@ async fn test_capability_mounts_applied_on_session_creation() {
     println!("\nStep 7: Reading /samples/config.yaml...");
     let config_response = client
         .get(format!("{}/samples/config.yaml", fs_url))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to read config.yaml");
@@ -2149,7 +2055,6 @@ async fn test_capability_mounts_applied_on_session_creation() {
             "agent_id": agent.id,
             "title": "Second Mount Test Session"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create second session");
@@ -2166,7 +2071,6 @@ async fn test_capability_mounts_applied_on_session_creation() {
     let stat2_response = client
         .post(format!("{}/_/stat", fs_url2))
         .json(&json!({"path": "/samples"}))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to stat /samples in session2");
@@ -2183,7 +2087,6 @@ async fn test_capability_mounts_applied_on_session_creation() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
@@ -2216,7 +2119,6 @@ async fn test_mcp_server_crud() {
             "description": "A test MCP server for integration testing",
             "url": "https://mcp.example.com/v1/mcp"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create MCP server");
@@ -2243,7 +2145,6 @@ async fn test_mcp_server_crud() {
     println!("\nStep 2: Listing MCP servers...");
     let list_response = client
         .get(format!("{}/v1/mcp-servers", API_BASE_URL))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list MCP servers");
@@ -2260,7 +2161,6 @@ async fn test_mcp_server_crud() {
     println!("\nStep 3: Getting MCP server by ID...");
     let get_response = client
         .get(format!("{}/v1/mcp-servers/{}", API_BASE_URL, server.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to get MCP server");
@@ -2283,7 +2183,6 @@ async fn test_mcp_server_crud() {
             "description": "Updated description",
             "url": "https://mcp.updated.com/v1/mcp"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to update MCP server");
@@ -2308,7 +2207,6 @@ async fn test_mcp_server_crud() {
         .json(&json!({
             "status": "disabled"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to disable MCP server");
@@ -2330,7 +2228,6 @@ async fn test_mcp_server_crud() {
             "url": "https://secure.mcp.com/v1/mcp",
             "api_key": "test-api-key-12345"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create MCP server with API key");
@@ -2358,7 +2255,6 @@ async fn test_mcp_server_crud() {
                 "X-Another-Header": "another-value"
             }
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create MCP server with headers");
@@ -2387,7 +2283,6 @@ async fn test_mcp_server_crud() {
             "name": "",
             "url": "https://mcp.example.com/v1/mcp"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to send request");
@@ -2407,7 +2302,6 @@ async fn test_mcp_server_crud() {
             "name": "test-server",
             "url": ""
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to send request");
@@ -2426,7 +2320,6 @@ async fn test_mcp_server_crud() {
             "{}/v1/mcp-servers/mcp_00000000000000000000000000000000",
             API_BASE_URL
         ))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to get non-existent server");
@@ -2442,7 +2335,6 @@ async fn test_mcp_server_crud() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/mcp-servers/{}", API_BASE_URL, server.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete MCP server");
@@ -2451,7 +2343,6 @@ async fn test_mcp_server_crud() {
             "{}/v1/mcp-servers/{}",
             API_BASE_URL, server_with_key.id
         ))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete MCP server with key");
@@ -2460,7 +2351,6 @@ async fn test_mcp_server_crud() {
             "{}/v1/mcp-servers/{}",
             API_BASE_URL, server_with_headers.id
         ))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete MCP server with headers");
@@ -2468,7 +2358,6 @@ async fn test_mcp_server_crud() {
     // Verify deletion
     let verify_deleted = client
         .get(format!("{}/v1/mcp-servers/{}", API_BASE_URL, server.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to verify deletion");
@@ -2511,7 +2400,6 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
             "name": "LlmSim Tool Test Provider",
             "provider_type": "llmsim"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create provider");
@@ -2539,7 +2427,6 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
             "model_id": "llmsim-tool-test",
             "display_name": "LlmSim Tool Test Model"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create model");
@@ -2565,7 +2452,7 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
             "capabilities": [{"ref": "current_time", "config": {}}],
             "default_model_id": model.id
         }))
-        .header(ORG_HEADER, DEFAULT_ORG).send()
+        .send()
         .await
         .expect("Failed to create agent");
 
@@ -2581,7 +2468,6 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id, "title": "Dad Jokes Session"}))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -2605,7 +2491,6 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
                 "content": [{"type": "text", "text": "Tell me a dad joke about the current time!"}]
             }
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to send message");
@@ -2627,7 +2512,6 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
                 "{}/v1/sessions/{}/messages",
                 API_BASE_URL, session.id
             ))
-            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await;
 
@@ -2699,7 +2583,6 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
             "{}/v1/sessions/{}/messages",
             API_BASE_URL, session.id
         ))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to get final messages");
@@ -2752,7 +2635,6 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
@@ -2761,13 +2643,11 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
             "{}/v1/llm-providers/{}/models/{}",
             API_BASE_URL, provider.id, model.id
         ))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete model");
     client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete provider");
@@ -2816,7 +2696,6 @@ async fn test_agent_execution_openai_with_tool_calls() {
             "api_key": api_key,
             "is_default": false
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create provider");
@@ -2845,7 +2724,6 @@ async fn test_agent_execution_openai_with_tool_calls() {
             "model_id": "gpt-4o-mini",
             "display_name": "GPT-4o Mini (Tool Test)"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create model");
@@ -2868,7 +2746,7 @@ async fn test_agent_execution_openai_with_tool_calls() {
             "capabilities": [{"ref": "current_time", "config": {}}],
             "default_model_id": model.id
         }))
-        .header(ORG_HEADER, DEFAULT_ORG).send()
+        .send()
         .await
         .expect("Failed to create agent");
 
@@ -2881,7 +2759,6 @@ async fn test_agent_execution_openai_with_tool_calls() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id, "title": "OpenAI Dad Jokes Session"}))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -2905,7 +2782,6 @@ async fn test_agent_execution_openai_with_tool_calls() {
                 "content": [{"type": "text", "text": "Tell me a dad joke about the current time!"}]
             }
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to send message");
@@ -2926,7 +2802,6 @@ async fn test_agent_execution_openai_with_tool_calls() {
                 "{}/v1/sessions/{}/messages",
                 API_BASE_URL, session.id
             ))
-            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await;
 
@@ -2992,7 +2867,6 @@ async fn test_agent_execution_openai_with_tool_calls() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
@@ -3001,13 +2875,11 @@ async fn test_agent_execution_openai_with_tool_calls() {
             "{}/v1/llm-providers/{}/models/{}",
             API_BASE_URL, provider.id, model.id
         ))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete model");
     client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete provider");
@@ -3072,7 +2944,6 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
             "api_key": api_key,
             "is_default": false
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create provider");
@@ -3101,7 +2972,6 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
             "model_id": "claude-3-5-haiku-latest",
             "display_name": "Claude 3.5 Haiku (Tool Test)"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create model");
@@ -3124,7 +2994,7 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
             "capabilities": [{"ref": "current_time", "config": {}}],
             "default_model_id": model.id
         }))
-        .header(ORG_HEADER, DEFAULT_ORG).send()
+        .send()
         .await
         .expect("Failed to create agent");
 
@@ -3137,7 +3007,6 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id, "title": "Anthropic Dad Jokes Session"}))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -3161,7 +3030,6 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
                 "content": [{"type": "text", "text": "Tell me a dad joke about the current time!"}]
             }
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to send message");
@@ -3182,7 +3050,6 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
                 "{}/v1/sessions/{}/messages",
                 API_BASE_URL, session.id
             ))
-            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await;
 
@@ -3248,7 +3115,6 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
@@ -3257,13 +3123,11 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
             "{}/v1/llm-providers/{}/models/{}",
             API_BASE_URL, provider.id, model.id
         ))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete model");
     client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete provider");
@@ -3313,7 +3177,6 @@ async fn test_agent_execution_multiple_tool_calls() {
             "name": "LlmSim Multi-Tool Test",
             "provider_type": "llmsim"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create provider");
@@ -3340,7 +3203,6 @@ async fn test_agent_execution_multiple_tool_calls() {
             "model_id": "llmsim-multi-tool",
             "display_name": "LlmSim Multi-Tool Model"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create model");
@@ -3358,7 +3220,7 @@ async fn test_agent_execution_multiple_tool_calls() {
             "capabilities": [{"ref": "test_math", "config": {}}],
             "default_model_id": model.id
         }))
-        .header(ORG_HEADER, DEFAULT_ORG).send()
+        .send()
         .await
         .expect("Failed to create agent");
 
@@ -3371,7 +3233,6 @@ async fn test_agent_execution_multiple_tool_calls() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id}))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -3391,7 +3252,7 @@ async fn test_agent_execution_multiple_tool_calls() {
                 "content": [{"type": "text", "text": "Calculate 5 + 3, then multiply the result by 2"}]
             }
         }))
-        .header(ORG_HEADER, DEFAULT_ORG).send()
+        .send()
         .await
         .expect("Failed to send message");
 
@@ -3409,7 +3270,6 @@ async fn test_agent_execution_multiple_tool_calls() {
                 "{}/v1/sessions/{}/messages",
                 API_BASE_URL, session.id
             ))
-            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await;
 
@@ -3442,7 +3302,6 @@ async fn test_agent_execution_multiple_tool_calls() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
@@ -3451,13 +3310,11 @@ async fn test_agent_execution_multiple_tool_calls() {
             "{}/v1/llm-providers/{}/models/{}",
             API_BASE_URL, provider.id, model.id
         ))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete model");
     client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete provider");
@@ -3494,7 +3351,6 @@ async fn test_streaming_events_emitted() {
             "name": "Streaming Test Provider",
             "provider_type": "llmsim"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create provider");
@@ -3522,7 +3378,6 @@ async fn test_streaming_events_emitted() {
             "model_id": "llmsim-streaming",
             "display_name": "LlmSim Streaming Model"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create model");
@@ -3544,7 +3399,6 @@ async fn test_streaming_events_emitted() {
             "system_prompt": "You are a helpful assistant. Respond briefly.",
             "default_model_id": model.id.to_string()
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create agent");
@@ -3558,7 +3412,6 @@ async fn test_streaming_events_emitted() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id, "title": "Streaming Test Session"}))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -3582,7 +3435,6 @@ async fn test_streaming_events_emitted() {
                 "content": [{"type": "text", "text": "Hello, how are you?"}]
             }
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create message");
@@ -3602,7 +3454,6 @@ async fn test_streaming_events_emitted() {
                 "{}/v1/sessions/{}/messages",
                 API_BASE_URL, session.id
             ))
-            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await;
 
@@ -3643,7 +3494,6 @@ async fn test_streaming_events_emitted() {
             "{}/v1/sessions/{}/events",
             API_BASE_URL, session.id
         ))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list events");
@@ -3751,19 +3601,16 @@ async fn test_streaming_events_emitted() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
     client
         .delete(format!("{}/v1/llm-models/{}", API_BASE_URL, model.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete model");
     client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete provider");
@@ -3791,7 +3638,6 @@ async fn test_cancel_turn_endpoint() {
             "name": "LlmSim Cancel Test",
             "provider_type": "llmsim"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create provider");
@@ -3821,7 +3667,6 @@ async fn test_cancel_turn_endpoint() {
             "model_id": "llmsim-cancel-test",
             "display_name": "LlmSim Cancel Test Model"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create model");
@@ -3843,7 +3688,6 @@ async fn test_cancel_turn_endpoint() {
             "system_prompt": "You are a helpful assistant.",
             "default_model_id": model.id.to_string()
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create agent");
@@ -3860,7 +3704,6 @@ async fn test_cancel_turn_endpoint() {
             "agent_id": agent.id,
             "title": "Cancel Test Session"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -3879,7 +3722,6 @@ async fn test_cancel_turn_endpoint() {
             "{}/v1/sessions/{}/cancel",
             API_BASE_URL, session.id
         ))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to call cancel endpoint");
@@ -3905,14 +3747,12 @@ async fn test_cancel_turn_endpoint() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
 
     client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete provider");
@@ -3958,7 +3798,6 @@ async fn test_anthropic_extended_thinking() {
             "api_key": api_key,
             "is_default": false
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create provider");
@@ -3987,7 +3826,6 @@ async fn test_anthropic_extended_thinking() {
             "model_id": "claude-sonnet-4-20250514",
             "display_name": "Claude Sonnet 4 (Thinking Test)"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create model");
@@ -4009,7 +3847,6 @@ async fn test_anthropic_extended_thinking() {
             "system_prompt": "You are a helpful assistant. Think through problems step by step.",
             "default_model_id": model.id
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create agent");
@@ -4023,7 +3860,6 @@ async fn test_anthropic_extended_thinking() {
     let session_response = client
         .post(format!("{}/v1/agents/{}/sessions", API_BASE_URL, agent.id))
         .json(&json!({"title": "Extended Thinking Test Session"}))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -4053,7 +3889,6 @@ async fn test_anthropic_extended_thinking() {
                 }
             }
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to send message");
@@ -4079,7 +3914,6 @@ async fn test_anthropic_extended_thinking() {
                 "{}/v1/agents/{}/sessions/{}",
                 API_BASE_URL, agent.id, session.id
             ))
-            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await;
 
@@ -4106,7 +3940,6 @@ async fn test_anthropic_extended_thinking() {
             "{}/v1/agents/{}/sessions/{}/events",
             API_BASE_URL, agent.id, session.id
         ))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to get events");
@@ -4193,7 +4026,6 @@ async fn test_anthropic_extended_thinking() {
                 }
             }
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to send follow-up message");
@@ -4211,7 +4043,6 @@ async fn test_anthropic_extended_thinking() {
                 "{}/v1/agents/{}/sessions/{}",
                 API_BASE_URL, agent.id, session.id
             ))
-            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await;
 
@@ -4241,7 +4072,6 @@ async fn test_anthropic_extended_thinking() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
@@ -4250,13 +4080,11 @@ async fn test_anthropic_extended_thinking() {
             "{}/v1/llm-providers/{}/models/{}",
             API_BASE_URL, provider.id, model.id
         ))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete model");
     client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete provider");
@@ -4325,7 +4153,6 @@ async fn test_anthropic_extended_thinking_with_tools() {
             "api_key": api_key,
             "is_default": false
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create provider");
@@ -4354,7 +4181,6 @@ async fn test_anthropic_extended_thinking_with_tools() {
             "model_id": "claude-sonnet-4-20250514",
             "display_name": "Claude Sonnet 4 (Thinking+Tools Test)"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create model");
@@ -4379,7 +4205,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
                 {"ref": "current_time"}
             ]
         }))
-        .header(ORG_HEADER, DEFAULT_ORG).send()
+        .send()
         .await
         .expect("Failed to create agent");
 
@@ -4392,7 +4218,6 @@ async fn test_anthropic_extended_thinking_with_tools() {
     let session_response = client
         .post(format!("{}/v1/agents/{}/sessions", API_BASE_URL, agent.id))
         .json(&json!({"title": "Time Reporting with Thinking Test"}))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session");
@@ -4422,7 +4247,6 @@ async fn test_anthropic_extended_thinking_with_tools() {
                 }
             }
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to send message");
@@ -4446,7 +4270,6 @@ async fn test_anthropic_extended_thinking_with_tools() {
                 "{}/v1/agents/{}/sessions/{}",
                 API_BASE_URL, agent.id, session.id
             ))
-            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await;
 
@@ -4480,7 +4303,6 @@ async fn test_anthropic_extended_thinking_with_tools() {
             "{}/v1/agents/{}/sessions/{}/events",
             API_BASE_URL, agent.id, session.id
         ))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to get events");
@@ -4543,7 +4365,6 @@ async fn test_anthropic_extended_thinking_with_tools() {
                 }
             }
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to send follow-up message");
@@ -4561,7 +4382,6 @@ async fn test_anthropic_extended_thinking_with_tools() {
                 "{}/v1/agents/{}/sessions/{}",
                 API_BASE_URL, agent.id, session.id
             ))
-            .header(ORG_HEADER, DEFAULT_ORG)
             .send()
             .await;
 
@@ -4597,7 +4417,6 @@ async fn test_anthropic_extended_thinking_with_tools() {
     println!("\nCleaning up...");
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
@@ -4606,13 +4425,11 @@ async fn test_anthropic_extended_thinking_with_tools() {
             "{}/v1/llm-providers/{}/models/{}",
             API_BASE_URL, provider.id, model.id
         ))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete model");
     client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete provider");
@@ -4665,7 +4482,6 @@ async fn test_events_api_contract() {
             "name": "Events Contract Test Agent",
             "system_prompt": "You are helpful"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create agent")
@@ -4676,7 +4492,6 @@ async fn test_events_api_contract() {
     let session: Session = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id, "title": "Events Contract Test"}))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session")
@@ -4693,7 +4508,6 @@ async fn test_events_api_contract() {
             "{}/v1/sessions/{}/events",
             API_BASE_URL, session.id
         ))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to list events");
@@ -4756,7 +4570,6 @@ async fn test_events_api_contract() {
     // Cleanup
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");
@@ -4780,7 +4593,6 @@ async fn test_events_sse_contract() {
             "name": "SSE Contract Test Agent",
             "system_prompt": "You are helpful"
         }))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create agent")
@@ -4791,7 +4603,6 @@ async fn test_events_sse_contract() {
     let session: Session = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id, "title": "SSE Contract Test"}))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to create session")
@@ -4808,7 +4619,6 @@ async fn test_events_sse_contract() {
     let sse_response = client
         .get(&sse_url)
         .header("Accept", "text/event-stream")
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to connect to SSE");
@@ -4848,7 +4658,6 @@ async fn test_events_sse_contract() {
     // Cleanup
     client
         .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
-        .header(ORG_HEADER, DEFAULT_ORG)
         .send()
         .await
         .expect("Failed to delete agent");

--- a/crates/server/tests/integration_test.rs
+++ b/crates/server/tests/integration_test.rs
@@ -7,8 +7,6 @@ use everruns_core::{Agent, LlmModel, Session, SessionFile};
 use serde_json::{Value, json};
 
 const API_BASE_URL: &str = "http://localhost:9000";
-// Default organization ID for org-scoped routes
-const DEFAULT_ORG: &str = "org_00000000000000000000000000000001";
 
 #[tokio::test]
 async fn test_full_agent_session_workflow() {
@@ -19,7 +17,7 @@ async fn test_full_agent_session_workflow() {
     // Step 1: Create an agent
     println!("\nStep 1: Creating agent...");
     let create_agent_response = client
-        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL))
         .json(&json!({
             "name": "Test Agent",
             "description": "An agent for testing",
@@ -48,7 +46,7 @@ async fn test_full_agent_session_workflow() {
     // Step 2: List agents
     println!("\nStep 2: Listing agents...");
     let list_response = client
-        .get(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
+        .get(format!("{}/v1/agents", API_BASE_URL))
         .send()
         .await
         .expect("Failed to list agents");
@@ -64,10 +62,7 @@ async fn test_full_agent_session_workflow() {
     // Step 3: Get agent by ID
     println!("\nStep 3: Getting agent by ID...");
     let get_response = client
-        .get(format!(
-            "{}/v1/agents/{}",
-            API_BASE_URL, DEFAULT_ORG, agent.id
-        ))
+        .get(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
         .send()
         .await
         .expect("Failed to get agent");
@@ -80,10 +75,7 @@ async fn test_full_agent_session_workflow() {
     // Step 4: Update agent
     println!("\nStep 4: Updating agent...");
     let update_response = client
-        .patch(format!(
-            "{}/v1/agents/{}",
-            API_BASE_URL, DEFAULT_ORG, agent.id
-        ))
+        .patch(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
         .json(&json!({
             "name": "Updated Test Agent",
             "description": "Updated description"
@@ -100,7 +92,7 @@ async fn test_full_agent_session_workflow() {
     // Step 5: Create a session
     println!("\nStep 5: Creating session...");
     let session_response = client
-        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({
             "agent_id": agent.id,
             "title": "Test Session"
@@ -122,7 +114,7 @@ async fn test_full_agent_session_workflow() {
     let message_response = client
         .post(format!(
             "{}/v1/sessions/{}/messages",
-            API_BASE_URL, DEFAULT_ORG, session.id
+            API_BASE_URL, session.id
         ))
         .json(&json!({
             "message": {
@@ -147,7 +139,7 @@ async fn test_full_agent_session_workflow() {
     let messages_response = client
         .get(format!(
             "{}/v1/sessions/{}/messages",
-            API_BASE_URL, DEFAULT_ORG, session.id
+            API_BASE_URL, session.id
         ))
         .send()
         .await
@@ -164,10 +156,7 @@ async fn test_full_agent_session_workflow() {
     // Step 8: Get session
     println!("\nStep 8: Getting session...");
     let get_session_response = client
-        .get(format!(
-            "{}/v1/sessions/{}",
-            API_BASE_URL, DEFAULT_ORG, session.id
-        ))
+        .get(format!("{}/v1/sessions/{}", API_BASE_URL, session.id))
         .send()
         .await
         .expect("Failed to get session");
@@ -185,7 +174,7 @@ async fn test_full_agent_session_workflow() {
     let events_response = client
         .get(format!(
             "{}/v1/sessions/{}/events",
-            API_BASE_URL, DEFAULT_ORG, session.id
+            API_BASE_URL, session.id
         ))
         .send()
         .await
@@ -249,10 +238,7 @@ async fn test_llm_provider_and_model_workflow() {
     // Step 1: Create an LLM provider
     println!("\nStep 1: Creating LLM provider...");
     let create_provider_response = client
-        .post(format!(
-            "{}/v1/llm-providers",
-            API_BASE_URL, DEFAULT_ORG
-        ))
+        .post(format!("{}/v1/llm-providers", API_BASE_URL))
         .json(&json!({
             "name": "Test OpenAI Provider",
             "provider_type": "openai",
@@ -279,7 +265,7 @@ async fn test_llm_provider_and_model_workflow() {
     let create_model_response = client
         .post(format!(
             "{}/v1/llm-providers/{}/models",
-            API_BASE_URL, DEFAULT_ORG, provider.id
+            API_BASE_URL, provider.id
         ))
         .json(&json!({
             "model_id": "gpt-5.2",
@@ -306,19 +292,13 @@ async fn test_llm_provider_and_model_workflow() {
     println!("\nCleaning up...");
 
     client
-        .delete(format!(
-            "{}/v1/llm-models/{}",
-            API_BASE_URL, DEFAULT_ORG, model.id
-        ))
+        .delete(format!("{}/v1/llm-models/{}", API_BASE_URL, model.id))
         .send()
         .await
         .expect("Failed to delete model");
 
     client
-        .delete(format!(
-            "{}/v1/llm-providers/{}",
-            API_BASE_URL, DEFAULT_ORG, provider.id
-        ))
+        .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
         .send()
         .await
         .expect("Failed to delete provider");
@@ -335,10 +315,7 @@ async fn test_llm_model_profile() {
     // Step 1: Create an LLM provider
     println!("\nStep 1: Creating OpenAI provider...");
     let create_provider_response = client
-        .post(format!(
-            "{}/v1/llm-providers",
-            API_BASE_URL, DEFAULT_ORG
-        ))
+        .post(format!("{}/v1/llm-providers", API_BASE_URL))
         .json(&json!({
             "name": "Test Profile Provider",
             "provider_type": "openai",
@@ -360,7 +337,7 @@ async fn test_llm_model_profile() {
     let create_model_response = client
         .post(format!(
             "{}/v1/llm-providers/{}/models",
-            API_BASE_URL, DEFAULT_ORG, provider.id
+            API_BASE_URL, provider.id
         ))
         .json(&json!({
             "model_id": "gpt-4o",
@@ -383,10 +360,7 @@ async fn test_llm_model_profile() {
     // Step 3: Get the model via the list endpoint which includes profile
     println!("\nStep 3: Getting model with profile via list endpoint...");
     let list_models_response = client
-        .get(format!(
-            "{}/v1/llm-models",
-            API_BASE_URL, DEFAULT_ORG
-        ))
+        .get(format!("{}/v1/llm-models", API_BASE_URL))
         .send()
         .await
         .expect("Failed to list models");
@@ -429,19 +403,13 @@ async fn test_llm_model_profile() {
     // Cleanup
     println!("\nCleaning up...");
     client
-        .delete(format!(
-            "{}/v1/llm-models/{}",
-            API_BASE_URL, DEFAULT_ORG, model_id
-        ))
+        .delete(format!("{}/v1/llm-models/{}", API_BASE_URL, model_id))
         .send()
         .await
         .expect("Failed to delete model");
 
     client
-        .delete(format!(
-            "{}/v1/llm-providers/{}",
-            API_BASE_URL, DEFAULT_ORG, provider.id
-        ))
+        .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
         .send()
         .await
         .expect("Failed to delete provider");
@@ -458,10 +426,7 @@ async fn test_session_inherits_agent_default_model() {
     // Step 1: Create an LLM provider
     println!("\nStep 1: Creating LLM provider...");
     let provider_response = client
-        .post(format!(
-            "{}/v1/llm-providers",
-            API_BASE_URL, DEFAULT_ORG
-        ))
+        .post(format!("{}/v1/llm-providers", API_BASE_URL))
         .json(&json!({
             "name": "Test Provider for Session Model",
             "provider_type": "openai",
@@ -482,7 +447,7 @@ async fn test_session_inherits_agent_default_model() {
     let model_response = client
         .post(format!(
             "{}/v1/llm-providers/{}/models",
-            API_BASE_URL, DEFAULT_ORG, provider.id
+            API_BASE_URL, provider.id
         ))
         .json(&json!({
             "model_id": "test-model",
@@ -499,7 +464,7 @@ async fn test_session_inherits_agent_default_model() {
     // Step 3: Create an agent with default_model_id
     println!("\nStep 3: Creating agent with default_model_id...");
     let agent_response = client
-        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL))
         .json(&json!({
             "name": "Agent with Default Model",
             "system_prompt": "Test agent",
@@ -520,7 +485,7 @@ async fn test_session_inherits_agent_default_model() {
     // Step 4: Create a session WITHOUT specifying model_id
     println!("\nStep 4: Creating session without model_id...");
     let session_response = client
-        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({
             "agent_id": agent.id,
             "title": "Test Session"
@@ -553,7 +518,7 @@ async fn test_session_inherits_agent_default_model() {
     let model2_response = client
         .post(format!(
             "{}/v1/llm-providers/{}/models",
-            API_BASE_URL, DEFAULT_ORG, provider.id
+            API_BASE_URL, provider.id
         ))
         .json(&json!({
             "model_id": "test-model-2",
@@ -570,7 +535,7 @@ async fn test_session_inherits_agent_default_model() {
         .expect("Failed to parse second model");
 
     let session2_response = client
-        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({
             "agent_id": agent.id,
             "title": "Test Session 2",
@@ -600,34 +565,22 @@ async fn test_session_inherits_agent_default_model() {
     // Cleanup
     println!("\nCleaning up...");
     client
-        .delete(format!(
-            "{}/v1/agents/{}",
-            API_BASE_URL, DEFAULT_ORG, agent.id
-        ))
+        .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
         .send()
         .await
         .expect("Failed to delete agent");
     client
-        .delete(format!(
-            "{}/v1/llm-models/{}",
-            API_BASE_URL, DEFAULT_ORG, model.id
-        ))
+        .delete(format!("{}/v1/llm-models/{}", API_BASE_URL, model.id))
         .send()
         .await
         .expect("Failed to delete model");
     client
-        .delete(format!(
-            "{}/v1/llm-models/{}",
-            API_BASE_URL, DEFAULT_ORG, model2.id
-        ))
+        .delete(format!("{}/v1/llm-models/{}", API_BASE_URL, model2.id))
         .send()
         .await
         .expect("Failed to delete model2");
     client
-        .delete(format!(
-            "{}/v1/llm-providers/{}",
-            API_BASE_URL, DEFAULT_ORG, provider.id
-        ))
+        .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
         .send()
         .await
         .expect("Failed to delete provider");
@@ -644,7 +597,7 @@ async fn test_session_filesystem() {
     // Step 1: Create an agent
     println!("\nStep 1: Creating agent...");
     let agent_response = client
-        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL))
         .json(&json!({
             "name": "Filesystem Test Agent",
             "system_prompt": "Test agent for filesystem"
@@ -659,7 +612,7 @@ async fn test_session_filesystem() {
     // Step 2: Create a session
     println!("\nStep 2: Creating session...");
     let session_response = client
-        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({
             "agent_id": agent.id,
             "title": "Filesystem Test Session"
@@ -674,10 +627,7 @@ async fn test_session_filesystem() {
         .expect("Failed to parse session");
     println!("Created session: {}", session.id);
 
-    let fs_url = format!(
-        "{}/v1/sessions/{}/fs",
-        API_BASE_URL, DEFAULT_ORG, session.id
-    );
+    let fs_url = format!("{}/v1/sessions/{}/fs", API_BASE_URL, session.id);
 
     // Step 3: List root directory (should be empty)
     println!("\nStep 3: Listing root directory...");
@@ -876,10 +826,7 @@ async fn test_session_filesystem() {
     // Cleanup
     println!("\nCleaning up...");
     client
-        .delete(format!(
-            "{}/v1/agents/{}",
-            API_BASE_URL, DEFAULT_ORG, agent.id
-        ))
+        .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
         .send()
         .await
         .expect("Failed to delete agent");
@@ -908,10 +855,7 @@ async fn test_message_triggers_agent_workflow() {
     // Step 0: Create LlmSim provider and model (no real API keys needed)
     println!("\nStep 0: Creating LlmSim provider and model...");
     let provider_response = client
-        .post(format!(
-            "{}/v1/llm-providers",
-            API_BASE_URL, DEFAULT_ORG
-        ))
+        .post(format!("{}/v1/llm-providers", API_BASE_URL))
         .json(&json!({
             "name": "LlmSim Test Provider",
             "provider_type": "llmsim"
@@ -937,7 +881,7 @@ async fn test_message_triggers_agent_workflow() {
     let model_response = client
         .post(format!(
             "{}/v1/llm-providers/{}/models",
-            API_BASE_URL, DEFAULT_ORG, provider.id
+            API_BASE_URL, provider.id
         ))
         .json(&json!({
             "model_id": "llmsim-test",
@@ -961,7 +905,7 @@ async fn test_message_triggers_agent_workflow() {
     // Step 1: Create agent with LlmSim model
     println!("\nStep 1: Creating agent with LlmSim model...");
     let agent_response = client
-        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL))
         .json(&json!({
             "name": "Workflow Test Agent",
             "system_prompt": "You are a helpful assistant. Respond briefly.",
@@ -981,7 +925,7 @@ async fn test_message_triggers_agent_workflow() {
     // Step 2: Create session
     println!("\nStep 2: Creating session...");
     let session_response = client
-        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id, "title": "Workflow Test Session"}))
         .send()
         .await
@@ -1000,7 +944,7 @@ async fn test_message_triggers_agent_workflow() {
     let message_response = client
         .post(format!(
             "{}/v1/sessions/{}/messages",
-            API_BASE_URL, DEFAULT_ORG, session.id
+            API_BASE_URL, session.id
         ))
         .json(&json!({
             "message": {
@@ -1040,7 +984,7 @@ async fn test_message_triggers_agent_workflow() {
         let messages_response = client
             .get(format!(
                 "{}/v1/sessions/{}/messages",
-                API_BASE_URL, DEFAULT_ORG, session.id
+                API_BASE_URL, session.id
             ))
             .send()
             .await;
@@ -1091,7 +1035,7 @@ async fn test_message_triggers_agent_workflow() {
         if let Ok(resp) = client
             .get(format!(
                 "{}/v1/sessions/{}/events",
-                API_BASE_URL, DEFAULT_ORG, session.id
+                API_BASE_URL, session.id
             ))
             .send()
             .await
@@ -1128,7 +1072,7 @@ async fn test_message_triggers_agent_workflow() {
     let events_response = client
         .get(format!(
             "{}/v1/sessions/{}/events",
-            API_BASE_URL, DEFAULT_ORG, session.id
+            API_BASE_URL, session.id
         ))
         .send()
         .await
@@ -1151,26 +1095,17 @@ async fn test_message_triggers_agent_workflow() {
     // Cleanup
     println!("\nCleaning up...");
     client
-        .delete(format!(
-            "{}/v1/agents/{}",
-            API_BASE_URL, DEFAULT_ORG, agent.id
-        ))
+        .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
         .send()
         .await
         .expect("Failed to delete agent");
     client
-        .delete(format!(
-            "{}/v1/llm-models/{}",
-            API_BASE_URL, DEFAULT_ORG, model.id
-        ))
+        .delete(format!("{}/v1/llm-models/{}", API_BASE_URL, model.id))
         .send()
         .await
         .expect("Failed to delete model");
     client
-        .delete(format!(
-            "{}/v1/llm-providers/{}",
-            API_BASE_URL, DEFAULT_ORG, provider.id
-        ))
+        .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
         .send()
         .await
         .expect("Failed to delete provider");
@@ -1205,10 +1140,7 @@ async fn test_no_duplicate_tool_calls() {
     };
 
     let provider_response = client
-        .post(format!(
-            "{}/v1/llm-providers",
-            API_BASE_URL, DEFAULT_ORG
-        ))
+        .post(format!("{}/v1/llm-providers", API_BASE_URL))
         .json(&json!({
             "name": "Duplicate Tool Test Provider",
             "provider_type": "openai",
@@ -1230,7 +1162,7 @@ async fn test_no_duplicate_tool_calls() {
     let model_response = client
         .post(format!(
             "{}/v1/llm-providers/{}/models",
-            API_BASE_URL, DEFAULT_ORG, provider.id
+            API_BASE_URL, provider.id
         ))
         .json(&json!({
             "model_id": "gpt-4o-mini",
@@ -1251,7 +1183,7 @@ async fn test_no_duplicate_tool_calls() {
     // Step 3: Create an agent with current_time capability
     println!("\nStep 3: Creating agent with current_time capability...");
     let agent_response = client
-        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL))
         .json(&json!({
             "name": "Time Tool Test Agent",
             "system_prompt": "You are a helpful time assistant. When asked about the current time, use the get_current_time tool.",
@@ -1271,7 +1203,7 @@ async fn test_no_duplicate_tool_calls() {
     // Step 4: Create a session
     println!("\nStep 4: Creating session...");
     let session_response = client
-        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id}))
         .send()
         .await
@@ -1288,7 +1220,7 @@ async fn test_no_duplicate_tool_calls() {
     let message_response = client
         .post(format!(
             "{}/v1/sessions/{}/messages",
-            API_BASE_URL, DEFAULT_ORG, session.id
+            API_BASE_URL, session.id
         ))
         .json(&json!({
             "message": {
@@ -1314,7 +1246,7 @@ async fn test_no_duplicate_tool_calls() {
         let messages_response = client
             .get(format!(
                 "{}/v1/sessions/{}/messages",
-                API_BASE_URL, DEFAULT_ORG, session.id
+                API_BASE_URL, session.id
             ))
             .send()
             .await;
@@ -1359,7 +1291,7 @@ async fn test_no_duplicate_tool_calls() {
     let messages_response = client
         .get(format!(
             "{}/v1/sessions/{}/messages",
-            API_BASE_URL, DEFAULT_ORG, session.id
+            API_BASE_URL, session.id
         ))
         .send()
         .await
@@ -1427,26 +1359,17 @@ async fn test_no_duplicate_tool_calls() {
     // Cleanup
     println!("\nCleaning up...");
     client
-        .delete(format!(
-            "{}/v1/agents/{}",
-            API_BASE_URL, DEFAULT_ORG, agent.id
-        ))
+        .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
         .send()
         .await
         .expect("Failed to delete agent");
     client
-        .delete(format!(
-            "{}/v1/llm-models/{}",
-            API_BASE_URL, DEFAULT_ORG, model.id
-        ))
+        .delete(format!("{}/v1/llm-models/{}", API_BASE_URL, model.id))
         .send()
         .await
         .expect("Failed to delete model");
     client
-        .delete(format!(
-            "{}/v1/llm-providers/{}",
-            API_BASE_URL, DEFAULT_ORG, provider.id
-        ))
+        .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
         .send()
         .await
         .expect("Failed to delete provider");
@@ -1462,7 +1385,7 @@ async fn test_sessions_pagination() {
 
     // Create an agent for the test
     let agent_response = client
-        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL))
         .json(&json!({
             "name": "Pagination Test Agent",
             "system_prompt": "Test agent"
@@ -1479,7 +1402,7 @@ async fn test_sessions_pagination() {
     println!("Creating 15 sessions...");
     for i in 1..=15 {
         let response = client
-            .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
+            .post(format!("{}/v1/sessions", API_BASE_URL))
             .json(&json!({ "agent_id": agent.id, "title": format!("Session {}", i) }))
             .send()
             .await
@@ -1493,7 +1416,7 @@ async fn test_sessions_pagination() {
     let response = client
         .get(format!(
             "{}/v1/sessions?agent_id={}",
-            API_BASE_URL, DEFAULT_ORG, agent.id
+            API_BASE_URL, agent.id
         ))
         .send()
         .await
@@ -1517,7 +1440,7 @@ async fn test_sessions_pagination() {
     let response = client
         .get(format!(
             "{}/v1/sessions?agent_id={}&limit=5",
-            API_BASE_URL, DEFAULT_ORG, agent.id
+            API_BASE_URL, agent.id
         ))
         .send()
         .await
@@ -1540,7 +1463,7 @@ async fn test_sessions_pagination() {
     let response = client
         .get(format!(
             "{}/v1/sessions?agent_id={}&offset=5&limit=5",
-            API_BASE_URL, DEFAULT_ORG, agent.id
+            API_BASE_URL, agent.id
         ))
         .send()
         .await
@@ -1560,7 +1483,7 @@ async fn test_sessions_pagination() {
     let response = client
         .get(format!(
             "{}/v1/sessions?agent_id={}&offset=10&limit=10",
-            API_BASE_URL, DEFAULT_ORG, agent.id
+            API_BASE_URL, agent.id
         ))
         .send()
         .await
@@ -1582,7 +1505,7 @@ async fn test_sessions_pagination() {
     let response = client
         .get(format!(
             "{}/v1/sessions?agent_id={}&offset=20",
-            API_BASE_URL, DEFAULT_ORG, agent.id
+            API_BASE_URL, agent.id
         ))
         .send()
         .await
@@ -1604,7 +1527,7 @@ async fn test_sessions_pagination() {
     let response = client
         .get(format!(
             "{}/v1/sessions?agent_id={}&limit=200",
-            API_BASE_URL, DEFAULT_ORG, agent.id
+            API_BASE_URL, agent.id
         ))
         .send()
         .await
@@ -1619,10 +1542,7 @@ async fn test_sessions_pagination() {
     // Cleanup
     println!("\nCleaning up...");
     client
-        .delete(format!(
-            "{}/v1/agents/{}",
-            API_BASE_URL, DEFAULT_ORG, agent.id
-        ))
+        .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
         .send()
         .await
         .expect("Failed to delete agent");
@@ -1655,10 +1575,7 @@ async fn test_second_message_triggers_workflow() {
     // Step 0: Create LlmSim provider and model (no real API keys needed)
     println!("\nStep 0: Creating LlmSim provider and model...");
     let provider_response = client
-        .post(format!(
-            "{}/v1/llm-providers",
-            API_BASE_URL, DEFAULT_ORG
-        ))
+        .post(format!("{}/v1/llm-providers", API_BASE_URL))
         .json(&json!({
             "name": "LlmSim Second Message Test",
             "provider_type": "llmsim"
@@ -1684,7 +1601,7 @@ async fn test_second_message_triggers_workflow() {
     let model_response = client
         .post(format!(
             "{}/v1/llm-providers/{}/models",
-            API_BASE_URL, DEFAULT_ORG, provider.id
+            API_BASE_URL, provider.id
         ))
         .json(&json!({
             "model_id": "llmsim-second-msg-test",
@@ -1708,7 +1625,7 @@ async fn test_second_message_triggers_workflow() {
     // Step 1: Create agent with LlmSim model
     println!("\nStep 1: Creating agent with LlmSim model...");
     let agent_response = client
-        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL))
         .json(&json!({
             "name": "Second Message Test Agent",
             "system_prompt": "You are a helpful assistant. Respond briefly.",
@@ -1728,7 +1645,7 @@ async fn test_second_message_triggers_workflow() {
     // Step 2: Create session
     println!("\nStep 2: Creating session...");
     let session_response = client
-        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id, "title": "Second Message Test Session"}))
         .send()
         .await
@@ -1746,7 +1663,7 @@ async fn test_second_message_triggers_workflow() {
     let first_message_response = client
         .post(format!(
             "{}/v1/sessions/{}/messages",
-            API_BASE_URL, DEFAULT_ORG, session.id
+            API_BASE_URL, session.id
         ))
         .json(&json!({
             "message": {
@@ -1773,7 +1690,7 @@ async fn test_second_message_triggers_workflow() {
         let messages_response = client
             .get(format!(
                 "{}/v1/sessions/{}/messages",
-                API_BASE_URL, DEFAULT_ORG, session.id
+                API_BASE_URL, session.id
             ))
             .send()
             .await;
@@ -1813,7 +1730,7 @@ async fn test_second_message_triggers_workflow() {
     let second_message_response = client
         .post(format!(
             "{}/v1/sessions/{}/messages",
-            API_BASE_URL, DEFAULT_ORG, session.id
+            API_BASE_URL, session.id
         ))
         .json(&json!({
             "message": {
@@ -1843,7 +1760,7 @@ async fn test_second_message_triggers_workflow() {
         let messages_response = client
             .get(format!(
                 "{}/v1/sessions/{}/messages",
-                API_BASE_URL, DEFAULT_ORG, session.id
+                API_BASE_URL, session.id
             ))
             .send()
             .await;
@@ -1881,7 +1798,7 @@ async fn test_second_message_triggers_workflow() {
         if let Ok(resp) = client
             .get(format!(
                 "{}/v1/sessions/{}/messages",
-                API_BASE_URL, DEFAULT_ORG, session.id
+                API_BASE_URL, session.id
             ))
             .send()
             .await
@@ -1911,7 +1828,7 @@ async fn test_second_message_triggers_workflow() {
     let final_messages_response = client
         .get(format!(
             "{}/v1/sessions/{}/messages",
-            API_BASE_URL, DEFAULT_ORG, session.id
+            API_BASE_URL, session.id
         ))
         .send()
         .await
@@ -1944,26 +1861,17 @@ async fn test_second_message_triggers_workflow() {
     // Cleanup
     println!("\nCleaning up...");
     client
-        .delete(format!(
-            "{}/v1/agents/{}",
-            API_BASE_URL, DEFAULT_ORG, agent.id
-        ))
+        .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
         .send()
         .await
         .expect("Failed to delete agent");
     client
-        .delete(format!(
-            "{}/v1/llm-models/{}",
-            API_BASE_URL, DEFAULT_ORG, model.id
-        ))
+        .delete(format!("{}/v1/llm-models/{}", API_BASE_URL, model.id))
         .send()
         .await
         .expect("Failed to delete model");
     client
-        .delete(format!(
-            "{}/v1/llm-providers/{}",
-            API_BASE_URL, DEFAULT_ORG, provider.id
-        ))
+        .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
         .send()
         .await
         .expect("Failed to delete provider");
@@ -1987,7 +1895,7 @@ async fn test_capability_mounts_applied_on_session_creation() {
     // Step 1: Create an agent with sample_data capability
     println!("\nStep 1: Creating agent with sample_data capability...");
     let agent_response = client
-        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL))
         .json(&json!({
             "name": "Mount Test Agent",
             "system_prompt": "Test agent for capability mounts",
@@ -2020,7 +1928,7 @@ async fn test_capability_mounts_applied_on_session_creation() {
     // Step 2: Create a session (this should trigger mount application)
     println!("\nStep 2: Creating session...");
     let session_response = client
-        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({
             "agent_id": agent.id,
             "title": "Mount Test Session"
@@ -2036,10 +1944,7 @@ async fn test_capability_mounts_applied_on_session_creation() {
         .expect("Failed to parse session");
     println!("Created session: {}", session.id);
 
-    let fs_url = format!(
-        "{}/v1/sessions/{}/fs",
-        API_BASE_URL, DEFAULT_ORG, session.id
-    );
+    let fs_url = format!("{}/v1/sessions/{}/fs", API_BASE_URL, session.id);
 
     // Step 3: Verify /samples directory exists
     println!("\nStep 3: Verifying /samples directory exists...");
@@ -2143,7 +2048,7 @@ async fn test_capability_mounts_applied_on_session_creation() {
     // Step 8: Create a second session - verify mounts are independent
     println!("\nStep 8: Creating second session...");
     let session2_response = client
-        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({
             "agent_id": agent.id,
             "title": "Second Mount Test Session"
@@ -2160,10 +2065,7 @@ async fn test_capability_mounts_applied_on_session_creation() {
     println!("Created session2: {}", session2.id);
 
     // Verify second session also has mounts
-    let fs_url2 = format!(
-        "{}/v1/sessions/{}/fs",
-        API_BASE_URL, DEFAULT_ORG, session2.id
-    );
+    let fs_url2 = format!("{}/v1/sessions/{}/fs", API_BASE_URL, session2.id);
     let stat2_response = client
         .post(format!("{}/_/stat", fs_url2))
         .json(&json!({"path": "/samples"}))
@@ -2182,10 +2084,7 @@ async fn test_capability_mounts_applied_on_session_creation() {
     // Cleanup
     println!("\nCleaning up...");
     client
-        .delete(format!(
-            "{}/v1/agents/{}",
-            API_BASE_URL, DEFAULT_ORG, agent.id
-        ))
+        .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
         .send()
         .await
         .expect("Failed to delete agent");
@@ -2212,10 +2111,7 @@ async fn test_mcp_server_crud() {
     // Step 1: Create an MCP server
     println!("\nStep 1: Creating MCP server...");
     let create_response = client
-        .post(format!(
-            "{}/v1/mcp-servers",
-            API_BASE_URL, DEFAULT_ORG
-        ))
+        .post(format!("{}/v1/mcp-servers", API_BASE_URL))
         .json(&json!({
             "name": "test-mcp-server",
             "description": "A test MCP server for integration testing",
@@ -2246,10 +2142,7 @@ async fn test_mcp_server_crud() {
     // Step 2: List MCP servers
     println!("\nStep 2: Listing MCP servers...");
     let list_response = client
-        .get(format!(
-            "{}/v1/mcp-servers",
-            API_BASE_URL, DEFAULT_ORG
-        ))
+        .get(format!("{}/v1/mcp-servers", API_BASE_URL))
         .send()
         .await
         .expect("Failed to list MCP servers");
@@ -2265,10 +2158,7 @@ async fn test_mcp_server_crud() {
     // Step 3: Get MCP server by ID
     println!("\nStep 3: Getting MCP server by ID...");
     let get_response = client
-        .get(format!(
-            "{}/v1/mcp-servers/{}",
-            API_BASE_URL, DEFAULT_ORG, server.id
-        ))
+        .get(format!("{}/v1/mcp-servers/{}", API_BASE_URL, server.id))
         .send()
         .await
         .expect("Failed to get MCP server");
@@ -2285,10 +2175,7 @@ async fn test_mcp_server_crud() {
     // Step 4: Update MCP server
     println!("\nStep 4: Updating MCP server...");
     let update_response = client
-        .patch(format!(
-            "{}/v1/mcp-servers/{}",
-            API_BASE_URL, DEFAULT_ORG, server.id
-        ))
+        .patch(format!("{}/v1/mcp-servers/{}", API_BASE_URL, server.id))
         .json(&json!({
             "name": "updated-mcp-server",
             "description": "Updated description",
@@ -2314,10 +2201,7 @@ async fn test_mcp_server_crud() {
     // Step 5: Update MCP server status to disabled
     println!("\nStep 5: Disabling MCP server...");
     let disable_response = client
-        .patch(format!(
-            "{}/v1/mcp-servers/{}",
-            API_BASE_URL, DEFAULT_ORG, server.id
-        ))
+        .patch(format!("{}/v1/mcp-servers/{}", API_BASE_URL, server.id))
         .json(&json!({
             "status": "disabled"
         }))
@@ -2336,10 +2220,7 @@ async fn test_mcp_server_crud() {
     // Step 6: Create MCP server with API key
     println!("\nStep 6: Creating MCP server with API key...");
     let create_with_key_response = client
-        .post(format!(
-            "{}/v1/mcp-servers",
-            API_BASE_URL, DEFAULT_ORG
-        ))
+        .post(format!("{}/v1/mcp-servers", API_BASE_URL))
         .json(&json!({
             "name": "mcp-server-with-key",
             "url": "https://secure.mcp.com/v1/mcp",
@@ -2363,10 +2244,7 @@ async fn test_mcp_server_crud() {
     // Step 7: Create MCP server with custom headers
     println!("\nStep 7: Creating MCP server with custom headers...");
     let create_with_headers_response = client
-        .post(format!(
-            "{}/v1/mcp-servers",
-            API_BASE_URL, DEFAULT_ORG
-        ))
+        .post(format!("{}/v1/mcp-servers", API_BASE_URL))
         .json(&json!({
             "name": "mcp-server-with-headers",
             "url": "https://headers.mcp.com/v1/mcp",
@@ -2398,10 +2276,7 @@ async fn test_mcp_server_crud() {
     // Step 8: Test validation - empty name
     println!("\nStep 8: Testing validation - empty name...");
     let empty_name_response = client
-        .post(format!(
-            "{}/v1/mcp-servers",
-            API_BASE_URL, DEFAULT_ORG
-        ))
+        .post(format!("{}/v1/mcp-servers", API_BASE_URL))
         .json(&json!({
             "name": "",
             "url": "https://mcp.example.com/v1/mcp"
@@ -2420,10 +2295,7 @@ async fn test_mcp_server_crud() {
     // Step 9: Test validation - empty URL
     println!("\nStep 9: Testing validation - empty URL...");
     let empty_url_response = client
-        .post(format!(
-            "{}/v1/mcp-servers",
-            API_BASE_URL, DEFAULT_ORG
-        ))
+        .post(format!("{}/v1/mcp-servers", API_BASE_URL))
         .json(&json!({
             "name": "test-server",
             "url": ""
@@ -2444,7 +2316,7 @@ async fn test_mcp_server_crud() {
     let not_found_response = client
         .get(format!(
             "{}/v1/mcp-servers/mcp_00000000000000000000000000000000",
-            API_BASE_URL, DEFAULT_ORG
+            API_BASE_URL
         ))
         .send()
         .await
@@ -2460,17 +2332,14 @@ async fn test_mcp_server_crud() {
     // Cleanup
     println!("\nCleaning up...");
     client
-        .delete(format!(
-            "{}/v1/mcp-servers/{}",
-            API_BASE_URL, DEFAULT_ORG, server.id
-        ))
+        .delete(format!("{}/v1/mcp-servers/{}", API_BASE_URL, server.id))
         .send()
         .await
         .expect("Failed to delete MCP server");
     client
         .delete(format!(
             "{}/v1/mcp-servers/{}",
-            API_BASE_URL, DEFAULT_ORG, server_with_key.id
+            API_BASE_URL, server_with_key.id
         ))
         .send()
         .await
@@ -2478,7 +2347,7 @@ async fn test_mcp_server_crud() {
     client
         .delete(format!(
             "{}/v1/mcp-servers/{}",
-            API_BASE_URL, DEFAULT_ORG, server_with_headers.id
+            API_BASE_URL, server_with_headers.id
         ))
         .send()
         .await
@@ -2486,10 +2355,7 @@ async fn test_mcp_server_crud() {
 
     // Verify deletion
     let verify_deleted = client
-        .get(format!(
-            "{}/v1/mcp-servers/{}",
-            API_BASE_URL, DEFAULT_ORG, server.id
-        ))
+        .get(format!("{}/v1/mcp-servers/{}", API_BASE_URL, server.id))
         .send()
         .await
         .expect("Failed to verify deletion");
@@ -2527,10 +2393,7 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
     // Step 1: Create LlmSim provider and model
     println!("\nStep 1: Creating LlmSim provider and model...");
     let provider_response = client
-        .post(format!(
-            "{}/v1/llm-providers",
-            API_BASE_URL, DEFAULT_ORG
-        ))
+        .post(format!("{}/v1/llm-providers", API_BASE_URL))
         .json(&json!({
             "name": "LlmSim Tool Test Provider",
             "provider_type": "llmsim"
@@ -2556,7 +2419,7 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
     let model_response = client
         .post(format!(
             "{}/v1/llm-providers/{}/models",
-            API_BASE_URL, DEFAULT_ORG, provider.id
+            API_BASE_URL, provider.id
         ))
         .json(&json!({
             "model_id": "llmsim-tool-test",
@@ -2580,7 +2443,7 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
     // Step 2: Create a dad jokes agent with current_time capability
     println!("\nStep 2: Creating dad jokes agent with current_time capability...");
     let agent_response = client
-        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL))
         .json(&json!({
             "name": "Dad Jokes Time Agent",
             "system_prompt": "You are a dad jokes comedian. When asked for a joke about the time, first use the get_current_time tool to get the current time, then tell a dad joke that incorporates the time. Your jokes should be punny and family-friendly.",
@@ -2601,7 +2464,7 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
     // Step 3: Create a session
     println!("\nStep 3: Creating session...");
     let session_response = client
-        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id, "title": "Dad Jokes Session"}))
         .send()
         .await
@@ -2619,7 +2482,7 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
     let message_response = client
         .post(format!(
             "{}/v1/sessions/{}/messages",
-            API_BASE_URL, DEFAULT_ORG, session.id
+            API_BASE_URL, session.id
         ))
         .json(&json!({
             "message": {
@@ -2645,7 +2508,7 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
         let messages_response = client
             .get(format!(
                 "{}/v1/sessions/{}/messages",
-                API_BASE_URL, DEFAULT_ORG, session.id
+                API_BASE_URL, session.id
             ))
             .send()
             .await;
@@ -2716,7 +2579,7 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
     let final_messages_response = client
         .get(format!(
             "{}/v1/sessions/{}/messages",
-            API_BASE_URL, DEFAULT_ORG, session.id
+            API_BASE_URL, session.id
         ))
         .send()
         .await
@@ -2769,26 +2632,20 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
     // Cleanup
     println!("\nCleaning up...");
     client
-        .delete(format!(
-            "{}/v1/agents/{}",
-            API_BASE_URL, DEFAULT_ORG, agent.id
-        ))
+        .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
         .send()
         .await
         .expect("Failed to delete agent");
     client
         .delete(format!(
             "{}/v1/llm-providers/{}/models/{}",
-            API_BASE_URL, DEFAULT_ORG, provider.id, model.id
+            API_BASE_URL, provider.id, model.id
         ))
         .send()
         .await
         .expect("Failed to delete model");
     client
-        .delete(format!(
-            "{}/v1/llm-providers/{}",
-            API_BASE_URL, DEFAULT_ORG, provider.id
-        ))
+        .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
         .send()
         .await
         .expect("Failed to delete provider");
@@ -2830,10 +2687,7 @@ async fn test_agent_execution_openai_with_tool_calls() {
     let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY should be set");
 
     let provider_response = client
-        .post(format!(
-            "{}/v1/llm-providers",
-            API_BASE_URL, DEFAULT_ORG
-        ))
+        .post(format!("{}/v1/llm-providers", API_BASE_URL))
         .json(&json!({
             "name": "OpenAI Tool Test Provider",
             "provider_type": "openai",
@@ -2862,7 +2716,7 @@ async fn test_agent_execution_openai_with_tool_calls() {
     let model_response = client
         .post(format!(
             "{}/v1/llm-providers/{}/models",
-            API_BASE_URL, DEFAULT_ORG, provider.id
+            API_BASE_URL, provider.id
         ))
         .json(&json!({
             "model_id": "gpt-4o-mini",
@@ -2883,7 +2737,7 @@ async fn test_agent_execution_openai_with_tool_calls() {
     // Step 2: Create dad jokes agent with current_time capability
     println!("\nStep 2: Creating dad jokes agent with current_time capability...");
     let agent_response = client
-        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL))
         .json(&json!({
             "name": "OpenAI Dad Jokes Agent",
             "system_prompt": "You are a dad jokes comedian. When the user asks for a joke about the time, you MUST first use the get_current_time tool to get the current time, then tell a short dad joke that somehow references the time you received. Keep your response brief.",
@@ -2901,7 +2755,7 @@ async fn test_agent_execution_openai_with_tool_calls() {
     // Step 3: Create session
     println!("\nStep 3: Creating session...");
     let session_response = client
-        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id, "title": "OpenAI Dad Jokes Session"}))
         .send()
         .await
@@ -2919,7 +2773,7 @@ async fn test_agent_execution_openai_with_tool_calls() {
     let message_response = client
         .post(format!(
             "{}/v1/sessions/{}/messages",
-            API_BASE_URL, DEFAULT_ORG, session.id
+            API_BASE_URL, session.id
         ))
         .json(&json!({
             "message": {
@@ -2944,7 +2798,7 @@ async fn test_agent_execution_openai_with_tool_calls() {
         let messages_response = client
             .get(format!(
                 "{}/v1/sessions/{}/messages",
-                API_BASE_URL, DEFAULT_ORG, session.id
+                API_BASE_URL, session.id
             ))
             .send()
             .await;
@@ -3010,26 +2864,20 @@ async fn test_agent_execution_openai_with_tool_calls() {
     // Cleanup first before assertions
     println!("\nCleaning up...");
     client
-        .delete(format!(
-            "{}/v1/agents/{}",
-            API_BASE_URL, DEFAULT_ORG, agent.id
-        ))
+        .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
         .send()
         .await
         .expect("Failed to delete agent");
     client
         .delete(format!(
             "{}/v1/llm-providers/{}/models/{}",
-            API_BASE_URL, DEFAULT_ORG, provider.id, model.id
+            API_BASE_URL, provider.id, model.id
         ))
         .send()
         .await
         .expect("Failed to delete model");
     client
-        .delete(format!(
-            "{}/v1/llm-providers/{}",
-            API_BASE_URL, DEFAULT_ORG, provider.id
-        ))
+        .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
         .send()
         .await
         .expect("Failed to delete provider");
@@ -3087,10 +2935,7 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
     let api_key = std::env::var("ANTHROPIC_API_KEY").expect("ANTHROPIC_API_KEY should be set");
 
     let provider_response = client
-        .post(format!(
-            "{}/v1/llm-providers",
-            API_BASE_URL, DEFAULT_ORG
-        ))
+        .post(format!("{}/v1/llm-providers", API_BASE_URL))
         .json(&json!({
             "name": "Anthropic Tool Test Provider",
             "provider_type": "anthropic",
@@ -3119,7 +2964,7 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
     let model_response = client
         .post(format!(
             "{}/v1/llm-providers/{}/models",
-            API_BASE_URL, DEFAULT_ORG, provider.id
+            API_BASE_URL, provider.id
         ))
         .json(&json!({
             "model_id": "claude-3-5-haiku-latest",
@@ -3140,7 +2985,7 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
     // Step 2: Create dad jokes agent with current_time capability
     println!("\nStep 2: Creating dad jokes agent with current_time capability...");
     let agent_response = client
-        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL))
         .json(&json!({
             "name": "Anthropic Dad Jokes Agent",
             "system_prompt": "You are a dad jokes comedian. When the user asks for a joke about the time, you MUST first use the get_current_time tool to get the current time, then tell a short dad joke that somehow references the time you received. Keep your response brief.",
@@ -3158,7 +3003,7 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
     // Step 3: Create session
     println!("\nStep 3: Creating session...");
     let session_response = client
-        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id, "title": "Anthropic Dad Jokes Session"}))
         .send()
         .await
@@ -3176,7 +3021,7 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
     let message_response = client
         .post(format!(
             "{}/v1/sessions/{}/messages",
-            API_BASE_URL, DEFAULT_ORG, session.id
+            API_BASE_URL, session.id
         ))
         .json(&json!({
             "message": {
@@ -3201,7 +3046,7 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
         let messages_response = client
             .get(format!(
                 "{}/v1/sessions/{}/messages",
-                API_BASE_URL, DEFAULT_ORG, session.id
+                API_BASE_URL, session.id
             ))
             .send()
             .await;
@@ -3267,26 +3112,20 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
     // Cleanup first before assertions
     println!("\nCleaning up...");
     client
-        .delete(format!(
-            "{}/v1/agents/{}",
-            API_BASE_URL, DEFAULT_ORG, agent.id
-        ))
+        .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
         .send()
         .await
         .expect("Failed to delete agent");
     client
         .delete(format!(
             "{}/v1/llm-providers/{}/models/{}",
-            API_BASE_URL, DEFAULT_ORG, provider.id, model.id
+            API_BASE_URL, provider.id, model.id
         ))
         .send()
         .await
         .expect("Failed to delete model");
     client
-        .delete(format!(
-            "{}/v1/llm-providers/{}",
-            API_BASE_URL, DEFAULT_ORG, provider.id
-        ))
+        .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
         .send()
         .await
         .expect("Failed to delete provider");
@@ -3331,10 +3170,7 @@ async fn test_agent_execution_multiple_tool_calls() {
     // Step 1: Create LlmSim provider and model
     println!("\nStep 1: Creating LlmSim provider and model...");
     let provider_response = client
-        .post(format!(
-            "{}/v1/llm-providers",
-            API_BASE_URL, DEFAULT_ORG
-        ))
+        .post(format!("{}/v1/llm-providers", API_BASE_URL))
         .json(&json!({
             "name": "LlmSim Multi-Tool Test",
             "provider_type": "llmsim"
@@ -3359,7 +3195,7 @@ async fn test_agent_execution_multiple_tool_calls() {
     let model_response = client
         .post(format!(
             "{}/v1/llm-providers/{}/models",
-            API_BASE_URL, DEFAULT_ORG, provider.id
+            API_BASE_URL, provider.id
         ))
         .json(&json!({
             "model_id": "llmsim-multi-tool",
@@ -3375,7 +3211,7 @@ async fn test_agent_execution_multiple_tool_calls() {
     // Step 2: Create agent with test_math capability
     println!("\nStep 2: Creating math agent with test_math capability...");
     let agent_response = client
-        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL))
         .json(&json!({
             "name": "Math Calculator Agent",
             "system_prompt": "You are a math calculator. Use the available math tools (add, subtract, multiply, divide) to solve problems. Show your work step by step.",
@@ -3393,7 +3229,7 @@ async fn test_agent_execution_multiple_tool_calls() {
     // Step 3: Create session and send message
     println!("\nStep 3: Creating session and sending message...");
     let session_response = client
-        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id}))
         .send()
         .await
@@ -3407,7 +3243,7 @@ async fn test_agent_execution_multiple_tool_calls() {
     let message_response = client
         .post(format!(
             "{}/v1/sessions/{}/messages",
-            API_BASE_URL, DEFAULT_ORG, session.id
+            API_BASE_URL, session.id
         ))
         .json(&json!({
             "message": {
@@ -3430,7 +3266,7 @@ async fn test_agent_execution_multiple_tool_calls() {
         let messages_response = client
             .get(format!(
                 "{}/v1/sessions/{}/messages",
-                API_BASE_URL, DEFAULT_ORG, session.id
+                API_BASE_URL, session.id
             ))
             .send()
             .await;
@@ -3463,26 +3299,20 @@ async fn test_agent_execution_multiple_tool_calls() {
     // Cleanup
     println!("\nCleaning up...");
     client
-        .delete(format!(
-            "{}/v1/agents/{}",
-            API_BASE_URL, DEFAULT_ORG, agent.id
-        ))
+        .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
         .send()
         .await
         .expect("Failed to delete agent");
     client
         .delete(format!(
             "{}/v1/llm-providers/{}/models/{}",
-            API_BASE_URL, DEFAULT_ORG, provider.id, model.id
+            API_BASE_URL, provider.id, model.id
         ))
         .send()
         .await
         .expect("Failed to delete model");
     client
-        .delete(format!(
-            "{}/v1/llm-providers/{}",
-            API_BASE_URL, DEFAULT_ORG, provider.id
-        ))
+        .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
         .send()
         .await
         .expect("Failed to delete provider");
@@ -3514,10 +3344,7 @@ async fn test_streaming_events_emitted() {
     // Step 1: Create LlmSim provider and model
     println!("\nStep 1: Creating LlmSim provider and model...");
     let provider_response = client
-        .post(format!(
-            "{}/v1/llm-providers",
-            API_BASE_URL, DEFAULT_ORG
-        ))
+        .post(format!("{}/v1/llm-providers", API_BASE_URL))
         .json(&json!({
             "name": "Streaming Test Provider",
             "provider_type": "llmsim"
@@ -3543,7 +3370,7 @@ async fn test_streaming_events_emitted() {
     let model_response = client
         .post(format!(
             "{}/v1/llm-providers/{}/models",
-            API_BASE_URL, DEFAULT_ORG, provider.id
+            API_BASE_URL, provider.id
         ))
         .json(&json!({
             "model_id": "llmsim-streaming",
@@ -3564,7 +3391,7 @@ async fn test_streaming_events_emitted() {
     // Step 2: Create agent
     println!("\nStep 2: Creating agent...");
     let agent_response = client
-        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL))
         .json(&json!({
             "name": "Streaming Test Agent",
             "system_prompt": "You are a helpful assistant. Respond briefly.",
@@ -3581,7 +3408,7 @@ async fn test_streaming_events_emitted() {
     // Step 3: Create session
     println!("\nStep 3: Creating session...");
     let session_response = client
-        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id, "title": "Streaming Test Session"}))
         .send()
         .await
@@ -3599,7 +3426,7 @@ async fn test_streaming_events_emitted() {
     let message_response = client
         .post(format!(
             "{}/v1/sessions/{}/messages",
-            API_BASE_URL, DEFAULT_ORG, session.id
+            API_BASE_URL, session.id
         ))
         .json(&json!({
             "message": {
@@ -3623,7 +3450,7 @@ async fn test_streaming_events_emitted() {
         let messages_response = client
             .get(format!(
                 "{}/v1/sessions/{}/messages",
-                API_BASE_URL, DEFAULT_ORG, session.id
+                API_BASE_URL, session.id
             ))
             .send()
             .await;
@@ -3663,7 +3490,7 @@ async fn test_streaming_events_emitted() {
     let events_response = client
         .get(format!(
             "{}/v1/sessions/{}/events",
-            API_BASE_URL, DEFAULT_ORG, session.id
+            API_BASE_URL, session.id
         ))
         .send()
         .await
@@ -3771,26 +3598,17 @@ async fn test_streaming_events_emitted() {
     // Cleanup
     println!("\nCleaning up...");
     client
-        .delete(format!(
-            "{}/v1/agents/{}",
-            API_BASE_URL, DEFAULT_ORG, agent.id
-        ))
+        .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
         .send()
         .await
         .expect("Failed to delete agent");
     client
-        .delete(format!(
-            "{}/v1/llm-models/{}",
-            API_BASE_URL, DEFAULT_ORG, model.id
-        ))
+        .delete(format!("{}/v1/llm-models/{}", API_BASE_URL, model.id))
         .send()
         .await
         .expect("Failed to delete model");
     client
-        .delete(format!(
-            "{}/v1/llm-providers/{}",
-            API_BASE_URL, DEFAULT_ORG, provider.id
-        ))
+        .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
         .send()
         .await
         .expect("Failed to delete provider");
@@ -3813,10 +3631,7 @@ async fn test_cancel_turn_endpoint() {
     // Step 1: Create LlmSim provider
     println!("\nStep 1: Creating LlmSim provider...");
     let provider_response = client
-        .post(format!(
-            "{}/v1/llm-providers",
-            API_BASE_URL, DEFAULT_ORG
-        ))
+        .post(format!("{}/v1/llm-providers", API_BASE_URL))
         .json(&json!({
             "name": "LlmSim Cancel Test",
             "provider_type": "llmsim"
@@ -3844,7 +3659,7 @@ async fn test_cancel_turn_endpoint() {
     let model_response = client
         .post(format!(
             "{}/v1/llm-providers/{}/models",
-            API_BASE_URL, DEFAULT_ORG, provider.id
+            API_BASE_URL, provider.id
         ))
         .json(&json!({
             "model_id": "llmsim-cancel-test",
@@ -3865,7 +3680,7 @@ async fn test_cancel_turn_endpoint() {
     // Step 3: Create agent with LlmSim model
     println!("\nStep 3: Creating agent...");
     let agent_response = client
-        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL))
         .json(&json!({
             "name": "Cancel Test Agent",
             "system_prompt": "You are a helpful assistant.",
@@ -3882,7 +3697,7 @@ async fn test_cancel_turn_endpoint() {
     // Step 4: Create session
     println!("\nStep 4: Creating session...");
     let session_response = client
-        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({
             "agent_id": agent.id,
             "title": "Cancel Test Session"
@@ -3903,7 +3718,7 @@ async fn test_cancel_turn_endpoint() {
     let cancel_response = client
         .post(format!(
             "{}/v1/sessions/{}/cancel",
-            API_BASE_URL, DEFAULT_ORG, session.id
+            API_BASE_URL, session.id
         ))
         .send()
         .await
@@ -3929,19 +3744,13 @@ async fn test_cancel_turn_endpoint() {
     // Cleanup
     println!("\nCleaning up...");
     client
-        .delete(format!(
-            "{}/v1/agents/{}",
-            API_BASE_URL, DEFAULT_ORG, agent.id
-        ))
+        .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
         .send()
         .await
         .expect("Failed to delete agent");
 
     client
-        .delete(format!(
-            "{}/v1/llm-providers/{}",
-            API_BASE_URL, DEFAULT_ORG, provider.id
-        ))
+        .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
         .send()
         .await
         .expect("Failed to delete provider");
@@ -3980,10 +3789,7 @@ async fn test_anthropic_extended_thinking() {
     };
 
     let provider_response = client
-        .post(format!(
-            "{}/v1/llm-providers",
-            API_BASE_URL, DEFAULT_ORG
-        ))
+        .post(format!("{}/v1/llm-providers", API_BASE_URL))
         .json(&json!({
             "name": "Anthropic Thinking Test Provider",
             "provider_type": "anthropic",
@@ -4012,7 +3818,7 @@ async fn test_anthropic_extended_thinking() {
     let model_response = client
         .post(format!(
             "{}/v1/llm-providers/{}/models",
-            API_BASE_URL, DEFAULT_ORG, provider.id
+            API_BASE_URL, provider.id
         ))
         .json(&json!({
             "model_id": "claude-sonnet-4-20250514",
@@ -4033,7 +3839,7 @@ async fn test_anthropic_extended_thinking() {
     // Step 2: Create agent (no tool calls - tests basic thinking flow)
     println!("\nStep 2: Creating agent...");
     let agent_response = client
-        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL))
         .json(&json!({
             "name": "Thinking Test Agent",
             "system_prompt": "You are a helpful assistant. Think through problems step by step.",
@@ -4050,10 +3856,7 @@ async fn test_anthropic_extended_thinking() {
     // Step 3: Create session
     println!("\nStep 3: Creating session...");
     let session_response = client
-        .post(format!(
-            "{}/v1/agents/{}/sessions",
-            API_BASE_URL, DEFAULT_ORG, agent.id
-        ))
+        .post(format!("{}/v1/agents/{}/sessions", API_BASE_URL, agent.id))
         .json(&json!({"title": "Extended Thinking Test Session"}))
         .send()
         .await
@@ -4072,7 +3875,7 @@ async fn test_anthropic_extended_thinking() {
     let message_response = client
         .post(format!(
             "{}/v1/agents/{}/sessions/{}/messages",
-            API_BASE_URL, DEFAULT_ORG, agent.id, session.id
+            API_BASE_URL, agent.id, session.id
         ))
         .json(&json!({
             "message": {
@@ -4107,7 +3910,7 @@ async fn test_anthropic_extended_thinking() {
         let session_response = client
             .get(format!(
                 "{}/v1/agents/{}/sessions/{}",
-                API_BASE_URL, DEFAULT_ORG, agent.id, session.id
+                API_BASE_URL, agent.id, session.id
             ))
             .send()
             .await;
@@ -4133,7 +3936,7 @@ async fn test_anthropic_extended_thinking() {
     let events_response = client
         .get(format!(
             "{}/v1/agents/{}/sessions/{}/events",
-            API_BASE_URL, DEFAULT_ORG, agent.id, session.id
+            API_BASE_URL, agent.id, session.id
         ))
         .send()
         .await
@@ -4209,7 +4012,7 @@ async fn test_anthropic_extended_thinking() {
     let followup_response = client
         .post(format!(
             "{}/v1/agents/{}/sessions/{}/messages",
-            API_BASE_URL, DEFAULT_ORG, agent.id, session.id
+            API_BASE_URL, agent.id, session.id
         ))
         .json(&json!({
             "message": {
@@ -4236,7 +4039,7 @@ async fn test_anthropic_extended_thinking() {
         let session_response = client
             .get(format!(
                 "{}/v1/agents/{}/sessions/{}",
-                API_BASE_URL, DEFAULT_ORG, agent.id, session.id
+                API_BASE_URL, agent.id, session.id
             ))
             .send()
             .await;
@@ -4266,26 +4069,20 @@ async fn test_anthropic_extended_thinking() {
     // Cleanup
     println!("\nCleaning up...");
     client
-        .delete(format!(
-            "{}/v1/agents/{}",
-            API_BASE_URL, DEFAULT_ORG, agent.id
-        ))
+        .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
         .send()
         .await
         .expect("Failed to delete agent");
     client
         .delete(format!(
             "{}/v1/llm-providers/{}/models/{}",
-            API_BASE_URL, DEFAULT_ORG, provider.id, model.id
+            API_BASE_URL, provider.id, model.id
         ))
         .send()
         .await
         .expect("Failed to delete model");
     client
-        .delete(format!(
-            "{}/v1/llm-providers/{}",
-            API_BASE_URL, DEFAULT_ORG, provider.id
-        ))
+        .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
         .send()
         .await
         .expect("Failed to delete provider");
@@ -4347,10 +4144,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
     };
 
     let provider_response = client
-        .post(format!(
-            "{}/v1/llm-providers",
-            API_BASE_URL, DEFAULT_ORG
-        ))
+        .post(format!("{}/v1/llm-providers", API_BASE_URL))
         .json(&json!({
             "name": "Anthropic Thinking+Tools Test",
             "provider_type": "anthropic",
@@ -4379,7 +4173,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
     let model_response = client
         .post(format!(
             "{}/v1/llm-providers/{}/models",
-            API_BASE_URL, DEFAULT_ORG, provider.id
+            API_BASE_URL, provider.id
         ))
         .json(&json!({
             "model_id": "claude-sonnet-4-20250514",
@@ -4400,7 +4194,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
     // Step 2: Create agent WITH current_time tool
     println!("\nStep 2: Creating agent with current_time tool...");
     let agent_response = client
-        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL))
         .json(&json!({
             "name": "Time Reporter Agent",
             "system_prompt": "You help users with simple requests. When asked for the time, call the current_time tool once and report the result.",
@@ -4420,10 +4214,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
     // Step 3: Create session
     println!("\nStep 3: Creating session...");
     let session_response = client
-        .post(format!(
-            "{}/v1/agents/{}/sessions",
-            API_BASE_URL, DEFAULT_ORG, agent.id
-        ))
+        .post(format!("{}/v1/agents/{}/sessions", API_BASE_URL, agent.id))
         .json(&json!({"title": "Time Reporting with Thinking Test"}))
         .send()
         .await
@@ -4442,7 +4233,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
     let message_response = client
         .post(format!(
             "{}/v1/agents/{}/sessions/{}/messages",
-            API_BASE_URL, DEFAULT_ORG, agent.id, session.id
+            API_BASE_URL, agent.id, session.id
         ))
         .json(&json!({
             "message": {
@@ -4475,7 +4266,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
         let session_response = client
             .get(format!(
                 "{}/v1/agents/{}/sessions/{}",
-                API_BASE_URL, DEFAULT_ORG, agent.id, session.id
+                API_BASE_URL, agent.id, session.id
             ))
             .send()
             .await;
@@ -4508,7 +4299,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
     let events_response = client
         .get(format!(
             "{}/v1/agents/{}/sessions/{}/events",
-            API_BASE_URL, DEFAULT_ORG, agent.id, session.id
+            API_BASE_URL, agent.id, session.id
         ))
         .send()
         .await
@@ -4560,7 +4351,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
     let followup_response = client
         .post(format!(
             "{}/v1/agents/{}/sessions/{}/messages",
-            API_BASE_URL, DEFAULT_ORG, agent.id, session.id
+            API_BASE_URL, agent.id, session.id
         ))
         .json(&json!({
             "message": {
@@ -4587,7 +4378,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
         let session_response = client
             .get(format!(
                 "{}/v1/agents/{}/sessions/{}",
-                API_BASE_URL, DEFAULT_ORG, agent.id, session.id
+                API_BASE_URL, agent.id, session.id
             ))
             .send()
             .await;
@@ -4623,26 +4414,20 @@ async fn test_anthropic_extended_thinking_with_tools() {
     // Cleanup
     println!("\nCleaning up...");
     client
-        .delete(format!(
-            "{}/v1/agents/{}",
-            API_BASE_URL, DEFAULT_ORG, agent.id
-        ))
+        .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
         .send()
         .await
         .expect("Failed to delete agent");
     client
         .delete(format!(
             "{}/v1/llm-providers/{}/models/{}",
-            API_BASE_URL, DEFAULT_ORG, provider.id, model.id
+            API_BASE_URL, provider.id, model.id
         ))
         .send()
         .await
         .expect("Failed to delete model");
     client
-        .delete(format!(
-            "{}/v1/llm-providers/{}",
-            API_BASE_URL, DEFAULT_ORG, provider.id
-        ))
+        .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
         .send()
         .await
         .expect("Failed to delete provider");
@@ -4690,7 +4475,7 @@ async fn test_events_api_contract() {
 
     // Step 1: Create agent and session
     let agent: Agent = client
-        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL))
         .json(&json!({
             "name": "Events Contract Test Agent",
             "system_prompt": "You are helpful"
@@ -4703,7 +4488,7 @@ async fn test_events_api_contract() {
         .expect("Failed to parse agent");
 
     let session: Session = client
-        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id, "title": "Events Contract Test"}))
         .send()
         .await
@@ -4719,7 +4504,7 @@ async fn test_events_api_contract() {
     let events_response = client
         .get(format!(
             "{}/v1/sessions/{}/events",
-            API_BASE_URL, DEFAULT_ORG, session.id
+            API_BASE_URL, session.id
         ))
         .send()
         .await
@@ -4782,10 +4567,7 @@ async fn test_events_api_contract() {
 
     // Cleanup
     client
-        .delete(format!(
-            "{}/v1/agents/{}",
-            API_BASE_URL, DEFAULT_ORG, agent.id
-        ))
+        .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
         .send()
         .await
         .expect("Failed to delete agent");
@@ -4804,7 +4586,7 @@ async fn test_events_sse_contract() {
 
     // Step 1: Create agent and session
     let agent: Agent = client
-        .post(format!("{}/v1/agents", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/agents", API_BASE_URL))
         .json(&json!({
             "name": "SSE Contract Test Agent",
             "system_prompt": "You are helpful"
@@ -4817,7 +4599,7 @@ async fn test_events_sse_contract() {
         .expect("Failed to parse agent");
 
     let session: Session = client
-        .post(format!("{}/v1/sessions", API_BASE_URL, DEFAULT_ORG))
+        .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({"agent_id": agent.id, "title": "SSE Contract Test"}))
         .send()
         .await
@@ -4830,10 +4612,7 @@ async fn test_events_sse_contract() {
 
     // Step 2: Connect to SSE stream and verify headers and initial data
     println!("\nConnecting to SSE stream...");
-    let sse_url = format!(
-        "{}/v1/sessions/{}/sse",
-        API_BASE_URL, DEFAULT_ORG, session.id
-    );
+    let sse_url = format!("{}/v1/sessions/{}/sse", API_BASE_URL, session.id);
 
     let sse_response = client
         .get(&sse_url)
@@ -4876,10 +4655,7 @@ async fn test_events_sse_contract() {
 
     // Cleanup
     client
-        .delete(format!(
-            "{}/v1/agents/{}",
-            API_BASE_URL, DEFAULT_ORG, agent.id
-        ))
+        .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.id))
         .send()
         .await
         .expect("Failed to delete agent");

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -16,24 +16,13 @@
     }
   ],
   "paths": {
-    "/v1/orgs/{org}/agents": {
+    "/v1/agents": {
       "get": {
         "tags": [
           "agents"
         ],
-        "summary": "GET /v1/orgs/{org}/agents - List all active agents",
+        "summary": "GET /v1/agents - List all active agents",
         "operationId": "list_agents",
-        "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "description": "List of agents",
@@ -54,19 +43,8 @@
         "tags": [
           "agents"
         ],
-        "summary": "POST /v1/orgs/{org}/agents - Create a new agent",
+        "summary": "POST /v1/agents - Create a new agent",
         "operationId": "create_agent",
-        "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -111,25 +89,14 @@
         }
       }
     },
-    "/v1/orgs/{org}/agents/import": {
+    "/v1/agents/import": {
       "post": {
         "tags": [
           "agents"
         ],
-        "summary": "POST /v1/orgs/{org}/agents/import - Import agent from Markdown, YAML, or JSON",
+        "summary": "POST /v1/agents/import - Import agent from Markdown, YAML, or JSON",
         "description": "Accepts agent definition in multiple formats:\n- Markdown with YAML front matter (if starts with ---)\n- Pure YAML\n- Pure JSON\n- Plain text (treated as system prompt, name auto-generated)",
         "operationId": "import_agent",
-        "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
         "requestBody": {
           "content": {
             "text/plain": {
@@ -174,23 +141,14 @@
         }
       }
     },
-    "/v1/orgs/{org}/agents/{agent_id}": {
+    "/v1/agents/{agent_id}": {
       "get": {
         "tags": [
           "agents"
         ],
-        "summary": "GET /v1/orgs/{org}/agents/{agent_id} - Get agent by ID",
+        "summary": "GET /v1/agents/{agent_id} - Get agent by ID",
         "operationId": "get_agent",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "agent_id",
             "in": "path",
@@ -227,18 +185,9 @@
         "tags": [
           "agents"
         ],
-        "summary": "DELETE /v1/orgs/{org}/agents/{agent_id} - Archive agent",
+        "summary": "DELETE /v1/agents/{agent_id} - Archive agent",
         "operationId": "delete_agent",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "agent_id",
             "in": "path",
@@ -268,18 +217,9 @@
         "tags": [
           "agents"
         ],
-        "summary": "PATCH /v1/orgs/{org}/agents/{agent_id} - Update agent",
+        "summary": "PATCH /v1/agents/{agent_id} - Update agent",
         "operationId": "update_agent",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "agent_id",
             "in": "path",
@@ -344,23 +284,14 @@
         }
       }
     },
-    "/v1/orgs/{org}/agents/{agent_id}/export": {
+    "/v1/agents/{agent_id}/export": {
       "get": {
         "tags": [
           "agents"
         ],
-        "summary": "GET /v1/orgs/{org}/agents/{agent_id}/export - Export agent in Markdown format with YAML front matter",
+        "summary": "GET /v1/agents/{agent_id}/export - Export agent in Markdown format with YAML front matter",
         "operationId": "export_agent",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "agent_id",
             "in": "path",
@@ -390,24 +321,13 @@
         }
       }
     },
-    "/v1/orgs/{org}/capabilities": {
+    "/v1/capabilities": {
       "get": {
         "tags": [
           "capabilities"
         ],
-        "summary": "GET /v1/orgs/{org}/capabilities - List all available capabilities",
+        "summary": "GET /v1/capabilities - List all available capabilities",
         "operationId": "list_capabilities",
-        "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "description": "List of available capabilities",
@@ -422,23 +342,14 @@
         }
       }
     },
-    "/v1/orgs/{org}/capabilities/{capability_id}": {
+    "/v1/capabilities/{capability_id}": {
       "get": {
         "tags": [
           "capabilities"
         ],
-        "summary": "GET /v1/orgs/{org}/capabilities/{capability_id} - Get a specific capability",
+        "summary": "GET /v1/capabilities/{capability_id} - Get a specific capability",
         "operationId": "get_capability",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "capability_id",
             "in": "path",
@@ -466,7 +377,7 @@
         }
       }
     },
-    "/v1/orgs/{org}/llm-models": {
+    "/v1/llm-models": {
       "get": {
         "tags": [
           "llm-models"
@@ -474,15 +385,6 @@
         "summary": "List all models across all providers",
         "operationId": "list_all_models",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "source",
             "in": "query",
@@ -532,7 +434,7 @@
         }
       }
     },
-    "/v1/orgs/{org}/llm-models/{id}": {
+    "/v1/llm-models/{id}": {
       "get": {
         "tags": [
           "llm-models"
@@ -540,15 +442,6 @@
         "summary": "Get a specific model with provider info and profile",
         "operationId": "get_model",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "id",
             "in": "path",
@@ -586,15 +479,6 @@
         "operationId": "delete_model",
         "parameters": [
           {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
             "name": "id",
             "in": "path",
             "description": "Model ID (prefixed, e.g., mod_...)",
@@ -623,15 +507,6 @@
         "summary": "Update a model",
         "operationId": "update_model",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "id",
             "in": "path",
@@ -672,24 +547,13 @@
         }
       }
     },
-    "/v1/orgs/{org}/llm-providers": {
+    "/v1/llm-providers": {
       "get": {
         "tags": [
           "llm-providers"
         ],
         "summary": "List all LLM providers",
         "operationId": "list_providers",
-        "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "description": "List of providers",
@@ -709,17 +573,6 @@
         ],
         "summary": "Create a new LLM provider",
         "operationId": "create_provider",
-        "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -750,7 +603,7 @@
         }
       }
     },
-    "/v1/orgs/{org}/llm-providers/{id}": {
+    "/v1/llm-providers/{id}": {
       "get": {
         "tags": [
           "llm-providers"
@@ -758,15 +611,6 @@
         "summary": "Get a specific LLM provider",
         "operationId": "get_provider",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "id",
             "in": "path",
@@ -804,15 +648,6 @@
         "operationId": "delete_provider",
         "parameters": [
           {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
             "name": "id",
             "in": "path",
             "description": "Provider ID (prefixed, e.g., prov_...)",
@@ -841,15 +676,6 @@
         "summary": "Update an LLM provider",
         "operationId": "update_provider",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "id",
             "in": "path",
@@ -890,7 +716,7 @@
         }
       }
     },
-    "/v1/orgs/{org}/llm-providers/{provider_id}/models": {
+    "/v1/llm-providers/{provider_id}/models": {
       "get": {
         "tags": [
           "llm-models"
@@ -898,15 +724,6 @@
         "summary": "List models for a specific provider",
         "operationId": "list_provider_models",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "provider_id",
             "in": "path",
@@ -940,15 +757,6 @@
         "summary": "Create a new model for a provider",
         "operationId": "create_model",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "provider_id",
             "in": "path",
@@ -989,24 +797,13 @@
         }
       }
     },
-    "/v1/orgs/{org}/mcp-servers": {
+    "/v1/mcp-servers": {
       "get": {
         "tags": [
           "mcp-servers"
         ],
-        "summary": "GET /v1/orgs/{org}/mcp-servers - List all MCP servers",
+        "summary": "GET /v1/mcp-servers - List all MCP servers",
         "operationId": "list_mcp_servers",
-        "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "description": "List of MCP servers",
@@ -1027,19 +824,8 @@
         "tags": [
           "mcp-servers"
         ],
-        "summary": "POST /v1/orgs/{org}/mcp-servers - Create a new MCP server",
+        "summary": "POST /v1/mcp-servers - Create a new MCP server",
         "operationId": "create_mcp_server",
-        "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -1084,23 +870,14 @@
         }
       }
     },
-    "/v1/orgs/{org}/mcp-servers/{server_id}": {
+    "/v1/mcp-servers/{server_id}": {
       "get": {
         "tags": [
           "mcp-servers"
         ],
-        "summary": "GET /v1/orgs/{org}/mcp-servers/{server_id} - Get MCP server by ID",
+        "summary": "GET /v1/mcp-servers/{server_id} - Get MCP server by ID",
         "operationId": "get_mcp_server",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "server_id",
             "in": "path",
@@ -1137,18 +914,9 @@
         "tags": [
           "mcp-servers"
         ],
-        "summary": "DELETE /v1/orgs/{org}/mcp-servers/{server_id} - Delete MCP server",
+        "summary": "DELETE /v1/mcp-servers/{server_id} - Delete MCP server",
         "operationId": "delete_mcp_server",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "server_id",
             "in": "path",
@@ -1178,18 +946,9 @@
         "tags": [
           "mcp-servers"
         ],
-        "summary": "PATCH /v1/orgs/{org}/mcp-servers/{server_id} - Update MCP server",
+        "summary": "PATCH /v1/mcp-servers/{server_id} - Update MCP server",
         "operationId": "update_mcp_server",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "server_id",
             "in": "path",
@@ -1254,23 +1013,14 @@
         }
       }
     },
-    "/v1/orgs/{org}/sessions": {
+    "/v1/sessions": {
       "get": {
         "tags": [
           "sessions"
         ],
-        "summary": "GET /v1/orgs/{org}/sessions - List sessions in organization",
+        "summary": "GET /v1/sessions - List sessions in organization",
         "operationId": "list_sessions",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "agent_id",
             "in": "query",
@@ -1336,19 +1086,8 @@
         "tags": [
           "sessions"
         ],
-        "summary": "POST /v1/orgs/{org}/sessions - Create a new session",
+        "summary": "POST /v1/sessions - Create a new session",
         "operationId": "create_session",
-        "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -1379,23 +1118,14 @@
         }
       }
     },
-    "/v1/orgs/{org}/sessions/{session_id}": {
+    "/v1/sessions/{session_id}": {
       "get": {
         "tags": [
           "sessions"
         ],
-        "summary": "GET /v1/orgs/{org}/sessions/{session_id} - Get session",
+        "summary": "GET /v1/sessions/{session_id} - Get session",
         "operationId": "get_session",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -1432,18 +1162,9 @@
         "tags": [
           "sessions"
         ],
-        "summary": "DELETE /v1/orgs/{org}/sessions/{session_id} - Delete session",
+        "summary": "DELETE /v1/sessions/{session_id} - Delete session",
         "operationId": "delete_session",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -1473,18 +1194,9 @@
         "tags": [
           "sessions"
         ],
-        "summary": "PATCH /v1/orgs/{org}/sessions/{session_id} - Update session",
+        "summary": "PATCH /v1/sessions/{session_id} - Update session",
         "operationId": "update_session",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -1528,24 +1240,15 @@
         }
       }
     },
-    "/v1/orgs/{org}/sessions/{session_id}/cancel": {
+    "/v1/sessions/{session_id}/cancel": {
       "post": {
         "tags": [
           "sessions"
         ],
-        "summary": "POST /v1/orgs/{org}/sessions/{session_id}/cancel - Cancel current turn",
+        "summary": "POST /v1/sessions/{session_id}/cancel - Cancel current turn",
         "description": "Cancels the currently running turn in the session. If no turn is running,\nthis is a no-op and returns success (idempotent). When a turn is active:\n1. Cancel the underlying workflow execution\n2. Emit a turn.cancelled event\n3. Insert an agent message indicating the turn was cancelled\n4. Set the session status back to idle",
         "operationId": "cancel_turn",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -1579,23 +1282,14 @@
         }
       }
     },
-    "/v1/orgs/{org}/sessions/{session_id}/events": {
+    "/v1/sessions/{session_id}/events": {
       "get": {
         "tags": [
           "events"
         ],
-        "summary": "GET /v1/orgs/{org}/sessions/{session_id}/events - List events (JSON)",
+        "summary": "GET /v1/sessions/{session_id}/events - List events (JSON)",
         "operationId": "list_events",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -1656,7 +1350,7 @@
         }
       }
     },
-    "/v1/orgs/{org}/sessions/{session_id}/fs": {
+    "/v1/sessions/{session_id}/fs": {
       "get": {
         "tags": [
           "filesystem"
@@ -1664,15 +1358,6 @@
         "summary": "GET /fs - Get root directory listing",
         "operationId": "get_root",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -1705,7 +1390,7 @@
         }
       }
     },
-    "/v1/orgs/{org}/sessions/{session_id}/fs/_/copy": {
+    "/v1/sessions/{session_id}/fs/_/copy": {
       "post": {
         "tags": [
           "filesystem"
@@ -1713,15 +1398,6 @@
         "summary": "POST /fs/_/copy - Copy file",
         "operationId": "copy_file",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -1768,7 +1444,7 @@
         }
       }
     },
-    "/v1/orgs/{org}/sessions/{session_id}/fs/_/grep": {
+    "/v1/sessions/{session_id}/fs/_/grep": {
       "post": {
         "tags": [
           "filesystem"
@@ -1776,15 +1452,6 @@
         "summary": "POST /fs/_/grep - Search files",
         "operationId": "grep_files",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -1825,7 +1492,7 @@
         }
       }
     },
-    "/v1/orgs/{org}/sessions/{session_id}/fs/_/move": {
+    "/v1/sessions/{session_id}/fs/_/move": {
       "post": {
         "tags": [
           "filesystem"
@@ -1833,15 +1500,6 @@
         "summary": "POST /fs/_/move - Move/rename file",
         "operationId": "move_file",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -1888,7 +1546,7 @@
         }
       }
     },
-    "/v1/orgs/{org}/sessions/{session_id}/fs/_/stat": {
+    "/v1/sessions/{session_id}/fs/_/stat": {
       "post": {
         "tags": [
           "filesystem"
@@ -1896,15 +1554,6 @@
         "summary": "POST /fs/_/stat - Get file or directory stat",
         "operationId": "stat_file",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -1948,7 +1597,7 @@
         }
       }
     },
-    "/v1/orgs/{org}/sessions/{session_id}/fs/{path}": {
+    "/v1/sessions/{session_id}/fs/{path}": {
       "get": {
         "tags": [
           "filesystem"
@@ -1956,15 +1605,6 @@
         "summary": "GET /fs/*path - Get file content or directory listing",
         "operationId": "get_path",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -2015,15 +1655,6 @@
         "summary": "PUT /fs/*path - Update file content",
         "operationId": "update_path",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -2083,15 +1714,6 @@
         "operationId": "create_path",
         "parameters": [
           {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
             "name": "session_id",
             "in": "path",
             "description": "Session ID (prefixed, e.g., sess_...)",
@@ -2150,15 +1772,6 @@
         "operationId": "delete_path",
         "parameters": [
           {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
             "name": "session_id",
             "in": "path",
             "description": "Session ID (prefixed, e.g., sess_...)",
@@ -2206,23 +1819,14 @@
         }
       }
     },
-    "/v1/orgs/{org}/sessions/{session_id}/messages": {
+    "/v1/sessions/{session_id}/messages": {
       "get": {
         "tags": [
           "messages"
         ],
-        "summary": "GET /v1/orgs/{org}/sessions/{session_id}/messages - List messages (PRIMARY data)",
+        "summary": "GET /v1/sessions/{session_id}/messages - List messages (PRIMARY data)",
         "operationId": "list_messages",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -2259,18 +1863,9 @@
         "tags": [
           "messages"
         ],
-        "summary": "POST /v1/orgs/{org}/sessions/{session_id}/messages - Create message (user message triggers workflow)",
+        "summary": "POST /v1/sessions/{session_id}/messages - Create message (user message triggers workflow)",
         "operationId": "create_message",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",
@@ -2314,23 +1909,14 @@
         }
       }
     },
-    "/v1/orgs/{org}/sessions/{session_id}/sse": {
+    "/v1/sessions/{session_id}/sse": {
       "get": {
         "tags": [
           "events"
         ],
-        "summary": "GET /v1/orgs/{org}/sessions/{session_id}/sse - Stream events (SSE notifications)",
+        "summary": "GET /v1/sessions/{session_id}/sse - Stream events (SSE notifications)",
         "operationId": "stream_sse",
         "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "description": "Organization public ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "session_id",
             "in": "path",

--- a/docs/features/events.md
+++ b/docs/features/events.md
@@ -21,7 +21,7 @@ Every action during a session - from user messages to LLM responses to tool exec
 Subscribe to real-time events via Server-Sent Events:
 
 ```bash
-curl -N "https://api.everruns.com/v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}/sse" \
+curl -N "https://api.everruns.com/v1/agents/{agent_id}/sessions/{session_id}/sse" \
   -H "Authorization: Bearer $API_KEY"
 ```
 
@@ -30,7 +30,7 @@ curl -N "https://api.everruns.com/v1/orgs/{org}/agents/{agent_id}/sessions/{sess
 Alternatively, poll for events with pagination:
 
 ```bash
-curl "https://api.everruns.com/v1/orgs/{org}/agents/{agent_id}/sessions/{session_id}/events?since_id={last_event_id}" \
+curl "https://api.everruns.com/v1/agents/{agent_id}/sessions/{session_id}/events?since_id={last_event_id}" \
   -H "Authorization: Bearer $API_KEY"
 ```
 

--- a/docs/getting-started/docker-compose.md
+++ b/docs/getting-started/docker-compose.md
@@ -89,12 +89,12 @@ If you didn't set `DEFAULT_OPENAI_API_KEY` or `DEFAULT_ANTHROPIC_API_KEY` in you
 
 ```bash
 # Create a session (agent_id in request body)
-curl -X POST http://localhost:8080/api/v1/orgs/default/sessions \
+curl -X POST http://localhost:8080/api/v1/sessions \
   -H "Content-Type: application/json" \
   -d '{"agent_id": "{agent_id}"}'
 
 # Send a message
-curl -X POST http://localhost:8080/api/v1/orgs/default/sessions/{session_id}/messages \
+curl -X POST http://localhost:8080/api/v1/sessions/{session_id}/messages \
   -H "Content-Type: application/json" \
   -d '{"message": {"role": "user", "content": [{"type": "text", "text": "Hello!"}]}}'
 ```

--- a/examples/agent_api_example.ipynb
+++ b/examples/agent_api_example.ipynb
@@ -79,7 +79,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "session_data = {\n    \"agent_id\": agent_id,\n    \"title\": \"Python API Test Session\"\n}\n\nresponse = requests.post(f\"{API_V1}/orgs/default/sessions\", json=session_data)\nresponse.raise_for_status()\nsession = response.json()\n\nsession_id = session[\"id\"]\nprint(f\"Created session: {session_id}\")"
+   "source": "session_data = {\n    \"agent_id\": agent_id,\n    \"title\": \"Python API Test Session\"\n}\n\nresponse = requests.post(f\"{API_V1}/sessions\", json=session_data)\nresponse.raise_for_status()\nsession = response.json()\n\nsession_id = session[\"id\"]\nprint(f\"Created session: {session_id}\")"
   },
   {
    "cell_type": "markdown",
@@ -95,7 +95,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "message_data = {\n    \"message\": {\n        \"role\": \"user\",\n        \"content\": [\n            {\"type\": \"text\", \"text\": \"What is 2 + 2? Please explain briefly.\"}\n        ]\n    }\n}\n\nresponse = requests.post(\n    f\"{API_V1}/orgs/default/sessions/{session_id}/messages\",\n    json=message_data\n)\nresponse.raise_for_status()\nprint(f\"Sent message: {response.json()['id']}\")"
+   "source": "message_data = {\n    \"message\": {\n        \"role\": \"user\",\n        \"content\": [\n            {\"type\": \"text\", \"text\": \"What is 2 + 2? Please explain briefly.\"}\n        ]\n    }\n}\n\nresponse = requests.post(\n    f\"{API_V1}/sessions/{session_id}/messages\",\n    json=message_data\n)\nresponse.raise_for_status()\nprint(f\"Sent message: {response.json()['id']}\")"
   },
   {
    "cell_type": "markdown",
@@ -107,7 +107,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "def read_until_output(session_id: str, timeout: int = 60):\n    \"\"\"Poll events continuously until an agent message appears.\n    \n    Prints all events as they arrive. Returns the agent's response text.\n    \"\"\"\n    url = f\"{API_V1}/orgs/default/sessions/{session_id}/events\"\n    seen_sequences = set()\n    start_time = time.time()\n    \n    while time.time() - start_time < timeout:\n        response = requests.get(url)\n        response.raise_for_status()\n        events = response.json().get(\"data\", [])\n        \n        for event in events:\n            seq = event[\"sequence\"]\n            if seq in seen_sequences:\n                continue\n            seen_sequences.add(seq)\n            \n            event_type = event[\"event_type\"]\n            data = event[\"data\"]\n            \n            print(f\"[{seq}] {event_type}\")\n            \n            # For message.agent, format nicely and return text\n            if event_type == \"message.agent\":\n                content = data.get(\"content\", [])\n                text_parts = [p[\"text\"] for p in content if p.get(\"type\") == \"text\"]\n                text = \"\\n\".join(text_parts)\n                print(json.dumps(data, indent=2))\n                print()\n                return text\n            else:\n                # Print full event data for all other events\n                print(json.dumps(data, indent=2))\n                print()\n            \n            # Check for failure\n            if event_type == \"session.failed\":\n                return None\n        \n        time.sleep(0.5)\n    \n    return None\n\n# Read events until we get the agent's response\nprint(\"Polling for events...\\n\")\nagent_response = read_until_output(session_id)\n\nif agent_response:\n    print(\"=\" * 40)\n    print(\"AGENT RESPONSE:\")\n    print(agent_response)\nelse:\n    print(\"No response received\")"
+   "source": "def read_until_output(session_id: str, timeout: int = 60):\n    \"\"\"Poll events continuously until an agent message appears.\n    \n    Prints all events as they arrive. Returns the agent's response text.\n    \"\"\"\n    url = f\"{API_V1}/sessions/{session_id}/events\"\n    seen_sequences = set()\n    start_time = time.time()\n    \n    while time.time() - start_time < timeout:\n        response = requests.get(url)\n        response.raise_for_status()\n        events = response.json().get(\"data\", [])\n        \n        for event in events:\n            seq = event[\"sequence\"]\n            if seq in seen_sequences:\n                continue\n            seen_sequences.add(seq)\n            \n            event_type = event[\"event_type\"]\n            data = event[\"data\"]\n            \n            print(f\"[{seq}] {event_type}\")\n            \n            # For message.agent, format nicely and return text\n            if event_type == \"message.agent\":\n                content = data.get(\"content\", [])\n                text_parts = [p[\"text\"] for p in content if p.get(\"type\") == \"text\"]\n                text = \"\\n\".join(text_parts)\n                print(json.dumps(data, indent=2))\n                print()\n                return text\n            else:\n                # Print full event data for all other events\n                print(json.dumps(data, indent=2))\n                print()\n            \n            # Check for failure\n            if event_type == \"session.failed\":\n                return None\n        \n        time.sleep(0.5)\n    \n    return None\n\n# Read events until we get the agent's response\nprint(\"Polling for events...\\n\")\nagent_response = read_until_output(session_id)\n\nif agent_response:\n    print(\"=\" * 40)\n    print(\"AGENT RESPONSE:\")\n    print(agent_response)\nelse:\n    print(\"No response received\")"
   },
   {
    "cell_type": "markdown",
@@ -123,7 +123,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# Send follow-up message\nmessage_data = {\n    \"message\": {\n        \"content\": [\n            {\"type\": \"text\", \"text\": \"What about 3 + 3?\"}\n        ]\n    }\n}\n\nresponse = requests.post(\n    f\"{API_V1}/orgs/default/sessions/{session_id}/messages\",\n    json=message_data\n)\nresponse.raise_for_status()\nprint(\"Sent follow-up message\\n\")\n\n# Read response\nagent_response = read_until_output(session_id)\n\nif agent_response:\n    print(f\"\\n--- AGENT ---\")\n    print(agent_response)"
+   "source": "# Send follow-up message\nmessage_data = {\n    \"message\": {\n        \"content\": [\n            {\"type\": \"text\", \"text\": \"What about 3 + 3?\"}\n        ]\n    }\n}\n\nresponse = requests.post(\n    f\"{API_V1}/sessions/{session_id}/messages\",\n    json=message_data\n)\nresponse.raise_for_status()\nprint(\"Sent follow-up message\\n\")\n\n# Read response\nagent_response = read_until_output(session_id)\n\nif agent_response:\n    print(f\"\\n--- AGENT ---\")\n    print(agent_response)"
   },
   {
    "cell_type": "markdown",
@@ -139,12 +139,12 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# Delete session\nrequests.delete(f\"{API_V1}/orgs/default/sessions/{session_id}\")\nprint(f\"Deleted session: {session_id}\")\n\n# Archive agent\nrequests.delete(f\"{API_V1}/agents/{agent_id}\")\nprint(f\"Archived agent: {agent_id}\")"
+   "source": "# Delete session\nrequests.delete(f\"{API_V1}/sessions/{session_id}\")\nprint(f\"Deleted session: {session_id}\")\n\n# Archive agent\nrequests.delete(f\"{API_V1}/agents/{agent_id}\")\nprint(f\"Archived agent: {agent_id}\")"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "<cell_type>markdown</cell_type>## Summary\n\nCore API workflow:\n\n1. `POST /v1/agents` - Create agent\n2. `POST /v1/orgs/{org}/sessions` - Create session (with agent_id in body)\n3. `POST /v1/orgs/{org}/sessions/{id}/messages` - Send user message (triggers agentic loop)\n4. `GET /v1/orgs/{org}/sessions/{id}/events` - Poll events to get agent response\n\n### Event Types\n\nEvents follow the pattern `{entity}.{action}` and contain all session activity:\n\n**Message Events:**\n- `message.user` - User message\n- `message.agent` - Agent response with content\n- `message.tool_call` - Tool invocation by agent\n- `message.tool_result` - Result of tool execution\n\n**Session Events:**\n- `session.started`, `session.completed`, `session.failed` - Session lifecycle\n\n**Step Events:**\n- `step.started`, `step.generating`, `step.generated`, `step.error` - Processing steps\n\nAPI docs: http://localhost:9000/swagger-ui/"
+   "source": "## Summary\n\nCore API workflow:\n\n1. `POST /v1/agents` - Create agent\n2. `POST /v1/sessions` - Create session (with agent_id in body)\n3. `POST /v1/sessions/{id}/messages` - Send user message (triggers agentic loop)\n4. `GET /v1/sessions/{id}/events` - Poll events to get agent response\n\n### Event Types\n\nEvents follow the pattern `{entity}.{action}` and contain all session activity:\n\n**Message Events:**\n- `message.user` - User message\n- `message.agent` - Agent response with content\n- `message.tool_call` - Tool invocation by agent\n- `message.tool_result` - Result of tool execution\n\n**Session Events:**\n- `session.started`, `session.completed`, `session.failed` - Session lifecycle\n\n**Step Events:**\n- `step.started`, `step.generating`, `step.generated`, `step.error` - Processing steps\n\nAPI docs: http://localhost:9000/swagger-ui/"
   }
  ],
  "metadata": {

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -38,14 +38,14 @@ See [authentication.md](authentication.md) for full authentication specification
 
 | Method | Path | Description |
 |--------|------|-------------|
-| POST | `/v1/orgs/{org}/agents` | Create agent |
-| GET | `/v1/orgs/{org}/agents` | List agents (paginated) |
-| GET | `/v1/orgs/{org}/agents/{id}` | Get agent by ID |
-| PATCH | `/v1/orgs/{org}/agents/{id}` | Update agent |
-| DELETE | `/v1/orgs/{org}/agents/{id}` | Archive agent (soft delete) |
-| POST | `/v1/orgs/{org}/agents/import` | Import agent from file content |
-| GET | `/v1/orgs/{org}/agents/{id}/export` | Export agent as Markdown |
-| POST | `/v1/orgs/{org}/agents/preview` | Preview final agent shape |
+| POST | `/v1/agents` | Create agent |
+| GET | `/v1/agents` | List agents (paginated) |
+| GET | `/v1/agents/{id}` | Get agent by ID |
+| PATCH | `/v1/agents/{id}` | Update agent |
+| DELETE | `/v1/agents/{id}` | Archive agent (soft delete) |
+| POST | `/v1/agents/import` | Import agent from file content |
+| GET | `/v1/agents/{id}/export` | Export agent as Markdown |
+| POST | `/v1/agents/preview` | Preview final agent shape |
 
 #### Agent Preview
 
@@ -53,7 +53,7 @@ The preview endpoint computes the final agent shape without persisting anything.
 
 **Request:**
 ```json
-POST /v1/orgs/{org}/agents/preview
+POST /v1/agents/preview
 {
   "system_prompt": "You are a helpful assistant.",
   "capabilities": [
@@ -91,18 +91,18 @@ Sessions are top-level entities under organizations. Each session has an agent a
 
 | Method | Path | Description |
 |--------|------|-------------|
-| POST | `/v1/orgs/{org}/sessions` | Create session |
-| GET | `/v1/orgs/{org}/sessions` | List sessions (paginated) |
-| GET | `/v1/orgs/{org}/sessions/{session_id}` | Get session |
-| PATCH | `/v1/orgs/{org}/sessions/{session_id}` | Update session |
-| DELETE | `/v1/orgs/{org}/sessions/{session_id}` | Delete session |
-| POST | `/v1/orgs/{org}/sessions/{session_id}/cancel` | Cancel current turn |
+| POST | `/v1/sessions` | Create session |
+| GET | `/v1/sessions` | List sessions (paginated) |
+| GET | `/v1/sessions/{session_id}` | Get session |
+| PATCH | `/v1/sessions/{session_id}` | Update session |
+| DELETE | `/v1/sessions/{session_id}` | Delete session |
+| POST | `/v1/sessions/{session_id}/cancel` | Cancel current turn |
 
 #### Create Session
 
 **Request:**
 ```json
-POST /v1/orgs/{org}/sessions
+POST /v1/sessions
 {
   "agent_id": "agent_01234567-...",
   "title": "Optional title",
@@ -118,7 +118,7 @@ The `agent_id` field is required and specifies which agent will work in this ses
 Supports optional filtering by agent:
 
 ```
-GET /v1/orgs/{org}/sessions?agent_id=agent_01234567-...
+GET /v1/sessions?agent_id=agent_01234567-...
 ```
 
 Without the `agent_id` query parameter, returns all sessions in the organization.
@@ -145,8 +145,8 @@ Messages store all conversation content (user, assistant, tool calls, tool resul
 
 | Method | Path | Description |
 |--------|------|-------------|
-| POST | `/v1/orgs/{org}/sessions/{session_id}/messages` | Create message (triggers workflow) |
-| GET | `/v1/orgs/{org}/sessions/{session_id}/messages` | List messages |
+| POST | `/v1/sessions/{session_id}/messages` | Create message (triggers workflow) |
+| GET | `/v1/sessions/{session_id}/messages` | List messages |
 
 ### Images
 
@@ -154,11 +154,11 @@ Org-scoped image storage for message attachments. Images are stored with optiona
 
 | Method | Path | Description |
 |--------|------|-------------|
-| POST | `/v1/orgs/{org}/images` | Upload image (multipart/form-data) |
-| GET | `/v1/orgs/{org}/images` | List images (paginated) |
-| GET | `/v1/orgs/{org}/images/{id}` | Get image data |
-| GET | `/v1/orgs/{org}/images/{id}/thumbnail` | Get thumbnail (200x200 max) |
-| DELETE | `/v1/orgs/{org}/images/{id}` | Delete image |
+| POST | `/v1/images` | Upload image (multipart/form-data) |
+| GET | `/v1/images` | List images (paginated) |
+| GET | `/v1/images/{id}` | Get image data |
+| GET | `/v1/images/{id}/thumbnail` | Get thumbnail (200x200 max) |
+| DELETE | `/v1/images/{id}` | Delete image |
 
 **Upload Request (multipart/form-data):**
 
@@ -191,7 +191,7 @@ Org-scoped image storage for message attachments. Images are stored with optiona
 Images can be attached to messages using the `image_file` content part type:
 
 ```json
-POST /v1/orgs/{org}/sessions/{session_id}/messages
+POST /v1/sessions/{session_id}/messages
 {
   "message": {
     "content": [
@@ -210,16 +210,16 @@ Virtual filesystem scoped to each session. See [session-filesystem.md](session-f
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/v1/orgs/{org}/sessions/{session_id}/fs` | List root directory |
-| GET | `/v1/orgs/{org}/sessions/{session_id}/fs/{path}` | Read file or list directory |
-| POST | `/v1/orgs/{org}/sessions/{session_id}/fs/{path}` | Create file or directory |
-| PUT | `/v1/orgs/{org}/sessions/{session_id}/fs/{path}` | Update file content |
-| DELETE | `/v1/orgs/{org}/sessions/{session_id}/fs/{path}` | Delete file |
-| DELETE | `/v1/orgs/{org}/sessions/{session_id}/fs/{path}?recursive=true` | Delete directory recursively |
-| POST | `/v1/orgs/{org}/sessions/{session_id}/fs/_/stat` | Get file metadata |
-| POST | `/v1/orgs/{org}/sessions/{session_id}/fs/_/move` | Move/rename file |
-| POST | `/v1/orgs/{org}/sessions/{session_id}/fs/_/copy` | Copy file |
-| POST | `/v1/orgs/{org}/sessions/{session_id}/fs/_/grep` | Search files by content |
+| GET | `/v1/sessions/{session_id}/fs` | List root directory |
+| GET | `/v1/sessions/{session_id}/fs/{path}` | Read file or list directory |
+| POST | `/v1/sessions/{session_id}/fs/{path}` | Create file or directory |
+| PUT | `/v1/sessions/{session_id}/fs/{path}` | Update file content |
+| DELETE | `/v1/sessions/{session_id}/fs/{path}` | Delete file |
+| DELETE | `/v1/sessions/{session_id}/fs/{path}?recursive=true` | Delete directory recursively |
+| POST | `/v1/sessions/{session_id}/fs/_/stat` | Get file metadata |
+| POST | `/v1/sessions/{session_id}/fs/_/move` | Move/rename file |
+| POST | `/v1/sessions/{session_id}/fs/_/copy` | Copy file |
+| POST | `/v1/sessions/{session_id}/fs/_/grep` | Search files by content |
 
 **Note:** Paths starting with `_` are reserved for system actions and cannot be used for file creation or updates.
 
@@ -229,25 +229,25 @@ Server-Sent Events (SSE) for real-time UI updates and event listing.
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/v1/orgs/{org}/sessions/{session_id}/sse` | Stream events (SSE) |
-| GET | `/v1/orgs/{org}/sessions/{session_id}/events` | List events (JSON) |
+| GET | `/v1/sessions/{session_id}/sse` | Stream events (SSE) |
+| GET | `/v1/sessions/{session_id}/events` | List events (JSON) |
 
 ### LLM Provider Configuration
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/v1/orgs/{org}/llm-providers` | List providers |
-| POST | `/v1/orgs/{org}/llm-providers` | Create provider |
-| GET | `/v1/orgs/{org}/llm-providers/{id}` | Get provider |
-| PATCH | `/v1/orgs/{org}/llm-providers/{id}` | Update provider (API key, base URL) |
-| DELETE | `/v1/orgs/{org}/llm-providers/{id}` | Delete provider |
-| POST | `/v1/orgs/{org}/llm-providers/{id}/sync-models` | Sync models from provider API |
-| GET | `/v1/orgs/{org}/llm-providers/{id}/models` | List models for provider |
-| POST | `/v1/orgs/{org}/llm-providers/{id}/models` | Create model for provider |
-| GET | `/v1/orgs/{org}/llm-models` | List all models |
-| GET | `/v1/orgs/{org}/llm-models/{id}` | Get model |
-| PATCH | `/v1/orgs/{org}/llm-models/{id}` | Update model |
-| DELETE | `/v1/orgs/{org}/llm-models/{id}` | Delete model |
+| GET | `/v1/llm-providers` | List providers |
+| POST | `/v1/llm-providers` | Create provider |
+| GET | `/v1/llm-providers/{id}` | Get provider |
+| PATCH | `/v1/llm-providers/{id}` | Update provider (API key, base URL) |
+| DELETE | `/v1/llm-providers/{id}` | Delete provider |
+| POST | `/v1/llm-providers/{id}/sync-models` | Sync models from provider API |
+| GET | `/v1/llm-providers/{id}/models` | List models for provider |
+| POST | `/v1/llm-providers/{id}/models` | Create model for provider |
+| GET | `/v1/llm-models` | List all models |
+| GET | `/v1/llm-models/{id}` | Get model |
+| PATCH | `/v1/llm-models/{id}` | Update model |
+| DELETE | `/v1/llm-models/{id}` | Delete model |
 
 #### Model Sync
 
@@ -255,7 +255,7 @@ The sync endpoint discovers available models from a provider's API:
 
 **Request:**
 ```
-POST /v1/orgs/{org}/llm-providers/{id}/sync-models
+POST /v1/llm-providers/{id}/sync-models
 ```
 
 **Response (success):**
@@ -279,7 +279,7 @@ Providers with custom base URLs or providers that don't support model listing re
 
 #### List Models Query Parameters
 
-`GET /v1/orgs/{org}/llm-models` supports:
+`GET /v1/llm-models` supports:
 - `source` - Filter by source: `manual`, `discovered`, `predefined`
 - `include_stale` - Include stale models (default: `true`)
 - `favorites_only` - Only return favorites (default: `false`)
@@ -288,8 +288,8 @@ Providers with custom base URLs or providers that don't support model listing re
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/v1/orgs/{org}/capabilities` | List available capabilities |
-| GET | `/v1/orgs/{org}/capabilities/{capability_id}` | Get capability details |
+| GET | `/v1/capabilities` | List available capabilities |
+| GET | `/v1/capabilities/{capability_id}` | Get capability details |
 
 Capabilities are modular functionality units that can be enabled on agents. They provide:
 - **Tool groups**: Sets of related tools (e.g., `session_file_system` provides read/write/grep tools)
@@ -316,7 +316,7 @@ Capabilities are modular functionality units that can be enabled on agents. They
 
 Create agent with capabilities:
 ```json
-POST /v1/orgs/{org}/agents
+POST /v1/agents
 {
   "name": "Research Assistant",
   "system_prompt": "You are a helpful research assistant.",
@@ -326,7 +326,7 @@ POST /v1/orgs/{org}/agents
 
 Update agent capabilities:
 ```json
-PATCH /v1/orgs/{org}/agents/{agent_id}
+PATCH /v1/agents/{agent_id}
 {
   "capabilities": ["current_time", "web_fetch", "session_file_system"]
 }
@@ -334,7 +334,7 @@ PATCH /v1/orgs/{org}/agents/{agent_id}
 
 Agent response includes capabilities:
 ```json
-GET /v1/orgs/{org}/agents/{agent_id}
+GET /v1/agents/{agent_id}
 {
   "id": "...",
   "name": "Research Assistant",
@@ -450,16 +450,16 @@ Endpoints that return lists support pagination via query parameters:
 
 | Endpoint | Default Limit | Notes |
 |----------|---------------|-------|
-| `GET /v1/orgs/{org}/sessions` | 20 | Ordered by `created_at DESC`, optional `agent_id` filter |
+| `GET /v1/sessions` | 20 | Ordered by `created_at DESC`, optional `agent_id` filter |
 
 **Non-Paginated List Endpoints:**
 
 These endpoints return all items wrapped in `{"data": [...], "total": N}`:
-- `GET /v1/orgs/{org}/agents` - Returns all agents
-- `GET /v1/orgs/{org}/sessions/{session_id}/messages` - Returns all messages
-- `GET /v1/orgs/{org}/sessions/{session_id}/events` - Returns all events
-- `GET /v1/orgs/{org}/llm-providers` - Returns all providers
-- `GET /v1/orgs/{org}/llm-models` - Returns all models
+- `GET /v1/agents` - Returns all agents
+- `GET /v1/sessions/{session_id}/messages` - Returns all messages
+- `GET /v1/sessions/{session_id}/events` - Returns all events
+- `GET /v1/llm-providers` - Returns all providers
+- `GET /v1/llm-models` - Returns all models
 - `GET /v1/durable/workers` - Returns all workers
 - `GET /v1/durable/workflows` - Returns all workflows
 - `GET /v1/durable/workflows/{id}/events` - Returns workflow events
@@ -467,19 +467,19 @@ These endpoints return all items wrapped in `{"data": [...], "total": N}`:
 - `GET /v1/durable/dlq` - Returns all DLQ entries
 - `GET /v1/durable/circuit-breakers` - Returns all circuit breakers
 
-**Exception:** The `/v1/orgs/{org}/capabilities` endpoint uses `items` instead of `data` for historical reasons.
+**Exception:** The `/v1/capabilities` endpoint uses `items` instead of `data` for historical reasons.
 
 **Example Usage:**
 
 ```bash
 # First page (default)
-GET /v1/orgs/{org}/agents/{id}/sessions
+GET /v1/agents/{id}/sessions
 
 # Second page
-GET /v1/orgs/{org}/agents/{id}/sessions?offset=20&limit=20
+GET /v1/agents/{id}/sessions?offset=20&limit=20
 
 # Custom page size
-GET /v1/orgs/{org}/agents/{id}/sessions?limit=10
+GET /v1/agents/{id}/sessions?limit=10
 ```
 
 ### Error Responses

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -677,18 +677,18 @@ All endpoints are organization-scoped.
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/v1/orgs/{org}/capabilities` | List all available capabilities |
-| GET | `/v1/orgs/{org}/capabilities/{capability_id}` | Get capability details |
+| GET | `/v1/capabilities` | List all available capabilities |
+| GET | `/v1/capabilities/{capability_id}` | Get capability details |
 
 Agent capabilities are managed through the agents API:
-- `POST /v1/orgs/{org}/agents` - Create agent with capabilities
-- `PATCH /v1/orgs/{org}/agents/{id}` - Update agent capabilities
-- `GET /v1/orgs/{org}/agents/{id}` - Get agent (includes capabilities)
+- `POST /v1/agents` - Create agent with capabilities
+- `PATCH /v1/agents/{id}` - Update agent capabilities
+- `GET /v1/agents/{id}` - Get agent (includes capabilities)
 
 #### List Capabilities
 
 ```http
-GET /v1/orgs/{org}/capabilities
+GET /v1/capabilities
 
 Response:
 {
@@ -733,7 +733,7 @@ Response:
 #### Create Agent with Capabilities
 
 ```http
-POST /v1/orgs/{org}/agents
+POST /v1/agents
 Content-Type: application/json
 
 {
@@ -762,7 +762,7 @@ Response:
 #### Update Agent Capabilities
 
 ```http
-PATCH /v1/orgs/{org}/agents/{agent_id}
+PATCH /v1/agents/{agent_id}
 Content-Type: application/json
 
 {
@@ -903,7 +903,7 @@ pub trait Capability: Send + Sync {
 
 #### Mount Application Flow
 
-1. Session is created via POST `/v1/orgs/{org}/sessions` (with `agent_id` in body)
+1. Session is created via POST `/v1/sessions` (with `agent_id` in body)
 2. SessionService fetches agent's capabilities
 3. Mounts are collected from all enabled capabilities
 4. Files and directories are created in session filesystem

--- a/specs/models.md
+++ b/specs/models.md
@@ -585,7 +585,7 @@ Automatic discovery of available models from provider APIs.
 **Discovery Flow:**
 
 1. **Background Sync** - Every 24 hours (configurable via `MODEL_SYNC_INTERVAL_HOURS`, set to 0 to disable)
-2. **Manual Sync** - `POST /v1/orgs/:org/llm-providers/:id/sync-models`
+2. **Manual Sync** - `POST /v1/llm-providers/:id/sync-models`
 
 **Sync Behavior:**
 
@@ -597,7 +597,7 @@ Automatic discovery of available models from provider APIs.
 
 **Listing Models:**
 
-`GET /v1/orgs/:org/llm-models` supports query parameters:
+`GET /v1/llm-models` supports query parameters:
 - `source` - Filter by source (`manual`, `discovered`, `predefined`)
 - `include_stale` - Include stale models (default: true)
 - `favorites_only` - Only return favorites (default: false)

--- a/specs/multitenancy.md
+++ b/specs/multitenancy.md
@@ -11,13 +11,28 @@ This document defines the multitenancy model for Everruns, enabling organization
 | Membership model | Members only (no roles) | Simplicity; roles can be added later |
 | Multi-org support | Yes | Users switch between orgs in UI |
 | Personal namespace | No | Org-only model; SaaS auto-creates org on signup |
-| API org identifier | Path-based `/v1/orgs/{org_public_id}/...` | Explicit, debuggable, RESTful |
+| API org identifier | Auth-derived (X-Org-Id header or API key) | Cleaner URLs, org derived from auth context |
 | Org ID format | BIGINT internal + TEXT public_id | Performance + security |
 | Resource sharing | No cross-org sharing | Isolation by default |
-| API keys | Org-scoped | Limited blast radius if leaked |
+| API keys | Org-scoped (1:1 with org) | Limited blast radius; org derived from key |
 | InMemory storage | Supports multitenancy | Consistency across modes |
 | Default org | Seeded on startup | No "first boot" concept |
 | Migration | Reset (no backward compat) | Clean slate |
+
+### Why Auth-Derived Org Instead of Path-Based
+
+**Previous approach:** `/v1/orgs/{org}/agents` - org was explicit in every API path.
+
+**Current approach:** `/v1/agents` - org is derived from authentication context:
+- **API key auth:** Org derived directly from API key (1:1 relationship)
+- **Session auth (UI):** Org specified via `X-Org-Id` header
+- **SSE connections:** Org specified via `org_id` query parameter (EventSource doesn't support headers)
+
+**Rationale:**
+1. **Redundancy eliminated** - API keys are org-scoped, so requiring both org AND API key was redundant
+2. **Cleaner URLs** - Paths like `/v1/agents` are simpler than `/v1/orgs/{org}/agents`
+3. **Better DX** - API users only need their API key, not also the org ID
+4. **Security** - Org is always validated against auth context, preventing org enumeration
 
 ## Requirements
 
@@ -116,19 +131,23 @@ CREATE INDEX idx_api_keys_org_id ON api_keys(org_id);
 
 ### API Design
 
-**Path Structure:**
+**Path Structure (org derived from auth context):**
 ```
-/v1/orgs/{org_public_id}/agents
-/v1/orgs/{org_public_id}/agents/{agent_id}
-/v1/orgs/{org_public_id}/sessions
-/v1/orgs/{org_public_id}/sessions/{session_id}
-/v1/orgs/{org_public_id}/sessions/{session_id}/messages
-/v1/orgs/{org_public_id}/sessions/{session_id}/sse
-/v1/orgs/{org_public_id}/llm-providers
-/v1/orgs/{org_public_id}/llm-providers/{provider_id}
-/v1/orgs/{org_public_id}/llm-models
-/v1/orgs/{org_public_id}/api-keys
+/v1/agents
+/v1/agents/{agent_id}
+/v1/sessions
+/v1/sessions/{session_id}
+/v1/sessions/{session_id}/messages
+/v1/sessions/{session_id}/sse
+/v1/llm-providers
+/v1/llm-providers/{provider_id}
+/v1/llm-models
 ```
+
+**Org Resolution:**
+- **API key auth:** Org looked up from `api_keys.org_id` (no header needed)
+- **Session auth:** Requires `X-Org-Id: org_xxx` header
+- **SSE endpoints:** Accepts `org_id=org_xxx` query param (EventSource limitation)
 
 **Global Endpoints (no org scope):**
 ```
@@ -136,6 +155,7 @@ CREATE INDEX idx_api_keys_org_id ON api_keys(org_id);
 /v1/auth/*
 /v1/users/me
 /v1/capabilities
+/v1/orgs  (org CRUD - uses auth context)
 ```
 
 **User Info Response Enhancement:**
@@ -178,20 +198,24 @@ pub struct OrgMembership {
 }
 ```
 
-**Org Context Extractor:**
+**ResolvedOrg Extractor:**
 ```rust
-/// Extracts organization from path parameter and validates user membership.
-/// Returns 404 if org not found or user is not a member.
-pub struct OrgContext {
+/// Extracts organization from authentication context.
+/// - API key auth: uses org_id from the API key (1:1 relationship)
+/// - Session auth: uses X-Org-Id header (or org_id query param for SSE)
+/// Returns 401/404 if org not found or user is not a member.
+pub struct ResolvedOrg {
     pub org_id: i64,        // For DB queries
     pub public_id: String,  // For API responses
+    pub name: String,
 }
 
-impl<S> FromRequestParts<S> for OrgContext {
-    // 1. Extract org_public_id from path
-    // 2. Look up organization by public_id
-    // 3. Verify AuthUser is member of org
-    // 4. Return OrgContext or 404
+impl<S> FromRequestParts<S> for ResolvedOrg {
+    // 1. Extract AuthUser from request
+    // 2. For API key auth: use single org from AuthUser.organizations
+    // 3. For session auth: get org from X-Org-Id header (or org_id query param)
+    // 4. Validate user is member of requested org
+    // 5. Return ResolvedOrg or error
 }
 ```
 
@@ -417,13 +441,10 @@ ApiError::Forbidden("You don't have access to this agent")
 
 ### Phase 4: API Routes ✅
 - [x] Add org CRUD endpoints (`/v1/orgs`)
-- [x] Migrate all agent routes to `/v1/orgs/{org}/agents/...`
-- [x] Migrate LLM provider routes to `/v1/orgs/{org}/llm-providers/...`
-- [x] Migrate LLM model routes to `/v1/orgs/{org}/llm-models/...`
-- [x] Migrate API key routes to `/v1/orgs/{org}/api-keys/...`
-- [x] Migrate capabilities routes to `/v1/orgs/{org}/capabilities/...`
-- [x] Migrate MCP server routes to `/v1/orgs/{org}/mcp-servers/...`
-- [x] Migrate session files routes to `/v1/orgs/{org}/agents/{agent}/sessions/{session}/fs/...`
+- [x] ~~Migrate all routes to `/v1/orgs/{org}/...`~~ (superseded)
+- [x] Remove org from API paths - use ResolvedOrg extractor instead
+- [x] All routes now at `/v1/agents`, `/v1/sessions`, `/v1/llm-providers`, etc.
+- [x] Org derived from auth context (API key or X-Org-Id header)
 - [x] Update OpenAPI spec
 
 ### Phase 5: Seeds ✅
@@ -452,8 +473,13 @@ ApiError::Forbidden("You don't have access to this agent")
 
 ## Implementation Notes
 
-### OrgContext Extractor
-The `OrgContext` extractor (`server/src/api/org_context.rs`) extracts org from URI path directly since Axum's `Path<T>` extractor consumes the request body. It validates membership against the authenticated user's organizations.
+### ResolvedOrg Extractor
+The `ResolvedOrg` extractor (`server/src/auth/middleware.rs`) derives org from the authentication context:
+- **API key auth:** The API key's `org_id` is used directly (API keys have a 1:1 relationship with orgs)
+- **Session auth:** The `X-Org-Id` header specifies which org to use
+- **SSE endpoints:** Accept `org_id` query param since EventSource doesn't support custom headers
+
+This approach eliminates redundancy (no need to specify org when API key already implies it) and provides cleaner URLs.
 
 ### Anonymous Auth Mode (AUTH_MODE=none)
 When auth is disabled, the UI uses a hardcoded default organization:

--- a/specs/multitenancy.md
+++ b/specs/multitenancy.md
@@ -11,10 +11,11 @@ This document defines the multitenancy model for Everruns, enabling organization
 | Membership model | Members only (no roles) | Simplicity; roles can be added later |
 | Multi-org support | Yes | Users switch between orgs in UI |
 | Personal namespace | No | Org-only model; SaaS auto-creates org on signup |
-| API org identifier | Auth-derived (X-Org-Id header or API key) | Cleaner URLs, org derived from auth context |
+| API org identifier | Auth-derived (cookie or API key) | Cleaner URLs, org derived from auth context |
 | Org ID format | BIGINT internal + TEXT public_id | Performance + security |
 | Resource sharing | No cross-org sharing | Isolation by default |
 | API keys | Org-scoped (1:1 with org) | Limited blast radius; org derived from key |
+| Session org selection | Cookie-based | Consistent for all requests including SSE |
 | InMemory storage | Supports multitenancy | Consistency across modes |
 | Default org | Seeded on startup | No "first boot" concept |
 | Migration | Reset (no backward compat) | Clean slate |
@@ -25,14 +26,51 @@ This document defines the multitenancy model for Everruns, enabling organization
 
 **Current approach:** `/v1/agents` - org is derived from authentication context:
 - **API key auth:** Org derived directly from API key (1:1 relationship)
-- **Session auth (UI):** Org specified via `X-Org-Id` header
-- **SSE connections:** Org specified via `org_id` query parameter (EventSource doesn't support headers)
+- **Session auth (UI):** Org stored in `everruns_org` cookie
 
 **Rationale:**
 1. **Redundancy eliminated** - API keys are org-scoped, so requiring both org AND API key was redundant
 2. **Cleaner URLs** - Paths like `/v1/agents` are simpler than `/v1/orgs/{org}/agents`
 3. **Better DX** - API users only need their API key, not also the org ID
 4. **Security** - Org is always validated against auth context, preventing org enumeration
+5. **Consistency** - Cookie works uniformly for all requests including SSE (EventSource)
+
+### Cookie-Based Org Selection (Session Auth)
+
+When using session/JWT authentication (UI), the selected organization is stored in a cookie.
+
+**Cookie specification:**
+```
+Name: everruns_org
+Value: org_xxx (organization public_id)
+Path: /
+HttpOnly: true (not accessible via JavaScript)
+SameSite: Lax
+Secure: true (in production)
+```
+
+**Switching organizations:**
+```
+POST /v1/users/me/switch-org
+Content-Type: application/json
+
+{"org_id": "org_xxx"}
+
+Response:
+200 OK
+Set-Cookie: everruns_org=org_xxx; Path=/; HttpOnly; SameSite=Lax
+```
+
+**Benefits over header-based approach:**
+- Works automatically with EventSource (SSE) - no query param workaround needed
+- No client-side header management required
+- Cookie sent automatically with all requests
+- HttpOnly prevents XSS attacks from reading org context
+
+**Server resolution order:**
+1. API key auth → use org from API key
+2. Session auth → read `everruns_org` cookie
+3. No org found → return 401 (Missing organization context)
 
 ## Requirements
 
@@ -145,15 +183,15 @@ CREATE INDEX idx_api_keys_org_id ON api_keys(org_id);
 ```
 
 **Org Resolution:**
-- **API key auth:** Org looked up from `api_keys.org_id` (no header needed)
-- **Session auth:** Requires `X-Org-Id: org_xxx` header
-- **SSE endpoints:** Accepts `org_id=org_xxx` query param (EventSource limitation)
+- **API key auth:** Org looked up from `api_keys.org_id` (no cookie/header needed)
+- **Session auth:** Org read from `everruns_org` cookie
 
 **Global Endpoints (no org scope):**
 ```
 /health
 /v1/auth/*
 /v1/users/me
+/v1/users/me/switch-org  (sets org cookie)
 /v1/capabilities
 /v1/orgs  (org CRUD - uses auth context)
 ```
@@ -202,7 +240,7 @@ pub struct OrgMembership {
 ```rust
 /// Extracts organization from authentication context.
 /// - API key auth: uses org_id from the API key (1:1 relationship)
-/// - Session auth: uses X-Org-Id header (or org_id query param for SSE)
+/// - Session auth: reads everruns_org cookie
 /// Returns 401/404 if org not found or user is not a member.
 pub struct ResolvedOrg {
     pub org_id: i64,        // For DB queries
@@ -213,7 +251,7 @@ pub struct ResolvedOrg {
 impl<S> FromRequestParts<S> for ResolvedOrg {
     // 1. Extract AuthUser from request
     // 2. For API key auth: use single org from AuthUser.organizations
-    // 3. For session auth: get org from X-Org-Id header (or org_id query param)
+    // 3. For session auth: read org from everruns_org cookie
     // 4. Validate user is member of requested org
     // 5. Return ResolvedOrg or error
 }
@@ -444,7 +482,7 @@ ApiError::Forbidden("You don't have access to this agent")
 - [x] ~~Migrate all routes to `/v1/orgs/{org}/...`~~ (superseded)
 - [x] Remove org from API paths - use ResolvedOrg extractor instead
 - [x] All routes now at `/v1/agents`, `/v1/sessions`, `/v1/llm-providers`, etc.
-- [x] Org derived from auth context (API key or X-Org-Id header)
+- [x] Org derived from auth context (API key or cookie)
 - [x] Update OpenAPI spec
 
 ### Phase 5: Seeds ✅
@@ -476,10 +514,10 @@ ApiError::Forbidden("You don't have access to this agent")
 ### ResolvedOrg Extractor
 The `ResolvedOrg` extractor (`server/src/auth/middleware.rs`) derives org from the authentication context:
 - **API key auth:** The API key's `org_id` is used directly (API keys have a 1:1 relationship with orgs)
-- **Session auth:** The `X-Org-Id` header specifies which org to use
-- **SSE endpoints:** Accept `org_id` query param since EventSource doesn't support custom headers
+- **Session auth (JWT):** Org from `everruns_org` cookie (set via `POST /v1/users/me/switch-org`)
+- **Anonymous auth (None):** Uses the default org automatically
 
-This approach eliminates redundancy (no need to specify org when API key already implies it) and provides cleaner URLs.
+This approach eliminates redundancy (no need to specify org when API key already implies it) and provides cleaner URLs. The cookie-based approach for session auth works seamlessly with SSE (EventSource) since cookies are automatically sent with all requests.
 
 ### Anonymous Auth Mode (AUTH_MODE=none)
 When auth is disabled, the UI uses a hardcoded default organization:

--- a/specs/session-filesystem.md
+++ b/specs/session-filesystem.md
@@ -64,7 +64,7 @@ This document defines the session-level virtual filesystem for Everruns. Each se
 
 ### API Endpoints
 
-All endpoints under `/v1/orgs/{org}/sessions/{session_id}/fs`
+All endpoints under `/v1/sessions/{session_id}/fs`
 
 #### CRUD Operations
 
@@ -92,7 +92,7 @@ All endpoints under `/v1/orgs/{org}/sessions/{session_id}/fs`
 
 **Create File:**
 ```json
-POST /v1/orgs/{org}/sessions/{id}/fs/src/main.rs
+POST /v1/sessions/{id}/fs/src/main.rs
 {
   "content": "fn main() {}",
   "encoding": "text"

--- a/test_cases/research_agent/TC001_research_agent_full_workflow.md
+++ b/test_cases/research_agent/TC001_research_agent_full_workflow.md
@@ -34,7 +34,7 @@ Verify that the research agent completes a full research workflow: receives a qu
 
 2. Create session:
    ```bash
-   curl -s -X POST "http://localhost:9000/v1/orgs/default/sessions" \
+   curl -s -X POST "http://localhost:9000/v1/sessions" \
      -H "Content-Type: application/json" \
      -d '{"agent_id": "{agent_id}"}'
    ```
@@ -42,7 +42,7 @@ Verify that the research agent completes a full research workflow: receives a qu
 
 3. Send research request:
    ```bash
-   curl -s -X POST "http://localhost:9000/v1/orgs/default/sessions/{session_id}/messages" \
+   curl -s -X POST "http://localhost:9000/v1/sessions/{session_id}/messages" \
      -H "Content-Type: application/json" \
      -d '{
        "message": {
@@ -57,13 +57,13 @@ Verify that the research agent completes a full research workflow: receives a qu
 5. Retrieve all data for assertions:
    ```bash
    # Events
-   curl -s "http://localhost:9000/v1/orgs/default/sessions/{session_id}/events"
+   curl -s "http://localhost:9000/v1/sessions/{session_id}/events"
 
    # Files
-   curl -s "http://localhost:9000/v1/orgs/default/sessions/{session_id}/fs?recursive=true"
+   curl -s "http://localhost:9000/v1/sessions/{session_id}/fs?recursive=true"
 
    # Report content
-   curl -s "http://localhost:9000/v1/orgs/default/sessions/{session_id}/fs/research/report.md"
+   curl -s "http://localhost:9000/v1/sessions/{session_id}/fs/research/report.md"
    ```
 
 ## Expected Result


### PR DESCRIPTION
## Summary

- **Breaking change**: Remove organization from API paths - org is now derived from auth context
- API keys are org-scoped (1:1), so requiring both org AND API key was redundant
- For session auth (UI), org is specified via `everruns_org` cookie (set by `POST /v1/users/me/switch-org`)
- Cookies work automatically with all requests including SSE (EventSource)

### Path changes

| Before | After |
|--------|-------|
| `/v1/orgs/{org}/agents` | `/v1/agents` |
| `/v1/orgs/{org}/sessions` | `/v1/sessions` |
| `/v1/orgs/{org}/llm-providers` | `/v1/llm-providers` |
| `/v1/orgs/{org}/mcp-servers` | `/v1/mcp-servers` |
| `/v1/orgs/{org}/capabilities` | `/v1/capabilities` |

### Org resolution by auth method

| Auth Method | Org Source |
|-------------|------------|
| API Key | Derived from API key (1:1 with org) |
| JWT (session) | `everruns_org` cookie |
| None (anonymous) | Default org |

### New endpoint

`POST /v1/users/me/switch-org` - Sets the `everruns_org` cookie for session auth

### Design rationale

1. **Redundancy eliminated** - API keys are org-scoped, so requiring both org AND API key was redundant
2. **Cleaner URLs** - Paths like `/v1/agents` are simpler than `/v1/orgs/{org}/agents`
3. **Better DX** - API users only need their API key, not also the org ID
4. **Unified org handling** - Cookie-based approach works for all requests including SSE
5. **Security** - Org is always validated against auth context, preventing org enumeration

## Test plan

- [x] Cargo check, clippy, fmt pass
- [x] Unit tests pass
- [x] Integration tests pass (updated to work with AUTH_MODE=none)
- [x] UI build and lint pass
- [x] OpenAPI spec updated
- [x] All docs, examples, specs updated
- [x] Specs updated with cookie-based org selection documentation