### PR TITLE
feat(session-sqldb): session-scoped SQL databases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ Fix root cause. Unsure: read more code; if stuck, ask w/ short options. Unrecogn
 - `specs/id-schema.md` - Standardized prefixed ID format
 - `specs/braintrust-integration.md` - Braintrust observability
 - `specs/test-cases.md` - Manual test case format
+- `specs/session-sqldb.md` - Session-scoped SQL databases (SQLite over PostgreSQL VFS)
 
 ### Skills
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1158,7 +1170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1379,6 +1391,7 @@ dependencies = [
  "everruns-core",
  "everruns-durable",
  "everruns-internal-protocol",
+ "everruns-session-sqldb",
  "everruns-worker",
  "futures",
  "hex",
@@ -1406,6 +1419,25 @@ dependencies = [
  "tracing-subscriber",
  "utoipa",
  "utoipa-swagger-ui",
+ "uuid",
+]
+
+[[package]]
+name = "everruns-session-sqldb"
+version = "0.5.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "everruns-core",
+ "parking_lot",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
  "uuid",
 ]
 
@@ -1447,6 +1479,18 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
@@ -1812,6 +1856,9 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1833,6 +1880,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2816,7 +2872,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3594,7 +3650,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3980,6 +4036,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.10.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink 0.9.1",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4044,7 +4114,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4102,7 +4172,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4533,7 +4603,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hashbrown 0.15.5",
- "hashlink",
+ "hashlink 0.10.0",
  "indexmap",
  "log",
  "memchr",
@@ -4843,7 +4913,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5871,7 +5941,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/internal-protocol",
     "crates/cli",
     "crates/durable",
+    "crates/session-sqldb",
 ]
 
 [workspace.package]

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -107,6 +107,8 @@ where
     event_emitter: E,
     /// Optional file store for context-aware tools
     file_store: Option<Arc<dyn SessionFileStore>>,
+    /// Optional SQL database store for sql_execute/sql_query/sql_schema tools
+    sqldb_store: Option<crate::traits::SessionSqlDbStoreRef>,
 }
 
 impl<T, E> ActAtom<T, E>
@@ -120,6 +122,7 @@ where
             tool_executor,
             event_emitter,
             file_store: None,
+            sqldb_store: None,
         }
     }
 
@@ -133,7 +136,14 @@ where
             tool_executor,
             event_emitter,
             file_store: Some(file_store),
+            sqldb_store: None,
         }
+    }
+
+    /// Set the SQL database store on this atom
+    pub fn with_sqldb_store(mut self, store: crate::traits::SessionSqlDbStoreRef) -> Self {
+        self.sqldb_store = Some(store);
+        self
     }
 }
 
@@ -393,8 +403,15 @@ where
         };
 
         // Execute the tool
