### PR TITLE
chore(agents): clarify commit type for specs and AGENTS.md updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,8 @@ just --list             # All commands
 
 Types: feat, fix, docs, refactor, test, chore
 
+Use `chore` for updates to `specs/` and `AGENTS.md`.
+
 ### PRs
 
 **REQUIRED:** Use `.github/pull_request_template.md`. Squash and Merge.


### PR DESCRIPTION
## What
Add guidance that updates to `specs/` and `AGENTS.md` should use `chore` commit type.

## Why
Clarify commit conventions for documentation/spec changes.

## How
Add one line to Commits section in AGENTS.md.

## Risk
- Low
- Documentation only

## Checklist
- [x] Tests added or updated (N/A - docs only)
- [x] Backward compatibility considered (N/A)

https://claude.ai/code/session_01X1sF8B1WrbzRbfKSf742tj