### PR TITLE
fix(durable): populate worker stats in API response

### DIFF
--- a/crates/durable/src/persistence/postgres.rs
+++ b/crates/durable/src/persistence/postgres.rs
@@ -863,13 +863,29 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
     #[instrument(skip(self))]
     async fn list_workers(&self, filter: WorkerFilter) -> Result<Vec<WorkerInfo>, StoreError> {
         // Only show workers with recent heartbeat (within 60 seconds)
+        // Join with task queue to compute completed/failed counts
         let query = r#"
-            SELECT id, worker_group, activity_types, max_concurrency, current_load,
-                   status, started_at, last_heartbeat_at, accepting_tasks
-            FROM durable_workers
-            WHERE last_heartbeat_at > NOW() - INTERVAL '60 seconds'
-              AND ($1::text IS NULL OR status = $1)
-              AND ($2::text IS NULL OR worker_group = $2)
+            SELECT w.id, w.worker_group, w.activity_types, w.max_concurrency, w.current_load,
+                   w.status, w.started_at, w.last_heartbeat_at, w.accepting_tasks,
+                   w.backpressure_reason, w.hostname, w.version, w.metadata,
+                   COALESCE(stats.tasks_completed, 0) AS tasks_completed,
+                   COALESCE(stats.tasks_failed, 0) AS tasks_failed,
+                   stats.avg_task_duration_ms
+            FROM durable_workers w
+            LEFT JOIN (
+                SELECT claimed_by,
+                       COUNT(*) FILTER (WHERE status = 'completed') AS tasks_completed,
+                       COUNT(*) FILTER (WHERE status IN ('failed', 'dead')) AS tasks_failed,
+                       AVG(EXTRACT(EPOCH FROM (heartbeat_at - claimed_at)) * 1000)
+                           FILTER (WHERE status = 'completed' AND claimed_at IS NOT NULL AND heartbeat_at IS NOT NULL)
+                           AS avg_task_duration_ms
+                FROM durable_task_queue
+                WHERE claimed_by IS NOT NULL
+                GROUP BY claimed_by
+            ) stats ON stats.claimed_by = w.id
+            WHERE w.last_heartbeat_at > NOW() - INTERVAL '60 seconds'
+              AND ($1::text IS NULL OR w.status = $1)
+              AND ($2::text IS NULL OR w.worker_group = $2)
             "#;
 
         let rows = sqlx::query(query)
@@ -892,8 +908,17 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
                 current_load: row.get::<i32, _>("current_load") as u32,
                 status: row.get("status"),
                 accepting_tasks: row.get("accepting_tasks"),
+                backpressure_reason: row.get("backpressure_reason"),
                 started_at: row.get("started_at"),
                 last_heartbeat_at: row.get("last_heartbeat_at"),
+                hostname: row.get("hostname"),
+                version: row.get("version"),
+                metadata: row.get("metadata"),
+                tasks_completed: row.get::<i64, _>("tasks_completed") as u64,
+                tasks_failed: row.get::<i64, _>("tasks_failed") as u64,
+                avg_task_duration_ms: row
+                    .get::<Option<f64>, _>("avg_task_duration_ms")
+                    .map(|v| v as u64),
             })
             .collect();
 

--- a/crates/durable/src/persistence/store.rs
+++ b/crates/durable/src/persistence/store.rs
@@ -259,8 +259,18 @@ pub struct WorkerInfo {
     pub current_load: u32,
     pub status: String,
     pub accepting_tasks: bool,
+    pub backpressure_reason: Option<String>,
     pub started_at: DateTime<Utc>,
     pub last_heartbeat_at: DateTime<Utc>,
+    pub hostname: Option<String>,
+    pub version: Option<String>,
+    pub metadata: Option<serde_json::Value>,
+    /// Total tasks completed by this worker
+    pub tasks_completed: u64,
+    /// Total tasks failed by this worker
+    pub tasks_failed: u64,
+    /// Average task duration in milliseconds
+    pub avg_task_duration_ms: Option<u64>,
 }
 
 /// Filter for listing DLQ entries

