### PR TITLE
fix(ui): fix workspace file browser display issues

### DIFF
--- a/apps/ui/src/__tests__/file-browser.test.tsx
+++ b/apps/ui/src/__tests__/file-browser.test.tsx
@@ -52,9 +52,11 @@ jest.mock("@/hooks/use-session-files", () => ({
 }));
 
 // Mock the session-files utilities
+const mockListFiles = jest.fn();
 jest.mock("@/lib/api/session-files", () => ({
   formatFileSize: (bytes: number) => `${bytes} B`,
   joinPath: (base: string, name: string) => `${base}/${name}`,
+  listFiles: (...args: unknown[]) => mockListFiles(...args),
 }));
 
 import { FileBrowser } from "@/components/files/file-browser";
@@ -477,50 +479,42 @@ describe("FileBrowser Delete", () => {
 // ============================================
 
 describe("FileBrowser Directory Expansion", () => {
+  const mockDirectory = {
+    id: "1",
+    session_id: "test-session",
+    path: "/src",
+    name: "src",
+    is_directory: true,
+    is_readonly: false,
+    size_bytes: 0,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+  };
+
+  const mockSubFile = {
+    id: "2",
+    session_id: "test-session",
+    path: "/src/index.ts",
+    name: "index.ts",
+    is_directory: false,
+    is_readonly: false,
+    size_bytes: 500,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
-    global.fetch = jest.fn();
   });
 
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
-  it("loads directory contents when expanded", async () => {
-    const mockDirectory = {
-      id: "1",
-      session_id: "test-session",
-      path: "/workspace/src",
-      name: "src",
-      is_directory: true,
-      is_readonly: false,
-      size_bytes: 0,
-      created_at: "2024-01-01T00:00:00Z",
-      updated_at: "2024-01-01T00:00:00Z",
-    };
-
-    const mockSubFile = {
-      id: "2",
-      session_id: "test-session",
-      path: "/workspace/src/index.ts",
-      name: "index.ts",
-      is_directory: false,
-      is_readonly: false,
-      size_bytes: 500,
-      created_at: "2024-01-01T00:00:00Z",
-      updated_at: "2024-01-01T00:00:00Z",
-    };
-
+  it("calls listFiles API when directory is expanded", async () => {
     (useFiles as jest.Mock).mockReturnValue({
       data: [mockDirectory],
       isLoading: false,
       refetch: mockRefetch,
     });
 
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ data: [mockSubFile] }),
-    });
+    mockListFiles.mockResolvedValue([mockSubFile]);
 
     renderWithProviders(<FileBrowser sessionId="test-session" />);
 
@@ -528,9 +522,54 @@ describe("FileBrowser Directory Expansion", () => {
     fireEvent.click(screen.getByText("src"));
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith(
-        "/api/sessions/test-session/files?path=%2Fworkspace%2Fsrc",
-      );
+      expect(mockListFiles).toHaveBeenCalledWith("test-session", "/src");
+    });
+  });
+
+  it("renders subdirectory files after expansion", async () => {
+    (useFiles as jest.Mock).mockReturnValue({
+      data: [mockDirectory],
+      isLoading: false,
+      refetch: mockRefetch,
+    });
+
+    mockListFiles.mockResolvedValue([mockSubFile]);
+
+    renderWithProviders(<FileBrowser sessionId="test-session" />);
+
+    fireEvent.click(screen.getByText("src"));
+
+    await waitFor(() => {
+      expect(screen.getByText("index.ts")).toBeInTheDocument();
+    });
+  });
+
+  it("reloads expanded directories on refresh", async () => {
+    (useFiles as jest.Mock).mockReturnValue({
+      data: [mockDirectory],
+      isLoading: false,
+      refetch: mockRefetch,
+    });
+
+    mockListFiles.mockResolvedValue([mockSubFile]);
+
+    renderWithProviders(<FileBrowser sessionId="test-session" />);
+
+    // Expand directory first
+    fireEvent.click(screen.getByText("src"));
+    await waitFor(() => {
+      expect(mockListFiles).toHaveBeenCalledWith("test-session", "/src");
+    });
+
+    mockListFiles.mockClear();
+    mockListFiles.mockResolvedValue([mockSubFile]);
+
+    // Click refresh
+    fireEvent.click(screen.getByTitle("Refresh"));
+
+    await waitFor(() => {
+      expect(mockRefetch).toHaveBeenCalled();
+      expect(mockListFiles).toHaveBeenCalledWith("test-session", "/src");
     });
   });
 });

