### PR TITLE
fix(auth): ensure org cookie is set on auth and UI waits for org initialization

### DIFF
--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -111,6 +111,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -727,6 +728,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -750,6 +752,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2080,6 +2083,7 @@
       "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.57.0"
       },
@@ -2562,8 +2566,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2758,6 +2761,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2768,6 +2772,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3338,6 +3343,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3854,8 +3860,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -4635,6 +4640,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -5612,6 +5618,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -6012,7 +6019,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7541,7 +7547,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7557,7 +7562,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7607,6 +7611,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7616,6 +7621,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7628,8 +7634,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -8543,6 +8548,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/apps/ui/src/app/(main)/layout.tsx
+++ b/apps/ui/src/app/(main)/layout.tsx
@@ -5,6 +5,7 @@ import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Sidebar } from "@/components/layout/sidebar";
 import { useAuth } from "@/providers/auth-provider";
+import { useOrg } from "@/providers/org-provider";
 import { Loader2 } from "lucide-react";
 
 interface MainLayoutProps {
@@ -13,16 +14,20 @@ interface MainLayoutProps {
 
 export default function MainLayout({ children }: MainLayoutProps) {
   const router = useRouter();
-  const { isAuthenticated, isLoading, requiresAuth } = useAuth();
+  const { isAuthenticated, isLoading: authLoading, requiresAuth } = useAuth();
+  const { isLoading: orgLoading } = useOrg();
+
+  // Combined loading state - wait for both auth and org to initialize
+  const isLoading = authLoading || orgLoading;
 
   // Redirect to login if auth is required but user is not authenticated
   useEffect(() => {
-    if (!isLoading && requiresAuth && !isAuthenticated) {
+    if (!authLoading && requiresAuth && !isAuthenticated) {
       router.replace("/login");
     }
-  }, [isLoading, requiresAuth, isAuthenticated, router]);
+  }, [authLoading, requiresAuth, isAuthenticated, router]);
 
-  // Show loading state while checking auth
+  // Show loading state while checking auth and initializing org
   if (isLoading) {
     return (
       <div className="flex h-screen items-center justify-center">
@@ -39,7 +44,9 @@ export default function MainLayout({ children }: MainLayoutProps) {
   return (
     <div className="flex h-screen">
       <Sidebar />
-      <main className="flex-1 overflow-auto bg-background bg-brand-dots">{children}</main>
+      <main className="flex-1 overflow-auto bg-background bg-brand-dots">
+        {children}
+      </main>
     </div>
   );
 }

--- a/apps/ui/src/hooks/use-agents.ts
+++ b/apps/ui/src/hooks/use-agents.ts
@@ -13,29 +13,45 @@ import {
   updateAgent,
 } from "@/lib/api/agents";
 import { queryKeys } from "@/lib/query-keys";
-import type { CreateAgentRequest, PreviewAgentRequest, UpdateAgentRequest } from "@/lib/api/types";
+import type {
+  CreateAgentRequest,
+  PreviewAgentRequest,
+  UpdateAgentRequest,
+} from "@/lib/api/types";
 import { useOrg } from "@/providers/org-provider";
 
 export function useAgents() {
-  const { currentOrg } = useOrg();
+  const { currentOrg, isLoading: orgLoading } = useOrg();
   const org = currentOrg?.public_id;
 
-  return useQuery({
+  const query = useQuery({
     queryKey: [...queryKeys.agents.list(), org],
     queryFn: () => listAgents(),
     enabled: !!org,
   });
+
+  // Include org loading state so pages show skeleton while org initializes
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading,
+  };
 }
 
 export function useAgent(agentId: string | undefined) {
-  const { currentOrg } = useOrg();
+  const { currentOrg, isLoading: orgLoading } = useOrg();
   const org = currentOrg?.public_id;
 
-  return useQuery({
+  const query = useQuery({
     queryKey: [...queryKeys.agents.detail(agentId!), org],
     queryFn: () => getAgent(agentId!),
     enabled: !!org && !!agentId,
   });
+
+  // Include org loading state so pages show skeleton while org initializes
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading,
+  };
 }
 
 export function useCreateAgent() {
@@ -62,7 +78,9 @@ export function useUpdateAgent() {
     }) => updateAgent(agentId, request),
     onSuccess: (_, { agentId }) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.all });
-      queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(agentId) });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.agents.detail(agentId),
+      });
     },
   });
 }

