### PR TITLE
feat(harness): add Harness abstraction between Organization and Agent

### DIFF
--- a/apps/ui/src/__tests__/agent-detail-model.test.tsx
+++ b/apps/ui/src/__tests__/agent-detail-model.test.tsx
@@ -70,34 +70,43 @@ const mockAgent: Agent = {
 const mockSessions: Session[] = [
   {
     id: "session-1",
+    organization_id: "org-1",
+    harness_id: "harness-1",
     agent_id: "agent-1",
     title: "Session with GPT-4o",
     tags: [],
     model_id: "model-1",
     status: "idle",
     created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
     started_at: "2025-01-01T00:00:01Z",
     finished_at: null,
   },
   {
     id: "session-2",
+    organization_id: "org-1",
+    harness_id: "harness-1",
     agent_id: "agent-1",
     title: "Session with Claude",
     tags: [],
     model_id: "model-2",
     status: "idle",
     created_at: "2025-01-01T01:00:00Z",
+    updated_at: "2025-01-01T01:00:00Z",
     started_at: null,
     finished_at: null,
   },
   {
     id: "session-3",
+    organization_id: "org-1",
+    harness_id: "harness-1",
     agent_id: "agent-1",
     title: "Session without model",
     tags: [],
     model_id: null,
     status: "started",
     created_at: "2025-01-01T02:00:00Z",
+    updated_at: "2025-01-01T02:00:00Z",
     started_at: null,
     finished_at: null,
   },
@@ -139,6 +148,7 @@ const mockUseCreateSession = jest.fn();
 const mockUseCapabilities = jest.fn();
 const mockUseLlmModels = jest.fn();
 const mockUseExportAgent = jest.fn();
+const mockUseHarnesses = jest.fn();
 
 jest.mock("@/hooks", () => ({
   useAgent: (...args: unknown[]) => mockUseAgent(...args),
@@ -147,6 +157,7 @@ jest.mock("@/hooks", () => ({
   useCapabilities: () => mockUseCapabilities(),
   useLlmModels: () => mockUseLlmModels(),
   useExportAgent: () => mockUseExportAgent(),
+  useHarnesses: () => mockUseHarnesses(),
 }));
 
 // Helper to render with Suspense for React.use()
@@ -175,6 +186,7 @@ describe("AgentDetailPage - LLM Model Display in Sessions List", () => {
     mockUseCapabilities.mockReturnValue({ data: [] });
     mockUseLlmModels.mockReturnValue({ data: mockLlmModels });
     mockUseExportAgent.mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
+    mockUseHarnesses.mockReturnValue({ data: [] });
   });
 
   it("renders agent page structure", async () => {
@@ -268,6 +280,7 @@ describe("AgentDetailPage - Default Model Display in Configuration", () => {
     mockUseCapabilities.mockReturnValue({ data: [] });
     mockUseLlmModels.mockReturnValue({ data: mockLlmModels });
     mockUseExportAgent.mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
+    mockUseHarnesses.mockReturnValue({ data: [] });
   });
 
   it("displays default model with provider icon when agent has default_model_id", async () => {

--- a/apps/ui/src/__tests__/recent-sessions.test.tsx
+++ b/apps/ui/src/__tests__/recent-sessions.test.tsx
@@ -6,12 +6,15 @@ import type { Session, Agent, LlmModelWithProvider } from "@/lib/api/types";
 function createSession(overrides?: Partial<Session>): Session {
   return {
     id: "session-1",
+    organization_id: "default",
+    harness_id: "harness-1",
     agent_id: "agent-1",
     title: "Test Session",
     tags: [],
     model_id: null,
     status: "started",
     created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
     started_at: null,
     finished_at: null,
     ...overrides,
@@ -84,7 +87,10 @@ describe("RecentSessions", () => {
 
   describe("model display", () => {
     it("displays model name when session has a model_id and model data is provided", () => {
-      const model = createLlmModel({ id: "model-123", display_name: "Claude 3.5 Sonnet" });
+      const model = createLlmModel({
+        id: "model-123",
+        display_name: "Claude 3.5 Sonnet",
+      });
       const session = createSession({ model_id: "model-123" });
       const agent = createAgent();
 
@@ -114,11 +120,26 @@ describe("RecentSessions", () => {
 
     it("displays multiple sessions with different models", () => {
       const model1 = createLlmModel({ id: "model-1", display_name: "GPT-4o" });
-      const model2 = createLlmModel({ id: "model-2", display_name: "Claude 3.5 Sonnet" });
+      const model2 = createLlmModel({
+        id: "model-2",
+        display_name: "Claude 3.5 Sonnet",
+      });
 
-      const session1 = createSession({ id: "s1", model_id: "model-1", title: "Session 1" });
-      const session2 = createSession({ id: "s2", model_id: "model-2", title: "Session 2" });
-      const session3 = createSession({ id: "s3", model_id: null, title: "Session 3" });
+      const session1 = createSession({
+        id: "s1",
+        model_id: "model-1",
+        title: "Session 1",
+      });
+      const session2 = createSession({
+        id: "s2",
+        model_id: "model-2",
+        title: "Session 2",
+      });
+      const session3 = createSession({
+        id: "s3",
+        model_id: null,
+        title: "Session 3",
+      });
 
       const agent = createAgent();
 

--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -68,6 +68,7 @@ describe("Sidebar", () => {
     render(<Sidebar />);
 
     expect(screen.getByText("Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("Harnesses")).toBeInTheDocument();
     expect(screen.getByText("Agents")).toBeInTheDocument();
     expect(screen.getByText("Capabilities")).toBeInTheDocument();
     expect(screen.getByText("Settings")).toBeInTheDocument();
@@ -77,11 +78,13 @@ describe("Sidebar", () => {
     render(<Sidebar />);
 
     const dashboardLink = screen.getByRole("link", { name: "Dashboard" });
+    const harnessesLink = screen.getByRole("link", { name: "Harnesses" });
     const agentsLink = screen.getByRole("link", { name: "Agents" });
     const capabilitiesLink = screen.getByRole("link", { name: "Capabilities" });
     const settingsLink = screen.getByRole("link", { name: "Settings" });
 
     expect(dashboardLink).toHaveAttribute("href", "/dashboard");
+    expect(harnessesLink).toHaveAttribute("href", "/harnesses");
     expect(agentsLink).toHaveAttribute("href", "/agents");
     expect(capabilitiesLink).toHaveAttribute("href", "/capabilities");
     expect(settingsLink).toHaveAttribute("href", "/settings");
@@ -90,10 +93,8 @@ describe("Sidebar", () => {
   it("does not render legacy navigation items", () => {
     render(<Sidebar />);
 
-    expect(screen.queryByText("Harnesses")).not.toBeInTheDocument();
     expect(screen.queryByText("Runs")).not.toBeInTheDocument();
     expect(screen.queryByText("Chat")).not.toBeInTheDocument();
-    expect(screen.queryByRole("link", { name: /harnesses/i })).not.toBeInTheDocument();
   });
 
   it("highlights the active navigation item", () => {
@@ -118,7 +119,7 @@ describe("Sidebar", () => {
     expect(screen.getByText("Everruns v0.1.0")).toBeInTheDocument();
   });
 
-  it("has exactly 4 navigation items", () => {
+  it("has exactly 5 navigation items", () => {
     render(<Sidebar />);
 
     // Get nav links (excluding logo link)
@@ -128,11 +129,11 @@ describe("Sidebar", () => {
         (link) =>
           link.getAttribute("href") !== "/dashboard" || link.textContent?.includes("Dashboard"),
       );
-    // Filter to only nav items (Dashboard, Agents, Capabilities, Settings)
-    const navItems = ["Dashboard", "Agents", "Capabilities", "Settings"];
+    // Filter to only nav items (Dashboard, Harnesses, Agents, Capabilities, Settings)
+    const navItems = ["Dashboard", "Harnesses", "Agents", "Capabilities", "Settings"];
     const foundNavLinks = navLinks.filter((link) =>
       navItems.some((item) => link.textContent?.includes(item)),
     );
-    expect(foundNavLinks).toHaveLength(4);
+    expect(foundNavLinks).toHaveLength(5);
   });
 });

--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -3,6 +3,7 @@
 import { use, useMemo, useCallback, useState } from "react";
 import {
   useAgent,
+  useHarnesses,
   useSessions,
   useCreateSession,
   useCapabilities,
@@ -58,6 +59,7 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
   const { data: llmModels } = useLlmModels();
   const createSession = useCreateSession();
   const exportAgent = useExportAgent();
+  const { data: harnesses } = useHarnesses();
 
   // Create a map of model_id -> model for quick lookups
   const modelMap = useMemo(() => {
@@ -69,9 +71,11 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
   const defaultModel = agent?.default_model_id ? modelMap.get(agent.default_model_id) : undefined;
 
   const handleNewSession = async () => {
+    const harnessId = harnesses?.[0]?.id;
+    if (!harnessId) return;
     try {
       const session = await createSession.mutateAsync({
-        request: { agent_id: agentId },
+        request: { harness_id: harnessId, agent_id: agentId },
       });
       router.push(`/sessions/${session.id}`);
     } catch (error) {

--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { use, useState, useMemo } from "react";
-import { useAgent, useSessions, useCreateSession, useLlmModels } from "@/hooks";
+import { useAgent, useHarnesses, useSessions, useCreateSession, useLlmModels } from "@/hooks";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
@@ -26,6 +26,7 @@ export default function SessionsListPage({ params }: { params: Promise<{ agentId
   });
   const { data: llmModels } = useLlmModels();
   const createSession = useCreateSession();
+  const { data: harnesses } = useHarnesses();
 
   const sessions = sessionsResponse?.data ?? [];
   const totalSessions = sessionsResponse?.total ?? 0;
@@ -38,9 +39,11 @@ export default function SessionsListPage({ params }: { params: Promise<{ agentId
   }, [llmModels]);
 
   const handleNewSession = async () => {
+    const harnessId = harnesses?.[0]?.id;
+    if (!harnessId) return;
     try {
       const session = await createSession.mutateAsync({
-        request: { agent_id: agentId },
+        request: { harness_id: harnessId, agent_id: agentId },
       });
       router.push(`/sessions/${session.id}`);
     } catch (error) {

--- a/apps/ui/src/app/(main)/dashboard/page.tsx
+++ b/apps/ui/src/app/(main)/dashboard/page.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { useState } from "react";
-import { useAgents, useCapabilities, useSessions, useLlmModels, useCreateSession } from "@/hooks";
+import {
+  useAgents,
+  useHarnesses,
+  useCapabilities,
+  useSessions,
+  useLlmModels,
+  useCreateSession,
+} from "@/hooks";
 import { useRouter } from "next/navigation";
 import { Header } from "@/components/layout/header";
 import { StatsCards } from "@/components/dashboard/stats-cards";
@@ -31,6 +38,7 @@ export default function DashboardPage() {
   });
   const { data: llmModels } = useLlmModels();
   const createSession = useCreateSession();
+  const { data: harnesses } = useHarnesses();
 
   const [newSessionDialogOpen, setNewSessionDialogOpen] = useState(false);
   const [newSessionAgentId, setNewSessionAgentId] = useState<string>("");
@@ -41,10 +49,14 @@ export default function DashboardPage() {
   };
 
   const handleCreateSession = async () => {
-    if (!newSessionAgentId) return;
+    const harnessId = harnesses?.[0]?.id;
+    if (!harnessId) return;
     try {
       const session = await createSession.mutateAsync({
-        request: { agent_id: newSessionAgentId },
+        request: {
+          harness_id: harnessId,
+          agent_id: newSessionAgentId || undefined,
+        },
       });
       setNewSessionDialogOpen(false);
       router.push(`/sessions/${session.id}`);

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
@@ -1,0 +1,299 @@
+"use client";
+
+import { use, useState, useMemo, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { useHarness, useUpdateHarness, useDeleteHarness, useCapabilities } from "@/hooks";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { PromptEditor } from "@/components/ui/prompt-editor";
+import { Skeleton } from "@/components/ui/skeleton";
+import { CapabilitySelector } from "@/components/agents/capability-selector";
+import { ModelPicker } from "@/components/models/model-picker";
+import { ArrowLeft, Save, Trash2 } from "lucide-react";
+import type { AgentCapabilityConfig } from "@/lib/api/types";
+
+interface FormData {
+  name: string;
+  description: string;
+  system_prompt: string;
+  tags: string;
+  default_model_id: string;
+}
+
+export default function EditHarnessPage({ params }: { params: Promise<{ harnessId: string }> }) {
+  const { harnessId } = use(params);
+  const router = useRouter();
+
+  const { data: harness, isLoading: harnessLoading } = useHarness(harnessId);
+  const updateHarness = useUpdateHarness();
+  const deleteHarness = useDeleteHarness();
+
+  const { data: allCapabilities, isLoading: capabilitiesLoading } = useCapabilities();
+
+  const [formChanges, setFormChanges] = useState<Partial<FormData>>({});
+
+  const initialFormData = useMemo((): FormData => {
+    if (!harness) {
+      return {
+        name: "",
+        description: "",
+        system_prompt: "",
+        tags: "",
+        default_model_id: "",
+      };
+    }
+    return {
+      name: harness.name,
+      description: harness.description || "",
+      system_prompt: harness.system_prompt,
+      tags: harness.tags.join(", "),
+      default_model_id: harness.default_model_id || "",
+    };
+  }, [harness]);
+
+  const formData = useMemo(
+    () => ({ ...initialFormData, ...formChanges }),
+    [initialFormData, formChanges],
+  );
+
+  const handleFormChange = useCallback((field: keyof FormData, value: string) => {
+    setFormChanges((prev) => ({ ...prev, [field]: value }));
+  }, []);
+
+  const initialCapabilities = useMemo(() => {
+    return harness?.capabilities ?? [];
+  }, [harness?.capabilities]);
+
+  const [localCapabilities, setLocalCapabilities] = useState<AgentCapabilityConfig[] | null>(null);
+  const selectedCapabilities = localCapabilities ?? initialCapabilities;
+
+  const handleCapabilitiesChange = useCallback((newCapabilities: AgentCapabilityConfig[]) => {
+    setLocalCapabilities(newCapabilities);
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    try {
+      const tags = formData.tags
+        .split(",")
+        .map((t) => t.trim())
+        .filter((t) => t.length > 0);
+
+      const capabilitiesToSave = localCapabilities ?? initialCapabilities;
+      const capabilitiesChanged =
+        JSON.stringify(capabilitiesToSave) !== JSON.stringify(initialCapabilities);
+
+      await updateHarness.mutateAsync({
+        harnessId,
+        request: {
+          name: formData.name,
+          description: formData.description || undefined,
+          system_prompt: formData.system_prompt,
+          tags,
+          default_model_id: formData.default_model_id || undefined,
+          ...(capabilitiesChanged && { capabilities: capabilitiesToSave }),
+        },
+      });
+
+      router.push(`/harnesses/${harnessId}`);
+    } catch (error) {
+      console.error("Failed to update harness:", error);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!confirm("Are you sure you want to delete this harness? This action cannot be undone.")) {
+      return;
+    }
+
+    try {
+      await deleteHarness.mutateAsync(harnessId);
+      router.push("/harnesses");
+    } catch (error) {
+      console.error("Failed to delete harness:", error);
+    }
+  };
+
+  const isLoading = harnessLoading || capabilitiesLoading;
+  const isSaving = updateHarness.isPending;
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto p-6">
+        <Skeleton className="h-8 w-1/4 mb-6" />
+        <div className="grid gap-6 lg:grid-cols-3">
+          <div className="lg:col-span-2">
+            <Skeleton className="h-[500px] w-full" />
+          </div>
+          <div>
+            <Skeleton className="h-[300px] w-full" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!harness) {
+    return (
+      <div className="container mx-auto p-6">
+        <div className="text-red-500">Harness not found</div>
+        <Link href="/harnesses" className="text-blue-500 hover:underline">
+          Back to harnesses
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto p-6">
+      <Link
+        href={`/harnesses/${harnessId}`}
+        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-6"
+      >
+        <ArrowLeft className="w-4 h-4 mr-2" />
+        Back to Harness
+      </Link>
+
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold">Edit Harness</h1>
+      </div>
+
+      <form onSubmit={handleSubmit}>
+        <div className="grid gap-6 lg:grid-cols-3">
+          {/* Main form */}
+          <div className="lg:col-span-2 space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Harness Details</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <div className="space-y-2">
+                  <Label htmlFor="name">Name</Label>
+                  <Input
+                    id="name"
+                    placeholder="My Harness"
+                    value={formData.name}
+                    onChange={(e) => handleFormChange("name", e.target.value)}
+                    required
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="description">Description</Label>
+                  <Textarea
+                    id="description"
+                    placeholder="Describe what this harness does..."
+                    value={formData.description}
+                    onChange={(e) => handleFormChange("description", e.target.value)}
+                    rows={2}
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="tags">Tags</Label>
+                  <Input
+                    id="tags"
+                    placeholder="tag1, tag2, tag3"
+                    value={formData.tags}
+                    onChange={(e) => handleFormChange("tags", e.target.value)}
+                  />
+                  <p className="text-xs text-muted-foreground">Comma-separated list of tags</p>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="model">Model (optional)</Label>
+                  <ModelPicker
+                    value={formData.default_model_id || ""}
+                    onChange={(value) => handleFormChange("default_model_id", value)}
+                    placeholder="Use default model"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Select a specific model or leave empty to use the default
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="system_prompt">System Prompt</Label>
+                  <PromptEditor
+                    id="system_prompt"
+                    placeholder="You are a helpful assistant..."
+                    value={formData.system_prompt}
+                    onChange={(value) => handleFormChange("system_prompt", value)}
+                    required
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Instructions for the AI model (supports Markdown)
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Danger Zone */}
+            <Card className="border-destructive/50">
+              <CardHeader>
+                <CardTitle className="text-destructive">Danger Zone</CardTitle>
+                <CardDescription>Irreversible actions that affect this harness</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="font-medium">Delete this harness</p>
+                    <p className="text-sm text-muted-foreground">
+                      Once deleted, this harness will be permanently removed.
+                    </p>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    onClick={handleDelete}
+                    disabled={deleteHarness.isPending}
+                  >
+                    <Trash2 className="w-4 h-4 mr-2" />
+                    {deleteHarness.isPending ? "Deleting..." : "Delete Harness"}
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Capabilities sidebar */}
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Capabilities</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <CapabilitySelector
+                  capabilities={allCapabilities || []}
+                  selected={selectedCapabilities}
+                  onChange={handleCapabilitiesChange}
+                  disabled={isSaving}
+                />
+              </CardContent>
+            </Card>
+
+            {/* Save button */}
+            <div className="flex gap-4">
+              <Button type="submit" disabled={isSaving} className="flex-1">
+                <Save className="w-4 h-4 mr-2" />
+                {isSaving ? "Saving..." : "Save Changes"}
+              </Button>
+              <Button type="button" variant="outline" onClick={() => router.back()}>
+                Cancel
+              </Button>
+            </div>
+
+            {updateHarness.error && (
+              <p className="text-sm text-destructive">Error: {updateHarness.error.message}</p>
+            )}
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { use, useMemo } from "react";
+import { useHarness, useCapabilities, useLlmModels, useDeleteHarness } from "@/hooks";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { MarkdownDisplay } from "@/components/ui/prompt-editor";
+import { InlineStreamdownMessage } from "@/components/chat/streamdown-message";
+import { ProviderIcon } from "@/components/providers/provider-icon";
+import { ArrowLeft, Pencil, Trash2 } from "lucide-react";
+import { CopyButton } from "@/components/ui/copy-button";
+import type { Capability, LlmModelWithProvider } from "@/lib/api/types";
+import { getCapabilityIcon } from "@/lib/capability-icons";
+
+export default function HarnessDetailPage({ params }: { params: Promise<{ harnessId: string }> }) {
+  const { harnessId } = use(params);
+  const router = useRouter();
+  const { data: harness, isLoading: harnessLoading } = useHarness(harnessId);
+  const { data: allCapabilities } = useCapabilities();
+  const { data: llmModels } = useLlmModels();
+  const deleteHarness = useDeleteHarness();
+
+  const modelMap = useMemo(() => {
+    if (!llmModels) return new Map<string, LlmModelWithProvider>();
+    return new Map(llmModels.map((m) => [m.id, m]));
+  }, [llmModels]);
+
+  const defaultModel = harness?.default_model_id
+    ? modelMap.get(harness.default_model_id)
+    : undefined;
+
+  const getCapabilityInfo = (capabilityId: string): Capability | undefined =>
+    allCapabilities?.find((c) => c.id === capabilityId);
+
+  const harnessCapabilities = harness?.capabilities ?? [];
+
+  const handleDelete = async () => {
+    if (!confirm("Are you sure you want to delete this harness? This action cannot be undone.")) {
+      return;
+    }
+    try {
+      await deleteHarness.mutateAsync(harnessId);
+      router.push("/harnesses");
+    } catch (error) {
+      console.error("Failed to delete harness:", error);
+    }
+  };
+
+  if (harnessLoading) {
+    return (
+      <div className="container mx-auto p-6">
+        <Skeleton className="h-8 w-1/3 mb-4" />
+        <Skeleton className="h-4 w-2/3 mb-8" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (!harness) {
+    return (
+      <div className="container mx-auto p-6">
+        <div className="text-red-500">Harness not found</div>
+        <Link href="/harnesses" className="text-blue-500 hover:underline">
+          Back to harnesses
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto p-6">
+      <Link
+        href="/harnesses"
+        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-6"
+      >
+        <ArrowLeft className="w-4 h-4 mr-2" />
+        Back to Harnesses
+      </Link>
+
+      <div className="flex items-start justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold flex items-center gap-2">
+            {harness.name}
+            <CopyButton value={harness.id} />
+            <Badge variant={harness.status === "active" ? "default" : "secondary"}>
+              {harness.status}
+            </Badge>
+          </h1>
+        </div>
+        <div className="flex gap-2">
+          <Link href={`/harnesses/${harnessId}/edit`}>
+            <Button variant="outline">
+              <Pencil className="w-4 h-4 mr-2" />
+              Edit
+            </Button>
+          </Link>
+          <Button variant="destructive" onClick={handleDelete} disabled={deleteHarness.isPending}>
+            <Trash2 className="w-4 h-4 mr-2" />
+            {deleteHarness.isPending ? "Deleting..." : "Delete"}
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <div className="lg:col-span-2 space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>System Prompt</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <MarkdownDisplay content={harness.system_prompt} />
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Capabilities</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {harnessCapabilities.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No capabilities enabled.{" "}
+                  <Link
+                    href={`/harnesses/${harnessId}/edit`}
+                    className="text-primary hover:underline"
+                  >
+                    Add some
+                  </Link>
+                </p>
+              ) : (
+                <div className="space-y-2">
+                  {harnessCapabilities.map((capConfig) => {
+                    const cap = getCapabilityInfo(capConfig.ref);
+                    if (!cap) return null;
+                    const IconComponent = getCapabilityIcon(cap.icon);
+
+                    return (
+                      <div
+                        key={capConfig.ref}
+                        className="flex items-center gap-2 p-2 rounded-md border bg-muted/50"
+                      >
+                        <IconComponent className="w-4 h-4" />
+                        <div className="flex-1">
+                          <p className="text-sm font-medium">{cap.name}</p>
+                          <p className="text-xs text-muted-foreground">{cap.description}</p>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Configuration</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {defaultModel && (
+                <div>
+                  <p className="text-sm font-medium mb-2">Default Model</p>
+                  <div className="flex items-center gap-2">
+                    <ProviderIcon providerType={defaultModel.provider_type} size="sm" />
+                    <span className="text-sm">{defaultModel.display_name}</span>
+                  </div>
+                </div>
+              )}
+
+              {harness.description && (
+                <div>
+                  <p className="text-sm font-medium">Description</p>
+                  <div className="text-sm text-muted-foreground">
+                    <InlineStreamdownMessage>{harness.description}</InlineStreamdownMessage>
+                  </div>
+                </div>
+              )}
+
+              {harness.tags.length > 0 && (
+                <div>
+                  <p className="text-sm font-medium mb-2">Tags</p>
+                  <div className="flex flex-wrap gap-1">
+                    {harness.tags.map((tag) => (
+                      <Badge key={tag} variant="outline">
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              <div>
+                <p className="text-sm font-medium">Created</p>
+                <p className="text-sm text-muted-foreground">
+                  {new Date(harness.created_at).toLocaleString()}
+                </p>
+              </div>
+
+              <div>
+                <p className="text-sm font-medium">Updated</p>
+                <p className="text-sm text-muted-foreground">
+                  {new Date(harness.updated_at).toLocaleString()}
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/app/(main)/harnesses/new/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/new/page.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { useCreateHarness, useLlmModels, useCapabilities } from "@/hooks";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { PromptEditor } from "@/components/ui/prompt-editor";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { ProviderIcon } from "@/components/providers/provider-icon";
+import { CapabilitySelector } from "@/components/agents/capability-selector";
+import type { AgentCapabilityConfig } from "@/lib/api/types";
+
+export default function NewHarnessPage() {
+  const router = useRouter();
+  const createHarness = useCreateHarness();
+  const { data: models = [] } = useLlmModels();
+  const { data: allCapabilities = [] } = useCapabilities();
+
+  const [formData, setFormData] = useState({
+    name: "",
+    description: "",
+    system_prompt: "",
+    default_model_id: "",
+    tags: "",
+  });
+
+  const [selectedCapabilities, setSelectedCapabilities] = useState<AgentCapabilityConfig[]>([]);
+
+  const handleCapabilitiesChange = useCallback((capabilities: AgentCapabilityConfig[]) => {
+    setSelectedCapabilities(capabilities);
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    try {
+      const tags = formData.tags
+        .split(",")
+        .map((t) => t.trim())
+        .filter((t) => t.length > 0);
+
+      const harness = await createHarness.mutateAsync({
+        name: formData.name,
+        description: formData.description || undefined,
+        system_prompt: formData.system_prompt,
+        default_model_id: formData.default_model_id || undefined,
+        tags: tags.length > 0 ? tags : undefined,
+        capabilities: selectedCapabilities.length > 0 ? selectedCapabilities : undefined,
+      });
+
+      router.push(`/harnesses/${harness.id}`);
+    } catch (error) {
+      console.error("Failed to create harness:", error);
+    }
+  };
+
+  return (
+    <div className="container mx-auto p-6">
+      <Link
+        href="/harnesses"
+        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-6"
+      >
+        <ArrowLeft className="w-4 h-4 mr-2" />
+        Back to Harnesses
+      </Link>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Create New Harness</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div className="space-y-2">
+              <Label htmlFor="name">Name</Label>
+              <Input
+                id="name"
+                placeholder="My Harness"
+                value={formData.name}
+                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="description">Description</Label>
+              <Textarea
+                id="description"
+                placeholder="Describe what this harness does..."
+                value={formData.description}
+                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                rows={2}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="tags">Tags</Label>
+              <Input
+                id="tags"
+                placeholder="tag1, tag2, tag3"
+                value={formData.tags}
+                onChange={(e) => setFormData({ ...formData, tags: e.target.value })}
+              />
+              <p className="text-xs text-muted-foreground">Comma-separated list of tags</p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="model">Model (optional)</Label>
+              <Select
+                value={formData.default_model_id || "none"}
+                onValueChange={(value) =>
+                  setFormData({
+                    ...formData,
+                    default_model_id: value === "none" ? "" : value,
+                  })
+                }
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue>
+                    {(() => {
+                      const selectedModel = models.find((m) => m.id === formData.default_model_id);
+                      if (!selectedModel) return "Use default model";
+                      return (
+                        <div className="flex items-center gap-2">
+                          <ProviderIcon
+                            providerType={selectedModel.provider_type}
+                            size="sm"
+                            showBackground={false}
+                          />
+                          <span>
+                            {selectedModel.display_name} ({selectedModel.provider_name})
+                          </span>
+                        </div>
+                      );
+                    })()}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">Use default model</SelectItem>
+                  {models.map((model) => (
+                    <SelectItem key={model.id} value={model.id}>
+                      <div className="flex items-center gap-2">
+                        <ProviderIcon
+                          providerType={model.provider_type}
+                          size="sm"
+                          showBackground={false}
+                        />
+                        <span>
+                          {model.display_name} ({model.provider_name})
+                        </span>
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                Select a specific model or leave empty to use the default
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Capabilities (optional)</Label>
+              <CapabilitySelector
+                capabilities={allCapabilities}
+                selected={selectedCapabilities}
+                onChange={handleCapabilitiesChange}
+                disabled={createHarness.isPending}
+                label=""
+              />
+              <p className="text-xs text-muted-foreground">
+                Add capabilities to give your harness tools and specialized behaviors
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="system_prompt">System Prompt</Label>
+              <PromptEditor
+                id="system_prompt"
+                placeholder="You are a helpful assistant..."
+                value={formData.system_prompt}
+                onChange={(value) => setFormData({ ...formData, system_prompt: value })}
+                required
+              />
+              <p className="text-xs text-muted-foreground">
+                Instructions for the AI model (supports Markdown)
+              </p>
+            </div>
+
+            <div className="flex gap-4">
+              <Button type="submit" disabled={createHarness.isPending}>
+                {createHarness.isPending ? "Creating..." : "Create Harness"}
+              </Button>
+              <Button type="button" variant="outline" onClick={() => router.back()}>
+                Cancel
+              </Button>
+            </div>
+
+            {createHarness.error && (
+              <p className="text-sm text-destructive">Error: {createHarness.error.message}</p>
+            )}
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/ui/src/app/(main)/harnesses/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/page.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useHarnesses, useCapabilities } from "@/hooks";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Plus } from "lucide-react";
+import { HarnessCard } from "@/components/harnesses";
+
+export default function HarnessesPage() {
+  const { data: harnesses, isLoading, error } = useHarnesses();
+  const { data: allCapabilities } = useCapabilities();
+
+  if (error) {
+    return (
+      <div className="container mx-auto p-6">
+        <div className="text-red-500">Error loading harnesses: {error.message}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto p-6">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold">Harnesses</h1>
+        <Link href="/harnesses/new">
+          <Button variant="accent">
+            <Plus className="w-4 h-4 mr-2" />
+            New Harness
+          </Button>
+        </Link>
+      </div>
+
+      {isLoading ? (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {[...Array(6)].map((_, i) => (
+            <Card key={i}>
+              <CardHeader>
+                <Skeleton className="h-6 w-3/4" />
+              </CardHeader>
+              <CardContent>
+                <Skeleton className="h-4 w-full mb-2" />
+                <Skeleton className="h-4 w-2/3" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      ) : harnesses?.length === 0 ? (
+        <div className="text-center py-12">
+          <p className="text-muted-foreground mb-4">No harnesses yet</p>
+          <Link href="/harnesses/new">
+            <Button>
+              <Plus className="w-4 h-4 mr-2" />
+              Create your first harness
+            </Button>
+          </Link>
+        </div>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {harnesses?.map((harness) => (
+            <HarnessCard
+              key={harness.id}
+              harness={harness}
+              allCapabilities={allCapabilities}
+              showEditButton
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
@@ -96,8 +96,8 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
   // Fetch session first to get agent_id
   const { data: session, isLoading: sessionLoading } = useSession(sessionId);
 
-  // Derive agentId from session
-  const agentId = session?.agent_id;
+  // Derive agentId from session (convert null to undefined)
+  const agentId = session?.agent_id ?? undefined;
 
   // Fetch agent using derived agentId
   const { data: agent } = useAgent(agentId ?? "");
@@ -415,12 +415,18 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
   // Get tool calls from message event data
   const getToolCalls = (
     data: OutputMessageCompletedData,
-  ): Array<{ id: string; name: string; arguments: Record<string, unknown> }> => {
+  ): Array<{
+    id: string;
+    name: string;
+    arguments: Record<string, unknown>;
+  }> => {
     const content = data.message?.content;
     if (!content) return [];
-    return content
-      .filter(isToolCallPart)
-      .map((part) => ({ id: part.id, name: part.name, arguments: part.arguments }));
+    return content.filter(isToolCallPart).map((part) => ({
+      id: part.id,
+      name: part.name,
+      arguments: part.arguments,
+    }));
   };
 
   const value: SessionContextValue = {

--- a/apps/ui/src/app/(main)/sessions/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { useAgents, useSessions, useCreateSession, useLlmModels } from "@/hooks";
+import { useAgents, useHarnesses, useSessions, useCreateSession, useLlmModels } from "@/hooks";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -16,7 +16,9 @@ import {
 } from "@/components/ui/dialog";
 import { SessionCard } from "@/components/session/session-card";
 import { AgentSelect } from "@/components/agent/agent-select";
+import { HarnessSelect } from "@/components/harness/harness-select";
 import { AgentFilterMenu } from "@/components/agent/agent-filter-menu";
+import { Label } from "@/components/ui/label";
 import { Plus, ChevronLeft, ChevronRight } from "lucide-react";
 import type { LlmModelWithProvider, Agent } from "@/lib/api/types";
 
@@ -27,10 +29,12 @@ export default function SessionsPage() {
   const [page, setPage] = useState(0);
   const [selectedAgentId, setSelectedAgentId] = useState<string>("");
   const [newSessionDialogOpen, setNewSessionDialogOpen] = useState(false);
+  const [newSessionHarnessId, setNewSessionHarnessId] = useState<string>("");
   const [newSessionAgentId, setNewSessionAgentId] = useState<string>("");
   const offset = page * PAGE_SIZE;
 
   const { data: agents, isLoading: agentsLoading } = useAgents();
+  const { data: harnesses } = useHarnesses();
   const { data: sessionsResponse, isLoading: sessionsLoading } = useSessions(
     selectedAgentId || undefined, // Pass undefined to get all sessions
     { offset, limit: PAGE_SIZE },
@@ -55,19 +59,24 @@ export default function SessionsPage() {
   }, [agents]);
 
   const handleOpenNewSessionDialog = () => {
-    // Pre-select the filtered agent if one is selected, otherwise first agent
-    setNewSessionAgentId(selectedAgentId || agents?.[0]?.id || "");
+    // Pre-select the first harness
+    setNewSessionHarnessId(harnesses?.[0]?.id || "");
+    // Pre-select the filtered agent if one is selected, otherwise leave empty (optional)
+    setNewSessionAgentId(selectedAgentId || "");
     setNewSessionDialogOpen(true);
   };
 
   const handleCreateSession = async () => {
-    if (!newSessionAgentId) {
-      console.error("No agent selected");
+    if (!newSessionHarnessId) {
+      console.error("No harness selected");
       return;
     }
     try {
       const session = await createSession.mutateAsync({
-        request: { agent_id: newSessionAgentId },
+        request: {
+          harness_id: newSessionHarnessId,
+          agent_id: newSessionAgentId || undefined,
+        },
       });
       setNewSessionDialogOpen(false);
       // Use org-level session URL
@@ -94,7 +103,7 @@ export default function SessionsPage() {
     <div className="container mx-auto p-6">
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold">Sessions</h1>
-        <Button variant="accent" onClick={handleOpenNewSessionDialog} disabled={!agents?.length}>
+        <Button variant="accent" onClick={handleOpenNewSessionDialog} disabled={!harnesses?.length}>
           <Plus className="w-4 h-4 mr-2" />
           New Session
         </Button>
@@ -126,7 +135,7 @@ export default function SessionsPage() {
           ) : (
             <div className="space-y-2">
               {sessions.map((session) => {
-                const agent = agentMap.get(session.agent_id);
+                const agent = session.agent_id ? agentMap.get(session.agent_id) : undefined;
                 return (
                   <SessionCard
                     key={session.id}
@@ -179,14 +188,29 @@ export default function SessionsPage() {
         <DialogContent>
           <DialogHeader>
             <DialogTitle>New Session</DialogTitle>
-            <DialogDescription>Select an agent to start a new conversation.</DialogDescription>
+            <DialogDescription>
+              Select a harness and optionally an agent to start a new conversation.
+            </DialogDescription>
           </DialogHeader>
-          <div className="py-4">
-            <AgentSelect
-              value={newSessionAgentId}
-              onValueChange={setNewSessionAgentId}
-              placeholder="Select an agent"
-            />
+          <div className="py-4 space-y-4">
+            <div className="space-y-2">
+              <Label>Harness (required)</Label>
+              <HarnessSelect
+                value={newSessionHarnessId}
+                onValueChange={setNewSessionHarnessId}
+                placeholder="Select a harness"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Agent (optional)</Label>
+              <AgentSelect
+                value={newSessionAgentId}
+                onValueChange={setNewSessionAgentId}
+                placeholder="Select an agent"
+                includeAll
+                allLabel="No agent"
+              />
+            </div>
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setNewSessionDialogOpen(false)}>
@@ -194,7 +218,7 @@ export default function SessionsPage() {
             </Button>
             <Button
               onClick={handleCreateSession}
-              disabled={!newSessionAgentId || createSession.isPending}
+              disabled={!newSessionHarnessId || createSession.isPending}
             >
               {createSession.isPending ? "Creating..." : "Create Session"}
             </Button>

--- a/apps/ui/src/app/dev/session-card/page.tsx
+++ b/apps/ui/src/app/dev/session-card/page.tsx
@@ -52,6 +52,7 @@ const sampleSessions = {
   running: {
     id: "019234ab-cdef-7890-1234-567890abcdef",
     organization_id: "org_default",
+    harness_id: "harness-default",
     agent_id: "agent-123",
     title:
       "Working on implementing user authentication with OAuth 2.0 support for Google and GitHub providers",
@@ -76,6 +77,7 @@ const sampleSessions = {
   idle: {
     id: "019234cd-efgh-7890-1234-567890abcdef",
     organization_id: "org_default",
+    harness_id: "harness-default",
     agent_id: "agent-123",
     title: "Completed code review for the API endpoints",
     preview: "Please review the changes in src/api/routes.ts and check for any issues",
@@ -98,6 +100,7 @@ const sampleSessions = {
   new: {
     id: "019234ef-ijkl-7890-1234-567890abcdef",
     organization_id: "org_default",
+    harness_id: "harness-default",
     agent_id: "agent-123",
     title: null,
     preview: null,
@@ -114,6 +117,7 @@ const sampleSessions = {
   withPreviewOnly: {
     id: "019234ab-wxyz-7890-1234-567890abcdef",
     organization_id: "org_default",
+    harness_id: "harness-default",
     agent_id: "agent-123",
     title: null,
     preview: "Help me debug this failing test in the authentication module",
@@ -136,6 +140,7 @@ const sampleSessions = {
   longSummary: {
     id: "019234gh-mnop-7890-1234-567890abcdef",
     organization_id: "org_default",
+    harness_id: "harness-default",
     agent_id: "agent-123",
     title: "Investigating the performance bottleneck in the database query layer",
     preview:

--- a/apps/ui/src/components/dashboard/recent-sessions.tsx
+++ b/apps/ui/src/components/dashboard/recent-sessions.tsx
@@ -68,7 +68,7 @@ export function RecentSessions({ sessions, agents, models = [] }: RecentSessions
         ) : (
           <div className="space-y-2">
             {recentSessions.map((session) => {
-              const agent = agentMap.get(session.agent_id);
+              const agent = session.agent_id ? agentMap.get(session.agent_id) : undefined;
               const model = session.model_id ? modelMap.get(session.model_id) : undefined;
               return (
                 <Link

--- a/apps/ui/src/components/harness/harness-select.tsx
+++ b/apps/ui/src/components/harness/harness-select.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useHarnesses } from "@/hooks";
+import type { Harness } from "@/lib/api/types";
+
+interface HarnessSelectProps {
+  /** Selected harness ID */
+  value: string;
+  /** Callback when selection changes */
+  onValueChange: (harnessId: string) => void;
+  /** Placeholder text when nothing selected */
+  placeholder?: string;
+  /** Additional className for trigger */
+  className?: string;
+  /** Disable the select */
+  disabled?: boolean;
+}
+
+/**
+ * Harness select dropdown that displays harness names but uses IDs as values.
+ * Handles the ID-to-name mapping automatically.
+ */
+export function HarnessSelect({
+  value,
+  onValueChange,
+  placeholder = "Select harness",
+  className,
+  disabled,
+}: HarnessSelectProps) {
+  const { data: harnesses = [] } = useHarnesses();
+
+  const harnessMap = useMemo(() => {
+    return new Map<string, Harness>(harnesses.map((h) => [h.id, h]));
+  }, [harnesses]);
+
+  const displayValue = value ? harnessMap.get(value)?.name : undefined;
+
+  return (
+    <Select value={value} onValueChange={onValueChange} disabled={disabled}>
+      <SelectTrigger className={className}>
+        <SelectValue placeholder={placeholder}>{displayValue}</SelectValue>
+      </SelectTrigger>
+      <SelectContent>
+        {harnesses.map((harness) => (
+          <SelectItem key={harness.id} value={harness.id}>
+            {harness.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/apps/ui/src/components/harnesses/harness-card.tsx
+++ b/apps/ui/src/components/harnesses/harness-card.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import Link from "next/link";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Pencil } from "lucide-react";
+import { CopyButton } from "@/components/ui/copy-button";
+import type { Harness, Capability, CapabilityId } from "@/lib/api/types";
+import { getCapabilityIcon } from "@/lib/capability-icons";
+import { InlineStreamdownMessage } from "@/components/chat/streamdown-message";
+
+interface HarnessCardProps {
+  harness: Harness;
+  allCapabilities?: Capability[];
+  showEditButton?: boolean;
+  compact?: boolean;
+}
+
+export function HarnessCard({
+  harness,
+  allCapabilities,
+  showEditButton = false,
+  compact = false,
+}: HarnessCardProps) {
+  const getCapabilityInfo = (capabilityId: CapabilityId): Capability | undefined =>
+    allCapabilities?.find((c) => c.id === capabilityId);
+
+  const harnessCapabilities = harness.capabilities ?? [];
+
+  return (
+    <Card className="hover:shadow-md transition-shadow">
+      <CardHeader className="flex flex-row items-start justify-between space-y-0">
+        <div className="flex items-center gap-2">
+          <CardTitle className="text-lg">
+            <Link href={`/harnesses/${harness.id}`} className="hover:underline">
+              {harness.name}
+            </Link>
+          </CardTitle>
+          <CopyButton value={harness.id} />
+        </div>
+        <Badge variant={harness.status === "active" ? "default" : "secondary"}>
+          {harness.status}
+        </Badge>
+      </CardHeader>
+      <CardContent>
+        {harness.description ? (
+          <div className="text-sm text-muted-foreground mb-3 line-clamp-2">
+            <InlineStreamdownMessage>{harness.description}</InlineStreamdownMessage>
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground mb-3 italic">No description provided</p>
+        )}
+
+        {/* Capabilities display */}
+        {harnessCapabilities.length > 0 && (
+          <div className="flex flex-wrap gap-1 mb-3">
+            <TooltipProvider>
+              {harnessCapabilities.map((capConfig) => {
+                const cap = getCapabilityInfo(capConfig.ref);
+                if (!cap) return null;
+                const IconComponent = getCapabilityIcon(cap.icon);
+
+                return (
+                  <Tooltip key={capConfig.ref}>
+                    <TooltipTrigger className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-muted text-xs cursor-default">
+                      <IconComponent className="w-3 h-3" />
+                      {!compact && <span>{cap.name}</span>}
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p className="font-medium">{cap.name}</p>
+                      <p className="text-xs text-muted-foreground">{cap.description}</p>
+                    </TooltipContent>
+                  </Tooltip>
+                );
+              })}
+            </TooltipProvider>
+          </div>
+        )}
+
+        {/* Tags */}
+        {harness.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1 mb-3">
+            {harness.tags.map((tag) => (
+              <Badge key={tag} variant="outline" className="text-xs">
+                {tag}
+              </Badge>
+            ))}
+          </div>
+        )}
+
+        {/* Footer */}
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-muted-foreground">
+            Created {new Date(harness.created_at).toLocaleDateString()}
+          </span>
+          {showEditButton && (
+            <Link href={`/harnesses/${harness.id}/edit`}>
+              <Button variant="ghost" size="icon" className="h-8 w-8">
+                <Pencil className="w-4 h-4" />
+              </Button>
+            </Link>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/ui/src/components/harnesses/index.ts
+++ b/apps/ui/src/components/harnesses/index.ts
@@ -1,0 +1,1 @@
+export { HarnessCard } from "./harness-card";

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -35,12 +35,14 @@ import {
   Workflow,
   Building2,
   Check,
+  Shield,
 } from "lucide-react";
 
 const isDev = process.env.NODE_ENV === "development";
 
 const navigation = [
   { name: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
+  { name: "Harnesses", href: "/harnesses", icon: Shield },
   { name: "Agents", href: "/agents", icon: Boxes },
   { name: "Sessions", href: "/sessions", icon: MessageSquare },
   { name: "Capabilities", href: "/capabilities", icon: Puzzle },

--- a/apps/ui/src/hooks/index.ts
+++ b/apps/ui/src/hooks/index.ts
@@ -1,5 +1,6 @@
 // Hooks exports
 export * from "./use-agents";
+export * from "./use-harnesses";
 export * from "./use-capabilities";
 export * from "./use-sessions";
 export * from "./use-llm-providers";

--- a/apps/ui/src/hooks/use-harnesses.ts
+++ b/apps/ui/src/hooks/use-harnesses.ts
@@ -1,0 +1,83 @@
+// Harness hooks
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  createHarness,
+  deleteHarness,
+  getHarness,
+  listHarnesses,
+  updateHarness,
+} from "@/lib/api/harnesses";
+import { queryKeys } from "@/lib/query-keys";
+import type { CreateHarnessRequest, UpdateHarnessRequest } from "@/lib/api/types";
+import { useOrg } from "@/providers/org-provider";
+
+export function useHarnesses() {
+  const { currentOrg, isLoading: orgLoading } = useOrg();
+  const org = currentOrg?.public_id;
+
+  const query = useQuery({
+    queryKey: [...queryKeys.harnesses.list(), org],
+    queryFn: () => listHarnesses(),
+    enabled: !!org,
+  });
+
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading,
+  };
+}
+
+export function useHarness(harnessId: string | undefined) {
+  const { currentOrg, isLoading: orgLoading } = useOrg();
+  const org = currentOrg?.public_id;
+
+  const query = useQuery({
+    queryKey: [...queryKeys.harnesses.detail(harnessId!), org],
+    queryFn: () => getHarness(harnessId!),
+    enabled: !!org && !!harnessId,
+  });
+
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading,
+  };
+}
+
+export function useCreateHarness() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: CreateHarnessRequest) => createHarness(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.harnesses.all });
+    },
+  });
+}
+
+export function useUpdateHarness() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ harnessId, request }: { harnessId: string; request: UpdateHarnessRequest }) =>
+      updateHarness(harnessId, request),
+    onSuccess: (_, { harnessId }) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.harnesses.all });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.harnesses.detail(harnessId),
+      });
+    },
+  });
+}
+
+export function useDeleteHarness() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (harnessId: string) => deleteHarness(harnessId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.harnesses.all });
+    },
+  });
+}

--- a/apps/ui/src/lib/api/harnesses.ts
+++ b/apps/ui/src/lib/api/harnesses.ts
@@ -1,0 +1,32 @@
+// Harness API functions
+// Org is sent via everruns_org cookie (set by OrgProvider via /v1/users/me/switch-org)
+
+import { api } from "./client";
+import type { Harness, CreateHarnessRequest, UpdateHarnessRequest, ListResponse } from "./types";
+
+export async function createHarness(request: CreateHarnessRequest): Promise<Harness> {
+  const response = await api.post<Harness>("/v1/harnesses", request);
+  return response.data;
+}
+
+export async function listHarnesses(): Promise<Harness[]> {
+  const response = await api.get<ListResponse<Harness>>("/v1/harnesses");
+  return response.data.data;
+}
+
+export async function getHarness(harnessId: string): Promise<Harness> {
+  const response = await api.get<Harness>(`/v1/harnesses/${harnessId}`);
+  return response.data;
+}
+
+export async function updateHarness(
+  harnessId: string,
+  request: UpdateHarnessRequest,
+): Promise<Harness> {
+  const response = await api.patch<Harness>(`/v1/harnesses/${harnessId}`, request);
+  return response.data;
+}
+
+export async function deleteHarness(harnessId: string): Promise<void> {
+  await api.delete(`/v1/harnesses/${harnessId}`);
+}

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -59,6 +59,55 @@ export interface UpdateAgentRequest {
   status?: AgentStatus;
 }
 
+// ============================================
+// Harness types
+// ============================================
+
+export type HarnessStatus = "active" | "archived";
+
+export interface Harness {
+  id: string;
+  name: string;
+  description: string | null;
+  system_prompt: string;
+  default_model_id: string | null;
+  tags: string[];
+  /** Capabilities with per-harness configuration */
+  capabilities: AgentCapabilityConfig[];
+  status: HarnessStatus;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateHarnessRequest {
+  name: string;
+  description?: string;
+  system_prompt: string;
+  default_model_id?: string;
+  tags?: string[];
+  /** Capabilities with per-harness configuration */
+  capabilities?: AgentCapabilityConfig[];
+}
+
+export interface UpdateHarnessRequest {
+  name?: string;
+  description?: string;
+  system_prompt?: string;
+  default_model_id?: string;
+  tags?: string[];
+  /** Capabilities with per-harness configuration */
+  capabilities?: AgentCapabilityConfig[];
+  status?: HarnessStatus;
+}
+
+/** Request to preview the final harness shape with capabilities applied */
+export interface PreviewHarnessRequest {
+  /** The base system prompt (before capability additions) */
+  system_prompt: string;
+  /** Capability IDs to apply */
+  capabilities?: AgentCapabilityConfig[];
+}
+
 /** Request to preview the final agent shape with capabilities applied */
 export interface PreviewAgentRequest {
   /** The base system prompt (before capability additions) */
@@ -90,7 +139,8 @@ export interface Session {
   id: string;
   /** Organization this session belongs to */
   organization_id: string;
-  agent_id: string;
+  harness_id: string;
+  agent_id: string | null;
   title: string | null;
   /** Preview text from the first user message (truncated) */
   preview?: string | null;
@@ -110,8 +160,10 @@ export interface Session {
 }
 
 export interface CreateSessionRequest {
-  /** Agent ID to work in this session (required) */
-  agent_id: string;
+  /** Harness ID for this session (required) */
+  harness_id: string;
+  /** Agent ID to work in this session (optional) */
+  agent_id?: string;
   title?: string;
   tags?: string[];
   model_id?: string;
@@ -149,23 +201,39 @@ export type ContentPart =
   | { type: "text"; text: string }
   | { type: "image"; url?: string; base64?: string; media_type?: string }
   | { type: "image_file"; image_id: string; filename?: string }
-  | { type: "tool_call"; id: string; name: string; arguments: Record<string, unknown> }
-  | { type: "tool_result"; tool_call_id: string; result?: unknown; error?: string };
+  | {
+      type: "tool_call";
+      id: string;
+      name: string;
+      arguments: Record<string, unknown>;
+    }
+  | {
+      type: "tool_result";
+      tool_call_id: string;
+      result?: unknown;
+      error?: string;
+    };
 
 // Helper type guards for ContentPart
 export function isTextPart(part: ContentPart): part is { type: "text"; text: string } {
   return part.type === "text";
 }
 
-export function isToolCallPart(
-  part: ContentPart,
-): part is { type: "tool_call"; id: string; name: string; arguments: Record<string, unknown> } {
+export function isToolCallPart(part: ContentPart): part is {
+  type: "tool_call";
+  id: string;
+  name: string;
+  arguments: Record<string, unknown>;
+} {
   return part.type === "tool_call";
 }
 
-export function isToolResultPart(
-  part: ContentPart,
-): part is { type: "tool_result"; tool_call_id: string; result?: unknown; error?: string } {
+export function isToolResultPart(part: ContentPart): part is {
+  type: "tool_result";
+  tool_call_id: string;
+  result?: unknown;
+  error?: string;
+} {
   return part.type === "tool_result";
 }
 
@@ -250,9 +318,11 @@ export function getTextFromContent(content: ContentPart[]): string {
 export function getToolCallsFromContent(
   content: ContentPart[],
 ): Array<{ id: string; name: string; arguments: Record<string, unknown> }> {
-  return content
-    .filter(isToolCallPart)
-    .map((part) => ({ id: part.id, name: part.name, arguments: part.arguments }));
+  return content.filter(isToolCallPart).map((part) => ({
+    id: part.id,
+    name: part.name,
+    arguments: part.arguments,
+  }));
 }
 
 // ============================================
@@ -406,7 +476,11 @@ export interface ToolStartedData {
 
 /** Data for tool.call_requested event (client-side tool calls awaiting results) */
 export interface ToolCallRequestedData {
-  tool_calls: Array<{ id: string; name: string; arguments: Record<string, unknown> }>;
+  tool_calls: Array<{
+    id: string;
+    name: string;
+    arguments: Record<string, unknown>;
+  }>;
 }
 
 /** Data for tool.completed event */

--- a/apps/ui/src/lib/query-keys.ts
+++ b/apps/ui/src/lib/query-keys.ts
@@ -19,6 +19,13 @@ export const queryKeys = {
     detail: (agentId: string) => ["agent", agentId] as const,
   },
 
+  // Harness queries
+  harnesses: {
+    all: ["harnesses"] as const,
+    list: () => ["harnesses"] as const,
+    detail: (harnessId: string) => ["harness", harnessId] as const,
+  },
+
   // Session queries (sessions are org-level, with optional agent filter)
   sessions: {
     all: () => ["sessions"] as const,

--- a/crates/cli/src/commands/sessions.rs
+++ b/crates/cli/src/commands/sessions.rs
@@ -3,15 +3,19 @@
 use crate::output::{OutputFormat, print_field, print_table_header, print_table_row};
 use anyhow::Result;
 use clap::Subcommand;
-use everruns_sdk::{CreateSessionRequest, Everruns};
+use everruns_sdk::Everruns;
 
 #[derive(Subcommand)]
 pub enum SessionsCommand {
     /// Create a new session
     Create {
-        /// Agent ID (e.g. agt_xxx)
+        /// Harness ID (e.g. harness_xxx)
+        #[arg(long, short = 'H')]
+        harness: String,
+
+        /// Agent ID (optional, e.g. agent_xxx)
         #[arg(long, short)]
-        agent: String,
+        agent: Option<String>,
 
         /// Session title
         #[arg(long)]
@@ -35,46 +39,82 @@ pub enum SessionsCommand {
 pub async fn run(
     command: SessionsCommand,
     client: &Everruns,
+    api_url: &str,
+    api_key: &str,
     output: OutputFormat,
     quiet: bool,
 ) -> Result<()> {
     match command {
         SessionsCommand::Create {
+            harness,
             agent,
             title,
             model,
-        } => create(client, output, quiet, agent, title, model).await,
+        } => {
+            create(
+                api_url, api_key, output, quiet, harness, agent, title, model,
+            )
+            .await
+        }
         SessionsCommand::List => list(client, output).await,
         SessionsCommand::Get { session } => get(client, output, session).await,
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn create(
-    client: &Everruns,
+    api_url: &str,
+    api_key: &str,
     output: OutputFormat,
     quiet: bool,
-    agent_id: String,
+    harness_id: String,
+    agent_id: Option<String>,
     title: Option<String>,
     model_id: Option<String>,
 ) -> Result<()> {
-    let mut req = CreateSessionRequest::new(&agent_id);
+    // SDK doesn't support harness_id yet, use reqwest directly
+    let mut body = serde_json::json!({
+        "harness_id": harness_id,
+    });
+    if let Some(a) = agent_id {
+        body["agent_id"] = serde_json::Value::String(a);
+    }
     if let Some(t) = title {
-        req = req.title(t);
+        body["title"] = serde_json::Value::String(t);
     }
     if let Some(m) = model_id {
-        req = req.model_id(m);
+        body["model_id"] = serde_json::Value::String(m);
     }
 
-    let session = client.sessions().create_with_options(req).await?;
+    let http = reqwest::Client::new();
+    let url = format!("{}/v1/sessions", api_url.trim_end_matches('/'));
+    let resp = http
+        .post(&url)
+        .header("Authorization", api_key)
+        .header("Content-Type", "application/json")
+        .json(&body)
+        .send()
+        .await?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        anyhow::bail!("Failed to create session: {} {}", status, text);
+    }
+
+    let session: serde_json::Value = resp.json().await?;
 
     if output.is_text() {
+        let id = session["id"].as_str().unwrap_or("unknown");
         if quiet {
-            println!("{}", session.id);
+            println!("{}", id);
         } else {
-            println!("Created session: {}", session.id);
-            print_field("Agent", &session.agent_id);
-            let status = format!("{:?}", session.status).to_lowercase();
-            print_field("Status", &status);
+            println!("Created session: {}", id);
+            if let Some(agent) = session["agent_id"].as_str() {
+                print_field("Agent", agent);
+            }
+            let status = session["status"].as_str().unwrap_or("unknown");
+            print_field("Status", status);
         }
     } else {
         output.print_value(&session);

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -104,7 +104,15 @@ async fn main() -> anyhow::Result<()> {
             commands::capabilities::run(&api_url, &api_key, output_format, &status).await
         }
         Commands::Sessions { command } => {
-            commands::sessions::run(command, &client, output_format, cli.quiet).await
+            commands::sessions::run(
+                command,
+                &client,
+                &api_url,
+                &api_key,
+                output_format,
+                cli.quiet,
+            )
+            .await
         }
         Commands::Chat {
             message,
@@ -159,6 +167,8 @@ mod tests {
             "everruns",
             "sessions",
             "create",
+            "--harness",
+            "harness_abc",
             "--agent",
             "agt_abc",
             "--title",
@@ -167,12 +177,14 @@ mod tests {
         .unwrap();
         if let Commands::Sessions { command } = cli.command {
             if let commands::sessions::SessionsCommand::Create {
+                harness,
                 agent,
                 title,
                 model,
             } = command
             {
-                assert_eq!(agent, "agt_abc");
+                assert_eq!(harness, "harness_abc");
+                assert_eq!(agent, Some("agt_abc".to_string()));
                 assert_eq!(title, Some("Test Session".to_string()));
                 assert_eq!(model, None);
             } else {

--- a/crates/core/examples/turn_based_execution.rs
+++ b/crates/core/examples/turn_based_execution.rs
@@ -24,7 +24,7 @@
 
 use chrono::Utc;
 use everruns_core::{
-    AgentId, InputMessage, MessageRetriever,
+    Harness, HarnessStatus, InputMessage, MessageRetriever,
     agent::{Agent, AgentStatus},
     atoms::{
         ActAtom, ActInput, Atom, AtomContext, InputAtom, InputAtomInput, ReasonAtom, ReasonInput,
@@ -32,12 +32,12 @@ use everruns_core::{
     capabilities::CapabilityRegistry,
     llm_driver_registry::DriverRegistry,
     memory::{
-        InMemoryAgentStore, InMemoryEventEmitter, InMemoryLlmProviderStore,
+        InMemoryAgentStore, InMemoryEventEmitter, InMemoryHarnessStore, InMemoryLlmProviderStore,
         InMemoryMessageRetriever, InMemorySessionStore,
     },
     session::{Session, SessionStatus},
     tools::{Tool, ToolExecutionResult, ToolRegistry, ToolRegistryBuilder},
-    typed_id::TurnId,
+    typed_id::{AgentId, HarnessId, TurnId},
 };
 use serde_json::{Value, json};
 use uuid::Uuid;
@@ -101,16 +101,33 @@ async fn main() -> anyhow::Result<()> {
     println!("=== Turn-Based Execution with New Atoms ===\n");
 
     // Create shared dependencies
+    let harness_store = InMemoryHarnessStore::new();
     let agent_store = InMemoryAgentStore::new();
     let session_store = InMemorySessionStore::new();
     let message_retriever = InMemoryMessageRetriever::new();
     let provider_store = InMemoryLlmProviderStore::from_env().await;
     let tools: ToolRegistry = ToolRegistryBuilder::new().tool(GetWeatherTool).build();
 
-    // Create an agent in the store
+    // Create a harness in the store
+    let harness_id = HarnessId::new();
     let agent_id = Uuid::now_v7();
     let session_id = Uuid::now_v7();
     let now = Utc::now();
+    let harness = Harness {
+        id: harness_id,
+        name: "Default Harness".to_string(),
+        description: None,
+        system_prompt: "You are a helpful assistant.".to_string(),
+        default_model_id: None,
+        tags: vec![],
+        capabilities: vec![],
+        status: HarnessStatus::Active,
+        created_at: now,
+        updated_at: now,
+    };
+    harness_store.add_harness(harness).await;
+
+    // Create an agent in the store
     let agent = Agent {
         public_id: AgentId::from_uuid(agent_id),
         internal_id: agent_id,
@@ -132,7 +149,8 @@ async fn main() -> anyhow::Result<()> {
     let session = Session {
         id: session_id.into(),
         organization_id: "default".to_string(),
-        agent_id: agent_id.into(),
+        harness_id,
+        agent_id: Some(AgentId::from_uuid(agent_id)),
         title: Some("Weather Query".to_string()),
         preview: None,
         output_preview: None,
@@ -187,6 +205,7 @@ async fn main() -> anyhow::Result<()> {
 
     let input_atom = InputAtom::new(message_retriever.clone());
     let reason_atom = ReasonAtom::new(
+        harness_store,
         agent_store.clone(),
         session_store,
         message_retriever.clone(),
@@ -234,7 +253,8 @@ async fn main() -> anyhow::Result<()> {
         let reason_result = reason_atom
             .execute(ReasonInput {
                 context: reason_context,
-                agent_id: agent_id.into(),
+                harness_id,
+                agent_id: Some(AgentId::from_uuid(agent_id)),
                 org_id: 0,
                 mcp_tool_definitions: vec![],
             })
@@ -275,7 +295,8 @@ async fn main() -> anyhow::Result<()> {
         let act_result = act_atom
             .execute(ActInput {
                 context: act_context,
-                agent_id: agent_id.into(),
+                harness_id,
+                agent_id: Some(AgentId::from_uuid(agent_id)),
                 tool_calls: reason_result.tool_calls.clone(),
                 tool_definitions: reason_result.tool_definitions.clone(),
             })

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -37,7 +37,7 @@ use crate::events::{
 use crate::message::ContentPart;
 use crate::tool_types::{ToolCall, ToolDefinition, ToolResult};
 use crate::traits::{EventEmitter, SessionFileStore, ToolContext, ToolExecutor};
-use crate::typed_id::AgentId;
+use crate::typed_id::{AgentId, HarnessId};
 use uuid::Uuid;
 
 // ============================================================================
@@ -49,8 +49,11 @@ use uuid::Uuid;
 pub struct ActInput {
     /// Atom execution context
     pub context: AtomContext,
-    /// Agent ID (needed for scheduling follow-up reason activity)
-    pub agent_id: AgentId,
+    /// Harness ID (needed for scheduling follow-up reason activity)
+    pub harness_id: HarnessId,
+    /// Agent ID (needed for scheduling follow-up reason activity, optional)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<AgentId>,
     /// Tool calls to execute
     pub tool_calls: Vec<ToolCall>,
     /// Available tool definitions for resolution
@@ -552,7 +555,7 @@ mod tests {
     use super::*;
     use crate::tools::ToolRegistry;
     use crate::traits::NoopEventEmitter;
-    use crate::typed_id::{AgentId, MessageId, SessionId, TurnId};
+    use crate::typed_id::{AgentId, HarnessId, MessageId, SessionId, TurnId};
     use serde_json::json;
 
     #[tokio::test]
@@ -564,7 +567,8 @@ mod tests {
         let context = AtomContext::new(SessionId::new(), TurnId::new(), MessageId::new());
         let input = ActInput {
             context,
-            agent_id: AgentId::new(),
+            harness_id: HarnessId::from_seed(1),
+            agent_id: Some(AgentId::new()),
             tool_calls: vec![],
             tool_definitions: vec![],
         };
@@ -586,7 +590,8 @@ mod tests {
         let context = AtomContext::new(SessionId::new(), TurnId::new(), MessageId::new());
         let input = ActInput {
             context,
-            agent_id: AgentId::new(),
+            harness_id: HarnessId::from_seed(1),
+            agent_id: Some(AgentId::new()),
             tool_calls: vec![ToolCall {
                 id: "call_1".to_string(),
                 name: "nonexistent_tool".to_string(),

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -45,10 +45,10 @@ use crate::openresponses_protocol::{
 use crate::runtime_agent::RuntimeAgentBuilder;
 use crate::tool_types::{ToolCall, ToolDefinition};
 use crate::traits::{
-    AgentStore, EventEmitter, ImageResolver, LlmProviderStore, ModelWithProvider, ResolvedImage,
-    SessionStore,
+    AgentStore, EventEmitter, HarnessStore, ImageResolver, LlmProviderStore, ModelWithProvider,
+    ResolvedImage, SessionStore,
 };
-use crate::typed_id::{AgentId, SessionId};
+use crate::typed_id::{AgentId, HarnessId, SessionId};
 
 // ============================================================================
 // Helper Functions
@@ -98,8 +98,11 @@ fn patch_dangling_tool_calls(messages: &[Message]) -> Vec<Message> {
 pub struct ReasonInput {
     /// Atom execution context
     pub context: AtomContext,
-    /// Agent ID for loading configuration
-    pub agent_id: AgentId,
+    /// Harness ID for loading base configuration
+    pub harness_id: HarnessId,
+    /// Agent ID for loading configuration (optional)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<AgentId>,
     /// Organization ID for multi-tenancy tracking
     #[serde(default)]
     pub org_id: i64,
@@ -158,14 +161,16 @@ fn default_max_iterations() -> usize {
 /// 9. Stores the assistant response
 /// 10. Emits reason.completed event
 /// 11. Returns the result with tool calls (if any)
-pub struct ReasonAtom<A, S, M, P, E>
+pub struct ReasonAtom<H, A, S, M, P, E>
 where
+    H: HarnessStore,
     A: AgentStore,
     S: SessionStore,
     M: MessageRetriever,
     P: LlmProviderStore,
     E: EventEmitter,
 {
+    harness_store: H,
     agent_store: A,
     session_store: S,
     message_retriever: M,
@@ -179,8 +184,9 @@ where
     file_store: Option<Arc<dyn crate::traits::SessionFileStore>>,
 }
 
-impl<A, S, M, P, E> ReasonAtom<A, S, M, P, E>
+impl<H, A, S, M, P, E> ReasonAtom<H, A, S, M, P, E>
 where
+    H: HarnessStore,
     A: AgentStore,
     S: SessionStore,
     M: MessageRetriever,
@@ -188,7 +194,9 @@ where
     E: EventEmitter,
 {
     /// Create a new ReasonAtom
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
+        harness_store: H,
         agent_store: A,
         session_store: S,
         message_retriever: M,
@@ -198,6 +206,7 @@ where
         event_emitter: E,
     ) -> Self {
         Self {
+            harness_store,
             agent_store,
             session_store,
             message_retriever,
@@ -239,8 +248,9 @@ where
 }
 
 #[async_trait]
-impl<A, S, M, P, E> Atom for ReasonAtom<A, S, M, P, E>
+impl<H, A, S, M, P, E> Atom for ReasonAtom<H, A, S, M, P, E>
 where
+    H: HarnessStore + Send + Sync,
     A: AgentStore + Send + Sync,
     S: SessionStore + Send + Sync,
     M: MessageRetriever + Send + Sync,
@@ -257,6 +267,7 @@ where
     async fn execute(&self, input: Self::Input) -> Result<Self::Output> {
         let ReasonInput {
             context,
+            harness_id,
             agent_id,
             org_id,
             mcp_tool_definitions,
@@ -266,7 +277,8 @@ where
             session_id = %context.session_id,
             turn_id = %context.turn_id,
             exec_id = %context.exec_id,
-            agent_id = %agent_id,
+            harness_id = %harness_id,
+            agent_id = ?agent_id,
             mcp_tools_count = %mcp_tool_definitions.len(),
             "ReasonAtom: starting LLM call"
         );
@@ -299,6 +311,7 @@ where
                 context.session_id,
                 event_context.clone(),
                 ReasonStartedData {
+                    harness_id,
                     agent_id,
                     metadata: None, // Will be populated after model resolution
                 },
@@ -316,6 +329,7 @@ where
         let result = match self
             .execute_llm_call(
                 context.session_id,
+                harness_id,
                 agent_id,
                 org_id,
                 &context,
@@ -449,8 +463,9 @@ where
     }
 }
 
-impl<A, S, M, P, E> ReasonAtom<A, S, M, P, E>
+impl<H, A, S, M, P, E> ReasonAtom<H, A, S, M, P, E>
 where
+    H: HarnessStore + Send + Sync,
     A: AgentStore + Send + Sync,
     S: SessionStore + Send + Sync,
     M: MessageRetriever + Send + Sync,
@@ -462,21 +477,34 @@ where
     async fn execute_llm_call(
         &self,
         session_id: SessionId,
-        agent_id: AgentId,
+        harness_id: HarnessId,
+        agent_id: Option<AgentId>,
         org_id: i64,
         context: &AtomContext,
         mcp_tool_definitions: &[ToolDefinition],
         trace_id: &str,
         reason_span_id: &str,
     ) -> Result<ReasonResult> {
-        // 1. Retrieve agent
-        let agent = self
-            .agent_store
-            .get_agent(agent_id)
+        // 1. Retrieve harness
+        let harness = self
+            .harness_store
+            .get_harness(harness_id)
             .await?
-            .ok_or_else(|| AgentLoopError::agent_not_found(agent_id))?;
+            .ok_or_else(|| AgentLoopError::harness_not_found(harness_id))?;
 
-        // 2. Retrieve session
+        // 2. Retrieve agent (optional)
+        let agent = if let Some(agent_id) = agent_id {
+            Some(
+                self.agent_store
+                    .get_agent(agent_id)
+                    .await?
+                    .ok_or_else(|| AgentLoopError::agent_not_found(agent_id))?,
+            )
+        } else {
+            None
+        };
+
+        // 3. Retrieve session
         let session = self
             .session_store
             .get_session(session_id)
@@ -498,21 +526,29 @@ where
             .and_then(|m| m.controls.as_ref())
             .and_then(|c| c.model_id);
 
-        // 5. Resolve model using chain: controls.model_id > session.model_id > agent.default_model_id
+        // 5. Resolve model: controls > session > agent > harness
+        let agent_model_id = agent.as_ref().and_then(|a| a.default_model_id);
         let (model_with_provider, resolved_model_id) = self
-            .resolve_model(controls_model_id, session.model_id, agent.default_model_id)
+            .resolve_model(
+                controls_model_id,
+                session.model_id,
+                agent_model_id,
+                harness.default_model_id,
+            )
             .await?;
 
-        // 6. Build runtime agent from agent with capabilities applied
-        // Then apply session-level capabilities (additive to agent capabilities)
-        // Also include MCP tool definitions that were pre-resolved by control-plane
+        // 6. Build runtime agent: harness (base) → agent (optional) → session caps
         let session_capability_ids: Vec<String> = session
             .capabilities
             .iter()
             .map(|cap| cap.capability_id().to_string())
             .collect();
-        let mut builder = RuntimeAgentBuilder::new()
-            .with_agent(&agent, &self.capability_registry)
+        let mut builder =
+            RuntimeAgentBuilder::new().with_harness(&harness, &self.capability_registry);
+        if let Some(ref agent) = agent {
+            builder = builder.with_agent(agent, &self.capability_registry);
+        }
+        builder = builder
             .with_capabilities(&session_capability_ids, &self.capability_registry)
             .tools(mcp_tool_definitions.iter().cloned())
             .model(&model_with_provider.model);
@@ -523,10 +559,15 @@ where
         }
 
         // 6b. Read AGENTS.md if agent_instructions capability is enabled
-        let has_agent_instructions =
-            agent.capabilities.iter().any(|c| {
-                c.capability_id() == crate::capabilities::AGENT_INSTRUCTIONS_CAPABILITY_ID
-            }) || session_capability_ids
+        let has_agent_instructions = agent
+            .as_ref()
+            .map(|a| {
+                a.capabilities.iter().any(|c| {
+                    c.capability_id() == crate::capabilities::AGENT_INSTRUCTIONS_CAPABILITY_ID
+                })
+            })
+            .unwrap_or(false)
+            || session_capability_ids
                 .iter()
                 .any(|id| id == crate::capabilities::AGENT_INSTRUCTIONS_CAPABILITY_ID);
 
@@ -620,10 +661,13 @@ where
         // TypedId::to_string() produces prefixed format (e.g., "session_abc123")
         llm_config_builder = llm_config_builder
             .with_metadata("session_id", session_id.to_string())
-            .with_metadata("agent_id", agent_id.to_string())
+            .with_metadata("harness_id", harness_id.to_string())
             .with_metadata("turn_id", context.turn_id.to_string())
             .with_metadata("exec_id", context.exec_id.to_string())
             .with_metadata("org_id", format!("org_{:032x}", org_id));
+        if let Some(agent_id) = agent_id {
+            llm_config_builder = llm_config_builder.with_metadata("agent_id", agent_id.to_string());
+        }
 
         // Add model_id if we have one (not available for system default model)
         if let Some(model_id) = &resolved_model_id {
@@ -1181,42 +1225,31 @@ where
         })
     }
 
-    /// Resolve model using priority chain
-    /// Resolve model and return both the ModelWithProvider and the resolved model_id (if known)
+    /// Resolve model using priority chain: controls > session > agent > harness > system default
     async fn resolve_model(
         &self,
         controls_model_id: Option<crate::typed_id::ModelId>,
         session_model_id: Option<crate::typed_id::ModelId>,
         agent_model_id: Option<crate::typed_id::ModelId>,
+        harness_model_id: Option<crate::typed_id::ModelId>,
     ) -> Result<(ModelWithProvider, Option<crate::typed_id::ModelId>)> {
-        // Try controls.model_id first (highest priority)
-        if let Some(model_id) = controls_model_id
-            && let Some(model_with_provider) = self
+        // Try in priority order: controls > session > agent > harness
+        for model_id in [
+            controls_model_id,
+            session_model_id,
+            agent_model_id,
+            harness_model_id,
+        ]
+        .into_iter()
+        .flatten()
+        {
+            if let Some(model_with_provider) = self
                 .provider_store
                 .get_model_with_provider(model_id)
                 .await?
-        {
-            return Ok((model_with_provider, Some(model_id)));
-        }
-
-        // Try session.model_id second
-        if let Some(model_id) = session_model_id
-            && let Some(model_with_provider) = self
-                .provider_store
-                .get_model_with_provider(model_id)
-                .await?
-        {
-            return Ok((model_with_provider, Some(model_id)));
-        }
-
-        // Try agent.default_model_id third
-        if let Some(model_id) = agent_model_id
-            && let Some(model_with_provider) = self
-                .provider_store
-                .get_model_with_provider(model_id)
-                .await?
-        {
-            return Ok((model_with_provider, Some(model_id)));
+            {
+                return Ok((model_with_provider, Some(model_id)));
+            }
         }
 
         // Fall back to system default model (no model_id available)

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -1,6 +1,6 @@
 // Error types for the agent loop
 
-use crate::typed_id::{AgentId, SessionId};
+use crate::typed_id::{AgentId, HarnessId, SessionId};
 use thiserror::Error;
 
 /// Result type alias for agent loop operations
@@ -50,6 +50,10 @@ pub enum AgentLoopError {
     #[error("Agent not found: {0}")]
     AgentNotFound(AgentId),
 
+    /// Harness not found
+    #[error("Harness not found: {0}")]
+    HarnessNotFound(HarnessId),
+
     /// Session not found
     #[error("Session not found: {0}")]
     SessionNotFound(SessionId),
@@ -94,6 +98,11 @@ impl AgentLoopError {
     /// Create an agent not found error
     pub fn agent_not_found(agent_id: AgentId) -> Self {
         AgentLoopError::AgentNotFound(agent_id)
+    }
+
+    /// Create a harness not found error
+    pub fn harness_not_found(harness_id: HarnessId) -> Self {
+        AgentLoopError::HarnessNotFound(harness_id)
     }
 
     /// Create a session not found error

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -25,7 +25,7 @@ use uuid::Uuid;
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
 
-use crate::typed_id::{AgentId, EventId, ExecId, MessageId, ModelId, SessionId, TurnId};
+use crate::typed_id::{AgentId, EventId, ExecId, HarnessId, MessageId, ModelId, SessionId, TurnId};
 
 // ============================================================================
 // Event Type Constants
@@ -506,8 +506,12 @@ impl OutputMessageCompletedData {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct ReasonStartedData {
-    /// Agent ID being used
-    pub agent_id: AgentId,
+    /// Harness ID being used
+    pub harness_id: HarnessId,
+
+    /// Agent ID being used (optional)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<AgentId>,
 
     /// Metadata about the model being used
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1177,9 +1181,14 @@ pub struct TurnCancelledData {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct SessionStartedData {
-    /// Agent ID
-    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "agent_01933b5a00007000800000000000001"))]
-    pub agent_id: AgentId,
+    /// Harness ID
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "harness_01933b5a00007000800000000000001"))]
+    pub harness_id: HarnessId,
+
+    /// Agent ID (optional)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = "agent_01933b5a00007000800000000000001"))]
+    pub agent_id: Option<AgentId>,
 
     /// Model ID if specified
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1685,7 +1694,8 @@ mod tests {
             .with_turn(turn_id, input_message_id)
             .with_exec(exec_id)
             .build(ReasonStartedData {
-                agent_id: AgentId::new(),
+                harness_id: HarnessId::from_seed(1),
+                agent_id: Some(AgentId::new()),
                 metadata: Some(ModelMetadata {
                     model: "gpt-4o".to_string(),
                     model_id: None,
@@ -2162,6 +2172,12 @@ mod contract_tests {
         ))
     }
 
+    fn test_harness_id() -> HarnessId {
+        HarnessId::from_uuid(uuid::Uuid::from_u128(
+            0x0000_0000_0000_0000_0000_0000_0000_0005,
+        ))
+    }
+
     // ========================================================================
     // Serialization Snapshot Tests
     // ========================================================================
@@ -2284,7 +2300,8 @@ mod contract_tests {
     #[test]
     fn snapshot_reason_started() {
         let data = ReasonStartedData {
-            agent_id: test_agent_id(),
+            harness_id: test_harness_id(),
+            agent_id: Some(test_agent_id()),
             metadata: Some(ModelMetadata {
                 model: "gpt-4o".to_string(),
                 model_id: None,
@@ -2445,7 +2462,8 @@ mod contract_tests {
     #[test]
     fn snapshot_session_started() {
         let data = SessionStartedData {
-            agent_id: test_agent_id(),
+            harness_id: test_harness_id(),
+            agent_id: Some(test_agent_id()),
             model_id: None,
         };
         with_settings!({
@@ -2620,7 +2638,8 @@ mod contract_tests {
             (
                 REASON_STARTED,
                 ReasonStartedData {
-                    agent_id: test_agent_id(),
+                    harness_id: test_harness_id(),
+                    agent_id: Some(test_agent_id()),
                     metadata: None,
                 }
                 .into(),
@@ -2643,7 +2662,8 @@ mod contract_tests {
             (
                 SESSION_STARTED,
                 SessionStartedData {
-                    agent_id: test_agent_id(),
+                    harness_id: test_harness_id(),
+                    agent_id: Some(test_agent_id()),
                     model_id: None,
                 }
                 .into(),

--- a/crates/core/src/harness.rs
+++ b/crates/core/src/harness.rs
@@ -1,0 +1,80 @@
+// Harness domain types
+//
+// Harness defines base rules and capabilities for sessions.
+// Agent (optional) provides domain-specific customizations on top.
+// Hierarchy: Harness → Agent → Session
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::capability_types::AgentCapabilityConfig;
+use crate::typed_id::{HarnessId, ModelId};
+
+#[cfg(feature = "openapi")]
+use utoipa::ToSchema;
+
+/// Harness lifecycle status.
+/// - `active`: Harness is available for use
+/// - `archived`: Harness is soft-deleted and hidden from listings
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum HarnessStatus {
+    /// Harness is available for use.
+    Active,
+    /// Harness is soft-deleted and hidden from listings.
+    Archived,
+}
+
+impl std::fmt::Display for HarnessStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HarnessStatus::Active => write!(f, "active"),
+            HarnessStatus::Archived => write!(f, "archived"),
+        }
+    }
+}
+
+impl From<&str> for HarnessStatus {
+    fn from(s: &str) -> Self {
+        match s {
+            "archived" => HarnessStatus::Archived,
+            _ => HarnessStatus::Active,
+        }
+    }
+}
+
+/// Harness configuration for sessions.
+/// A harness defines the base behavior and capabilities that apply to all sessions.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct Harness {
+    /// Unique identifier for the harness (format: harness_{32-hex}).
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "harness_01933b5a00007000800000000000001"))]
+    pub id: HarnessId,
+    /// Display name of the harness.
+    pub name: String,
+    /// Human-readable description of what the harness does.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// System prompt that defines the harness's base behavior.
+    /// Forms the foundation of the prompt stack.
+    pub system_prompt: String,
+    /// Default LLM model ID for this harness.
+    /// Lowest priority in chain: controls > session > agent > harness.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = "model_01933b5a00007000800000000000001"))]
+    pub default_model_id: Option<ModelId>,
+    /// Tags for organizing and filtering harnesses.
+    #[serde(default)]
+    pub tags: Vec<String>,
+    /// Capabilities enabled for this harness with per-harness configuration.
+    #[serde(default)]
+    pub capabilities: Vec<AgentCapabilityConfig>,
+    /// Current lifecycle status of the harness.
+    pub status: HarnessStatus,
+    /// Timestamp when the harness was created.
+    pub created_at: DateTime<Utc>,
+    /// Timestamp when the harness was last updated.
+    pub updated_at: DateTime<Utc>,
+}

--- a/crates/core/src/in_memory_loop.rs
+++ b/crates/core/src/in_memory_loop.rs
@@ -25,8 +25,8 @@ use crate::llm_driver_registry::{DriverRegistry, ProviderType};
 use crate::llm_models::LlmProviderType;
 use crate::llmsim_driver::{LlmSimConfig, LlmSimDriver};
 use crate::memory::{
-    InMemoryAgentStore, InMemoryEventEmitter, InMemoryLlmProviderStore, InMemoryMessageRetriever,
-    InMemorySessionStore,
+    InMemoryAgentStore, InMemoryEventEmitter, InMemoryHarnessStore, InMemoryLlmProviderStore,
+    InMemoryMessageRetriever, InMemorySessionStore,
 };
 use crate::message::Message;
 use crate::message_retriever::{InputMessage, MessageRetriever};
@@ -35,7 +35,7 @@ use crate::tool_types::ToolCall;
 use crate::tools::{Tool, ToolRegistry, ToolRegistryBuilder};
 use crate::traits::{EventEmitter, ModelWithProvider};
 use crate::turn::{TurnAction, TurnContext, TurnOutcome, TurnStateMachine};
-use crate::typed_id::{AgentId, SessionId, TurnId};
+use crate::typed_id::{AgentId, HarnessId, SessionId, TurnId};
 
 // ============================================================================
 // Bridging Event Emitter
@@ -311,6 +311,7 @@ impl InMemoryAgenticLoopBuilder {
     /// Build the agentic loop
     pub async fn build(self) -> Result<InMemoryAgenticLoop> {
         // Create stores
+        let harness_store = InMemoryHarnessStore::new();
         let agent_store = InMemoryAgentStore::new();
         let session_store = InMemorySessionStore::new();
         let message_retriever = InMemoryMessageRetriever::new();
@@ -323,9 +324,25 @@ impl InMemoryAgenticLoopBuilder {
             .map(|cap| AgentCapabilityConfig::new(cap.id()))
             .collect();
 
+        // Create harness
+        let harness_id = HarnessId::new();
+        let now = Utc::now();
+        let harness = crate::harness::Harness {
+            id: harness_id,
+            name: "In-Memory Harness".to_string(),
+            description: None,
+            system_prompt: self.system_prompt.clone(),
+            default_model_id: None,
+            tags: vec![],
+            capabilities: vec![],
+            status: crate::harness::HarnessStatus::Active,
+            created_at: now,
+            updated_at: now,
+        };
+        harness_store.add_harness(harness).await;
+
         // Create agent
         let agent_id = AgentId::new();
-        let now = Utc::now();
         let agent = Agent {
             public_id: agent_id,
             internal_id: agent_id.uuid(),
@@ -348,7 +365,8 @@ impl InMemoryAgenticLoopBuilder {
         let session = Session {
             id: session_id,
             organization_id: crate::DEFAULT_ORG_PUBLIC_ID.to_string(),
-            agent_id,
+            harness_id,
+            agent_id: Some(agent_id),
             title: Some("In-Memory Session".to_string()),
             preview: None,
             output_preview: None,
@@ -418,6 +436,7 @@ impl InMemoryAgenticLoopBuilder {
 
         let input_atom = InputAtom::new(message_retriever.clone());
         let reason_atom = ReasonAtom::new(
+            harness_store.clone(),
             agent_store.clone(),
             session_store.clone(),
             message_retriever.clone(),
@@ -429,8 +448,10 @@ impl InMemoryAgenticLoopBuilder {
         let act_atom = ActAtom::new(tool_registry.clone(), event_emitter.clone());
 
         Ok(InMemoryAgenticLoop {
+            harness_id,
             agent_id,
             session_id,
+            harness_store,
             agent_store,
             session_store,
             message_retriever,
@@ -478,8 +499,11 @@ impl InMemoryAgenticLoopBuilder {
 ///     .await?;
 /// ```
 pub struct InMemoryAgenticLoop {
+    harness_id: HarnessId,
     agent_id: AgentId,
     session_id: SessionId,
+    #[allow(dead_code)]
+    harness_store: InMemoryHarnessStore,
     #[allow(dead_code)]
     agent_store: InMemoryAgentStore,
     #[allow(dead_code)]
@@ -492,6 +516,7 @@ pub struct InMemoryAgenticLoop {
     input_atom: Arc<InputAtom<InMemoryMessageRetriever>>,
     reason_atom: Arc<
         ReasonAtom<
+            InMemoryHarnessStore,
             InMemoryAgentStore,
             InMemorySessionStore,
             InMemoryMessageRetriever,
@@ -592,7 +617,8 @@ impl InMemoryAgenticLoop {
                         .reason_atom
                         .execute(ReasonInput {
                             context: base_context.next_exec(),
-                            agent_id: self.agent_id,
+                            harness_id: self.harness_id,
+                            agent_id: Some(self.agent_id),
                             org_id: 0,
                             mcp_tool_definitions: vec![],
                         })
@@ -625,7 +651,8 @@ impl InMemoryAgenticLoop {
                     self.act_atom
                         .execute(ActInput {
                             context: base_context.next_exec(),
-                            agent_id: self.agent_id,
+                            harness_id: self.harness_id,
+                            agent_id: Some(self.agent_id),
                             tool_calls: reason_result.tool_calls,
                             tool_definitions: reason_result.tool_definitions,
                         })

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -40,6 +40,7 @@ pub mod typed_id;
 pub mod agent;
 pub mod capability_dto;
 pub mod events;
+pub mod harness;
 pub mod llm_model_profiles;
 pub mod llm_models;
 pub mod mcp_server;
@@ -92,9 +93,9 @@ pub use message_filter::{
 pub use message_retriever::{InputMessage, MessageRetriever};
 pub use runtime_agent::{RuntimeAgent, RuntimeAgentBuilder};
 pub use traits::{
-    EventEmitter, ImageResolver, KeyInfo, LlmProviderStore, ModelWithProvider, NoopEventEmitter,
-    ResolvedImage, SecretInfo, SessionFileStore, SessionSqlDbStoreRef, SessionStorageStore,
-    SessionStore, ToolContext, ToolExecutor,
+    EventEmitter, HarnessStore, ImageResolver, KeyInfo, LlmProviderStore, ModelWithProvider,
+    NoopEventEmitter, ResolvedImage, SecretInfo, SessionFileStore, SessionSqlDbStoreRef,
+    SessionStorageStore, SessionStore, ToolContext, ToolExecutor,
 };
 
 // Event listener re-exports
@@ -175,6 +176,7 @@ pub use events::{
     TokenUsage, ToolCallRequestedData, ToolCallSummary, ToolCompletedData, ToolStartedData,
     TurnCancelledData, TurnCompletedData, TurnFailedData, TurnStartedData,
 };
+pub use harness::{Harness, HarnessStatus};
 pub use llm_model_profiles::get_model_profile;
 pub use llm_models::{
     LlmModel, LlmModelCost, LlmModelLimits, LlmModelModalities, LlmModelProfile, LlmModelSource,
@@ -198,8 +200,8 @@ pub use session_sqldb::{
     SqlQueryResult, TableSchema,
 };
 pub use typed_id::{
-    AgentId, EventId, ExecId, IdMarker, IdParseError, ImageId, McpServerId, MessageId, ModelId,
-    OrgId, ProviderId, SessionId, TurnId, TypedId,
+    AgentId, EventId, ExecId, HarnessId, IdMarker, IdParseError, ImageId, McpServerId, MessageId,
+    ModelId, OrgId, ProviderId, SessionId, TurnId, TypedId,
 };
 
 // Deployment configuration

--- a/crates/core/src/memory.rs
+++ b/crates/core/src/memory.rs
@@ -6,11 +6,12 @@
 // - Quick prototyping
 
 use crate::agent::Agent;
+use crate::harness::Harness;
 use crate::llm_models::LlmProviderType;
 use crate::session::Session;
 use crate::tool_types::{ToolCall, ToolDefinition, ToolResult};
 use crate::traits::ModelWithProvider;
-use crate::typed_id::{AgentId, EventId, MessageId, ModelId, SessionId};
+use crate::typed_id::{AgentId, EventId, HarnessId, MessageId, ModelId, SessionId};
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -20,7 +21,7 @@ use uuid::Uuid;
 use crate::error::Result;
 use crate::message::Message;
 use crate::message_retriever::{InputMessage, MessageRetriever};
-use crate::traits::{AgentStore, LlmProviderStore, SessionStore, ToolExecutor};
+use crate::traits::{AgentStore, HarnessStore, LlmProviderStore, SessionStore, ToolExecutor};
 use chrono::Utc;
 
 // ============================================================================
@@ -181,6 +182,40 @@ impl InMemoryAgentStore {
 impl AgentStore for InMemoryAgentStore {
     async fn get_agent(&self, agent_id: AgentId) -> Result<Option<Agent>> {
         Ok(self.agents.read().await.get(&agent_id).cloned())
+    }
+}
+
+// ============================================================================
+// InMemoryHarnessStore - Stores harnesses in memory
+// ============================================================================
+
+/// In-memory harness store
+///
+/// Stores harnesses in a HashMap keyed by harness ID.
+/// Useful for testing and examples where you want to configure harnesses without a database.
+#[derive(Debug, Default, Clone)]
+pub struct InMemoryHarnessStore {
+    harnesses: Arc<RwLock<HashMap<HarnessId, Harness>>>,
+}
+
+impl InMemoryHarnessStore {
+    /// Create a new in-memory harness store
+    pub fn new() -> Self {
+        Self {
+            harnesses: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Add a harness to the store
+    pub async fn add_harness(&self, harness: Harness) {
+        self.harnesses.write().await.insert(harness.id, harness);
+    }
+}
+
+#[async_trait]
+impl HarnessStore for InMemoryHarnessStore {
+    async fn get_harness(&self, harness_id: HarnessId) -> Result<Option<Harness>> {
+        Ok(self.harnesses.read().await.get(&harness_id).cloned())
     }
 }
 
@@ -846,7 +881,8 @@ mod tests {
                 session_id,
                 event_context,
                 ReasonStartedData {
-                    agent_id: AgentId::new(),
+                    harness_id: HarnessId::from_seed(1),
+                    agent_id: Some(AgentId::new()),
                     metadata: None,
                 },
             ))

--- a/crates/core/src/observation/braintrust.rs
+++ b/crates/core/src/observation/braintrust.rs
@@ -733,7 +733,7 @@ impl BraintrustListener {
     ) -> BraintrustLogEvent {
         let mut metadata = serde_json::json!({
             "session_id": event.session_id.to_string(),
-            "agent_id": data.agent_id.to_string(),
+            "agent_id": data.agent_id.map(|id| id.to_string()),
         });
 
         if let Some(model_meta) = &data.metadata {
@@ -1199,7 +1199,7 @@ impl EventListener for BraintrustListener {
 
             // Atom lifecycle events (reason/act phases)
             EventData::ReasonStarted(data) => {
-                debug!(agent_id = %data.agent_id, "Processing reason.started for Braintrust");
+                debug!(agent_id = ?data.agent_id, "Processing reason.started for Braintrust");
                 self.convert_reason_started(event, data)
             }
             EventData::ReasonCompleted(data) => {
@@ -1318,7 +1318,7 @@ mod tests {
         ReasonCompletedData, TokenUsage, ToolCompletedData, TurnCompletedData, TurnStartedData,
     };
     use crate::message::Message;
-    use crate::typed_id::{AgentId, MessageId, SessionId, TurnId};
+    use crate::typed_id::{AgentId, HarnessId, MessageId, SessionId, TurnId};
     use uuid::Uuid;
 
     fn test_config() -> BraintrustConfig {
@@ -1572,7 +1572,8 @@ mod tests {
         context.parent_span_id = Some(turn_id.to_string());
 
         let data = ReasonStartedData {
-            agent_id: AgentId::new(),
+            harness_id: HarnessId::from_seed(1),
+            agent_id: Some(AgentId::new()),
             metadata: None,
         };
         let event = Event::new(
@@ -1779,7 +1780,8 @@ mod tests {
 
         // reason.started
         let started_data = ReasonStartedData {
-            agent_id: AgentId::new(),
+            harness_id: HarnessId::from_seed(1),
+            agent_id: Some(AgentId::new()),
             metadata: None,
         };
         let started_event = Event::new(
@@ -1857,7 +1859,8 @@ mod tests {
         reason_ctx.span_id = Some(reason_span_id.clone());
         reason_ctx.parent_span_id = Some(turn_id.to_string());
         let reason_data = ReasonStartedData {
-            agent_id: AgentId::new(),
+            harness_id: HarnessId::from_seed(1),
+            agent_id: Some(AgentId::new()),
             metadata: None,
         };
         let reason_event = Event::new(
@@ -2055,7 +2058,8 @@ mod tests {
 
         // reason.started - should NOT have _is_merge
         let started_data = ReasonStartedData {
-            agent_id: AgentId::new(),
+            harness_id: HarnessId::from_seed(1),
+            agent_id: Some(AgentId::new()),
             metadata: None,
         };
         let started_event = Event::new(

--- a/crates/core/src/observation/otel.rs
+++ b/crates/core/src/observation/otel.rs
@@ -803,7 +803,7 @@ mod tests {
     };
     use crate::message::Message;
     use crate::tool_types::ToolCall;
-    use crate::typed_id::{AgentId, MessageId, SessionId, TurnId};
+    use crate::typed_id::{AgentId, HarnessId, MessageId, SessionId, TurnId};
     use serde_json::json;
     use uuid::Uuid;
 
@@ -1040,7 +1040,8 @@ mod tests {
 
         // Start reason with context
         let started = ReasonStartedData {
-            agent_id: AgentId::from_uuid(Uuid::now_v7()),
+            harness_id: HarnessId::from_seed(1),
+            agent_id: Some(AgentId::from_uuid(Uuid::now_v7())),
             metadata: None,
         };
         let event = event_with_context(
@@ -1603,7 +1604,8 @@ mod tests {
         // 2. Start reason (child of turn)
         let reason_span_id = "reason_r1";
         let reason_started = ReasonStartedData {
-            agent_id: AgentId::from_uuid(Uuid::now_v7()),
+            harness_id: HarnessId::from_seed(1),
+            agent_id: Some(AgentId::from_uuid(Uuid::now_v7())),
             metadata: None,
         };
         listener
@@ -1716,7 +1718,8 @@ mod tests {
                 Some(r1),
                 Some(&turn_id.to_string()),
                 EventData::ReasonStarted(ReasonStartedData {
-                    agent_id: AgentId::from_uuid(Uuid::now_v7()),
+                    harness_id: HarnessId::from_seed(1),
+                    agent_id: Some(AgentId::from_uuid(Uuid::now_v7())),
                     metadata: None,
                 }),
             ))
@@ -1773,7 +1776,8 @@ mod tests {
                 Some(r2),
                 Some(&turn_id.to_string()),
                 EventData::ReasonStarted(ReasonStartedData {
-                    agent_id: AgentId::from_uuid(Uuid::now_v7()),
+                    harness_id: HarnessId::from_seed(1),
+                    agent_id: Some(AgentId::from_uuid(Uuid::now_v7())),
                     metadata: None,
                 }),
             ))
@@ -1849,7 +1853,8 @@ mod tests {
                 Some(r1),
                 Some(&turn_key),
                 EventData::ReasonStarted(ReasonStartedData {
-                    agent_id: AgentId::from_uuid(Uuid::now_v7()),
+                    harness_id: HarnessId::from_seed(1),
+                    agent_id: Some(AgentId::from_uuid(Uuid::now_v7())),
                     metadata: None,
                 }),
             ))
@@ -1983,7 +1988,8 @@ mod tests {
                 Some(r2),
                 Some(&turn_key),
                 EventData::ReasonStarted(ReasonStartedData {
-                    agent_id: AgentId::from_uuid(Uuid::now_v7()),
+                    harness_id: HarnessId::from_seed(1),
+                    agent_id: Some(AgentId::from_uuid(Uuid::now_v7())),
                     metadata: None,
                 }),
             ))

--- a/crates/core/src/runtime_agent.rs
+++ b/crates/core/src/runtime_agent.rs
@@ -2,10 +2,17 @@
 //
 // RuntimeAgent is a DB-agnostic configuration struct that can be:
 // - Created directly for standalone usage
-// - Built from an Agent entity via the `with_agent` builder method
+// - Built from a Harness and/or Agent entity via builder methods
+//
+// Prompt layering order (via prepend pattern):
+// 1. with_harness() - sets harness system_prompt + harness caps
+// 2. with_agent() - prepends agent prompt + agent caps (optional)
+// 3. with_capabilities() - prepends session caps
+// Result: [session_caps] [agent_caps] [agent_prompt] [harness_caps] [harness_prompt]
 
 use crate::agent::Agent;
 use crate::capabilities::{CapabilityRegistry, collect_capabilities, resolve_dependencies};
+use crate::harness::Harness;
 use crate::tool_types::ToolDefinition;
 use serde::{Deserialize, Serialize};
 
@@ -82,27 +89,34 @@ impl RuntimeAgentBuilder {
         }
     }
 
+    /// Apply a Harness's configuration to this builder.
+    ///
+    /// Sets the system prompt from the harness and applies harness capabilities.
+    /// Call this BEFORE `with_agent()` to establish the base prompt layer.
+    pub fn with_harness(self, harness: &Harness, registry: &CapabilityRegistry) -> Self {
+        let capability_ids: Vec<String> = harness
+            .capabilities
+            .iter()
+            .map(|cap| cap.capability_id().to_string())
+            .collect();
+
+        self.system_prompt(&harness.system_prompt)
+            .with_capabilities(&capability_ids, registry)
+    }
+
     /// Apply an Agent's configuration to this builder.
     ///
-    /// This sets the system prompt from the agent and applies the agent's
-    /// capabilities (tools and system prompt additions).
-    ///
-    /// # Arguments
-    ///
-    /// * `agent` - The Agent entity to apply
-    /// * `registry` - The capability registry containing capability implementations
+    /// Prepends the agent's system prompt and capabilities on top of the
+    /// existing prompt (typically from a harness). Call after `with_harness()`.
     ///
     /// # Example
     ///
     /// ```ignore
-    /// use everruns_core::runtime_agent::RuntimeAgentBuilder;
-    /// use everruns_core::capabilities::CapabilityRegistry;
-    ///
-    /// let registry = CapabilityRegistry::with_builtins();
     /// let runtime_agent = RuntimeAgentBuilder::new()
+    ///     .with_harness(&harness, &registry)
     ///     .with_agent(&agent, &registry)
+    ///     .with_capabilities(&session_caps, &registry)
     ///     .model("gpt-4o")
-    ///     .temperature(0.7)
     ///     .build();
     /// ```
     pub fn with_agent(self, agent: &Agent, registry: &CapabilityRegistry) -> Self {

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::capability_types::AgentCapabilityConfig;
 use crate::events::TokenUsage;
 use crate::tool_types::ToolDefinition;
-use crate::typed_id::{AgentId, ModelId, SessionId};
+use crate::typed_id::{AgentId, HarnessId, ModelId, SessionId};
 
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
@@ -68,9 +68,13 @@ pub struct Session {
     /// Organization this session belongs to (format: org_{32-hex}).
     #[cfg_attr(feature = "openapi", schema(value_type = String, example = "org_00000000000000000000000000000001"))]
     pub organization_id: String,
-    /// ID of the agent working in this session (format: agent_{32-hex}).
-    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "agent_01933b5a00007000800000000000001"))]
-    pub agent_id: AgentId,
+    /// ID of the harness for this session (format: harness_{32-hex}).
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "harness_01933b5a00007000800000000000001"))]
+    pub harness_id: HarnessId,
+    /// ID of the agent working in this session (format: agent_{32-hex}). Optional.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = "agent_01933b5a00007000800000000000001"))]
+    pub agent_id: Option<AgentId>,
     /// Human-readable title for the session.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,

--- a/crates/core/src/snapshots/everruns_core__events__contract_tests__event_data_reason_started.snap
+++ b/crates/core/src/snapshots/everruns_core__events__contract_tests__event_data_reason_started.snap
@@ -3,6 +3,7 @@ source: crates/core/src/events.rs
 expression: data
 ---
 {
+  "harness_id": "harness_00000000000000000000000000000005",
   "agent_id": "agent_00000000000000000000000000000004",
   "metadata": {
     "model": "gpt-4o"

--- a/crates/core/src/snapshots/everruns_core__events__contract_tests__event_data_session_started.snap
+++ b/crates/core/src/snapshots/everruns_core__events__contract_tests__event_data_session_started.snap
@@ -3,5 +3,6 @@ source: crates/core/src/events.rs
 expression: data
 ---
 {
+  "harness_id": "harness_00000000000000000000000000000005",
   "agent_id": "agent_00000000000000000000000000000004"
 }

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -6,10 +6,11 @@
 // - Channel-based implementations for streaming
 
 use crate::agent::Agent;
+use crate::harness::Harness;
 use crate::llm_models::LlmProviderType;
 use crate::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
 use crate::tool_types::{ToolCall, ToolDefinition, ToolResult};
-use crate::typed_id::{AgentId, ModelId, SessionId};
+use crate::typed_id::{AgentId, HarnessId, ModelId, SessionId};
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -36,6 +37,21 @@ use crate::error::Result;
 pub trait AgentStore: Send + Sync {
     /// Get an agent by ID
     async fn get_agent(&self, agent_id: AgentId) -> Result<Option<Agent>>;
+}
+
+// ============================================================================
+// HarnessStore - For retrieving harness configurations
+// ============================================================================
+
+/// Trait for retrieving harness configurations
+///
+/// Implementations can:
+/// - Load harnesses from a database
+/// - Keep harnesses in memory for testing
+#[async_trait]
+pub trait HarnessStore: Send + Sync {
+    /// Get a harness by ID
+    async fn get_harness(&self, harness_id: HarnessId) -> Result<Option<Harness>>;
 }
 
 // ============================================================================

--- a/crates/core/src/typed_id.rs
+++ b/crates/core/src/typed_id.rs
@@ -301,6 +301,13 @@ impl IdMarker for AgentIdMarker {
     const PREFIX: &'static str = "agent";
 }
 
+/// Marker for Harness IDs
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct HarnessIdMarker;
+impl IdMarker for HarnessIdMarker {
+    const PREFIX: &'static str = "harness";
+}
+
 /// Marker for Session IDs
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct SessionIdMarker;
@@ -372,6 +379,8 @@ impl IdMarker for ExecIdMarker {
 pub type OrgId = TypedId<OrgIdMarker>;
 /// Agent ID
 pub type AgentId = TypedId<AgentIdMarker>;
+/// Harness ID
+pub type HarnessId = TypedId<HarnessIdMarker>;
 /// Session ID
 pub type SessionId = TypedId<SessionIdMarker>;
 /// Message ID

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -10,32 +10,54 @@ use everruns_core::MessageRetriever;
 use everruns_core::agent::{Agent, AgentStatus};
 use everruns_core::atoms::{Atom, AtomContext, ReasonAtom, ReasonInput};
 use everruns_core::capabilities::CapabilityRegistry;
+use everruns_core::harness::{Harness, HarnessStatus};
 use everruns_core::llm_driver_registry::{DriverRegistry, ProviderType};
 use everruns_core::llm_models::LlmProviderType;
 use everruns_core::llmsim_driver::{LlmSimConfig, LlmSimDriver, register_driver};
 use everruns_core::memory::{
-    InMemoryAgentStore, InMemoryLlmProviderStore, InMemoryMessageRetriever, InMemorySessionStore,
+    InMemoryAgentStore, InMemoryHarnessStore, InMemoryLlmProviderStore, InMemoryMessageRetriever,
+    InMemorySessionStore,
 };
 use everruns_core::session::{Session, SessionStatus};
 use everruns_core::traits::{ModelWithProvider, NoopEventEmitter};
-use everruns_core::typed_id::{MessageId, SessionId, TurnId};
+use everruns_core::typed_id::{HarnessId, MessageId, SessionId, TurnId};
 use everruns_core::{Message, ToolCall};
 use serde_json::json;
 use uuid::Uuid;
 
 /// Create a basic test setup with in-memory stores
 async fn setup_test_environment() -> (
+    InMemoryHarnessStore,
     InMemoryAgentStore,
     InMemorySessionStore,
     InMemoryMessageRetriever,
     InMemoryLlmProviderStore,
-    Uuid, // agent_id
-    Uuid, // session_id
+    HarnessId, // harness_id
+    Uuid,      // agent_id
+    Uuid,      // session_id
 ) {
+    let harness_store = InMemoryHarnessStore::new();
     let agent_store = InMemoryAgentStore::new();
     let session_store = InMemorySessionStore::new();
     let message_retriever = InMemoryMessageRetriever::new();
     let provider_store = InMemoryLlmProviderStore::new();
+
+    // Create a test harness
+    let harness_id = HarnessId::from_seed(1);
+    let now = chrono::Utc::now();
+    let harness = Harness {
+        id: harness_id,
+        name: "Test Harness".to_string(),
+        description: None,
+        system_prompt: "You are a helpful assistant.".to_string(),
+        default_model_id: None,
+        tags: vec![],
+        capabilities: vec![],
+        status: HarnessStatus::Active,
+        created_at: now,
+        updated_at: now,
+    };
+    harness_store.add_harness(harness).await;
 
     // Create a test agent
     let agent_id = Uuid::now_v7();
@@ -50,19 +72,19 @@ async fn setup_test_environment() -> (
         default_model_id: None,
         tags: vec![],
         status: AgentStatus::Active,
-        created_at: chrono::Utc::now(),
-        updated_at: chrono::Utc::now(),
+        created_at: now,
+        updated_at: now,
         usage: None,
     };
     agent_store.add_agent(agent).await;
 
     // Create a test session
     let session_id = Uuid::now_v7();
-    let now = chrono::Utc::now();
     let session = Session {
         id: session_id.into(),
         organization_id: "default".to_string(),
-        agent_id: agent_id.into(),
+        harness_id,
+        agent_id: Some(agent_id.into()),
         title: Some("Test Session".to_string()),
         preview: None,
         output_preview: None,
@@ -89,10 +111,12 @@ async fn setup_test_environment() -> (
     provider_store.set_default_model(model).await;
 
     (
+        harness_store,
         agent_store,
         session_store,
         message_retriever,
         provider_store,
+        harness_id,
         agent_id,
         session_id,
     )
@@ -118,8 +142,16 @@ fn create_context(session_id: Uuid) -> AtomContext {
 async fn test_reason_atom_with_fixed_response() {
     use everruns_core::memory::InMemoryEventEmitter;
 
-    let (agent_store, session_store, message_retriever, provider_store, agent_id, session_id) =
-        setup_test_environment().await;
+    let (
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever,
+        provider_store,
+        harness_id,
+        agent_id,
+        session_id,
+    ) = setup_test_environment().await;
 
     // Add a user message
     message_retriever
@@ -136,6 +168,7 @@ async fn test_reason_atom_with_fixed_response() {
     let event_emitter = InMemoryEventEmitter::new();
 
     let atom = ReasonAtom::new(
+        harness_store,
         agent_store,
         session_store,
         message_retriever.clone(),
@@ -148,7 +181,8 @@ async fn test_reason_atom_with_fixed_response() {
     let context = create_context(session_id);
     let input = ReasonInput {
         context,
-        agent_id: agent_id.into(),
+        harness_id,
+        agent_id: Some(agent_id.into()),
         org_id: 0,
         mcp_tool_definitions: vec![],
     };
@@ -184,8 +218,16 @@ async fn test_reason_atom_with_fixed_response() {
 
 #[tokio::test]
 async fn test_reason_atom_with_tool_calls() {
-    let (agent_store, session_store, message_retriever, provider_store, agent_id, session_id) =
-        setup_test_environment().await;
+    let (
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever,
+        provider_store,
+        harness_id,
+        agent_id,
+        session_id,
+    ) = setup_test_environment().await;
 
     // Add a user message
     message_retriever
@@ -208,6 +250,7 @@ async fn test_reason_atom_with_tool_calls() {
     );
 
     let atom = ReasonAtom::new(
+        harness_store,
         agent_store,
         session_store,
         message_retriever.clone(),
@@ -220,7 +263,8 @@ async fn test_reason_atom_with_tool_calls() {
     let context = create_context(session_id);
     let input = ReasonInput {
         context,
-        agent_id: agent_id.into(),
+        harness_id,
+        agent_id: Some(agent_id.into()),
         org_id: 0,
         mcp_tool_definitions: vec![],
     };
@@ -240,8 +284,16 @@ async fn test_reason_atom_with_tool_calls() {
 
 #[tokio::test]
 async fn test_reason_atom_with_echo_response() {
-    let (agent_store, session_store, message_retriever, provider_store, agent_id, session_id) =
-        setup_test_environment().await;
+    let (
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever,
+        provider_store,
+        harness_id,
+        agent_id,
+        session_id,
+    ) = setup_test_environment().await;
 
     // Add a user message
     message_retriever
@@ -255,6 +307,7 @@ async fn test_reason_atom_with_echo_response() {
     let driver_registry = create_custom_driver_registry(LlmSimConfig::echo());
 
     let atom = ReasonAtom::new(
+        harness_store,
         agent_store,
         session_store,
         message_retriever.clone(),
@@ -267,7 +320,8 @@ async fn test_reason_atom_with_echo_response() {
     let context = create_context(session_id);
     let input = ReasonInput {
         context,
-        agent_id: agent_id.into(),
+        harness_id,
+        agent_id: Some(agent_id.into()),
         org_id: 0,
         mcp_tool_definitions: vec![],
     };
@@ -288,8 +342,16 @@ async fn test_reason_atom_with_different_configs() {
     // registry.create_driver() call creates a fresh driver. For registry-based
     // usage, use fixed responses or test sequences at the driver level.
 
-    let (agent_store, session_store, message_retriever, provider_store, agent_id, session_id) =
-        setup_test_environment().await;
+    let (
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever,
+        provider_store,
+        harness_id,
+        agent_id,
+        session_id,
+    ) = setup_test_environment().await;
 
     // First test with one configuration
     message_retriever
@@ -299,6 +361,7 @@ async fn test_reason_atom_with_different_configs() {
     let driver_registry1 = create_custom_driver_registry(LlmSimConfig::fixed("Response A"));
 
     let atom1 = ReasonAtom::new(
+        harness_store.clone(),
         agent_store.clone(),
         session_store.clone(),
         message_retriever.clone(),
@@ -312,7 +375,8 @@ async fn test_reason_atom_with_different_configs() {
     let result1 = atom1
         .execute(ReasonInput {
             context: context1,
-            agent_id: agent_id.into(),
+            harness_id,
+            agent_id: Some(agent_id.into()),
             org_id: 0,
             mcp_tool_definitions: vec![],
         })
@@ -327,7 +391,8 @@ async fn test_reason_atom_with_different_configs() {
     let session2 = Session {
         id: session_id2.into(),
         organization_id: "default".to_string(),
-        agent_id: agent_id.into(),
+        harness_id,
+        agent_id: Some(agent_id.into()),
         title: Some("Test Session 2".to_string()),
         preview: None,
         output_preview: None,
@@ -350,6 +415,7 @@ async fn test_reason_atom_with_different_configs() {
     let driver_registry2 = create_custom_driver_registry(LlmSimConfig::fixed("Response B"));
 
     let atom2 = ReasonAtom::new(
+        harness_store.clone(),
         agent_store.clone(),
         session_store.clone(),
         message_retriever.clone(),
@@ -363,7 +429,8 @@ async fn test_reason_atom_with_different_configs() {
     let result2 = atom2
         .execute(ReasonInput {
             context: context2,
-            agent_id: agent_id.into(),
+            harness_id,
+            agent_id: Some(agent_id.into()),
             org_id: 0,
             mcp_tool_definitions: vec![],
         })
@@ -377,8 +444,16 @@ async fn test_reason_atom_with_different_configs() {
 async fn test_reason_atom_with_multi_turn_conversation() {
     use everruns_core::memory::InMemoryEventEmitter;
 
-    let (agent_store, session_store, message_retriever, provider_store, agent_id, session_id) =
-        setup_test_environment().await;
+    let (
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever,
+        provider_store,
+        harness_id,
+        agent_id,
+        session_id,
+    ) = setup_test_environment().await;
 
     // Seed a multi-turn conversation
     message_retriever
@@ -399,6 +474,7 @@ async fn test_reason_atom_with_multi_turn_conversation() {
     let event_emitter = InMemoryEventEmitter::new();
 
     let atom = ReasonAtom::new(
+        harness_store,
         agent_store,
         session_store,
         message_retriever.clone(),
@@ -411,7 +487,8 @@ async fn test_reason_atom_with_multi_turn_conversation() {
     let context = create_context(session_id);
     let input = ReasonInput {
         context,
-        agent_id: agent_id.into(),
+        harness_id,
+        agent_id: Some(agent_id.into()),
         org_id: 0,
         mcp_tool_definitions: vec![],
     };
@@ -448,8 +525,16 @@ async fn test_reason_atom_with_multi_turn_conversation() {
 
 #[tokio::test]
 async fn test_reason_atom_with_tool_result_continuation() {
-    let (agent_store, session_store, message_retriever, provider_store, agent_id, session_id) =
-        setup_test_environment().await;
+    let (
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever,
+        provider_store,
+        harness_id,
+        agent_id,
+        session_id,
+    ) = setup_test_environment().await;
 
     // Simulate a conversation where tool was called and result is available
     let tool_call = ToolCall {
@@ -475,9 +560,10 @@ async fn test_reason_atom_with_tool_result_continuation() {
 
     // LlmSim should now provide a response based on the tool result
     let driver_registry =
-        create_custom_driver_registry(LlmSimConfig::fixed("It's 22°C and sunny in Tokyo!"));
+        create_custom_driver_registry(LlmSimConfig::fixed("It's 22\u{00b0}C and sunny in Tokyo!"));
 
     let atom = ReasonAtom::new(
+        harness_store,
         agent_store,
         session_store,
         message_retriever.clone(),
@@ -490,7 +576,8 @@ async fn test_reason_atom_with_tool_result_continuation() {
     let context = create_context(session_id);
     let input = ReasonInput {
         context,
-        agent_id: agent_id.into(),
+        harness_id,
+        agent_id: Some(agent_id.into()),
         org_id: 0,
         mcp_tool_definitions: vec![],
     };
@@ -507,8 +594,16 @@ async fn test_reason_atom_with_tool_result_continuation() {
 
 #[tokio::test]
 async fn test_reason_atom_with_lorem_response() {
-    let (agent_store, session_store, message_retriever, provider_store, agent_id, session_id) =
-        setup_test_environment().await;
+    let (
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever,
+        provider_store,
+        harness_id,
+        agent_id,
+        session_id,
+    ) = setup_test_environment().await;
 
     message_retriever
         .seed(
@@ -521,6 +616,7 @@ async fn test_reason_atom_with_lorem_response() {
     let driver_registry = create_custom_driver_registry(LlmSimConfig::lorem(100));
 
     let atom = ReasonAtom::new(
+        harness_store,
         agent_store,
         session_store,
         message_retriever.clone(),
@@ -533,7 +629,8 @@ async fn test_reason_atom_with_lorem_response() {
     let context = create_context(session_id);
     let input = ReasonInput {
         context,
-        agent_id: agent_id.into(),
+        harness_id,
+        agent_id: Some(agent_id.into()),
         org_id: 0,
         mcp_tool_definitions: vec![],
     };
@@ -553,8 +650,16 @@ async fn test_reason_atom_with_lorem_response() {
 async fn test_reason_atom_handles_llm_error() {
     use everruns_core::memory::InMemoryEventEmitter;
 
-    let (agent_store, session_store, message_retriever, provider_store, agent_id, session_id) =
-        setup_test_environment().await;
+    let (
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever,
+        provider_store,
+        harness_id,
+        agent_id,
+        session_id,
+    ) = setup_test_environment().await;
 
     // Add a user message
     message_retriever
@@ -568,6 +673,7 @@ async fn test_reason_atom_handles_llm_error() {
     let event_emitter = InMemoryEventEmitter::new();
 
     let atom = ReasonAtom::new(
+        harness_store,
         agent_store,
         session_store,
         message_retriever.clone(),
@@ -580,7 +686,8 @@ async fn test_reason_atom_handles_llm_error() {
     let context = create_context(session_id);
     let input = ReasonInput {
         context,
-        agent_id: agent_id.into(),
+        harness_id,
+        agent_id: Some(agent_id.into()),
         org_id: 0,
         mcp_tool_definitions: vec![],
     };
@@ -640,8 +747,16 @@ async fn test_reason_atom_handles_llm_error() {
 async fn test_reason_atom_emits_output_message_completed_on_success() {
     use everruns_core::memory::InMemoryEventEmitter;
 
-    let (agent_store, session_store, message_retriever, provider_store, agent_id, session_id) =
-        setup_test_environment().await;
+    let (
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever,
+        provider_store,
+        harness_id,
+        agent_id,
+        session_id,
+    ) = setup_test_environment().await;
 
     // Add a user message
     message_retriever
@@ -659,6 +774,7 @@ async fn test_reason_atom_emits_output_message_completed_on_success() {
     let event_emitter = InMemoryEventEmitter::new();
 
     let atom = ReasonAtom::new(
+        harness_store,
         agent_store,
         session_store,
         message_retriever.clone(),
@@ -671,7 +787,8 @@ async fn test_reason_atom_emits_output_message_completed_on_success() {
     let context = create_context(session_id);
     let input = ReasonInput {
         context,
-        agent_id: agent_id.into(),
+        harness_id,
+        agent_id: Some(agent_id.into()),
         org_id: 0,
         mcp_tool_definitions: vec![],
     };

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -26,6 +26,9 @@ service WorkerService {
     // Agent operations
     rpc GetAgent(GetAgentRequest) returns (GetAgentResponse);
 
+    // Harness operations
+    rpc GetHarness(GetHarnessRequest) returns (GetHarnessResponse);
+
     // Session operations
     rpc GetSession(GetSessionRequest) returns (GetSessionResponse);
     rpc SetSessionStatus(SetSessionStatusRequest) returns (SetSessionStatusResponse);
@@ -153,6 +156,8 @@ message GetTurnContextResponse {
     // MCP tool definitions from agent's MCP capabilities
     // These are pre-resolved to avoid MCP capability lookup in worker
     repeated McpToolDef mcp_tool_definitions = 5;
+    // Harness for this session (always present)
+    optional Harness harness = 6;
 }
 
 // MCP tool definition for passing to worker
@@ -192,12 +197,37 @@ message GetAgentResponse {
 }
 
 // ============================================================================
+// Harness types
+// ============================================================================
+
+message Harness {
+    Uuid id = 1;
+    string name = 2;
+    string description = 3;
+    string system_prompt = 4;
+    optional Uuid default_model_id = 5;
+    string status = 6;
+    Timestamp created_at = 7;
+    Timestamp updated_at = 8;
+    repeated string capability_ids = 9;
+}
+
+message GetHarnessRequest {
+    Uuid harness_id = 1;
+    int64 org_id = 2;
+}
+
+message GetHarnessResponse {
+    optional Harness harness = 1;
+}
+
+// ============================================================================
 // Session types
 // ============================================================================
 
 message Session {
     Uuid id = 1;
-    Uuid agent_id = 2;
+    optional Uuid agent_id = 2;
     string title = 3;
     string status = 4;
     Timestamp created_at = 5;
@@ -207,6 +237,8 @@ message Session {
     string organization_id = 8;
     // Session-level capabilities (JSON-encoded AgentCapabilityConfig)
     repeated string capabilities = 9;
+    // Harness ID (required for sessions)
+    optional Uuid harness_id = 10;
 }
 
 message GetSessionRequest {

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -300,6 +300,62 @@ pub fn schema_agent_to_proto(value: &everruns_core::Agent) -> proto::Agent {
     }
 }
 
+/// Convert schemas Harness to proto Harness
+pub fn schema_harness_to_proto(value: &everruns_core::Harness) -> proto::Harness {
+    proto::Harness {
+        id: Some(uuid_to_proto_uuid(value.id.uuid())),
+        name: value.name.clone(),
+        description: value.description.clone().unwrap_or_default(),
+        system_prompt: value.system_prompt.clone(),
+        default_model_id: value
+            .default_model_id
+            .map(|id| uuid_to_proto_uuid(id.uuid())),
+        status: value.status.to_string(),
+        created_at: Some(datetime_to_proto_timestamp(value.created_at)),
+        updated_at: Some(datetime_to_proto_timestamp(value.updated_at)),
+        capability_ids: value
+            .capabilities
+            .iter()
+            .map(|c| c.capability_id().to_string())
+            .collect(),
+    }
+}
+
+/// Convert proto Harness to schemas Harness
+pub fn proto_harness_to_schema(
+    value: proto::Harness,
+) -> Result<everruns_core::Harness, ConversionError> {
+    let id_str = value
+        .id
+        .as_ref()
+        .map(|u| format!("harness_{}", u.value.replace("-", "")))
+        .unwrap_or_default();
+    let model_id_str = value
+        .default_model_id
+        .as_ref()
+        .map(|u| format!("model_{}", u.value.replace("-", "")));
+
+    let capabilities: Vec<serde_json::Value> = value
+        .capability_ids
+        .iter()
+        .map(|id| serde_json::json!({"ref": id, "config": {}}))
+        .collect();
+
+    let json = serde_json::json!({
+        "id": id_str,
+        "name": value.name,
+        "description": if value.description.is_empty() { None } else { Some(&value.description) },
+        "system_prompt": value.system_prompt,
+        "default_model_id": model_id_str,
+        "tags": Vec::<String>::new(),
+        "capabilities": capabilities,
+        "status": value.status,
+        "created_at": value.created_at.as_ref().map(|t| proto_timestamp_to_datetime(t).to_rfc3339()),
+        "updated_at": value.updated_at.as_ref().map(|t| proto_timestamp_to_datetime(t).to_rfc3339()),
+    });
+    serde_json::from_value(json).map_err(ConversionError::from)
+}
+
 /// Convert proto Session to schemas Session using JSON
 pub fn proto_session_to_schema(
     value: proto::Session,
@@ -317,8 +373,12 @@ pub fn proto_session_to_schema(
     let agent_id_str = value
         .agent_id
         .as_ref()
-        .map(|u| format!("agent_{}", u.value.replace("-", "")))
-        .unwrap_or_default();
+        .map(|u| format!("agent_{}", u.value.replace("-", "")));
+    let harness_id_str = value
+        .harness_id
+        .as_ref()
+        .map(|u| format!("harness_{}", u.value.replace("-", "")))
+        .unwrap_or_else(|| format!("harness_{}", uuid::Uuid::nil().simple()));
     let model_id_str = value
         .default_model_id
         .as_ref()
@@ -326,6 +386,7 @@ pub fn proto_session_to_schema(
 
     let json = serde_json::json!({
         "id": id_str,
+        "harness_id": harness_id_str,
         "agent_id": agent_id_str,
         "title": if value.title.is_empty() { None } else { Some(&value.title) },
         "tags": tags,
@@ -342,7 +403,7 @@ pub fn proto_session_to_schema(
 pub fn schema_session_to_proto(value: &everruns_core::Session) -> proto::Session {
     proto::Session {
         id: Some(uuid_to_proto_uuid(value.id.uuid())),
-        agent_id: Some(uuid_to_proto_uuid(value.agent_id.uuid())),
+        agent_id: value.agent_id.map(|id| uuid_to_proto_uuid(id.uuid())),
         title: value.title.clone().unwrap_or_default(),
         status: value.status.to_string(),
         created_at: Some(datetime_to_proto_timestamp(value.created_at)),
@@ -354,6 +415,7 @@ pub fn schema_session_to_proto(value: &everruns_core::Session) -> proto::Session
             .iter()
             .filter_map(|c| serde_json::to_string(c).ok())
             .collect(),
+        harness_id: Some(uuid_to_proto_uuid(value.harness_id.uuid())),
     }
 }
 

--- a/crates/server/migrations/006_harnesses.sql
+++ b/crates/server/migrations/006_harnesses.sql
@@ -1,0 +1,35 @@
+-- Migration: Add harnesses table and link to sessions
+--
+-- Harness defines base rules and capabilities for sessions.
+-- Hierarchy: Harness (required) → Agent (optional) → Session
+
+-- Harnesses table (same structure as agents, no usage tracking)
+CREATE TABLE harnesses (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    org_id BIGINT NOT NULL REFERENCES organizations(org_id) DEFAULT 1,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    system_prompt TEXT NOT NULL,
+    default_model_id UUID REFERENCES llm_models(id),
+    tags TEXT[] NOT NULL DEFAULT '{}',
+    status VARCHAR(50) NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'archived')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_harnesses_org_id ON harnesses(org_id);
+
+-- Harness capabilities junction table
+CREATE TABLE harness_capabilities (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    harness_id UUID NOT NULL REFERENCES harnesses(id) ON DELETE CASCADE,
+    capability_id VARCHAR(50) NOT NULL,
+    position INTEGER NOT NULL DEFAULT 0,
+    config JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(harness_id, capability_id)
+);
+CREATE INDEX idx_harness_caps_harness_id ON harness_capabilities(harness_id);
+
+-- Add harness_id to sessions (nullable for existing data), make agent_id optional
+ALTER TABLE sessions ADD COLUMN harness_id UUID REFERENCES harnesses(id);
+ALTER TABLE sessions ALTER COLUMN agent_id DROP NOT NULL;

--- a/crates/server/src/api/harnesses.rs
+++ b/crates/server/src/api/harnesses.rs
@@ -1,0 +1,353 @@
+// Harness CRUD HTTP routes
+// Routes use ResolvedOrg: org derived from auth context (API key or cookie)
+
+use crate::auth::{AuthState, ResolvedOrg};
+use crate::storage::StorageBackend;
+use axum::extract::FromRef;
+use axum::{
+    Json, Router,
+    extract::{Path, State},
+    http::StatusCode,
+    routing::{get, post},
+};
+use everruns_core::typed_id::{HarnessId, ModelId};
+use everruns_core::{AgentCapabilityConfig, Harness, HarnessStatus, ToolDefinition};
+
+use super::common::{ApiOptionExt, ApiResultExt, ErrorResponse, ListResponse};
+use super::validation::{validate_create_agent_input, validate_update_agent_input};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use utoipa::ToSchema;
+
+use crate::services::{CapabilityService, HarnessService};
+
+/// Request to create a new harness
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct CreateHarnessRequest {
+    /// The name of the harness.
+    #[schema(example = "Deep Research")]
+    pub name: String,
+    /// Description of what the harness does.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "Research harness with planning and web capabilities")]
+    pub description: Option<String>,
+    /// The system prompt defining the harness's base behavior.
+    #[schema(example = "You are a research assistant with deep analytical capabilities.")]
+    pub system_prompt: String,
+    /// Default LLM model ID for this harness. Lowest priority in model chain.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>, example = "model_01933b5a00007000800000000000001")]
+    pub default_model_id: Option<ModelId>,
+    /// Tags for organizing harnesses.
+    #[serde(default)]
+    #[schema(example = json!(["research", "planning"]))]
+    pub tags: Vec<String>,
+    /// Capabilities to enable with per-harness configuration.
+    #[serde(default)]
+    #[schema(example = json!([{"ref": "current_time", "config": {}}, {"ref": "web_fetch", "config": {}}]))]
+    pub capabilities: Vec<AgentCapabilityConfig>,
+}
+
+/// Request to update a harness. Only provided fields will be updated.
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct UpdateHarnessRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "Updated Research Harness")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_prompt: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>)]
+    pub default_model_id: Option<ModelId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<Vec<AgentCapabilityConfig>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<HarnessStatus>,
+}
+
+/// Request to preview harness shape with capabilities applied
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct PreviewHarnessRequest {
+    #[schema(example = "You are a research assistant.")]
+    pub system_prompt: String,
+    #[serde(default)]
+    pub capabilities: Vec<AgentCapabilityConfig>,
+}
+
+/// Preview response showing merged prompt and tools
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct HarnessPreviewResponse {
+    pub system_prompt: String,
+    #[schema(value_type = Vec<Object>)]
+    pub tools: Vec<ToolDefinition>,
+}
+
+/// App state for harness routes
+#[derive(Clone)]
+pub struct AppState {
+    pub service: Arc<HarnessService>,
+    pub capability_service: Arc<CapabilityService>,
+    pub auth: AuthState,
+}
+
+impl AppState {
+    pub fn new(
+        db: Arc<StorageBackend>,
+        capability_service: Arc<CapabilityService>,
+        auth: AuthState,
+    ) -> Self {
+        Self {
+            service: Arc::new(HarnessService::new(db)),
+            capability_service,
+            auth,
+        }
+    }
+}
+
+impl FromRef<AppState> for AuthState {
+    fn from_ref(input: &AppState) -> Self {
+        input.auth.clone()
+    }
+}
+
+/// Create harness routes (no import/export)
+pub fn routes(state: AppState) -> Router {
+    Router::new()
+        .route("/v1/harnesses", post(create_harness).get(list_harnesses))
+        .route("/v1/harnesses/preview", post(preview_harness))
+        .route(
+            "/v1/harnesses/{harness_id}",
+            get(get_harness)
+                .patch(update_harness)
+                .delete(delete_harness),
+        )
+        .with_state(state)
+}
+
+/// POST /v1/harnesses
+#[utoipa::path(
+    post,
+    path = "/v1/harnesses",
+    request_body = CreateHarnessRequest,
+    responses(
+        (status = 201, description = "Harness created", body = Harness),
+        (status = 400, description = "Invalid input", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "harnesses"
+)]
+pub async fn create_harness(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Json(req): Json<CreateHarnessRequest>,
+) -> Result<(StatusCode, Json<Harness>), (StatusCode, Json<ErrorResponse>)> {
+    // Reuse agent validation (same limits)
+    validate_create_agent_input(
+        &req.name,
+        req.description.as_deref(),
+        &req.system_prompt,
+        req.capabilities.len(),
+    )?;
+
+    let harness = state
+        .service
+        .create(org.org_id, req)
+        .await
+        .log_internal_error_json("create harness")?;
+
+    Ok((StatusCode::CREATED, Json(harness)))
+}
+
+/// GET /v1/harnesses
+#[utoipa::path(
+    get,
+    path = "/v1/harnesses",
+    responses(
+        (status = 200, description = "List of harnesses", body = ListResponse<Harness>),
+        (status = 500, description = "Internal server error")
+    ),
+    tag = "harnesses"
+)]
+pub async fn list_harnesses(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+) -> Result<Json<ListResponse<Harness>>, StatusCode> {
+    let harnesses = state
+        .service
+        .list(org.org_id)
+        .await
+        .log_internal_error("list harnesses")?;
+
+    Ok(Json(ListResponse::new(harnesses)))
+}
+
+/// GET /v1/harnesses/{harness_id}
+#[utoipa::path(
+    get,
+    path = "/v1/harnesses/{harness_id}",
+    params(
+        ("harness_id" = String, Path, description = "Harness ID (prefixed)")
+    ),
+    responses(
+        (status = 200, description = "Harness found", body = Harness),
+        (status = 400, description = "Invalid harness ID"),
+        (status = 404, description = "Harness not found"),
+        (status = 500, description = "Internal server error")
+    ),
+    tag = "harnesses"
+)]
+pub async fn get_harness(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(harness_id): Path<String>,
+) -> Result<Json<Harness>, (StatusCode, Json<ErrorResponse>)> {
+    let harness_id: HarnessId = harness_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid harness ID: {}", e),
+            }),
+        )
+    })?;
+
+    let harness = state
+        .service
+        .get(org.org_id, harness_id.uuid())
+        .await
+        .log_internal_error_json("get harness")?
+        .ok_or_not_found_json("Harness")?;
+
+    Ok(Json(harness))
+}
+
+/// PATCH /v1/harnesses/{harness_id}
+#[utoipa::path(
+    patch,
+    path = "/v1/harnesses/{harness_id}",
+    params(
+        ("harness_id" = String, Path, description = "Harness ID (prefixed)")
+    ),
+    request_body = UpdateHarnessRequest,
+    responses(
+        (status = 200, description = "Harness updated", body = Harness),
+        (status = 400, description = "Invalid input", body = ErrorResponse),
+        (status = 404, description = "Harness not found", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "harnesses"
+)]
+pub async fn update_harness(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(harness_id): Path<String>,
+    Json(req): Json<UpdateHarnessRequest>,
+) -> Result<Json<Harness>, (StatusCode, Json<ErrorResponse>)> {
+    let harness_id: HarnessId = harness_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid harness ID: {}", e),
+            }),
+        )
+    })?;
+
+    // Reuse agent validation (same limits)
+    validate_update_agent_input(
+        req.name.as_deref(),
+        req.description.as_deref(),
+        req.system_prompt.as_deref(),
+        req.capabilities.as_ref().map(|c| c.len()),
+    )?;
+
+    let harness = state
+        .service
+        .update(org.org_id, harness_id.uuid(), req)
+        .await
+        .log_internal_error_json("update harness")?
+        .ok_or_not_found_json("Harness")?;
+
+    Ok(Json(harness))
+}
+
+/// DELETE /v1/harnesses/{harness_id}
+#[utoipa::path(
+    delete,
+    path = "/v1/harnesses/{harness_id}",
+    params(
+        ("harness_id" = String, Path, description = "Harness ID (prefixed)")
+    ),
+    responses(
+        (status = 204, description = "Harness archived"),
+        (status = 400, description = "Invalid harness ID"),
+        (status = 404, description = "Harness not found"),
+        (status = 500, description = "Internal server error")
+    ),
+    tag = "harnesses"
+)]
+pub async fn delete_harness(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(harness_id): Path<String>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let harness_id: HarnessId = harness_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid harness ID: {}", e),
+            }),
+        )
+    })?;
+
+    let deleted = state
+        .service
+        .delete(org.org_id, harness_id.uuid())
+        .await
+        .log_internal_error_json("delete harness")?;
+
+    if deleted {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: "Harness not found".to_string(),
+            }),
+        ))
+    }
+}
+
+/// POST /v1/harnesses/preview
+#[utoipa::path(
+    post,
+    path = "/v1/harnesses/preview",
+    request_body = PreviewHarnessRequest,
+    responses(
+        (status = 200, description = "Harness preview generated", body = HarnessPreviewResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "harnesses"
+)]
+pub async fn preview_harness(
+    _org: ResolvedOrg,
+    State(state): State<AppState>,
+    Json(req): Json<PreviewHarnessRequest>,
+) -> Result<Json<HarnessPreviewResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let (system_prompt, tools) = state
+        .capability_service
+        .preview(&req.system_prompt, &req.capabilities)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to generate harness preview: {}", e);
+            ErrorResponse::new("Internal server error")
+                .into_response(StatusCode::INTERNAL_SERVER_ERROR)
+        })?;
+
+    Ok(Json(HarnessPreviewResponse {
+        system_prompt,
+        tools,
+    }))
+}

--- a/crates/server/src/api/messages.rs
+++ b/crates/server/src/api/messages.rs
@@ -262,7 +262,13 @@ pub async fn create_message(
 
     let message = state
         .message_service
-        .create(org.org_id, session.agent_id.uuid(), session_id.uuid(), req)
+        .create(
+            org.org_id,
+            session.harness_id.uuid(),
+            session.agent_id.map(|a| a.uuid()),
+            session_id.uuid(),
+            req,
+        )
         .await
         .map_err(|e| {
             tracing::error!("Failed to create message: {}", e);

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -8,6 +8,7 @@ pub mod capabilities;
 pub mod common;
 pub mod durable;
 pub mod events;
+pub mod harnesses;
 pub mod images;
 pub mod llm_models;
 pub mod llm_providers;

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -13,7 +13,7 @@ use axum::{
 };
 use everruns_core::capability_types::AgentCapabilityConfig;
 use everruns_core::events::{EventContext, EventRequest, InputMessageData, TurnCancelledData};
-use everruns_core::typed_id::{AgentId, MessageId, ModelId, SessionId, TurnId};
+use everruns_core::typed_id::{AgentId, HarnessId, MessageId, ModelId, SessionId, TurnId};
 use everruns_core::{Message, Session};
 use everruns_worker::AgentRunner;
 
@@ -25,9 +25,13 @@ use utoipa::{IntoParams, ToSchema};
 /// Request to create a session
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct CreateSessionRequest {
-    /// ID of the agent to work in this session (format: agent_{32-hex}).
-    #[schema(value_type = String, example = "agent_01933b5a00007000800000000000001")]
-    pub agent_id: AgentId,
+    /// ID of the harness for this session (format: harness_{32-hex}).
+    #[schema(value_type = String, example = "harness_01933b5a00007000800000000000001")]
+    pub harness_id: HarnessId,
+    /// ID of the agent to work in this session (optional, format: agent_{32-hex}).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>, example = "agent_01933b5a00007000800000000000001")]
+    pub agent_id: Option<AgentId>,
     /// Human-readable title for the session.
     #[serde(default)]
     #[schema(example = "Debug login issue")]
@@ -165,25 +169,32 @@ pub async fn create_session(
     State(state): State<AppState>,
     Json(req): Json<CreateSessionRequest>,
 ) -> Result<(StatusCode, Json<Session>), (StatusCode, Json<ErrorResponse>)> {
-    // Resolve agent public_id to internal UUID for FK storage
-    let agent_row = state
-        .db
-        .get_agent_by_public_id(org.org_id, &req.agent_id.to_string())
-        .await
-        .log_internal_error_json("resolve agent")?
-        .ok_or_not_found_json("Agent")?;
+    // Resolve agent public_id to internal UUID for FK storage (if agent specified)
+    let (agent_internal_id, agent_public_id) = if let Some(ref agent_id) = req.agent_id {
+        let agent_row = state
+            .db
+            .get_agent_by_public_id(org.org_id, &agent_id.to_string())
+            .await
+            .log_internal_error_json("resolve agent")?
+            .ok_or_not_found_json("Agent")?;
 
-    let agent_public_id: AgentId = agent_row
-        .public_id
-        .parse()
-        .unwrap_or_else(|_| AgentId::from_uuid(agent_row.id.uuid()));
+        let public_id: AgentId = agent_row
+            .public_id
+            .parse()
+            .unwrap_or_else(|_| AgentId::from_uuid(agent_row.id.uuid()));
+
+        (Some(agent_row.id.uuid()), Some(public_id))
+    } else {
+        (None, None)
+    };
 
     let session = state
         .session_service
         .create(
             org.org_id,
             &org.public_id,
-            agent_row.id.uuid(),
+            req.harness_id.uuid(),
+            agent_internal_id,
             agent_public_id,
             req,
         )
@@ -456,14 +467,16 @@ pub async fn cancel_turn(
 mod tests {
     use super::*;
 
+    const TEST_HARNESS_ID: &str = "harness_550e8400e29b41d4a716446655440000";
     const TEST_AGENT_ID: &str = "agent_550e8400e29b41d4a716446655440000";
 
     #[test]
     fn test_create_session_request_minimal() {
-        // Test with only required agent_id
-        let json = format!(r#"{{"agent_id": "{}"}}"#, TEST_AGENT_ID);
+        // Test with only required harness_id
+        let json = format!(r#"{{"harness_id": "{}"}}"#, TEST_HARNESS_ID);
         let req: CreateSessionRequest = serde_json::from_str(&json).unwrap();
-        assert_eq!(req.agent_id.to_string(), TEST_AGENT_ID);
+        assert_eq!(req.harness_id.to_string(), TEST_HARNESS_ID);
+        assert_eq!(req.agent_id, None);
         assert_eq!(req.title, None);
         assert!(req.tags.is_empty());
         assert_eq!(req.model_id, None);
@@ -471,18 +484,30 @@ mod tests {
     }
 
     #[test]
-    fn test_create_session_request_missing_agent_id() {
-        // agent_id is required, so this should fail
+    fn test_create_session_request_missing_harness_id() {
+        // harness_id is required, so this should fail
         let json = r#"{}"#;
         let result: Result<CreateSessionRequest, _> = serde_json::from_str(json);
         assert!(result.is_err());
     }
 
     #[test]
+    fn test_create_session_request_with_agent_id() {
+        // agent_id is optional
+        let json = format!(
+            r#"{{"harness_id": "{}", "agent_id": "{}"}}"#,
+            TEST_HARNESS_ID, TEST_AGENT_ID
+        );
+        let req: CreateSessionRequest = serde_json::from_str(&json).unwrap();
+        let expected_agent_id: AgentId = TEST_AGENT_ID.parse().unwrap();
+        assert_eq!(req.agent_id, Some(expected_agent_id));
+    }
+
+    #[test]
     fn test_create_session_request_with_title() {
         let json = format!(
-            r#"{{"agent_id": "{}", "title": "Test Session"}}"#,
-            TEST_AGENT_ID
+            r#"{{"harness_id": "{}", "agent_id": "{}", "title": "Test Session"}}"#,
+            TEST_HARNESS_ID, TEST_AGENT_ID
         );
         let req: CreateSessionRequest = serde_json::from_str(&json).unwrap();
         assert_eq!(req.title, Some("Test Session".to_string()));
@@ -494,8 +519,8 @@ mod tests {
     fn test_create_session_request_with_model_id() {
         let model_id: ModelId = "model_550e8400e29b41d4a716446655440000".parse().unwrap();
         let json = format!(
-            r#"{{"agent_id": "{}", "model_id": "{}"}}"#,
-            TEST_AGENT_ID, model_id
+            r#"{{"harness_id": "{}", "agent_id": "{}", "model_id": "{}"}}"#,
+            TEST_HARNESS_ID, TEST_AGENT_ID, model_id
         );
         let req: CreateSessionRequest = serde_json::from_str(&json).unwrap();
         assert_eq!(req.model_id, Some(model_id));
@@ -505,8 +530,8 @@ mod tests {
     fn test_create_session_request_full() {
         let model_id: ModelId = "model_550e8400e29b41d4a716446655440001".parse().unwrap();
         let json = format!(
-            r#"{{"agent_id": "{}", "title": "Full Session", "tags": ["tag1", "tag2"], "model_id": "{}"}}"#,
-            TEST_AGENT_ID, model_id
+            r#"{{"harness_id": "{}", "agent_id": "{}", "title": "Full Session", "tags": ["tag1", "tag2"], "model_id": "{}"}}"#,
+            TEST_HARNESS_ID, TEST_AGENT_ID, model_id
         );
         let req: CreateSessionRequest = serde_json::from_str(&json).unwrap();
         assert_eq!(req.title, Some("Full Session".to_string()));
@@ -519,13 +544,14 @@ mod tests {
     fn test_create_session_request_with_capabilities() {
         let json = format!(
             r#"{{
+                "harness_id": "{}",
                 "agent_id": "{}",
                 "capabilities": [
                     {{"ref": "current_time"}},
                     {{"ref": "web_fetch", "config": {{"timeout_ms": 30000}}}}
                 ]
             }}"#,
-            TEST_AGENT_ID
+            TEST_HARNESS_ID, TEST_AGENT_ID
         );
         let req: CreateSessionRequest = serde_json::from_str(&json).unwrap();
         assert_eq!(req.capabilities.len(), 2);

--- a/crates/server/src/api/tool_results.rs
+++ b/crates/server/src/api/tool_results.rs
@@ -222,11 +222,12 @@ pub async fn submit_tool_results(
 
     // Resume the workflow by starting another run
     let runner = state.runner.clone();
+    let harness_id = session.harness_id;
     let agent_id = session.agent_id;
     let org_id = org.org_id;
     tokio::spawn(async move {
         if let Err(e) = runner
-            .start_run(org_id, session_id, agent_id, input_message_id)
+            .start_run(org_id, session_id, harness_id, agent_id, input_message_id)
             .await
         {
             tracing::error!(

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -14,11 +14,11 @@ use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::events::{Event, EventRequest};
 use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
 use everruns_core::traits::ResolvedImage;
-use everruns_core::typed_id::{AgentId, MessageId, SessionId};
+use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId};
 use everruns_core::{
-    Agent, AgentStatus, ContentPart, DEFAULT_ORG_PUBLIC_ID, DriverRegistry, EventData,
-    LlmProviderType, Message, MessageRole, Session, SessionStatus, ToolDefinition, ToolRegistry,
-    ToolResultContentPart,
+    Agent, AgentStatus, ContentPart, DEFAULT_ORG_PUBLIC_ID, DriverRegistry, EventData, Harness,
+    HarnessStatus, LlmProviderType, Message, MessageRole, Session, SessionStatus, ToolDefinition,
+    ToolRegistry, ToolResultContentPart,
 };
 use everruns_worker::create_driver_registry;
 use everruns_worker::mcp_executor::McpServerInfo;
@@ -138,6 +138,11 @@ impl WorkerAdapters for DirectWorkerAdapters {
     // Agent Operations
     // =========================================================================
 
+    async fn get_harness(&self, org_id: i64, harness_id: Uuid) -> Result<Option<Harness>> {
+        // Delegate to the private helper method
+        Self::get_harness_impl(self, org_id, harness_id).await
+    }
+
     async fn get_agent(&self, org_id: i64, agent_id: Uuid) -> Result<Option<Agent>> {
         let agent_id_typed = AgentId::from_uuid(agent_id);
         let row = self
@@ -207,6 +212,7 @@ impl WorkerAdapters for DirectWorkerAdapters {
             Session {
                 id: r.id,
                 organization_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
+                harness_id: r.harness_id.unwrap_or_else(|| HarnessId::from_seed(1)),
                 agent_id: r.agent_id,
                 title: r.title,
                 preview: None,
@@ -656,31 +662,58 @@ impl WorkerAdapters for DirectWorkerAdapters {
             .await?
             .ok_or_else(|| store_error("Session not found"))?;
 
-        // Load agent
-        let agent = self
-            .get_agent(org_id, session.agent_id.uuid())
-            .await?
-            .ok_or_else(|| store_error("Agent not found"))?;
+        // Load agent (optional)
+        let agent = if let Some(agent_id) = session.agent_id {
+            self.get_agent(org_id, agent_id.uuid()).await?
+        } else {
+            None
+        };
+
+        // Load harness
+        let harness = self
+            .get_harness_impl(org_id, session.harness_id.uuid())
+            .await?;
 
         // Load messages
         let messages = self.load_messages(session_id).await?;
 
-        // Load model
+        // Load model (session > agent > harness > default)
         let model = if let Some(model_id) = session.model_id {
             self.get_model_with_provider(org_id, model_id.uuid())
                 .await?
-        } else if let Some(model_id) = agent.default_model_id {
-            self.get_model_with_provider(org_id, model_id.uuid())
-                .await?
+        } else if let Some(ref a) = agent {
+            if let Some(model_id) = a.default_model_id {
+                self.get_model_with_provider(org_id, model_id.uuid())
+                    .await?
+            } else if let Some(ref h) = harness {
+                if let Some(model_id) = h.default_model_id {
+                    self.get_model_with_provider(org_id, model_id.uuid())
+                        .await?
+                } else {
+                    self.get_default_model(org_id).await?
+                }
+            } else {
+                self.get_default_model(org_id).await?
+            }
+        } else if let Some(ref h) = harness {
+            if let Some(model_id) = h.default_model_id {
+                self.get_model_with_provider(org_id, model_id.uuid())
+                    .await?
+            } else {
+                self.get_default_model(org_id).await?
+            }
         } else {
             self.get_default_model(org_id).await?
         };
 
-        // Build MCP tool definitions
-        let mcp_tool_definitions = self
-            .build_mcp_tool_definitions(agent.internal_id)
-            .await
-            .unwrap_or_default();
+        // Build MCP tool definitions from agent capabilities (if agent present)
+        let mcp_tool_definitions = if let Some(ref a) = agent {
+            self.build_mcp_tool_definitions(a.internal_id)
+                .await
+                .unwrap_or_default()
+        } else {
+            vec![]
+        };
 
         Ok(TurnContext {
             agent,
@@ -742,6 +775,48 @@ impl WorkerAdapters for DirectWorkerAdapters {
 }
 
 impl DirectWorkerAdapters {
+    /// Get a harness by ID (direct DB access)
+    async fn get_harness_impl(&self, org_id: i64, harness_id: Uuid) -> Result<Option<Harness>> {
+        let harness_id_typed = HarnessId::from_uuid(harness_id);
+        let row = self
+            .db
+            .get_harness(org_id, harness_id_typed)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to get harness: {}", e);
+                store_error("Failed to get harness")
+            })?;
+
+        let capabilities = if row.is_some() {
+            self.db
+                .get_harness_capabilities(harness_id)
+                .await
+                .unwrap_or_default()
+        } else {
+            vec![]
+        };
+
+        Ok(row.map(|r| Harness {
+            id: r.id,
+            name: r.name,
+            description: r.description,
+            system_prompt: r.system_prompt,
+            default_model_id: r.default_model_id,
+            tags: r.tags,
+            capabilities: capabilities
+                .into_iter()
+                .map(|c| AgentCapabilityConfig::with_config(c.capability_id, c.config))
+                .collect(),
+            status: match r.status.as_str() {
+                "active" => HarnessStatus::Active,
+                "archived" => HarnessStatus::Archived,
+                _ => HarnessStatus::Active,
+            },
+            created_at: r.created_at,
+            updated_at: r.updated_at,
+        }))
+    }
+
     /// Build MCP tool definitions from agent's MCP capabilities
     async fn build_mcp_tool_definitions(&self, agent_id: Uuid) -> Result<Vec<ToolDefinition>> {
         use everruns_core::capabilities::mcp::parse_mcp_capability_id;

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -6,8 +6,8 @@
 // Decision: No direct database access - all operations go through services layer
 
 use crate::services::{
-    AgentService, EventService, LlmResolverService, McpServerService, SessionFileService,
-    SessionService,
+    AgentService, EventService, HarnessService, LlmResolverService, McpServerService,
+    SessionFileService, SessionService,
     session_file::{CreateDirectoryInput, CreateFileInput, GrepInput, UpdateFileInput},
 };
 use crate::storage::{EncryptionService, StorageBackend};
@@ -31,26 +31,26 @@ use everruns_internal_protocol::proto::{
     EnqueueDurableTaskRequest, EnqueueDurableTaskResponse, FailDurableTaskRequest,
     FailDurableTaskResponse, GetAgentRequest, GetAgentResponse, GetDefaultModelRequest,
     GetDefaultModelResponse, GetDurableWorkflowStatusRequest, GetDurableWorkflowStatusResponse,
-    GetMcpServerByPrefixRequest, GetMcpServerByPrefixResponse, GetModelWithProviderRequest,
-    GetModelWithProviderResponse, GetSessionRequest, GetSessionResponse, GetTurnContextRequest,
-    GetTurnContextResponse, HeartbeatDurableTaskRequest, HeartbeatDurableTaskResponse,
-    HeartbeatDurableWorkerRequest, HeartbeatDurableWorkerResponse, LoadMessagesRequest,
-    LoadMessagesResponse, McpServerInfo, McpToolDef, RecordCircuitBreakerFailureRequest,
-    RecordCircuitBreakerFailureResponse, RecordCircuitBreakerSuccessRequest,
-    RecordCircuitBreakerSuccessResponse, RegisterDurableWorkerRequest,
-    RegisterDurableWorkerResponse, ResolveImageRequest, ResolveImageResponse, ResolveImagesRequest,
-    ResolveImagesResponse, ResolvedImageData, SessionCreateDirectoryRequest,
-    SessionCreateDirectoryResponse, SessionDeleteFileRequest, SessionDeleteFileResponse,
-    SessionGrepFilesRequest, SessionGrepFilesResponse, SessionListDirectoryRequest,
-    SessionListDirectoryResponse, SessionReadFileRequest, SessionReadFileResponse,
-    SessionStatFileRequest, SessionStatFileResponse, SessionWriteFileRequest,
-    SessionWriteFileResponse, SetSessionStatusRequest, SetSessionStatusResponse,
-    SubscribeTaskNotificationsRequest, TaskNotification, TaskNotificationType,
-    UpdateDurableWorkflowStatusRequest, UpdateDurableWorkflowStatusResponse,
+    GetHarnessRequest, GetHarnessResponse, GetMcpServerByPrefixRequest,
+    GetMcpServerByPrefixResponse, GetModelWithProviderRequest, GetModelWithProviderResponse,
+    GetSessionRequest, GetSessionResponse, GetTurnContextRequest, GetTurnContextResponse,
+    HeartbeatDurableTaskRequest, HeartbeatDurableTaskResponse, HeartbeatDurableWorkerRequest,
+    HeartbeatDurableWorkerResponse, LoadMessagesRequest, LoadMessagesResponse, McpServerInfo,
+    McpToolDef, RecordCircuitBreakerFailureRequest, RecordCircuitBreakerFailureResponse,
+    RecordCircuitBreakerSuccessRequest, RecordCircuitBreakerSuccessResponse,
+    RegisterDurableWorkerRequest, RegisterDurableWorkerResponse, ResolveImageRequest,
+    ResolveImageResponse, ResolveImagesRequest, ResolveImagesResponse, ResolvedImageData,
+    SessionCreateDirectoryRequest, SessionCreateDirectoryResponse, SessionDeleteFileRequest,
+    SessionDeleteFileResponse, SessionGrepFilesRequest, SessionGrepFilesResponse,
+    SessionListDirectoryRequest, SessionListDirectoryResponse, SessionReadFileRequest,
+    SessionReadFileResponse, SessionStatFileRequest, SessionStatFileResponse,
+    SessionWriteFileRequest, SessionWriteFileResponse, SetSessionStatusRequest,
+    SetSessionStatusResponse, SubscribeTaskNotificationsRequest, TaskNotification,
+    TaskNotificationType, UpdateDurableWorkflowStatusRequest, UpdateDurableWorkflowStatusResponse,
 };
 use everruns_internal_protocol::{
     WorkerService, WorkerServiceServer, proto_event_request_to_schema, schema_agent_to_proto,
-    schema_event_to_proto,
+    schema_event_to_proto, schema_harness_to_proto,
 };
 use std::pin::Pin;
 use std::sync::Arc;
@@ -64,6 +64,7 @@ use tonic::{Request, Response, Status, Streaming};
 pub struct WorkerServiceImpl {
     event_service: EventService,
     agent_service: AgentService,
+    harness_service: HarnessService,
     session_service: SessionService,
     session_file_service: SessionFileService,
     llm_resolver_service: LlmResolverService,
@@ -82,6 +83,7 @@ impl WorkerServiceImpl {
         encryption: Option<Arc<EncryptionService>>,
     ) -> Self {
         let agent_service = AgentService::new(db.clone());
+        let harness_service = HarnessService::new(db.clone());
         let session_service = SessionService::new(db.clone());
         let session_file_service = SessionFileService::new(db.clone());
         let llm_resolver_service = LlmResolverService::new(db.clone(), encryption.clone());
@@ -96,6 +98,7 @@ impl WorkerServiceImpl {
         Self {
             event_service,
             agent_service,
+            harness_service,
             session_service,
             session_file_service,
             llm_resolver_service,
@@ -285,25 +288,39 @@ impl WorkerService for WorkerServiceImpl {
             })?
             .ok_or_else(|| Status::not_found("Session not found"))?;
 
-        // Get agent with capabilities via AgentService
-        let agent = self
-            .agent_service
-            .get(req.org_id, session.agent_id.uuid())
+        // Get agent with capabilities via AgentService (optional)
+        let agent = if let Some(agent_id) = session.agent_id {
+            self.agent_service
+                .get(req.org_id, agent_id.uuid())
+                .await
+                .map_err(|e| {
+                    tracing::error!("Failed to get agent: {}", e);
+                    Status::internal("Failed to get agent")
+                })?
+        } else {
+            None
+        };
+
+        // Load harness
+        let harness = self
+            .harness_service
+            .get(req.org_id, session.harness_id.uuid())
             .await
             .map_err(|e| {
-                tracing::error!("Failed to get agent: {}", e);
-                Status::internal("Failed to get agent")
-            })?
-            .ok_or_else(|| Status::not_found("Agent not found"))?;
+                tracing::error!("Failed to get harness: {}", e);
+                Status::internal("Failed to get harness")
+            })?;
 
         // Convert to proto types
         use everruns_internal_protocol::{datetime_to_proto_timestamp, uuid_to_proto_uuid};
 
-        let proto_agent = schema_agent_to_proto(&agent);
+        let proto_agent = agent.as_ref().map(schema_agent_to_proto);
+        let proto_harness = harness.as_ref().map(schema_harness_to_proto);
 
         let proto_session = proto::Session {
             id: Some(uuid_to_proto_uuid(session.id.uuid())),
-            agent_id: Some(uuid_to_proto_uuid(session.agent_id.uuid())),
+            agent_id: session.agent_id.map(|id| uuid_to_proto_uuid(id.uuid())),
+            harness_id: Some(uuid_to_proto_uuid(session.harness_id.uuid())),
             title: session.title.clone().unwrap_or_default(),
             status: session.status.to_string(),
             created_at: Some(datetime_to_proto_timestamp(session.created_at)),
@@ -372,8 +389,11 @@ impl WorkerService for WorkerServiceImpl {
         }
 
         // Get model with provider (decrypted API key) via LlmResolverService
-        // Priority: session model > agent model > default model
-        let model_id = session.model_id.or(agent.default_model_id);
+        // Priority: session model > agent model > harness model > default model
+        let model_id = session
+            .model_id
+            .or(agent.as_ref().and_then(|a| a.default_model_id))
+            .or(harness.as_ref().and_then(|h| h.default_model_id));
 
         let model: Option<proto::ModelWithProvider> = if let Some(mid) = model_id {
             self.llm_resolver_service
@@ -398,14 +418,19 @@ impl WorkerService for WorkerServiceImpl {
 
         // Build MCP tool definitions from agent's MCP capabilities
         // This resolves MCP tools so the worker doesn't need to look them up
-        let mcp_tool_definitions = self.build_mcp_tool_definitions(&agent).await;
+        let mcp_tool_definitions = if let Some(ref a) = agent {
+            self.build_mcp_tool_definitions(a).await
+        } else {
+            vec![]
+        };
 
         Ok(Response::new(GetTurnContextResponse {
-            agent: Some(proto_agent),
+            agent: proto_agent,
             session: Some(proto_session),
             messages: proto_messages,
             model,
             mcp_tool_definitions,
+            harness: proto_harness,
         }))
     }
 
@@ -474,6 +499,26 @@ impl WorkerService for WorkerServiceImpl {
         Ok(Response::new(GetAgentResponse { agent: proto_agent }))
     }
 
+    async fn get_harness(
+        &self,
+        request: Request<GetHarnessRequest>,
+    ) -> Result<Response<GetHarnessResponse>, Status> {
+        let req = request.into_inner();
+        let harness_id = parse_uuid(req.harness_id.as_ref())?;
+
+        let harness = self
+            .harness_service
+            .get(req.org_id, harness_id)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to get harness: {}", e)))?;
+
+        let proto_harness = harness.map(|h| schema_harness_to_proto(&h));
+
+        Ok(Response::new(GetHarnessResponse {
+            harness: proto_harness,
+        }))
+    }
+
     async fn get_session(
         &self,
         request: Request<GetSessionRequest>,
@@ -496,7 +541,8 @@ impl WorkerService for WorkerServiceImpl {
 
         let proto_session = session.map(|s| proto::Session {
             id: Some(uuid_to_proto_uuid(s.id.uuid())),
-            agent_id: Some(uuid_to_proto_uuid(s.agent_id.uuid())),
+            agent_id: s.agent_id.map(|id| uuid_to_proto_uuid(id.uuid())),
+            harness_id: Some(uuid_to_proto_uuid(s.harness_id.uuid())),
             title: s.title.clone().unwrap_or_default(),
             status: s.status.to_string(),
             created_at: Some(datetime_to_proto_timestamp(s.created_at)),
@@ -546,7 +592,8 @@ impl WorkerService for WorkerServiceImpl {
 
         let proto_session = proto::Session {
             id: Some(uuid_to_proto_uuid(session.id.uuid())),
-            agent_id: Some(uuid_to_proto_uuid(session.agent_id.uuid())),
+            agent_id: session.agent_id.map(|id| uuid_to_proto_uuid(id.uuid())),
+            harness_id: Some(uuid_to_proto_uuid(session.harness_id.uuid())),
             title: session.title.clone().unwrap_or_default(),
             status: session.status.to_string(),
             created_at: Some(datetime_to_proto_timestamp(session.created_at)),

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -8,8 +8,8 @@
 use crate::storage::{
     StorageBackend,
     models::{
-        CreateAgentRow, CreateLlmModelRow, CreateLlmProviderRow, CreateMcpServerRow,
-        CreateOrganizationRow,
+        CreateAgentRow, CreateHarnessRow, CreateLlmModelRow, CreateLlmProviderRow,
+        CreateMcpServerRow, CreateOrganizationRow,
     },
 };
 use everruns_core::{DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, DeploymentGrade};
@@ -44,6 +44,9 @@ mod seed_ids {
 
     // MCP Servers (0x500-0x5FF)
     pub const MS_LEARN_MCP: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000501);
+
+    // Harnesses (0x600-0x6FF)
+    pub const DEFAULT_HARNESS: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000601);
 
     // OpenAI Models (0x200-0x2FF)
     pub const GPT_5_2: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000201);
@@ -102,7 +105,7 @@ mod seed_ids {
 
 /// Result of running a seeder
 #[derive(Debug, Default)]
-struct SeedResult {
+pub struct SeedResult {
     created: usize,
     skipped: usize,
 }
@@ -146,6 +149,72 @@ async fn seed_default_organization(db: &StorageBackend) -> anyhow::Result<SeedRe
                 "Default organization already exists, skipping"
             );
             result.skipped += 1;
+        }
+    }
+
+    Ok(result)
+}
+
+// ============================================
+// Harness Seeder
+// ============================================
+
+/// Seed harness definition
+struct SeedHarness {
+    id: Uuid,
+    name: &'static str,
+    description: &'static str,
+    system_prompt: &'static str,
+    tags: &'static [&'static str],
+    capabilities: &'static [&'static str],
+}
+
+/// Built-in seed harnesses
+const SEED_HARNESSES: &[SeedHarness] = &[SeedHarness {
+    id: seed_ids::DEFAULT_HARNESS,
+    name: "Default",
+    description: "Default harness with no special configuration. Provides a blank canvas for sessions.",
+    system_prompt: "You are a helpful assistant.",
+    tags: &["default", "seed"],
+    capabilities: &[],
+}];
+
+/// Seed harnesses into the database
+async fn seed_harnesses(db: &StorageBackend) -> anyhow::Result<SeedResult> {
+    let mut result = SeedResult::default();
+
+    for seed in SEED_HARNESSES {
+        let input = CreateHarnessRow {
+            name: seed.name.to_string(),
+            description: Some(seed.description.to_string()),
+            system_prompt: seed.system_prompt.to_string(),
+            default_model_id: None,
+            tags: seed.tags.iter().map(|s| s.to_string()).collect(),
+        };
+
+        match db
+            .create_harness_with_id(DEFAULT_ORG_ID, seed.id.into(), input)
+            .await?
+        {
+            Some(row) => {
+                // Set capabilities if any
+                if !seed.capabilities.is_empty() {
+                    let cap_tuples: Vec<(String, i32, serde_json::Value)> = seed
+                        .capabilities
+                        .iter()
+                        .enumerate()
+                        .map(|(idx, cap)| (cap.to_string(), idx as i32, serde_json::json!({})))
+                        .collect();
+                    db.set_harness_capabilities(row.id.uuid(), cap_tuples)
+                        .await?;
+                }
+                tracing::info!(name = seed.name, id = %seed.id, "Created seed harness");
+                result.created += 1;
+            }
+            None => {
+                tracing::debug!(name = seed.name, id = %seed.id, "Harness already exists, skipping");
+                result.skipped += 1;
+            }
         }
     }
 
@@ -1125,7 +1194,7 @@ async fn run_seed_with_retry(
 /// Run all seeders in order
 /// Order: organization → providers → models → mcp_servers → agents
 /// Organization must be seeded first (all resources have org_id FK)
-async fn seed_all(db: &StorageBackend, grade: DeploymentGrade) -> anyhow::Result<SeedResult> {
+pub async fn seed_all(db: &StorageBackend, grade: DeploymentGrade) -> anyhow::Result<SeedResult> {
     let mut result = SeedResult::default();
 
     // Seed default organization first (all other resources depend on it)
@@ -1163,6 +1232,15 @@ async fn seed_all(db: &StorageBackend, grade: DeploymentGrade) -> anyhow::Result
         "MCP servers seeded"
     );
     result.merge(mcp_result);
+
+    // Seed harnesses (before agents, sessions may reference them)
+    let harness_result = seed_harnesses(db).await?;
+    tracing::debug!(
+        created = harness_result.created,
+        skipped = harness_result.skipped,
+        "Harnesses seeded"
+    );
+    result.merge(harness_result);
 
     // Seed agents (respects deployment grade for dev-only agents)
     let agent_result = seed_agents(db, grade).await?;

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -230,6 +230,8 @@ pub async fn run(
     ));
     let capabilities_state =
         api::capabilities::AppState::new(capability_service.clone(), auth_state.clone());
+    let harnesses_state =
+        api::harnesses::AppState::new(db.clone(), capability_service.clone(), auth_state.clone());
     let agents_state =
         api::agents::AppState::new(db.clone(), capability_service, auth_state.clone());
     let session_files_state = api::session_files::AppState::new(db.clone(), auth_state.clone());
@@ -271,6 +273,7 @@ pub async fn run(
     // Build API routes
     let mut api_routes = Router::new()
         .merge(api::agents::routes(agents_state))
+        .merge(api::harnesses::routes(harnesses_state))
         .merge(api::sessions::routes(sessions_state))
         .merge(api::messages::routes(messages_state))
         .merge(api::tool_results::routes(tool_results_state))

--- a/crates/server/src/services/harness.rs
+++ b/crates/server/src/services/harness.rs
@@ -1,0 +1,159 @@
+// Harness service for business logic
+//
+// Manages harness CRUD operations, capability lifecycle.
+
+use crate::api::harnesses::{CreateHarnessRequest, UpdateHarnessRequest};
+use crate::storage::{
+    HarnessRow, StorageBackend,
+    models::{CreateHarnessRow, UpdateHarness},
+};
+use anyhow::Result;
+use everruns_core::{AgentCapabilityConfig, Harness, HarnessId, HarnessStatus};
+use std::sync::Arc;
+use uuid::Uuid;
+
+pub struct HarnessService {
+    db: Arc<StorageBackend>,
+}
+
+impl HarnessService {
+    pub fn new(db: Arc<StorageBackend>) -> Self {
+        Self { db }
+    }
+
+    pub async fn create(&self, org_id: i64, req: CreateHarnessRequest) -> Result<Harness> {
+        let input = CreateHarnessRow {
+            name: req.name,
+            description: req.description,
+            system_prompt: req.system_prompt,
+            default_model_id: req.default_model_id,
+            tags: req.tags,
+        };
+        let row = self.db.create_harness(org_id, input).await?;
+        let harness_id = row.id;
+
+        // Set capabilities if provided
+        let capabilities = if !req.capabilities.is_empty() {
+            let cap_tuples: Vec<(String, i32, serde_json::Value)> = req
+                .capabilities
+                .iter()
+                .enumerate()
+                .map(|(idx, cap)| {
+                    (
+                        cap.capability_ref.to_string(),
+                        idx as i32,
+                        cap.config.clone(),
+                    )
+                })
+                .collect();
+            self.db
+                .set_harness_capabilities(harness_id.uuid(), cap_tuples)
+                .await?;
+            req.capabilities
+        } else {
+            vec![]
+        };
+
+        Ok(Self::row_to_harness(row, capabilities))
+    }
+
+    pub async fn get(&self, org_id: i64, id: Uuid) -> Result<Option<Harness>> {
+        let row = self
+            .db
+            .get_harness(org_id, HarnessId::from_uuid(id))
+            .await?;
+        match row {
+            Some(row) => {
+                let capabilities = self.get_capabilities(id).await?;
+                Ok(Some(Self::row_to_harness(row, capabilities)))
+            }
+            None => Ok(None),
+        }
+    }
+
+    pub async fn list(&self, org_id: i64) -> Result<Vec<Harness>> {
+        let rows = self.db.list_harnesses(org_id).await?;
+
+        let mut harnesses = Vec::with_capacity(rows.len());
+        for row in rows {
+            let capabilities = self.get_capabilities(row.id.uuid()).await?;
+            harnesses.push(Self::row_to_harness(row, capabilities));
+        }
+
+        Ok(harnesses)
+    }
+
+    pub async fn update(
+        &self,
+        org_id: i64,
+        id: Uuid,
+        req: UpdateHarnessRequest,
+    ) -> Result<Option<Harness>> {
+        let input = UpdateHarness {
+            name: req.name,
+            description: req.description,
+            system_prompt: req.system_prompt,
+            default_model_id: req.default_model_id,
+            tags: req.tags,
+            status: req.status.map(|s| s.to_string()),
+        };
+        let row = self
+            .db
+            .update_harness(org_id, HarnessId::from_uuid(id), input)
+            .await?;
+
+        match row {
+            Some(row) => {
+                let capabilities = if let Some(caps) = req.capabilities {
+                    let cap_tuples: Vec<(String, i32, serde_json::Value)> = caps
+                        .iter()
+                        .enumerate()
+                        .map(|(idx, cap)| {
+                            (
+                                cap.capability_ref.to_string(),
+                                idx as i32,
+                                cap.config.clone(),
+                            )
+                        })
+                        .collect();
+                    self.db.set_harness_capabilities(id, cap_tuples).await?;
+                    caps
+                } else {
+                    self.get_capabilities(id).await?
+                };
+
+                Ok(Some(Self::row_to_harness(row, capabilities)))
+            }
+            None => Ok(None),
+        }
+    }
+
+    pub async fn delete(&self, org_id: i64, id: Uuid) -> Result<bool> {
+        self.db
+            .delete_harness(org_id, HarnessId::from_uuid(id))
+            .await
+    }
+
+    async fn get_capabilities(&self, harness_id: Uuid) -> Result<Vec<AgentCapabilityConfig>> {
+        let rows = self.db.get_harness_capabilities(harness_id).await?;
+        Ok(rows
+            .into_iter()
+            .map(|row| AgentCapabilityConfig::with_config(row.capability_id, row.config))
+            .collect())
+    }
+
+    fn row_to_harness(row: HarnessRow, capabilities: Vec<AgentCapabilityConfig>) -> Harness {
+        Harness {
+            id: row.id,
+            name: row.name,
+            description: row.description,
+            system_prompt: row.system_prompt,
+            default_model_id: row.default_model_id,
+            tags: row.tags,
+            capabilities,
+            status: HarnessStatus::from(row.status.as_str()),
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+        }
+    }
+}

--- a/crates/server/src/services/message.rs
+++ b/crates/server/src/services/message.rs
@@ -14,7 +14,7 @@ use everruns_core::Event;
 use everruns_core::events::{
     EventContext, EventRequest, InputMessageData, OutputMessageCompletedData, ToolCompletedData,
 };
-use everruns_core::typed_id::{AgentId, MessageId, SessionId};
+use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId};
 use everruns_worker::AgentRunner;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -43,13 +43,15 @@ impl MessageService {
     pub async fn create(
         &self,
         org_id: i64,
-        agent_id: Uuid,
+        harness_id: Uuid,
+        agent_id: Option<Uuid>,
         session_id: Uuid,
         req: CreateMessageRequest,
     ) -> Result<Message> {
         tracing::info!(
             session_id = %session_id,
-            agent_id = %agent_id,
+            harness_id = %harness_id,
+            agent_id = ?agent_id,
             "Creating user message"
         );
 
@@ -79,7 +81,8 @@ impl MessageService {
 
         // Convert to typed IDs for emit/runner
         let session_id_typed = SessionId::from_uuid(session_id);
-        let agent_id_typed = AgentId::from_uuid(agent_id);
+        let harness_id_typed = HarnessId::from_uuid(harness_id);
+        let agent_id_typed = agent_id.map(AgentId::from_uuid);
         let message_id_typed = MessageId::from_uuid(message_id);
 
         // Emit as typed event using EventService
@@ -109,7 +112,13 @@ impl MessageService {
         let runner = self.runner.clone();
         tokio::spawn(async move {
             if let Err(e) = runner
-                .start_run(org_id, session_id_typed, agent_id_typed, message_id_typed)
+                .start_run(
+                    org_id,
+                    session_id_typed,
+                    harness_id_typed,
+                    agent_id_typed,
+                    message_id_typed,
+                )
                 .await
             {
                 tracing::error!(

--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -4,6 +4,7 @@
 pub mod agent;
 pub mod capability;
 pub mod event;
+pub mod harness;
 pub mod llm_model;
 pub mod llm_provider;
 pub mod llm_resolver;
@@ -17,6 +18,7 @@ pub mod usage_tracking;
 pub use agent::AgentService;
 pub use capability::CapabilityService;
 pub use event::EventService;
+pub use harness::HarnessService;
 pub use llm_model::LlmModelService;
 pub use llm_provider::LlmProviderService;
 pub use llm_resolver::{LlmResolverService, ResolvedModel};

--- a/crates/server/src/services/session.rs
+++ b/crates/server/src/services/session.rs
@@ -14,8 +14,8 @@ use crate::storage::{
 };
 use anyhow::Result;
 use everruns_core::{
-    AgentCapabilityConfig, AgentId, CapabilityRegistry, ModelId, Session, SessionId, SessionStatus,
-    TokenUsage, capabilities::collect_capabilities,
+    AgentCapabilityConfig, AgentId, CapabilityRegistry, HarnessId, ModelId, Session, SessionId,
+    SessionStatus, TokenUsage, capabilities::collect_capabilities,
 };
 use std::sync::Arc;
 use uuid::Uuid;
@@ -50,19 +50,33 @@ impl SessionService {
         &self,
         org_id: i64,
         org_public_id: &str,
-        agent_internal_id: Uuid,
-        agent_public_id: AgentId,
+        harness_id: Uuid,
+        agent_internal_id: Option<Uuid>,
+        agent_public_id: Option<AgentId>,
         req: CreateSessionRequest,
     ) -> Result<Session> {
-        let agent_id = AgentId::from_uuid(agent_internal_id);
+        let harness_id = HarnessId::from_uuid(harness_id);
+        let agent_id = agent_internal_id.map(AgentId::from_uuid);
 
-        // If model_id not provided, use the agent's default_model_id
+        // Resolve model_id: session > agent > harness
         let model_id: Option<ModelId> = match req.model_id {
             Some(id) => Some(id),
             None => {
-                // Look up the agent to get its default_model_id
-                let agent = self.db.get_agent(org_id, agent_id).await?;
-                agent.and_then(|a| a.default_model_id)
+                // Try agent's default_model_id first
+                let agent_model = if let Some(aid) = agent_id {
+                    let agent = self.db.get_agent(org_id, aid).await?;
+                    agent.and_then(|a| a.default_model_id)
+                } else {
+                    None
+                };
+                // Fall back to harness's default_model_id
+                match agent_model {
+                    Some(id) => Some(id),
+                    None => {
+                        let harness = self.db.get_harness(org_id, harness_id).await?;
+                        harness.and_then(|h| h.default_model_id)
+                    }
+                }
             }
         };
 
@@ -71,6 +85,7 @@ impl SessionService {
 
         let input = CreateSessionRow {
             org_id,
+            harness_id: Some(harness_id),
             agent_id,
             title: req.title,
             tags: req.tags,
@@ -83,34 +98,46 @@ impl SessionService {
         // Override agent_id with public_id (DB stores internal UUID as FK)
         session.agent_id = agent_public_id;
 
-        // Apply capability mounts to the session filesystem (agent + session capabilities)
-        self.apply_capability_mounts(agent_internal_id, &req.capabilities, session.id.uuid())
-            .await?;
+        // Apply capability mounts (harness + agent + session capabilities)
+        self.apply_capability_mounts(
+            harness_id.uuid(),
+            agent_id.map(|a| a.uuid()),
+            &req.capabilities,
+            session.id.uuid(),
+        )
+        .await?;
 
         Ok(session)
     }
 
     /// Apply capability mounts to a session's filesystem.
     ///
-    /// This method:
-    /// 1. Gets the agent's enabled capabilities
-    /// 2. Collects mount points from those capabilities
-    /// 3. Adds session-level capabilities (additive)
-    /// 4. Creates the mounted files/directories in the session filesystem
+    /// Collects mounts from harness + agent + session capabilities.
     async fn apply_capability_mounts(
         &self,
-        agent_id: Uuid,
+        harness_id: Uuid,
+        agent_id: Option<Uuid>,
         session_capabilities: &[AgentCapabilityConfig],
         session_id: impl Into<uuid::Uuid> + Copy,
     ) -> Result<()> {
         let session_id = session_id.into();
 
-        // Get agent's capability IDs
-        let capability_rows = self.db.get_agent_capabilities(agent_id).await?;
-        let mut capability_ids: Vec<String> = capability_rows
+        // Collect capability IDs: harness caps first, then agent, then session
+        let harness_cap_rows = self.db.get_harness_capabilities(harness_id).await?;
+        let mut capability_ids: Vec<String> = harness_cap_rows
             .iter()
             .map(|r| r.capability_id.clone())
             .collect();
+
+        // Add agent's capability IDs
+        if let Some(agent_id) = agent_id {
+            let agent_cap_rows = self.db.get_agent_capabilities(agent_id).await?;
+            for r in &agent_cap_rows {
+                if !capability_ids.contains(&r.capability_id) {
+                    capability_ids.push(r.capability_id.clone());
+                }
+            }
+        }
 
         // Add session-level capabilities (additive)
         for cap in session_capabilities {
@@ -140,14 +167,14 @@ impl SessionService {
         if !result.is_success() {
             tracing::warn!(
                 session_id = %session_id,
-                agent_id = %agent_id,
+                agent_id = ?agent_id,
                 errors = ?result.errors,
                 "Some capability mounts failed to apply"
             );
         } else {
             tracing::debug!(
                 session_id = %session_id,
-                agent_id = %agent_id,
+                agent_id = ?agent_id,
                 files_created = result.files_created,
                 directories_created = result.directories_created,
                 mount_points = result.mount_points_applied,
@@ -274,13 +301,11 @@ impl SessionService {
     /// Resolve a session's agent_id from internal UUID to the agent's public_id.
     /// The DB stores the internal UUID as FK; the API should return the public_id.
     async fn resolve_session_agent_id(&self, org_id: i64, session: &mut Session) -> Result<()> {
-        if let Some(public_id) = self
-            .db
-            .get_agent_public_id(org_id, session.agent_id)
-            .await?
+        if let Some(aid) = session.agent_id
+            && let Some(public_id) = self.db.get_agent_public_id(org_id, aid).await?
             && let Ok(agent_id) = public_id.parse::<AgentId>()
         {
-            session.agent_id = agent_id;
+            session.agent_id = Some(agent_id);
         }
         Ok(())
     }
@@ -313,6 +338,7 @@ impl SessionService {
         Session {
             id: row.id,
             organization_id: org_public_id.to_string(),
+            harness_id: row.harness_id.unwrap_or_else(|| HarnessId::from_seed(1)),
             agent_id: row.agent_id,
             title: row.title,
             preview: None,        // Populated separately in list()

--- a/crates/server/src/services/usage_tracking.rs
+++ b/crates/server/src/services/usage_tracking.rs
@@ -67,16 +67,20 @@ impl EventListener for UsageTrackingListener {
         };
 
         // Get org_id from agent (sessions don't have direct org_id)
-        let org_id = match self.db.get_agent(DEFAULT_ORG_ID, session.agent_id).await {
-            Ok(Some(agent)) => agent.org_id,
-            Ok(None) => {
-                error!("Agent not found for usage tracking: {}", session.agent_id);
-                DEFAULT_ORG_ID
+        let org_id = if let Some(agent_id) = session.agent_id {
+            match self.db.get_agent(DEFAULT_ORG_ID, agent_id).await {
+                Ok(Some(agent)) => agent.org_id,
+                Ok(None) => {
+                    error!("Agent not found for usage tracking: {}", agent_id);
+                    DEFAULT_ORG_ID
+                }
+                Err(e) => {
+                    error!("Failed to get agent for usage tracking: {}", e);
+                    DEFAULT_ORG_ID
+                }
             }
-            Err(e) => {
-                error!("Failed to get agent for usage tracking: {}", e);
-                DEFAULT_ORG_ID
-            }
+        } else {
+            DEFAULT_ORG_ID
         };
 
         // Insert into llm_generations with org_id
@@ -121,17 +125,18 @@ impl EventListener for UsageTrackingListener {
             error!("Failed to update session usage: {}", e);
         }
 
-        // Update agent totals
-        if let Err(e) = self
-            .db
-            .increment_agent_usage(
-                session.agent_id.uuid(),
-                input_tokens,
-                output_tokens,
-                cache_read_tokens,
-                cache_creation_tokens,
-            )
-            .await
+        // Update agent totals (skip if no agent)
+        if let Some(agent_id) = session.agent_id
+            && let Err(e) = self
+                .db
+                .increment_agent_usage(
+                    agent_id.uuid(),
+                    input_tokens,
+                    output_tokens,
+                    cache_read_tokens,
+                    cache_creation_tokens,
+                )
+                .await
         {
             error!("Failed to update agent usage: {}", e);
         }

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -6,7 +6,7 @@
 
 use anyhow::Result;
 use everruns_core::message_filter::MessageQuery;
-use everruns_core::typed_id::{AgentId, EventId, SessionId};
+use everruns_core::typed_id::{AgentId, EventId, HarnessId, SessionId};
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -216,6 +216,44 @@ impl StorageBackend {
 
     pub async fn get_agent_public_id(&self, org_id: i64, id: AgentId) -> Result<Option<String>> {
         dispatch!(self, get_agent_public_id, org_id, id)
+    }
+
+    // ============================================
+    // Harnesses
+    // ============================================
+
+    pub async fn create_harness(&self, org_id: i64, input: CreateHarnessRow) -> Result<HarnessRow> {
+        dispatch!(self, create_harness, org_id, input)
+    }
+
+    pub async fn create_harness_with_id(
+        &self,
+        org_id: i64,
+        id: HarnessId,
+        input: CreateHarnessRow,
+    ) -> Result<Option<HarnessRow>> {
+        dispatch!(self, create_harness_with_id, org_id, id, input)
+    }
+
+    pub async fn get_harness(&self, org_id: i64, id: HarnessId) -> Result<Option<HarnessRow>> {
+        dispatch!(self, get_harness, org_id, id)
+    }
+
+    pub async fn list_harnesses(&self, org_id: i64) -> Result<Vec<HarnessRow>> {
+        dispatch!(self, list_harnesses, org_id)
+    }
+
+    pub async fn update_harness(
+        &self,
+        org_id: i64,
+        id: HarnessId,
+        input: UpdateHarness,
+    ) -> Result<Option<HarnessRow>> {
+        dispatch!(self, update_harness, org_id, id, input)
+    }
+
+    pub async fn delete_harness(&self, org_id: i64, id: HarnessId) -> Result<bool> {
+        dispatch!(self, delete_harness, org_id, id)
     }
 
     // ============================================
@@ -484,6 +522,25 @@ impl StorageBackend {
         capability_id: &str,
     ) -> Result<bool> {
         dispatch!(self, remove_agent_capability, agent_id, capability_id)
+    }
+
+    // ============================================
+    // Harness Capabilities
+    // ============================================
+
+    pub async fn get_harness_capabilities(
+        &self,
+        harness_id: Uuid,
+    ) -> Result<Vec<HarnessCapabilityRow>> {
+        dispatch!(self, get_harness_capabilities, harness_id)
+    }
+
+    pub async fn set_harness_capabilities(
+        &self,
+        harness_id: Uuid,
+        capabilities: Vec<(String, i32, serde_json::Value)>,
+    ) -> Result<Vec<HarnessCapabilityRow>> {
+        dispatch!(self, set_harness_capabilities, harness_id, capabilities)
     }
 
     // ============================================

--- a/crates/server/src/storage/harness_store.rs
+++ b/crates/server/src/storage/harness_store.rs
@@ -1,0 +1,81 @@
+// Database-backed HarnessStore implementation
+//
+// Implements the core HarnessStore trait for retrieving
+// harness configurations from the database.
+
+use async_trait::async_trait;
+use everruns_core::{
+    AgentCapabilityConfig, AgentLoopError, DEFAULT_ORG_ID, HarnessId, Result,
+    harness::{Harness, HarnessStatus},
+    traits::HarnessStore,
+};
+
+use super::repositories::Database;
+
+// ============================================================================
+// DbHarnessStore - Retrieves harnesses from the database
+// ============================================================================
+
+/// Database-backed harness store
+///
+/// Retrieves harness configurations from the database.
+/// Used by ReasonAtom to load harness data during workflow execution.
+#[derive(Clone)]
+pub struct DbHarnessStore {
+    db: Database,
+}
+
+impl DbHarnessStore {
+    pub fn new(db: Database) -> Self {
+        Self { db }
+    }
+}
+
+#[async_trait]
+impl HarnessStore for DbHarnessStore {
+    async fn get_harness(&self, harness_id: HarnessId) -> Result<Option<Harness>> {
+        let harness_row = self
+            .db
+            .get_harness(DEFAULT_ORG_ID, harness_id)
+            .await
+            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+
+        match harness_row {
+            Some(row) => {
+                let capability_rows = self
+                    .db
+                    .get_harness_capabilities(harness_id.uuid())
+                    .await
+                    .map_err(|e| AgentLoopError::store(e.to_string()))?;
+
+                let capabilities: Vec<AgentCapabilityConfig> = capability_rows
+                    .into_iter()
+                    .map(|c| AgentCapabilityConfig::with_config(c.capability_id, c.config))
+                    .collect();
+
+                Ok(Some(Harness {
+                    id: row.id,
+                    name: row.name,
+                    description: row.description,
+                    system_prompt: row.system_prompt,
+                    default_model_id: row.default_model_id,
+                    tags: row.tags,
+                    capabilities,
+                    status: HarnessStatus::from(row.status.as_str()),
+                    created_at: row.created_at,
+                    updated_at: row.updated_at,
+                }))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+// ============================================================================
+// Factory functions
+// ============================================================================
+
+/// Create a database-backed harness store
+pub fn create_db_harness_store(db: Database) -> DbHarnessStore {
+    DbHarnessStore::new(db)
+}

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -9,8 +9,8 @@ use anyhow::{Result, anyhow};
 use chrono::{DateTime, Utc};
 use everruns_core::message_filter::{MessageFilter, MessageQuery};
 use everruns_core::{
-    AgentId, DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, EventId, ImageId, McpServerId, ModelId,
-    ProviderId, SessionId,
+    AgentId, DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, EventId, HarnessId, ImageId, McpServerId,
+    ModelId, ProviderId, SessionId,
 };
 use parking_lot::RwLock;
 use std::collections::HashMap;
@@ -35,6 +35,8 @@ pub struct InMemoryDatabase {
     llm_providers: RwLock<HashMap<ProviderId, LlmProviderRow>>,
     llm_models: RwLock<HashMap<ModelId, LlmModelRow>>,
     agent_capabilities: RwLock<HashMap<(AgentId, String), AgentCapabilityRow>>,
+    harnesses: RwLock<HashMap<HarnessId, HarnessRow>>,
+    harness_capabilities: RwLock<HashMap<(HarnessId, String), HarnessCapabilityRow>>,
     session_files: RwLock<HashMap<Uuid, SessionFileRow>>,
     mcp_servers: RwLock<HashMap<McpServerId, McpServerRow>>,
     images: RwLock<HashMap<ImageId, ImageRow>>,
@@ -75,6 +77,8 @@ impl Default for InMemoryDatabase {
             llm_providers: RwLock::new(HashMap::new()),
             llm_models: RwLock::new(HashMap::new()),
             agent_capabilities: RwLock::new(HashMap::new()),
+            harnesses: RwLock::new(HashMap::new()),
+            harness_capabilities: RwLock::new(HashMap::new()),
             session_files: RwLock::new(HashMap::new()),
             mcp_servers: RwLock::new(HashMap::new()),
             images: RwLock::new(HashMap::new()),
@@ -533,6 +537,126 @@ impl InMemoryDatabase {
     }
 
     // ============================================
+    // Harnesses
+    // ============================================
+
+    pub async fn create_harness(&self, org_id: i64, input: CreateHarnessRow) -> Result<HarnessRow> {
+        let now = Self::now();
+        let id = HarnessId::new();
+        let row = HarnessRow {
+            id,
+            org_id,
+            name: input.name,
+            description: input.description,
+            system_prompt: input.system_prompt,
+            default_model_id: input.default_model_id,
+            tags: input.tags,
+            status: "active".to_string(),
+            created_at: now,
+            updated_at: now,
+        };
+        self.harnesses.write().insert(id, row.clone());
+        Ok(row)
+    }
+
+    /// Create harness with a specific ID, idempotent (returns None if exists)
+    pub async fn create_harness_with_id(
+        &self,
+        org_id: i64,
+        id: HarnessId,
+        input: CreateHarnessRow,
+    ) -> Result<Option<HarnessRow>> {
+        let mut harnesses = self.harnesses.write();
+        if harnesses.contains_key(&id) {
+            return Ok(None); // Already exists
+        }
+        let now = Self::now();
+        let row = HarnessRow {
+            id,
+            org_id,
+            name: input.name,
+            description: input.description,
+            system_prompt: input.system_prompt,
+            default_model_id: input.default_model_id,
+            tags: input.tags,
+            status: "active".to_string(),
+            created_at: now,
+            updated_at: now,
+        };
+        harnesses.insert(id, row.clone());
+        Ok(Some(row))
+    }
+
+    pub async fn get_harness(&self, org_id: i64, id: HarnessId) -> Result<Option<HarnessRow>> {
+        Ok(self
+            .harnesses
+            .read()
+            .get(&id)
+            .filter(|h| h.org_id == org_id)
+            .cloned())
+    }
+
+    pub async fn list_harnesses(&self, org_id: i64) -> Result<Vec<HarnessRow>> {
+        let harnesses = self.harnesses.read();
+        let mut result: Vec<_> = harnesses
+            .values()
+            .filter(|h| h.org_id == org_id && h.status == "active")
+            .cloned()
+            .collect();
+        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(result)
+    }
+
+    pub async fn update_harness(
+        &self,
+        org_id: i64,
+        id: HarnessId,
+        input: UpdateHarness,
+    ) -> Result<Option<HarnessRow>> {
+        let mut harnesses = self.harnesses.write();
+        if let Some(harness) = harnesses.get_mut(&id).filter(|h| h.org_id == org_id) {
+            if let Some(name) = input.name {
+                harness.name = name;
+            }
+            if let Some(description) = input.description {
+                harness.description = Some(description);
+            }
+            if let Some(system_prompt) = input.system_prompt {
+                harness.system_prompt = system_prompt;
+            }
+            if let Some(default_model_id) = input.default_model_id {
+                harness.default_model_id = Some(default_model_id);
+            }
+            if let Some(tags) = input.tags {
+                harness.tags = tags;
+            }
+            if let Some(status) = input.status {
+                harness.status = status;
+            }
+            harness.updated_at = Self::now();
+            return Ok(Some(harness.clone()));
+        }
+        Ok(None)
+    }
+
+    pub async fn delete_harness(&self, org_id: i64, id: HarnessId) -> Result<bool> {
+        // Delete capabilities first
+        {
+            let mut caps = self.harness_capabilities.write();
+            let to_remove: Vec<_> = caps.keys().filter(|(hid, _)| *hid == id).cloned().collect();
+            for key in to_remove {
+                caps.remove(&key);
+            }
+        }
+        // Only delete if org_id matches
+        let mut harnesses = self.harnesses.write();
+        if harnesses.get(&id).map(|h| h.org_id) == Some(org_id) {
+            return Ok(harnesses.remove(&id).is_some());
+        }
+        Ok(false)
+    }
+
+    // ============================================
     // Sessions
     // ============================================
 
@@ -542,6 +666,7 @@ impl InMemoryDatabase {
         let row = SessionRow {
             id,
             org_id: input.org_id,
+            harness_id: input.harness_id,
             agent_id: input.agent_id,
             title: input.title,
             tags: input.tags,
@@ -601,7 +726,7 @@ impl InMemoryDatabase {
                 // Filter by org_id
                 s.org_id == org_id
                     // Optionally filter by agent_id
-                    && agent_id.is_none_or(|aid| s.agent_id == aid)
+                    && agent_id.is_none_or(|aid| s.agent_id == Some(aid))
             })
             .cloned()
             .collect();
@@ -1515,6 +1640,62 @@ impl InMemoryDatabase {
             .write()
             .remove(&(agent_id, capability_id.to_string()))
             .is_some())
+    }
+
+    // ============================================
+    // Harness Capabilities
+    // ============================================
+
+    pub async fn get_harness_capabilities(
+        &self,
+        harness_id: Uuid,
+    ) -> Result<Vec<HarnessCapabilityRow>> {
+        let harness_id = HarnessId::from_uuid(harness_id);
+        let caps = self.harness_capabilities.read();
+        let mut result: Vec<_> = caps
+            .iter()
+            .filter(|((hid, _), _)| *hid == harness_id)
+            .map(|(_, c)| c.clone())
+            .collect();
+        result.sort_by_key(|c| c.position);
+        Ok(result)
+    }
+
+    pub async fn set_harness_capabilities(
+        &self,
+        harness_id: Uuid,
+        capabilities: Vec<(String, i32, serde_json::Value)>,
+    ) -> Result<Vec<HarnessCapabilityRow>> {
+        let harness_id = HarnessId::from_uuid(harness_id);
+        let now = Self::now();
+        let mut caps = self.harness_capabilities.write();
+
+        // Remove existing capabilities for this harness
+        let to_remove: Vec<_> = caps
+            .keys()
+            .filter(|(hid, _)| *hid == harness_id)
+            .cloned()
+            .collect();
+        for key in to_remove {
+            caps.remove(&key);
+        }
+
+        // Add new capabilities
+        let mut result = Vec::new();
+        for (capability_id, position, config) in capabilities.into_iter() {
+            let row = HarnessCapabilityRow {
+                id: Uuid::now_v7(),
+                harness_id,
+                capability_id: capability_id.clone(),
+                position,
+                config,
+                created_at: now,
+            };
+            caps.insert((harness_id, capability_id), row.clone());
+            result.push(row);
+        }
+
+        Ok(result)
     }
 
     // ============================================
@@ -2454,7 +2635,8 @@ mod tests {
         let session = db
             .create_session(CreateSessionRow {
                 org_id: DEFAULT_ORG_ID,
-                agent_id: agent.id,
+                harness_id: None,
+                agent_id: Some(agent.id),
                 title: Some("Test Session".to_string()),
                 tags: vec![],
                 model_id: None,
@@ -2498,7 +2680,8 @@ mod tests {
         let session = db
             .create_session(CreateSessionRow {
                 org_id: DEFAULT_ORG_ID,
-                agent_id: agent.id,
+                harness_id: None,
+                agent_id: Some(agent.id),
                 title: Some("Test Session".to_string()),
                 tags: vec![],
                 model_id: None,
@@ -2557,7 +2740,8 @@ mod tests {
         let session = db
             .create_session(CreateSessionRow {
                 org_id: DEFAULT_ORG_ID,
-                agent_id: agent.id,
+                harness_id: None,
+                agent_id: Some(agent.id),
                 title: None,
                 tags: vec![],
                 model_id: None,
@@ -2613,7 +2797,8 @@ mod tests {
         for i in 0..15 {
             db.create_session(CreateSessionRow {
                 org_id: DEFAULT_ORG_ID,
-                agent_id: agent.id,
+                harness_id: None,
+                agent_id: Some(agent.id),
                 title: Some(format!("Session {}", i)),
                 tags: vec![],
                 model_id: None,
@@ -2694,7 +2879,8 @@ mod tests {
         for i in 1..=5 {
             db.create_session(CreateSessionRow {
                 org_id: DEFAULT_ORG_ID,
-                agent_id: agent.id,
+                harness_id: None,
+                agent_id: Some(agent.id),
                 title: Some(format!("Session {}", i)),
                 tags: vec![],
                 model_id: None,

--- a/crates/server/src/storage/mod.rs
+++ b/crates/server/src/storage/mod.rs
@@ -12,6 +12,7 @@
 pub mod agent_store;
 pub mod backend;
 pub mod encryption;
+pub mod harness_store;
 pub mod llm_provider_store;
 pub mod memory;
 pub mod message_store;
@@ -31,6 +32,7 @@ pub use encryption::{
     ENCRYPTED_COLUMNS, EncryptedColumn, EncryptedPayload, EncryptionService,
     generate_encryption_key,
 };
+pub use harness_store::{DbHarnessStore, create_db_harness_store};
 pub use llm_provider_store::{DbLlmProviderStore, create_db_llm_provider_store};
 pub use memory::InMemoryDatabase;
 pub use message_store::{DbMessageRetriever, create_db_message_retriever};

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -1,7 +1,9 @@
 // Database models (internal, may differ from public DTOs)
 
 use chrono::{DateTime, Utc};
-use everruns_core::{AgentId, EventId, ImageId, McpServerId, ModelId, ProviderId, SessionId};
+use everruns_core::{
+    AgentId, EventId, HarnessId, ImageId, McpServerId, ModelId, ProviderId, SessionId,
+};
 use sqlx::FromRow;
 use uuid::Uuid;
 
@@ -219,6 +221,61 @@ pub struct UpdateAgent {
 }
 
 // ============================================
+// Harness models (base configuration for sessions)
+// ============================================
+
+#[derive(Debug, Clone, FromRow)]
+pub struct HarnessRow {
+    pub id: HarnessId,
+    pub org_id: i64,
+    pub name: String,
+    pub description: Option<String>,
+    pub system_prompt: String,
+    pub default_model_id: Option<ModelId>,
+    pub tags: Vec<String>,
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateHarnessRow {
+    pub name: String,
+    pub description: Option<String>,
+    pub system_prompt: String,
+    pub default_model_id: Option<ModelId>,
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct UpdateHarness {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub system_prompt: Option<String>,
+    pub default_model_id: Option<ModelId>,
+    pub tags: Option<Vec<String>>,
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Clone, FromRow)]
+pub struct HarnessCapabilityRow {
+    pub id: Uuid,
+    pub harness_id: HarnessId,
+    pub capability_id: String,
+    pub position: i32,
+    pub config: serde_json::Value,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateHarnessCapabilityRow {
+    pub harness_id: HarnessId,
+    pub capability_id: String,
+    pub position: i32,
+    pub config: serde_json::Value,
+}
+
+// ============================================
 // Session models (instance of agentic loop)
 // ============================================
 
@@ -226,7 +283,9 @@ pub struct UpdateAgent {
 pub struct SessionRow {
     pub id: SessionId,
     pub org_id: i64,
-    pub agent_id: AgentId,
+    #[sqlx(default)]
+    pub harness_id: Option<HarnessId>,
+    pub agent_id: Option<AgentId>,
     pub title: Option<String>,
     pub tags: Vec<String>,
     pub model_id: Option<ModelId>,
@@ -258,7 +317,8 @@ pub struct SessionRow {
 #[derive(Debug, Clone)]
 pub struct CreateSessionRow {
     pub org_id: i64,
-    pub agent_id: AgentId,
+    pub harness_id: Option<HarnessId>,
+    pub agent_id: Option<AgentId>,
     pub title: Option<String>,
     pub tags: Vec<String>,
     pub model_id: Option<ModelId>,

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -4,7 +4,7 @@
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use everruns_core::message_filter::{MessageFilter, MessageQuery};
-use everruns_core::typed_id::{AgentId, EventId, SessionId};
+use everruns_core::typed_id::{AgentId, EventId, HarnessId, SessionId};
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -562,20 +562,158 @@ impl Database {
     }
 
     // ============================================
+    // Harnesses (base configuration for sessions)
+    // ============================================
+
+    pub async fn create_harness(&self, org_id: i64, input: CreateHarnessRow) -> Result<HarnessRow> {
+        let row = sqlx::query_as::<_, HarnessRow>(
+            r#"
+            INSERT INTO harnesses (org_id, name, description, system_prompt, default_model_id, tags, status)
+            VALUES ($1, $2, $3, $4, $5, $6, 'active')
+            RETURNING id, org_id, name, description, system_prompt, default_model_id, tags, status, created_at, updated_at
+            "#,
+        )
+        .bind(org_id)
+        .bind(&input.name)
+        .bind(&input.description)
+        .bind(&input.system_prompt)
+        .bind(input.default_model_id.map(|m| m.uuid()))
+        .bind(&input.tags)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    /// Create harness with a specific ID, idempotent (ON CONFLICT DO NOTHING)
+    /// Returns None if harness already exists with this ID
+    pub async fn create_harness_with_id(
+        &self,
+        org_id: i64,
+        id: HarnessId,
+        input: CreateHarnessRow,
+    ) -> Result<Option<HarnessRow>> {
+        let row = sqlx::query_as::<_, HarnessRow>(
+            r#"
+            INSERT INTO harnesses (id, org_id, name, description, system_prompt, default_model_id, tags, status)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, 'active')
+            ON CONFLICT (id) DO NOTHING
+            RETURNING id, org_id, name, description, system_prompt, default_model_id, tags, status, created_at, updated_at
+            "#,
+        )
+        .bind(id.uuid())
+        .bind(org_id)
+        .bind(&input.name)
+        .bind(&input.description)
+        .bind(&input.system_prompt)
+        .bind(input.default_model_id.map(|m| m.uuid()))
+        .bind(&input.tags)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    pub async fn get_harness(&self, org_id: i64, id: HarnessId) -> Result<Option<HarnessRow>> {
+        let row = sqlx::query_as::<_, HarnessRow>(
+            r#"
+            SELECT id, org_id, name, description, system_prompt, default_model_id, tags, status, created_at, updated_at
+            FROM harnesses
+            WHERE org_id = $1 AND id = $2
+            "#,
+        )
+        .bind(org_id)
+        .bind(id.uuid())
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    pub async fn list_harnesses(&self, org_id: i64) -> Result<Vec<HarnessRow>> {
+        let rows = sqlx::query_as::<_, HarnessRow>(
+            r#"
+            SELECT id, org_id, name, description, system_prompt, default_model_id, tags, status, created_at, updated_at
+            FROM harnesses
+            WHERE org_id = $1 AND status = 'active'
+            ORDER BY created_at DESC
+            "#,
+        )
+        .bind(org_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+
+    pub async fn update_harness(
+        &self,
+        org_id: i64,
+        id: HarnessId,
+        input: UpdateHarness,
+    ) -> Result<Option<HarnessRow>> {
+        let row = sqlx::query_as::<_, HarnessRow>(
+            r#"
+            UPDATE harnesses
+            SET
+                name = COALESCE($3, name),
+                description = COALESCE($4, description),
+                system_prompt = COALESCE($5, system_prompt),
+                default_model_id = COALESCE($6, default_model_id),
+                tags = COALESCE($7, tags),
+                status = COALESCE($8, status),
+                updated_at = NOW()
+            WHERE org_id = $1 AND id = $2
+            RETURNING id, org_id, name, description, system_prompt, default_model_id, tags, status, created_at, updated_at
+            "#,
+        )
+        .bind(org_id)
+        .bind(id.uuid())
+        .bind(&input.name)
+        .bind(&input.description)
+        .bind(&input.system_prompt)
+        .bind(input.default_model_id.map(|m| m.uuid()))
+        .bind(&input.tags)
+        .bind(&input.status)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    pub async fn delete_harness(&self, org_id: i64, id: HarnessId) -> Result<bool> {
+        // Archive instead of hard delete
+        let result = sqlx::query(
+            r#"
+            UPDATE harnesses
+            SET status = 'archived', updated_at = NOW()
+            WHERE org_id = $1 AND id = $2 AND status = 'active'
+            "#,
+        )
+        .bind(org_id)
+        .bind(id.uuid())
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    // ============================================
     // Sessions (instance of agentic loop)
     // ============================================
 
     pub async fn create_session(&self, input: CreateSessionRow) -> Result<SessionRow> {
         let row = sqlx::query_as::<_, SessionRow>(
             r#"
-            INSERT INTO sessions (org_id, agent_id, title, tags, model_id, capabilities, tools, status)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, 'started')
-            RETURNING id, org_id, agent_id, title, tags, model_id, capabilities, tools, status, created_at, updated_at, started_at, finished_at,
+            INSERT INTO sessions (org_id, harness_id, agent_id, title, tags, model_id, capabilities, tools, status)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'started')
+            RETURNING id, org_id, harness_id, agent_id, title, tags, model_id, capabilities, tools, status, created_at, updated_at, started_at, finished_at,
                       total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens
             "#,
         )
         .bind(input.org_id)
-        .bind(input.agent_id)
+        .bind(input.harness_id.map(|h| h.uuid()))
+        .bind(input.agent_id.map(|a| a.uuid()))
         .bind(&input.title)
         .bind(&input.tags)
         .bind(input.model_id)
@@ -591,7 +729,7 @@ impl Database {
     pub async fn get_session(&self, org_id: i64, id: SessionId) -> Result<Option<SessionRow>> {
         let row = sqlx::query_as::<_, SessionRow>(
             r#"
-            SELECT id, org_id, agent_id, title, tags, model_id, capabilities, tools, status, created_at, updated_at, started_at, finished_at,
+            SELECT id, org_id, harness_id, agent_id, title, tags, model_id, capabilities, tools, status, created_at, updated_at, started_at, finished_at,
                    total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens
             FROM sessions
             WHERE org_id = $1 AND id = $2
@@ -643,7 +781,7 @@ impl Database {
         let rows = if let Some(aid) = agent_id {
             sqlx::query_as::<_, SessionRow>(
                 r#"
-                SELECT id, org_id, agent_id, title, tags, model_id, capabilities, status, created_at, updated_at, started_at, finished_at,
+                SELECT id, org_id, harness_id, agent_id, title, tags, model_id, capabilities, tools, status, created_at, updated_at, started_at, finished_at,
                        total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens
                 FROM sessions
                 WHERE org_id = $1 AND agent_id = $2
@@ -660,7 +798,7 @@ impl Database {
         } else {
             sqlx::query_as::<_, SessionRow>(
                 r#"
-                SELECT id, org_id, agent_id, title, tags, model_id, capabilities, status, created_at, updated_at, started_at, finished_at,
+                SELECT id, org_id, harness_id, agent_id, title, tags, model_id, capabilities, tools, status, created_at, updated_at, started_at, finished_at,
                        total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens
                 FROM sessions
                 WHERE org_id = $1
@@ -697,7 +835,7 @@ impl Database {
                 started_at = COALESCE($7, started_at),
                 finished_at = COALESCE($8, finished_at)
             WHERE org_id = $1 AND id = $2
-            RETURNING id, org_id, agent_id, title, tags, model_id, capabilities, tools, status, created_at, updated_at, started_at, finished_at,
+            RETURNING id, org_id, harness_id, agent_id, title, tags, model_id, capabilities, tools, status, created_at, updated_at, started_at, finished_at,
                       total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens
             "#,
         )
@@ -1622,6 +1760,64 @@ impl Database {
         .await?;
 
         Ok(result.rows_affected() > 0)
+    }
+
+    // ============================================
+    // Harness Capabilities
+    // ============================================
+
+    /// Get capabilities for a harness, ordered by position
+    pub async fn get_harness_capabilities(
+        &self,
+        harness_id: Uuid,
+    ) -> Result<Vec<HarnessCapabilityRow>> {
+        let rows = sqlx::query_as::<_, HarnessCapabilityRow>(
+            r#"
+            SELECT id, harness_id, capability_id, position, config, created_at
+            FROM harness_capabilities
+            WHERE harness_id = $1
+            ORDER BY position ASC
+            "#,
+        )
+        .bind(harness_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+
+    /// Set capabilities for a harness (replaces existing capabilities)
+    /// capabilities: list of (capability_id, position, config) tuples
+    pub async fn set_harness_capabilities(
+        &self,
+        harness_id: Uuid,
+        capabilities: Vec<(String, i32, serde_json::Value)>,
+    ) -> Result<Vec<HarnessCapabilityRow>> {
+        let mut tx = self.pool.begin().await?;
+
+        sqlx::query("DELETE FROM harness_capabilities WHERE harness_id = $1")
+            .bind(harness_id)
+            .execute(&mut *tx)
+            .await?;
+
+        for (capability_id, position, config) in &capabilities {
+            sqlx::query(
+                r#"
+                INSERT INTO harness_capabilities (harness_id, capability_id, position, config)
+                VALUES ($1, $2, $3, $4)
+                "#,
+            )
+            .bind(harness_id)
+            .bind(capability_id)
+            .bind(position)
+            .bind(config)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        tx.commit().await?;
+
+        self.get_harness_capabilities(harness_id).await
     }
 
     // ============================================

--- a/crates/server/src/storage/session_store.rs
+++ b/crates/server/src/storage/session_store.rs
@@ -5,7 +5,8 @@
 
 use async_trait::async_trait;
 use everruns_core::{
-    AgentLoopError, DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, Result, SessionId, TokenUsage,
+    AgentLoopError, DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, HarnessId, Result, SessionId,
+    TokenUsage,
     session::{Session, SessionStatus},
     traits::SessionStore,
 };
@@ -69,6 +70,7 @@ impl SessionStore for DbSessionStore {
                 Ok(Some(Session {
                     id: row.id,
                     organization_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
+                    harness_id: row.harness_id.unwrap_or_else(|| HarnessId::from_seed(1)),
                     agent_id: row.agent_id,
                     title: row.title,
                     preview: None, // Preview populated separately when listing sessions

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -19,6 +19,9 @@ use test_harness::TestServer;
 use everruns_core::llm_models::LlmProvider;
 use everruns_core::{Agent, LlmModel, Session, SessionFile};
 
+/// Seed harness ID from seed.rs (DEFAULT_HARNESS = 0x01933b5a_0000_7000_8000_000000000601)
+const SEED_HARNESS_ID: &str = "harness_01933b5a000070008000000000000601";
+
 // ============================================
 // Health Endpoint Tests
 // ============================================
@@ -211,6 +214,7 @@ async fn test_create_session() {
         .post(
             "/v1/sessions",
             json!({
+                "harness_id": SEED_HARNESS_ID,
                 "agent_id": agent.public_id,
                 "title": "Test Session"
             }),
@@ -219,7 +223,7 @@ async fn test_create_session() {
         .assert_status(StatusCode::CREATED)
         .json();
 
-    assert_eq!(session.agent_id, agent.public_id);
+    assert_eq!(session.agent_id, Some(agent.public_id));
     assert_eq!(session.title.as_deref(), Some("Test Session"));
 }
 
@@ -244,6 +248,7 @@ async fn test_get_session() {
         .post(
             "/v1/sessions",
             json!({
+                "harness_id": SEED_HARNESS_ID,
                 "agent_id": agent.public_id,
                 "title": "Get Test Session"
             }),
@@ -285,6 +290,7 @@ async fn test_sessions_pagination() {
             .post(
                 "/v1/sessions",
                 json!({
+                    "harness_id": SEED_HARNESS_ID,
                     "agent_id": agent.public_id,
                     "title": format!("Session {}", i)
                 }),
@@ -352,6 +358,7 @@ async fn test_create_user_message() {
         .post(
             "/v1/sessions",
             json!({
+                "harness_id": SEED_HARNESS_ID,
                 "agent_id": agent.public_id
             }),
         )
@@ -398,6 +405,7 @@ async fn test_list_messages() {
         .post(
             "/v1/sessions",
             json!({
+                "harness_id": SEED_HARNESS_ID,
                 "agent_id": agent.public_id
             }),
         )
@@ -456,6 +464,7 @@ async fn test_list_events() {
         .post(
             "/v1/sessions",
             json!({
+                "harness_id": SEED_HARNESS_ID,
                 "agent_id": agent.public_id
             }),
         )
@@ -633,6 +642,7 @@ async fn test_session_inherits_agent_default_model() {
         .post(
             "/v1/sessions",
             json!({
+                "harness_id": SEED_HARNESS_ID,
                 "agent_id": agent.public_id,
                 "title": "Inheritance Test"
             }),
@@ -684,6 +694,7 @@ async fn test_session_filesystem() {
         .post(
             "/v1/sessions",
             json!({
+                "harness_id": SEED_HARNESS_ID,
                 "agent_id": agent.public_id
             }),
         )
@@ -834,6 +845,7 @@ async fn test_session_databases_crud() {
         .post(
             "/v1/sessions",
             json!({
+                "harness_id": SEED_HARNESS_ID,
                 "agent_id": agent.public_id.to_string()
             }),
         )
@@ -936,7 +948,7 @@ async fn test_session_databases_schema() {
     let session: Session = server
         .post(
             "/v1/sessions",
-            json!({"agent_id": agent.public_id.to_string()}),
+            json!({"harness_id": SEED_HARNESS_ID, "agent_id": agent.public_id.to_string()}),
         )
         .await
         .assert_status(StatusCode::CREATED)
@@ -990,7 +1002,7 @@ async fn test_session_databases_invalid_name() {
     let session: Session = server
         .post(
             "/v1/sessions",
-            json!({"agent_id": agent.public_id.to_string()}),
+            json!({"harness_id": SEED_HARNESS_ID, "agent_id": agent.public_id.to_string()}),
         )
         .await
         .assert_status(StatusCode::CREATED)

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -180,7 +180,8 @@ async fn test_session_crud() {
     let session = backend
         .create_session(CreateSessionRow {
             org_id: TEST_ORG_ID,
-            agent_id: agent.id,
+            harness_id: None,
+            agent_id: Some(agent.id),
             title: Some("Test Session".to_string()),
             tags: vec![],
             model_id: None,
@@ -190,7 +191,7 @@ async fn test_session_crud() {
         .await
         .expect("Failed to create session");
 
-    assert_eq!(session.agent_id, agent.id);
+    assert_eq!(session.agent_id, Some(agent.id));
 
     // Get session
     let fetched = backend
@@ -269,7 +270,8 @@ async fn test_event_crud() {
     let session = backend
         .create_session(CreateSessionRow {
             org_id: TEST_ORG_ID,
-            agent_id: agent.id,
+            harness_id: None,
+            agent_id: Some(agent.id),
             title: None,
             tags: vec![],
             model_id: None,
@@ -340,7 +342,8 @@ async fn test_event_exclude_types() {
     let session = backend
         .create_session(CreateSessionRow {
             org_id: TEST_ORG_ID,
-            agent_id: agent.id,
+            harness_id: None,
+            agent_id: Some(agent.id),
             title: None,
             tags: vec![],
             model_id: None,
@@ -575,7 +578,8 @@ async fn test_session_file_crud() {
     let session = backend
         .create_session(CreateSessionRow {
             org_id: TEST_ORG_ID,
-            agent_id: agent.id,
+            harness_id: None,
+            agent_id: Some(agent.id),
             title: None,
             tags: vec![],
             model_id: None,
@@ -946,7 +950,8 @@ async fn test_session_usage_tracking() {
     let session = backend
         .create_session(CreateSessionRow {
             org_id: TEST_ORG_ID,
-            agent_id: agent.id,
+            harness_id: None,
+            agent_id: Some(agent.id),
             title: None,
             tags: vec![],
             model_id: None,
@@ -1023,7 +1028,8 @@ async fn test_session_previews() {
     let session = backend
         .create_session(CreateSessionRow {
             org_id: TEST_ORG_ID,
-            agent_id: agent.id,
+            harness_id: None,
+            agent_id: Some(agent.id),
             title: None,
             tags: vec![],
             model_id: None,

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -33,7 +33,7 @@ use everruns_durable::{
     InMemoryWorkflowEventStore, PostgresWorkflowEventStore, WorkflowEventStore,
 };
 use everruns_server::{
-    api, auth, services,
+    api, auth, seed, services,
     storage::{EncryptionService, StorageBackend},
 };
 use everruns_worker::{RunnerBackend, create_driver_registry, create_runner_with_backend};
@@ -96,6 +96,12 @@ impl TestServer {
             }
         };
 
+        // Seed default data synchronously (harnesses, agents, providers, etc.)
+        let grade = everruns_core::DeploymentGrade::from_env();
+        seed::seed_all(&db, grade)
+            .await
+            .expect("Failed to seed test data");
+
         // Initialize encryption service (use test key)
         let encryption = Some(Arc::new(
             EncryptionService::new("kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=", &[])
@@ -152,6 +158,11 @@ impl TestServer {
         ));
         let capabilities_state =
             api::capabilities::AppState::new(capability_service.clone(), auth_state.clone());
+        let harnesses_state = api::harnesses::AppState::new(
+            db.clone(),
+            capability_service.clone(),
+            auth_state.clone(),
+        );
         let agents_state =
             api::agents::AppState::new(db.clone(), capability_service, auth_state.clone());
         let session_files_state = api::session_files::AppState::new(db.clone(), auth_state.clone());
@@ -175,6 +186,7 @@ impl TestServer {
         // Build API routes
         let api_routes = Router::new()
             .merge(api::agents::routes(agents_state))
+            .merge(api::harnesses::routes(harnesses_state))
             .merge(api::sessions::routes(sessions_state))
             .merge(api::messages::routes(messages_state))
             .merge(api::events::routes(events_state))

--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -23,6 +23,9 @@ const API_BASE_URL: &str = "http://localhost:9000";
 // Note: With AUTH_MODE=none, org is derived from the anonymous user's default org.
 // No cookie or header needed for integration tests.
 
+/// Seed harness ID from seed.rs (DEFAULT_HARNESS = 0x01933b5a_0000_7000_8000_000000000601)
+const SEED_HARNESS_ID: &str = "harness_01933b5a000070008000000000000601";
+
 #[tokio::test]
 async fn test_full_agent_session_workflow() {
     let client = reqwest::Client::new();
@@ -109,6 +112,7 @@ async fn test_full_agent_session_workflow() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({
+            "harness_id": SEED_HARNESS_ID,
             "agent_id": agent.public_id,
             "title": "Test Session"
         }))
@@ -122,7 +126,7 @@ async fn test_full_agent_session_workflow() {
         .await
         .expect("Failed to parse session");
     println!("Created session: {}", session.id);
-    assert_eq!(session.agent_id, agent.public_id);
+    assert_eq!(session.agent_id, Some(agent.public_id));
 
     // Step 6: Add message (user message)
     println!("\nStep 6: Adding user message...");
@@ -502,6 +506,7 @@ async fn test_session_inherits_agent_default_model() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({
+            "harness_id": SEED_HARNESS_ID,
             "agent_id": agent.public_id,
             "title": "Test Session"
         }))
@@ -552,6 +557,7 @@ async fn test_session_inherits_agent_default_model() {
     let session2_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({
+            "harness_id": SEED_HARNESS_ID,
             "agent_id": agent.public_id,
             "title": "Test Session 2",
             "model_id": model2.id.to_string()
@@ -629,6 +635,7 @@ async fn test_session_filesystem() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({
+            "harness_id": SEED_HARNESS_ID,
             "agent_id": agent.public_id,
             "title": "Filesystem Test Session"
         }))
@@ -878,6 +885,7 @@ async fn test_session_filesystem_workspace_prefix() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({
+            "harness_id": SEED_HARNESS_ID,
             "agent_id": agent.public_id,
             "title": "Workspace Test Session"
         }))
@@ -1090,7 +1098,7 @@ async fn test_agent_filesystem_and_bash_workspace_integration() {
     println!("\nStep 3: Creating session...");
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
-        .json(&json!({"agent_id": agent.public_id, "title": "FS Bash Integration Test"}))
+        .json(&json!({"harness_id": SEED_HARNESS_ID, "agent_id": agent.public_id, "title": "FS Bash Integration Test"}))
         .send()
         .await
         .expect("Failed to create session");
@@ -1346,7 +1354,7 @@ async fn test_message_triggers_agent_workflow() {
     println!("\nStep 2: Creating session...");
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
-        .json(&json!({"agent_id": agent.public_id, "title": "Workflow Test Session"}))
+        .json(&json!({"harness_id": SEED_HARNESS_ID, "agent_id": agent.public_id, "title": "Workflow Test Session"}))
         .send()
         .await
         .expect("Failed to create session");
@@ -1624,7 +1632,7 @@ async fn test_no_duplicate_tool_calls() {
     println!("\nStep 4: Creating session...");
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
-        .json(&json!({"agent_id": agent.public_id}))
+        .json(&json!({"harness_id": SEED_HARNESS_ID, "agent_id": agent.public_id}))
         .send()
         .await
         .expect("Failed to create session");
@@ -1823,7 +1831,7 @@ async fn test_sessions_pagination() {
     for i in 1..=15 {
         let response = client
             .post(format!("{}/v1/sessions", API_BASE_URL))
-            .json(&json!({ "agent_id": agent.public_id, "title": format!("Session {}", i) }))
+            .json(&json!({ "harness_id": SEED_HARNESS_ID, "agent_id": agent.public_id, "title": format!("Session {}", i) }))
             .send()
             .await
             .expect("Failed to create session");
@@ -2066,7 +2074,7 @@ async fn test_second_message_triggers_workflow() {
     println!("\nStep 2: Creating session...");
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
-        .json(&json!({"agent_id": agent.public_id, "title": "Second Message Test Session"}))
+        .json(&json!({"harness_id": SEED_HARNESS_ID, "agent_id": agent.public_id, "title": "Second Message Test Session"}))
         .send()
         .await
         .expect("Failed to create session");
@@ -2350,6 +2358,7 @@ async fn test_capability_mounts_applied_on_session_creation() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({
+            "harness_id": SEED_HARNESS_ID,
             "agent_id": agent.public_id,
             "title": "Mount Test Session"
         }))
@@ -2470,6 +2479,7 @@ async fn test_capability_mounts_applied_on_session_creation() {
     let session2_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({
+            "harness_id": SEED_HARNESS_ID,
             "agent_id": agent.public_id,
             "title": "Second Mount Test Session"
         }))
@@ -2885,7 +2895,7 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
     println!("\nStep 3: Creating session...");
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
-        .json(&json!({"agent_id": agent.public_id, "title": "Dad Jokes Session"}))
+        .json(&json!({"harness_id": SEED_HARNESS_ID, "agent_id": agent.public_id, "title": "Dad Jokes Session"}))
         .send()
         .await
         .expect("Failed to create session");
@@ -3176,7 +3186,7 @@ async fn test_agent_execution_openai_with_tool_calls() {
     println!("\nStep 3: Creating session...");
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
-        .json(&json!({"agent_id": agent.public_id, "title": "OpenAI Dad Jokes Session"}))
+        .json(&json!({"harness_id": SEED_HARNESS_ID, "agent_id": agent.public_id, "title": "OpenAI Dad Jokes Session"}))
         .send()
         .await
         .expect("Failed to create session");
@@ -3424,7 +3434,7 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
     println!("\nStep 3: Creating session...");
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
-        .json(&json!({"agent_id": agent.public_id, "title": "Anthropic Dad Jokes Session"}))
+        .json(&json!({"harness_id": SEED_HARNESS_ID, "agent_id": agent.public_id, "title": "Anthropic Dad Jokes Session"}))
         .send()
         .await
         .expect("Failed to create session");
@@ -3650,7 +3660,7 @@ async fn test_agent_execution_multiple_tool_calls() {
     println!("\nStep 3: Creating session and sending message...");
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
-        .json(&json!({"agent_id": agent.public_id}))
+        .json(&json!({"harness_id": SEED_HARNESS_ID, "agent_id": agent.public_id}))
         .send()
         .await
         .expect("Failed to create session");
@@ -3829,7 +3839,7 @@ async fn test_streaming_events_emitted() {
     println!("\nStep 3: Creating session...");
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
-        .json(&json!({"agent_id": agent.public_id, "title": "Streaming Test Session"}))
+        .json(&json!({"harness_id": SEED_HARNESS_ID, "agent_id": agent.public_id, "title": "Streaming Test Session"}))
         .send()
         .await
         .expect("Failed to create session");
@@ -4154,6 +4164,7 @@ async fn test_cancel_turn_endpoint() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({
+            "harness_id": SEED_HARNESS_ID,
             "agent_id": agent.public_id,
             "title": "Cancel Test Session"
         }))
@@ -4953,7 +4964,7 @@ async fn test_events_api_contract() {
 
     let session: Session = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
-        .json(&json!({"agent_id": agent.public_id, "title": "Events Contract Test"}))
+        .json(&json!({"harness_id": SEED_HARNESS_ID, "agent_id": agent.public_id, "title": "Events Contract Test"}))
         .send()
         .await
         .expect("Failed to create session")
@@ -5064,7 +5075,7 @@ async fn test_events_sse_contract() {
 
     let session: Session = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
-        .json(&json!({"agent_id": agent.public_id, "title": "SSE Contract Test"}))
+        .json(&json!({"harness_id": SEED_HARNESS_ID, "agent_id": agent.public_id, "title": "SSE Contract Test"}))
         .send()
         .await
         .expect("Failed to create session")

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -21,8 +21,8 @@ use std::sync::Arc;
 
 use crate::adapters::create_driver_registry;
 use crate::grpc_adapters::{
-    GrpcAgentStore, GrpcClient, GrpcEventEmitter, GrpcImageResolver, GrpcLlmProviderStore,
-    GrpcMessageRetriever, GrpcSessionFileStore, GrpcSessionStore,
+    GrpcAgentStore, GrpcClient, GrpcEventEmitter, GrpcHarnessStore, GrpcImageResolver,
+    GrpcLlmProviderStore, GrpcMessageRetriever, GrpcSessionFileStore, GrpcSessionStore,
 };
 
 // Re-export atom types for activity callers
@@ -150,7 +150,7 @@ pub async fn reason_activity(
         org_id = org_id,
         session_id = %input.context.session_id,
         turn_id = %input.context.turn_id,
-        agent_id = %input.agent_id,
+        agent_id = ?input.agent_id,
         "Executing reason_activity"
     );
 
@@ -159,6 +159,7 @@ pub async fn reason_activity(
     let input_message_id = input.context.input_message_id;
 
     // Create atom dependencies using gRPC adapters
+    let harness_store = GrpcHarnessStore::new(grpc_client.clone(), org_id);
     let agent_store = GrpcAgentStore::new(grpc_client.clone(), org_id);
     let session_store = GrpcSessionStore::new(grpc_client.clone(), org_id);
     let message_retriever = GrpcMessageRetriever::new(grpc_client.clone());
@@ -174,6 +175,7 @@ pub async fn reason_activity(
     let file_store = Arc::new(GrpcSessionFileStore::new(grpc_client.clone()));
 
     let atom = ReasonAtom::new(
+        harness_store,
         agent_store,
         session_store,
         message_retriever,
@@ -296,7 +298,9 @@ pub async fn act_activity(
 
     // Load agent capabilities and register their tools
     let agent_store = GrpcAgentStore::new(grpc_client.clone(), org_id);
-    if let Ok(Some(agent)) = agent_store.get_agent(input.agent_id).await {
+    if let Some(agent_id) = input.agent_id
+        && let Ok(Some(agent)) = agent_store.get_agent(agent_id).await
+    {
         // Extract capability IDs, filtering out MCP capabilities (handled separately)
         let builtin_cap_ids: Vec<String> = agent
             .capabilities
@@ -356,7 +360,7 @@ pub mod activity_types {
 mod tests {
     use super::*;
     use everruns_core::atoms::AtomContext;
-    use everruns_core::typed_id::{AgentId, MessageId, SessionId, TurnId};
+    use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId, TurnId};
     use everruns_core::{BuiltinTool, ToolCall, ToolDefinition, ToolPolicy};
     use serde_json::json;
     use uuid::Uuid;
@@ -385,8 +389,11 @@ mod tests {
 
         let input = ReasonInput {
             context: context.clone(),
-            agent_id: AgentId::from_uuid(
+            agent_id: Some(AgentId::from_uuid(
                 Uuid::parse_str("880e8400-e29b-41d4-a716-446655440000").unwrap(),
+            )),
+            harness_id: HarnessId::from_uuid(
+                Uuid::parse_str("990e8400-e29b-41d4-a716-446655440000").unwrap(),
             ),
             org_id: 1,
             mcp_tool_definitions: vec![],
@@ -395,7 +402,7 @@ mod tests {
         let json = serde_json::to_string(&input).unwrap();
         let parsed: ReasonInput = serde_json::from_str(&json).unwrap();
         assert_eq!(
-            parsed.agent_id.uuid(),
+            parsed.agent_id.unwrap().uuid(),
             Uuid::parse_str("880e8400-e29b-41d4-a716-446655440000").unwrap()
         );
     }
@@ -406,7 +413,8 @@ mod tests {
 
         let input = ActInput {
             context: context.clone(),
-            agent_id: AgentId::new(),
+            agent_id: Some(AgentId::new()),
+            harness_id: HarnessId::new(),
             tool_calls: vec![ToolCall {
                 id: "call_1".to_string(),
                 name: "get_weather".to_string(),

--- a/crates/worker/src/durable_runner.rs
+++ b/crates/worker/src/durable_runner.rs
@@ -6,7 +6,7 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use everruns_core::typed_id::{AgentId, MessageId, SessionId, TurnId};
+use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId, TurnId};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -33,7 +33,8 @@ use everruns_durable::{
 pub struct DurableTurnInput {
     pub org_id: i64,
     pub session_id: SessionId,
-    pub agent_id: AgentId,
+    pub harness_id: HarnessId,
+    pub agent_id: Option<AgentId>,
     pub input_message_id: MessageId,
     /// Turn ID for trace correlation. Created by input activity, propagated to reason/act.
     /// Uses typed TurnId for type safety and consistent prefixed format.
@@ -466,13 +467,15 @@ impl AgentRunner for DurableRunner {
         &self,
         org_id: i64,
         session_id: SessionId,
-        agent_id: AgentId,
+        harness_id: HarnessId,
+        agent_id: Option<AgentId>,
         input_message_id: MessageId,
     ) -> Result<()> {
         info!(
             org_id = org_id,
             session_id = %session_id,
-            agent_id = %agent_id,
+            harness_id = %harness_id,
+            ?agent_id,
             input_message_id = %input_message_id,
             "Starting durable turn workflow for session"
         );
@@ -482,6 +485,7 @@ impl AgentRunner for DurableRunner {
         let input = DurableTurnInput {
             org_id,
             session_id,
+            harness_id,
             agent_id,
             input_message_id,
             turn_id: None,
@@ -640,7 +644,7 @@ impl AgentRunner for DurableRunner {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use everruns_core::typed_id::{AgentId, MessageId, SessionId};
+    use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId};
 
     #[test]
     fn test_durable_turn_input_serialization() {
@@ -649,7 +653,8 @@ mod tests {
         let input = DurableTurnInput {
             org_id: DEFAULT_ORG_ID,
             session_id: SessionId::new(),
-            agent_id: AgentId::new(),
+            harness_id: HarnessId::new(),
+            agent_id: Some(AgentId::new()),
             input_message_id: MessageId::new(),
             turn_id: None,
         };
@@ -672,12 +677,19 @@ mod tests {
         let runner = DurableRunner::new_in_memory();
 
         let session_id = SessionId::new();
+        let harness_id = HarnessId::new();
         let agent_id = AgentId::new();
         let message_id = MessageId::new();
 
         // First call should create a new workflow
         runner
-            .start_run(DEFAULT_ORG_ID, session_id, agent_id, message_id)
+            .start_run(
+                DEFAULT_ORG_ID,
+                session_id,
+                harness_id,
+                Some(agent_id),
+                message_id,
+            )
             .await
             .expect("First start_run should succeed");
 
@@ -693,13 +705,20 @@ mod tests {
         let runner = DurableRunner::new_in_memory();
 
         let session_id = SessionId::new();
+        let harness_id = HarnessId::new();
         let agent_id = AgentId::new();
         let message_id1 = MessageId::new();
         let message_id2 = MessageId::new();
 
         // First message
         runner
-            .start_run(DEFAULT_ORG_ID, session_id, agent_id, message_id1)
+            .start_run(
+                DEFAULT_ORG_ID,
+                session_id,
+                harness_id,
+                Some(agent_id),
+                message_id1,
+            )
             .await
             .expect("First start_run should succeed");
 
@@ -707,7 +726,13 @@ mod tests {
 
         // Second message while still running - should skip (not error)
         runner
-            .start_run(DEFAULT_ORG_ID, session_id, agent_id, message_id2)
+            .start_run(
+                DEFAULT_ORG_ID,
+                session_id,
+                harness_id,
+                Some(agent_id),
+                message_id2,
+            )
             .await
             .expect("Second start_run should skip gracefully");
 
@@ -727,13 +752,20 @@ mod tests {
         let runner = DurableRunner::new_in_memory();
 
         let session_id = SessionId::new();
+        let harness_id = HarnessId::new();
         let agent_id = AgentId::new();
         let message_id1 = MessageId::new();
         let message_id2 = MessageId::new();
 
         // First message - creates workflow
         runner
-            .start_run(DEFAULT_ORG_ID, session_id, agent_id, message_id1)
+            .start_run(
+                DEFAULT_ORG_ID,
+                session_id,
+                harness_id,
+                Some(agent_id),
+                message_id1,
+            )
             .await
             .expect("First start_run should succeed");
 
@@ -758,7 +790,13 @@ mod tests {
         // This is the bug fix - previously this would fail because it tried
         // to create a workflow with the same ID
         runner
-            .start_run(DEFAULT_ORG_ID, session_id, agent_id, message_id2)
+            .start_run(
+                DEFAULT_ORG_ID,
+                session_id,
+                harness_id,
+                Some(agent_id),
+                message_id2,
+            )
             .await
             .expect("Second start_run should succeed (reset workflow)");
 
@@ -777,13 +815,20 @@ mod tests {
         let runner = DurableRunner::new_in_memory();
 
         let session_id = SessionId::new();
+        let harness_id = HarnessId::new();
         let agent_id = AgentId::new();
         let message_id1 = MessageId::new();
         let message_id2 = MessageId::new();
 
         // First message
         runner
-            .start_run(DEFAULT_ORG_ID, session_id, agent_id, message_id1)
+            .start_run(
+                DEFAULT_ORG_ID,
+                session_id,
+                harness_id,
+                Some(agent_id),
+                message_id1,
+            )
             .await
             .expect("First start_run should succeed");
 
@@ -805,7 +850,13 @@ mod tests {
 
         // Second message - should reset failed workflow
         runner
-            .start_run(DEFAULT_ORG_ID, session_id, agent_id, message_id2)
+            .start_run(
+                DEFAULT_ORG_ID,
+                session_id,
+                harness_id,
+                Some(agent_id),
+                message_id2,
+            )
             .await
             .expect("Second start_run should reset failed workflow");
 

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -687,7 +687,8 @@ impl DurableWorker {
                 let turn_input = DurableTurnInput {
                     org_id: act_task_input.org_id,
                     session_id: act_task_input.act_input.context.session_id,
-                    agent_id: act_task_input.act_input.agent_id, // Pass through agent_id for follow-up reason
+                    harness_id: act_task_input.act_input.harness_id,
+                    agent_id: act_task_input.act_input.agent_id,
                     input_message_id: act_task_input.act_input.context.input_message_id,
                     turn_id: Some(act_task_input.act_input.context.turn_id),
                 };
@@ -875,6 +876,7 @@ impl DurableWorker {
 
         let reason_input = ReasonInput {
             context,
+            harness_id: input.harness_id,
             agent_id: input.agent_id,
             org_id: input.org_id,
             mcp_tool_definitions: turn_context.mcp_tool_definitions,
@@ -989,6 +991,7 @@ impl DurableWorker {
                 let input_with_turn = DurableTurnInput {
                     org_id: input.org_id,
                     session_id: input.session_id,
+                    harness_id: input.harness_id,
                     agent_id: input.agent_id,
                     input_message_id: input.input_message_id,
                     turn_id,
@@ -1029,7 +1032,8 @@ impl DurableWorker {
                                 input_message_id: input.input_message_id,
                                 exec_id: ExecId::new(),
                             },
-                            agent_id: input.agent_id, // Pass through for follow-up reason activity
+                            harness_id: input.harness_id,
+                            agent_id: input.agent_id,
                             tool_calls: reason_result.tool_calls,
                             tool_definitions: reason_result.tool_definitions,
                         },

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -12,10 +12,11 @@ use everruns_core::events::{Event, EventRequest};
 use everruns_core::message_retriever::{InputMessage, MessageRetriever};
 use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
 use everruns_core::traits::{
-    AgentStore, EventEmitter, LlmProviderStore, ModelWithProvider, SessionFileStore, SessionStore,
+    AgentStore, EventEmitter, HarnessStore, LlmProviderStore, ModelWithProvider, SessionFileStore,
+    SessionStore,
 };
 use everruns_core::typed_id::{AgentId, MessageId, ModelId, SessionId};
-use everruns_core::{Agent, Message, Session};
+use everruns_core::{Agent, Harness, HarnessStatus, Message, Session};
 use everruns_internal_protocol::proto;
 use everruns_internal_protocol::{
     WorkerServiceClient, json_to_proto_list, json_to_proto_struct, proto_list_to_json,
@@ -394,6 +395,79 @@ fn proto_agent_to_agent(proto_agent: proto::Agent) -> Result<Agent> {
 }
 
 // ============================================================================
+// HarnessStore implementation
+// ============================================================================
+
+/// gRPC-backed harness store
+pub struct GrpcHarnessStore {
+    client: GrpcClient,
+    org_id: i64,
+}
+
+impl GrpcHarnessStore {
+    pub fn new(client: GrpcClient, org_id: i64) -> Self {
+        Self { client, org_id }
+    }
+}
+
+#[async_trait]
+impl HarnessStore for GrpcHarnessStore {
+    async fn get_harness(&self, harness_id: everruns_core::HarnessId) -> Result<Option<Harness>> {
+        let mut client = self.client.inner.lock().await;
+
+        let request = proto::GetHarnessRequest {
+            harness_id: Some(uuid_to_proto(harness_id.uuid())),
+            org_id: self.org_id,
+        };
+
+        let response = client
+            .get_harness(request)
+            .await
+            .map_err(|e| grpc_error(format!("gRPC get_harness failed: {}", e)))?;
+
+        match response.into_inner().harness {
+            Some(proto_harness) => {
+                let harness = proto_harness_to_harness(proto_harness)?;
+                Ok(Some(harness))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+fn proto_harness_to_harness(proto_harness: proto::Harness) -> Result<Harness> {
+    let id = proto_uuid_to_uuid(proto_harness.id.as_ref())?;
+    let default_model_id = proto_harness
+        .default_model_id
+        .as_ref()
+        .map(|u| proto_uuid_to_uuid(Some(u)))
+        .transpose()?;
+
+    let status = match proto_harness.status.to_lowercase().as_str() {
+        "active" => HarnessStatus::Active,
+        "archived" => HarnessStatus::Archived,
+        _ => HarnessStatus::Active,
+    };
+
+    Ok(Harness {
+        id: id.into(),
+        name: proto_harness.name,
+        description: non_empty_string(proto_harness.description),
+        system_prompt: proto_harness.system_prompt,
+        default_model_id: default_model_id.map(|u| u.into()),
+        tags: vec![],
+        capabilities: proto_harness
+            .capability_ids
+            .into_iter()
+            .map(everruns_core::AgentCapabilityConfig::new)
+            .collect(),
+        status,
+        created_at: proto_timestamp_or_now(proto_harness.created_at.as_ref()),
+        updated_at: proto_timestamp_or_now(proto_harness.updated_at.as_ref()),
+    })
+}
+
+// ============================================================================
 // SessionStore implementation
 // ============================================================================
 
@@ -436,7 +510,17 @@ impl SessionStore for GrpcSessionStore {
 
 fn proto_session_to_session(proto_session: proto::Session) -> Result<Session> {
     let id = proto_uuid_to_uuid(proto_session.id.as_ref())?;
-    let agent_id = proto_uuid_to_uuid(proto_session.agent_id.as_ref())?;
+    let agent_id = proto_session
+        .agent_id
+        .as_ref()
+        .map(|u| proto_uuid_to_uuid(Some(u)))
+        .transpose()?;
+    let harness_id = proto_session
+        .harness_id
+        .as_ref()
+        .map(|u| proto_uuid_to_uuid(Some(u)))
+        .transpose()?
+        .unwrap_or(uuid::Uuid::nil());
     let model_id = proto_session
         .default_model_id
         .as_ref()
@@ -466,7 +550,8 @@ fn proto_session_to_session(proto_session: proto::Session) -> Result<Session> {
     Ok(Session {
         id: id.into(),
         organization_id: proto_session.organization_id,
-        agent_id: agent_id.into(),
+        agent_id: agent_id.map(|u| u.into()),
+        harness_id: harness_id.into(),
         title: non_empty_string(proto_session.title),
         preview: None,
         output_preview: None,
@@ -861,7 +946,7 @@ fn proto_event_to_core(proto_event: proto::Event) -> Result<Event> {
 
 /// Turn context loaded in one batched gRPC call
 pub struct TurnContext {
-    pub agent: Agent,
+    pub agent: Option<Agent>,
     pub session: Session,
     pub messages: Vec<Message>,
     pub model: Option<ModelWithProvider>,
@@ -891,14 +976,11 @@ pub async fn load_turn_context(
 
     let inner = response.into_inner();
 
-    let proto_agent = inner
-        .agent
-        .ok_or_else(|| grpc_error("No agent in turn context"))?;
+    let agent = inner.agent.map(proto_agent_to_agent).transpose()?;
     let proto_session = inner
         .session
         .ok_or_else(|| grpc_error("No session in turn context"))?;
 
-    let agent = proto_agent_to_agent(proto_agent)?;
     let session = proto_session_to_session(proto_session)?;
 
     let messages: Vec<Message> = inner

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -9,15 +9,15 @@ use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::events::{Event, EventRequest};
 use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
 use everruns_core::traits::{AgentStore, ResolvedImage};
-use everruns_core::typed_id::{AgentId, MessageId, ModelId, SessionId};
-use everruns_core::{Agent, DriverRegistry, Message, Session, ToolRegistry};
+use everruns_core::typed_id::{AgentId, HarnessId, MessageId, ModelId, SessionId};
+use everruns_core::{Agent, DriverRegistry, Harness, Message, Session, ToolRegistry};
 use std::collections::HashMap;
 use uuid::Uuid;
 
 use crate::adapters::create_driver_registry;
 use crate::grpc_adapters::{
-    GrpcAgentStore, GrpcClient, GrpcEventEmitter, GrpcImageResolver, GrpcLlmProviderStore,
-    GrpcMessageRetriever, GrpcSessionFileStore, GrpcSessionStore,
+    GrpcAgentStore, GrpcClient, GrpcEventEmitter, GrpcHarnessStore, GrpcImageResolver,
+    GrpcLlmProviderStore, GrpcMessageRetriever, GrpcSessionFileStore, GrpcSessionStore,
 };
 use crate::mcp_executor::McpServerInfo;
 use crate::worker_adapters::{ModelWithProvider, TurnContext, WorkerAdapters};
@@ -59,6 +59,12 @@ impl WorkerAdapters for GrpcWorkerAdapters {
     async fn get_agent(&self, org_id: i64, agent_id: Uuid) -> Result<Option<Agent>> {
         let store = GrpcAgentStore::new(self.client.clone(), org_id);
         store.get_agent(AgentId::from_uuid(agent_id)).await
+    }
+
+    async fn get_harness(&self, org_id: i64, harness_id: Uuid) -> Result<Option<Harness>> {
+        let store = GrpcHarnessStore::new(self.client.clone(), org_id);
+        everruns_core::traits::HarnessStore::get_harness(&store, HarnessId::from_uuid(harness_id))
+            .await
     }
 
     // =========================================================================

--- a/crates/worker/src/runner.rs
+++ b/crates/worker/src/runner.rs
@@ -15,7 +15,7 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use everruns_core::typed_id::{AgentId, MessageId, SessionId};
+use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId};
 use everruns_durable::InMemoryWorkflowEventStore;
 use std::sync::Arc;
 
@@ -40,7 +40,8 @@ pub trait AgentRunner: Send + Sync {
         &self,
         org_id: i64,
         session_id: SessionId,
-        agent_id: AgentId,
+        harness_id: HarnessId,
+        agent_id: Option<AgentId>,
         input_message_id: MessageId,
     ) -> Result<()>;
 

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -30,8 +30,9 @@ use uuid::Uuid;
 
 use crate::durable_runner::DurableTurnInput;
 use crate::worker_adapters::{
-    AdapterAgentStore, AdapterEventEmitter, AdapterImageResolver, AdapterLlmProviderStore,
-    AdapterMessageRetriever, AdapterSessionFileStore, AdapterSessionStore, WorkerAdapters,
+    AdapterAgentStore, AdapterEventEmitter, AdapterHarnessStore, AdapterImageResolver,
+    AdapterLlmProviderStore, AdapterMessageRetriever, AdapterSessionFileStore, AdapterSessionStore,
+    WorkerAdapters,
 };
 
 // Re-export atom types
@@ -421,6 +422,7 @@ where
             let turn_input = DurableTurnInput {
                 org_id: everruns_core::DEFAULT_ORG_ID,
                 session_id: act_input.context.session_id,
+                harness_id: act_input.harness_id,
                 agent_id: act_input.agent_id,
                 input_message_id: act_input.context.input_message_id,
                 turn_id: Some(act_input.context.turn_id),
@@ -607,6 +609,7 @@ async fn execute_reason_activity<A: WorkerAdapters>(
         .await?;
 
     // Create atom dependencies
+    let harness_store = AdapterHarnessStore::new(adapters.clone(), input.org_id);
     let agent_store = AdapterAgentStore::new(adapters.clone(), input.org_id);
     let session_store = AdapterSessionStore::new(adapters.clone(), input.org_id);
     let message_retriever = AdapterMessageRetriever::new(adapters.clone());
@@ -617,6 +620,7 @@ async fn execute_reason_activity<A: WorkerAdapters>(
     let image_resolver = Arc::new(AdapterImageResolver::new(adapters.clone()));
 
     let atom = ReasonAtom::new(
+        harness_store,
         agent_store,
         session_store,
         message_retriever,
@@ -629,6 +633,7 @@ async fn execute_reason_activity<A: WorkerAdapters>(
 
     let reason_input = everruns_core::ReasonInput {
         context: context.clone(),
+        harness_id: input.harness_id,
         agent_id: input.agent_id,
         org_id: input.org_id,
         mcp_tool_definitions: turn_context.mcp_tool_definitions,
@@ -755,7 +760,11 @@ async fn execute_act_activity<A: WorkerAdapters>(
     );
 
     // Build tool registry with defaults and capability tools
-    let tool_registry = adapters.build_tool_registry(input.agent_id.uuid()).await?;
+    let tool_registry = if let Some(agent_id) = input.agent_id {
+        adapters.build_tool_registry(agent_id.uuid()).await?
+    } else {
+        everruns_core::ToolRegistry::with_defaults()
+    };
 
     let event_emitter = AdapterEventEmitter::new(adapters.clone());
     let file_store = Arc::new(AdapterSessionFileStore::new(adapters.clone()));
@@ -796,6 +805,7 @@ async fn schedule_next_activity<S: WorkflowEventStore>(
             let input_with_turn = DurableTurnInput {
                 org_id: input.org_id,
                 session_id: input.session_id,
+                harness_id: input.harness_id,
                 agent_id: input.agent_id,
                 input_message_id: input.input_message_id,
                 turn_id,
@@ -859,6 +869,7 @@ async fn schedule_next_activity<S: WorkflowEventStore>(
                             input_message_id: input.input_message_id,
                             exec_id: ExecId::new(),
                         },
+                        harness_id: input.harness_id,
                         agent_id: input.agent_id,
                         tool_calls: server_tool_calls,
                         tool_definitions: reason_result.tool_definitions.clone(),

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -11,9 +11,9 @@ use everruns_core::error::Result;
 use everruns_core::events::{Event, EventRequest};
 use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
 use everruns_core::traits::{ImageResolver, ResolvedImage};
-use everruns_core::typed_id::{AgentId, MessageId, ModelId, SessionId};
+use everruns_core::typed_id::{AgentId, HarnessId, MessageId, ModelId, SessionId};
 use everruns_core::{
-    Agent, DriverRegistry, LlmProviderType, Message, Session, ToolDefinition, ToolRegistry,
+    Agent, DriverRegistry, Harness, LlmProviderType, Message, Session, ToolDefinition, ToolRegistry,
 };
 use std::collections::HashMap;
 use uuid::Uuid;
@@ -38,6 +38,9 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
 
     /// Get agent by ID
     async fn get_agent(&self, org_id: i64, agent_id: Uuid) -> Result<Option<Agent>>;
+
+    /// Get harness by ID
+    async fn get_harness(&self, org_id: i64, harness_id: Uuid) -> Result<Option<Harness>>;
 
     // =========================================================================
     // Session Operations
@@ -189,7 +192,7 @@ pub struct ModelWithProvider {
 /// Turn context loaded in one batched call
 #[derive(Debug, Clone)]
 pub struct TurnContext {
-    pub agent: Agent,
+    pub agent: Option<Agent>,
     pub session: Session,
     pub messages: Vec<Message>,
     pub model: Option<ModelWithProvider>,
@@ -217,6 +220,27 @@ impl<A: WorkerAdapters> AdapterAgentStore<A> {
 impl<A: WorkerAdapters> everruns_core::traits::AgentStore for AdapterAgentStore<A> {
     async fn get_agent(&self, agent_id: AgentId) -> Result<Option<Agent>> {
         self.adapters.get_agent(self.org_id, agent_id.uuid()).await
+    }
+}
+
+/// Adapter-based HarnessStore implementation
+pub struct AdapterHarnessStore<A: WorkerAdapters> {
+    adapters: A,
+    org_id: i64,
+}
+
+impl<A: WorkerAdapters> AdapterHarnessStore<A> {
+    pub fn new(adapters: A, org_id: i64) -> Self {
+        Self { adapters, org_id }
+    }
+}
+
+#[async_trait]
+impl<A: WorkerAdapters> everruns_core::traits::HarnessStore for AdapterHarnessStore<A> {
+    async fn get_harness(&self, harness_id: HarnessId) -> Result<Option<Harness>> {
+        self.adapters
+            .get_harness(self.org_id, harness_id.uuid())
+            .await
     }
 }
 

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -4482,12 +4482,15 @@
         "type": "object",
         "description": "Request to create a session",
         "required": [
-          "agent_id"
+          "harness_id"
         ],
         "properties": {
           "agent_id": {
-            "type": "string",
-            "description": "ID of the agent to work in this session (format: agent_{32-hex}).",
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ID of the agent to work in this session (optional, format: agent_{32-hex}).",
             "example": "agent_01933b5a00007000800000000000001"
           },
           "capabilities": {
@@ -4496,6 +4499,11 @@
               "$ref": "#/components/schemas/AgentCapabilityConfig"
             },
             "description": "Session-level capabilities (additive to agent capabilities).\nApplied after agent capabilities when building RuntimeAgent."
+          },
+          "harness_id": {
+            "type": "string",
+            "description": "ID of the harness for this session (format: harness_{32-hex}).",
+            "example": "harness_01933b5a00007000800000000000001"
           },
           "model_id": {
             "type": [
@@ -7221,15 +7229,18 @@
               "required": [
                 "id",
                 "organization_id",
-                "agent_id",
+                "harness_id",
                 "status",
                 "created_at",
                 "updated_at"
               ],
               "properties": {
                 "agent_id": {
-                  "type": "string",
-                  "description": "ID of the agent working in this session (format: agent_{32-hex}).",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "ID of the agent working in this session (format: agent_{32-hex}). Optional.",
                   "example": "agent_01933b5a00007000800000000000001"
                 },
                 "capabilities": {
@@ -7251,6 +7262,11 @@
                   ],
                   "format": "date-time",
                   "description": "Timestamp when the session finished (completed or failed)."
+                },
+                "harness_id": {
+                  "type": "string",
+                  "description": "ID of the harness for this session (format: harness_{32-hex}).",
+                  "example": "harness_01933b5a00007000800000000000001"
                 },
                 "id": {
                   "type": "string",
@@ -7451,12 +7467,23 @@
         "type": "object",
         "description": "Data for reason.started event",
         "required": [
-          "agent_id"
+          "harness_id"
         ],
         "properties": {
           "agent_id": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/TypedId",
+                "description": "Agent ID being used (optional)"
+              }
+            ]
+          },
+          "harness_id": {
             "$ref": "#/components/schemas/TypedId",
-            "description": "Agent ID being used"
+            "description": "Harness ID being used"
           },
           "metadata": {
             "oneOf": [
@@ -7926,15 +7953,18 @@
         "required": [
           "id",
           "organization_id",
-          "agent_id",
+          "harness_id",
           "status",
           "created_at",
           "updated_at"
         ],
         "properties": {
           "agent_id": {
-            "type": "string",
-            "description": "ID of the agent working in this session (format: agent_{32-hex}).",
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ID of the agent working in this session (format: agent_{32-hex}). Optional.",
             "example": "agent_01933b5a00007000800000000000001"
           },
           "capabilities": {
@@ -7956,6 +7986,11 @@
             ],
             "format": "date-time",
             "description": "Timestamp when the session finished (completed or failed)."
+          },
+          "harness_id": {
+            "type": "string",
+            "description": "ID of the harness for this session (format: harness_{32-hex}).",
+            "example": "harness_01933b5a00007000800000000000001"
           },
           "id": {
             "type": "string",
@@ -8158,13 +8193,21 @@
         "type": "object",
         "description": "Data for session.started event",
         "required": [
-          "agent_id"
+          "harness_id"
         ],
         "properties": {
           "agent_id": {
-            "type": "string",
-            "description": "Agent ID",
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Agent ID (optional)",
             "example": "agent_01933b5a00007000800000000000001"
+          },
+          "harness_id": {
+            "type": "string",
+            "description": "Harness ID",
+            "example": "harness_01933b5a00007000800000000000001"
           },
           "model_id": {
             "type": [

--- a/scripts/cli-e2e-test.sh
+++ b/scripts/cli-e2e-test.sh
@@ -127,12 +127,31 @@ else
 fi
 
 # ========================================
+# Test: Harness (get seed harness for session creation)
+# ========================================
+
+log_test "get seed harness"
+HARNESSES_OUTPUT=$(curl -s "$API_URL/v1/harnesses" -H "Authorization: ${EVERRUNS_API_KEY:-test}") || {
+  log_fail "list harnesses failed"
+  exit 1
+}
+HARNESS_ID=$(echo "$HARNESSES_OUTPUT" | jq -r '.data[0].id')
+if [ -n "$HARNESS_ID" ] && [ "$HARNESS_ID" != "null" ]; then
+  log_pass "found seed harness: $HARNESS_ID"
+else
+  log_fail "no harness found (required for session creation)"
+  echo "$HARNESSES_OUTPUT"
+  exit 1
+fi
+
+# ========================================
 # Test: Sessions CRUD
 # ========================================
 
-# Create session (uses prefixed agent ID)
+# Create session (uses prefixed harness + agent IDs)
 log_test "sessions create"
 SESSION_OUTPUT=$($CLI --api-url "$API_URL" sessions create \
+  --harness "$HARNESS_ID" \
   --agent "$AGENT_ID" \
   --title "CLI E2E Test Session" \
   --output json 2>&1) || {


### PR DESCRIPTION
## Summary

- Add **Harness** entity that sits between Organization and Agent: `Harness (required) → Agent (optional) → Session`
- Harness defines base rules (system_prompt, capabilities, model) while Agent provides domain-specific customizations
- Session creation now requires `harness_id`; `agent_id` becomes optional
- Full CRUD API, storage (PostgreSQL + in-memory), worker propagation, gRPC protocol, and UI pages

## Changes

### Core (`crates/core/`)
- `Harness` entity, `HarnessId` typed ID, `HarnessStore` trait
- `RuntimeAgentBuilder.with_harness()` for prompt layering
- `ReasonAtom<H,A,S,M,P,E>` with `HarnessStore` as first generic param
- `Session.agent_id` now `Option<AgentId>`

### Storage & API (`crates/server/`)
- Migration `005_harnesses.sql`: `harnesses` + `harness_capabilities` tables
- PostgreSQL + in-memory CRUD implementations
- Full harness CRUD endpoints: `POST/GET/PATCH/DELETE /v1/harnesses`
- Session creation requires `harness_id`, `agent_id` optional

### Worker (`crates/worker/`)
- `harness_id` propagated through `DurableTurnInput`, activities
- Model resolution chain: `controls > session > agent > harness > default`
- Prompt layering: `[session_caps][agent_caps][agent_prompt][harness_caps][harness_prompt]`

### gRPC Protocol (`crates/internal-protocol/`)
- `GetHarness` RPC, `Harness` proto message
- Updated `Session` proto with optional `agent_id` + required `harness_id`

### UI (`apps/ui/`)
- Harness CRUD pages (list, create, detail, edit)
- `HarnessSelect` component for session creation
- TypeScript types, API client, React hooks
- Updated session creation flows across all pages

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test` — 855+ tests pass, 0 new failures
- [x] `npm run build` clean
- [x] `npm run lint` clean (warnings only)
- [x] API smoke test: harness CRUD, session creation with/without agent
- [x] UI smoke test: all harness pages render correctly (screenshots below)