### PR TITLE
chore: add Doppler CLI for secrets management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,11 +64,13 @@ Fix root cause. Unsure: read more code; if stuck, ask w/ short options. Unrecogn
 ### Cloud Agent Start
 
 ```bash
-./scripts/init-cloud-env.sh       # Install just + gh
+./scripts/init-cloud-env.sh       # Install just + gh + doppler
 just start-dev --no-watch         # DEV MODE (no Docker)
 ```
 
 Pre-configured: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`
+
+Doppler CLI is available in cloud environments for secrets management. Use `doppler run -- <command>` to inject secrets.
 
 ### Local Dev
 

--- a/scripts/init-cloud-env.sh
+++ b/scripts/init-cloud-env.sh
@@ -7,6 +7,7 @@
 # This script installs:
 # - just: command runner (see justfile)
 # - gh: GitHub CLI (for PR/issue operations)
+# - doppler: secrets manager CLI
 #
 # Run this BEFORE any other commands in a fresh cloud environment.
 
@@ -96,6 +97,23 @@ install_gh() {
     fi
 }
 
+install_doppler() {
+    if command -v doppler &> /dev/null; then
+        info "doppler already installed: $(doppler --version 2>/dev/null)"
+        return 0
+    fi
+
+    info "Installing Doppler CLI..."
+
+    curl -sS https://cli.doppler.com/install.sh | sh 2>/dev/null
+
+    if command -v doppler &> /dev/null; then
+        info "doppler installed: $(doppler --version 2>/dev/null)"
+    else
+        error "Failed to install doppler"
+    fi
+}
+
 configure_gh_repo() {
     # Set default repo for gh CLI (needed when git remote uses local proxy)
     # Extract repo from git remote URL (handles both github.com and proxy URLs)
@@ -164,6 +182,7 @@ main() {
 
     install_just
     install_gh
+    install_doppler
     configure_gh_repo
 
     END_TIME=$(date +%s)
@@ -176,6 +195,7 @@ main() {
     echo "Installed tools:"
     echo "  - just $(just --version 2>/dev/null || echo '(not in PATH)')"
     echo "  - gh $(gh --version 2>/dev/null | head -1 || echo '(not in PATH)')"
+    echo "  - doppler $(doppler --version 2>/dev/null || echo '(not in PATH)')"
     echo ""
     echo "Next steps:"
     echo "  just --list              # See available commands"

--- a/scripts/init-cloud-env.sh
+++ b/scripts/init-cloud-env.sh
@@ -103,9 +103,39 @@ install_doppler() {
         return 0
     fi
 
-    info "Installing Doppler CLI..."
+    info "Installing Doppler CLI (pre-built binary)..."
 
-    curl -sS https://cli.doppler.com/install.sh | sh 2>/dev/null
+    # Detect architecture
+    ARCH=$(uname -m)
+    case "$ARCH" in
+        x86_64)  DOP_ARCH="amd64" ;;
+        aarch64) DOP_ARCH="arm64" ;;
+        *)       error "Unsupported architecture: $ARCH" ;;
+    esac
+
+    # Get latest version from GitHub API
+    DOP_VERSION=$(curl -sS https://api.github.com/repos/DopplerHQ/cli/releases/latest | grep '"tag_name"' | cut -d'"' -f4)
+
+    if [[ -z "$DOP_VERSION" ]]; then
+        DOP_VERSION="3.75.2"
+        warn "Could not fetch latest doppler version, using fallback: $DOP_VERSION"
+    fi
+
+    DOP_TARBALL="doppler_${DOP_VERSION}_linux_${DOP_ARCH}.tar.gz"
+    DOP_URL="https://github.com/DopplerHQ/cli/releases/download/${DOP_VERSION}/${DOP_TARBALL}"
+
+    # Download and extract
+    TEMP_DIR=$(mktemp -d)
+    trap "rm -rf $TEMP_DIR" EXIT
+
+    info "Downloading doppler v${DOP_VERSION}..."
+    curl -sSL "$DOP_URL" -o "$TEMP_DIR/$DOP_TARBALL"
+
+    tar -xzf "$TEMP_DIR/$DOP_TARBALL" -C "$TEMP_DIR"
+
+    # Install binary
+    cp "$TEMP_DIR/doppler" "$INSTALL_DIR/doppler"
+    chmod +x "$INSTALL_DIR/doppler"
 
     if command -v doppler &> /dev/null; then
         info "doppler installed: $(doppler --version 2>/dev/null)"
@@ -171,6 +201,23 @@ configure_gh_repo() {
     fi
 }
 
+configure_doppler() {
+    if [[ -z "${DOPPLER_TOKEN:-}" ]]; then
+        warn "DOPPLER_TOKEN not set, skipping Doppler configuration"
+        return 0
+    fi
+
+    if ! command -v doppler &> /dev/null; then
+        warn "doppler not installed, skipping configuration"
+        return 0
+    fi
+
+    info "Configuring Doppler (project: everruns-dev, config: dev)..."
+    doppler setup --project everruns-dev --config dev --no-interactive 2>/dev/null \
+        && info "Doppler configured for everruns-dev/dev" \
+        || warn "Failed to configure Doppler"
+}
+
 main() {
     echo "================================================"
     echo "  Cloud Environment Initialization"
@@ -184,6 +231,7 @@ main() {
     install_gh
     install_doppler
     configure_gh_repo
+    configure_doppler
 
     END_TIME=$(date +%s)
     ELAPSED=$((END_TIME - START_TIME))

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -375,6 +375,7 @@ Capabilities are modular functionality units that extend Agent behavior. See [sp
 2. **Dev Mode**: In-memory storage mode for quick local development without PostgreSQL
 3. **CI/CD**: GitHub Actions for format, lint, test, smoke test, Docker build
 4. **License Compliance**: cargo-deny for dependency license checking
+5. **Secrets Management**: [Doppler](https://www.doppler.com/) for development secrets (API keys, tokens). Project: `everruns-dev`, config: `dev`. Use `doppler run -- <command>` to inject secrets into processes.
 
 ### Development Mode (DEV_MODE)
 


### PR DESCRIPTION
## What
Add Doppler CLI installation to cloud environment init script and document it in AGENTS.md and specs.

## Why
Secrets are moving to Doppler. Cloud agents need the CLI installed and configured to access API keys and tokens.

## How
- `scripts/init-cloud-env.sh`: Added `install_doppler()` (direct binary download from GitHub releases) and `configure_doppler()` (auto-setup when `DOPPLER_TOKEN` is set)
- `AGENTS.md`: Documented Doppler availability in cloud environments
- `specs/architecture.md`: Added Doppler under Infrastructure section

## Risk
- Low
- Script-only change, no application code affected. Doppler install is additive — existing tools (`just`, `gh`) unaffected.

## Checklist
- [x] Tests added or updated (N/A — script change, verified manually)
- [x] Backward compatibility considered (additive only)