### PR TITLE
feat(llm): add support for /v1/responses/compact endpoint with reactive compaction

### DIFF
--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -28,10 +28,10 @@ use super::{Atom, AtomContext};
 use crate::capabilities::CapabilityRegistry;
 use crate::error::{AgentLoopError, Result};
 use crate::events::{
-    EventContext, EventRequest, LlmGenerationData, LlmRetryInfo, OutputMessageCompletedData,
-    OutputMessageDeltaData, OutputMessageStartedData, ReasonCompletedData, ReasonStartedData,
-    ReasonThinkingCompletedData, ReasonThinkingDeltaData, ReasonThinkingStartedData, TokenUsage,
-    ToolDefinitionSummary,
+    EventContext, EventRequest, LlmCompactionInfo, LlmGenerationData, LlmRetryInfo,
+    OutputMessageCompletedData, OutputMessageDeltaData, OutputMessageStartedData,
+    ReasonCompletedData, ReasonStartedData, ReasonThinkingCompletedData, ReasonThinkingDeltaData,
+    ReasonThinkingStartedData, TokenUsage, ToolDefinitionSummary,
 };
 use crate::llm_driver_registry::{
     DriverRegistry, LlmCallConfigBuilder, LlmCompletionMetadata, LlmMessage, LlmMessageContent,
@@ -39,6 +39,9 @@ use crate::llm_driver_registry::{
 };
 use crate::message::{Message, MessageRole};
 use crate::message_retriever::MessageRetriever;
+use crate::openresponses_protocol::{
+    CompactInputItem, CompactRequest, compact_output_to_messages, messages_to_compact_input,
+};
 use crate::runtime_agent::RuntimeAgentBuilder;
 use crate::tool_types::{ToolCall, ToolDefinition};
 use crate::traits::{
@@ -645,9 +648,129 @@ where
         // Track LLM call timing
         let llm_start = Instant::now();
 
-        let mut stream = llm_driver
-            .chat_completion_stream(llm_messages, &llm_config)
-            .await?;
+        // Try LLM call with automatic compaction on RequestTooLarge
+        let mut compaction_info: Option<LlmCompactionInfo> = None;
+        let mut llm_messages_for_call = llm_messages.clone();
+
+        let mut stream = match llm_driver
+            .chat_completion_stream(llm_messages_for_call.clone(), &llm_config)
+            .await
+        {
+            Ok(stream) => stream,
+            Err(e) if e.is_request_too_large() && llm_driver.supports_compact() => {
+                // Context too large - try compacting
+                tracing::info!(
+                    session_id = %session_id,
+                    turn_id = %context.turn_id,
+                    "ReasonAtom: context too large, attempting compaction"
+                );
+
+                let compact_start = Instant::now();
+
+                // Convert messages to compact input format
+                // Skip the system message (index 0) as it's passed separately as instructions
+                let messages_to_compact = if has_system_prompt {
+                    &llm_messages_for_call[1..]
+                } else {
+                    &llm_messages_for_call[..]
+                };
+
+                let compact_input = messages_to_compact_input(messages_to_compact);
+                let input_count = compact_input.len();
+
+                // Build compact request
+                let compact_request = CompactRequest {
+                    model: runtime_agent.model.clone(),
+                    input: compact_input,
+                    previous_response_id: None,
+                    instructions: if has_system_prompt {
+                        Some(runtime_agent.system_prompt.clone())
+                    } else {
+                        None
+                    },
+                };
+
+                // Call compact endpoint
+                let compact_response =
+                    llm_driver.compact(compact_request).await?.ok_or_else(|| {
+                        AgentLoopError::llm("Compaction failed: driver returned None".to_string())
+                    })?;
+
+                let compact_duration_ms = compact_start.elapsed().as_millis() as u64;
+
+                // Convert compacted output to messages
+                let (compacted_messages, compaction_items) =
+                    compact_output_to_messages(&compact_response.output);
+
+                // Track compaction token usage
+                let input_tokens_after = compact_response
+                    .usage
+                    .as_ref()
+                    .and_then(|u| u.output_tokens);
+
+                tracing::info!(
+                    session_id = %session_id,
+                    turn_id = %context.turn_id,
+                    input_items = input_count,
+                    output_items = compact_response.output.len(),
+                    compaction_items = compaction_items.len(),
+                    duration_ms = compact_duration_ms,
+                    "ReasonAtom: compaction completed"
+                );
+
+                // Record compaction info for event
+                compaction_info = Some(LlmCompactionInfo::new(
+                    Some(input_count as u32),
+                    input_tokens_after,
+                    Some(compact_duration_ms),
+                ));
+
+                // Rebuild messages for retry
+                // Start with system prompt if present
+                let mut compacted_llm_messages = Vec::new();
+                if has_system_prompt {
+                    compacted_llm_messages.push(llm_messages_for_call[0].clone());
+                }
+
+                // Add compacted messages
+                compacted_llm_messages.extend(compacted_messages);
+
+                // Add compaction items as a special message if present
+                // These contain encrypted context that the model needs
+                for item in compaction_items {
+                    if let CompactInputItem::Compaction { encrypted_content } = item {
+                        // Add as a system message containing the encrypted context
+                        // This preserves the latent context for the model
+                        compacted_llm_messages.push(LlmMessage {
+                            role: LlmMessageRole::System,
+                            content: LlmMessageContent::Text(format!(
+                                "[COMPACTED_CONTEXT:{}]",
+                                encrypted_content
+                            )),
+                            tool_calls: None,
+                            tool_call_id: None,
+                            thinking: None,
+                            thinking_signature: None,
+                        });
+                    }
+                }
+
+                llm_messages_for_call = compacted_llm_messages;
+
+                // Retry with compacted messages
+                tracing::info!(
+                    session_id = %session_id,
+                    turn_id = %context.turn_id,
+                    message_count = llm_messages_for_call.len(),
+                    "ReasonAtom: retrying LLM call with compacted context"
+                );
+
+                llm_driver
+                    .chat_completion_stream(llm_messages_for_call.clone(), &llm_config)
+                    .await?
+            }
+            Err(e) => return Err(e),
+        };
 
         // 14. Process stream with batched output.message.delta emissions
         // Batch deltas every 100ms to reduce event volume while providing real-time feedback
@@ -894,25 +1017,33 @@ where
                 attempts: rm.attempts,
                 total_wait_ms: rm.total_retry_wait.as_millis() as u64,
             });
