### PR TITLE
fix(example): export EVERRUNS_TAG in pull recipe

### DIFF
--- a/example.just
+++ b/example.just
@@ -48,4 +48,4 @@ logs *args:
 # Pull latest images for example docker-compose-full
 # Optional: specify image tag (e.g., `just example pull v0.1.0`)
 pull tag="latest":
-    EVERRUNS_TAG={{tag}} && cd examples && docker compose -f docker-compose-full.yaml pull
+    export EVERRUNS_TAG={{tag}} && cd examples && docker compose -f docker-compose-full.yaml pull


### PR DESCRIPTION
## Summary

- Fix `just example pull <tag>` not passing the tag to docker-compose
- Add `export` to make `EVERRUNS_TAG` available to child processes

**Root cause**: The pull recipe set `EVERRUNS_TAG={{tag}}` without exporting, so docker-compose couldn't see it and defaulted to `:latest`.

## Test plan

- [ ] Run `just example pull v0.1.0` and verify images are pulled with `:v0.1.0` tag (not `:latest`)

https://claude.ai/code/session_012sqJZZgWXfNG2vLsHEa83r