### PR TITLE
fix(ui): wrap EventFilter menu content in DropdownMenuGroup

### DIFF
--- a/apps/ui/src/components/events/event-filter.tsx
+++ b/apps/ui/src/components/events/event-filter.tsx
@@ -8,8 +8,8 @@ import {
   DropdownMenuPositioner,
   DropdownMenuContent,
   DropdownMenuCheckboxItem,
+  DropdownMenuGroup,
   DropdownMenuLabel,
-  DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 
@@ -39,14 +39,15 @@ export function EventFilter({
       </DropdownMenuTrigger>
       <DropdownMenuPositioner align="end">
         <DropdownMenuContent className="w-56">
-          <DropdownMenuLabel>Event Filters</DropdownMenuLabel>
-          <DropdownMenuSeparator />
-          <DropdownMenuCheckboxItem
-            checked={hideDeltaEvents}
-            onCheckedChange={onHideDeltaEventsChange}
-          >
-            Hide streaming events
-          </DropdownMenuCheckboxItem>
+          <DropdownMenuGroup>
+            <DropdownMenuLabel>Event Filters</DropdownMenuLabel>
+            <DropdownMenuCheckboxItem
+              checked={hideDeltaEvents}
+              onCheckedChange={onHideDeltaEventsChange}
+            >
+              Hide streaming events
+            </DropdownMenuCheckboxItem>
+          </DropdownMenuGroup>
         </DropdownMenuContent>
       </DropdownMenuPositioner>
     </DropdownMenu>


### PR DESCRIPTION
## Summary
- Fix error when clicking the filter checkbox in Session > Events page
- `DropdownMenuLabel` (wrapping Base UI's `Menu.GroupLabel`) requires a parent `DropdownMenuGroup`
- Follows the same pattern used in `sidebar.tsx` for organization and user menus

## Test plan
- [ ] Navigate to Session > Events page
- [ ] Click the Filter button to open dropdown
- [ ] Click "Hide streaming events" checkbox - should toggle without error
- [ ] Verify filter state persists (events list updates accordingly)

https://claude.ai/code/session_01Vgy2bam4GzywVWTCt1X5yE