+        // Build LlmGenerationData with retry and compaction info
+        let mut generation_data = LlmGenerationData::success_with_retry(
+            messages_for_event.clone(),
+            tools_summary,
+            Some(text.clone()).filter(|s| !s.is_empty()),
+            tool_calls.clone(),
+            runtime_agent.model.clone(),
+            Some(model_with_provider.provider_type.to_string()),
+            usage.clone(),
+            Some(llm_duration_ms),
+            time_to_first_token_ms,
+            finish_reasons,
+            None, // response_id
+            retry_info,
+        );
+
+        // Add compaction info if compaction was performed
+        if let Some(info) = compaction_info {
+            generation_data = generation_data.with_compaction(info);
+        }
+
         if let Err(e) = self
             .event_emitter
             .emit(EventRequest::new(
                 session_id,
                 event_context,
-                LlmGenerationData::success_with_retry(
-                    messages_for_event.clone(),
-                    tools_summary,
-                    Some(text.clone()).filter(|s| !s.is_empty()),
-                    tool_calls.clone(),
-                    runtime_agent.model.clone(),
-                    Some(model_with_provider.provider_type.to_string()),
-                    usage.clone(),
-                    Some(llm_duration_ms),
-                    time_to_first_token_ms,
-                    finish_reasons,
-                    None, // response_id
-                    retry_info,
-                ),
+                generation_data,
             ))
             .await
         {

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -785,6 +785,11 @@ pub struct LlmGenerationMetadata {
     /// Contains number of retries and total wait time
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retry: Option<LlmRetryInfo>,
+
+    /// Compaction information if context was compressed before generation
+    /// Occurs when the conversation context exceeded the model's limit
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub compaction: Option<LlmCompactionInfo>,
 }
 
 /// Information about rate limit retries during LLM generation
@@ -796,6 +801,45 @@ pub struct LlmRetryInfo {
 
     /// Total time spent waiting between retries in milliseconds
     pub total_wait_ms: u64,
+}
+
+/// Information about context compaction performed before LLM generation
+///
+/// When the conversation context exceeds the model's limit, compaction is
+/// automatically triggered to compress the context before retrying.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct LlmCompactionInfo {
+    /// Whether compaction was performed
+    pub compacted: bool,
+
+    /// Number of input tokens before compaction
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_tokens_before: Option<u32>,
+
+    /// Number of input tokens after compaction
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_tokens_after: Option<u32>,
+
+    /// Duration of the compaction operation in milliseconds
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+}
+
+impl LlmCompactionInfo {
+    /// Create info for a successful compaction
+    pub fn new(
+        input_tokens_before: Option<u32>,
+        input_tokens_after: Option<u32>,
+        duration_ms: Option<u64>,
+    ) -> Self {
+        Self {
+            compacted: true,
+            input_tokens_before,
+            input_tokens_after,
+            duration_ms,
+        }
+    }
 }
 
 /// Data for llm.generation event
@@ -855,6 +899,7 @@ impl LlmGenerationData {
                 finish_reasons,
                 response_id: None,
                 retry: None,
+                compaction: None,
             },
         }
     }
@@ -889,6 +934,7 @@ impl LlmGenerationData {
                 finish_reasons,
                 response_id,
                 retry: None,
+                compaction: None,
             },
         }
     }
@@ -924,6 +970,7 @@ impl LlmGenerationData {
                 finish_reasons,
                 response_id,
                 retry,
+                compaction: None,
             },
         }
     }
@@ -956,8 +1003,23 @@ impl LlmGenerationData {
                 finish_reasons: Some(vec!["error".to_string()]),
                 response_id: None,
                 retry: None,
+                compaction: None,
             },
         }
+    }
+
+    /// Set compaction info on this generation event
+    ///
+    /// Call this when context was compacted before a successful retry.
+    pub fn with_compaction(mut self, compaction: LlmCompactionInfo) -> Self {
+        self.metadata.compaction = Some(compaction);
+        self
+    }
+
+    /// Set retry info on this generation event
+    pub fn with_retry(mut self, retry: LlmRetryInfo) -> Self {
+        self.metadata.retry = Some(retry);
+        self
     }
 }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -114,7 +114,10 @@ pub use openai_protocol::OpenAIProtocolLlmDriver;
 
 // Open Responses Protocol driver (https://www.openresponses.org/)
 // Vendor-neutral API standard, recommended for new projects
-pub use openresponses_protocol::OpenResponsesProtocolLlmDriver;
+pub use openresponses_protocol::{
+    CompactContent, CompactContentPart, CompactInputItem, CompactOutputItem, CompactRequest,
+    CompactResponse, CompactUsage, OpenResponsesProtocolLlmDriver,
+};
 
 // Tool abstraction re-exports
 pub use tools::{

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -116,7 +116,8 @@ pub use openai_protocol::OpenAIProtocolLlmDriver;
 // Vendor-neutral API standard, recommended for new projects
 pub use openresponses_protocol::{
     CompactContent, CompactContentPart, CompactInputItem, CompactOutputItem, CompactRequest,
-    CompactResponse, CompactUsage, OpenResponsesProtocolLlmDriver,
+    CompactResponse, CompactUsage, OpenResponsesProtocolLlmDriver, compact_output_to_messages,
+    messages_to_compact_input,
 };
 
 // Tool abstraction re-exports
@@ -158,8 +159,8 @@ pub use capability_dto::{AgentCapability, CapabilityInfo};
 pub use events::{
     ACT_COMPLETED, ACT_STARTED, ActCompletedData, ActStartedData, Event, EventBuilder,
     EventContext, EventData, EventRequest, INPUT_MESSAGE, InputMessageData, LLM_GENERATION,
-    LlmGenerationData, LlmGenerationMetadata, LlmGenerationOutput, LlmRetryInfo, ModelMetadata,
-    OUTPUT_MESSAGE_COMPLETED, OUTPUT_MESSAGE_DELTA, OUTPUT_MESSAGE_STARTED,
+    LlmCompactionInfo, LlmGenerationData, LlmGenerationMetadata, LlmGenerationOutput, LlmRetryInfo,
+    ModelMetadata, OUTPUT_MESSAGE_COMPLETED, OUTPUT_MESSAGE_DELTA, OUTPUT_MESSAGE_STARTED,
     OutputMessageCompletedData, OutputMessageDeltaData, OutputMessageStartedData, REASON_COMPLETED,
     REASON_STARTED, REASON_THINKING_COMPLETED, REASON_THINKING_DELTA, REASON_THINKING_STARTED,
     ReasonCompletedData, ReasonStartedData, ReasonThinkingCompletedData, ReasonThinkingDeltaData,

--- a/crates/core/src/llm_driver_registry.rs
+++ b/crates/core/src/llm_driver_registry.rs
@@ -15,6 +15,7 @@
 // specific provider implementations.
 
 use crate::error::{AgentLoopError, Result};
+use crate::openresponses_protocol::{CompactRequest, CompactResponse};
 use crate::runtime_agent::RuntimeAgent;
 use crate::tool_types::{ToolCall, ToolDefinition};
 use async_trait::async_trait;
@@ -158,6 +159,43 @@ pub trait LlmDriver: Send + Sync {
         // Default: not supported. Providers override if they support listing.
         Ok(None)
     }
+
+    /// Check if this driver supports the compact endpoint
+    ///
+    /// The compact endpoint compresses conversation history by replacing
+    /// assistant messages, tool calls, and tool results with an encrypted
+    /// compaction item. User messages are kept verbatim.
+    ///
+    /// Returns `true` if the driver supports compaction, `false` otherwise.
+    /// Currently only supported by OpenAI's Responses API.
+    fn supports_compact(&self) -> bool {
+        // Default: not supported
+        false
+    }
+
+    /// Compact a conversation to reduce context size
+    ///
+    /// This method compresses conversation history by calling the provider's
+    /// compact endpoint. User messages are kept verbatim, while assistant
+    /// messages, tool calls, and tool results are replaced by an encrypted
+    /// compaction item that preserves latent context but is opaque.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The compact request containing the model and input items
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(Some(response))` if compaction succeeded,
+    /// `Ok(None)` if compaction is not supported by this driver,
+    /// or `Err` if an error occurred.
+    ///
+    /// The response contains the compacted output items which can be used
+    /// directly as input for the next chat completion call.
+    async fn compact(&self, _request: CompactRequest) -> Result<Option<CompactResponse>> {
+        // Default: not supported
+        Ok(None)
+    }
 }
 
 /// Implement LlmDriver for Box<dyn LlmDriver> to allow dynamic dispatch
@@ -181,6 +219,14 @@ impl LlmDriver for Box<dyn LlmDriver> {
 
     async fn list_models(&self) -> Result<Option<Vec<DiscoveredModel>>> {
         (**self).list_models().await
+    }
+
+    fn supports_compact(&self) -> bool {
+        (**self).supports_compact()
+    }
+
+    async fn compact(&self, request: CompactRequest) -> Result<Option<CompactResponse>> {
+        (**self).compact(request).await
     }
 }
 

--- a/crates/core/src/observation/braintrust.rs
+++ b/crates/core/src/observation/braintrust.rs
@@ -1420,6 +1420,7 @@ mod tests {
                 finish_reasons: Some(vec!["stop".to_string()]),
                 response_id: Some("resp_123".to_string()),
                 retry: None,
+                compaction: None,
             },
         };
 
@@ -1632,6 +1633,7 @@ mod tests {
                 finish_reasons: None,
                 response_id: None,
                 retry: None,
+                compaction: None,
             },
         };
         let event = Event::new(
@@ -1894,6 +1896,7 @@ mod tests {
                 finish_reasons: None,
                 response_id: None,
                 retry: None,
+                compaction: None,
             },
         };
         let llm_event = Event::new(

--- a/crates/core/src/observation/otel.rs
+++ b/crates/core/src/observation/otel.rs
@@ -398,6 +398,7 @@ mod tests {
                 finish_reasons: Some(vec!["stop".to_string()]),
                 response_id: Some("resp_123".to_string()),
                 retry: None,
+                compaction: None,
             },
         };
 
@@ -444,6 +445,7 @@ mod tests {
                 finish_reasons: Some(vec!["tool_calls".to_string()]),
                 response_id: Some("resp_456".to_string()),
                 retry: None,
+                compaction: None,
             },
         };
 
@@ -478,6 +480,7 @@ mod tests {
                 finish_reasons: None, // No finish reasons
                 response_id: None,    // No response ID
                 retry: None,
+                compaction: None,
             },
         };
 

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -35,6 +35,7 @@ use crate::llm_driver_registry::{
 use crate::llm_retry::{
     LlmRetryConfig, RateLimitInfo, RetryMetadata, is_rate_limit_status, is_transient_error,
 };
+use crate::openai_protocol::is_openai_request_too_large;
 use crate::tool_types::{ToolCall, ToolDefinition};
 
 const DEFAULT_API_URL: &str = "https://api.openai.com/v1/responses";
@@ -310,6 +311,15 @@ impl OpenResponsesProtocolLlmDriver {
 
             // Non-retryable error or max retries exceeded
             let error_text = response.text().await.unwrap_or_default();
+
+            // Check if this is a request-too-large error (context length exceeded)
+            if is_openai_request_too_large(status, &error_text) {
+                return Err(AgentLoopError::request_too_large(format!(
+                    "OpenAI Responses compact API ({}): {}",
+                    status, error_text
+                )));
+            }
+
             let error_msg = format!(
                 "OpenAI Responses compact API error ({}): {}",
                 status, error_text
@@ -513,6 +523,15 @@ impl LlmDriver for OpenResponsesProtocolLlmDriver {
 
             // Non-retryable error or max retries exceeded
             let error_text = response.text().await.unwrap_or_default();
+
+            // Check if this is a request-too-large error (context length exceeded)
+            if is_openai_request_too_large(status, &error_text) {
+                return Err(AgentLoopError::request_too_large(format!(
+                    "OpenAI Responses API ({}): {}",
+                    status, error_text
+                )));
+            }
+
             let error_msg = format!("OpenAI Responses API error ({}): {}", status, error_text);
 
             // If we exhausted retries, include that in the error message
@@ -919,6 +938,205 @@ pub struct CompactUsage {
     pub output_tokens: Option<u32>,
     /// Total tokens used
     pub total_tokens: Option<u32>,
+}
+
+// ============================================================================
+// Compaction Conversion Utilities
+// ============================================================================
+
+impl CompactInputItem {
+    /// Convert an LlmMessage to CompactInputItem(s)
+    ///
+    /// An assistant message with tool_calls is expanded into multiple items:
+    /// one Message for the text content and one FunctionCall for each tool call.
+    pub fn from_llm_message(msg: &LlmMessage) -> Vec<Self> {
+        let mut items = Vec::new();
+
+        let role = match msg.role {
+            LlmMessageRole::System => "developer",
+            LlmMessageRole::User => "user",
+            LlmMessageRole::Assistant => "assistant",
+            LlmMessageRole::Tool => "tool",
+        };
+
+        // Handle tool result messages differently
+        if msg.role == LlmMessageRole::Tool
+            && let Some(tool_call_id) = &msg.tool_call_id
+        {
+            let output = match &msg.content {
+                LlmMessageContent::Text(text) => text.clone(),
+                LlmMessageContent::Parts(parts) => parts
+                    .iter()
+                    .filter_map(|p| match p {
+                        LlmContentPart::Text { text } => Some(text.clone()),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>()
+                    .join(""),
+            };
+            items.push(CompactInputItem::FunctionCallOutput {
+                call_id: tool_call_id.clone(),
+                output,
+            });
+            return items;
+        }
+
+        // Add message content (if non-empty)
+        let content = Self::content_from_llm_message(msg);
+        let has_content = match &content {
+            CompactContent::Text(t) => !t.is_empty(),
+            CompactContent::Parts(p) => !p.is_empty(),
+        };
+
+        if has_content || msg.tool_calls.is_none() {
+            items.push(CompactInputItem::Message {
+                role: role.to_string(),
+                content,
+            });
+        }
+
+        // Add function calls for assistant messages
+        if msg.role == LlmMessageRole::Assistant
+            && let Some(tool_calls) = &msg.tool_calls
+        {
+            for tc in tool_calls {
+                items.push(CompactInputItem::FunctionCall {
+                    call_id: tc.id.clone(),
+                    name: tc.name.clone(),
+                    arguments: tc.arguments.to_string(),
+                });
+            }
+        }
+
+        items
+    }
+
+    /// Convert LlmMessageContent to CompactContent
+    fn content_from_llm_message(msg: &LlmMessage) -> CompactContent {
+        match &msg.content {
+            LlmMessageContent::Text(text) => CompactContent::Text(text.clone()),
+            LlmMessageContent::Parts(parts) => {
+                let compact_parts: Vec<CompactContentPart> = parts
+                    .iter()
+                    .filter_map(|part| match part {
+                        LlmContentPart::Text { text } => {
+                            Some(CompactContentPart::InputText { text: text.clone() })
+                        }
+                        LlmContentPart::Image { url } => {
+                            // URL is already in data URL format (data:image/png;base64,...)
+                            Some(CompactContentPart::InputImage {
+                                image_url: url.clone(),
+                            })
+                        }
+                        LlmContentPart::Audio { .. } => None, // Audio not supported in compact
+                    })
+                    .collect();
+                if compact_parts.len() == 1
+                    && let CompactContentPart::InputText { text } = &compact_parts[0]
+                {
+                    return CompactContent::Text(text.clone());
+                }
+                CompactContent::Parts(compact_parts)
+            }
+        }
+    }
+}
+
+impl CompactOutputItem {
+    /// Convert a CompactOutputItem to LlmMessage
+    ///
+    /// Compaction items are converted to a special system message containing
+    /// the encrypted context that will be included in subsequent requests.
+    pub fn to_llm_message(&self) -> Option<LlmMessage> {
+        match self {
+            CompactOutputItem::Message { role, content } => {
+                let llm_role = match role.as_str() {
+                    "user" => LlmMessageRole::User,
+                    "assistant" => LlmMessageRole::Assistant,
+                    "developer" | "system" => LlmMessageRole::System,
+                    "tool" => LlmMessageRole::Tool,
+                    _ => LlmMessageRole::User, // Default to user
+                };
+
+                let llm_content = match content {
+                    CompactContent::Text(text) => LlmMessageContent::Text(text.clone()),
+                    CompactContent::Parts(parts) => {
+                        let llm_parts: Vec<LlmContentPart> = parts
+                            .iter()
+                            .map(|p| match p {
+                                CompactContentPart::InputText { text } => {
+                                    LlmContentPart::Text { text: text.clone() }
+                                }
+                                CompactContentPart::InputImage { image_url } => {
+                                    // Pass the URL directly - it's already in data URL format
+                                    LlmContentPart::Image {
+                                        url: image_url.clone(),
+                                    }
+                                }
+                            })
+                            .collect();
+                        LlmMessageContent::Parts(llm_parts)
+                    }
+                };
+
+                Some(LlmMessage {
+                    role: llm_role,
+                    content: llm_content,
+                    tool_calls: None,
+                    tool_call_id: None,
+                    thinking: None,
+                    thinking_signature: None,
+                })
+            }
+            CompactOutputItem::Compaction { .. } => {
+                // Compaction items are handled separately - they're passed as-is
+                // to the next request, not converted to messages
+                None
+            }
+        }
+    }
+}
+
+/// Convert a slice of LlmMessages to CompactInputItems
+pub fn messages_to_compact_input(messages: &[LlmMessage]) -> Vec<CompactInputItem> {
+    messages
+        .iter()
+        .flat_map(CompactInputItem::from_llm_message)
+        .collect()
+}
+
+/// Convert CompactResponse output to LlmMessages plus any compaction items
+///
+/// Returns a tuple of (regular messages, compaction items).
+/// The compaction items should be preserved and included in subsequent compact requests.
+pub fn compact_output_to_messages(
+    output: &[CompactOutputItem],
+) -> (Vec<LlmMessage>, Vec<CompactInputItem>) {
+    let mut messages = Vec::new();
+    let mut compaction_items = Vec::new();
+
+    for item in output {
+        match item {
+            CompactOutputItem::Message { role, content } => {
+                if let Some(msg) = item.to_llm_message() {
+                    messages.push(msg);
+                } else {
+                    // Re-add as compact input for next request
+                    compaction_items.push(CompactInputItem::Message {
+                        role: role.clone(),
+                        content: content.clone(),
+                    });
+                }
+            }
+            CompactOutputItem::Compaction { encrypted_content } => {
+                compaction_items.push(CompactInputItem::Compaction {
+                    encrypted_content: encrypted_content.clone(),
+                });
+            }
+        }
+    }
+
+    (messages, compaction_items)
 }
 
 // ============================================================================

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -203,6 +203,157 @@ impl OpenResponsesProtocolLlmDriver {
             .collect()
     }
 
+    /// Compact a conversation to reduce context size
+    ///
+    /// This method calls the /v1/responses/compact endpoint to compress the conversation
+    /// history. User messages are kept verbatim, while assistant messages, tool calls,
+    /// and tool results are replaced by an encrypted compaction item.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The compact request containing the model and input items
+    ///
+    /// # Returns
+    ///
+    /// Returns a `CompactResponse` containing the compacted output items.
+    /// The output can be used directly as input for the next /v1/responses call.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use everruns_core::{OpenResponsesProtocolLlmDriver, CompactRequest, CompactInputItem, CompactContent};
+    ///
+    /// let driver = OpenResponsesProtocolLlmDriver::new("your-api-key");
+    ///
+    /// let request = CompactRequest {
+    ///     model: "gpt-4o".to_string(),
+    ///     input: vec![
+    ///         CompactInputItem::Message {
+    ///             role: "user".to_string(),
+    ///             content: CompactContent::Text("Hello!".to_string()),
+    ///         },
+    ///     ],
+    ///     previous_response_id: None,
+    ///     instructions: None,
+    /// };
+    ///
+    /// let response = driver.compact(request).await?;
+    /// // Use response.output as input for the next /v1/responses call
+    /// ```
+    pub async fn compact(&self, request: CompactRequest) -> Result<CompactResponse> {
+        // Build the compact endpoint URL
+        // Replace /v1/responses with /v1/responses/compact
+        let compact_url = if self.api_url.ends_with("/responses") {
+            format!("{}/compact", self.api_url)
+        } else if self.api_url.ends_with("/responses/") {
+            format!("{}compact", self.api_url)
+        } else {
+            // Custom URL - just append /compact
+            format!("{}/compact", self.api_url.trim_end_matches('/'))
+        };
+
+        // Retry loop for rate limit (429) and transient errors
+        let mut retry_metadata = RetryMetadata::default();
+        let mut last_error: Option<String> = None;
+
+        let response = loop {
+            let response = self
+                .client
+                .post(&compact_url)
+                .header("Authorization", format!("Bearer {}", self.api_key))
+                .header("Content-Type", "application/json")
+                .json(&request)
+                .send()
+                .await
+                .map_err(|e| {
+                    AgentLoopError::llm(format!("Failed to send compact request: {}", e))
+                })?;
+
+            let status = response.status();
+
+            if status.is_success() {
+                break response;
+            }
+
+            // Check if this is a retryable error
+            if is_transient_error(status) && retry_metadata.attempts < self.retry_config.max_retries
+            {
+                let rate_limit_info = if is_rate_limit_status(status) {
+                    Some(RateLimitInfo::from_openai_headers(response.headers()))
+                } else {
+                    None
+                };
+
+                let error_text = response.text().await.unwrap_or_default();
+
+                let wait_duration = rate_limit_info
+                    .as_ref()
+                    .map(|info| info.recommended_wait(&self.retry_config, retry_metadata.attempts))
+                    .unwrap_or_else(|| {
+                        self.retry_config.calculate_backoff(retry_metadata.attempts)
+                    });
+
+                tracing::warn!(
+                    status = %status,
+                    attempt = retry_metadata.attempts + 1,
+                    max_retries = self.retry_config.max_retries,
+                    wait_secs = wait_duration.as_secs_f64(),
+                    "OpenResponsesDriver: compact rate limit or transient error, retrying"
+                );
+
+                retry_metadata.record_retry(wait_duration, rate_limit_info);
+                last_error = Some(error_text);
+
+                tokio::time::sleep(wait_duration).await;
+                continue;
+            }
+
+            // Non-retryable error or max retries exceeded
+            let error_text = response.text().await.unwrap_or_default();
+            let error_msg = format!(
+                "OpenAI Responses compact API error ({}): {}",
+                status, error_text
+            );
+
+            if retry_metadata.attempts > 0 {
+                return Err(AgentLoopError::llm(format!(
+                    "{} (after {} retries, last error: {})",
+                    error_msg,
+                    retry_metadata.attempts,
+                    last_error.unwrap_or_default()
+                )));
+            }
+
+            return Err(AgentLoopError::llm(error_msg));
+        };
+
+        if retry_metadata.had_retries() {
+            tracing::info!(
+                attempts = retry_metadata.attempts,
+                total_wait_secs = retry_metadata.total_retry_wait.as_secs_f64(),
+                "OpenResponsesDriver: compact request succeeded after retries"
+            );
+        }
+
+        // Parse the response
+        let compact_response: CompactResponse = response
+            .json()
+            .await
+            .map_err(|e| AgentLoopError::llm(format!("Failed to parse compact response: {}", e)))?;
+
+        Ok(compact_response)
+    }
+
+    /// Check if this driver supports the compact endpoint
+    ///
+    /// Returns true for OpenAI's Responses API. Custom endpoints may or may not
+    /// support compaction.
+    pub fn supports_compact(&self) -> bool {
+        // We assume compact is supported for the default OpenAI endpoint
+        // For custom endpoints, callers should try and handle errors gracefully
+        self.api_url.starts_with("https://api.openai.com/")
+    }
+
     /// Build input items from messages, extracting system/developer instructions
     ///
     /// Handles the conversion of assistant messages with tool_calls into separate
@@ -620,6 +771,21 @@ impl LlmDriver for OpenResponsesProtocolLlmDriver {
 
         Ok(converted_stream)
     }
+
+    fn supports_compact(&self) -> bool {
+        // Delegate to the inherent method
+        OpenResponsesProtocolLlmDriver::supports_compact(self)
+    }
+
+    async fn compact(
+        &self,
+        request: crate::openresponses_protocol::CompactRequest,
+    ) -> Result<Option<crate::openresponses_protocol::CompactResponse>> {
+        // Delegate to the inherent method and wrap in Some
+        Ok(Some(
+            OpenResponsesProtocolLlmDriver::compact(self, request).await?,
+        ))
+    }
 }
 
 impl std::fmt::Debug for OpenResponsesProtocolLlmDriver {
@@ -641,6 +807,118 @@ struct ToolCallAccumulator {
     id: String,
     name: String,
     arguments: String,
+}
+
+// ============================================================================
+// Compact Endpoint Types (Public API)
+// ============================================================================
+
+/// Request for the /v1/responses/compact endpoint
+///
+/// This endpoint compacts a conversation by replacing prior assistant messages,
+/// tool calls, and tool results with an encrypted compaction item that preserves
+/// latent context but is opaque. User messages are kept verbatim.
+#[derive(Debug, Clone, Serialize)]
+pub struct CompactRequest {
+    /// Model to use for compaction (required)
+    pub model: String,
+    /// Input items to compact (the current conversation window)
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub input: Vec<CompactInputItem>,
+    /// Previous response ID (optional, alternative to input)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_response_id: Option<String>,
+    /// System instructions (optional, applies only to the compaction request)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
+}
+
+/// Input item for compact request
+///
+/// These are the same types as ResponsesInputItem but exposed publicly
+/// for callers to construct compact requests.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum CompactInputItem {
+    /// A message (user, assistant, or developer)
+    #[serde(rename = "message")]
+    Message {
+        role: String,
+        content: CompactContent,
+    },
+    /// A function call from the assistant
+    #[serde(rename = "function_call")]
+    FunctionCall {
+        call_id: String,
+        name: String,
+        arguments: String,
+    },
+    /// Output from a function call
+    #[serde(rename = "function_call_output")]
+    FunctionCallOutput { call_id: String, output: String },
+    /// A compaction item (from a previous compact call)
+    #[serde(rename = "compaction")]
+    Compaction { encrypted_content: String },
+}
+
+/// Content for compact input items
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CompactContent {
+    /// Simple text content
+    Text(String),
+    /// Array of content parts
+    Parts(Vec<CompactContentPart>),
+}
+
+/// Content part for compact input
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum CompactContentPart {
+    /// Text content
+    #[serde(rename = "input_text")]
+    InputText { text: String },
+    /// Image content
+    #[serde(rename = "input_image")]
+    InputImage { image_url: String },
+}
+
+/// Response from the /v1/responses/compact endpoint
+#[derive(Debug, Clone, Deserialize)]
+pub struct CompactResponse {
+    /// The compacted output items
+    pub output: Vec<CompactOutputItem>,
+    /// Token usage information
+    pub usage: Option<CompactUsage>,
+}
+
+/// Output item from compact response
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum CompactOutputItem {
+    /// A user message (kept verbatim)
+    #[serde(rename = "message")]
+    Message {
+        role: String,
+        content: CompactContent,
+    },
+    /// An encrypted compaction item
+    #[serde(rename = "compaction")]
+    Compaction {
+        /// Encrypted content that preserves latent context
+        encrypted_content: String,
+    },
+}
+
+/// Token usage from compact response
+#[derive(Debug, Clone, Deserialize)]
+pub struct CompactUsage {
+    /// Input tokens processed
+    pub input_tokens: Option<u32>,
+    /// Output tokens generated
+    pub output_tokens: Option<u32>,
+    /// Total tokens used
+    pub total_tokens: Option<u32>,
 }
 
 // ============================================================================
@@ -1035,5 +1313,168 @@ mod tests {
         let json = serde_json::to_value(&input[2]).unwrap();
         assert_eq!(json["type"], "function_call");
         assert_eq!(json["call_id"], "call_abc");
+    }
+
+    // ========================================================================
+    // Compact endpoint tests
+    // ========================================================================
+
+    #[test]
+    fn test_compact_request_serialization() {
+        let request = CompactRequest {
+            model: "gpt-4o".to_string(),
+            input: vec![
+                CompactInputItem::Message {
+                    role: "user".to_string(),
+                    content: CompactContent::Text("Hello!".to_string()),
+                },
+                CompactInputItem::Message {
+                    role: "assistant".to_string(),
+                    content: CompactContent::Text("Hi there!".to_string()),
+                },
+            ],
+            previous_response_id: None,
+            instructions: Some("Be helpful".to_string()),
+        };
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(json["model"], "gpt-4o");
+        assert_eq!(json["instructions"], "Be helpful");
+        assert!(json["input"].is_array());
+        assert_eq!(json["input"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_compact_input_item_message_serialization() {
+        let item = CompactInputItem::Message {
+            role: "user".to_string(),
+            content: CompactContent::Text("Test message".to_string()),
+        };
+
+        let json = serde_json::to_value(&item).unwrap();
+        assert_eq!(json["type"], "message");
+        assert_eq!(json["role"], "user");
+        assert_eq!(json["content"], "Test message");
+    }
+
+    #[test]
+    fn test_compact_input_item_function_call_serialization() {
+        let item = CompactInputItem::FunctionCall {
+            call_id: "call_123".to_string(),
+            name: "get_weather".to_string(),
+            arguments: r#"{"city":"NYC"}"#.to_string(),
+        };
+
+        let json = serde_json::to_value(&item).unwrap();
+        assert_eq!(json["type"], "function_call");
+        assert_eq!(json["call_id"], "call_123");
+        assert_eq!(json["name"], "get_weather");
+        assert_eq!(json["arguments"], r#"{"city":"NYC"}"#);
+    }
+
+    #[test]
+    fn test_compact_input_item_compaction_serialization() {
+        let item = CompactInputItem::Compaction {
+            encrypted_content: "encrypted_data_here".to_string(),
+        };
+
+        let json = serde_json::to_value(&item).unwrap();
+        assert_eq!(json["type"], "compaction");
+        assert_eq!(json["encrypted_content"], "encrypted_data_here");
+    }
+
+    #[test]
+    fn test_compact_output_item_deserialization() {
+        let json = r#"{
+            "type": "message",
+            "role": "user",
+            "content": "Hello"
+        }"#;
+
+        let item: CompactOutputItem = serde_json::from_str(json).unwrap();
+        match item {
+            CompactOutputItem::Message { role, content } => {
+                assert_eq!(role, "user");
+                match content {
+                    CompactContent::Text(text) => assert_eq!(text, "Hello"),
+                    _ => panic!("Expected text content"),
+                }
+            }
+            _ => panic!("Expected Message item"),
+        }
+    }
+
+    #[test]
+    fn test_compact_output_compaction_deserialization() {
+        let json = r#"{
+            "type": "compaction",
+            "encrypted_content": "abc123encrypted"
+        }"#;
+
+        let item: CompactOutputItem = serde_json::from_str(json).unwrap();
+        match item {
+            CompactOutputItem::Compaction { encrypted_content } => {
+                assert_eq!(encrypted_content, "abc123encrypted");
+            }
+            _ => panic!("Expected Compaction item"),
+        }
+    }
+
+    #[test]
+    fn test_compact_response_deserialization() {
+        let json = r#"{
+            "output": [
+                {"type": "message", "role": "user", "content": "Hello"},
+                {"type": "compaction", "encrypted_content": "xyz789"}
+            ],
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "total_tokens": 150
+            }
+        }"#;
+
+        let response: CompactResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(response.output.len(), 2);
+        assert!(response.usage.is_some());
+        let usage = response.usage.unwrap();
+        assert_eq!(usage.input_tokens, Some(100));
+        assert_eq!(usage.output_tokens, Some(50));
+        assert_eq!(usage.total_tokens, Some(150));
+    }
+
+    #[test]
+    fn test_compact_content_parts_serialization() {
+        let content = CompactContent::Parts(vec![
+            CompactContentPart::InputText {
+                text: "Check this image".to_string(),
+            },
+            CompactContentPart::InputImage {
+                image_url: "data:image/png;base64,abc".to_string(),
+            },
+        ]);
+
+        let json = serde_json::to_value(&content).unwrap();
+        assert!(json.is_array());
+        assert_eq!(json[0]["type"], "input_text");
+        assert_eq!(json[0]["text"], "Check this image");
+        assert_eq!(json[1]["type"], "input_image");
+    }
+
+    #[test]
+    fn test_supports_compact_default_url() {
+        let driver = OpenResponsesProtocolLlmDriver::new("test-key");
+        // Default URL is OpenAI, should support compact
+        assert!(driver.supports_compact());
+    }
+
+    #[test]
+    fn test_supports_compact_custom_url() {
+        let driver = OpenResponsesProtocolLlmDriver::with_base_url(
+            "test-key",
+            "https://custom.api.com/v1/responses",
+        );
+        // Custom URL, compact support unknown
+        assert!(!driver.supports_compact());
     }
 }

--- a/crates/openai/src/driver.rs
+++ b/crates/openai/src/driver.rs
@@ -18,6 +18,7 @@ use everruns_core::llm_driver_registry::{
     BoxedLlmDriver, DiscoveredModel, DriverRegistry, LlmCallConfig, LlmDriver, LlmMessage,
     LlmResponseStream, ProviderType,
 };
+use everruns_core::{CompactRequest, CompactResponse};
 
 use crate::types::OpenAiModelsResponse;
 
@@ -94,6 +95,32 @@ impl OpenAILlmDriver {
     pub fn uses_custom_url(&self) -> bool {
         self.uses_custom_url
     }
+
+    /// Compact a conversation to reduce context size
+    ///
+    /// This method calls the /v1/responses/compact endpoint to compress the conversation
+    /// history. User messages are kept verbatim, while assistant messages, tool calls,
+    /// and tool results are replaced by an encrypted compaction item.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The compact request containing the model and input items
+    ///
+    /// # Returns
+    ///
+    /// Returns a `CompactResponse` containing the compacted output items.
+    /// The output can be used directly as input for the next /v1/responses call.
+    pub async fn compact_conversation(&self, request: CompactRequest) -> Result<CompactResponse> {
+        self.inner.compact(request).await
+    }
+
+    /// Check if this driver supports the compact endpoint
+    ///
+    /// Returns true for OpenAI's Responses API. Custom endpoints may or may not
+    /// support compaction.
+    pub fn can_compact(&self) -> bool {
+        self.inner.supports_compact()
+    }
 }
 
 #[async_trait]