--- a/crates/durable/src/worker/pool.rs
+++ b/crates/durable/src/worker/pool.rs
@@ -365,8 +365,15 @@ impl WorkerPool {
             current_load: 0,
             status: "active".to_string(),
             accepting_tasks: true,
+            backpressure_reason: None,
             started_at: Utc::now(),
             last_heartbeat_at: Utc::now(),
+            hostname: None,
+            version: None,
+            metadata: None,
+            tasks_completed: 0,
+            tasks_failed: 0,
+            avg_task_duration_ms: None,
         };
 
         self.store.register_worker(worker_info).await?;

--- a/crates/durable/tests/postgres_integration_test.rs
+++ b/crates/durable/tests/postgres_integration_test.rs
@@ -704,8 +704,15 @@ async fn test_worker_registration() {
             current_load: 0,
             status: "active".to_string(),
             accepting_tasks: true,
+            backpressure_reason: None,
             started_at: Utc::now(),
             last_heartbeat_at: Utc::now(),
+            hostname: None,
+            version: None,
+            metadata: None,
+            tasks_completed: 0,
+            tasks_failed: 0,
+            avg_task_duration_ms: None,
         })
         .await
         .unwrap();

--- a/crates/server/src/api/durable.rs
+++ b/crates/server/src/api/durable.rs
@@ -183,8 +183,23 @@ pub struct WorkerResponse {
     pub current_load: u32,
     pub status: String,
     pub accepting_tasks: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub backpressure_reason: Option<String>,
     pub started_at: DateTime<Utc>,
     pub last_heartbeat_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hostname: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+    /// Total tasks completed by this worker
+    pub tasks_completed: u64,
+    /// Total tasks failed by this worker
+    pub tasks_failed: u64,
+    /// Average task duration in milliseconds
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub avg_task_duration_ms: Option<u64>,
 }
 
 impl From<WorkerInfo> for WorkerResponse {
@@ -197,8 +212,15 @@ impl From<WorkerInfo> for WorkerResponse {
             current_load: w.current_load,
             status: w.status,
             accepting_tasks: w.accepting_tasks,
+            backpressure_reason: w.backpressure_reason,
             started_at: w.started_at,
             last_heartbeat_at: w.last_heartbeat_at,
+            hostname: w.hostname,
+            version: w.version,
+            metadata: w.metadata,
+            tasks_completed: w.tasks_completed,
+            tasks_failed: w.tasks_failed,
+            avg_task_duration_ms: w.avg_task_duration_ms,
         }
     }
 }

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -1499,8 +1499,15 @@ impl WorkerService for WorkerServiceImpl {
             current_load: 0,
             status: "active".to_string(),
             accepting_tasks: true,
+            backpressure_reason: None,
             started_at: chrono::Utc::now(),
             last_heartbeat_at: chrono::Utc::now(),
+            hostname: None,
+            version: None,
+            metadata: None,
+            tasks_completed: 0,
+            tasks_failed: 0,
+            avg_task_duration_ms: None,
         };
 
         store.register_worker(worker_info).await.map_err(|e| {

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -180,8 +180,15 @@ where
             current_load: 0,
             status: "active".to_string(),
             accepting_tasks: true,
+            backpressure_reason: None,
             started_at: chrono::Utc::now(),
             last_heartbeat_at: chrono::Utc::now(),
+            hostname: None,
+            version: None,
+            metadata: None,
+            tasks_completed: 0,
+            tasks_failed: 0,
+            avg_task_duration_ms: None,
         };
         if let Err(e) = self.store.register_worker(worker_info).await {
             warn!(error = %e, "Failed to register worker (will continue anyway)");


### PR DESCRIPTION
## Summary

- Fix "Completed" counter always showing 0 in durable workers UI
- Add missing fields to API response: `tasks_completed`, `tasks_failed`, `avg_task_duration_ms`
- Also add `hostname`, `version`, `metadata`, `backpressure_reason` which exist in DB but weren't returned

## Test plan

- [ ] Start server in full mode with PostgreSQL
- [ ] Navigate to Durable > Workers page
- [ ] Run some workflows that complete/fail
- [ ] Verify completed/failed counts appear correctly
- [ ] Verify avg_task_duration shows realistic values

https://claude.ai/code/session_01EQL5JE37pYW82za6z9aJj4