### PR TITLE
fix(ci): suppress 'no jobs were run' notifications in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,28 @@ permissions:
   contents: read
 
 jobs:
-  release:
+  # Check if this is a release commit - always runs to suppress "no jobs ran" notifications
+  check-release:
     runs-on: ubuntu-latest
-    # Run if commit message matches release pattern OR manual trigger
-    if: startsWith(github.event.head_commit.message, 'chore(release): prepare v') || github.event_name == 'workflow_dispatch'
+    outputs:
+      is_release: ${{ steps.check.outputs.is_release }}
+    steps:
+      - name: Check if release commit
+        id: check
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || \
+             [[ "${{ github.event.head_commit.message }}" == chore\(release\):\ prepare\ v* ]]; then
+            echo "is_release=true" >> $GITHUB_OUTPUT
+            echo "This is a release commit, proceeding with release"
+          else
+            echo "is_release=false" >> $GITHUB_OUTPUT
+            echo "Not a release commit, skipping release job"
+          fi
+
+  release:
+    needs: check-release
+    if: needs.check-release.outputs.is_release == 'true'
+    runs-on: ubuntu-latest
 
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Add `check-release` job that always runs to determine if commit is a release commit
- Prevents GitHub from sending "No jobs were run" notifications on regular commits to main

## Test plan

- [x] Workflow syntax is valid
- [ ] CI passes
- [ ] Next push to main shows check-release job running instead of "no jobs ran"