--- a/apps/ui/src/components/files/file-browser.tsx
+++ b/apps/ui/src/components/files/file-browser.tsx
@@ -38,7 +38,7 @@ import {
   useCreateDirectory,
   useDeleteFile,
 } from "@/hooks/use-session-files";
-import { formatFileSize, joinPath } from "@/lib/api/session-files";
+import { formatFileSize, joinPath, listFiles } from "@/lib/api/session-files";
 import type { FileInfo } from "@/lib/api/types";
 
 interface FileBrowserProps {
@@ -149,13 +149,8 @@ export function FileBrowser({ sessionId, onFileSelect, selectedPath }: FileBrows
   const loadDirectory = useCallback(
     async (path: string) => {
       try {
-        const response = await fetch(
-          `/api/sessions/${sessionId}/files?path=${encodeURIComponent(path)}`,
-        );
-        if (response.ok) {
-          const data = await response.json();
-          setLoadedDirs((prev) => new Map(prev).set(path, data.data || data));
-        }
+        const files = await listFiles(sessionId, path);
+        setLoadedDirs((prev) => new Map(prev).set(path, files));
       } catch {
         // Error loading directory
       }
@@ -180,7 +175,13 @@ export function FileBrowser({ sessionId, onFileSelect, selectedPath }: FileBrows
   const handleRefresh = useCallback(() => {
     setLoadedDirs(new Map());
     refetchRoot();
-  }, [refetchRoot]);
+    // Reload expanded subdirectories
+    for (const path of expandedPaths) {
+      if (path !== "/workspace") {
+        loadDirectory(path);
+      }
+    }
+  }, [refetchRoot, expandedPaths, loadDirectory]);
 
   const handleCreateFile = async () => {
     if (!newFileName.trim()) return;

--- a/apps/ui/src/components/files/file-viewer.tsx
+++ b/apps/ui/src/components/files/file-viewer.tsx
@@ -188,16 +188,17 @@ export function FileViewer({ sessionId, file, onClose }: FileViewerProps) {
             onChange={(e) => setEditContent(e.target.value)}
             spellCheck={false}
           />
+        ) : !fileData?.content && fileData?.content !== "" ? (
+          <div className="flex flex-col items-center justify-center h-full text-muted-foreground">
+            <File className="h-12 w-12 mb-2 opacity-30" />
+            <p className="text-sm">Empty file</p>
+          </div>
         ) : hasPreview && viewMode === "preview" ? (
-          <FilePreview
-            content={fileData?.content ?? ""}
-            extension={extension}
-            encoding={encoding}
-          />
+          <FilePreview content={fileData.content} extension={extension} encoding={encoding} />
         ) : (
           <ScrollArea className="h-full">
             <pre className="p-4 text-sm font-mono whitespace-pre-wrap break-words">
-              {fileData?.content ?? "Empty file"}
+              {fileData?.content || "Empty file"}
             </pre>
           </ScrollArea>
         )}


### PR DESCRIPTION
## What
Fix workspace tab showing "0 B" / "Invalid JSON" for files and broken subdirectory expansion.

## Why
- `loadDirectory` fetched from non-existent endpoint (`/api/sessions/{id}/files?path=...` → 404), so expanding any subdirectory silently failed
- When file content was `undefined`, viewer passed `""` to `JSONPreview` → `JSON.parse("")` threw → showed "Invalid JSON" instead of meaningful empty state
- Refresh didn't reload expanded subdirectories

## How
- Replace raw `fetch()` in `loadDirectory` with `listFiles()` API function (correct `/v1/sessions/{id}/fs/{path}` endpoint)
- `handleRefresh` now reloads all expanded subdirectories after root refetch
- Add explicit "Empty file" state in `FileViewer` when content is missing, before falling through to preview

## Risk
- Low
- Only touches frontend file browser/viewer components

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered