### PR TITLE
fix(durable): add Resume button for drained workers

### DIFF
--- a/apps/ui/src/app/(main)/durable/workers/page.tsx
+++ b/apps/ui/src/app/(main)/durable/workers/page.tsx
@@ -19,7 +19,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { useWorkers, useDrainWorker } from "@/hooks";
+import { useWorkers, useDrainWorker, useResumeWorker } from "@/hooks";
 import type { DurableWorker, WorkerStatus } from "@/lib/api/types";
 import {
   Server,
@@ -28,6 +28,7 @@ import {
   Clock,
   RefreshCw,
   Pause,
+  Play,
   CheckCircle,
 } from "lucide-react";
 
@@ -89,7 +90,15 @@ function formatDuration(ms: number): string {
   return `${(ms / 60000).toFixed(1)}m`;
 }
 
-function WorkerRow({ worker, onDrain }: { worker: DurableWorker; onDrain: (id: string) => void }) {
+function WorkerRow({
+  worker,
+  onDrain,
+  onResume,
+}: {
+  worker: DurableWorker;
+  onDrain: (id: string) => void;
+  onResume: (id: string) => void;
+}) {
   const loadPercentage = worker.max_concurrency > 0
     ? (worker.current_load / worker.max_concurrency) * 100
     : 0;
@@ -198,6 +207,16 @@ function WorkerRow({ worker, onDrain }: { worker: DurableWorker; onDrain: (id: s
             Drain
           </Button>
         )}
+        {worker.status === "draining" && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onResume(worker.id)}
+          >
+            <Play className="h-3 w-3 mr-1" />
+            Resume
+          </Button>
+        )}
       </TableCell>
     </TableRow>
   );
@@ -206,6 +225,7 @@ function WorkerRow({ worker, onDrain }: { worker: DurableWorker; onDrain: (id: s
 export default function WorkersPage() {
   const { data, isLoading, error, refetch } = useWorkers();
   const drainMutation = useDrainWorker();
+  const resumeMutation = useResumeWorker();
 
   if (isLoading) {
     return (
@@ -288,6 +308,10 @@ export default function WorkersPage() {
     }
   };
 
+  const handleResume = (workerId: string) => {
+    resumeMutation.mutate(workerId);
+  };
+
   return (
     <>
       <Header title="Workers" />
@@ -346,6 +370,7 @@ export default function WorkersPage() {
                         key={worker.id}
                         worker={worker}
                         onDrain={handleDrain}
+                        onResume={handleResume}
                       />
                     ))}
                   </TableBody>

--- a/apps/ui/src/hooks/use-durable.ts
+++ b/apps/ui/src/hooks/use-durable.ts
@@ -7,6 +7,7 @@ import {
   getDurableHealth,
   listWorkers,
   drainWorker,
+  resumeWorker,
   listWorkflows,
   getWorkflow,
   getWorkflowEvents,
@@ -299,6 +300,19 @@ export function useDrainWorker() {
 
   return useMutation({
     mutationFn: (workerId: string) => drainWorker(workerId),
+    onSuccess: () => {
+      // Invalidate to trigger immediate refetch; SSE will update shortly
+      queryClient.invalidateQueries({ queryKey: ["durable", "workers"] });
+      queryClient.invalidateQueries({ queryKey: ["durable", "health"] });
+    },
+  });
+}
+
+export function useResumeWorker() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (workerId: string) => resumeWorker(workerId),
     onSuccess: () => {
       // Invalidate to trigger immediate refetch; SSE will update shortly
       queryClient.invalidateQueries({ queryKey: ["durable", "workers"] });

--- a/apps/ui/src/lib/api/durable.ts
+++ b/apps/ui/src/lib/api/durable.ts
@@ -58,6 +58,10 @@ export async function drainWorker(workerId: string): Promise<void> {
   await api.post(`/v1/durable/workers/${encodeURIComponent(workerId)}/drain`);
 }
 
+export async function resumeWorker(workerId: string): Promise<void> {
+  await api.post(`/v1/durable/workers/${encodeURIComponent(workerId)}/resume`);
+}
+
 // ============================================
 // Workflows
 // ============================================

--- a/crates/durable/src/persistence/postgres.rs
+++ b/crates/durable/src/persistence/postgres.rs
@@ -833,12 +833,17 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
         current_load: usize,
         accepting_tasks: bool,
     ) -> Result<(), StoreError> {
+        // Only update accepting_tasks if worker is NOT draining.
+        // When draining, we preserve accepting_tasks = false set by drain_worker.
         sqlx::query(
             r#"
             UPDATE durable_workers
             SET last_heartbeat_at = NOW(),
                 current_load = $2,
-                accepting_tasks = $3
+                accepting_tasks = CASE
+                    WHEN status = 'draining' THEN false
+                    ELSE $3
+                END
             WHERE id = $1
             "#,
         )
@@ -1521,6 +1526,28 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
         })?;
 
         debug!(worker_id, "drained worker");
+        Ok(())
+    }
+
+    #[instrument(skip(self))]
+    async fn resume_worker(&self, worker_id: &str) -> Result<(), StoreError> {
+        sqlx::query(
+            r#"
+            UPDATE durable_workers
+            SET status = 'active',
+                accepting_tasks = true
+            WHERE id = $1 AND status = 'draining'
+            "#,
+        )
+        .bind(worker_id)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| {
+            error!("Failed to resume worker: {}", e);
+            StoreError::Database(e.to_string())
+        })?;
+
+        debug!(worker_id, "resumed worker");
         Ok(())
     }
 

--- a/crates/durable/src/persistence/store.rs
+++ b/crates/durable/src/persistence/store.rs
@@ -580,6 +580,11 @@ pub trait WorkflowEventStore: Send + Sync + 'static {
         Ok(())
     }
 
+    /// Resume a draining worker (set status back to active, start accepting new tasks)
+    async fn resume_worker(&self, _worker_id: &str) -> Result<(), StoreError> {
+        Ok(())
+    }
+
     /// Get system health summary
     async fn get_system_health(&self) -> Result<SystemHealth, StoreError> {
         Ok(SystemHealth {

--- a/crates/server/src/api/durable.rs
+++ b/crates/server/src/api/durable.rs
@@ -76,6 +76,7 @@ pub fn routes(state: AppState) -> Router {
         // Workers
         .route("/v1/durable/workers", get(list_workers))
         .route("/v1/durable/workers/:worker_id/drain", post(drain_worker))
+        .route("/v1/durable/workers/:worker_id/resume", post(resume_worker))
         // Workflows
         .route("/v1/durable/workflows", get(list_workflows))
         .route("/v1/durable/workflows/:workflow_id", get(get_workflow))
@@ -553,6 +554,37 @@ pub async fn drain_worker(
     let store = state.get_store()?;
     store.drain_worker(&worker_id).await.map_err(|e| {
         tracing::error!("Failed to drain worker: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: "Internal server error".to_string(),
+            }),
+        )
+    })?;
+
+    Ok(StatusCode::OK)
+}
+
+/// POST /v1/durable/workers/:worker_id/resume - Resume a draining worker
+#[utoipa::path(
+    post,
+    path = "/v1/durable/workers/{worker_id}/resume",
+    params(
+        ("worker_id" = String, Path, description = "Worker ID")
+    ),
+    responses(
+        (status = 200, description = "Worker resumed"),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "durable"
+)]
+pub async fn resume_worker(
+    State(state): State<AppState>,
+    Path(worker_id): Path<String>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let store = state.get_store()?;
+    store.resume_worker(&worker_id).await.map_err(|e| {
+        tracing::error!("Failed to resume worker: {}", e);
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse {

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -408,6 +408,8 @@ Administrative endpoints for monitoring and managing the durable execution engin
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/v1/durable/workers` | List registered workers |
+| POST | `/v1/durable/workers/{id}/drain` | Drain worker (stop accepting tasks) |
+| POST | `/v1/durable/workers/{id}/resume` | Resume draining worker |
 | GET | `/v1/durable/workflows` | List workflows |
 | GET | `/v1/durable/workflows/{id}` | Get workflow details |
 | GET | `/v1/durable/workflows/{id}/events` | Get workflow event history |


### PR DESCRIPTION
## Summary

- Fix heartbeat to preserve `accepting_tasks=false` when worker status is 'draining'
- Add `POST /v1/durable/workers/:id/resume` endpoint to resume draining workers
- Add Resume button in UI for workers with status "draining"

## Problem

When clicking the Drain button on a worker:
1. DB sets `status='draining'` and `accepting_tasks=false`
2. Worker's heartbeat loop overwrites `accepting_tasks=true` from local state
3. Status shows "draining" but Accepting shows "Yes" - confusing
4. Drain button disappears (only shows for `status='active'`) with no way to resume

## Solution

1. **Backend**: Heartbeat SQL now preserves `accepting_tasks=false` when status='draining'
2. **API**: New `resume_worker` endpoint sets status back to 'active' and accepting_tasks to true
3. **UI**: Resume button with Play icon appears for draining workers

## Test plan

- [ ] Click Drain on active worker → status changes to "draining", Accepting shows "No"
- [ ] Click Resume on draining worker → status changes to "active", Drain button reappears
- [ ] Worker heartbeats don't reset accepting_tasks while draining

https://claude.ai/code/session_01NFFKho1PgNLZrbst8umtsr