### PR TITLE
chore(deps): update everruns-sdk 0.1→0.1.1 and bashkit v0.1.2→v0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,8 +432,8 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.1.2"
-source = "git+https://github.com/everruns/bashkit?tag=v0.1.2#a29d674eb2cdc90213c74a8bc6b0ba0879deeb49"
+version = "0.1.4"
+source = "git+https://github.com/everruns/bashkit?tag=v0.1.4#89127509c946b1eaf5950d6e9e2b57dfca683cb1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1356,12 +1356,13 @@ dependencies = [
 
 [[package]]
 name = "everruns-sdk"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5963af992b77866fc0df3f9d60b2033abf1c0632acc380777aa2912c6852d0b0"
+checksum = "d88d1f1e929b0282bc0a125b778aa397aa3863cf1c06574afd9de392103ad784"
 dependencies = [
  "async-stream",
  "futures",
+ "getrandom 0.2.17",
  "reqwest 0.12.28",
  "reqwest-eventsource",
  "secrecy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ time = "0.3"
 parking_lot = "0.12"
 
 # Everruns SDK
-everruns-sdk = "0.1"
+everruns-sdk = "0.1.1"
 
 # gRPC (tonic)
 tonic = "0.14"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -53,7 +53,7 @@ url = "2"
 fetchkit = { git = "https://github.com/everruns/fetchkit" }
 
 # Sandboxed bash interpreter
-bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.1.2" }
+bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.1.4" }
 
 # OpenAPI schema generation (optional, enabled by everruns-server)
 utoipa = { workspace = true, optional = true }


### PR DESCRIPTION
## What
Update two external dependencies to their latest versions:
- `everruns-sdk`: `0.1` → `0.1.1`
- `bashkit`: `v0.1.2` → `v0.1.4`

## Why
Pick up latest fixes and features from both packages:
- **bashkit v0.1.3**: 9 new CLI tools, security hardening (parser depth limits, path validation), improved bash compatibility for LLM scripts
- **bashkit v0.1.4**: jq builtin file argument support
- **everruns-sdk v0.1.1**: latest SDK release

## How
- Updated workspace dependency in root `Cargo.toml` for everruns-sdk
- Updated git tag in `crates/core/Cargo.toml` for bashkit
- Ran `cargo update` to refresh lockfile

## Risk
- Low
- No breaking API changes in either dependency. All 828 unit/integration tests pass.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered