### PR TITLE
feat(example): add logs command to listen to docker-compose logs

### DIFF
--- a/example.just
+++ b/example.just
@@ -35,3 +35,7 @@ stop:
 # Reset example docker-compose-full (removes volumes)
 reset:
     cd examples && docker compose -f docker-compose-full.yaml down -v
+
+# Follow logs from example docker-compose-full
+logs *args:
+    cd examples && docker compose -f docker-compose-full.yaml logs -f {{args}}


### PR DESCRIPTION
## Summary
- Adds `just example logs` command to follow docker-compose logs
- Supports optional service name arguments (e.g., `just example logs server`)

## Test plan
- [ ] Run `just example start` to start the example stack
- [ ] Run `just example logs` to verify logs are streamed
- [ ] Run `just example logs server` to verify service filtering works

https://claude.ai/code/session_013uH9K9wCymt7QUu8RFU8mq