-        let result = if let Some(ref store) = self.file_store {
-            let tool_context = ToolContext::with_file_store(context.session_id, store.clone());
+        let result = if self.file_store.is_some() || self.sqldb_store.is_some() {
+            let mut tool_context = if let Some(ref store) = self.file_store {
+                ToolContext::with_file_store(context.session_id, store.clone())
+            } else {
+                ToolContext::new(context.session_id)
+            };
+            if let Some(ref store) = self.sqldb_store {
+                tool_context.sqldb_store = Some(store.clone());
+            }
             self.tool_executor
                 .execute_with_context(&tool_call, tool_def, &tool_context)
                 .await

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -44,6 +44,7 @@ mod noop;
 mod research;
 mod sample_data;
 mod sandbox;
+mod session_sql_database;
 mod session_storage;
 mod stateless_todo_list;
 mod test_math;
@@ -91,6 +92,9 @@ pub use noop::NoopCapability;
 pub use research::ResearchCapability;
 pub use sample_data::SampleDataCapability;
 pub use sandbox::SandboxCapability;
+pub use session_sql_database::{
+    SessionSqlDatabaseCapability, SqlExecuteTool, SqlQueryTool, SqlSchemaTool,
+};
 pub use session_storage::{KvStoreTool, SecretStoreTool, SessionStorageCapability};
 pub use stateless_todo_list::{StatelessTodoListCapability, WriteTodosTool};
 pub use test_math::{AddTool, DivideTool, MultiplyTool, SubtractTool, TestMathCapability};
@@ -274,6 +278,7 @@ impl CapabilityRegistry {
         registry.register(SandboxCapability);
         registry.register(FileSystemCapability);
         registry.register(SessionStorageCapability);
+        registry.register(SessionSqlDatabaseCapability);
         registry.register(TestMathCapability);
         registry.register(TestWeatherCapability);
         registry.register(StatelessTodoListCapability);
@@ -852,6 +857,7 @@ mod tests {
         assert!(registry.has("sandbox"));
         assert!(registry.has("session_file_system"));
         assert!(registry.has("session_storage"));
+        assert!(registry.has("session_sql_database"));
         assert!(registry.has("test_math"));
         assert!(registry.has("test_weather"));
         assert!(registry.has("stateless_todo_list"));
@@ -864,7 +870,7 @@ mod tests {
         assert!(registry.has("fake_financial"));
         // Experimental capability included in dev
         assert!(registry.has("docker_container"));
-        assert_eq!(registry.len(), 17);
+        assert_eq!(registry.len(), 18);
     }
 
     #[test]
@@ -878,6 +884,7 @@ mod tests {
         assert!(registry.has("sandbox"));
         assert!(registry.has("session_file_system"));
         assert!(registry.has("session_storage"));
+        assert!(registry.has("session_sql_database"));
         assert!(registry.has("test_math"));
         assert!(registry.has("test_weather"));
         assert!(registry.has("stateless_todo_list"));
@@ -890,7 +897,7 @@ mod tests {
         assert!(registry.has("fake_financial"));
         // Experimental capability NOT included in prod
         assert!(!registry.has("docker_container"));
-        assert_eq!(registry.len(), 16);
+        assert_eq!(registry.len(), 17);
     }
 
     #[test]

--- a/crates/core/src/capabilities/session_sql_database.rs
+++ b/crates/core/src/capabilities/session_sql_database.rs
@@ -1,0 +1,436 @@
+// Session SQL Database Capability
+//
+// Provides session-scoped SQLite databases via three tools:
+// - sql_execute: DDL/DML (CREATE TABLE, INSERT, UPDATE, DELETE). Auto-creates DB.
+// - sql_query: Read-only SELECT queries returning columns + rows as JSON.
+// - sql_schema: Introspect database schema (tables, columns, types).
+
+use super::{Capability, CapabilityStatus};
+use crate::session_sqldb::SessionSqlDbError;
+use crate::tools::{Tool, ToolExecutionResult};
+use crate::traits::ToolContext;
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+/// Session SQL Database capability
+pub struct SessionSqlDatabaseCapability;
+
+impl Capability for SessionSqlDatabaseCapability {
+    fn id(&self) -> &str {
+        "session_sql_database"
+    }
+
+    fn name(&self) -> &str {
+        "SQL Database"
+    }
+
+    fn description(&self) -> &str {
+        "Session-scoped SQLite databases for structured data storage and querying."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("database")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Data")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(
+            r#"You have access to session-scoped SQL databases. Use these tools to create tables, insert data, and query data using standard SQLite SQL syntax.
+
+**Tools:**
+- `sql_execute`: Create tables, insert/update/delete data. Auto-creates the database if needed.
+- `sql_query`: Run SELECT queries. Returns columns and rows as JSON.
+- `sql_schema`: Inspect database schema (tables, columns, types).
+
+**Guidelines:**
+- Database names must be alphanumeric with underscores (e.g., "analytics", "user_data")
+- Use `sql_schema` to inspect existing tables before querying
+- Results are limited to 1000 rows per query
+- Databases are session-scoped and isolated
+- Standard SQLite SQL syntax is supported"#,
+        )
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(SqlExecuteTool),
+            Box::new(SqlQueryTool),
+            Box::new(SqlSchemaTool),
+        ]
+    }
+}
+
+// ============================================================================
+// Helper: convert SessionSqlDbError to ToolExecutionResult
+// ============================================================================
+
+fn sqldb_error_to_result(err: SessionSqlDbError) -> ToolExecutionResult {
+    if err.is_tool_error() {
+        ToolExecutionResult::tool_error(err.to_string())
+    } else {
+        ToolExecutionResult::internal_error_msg(err.to_string())
+    }
+}
+
+// ============================================================================
+// SqlExecuteTool
+// ============================================================================
+
+pub struct SqlExecuteTool;
+
+#[async_trait]
+impl Tool for SqlExecuteTool {
+    fn name(&self) -> &str {
+        "sql_execute"
+    }
+
+    fn description(&self) -> &str {
+        "Execute DDL/DML SQL (CREATE TABLE, INSERT, UPDATE, DELETE). Auto-creates database if it doesn't exist."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "database": {
+                    "type": "string",
+                    "description": "Database name (alphanumeric + underscores)"
+                },
+                "sql": {
+                    "type": "string",
+                    "description": "SQL statement(s) to execute"
+                }
+            },
+            "required": ["database", "sql"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "sql_execute requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let database = match arguments.get("database").and_then(|v| v.as_str()) {
+            Some(d) => d,
+            None => {
+                return ToolExecutionResult::tool_error("Missing required parameter: database");
+            }
+        };
+
+        let sql = match arguments.get("sql").and_then(|v| v.as_str()) {
+            Some(s) => s,
+            None => {
+                return ToolExecutionResult::tool_error("Missing required parameter: sql");
+            }
+        };
+
+        let store = match &context.sqldb_store {
+            Some(store) => store,
+            None => {
+                return ToolExecutionResult::tool_error(
+                    "SQL database not available in this context",
+                );
+            }
+        };
+
+        match store.sql_execute(context.session_id, database, sql).await {
+            Ok(result) => ToolExecutionResult::success(json!({
+                "database": database,
+                "success": true,
+                "rows_affected": result.rows_affected
+            })),
+            Err(e) => sqldb_error_to_result(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// SqlQueryTool
+// ============================================================================
+
+pub struct SqlQueryTool;
+
+#[async_trait]
+impl Tool for SqlQueryTool {
+    fn name(&self) -> &str {
+        "sql_query"
+    }
+
+    fn description(&self) -> &str {
+        "Execute a read-only SQL query (SELECT). Returns columns and rows as JSON."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "database": {
+                    "type": "string",
+                    "description": "Database name"
+                },
+                "sql": {
+                    "type": "string",
+                    "description": "SELECT query"
+                }
+            },
+            "required": ["database", "sql"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "sql_query requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let database = match arguments.get("database").and_then(|v| v.as_str()) {
+            Some(d) => d,
+            None => {
+                return ToolExecutionResult::tool_error("Missing required parameter: database");
+            }
+        };
+
+        let sql = match arguments.get("sql").and_then(|v| v.as_str()) {
+            Some(s) => s,
+            None => {
+                return ToolExecutionResult::tool_error("Missing required parameter: sql");
+            }
+        };
+
+        let store = match &context.sqldb_store {
+            Some(store) => store,
+            None => {
+                return ToolExecutionResult::tool_error(
+                    "SQL database not available in this context",
+                );
+            }
+        };
+
+        match store.sql_query(context.session_id, database, sql).await {
+            Ok(result) => {
+                let mut response = json!({
+                    "database": database,
+                    "columns": result.columns,
+                    "rows": result.rows,
+                    "row_count": result.row_count
+                });
+                if result.truncated {
+                    response["truncated"] = json!(true);
+                }
+                ToolExecutionResult::success(response)
+            }
+            Err(e) => sqldb_error_to_result(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// SqlSchemaTool
+// ============================================================================
+
+pub struct SqlSchemaTool;
+
+#[async_trait]
+impl Tool for SqlSchemaTool {
+    fn name(&self) -> &str {
+        "sql_schema"
+    }
+
+    fn description(&self) -> &str {
+        "Introspect database schema: tables, columns, types, and row counts."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "database": {
+                    "type": "string",
+                    "description": "Database name"
+                },
+                "table": {
+                    "type": "string",
+                    "description": "Specific table name (optional, omit to list all tables)"
+                }
+            },
+            "required": ["database"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "sql_schema requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let database = match arguments.get("database").and_then(|v| v.as_str()) {
+            Some(d) => d,
+            None => {
+                return ToolExecutionResult::tool_error("Missing required parameter: database");
+            }
+        };
+
+        let table = arguments.get("table").and_then(|v| v.as_str());
+
+        let store = match &context.sqldb_store {
+            Some(store) => store,
+            None => {
+                return ToolExecutionResult::tool_error(
+                    "SQL database not available in this context",
+                );
+            }
+        };
+
+        match store.sql_schema(context.session_id, database, table).await {
+            Ok(tables) => {
+                let tables_json: Vec<Value> = tables
+                    .into_iter()
+                    .map(|t| {
+                        json!({
+                            "name": t.name,
+                            "columns": t.columns.into_iter().map(|c| json!({
+                                "name": c.name,
+                                "type": c.column_type,
+                                "notnull": c.notnull,
+                                "pk": c.pk,
+                                "default_value": c.default_value
+                            })).collect::<Vec<_>>(),
+                            "row_count": t.row_count
+                        })
+                    })
+                    .collect();
+
+                ToolExecutionResult::success(json!({
+                    "database": database,
+                    "tables": tables_json
+                }))
+            }
+            Err(e) => sqldb_error_to_result(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::typed_id::SessionId;
+
+    #[test]
+    fn test_capability_metadata() {
+        let cap = SessionSqlDatabaseCapability;
+        assert_eq!(cap.id(), "session_sql_database");
+        assert_eq!(cap.name(), "SQL Database");
+        assert_eq!(cap.status(), CapabilityStatus::Available);
+        assert_eq!(cap.icon(), Some("database"));
+        assert_eq!(cap.category(), Some("Data"));
+    }
+
+    #[test]
+    fn test_capability_has_three_tools() {
+        let cap = SessionSqlDatabaseCapability;
+        let tools = cap.tools();
+        assert_eq!(tools.len(), 3);
+
+        let tool_names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(tool_names.contains(&"sql_execute"));
+        assert!(tool_names.contains(&"sql_query"));
+        assert!(tool_names.contains(&"sql_schema"));
+    }
+
+    #[test]
+    fn test_capability_has_system_prompt() {
+        let cap = SessionSqlDatabaseCapability;
+        let prompt = cap.system_prompt_addition().unwrap();
+        assert!(prompt.contains("sql_execute"));
+        assert!(prompt.contains("sql_query"));
+        assert!(prompt.contains("sql_schema"));
+        assert!(prompt.contains("SQLite"));
+    }
+
+    #[test]
+    fn test_tools_require_context() {
+        assert!(SqlExecuteTool.requires_context());
+        assert!(SqlQueryTool.requires_context());
+        assert!(SqlSchemaTool.requires_context());
+    }
+
+    #[tokio::test]
+    async fn test_sql_execute_without_context() {
+        let tool = SqlExecuteTool;
+        let result = tool
+            .execute(json!({"database": "test", "sql": "SELECT 1"}))
+            .await;
+        assert!(matches!(result, ToolExecutionResult::ToolError(_)));
+    }
+
+    #[tokio::test]
+    async fn test_sql_execute_missing_params() {
+        let tool = SqlExecuteTool;
+        let context = ToolContext::new(SessionId::new());
+
+        let result = tool
+            .execute_with_context(json!({"database": "test"}), &context)
+            .await;
+        if let ToolExecutionResult::ToolError(msg) = result {
+            assert!(msg.contains("sql"));
+        } else {
+            panic!("Expected tool error for missing sql");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sql_execute_no_store() {
+        let tool = SqlExecuteTool;
+        let context = ToolContext::new(SessionId::new());
+
+        let result = tool
+            .execute_with_context(
+                json!({"database": "test", "sql": "CREATE TABLE t (id INTEGER)"}),
+                &context,
+            )
+            .await;
+        if let ToolExecutionResult::ToolError(msg) = result {
+            assert!(msg.contains("not available"));
+        } else {
+            panic!("Expected tool error for missing store");
+        }
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -46,6 +46,7 @@ pub mod mcp_server;
 pub mod organization;
 pub mod session;
 pub mod session_file;
+pub mod session_sqldb;
 
 pub mod atoms;
 pub mod capabilities;
@@ -92,8 +93,8 @@ pub use message_retriever::{InputMessage, MessageRetriever};
 pub use runtime_agent::{RuntimeAgent, RuntimeAgentBuilder};
 pub use traits::{
     EventEmitter, ImageResolver, KeyInfo, LlmProviderStore, ModelWithProvider, NoopEventEmitter,
-    ResolvedImage, SecretInfo, SessionFileStore, SessionStorageStore, SessionStore, ToolContext,
-    ToolExecutor,
+    ResolvedImage, SecretInfo, SessionFileStore, SessionSqlDbStoreRef, SessionStorageStore,
+    SessionStore, ToolContext, ToolExecutor,
 };
 
 // Event listener re-exports
@@ -136,7 +137,8 @@ pub use capabilities::{
     MAX_RESOLVED_CAPABILITIES, MCP_CAPABILITY_PREFIX, McpCapability, MountAccess,
     MountDirectoryBuilder, MountEntry, MountPoint, MountSource, MultiplyTool, NoopCapability,
     ReadFileTool, ResearchCapability, ResolvedCapabilities, SampleDataCapability,
-    SandboxCapability, StatFileTool, StatelessTodoListCapability, SubtractTool, TestMathCapability,
+    SandboxCapability, SessionSqlDatabaseCapability, SqlExecuteTool, SqlQueryTool, SqlSchemaTool,
+    StatFileTool, StatelessTodoListCapability, SubtractTool, TestMathCapability,
     TestWeatherCapability, WriteFileTool, WriteTodosTool, apply_capabilities,
     collect_capabilities_with_configs, get_dependencies, is_mcp_capability, mcp_capability_id,
     parse_mcp_capability_id, resolve_dependencies,
@@ -189,6 +191,10 @@ pub use organization::{
 };
 pub use session::{Session, SessionStatus};
 pub use session_file::{FileInfo, FileStat, GrepMatch, GrepResult, SessionFile};
+pub use session_sqldb::{
+    ColumnSchema, DatabaseInfo, SessionSqlDbError, SessionSqlDbStore, SqlExecuteResult,
+    SqlQueryResult, TableSchema,
+};
 pub use typed_id::{
     AgentId, EventId, ExecId, IdMarker, IdParseError, ImageId, McpServerId, MessageId, ModelId,
     OrgId, ProviderId, SessionId, TurnId, TypedId,

--- a/crates/core/src/session_sqldb.rs
+++ b/crates/core/src/session_sqldb.rs
@@ -1,0 +1,167 @@
+// Session SQL Database types and trait
+//
+// Types and async trait for session-scoped SQL databases.
+// Defined in core so capability tools can depend on them.
+// Implementations live in the session-sqldb crate.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::typed_id::SessionId;
+
+/// Metadata about a session database (no content/pages).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DatabaseInfo {
+    pub name: String,
+    pub size_bytes: i64,
+    pub page_count: i32,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Result of a SELECT query.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SqlQueryResult {
+    pub columns: Vec<String>,
+    pub rows: Vec<Vec<serde_json::Value>>,
+    pub row_count: usize,
+    /// True if results were truncated due to limits
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub truncated: bool,
+}
+
+/// Result of an INSERT/UPDATE/DELETE/DDL statement.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SqlExecuteResult {
+    pub rows_affected: u64,
+}
+
+/// Schema of a table.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TableSchema {
+    pub name: String,
+    pub columns: Vec<ColumnSchema>,
+    pub row_count: i64,
+}
+
+/// Schema of a column.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ColumnSchema {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub column_type: String,
+    pub notnull: bool,
+    pub pk: bool,
+    pub default_value: Option<String>,
+}
+
+/// Error type for session SQL database operations.
+///
+/// Tool-visible errors (validation, not found, limits) vs internal errors
+/// are distinguished by the caller when converting to ToolExecutionResult.
+#[derive(Debug, thiserror::Error)]
+pub enum SessionSqlDbError {
+    #[error("database not found: {0}")]
+    DatabaseNotFound(String),
+
+    #[error("database already exists: {0}")]
+    DatabaseAlreadyExists(String),
+
+    #[error("invalid database name: {0}")]
+    InvalidDatabaseName(String),
+
+    #[error("database limit exceeded: {0}")]
+    LimitExceeded(String),
+
+    #[error("query error: {0}")]
+    QueryError(String),
+
+    #[error("query timeout after {0} seconds")]
+    QueryTimeout(u64),
+
+    #[error("result too large: {0}")]
+    ResultTooLarge(String),
+
+    #[error("operation blocked by authorizer: {0}")]
+    AuthorizerBlocked(String),
+
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+impl SessionSqlDbError {
+    /// Whether this error should be shown to the LLM as a tool error (vs internal error).
+    pub fn is_tool_error(&self) -> bool {
+        matches!(
+            self,
+            Self::DatabaseNotFound(_)
+                | Self::DatabaseAlreadyExists(_)
+                | Self::InvalidDatabaseName(_)
+                | Self::LimitExceeded(_)
+                | Self::QueryError(_)
+                | Self::QueryTimeout(_)
+                | Self::ResultTooLarge(_)
+                | Self::AuthorizerBlocked(_)
+        )
+    }
+}
+
+/// Async trait for session-scoped SQL database operations.
+///
+/// Implementations:
+/// - InMemorySqlDbBackend (DEV_MODE) in session-sqldb crate
+/// - Future: PostgreSQL VFS backend
+#[async_trait]
+pub trait SessionSqlDbStore: Send + Sync {
+    /// Create a named database in the session.
+    async fn create_database(
+        &self,
+        session_id: SessionId,
+        name: &str,
+    ) -> Result<DatabaseInfo, SessionSqlDbError>;
+
+    /// List all databases for a session.
+    async fn list_databases(
+        &self,
+        session_id: SessionId,
+    ) -> Result<Vec<DatabaseInfo>, SessionSqlDbError>;
+
+    /// Get metadata for a specific database.
+    async fn get_database(
+        &self,
+        session_id: SessionId,
+        name: &str,
+    ) -> Result<Option<DatabaseInfo>, SessionSqlDbError>;
+
+    /// Delete a database and all its pages.
+    async fn delete_database(
+        &self,
+        session_id: SessionId,
+        name: &str,
+    ) -> Result<bool, SessionSqlDbError>;
+
+    /// Execute DDL/DML SQL. Auto-creates database if it doesn't exist.
+    async fn sql_execute(
+        &self,
+        session_id: SessionId,
+        db_name: &str,
+        sql: &str,
+    ) -> Result<SqlExecuteResult, SessionSqlDbError>;
+
+    /// Execute read-only SQL query. Returns columns and rows.
+    async fn sql_query(
+        &self,
+        session_id: SessionId,
+        db_name: &str,
+        sql: &str,
+    ) -> Result<SqlQueryResult, SessionSqlDbError>;
+
+    /// Get schema for all tables (or a specific table) in a database.
+    async fn sql_schema(
+        &self,
+        session_id: SessionId,
+        db_name: &str,
+        table: Option<&str>,
+    ) -> Result<Vec<TableSchema>, SessionSqlDbError>;
+}

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -293,6 +293,9 @@ pub trait SessionStorageStore: Send + Sync {
 // ToolContext - Runtime context for tool execution
 // ============================================================================
 
+/// Type alias for the session SQL DB store trait object.
+pub type SessionSqlDbStoreRef = Arc<dyn crate::session_sqldb::SessionSqlDbStore>;
+
 /// Runtime context provided to tools during execution.
 ///
 /// This context contains:
@@ -311,6 +314,9 @@ pub struct ToolContext {
 
     /// Optional storage store for key/value and secret storage
     pub storage_store: Option<Arc<dyn SessionStorageStore>>,
+
+    /// Optional session SQL database store
+    pub sqldb_store: Option<SessionSqlDbStoreRef>,
 }
 
 impl ToolContext {
@@ -320,6 +326,7 @@ impl ToolContext {
             session_id,
             file_store: None,
             storage_store: None,
+            sqldb_store: None,
         }
     }
 
@@ -329,6 +336,7 @@ impl ToolContext {
             session_id,
             file_store: Some(file_store),
             storage_store: None,
+            sqldb_store: None,
         }
     }
 
@@ -341,6 +349,7 @@ impl ToolContext {
             session_id,
             file_store: None,
             storage_store: Some(storage_store),
+            sqldb_store: None,
         }
     }
 
@@ -354,7 +363,14 @@ impl ToolContext {
             session_id,
             file_store: Some(file_store),
             storage_store: Some(storage_store),
+            sqldb_store: None,
         }
+    }
+
+    /// Add a SQL database store to this context
+    pub fn with_sqldb_store(mut self, sqldb_store: SessionSqlDbStoreRef) -> Self {
+        self.sqldb_store = Some(sqldb_store);
+        self
     }
 }
 
@@ -364,6 +380,7 @@ impl std::fmt::Debug for ToolContext {
             .field("session_id", &self.session_id)
             .field("file_store", &self.file_store.is_some())
             .field("storage_store", &self.storage_store.is_some())
+            .field("sqldb_store", &self.sqldb_store.is_some())
             .finish()
     }
 }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -54,6 +54,7 @@ parking_lot.workspace = true
 cron = "0.15"
 
 everruns-core = { path = "../core", features = ["openapi", "sqlx"] }
+everruns-session-sqldb = { path = "../session-sqldb" }
 everruns-worker = { path = "../worker" }  # For AgentRunner trait
 everruns-internal-protocol = { path = "../internal-protocol" }
 everruns-durable = { path = "../durable" }  # For durable execution gRPC service

--- a/crates/server/migrations/005_session_sqldb.sql
+++ b/crates/server/migrations/005_session_sqldb.sql
@@ -1,0 +1,33 @@
+-- Session SQL Databases
+-- Page-level SQLite storage backed by PostgreSQL
+--
+-- Each session can have multiple named SQLite databases.
+-- Database content is stored as individual 4KB pages for efficient
+-- partial read/write via custom SQLite VFS.
+
+CREATE TABLE session_databases (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    session_id UUID NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    size_bytes BIGINT NOT NULL DEFAULT 0,
+    page_count INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT session_databases_unique_name UNIQUE (session_id, name),
+    CONSTRAINT session_databases_name_check CHECK (name ~ '^[a-zA-Z_][a-zA-Z0-9_]{0,63}$')
+);
+
+CREATE INDEX idx_session_databases_session_id ON session_databases(session_id);
+
+CREATE TRIGGER update_session_databases_updated_at
+    BEFORE UPDATE ON session_databases
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TABLE session_database_pages (
+    database_id UUID NOT NULL REFERENCES session_databases(id) ON DELETE CASCADE,
+    page_number INTEGER NOT NULL,
+    data BYTEA NOT NULL,
+    PRIMARY KEY (database_id, page_number)
+);
+
+CREATE INDEX idx_session_database_pages_db ON session_database_pages(database_id);

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -15,6 +15,7 @@ pub mod mcp_servers;
 pub mod messages;
 pub mod organizations;
 pub mod schedules;
+pub mod session_databases;
 pub mod session_files;
 pub mod session_storage;
 pub mod sessions;

--- a/crates/server/src/api/session_databases.rs
+++ b/crates/server/src/api/session_databases.rs
@@ -1,0 +1,321 @@
+// Session SQL Database HTTP routes
+//
+// CRUD for session-scoped databases + schema introspection.
+// Routes under /v1/sessions/{session_id}/databases.
+
+use crate::auth::{AuthState, ResolvedOrg};
+use axum::extract::FromRef;
+use axum::{
+    Json, Router,
+    extract::{Path, State},
+    http::StatusCode,
+    routing::get,
+};
+use everruns_core::session_sqldb::{DatabaseInfo, SessionSqlDbStore};
+use everruns_core::typed_id::SessionId;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use utoipa::ToSchema;
+
+use super::common::ListResponse;
+
+/// Request body for creating a database.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct CreateDatabaseRequest {
+    /// Database name (alphanumeric + underscores, max 64 chars)
+    pub name: String,
+}
+
+/// Database info response.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct DatabaseInfoResponse {
+    pub name: String,
+    pub size_bytes: i64,
+    pub page_count: i32,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl From<DatabaseInfo> for DatabaseInfoResponse {
+    fn from(info: DatabaseInfo) -> Self {
+        Self {
+            name: info.name,
+            size_bytes: info.size_bytes,
+            page_count: info.page_count,
+            created_at: info.created_at.to_rfc3339(),
+            updated_at: info.updated_at.to_rfc3339(),
+        }
+    }
+}
+
+/// Schema response for a database.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SchemaResponse {
+    pub database: String,
+    pub tables: Vec<serde_json::Value>,
+}
+
+/// App state for session database routes.
+#[derive(Clone)]
+pub struct AppState {
+    pub sqldb_store: Arc<dyn SessionSqlDbStore>,
+    pub auth: AuthState,
+}
+
+impl AppState {
+    pub fn new(sqldb_store: Arc<dyn SessionSqlDbStore>, auth: AuthState) -> Self {
+        Self { sqldb_store, auth }
+    }
+}
+
+impl FromRef<AppState> for AuthState {
+    fn from_ref(input: &AppState) -> Self {
+        input.auth.clone()
+    }
+}
+
+/// Create session database routes.
+pub fn routes(state: AppState) -> Router {
+    Router::new()
+        .route(
+            "/v1/sessions/:session_id/databases",
+            get(list_databases).post(create_database),
+        )
+        .route(
+            "/v1/sessions/:session_id/databases/:name",
+            get(get_database).delete(delete_database),
+        )
+        .route(
+            "/v1/sessions/:session_id/databases/:name/schema",
+            get(get_schema),
+        )
+        .with_state(state)
+}
+
+/// GET /v1/sessions/{session_id}/databases
+#[utoipa::path(
+    get,
+    path = "/v1/sessions/{session_id}/databases",
+    params(("session_id" = String, Path, description = "Session ID")),
+    responses(
+        (status = 200, description = "List of databases", body = ListResponse<DatabaseInfoResponse>),
+        (status = 400, description = "Invalid session ID"),
+    ),
+    tag = "session-databases"
+)]
+pub async fn list_databases(
+    _org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+) -> Result<Json<ListResponse<DatabaseInfoResponse>>, StatusCode> {
+    let session_id: SessionId = session_id.parse().map_err(|_| StatusCode::BAD_REQUEST)?;
+
+    let databases = state
+        .sqldb_store
+        .list_databases(session_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "Failed to list databases");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    let items: Vec<DatabaseInfoResponse> = databases.into_iter().map(Into::into).collect();
+    Ok(Json(ListResponse::new(items)))
+}
+
+/// POST /v1/sessions/{session_id}/databases
+#[utoipa::path(
+    post,
+    path = "/v1/sessions/{session_id}/databases",
+    params(("session_id" = String, Path, description = "Session ID")),
+    request_body = CreateDatabaseRequest,
+    responses(
+        (status = 201, description = "Database created", body = DatabaseInfoResponse),
+        (status = 400, description = "Invalid name or session ID"),
+        (status = 409, description = "Database already exists"),
+    ),
+    tag = "session-databases"
+)]
+pub async fn create_database(
+    _org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+    Json(req): Json<CreateDatabaseRequest>,
+) -> Result<(StatusCode, Json<DatabaseInfoResponse>), StatusCode> {
+    let session_id: SessionId = session_id.parse().map_err(|_| StatusCode::BAD_REQUEST)?;
+
+    let info = state
+        .sqldb_store
+        .create_database(session_id, &req.name)
+        .await
+        .map_err(|e| {
+            use everruns_core::session_sqldb::SessionSqlDbError;
+            match &e {
+                SessionSqlDbError::InvalidDatabaseName(_) => StatusCode::BAD_REQUEST,
+                SessionSqlDbError::DatabaseAlreadyExists(_) => StatusCode::CONFLICT,
+                SessionSqlDbError::LimitExceeded(_) => StatusCode::UNPROCESSABLE_ENTITY,
+                _ => {
+                    tracing::error!(error = %e, "Failed to create database");
+                    StatusCode::INTERNAL_SERVER_ERROR
+                }
+            }
+        })?;
+
+    Ok((StatusCode::CREATED, Json(info.into())))
+}
+
+/// GET /v1/sessions/{session_id}/databases/{name}
+#[utoipa::path(
+    get,
+    path = "/v1/sessions/{session_id}/databases/{name}",
+    params(
+        ("session_id" = String, Path, description = "Session ID"),
+        ("name" = String, Path, description = "Database name"),
+    ),
+    responses(
+        (status = 200, description = "Database info", body = DatabaseInfoResponse),
+        (status = 404, description = "Database not found"),
+    ),
+    tag = "session-databases"
+)]
+pub async fn get_database(
+    _org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path((session_id, name)): Path<(String, String)>,
+) -> Result<Json<DatabaseInfoResponse>, StatusCode> {
+    let session_id: SessionId = session_id.parse().map_err(|_| StatusCode::BAD_REQUEST)?;
+
+    let info = state
+        .sqldb_store
+        .get_database(session_id, &name)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "Failed to get database");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    Ok(Json(info.into()))
+}
+
+/// DELETE /v1/sessions/{session_id}/databases/{name}
+#[utoipa::path(
+    delete,
+    path = "/v1/sessions/{session_id}/databases/{name}",
+    params(
+        ("session_id" = String, Path, description = "Session ID"),
+        ("name" = String, Path, description = "Database name"),
+    ),
+    responses(
+        (status = 204, description = "Database deleted"),
+        (status = 404, description = "Database not found"),
+    ),
+    tag = "session-databases"
+)]
+pub async fn delete_database(
+    _org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path((session_id, name)): Path<(String, String)>,
+) -> Result<StatusCode, StatusCode> {
+    let session_id: SessionId = session_id.parse().map_err(|_| StatusCode::BAD_REQUEST)?;
+
+    let deleted = state
+        .sqldb_store
+        .delete_database(session_id, &name)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "Failed to delete database");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    if deleted {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(StatusCode::NOT_FOUND)
+    }
+}
+
+/// GET /v1/sessions/{session_id}/databases/{name}/schema
+#[utoipa::path(
+    get,
+    path = "/v1/sessions/{session_id}/databases/{name}/schema",
+    params(
+        ("session_id" = String, Path, description = "Session ID"),
+        ("name" = String, Path, description = "Database name"),
+    ),
+    responses(
+        (status = 200, description = "Database schema", body = SchemaResponse),
+        (status = 404, description = "Database not found"),
+    ),
+    tag = "session-databases"
+)]
+pub async fn get_schema(
+    _org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path((session_id, name)): Path<(String, String)>,
+) -> Result<Json<SchemaResponse>, StatusCode> {
+    let session_id: SessionId = session_id.parse().map_err(|_| StatusCode::BAD_REQUEST)?;
+
+    let tables = state
+        .sqldb_store
+        .sql_schema(session_id, &name, None)
+        .await
+        .map_err(|e| {
+            use everruns_core::session_sqldb::SessionSqlDbError;
+            match &e {
+                SessionSqlDbError::DatabaseNotFound(_) => StatusCode::NOT_FOUND,
+                _ => {
+                    tracing::error!(error = %e, "Failed to get schema");
+                    StatusCode::INTERNAL_SERVER_ERROR
+                }
+            }
+        })?;
+
+    let tables_json: Vec<serde_json::Value> = tables
+        .into_iter()
+        .map(|t| {
+            serde_json::json!({
+                "name": t.name,
+                "columns": t.columns.into_iter().map(|c| serde_json::json!({
+                    "name": c.name,
+                    "type": c.column_type,
+                    "notnull": c.notnull,
+                    "pk": c.pk,
+                    "default_value": c.default_value
+                })).collect::<Vec<_>>(),
+                "row_count": t.row_count
+            })
+        })
+        .collect();
+
+    Ok(Json(SchemaResponse {
+        database: name,
+        tables: tables_json,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_database_info_response_serialization() {
+        let info = DatabaseInfoResponse {
+            name: "test_db".to_string(),
+            size_bytes: 4096,
+            page_count: 1,
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+            updated_at: "2024-01-01T00:00:00Z".to_string(),
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        assert!(json.contains("test_db"));
+        assert!(json.contains("4096"));
+    }
+
+    #[test]
+    fn test_create_request_deserialization() {
+        let json = r#"{"name": "analytics"}"#;
+        let req: CreateDatabaseRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.name, "analytics");
+    }
+}

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -60,6 +60,7 @@ pub struct DirectWorkerAdapters {
     llm_resolver: Arc<LlmResolverService>,
     mcp_server_service: Arc<McpServerService>,
     capability_registry: CapabilityRegistry,
+    sqldb_store: Option<everruns_core::traits::SessionSqlDbStoreRef>,
 }
 
 impl DirectWorkerAdapters {
@@ -77,7 +78,14 @@ impl DirectWorkerAdapters {
             llm_resolver,
             mcp_server_service,
             capability_registry,
+            sqldb_store: None,
         }
+    }
+
+    /// Set the SQL database store for session-scoped SQL databases
+    pub fn with_sqldb_store(mut self, store: everruns_core::traits::SessionSqlDbStoreRef) -> Self {
+        self.sqldb_store = Some(store);
+        self
     }
 
     /// Ensure a directory exists, creating it and parents if needed
@@ -687,6 +695,10 @@ impl WorkerAdapters for DirectWorkerAdapters {
 
     fn driver_registry(&self) -> DriverRegistry {
         create_driver_registry()
+    }
+
+    fn sqldb_store(&self) -> Option<everruns_core::traits::SessionSqlDbStoreRef> {
+        self.sqldb_store.clone()
     }
 
     async fn build_tool_registry(&self, agent_id: Uuid) -> Result<ToolRegistry> {

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -162,6 +162,13 @@ async fn main() -> Result<()> {
     // This creates default agents if they don't exist
     seed::spawn_seed_task(db.clone());
 
+    // Create session SQL database store (in-memory for now, both dev and prod)
+    let sqldb_backend = Arc::new(everruns_session_sqldb::InMemorySqlDbBackend::new());
+    let sqldb_store: Arc<dyn everruns_core::session_sqldb::SessionSqlDbStore> = Arc::new(
+        everruns_session_sqldb::InMemorySqlDbStore::new(sqldb_backend),
+    );
+    tracing::info!("Session SQL database store initialized (in-memory)");
+
     // Initialize encryption service for API keys (optional - gracefully degrade if not configured)
     let encryption = match EncryptionService::from_env() {
         Ok(svc) => {
@@ -244,6 +251,8 @@ async fn main() -> Result<()> {
         api::agents::AppState::new(db.clone(), capability_service, auth_state.clone());
     let session_files_state = api::session_files::AppState::new(db.clone(), auth_state.clone());
     let session_storage_state = api::session_storage::AppState::new(db.clone(), auth_state.clone());
+    let session_databases_state =
+        api::session_databases::AppState::new(sqldb_store.clone(), auth_state.clone());
     let users_state = api::users::UsersState {
         db: db.clone(),
         auth: auth_state.clone(),
@@ -305,6 +314,7 @@ async fn main() -> Result<()> {
         .merge(api::capabilities::routes(capabilities_state))
         .merge(api::session_files::routes(session_files_state))
         .merge(api::session_storage::routes(session_storage_state))
+        .merge(api::session_databases::routes(session_databases_state))
         .merge(api::users::routes(users_state))
         .merge(api::durable::routes(durable_state))
         .merge(api::schedules::routes(schedules_state))
@@ -538,7 +548,8 @@ async fn main() -> Result<()> {
                 llm_resolver,
                 mcp_server_service,
                 capability_registry,
-            );
+            )
+            .with_sqldb_store(sqldb_store.clone());
 
             // Create and spawn the task worker with in-memory store
             let worker_config = TaskWorkerConfig::dev_mode();

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -39,6 +39,7 @@ mod seed_ids {
     pub const MS_LEARN_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000103);
     pub const PYTHON_CODER_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000104);
     pub const SHELL_ASSISTANT_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000105);
+    pub const DATA_ANALYST_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000106);
 
     // MCP Servers (0x500-0x5FF)
     pub const MS_LEARN_MCP: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000501);
@@ -378,6 +379,53 @@ Files you create are stored in the session's virtual filesystem:
 - The filesystem starts empty but persists throughout the session"#,
         tags: &["shell", "bash", "scripting", "demo", "seed"],
         capabilities: &["virtual_bash", "session_file_system"],
+        dev_only: false,
+    },
+    SeedAgent {
+        id: seed_ids::DATA_ANALYST_AGENT,
+        name: "Data Analyst",
+        description: "An agent that analyzes data using SQL databases, takes notes, and produces reports",
+        system_prompt: r#"You are a Data Analyst Agent. You help users analyze data by creating SQL databases,
+importing data, running queries, and producing clear reports.
+
+## Your Capabilities
+
+You have access to:
+- **sql_execute**: Create tables, insert/update/delete data. Databases are auto-created.
+- **sql_query**: Run SELECT queries returning columns and rows.
+- **sql_schema**: Inspect database schema (tables, columns, types).
+- **session_file_system**: Save reports and notes as files.
+- **stateless_todo_list**: Track analysis tasks.
+
+## Workflow
+
+1. **Understand the Data**: Ask what data the user wants to analyze.
+2. **Design Schema**: Create appropriate tables with `sql_execute`.
+3. **Import Data**: Insert the data into tables.
+4. **Analyze**: Run queries to answer questions — aggregations, joins, filters.
+5. **Report**: Summarize findings. Save reports to files.
+
+## Example
+
+```
+sql_execute(database="analytics", sql="CREATE TABLE sales (id INTEGER PRIMARY KEY, product TEXT, amount REAL, date TEXT)")
+sql_execute(database="analytics", sql="INSERT INTO sales VALUES (1, 'Widget', 29.99, '2024-01-15'), ...")
+sql_query(database="analytics", sql="SELECT product, SUM(amount) as total FROM sales GROUP BY product ORDER BY total DESC")
+```
+
+## Guidelines
+
+- Use descriptive table and column names
+- Add PRIMARY KEY constraints
+- Use appropriate types (INTEGER, REAL, TEXT)
+- Results are limited to 1000 rows per query
+- Databases persist for the session"#,
+        tags: &["data", "sql", "analytics", "demo", "seed"],
+        capabilities: &[
+            "session_sql_database",
+            "session_file_system",
+            "stateless_todo_list",
+        ],
         dev_only: false,
     },
 ];

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -802,3 +802,206 @@ async fn test_agent_with_capabilities() {
         "Agent should have 2 capabilities"
     );
 }
+
+// ============================================
+// Session SQL Database Tests
+// ============================================
+
+#[tokio::test]
+async fn test_session_databases_crud() {
+    let server = TestServer::new().await;
+
+    // Create agent + session for the test
+    let agent: Agent = server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": "SQL Test Agent",
+                "system_prompt": "Test",
+                "capabilities": [{"ref": "session_sql_database", "config": {}}]
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let session: Session = server
+        .post(
+            "/v1/sessions",
+            json!({
+                "agent_id": agent.id.to_string()
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let session_id = session.id.to_string();
+
+    // List databases (should be empty)
+    let list: Value = server
+        .get(&format!("/v1/sessions/{session_id}/databases"))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    assert_eq!(list["data"].as_array().unwrap().len(), 0);
+
+    // Create a database
+    let db_info: Value = server
+        .post(
+            &format!("/v1/sessions/{session_id}/databases"),
+            json!({"name": "analytics"}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+    assert_eq!(db_info["name"], "analytics");
+    assert_eq!(db_info["size_bytes"], 0);
+
+    // Get database
+    let db_info: Value = server
+        .get(&format!("/v1/sessions/{session_id}/databases/analytics"))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    assert_eq!(db_info["name"], "analytics");
+
+    // List databases (should have 1)
+    let list: Value = server
+        .get(&format!("/v1/sessions/{session_id}/databases"))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    assert_eq!(list["data"].as_array().unwrap().len(), 1);
+
+    // Create duplicate (should conflict)
+    server
+        .post(
+            &format!("/v1/sessions/{session_id}/databases"),
+            json!({"name": "analytics"}),
+        )
+        .await
+        .assert_status(StatusCode::CONFLICT);
+
+    // Get nonexistent database (should 404)
+    server
+        .get(&format!("/v1/sessions/{session_id}/databases/nope"))
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+
+    // Delete database
+    server
+        .delete(&format!("/v1/sessions/{session_id}/databases/analytics"))
+        .await
+        .assert_status(StatusCode::NO_CONTENT);
+
+    // Delete again (should 404)
+    server
+        .delete(&format!("/v1/sessions/{session_id}/databases/analytics"))
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+
+    // List should be empty again
+    let list: Value = server
+        .get(&format!("/v1/sessions/{session_id}/databases"))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    assert_eq!(list["data"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn test_session_databases_schema() {
+    let server = TestServer::new().await;
+
+    // Create agent + session
+    let agent: Agent = server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": "SQL Schema Agent",
+                "system_prompt": "Test",
+                "capabilities": [{"ref": "session_sql_database", "config": {}}]
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let session: Session = server
+        .post("/v1/sessions", json!({"agent_id": agent.id.to_string()}))
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let session_id = session.id.to_string();
+
+    // Create a database
+    server
+        .post(
+            &format!("/v1/sessions/{session_id}/databases"),
+            json!({"name": "test_db"}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    // Schema of empty database should have no tables
+    let schema: Value = server
+        .get(&format!(
+            "/v1/sessions/{session_id}/databases/test_db/schema"
+        ))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    assert_eq!(schema["database"], "test_db");
+    assert_eq!(schema["tables"].as_array().unwrap().len(), 0);
+
+    // Schema of nonexistent database should 404
+    server
+        .get(&format!("/v1/sessions/{session_id}/databases/nope/schema"))
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_session_databases_invalid_name() {
+    let server = TestServer::new().await;
+
+    let agent: Agent = server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": "SQL Invalid Name Agent",
+                "system_prompt": "Test",
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let session: Session = server
+        .post("/v1/sessions", json!({"agent_id": agent.id.to_string()}))
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let session_id = session.id.to_string();
+
+    // Invalid name (starts with number)
+    server
+        .post(
+            &format!("/v1/sessions/{session_id}/databases"),
+            json!({"name": "1bad"}),
+        )
+        .await
+        .assert_status(StatusCode::BAD_REQUEST);
+
+    // Invalid name (contains dash)
+    server
+        .post(
+            &format!("/v1/sessions/{session_id}/databases"),
+            json!({"name": "my-db"}),
+        )
+        .await
+        .assert_status(StatusCode::BAD_REQUEST);
+}

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -156,6 +156,13 @@ impl TestServer {
         let session_files_state = api::session_files::AppState::new(db.clone(), auth_state.clone());
         let session_storage_state =
             api::session_storage::AppState::new(db.clone(), auth_state.clone());
+        // Session SQL database store (in-memory for all test modes)
+        let sqldb_backend = Arc::new(everruns_session_sqldb::InMemorySqlDbBackend::new());
+        let sqldb_store: Arc<dyn everruns_core::session_sqldb::SessionSqlDbStore> = Arc::new(
+            everruns_session_sqldb::InMemorySqlDbStore::new(sqldb_backend),
+        );
+        let session_databases_state =
+            api::session_databases::AppState::new(sqldb_store, auth_state.clone());
         let users_state = api::users::UsersState {
             db: db.clone(),
             auth: auth_state.clone(),
@@ -176,6 +183,7 @@ impl TestServer {
             .merge(api::capabilities::routes(capabilities_state))
             .merge(api::session_files::routes(session_files_state))
             .merge(api::session_storage::routes(session_storage_state))
+            .merge(api::session_databases::routes(session_databases_state))
             .merge(api::users::routes(users_state))
             .merge(api::durable::routes(durable_state))
             .merge(api::images::routes(images_state))

--- a/crates/session-sqldb/Cargo.toml
+++ b/crates/session-sqldb/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "everruns-session-sqldb"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Session-scoped SQLite databases backed by PostgreSQL page-level storage"
+
+[dependencies]
+# SQLite
+rusqlite = { version = "0.32", features = ["bundled", "serialize", "column_decltype", "hooks"] }
+
+# Core types
+everruns-core = { path = "../core" }
+
+# Async
+tokio = { workspace = true, features = ["rt", "time", "sync"] }
+async-trait.workspace = true
+
+# Sync
+parking_lot.workspace = true
+
+# Serialization
+serde.workspace = true
+serde_json.workspace = true
+
+# Types
+chrono.workspace = true
+uuid.workspace = true
+
+# Error handling
+anyhow.workspace = true
+thiserror.workspace = true
+
+# Logging
+tracing.workspace = true
+
+# Base64 for BLOB encoding
+base64.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/session-sqldb/src/authorizer.rs
+++ b/crates/session-sqldb/src/authorizer.rs
@@ -1,0 +1,166 @@
+// SQLite authorizer callback
+//
+// Blocks dangerous operations: ATTACH, LOAD_EXTENSION, virtual tables,
+// and write-mode PRAGMAs. This is the primary security boundary for
+// session SQL databases.
+
+use rusqlite::Connection;
+use rusqlite::hooks::{AuthAction, AuthContext, Authorization};
+use tracing::warn;
+
+/// Allowed read-only PRAGMAs for schema introspection.
+const ALLOWED_PRAGMAS: &[&str] = &[
+    "table_info",
+    "table_list",
+    "table_xinfo",
+    "index_list",
+    "index_info",
+    "database_list",
+    "foreign_key_list",
+    "compile_options",
+    "encoding",
+    "page_count",
+    "page_size",
+    "freelist_count",
+];
+
+/// Install the authorizer on a connection.
+///
+/// Must be called before executing any user-provided SQL.
+pub fn install_authorizer(conn: &Connection) {
+    conn.authorizer(Some(authorizer_callback));
+}
+
+/// Remove the authorizer from a connection.
+pub fn remove_authorizer(conn: &Connection) {
+    conn.authorizer(None::<fn(AuthContext<'_>) -> Authorization>);
+}
+
+fn authorizer_callback(ctx: AuthContext<'_>) -> Authorization {
+    match ctx.action {
+        // Block ATTACH/DETACH — prevents accessing other database files
+        AuthAction::Attach { .. } => {
+            warn!("SQLite authorizer blocked ATTACH");
+            Authorization::Deny
+        }
+        AuthAction::Detach { .. } => {
+            warn!("SQLite authorizer blocked DETACH");
+            Authorization::Deny
+        }
+
+        // Block virtual tables
+        AuthAction::CreateVtable { .. } => {
+            warn!("SQLite authorizer blocked CREATE VIRTUAL TABLE");
+            Authorization::Deny
+        }
+        AuthAction::DropVtable { .. } => {
+            warn!("SQLite authorizer blocked DROP VIRTUAL TABLE");
+            Authorization::Deny
+        }
+
+        // Filter PRAGMAs — only allow known-safe read-only ones
+        AuthAction::Pragma { pragma_name, .. } => {
+            let name_lower = pragma_name.to_lowercase();
+            if ALLOWED_PRAGMAS.contains(&name_lower.as_str()) {
+                Authorization::Allow
+            } else {
+                warn!(pragma = %pragma_name, "SQLite authorizer blocked PRAGMA");
+                Authorization::Deny
+            }
+        }
+
+        // Block function calls to load_extension
+        AuthAction::Function {
+            function_name: "load_extension",
+        } => {
+            warn!("SQLite authorizer blocked load_extension");
+            Authorization::Deny
+        }
+
+        // Allow everything else (SELECT, INSERT, UPDATE, DELETE, CREATE TABLE, etc.)
+        _ => Authorization::Allow,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    fn setup_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        install_authorizer(&conn);
+        conn
+    }
+
+    #[test]
+    fn test_basic_operations_allowed() {
+        let conn = setup_conn();
+        conn.execute_batch("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+            .unwrap();
+        conn.execute("INSERT INTO t VALUES (1, 'test')", [])
+            .unwrap();
+        let val: String = conn
+            .query_row("SELECT name FROM t WHERE id = 1", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(val, "test");
+        conn.execute("UPDATE t SET name = 'updated' WHERE id = 1", [])
+            .unwrap();
+        conn.execute("DELETE FROM t WHERE id = 1", []).unwrap();
+        conn.execute_batch("DROP TABLE t").unwrap();
+    }
+
+    #[test]
+    fn test_attach_blocked() {
+        let conn = setup_conn();
+        let result = conn.execute_batch("ATTACH DATABASE ':memory:' AS other");
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("authorized") || err.contains("denied") || err.contains("not authorized"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn test_dangerous_pragma_blocked() {
+        let conn = setup_conn();
+        let result = conn.execute_batch("PRAGMA journal_mode=WAL");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_safe_pragma_allowed() {
+        let conn = setup_conn();
+        conn.execute_batch("CREATE TABLE t (id INTEGER)").unwrap();
+        let _: Vec<(i32, String)> = conn
+            .prepare("PRAGMA table_info('t')")
+            .unwrap()
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+    }
+
+    #[test]
+    fn test_create_virtual_table_blocked() {
+        let conn = setup_conn();
+        let result = conn.execute_batch("CREATE VIRTUAL TABLE vt USING fts5(content)");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_authorizer_removal() {
+        let conn = Connection::open_in_memory().unwrap();
+        install_authorizer(&conn);
+        assert!(
+            conn.execute_batch("ATTACH DATABASE ':memory:' AS other")
+                .is_err()
+        );
+        remove_authorizer(&conn);
+        assert!(
+            conn.execute_batch("ATTACH DATABASE ':memory:' AS other")
+                .is_ok()
+        );
+    }
+}

--- a/crates/session-sqldb/src/error.rs
+++ b/crates/session-sqldb/src/error.rs
@@ -1,0 +1,54 @@
+// Session SQL database error types
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum SqlDbError {
+    #[error("database not found: {0}")]
+    DatabaseNotFound(String),
+
+    #[error("database already exists: {0}")]
+    DatabaseAlreadyExists(String),
+
+    #[error("invalid database name: {0}")]
+    InvalidDatabaseName(String),
+
+    #[error("database limit exceeded: {0}")]
+    LimitExceeded(String),
+
+    #[error("query error: {0}")]
+    QueryError(String),
+
+    #[error("query timeout after {0} seconds")]
+    QueryTimeout(u64),
+
+    #[error("result too large: {0}")]
+    ResultTooLarge(String),
+
+    #[error("operation blocked by authorizer: {0}")]
+    AuthorizerBlocked(String),
+
+    #[error("sqlite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+impl From<SqlDbError> for everruns_core::session_sqldb::SessionSqlDbError {
+    fn from(e: SqlDbError) -> Self {
+        use everruns_core::session_sqldb::SessionSqlDbError;
+        match e {
+            SqlDbError::DatabaseNotFound(s) => SessionSqlDbError::DatabaseNotFound(s),
+            SqlDbError::DatabaseAlreadyExists(s) => SessionSqlDbError::DatabaseAlreadyExists(s),
+            SqlDbError::InvalidDatabaseName(s) => SessionSqlDbError::InvalidDatabaseName(s),
+            SqlDbError::LimitExceeded(s) => SessionSqlDbError::LimitExceeded(s),
+            SqlDbError::QueryError(s) => SessionSqlDbError::QueryError(s),
+            SqlDbError::QueryTimeout(s) => SessionSqlDbError::QueryTimeout(s),
+            SqlDbError::ResultTooLarge(s) => SessionSqlDbError::ResultTooLarge(s),
+            SqlDbError::AuthorizerBlocked(s) => SessionSqlDbError::AuthorizerBlocked(s),
+            SqlDbError::Sqlite(e) => SessionSqlDbError::Internal(e.to_string()),
+            SqlDbError::Internal(s) => SessionSqlDbError::Internal(s),
+        }
+    }
+}

--- a/crates/session-sqldb/src/executor.rs
+++ b/crates/session-sqldb/src/executor.rs
@@ -1,0 +1,398 @@
+// Shared query execution logic
+//
+// Operates on any rusqlite::Connection (VFS-backed or in-memory).
+// Handles authorizer installation, progress handler, result mapping.
+
+use crate::authorizer::install_authorizer;
+use crate::error::SqlDbError;
+use crate::limits::{
+    MAX_RESULT_ROWS, MAX_RESULT_SIZE_BYTES, PROGRESS_HANDLER_INTERVAL, QUERY_TIMEOUT_SECS,
+};
+use crate::types::{ColumnSchema, SqlExecuteResult, SqlQueryResult, TableSchema};
+use rusqlite::Connection;
+use serde_json::Value;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
+use tracing::debug;
+
+/// Configure a connection with safe defaults.
+///
+/// Call once after opening a connection, before the authorizer is installed.
+pub fn configure_connection(conn: &Connection) -> Result<(), SqlDbError> {
+    conn.execute_batch(
+        "PRAGMA journal_mode=MEMORY;
+         PRAGMA page_size=4096;
+         PRAGMA foreign_keys=ON;",
+    )
+    .map_err(|e| SqlDbError::Internal(format!("failed to configure connection: {e}")))?;
+    Ok(())
+}
+
+/// Install a progress handler that interrupts after timeout.
+fn install_progress_handler(conn: &Connection, interrupted: Arc<AtomicBool>) {
+    conn.progress_handler(
+        PROGRESS_HANDLER_INTERVAL,
+        Some(move || interrupted.load(Ordering::Relaxed)),
+    );
+}
+
+/// Remove the progress handler.
+fn clear_progress_handler(conn: &Connection) {
+    conn.progress_handler(0, None::<fn() -> bool>);
+}
+
+/// Execute a read-only SQL query, returning columns and rows as JSON.
+pub fn execute_query(conn: &Connection, sql: &str) -> Result<SqlQueryResult, SqlDbError> {
+    install_authorizer(conn);
+
+    let interrupted = Arc::new(AtomicBool::new(false));
+    install_progress_handler(conn, interrupted.clone());
+
+    // Start timeout tracker
+    let start = Instant::now();
+    let timeout_secs = QUERY_TIMEOUT_SECS;
+
+    // Set up timeout interrupt in a separate check
+    let interrupt_handle = conn.get_interrupt_handle();
+    let interrupted_clone = interrupted.clone();
+    let timeout_thread = std::thread::spawn(move || {
+        loop {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            if interrupted_clone.load(Ordering::Relaxed) {
+                break;
+            }
+            if start.elapsed().as_secs() >= timeout_secs {
+                interrupted_clone.store(true, Ordering::Relaxed);
+                interrupt_handle.interrupt();
+                break;
+            }
+        }
+    });
+
+    let result = execute_query_inner(conn, sql);
+
+    // Signal timeout thread to stop
+    interrupted.store(true, Ordering::Relaxed);
+    let _ = timeout_thread.join();
+
+    // Remove progress handler
+    clear_progress_handler(conn);
+
+    result
+}
+
+fn execute_query_inner(conn: &Connection, sql: &str) -> Result<SqlQueryResult, SqlDbError> {
+    let mut stmt = conn
+        .prepare(sql)
+        .map_err(|e| SqlDbError::QueryError(e.to_string()))?;
+
+    let columns: Vec<String> = stmt.column_names().iter().map(|s| s.to_string()).collect();
+    let col_count = columns.len();
+
+    let mut rows = Vec::new();
+    let mut truncated = false;
+    let mut total_size: usize = 0;
+
+    let mut raw_rows = stmt
+        .query([])
+        .map_err(|e| SqlDbError::QueryError(e.to_string()))?;
+
+    while let Some(row) = raw_rows
+        .next()
+        .map_err(|e| SqlDbError::QueryError(e.to_string()))?
+    {
+        if rows.len() >= MAX_RESULT_ROWS {
+            truncated = true;
+            break;
+        }
+
+        let mut json_row = Vec::with_capacity(col_count);
+        for i in 0..col_count {
+            let val = sqlite_value_to_json(row, i)?;
+            total_size += estimate_json_size(&val);
+            json_row.push(val);
+        }
+
+        if total_size > MAX_RESULT_SIZE_BYTES {
+            truncated = true;
+            break;
+        }
+
+        rows.push(json_row);
+    }
+
+    let row_count = rows.len();
+
+    Ok(SqlQueryResult {
+        columns,
+        rows,
+        row_count,
+        truncated,
+    })
+}
+
+/// Execute a write SQL statement, returning affected row count.
+pub fn execute_statement(conn: &Connection, sql: &str) -> Result<SqlExecuteResult, SqlDbError> {
+    install_authorizer(conn);
+
+    let interrupted = Arc::new(AtomicBool::new(false));
+    install_progress_handler(conn, interrupted.clone());
+
+    let start = Instant::now();
+    let timeout_secs = QUERY_TIMEOUT_SECS;
+    let interrupt_handle = conn.get_interrupt_handle();
+    let interrupted_clone = interrupted.clone();
+    let timeout_thread = std::thread::spawn(move || {
+        loop {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            if interrupted_clone.load(Ordering::Relaxed) {
+                break;
+            }
+            if start.elapsed().as_secs() >= timeout_secs {
+                interrupted_clone.store(true, Ordering::Relaxed);
+                interrupt_handle.interrupt();
+                break;
+            }
+        }
+    });
+
+    let result = conn
+        .execute_batch(sql)
+        .map_err(|e| SqlDbError::QueryError(e.to_string()));
+
+    interrupted.store(true, Ordering::Relaxed);
+    let _ = timeout_thread.join();
+    clear_progress_handler(conn);
+
+    result?;
+
+    let rows_affected = conn.changes();
+    debug!(rows_affected, "SQL execute completed");
+
+    Ok(SqlExecuteResult { rows_affected })
+}
+
+/// Get schema for all tables in the database.
+pub fn get_schema(conn: &Connection) -> Result<Vec<TableSchema>, SqlDbError> {
+    install_authorizer(conn);
+
+    let mut stmt = conn
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name")
+        .map_err(|e| SqlDbError::QueryError(e.to_string()))?;
+
+    let table_names: Vec<String> = stmt
+        .query_map([], |row| row.get(0))
+        .map_err(|e| SqlDbError::QueryError(e.to_string()))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| SqlDbError::QueryError(e.to_string()))?;
+
+    let mut tables = Vec::new();
+    for table_name in table_names {
+        let table = get_table_schema(conn, &table_name)?;
+        tables.push(table);
+    }
+
+    Ok(tables)
+}
+
+/// Get schema for a specific table.
+pub fn get_table_schema(conn: &Connection, table_name: &str) -> Result<TableSchema, SqlDbError> {
+    // Get columns via PRAGMA table_info
+    let pragma_sql = format!("PRAGMA table_info(\"{}\")", table_name.replace('"', "\"\""));
+    let mut stmt = conn
+        .prepare(&pragma_sql)
+        .map_err(|e| SqlDbError::QueryError(e.to_string()))?;
+
+    let columns: Vec<ColumnSchema> = stmt
+        .query_map([], |row| {
+            Ok(ColumnSchema {
+                name: row.get(1)?,
+                column_type: row.get::<_, String>(2).unwrap_or_default(),
+                notnull: row.get::<_, bool>(3).unwrap_or(false),
+                pk: row.get::<_, i32>(5).unwrap_or(0) > 0,
+                default_value: row.get(4).ok(),
+            })
+        })
+        .map_err(|e| SqlDbError::QueryError(e.to_string()))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| SqlDbError::QueryError(e.to_string()))?;
+
+    // Get row count
+    let count_sql = format!(
+        "SELECT COUNT(*) FROM \"{}\"",
+        table_name.replace('"', "\"\"")
+    );
+    let row_count: i64 = conn
+        .query_row(&count_sql, [], |row| row.get(0))
+        .unwrap_or(0);
+
+    Ok(TableSchema {
+        name: table_name.to_string(),
+        columns,
+        row_count,
+    })
+}
+
+/// Convert a SQLite value to JSON.
+fn sqlite_value_to_json(row: &rusqlite::Row<'_>, idx: usize) -> Result<Value, SqlDbError> {
+    use rusqlite::types::ValueRef;
+
+    let val_ref = row
+        .get_ref(idx)
+        .map_err(|e| SqlDbError::QueryError(e.to_string()))?;
+
+    Ok(match val_ref {
+        ValueRef::Null => Value::Null,
+        ValueRef::Integer(i) => Value::Number(serde_json::Number::from(i)),
+        ValueRef::Real(f) => serde_json::Number::from_f64(f)
+            .map(Value::Number)
+            .unwrap_or(Value::Null),
+        ValueRef::Text(t) => {
+            let s = std::str::from_utf8(t)
+                .map_err(|e| SqlDbError::QueryError(format!("invalid UTF-8: {e}")))?;
+            Value::String(s.to_string())
+        }
+        ValueRef::Blob(b) => {
+            use base64::Engine;
+            Value::String(base64::engine::general_purpose::STANDARD.encode(b))
+        }
+    })
+}
+
+/// Rough estimate of JSON value size in bytes.
+fn estimate_json_size(val: &Value) -> usize {
+    match val {
+        Value::Null => 4,
+        Value::Bool(_) => 5,
+        Value::Number(n) => n.to_string().len(),
+        Value::String(s) => s.len() + 2,
+        Value::Array(a) => a.iter().map(estimate_json_size).sum::<usize>() + a.len(),
+        Value::Object(o) => o.values().map(estimate_json_size).sum::<usize>() + o.len() * 4,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        configure_connection(&conn).unwrap();
+        conn
+    }
+
+    #[test]
+    fn test_execute_and_query() {
+        let conn = setup_conn();
+        execute_statement(
+            &conn,
+            "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, age INTEGER)",
+        )
+        .unwrap();
+
+        execute_statement(
+            &conn,
+            "INSERT INTO users VALUES (1, 'Alice', 30), (2, 'Bob', 25)",
+        )
+        .unwrap();
+
+        let result = execute_query(&conn, "SELECT * FROM users ORDER BY id").unwrap();
+        assert_eq!(result.columns, vec!["id", "name", "age"]);
+        assert_eq!(result.row_count, 2);
+        assert_eq!(result.rows[0], vec![json!(1), json!("Alice"), json!(30)]);
+        assert_eq!(result.rows[1], vec![json!(2), json!("Bob"), json!(25)]);
+        assert!(!result.truncated);
+    }
+
+    #[test]
+    fn test_null_values() {
+        let conn = setup_conn();
+        execute_statement(&conn, "CREATE TABLE t (id INTEGER, val TEXT)").unwrap();
+        execute_statement(&conn, "INSERT INTO t VALUES (1, NULL)").unwrap();
+
+        let result = execute_query(&conn, "SELECT * FROM t").unwrap();
+        assert_eq!(result.rows[0][1], Value::Null);
+    }
+
+    #[test]
+    fn test_real_values() {
+        let conn = setup_conn();
+        execute_statement(&conn, "CREATE TABLE t (val REAL)").unwrap();
+        execute_statement(&conn, "INSERT INTO t VALUES (2.72)").unwrap();
+
+        let result = execute_query(&conn, "SELECT * FROM t").unwrap();
+        assert_eq!(result.rows[0][0], json!(2.72));
+    }
+
+    #[test]
+    fn test_blob_values() {
+        let conn = setup_conn();
+        execute_statement(&conn, "CREATE TABLE t (val BLOB)").unwrap();
+        conn.execute("INSERT INTO t VALUES (?1)", [&[0u8, 1, 2, 3] as &[u8]])
+            .unwrap();
+
+        let result = execute_query(&conn, "SELECT * FROM t").unwrap();
+        // BLOB should be base64 encoded
+        assert_eq!(result.rows[0][0], json!("AAECAw=="));
+    }
+
+    #[test]
+    fn test_schema_introspection() {
+        let conn = setup_conn();
+        execute_statement(
+            &conn,
+            "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL, age INTEGER)",
+        )
+        .unwrap();
+        execute_statement(
+            &conn,
+            "INSERT INTO users VALUES (1, 'Alice', 30), (2, 'Bob', 25)",
+        )
+        .unwrap();
+
+        let schema = get_schema(&conn).unwrap();
+        assert_eq!(schema.len(), 1);
+        assert_eq!(schema[0].name, "users");
+        assert_eq!(schema[0].row_count, 2);
+        assert_eq!(schema[0].columns.len(), 3);
+
+        assert_eq!(schema[0].columns[0].name, "id");
+        assert!(schema[0].columns[0].pk);
+
+        assert_eq!(schema[0].columns[1].name, "name");
+        assert!(schema[0].columns[1].notnull);
+    }
+
+    #[test]
+    fn test_query_error() {
+        let conn = setup_conn();
+        let result = execute_query(&conn, "SELECT * FROM nonexistent");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_execute_statement_returns_rows_affected() {
+        let conn = setup_conn();
+        execute_statement(&conn, "CREATE TABLE t (id INTEGER, val TEXT)").unwrap();
+        execute_statement(&conn, "INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c')").unwrap();
+
+        let result = execute_statement(&conn, "DELETE FROM t WHERE id > 1").unwrap();
+        assert_eq!(result.rows_affected, 2);
+    }
+
+    #[test]
+    fn test_multiple_tables_schema() {
+        let conn = setup_conn();
+        execute_statement(&conn, "CREATE TABLE a (id INTEGER)").unwrap();
+        execute_statement(&conn, "CREATE TABLE b (id INTEGER, val TEXT)").unwrap();
+
+        let schema = get_schema(&conn).unwrap();
+        assert_eq!(schema.len(), 2);
+        let names: Vec<&str> = schema.iter().map(|t| t.name.as_str()).collect();
+        assert!(names.contains(&"a"));
+        assert!(names.contains(&"b"));
+    }
+
+    use serde_json::json;
+}

--- a/crates/session-sqldb/src/lib.rs
+++ b/crates/session-sqldb/src/lib.rs
@@ -1,0 +1,29 @@
+// Session SQL Database crate
+//
+// Provides session-scoped SQLite databases backed by PostgreSQL page-level
+// storage (production) or in-memory serialize/deserialize (DEV_MODE).
+//
+// Architecture:
+// - types.rs: Shared types (DatabaseInfo, SqlQueryResult, etc.)
+// - executor.rs: Shared query execution on rusqlite::Connection
+// - authorizer.rs: SQLite authorizer blocking dangerous operations
+// - validation.rs: Database name validation
+// - limits.rs: Size and resource limit constants
+// - memory.rs: In-memory backend for DEV_MODE
+// - store.rs: Async SessionSqlDbStore trait implementation
+// - error.rs: Error types
+
+pub mod authorizer;
+pub mod error;
+pub mod executor;
+pub mod limits;
+pub mod memory;
+pub mod store;
+pub mod types;
+pub mod validation;
+
+// Re-exports
+pub use error::SqlDbError;
+pub use memory::InMemorySqlDbBackend;
+pub use store::InMemorySqlDbStore;
+pub use types::{ColumnSchema, DatabaseInfo, SqlExecuteResult, SqlQueryResult, TableSchema};

--- a/crates/session-sqldb/src/limits.rs
+++ b/crates/session-sqldb/src/limits.rs
@@ -1,0 +1,26 @@
+// Size and resource limits for session SQL databases
+
+/// Maximum size of a single database in bytes (50 MB).
+pub const MAX_DB_SIZE_BYTES: i64 = 50 * 1024 * 1024;
+
+/// Maximum total database storage per session in bytes (100 MB).
+pub const MAX_SESSION_TOTAL_SIZE_BYTES: i64 = 100 * 1024 * 1024;
+
+/// Maximum number of databases per session.
+pub const MAX_DATABASES_PER_SESSION: usize = 10;
+
+/// SQLite page size in bytes.
+pub const PAGE_SIZE: usize = 4096;
+
+/// Maximum rows returned by a single query.
+pub const MAX_RESULT_ROWS: usize = 1000;
+
+/// Maximum result payload size in bytes (1 MB).
+pub const MAX_RESULT_SIZE_BYTES: usize = 1024 * 1024;
+
+/// Query timeout in seconds.
+pub const QUERY_TIMEOUT_SECS: u64 = 30;
+
+/// SQLite progress handler callback interval (VM instructions).
+/// Check timeout every 10,000 instructions.
+pub const PROGRESS_HANDLER_INTERVAL: i32 = 10_000;

--- a/crates/session-sqldb/src/memory.rs
+++ b/crates/session-sqldb/src/memory.rs
@@ -1,0 +1,436 @@
+// In-memory backend for session SQL databases
+//
+// Keeps SQLite connections alive in a HashMap keyed by (session_id, db_name).
+// Each connection is wrapped in a Mutex for thread-safe access.
+// Connection is Send (rusqlite bundled) so Mutex<Connection> is Send + Sync.
+
+use crate::error::SqlDbError;
+use crate::executor::{configure_connection, execute_query, execute_statement, get_schema};
+use crate::limits::{MAX_DATABASES_PER_SESSION, MAX_DB_SIZE_BYTES, MAX_SESSION_TOTAL_SIZE_BYTES};
+use crate::types::{DatabaseInfo, SqlExecuteResult, SqlQueryResult, TableSchema};
+use crate::validation::validate_database_name;
+use chrono::Utc;
+use everruns_core::typed_id::SessionId;
+use parking_lot::{Mutex, RwLock};
+use rusqlite::{Connection, DatabaseName};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tracing::debug;
+
+/// Key for database lookup: (session_id, database_name)
+type DbKey = (SessionId, String);
+
+/// Stored database state
+struct StoredDb {
+    info: DatabaseInfo,
+    /// Live SQLite connection
+    conn: Arc<Mutex<Connection>>,
+}
+
+/// In-memory backend using live SQLite connections.
+pub struct InMemorySqlDbBackend {
+    databases: RwLock<HashMap<DbKey, StoredDb>>,
+}
+
+impl InMemorySqlDbBackend {
+    pub fn new() -> Self {
+        Self {
+            databases: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Create a new configured in-memory connection.
+    fn new_connection() -> Result<Connection, SqlDbError> {
+        let conn = Connection::open_in_memory()
+            .map_err(|e| SqlDbError::Internal(format!("failed to open in-memory db: {e}")))?;
+        configure_connection(&conn)?;
+        Ok(conn)
+    }
+
+    /// Get the current database size by serializing (for tracking only).
+    fn estimate_db_size(conn: &Connection) -> i64 {
+        conn.serialize(DatabaseName::Main)
+            .map(|data| data.len() as i64)
+            .unwrap_or(0)
+    }
+
+    /// Update size tracking after a mutation.
+    fn update_size(&self, session_id: SessionId, name: &str) {
+        let key = (session_id, name.to_string());
+        let mut dbs = self.databases.write();
+        if let Some(stored) = dbs.get_mut(&key) {
+            let conn = stored.conn.lock();
+            let size_bytes = Self::estimate_db_size(&conn);
+            stored.info.size_bytes = size_bytes;
+            stored.info.page_count = ((size_bytes + 4095) / 4096) as i32;
+            stored.info.updated_at = Utc::now();
+        }
+    }
+
+    /// Check per-database and per-session size limits.
+    fn check_size_limits(
+        &self,
+        session_id: SessionId,
+        name: &str,
+        new_size: i64,
+    ) -> Result<(), SqlDbError> {
+        if new_size > MAX_DB_SIZE_BYTES {
+            return Err(SqlDbError::LimitExceeded(format!(
+                "database size {} exceeds limit {}",
+                new_size, MAX_DB_SIZE_BYTES
+            )));
+        }
+
+        let dbs = self.databases.read();
+        let other_size: i64 = dbs
+            .iter()
+            .filter(|(k, _)| k.0 == session_id && k.1 != name)
+            .map(|(_, v)| v.info.size_bytes)
+            .sum();
+        if other_size + new_size > MAX_SESSION_TOTAL_SIZE_BYTES {
+            return Err(SqlDbError::LimitExceeded(format!(
+                "session total size would exceed limit {}",
+                MAX_SESSION_TOTAL_SIZE_BYTES
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Count databases for a session.
+    fn count_databases(&self, session_id: SessionId) -> usize {
+        self.databases
+            .read()
+            .keys()
+            .filter(|(sid, _)| *sid == session_id)
+            .count()
+    }
+
+    pub fn create_database(
+        &self,
+        session_id: SessionId,
+        name: &str,
+    ) -> Result<DatabaseInfo, SqlDbError> {
+        validate_database_name(name)?;
+
+        let key = (session_id, name.to_string());
+
+        // Check if already exists
+        if self.databases.read().contains_key(&key) {
+            return Err(SqlDbError::DatabaseAlreadyExists(name.to_string()));
+        }
+
+        // Check database count limit
+        if self.count_databases(session_id) >= MAX_DATABASES_PER_SESSION {
+            return Err(SqlDbError::LimitExceeded(format!(
+                "maximum {} databases per session",
+                MAX_DATABASES_PER_SESSION
+            )));
+        }
+
+        let conn = Self::new_connection()?;
+        let now = Utc::now();
+        let info = DatabaseInfo {
+            name: name.to_string(),
+            size_bytes: 0,
+            page_count: 0,
+            created_at: now,
+            updated_at: now,
+        };
+
+        self.databases.write().insert(
+            key,
+            StoredDb {
+                info: info.clone(),
+                conn: Arc::new(Mutex::new(conn)),
+            },
+        );
+
+        debug!(session_id = %session_id, name, "Created in-memory database");
+        Ok(info)
+    }
+
+    pub fn get_database(
+        &self,
+        session_id: SessionId,
+        name: &str,
+    ) -> Result<Option<DatabaseInfo>, SqlDbError> {
+        let key = (session_id, name.to_string());
+        Ok(self.databases.read().get(&key).map(|d| d.info.clone()))
+    }
+
+    pub fn list_databases(&self, session_id: SessionId) -> Result<Vec<DatabaseInfo>, SqlDbError> {
+        let dbs = self.databases.read();
+        let mut result: Vec<DatabaseInfo> = dbs
+            .iter()
+            .filter(|(k, _)| k.0 == session_id)
+            .map(|(_, v)| v.info.clone())
+            .collect();
+        result.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(result)
+    }
+
+    pub fn delete_database(&self, session_id: SessionId, name: &str) -> Result<bool, SqlDbError> {
+        let key = (session_id, name.to_string());
+        Ok(self.databases.write().remove(&key).is_some())
+    }
+
+    /// Delete all databases for a session (used when session is deleted).
+    pub fn delete_session_databases(&self, session_id: SessionId) {
+        let mut dbs = self.databases.write();
+        dbs.retain(|(sid, _), _| *sid != session_id);
+    }
+
+    pub fn query(
+        &self,
+        session_id: SessionId,
+        db_name: &str,
+        sql: &str,
+    ) -> Result<SqlQueryResult, SqlDbError> {
+        validate_database_name(db_name)?;
+
+        let key = (session_id, db_name.to_string());
+        let dbs = self.databases.read();
+        let stored = dbs
+            .get(&key)
+            .ok_or_else(|| SqlDbError::DatabaseNotFound(db_name.to_string()))?;
+
+        let conn = stored.conn.lock();
+        execute_query(&conn, sql)
+    }
+
+    pub fn execute(
+        &self,
+        session_id: SessionId,
+        db_name: &str,
+        sql: &str,
+    ) -> Result<SqlExecuteResult, SqlDbError> {
+        validate_database_name(db_name)?;
+
+        // Auto-create database if it doesn't exist
+        if self.get_database(session_id, db_name)?.is_none() {
+            self.create_database(session_id, db_name)?;
+        }
+
+        let key = (session_id, db_name.to_string());
+        let result = {
+            let dbs = self.databases.read();
+            let stored = dbs
+                .get(&key)
+                .ok_or_else(|| SqlDbError::DatabaseNotFound(db_name.to_string()))?;
+            let conn = stored.conn.lock();
+            let result = execute_statement(&conn, sql)?;
+
+            // Check size limits after mutation
+            let new_size = Self::estimate_db_size(&conn);
+            drop(conn);
+            drop(dbs);
+            self.check_size_limits(session_id, db_name, new_size)?;
+            result
+        };
+
+        // Update size tracking
+        self.update_size(session_id, db_name);
+        Ok(result)
+    }
+
+    pub fn get_schema(
+        &self,
+        session_id: SessionId,
+        db_name: &str,
+    ) -> Result<Vec<TableSchema>, SqlDbError> {
+        validate_database_name(db_name)?;
+
+        let key = (session_id, db_name.to_string());
+        let dbs = self.databases.read();
+        let stored = dbs
+            .get(&key)
+            .ok_or_else(|| SqlDbError::DatabaseNotFound(db_name.to_string()))?;
+
+        let conn = stored.conn.lock();
+        get_schema(&conn)
+    }
+}
+
+impl Default for InMemorySqlDbBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::typed_id::SessionId;
+
+    fn session_id() -> SessionId {
+        SessionId::from(uuid::Uuid::new_v4())
+    }
+
+    #[test]
+    fn test_create_and_list() {
+        let backend = InMemorySqlDbBackend::new();
+        let sid = session_id();
+
+        let info = backend.create_database(sid, "test_db").unwrap();
+        assert_eq!(info.name, "test_db");
+        assert_eq!(info.size_bytes, 0);
+
+        let list = backend.list_databases(sid).unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].name, "test_db");
+    }
+
+    #[test]
+    fn test_create_duplicate() {
+        let backend = InMemorySqlDbBackend::new();
+        let sid = session_id();
+
+        backend.create_database(sid, "test_db").unwrap();
+        let result = backend.create_database(sid, "test_db");
+        assert!(matches!(result, Err(SqlDbError::DatabaseAlreadyExists(_))));
+    }
+
+    #[test]
+    fn test_delete() {
+        let backend = InMemorySqlDbBackend::new();
+        let sid = session_id();
+
+        backend.create_database(sid, "test_db").unwrap();
+        assert!(backend.delete_database(sid, "test_db").unwrap());
+        assert!(!backend.delete_database(sid, "test_db").unwrap());
+        assert!(backend.list_databases(sid).unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_session_isolation() {
+        let backend = InMemorySqlDbBackend::new();
+        let sid1 = session_id();
+        let sid2 = session_id();
+
+        backend.create_database(sid1, "db").unwrap();
+        backend.create_database(sid2, "db").unwrap();
+
+        assert_eq!(backend.list_databases(sid1).unwrap().len(), 1);
+        assert_eq!(backend.list_databases(sid2).unwrap().len(), 1);
+
+        backend.delete_session_databases(sid1);
+        assert!(backend.list_databases(sid1).unwrap().is_empty());
+        assert_eq!(backend.list_databases(sid2).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_max_databases_per_session() {
+        let backend = InMemorySqlDbBackend::new();
+        let sid = session_id();
+
+        for i in 0..MAX_DATABASES_PER_SESSION {
+            backend.create_database(sid, &format!("db_{i}")).unwrap();
+        }
+
+        let result = backend.create_database(sid, "one_too_many");
+        assert!(matches!(result, Err(SqlDbError::LimitExceeded(_))));
+    }
+
+    #[test]
+    fn test_execute_and_query_lifecycle() {
+        let backend = InMemorySqlDbBackend::new();
+        let sid = session_id();
+
+        // Auto-creates database
+        backend
+            .execute(
+                sid,
+                "mydb",
+                "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)",
+            )
+            .unwrap();
+
+        backend
+            .execute(
+                sid,
+                "mydb",
+                "INSERT INTO users VALUES (1, 'Alice'), (2, 'Bob')",
+            )
+            .unwrap();
+
+        let result = backend
+            .query(sid, "mydb", "SELECT * FROM users ORDER BY id")
+            .unwrap();
+        assert_eq!(result.row_count, 2);
+        assert_eq!(result.columns, vec!["id", "name"]);
+
+        // Verify data persists across calls
+        let result2 = backend
+            .query(sid, "mydb", "SELECT COUNT(*) as cnt FROM users")
+            .unwrap();
+        assert_eq!(result2.rows[0][0], serde_json::json!(2));
+    }
+
+    #[test]
+    fn test_query_nonexistent_database() {
+        let backend = InMemorySqlDbBackend::new();
+        let sid = session_id();
+
+        let result = backend.query(sid, "nope", "SELECT 1");
+        assert!(matches!(result, Err(SqlDbError::DatabaseNotFound(_))));
+    }
+
+    #[test]
+    fn test_schema() {
+        let backend = InMemorySqlDbBackend::new();
+        let sid = session_id();
+
+        backend
+            .execute(
+                sid,
+                "mydb",
+                "CREATE TABLE t1 (id INTEGER PRIMARY KEY, val TEXT NOT NULL);
+                 CREATE TABLE t2 (x REAL);
+                 INSERT INTO t1 VALUES (1, 'a');",
+            )
+            .unwrap();
+
+        let schema = backend.get_schema(sid, "mydb").unwrap();
+        assert_eq!(schema.len(), 2);
+
+        let t1 = schema.iter().find(|t| t.name == "t1").unwrap();
+        assert_eq!(t1.row_count, 1);
+        assert_eq!(t1.columns.len(), 2);
+        assert!(t1.columns[0].pk);
+        assert!(t1.columns[1].notnull);
+    }
+
+    #[test]
+    fn test_size_tracking() {
+        let backend = InMemorySqlDbBackend::new();
+        let sid = session_id();
+
+        backend
+            .execute(sid, "mydb", "CREATE TABLE t (val TEXT)")
+            .unwrap();
+
+        let info = backend.get_database(sid, "mydb").unwrap().unwrap();
+        // After creating a table, size should be > 0
+        assert!(info.size_bytes > 0);
+    }
+
+    #[test]
+    fn test_invalid_name_rejected() {
+        let backend = InMemorySqlDbBackend::new();
+        let sid = session_id();
+
+        assert!(matches!(
+            backend.create_database(sid, ""),
+            Err(SqlDbError::InvalidDatabaseName(_))
+        ));
+        assert!(matches!(
+            backend.create_database(sid, "1abc"),
+            Err(SqlDbError::InvalidDatabaseName(_))
+        ));
+        assert!(matches!(
+            backend.create_database(sid, "my-db"),
+            Err(SqlDbError::InvalidDatabaseName(_))
+        ));
+    }
+}

--- a/crates/session-sqldb/src/store.rs
+++ b/crates/session-sqldb/src/store.rs
@@ -1,0 +1,239 @@
+// SessionSqlDbStore trait implementation for InMemorySqlDbBackend
+//
+// Wraps synchronous InMemorySqlDbBackend calls with spawn_blocking
+// since SQLite operations can take up to 30 seconds (query timeout).
+
+use async_trait::async_trait;
+use everruns_core::session_sqldb::{
+    DatabaseInfo, SessionSqlDbError, SessionSqlDbStore, SqlExecuteResult, SqlQueryResult,
+    TableSchema,
+};
+use everruns_core::typed_id::SessionId;
+use std::sync::Arc;
+
+use crate::memory::InMemorySqlDbBackend;
+
+/// Async wrapper around InMemorySqlDbBackend implementing SessionSqlDbStore.
+#[derive(Clone)]
+pub struct InMemorySqlDbStore {
+    inner: Arc<InMemorySqlDbBackend>,
+}
+
+impl InMemorySqlDbStore {
+    pub fn new(backend: Arc<InMemorySqlDbBackend>) -> Self {
+        Self { inner: backend }
+    }
+
+    /// Get a reference to the underlying backend.
+    pub fn backend(&self) -> &Arc<InMemorySqlDbBackend> {
+        &self.inner
+    }
+}
+
+#[async_trait]
+impl SessionSqlDbStore for InMemorySqlDbStore {
+    async fn create_database(
+        &self,
+        session_id: SessionId,
+        name: &str,
+    ) -> Result<DatabaseInfo, SessionSqlDbError> {
+        let inner = self.inner.clone();
+        let name = name.to_string();
+        tokio::task::spawn_blocking(move || inner.create_database(session_id, &name))
+            .await
+            .map_err(|e| SessionSqlDbError::Internal(format!("spawn_blocking failed: {e}")))?
+            .map_err(Into::into)
+    }
+
+    async fn list_databases(
+        &self,
+        session_id: SessionId,
+    ) -> Result<Vec<DatabaseInfo>, SessionSqlDbError> {
+        let inner = self.inner.clone();
+        tokio::task::spawn_blocking(move || inner.list_databases(session_id))
+            .await
+            .map_err(|e| SessionSqlDbError::Internal(format!("spawn_blocking failed: {e}")))?
+            .map_err(Into::into)
+    }
+
+    async fn get_database(
+        &self,
+        session_id: SessionId,
+        name: &str,
+    ) -> Result<Option<DatabaseInfo>, SessionSqlDbError> {
+        let inner = self.inner.clone();
+        let name = name.to_string();
+        tokio::task::spawn_blocking(move || inner.get_database(session_id, &name))
+            .await
+            .map_err(|e| SessionSqlDbError::Internal(format!("spawn_blocking failed: {e}")))?
+            .map_err(Into::into)
+    }
+
+    async fn delete_database(
+        &self,
+        session_id: SessionId,
+        name: &str,
+    ) -> Result<bool, SessionSqlDbError> {
+        let inner = self.inner.clone();
+        let name = name.to_string();
+        tokio::task::spawn_blocking(move || inner.delete_database(session_id, &name))
+            .await
+            .map_err(|e| SessionSqlDbError::Internal(format!("spawn_blocking failed: {e}")))?
+            .map_err(Into::into)
+    }
+
+    async fn sql_execute(
+        &self,
+        session_id: SessionId,
+        db_name: &str,
+        sql: &str,
+    ) -> Result<SqlExecuteResult, SessionSqlDbError> {
+        let inner = self.inner.clone();
+        let db_name = db_name.to_string();
+        let sql = sql.to_string();
+        tokio::task::spawn_blocking(move || inner.execute(session_id, &db_name, &sql))
+            .await
+            .map_err(|e| SessionSqlDbError::Internal(format!("spawn_blocking failed: {e}")))?
+            .map_err(Into::into)
+    }
+
+    async fn sql_query(
+        &self,
+        session_id: SessionId,
+        db_name: &str,
+        sql: &str,
+    ) -> Result<SqlQueryResult, SessionSqlDbError> {
+        let inner = self.inner.clone();
+        let db_name = db_name.to_string();
+        let sql = sql.to_string();
+        tokio::task::spawn_blocking(move || inner.query(session_id, &db_name, &sql))
+            .await
+            .map_err(|e| SessionSqlDbError::Internal(format!("spawn_blocking failed: {e}")))?
+            .map_err(Into::into)
+    }
+
+    async fn sql_schema(
+        &self,
+        session_id: SessionId,
+        db_name: &str,
+        table: Option<&str>,
+    ) -> Result<Vec<TableSchema>, SessionSqlDbError> {
+        let inner = self.inner.clone();
+        let db_name = db_name.to_string();
+        let table = table.map(|s| s.to_string());
+        tokio::task::spawn_blocking(
+            move || -> Result<Vec<TableSchema>, crate::error::SqlDbError> {
+                let schemas = inner.get_schema(session_id, &db_name)?;
+                match &table {
+                    Some(table_name) => Ok(schemas
+                        .into_iter()
+                        .filter(|t| t.name == *table_name)
+                        .collect()),
+                    None => Ok(schemas),
+                }
+            },
+        )
+        .await
+        .map_err(|e| SessionSqlDbError::Internal(format!("spawn_blocking failed: {e}")))?
+        .map_err(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn session_id() -> SessionId {
+        SessionId::from(uuid::Uuid::new_v4())
+    }
+
+    #[tokio::test]
+    async fn test_store_create_and_list() {
+        let backend = Arc::new(InMemorySqlDbBackend::new());
+        let store = InMemorySqlDbStore::new(backend);
+        let sid = session_id();
+
+        let info = store.create_database(sid, "test_db").await.unwrap();
+        assert_eq!(info.name, "test_db");
+
+        let list = store.list_databases(sid).await.unwrap();
+        assert_eq!(list.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_store_execute_and_query() {
+        let backend = Arc::new(InMemorySqlDbBackend::new());
+        let store = InMemorySqlDbStore::new(backend);
+        let sid = session_id();
+
+        store
+            .sql_execute(
+                sid,
+                "mydb",
+                "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)",
+            )
+            .await
+            .unwrap();
+
+        store
+            .sql_execute(sid, "mydb", "INSERT INTO users VALUES (1, 'Alice')")
+            .await
+            .unwrap();
+
+        let result = store
+            .sql_query(sid, "mydb", "SELECT * FROM users")
+            .await
+            .unwrap();
+        assert_eq!(result.row_count, 1);
+        assert_eq!(result.columns, vec!["id", "name"]);
+    }
+
+    #[tokio::test]
+    async fn test_store_schema() {
+        let backend = Arc::new(InMemorySqlDbBackend::new());
+        let store = InMemorySqlDbStore::new(backend);
+        let sid = session_id();
+
+        store
+            .sql_execute(
+                sid,
+                "mydb",
+                "CREATE TABLE t1 (id INTEGER PRIMARY KEY, val TEXT NOT NULL)",
+            )
+            .await
+            .unwrap();
+
+        let schema = store.sql_schema(sid, "mydb", None).await.unwrap();
+        assert_eq!(schema.len(), 1);
+        assert_eq!(schema[0].name, "t1");
+        assert_eq!(schema[0].columns.len(), 2);
+
+        // Filter to specific table
+        let schema = store.sql_schema(sid, "mydb", Some("t1")).await.unwrap();
+        assert_eq!(schema.len(), 1);
+
+        let schema = store.sql_schema(sid, "mydb", Some("nope")).await.unwrap();
+        assert!(schema.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_store_delete() {
+        let backend = Arc::new(InMemorySqlDbBackend::new());
+        let store = InMemorySqlDbStore::new(backend);
+        let sid = session_id();
+
+        store.create_database(sid, "mydb").await.unwrap();
+        assert!(store.delete_database(sid, "mydb").await.unwrap());
+        assert!(!store.delete_database(sid, "mydb").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_store_query_nonexistent() {
+        let backend = Arc::new(InMemorySqlDbBackend::new());
+        let store = InMemorySqlDbStore::new(backend);
+        let sid = session_id();
+
+        let result = store.sql_query(sid, "nope", "SELECT 1").await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/session-sqldb/src/types.rs
+++ b/crates/session-sqldb/src/types.rs
@@ -1,0 +1,8 @@
+// Session SQL database types
+//
+// Re-exports from core. The canonical type definitions live in
+// everruns_core::session_sqldb. This module keeps backward compatibility.
+
+pub use everruns_core::session_sqldb::{
+    ColumnSchema, DatabaseInfo, SqlExecuteResult, SqlQueryResult, TableSchema,
+};

--- a/crates/session-sqldb/src/validation.rs
+++ b/crates/session-sqldb/src/validation.rs
@@ -1,0 +1,114 @@
+// Database name validation
+
+use crate::error::SqlDbError;
+
+/// Validate a database name.
+///
+/// Rules:
+/// - Must start with letter or underscore
+/// - Only alphanumeric and underscore characters
+/// - 1-64 characters long
+pub fn validate_database_name(name: &str) -> Result<(), SqlDbError> {
+    if name.is_empty() {
+        return Err(SqlDbError::InvalidDatabaseName(
+            "database name cannot be empty".to_string(),
+        ));
+    }
+
+    if name.len() > 64 {
+        return Err(SqlDbError::InvalidDatabaseName(
+            "database name cannot exceed 64 characters".to_string(),
+        ));
+    }
+
+    let first = name.chars().next().unwrap();
+    if !first.is_ascii_alphabetic() && first != '_' {
+        return Err(SqlDbError::InvalidDatabaseName(
+            "database name must start with a letter or underscore".to_string(),
+        ));
+    }
+
+    if !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        return Err(SqlDbError::InvalidDatabaseName(
+            "database name can only contain letters, numbers, and underscores".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_names() {
+        assert!(validate_database_name("main").is_ok());
+        assert!(validate_database_name("analytics").is_ok());
+        assert!(validate_database_name("user_data").is_ok());
+        assert!(validate_database_name("_private").is_ok());
+        assert!(validate_database_name("DB1").is_ok());
+        assert!(validate_database_name("a").is_ok());
+        assert!(validate_database_name("a_b_c_123").is_ok());
+    }
+
+    #[test]
+    fn test_empty_name() {
+        assert!(matches!(
+            validate_database_name(""),
+            Err(SqlDbError::InvalidDatabaseName(_))
+        ));
+    }
+
+    #[test]
+    fn test_too_long() {
+        let long_name = "a".repeat(65);
+        assert!(matches!(
+            validate_database_name(&long_name),
+            Err(SqlDbError::InvalidDatabaseName(_))
+        ));
+        // Exactly 64 is OK
+        let max_name = "a".repeat(64);
+        assert!(validate_database_name(&max_name).is_ok());
+    }
+
+    #[test]
+    fn test_starts_with_number() {
+        assert!(matches!(
+            validate_database_name("1abc"),
+            Err(SqlDbError::InvalidDatabaseName(_))
+        ));
+    }
+
+    #[test]
+    fn test_special_characters() {
+        assert!(matches!(
+            validate_database_name("my-db"),
+            Err(SqlDbError::InvalidDatabaseName(_))
+        ));
+        assert!(matches!(
+            validate_database_name("my.db"),
+            Err(SqlDbError::InvalidDatabaseName(_))
+        ));
+        assert!(matches!(
+            validate_database_name("my db"),
+            Err(SqlDbError::InvalidDatabaseName(_))
+        ));
+        assert!(matches!(
+            validate_database_name("my/db"),
+            Err(SqlDbError::InvalidDatabaseName(_))
+        ));
+    }
+
+    #[test]
+    fn test_sql_injection_in_name() {
+        assert!(matches!(
+            validate_database_name("'; DROP TABLE --"),
+            Err(SqlDbError::InvalidDatabaseName(_))
+        ));
+        assert!(matches!(
+            validate_database_name("db; SELECT *"),
+            Err(SqlDbError::InvalidDatabaseName(_))
+        ));
+    }
+}

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -712,7 +712,10 @@ async fn execute_act_activity<A: WorkerAdapters>(
     let event_emitter = AdapterEventEmitter::new(adapters.clone());
     let file_store = Arc::new(AdapterSessionFileStore::new(adapters.clone()));
 
-    let atom = ActAtom::with_file_store(tool_registry, event_emitter, file_store);
+    let mut atom = ActAtom::with_file_store(tool_registry, event_emitter, file_store);
+    if let Some(sqldb_store) = adapters.sqldb_store() {
+        atom = atom.with_sqldb_store(sqldb_store);
+    }
 
     let result = atom.execute(input.clone()).await?;
 

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -165,6 +165,12 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
 
     /// Create a tool registry with defaults and agent capabilities
     async fn build_tool_registry(&self, agent_id: Uuid) -> Result<ToolRegistry>;
+
+    /// Get the session SQL database store (if available).
+    /// Default returns None (not all backends support session SQL databases).
+    fn sqldb_store(&self) -> Option<everruns_core::traits::SessionSqlDbStoreRef> {
+        None
+    }
 }
 
 // =============================================================================

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -130,6 +130,7 @@ Capability IDs are string-based for extensibility. New capabilities can be added
 | `stateless_todo_list` | Task Management | Productivity | Available |
 | `sample_data` | Sample Data | Data | Available |
 | `docker_container` | Docker Container | Development | Available (Dev only) |
+| `session_sql_database` | SQL Database | Data | Available |
 | `research` | Research | AI | Coming Soon |
 | `sandbox` | Sandbox | Execution | Coming Soon |
 

--- a/specs/session-sqldb.md
+++ b/specs/session-sqldb.md
@@ -21,12 +21,13 @@ Session-scoped SQLite databases backed by PostgreSQL page-level storage. Each se
 - Raw FFI via `libsqlite3-sys`: Maximum control but maximum unsafety
 **Rationale:** Centralized `Vfs` trait model fits PostgreSQL connection pooling. Falls back to raw FFI if integration issues arise.
 
-### Decision 3: Serialize/Deserialize for DEV_MODE
-**Chosen:** rusqlite `serialize`/`deserialize` feature for in-memory backend
+### Decision 3: Live Connections for DEV_MODE
+**Chosen:** Persistent `Arc<Mutex<Connection>>` per database in-memory
 **Alternatives considered:**
+- Serialize/deserialize per access: rusqlite 0.32 `serialize`/`deserialize` API is cumbersome (`OwnedData`, `DatabaseName`) and unnecessary overhead
 - Full VFS for DEV_MODE too: Unnecessary complexity
 - No DEV_MODE support: Breaks dev workflow
-**Rationale:** Same API surface via trait. Serialize captures full DB as `Vec<u8>`, stored in HashMap. No VFS complexity for development.
+**Rationale:** Same API surface via trait. Each database holds a live in-memory SQLite connection. No VFS complexity for development. Size estimated via `conn.serialize()` length.
 
 ### Decision 4: Rollback Journal Mode
 **Chosen:** `PRAGMA journal_mode=MEMORY` (rollback journal in memory)
@@ -129,7 +130,7 @@ GET /v1/sessions/{session_id}/databases
 
 Response 200:
 {
-  "items": [
+  "data": [
     {
       "name": "analytics",
       "size_bytes": 12288,
@@ -137,8 +138,7 @@ Response 200:
       "created_at": "2024-01-01T00:00:00Z",
       "updated_at": "2024-01-01T00:00:00Z"
     }
-  ],
-  "total": 1
+  ]
 }
 ```
 
@@ -353,11 +353,12 @@ You have access to session-scoped SQL databases. Use these tools to create table
 
 In-memory backend provides full API parity without PostgreSQL:
 
-1. `Connection::open_in_memory()` for each database
-2. After each mutation: `conn.serialize("main")` → `Vec<u8>` stored in HashMap
-3. On next access: `conn.deserialize("main", data)` restores state
+1. `Connection::open_in_memory()` for each database, held as `Arc<Mutex<Connection>>`
+2. Live connections persist for session lifetime — no serialize/deserialize round-trips
+3. Size tracking via `conn.serialize(DatabaseName::Main)` length estimation
 4. No VFS complexity — standard rusqlite in-memory mode
-5. Concurrency via `parking_lot::RwLock` per database
+5. Concurrency via `RwLock` on the database map, `Mutex` per connection
+6. Async wrapper (`InMemorySqlDbStore`) uses `tokio::task::spawn_blocking`
 
 ## Future Extensibility
 
@@ -405,7 +406,22 @@ CREATE TABLE session_database_pages (
 CREATE INDEX idx_session_database_pages_db ON session_database_pages(database_id);
 ```
 
-## UI Integration
+## Implementation Status
+
+- [x] Core types and async trait (`crates/core/src/session_sqldb.rs`)
+- [x] Capability + 3 tools (`crates/core/src/capabilities/session_sql_database.rs`)
+- [x] In-memory backend (`crates/session-sqldb/src/memory.rs`)
+- [x] Async store wrapper (`crates/session-sqldb/src/store.rs`)
+- [x] Query executor with authorizer and limits (`crates/session-sqldb/src/executor.rs`)
+- [x] HTTP API routes (`crates/server/src/api/session_databases.rs`)
+- [x] Wired into server main, worker adapters, ActAtom
+- [x] Seed agent: Data Analyst
+- [x] Integration tests (CRUD, schema, validation)
+- [x] E2E verified: agent session with LLM using sql_execute/sql_query tools
+- [ ] PostgreSQL VFS backend (production)
+- [ ] UI integration
+
+## UI Integration (Future)
 
 - "Databases" tab on session detail page
 - Database list with name, size, page count

--- a/specs/session-sqldb.md
+++ b/specs/session-sqldb.md
@@ -1,0 +1,414 @@
+# Session SQL Database Specification
+
+## Abstract
+
+Session-scoped SQLite databases backed by PostgreSQL page-level storage. Each session can have multiple named SQLite databases. In production, a custom SQLite VFS stores 4KB pages as rows in PostgreSQL. In DEV_MODE, databases live in-memory using rusqlite's serialize/deserialize. Agents interact via standard SQL through capability tools.
+
+## Design Decisions
+
+### Decision 1: Page-Level VFS over Blob Storage
+**Chosen:** Custom SQLite VFS stores individual 4KB pages in PostgreSQL rows
+**Alternatives considered:**
+- Full blob (serialize entire DB as BYTEA): Simple but 50MB blobs per query wasteful
+- Table-level blobs: Doesn't map to SQLite's B-tree page architecture
+- PostgreSQL Large Objects: Quirky API, less control than explicit rows
+**Rationale:** Only dirty pages written per mutation (typically 3-5 pages regardless of DB size). SQLite's internal page cache (default ~8MB) serves hot reads from memory. No size ceiling — 50MB is just ~12K rows.
+
+### Decision 2: sqlite-plugin Crate for VFS
+**Chosen:** `sqlite-plugin` crate (v0.5.0) for VFS registration
+**Alternatives considered:**
+- `sqlite-vfs` crate: Unmaintained since 2022, prototype quality
+- Raw FFI via `libsqlite3-sys`: Maximum control but maximum unsafety
+**Rationale:** Centralized `Vfs` trait model fits PostgreSQL connection pooling. Falls back to raw FFI if integration issues arise.
+
+### Decision 3: Serialize/Deserialize for DEV_MODE
+**Chosen:** rusqlite `serialize`/`deserialize` feature for in-memory backend
+**Alternatives considered:**
+- Full VFS for DEV_MODE too: Unnecessary complexity
+- No DEV_MODE support: Breaks dev workflow
+**Rationale:** Same API surface via trait. Serialize captures full DB as `Vec<u8>`, stored in HashMap. No VFS complexity for development.
+
+### Decision 4: Rollback Journal Mode
+**Chosen:** `PRAGMA journal_mode=MEMORY` (rollback journal in memory)
+**Alternatives considered:**
+- WAL mode: Requires shared memory VFS methods (xShmMap/xShmLock), significantly more complex
+- DELETE journal mode: Creates journal files that VFS must handle
+**Rationale:** Memory journal avoids journal file handling entirely. Acceptable for session-scoped databases that don't need crash recovery beyond PostgreSQL's own durability.
+
+### Decision 5: Advisory Locks for Concurrency
+**Chosen:** PostgreSQL advisory locks per database for write serialization
+**Alternatives considered:**
+- Row-level locks on pages: Too granular, risk of deadlocks
+- Application-level mutex: Doesn't work across server instances
+**Rationale:** `pg_advisory_xact_lock(hashtext(database_id))` serializes writers per database. Reads are concurrent. Lock auto-released on transaction commit.
+
+### Decision 6: Own Crate
+**Chosen:** `crates/session-sqldb` isolates all SQLite/VFS logic
+**Alternatives considered:**
+- Inline in server crate: Mixes concerns
+- In core crate: Core should stay lightweight
+**Rationale:** Clean separation. Crate owns rusqlite dependency, VFS implementation, query execution, and security (authorizer). Server and core depend on it for types and backends.
+
+### Decision 7: Auto-Create on Execute
+**Chosen:** `sql_execute` tool auto-creates database if it doesn't exist
+**Alternatives considered:**
+- Require explicit create: Extra tool call overhead for LLMs
+- Auto-create on all tools: `sql_query` on nonexistent DB should error
+**Rationale:** Reduces friction. Agent can `sql_execute("main", "CREATE TABLE ...")` without a separate create step.
+
+## Data Model
+
+### SessionDatabase
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | UUID v7 | Unique identifier |
+| `session_id` | UUID v7 | Parent session (FK, CASCADE) |
+| `name` | string | Database name (validated) |
+| `size_bytes` | i64 | Total size of all pages |
+| `page_count` | i32 | Number of stored pages |
+| `created_at` | timestamp | Creation time |
+| `updated_at` | timestamp | Last modification time |
+
+### SessionDatabasePage
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `database_id` | UUID v7 | Parent database (FK, CASCADE) |
+| `page_number` | i32 | Page index (0-based) |
+| `data` | bytes | Page content (4096 bytes) |
+
+Primary key: `(database_id, page_number)`
+
+## Functional Requirements
+
+### Database Management
+- Create named databases within a session
+- List all databases for a session
+- Get metadata for a specific database
+- Delete a database and all its pages
+- Cascade delete when session is deleted (FK CASCADE)
+
+### Query Execution
+- Execute read-only SQL (SELECT) returning columns and rows as JSON
+- Execute write SQL (CREATE TABLE, INSERT, UPDATE, DELETE) returning affected row count
+- Auto-create database on first write operation
+- Standard SQLite SQL syntax support
+
+### Schema Introspection
+- List all tables in a database
+- Get column info (name, type, nullable, primary key, default) per table
+- Get approximate row count per table
+
+### Validation & Limits
+- Database names: `^[a-zA-Z_][a-zA-Z0-9_]{0,63}$`
+- Max 10 databases per session
+- Max 50 MB per database
+- Max 100 MB total per session
+- Max 1000 result rows per query
+- Max 1 MB result payload per query
+- Query timeout: 30 seconds
+
+### Row Serialization
+| SQLite Type | JSON Type |
+|-------------|-----------|
+| INTEGER | number |
+| REAL | number |
+| TEXT | string |
+| BLOB | string (base64) |
+| NULL | null |
+
+## API Endpoints
+
+All under `/v1/sessions/{session_id}/databases`.
+
+### List Databases
+
+```http
+GET /v1/sessions/{session_id}/databases
+
+Response 200:
+{
+  "items": [
+    {
+      "name": "analytics",
+      "size_bytes": 12288,
+      "page_count": 3,
+      "created_at": "2024-01-01T00:00:00Z",
+      "updated_at": "2024-01-01T00:00:00Z"
+    }
+  ],
+  "total": 1
+}
+```
+
+### Create Database
+
+```http
+POST /v1/sessions/{session_id}/databases
+Content-Type: application/json
+
+{ "name": "analytics" }
+
+Response 201:
+{
+  "name": "analytics",
+  "size_bytes": 0,
+  "page_count": 0,
+  "created_at": "...",
+  "updated_at": "..."
+}
+```
+
+### Get Database
+
+```http
+GET /v1/sessions/{session_id}/databases/{name}
+
+Response 200:
+{
+  "name": "analytics",
+  "size_bytes": 12288,
+  "page_count": 3,
+  "created_at": "...",
+  "updated_at": "..."
+}
+```
+
+### Delete Database
+
+```http
+DELETE /v1/sessions/{session_id}/databases/{name}
+
+Response 204 No Content
+```
+
+### Get Schema
+
+```http
+GET /v1/sessions/{session_id}/databases/{name}/schema
+
+Response 200:
+{
+  "database": "analytics",
+  "tables": [
+    {
+      "name": "users",
+      "columns": [
+        { "name": "id", "type": "INTEGER", "notnull": true, "pk": true, "default_value": null },
+        { "name": "email", "type": "TEXT", "notnull": true, "pk": false, "default_value": null }
+      ],
+      "row_count": 42
+    }
+  ]
+}
+```
+
+## Capability & Tools
+
+### Capability
+
+- **ID**: `session_sql_database`
+- **Name**: SQL Database
+- **Status**: Available
+- **Icon**: `database`
+- **Category**: Data
+- **Dependencies**: None
+
+### Tools
+
+#### sql_execute
+
+Execute DDL/DML SQL. Auto-creates database if it doesn't exist.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `database` | string | yes | Database name |
+| `sql` | string | yes | SQL statement(s) |
+
+**Response:**
+```json
+{ "database": "main", "success": true, "rows_affected": 1 }
+```
+
+#### sql_query
+
+Execute read-only SQL query. Returns columns and rows.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `database` | string | yes | Database name |
+| `sql` | string | yes | SELECT query |
+
+**Response:**
+```json
+{
+  "database": "main",
+  "columns": ["id", "name", "age"],
+  "rows": [[1, "Alice", 30], [2, "Bob", 28]],
+  "row_count": 2
+}
+```
+
+#### sql_schema
+
+Introspect database schema. Optionally filter to a single table.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `database` | string | yes | Database name |
+| `table` | string | no | Specific table name |
+
+**Response:**
+```json
+{
+  "database": "main",
+  "tables": [
+    {
+      "name": "users",
+      "columns": [
+        { "name": "id", "type": "INTEGER", "notnull": true, "pk": true, "default_value": null }
+      ],
+      "row_count": 42
+    }
+  ]
+}
+```
+
+### System Prompt Addition
+
+```
+You have access to session-scoped SQL databases. Use these tools to create tables, insert data, and query data using standard SQLite SQL syntax.
+
+**Tools:**
+- `sql_execute`: Create tables, insert/update/delete data. Auto-creates the database if needed.
+- `sql_query`: Run SELECT queries. Returns columns and rows as JSON.
+- `sql_schema`: Inspect database schema (tables, columns, types).
+
+**Guidelines:**
+- Database names must be alphanumeric with underscores (e.g., "analytics", "user_data")
+- Use `sql_schema` to inspect existing tables before querying
+- Results are limited to 1000 rows per query
+- Databases are session-scoped and isolated
+- Standard SQLite SQL syntax is supported
+```
+
+## Threat Model
+
+### T1: Dangerous SQLite Operations
+**Risk:** Agent uses ATTACH to access other databases, LOAD_EXTENSION to run arbitrary code, or modifies SQLite configuration via PRAGMAs.
+**Mitigation:** SQLite authorizer callback blocks:
+- ATTACH / DETACH
+- load_extension function
+- CREATE/DROP VIRTUAL TABLE
+- Write-mode PRAGMAs (journal_mode, page_size, locking_mode, synchronous, wal_*, mmap_size)
+**Allowed PRAGMAs:** table_info, table_list, table_xinfo, index_list, index_info, database_list, foreign_key_list (read-only introspection)
+
+### T2: Storage Exhaustion
+**Risk:** Agent creates huge databases consuming unbounded storage.
+**Mitigation:** Hard limits enforced at VFS write and create levels:
+- 50 MB per database
+- 100 MB total per session
+- 10 databases per session
+- VFS returns SQLITE_FULL when size exceeded
+
+### T3: CPU Exhaustion
+**Risk:** Expensive queries (cartesian joins, infinite recursive CTEs).
+**Mitigation:**
+- SQLite progress handler interrupts after 30 seconds
+- tokio::time::timeout wrapping blocking query execution
+
+### T4: Filesystem Escape
+**Risk:** SQLite tries to access files outside VFS.
+**Mitigation:**
+- Custom VFS intercepts ALL file I/O — no real filesystem access
+- Authorizer blocks ATTACH (prevents opening other files)
+- DEV_MODE uses Connection::open_in_memory() — no disk access
+
+### T5: Cross-Session Data Access
+**Risk:** Session A reads Session B's databases.
+**Mitigation:**
+- VFS file names use database UUID (not user-controlled names)
+- All PG queries filter through database_id → session_id FK chain
+- Authorizer blocks ATTACH (can't reference foreign UUIDs)
+
+### T6: Concurrent Write Corruption
+**Risk:** Parallel tool calls write to same database simultaneously.
+**Mitigation:**
+- PostgreSQL advisory lock per database for write serialization
+- DEV_MODE uses RwLock per database entry
+- Reads are concurrent, writes are serialized
+
+### T7: Result Size Exhaustion
+**Risk:** SELECT returns millions of rows exhausting server memory.
+**Mitigation:**
+- Max 1000 result rows
+- Max 1 MB result payload
+- Executor stops reading after limit, appends truncation notice
+
+## DEV_MODE
+
+In-memory backend provides full API parity without PostgreSQL:
+
+1. `Connection::open_in_memory()` for each database
+2. After each mutation: `conn.serialize("main")` → `Vec<u8>` stored in HashMap
+3. On next access: `conn.deserialize("main", data)` restores state
+4. No VFS complexity — standard rusqlite in-memory mode
+5. Concurrency via `parking_lot::RwLock` per database
+
+## Future Extensibility
+
+The internal `SqlDbBackend` trait can support different scopes:
+
+```rust
+enum DatabaseScope {
+    Session(SessionId),
+    // Future:
+    // Organization(OrgId),
+    // Agent(AgentId),
+}
+```
+
+Org-level databases would share the same crate, VFS, and query execution — only the API routing and FK relationships change.
+
+## Database Schema
+
+```sql
+CREATE TABLE session_databases (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    session_id UUID NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    size_bytes BIGINT NOT NULL DEFAULT 0,
+    page_count INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT session_databases_unique_name UNIQUE (session_id, name),
+    CONSTRAINT session_databases_name_check CHECK (name ~ '^[a-zA-Z_][a-zA-Z0-9_]{0,63}$')
+);
+
+CREATE INDEX idx_session_databases_session_id ON session_databases(session_id);
+
+CREATE TRIGGER update_session_databases_updated_at
+    BEFORE UPDATE ON session_databases
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TABLE session_database_pages (
+    database_id UUID NOT NULL REFERENCES session_databases(id) ON DELETE CASCADE,
+    page_number INTEGER NOT NULL,
+    data BYTEA NOT NULL,
+    PRIMARY KEY (database_id, page_number)
+);
+
+CREATE INDEX idx_session_database_pages_db ON session_database_pages(database_id);
+```
+
+## UI Integration
+
+- "Databases" tab on session detail page
+- Database list with name, size, page count
+- Schema viewer per database (tables, columns)
+- SQL query runner with results table
+- Create/delete database dialogs


### PR DESCRIPTION
## What
Session-scoped SQLite databases that agents can interact with via SQL tools. Each session can have multiple named databases with full CRUD, query execution, and schema introspection.

## Why
Agents need structured data storage for analytics, data processing, and stateful workflows. SQLite provides full SQL capability scoped to individual sessions.

## How
- **Core types & trait** (`crates/core/src/session_sqldb.rs`): `DatabaseInfo`, `SqlQueryResult`, `SqlExecuteResult`, `TableSchema`, `SessionSqlDbStore` async trait
- **Capability + 3 tools** (`crates/core/src/capabilities/session_sql_database.rs`): `sql_execute`, `sql_query`, `sql_schema`
- **In-memory backend** (`crates/session-sqldb/src/memory.rs`): Live `Arc<Mutex<Connection>>` per database for DEV_MODE
- **Async store** (`crates/session-sqldb/src/store.rs`): `InMemorySqlDbStore` wrapping backend with `spawn_blocking`
- **HTTP API** (`crates/server/src/api/session_databases.rs`): CRUD + schema under `/v1/sessions/{id}/databases`
- **Wiring**: ToolContext, ActAtom, WorkerAdapters, DirectWorkerAdapters, main.rs
- **Seed agent**: Data Analyst agent with `session_sql_database` capability
- **Security**: SQLite authorizer blocks ATTACH, LOAD_EXTENSION, dangerous PRAGMAs; limits on DB count/size/query rows

## Risk
- Low
- DEV_MODE only (in-memory). PostgreSQL VFS backend is future work.
- No breaking changes to existing APIs or capabilities.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered