### PR TITLE
docs: update editLink baseUrl to blob/main/docs/

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -59,7 +59,7 @@ export default defineConfig({
         ...openAPISidebarGroups,
       ],
       editLink: {
-        baseUrl: "https://github.com/everruns/everruns/edit/main/apps/docs/",
+        baseUrl: "https://github.com/everruns/everruns/blob/main/docs/",
       },
       lastUpdated: true,
     }),


### PR DESCRIPTION
## Summary
- Updates the docs edit link from `edit/main/apps/docs/` to `blob/main/docs/` to point to the correct documentation location

## Test plan
- [ ] Verify edit links in docs point to correct GitHub paths

https://claude.ai/code/session_01WaKjQ99cpEby5xc3a9eQrw