### PR TITLE
feat(ui): improve Workspace breadcrumbs visibility

### DIFF
--- a/apps/ui/src/__tests__/file-browser.test.tsx
+++ b/apps/ui/src/__tests__/file-browser.test.tsx
@@ -253,7 +253,7 @@ describe("FileBrowser Breadcrumbs", () => {
 
       const breadcrumbBar = screen.getByText("workspace").closest("div");
       expect(breadcrumbBar).toHaveClass("px-2");
-      expect(breadcrumbBar).toHaveClass("py-1.5");
+      expect(breadcrumbBar).toHaveClass("py-1");
     });
   });
 });

--- a/apps/ui/src/__tests__/file-browser.test.tsx
+++ b/apps/ui/src/__tests__/file-browser.test.tsx
@@ -1,0 +1,441 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+// Mock lucide-react icons
+jest.mock("lucide-react", () => ({
+  Folder: () => <span data-testid="folder-icon" />,
+  ChevronRight: () => <span data-testid="chevron-right" />,
+  ChevronDown: () => <span data-testid="chevron-down" />,
+  Plus: () => <span data-testid="plus-icon" />,
+  FolderPlus: () => <span data-testid="folder-plus-icon" />,
+  Trash2: () => <span data-testid="trash-icon" />,
+  RefreshCw: () => <span data-testid="refresh-icon" />,
+  Home: () => <span data-testid="home-icon" />,
+  Lock: () => <span data-testid="lock-icon" />,
+}));
+
+// Mock the file hooks
+const mockRefetch = jest.fn();
+jest.mock("@/hooks/use-session-files", () => ({
+  useFiles: jest.fn(() => ({
+    data: [],
+    isLoading: false,
+    refetch: mockRefetch,
+  })),
+  useCreateFile: jest.fn(() => ({ mutateAsync: jest.fn() })),
+  useCreateDirectory: jest.fn(() => ({ mutateAsync: jest.fn() })),
+  useDeleteFile: jest.fn(() => ({ mutateAsync: jest.fn() })),
+}));
+
+// Mock the session-files utilities
+jest.mock("@/lib/api/session-files", () => ({
+  formatFileSize: (bytes: number) => `${bytes} B`,
+  getParentPath: (path: string) => {
+    const parts = path.split("/").filter(Boolean);
+    if (parts.length <= 1) return null;
+    return "/" + parts.slice(0, -1).join("/");
+  },
+  joinPath: (base: string, name: string) => `${base}/${name}`,
+}));
+
+// Mock FileIcon
+jest.mock("@/components/files/file-icon", () => ({
+  FileIcon: () => <span data-testid="file-icon" />,
+}));
+
+import { FileBrowser } from "@/components/files/file-browser";
+import { useFiles } from "@/hooks/use-session-files";
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  const queryClient = createQueryClient();
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+};
+
+// ============================================
+// Breadcrumbs Tests
+// ============================================
+
+describe("FileBrowser Breadcrumbs", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("root level display", () => {
+    it("shows 'workspace' label when at root", () => {
+      renderWithProviders(<FileBrowser sessionId="test-session" />);
+
+      expect(screen.getByText("workspace")).toBeInTheDocument();
+    });
+
+    it("shows home button at root", () => {
+      renderWithProviders(<FileBrowser sessionId="test-session" />);
+
+      const homeButton = screen.getByTitle("Go to workspace root");
+      expect(homeButton).toBeInTheDocument();
+    });
+
+    it("shows slash separator after home button", () => {
+      renderWithProviders(<FileBrowser sessionId="test-session" />);
+
+      expect(screen.getByText("/")).toBeInTheDocument();
+    });
+
+    it("has visible breadcrumb background", () => {
+      renderWithProviders(<FileBrowser sessionId="test-session" />);
+
+      // The breadcrumb bar should have bg-muted/50 class for visibility
+      const breadcrumbBar = screen.getByText("workspace").closest("div");
+      expect(breadcrumbBar).toHaveClass("bg-muted/50");
+    });
+  });
+
+  describe("nested folder navigation", () => {
+    const mockFiles = [
+      {
+        id: "1",
+        session_id: "test-session",
+        path: "/workspace/src",
+        name: "src",
+        is_directory: true,
+        is_readonly: false,
+        size_bytes: 0,
+        created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-01T00:00:00Z",
+      },
+    ];
+
+    beforeEach(() => {
+      (useFiles as jest.Mock).mockReturnValue({
+        data: mockFiles,
+        isLoading: false,
+        refetch: mockRefetch,
+      });
+    });
+
+    it("updates breadcrumbs when navigating into a folder", () => {
+      renderWithProviders(<FileBrowser sessionId="test-session" />);
+
+      // Click on the src folder
+      const srcFolder = screen.getByText("src");
+      fireEvent.click(srcFolder);
+
+      // Should now show "src" in breadcrumbs with folder icon
+      const srcBreadcrumb = screen.getAllByText("src")[0]; // First one is in breadcrumbs
+      expect(srcBreadcrumb).toBeInTheDocument();
+    });
+
+    it("shows folder icon next to current folder in breadcrumbs", () => {
+      renderWithProviders(<FileBrowser sessionId="test-session" />);
+
+      // Click into a folder
+      const srcFolder = screen.getByText("src");
+      fireEvent.click(srcFolder);
+
+      // The folder icon should be present in breadcrumbs area
+      const folderIcons = screen.getAllByTestId("folder-icon");
+      expect(folderIcons.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("breadcrumb navigation", () => {
+    it("navigates to root when home button is clicked", () => {
+      // Start with files in a nested directory
+      (useFiles as jest.Mock).mockReturnValue({
+        data: [
+          {
+            id: "1",
+            session_id: "test-session",
+            path: "/workspace/src",
+            name: "src",
+            is_directory: true,
+            is_readonly: false,
+            size_bytes: 0,
+            created_at: "2024-01-01T00:00:00Z",
+            updated_at: "2024-01-01T00:00:00Z",
+          },
+        ],
+        isLoading: false,
+        refetch: mockRefetch,
+      });
+
+      renderWithProviders(<FileBrowser sessionId="test-session" />);
+
+      // Navigate into src
+      const srcFolder = screen.getByText("src");
+      fireEvent.click(srcFolder);
+
+      // Click home button
+      const homeButton = screen.getByTitle("Go to workspace root");
+      fireEvent.click(homeButton);
+
+      // Should show workspace label again
+      expect(screen.getByText("workspace")).toBeInTheDocument();
+    });
+  });
+
+  describe("intermediate breadcrumb segments", () => {
+    it("renders intermediate segments as clickable buttons", () => {
+      // Mock being in a deeply nested folder
+      (useFiles as jest.Mock).mockReturnValue({
+        data: [
+          {
+            id: "1",
+            session_id: "test-session",
+            path: "/workspace/src/components",
+            name: "components",
+            is_directory: true,
+            is_readonly: false,
+            size_bytes: 0,
+            created_at: "2024-01-01T00:00:00Z",
+            updated_at: "2024-01-01T00:00:00Z",
+          },
+        ],
+        isLoading: false,
+        refetch: mockRefetch,
+      });
+
+      renderWithProviders(<FileBrowser sessionId="test-session" />);
+
+      // Navigate into nested folders
+      fireEvent.click(screen.getByText("components"));
+
+      // Now update mock for the new folder
+      (useFiles as jest.Mock).mockReturnValue({
+        data: [
+          {
+            id: "2",
+            session_id: "test-session",
+            path: "/workspace/src/components/ui",
+            name: "ui",
+            is_directory: true,
+            is_readonly: false,
+            size_bytes: 0,
+            created_at: "2024-01-01T00:00:00Z",
+            updated_at: "2024-01-01T00:00:00Z",
+          },
+        ],
+        isLoading: false,
+        refetch: mockRefetch,
+      });
+
+      // The component should re-render with new breadcrumb path
+      // The last segment "components" should have font-medium class
+      const breadcrumbComponents = screen.getAllByText("components")[0];
+      expect(breadcrumbComponents).toBeInTheDocument();
+    });
+  });
+
+  describe("breadcrumb styling", () => {
+    it("has proper text size for visibility", () => {
+      renderWithProviders(<FileBrowser sessionId="test-session" />);
+
+      // Breadcrumb bar should have text-sm class
+      const breadcrumbBar = screen.getByText("workspace").closest("div");
+      expect(breadcrumbBar).toHaveClass("text-sm");
+    });
+
+    it("has rounded corners for modern look", () => {
+      renderWithProviders(<FileBrowser sessionId="test-session" />);
+
+      const breadcrumbBar = screen.getByText("workspace").closest("div");
+      expect(breadcrumbBar).toHaveClass("rounded-md");
+    });
+
+    it("has proper padding for clickable area", () => {
+      renderWithProviders(<FileBrowser sessionId="test-session" />);
+
+      const breadcrumbBar = screen.getByText("workspace").closest("div");
+      expect(breadcrumbBar).toHaveClass("px-2");
+      expect(breadcrumbBar).toHaveClass("py-1.5");
+    });
+  });
+});
+
+// ============================================
+// FileItem Tests
+// ============================================
+
+describe("FileBrowser FileItem", () => {
+  const mockFile = {
+    id: "1",
+    session_id: "test-session",
+    path: "/workspace/test.ts",
+    name: "test.ts",
+    is_directory: false,
+    is_readonly: false,
+    size_bytes: 1024,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+  };
+
+  const mockDirectory = {
+    id: "2",
+    session_id: "test-session",
+    path: "/workspace/src",
+    name: "src",
+    is_directory: true,
+    is_readonly: false,
+    size_bytes: 0,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders file with size badge", () => {
+    (useFiles as jest.Mock).mockReturnValue({
+      data: [mockFile],
+      isLoading: false,
+      refetch: mockRefetch,
+    });
+
+    renderWithProviders(<FileBrowser sessionId="test-session" />);
+
+    expect(screen.getByText("test.ts")).toBeInTheDocument();
+    expect(screen.getByText("1024 B")).toBeInTheDocument();
+  });
+
+  it("renders directory with folder icon", () => {
+    (useFiles as jest.Mock).mockReturnValue({
+      data: [mockDirectory],
+      isLoading: false,
+      refetch: mockRefetch,
+    });
+
+    renderWithProviders(<FileBrowser sessionId="test-session" />);
+
+    expect(screen.getByText("src")).toBeInTheDocument();
+    // Should have folder icons (one in title, potentially others in breadcrumbs/items)
+    const folderIcons = screen.getAllByTestId("folder-icon");
+    expect(folderIcons.length).toBeGreaterThan(0);
+  });
+
+  it("calls onFileSelect when file is clicked", () => {
+    const onFileSelect = jest.fn();
+    (useFiles as jest.Mock).mockReturnValue({
+      data: [mockFile],
+      isLoading: false,
+      refetch: mockRefetch,
+    });
+
+    renderWithProviders(<FileBrowser sessionId="test-session" onFileSelect={onFileSelect} />);
+
+    fireEvent.click(screen.getByText("test.ts"));
+    expect(onFileSelect).toHaveBeenCalledWith(mockFile);
+  });
+
+  it("navigates into directory when clicked", () => {
+    (useFiles as jest.Mock).mockReturnValue({
+      data: [mockDirectory],
+      isLoading: false,
+      refetch: mockRefetch,
+    });
+
+    renderWithProviders(<FileBrowser sessionId="test-session" />);
+
+    fireEvent.click(screen.getByText("src"));
+
+    // After clicking, src should appear in breadcrumbs
+    const srcElements = screen.getAllByText("src");
+    expect(srcElements.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows lock icon for readonly files", () => {
+    const readonlyFile = { ...mockFile, is_readonly: true };
+    (useFiles as jest.Mock).mockReturnValue({
+      data: [readonlyFile],
+      isLoading: false,
+      refetch: mockRefetch,
+    });
+
+    renderWithProviders(<FileBrowser sessionId="test-session" />);
+
+    expect(screen.getByTestId("lock-icon")).toBeInTheDocument();
+  });
+});
+
+// ============================================
+// Loading and Empty States
+// ============================================
+
+describe("FileBrowser States", () => {
+  it("shows loading state", () => {
+    (useFiles as jest.Mock).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      refetch: mockRefetch,
+    });
+
+    renderWithProviders(<FileBrowser sessionId="test-session" />);
+
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+
+  it("shows empty folder message", () => {
+    (useFiles as jest.Mock).mockReturnValue({
+      data: [],
+      isLoading: false,
+      refetch: mockRefetch,
+    });
+
+    renderWithProviders(<FileBrowser sessionId="test-session" />);
+
+    expect(screen.getByText("Empty folder")).toBeInTheDocument();
+  });
+});
+
+// ============================================
+// Parent Directory Navigation
+// ============================================
+
+describe("FileBrowser Parent Navigation", () => {
+  it("shows parent directory (..) link when not at root", () => {
+    (useFiles as jest.Mock).mockReturnValue({
+      data: [
+        {
+          id: "1",
+          session_id: "test-session",
+          path: "/workspace/src",
+          name: "src",
+          is_directory: true,
+          is_readonly: false,
+          size_bytes: 0,
+          created_at: "2024-01-01T00:00:00Z",
+          updated_at: "2024-01-01T00:00:00Z",
+        },
+      ],
+      isLoading: false,
+      refetch: mockRefetch,
+    });
+
+    renderWithProviders(<FileBrowser sessionId="test-session" />);
+
+    // Navigate into src folder
+    fireEvent.click(screen.getByText("src"));
+
+    // Should show ".." for parent navigation
+    expect(screen.getByText("..")).toBeInTheDocument();
+  });
+
+  it("does not show parent directory link at root", () => {
+    (useFiles as jest.Mock).mockReturnValue({
+      data: [],
+      isLoading: false,
+      refetch: mockRefetch,
+    });
+
+    renderWithProviders(<FileBrowser sessionId="test-session" />);
+
+    // At root, ".." should not be present
+    expect(screen.queryByText("..")).not.toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/components/files/file-browser.tsx
+++ b/apps/ui/src/components/files/file-browser.tsx
@@ -232,25 +232,46 @@ export function FileBrowser({ sessionId, onFileSelect, selectedPath }: FileBrows
           </div>
         </div>
         {/* Breadcrumbs */}
-        <div className="flex items-center gap-1 text-xs text-muted-foreground overflow-x-auto">
-          <Button variant="ghost" size="icon" className="h-5 w-5 shrink-0" onClick={navigateHome}>
-            <Home className="h-3 w-3" />
+        <div className="flex items-center gap-1 text-sm bg-muted/50 rounded-md px-2 py-1.5 overflow-x-auto">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6 shrink-0"
+            onClick={navigateHome}
+            title="Go to workspace root"
+          >
+            <Home className="h-4 w-4" />
           </Button>
-          {breadcrumbs.map((crumb, index) => (
-            <span key={crumb} className="flex items-center">
-              <ChevronRight className="h-3 w-3 mx-0.5" />
-              <button
-                type="button"
-                className="hover:text-foreground hover:underline"
-                onClick={() => {
-                  const path = `/workspace/${breadcrumbs.slice(0, index + 1).join("/")}`;
-                  setCurrentPath(path);
-                }}
-              >
-                {crumb}
-              </button>
-            </span>
-          ))}
+          <span className="text-muted-foreground">/</span>
+          {breadcrumbs.length === 0 ? (
+            <span className="font-medium text-foreground">workspace</span>
+          ) : (
+            breadcrumbs.map((crumb, index) => {
+              const isLast = index === breadcrumbs.length - 1;
+              return (
+                <span key={crumb} className="flex items-center">
+                  {index > 0 && <span className="text-muted-foreground mx-1">/</span>}
+                  {isLast ? (
+                    <span className="font-medium text-foreground flex items-center gap-1">
+                      <Folder className="h-3.5 w-3.5 text-blue-500" />
+                      {crumb}
+                    </span>
+                  ) : (
+                    <button
+                      type="button"
+                      className="text-muted-foreground hover:text-foreground hover:underline"
+                      onClick={() => {
+                        const path = `/workspace/${breadcrumbs.slice(0, index + 1).join("/")}`;
+                        setCurrentPath(path);
+                      }}
+                    >
+                      {crumb}
+                    </button>
+                  )}
+                </span>
+              );
+            })
+          )}
         </div>
       </CardHeader>
       <CardContent className="flex-1 p-0 overflow-hidden">

--- a/apps/ui/src/components/files/file-browser.tsx
+++ b/apps/ui/src/components/files/file-browser.tsx
@@ -144,7 +144,7 @@ export function FileBrowser({ sessionId, onFileSelect, selectedPath }: FileBrows
 
   return (
     <Card className="h-full flex flex-col">
-      <CardHeader className="pb-2">
+      <CardHeader className="pb-1">
         <div className="flex items-center justify-between">
           <CardTitle className="text-sm font-medium flex items-center gap-2">
             <Folder className="h-4 w-4" />
@@ -232,7 +232,7 @@ export function FileBrowser({ sessionId, onFileSelect, selectedPath }: FileBrows
           </div>
         </div>
         {/* Breadcrumbs */}
-        <div className="flex items-center gap-1 text-sm bg-muted/50 rounded-md px-2 py-1.5 overflow-x-auto">
+        <div className="flex items-center gap-1 text-sm bg-muted/50 rounded-md px-2 py-1 overflow-x-auto">
           <Button
             variant="ghost"
             size="icon"

--- a/apps/ui/src/components/files/file-browser.tsx
+++ b/apps/ui/src/components/files/file-browser.tsx
@@ -143,7 +143,7 @@ export function FileBrowser({ sessionId, onFileSelect, selectedPath }: FileBrows
   const breadcrumbs = currentPath.split("/").filter(Boolean).slice(1);
 
   return (
-    <Card className="h-full flex flex-col">
+    <Card className="h-full flex flex-col gap-0">
       <CardHeader className="pb-1">
         <div className="flex items-center justify-between">
           <CardTitle className="text-sm font-medium flex items-center gap-2">


### PR DESCRIPTION
## Summary
- Enhanced breadcrumbs bar with visible background (`bg-muted/50`) and rounded corners
- Increased text size from `text-xs` to `text-sm` for better readability
- Current folder now highlighted with bold text and blue folder icon
- Shows "workspace" label when at root level
- Uses `/` separators instead of chevrons for clearer path display
- Reduced spacing between breadcrumbs and file list

## Test plan
- [ ] Navigate to a session's Files/Workspace tab
- [ ] Verify breadcrumbs show "workspace" at root level with visible background
- [ ] Click into nested folders and verify path updates in breadcrumbs
- [ ] Verify current folder shows folder icon and bold text
- [ ] Click intermediate breadcrumb segments to navigate back
- [ ] Click home button to return to workspace root
- [ ] Run `npm test -- --testPathPatterns=file-browser` - all 20 tests pass