--- a/apps/ui/src/hooks/use-capabilities.ts
+++ b/apps/ui/src/hooks/use-capabilities.ts
@@ -5,31 +5,40 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import {
-  getCapability,
-  listCapabilities,
-} from "@/lib/api/capabilities";
+import { getCapability, listCapabilities } from "@/lib/api/capabilities";
 import type { CapabilityId } from "@/lib/api/types";
 import { useOrg } from "@/providers/org-provider";
 
 export function useCapabilities() {
-  const { currentOrg } = useOrg();
+  const { currentOrg, isLoading: orgLoading } = useOrg();
   const org = currentOrg?.public_id;
 
-  return useQuery({
+  const query = useQuery({
     queryKey: ["capabilities", org],
     queryFn: () => listCapabilities(),
     enabled: !!org,
   });
+
+  // Include org loading state so pages show skeleton while org initializes
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading,
+  };
 }
 
 export function useCapability(capabilityId: CapabilityId | undefined) {
-  const { currentOrg } = useOrg();
+  const { currentOrg, isLoading: orgLoading } = useOrg();
   const org = currentOrg?.public_id;
 
-  return useQuery({
+  const query = useQuery({
     queryKey: ["capability", capabilityId, org],
     queryFn: () => getCapability(capabilityId!),
     enabled: !!org && !!capabilityId,
   });
+
+  // Include org loading state so pages show skeleton while org initializes
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading,
+  };
 }

--- a/apps/ui/src/hooks/use-llm-providers.ts
+++ b/apps/ui/src/hooks/use-llm-providers.ts
@@ -26,26 +26,38 @@ import { useOrg } from "@/providers/org-provider";
 
 // Provider hooks
 export function useLlmProviders() {
-  const { currentOrg } = useOrg();
+  const { currentOrg, isLoading: orgLoading } = useOrg();
   const org = currentOrg?.public_id;
 
-  return useQuery({
+  const query = useQuery({
     queryKey: [...queryKeys.llmProviders.list(), org],
     queryFn: () => getLlmProviders(),
     enabled: !!org,
     staleTime: 30000,
   });
+
+  // Include org loading state so pages show skeleton while org initializes
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading,
+  };
 }
 
 export function useLlmProvider(providerId: string) {
-  const { currentOrg } = useOrg();
+  const { currentOrg, isLoading: orgLoading } = useOrg();
   const org = currentOrg?.public_id;
 
-  return useQuery({
+  const query = useQuery({
     queryKey: [...queryKeys.llmProviders.detail(providerId), org],
     queryFn: () => getLlmProvider(providerId),
     enabled: !!org && !!providerId,
   });
+
+  // Include org loading state so pages show skeleton while org initializes
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading,
+  };
 }
 
 export function useCreateLlmProvider() {
@@ -67,7 +79,9 @@ export function useUpdateLlmProvider(providerId: string) {
       updateLlmProvider(providerId, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.llmProviders.all });
-      queryClient.invalidateQueries({ queryKey: queryKeys.llmProviders.detail(providerId) });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.llmProviders.detail(providerId),
+      });
     },
   });
 }
@@ -99,47 +113,68 @@ export function useSyncProviderModels() {
 
 // Model hooks
 export function useLlmModels() {
-  const { currentOrg } = useOrg();
+  const { currentOrg, isLoading: orgLoading } = useOrg();
   const org = currentOrg?.public_id;
 
-  return useQuery({
+  const query = useQuery({
     queryKey: [...queryKeys.llmModels.list(), org],
     queryFn: () => getLlmModels(),
     enabled: !!org,
     staleTime: 30000,
   });
+
+  // Include org loading state so pages show skeleton while org initializes
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading,
+  };
 }
 
 export function useLlmProviderModels(providerId: string) {
-  const { currentOrg } = useOrg();
+  const { currentOrg, isLoading: orgLoading } = useOrg();
   const org = currentOrg?.public_id;
 
-  return useQuery({
+  const query = useQuery({
     queryKey: [...queryKeys.llmProviders.models(providerId), org],
     queryFn: () => getLlmProviderModels(providerId),
     enabled: !!org && !!providerId,
   });
+
+  // Include org loading state so pages show skeleton while org initializes
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading,
+  };
 }
 
 export function useLlmModel(modelId: string) {
-  const { currentOrg } = useOrg();
+  const { currentOrg, isLoading: orgLoading } = useOrg();
   const org = currentOrg?.public_id;
 
-  return useQuery({
+  const query = useQuery({
     queryKey: [...queryKeys.llmModels.detail(modelId), org],
     queryFn: () => getLlmModel(modelId),
     enabled: !!org && !!modelId,
   });
+
+  // Include org loading state so pages show skeleton while org initializes
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading,
+  };
 }
 
 export function useCreateLlmModel(providerId: string) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: CreateLlmModelRequest) => createLlmModel(providerId, data),
+    mutationFn: (data: CreateLlmModelRequest) =>
+      createLlmModel(providerId, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.llmModels.all });
-      queryClient.invalidateQueries({ queryKey: queryKeys.llmProviders.models(providerId) });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.llmProviders.models(providerId),
+      });
     },
   });
 }

--- a/apps/ui/src/hooks/use-mcp-servers.ts
+++ b/apps/ui/src/hooks/use-mcp-servers.ts
@@ -18,26 +18,38 @@ import { useOrg } from "@/providers/org-provider";
 // MCP Server hooks
 
 export function useMcpServers() {
-  const { currentOrg } = useOrg();
+  const { currentOrg, isLoading: orgLoading } = useOrg();
   const org = currentOrg?.public_id;
 
-  return useQuery({
+  const query = useQuery({
     queryKey: [...queryKeys.mcpServers.list(), org],
     queryFn: () => getMcpServers(),
     enabled: !!org,
     staleTime: 30000,
   });
+
+  // Include org loading state so pages show skeleton while org initializes
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading,
+  };
 }
 
 export function useMcpServer(serverId: string) {
-  const { currentOrg } = useOrg();
+  const { currentOrg, isLoading: orgLoading } = useOrg();
   const org = currentOrg?.public_id;
 
-  return useQuery({
+  const query = useQuery({
     queryKey: [...queryKeys.mcpServers.detail(serverId), org],
     queryFn: () => getMcpServer(serverId),
     enabled: !!org && !!serverId,
   });
+
+  // Include org loading state so pages show skeleton while org initializes
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading,
+  };
 }
 
 export function useCreateMcpServer() {
@@ -59,7 +71,9 @@ export function useUpdateMcpServer(serverId: string) {
       updateMcpServer(serverId, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.mcpServers.all });
-      queryClient.invalidateQueries({ queryKey: queryKeys.mcpServers.detail(serverId) });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.mcpServers.detail(serverId),
+      });
     },
   });
 }

