### PR TITLE
feat(sse): add connection cycling and retry hints for SSE endpoints

### DIFF
--- a/apps/ui/src/hooks/use-durable.ts
+++ b/apps/ui/src/hooks/use-durable.ts
@@ -97,6 +97,26 @@ export function useDurableSSE(options?: { enabled?: boolean }) {
         setError(null);
       });
 
+      // Listen for "disconnecting" event for graceful connection cycling
+      eventSource.addEventListener("disconnecting", (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          const retryMs = data.retry_ms ?? 1000;
+          console.debug("Durable SSE disconnecting, reconnecting in", retryMs, "ms");
+          cleanup();
+          setTimeout(() => {
+            if (isEnabled) {
+              connectSSE();
+            }
+          }, retryMs);
+        } catch {
+          cleanup();
+          if (isEnabled) {
+            connectSSE();
+          }
+        }
+      });
+
       eventSource.addEventListener("snapshot", (event) => {
         try {
           const snapshot: DurableSnapshot = JSON.parse(event.data);
@@ -188,6 +208,26 @@ export function useWorkflowSSE(
       eventSource.addEventListener("connected", () => {
         setIsConnected(true);
         setError(null);
+      });
+
+      // Listen for "disconnecting" event for graceful connection cycling
+      eventSource.addEventListener("disconnecting", (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          const retryMs = data.retry_ms ?? 1000;
+          console.debug("Workflow SSE disconnecting, reconnecting in", retryMs, "ms");
+          cleanup();
+          setTimeout(() => {
+            if (isEnabled && workflowId) {
+              connectSSE();
+            }
+          }, retryMs);
+        } catch {
+          cleanup();
+          if (isEnabled && workflowId) {
+            connectSSE();
+          }
+        }
       });
 
       eventSource.addEventListener("snapshot", (event) => {

--- a/apps/ui/src/hooks/use-sessions.ts
+++ b/apps/ui/src/hooks/use-sessions.ts
@@ -211,6 +211,28 @@ export function useEvents(
         setError(null);
       });
 
+      // Listen for "disconnecting" event for graceful connection cycling
+      // Server sends this before closing to allow immediate reconnect with since_id
+      eventSource.addEventListener("disconnecting", (messageEvent) => {
+        try {
+          const data = JSON.parse(messageEvent.data);
+          const retryMs = data.retry_ms ?? 100;
+          console.debug("SSE disconnecting event received, reconnecting in", retryMs, "ms");
+          cleanup();
+          setTimeout(() => {
+            if (isEnabled) {
+              connectSSE();
+            }
+          }, retryMs);
+        } catch {
+          // Fallback: reconnect immediately
+          cleanup();
+          if (isEnabled) {
+            connectSSE();
+          }
+        }
+      });
+
       // Fallback: onopen may fire, but "connected" event is more reliable
       eventSource.onopen = () => {
         setError(null);

--- a/crates/server/src/api/durable.rs
+++ b/crates/server/src/api/durable.rs
@@ -28,11 +28,12 @@ use futures::{
 };
 use serde::{Deserialize, Serialize};
 use std::{convert::Infallible, sync::Arc, time::Duration};
+use tokio::time::Instant;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
 use super::common::ErrorResponse;
-use super::sse::SseStreamConfig;
+use super::sse::{DisconnectReason, SseStreamConfig};
 
 /// App state for durable routes
 #[derive(Clone)]
@@ -1156,11 +1157,32 @@ struct WorkflowSnapshot {
 }
 
 /// GET /v1/durable/sse - Stream global durable state (SSE)
+///
+/// Establishes a Server-Sent Events (SSE) connection for real-time durable system monitoring.
+///
+/// ## Connection Lifecycle Events
+///
+/// - **connected**: Sent immediately when the stream is established.
+/// - **snapshot**: Sent when system state changes (health, workers, workflows, tasks, DLQ, circuit breakers).
+/// - **disconnecting**: Sent before the server closes the connection for graceful cycling.
+///   Data: `{"reason":"connection_cycle","retry_ms":1000}`
+///
+/// ## Connection Cycling
+///
+/// Connections are automatically cycled every 10 minutes. Before closing, the server sends
+/// a `disconnecting` event so clients can reconnect seamlessly.
+///
+/// ## Retry Hints
+///
+/// Each SSE event includes a `retry:` field (in milliseconds) that hints reconnection timing:
+/// - During active updates: 1000ms
+/// - During idle periods: increases with backoff up to 20000ms
+/// - After `disconnecting` event: 1000ms
 #[utoipa::path(
     get,
     path = "/v1/durable/sse",
     responses(
-        (status = 200, description = "SSE event stream", content_type = "text/event-stream"),
+        (status = 200, description = "SSE event stream with 'connected', 'snapshot', and 'disconnecting' events", content_type = "text/event-stream"),
         (status = 503, description = "Durable store not available")
     ),
     tag = "durable"
@@ -1177,189 +1199,247 @@ pub async fn stream_durable_sse(
 
     // Use monitoring config (relaxed polling for dashboards)
     let config = SseStreamConfig::monitoring();
+    let connection_start = Instant::now();
+
+    // Stream state machine
+    #[derive(Clone)]
+    enum StreamPhase {
+        SendConnected,
+        Polling,
+        SendDisconnecting,
+        Closed,
+    }
 
     #[derive(Clone)]
     struct StreamState {
+        phase: StreamPhase,
         backoff_ms: u64,
-        sent_connected: bool,
         config: SseStreamConfig,
+        connection_start: Instant,
         // Track last snapshot hash to detect changes
         last_hash: Option<u64>,
     }
 
     let initial_state = StreamState {
+        phase: StreamPhase::SendConnected,
         backoff_ms: config.min_backoff_ms,
-        sent_connected: false,
         config,
+        connection_start,
         last_hash: None,
     };
 
     let stream = stream::unfold((state, initial_state), |(state, stream_state)| async move {
-        // Send initial "connected" event
-        if !stream_state.sent_connected {
-            tracing::debug!("Durable SSE: sending connected event");
-            let connected_event = Ok(SseEvent::default()
-                .event("connected")
-                .data(r#"{"status":"connected"}"#));
-            let new_state = StreamState {
-                sent_connected: true,
-                ..stream_state
-            };
-            return Some((stream::iter(vec![connected_event]), (state, new_state)));
-        }
+        match stream_state.phase {
+            StreamPhase::Closed => None,
 
-        // Fetch current state
-        let store = match state.get_store() {
-            Ok(s) => s,
-            Err(_) => return None,
-        };
+            StreamPhase::SendDisconnecting => {
+                tracing::info!(
+                    duration_secs = stream_state.connection_start.elapsed().as_secs(),
+                    "Durable SSE: connection cycling, sending disconnecting event"
+                );
+                let disconnect_data = format!(
+                    r#"{{"reason":"{}","retry_ms":{}}}"#,
+                    DisconnectReason::ConnectionCycle.as_str(),
+                    stream_state.config.disconnect_retry_ms
+                );
+                let disconnecting_event = Ok(SseEvent::default()
+                    .event("disconnecting")
+                    .data(disconnect_data)
+                    .retry(stream_state.config.disconnect_retry()));
 
-        // Fetch all data in parallel-ish manner
-        let health = match store.get_system_health().await {
-            Ok(h) => HealthResponse::from(h),
-            Err(e) => {
-                tracing::error!("Failed to fetch health: {}", e);
-                return None;
+                let new_state = StreamState {
+                    phase: StreamPhase::Closed,
+                    ..stream_state
+                };
+                Some((stream::iter(vec![disconnecting_event]), (state, new_state)))
             }
-        };
 
-        let workers: Vec<WorkerResponse> = match store.list_workers(WorkerFilter::default()).await {
-            Ok(w) => w.into_iter().map(WorkerResponse::from).collect(),
-            Err(e) => {
-                tracing::error!("Failed to fetch workers: {}", e);
-                return None;
+            StreamPhase::SendConnected => {
+                tracing::debug!("Durable SSE: sending connected event");
+                let connected_event = Ok(SseEvent::default()
+                    .event("connected")
+                    .data(r#"{"status":"connected"}"#)
+                    .retry(stream_state.config.retry_hint(stream_state.backoff_ms)));
+                let new_state = StreamState {
+                    phase: StreamPhase::Polling,
+                    ..stream_state
+                };
+                Some((stream::iter(vec![connected_event]), (state, new_state)))
             }
-        };
 
-        let workflows_data = match store
-            .list_workflows(
-                WorkflowFilter::default(),
-                Pagination {
-                    offset: 0,
-                    limit: 100,
-                },
-            )
-            .await
-        {
-            Ok(w) => w,
-            Err(e) => {
-                tracing::error!("Failed to fetch workflows: {}", e);
-                return None;
+            StreamPhase::Polling => {
+                // Check for connection cycling
+                if stream_state.connection_start.elapsed()
+                    > stream_state.config.max_connection_duration()
+                {
+                    let new_state = StreamState {
+                        phase: StreamPhase::SendDisconnecting,
+                        ..stream_state
+                    };
+                    return Some((stream::iter(vec![]), (state, new_state)));
+                }
+
+                // Fetch current state
+                let store = match state.get_store() {
+                    Ok(s) => s,
+                    Err(_) => return None,
+                };
+
+                // Fetch all data in parallel-ish manner
+                let health = match store.get_system_health().await {
+                    Ok(h) => HealthResponse::from(h),
+                    Err(e) => {
+                        tracing::error!("Failed to fetch health: {}", e);
+                        return None;
+                    }
+                };
+
+                let workers: Vec<WorkerResponse> =
+                    match store.list_workers(WorkerFilter::default()).await {
+                        Ok(w) => w.into_iter().map(WorkerResponse::from).collect(),
+                        Err(e) => {
+                            tracing::error!("Failed to fetch workers: {}", e);
+                            return None;
+                        }
+                    };
+
+                let workflows_data = match store
+                    .list_workflows(
+                        WorkflowFilter::default(),
+                        Pagination {
+                            offset: 0,
+                            limit: 100,
+                        },
+                    )
+                    .await
+                {
+                    Ok(w) => w,
+                    Err(e) => {
+                        tracing::error!("Failed to fetch workflows: {}", e);
+                        return None;
+                    }
+                };
+                let workflows = WorkflowsListResponse {
+                    total: workflows_data.len(),
+                    data: workflows_data
+                        .into_iter()
+                        .map(WorkflowResponse::from)
+                        .collect(),
+                };
+
+                let tasks_data = match store
+                    .list_tasks(
+                        TaskFilter::default(),
+                        Pagination {
+                            offset: 0,
+                            limit: 100,
+                        },
+                    )
+                    .await
+                {
+                    Ok(t) => t,
+                    Err(e) => {
+                        tracing::error!("Failed to fetch tasks: {}", e);
+                        return None;
+                    }
+                };
+                let tasks = TasksListResponse {
+                    total: tasks_data.len(),
+                    data: tasks_data.into_iter().map(TaskResponse::from).collect(),
+                };
+
+                let dlq_data = match store
+                    .list_dlq(
+                        DlqFilter::default(),
+                        Pagination {
+                            offset: 0,
+                            limit: 100,
+                        },
+                    )
+                    .await
+                {
+                    Ok(d) => d,
+                    Err(e) => {
+                        tracing::error!("Failed to fetch DLQ: {}", e);
+                        return None;
+                    }
+                };
+                let dlq = DlqListResponse {
+                    total: dlq_data.len(),
+                    data: dlq_data.into_iter().map(DlqEntryResponse::from).collect(),
+                };
+
+                let cb_data = match store.list_circuit_breakers().await {
+                    Ok(c) => c,
+                    Err(e) => {
+                        tracing::error!("Failed to fetch circuit breakers: {}", e);
+                        return None;
+                    }
+                };
+                let circuit_breakers = CircuitBreakersListResponse {
+                    total: cb_data.len(),
+                    data: cb_data
+                        .into_iter()
+                        .map(CircuitBreakerResponse::from)
+                        .collect(),
+                };
+
+                let snapshot = DurableSnapshot {
+                    health,
+                    workers,
+                    workflows,
+                    tasks,
+                    dlq,
+                    circuit_breakers,
+                };
+
+                // Simple hash based on key metrics to detect changes
+                let current_hash = {
+                    use std::hash::{Hash, Hasher};
+                    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+                    snapshot.health.status.hash(&mut hasher);
+                    snapshot.health.active_workers.hash(&mut hasher);
+                    snapshot.health.running_workflows.hash(&mut hasher);
+                    snapshot.health.pending_tasks.hash(&mut hasher);
+                    snapshot.health.dlq_size.hash(&mut hasher);
+                    snapshot.workers.len().hash(&mut hasher);
+                    snapshot.workflows.total.hash(&mut hasher);
+                    snapshot.tasks.total.hash(&mut hasher);
+                    snapshot.dlq.total.hash(&mut hasher);
+                    snapshot.circuit_breakers.total.hash(&mut hasher);
+                    hasher.finish()
+                };
+
+                // Only send if changed or first snapshot
+                let has_changes = stream_state.last_hash != Some(current_hash);
+
+                if has_changes {
+                    let json =
+                        serde_json::to_string(&snapshot).unwrap_or_else(|_| "{}".to_string());
+                    let new_backoff = stream_state.config.min_backoff_ms;
+                    let event = Ok(SseEvent::default()
+                        .event("snapshot")
+                        .data(json)
+                        .retry(stream_state.config.retry_hint(new_backoff)));
+
+                    let new_state = StreamState {
+                        phase: StreamPhase::Polling,
+                        backoff_ms: new_backoff,
+                        last_hash: Some(current_hash),
+                        ..stream_state
+                    };
+                    Some((stream::iter(vec![event]), (state, new_state)))
+                } else {
+                    // No changes, wait with backoff
+                    tokio::time::sleep(Duration::from_millis(stream_state.backoff_ms)).await;
+                    let new_backoff = stream_state.config.next_backoff(stream_state.backoff_ms);
+                    let new_state = StreamState {
+                        backoff_ms: new_backoff,
+                        ..stream_state
+                    };
+                    Some((stream::iter(vec![]), (state, new_state)))
+                }
             }
-        };
-        let workflows = WorkflowsListResponse {
-            total: workflows_data.len(),
-            data: workflows_data
-                .into_iter()
-                .map(WorkflowResponse::from)
-                .collect(),
-        };
-
-        let tasks_data = match store
-            .list_tasks(
-                TaskFilter::default(),
-                Pagination {
-                    offset: 0,
-                    limit: 100,
-                },
-            )
-            .await
-        {
-            Ok(t) => t,
-            Err(e) => {
-                tracing::error!("Failed to fetch tasks: {}", e);
-                return None;
-            }
-        };
-        let tasks = TasksListResponse {
-            total: tasks_data.len(),
-            data: tasks_data.into_iter().map(TaskResponse::from).collect(),
-        };
-
-        let dlq_data = match store
-            .list_dlq(
-                DlqFilter::default(),
-                Pagination {
-                    offset: 0,
-                    limit: 100,
-                },
-            )
-            .await
-        {
-            Ok(d) => d,
-            Err(e) => {
-                tracing::error!("Failed to fetch DLQ: {}", e);
-                return None;
-            }
-        };
-        let dlq = DlqListResponse {
-            total: dlq_data.len(),
-            data: dlq_data.into_iter().map(DlqEntryResponse::from).collect(),
-        };
-
-        let cb_data = match store.list_circuit_breakers().await {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::error!("Failed to fetch circuit breakers: {}", e);
-                return None;
-            }
-        };
-        let circuit_breakers = CircuitBreakersListResponse {
-            total: cb_data.len(),
-            data: cb_data
-                .into_iter()
-                .map(CircuitBreakerResponse::from)
-                .collect(),
-        };
-
-        let snapshot = DurableSnapshot {
-            health,
-            workers,
-            workflows,
-            tasks,
-            dlq,
-            circuit_breakers,
-        };
-
-        // Simple hash based on key metrics to detect changes
-        let current_hash = {
-            use std::hash::{Hash, Hasher};
-            let mut hasher = std::collections::hash_map::DefaultHasher::new();
-            snapshot.health.status.hash(&mut hasher);
-            snapshot.health.active_workers.hash(&mut hasher);
-            snapshot.health.running_workflows.hash(&mut hasher);
-            snapshot.health.pending_tasks.hash(&mut hasher);
-            snapshot.health.dlq_size.hash(&mut hasher);
-            snapshot.workers.len().hash(&mut hasher);
-            snapshot.workflows.total.hash(&mut hasher);
-            snapshot.tasks.total.hash(&mut hasher);
-            snapshot.dlq.total.hash(&mut hasher);
-            snapshot.circuit_breakers.total.hash(&mut hasher);
-            hasher.finish()
-        };
-
-        // Only send if changed or first snapshot
-        let has_changes = stream_state.last_hash != Some(current_hash);
-
-        if has_changes {
-            let json = serde_json::to_string(&snapshot).unwrap_or_else(|_| "{}".to_string());
-            let event = Ok(SseEvent::default().event("snapshot").data(json));
-
-            let new_state = StreamState {
-                backoff_ms: stream_state.config.min_backoff_ms,
-                last_hash: Some(current_hash),
-                ..stream_state
-            };
-            Some((stream::iter(vec![event]), (state, new_state)))
-        } else {
-            // No changes, wait with backoff
-            tokio::time::sleep(Duration::from_millis(stream_state.backoff_ms)).await;
-            let new_backoff = stream_state.config.next_backoff(stream_state.backoff_ms);
-            let new_state = StreamState {
-                backoff_ms: new_backoff,
-                ..stream_state
-            };
-            Some((stream::iter(vec![]), (state, new_state)))
         }
     })
     .flatten();
@@ -1368,6 +1448,24 @@ pub async fn stream_durable_sse(
 }
 
 /// GET /v1/durable/workflows/:workflow_id/sse - Stream workflow state (SSE)
+///
+/// Establishes a Server-Sent Events (SSE) connection for real-time workflow monitoring.
+///
+/// ## Connection Lifecycle Events
+///
+/// - **connected**: Sent immediately when the stream is established.
+/// - **snapshot**: Sent when workflow state or events change.
+/// - **disconnecting**: Sent before the server closes the connection for graceful cycling.
+///   Data: `{"reason":"connection_cycle","retry_ms":1000}`
+///
+/// ## Connection Cycling
+///
+/// Connections are automatically cycled every 10 minutes. Before closing, the server sends
+/// a `disconnecting` event so clients can reconnect seamlessly.
+///
+/// ## Retry Hints
+///
+/// Each SSE event includes a `retry:` field (in milliseconds) that hints reconnection timing.
 #[utoipa::path(
     get,
     path = "/v1/durable/workflows/{workflow_id}/sse",
@@ -1375,7 +1473,7 @@ pub async fn stream_durable_sse(
         ("workflow_id" = Uuid, Path, description = "Workflow ID")
     ),
     responses(
-        (status = 200, description = "SSE event stream", content_type = "text/event-stream"),
+        (status = 200, description = "SSE event stream with 'connected', 'snapshot', and 'disconnecting' events", content_type = "text/event-stream"),
         (status = 404, description = "Workflow not found"),
         (status = 503, description = "Durable store not available")
     ),
@@ -1414,103 +1512,158 @@ pub async fn stream_workflow_sse(
 
     // Use monitoring config
     let config = SseStreamConfig::monitoring();
+    let connection_start = Instant::now();
+
+    // Stream state machine
+    #[derive(Clone)]
+    enum StreamPhase {
+        SendConnected,
+        Polling,
+        SendDisconnecting,
+        Closed,
+    }
 
     #[derive(Clone)]
     struct StreamState {
+        phase: StreamPhase,
         workflow_id: Uuid,
         backoff_ms: u64,
-        sent_connected: bool,
         config: SseStreamConfig,
+        connection_start: Instant,
         last_event_count: usize,
         last_status: Option<String>,
     }
 
     let initial_state = StreamState {
+        phase: StreamPhase::SendConnected,
         workflow_id,
         backoff_ms: config.min_backoff_ms,
-        sent_connected: false,
         config,
+        connection_start,
         last_event_count: 0,
         last_status: None,
     };
 
     let stream = stream::unfold((state, initial_state), |(state, stream_state)| async move {
-        // Send initial "connected" event
-        if !stream_state.sent_connected {
-            tracing::debug!(workflow_id = %stream_state.workflow_id, "Workflow SSE: sending connected event");
-            let connected_event = Ok(SseEvent::default()
-                .event("connected")
-                .data(r#"{"status":"connected"}"#));
-            let new_state = StreamState {
-                sent_connected: true,
-                ..stream_state
-            };
-            return Some((stream::iter(vec![connected_event]), (state, new_state)));
-        }
+        match stream_state.phase {
+            StreamPhase::Closed => None,
 
-        let store = match state.get_store() {
-            Ok(s) => s,
-            Err(_) => return None,
-        };
+            StreamPhase::SendDisconnecting => {
+                tracing::info!(
+                    workflow_id = %stream_state.workflow_id,
+                    duration_secs = stream_state.connection_start.elapsed().as_secs(),
+                    "Workflow SSE: connection cycling, sending disconnecting event"
+                );
+                let disconnect_data = format!(
+                    r#"{{"reason":"{}","retry_ms":{}}}"#,
+                    DisconnectReason::ConnectionCycle.as_str(),
+                    stream_state.config.disconnect_retry_ms
+                );
+                let disconnecting_event = Ok(SseEvent::default()
+                    .event("disconnecting")
+                    .data(disconnect_data)
+                    .retry(stream_state.config.disconnect_retry()));
 
-        // Fetch workflow
-        let workflows = match store
-            .list_workflows(WorkflowFilter::default(), Pagination { offset: 0, limit: 1000 })
-            .await
-        {
-            Ok(w) => w,
-            Err(e) => {
-                tracing::error!("Failed to fetch workflows: {}", e);
-                return None;
+                let new_state = StreamState {
+                    phase: StreamPhase::Closed,
+                    ..stream_state
+                };
+                Some((stream::iter(vec![disconnecting_event]), (state, new_state)))
             }
-        };
 
-        let workflow = match workflows.into_iter().find(|w| w.id == stream_state.workflow_id) {
-            Some(w) => WorkflowResponse::from(w),
-            None => {
-                // Workflow deleted, end stream
-                return None;
+            StreamPhase::SendConnected => {
+                tracing::debug!(workflow_id = %stream_state.workflow_id, "Workflow SSE: sending connected event");
+                let connected_event = Ok(SseEvent::default()
+                    .event("connected")
+                    .data(r#"{"status":"connected"}"#)
+                    .retry(stream_state.config.retry_hint(stream_state.backoff_ms)));
+                let new_state = StreamState {
+                    phase: StreamPhase::Polling,
+                    ..stream_state
+                };
+                Some((stream::iter(vec![connected_event]), (state, new_state)))
             }
-        };
 
-        // Fetch events
-        let events: Vec<WorkflowEventResponse> =
-            match store.get_workflow_events(stream_state.workflow_id).await {
-                Ok(e) => e.into_iter().map(WorkflowEventResponse::from).collect(),
-                Err(e) => {
-                    tracing::error!("Failed to fetch workflow events: {}", e);
-                    return None;
+            StreamPhase::Polling => {
+                // Check for connection cycling
+                if stream_state.connection_start.elapsed() > stream_state.config.max_connection_duration() {
+                    let new_state = StreamState {
+                        phase: StreamPhase::SendDisconnecting,
+                        ..stream_state
+                    };
+                    return Some((stream::iter(vec![]), (state, new_state)));
                 }
-            };
 
-        // Detect changes
-        let status_changed = stream_state.last_status.as_ref() != Some(&workflow.status);
-        let events_changed = events.len() != stream_state.last_event_count;
-        let has_changes = status_changed || events_changed;
+                let store = match state.get_store() {
+                    Ok(s) => s,
+                    Err(_) => return None,
+                };
 
-        if has_changes {
-            let new_status = workflow.status.clone();
-            let event_count = events.len();
-            let snapshot = WorkflowSnapshot { workflow, events };
-            let json = serde_json::to_string(&snapshot).unwrap_or_else(|_| "{}".to_string());
-            let event = Ok(SseEvent::default().event("snapshot").data(json));
+                // Fetch workflow
+                let workflows = match store
+                    .list_workflows(WorkflowFilter::default(), Pagination { offset: 0, limit: 1000 })
+                    .await
+                {
+                    Ok(w) => w,
+                    Err(e) => {
+                        tracing::error!("Failed to fetch workflows: {}", e);
+                        return None;
+                    }
+                };
 
-            let new_state = StreamState {
-                backoff_ms: stream_state.config.min_backoff_ms,
-                last_event_count: event_count,
-                last_status: Some(new_status),
-                ..stream_state
-            };
-            Some((stream::iter(vec![event]), (state, new_state)))
-        } else {
-            // No changes, wait with backoff
-            tokio::time::sleep(Duration::from_millis(stream_state.backoff_ms)).await;
-            let new_backoff = stream_state.config.next_backoff(stream_state.backoff_ms);
-            let new_state = StreamState {
-                backoff_ms: new_backoff,
-                ..stream_state
-            };
-            Some((stream::iter(vec![]), (state, new_state)))
+                let workflow = match workflows.into_iter().find(|w| w.id == stream_state.workflow_id) {
+                    Some(w) => WorkflowResponse::from(w),
+                    None => {
+                        // Workflow deleted, end stream
+                        return None;
+                    }
+                };
+
+                // Fetch events
+                let events: Vec<WorkflowEventResponse> =
+                    match store.get_workflow_events(stream_state.workflow_id).await {
+                        Ok(e) => e.into_iter().map(WorkflowEventResponse::from).collect(),
+                        Err(e) => {
+                            tracing::error!("Failed to fetch workflow events: {}", e);
+                            return None;
+                        }
+                    };
+
+                // Detect changes
+                let status_changed = stream_state.last_status.as_ref() != Some(&workflow.status);
+                let events_changed = events.len() != stream_state.last_event_count;
+                let has_changes = status_changed || events_changed;
+
+                if has_changes {
+                    let new_status = workflow.status.clone();
+                    let event_count = events.len();
+                    let new_backoff = stream_state.config.min_backoff_ms;
+                    let snapshot = WorkflowSnapshot { workflow, events };
+                    let json = serde_json::to_string(&snapshot).unwrap_or_else(|_| "{}".to_string());
+                    let event = Ok(SseEvent::default()
+                        .event("snapshot")
+                        .data(json)
+                        .retry(stream_state.config.retry_hint(new_backoff)));
+
+                    let new_state = StreamState {
+                        phase: StreamPhase::Polling,
+                        backoff_ms: new_backoff,
+                        last_event_count: event_count,
+                        last_status: Some(new_status),
+                        ..stream_state
+                    };
+                    Some((stream::iter(vec![event]), (state, new_state)))
+                } else {
+                    // No changes, wait with backoff
+                    tokio::time::sleep(Duration::from_millis(stream_state.backoff_ms)).await;
+                    let new_backoff = stream_state.config.next_backoff(stream_state.backoff_ms);
+                    let new_state = StreamState {
+                        backoff_ms: new_backoff,
+                        ..stream_state
+                    };
+                    Some((stream::iter(vec![]), (state, new_state)))
+                }
+            }
         }
     })
     .flatten();

--- a/crates/server/src/api/events.rs
+++ b/crates/server/src/api/events.rs
@@ -17,13 +17,14 @@ use everruns_core::{Event, EventListener};
 use serde::Deserialize;
 
 use super::common::{ErrorResponse, ListResponse};
-use super::sse::SseStreamConfig;
+use super::sse::{DisconnectReason, SseStreamConfig};
 use crate::services::EventService;
 use futures::{
     StreamExt,
     stream::{self, Stream},
 };
 use std::{convert::Infallible, sync::Arc, time::Duration};
+use tokio::time::Instant;
 use uuid::Uuid;
 
 use crate::services::SessionService;
@@ -97,6 +98,37 @@ pub fn routes(state: AppState) -> Router {
 // ============================================
 
 /// GET /v1/sessions/{session_id}/sse - Stream events (SSE notifications)
+///
+/// Establishes a Server-Sent Events (SSE) connection for real-time event streaming.
+///
+/// ## Connection Lifecycle Events
+///
+/// - **connected**: Sent immediately when the stream is established.
+///   Data: `{"status":"connected"}`
+///
+/// - **disconnecting**: Sent before the server closes the connection for graceful cycling.
+///   Data: `{"reason":"connection_cycle","retry_ms":100}`
+///   Clients should reconnect immediately using the `since_id` of the last received event.
+///
+/// ## Connection Cycling
+///
+/// Connections are automatically cycled every 5 minutes to prevent stale connections
+/// through proxies and load balancers. Before closing, the server sends a `disconnecting`
+/// event so clients can reconnect seamlessly without missing events.
+///
+/// ## Retry Hints
+///
+/// Each SSE event includes a `retry:` field (in milliseconds) that hints how long
+/// clients should wait before reconnecting if the connection is lost:
+/// - During active streaming: 100ms (fast reconnect)
+/// - During idle periods: increases with backoff up to 500ms
+/// - After `disconnecting` event: 100ms (immediate reconnect)
+///
+/// ## Resuming Streams
+///
+/// Use the `since_id` query parameter to resume from a specific event. The server
+/// will only send events with IDs greater than the specified value. Event IDs are
+/// UUID v7 (monotonically increasing), ensuring reliable ordering.
 #[utoipa::path(
     get,
     path = "/v1/sessions/{session_id}/sse",
@@ -105,7 +137,7 @@ pub fn routes(state: AppState) -> Router {
         EventsQuery
     ),
     responses(
-        (status = 200, description = "Event stream", content_type = "text/event-stream"),
+        (status = 200, description = "Event stream. Includes 'connected' on open, domain events during streaming, and 'disconnecting' before graceful close.", content_type = "text/event-stream"),
         (status = 400, description = "Invalid session ID"),
         (status = 404, description = "Session not found"),
         (status = 500, description = "Internal server error")
@@ -160,101 +192,167 @@ pub async fn stream_sse(
 
     // Use realtime config for session events (fast updates for interactive UX)
     let config = SseStreamConfig::realtime();
+    let connection_start = Instant::now();
 
-    // State for stream: (last_id, backoff_ms, sent_connected, exclude_types)
+    // Stream state machine
+    #[derive(Clone)]
+    enum StreamPhase {
+        /// Initial phase - send connected event
+        SendConnected,
+        /// Normal operation - poll for events
+        Polling,
+        /// Send disconnecting event then close
+        SendDisconnecting,
+        /// Stream has ended
+        Closed,
+    }
+
     #[derive(Clone)]
     struct StreamState {
+        phase: StreamPhase,
         last_id: Option<Uuid>,
         backoff_ms: u64,
-        sent_connected: bool,
         config: SseStreamConfig,
         exclude_types: Vec<String>,
+        connection_start: Instant,
     }
 
     let initial_state = StreamState {
+        phase: StreamPhase::SendConnected,
         last_id: initial_since_id,
         backoff_ms: config.min_backoff_ms,
-        sent_connected: false,
         config,
         exclude_types,
+        connection_start,
     };
 
     // Create stream that replays events from database
     // Uses since_id (UUID v7) for tracking - monotonically increasing
     // SSE format: event: <type>, data: <full core::Event JSON>, id: <event UUID>
-    // Includes exponential backoff (100ms → 10s) when no new events
+    // Features:
+    // - Exponential backoff (100ms → 500ms) when no new events
+    // - Connection cycling: graceful close after max_connection_duration with "disconnecting" event
+    // - Retry hints: SSE `retry:` field hints reconnection timing based on backoff
     let stream = stream::unfold(initial_state, move |state| {
         let event_service = event_service.clone();
         async move {
-            // Send initial "connected" event on first iteration
-            if !state.sent_connected {
-                tracing::debug!(session_id = %session_id, "SSE: sending connected event");
-                let connected_event = Ok(SseEvent::default()
-                    .event("connected")
-                    .data(r#"{"status":"connected"}"#));
-                let new_state = StreamState {
-                    sent_connected: true,
-                    ..state
-                };
-                return Some((stream::iter(vec![connected_event]), new_state));
-            }
-
-            // Fetch events since last ID
-            tracing::debug!(session_id = %session_id, last_id = ?state.last_id, "SSE: fetching events");
-            match event_service.list(session_id, None, state.last_id, &state.exclude_types).await {
-                Ok(events) if !events.is_empty() => {
-                    // Get the last event ID for next iteration (extract UUID for db query)
-                    let new_last_id = Some(events.last().unwrap().id.uuid());
-
-                    tracing::debug!(
-                        session_id = %session_id,
-                        last_id = ?state.last_id,
-                        new_last_id = ?new_last_id,
-                        event_count = events.len(),
-                        "SSE: fetched events"
-                    );
-
-                    // Convert events to SSE format with full Event as data
-                    let sse_events: Vec<Result<SseEvent, Infallible>> = events
-                        .into_iter()
-                        .map(|event| {
-                            let event_type = event.event_type.clone();
-                            let event_id = event.id.to_string();
-                            let json =
-                                serde_json::to_string(&event).unwrap_or_else(|_| "{}".to_string());
-
-                            Ok(SseEvent::default()
-                                .event(&event_type)
-                                .data(json)
-                                .id(event_id))
-                        })
-                        .collect();
-
-                    // Reset backoff on new events
-                    let new_state = StreamState {
-                        last_id: new_last_id,
-                        backoff_ms: state.config.min_backoff_ms,
-                        sent_connected: true,
-                        config: state.config,
-                        exclude_types: state.exclude_types,
-                    };
-                    Some((stream::iter(sse_events), new_state))
+            match state.phase {
+                StreamPhase::Closed => {
+                    // Stream has ended
+                    None
                 }
-                Ok(_) => {
-                    // No new events, wait with exponential backoff
-                    tokio::time::sleep(Duration::from_millis(state.backoff_ms)).await;
 
-                    // Increase backoff for next iteration (double, up to max)
-                    let new_backoff = state.config.next_backoff(state.backoff_ms);
+                StreamPhase::SendDisconnecting => {
+                    // Send disconnecting event and close
+                    tracing::info!(
+                        session_id = %session_id,
+                        duration_secs = state.connection_start.elapsed().as_secs(),
+                        "SSE: connection cycling, sending disconnecting event"
+                    );
+                    let disconnect_data = format!(
+                        r#"{{"reason":"{}","retry_ms":{}}}"#,
+                        DisconnectReason::ConnectionCycle.as_str(),
+                        state.config.disconnect_retry_ms
+                    );
+                    let disconnecting_event = Ok(SseEvent::default()
+                        .event("disconnecting")
+                        .data(disconnect_data)
+                        .retry(state.config.disconnect_retry()));
+
                     let new_state = StreamState {
-                        backoff_ms: new_backoff,
+                        phase: StreamPhase::Closed,
                         ..state
                     };
-                    Some((stream::iter(vec![]), new_state))
+                    Some((stream::iter(vec![disconnecting_event]), new_state))
                 }
-                Err(e) => {
-                    tracing::error!("Failed to fetch events: {}", e);
-                    None
+
+                StreamPhase::SendConnected => {
+                    // Send initial "connected" event
+                    tracing::debug!(session_id = %session_id, "SSE: sending connected event");
+                    let connected_event = Ok(SseEvent::default()
+                        .event("connected")
+                        .data(r#"{"status":"connected"}"#)
+                        .retry(state.config.retry_hint(state.backoff_ms)));
+
+                    let new_state = StreamState {
+                        phase: StreamPhase::Polling,
+                        ..state
+                    };
+                    Some((stream::iter(vec![connected_event]), new_state))
+                }
+
+                StreamPhase::Polling => {
+                    // Check for connection cycling - graceful close after max duration
+                    if state.connection_start.elapsed() > state.config.max_connection_duration() {
+                        let new_state = StreamState {
+                            phase: StreamPhase::SendDisconnecting,
+                            ..state
+                        };
+                        // Recurse immediately to send disconnecting event
+                        return Some((stream::iter(vec![]), new_state));
+                    }
+
+                    // Fetch events since last ID
+                    tracing::debug!(session_id = %session_id, last_id = ?state.last_id, "SSE: fetching events");
+                    match event_service.list(session_id, None, state.last_id, &state.exclude_types).await {
+                        Ok(events) if !events.is_empty() => {
+                            // Get the last event ID for next iteration
+                            let new_last_id = Some(events.last().unwrap().id.uuid());
+                            let new_backoff = state.config.min_backoff_ms; // Reset backoff
+
+                            tracing::debug!(
+                                session_id = %session_id,
+                                last_id = ?state.last_id,
+                                new_last_id = ?new_last_id,
+                                event_count = events.len(),
+                                "SSE: fetched events"
+                            );
+
+                            // Convert events to SSE format with retry hint
+                            let retry_duration = state.config.retry_hint(new_backoff);
+                            let sse_events: Vec<Result<SseEvent, Infallible>> = events
+                                .into_iter()
+                                .map(|event| {
+                                    let event_type = event.event_type.clone();
+                                    let event_id = event.id.to_string();
+                                    let json = serde_json::to_string(&event)
+                                        .unwrap_or_else(|_| "{}".to_string());
+
+                                    Ok(SseEvent::default()
+                                        .event(&event_type)
+                                        .data(json)
+                                        .id(event_id)
+                                        .retry(retry_duration))
+                                })
+                                .collect();
+
+                            let new_state = StreamState {
+                                phase: StreamPhase::Polling,
+                                last_id: new_last_id,
+                                backoff_ms: new_backoff,
+                                config: state.config,
+                                exclude_types: state.exclude_types,
+                                connection_start: state.connection_start,
+                            };
+                            Some((stream::iter(sse_events), new_state))
+                        }
+                        Ok(_) => {
+                            // No new events, wait with exponential backoff
+                            tokio::time::sleep(Duration::from_millis(state.backoff_ms)).await;
+
+                            // Increase backoff for next iteration
+                            let new_backoff = state.config.next_backoff(state.backoff_ms);
+                            let new_state = StreamState {
+                                backoff_ms: new_backoff,
+                                ..state
+                            };
+                            Some((stream::iter(vec![]), new_state))
+                        }
+                        Err(e) => {
+                            tracing::error!("Failed to fetch events: {}", e);
+                            None
+                        }
+                    }
                 }
             }
         }

--- a/crates/server/src/api/sse.rs
+++ b/crates/server/src/api/sse.rs
@@ -4,34 +4,53 @@
 // Different use cases have different latency requirements:
 // - Real-time (sessions): Fast updates for interactive UX
 // - Monitoring (durable): Relaxed updates for dashboards
+//
+// Connection Cycling:
+// SSE connections are gracefully closed after max_connection_duration to prevent
+// stale connections through proxies/load balancers. Before closing, a "disconnecting"
+// event is sent so clients can reconnect immediately with since_id to resume.
+//
+// SSE Retry Hints:
+// The SSE `retry:` field hints to clients how long to wait before reconnecting.
+// We use the current backoff value as the retry hint, so clients reconnect faster
+// when the stream is active (low backoff) and slower when idle (high backoff).
 
 use std::time::Duration;
 
-/// SSE stream configuration with backoff parameters
+/// SSE stream configuration with backoff and connection cycling parameters
 #[derive(Debug, Clone, Copy)]
 pub struct SseStreamConfig {
     /// Minimum backoff when polling for new events (ms)
     pub min_backoff_ms: u64,
     /// Maximum backoff when no new events (ms)
     pub max_backoff_ms: u64,
+    /// Maximum connection duration before graceful close (seconds)
+    /// Connection cycling prevents stale connections through proxies
+    pub max_connection_secs: u64,
+    /// Retry hint for immediate reconnect after disconnecting event (ms)
+    pub disconnect_retry_ms: u64,
 }
 
 impl SseStreamConfig {
     /// Fast polling for real-time session events
-    /// Min: 100ms, Max: 500ms
+    /// Min: 100ms, Max: 500ms, Connection cycle: 5 minutes
     pub fn realtime() -> Self {
         Self {
             min_backoff_ms: 100,
             max_backoff_ms: 500,
+            max_connection_secs: 300, // 5 minutes
+            disconnect_retry_ms: 100, // Fast reconnect
         }
     }
 
     /// Relaxed polling for monitoring dashboards
-    /// Min: 1000ms, Max: 20000ms
+    /// Min: 1000ms, Max: 20000ms, Connection cycle: 10 minutes
     pub fn monitoring() -> Self {
         Self {
             min_backoff_ms: 1000,
             max_backoff_ms: 20000,
+            max_connection_secs: 600,  // 10 minutes
+            disconnect_retry_ms: 1000, // 1 second reconnect
         }
     }
 
@@ -40,15 +59,49 @@ impl SseStreamConfig {
         Duration::from_millis(self.min_backoff_ms)
     }
 
+    /// Get maximum connection duration
+    pub fn max_connection_duration(&self) -> Duration {
+        Duration::from_secs(self.max_connection_secs)
+    }
+
     /// Calculate next backoff (exponential, capped at max)
     pub fn next_backoff(&self, current_ms: u64) -> u64 {
         (current_ms * 2).min(self.max_backoff_ms)
+    }
+
+    /// Get retry hint duration based on current backoff
+    /// Used in SSE `retry:` field to hint reconnection timing
+    pub fn retry_hint(&self, current_backoff_ms: u64) -> Duration {
+        Duration::from_millis(current_backoff_ms)
+    }
+
+    /// Get retry hint for disconnecting event (fast reconnect)
+    pub fn disconnect_retry(&self) -> Duration {
+        Duration::from_millis(self.disconnect_retry_ms)
     }
 }
 
 impl Default for SseStreamConfig {
     fn default() -> Self {
         Self::realtime()
+    }
+}
+
+/// Reason for SSE stream disconnection
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DisconnectReason {
+    /// Connection cycling - normal graceful close after max duration
+    ConnectionCycle,
+    /// Server shutdown
+    Shutdown,
+}
+
+impl DisconnectReason {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            DisconnectReason::ConnectionCycle => "connection_cycle",
+            DisconnectReason::Shutdown => "shutdown",
+        }
     }
 }
 
@@ -61,6 +114,8 @@ mod tests {
         let config = SseStreamConfig::realtime();
         assert_eq!(config.min_backoff_ms, 100);
         assert_eq!(config.max_backoff_ms, 500);
+        assert_eq!(config.max_connection_secs, 300);
+        assert_eq!(config.disconnect_retry_ms, 100);
     }
 
     #[test]
@@ -68,6 +123,8 @@ mod tests {
         let config = SseStreamConfig::monitoring();
         assert_eq!(config.min_backoff_ms, 1000);
         assert_eq!(config.max_backoff_ms, 20000);
+        assert_eq!(config.max_connection_secs, 600);
+        assert_eq!(config.disconnect_retry_ms, 1000);
     }
 
     #[test]
@@ -105,6 +162,7 @@ mod tests {
         let config = SseStreamConfig::default();
         assert_eq!(config.min_backoff_ms, 100);
         assert_eq!(config.max_backoff_ms, 500);
+        assert_eq!(config.max_connection_secs, 300);
     }
 
     #[test]
@@ -112,6 +170,41 @@ mod tests {
         let config = SseStreamConfig::realtime();
         let config2 = config; // Copy
         assert_eq!(config.min_backoff_ms, config2.min_backoff_ms);
+        assert_eq!(config.max_connection_secs, config2.max_connection_secs);
+    }
+
+    #[test]
+    fn test_max_connection_duration() {
+        let config = SseStreamConfig::realtime();
+        assert_eq!(config.max_connection_duration(), Duration::from_secs(300));
+
+        let config = SseStreamConfig::monitoring();
+        assert_eq!(config.max_connection_duration(), Duration::from_secs(600));
+    }
+
+    #[test]
+    fn test_retry_hint() {
+        let config = SseStreamConfig::realtime();
+        assert_eq!(config.retry_hint(100), Duration::from_millis(100));
+        assert_eq!(config.retry_hint(500), Duration::from_millis(500));
+    }
+
+    #[test]
+    fn test_disconnect_retry() {
+        let config = SseStreamConfig::realtime();
+        assert_eq!(config.disconnect_retry(), Duration::from_millis(100));
+
+        let config = SseStreamConfig::monitoring();
+        assert_eq!(config.disconnect_retry(), Duration::from_millis(1000));
+    }
+
+    #[test]
+    fn test_disconnect_reason() {
+        assert_eq!(
+            DisconnectReason::ConnectionCycle.as_str(),
+            "connection_cycle"
+        );
+        assert_eq!(DisconnectReason::Shutdown.as_str(), "shutdown");
     }
 
     #[test]

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1915,6 +1915,7 @@
           "events"
         ],
         "summary": "GET /v1/sessions/{session_id}/sse - Stream events (SSE notifications)",
+        "description": "Establishes a Server-Sent Events (SSE) connection for real-time event streaming.\n\n## Connection Lifecycle Events\n\n- **connected**: Sent immediately when the stream is established.\n  Data: `{\"status\":\"connected\"}`\n\n- **disconnecting**: Sent before the server closes the connection for graceful cycling.\n  Data: `{\"reason\":\"connection_cycle\",\"retry_ms\":100}`\n  Clients should reconnect immediately using the `since_id` of the last received event.\n\n## Connection Cycling\n\nConnections are automatically cycled every 5 minutes to prevent stale connections\nthrough proxies and load balancers. Before closing, the server sends a `disconnecting`\nevent so clients can reconnect seamlessly without missing events.\n\n## Retry Hints\n\nEach SSE event includes a `retry:` field (in milliseconds) that hints how long\nclients should wait before reconnecting if the connection is lost:\n- During active streaming: 100ms (fast reconnect)\n- During idle periods: increases with backoff up to 500ms\n- After `disconnecting` event: 100ms (immediate reconnect)\n\n## Resuming Streams\n\nUse the `since_id` query parameter to resume from a specific event. The server\nwill only send events with IDs greater than the specified value. Event IDs are\nUUID v7 (monotonically increasing), ensuring reliable ordering.",
         "operationId": "stream_sse",
         "parameters": [
           {
@@ -1956,7 +1957,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Event stream",
+            "description": "Event stream. Includes 'connected' on open, domain events during streaming, and 'disconnecting' before graceful close.",
             "content": {
               "text/event-stream": {}
             }

--- a/docs/features/events.md
+++ b/docs/features/events.md
@@ -21,7 +21,7 @@ Every action during a session - from user messages to LLM responses to tool exec
 Subscribe to real-time events via Server-Sent Events:
 
 ```bash
-curl -N "https://api.everruns.com/v1/agents/{agent_id}/sessions/{session_id}/sse" \
+curl -N "https://api.everruns.com/v1/sessions/{session_id}/sse" \
   -H "Authorization: Bearer $API_KEY"
 ```
 
@@ -30,8 +30,99 @@ curl -N "https://api.everruns.com/v1/agents/{agent_id}/sessions/{session_id}/sse
 Alternatively, poll for events with pagination:
 
 ```bash
-curl "https://api.everruns.com/v1/agents/{agent_id}/sessions/{session_id}/events?since_id={last_event_id}" \
+curl "https://api.everruns.com/v1/sessions/{session_id}/events?since_id={last_event_id}" \
   -H "Authorization: Bearer $API_KEY"
+```
+
+## SSE Connection Management
+
+### Connection Lifecycle Events
+
+SSE streams include special lifecycle events for connection management:
+
+| Event | Description |
+|-------|-------------|
+| `connected` | Sent immediately when the stream is established |
+| `disconnecting` | Sent before the server gracefully closes the connection |
+
+### Connection Cycling
+
+To prevent stale connections through proxies and load balancers, SSE connections are automatically cycled:
+
+| Stream Type | Cycle Interval |
+|-------------|----------------|
+| Session events | 5 minutes |
+| Durable monitoring | 10 minutes |
+
+Before closing, the server sends a `disconnecting` event:
+
+```json
+{
+  "event": "disconnecting",
+  "data": "{\"reason\":\"connection_cycle\",\"retry_ms\":100}"
+}
+```
+
+Clients should reconnect immediately using the `since_id` of the last received event. This ensures no events are missed during the transition.
+
+### Retry Hints
+
+Each SSE event includes a `retry:` field that hints how long clients should wait before reconnecting if the connection is unexpectedly lost:
+
+| Situation | Retry Hint |
+|-----------|------------|
+| Active streaming (new events) | 100ms |
+| Idle (no new events) | Increases with backoff up to 500ms |
+| After `disconnecting` event | 100ms (immediate reconnect) |
+
+The EventSource API automatically uses this hint for reconnection timing.
+
+### Resuming Streams
+
+Use the `since_id` query parameter to resume from the last received event:
+
+```bash
+curl -N "https://api.everruns.com/v1/sessions/{session_id}/sse?since_id={last_event_id}" \
+  -H "Authorization: Bearer $API_KEY"
+```
+
+Event IDs are UUID v7 (monotonically increasing by timestamp), ensuring reliable ordering and no duplicate events on reconnection.
+
+### JavaScript Example
+
+```javascript
+function connectSSE(sessionId, lastEventId) {
+  const url = new URL(`/v1/sessions/${sessionId}/sse`, API_BASE);
+  if (lastEventId) {
+    url.searchParams.set('since_id', lastEventId);
+  }
+
+  const eventSource = new EventSource(url, { withCredentials: true });
+
+  eventSource.addEventListener('connected', () => {
+    console.log('SSE connected');
+  });
+
+  eventSource.addEventListener('disconnecting', (event) => {
+    const data = JSON.parse(event.data);
+    console.log('SSE disconnecting, reconnecting in', data.retry_ms, 'ms');
+    eventSource.close();
+    setTimeout(() => connectSSE(sessionId, lastEventId), data.retry_ms);
+  });
+
+  eventSource.addEventListener('input.message', (event) => {
+    const eventData = JSON.parse(event.data);
+    lastEventId = eventData.id;
+    // Handle event...
+  });
+
+  // Handle other event types...
+
+  eventSource.onerror = () => {
+    eventSource.close();
+    setTimeout(() => connectSSE(sessionId, lastEventId), 2000);
+  };
+}
 ```
 
 ## Event Categories

--- a/specs/events.md
+++ b/specs/events.md
@@ -979,6 +979,56 @@ data: {"id":"...","type":"reason.started","ts":"...","session_id":"...","context
 
 The SSE `event` field matches the `type` field in the event payload.
 
+### SSE Connection Lifecycle
+
+SSE streams include special lifecycle events for connection management:
+
+| Event | Description |
+|-------|-------------|
+| `connected` | Sent immediately when the stream is established. Data: `{"status":"connected"}` |
+| `disconnecting` | Sent before graceful close. Data: `{"reason":"connection_cycle","retry_ms":100}` |
+
+### Connection Cycling
+
+To prevent stale connections through proxies and load balancers, SSE connections are automatically cycled:
+
+| Stream Type | Cycle Interval | Backoff Range |
+|-------------|----------------|---------------|
+| Session events (realtime) | 5 minutes | 100ms → 500ms |
+| Durable monitoring | 10 minutes | 1000ms → 20000ms |
+
+Before closing, the server sends a `disconnecting` event so clients can reconnect immediately using `since_id`. This ensures no events are missed.
+
+### Retry Hints
+
+Each SSE event includes a `retry:` field (in milliseconds) that hints reconnection timing:
+
+| Situation | Session Events | Durable Monitoring |
+|-----------|---------------|-------------------|
+| Active (new events) | 100ms | 1000ms |
+| Idle (backoff max) | 500ms | 20000ms |
+| After `disconnecting` | 100ms | 1000ms |
+
+The EventSource API automatically uses this hint.
+
+### SDK Implementation Requirements
+
+SDKs MUST:
+1. Track the last received event ID (`lastEventId`)
+2. Handle `disconnecting` event by reconnecting with `since_id` parameter
+3. Handle `onerror` with exponential backoff (EventSource default behavior)
+4. Use `retry:` hint for reconnection timing
+
+Example client implementation:
+
+```javascript
+eventSource.addEventListener('disconnecting', (event) => {
+  const data = JSON.parse(event.data);
+  eventSource.close();
+  setTimeout(() => reconnect(lastEventId), data.retry_ms);
+});
+```
+
 ## Filtering
 
 Events can be filtered by:


### PR DESCRIPTION
## Summary

- Add graceful connection cycling to prevent stale SSE connections through proxies/load balancers
- Add `disconnecting` event sent before server closes connection for graceful cycling
- Add SSE `retry:` field to hint reconnection timing based on current backoff state
- Update client-side hooks to handle `disconnecting` event for immediate reconnect

## Configuration

| Stream Type | Cycle Interval | Min Backoff | Max Backoff | Disconnect Retry |
|-------------|----------------|-------------|-------------|------------------|
| Realtime (sessions) | 5 min | 100ms | 500ms | 100ms |
| Monitoring (durable) | 10 min | 1000ms | 20000ms | 1000ms |

## SDK Implementation Requirements

SDKs MUST:
1. Track the last received event ID (`lastEventId`)
2. Handle `disconnecting` event by reconnecting with `since_id` parameter
3. Handle `onerror` with exponential backoff (EventSource default behavior)
4. Use `retry:` hint for reconnection timing

## Test plan

- [x] SSE unit tests pass (14 tests)
- [x] Smoke test session SSE: `connected` with `retry:100`
- [x] Smoke test durable SSE: `connected` + `snapshot` with `retry:1000`
- [ ] CI passes

https://claude.ai/code/session_01ApMMrwYzqdcgBwCmAJg7Fg