### PR TITLE
fix(durable): add index for stale task reclaim query

### DIFF
--- a/crates/server/migrations/002_durable_execution.sql
+++ b/crates/server/migrations/002_durable_execution.sql
@@ -116,9 +116,14 @@ CREATE INDEX idx_durable_task_queue_pending
     ON durable_task_queue(priority DESC, visible_at, activity_type)
     WHERE status = 'pending';
 
--- For heartbeat monitoring
+-- For heartbeat monitoring (worker lookup)
 CREATE INDEX idx_durable_task_queue_claimed
     ON durable_task_queue(claimed_by, heartbeat_at)
+    WHERE status = 'claimed';
+
+-- For stale task reclaiming (heartbeat_at range scan)
+CREATE INDEX idx_durable_task_queue_stale_reclaim
+    ON durable_task_queue(heartbeat_at)
     WHERE status = 'claimed';
 
 -- For workflow-level queries


### PR DESCRIPTION
## What
Add a new partial index `idx_durable_task_queue_stale_reclaim(heartbeat_at)` for efficient stale task reclaiming.

## Why
The `reclaim_stale_tasks` query was slow (>2.6s execution time alert):
```sql
UPDATE durable_task_queue
SET status = 'pending', claimed_by = NULL, claimed_at = NULL
WHERE status = 'claimed' AND heartbeat_at < $1
```

The existing index `idx_durable_task_queue_claimed(claimed_by, heartbeat_at)` has `heartbeat_at` as the second column. Range scans on a non-leading column require scanning all index entries, making the query slow.

## How
Add a new partial index with `heartbeat_at` as the leading column:
```sql
CREATE INDEX idx_durable_task_queue_stale_reclaim
    ON durable_task_queue(heartbeat_at)
    WHERE status = 'claimed';
```

## Risk
- Low
- Index creation is additive, no existing functionality affected
- For production: apply index manually using `CREATE INDEX CONCURRENTLY` for zero-downtime

## Checklist
- [x] Tests added or updated (existing tests cover query behavior)
- [x] Backward compatibility considered (additive change only)

https://claude.ai/code/session_0126mo4ERUPDJv3XsyqfSURc