### PR TITLE
fix(ci): fix release workflow syntax and add manual trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     # Only run if commit message matches release pattern
-    if: ${{ startsWith(github.event.head_commit.message, 'chore(release): prepare v') }}
+    if: startsWith(github.event.head_commit.message, 'chore(release): prepare v')
 
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g., 0.5.0)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -11,8 +17,8 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    # Only run if commit message matches release pattern
-    if: startsWith(github.event.head_commit.message, 'chore(release): prepare v')
+    # Run if commit message matches release pattern OR manual trigger
+    if: startsWith(github.event.head_commit.message, 'chore(release): prepare v') || github.event_name == 'workflow_dispatch'
 
     permissions:
       contents: write
@@ -23,13 +29,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Extract version from commit message
+      - name: Extract version from commit message or input
         id: version
         run: |
-          # Extract version from commit message like "chore(release): prepare v0.4.0"
-          VERSION=$(echo "${{ github.event.head_commit.message }}" | grep -oP 'prepare v\K[0-9]+\.[0-9]+\.[0-9]+')
+          # Use input version if manual trigger, otherwise extract from commit message
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            # Extract version from commit message like "chore(release): prepare v0.4.0"
+            VERSION=$(echo "${{ github.event.head_commit.message }}" | grep -oP 'prepare v\K[0-9]+\.[0-9]+\.[0-9]+')
+          fi
           if [ -z "$VERSION" ]; then
-            echo "::error::Could not extract version from commit message"
+            echo "::error::Could not extract version from commit message or input"
             exit 1
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -20,8 +20,8 @@ This specification defines the release process for Everruns. The process is desi
 1. CHANGELOG.md is the canonical source for release notes
 2. GitHub Release notes are extracted from the corresponding version section in CHANGELOG.md
 3. Each version section includes:
-   - **Highlights** - Key features (user-written, 3-5 items)
-   - **What's Changed** - List of commits with markdown links: `- <message> ([#PR](url)) by [@user](url))`
+   - **Highlights** - Key features (user-written, 5-10 items with PR links)
+   - **What's Changed** - List of commits: `- <message> ([#PR](url))`
    - **Migration Notes** - Breaking changes or upgrade instructions (if needed)
 
 ### Version Updates
@@ -46,6 +46,15 @@ This ensures lock files reflect the current version and any dependency updates.
 Release commits use: `chore(release): prepare vX.Y.Z`
 
 This commit message triggers the auto-tagging workflow on merge to main.
+
+### Manual Release Trigger
+
+If the automatic release workflow fails, you can manually trigger it:
+1. Go to **Actions → Release → Run workflow**
+2. Enter the version number (e.g., `0.5.0`)
+3. Click **Run workflow**
+
+The workflow will extract release notes from CHANGELOG.md and create the GitHub Release.
 
 ### GitHub Release
 


### PR DESCRIPTION
## Summary

- Fix YAML syntax error: remove redundant `${{ }}` wrapper from `if` condition
- Add `workflow_dispatch` trigger with version input for manual releases
- Update release-process.md spec with manual trigger docs and clarified format

## Test plan

- [ ] CI passes
- [ ] Verify workflow can be triggered manually from Actions tab

https://claude.ai/code/session_01BPpPznrxe6NDiNp1spiakm