### PR TITLE
fix(examples): docker-compose YAML fixes and add image tag option

### DIFF
--- a/example.just
+++ b/example.just
@@ -1,7 +1,8 @@
 # Example docker-compose commands
 
 # Start example docker-compose-full (checks local compose not running)
-start:
+# Optional: specify image tag (e.g., `just example start v0.1.0`)
+start tag="latest":
     #!/usr/bin/env bash
     set -euo pipefail
     # Check if local docker compose containers are running
@@ -10,6 +11,10 @@ start:
         echo "   Stop it first with: just stop-docker"
         exit 1
     fi
+
+    # Set image tag
+    export EVERRUNS_TAG="{{tag}}"
+    echo "✅ Using image tag: $EVERRUNS_TAG"
 
     # Pass through API keys from environment if set
     if [[ -n "${OPENAI_API_KEY:-}" ]]; then
@@ -41,5 +46,6 @@ logs *args:
     cd examples && docker compose -f docker-compose-full.yaml logs -f {{args}}
 
 # Pull latest images for example docker-compose-full
-pull:
-    cd examples && docker compose -f docker-compose-full.yaml pull
+# Optional: specify image tag (e.g., `just example pull v0.1.0`)
+pull tag="latest":
+    EVERRUNS_TAG={{tag}} && cd examples && docker compose -f docker-compose-full.yaml pull

--- a/examples/docker-compose-full.yaml
+++ b/examples/docker-compose-full.yaml
@@ -52,7 +52,7 @@ services:
   # Note: Migrations are auto-applied on startup
   # ==========================================================================
   server:
-    image: ghcr.io/everruns/everruns-server:latest
+    image: ghcr.io/everruns/everruns-server:${EVERRUNS_TAG:-latest}
     container_name: everruns-server
     environment:
       DATABASE_URL: postgres://everruns:everruns@postgres:5432/everruns
@@ -79,7 +79,7 @@ services:
   # Workers (3 instances for parallel execution)
   # ==========================================================================
   worker-1:
-    image: ghcr.io/everruns/everruns-worker:latest
+    image: ghcr.io/everruns/everruns-worker:${EVERRUNS_TAG:-latest}
     container_name: everruns-worker-1
     environment:
       GRPC_ADDRESS: server:9001
@@ -91,7 +91,7 @@ services:
     restart: unless-stopped
 
   worker-2:
-    image: ghcr.io/everruns/everruns-worker:latest
+    image: ghcr.io/everruns/everruns-worker:${EVERRUNS_TAG:-latest}
     container_name: everruns-worker-2
     environment:
       GRPC_ADDRESS: server:9001
@@ -103,7 +103,7 @@ services:
     restart: unless-stopped
 
   worker-3:
-    image: ghcr.io/everruns/everruns-worker:latest
+    image: ghcr.io/everruns/everruns-worker:${EVERRUNS_TAG:-latest}
     container_name: everruns-worker-3
     environment:
       GRPC_ADDRESS: server:9001
@@ -118,7 +118,7 @@ services:
   # UI (Next.js dashboard)
   # ==========================================================================
   ui:
-    image: ghcr.io/everruns/everruns-ui:latest
+    image: ghcr.io/everruns/everruns-ui:${EVERRUNS_TAG:-latest}
     container_name: everruns-ui
     environment:
       PORT: "9100"

--- a/examples/docker-compose-full.yaml
+++ b/examples/docker-compose-full.yaml
@@ -150,11 +150,11 @@ services:
     image: jaegertracing/jaeger:2.4.0
     container_name: everruns-jaeger
     ports:
-      - "16686:16686"  # Jaeger UI
+      - "16686:16686" # Jaeger UI
     # OTLP ports exposed only to internal network
     expose:
-      - "4317"  # OTLP gRPC
-      - "4318"  # OTLP HTTP
+      - "4317" # OTLP gRPC
+      - "4318" # OTLP HTTP
     healthcheck:
       test: ["CMD-SHELL", "nc -z localhost 4318 || exit 1"]
       interval: 5s


### PR DESCRIPTION
## Summary

- Fix YAML parsing error by using single space before inline comments (some parsers fail with double spaces)
- Add optional `tag` argument to `just example start` and `just example pull` for specifying image versions

## Usage

```bash
just example start           # uses latest (default)
just example start v0.1.0    # uses v0.1.0 tag
just example pull v0.1.0     # pulls v0.1.0 images
```

## Test plan

- [x] YAML validates with Python PyYAML, ruamel.yaml, Go yaml.v3, and compose-go
- [ ] CI passes
- [ ] `just example start` works with default tag
- [ ] `just example start <tag>` works with custom tag

https://claude.ai/code/session_01BJf2HS6wHhjsofN26Wg1iT