@@ -113,6 +140,14 @@ impl LlmDriver for OpenAILlmDriver {
         }
 
         list_openai_models(self.inner.client(), self.inner.api_key()).await
+    }
+
+    fn supports_compact(&self) -> bool {
+        self.inner.supports_compact()
+    }
+
+    async fn compact(&self, request: CompactRequest) -> Result<Option<CompactResponse>> {
+        Ok(Some(self.inner.compact(request).await?))
     }
 }
 

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -4093,6 +4093,46 @@
           }
         }
       },
+      "LlmCompactionInfo": {
+        "type": "object",
+        "description": "Information about context compaction performed before LLM generation\n\nWhen the conversation context exceeds the model's limit, compaction is\nautomatically triggered to compress the context before retrying.",
+        "required": [
+          "compacted"
+        ],
+        "properties": {
+          "compacted": {
+            "type": "boolean",
+            "description": "Whether compaction was performed"
+          },
+          "duration_ms": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Duration of the compaction operation in milliseconds",
+            "minimum": 0
+          },
+          "input_tokens_after": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Number of input tokens after compaction",
+            "minimum": 0
+          },
+          "input_tokens_before": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Number of input tokens before compaction",
+            "minimum": 0
+          }
+        }
+      },
       "LlmGenerationData": {
         "type": "object",
         "description": "Data for llm.generation event\n\nEmitted after each LLM API call to provide full visibility into\nthe messages sent to the model and the response received.",
@@ -4134,6 +4174,17 @@
           "success"
         ],
         "properties": {
+          "compaction": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/LlmCompactionInfo",
+                "description": "Compaction information if context was compressed before generation\nOccurs when the conversation context exceeded the model's limit"
+              }
+            ]
+          },
           "duration_ms": {
             "type": [
               "integer",

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -295,6 +295,106 @@ pub struct LlmRetryInfo {
 2. **Exponential backoff**: When no `retry-after` header, uses exponential backoff with jitter
 3. **Rate limit type detection**: Distinguishes between request-based and token-based rate limits
 
+## Context Compaction (OpenAI Responses API)
+
+The `/v1/responses/compact` endpoint is a context-compression feature for the OpenAI Responses API. It reduces conversation context size when approaching the model's context window limit.
+
+### How It Works
+
+1. Send the current conversation window (the `input` items from `/v1/responses` calls)
+2. The endpoint returns a compacted window where:
+   - All prior **user messages** are kept verbatim
+   - Prior assistant messages, tool calls/results, and encrypted reasoning are replaced by one encrypted **compaction item**
+3. Use the returned `output` array as the `input` for the next `/v1/responses` call
+
+### LlmDriver Trait Methods
+
+```rust
+#[async_trait]
+pub trait LlmDriver: Send + Sync {
+    // ... existing methods ...
+
+    /// Check if this driver supports the compact endpoint
+    fn supports_compact(&self) -> bool {
+        false // Default: not supported
+    }
+
+    /// Compact a conversation to reduce context size
+    async fn compact(&self, request: CompactRequest) -> Result<Option<CompactResponse>> {
+        Ok(None) // Default: not supported
+    }
+}
+```
+
+### Request Types
+
+```rust
+pub struct CompactRequest {
+    pub model: String,                     // Required
+    pub input: Vec<CompactInputItem>,      // Conversation items
+    pub previous_response_id: Option<String>, // Alternative to input
+    pub instructions: Option<String>,      // Optional system prompt
+}
+
+pub enum CompactInputItem {
+    Message { role: String, content: CompactContent },
+    FunctionCall { call_id: String, name: String, arguments: String },
+    FunctionCallOutput { call_id: String, output: String },
+    Compaction { encrypted_content: String }, // From previous compact
+}
+```
+
+### Response Types
+
+```rust
+pub struct CompactResponse {
+    pub output: Vec<CompactOutputItem>,
+    pub usage: Option<CompactUsage>,
+}
+
+pub enum CompactOutputItem {
+    Message { role: String, content: CompactContent }, // User messages kept
+    Compaction { encrypted_content: String },          // Encrypted context
+}
+```
+
+### Usage Example
+
+```rust
+use everruns_core::{CompactRequest, CompactInputItem, CompactContent};
+
+// Build compact request from conversation history
+let request = CompactRequest {
+    model: "gpt-4o".to_string(),
+    input: vec![
+        CompactInputItem::Message {
+            role: "user".to_string(),
+            content: CompactContent::Text("Hello!".to_string()),
+        },
+        // ... more conversation items
+    ],
+    previous_response_id: None,
+    instructions: None,
+};
+
+// Check if driver supports compact
+if driver.supports_compact() {
+    let response = driver.compact(request).await?;
+    if let Some(compact_response) = response {
+        // Use compact_response.output as input for next /v1/responses call
+    }
+}
+```
+
+### Provider Support
+
+| Provider | Compact Support |
+|----------|----------------|
+| OpenAI (Responses API) | Yes |
+| OpenAI (Completions API) | No |
+| Anthropic | No |
+| LlmSim | No |
+
 ## Testing
 
 1. **Unit Tests**: Each driver MUST have tests for error detection functions


### PR DESCRIPTION
## Summary

- Add support for OpenAI's `/v1/responses/compact` endpoint for context compression
- Implement reactive compaction: automatically compact when `RequestTooLarge` error occurs
- Add `LlmCompactionInfo` to track compaction metadata in events

## Changes

### Compact Endpoint Support
- Add `CompactRequest`, `CompactResponse`, and related types for the compact API
- Add `supports_compact()` and `compact()` methods to `LlmDriver` trait
- Implement compact in `OpenResponsesProtocolLlmDriver` with retry logic

### Reactive Compaction
- Detect `RequestTooLarge` errors in `openresponses_protocol.rs`
- In `ReasonAtom`, catch `RequestTooLarge` and if driver supports compact:
  1. Convert messages to compact input format
  2. Call compact endpoint
  3. Convert compacted output back to messages
  4. Retry LLM call with compacted context
- Track compaction metadata in `llm.generation` event

### Event Tracking
- Add `LlmCompactionInfo` struct with `input_tokens_before`, `input_tokens_after`, `duration_ms`
- Add `compaction` field to `LlmGenerationMetadata`
- Add `with_compaction()` builder method to `LlmGenerationData`

### Conversion Utilities
- `messages_to_compact_input()`: Convert `LlmMessage[]` to `CompactInputItem[]`
- `compact_output_to_messages()`: Convert compact response back to messages

## Test plan

- [x] Unit tests for compact type serialization/deserialization pass
- [x] Unit tests for `supports_compact()` detection pass
- [x] `cargo clippy` passes
- [x] `cargo test -p everruns-core --lib` passes
- [ ] Manual smoke test with long conversation hitting context limit (requires real API)

https://claude.ai/code/session_0116qgXaLM6aj7oRb5hDocQo