### PR TITLE
fix(ui): remove redundant refresh button from Worker Pool page

### DIFF
--- a/apps/ui/src/app/(main)/durable/workers/page.tsx
+++ b/apps/ui/src/app/(main)/durable/workers/page.tsx
@@ -321,15 +321,9 @@ export default function WorkersPage() {
 
         {/* Workers Table */}
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between">
-            <div>
-              <CardTitle>Worker Pool</CardTitle>
-              <CardDescription>All registered workers and their current status</CardDescription>
-            </div>
-            <Button variant="outline" size="sm" onClick={() => refetch()}>
-              <RefreshCw className="h-4 w-4 mr-2" />
-              Refresh
-            </Button>
+          <CardHeader>
+            <CardTitle>Worker Pool</CardTitle>
+            <CardDescription>All registered workers and their current status</CardDescription>
           </CardHeader>
           <CardContent>
             {workers.length > 0 ? (


### PR DESCRIPTION
## Summary
- Remove manual refresh button from Worker Pool page since SSE provides real-time updates
- The page uses `useDurableSSE()` in the durable layout which streams worker state updates
- Keeps retry button in error state for recovering from initial load failures

## Test plan
- [ ] Navigate to Worker Pool page (`/durable/workers`)
- [ ] Verify refresh button is no longer present in the table header
- [ ] Verify worker data still updates in real-time via SSE
- [ ] Verify retry button still works when backend is unavailable

https://claude.ai/code/session_0181mMytLLCaFHHFFK5Tg53L