--- a/apps/ui/src/hooks/use-organizations.ts
+++ b/apps/ui/src/hooks/use-organizations.ts
@@ -7,15 +7,21 @@ import type { UpdateOrganizationRequest } from "@/lib/api/types";
 import { useOrg } from "@/providers/org-provider";
 
 export function useOrganization() {
-  const { currentOrg } = useOrg();
+  const { currentOrg, isLoading: orgLoading } = useOrg();
   const org = currentOrg?.public_id;
 
-  return useQuery({
+  const query = useQuery({
     queryKey: [...queryKeys.organizations.detail(org ?? ""), org],
     queryFn: () => getOrganization(org!),
     enabled: !!org,
     staleTime: 30000,
   });
+
+  // Include org loading state so pages show skeleton while org initializes
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading,
+  };
 }
 
 export function useUpdateOrganization() {
@@ -24,11 +30,14 @@ export function useUpdateOrganization() {
   const org = currentOrg?.public_id;
 
   return useMutation({
-    mutationFn: (data: UpdateOrganizationRequest) => updateOrganization(org!, data),
+    mutationFn: (data: UpdateOrganizationRequest) =>
+      updateOrganization(org!, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.organizations.all });
       if (org) {
-        queryClient.invalidateQueries({ queryKey: queryKeys.organizations.detail(org) });
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.organizations.detail(org),
+        });
       }
       // Also invalidate auth session to refresh user's org list
       queryClient.invalidateQueries({ queryKey: queryKeys.users.me() });

--- a/apps/ui/src/hooks/use-session-files.ts
+++ b/apps/ui/src/hooks/use-session-files.ts
@@ -42,46 +42,64 @@ const fileKeys = {
 export function useFiles(
   sessionId: string | undefined,
   path: string = "/",
-  recursive: boolean = false
+  recursive: boolean = false,
 ) {
-  const { currentOrg } = useOrg();
+  const { currentOrg, isLoading: orgLoading } = useOrg();
   const org = currentOrg?.public_id;
 
-  return useQuery({
+  const query = useQuery({
     queryKey: fileKeys.list(org!, sessionId!, path, recursive),
     queryFn: () => listFiles(sessionId!, path, recursive),
     enabled: !!org && !!sessionId,
   });
+
+  // Include org loading state so pages show skeleton while org initializes
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading,
+  };
 }
 
 /** Read a file */
 export function useFile(
   sessionId: string | undefined,
-  path: string | undefined
+  path: string | undefined,
 ) {
-  const { currentOrg } = useOrg();
+  const { currentOrg, isLoading: orgLoading } = useOrg();
   const org = currentOrg?.public_id;
 
-  return useQuery({
+  const query = useQuery({
     queryKey: fileKeys.file(org!, sessionId!, path!),
     queryFn: () => readFile(sessionId!, path!),
     enabled: !!org && !!sessionId && !!path,
   });
+
+  // Include org loading state so pages show skeleton while org initializes
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading,
+  };
 }
 
 /** Get file stat */
 export function useFileStat(
   sessionId: string | undefined,
-  path: string | undefined
+  path: string | undefined,
 ) {
-  const { currentOrg } = useOrg();
+  const { currentOrg, isLoading: orgLoading } = useOrg();
   const org = currentOrg?.public_id;
 
-  return useQuery({
+  const query = useQuery({
     queryKey: fileKeys.stat(org!, sessionId!, path!),
     queryFn: () => statFile(sessionId!, path!),
     enabled: !!org && !!sessionId && !!path,
   });
+
+  // Include org loading state so pages show skeleton while org initializes
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading,
+  };
 }
 
 // ============================================
@@ -117,13 +135,8 @@ export function useCreateDirectory() {
   const org = currentOrg?.public_id;
 
   return useMutation({
-    mutationFn: ({
-      sessionId,
-      path,
-    }: {
-      sessionId: string;
-      path: string;
-    }) => mkdir(sessionId, path),
+    mutationFn: ({ sessionId, path }: { sessionId: string; path: string }) =>
+      mkdir(sessionId, path),
     onSuccess: (_, { sessionId }) => {
       queryClient.invalidateQueries({
         queryKey: fileKeys.all(org!, sessionId),

--- a/apps/ui/src/hooks/use-sessions.ts
+++ b/apps/ui/src/hooks/use-sessions.ts
@@ -13,7 +13,13 @@ import {
 } from "@/lib/api/sessions";
 import { getSseUrl } from "@/lib/api/events";
 import { queryKeys } from "@/lib/query-keys";
-import type { CreateSessionRequest, UpdateSessionRequest, Controls, Event, PaginationParams } from "@/lib/api/types";
+import type {
+  CreateSessionRequest,
+  UpdateSessionRequest,
+  Controls,
+  Event,
+  PaginationParams,
+} from "@/lib/api/types";
 import { useOrg } from "@/providers/org-provider";
 
 /**
@@ -21,49 +27,62 @@ import { useOrg } from "@/providers/org-provider";
  * Optionally filter by agentId.
  * Returns { data, total, offset, limit } for pagination controls.
  */
-export function useSessions(
-  agentId?: string,
-  params?: PaginationParams
-) {
-  const { currentOrg } = useOrg();
+export function useSessions(agentId?: string, params?: PaginationParams) {
+  const { currentOrg, isLoading: orgLoading } = useOrg();
   const org = currentOrg?.public_id;
 
-  return useQuery({
-    queryKey: queryKeys.sessions.list(org, agentId, params?.offset ?? 0, params?.limit ?? 20),
+  const query = useQuery({
+    queryKey: queryKeys.sessions.list(
+      org,
+      agentId,
+      params?.offset ?? 0,
+      params?.limit ?? 20,
+    ),
     queryFn: () => listSessions({ ...params, agentId }),
     enabled: !!org,
   });
+
+  // Include org loading state so pages show skeleton while org initializes
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading,
+  };
 }
 
 export function useSession(
   sessionId: string | undefined,
-  options?: { refetchInterval?: number | false }
+  options?: { refetchInterval?: number | false },
 ) {
-  const { currentOrg } = useOrg();
+  const { currentOrg, isLoading: orgLoading } = useOrg();
   const org = currentOrg?.public_id;
 
-  return useQuery({
+  const query = useQuery({
     queryKey: queryKeys.sessions.detail(org, sessionId!),
     queryFn: () => getSession(sessionId!),
     enabled: !!org && !!sessionId,
     refetchInterval: options?.refetchInterval,
   });
+
+  // Include org loading state so pages show skeleton while org initializes
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading,
+  };
 }
 
 export function useCreateSession() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({
-      request,
-    }: {
-      request: CreateSessionRequest;
-    }) => createSession(request),
+    mutationFn: ({ request }: { request: CreateSessionRequest }) =>
+      createSession(request),
     onSuccess: (_, { request }) => {
       // Invalidate sessions list - both all sessions and agent-specific
       queryClient.invalidateQueries({ queryKey: queryKeys.sessions.all() });
       if (request.agent_id) {
-        queryClient.invalidateQueries({ queryKey: queryKeys.sessions.byAgent(request.agent_id) });
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.sessions.byAgent(request.agent_id),
+        });
       }
     },
   });
@@ -95,11 +114,8 @@ export function useDeleteSession() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({
-      sessionId,
-    }: {
-      sessionId: string;
-    }) => deleteSession(sessionId),
+    mutationFn: ({ sessionId }: { sessionId: string }) =>
+      deleteSession(sessionId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.sessions.all() });
     },
@@ -141,7 +157,7 @@ export function useSendMessage() {
  */
 export function useEvents(
   sessionId: string | undefined,
-  options?: { enabled?: boolean }
+  options?: { enabled?: boolean },
 ) {
   const { currentOrg } = useOrg();
   const org = currentOrg?.public_id;

--- a/apps/ui/src/providers/auth-provider.tsx
+++ b/apps/ui/src/providers/auth-provider.tsx
@@ -4,11 +4,7 @@
 // Decision: Use React Context + React Query for auth state management
 // Decision: Check auth config first, then only require login if auth is enabled
 
-import {
-  createContext,
-  useContext,
-  type ReactNode,
-} from "react";
+import { createContext, useContext, type ReactNode } from "react";
 import { useAuthConfig, useCurrentUser } from "@/hooks/use-auth";
 import type { AuthConfigResponse, UserInfoResponse } from "@/lib/api/types";
 
@@ -42,14 +38,13 @@ export function AuthProvider({ children }: AuthProviderProps) {
     error: configError,
   } = useAuthConfig();
 
-  // Only fetch user if auth is required
-  const shouldFetchUser = config?.mode !== "none";
-
+  // Always fetch user - this also sets the org cookie if missing
+  // In "none" mode, returns anonymous user with default org
   const {
     data: user,
     isLoading: userLoading,
     error: userError,
-  } = useCurrentUser(shouldFetchUser);
+  } = useCurrentUser(!!config);
 
   // Determine if authentication is required based on mode
   const requiresAuth = config ? config.mode !== "none" : false;
@@ -59,14 +54,14 @@ export function AuthProvider({ children }: AuthProviderProps) {
   // 2. User data exists
   const isAuthenticated = !requiresAuth || !!user;
 
-  // Overall loading state
-  const isLoading = configLoading || (requiresAuth && userLoading);
+  // Overall loading state - always wait for user fetch (sets org cookie)
+  const isLoading = configLoading || userLoading;
 
   const value: AuthContextValue = {
     config,
     configLoading,
     configError: configError as Error | null,
-    user: requiresAuth ? user ?? null : null,
+    user: user ?? null,
     userLoading,
     userError: userError as Error | null,
     isAuthenticated,

--- a/apps/ui/src/providers/org-provider.tsx
+++ b/apps/ui/src/providers/org-provider.tsx
@@ -3,8 +3,8 @@
 // Organization context and provider for multitenancy
 // Decision: Current org stored in localStorage for persistence across sessions
 // Decision: Default org ID used as fallback
-// Decision: When AUTH_MODE=none, use default org directly
 // Decision: Org selection via server-side cookie (everruns_org) for SSE compatibility
+// Decision: /v1/auth/me sets org cookie if missing, so we always have org context
 
 import {
   createContext,
@@ -22,12 +22,6 @@ import type { OrganizationMembership } from "@/lib/api/types";
 // Default organization public ID (matches backend DEFAULT_ORG_PUBLIC_ID)
 const DEFAULT_ORG_PUBLIC_ID = "org_00000000000000000000000000000001";
 const STORAGE_KEY = "everruns_current_org";
-
-// Default organization membership for anonymous auth mode
-const DEFAULT_ORG_MEMBERSHIP: OrganizationMembership = {
-  public_id: DEFAULT_ORG_PUBLIC_ID,
-  name: "Default Organization",
-};
 
 interface OrgContextValue {
   /** Currently selected organization */
@@ -47,21 +41,16 @@ interface OrgProviderProps {
 }
 
 export function OrgProvider({ children }: OrgProviderProps) {
-  const { user, isLoading: authLoading, requiresAuth } = useAuth();
-  const [currentOrg, setCurrentOrgState] = useState<OrganizationMembership | null>(null);
+  const { user, isLoading: authLoading } = useAuth();
+  const [currentOrg, setCurrentOrgState] =
+    useState<OrganizationMembership | null>(null);
   const [isInitialized, setIsInitialized] = useState(false);
 
   // Memoize organizations to prevent infinite re-renders
-  // When auth is not required (AUTH_MODE=none), use default org
+  // User is always fetched (even in none mode) and includes organizations
   const organizations = useMemo(
-    () => {
-      if (!requiresAuth) {
-        // Anonymous mode: use default organization
-        return [DEFAULT_ORG_MEMBERSHIP];
-      }
-      return user?.organizations ?? [];
-    },
-    [user?.organizations, requiresAuth]
+    () => user?.organizations ?? [],
+    [user?.organizations],
   );
 
   // Initialize current org from localStorage or default
@@ -73,7 +62,9 @@ export function OrgProvider({ children }: OrgProviderProps) {
 
     if (storedOrgId && organizations.length > 0) {
       // Find the stored org in user's organizations
-      const storedOrg = organizations.find(org => org.public_id === storedOrgId);
+      const storedOrg = organizations.find(
+        (org) => org.public_id === storedOrgId,
+      );
       if (storedOrg) {
         setCurrentOrgState(storedOrg);
         setIsInitialized(true);
@@ -83,7 +74,9 @@ export function OrgProvider({ children }: OrgProviderProps) {
 
     // Fall back to default org or first available org
     if (organizations.length > 0) {
-      const defaultOrg = organizations.find(org => org.public_id === DEFAULT_ORG_PUBLIC_ID);
+      const defaultOrg = organizations.find(
+        (org) => org.public_id === DEFAULT_ORG_PUBLIC_ID,
+      );
       setCurrentOrgState(defaultOrg ?? organizations[0]);
     }
 
@@ -95,8 +88,13 @@ export function OrgProvider({ children }: OrgProviderProps) {
     if (!isInitialized || organizations.length === 0) return;
 
     // If current org is no longer valid, reset to default
-    if (currentOrg && !organizations.find(org => org.public_id === currentOrg.public_id)) {
-      const defaultOrg = organizations.find(org => org.public_id === DEFAULT_ORG_PUBLIC_ID);
+    if (
+      currentOrg &&
+      !organizations.find((org) => org.public_id === currentOrg.public_id)
+    ) {
+      const defaultOrg = organizations.find(
+        (org) => org.public_id === DEFAULT_ORG_PUBLIC_ID,
+      );
       setCurrentOrgState(defaultOrg ?? organizations[0]);
     }
   }, [organizations, currentOrg, isInitialized]);
@@ -111,12 +109,15 @@ export function OrgProvider({ children }: OrgProviderProps) {
     }
   }, []);
 
-  const setCurrentOrg = useCallback((org: OrganizationMembership) => {
-    setCurrentOrgState(org);
-    localStorage.setItem(STORAGE_KEY, org.public_id);
-    // Set server-side cookie via API
-    void syncOrgCookie(org.public_id);
-  }, [syncOrgCookie]);
+  const setCurrentOrg = useCallback(
+    (org: OrganizationMembership) => {
+      setCurrentOrgState(org);
+      localStorage.setItem(STORAGE_KEY, org.public_id);
+      // Set server-side cookie via API
+      void syncOrgCookie(org.public_id);
+    },
+    [syncOrgCookie],
+  );
 
   // Sync currentOrg to server cookie on mount/change
   useEffect(() => {

--- a/apps/ui/src/providers/org-provider.tsx
+++ b/apps/ui/src/providers/org-provider.tsx
@@ -87,9 +87,9 @@ export function OrgProvider({ children }: OrgProviderProps) {
   useEffect(() => {
     if (!isInitialized || organizations.length === 0) return;
 
-    // If current org is no longer valid, reset to default
+    // If current org is null or no longer valid, set to default
     if (
-      currentOrg &&
+      !currentOrg ||
       !organizations.find((org) => org.public_id === currentOrg.public_id)
     ) {
       const defaultOrg = organizations.find(

--- a/crates/server/src/auth/middleware.rs
+++ b/crates/server/src/auth/middleware.rs
@@ -215,6 +215,22 @@ async fn validate_jwt_token(token: &str, auth_state: &AuthState) -> Result<AuthU
     // Fetch organization memberships for the user
     let organizations = fetch_user_organizations(&auth_state.db, user_id).await?;
 
+    // If user has no organizations (e.g., add_organization_member failed silently during
+    // registration), fall back to default organization to ensure UI can function
+    let organizations = if organizations.is_empty() {
+        tracing::warn!(
+            user_id = %user_id,
+            "User has no organizations, falling back to default org"
+        );
+        vec![OrgMembership {
+            org_id: DEFAULT_ORG_ID,
+            public_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
+            name: "Default Organization".to_string(),
+        }]
+    } else {
+        organizations
+    };
+
     Ok(AuthUser {
         id: user_id,
         email: claims.email,

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -241,7 +241,20 @@ pub async fn login(
     let roles: Vec<String> = serde_json::from_value(user.roles.clone()).unwrap_or_default();
 
     // Fetch organization memberships
-    let organizations = fetch_user_organizations(&state.db, user.id).await?;
+    let organizations = fetch_user_organizations(&state.db, user.id)
+        .await
+        .unwrap_or_default();
+
+    // Fallback to default org if empty (add_organization_member may have failed silently)
+    let organizations = if organizations.is_empty() {
+        vec![OrgMembership {
+            org_id: DEFAULT_ORG_ID,
+            public_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
+            name: "Default Organization".to_string(),
+        }]
+    } else {
+        organizations
+    };
 
     let auth_user = AuthUser {
         id: user.id,
@@ -319,14 +332,18 @@ pub async fn register(
     // Fetch organization memberships (should include default org now)
     let organizations = fetch_user_organizations(&state.db, user.id)
         .await
-        .unwrap_or_else(|_| {
-            // Fallback to default org if fetch fails
-            vec![OrgMembership {
-                org_id: DEFAULT_ORG_ID,
-                public_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
-                name: "Default Organization".to_string(),
-            }]
-        });
+        .unwrap_or_default();
+
+    // Fallback to default org if empty (add_organization_member may have failed silently)
+    let organizations = if organizations.is_empty() {
+        vec![OrgMembership {
+            org_id: DEFAULT_ORG_ID,
+            public_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
+            name: "Default Organization".to_string(),
+        }]
+    } else {
+        organizations
+    };
 
     let auth_user = AuthUser {
         id: user.id,
@@ -390,7 +407,20 @@ pub async fn refresh_token(
     let roles: Vec<String> = serde_json::from_value(user.roles.clone()).unwrap_or_default();
 
     // Fetch organization memberships
-    let organizations = fetch_user_organizations(&state.db, user.id).await?;
+    let organizations = fetch_user_organizations(&state.db, user.id)
+        .await
+        .unwrap_or_default();
+
+    // Fallback to default org if empty (add_organization_member may have failed silently)
+    let organizations = if organizations.is_empty() {
+        vec![OrgMembership {
+            org_id: DEFAULT_ORG_ID,
+            public_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
+            name: "Default Organization".to_string(),
+        }]
+    } else {
+        organizations
+    };
 
     let auth_user = AuthUser {
         id: user.id,
@@ -412,19 +442,16 @@ pub async fn logout(jar: CookieJar) -> CookieJar {
 
 /// GET /v1/auth/me - Get current user info
 pub async fn get_current_user(user: AuthUser) -> Json<UserInfoResponse> {
-    let organizations = if user.organizations.is_empty() {
-        None
-    } else {
-        Some(
-            user.organizations
-                .iter()
-                .map(|o| OrgMembershipResponse {
-                    public_id: o.public_id.clone(),
-                    name: o.name.clone(),
-                })
-                .collect(),
-        )
-    };
+    // Always return organizations array (middleware ensures at least default org)
+    let organizations = Some(
+        user.organizations
+            .iter()
+            .map(|o| OrgMembershipResponse {
+                public_id: o.public_id.clone(),
+                name: o.name.clone(),
+            })
+            .collect(),
+    );
 
     Json(UserInfoResponse {
         id: user.id.to_string(),
@@ -585,14 +612,18 @@ pub async fn oauth_callback(
     // Fetch organization memberships
     let organizations = fetch_user_organizations(&state.db, user.id)
         .await
-        .unwrap_or_else(|_| {
-            // Fallback to default org if fetch fails
-            vec![OrgMembership {
-                org_id: DEFAULT_ORG_ID,
-                public_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
-                name: "Default Organization".to_string(),
-            }]
-        });
+        .unwrap_or_default();
+
+    // Fallback to default org if empty (add_organization_member may have failed silently)
+    let organizations = if organizations.is_empty() {
+        vec![OrgMembership {
+            org_id: DEFAULT_ORG_ID,
+            public_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
+            name: "Default Organization".to_string(),
+        }]
+    } else {
+        organizations
+    };
 
     let auth_user = AuthUser {
         id: user.id,

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -826,7 +826,7 @@ async fn get_or_create_admin_user(
     state: &AuthState,
     admin: &super::config::AdminConfig,
 ) -> Result<AuthUser, AuthError> {
-    let user = state
+    let existing_user = state
         .db
         .get_user_by_email(&admin.email)
         .await
@@ -835,7 +835,7 @@ async fn get_or_create_admin_user(
             AuthError::unauthorized("Login failed")
         })?;
 
-    let user = if let Some(user) = user {
+    let user = if let Some(user) = existing_user {
         user
     } else {
         // Create admin user
@@ -844,7 +844,7 @@ async fn get_or_create_admin_user(
             AuthError::unauthorized("Login failed")
         })?;
 
-        state
+        let created_user = state
             .db
             .create_user(CreateUserRow {
                 email: admin.email.clone(),
@@ -860,13 +860,44 @@ async fn get_or_create_admin_user(
             .map_err(|e| {
                 tracing::error!("User creation error: {}", e);
                 AuthError::unauthorized("Login failed")
-            })?
+            })?;
+
+        // Add admin user to default organization
+        let _ = state
+            .db
+            .add_organization_member(DEFAULT_ORG_ID, created_user.id)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to add admin user to default org: {}", e);
+                // Continue anyway
+            });
+
+        created_user
     };
 
     let roles: Vec<String> = serde_json::from_value(user.roles.clone()).unwrap_or_default();
 
     // Fetch organization memberships
-    let organizations = fetch_user_organizations(&state.db, user.id).await?;
+    let organizations = fetch_user_organizations(&state.db, user.id)
+        .await
+        .unwrap_or_default();
+
+    // Fallback to default org if empty (for existing admin users not in any org)
+    let organizations = if organizations.is_empty() {
+        // Try to add user to default org
+        let _ = state
+            .db
+            .add_organization_member(DEFAULT_ORG_ID, user.id)
+            .await;
+
+        vec![OrgMembership {
+            org_id: DEFAULT_ORG_ID,
+            public_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
+            name: "Default Organization".to_string(),
+        }]
+    } else {
+        organizations
+    };
 
     Ok(AuthUser {
         id: user.id,

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -832,7 +832,18 @@ async fn generate_token_response(
         ))
         .build();
 
-    let jar = jar.add(access_cookie).add(refresh_cookie);
+    let mut jar = jar.add(access_cookie).add(refresh_cookie);
+
+    // Set org cookie to user's first org (ensures org context for subsequent API calls)
+    if let Some(org) = user.organizations.first() {
+        let org_cookie = Cookie::build((ORG_COOKIE_NAME, org.public_id.clone()))
+            .path("/")
+            .http_only(false) // Allow JS to read for UI state
+            .secure(true)
+            .same_site(SameSite::Lax)
+            .build();
+        jar = jar.add(org_cookie);
+    }
 
     Ok((
         jar,

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -21,7 +21,7 @@ use super::{
     api_key::generate_api_key,
     config::AuthMode,
     jwt::hash_token,
-    middleware::{AuthError, AuthMethod, AuthState, AuthUser, ResolvedOrg},
+    middleware::{AuthError, AuthMethod, AuthState, AuthUser, ORG_COOKIE_NAME, ResolvedOrg},
     oauth::{GitHubOAuthService, GoogleOAuthService, OAuthProvider},
 };
 use crate::api::common::ListResponse;
@@ -441,7 +441,11 @@ pub async fn logout(jar: CookieJar) -> CookieJar {
 }
 
 /// GET /v1/auth/me - Get current user info
-pub async fn get_current_user(user: AuthUser) -> Json<UserInfoResponse> {
+/// Also sets everruns_org cookie if missing (using user's first org)
+pub async fn get_current_user(
+    user: AuthUser,
+    jar: CookieJar,
+) -> (CookieJar, Json<UserInfoResponse>) {
     // Always return organizations array (middleware ensures at least default org)
     let organizations = Some(
         user.organizations
@@ -453,14 +457,34 @@ pub async fn get_current_user(user: AuthUser) -> Json<UserInfoResponse> {
             .collect(),
     );
 
-    Json(UserInfoResponse {
-        id: user.id.to_string(),
-        email: user.email,
-        name: user.name,
-        roles: user.roles,
-        avatar_url: None,
-        organizations,
-    })
+    // Set org cookie if missing (ensures subsequent API calls have org context)
+    let jar = if jar.get(ORG_COOKIE_NAME).is_none() {
+        if let Some(org) = user.organizations.first() {
+            let cookie = Cookie::build((ORG_COOKIE_NAME, org.public_id.clone()))
+                .path("/")
+                .http_only(false) // Allow JS to read for UI state
+                .secure(true)
+                .same_site(SameSite::Lax)
+                .build();
+            jar.add(cookie)
+        } else {
+            jar
+        }
+    } else {
+        jar
+    };
+
+    (
+        jar,
+        Json(UserInfoResponse {
+            id: user.id.to_string(),
+            email: user.email,
+            name: user.name,
+            roles: user.roles,
+            avatar_url: None,
+            organizations,
+        }),
+    )
 }
 
 /// GET /v1/auth/oauth/:provider - Redirect to OAuth provider

--- a/specs/multitenancy.md
+++ b/specs/multitenancy.md
@@ -520,11 +520,89 @@ The `ResolvedOrg` extractor (`server/src/auth/middleware.rs`) derives org from t
 This approach eliminates redundancy (no need to specify org when API key already implies it) and provides cleaner URLs. The cookie-based approach for session auth works seamlessly with SSE (EventSource) since cookies are automatically sent with all requests.
 
 ### Anonymous Auth Mode (AUTH_MODE=none)
-When auth is disabled, the UI uses a hardcoded default organization:
+When auth is disabled, the system uses the default organization:
 - `public_id`: `org_00000000000000000000000000000001`
 - `name`: "Default Organization"
 
-The frontend `OrgProvider` handles this by returning `DEFAULT_ORG_MEMBERSHIP` when `!requiresAuth`.
+The backend `AuthUser::anonymous()` returns a user with the default org in their organizations list. The `ResolvedOrg` extractor uses this directly (no cookie needed for `AuthMethod::None`).
+
+### Org Cookie Initialization
+
+**Problem:** Race condition where UI components try to fetch org-scoped data before the org cookie is set.
+
+**Solution:** The org cookie is set automatically during authentication:
+
+1. **Login/Register/OAuth/Refresh endpoints:** `generate_token_response()` sets `everruns_org` cookie to user's first org
+2. **GET /v1/auth/me:** Sets `everruns_org` cookie if missing (fallback for edge cases)
+3. **Anonymous mode:** No cookie needed - `ResolvedOrg` uses default org from `AuthUser.organizations`
+
+**Cookie specification:**
+```
+Name: everruns_org
+Value: org_xxx (organization public_id)
+Path: /
+HttpOnly: false (allows JS to read for UI state sync)
+SameSite: Lax
+Secure: true
+```
+
+### UI Initialization Lifecycle
+
+**Problem:** Pages showing empty states instead of loading skeletons when org context isn't ready yet.
+
+**Root cause:** React Query returns `isLoading: false` when query is disabled (`enabled: false`). If org isn't ready, queries are disabled, and pages render empty states.
+
+**Solution:** Two-part fix:
+
+1. **Hooks include org loading state:**
+   ```typescript
+   export function useAgents() {
+     const { currentOrg, isLoading: orgLoading } = useOrg();
+     const query = useQuery({
+       queryKey: [...queryKeys.agents.list(), currentOrg?.public_id],
+       queryFn: () => listAgents(),
+       enabled: !!currentOrg,
+     });
+     // Return isLoading=true while org is initializing
+     return {
+       ...query,
+       isLoading: orgLoading || query.isLoading,
+     };
+   }
+   ```
+
+2. **Main layout shows global loader:**
+   ```typescript
+   // apps/ui/src/app/(main)/layout.tsx
+   const { isLoading: authLoading } = useAuth();
+   const { isLoading: orgLoading } = useOrg();
+   
+   if (authLoading || orgLoading) {
+     return <Loader />; // Spinner while initializing
+   }
+   ```
+
+**Affected hooks (all updated to include org loading):**
+- `useAgents`, `useAgent`
+- `useSessions`, `useSession`
+- `useCapabilities`, `useCapability`
+- `useLlmProviders`, `useLlmProvider`, `useLlmModels`, `useLlmProviderModels`, `useLlmModel`
+- `useMcpServers`, `useMcpServer`
+- `useOrganization`
+- `useFiles`, `useFile`, `useFileStat`
+
+**OrgProvider initialization flow:**
+1. `AuthProvider` fetches `/v1/auth/config` and `/v1/auth/me`
+2. `/v1/auth/me` returns user with organizations list (and sets org cookie if missing)
+3. `OrgProvider` waits for `authLoading` to become false
+4. `OrgProvider` initializes `currentOrg` from user's organizations
+5. Data hooks become enabled and fetch org-scoped data
+
+**Post-login flow:**
+1. Login API succeeds, sets auth + org cookies
+2. `useLogin` calls `refetchQueries` for user data
+3. `OrgProvider` sees organizations change, sets `currentOrg`
+4. Dashboard queries fire with org context ready
 
 ### System-Wide Resources
 Some resources remain system-wide (not org-scoped):


### PR DESCRIPTION
## Summary

- **Backend**: Set `everruns_org` cookie automatically during login/register/OAuth/refresh
- **Backend**: `/v1/auth/me` sets org cookie if missing (fallback for existing sessions)
- **Backend**: Admin auth mode users are now added to default org
- **Backend**: Fallback to default org when user has no organizations
- **UI**: All data hooks include org loading state to show proper loading indicators
- **UI**: Main layout shows global loader until both auth and org are initialized
- **Docs**: Updated `specs/multitenancy.md` with org cookie initialization and UI lifecycle

## Test plan

- [x] Cargo fmt check passes
- [x] Cargo clippy passes
- [x] UI build passes
- [x] Smoke test with AUTH_MODE=admin:
  - Login returns JWT and sets `everruns_org` cookie
  - Agents API works with org cookie