### PR TITLE
fix(telemetry): switch from gRPC to HTTP OTLP to fix DNS errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2784,8 +2784,6 @@ dependencies = [
  "prost",
  "reqwest",
  "thiserror 2.0.17",
- "tokio",
- "tonic",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # OpenTelemetry
 opentelemetry = "0.28"
 opentelemetry_sdk = { version = "0.28", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.28", features = ["grpc-tonic"] }
+opentelemetry-otlp = { version = "0.28", features = ["http-proto", "reqwest-client"] }
 tracing-opentelemetry = "0.29"
 
 # OpenAPI documentation

--- a/crates/core/src/telemetry.rs
+++ b/crates/core/src/telemetry.rs
@@ -338,8 +338,9 @@ fn build_otlp_tracer(
     resource: Resource,
 ) -> Result<(SdkTracerProvider, opentelemetry_sdk::trace::Tracer), opentelemetry::trace::TraceError>
 {
+    // Use HTTP OTLP instead of gRPC - more reliable with Docker DNS
     let exporter = SpanExporter::builder()
-        .with_tonic()
+        .with_http()
         .with_endpoint(endpoint)
         .with_timeout(Duration::from_secs(10))
         .build()?;

--- a/examples/docker-compose-full.yaml
+++ b/examples/docker-compose-full.yaml
@@ -62,12 +62,12 @@ services:
       HOST: 0.0.0.0
       PORT: "9000"
       RUST_LOG: info
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4318
     depends_on:
       postgres:
         condition: service_healthy
       jaeger:
-        condition: service_started
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "/app/everruns-server", "--version"]
       interval: 10s
@@ -84,7 +84,7 @@ services:
     environment:
       GRPC_ADDRESS: server:9001
       RUST_LOG: info
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4318
     depends_on:
       server:
         condition: service_started
@@ -96,7 +96,7 @@ services:
     environment:
       GRPC_ADDRESS: server:9001
       RUST_LOG: info
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4318
     depends_on:
       server:
         condition: service_started
@@ -108,7 +108,7 @@ services:
     environment:
       GRPC_ADDRESS: server:9001
       RUST_LOG: info
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4318
     depends_on:
       server:
         condition: service_started
@@ -155,6 +155,12 @@ services:
     expose:
       - "4317"  # OTLP gRPC
       - "4318"  # OTLP HTTP
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z localhost 4318 || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
 
 # ==========================================================================
 # Configs (inline configuration files)


### PR DESCRIPTION
## Summary

- Switch OpenTelemetry OTLP exporter from gRPC (tonic) to HTTP (reqwest) to fix recurring DNS errors in Docker
- gRPC/tonic has DNS caching issues with Docker's internal DNS that cause "dns error" messages
- HTTP OTLP is more reliable since each request does independent DNS resolution

## Changes

- `Cargo.toml`: Change `opentelemetry-otlp` features from `grpc-tonic` to `http-proto`, `reqwest-client`
- `telemetry.rs`: Use `with_http()` instead of `with_tonic()`
- `docker-compose-full.yaml`: 
  - Change OTLP endpoint from port 4317 (gRPC) to 4318 (HTTP)
  - Add Jaeger healthcheck and restart policy for reliability
  - Server now waits for Jaeger to be healthy before starting

## Test plan

- [x] `cargo build` passes
- [x] `cargo clippy` passes  
- [x] Telemetry unit tests pass
- [ ] CI passes
- [ ] Manual test: `just example start` should show no DNS errors

https://claude.ai/code/session_01EDV74d8WdU1zLFmUyvbuWY