### PR TITLE
fix(example): distinguish local vs example compose containers

### DIFF
--- a/example.just
+++ b/example.just
@@ -5,9 +5,12 @@
 start tag="latest":
     #!/usr/bin/env bash
     set -euo pipefail
-    # Check if local docker compose containers are running
-    if docker ps --format '{{"{{"}}.Names{{"}}"}}' 2>/dev/null | grep -q '^everruns-postgres$\|^everruns-jaeger$'; then
-        echo "❌ Local docker compose appears to be running (found everruns-postgres or everruns-jaeger)."
+    # Check if local docker compose containers are running (not from example compose)
+    # We check the com.docker.compose.project label to distinguish local vs example containers
+    local_postgres=$(docker ps --filter "name=^everruns-postgres$" --filter "label=com.docker.compose.project=local" --format '{{"{{"}}.Names{{"}}"}}' 2>/dev/null || true)
+    local_jaeger=$(docker ps --filter "name=^everruns-jaeger$" --filter "label=com.docker.compose.project=local" --format '{{"{{"}}.Names{{"}}"}}' 2>/dev/null || true)
+    if [[ -n "$local_postgres" || -n "$local_jaeger" ]]; then
+        echo "❌ Local docker compose appears to be running (found containers from 'local' project)."
         echo "   Stop it first with: just stop-docker"
         exit 1
     fi


### PR DESCRIPTION
## Summary
- Fix `just example start` failing when example stack is already running
- Use Docker's `com.docker.compose.project` label to distinguish containers from `local` vs `examples` compose
- Only block startup when containers from `local` project are running

## Test plan
- [ ] Run `just example start` twice - second run should not fail
- [ ] Start local compose (`just start-docker`), then `just example start` - should fail with helpful message
- [ ] Stop local compose, then `just example start` - should succeed

https://claude.ai/code/session_01QnGgyNy6wLgMts2DRjhqYv