### PR TITLE
feat(example): pass through OPENAI/ANTHROPIC API keys to docker compose

### DIFF
--- a/example.just
+++ b/example.just
@@ -10,6 +10,17 @@ start:
         echo "   Stop it first with: just stop-docker"
         exit 1
     fi
+
+    # Pass through API keys from environment if set
+    if [[ -n "${OPENAI_API_KEY:-}" ]]; then
+        echo "✅ OPENAI_API_KEY found, setting DEFAULT_OPENAI_API_KEY"
+        export DEFAULT_OPENAI_API_KEY="$OPENAI_API_KEY"
+    fi
+    if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+        echo "✅ ANTHROPIC_API_KEY found, setting DEFAULT_ANTHROPIC_API_KEY"
+        export DEFAULT_ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY"
+    fi
+
     echo "✅ Local docker compose not running, starting example full stack..."
     cd examples
     docker compose -f docker-compose-full.yaml up -d


### PR DESCRIPTION
## Summary
- When `OPENAI_API_KEY` is set in the environment, passes it through as `DEFAULT_OPENAI_API_KEY` to docker compose
- When `ANTHROPIC_API_KEY` is set in the environment, passes it through as `DEFAULT_ANTHROPIC_API_KEY` to docker compose
- Outputs confirmation to stdout when each key is detected

## Test plan
- [x] Verified script syntax with `just --dry-run example start`
- [x] Tested API key detection logic with mock environment variables
- [x] Confirmed proper output when no keys, one key, or both keys are set

https://claude.ai/code/session_01MdC1ScZavZCaXtX2uYKDM6