### PR TITLE
chore(deps): update bashkit to v0.1.1 and use dynamic tool config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,8 +420,8 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.1.0"
-source = "git+https://github.com/everruns/bashkit?tag=v0.1.0#e91d635a3276662694dd0a26151a78c68c9f7732"
+version = "0.1.1"
+source = "git+https://github.com/everruns/bashkit?tag=v0.1.1#9159db168bbbc249b542d33c5ce71dddb62178d8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -433,6 +433,7 @@ dependencies = [
  "jaq-json",
  "jaq-std",
  "regex",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1492,7 +1493,7 @@ dependencies = [
  "bytes",
  "futures",
  "reqwest 0.13.1",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -3784,6 +3785,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4139,7 +4160,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
- "schemars_derive",
+ "schemars_derive 0.8.22",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -4149,6 +4183,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -53,7 +53,7 @@ url = "2"
 fetchkit = { git = "https://github.com/everruns/fetchkit" }
 
 # Sandboxed bash interpreter
-bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.1.0" }
+bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.1.1" }
 
 # OpenAPI schema generation (optional, enabled by everruns-server)
 utoipa = { workspace = true, optional = true }

--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -17,11 +17,48 @@ use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::{SessionFileStore, ToolContext};
 use crate::typed_id::SessionId;
 use async_trait::async_trait;
-use bashkit::{Bash, DirEntry, ExecutionLimits, FileSystem, FileType, Metadata};
+use bashkit::{
+    Bash, BashTool as BashkitTool, DirEntry, ExecutionLimits, FileSystem, FileType, Metadata,
+    Tool as BashkitToolTrait,
+};
 use serde_json::{Value, json};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::time::SystemTime;
+
+// ============================================================================
+// Static configuration
+// ============================================================================
+
+/// Shared execution limits for bashkit.
+fn execution_limits() -> ExecutionLimits {
+    ExecutionLimits::new()
+        .max_commands(1000)
+        .max_loop_iterations(10000)
+        .max_function_depth(100)
+        .max_input_bytes(1_000_000) // 1MB max script size
+        .max_ast_depth(100)
+        .parser_timeout(std::time::Duration::from_secs(5))
+}
+
+/// Configured bashkit tool instance with everruns settings.
+static BASHKIT_TOOL: LazyLock<BashkitTool> = LazyLock::new(|| {
+    BashkitTool::builder()
+        .username("everruns")
+        .hostname("everruns")
+        .limits(execution_limits())
+        .env("HOME", "/home/agent")
+        .env("SHELL", "/bin/bash")
+        .env("PATH", "/usr/local/bin:/usr/bin:/bin")
+        .env("WORKSPACE", "/workspace")
+        .build()
+});
+
+/// Tool description from bashkit library.
+static TOOL_DESCRIPTION: LazyLock<String> = LazyLock::new(|| BASHKIT_TOOL.description());
+
+/// System prompt addition from bashkit library.
+static TOOL_SYSTEM_PROMPT: LazyLock<String> = LazyLock::new(|| BASHKIT_TOOL.system_prompt());
 
 /// Virtual Bash capability - execute bash commands in a sandboxed environment
 pub struct VirtualBashCapability;
@@ -60,48 +97,7 @@ impl Capability for VirtualBashCapability {
     }
 
     fn system_prompt_addition(&self) -> Option<&str> {
-        Some(
-            r#"You have access to a virtual bash shell that executes commands in an isolated environment.
-
-## Bash Tool
-
-Use the `bash` tool to execute shell commands. The environment includes:
-
-**Built-in Commands:**
-- File operations: `cat`, `ls`, `cp`, `mv`, `rm`, `mkdir`, `touch`
-- Text processing: `echo`, `printf`, `grep`, `sed`, `awk`, `jq`
-- Control flow: `if/else`, `for`, `while`, `case`
-- Variables: `export`, `set`, `unset`, `local`
-- Other: `cd`, `pwd`, `test`, `[`, `true`, `false`, `exit`, `source`
-
-**Shell Features:**
-- Pipes: `cmd1 | cmd2`
-- Redirections: `>`, `>>`, `<`, `<<<`
-- Command substitution: `$(cmd)`
-- Arithmetic: `$((1 + 2))`
-- Parameter expansion: `$VAR`, `${VAR:-default}`, `${#VAR}`
-- Glob patterns: `*.txt`, `**/*.rs`
-- Here documents: `<<EOF ... EOF`
-
-**Workspace:**
-- Session data is mounted at `/workspace`
-- Files you create with `write_file` are accessible in bash at `/workspace`
-- Files created in bash under `/workspace` are accessible via `read_file`
-- Working directory starts at `/workspace`
-- HOME is set to `/home/agent`
-
-**Limits:**
-- Maximum 1000 commands per execution
-- Maximum 10000 loop iterations
-- Maximum 100 function call depth
-- Maximum 1MB input script size
-- Parser timeout: 5 seconds
-
-**Best Practices:**
-- Use bash for complex text processing and file manipulation
-- Combine multiple operations with pipes for efficiency
-- Check exit codes for error handling: `cmd && echo "success" || echo "failed"`"#,
-        )
+        Some(&TOOL_SYSTEM_PROMPT)
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
@@ -128,7 +124,7 @@ impl Tool for BashTool {
     }
 
     fn description(&self) -> &str {
-        "Execute a bash command in a sandboxed environment. The session filesystem is mounted at root."
+        &TOOL_DESCRIPTION
     }
 
     fn parameters_schema(&self) -> Value {
@@ -197,16 +193,7 @@ impl Tool for BashTool {
             file_store,
         ));
 
-        // Configure bash with resource limits
-        // Security limits added in bashkit 0.1.0: parser_timeout, max_input_bytes, max_ast_depth
-        let limits = ExecutionLimits::new()
-            .max_commands(1000)
-            .max_loop_iterations(10000)
-            .max_function_depth(100)
-            .max_input_bytes(1_000_000) // 1MB max script size
-            .max_ast_depth(100)
-            .parser_timeout(std::time::Duration::from_secs(5));
-
+        // Configure bash with resource limits (uses shared execution_limits)
         let mut bash = Bash::builder()
             .fs(session_fs)
             .cwd(working_dir)
@@ -216,7 +203,7 @@ impl Tool for BashTool {
             .env("SHELL", "/bin/bash")
             .env("PATH", "/usr/local/bin:/usr/bin:/bin")
             .env("WORKSPACE", "/workspace")
-            .limits(limits)
+            .limits(execution_limits())
             .build();
 
         // Execute with timeout
@@ -805,9 +792,13 @@ mod tests {
     fn test_capability_has_system_prompt() {
         let cap = VirtualBashCapability;
         let prompt = cap.system_prompt_addition().unwrap();
-        assert!(prompt.contains("bash"));
-        assert!(prompt.contains("pipes"));
-        assert!(prompt.contains("/workspace"));
+        // System prompt is now provided by bashkit library
+        assert!(!prompt.is_empty(), "System prompt should not be empty");
+        // Should contain the configured username/hostname
+        assert!(
+            prompt.contains("everruns"),
+            "System prompt should contain configured identity"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What
- Updated bashkit dependency from v0.1.0 to v0.1.1
- Refactored virtual bash capability to use bashkit's dynamic description and system prompt

## Why
- Bashkit v0.1.1 provides `Tool` trait with `description()` and `system_prompt()` methods
- Eliminates ~40 lines of hardcoded system prompt text
- Centralizes tool configuration for consistency

## How
- Added `execution_limits()` function for shared limit configuration (was duplicated)
- Created static `BASHKIT_TOOL` configured with everruns settings
- `TOOL_DESCRIPTION` and `TOOL_SYSTEM_PROMPT` lazily initialized from bashkit
- `BashTool::description()` now returns `&TOOL_DESCRIPTION`
- `VirtualBashCapability::system_prompt_addition()` now returns `&TOOL_SYSTEM_PROMPT`

## Risk
- Low
- Changes are internal refactoring with no API changes
- All 44 virtual_bash tests pass

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (no API changes)

https://claude.ai/code/session_01FUDQS1VHM7C1TyCT9hMmPd