### PR TITLE
feat(ui): agent trajectory visualization in session UI

### DIFF
--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -11,6 +11,7 @@
         "@base-ui/react": "^1.1.0",
         "@streamdown/code": "^1.0.1",
         "@tanstack/react-query": "^5.90.16",
+        "@xyflow/react": "^12.10.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -4255,6 +4256,55 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -4730,6 +4780,38 @@
         "win32"
       ]
     },
+    "node_modules/@xyflow/react": {
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.0.tgz",
+      "integrity": "sha512-eOtz3whDMWrB4KWVatIBrKuxECHqip6PfA8fTpaS2RUGVpiEAe+nqDKsLqkViVWxDGreq0lWX71Xth/SPAzXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.74",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.74",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.74.tgz",
+      "integrity": "sha512-7v7B/PkiVrkdZzSbL+inGAo6tkR/WQHHG0/jhSvLQToCsfa8YubOGmBYd1s08tpKpihdHDZFwzQZeR69QSBb4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -5192,6 +5274,12 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -5379,6 +5467,111 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -11300,6 +11493,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -19,6 +19,7 @@
     "@base-ui/react": "^1.1.0",
     "@streamdown/code": "^1.0.1",
     "@tanstack/react-query": "^5.90.16",
+    "@xyflow/react": "^12.10.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
@@ -16,6 +16,7 @@ import {
   Zap,
   Database,
   Bot,
+  GitBranch,
 } from "lucide-react";
 import { cn, shortenId } from "@/lib/utils";
 import { CopyButton } from "@/components/ui/copy-button";
@@ -60,6 +61,7 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
   // Determine active tab from pathname
   const getActiveTab = () => {
     if (pathname.endsWith("/files")) return "files";
+    if (pathname.endsWith("/trajectory")) return "trajectory";
     if (pathname.endsWith("/events")) return "events";
     if (pathname.endsWith("/storage")) return "storage";
     return "chat"; // Default to chat (includes /chat and base path)
@@ -198,6 +200,19 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
           >
             <Folder className="h-4 w-4" />
             Workspace
+          </Link>
+          <Link
+            href={`${basePath}/trajectory`}
+            className={cn(
+              buttonVariants({
+                variant: activeTab === "trajectory" ? "default" : "ghost",
+                size: "sm",
+              }),
+              "gap-2",
+            )}
+          >
+            <GitBranch className="h-4 w-4" />
+            Trajectory
           </Link>
           <Link
             href={`${basePath}/storage`}

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
@@ -202,19 +202,6 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
             Workspace
           </Link>
           <Link
-            href={`${basePath}/trajectory`}
-            className={cn(
-              buttonVariants({
-                variant: activeTab === "trajectory" ? "default" : "ghost",
-                size: "sm",
-              }),
-              "gap-2",
-            )}
-          >
-            <GitBranch className="h-4 w-4" />
-            Trajectory
-          </Link>
-          <Link
             href={`${basePath}/storage`}
             className={cn(
               buttonVariants({
@@ -239,6 +226,19 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
           >
             <Activity className="h-4 w-4" />
             Events
+          </Link>
+          <Link
+            href={`${basePath}/trajectory`}
+            className={cn(
+              buttonVariants({
+                variant: activeTab === "trajectory" ? "default" : "ghost",
+                size: "sm",
+              }),
+              "gap-2",
+            )}
+          >
+            <GitBranch className="h-4 w-4" />
+            Trajectory
           </Link>
         </div>
       </div>

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/trajectory/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/trajectory/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { Skeleton } from "@/components/ui/skeleton";
+import { useSessionContext } from "../session-context";
+import { TrajectoryView } from "@/components/trajectory/trajectory-view";
+
+export default function TrajectoryPage() {
+  const { events, eventsLoading } = useSessionContext();
+
+  if (eventsLoading) {
+    return (
+      <div className="flex-1 p-4 space-y-4">
+        <Skeleton className="h-8 w-1/4" />
+        <Skeleton className="h-[calc(100%-3rem)] w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 overflow-hidden">
+      <TrajectoryView events={events ?? []} />
+    </div>
+  );
+}

--- a/apps/ui/src/components/trajectory/trajectory-nodes.tsx
+++ b/apps/ui/src/components/trajectory/trajectory-nodes.tsx
@@ -1,15 +1,15 @@
 // Custom React Flow node components for trajectory visualization.
-// Designed to be compact for rendering thousands of nodes.
+// TurnGroupNode renders as a container box; child nodes render inside it.
 
 import { memo } from "react";
 import { Handle, Position, type NodeProps } from "@xyflow/react";
-import { User, Bot, Brain, Wrench, Play, CheckCircle2, XCircle, Clock } from "lucide-react";
+import { User, Bot, Brain, Wrench, CheckCircle2, XCircle, Clock } from "lucide-react";
 import type {
   UserMessageNodeData,
   AgentMessageNodeData,
   ReasoningNodeData,
   ToolGroupNodeData,
-  TurnNodeData,
+  TurnGroupNodeData,
 } from "./trajectory-utils";
 
 function formatDuration(ms?: number): string {
@@ -18,48 +18,47 @@ function formatDuration(ms?: number): string {
   return `${(ms / 1000).toFixed(1)}s`;
 }
 
-// --- Turn boundary nodes ---
+// --- Turn group node (container box) ---
 
-export const TurnStartNode = memo(function TurnStartNode({
+export const TurnGroupNode = memo(function TurnGroupNode({
   data,
-}: NodeProps & { data: TurnNodeData }) {
-  const d = data as TurnNodeData;
-  return (
-    <div className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-muted border border-border text-xs font-medium text-muted-foreground">
-      <Play className="w-3 h-3" />
-      <span>{d.label}</span>
-      {d.iterations > 0 && (
-        <span className="text-muted-foreground/60">
-          {d.iterations} iter{d.iterations !== 1 ? "s" : ""}
-        </span>
-      )}
-      {d.durationMs != null && (
-        <span className="text-muted-foreground/60">
-          <Clock className="w-2.5 h-2.5 inline mr-0.5" />
-          {formatDuration(d.durationMs)}
-        </span>
-      )}
-      <Handle type="target" position={Position.Top} className="!w-1.5 !h-1.5 !bg-border" />
-      <Handle type="source" position={Position.Bottom} className="!w-1.5 !h-1.5 !bg-border" />
-    </div>
-  );
-});
-
-export const TurnEndNode = memo(function TurnEndNode({ data }: NodeProps & { data: TurnNodeData }) {
-  const d = data as TurnNodeData;
+}: NodeProps & { data: TurnGroupNodeData }) {
+  const d = data as TurnGroupNodeData;
   const failed = d.failed;
   return (
     <div
-      className={`flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium border ${
+      className={`w-full h-full rounded-xl border-2 ${
         failed
-          ? "bg-red-50 border-red-200 text-red-700 dark:bg-red-950 dark:border-red-800 dark:text-red-300"
-          : "bg-muted border-border text-muted-foreground"
+          ? "border-red-300 bg-red-50/50 dark:border-red-700 dark:bg-red-950/30"
+          : "border-border bg-muted/20 dark:bg-muted/10"
       }`}
     >
-      {failed ? <XCircle className="w-3 h-3" /> : <CheckCircle2 className="w-3 h-3" />}
-      <span>{d.label}</span>
-      <Handle type="target" position={Position.Top} className="!w-1.5 !h-1.5 !bg-border" />
-      <Handle type="source" position={Position.Bottom} className="!w-1.5 !h-1.5 !bg-border" />
+      <div
+        className={`flex items-center gap-2 px-3 py-2 text-xs font-semibold rounded-t-[10px] ${
+          failed
+            ? "text-red-700 bg-red-100/60 dark:text-red-300 dark:bg-red-900/30"
+            : "text-foreground/80 bg-muted/40"
+        }`}
+      >
+        <span>{d.label}</span>
+        {d.iterations > 0 && (
+          <span className="font-normal text-muted-foreground">
+            {d.iterations} iter{d.iterations !== 1 ? "s" : ""}
+          </span>
+        )}
+        {d.durationMs != null && (
+          <span className="font-normal text-muted-foreground">
+            <Clock className="w-2.5 h-2.5 inline mr-0.5" />
+            {formatDuration(d.durationMs)}
+          </span>
+        )}
+        {failed && (
+          <span className="ml-auto flex items-center gap-1 text-red-600 dark:text-red-400">
+            <XCircle className="w-3 h-3" />
+            Failed
+          </span>
+        )}
+      </div>
     </div>
   );
 });
@@ -71,13 +70,13 @@ export const UserMessageNode = memo(function UserMessageNode({
 }: NodeProps & { data: UserMessageNodeData }) {
   const d = data as UserMessageNodeData;
   return (
-    <div className="max-w-[320px] rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 dark:border-blue-800 dark:bg-blue-950">
-      <div className="flex items-center gap-1.5 text-xs font-medium text-blue-700 dark:text-blue-300 mb-1">
+    <div className="w-[308px] rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 dark:border-blue-800 dark:bg-blue-950">
+      <div className="flex items-center gap-1.5 text-xs font-medium text-blue-700 dark:text-blue-300 mb-0.5">
         <User className="w-3 h-3" />
         User
       </div>
       {d.preview && (
-        <p className="text-xs text-blue-900/80 dark:text-blue-200/80 line-clamp-2 leading-relaxed">
+        <p className="text-[11px] text-blue-900/80 dark:text-blue-200/80 line-clamp-2 leading-relaxed">
           {d.preview}
         </p>
       )}
@@ -94,13 +93,13 @@ export const AgentMessageNode = memo(function AgentMessageNode({
 }: NodeProps & { data: AgentMessageNodeData }) {
   const d = data as AgentMessageNodeData;
   return (
-    <div className="max-w-[320px] rounded-lg border border-violet-200 bg-violet-50 px-3 py-2 dark:border-violet-800 dark:bg-violet-950">
-      <div className="flex items-center gap-1.5 text-xs font-medium text-violet-700 dark:text-violet-300 mb-1">
+    <div className="w-[308px] rounded-lg border border-violet-200 bg-violet-50 px-3 py-2 dark:border-violet-800 dark:bg-violet-950">
+      <div className="flex items-center gap-1.5 text-xs font-medium text-violet-700 dark:text-violet-300 mb-0.5">
         <Bot className="w-3 h-3" />
-        Agent Response
+        Agent
       </div>
       {d.preview && (
-        <p className="text-xs text-violet-900/80 dark:text-violet-200/80 line-clamp-2 leading-relaxed">
+        <p className="text-[11px] text-violet-900/80 dark:text-violet-200/80 line-clamp-2 leading-relaxed">
           {d.preview}
         </p>
       )}
@@ -117,9 +116,9 @@ export const ReasoningNode = memo(function ReasoningNode({
 }: NodeProps & { data: ReasoningNodeData }) {
   const d = data as ReasoningNodeData;
   return (
-    <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-1.5 dark:border-amber-800 dark:bg-amber-950">
+    <div className="w-[308px] rounded-lg border border-amber-200 bg-amber-50 px-2.5 py-1.5 dark:border-amber-800 dark:bg-amber-950">
       <div className="flex items-center gap-2 text-xs">
-        <Brain className="w-3 h-3 text-amber-600 dark:text-amber-400" />
+        <Brain className="w-3 h-3 text-amber-600 dark:text-amber-400 shrink-0" />
         <span className="font-medium text-amber-700 dark:text-amber-300">{d.label}</span>
         {d.toolCallCount > 0 && (
           <span className="text-amber-600/70 dark:text-amber-400/70">
@@ -127,7 +126,7 @@ export const ReasoningNode = memo(function ReasoningNode({
           </span>
         )}
         {d.durationMs != null && (
-          <span className="text-amber-600/50 dark:text-amber-400/50">
+          <span className="ml-auto text-amber-600/50 dark:text-amber-400/50">
             {formatDuration(d.durationMs)}
           </span>
         )}
@@ -147,7 +146,7 @@ export const ToolGroupNode = memo(function ToolGroupNode({
   const hasErrors = d.errorCount > 0;
   return (
     <div
-      className={`max-w-[320px] rounded-lg border px-3 py-2 ${
+      className={`w-[308px] rounded-lg border px-2.5 py-2 ${
         hasErrors
           ? "border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-950"
           : "border-emerald-200 bg-emerald-50 dark:border-emerald-800 dark:bg-emerald-950"
@@ -155,7 +154,7 @@ export const ToolGroupNode = memo(function ToolGroupNode({
     >
       <div className="flex items-center gap-2 text-xs mb-1">
         <Wrench
-          className={`w-3 h-3 ${hasErrors ? "text-red-600 dark:text-red-400" : "text-emerald-600 dark:text-emerald-400"}`}
+          className={`w-3 h-3 shrink-0 ${hasErrors ? "text-red-600 dark:text-red-400" : "text-emerald-600 dark:text-emerald-400"}`}
         />
         <span
           className={`font-medium ${hasErrors ? "text-red-700 dark:text-red-300" : "text-emerald-700 dark:text-emerald-300"}`}
@@ -163,7 +162,7 @@ export const ToolGroupNode = memo(function ToolGroupNode({
           {d.label}
         </span>
         {d.durationMs != null && (
-          <span className="text-muted-foreground/50">{formatDuration(d.durationMs)}</span>
+          <span className="ml-auto text-muted-foreground/50">{formatDuration(d.durationMs)}</span>
         )}
       </div>
       <div className="flex flex-wrap gap-1">
@@ -199,12 +198,10 @@ export const ToolGroupNode = memo(function ToolGroupNode({
   );
 });
 
-// Export node type mapping for React Flow
 export const trajectoryNodeTypes = {
   userMessage: UserMessageNode,
   agentMessage: AgentMessageNode,
   reasoning: ReasoningNode,
   toolGroup: ToolGroupNode,
-  turnStart: TurnStartNode,
-  turnEnd: TurnEndNode,
+  turnGroup: TurnGroupNode,
 };

--- a/apps/ui/src/components/trajectory/trajectory-nodes.tsx
+++ b/apps/ui/src/components/trajectory/trajectory-nodes.tsx
@@ -1,0 +1,210 @@
+// Custom React Flow node components for trajectory visualization.
+// Designed to be compact for rendering thousands of nodes.
+
+import { memo } from "react";
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import { User, Bot, Brain, Wrench, Play, CheckCircle2, XCircle, Clock } from "lucide-react";
+import type {
+  UserMessageNodeData,
+  AgentMessageNodeData,
+  ReasoningNodeData,
+  ToolGroupNodeData,
+  TurnNodeData,
+} from "./trajectory-utils";
+
+function formatDuration(ms?: number): string {
+  if (ms == null) return "";
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+// --- Turn boundary nodes ---
+
+export const TurnStartNode = memo(function TurnStartNode({
+  data,
+}: NodeProps & { data: TurnNodeData }) {
+  const d = data as TurnNodeData;
+  return (
+    <div className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-muted border border-border text-xs font-medium text-muted-foreground">
+      <Play className="w-3 h-3" />
+      <span>{d.label}</span>
+      {d.iterations > 0 && (
+        <span className="text-muted-foreground/60">
+          {d.iterations} iter{d.iterations !== 1 ? "s" : ""}
+        </span>
+      )}
+      {d.durationMs != null && (
+        <span className="text-muted-foreground/60">
+          <Clock className="w-2.5 h-2.5 inline mr-0.5" />
+          {formatDuration(d.durationMs)}
+        </span>
+      )}
+      <Handle type="target" position={Position.Top} className="!w-1.5 !h-1.5 !bg-border" />
+      <Handle type="source" position={Position.Bottom} className="!w-1.5 !h-1.5 !bg-border" />
+    </div>
+  );
+});
+
+export const TurnEndNode = memo(function TurnEndNode({ data }: NodeProps & { data: TurnNodeData }) {
+  const d = data as TurnNodeData;
+  const failed = d.failed;
+  return (
+    <div
+      className={`flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium border ${
+        failed
+          ? "bg-red-50 border-red-200 text-red-700 dark:bg-red-950 dark:border-red-800 dark:text-red-300"
+          : "bg-muted border-border text-muted-foreground"
+      }`}
+    >
+      {failed ? <XCircle className="w-3 h-3" /> : <CheckCircle2 className="w-3 h-3" />}
+      <span>{d.label}</span>
+      <Handle type="target" position={Position.Top} className="!w-1.5 !h-1.5 !bg-border" />
+      <Handle type="source" position={Position.Bottom} className="!w-1.5 !h-1.5 !bg-border" />
+    </div>
+  );
+});
+
+// --- User message node ---
+
+export const UserMessageNode = memo(function UserMessageNode({
+  data,
+}: NodeProps & { data: UserMessageNodeData }) {
+  const d = data as UserMessageNodeData;
+  return (
+    <div className="max-w-[320px] rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 dark:border-blue-800 dark:bg-blue-950">
+      <div className="flex items-center gap-1.5 text-xs font-medium text-blue-700 dark:text-blue-300 mb-1">
+        <User className="w-3 h-3" />
+        User
+      </div>
+      {d.preview && (
+        <p className="text-xs text-blue-900/80 dark:text-blue-200/80 line-clamp-2 leading-relaxed">
+          {d.preview}
+        </p>
+      )}
+      <Handle type="target" position={Position.Top} className="!w-1.5 !h-1.5 !bg-blue-400" />
+      <Handle type="source" position={Position.Bottom} className="!w-1.5 !h-1.5 !bg-blue-400" />
+    </div>
+  );
+});
+
+// --- Agent message node ---
+
+export const AgentMessageNode = memo(function AgentMessageNode({
+  data,
+}: NodeProps & { data: AgentMessageNodeData }) {
+  const d = data as AgentMessageNodeData;
+  return (
+    <div className="max-w-[320px] rounded-lg border border-violet-200 bg-violet-50 px-3 py-2 dark:border-violet-800 dark:bg-violet-950">
+      <div className="flex items-center gap-1.5 text-xs font-medium text-violet-700 dark:text-violet-300 mb-1">
+        <Bot className="w-3 h-3" />
+        Agent Response
+      </div>
+      {d.preview && (
+        <p className="text-xs text-violet-900/80 dark:text-violet-200/80 line-clamp-2 leading-relaxed">
+          {d.preview}
+        </p>
+      )}
+      <Handle type="target" position={Position.Top} className="!w-1.5 !h-1.5 !bg-violet-400" />
+      <Handle type="source" position={Position.Bottom} className="!w-1.5 !h-1.5 !bg-violet-400" />
+    </div>
+  );
+});
+
+// --- Reasoning node ---
+
+export const ReasoningNode = memo(function ReasoningNode({
+  data,
+}: NodeProps & { data: ReasoningNodeData }) {
+  const d = data as ReasoningNodeData;
+  return (
+    <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-1.5 dark:border-amber-800 dark:bg-amber-950">
+      <div className="flex items-center gap-2 text-xs">
+        <Brain className="w-3 h-3 text-amber-600 dark:text-amber-400" />
+        <span className="font-medium text-amber-700 dark:text-amber-300">{d.label}</span>
+        {d.toolCallCount > 0 && (
+          <span className="text-amber-600/70 dark:text-amber-400/70">
+            → {d.toolCallCount} tool{d.toolCallCount !== 1 ? "s" : ""}
+          </span>
+        )}
+        {d.durationMs != null && (
+          <span className="text-amber-600/50 dark:text-amber-400/50">
+            {formatDuration(d.durationMs)}
+          </span>
+        )}
+      </div>
+      <Handle type="target" position={Position.Top} className="!w-1.5 !h-1.5 !bg-amber-400" />
+      <Handle type="source" position={Position.Bottom} className="!w-1.5 !h-1.5 !bg-amber-400" />
+    </div>
+  );
+});
+
+// --- Tool group node ---
+
+export const ToolGroupNode = memo(function ToolGroupNode({
+  data,
+}: NodeProps & { data: ToolGroupNodeData }) {
+  const d = data as ToolGroupNodeData;
+  const hasErrors = d.errorCount > 0;
+  return (
+    <div
+      className={`max-w-[320px] rounded-lg border px-3 py-2 ${
+        hasErrors
+          ? "border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-950"
+          : "border-emerald-200 bg-emerald-50 dark:border-emerald-800 dark:bg-emerald-950"
+      }`}
+    >
+      <div className="flex items-center gap-2 text-xs mb-1">
+        <Wrench
+          className={`w-3 h-3 ${hasErrors ? "text-red-600 dark:text-red-400" : "text-emerald-600 dark:text-emerald-400"}`}
+        />
+        <span
+          className={`font-medium ${hasErrors ? "text-red-700 dark:text-red-300" : "text-emerald-700 dark:text-emerald-300"}`}
+        >
+          {d.label}
+        </span>
+        {d.durationMs != null && (
+          <span className="text-muted-foreground/50">{formatDuration(d.durationMs)}</span>
+        )}
+      </div>
+      <div className="flex flex-wrap gap-1">
+        {d.tools.map((tool) => (
+          <span
+            key={tool.id}
+            className={`inline-flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded-md ${
+              tool.status === "error" || !tool.success
+                ? "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300"
+                : "bg-emerald-100 text-emerald-700 dark:bg-emerald-900 dark:text-emerald-300"
+            }`}
+          >
+            {tool.success ? (
+              <CheckCircle2 className="w-2.5 h-2.5" />
+            ) : (
+              <XCircle className="w-2.5 h-2.5" />
+            )}
+            {tool.name}
+          </span>
+        ))}
+      </div>
+      <Handle
+        type="target"
+        position={Position.Top}
+        className={`!w-1.5 !h-1.5 ${hasErrors ? "!bg-red-400" : "!bg-emerald-400"}`}
+      />
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        className={`!w-1.5 !h-1.5 ${hasErrors ? "!bg-red-400" : "!bg-emerald-400"}`}
+      />
+    </div>
+  );
+});
+
+// Export node type mapping for React Flow
+export const trajectoryNodeTypes = {
+  userMessage: UserMessageNode,
+  agentMessage: AgentMessageNode,
+  reasoning: ReasoningNode,
+  toolGroup: ToolGroupNode,
+  turnStart: TurnStartNode,
+  turnEnd: TurnEndNode,
+};

--- a/apps/ui/src/components/trajectory/trajectory-utils.ts
+++ b/apps/ui/src/components/trajectory/trajectory-utils.ts
@@ -1,5 +1,10 @@
 // Transforms session events into React Flow nodes and edges for trajectory visualization.
-// Designed for large trajectories (thousands of iterations) by keeping nodes compact.
+//
+// Performance design for large trajectories (1000+ turns):
+// - buildTurns() is O(n) single-pass over events
+// - buildTrajectory() is O(n) over turns
+// - Callers should gate recomputation on STRUCTURAL_EVENT_TYPES count,
+//   NOT on every SSE delta event (which fires 10-30x per second during streaming).
 
 import type { Node, Edge } from "@xyflow/react";
 import type {
@@ -86,6 +91,34 @@ export type TrajectoryNodeType =
   | "turnStart"
   | "turnEnd";
 
+// --- Trajectory stats ---
+
+export interface TrajectoryStats {
+  turnCount: number;
+  completedTurns: number;
+  failedTurns: number;
+  totalIterations: number;
+  totalToolCalls: number;
+  totalToolErrors: number;
+  totalDurationMs: number;
+}
+
+// --- Event types that change the trajectory structure ---
+// Only recompute the flow graph when one of these arrives.
+// Delta events (output.message.delta, reason.thinking.delta) are excluded.
+export const STRUCTURAL_EVENT_TYPES = new Set([
+  "turn.started",
+  "turn.completed",
+  "turn.failed",
+  "turn.cancelled",
+  "input.message",
+  "output.message.completed",
+  "reason.completed",
+  "act.started",
+  "act.completed",
+  "tool.completed",
+]);
+
 // --- Layout constants ---
 // Different spacing per node type to prevent overlap
 const SPACING_MARKER = 50; // turn start/end pills
@@ -105,7 +138,6 @@ interface TurnAccumulator {
   turnId: string;
   startTs: string;
   inputMessageId?: string;
-  // Collected within this turn
   userMessage?: { eventId: string; text: string; ts: string };
   iterations: IterationAccumulator[];
   agentMessage?: { eventId: string; text: string; ts: string; hasToolCalls: boolean };
@@ -142,17 +174,15 @@ interface IterationAccumulator {
 
 /**
  * Build structured turns from raw events.
- * Events arrive chronologically; we group them into turns and iterations.
+ * Single O(n) pass. Only processes structural event types.
  */
 function buildTurns(events: Event[]): TurnAccumulator[] {
   const turns: TurnAccumulator[] = [];
   let currentTurn: TurnAccumulator | null = null;
   let currentIteration: IterationAccumulator | null = null;
 
-  // Map of tool_call_id -> tool completed data (for matching)
+  // Collect tool results first (needed for matching with act.started)
   const toolResults = new Map<string, ToolCompletedData>();
-
-  // First pass: collect tool results
   for (const event of events) {
     if (event.type === "tool.completed") {
       const data = event.data as ToolCompletedData;
@@ -161,6 +191,8 @@ function buildTurns(events: Event[]): TurnAccumulator[] {
   }
 
   for (const event of events) {
+    if (!STRUCTURAL_EVENT_TYPES.has(event.type)) continue;
+
     switch (event.type) {
       case "turn.started": {
         const data = event.data as TurnStartedData;
@@ -183,7 +215,6 @@ function buildTurns(events: Event[]): TurnAccumulator[] {
         if (currentTurn) {
           currentTurn.userMessage = { eventId: event.id, text, ts: event.ts };
         } else {
-          // Message outside a turn (shouldn't happen normally, but handle gracefully)
           const orphanTurn: TurnAccumulator = {
             turnId: `orphan-${event.id}`,
             startTs: event.ts,
@@ -287,10 +318,52 @@ function buildTurns(events: Event[]): TurnAccumulator[] {
 }
 
 /**
- * Convert structured turns into React Flow nodes and edges.
+ * Compute aggregate stats from turns.
  */
-export function buildTrajectory(events: Event[]): { nodes: Node[]; edges: Edge[] } {
+function computeStats(turns: TurnAccumulator[]): TrajectoryStats {
+  let completedTurns = 0;
+  let failedTurns = 0;
+  let totalIterations = 0;
+  let totalToolCalls = 0;
+  let totalToolErrors = 0;
+  let totalDurationMs = 0;
+
+  for (const turn of turns) {
+    if (turn.completed) completedTurns++;
+    if (turn.failed) failedTurns++;
+    totalIterations += turn.iterationCount ?? turn.iterations.length;
+    if (turn.durationMs) totalDurationMs += turn.durationMs;
+
+    for (const iter of turn.iterations) {
+      if (iter.toolGroup) {
+        totalToolCalls += iter.toolGroup.tools.length;
+        totalToolErrors += iter.toolGroup.errorCount;
+      }
+    }
+  }
+
+  return {
+    turnCount: turns.length,
+    completedTurns,
+    failedTurns,
+    totalIterations,
+    totalToolCalls,
+    totalToolErrors,
+    totalDurationMs,
+  };
+}
+
+/**
+ * Convert structured turns into React Flow nodes and edges.
+ * Returns stats alongside the graph for the header bar.
+ */
+export function buildTrajectory(events: Event[]): {
+  nodes: Node[];
+  edges: Edge[];
+  stats: TrajectoryStats;
+} {
   const turns = buildTurns(events);
+  const stats = computeStats(turns);
   const nodes: Node[] = [];
   const edges: Edge[] = [];
   let y = 0;
@@ -427,5 +500,19 @@ export function buildTrajectory(events: Event[]): { nodes: Node[]; edges: Edge[]
     }
   }
 
-  return { nodes, edges };
+  return { nodes, edges, stats };
+}
+
+/**
+ * Count structural events in an event list.
+ * Use as a stable memoization key — only changes when the trajectory
+ * structure changes, not on every SSE delta.
+ */
+export function countStructuralEvents(events: Event[] | undefined): number {
+  if (!events) return 0;
+  let count = 0;
+  for (const e of events) {
+    if (STRUCTURAL_EVENT_TYPES.has(e.type)) count++;
+  }
+  return count;
 }

--- a/apps/ui/src/components/trajectory/trajectory-utils.ts
+++ b/apps/ui/src/components/trajectory/trajectory-utils.ts
@@ -87,7 +87,10 @@ export type TrajectoryNodeType =
   | "turnEnd";
 
 // --- Layout constants ---
-const NODE_SPACING_Y = 60;
+// Different spacing per node type to prevent overlap
+const SPACING_MARKER = 50; // turn start/end pills
+const SPACING_COMPACT = 55; // reasoning (single-line)
+const SPACING_CONTENT = 100; // user message, agent message, tool group (multi-line)
 const MAIN_X = 0;
 
 // Truncate text for preview
@@ -340,7 +343,7 @@ export function buildTrajectory(events: Event[]): { nodes: Node[]; edges: Edge[]
       timestamp: turn.startTs,
     } as TurnNodeData);
     connectToPrev(turnStartId);
-    y += NODE_SPACING_Y;
+    y += SPACING_MARKER;
 
     // User message
     if (turn.userMessage) {
@@ -352,7 +355,7 @@ export function buildTrajectory(events: Event[]): { nodes: Node[]; edges: Edge[]
         timestamp: turn.userMessage.ts,
       } as UserMessageNodeData);
       connectToPrev(umId);
-      y += NODE_SPACING_Y;
+      y += SPACING_CONTENT;
     }
 
     // Iterations (reasoning + tool calls)
@@ -372,7 +375,7 @@ export function buildTrajectory(events: Event[]): { nodes: Node[]; edges: Edge[]
           timestamp: iter.reasoning.ts,
         } as ReasoningNodeData);
         connectToPrev(rId);
-        y += NODE_SPACING_Y;
+        y += SPACING_COMPACT;
       }
 
       // Tool group node
@@ -388,7 +391,8 @@ export function buildTrajectory(events: Event[]): { nodes: Node[]; edges: Edge[]
           timestamp: iter.toolGroup.ts,
         } as ToolGroupNodeData);
         connectToPrev(tgId);
-        y += NODE_SPACING_Y;
+        // More tools = taller node
+        y += SPACING_CONTENT + Math.max(0, (iter.toolGroup.tools.length - 3) * 20);
       }
     }
 
@@ -403,7 +407,7 @@ export function buildTrajectory(events: Event[]): { nodes: Node[]; edges: Edge[]
         hasToolCalls: turn.agentMessage.hasToolCalls,
       } as AgentMessageNodeData);
       connectToPrev(amId);
-      y += NODE_SPACING_Y;
+      y += SPACING_CONTENT;
     }
 
     // Turn end marker
@@ -419,7 +423,7 @@ export function buildTrajectory(events: Event[]): { nodes: Node[]; edges: Edge[]
         timestamp: turn.startTs,
       } as TurnNodeData);
       connectToPrev(turnEndId);
-      y += NODE_SPACING_Y * 0.5;
+      y += SPACING_MARKER;
     }
   }
 

--- a/apps/ui/src/components/trajectory/trajectory-utils.ts
+++ b/apps/ui/src/components/trajectory/trajectory-utils.ts
@@ -1,0 +1,427 @@
+// Transforms session events into React Flow nodes and edges for trajectory visualization.
+// Designed for large trajectories (thousands of iterations) by keeping nodes compact.
+
+import type { Node, Edge } from "@xyflow/react";
+import type {
+  Event,
+  InputMessageData,
+  OutputMessageCompletedData,
+  TurnStartedData,
+  TurnCompletedData,
+  TurnFailedData,
+  ReasonCompletedData,
+  ActStartedData,
+  ActCompletedData,
+  ToolCompletedData,
+} from "@/lib/api/types";
+import { getTextFromContent } from "@/lib/api/types";
+
+// --- Node data types ---
+
+export interface UserMessageNodeData {
+  label: string;
+  preview: string;
+  eventId: string;
+  timestamp: string;
+}
+
+export interface AgentMessageNodeData {
+  label: string;
+  preview: string;
+  eventId: string;
+  timestamp: string;
+  hasToolCalls: boolean;
+}
+
+export interface ReasoningNodeData {
+  label: string;
+  iteration: number;
+  hasToolCalls: boolean;
+  toolCallCount: number;
+  durationMs?: number;
+  eventId: string;
+  timestamp: string;
+}
+
+export interface ToolGroupNodeData {
+  label: string;
+  tools: Array<{
+    id: string;
+    name: string;
+    success: boolean;
+    status: string;
+    durationMs?: number;
+  }>;
+  successCount: number;
+  errorCount: number;
+  durationMs?: number;
+  eventId: string;
+  timestamp: string;
+}
+
+export interface TurnNodeData {
+  label: string;
+  turnId: string;
+  iterations: number;
+  durationMs?: number;
+  failed: boolean;
+  errorMessage?: string;
+  timestamp: string;
+}
+
+// Union of all node data types
+export type TrajectoryNodeData =
+  | UserMessageNodeData
+  | AgentMessageNodeData
+  | ReasoningNodeData
+  | ToolGroupNodeData
+  | TurnNodeData;
+
+// Node type identifiers
+export type TrajectoryNodeType =
+  | "userMessage"
+  | "agentMessage"
+  | "reasoning"
+  | "toolGroup"
+  | "turnStart"
+  | "turnEnd";
+
+// --- Layout constants ---
+const NODE_SPACING_Y = 60;
+const MAIN_X = 0;
+
+// Truncate text for preview
+function truncate(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text;
+  return text.slice(0, maxLen) + "…";
+}
+
+// --- Build trajectory from events ---
+
+interface TurnAccumulator {
+  turnId: string;
+  startTs: string;
+  inputMessageId?: string;
+  // Collected within this turn
+  userMessage?: { eventId: string; text: string; ts: string };
+  iterations: IterationAccumulator[];
+  agentMessage?: { eventId: string; text: string; ts: string; hasToolCalls: boolean };
+  completed: boolean;
+  failed: boolean;
+  errorMessage?: string;
+  durationMs?: number;
+  iterationCount?: number;
+}
+
+interface IterationAccumulator {
+  reasoning?: {
+    eventId: string;
+    ts: string;
+    hasToolCalls: boolean;
+    toolCallCount: number;
+    durationMs?: number;
+  };
+  toolGroup?: {
+    eventId: string;
+    ts: string;
+    tools: Array<{
+      id: string;
+      name: string;
+      success: boolean;
+      status: string;
+      durationMs?: number;
+    }>;
+    successCount: number;
+    errorCount: number;
+    durationMs?: number;
+  };
+}
+
+/**
+ * Build structured turns from raw events.
+ * Events arrive chronologically; we group them into turns and iterations.
+ */
+function buildTurns(events: Event[]): TurnAccumulator[] {
+  const turns: TurnAccumulator[] = [];
+  let currentTurn: TurnAccumulator | null = null;
+  let currentIteration: IterationAccumulator | null = null;
+
+  // Map of tool_call_id -> tool completed data (for matching)
+  const toolResults = new Map<string, ToolCompletedData>();
+
+  // First pass: collect tool results
+  for (const event of events) {
+    if (event.type === "tool.completed") {
+      const data = event.data as ToolCompletedData;
+      toolResults.set(data.tool_call_id, data);
+    }
+  }
+
+  for (const event of events) {
+    switch (event.type) {
+      case "turn.started": {
+        const data = event.data as TurnStartedData;
+        currentTurn = {
+          turnId: data.turn_id,
+          startTs: event.ts,
+          inputMessageId: data.input_message_id,
+          iterations: [],
+          completed: false,
+          failed: false,
+        };
+        currentIteration = null;
+        turns.push(currentTurn);
+        break;
+      }
+
+      case "input.message": {
+        const data = event.data as InputMessageData;
+        const text = getTextFromContent(data.message?.content || []);
+        if (currentTurn) {
+          currentTurn.userMessage = { eventId: event.id, text, ts: event.ts };
+        } else {
+          // Message outside a turn (shouldn't happen normally, but handle gracefully)
+          const orphanTurn: TurnAccumulator = {
+            turnId: `orphan-${event.id}`,
+            startTs: event.ts,
+            userMessage: { eventId: event.id, text, ts: event.ts },
+            iterations: [],
+            completed: false,
+            failed: false,
+          };
+          turns.push(orphanTurn);
+          currentTurn = orphanTurn;
+        }
+        break;
+      }
+
+      case "reason.completed": {
+        if (!currentTurn) break;
+        const data = event.data as ReasonCompletedData;
+        currentIteration = {
+          reasoning: {
+            eventId: event.id,
+            ts: event.ts,
+            hasToolCalls: data.has_tool_calls,
+            toolCallCount: data.tool_call_count,
+            durationMs: data.duration_ms,
+          },
+        };
+        currentTurn.iterations.push(currentIteration);
+        break;
+      }
+
+      case "act.started": {
+        if (!currentTurn || !currentIteration) break;
+        const data = event.data as ActStartedData;
+        currentIteration.toolGroup = {
+          eventId: event.id,
+          ts: event.ts,
+          tools: data.tool_calls.map((tc) => {
+            const result = toolResults.get(tc.id);
+            return {
+              id: tc.id,
+              name: tc.name,
+              success: result?.success ?? true,
+              status: result?.status ?? "pending",
+              durationMs: result?.duration_ms,
+            };
+          }),
+          successCount: 0,
+          errorCount: 0,
+        };
+        break;
+      }
+
+      case "act.completed": {
+        if (!currentTurn || !currentIteration?.toolGroup) break;
+        const data = event.data as ActCompletedData;
+        currentIteration.toolGroup.successCount = data.success_count;
+        currentIteration.toolGroup.errorCount = data.error_count;
+        currentIteration.toolGroup.durationMs = data.duration_ms;
+        break;
+      }
+
+      case "output.message.completed": {
+        if (!currentTurn) break;
+        const data = event.data as OutputMessageCompletedData;
+        const text = getTextFromContent(data.message?.content || []);
+        const hasToolCalls = data.message?.content?.some((p) => p.type === "tool_call") ?? false;
+        currentTurn.agentMessage = {
+          eventId: event.id,
+          text,
+          ts: event.ts,
+          hasToolCalls,
+        };
+        break;
+      }
+
+      case "turn.completed": {
+        if (!currentTurn) break;
+        const data = event.data as TurnCompletedData;
+        currentTurn.completed = true;
+        currentTurn.durationMs = data.duration_ms;
+        currentTurn.iterationCount = data.iterations;
+        currentTurn = null;
+        currentIteration = null;
+        break;
+      }
+
+      case "turn.failed": {
+        if (!currentTurn) break;
+        const data = event.data as TurnFailedData;
+        currentTurn.completed = true;
+        currentTurn.failed = true;
+        currentTurn.errorMessage = data.error;
+        currentTurn = null;
+        currentIteration = null;
+        break;
+      }
+    }
+  }
+
+  return turns;
+}
+
+/**
+ * Convert structured turns into React Flow nodes and edges.
+ */
+export function buildTrajectory(events: Event[]): { nodes: Node[]; edges: Edge[] } {
+  const turns = buildTurns(events);
+  const nodes: Node[] = [];
+  const edges: Edge[] = [];
+  let y = 0;
+  let prevNodeId: string | null = null;
+
+  function addNode(
+    id: string,
+    type: TrajectoryNodeType,
+    data: TrajectoryNodeData,
+    x: number = MAIN_X,
+  ) {
+    nodes.push({
+      id,
+      type,
+      position: { x, y },
+      data: data as unknown as Record<string, unknown>,
+    });
+  }
+
+  function addEdge(source: string, target: string, animated = false) {
+    edges.push({
+      id: `e-${source}-${target}`,
+      source,
+      target,
+      animated,
+      style: { strokeWidth: 1.5 },
+    });
+  }
+
+  function connectToPrev(nodeId: string, animated = false) {
+    if (prevNodeId) {
+      addEdge(prevNodeId, nodeId, animated);
+    }
+    prevNodeId = nodeId;
+  }
+
+  for (let turnIdx = 0; turnIdx < turns.length; turnIdx++) {
+    const turn = turns[turnIdx];
+    const turnPrefix = `turn-${turnIdx}`;
+
+    // Turn start marker
+    const turnStartId = `${turnPrefix}-start`;
+    addNode(turnStartId, "turnStart", {
+      label: `Turn ${turnIdx + 1}`,
+      turnId: turn.turnId,
+      iterations: turn.iterationCount ?? turn.iterations.length,
+      durationMs: turn.durationMs,
+      failed: turn.failed,
+      errorMessage: turn.errorMessage,
+      timestamp: turn.startTs,
+    } as TurnNodeData);
+    connectToPrev(turnStartId);
+    y += NODE_SPACING_Y;
+
+    // User message
+    if (turn.userMessage) {
+      const umId = `${turnPrefix}-user`;
+      addNode(umId, "userMessage", {
+        label: "User",
+        preview: truncate(turn.userMessage.text, 120),
+        eventId: turn.userMessage.eventId,
+        timestamp: turn.userMessage.ts,
+      } as UserMessageNodeData);
+      connectToPrev(umId);
+      y += NODE_SPACING_Y;
+    }
+
+    // Iterations (reasoning + tool calls)
+    for (let iterIdx = 0; iterIdx < turn.iterations.length; iterIdx++) {
+      const iter = turn.iterations[iterIdx];
+
+      // Reasoning node
+      if (iter.reasoning) {
+        const rId = `${turnPrefix}-reason-${iterIdx}`;
+        addNode(rId, "reasoning", {
+          label: `Reasoning ${iterIdx + 1}`,
+          iteration: iterIdx + 1,
+          hasToolCalls: iter.reasoning.hasToolCalls,
+          toolCallCount: iter.reasoning.toolCallCount,
+          durationMs: iter.reasoning.durationMs,
+          eventId: iter.reasoning.eventId,
+          timestamp: iter.reasoning.ts,
+        } as ReasoningNodeData);
+        connectToPrev(rId);
+        y += NODE_SPACING_Y;
+      }
+
+      // Tool group node
+      if (iter.toolGroup && iter.toolGroup.tools.length > 0) {
+        const tgId = `${turnPrefix}-tools-${iterIdx}`;
+        addNode(tgId, "toolGroup", {
+          label: `Tools (${iter.toolGroup.tools.length})`,
+          tools: iter.toolGroup.tools,
+          successCount: iter.toolGroup.successCount,
+          errorCount: iter.toolGroup.errorCount,
+          durationMs: iter.toolGroup.durationMs,
+          eventId: iter.toolGroup.eventId,
+          timestamp: iter.toolGroup.ts,
+        } as ToolGroupNodeData);
+        connectToPrev(tgId);
+        y += NODE_SPACING_Y;
+      }
+    }
+
+    // Agent message
+    if (turn.agentMessage) {
+      const amId = `${turnPrefix}-agent`;
+      addNode(amId, "agentMessage", {
+        label: "Agent",
+        preview: truncate(turn.agentMessage.text, 120),
+        eventId: turn.agentMessage.eventId,
+        timestamp: turn.agentMessage.ts,
+        hasToolCalls: turn.agentMessage.hasToolCalls,
+      } as AgentMessageNodeData);
+      connectToPrev(amId);
+      y += NODE_SPACING_Y;
+    }
+
+    // Turn end marker
+    if (turn.completed) {
+      const turnEndId = `${turnPrefix}-end`;
+      addNode(turnEndId, "turnEnd", {
+        label: turn.failed ? "Turn Failed" : "Turn Done",
+        turnId: turn.turnId,
+        iterations: turn.iterationCount ?? turn.iterations.length,
+        durationMs: turn.durationMs,
+        failed: turn.failed,
+        errorMessage: turn.errorMessage,
+        timestamp: turn.startTs,
+      } as TurnNodeData);
+      connectToPrev(turnEndId);
+      y += NODE_SPACING_Y * 0.5;
+    }
+  }
+
+  return { nodes, edges };
+}

--- a/apps/ui/src/components/trajectory/trajectory-utils.ts
+++ b/apps/ui/src/components/trajectory/trajectory-utils.ts
@@ -1,5 +1,8 @@
 // Transforms session events into React Flow nodes and edges for trajectory visualization.
 //
+// Layout: each turn is a group node (box) containing child nodes.
+// Children use parentId + relative positioning. Edges use bezier curves.
+//
 // Performance design for large trajectories (1000+ turns):
 // - buildTurns() is O(n) single-pass over events
 // - buildTrajectory() is O(n) over turns
@@ -64,9 +67,10 @@ export interface ToolGroupNodeData {
   timestamp: string;
 }
 
-export interface TurnNodeData {
+export interface TurnGroupNodeData {
   label: string;
   turnId: string;
+  turnNumber: number;
   iterations: number;
   durationMs?: number;
   failed: boolean;
@@ -80,7 +84,7 @@ export type TrajectoryNodeData =
   | AgentMessageNodeData
   | ReasoningNodeData
   | ToolGroupNodeData
-  | TurnNodeData;
+  | TurnGroupNodeData;
 
 // Node type identifiers
 export type TrajectoryNodeType =
@@ -88,8 +92,7 @@ export type TrajectoryNodeType =
   | "agentMessage"
   | "reasoning"
   | "toolGroup"
-  | "turnStart"
-  | "turnEnd";
+  | "turnGroup";
 
 // --- Trajectory stats ---
 
@@ -104,8 +107,6 @@ export interface TrajectoryStats {
 }
 
 // --- Event types that change the trajectory structure ---
-// Only recompute the flow graph when one of these arrives.
-// Delta events (output.message.delta, reason.thinking.delta) are excluded.
 export const STRUCTURAL_EVENT_TYPES = new Set([
   "turn.started",
   "turn.completed",
@@ -120,13 +121,15 @@ export const STRUCTURAL_EVENT_TYPES = new Set([
 ]);
 
 // --- Layout constants ---
-// Different spacing per node type to prevent overlap
-const SPACING_MARKER = 50; // turn start/end pills
-const SPACING_COMPACT = 55; // reasoning (single-line)
-const SPACING_CONTENT = 100; // user message, agent message, tool group (multi-line)
-const MAIN_X = 0;
+const GROUP_PAD_X = 16;
+const GROUP_PAD_TOP = 44; // space for turn header inside group
+const GROUP_PAD_BOTTOM = 16;
+const GROUP_WIDTH = 340;
+const CHILD_X = GROUP_PAD_X; // child x offset inside group
+const CHILD_SPACING_COMPACT = 44; // reasoning
+const CHILD_SPACING_CONTENT = 80; // user msg, agent msg, tools
+const GROUP_GAP = 40; // vertical gap between turn groups
 
-// Truncate text for preview
 function truncate(text: string, maxLen: number): string {
   if (text.length <= maxLen) return text;
   return text.slice(0, maxLen) + "…";
@@ -172,16 +175,11 @@ interface IterationAccumulator {
   };
 }
 
-/**
- * Build structured turns from raw events.
- * Single O(n) pass. Only processes structural event types.
- */
 function buildTurns(events: Event[]): TurnAccumulator[] {
   const turns: TurnAccumulator[] = [];
   let currentTurn: TurnAccumulator | null = null;
   let currentIteration: IterationAccumulator | null = null;
 
-  // Collect tool results first (needed for matching with act.started)
   const toolResults = new Map<string, ToolCompletedData>();
   for (const event of events) {
     if (event.type === "tool.completed") {
@@ -317,9 +315,6 @@ function buildTurns(events: Event[]): TurnAccumulator[] {
   return turns;
 }
 
-/**
- * Compute aggregate stats from turns.
- */
 function computeStats(turns: TurnAccumulator[]): TrajectoryStats {
   let completedTurns = 0;
   let failedTurns = 0;
@@ -355,7 +350,10 @@ function computeStats(turns: TurnAccumulator[]): TrajectoryStats {
 
 /**
  * Convert structured turns into React Flow nodes and edges.
- * Returns stats alongside the graph for the header bar.
+ *
+ * Each turn is a group node containing child nodes via parentId.
+ * Edges connect children sequentially within a turn,
+ * and from the last child of one turn to the first child of the next.
  */
 export function buildTrajectory(events: Event[]): {
   nodes: Node[];
@@ -366,79 +364,57 @@ export function buildTrajectory(events: Event[]): {
   const stats = computeStats(turns);
   const nodes: Node[] = [];
   const edges: Edge[] = [];
-  let y = 0;
-  let prevNodeId: string | null = null;
+  let groupY = 0; // absolute Y for group placement
+  let prevChildId: string | null = null; // last child of previous turn
 
-  function addNode(
-    id: string,
-    type: TrajectoryNodeType,
-    data: TrajectoryNodeData,
-    x: number = MAIN_X,
-  ) {
-    nodes.push({
-      id,
-      type,
-      position: { x, y },
-      data: data as unknown as Record<string, unknown>,
-    });
-  }
-
-  function addEdge(source: string, target: string, animated = false) {
+  function addEdge(source: string, target: string) {
     edges.push({
       id: `e-${source}-${target}`,
       source,
       target,
-      animated,
-      style: { strokeWidth: 1.5 },
     });
-  }
-
-  function connectToPrev(nodeId: string, animated = false) {
-    if (prevNodeId) {
-      addEdge(prevNodeId, nodeId, animated);
-    }
-    prevNodeId = nodeId;
   }
 
   for (let turnIdx = 0; turnIdx < turns.length; turnIdx++) {
     const turn = turns[turnIdx];
-    const turnPrefix = `turn-${turnIdx}`;
+    const groupId = `turn-${turnIdx}-group`;
+    let childY = GROUP_PAD_TOP; // relative Y within group
+    let firstChildId: string | null = null;
+    let lastChildId: string | null = null;
 
-    // Turn start marker
-    const turnStartId = `${turnPrefix}-start`;
-    addNode(turnStartId, "turnStart", {
-      label: `Turn ${turnIdx + 1}`,
-      turnId: turn.turnId,
-      iterations: turn.iterationCount ?? turn.iterations.length,
-      durationMs: turn.durationMs,
-      failed: turn.failed,
-      errorMessage: turn.errorMessage,
-      timestamp: turn.startTs,
-    } as TurnNodeData);
-    connectToPrev(turnStartId);
-    y += SPACING_MARKER;
+    function addChild(id: string, type: TrajectoryNodeType, data: TrajectoryNodeData) {
+      nodes.push({
+        id,
+        type,
+        position: { x: CHILD_X, y: childY },
+        parentId: groupId,
+        extent: "parent" as const,
+        data: data as unknown as Record<string, unknown>,
+      });
+      if (!firstChildId) firstChildId = id;
+      if (lastChildId) addEdge(lastChildId, id);
+      lastChildId = id;
+    }
 
     // User message
     if (turn.userMessage) {
-      const umId = `${turnPrefix}-user`;
-      addNode(umId, "userMessage", {
+      const umId = `turn-${turnIdx}-user`;
+      addChild(umId, "userMessage", {
         label: "User",
-        preview: truncate(turn.userMessage.text, 120),
+        preview: truncate(turn.userMessage.text, 100),
         eventId: turn.userMessage.eventId,
         timestamp: turn.userMessage.ts,
       } as UserMessageNodeData);
-      connectToPrev(umId);
-      y += SPACING_CONTENT;
+      childY += CHILD_SPACING_CONTENT;
     }
 
-    // Iterations (reasoning + tool calls)
+    // Iterations
     for (let iterIdx = 0; iterIdx < turn.iterations.length; iterIdx++) {
       const iter = turn.iterations[iterIdx];
 
-      // Reasoning node
       if (iter.reasoning) {
-        const rId = `${turnPrefix}-reason-${iterIdx}`;
-        addNode(rId, "reasoning", {
+        const rId = `turn-${turnIdx}-reason-${iterIdx}`;
+        addChild(rId, "reasoning", {
           label: `Reasoning ${iterIdx + 1}`,
           iteration: iterIdx + 1,
           hasToolCalls: iter.reasoning.hasToolCalls,
@@ -447,14 +423,12 @@ export function buildTrajectory(events: Event[]): {
           eventId: iter.reasoning.eventId,
           timestamp: iter.reasoning.ts,
         } as ReasoningNodeData);
-        connectToPrev(rId);
-        y += SPACING_COMPACT;
+        childY += CHILD_SPACING_COMPACT;
       }
 
-      // Tool group node
       if (iter.toolGroup && iter.toolGroup.tools.length > 0) {
-        const tgId = `${turnPrefix}-tools-${iterIdx}`;
-        addNode(tgId, "toolGroup", {
+        const tgId = `turn-${turnIdx}-tools-${iterIdx}`;
+        addChild(tgId, "toolGroup", {
           label: `Tools (${iter.toolGroup.tools.length})`,
           tools: iter.toolGroup.tools,
           successCount: iter.toolGroup.successCount,
@@ -463,51 +437,59 @@ export function buildTrajectory(events: Event[]): {
           eventId: iter.toolGroup.eventId,
           timestamp: iter.toolGroup.ts,
         } as ToolGroupNodeData);
-        connectToPrev(tgId);
-        // More tools = taller node
-        y += SPACING_CONTENT + Math.max(0, (iter.toolGroup.tools.length - 3) * 20);
+        childY += CHILD_SPACING_CONTENT + Math.max(0, (iter.toolGroup.tools.length - 3) * 20);
       }
     }
 
     // Agent message
     if (turn.agentMessage) {
-      const amId = `${turnPrefix}-agent`;
-      addNode(amId, "agentMessage", {
+      const amId = `turn-${turnIdx}-agent`;
+      addChild(amId, "agentMessage", {
         label: "Agent",
-        preview: truncate(turn.agentMessage.text, 120),
+        preview: truncate(turn.agentMessage.text, 100),
         eventId: turn.agentMessage.eventId,
         timestamp: turn.agentMessage.ts,
         hasToolCalls: turn.agentMessage.hasToolCalls,
       } as AgentMessageNodeData);
-      connectToPrev(amId);
-      y += SPACING_CONTENT;
+      childY += CHILD_SPACING_CONTENT;
     }
 
-    // Turn end marker
-    if (turn.completed) {
-      const turnEndId = `${turnPrefix}-end`;
-      addNode(turnEndId, "turnEnd", {
-        label: turn.failed ? "Turn Failed" : "Turn Done",
+    // Calculate group height from accumulated child positions
+    const groupHeight = childY - CHILD_SPACING_CONTENT + CHILD_SPACING_COMPACT + GROUP_PAD_BOTTOM;
+
+    // Create turn group node
+    nodes.push({
+      id: groupId,
+      type: "turnGroup",
+      position: { x: 0, y: groupY },
+      data: {
+        label: `Turn ${turnIdx + 1}`,
         turnId: turn.turnId,
+        turnNumber: turnIdx + 1,
         iterations: turn.iterationCount ?? turn.iterations.length,
         durationMs: turn.durationMs,
         failed: turn.failed,
         errorMessage: turn.errorMessage,
         timestamp: turn.startTs,
-      } as TurnNodeData);
-      connectToPrev(turnEndId);
-      y += SPACING_MARKER;
+      } as unknown as Record<string, unknown>,
+      style: {
+        width: GROUP_WIDTH,
+        height: Math.max(groupHeight, GROUP_PAD_TOP + 40),
+      },
+    });
+
+    // Edge from previous turn's last child to this turn's first child
+    if (prevChildId && firstChildId) {
+      addEdge(prevChildId, firstChildId);
     }
+    prevChildId = lastChildId;
+
+    groupY += Math.max(groupHeight, GROUP_PAD_TOP + 40) + GROUP_GAP;
   }
 
   return { nodes, edges, stats };
 }
 
-/**
- * Count structural events in an event list.
- * Use as a stable memoization key — only changes when the trajectory
- * structure changes, not on every SSE delta.
- */
 export function countStructuralEvents(events: Event[] | undefined): number {
   if (!events) return 0;
   let count = 0;

--- a/apps/ui/src/components/trajectory/trajectory-view.tsx
+++ b/apps/ui/src/components/trajectory/trajectory-view.tsx
@@ -41,8 +41,7 @@ function miniMapNodeColor(node: { type?: string }): string {
       return "#f59e0b"; // amber
     case "toolGroup":
       return "#10b981"; // emerald
-    case "turnStart":
-    case "turnEnd":
+    case "turnGroup":
       return "#94a3b8"; // slate
     default:
       return "#6b7280";
@@ -146,7 +145,7 @@ export function TrajectoryView({ events, colorMode }: TrajectoryViewProps) {
           panOnScroll
           zoomOnScroll
           defaultEdgeOptions={{
-            type: "smoothstep",
+            type: "bezier",
             animated: false,
             style: { strokeWidth: 1.5 },
           }}

--- a/apps/ui/src/components/trajectory/trajectory-view.tsx
+++ b/apps/ui/src/components/trajectory/trajectory-view.tsx
@@ -1,0 +1,114 @@
+// Main trajectory visualization component.
+// Uses React Flow with MiniMap for navigating large agent trajectories.
+// Supports thousands of nodes via viewport culling.
+
+"use client";
+
+import { useMemo, useCallback } from "react";
+import {
+  ReactFlow,
+  MiniMap,
+  Controls,
+  Background,
+  BackgroundVariant,
+  useNodesState,
+  useEdgesState,
+  type ColorMode,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+
+import type { Event } from "@/lib/api/types";
+import { buildTrajectory } from "./trajectory-utils";
+import { trajectoryNodeTypes } from "./trajectory-nodes";
+
+interface TrajectoryViewProps {
+  events: Event[];
+  colorMode?: ColorMode;
+}
+
+// Minimap node color based on node type
+function miniMapNodeColor(node: { type?: string }): string {
+  switch (node.type) {
+    case "userMessage":
+      return "#3b82f6"; // blue
+    case "agentMessage":
+      return "#8b5cf6"; // violet
+    case "reasoning":
+      return "#f59e0b"; // amber
+    case "toolGroup":
+      return "#10b981"; // emerald
+    case "turnStart":
+    case "turnEnd":
+      return "#94a3b8"; // slate
+    default:
+      return "#6b7280";
+  }
+}
+
+export function TrajectoryView({ events, colorMode }: TrajectoryViewProps) {
+  // Build nodes/edges from events - memoized to avoid re-computation
+  const { initialNodes, initialEdges } = useMemo(() => {
+    const { nodes, edges } = buildTrajectory(events);
+    return { initialNodes: nodes, initialEdges: edges };
+  }, [events]);
+
+  const [nodes, , onNodesChange] = useNodesState(initialNodes);
+  const [edges, , onEdgesChange] = useEdgesState(initialEdges);
+
+  // Fit view on mount
+  const onInit = useCallback((instance: { fitView: (opts?: { padding?: number }) => void }) => {
+    // Small delay to ensure nodes are measured before fitting
+    requestAnimationFrame(() => {
+      instance.fitView({ padding: 0.2 });
+    });
+  }, []);
+
+  if (initialNodes.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full text-muted-foreground">
+        <div className="text-center">
+          <p className="text-lg font-medium">No trajectory data yet</p>
+          <p className="text-sm">Trajectory will appear as the agent processes turns</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full h-full">
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        nodeTypes={trajectoryNodeTypes}
+        onInit={onInit}
+        colorMode={colorMode ?? "system"}
+        fitView
+        minZoom={0.01}
+        maxZoom={2}
+        nodesDraggable={false}
+        nodesConnectable={false}
+        elementsSelectable={false}
+        panOnScroll
+        zoomOnScroll
+        defaultEdgeOptions={{
+          type: "smoothstep",
+          animated: false,
+          style: { strokeWidth: 1.5 },
+        }}
+      >
+        <Controls showInteractive={false} />
+        <MiniMap
+          nodeColor={miniMapNodeColor}
+          nodeStrokeWidth={0}
+          maskColor="rgba(0, 0, 0, 0.15)"
+          className="!bg-background !border-border"
+          pannable
+          zoomable
+        />
+        <Background variant={BackgroundVariant.Dots} gap={20} size={1} />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/apps/ui/src/components/trajectory/trajectory-view.tsx
+++ b/apps/ui/src/components/trajectory/trajectory-view.tsx
@@ -11,8 +11,6 @@ import {
   Controls,
   Background,
   BackgroundVariant,
-  useNodesState,
-  useEdgesState,
   type ColorMode,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
@@ -46,24 +44,17 @@ function miniMapNodeColor(node: { type?: string }): string {
 }
 
 export function TrajectoryView({ events, colorMode }: TrajectoryViewProps) {
-  // Build nodes/edges from events - memoized to avoid re-computation
-  const { initialNodes, initialEdges } = useMemo(() => {
-    const { nodes, edges } = buildTrajectory(events);
-    return { initialNodes: nodes, initialEdges: edges };
-  }, [events]);
-
-  const [nodes, , onNodesChange] = useNodesState(initialNodes);
-  const [edges, , onEdgesChange] = useEdgesState(initialEdges);
+  // Build nodes/edges from events - recomputed when events change (SSE updates)
+  const { nodes, edges } = useMemo(() => buildTrajectory(events), [events]);
 
   // Fit view on mount
   const onInit = useCallback((instance: { fitView: (opts?: { padding?: number }) => void }) => {
-    // Small delay to ensure nodes are measured before fitting
     requestAnimationFrame(() => {
       instance.fitView({ padding: 0.2 });
     });
   }, []);
 
-  if (initialNodes.length === 0) {
+  if (nodes.length === 0) {
     return (
       <div className="flex items-center justify-center h-full text-muted-foreground">
         <div className="text-center">
@@ -79,8 +70,6 @@ export function TrajectoryView({ events, colorMode }: TrajectoryViewProps) {
       <ReactFlow
         nodes={nodes}
         edges={edges}
-        onNodesChange={onNodesChange}
-        onEdgesChange={onEdgesChange}
         nodeTypes={trajectoryNodeTypes}
         onInit={onInit}
         colorMode={colorMode ?? "system"}

--- a/apps/ui/src/components/trajectory/trajectory-view.tsx
+++ b/apps/ui/src/components/trajectory/trajectory-view.tsx
@@ -1,6 +1,11 @@
 // Main trajectory visualization component.
 // Uses React Flow with MiniMap for navigating large agent trajectories.
-// Supports thousands of nodes via viewport culling.
+//
+// Performance for 1000+ turns:
+// - Memoization gated on structural event count (skips SSE deltas)
+// - React Flow viewport culling (only visible nodes in DOM)
+// - Nodes are not draggable/connectable/selectable (reduces event overhead)
+// - MiniMap for efficient navigation of large flows
 
 "use client";
 
@@ -14,9 +19,10 @@ import {
   type ColorMode,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
+import { Repeat, Wrench, XCircle, Clock } from "lucide-react";
 
 import type { Event } from "@/lib/api/types";
-import { buildTrajectory } from "./trajectory-utils";
+import { buildTrajectory, countStructuralEvents, type TrajectoryStats } from "./trajectory-utils";
 import { trajectoryNodeTypes } from "./trajectory-nodes";
 
 interface TrajectoryViewProps {
@@ -43,9 +49,65 @@ function miniMapNodeColor(node: { type?: string }): string {
   }
 }
 
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  const mins = Math.floor(ms / 60_000);
+  const secs = ((ms % 60_000) / 1000).toFixed(0);
+  return `${mins}m ${secs}s`;
+}
+
+function StatsBar({ stats }: { stats: TrajectoryStats }) {
+  return (
+    <div className="flex items-center gap-4 px-4 py-2 border-b text-xs text-muted-foreground bg-muted/30">
+      <span className="flex items-center gap-1">
+        <Repeat className="w-3 h-3" />
+        {stats.turnCount} turn{stats.turnCount !== 1 ? "s" : ""}
+        {stats.totalIterations > 0 && (
+          <span className="text-muted-foreground/60">
+            ({stats.totalIterations} iter{stats.totalIterations !== 1 ? "s" : ""})
+          </span>
+        )}
+      </span>
+      {stats.totalToolCalls > 0 && (
+        <span className="flex items-center gap-1">
+          <Wrench className="w-3 h-3" />
+          {stats.totalToolCalls} tool call{stats.totalToolCalls !== 1 ? "s" : ""}
+        </span>
+      )}
+      {stats.totalToolErrors > 0 && (
+        <span className="flex items-center gap-1 text-red-500">
+          <XCircle className="w-3 h-3" />
+          {stats.totalToolErrors} error{stats.totalToolErrors !== 1 ? "s" : ""}
+        </span>
+      )}
+      {stats.failedTurns > 0 && (
+        <span className="flex items-center gap-1 text-red-500">
+          {stats.failedTurns} failed turn{stats.failedTurns !== 1 ? "s" : ""}
+        </span>
+      )}
+      {stats.totalDurationMs > 0 && (
+        <span className="flex items-center gap-1">
+          <Clock className="w-3 h-3" />
+          {formatDuration(stats.totalDurationMs)}
+        </span>
+      )}
+    </div>
+  );
+}
+
 export function TrajectoryView({ events, colorMode }: TrajectoryViewProps) {
-  // Build nodes/edges from events - recomputed when events change (SSE updates)
-  const { nodes, edges } = useMemo(() => buildTrajectory(events), [events]);
+  // Count structural events as a stable primitive memoization key.
+  // This number only changes when a turn/reason/act/tool/message event arrives,
+  // NOT on every output.message.delta or reason.thinking.delta (which fire 10-30x/sec).
+  const structuralCount = useMemo(() => countStructuralEvents(events), [events]);
+
+  // Build nodes/edges/stats only when structural events change
+  const { nodes, edges, stats } = useMemo(
+    () => buildTrajectory(events),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: gate on structuralCount, not events ref
+    [structuralCount],
+  );
 
   // Fit view on mount
   const onInit = useCallback((instance: { fitView: (opts?: { padding?: number }) => void }) => {
@@ -66,38 +128,41 @@ export function TrajectoryView({ events, colorMode }: TrajectoryViewProps) {
   }
 
   return (
-    <div className="w-full h-full">
-      <ReactFlow
-        nodes={nodes}
-        edges={edges}
-        nodeTypes={trajectoryNodeTypes}
-        onInit={onInit}
-        colorMode={colorMode ?? "system"}
-        fitView
-        minZoom={0.01}
-        maxZoom={2}
-        nodesDraggable={false}
-        nodesConnectable={false}
-        elementsSelectable={false}
-        panOnScroll
-        zoomOnScroll
-        defaultEdgeOptions={{
-          type: "smoothstep",
-          animated: false,
-          style: { strokeWidth: 1.5 },
-        }}
-      >
-        <Controls showInteractive={false} />
-        <MiniMap
-          nodeColor={miniMapNodeColor}
-          nodeStrokeWidth={0}
-          maskColor="rgba(0, 0, 0, 0.15)"
-          className="!bg-background !border-border"
-          pannable
-          zoomable
-        />
-        <Background variant={BackgroundVariant.Dots} gap={20} size={1} />
-      </ReactFlow>
+    <div className="w-full h-full flex flex-col">
+      <StatsBar stats={stats} />
+      <div className="flex-1">
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          nodeTypes={trajectoryNodeTypes}
+          onInit={onInit}
+          colorMode={colorMode ?? "system"}
+          fitView
+          minZoom={0.01}
+          maxZoom={2}
+          nodesDraggable={false}
+          nodesConnectable={false}
+          elementsSelectable={false}
+          panOnScroll
+          zoomOnScroll
+          defaultEdgeOptions={{
+            type: "smoothstep",
+            animated: false,
+            style: { strokeWidth: 1.5 },
+          }}
+        >
+          <Controls showInteractive={false} />
+          <MiniMap
+            nodeColor={miniMapNodeColor}
+            nodeStrokeWidth={0}
+            maskColor="rgba(0, 0, 0, 0.15)"
+            className="!bg-background !border-border"
+            pannable
+            zoomable
+          />
+          <Background variant={BackgroundVariant.Dots} gap={20} size={1} />
+        </ReactFlow>
+      </div>
     </div>
   );
 }

--- a/apps/ui/src/hooks/use-sessions.ts
+++ b/apps/ui/src/hooks/use-sessions.ts
@@ -11,7 +11,7 @@ import {
   updateSession,
   sendUserMessage,
 } from "@/lib/api/sessions";
-import { getSseUrl } from "@/lib/api/events";
+import { getSseUrl, listEvents } from "@/lib/api/events";
 import { queryKeys } from "@/lib/query-keys";
 import type {
   CreateSessionRequest,
@@ -133,15 +133,43 @@ export function useSendMessage() {
 }
 
 // ============================================
-// Events hook - uses SSE for real-time updates
+// Events hook - REST batch load + SSE for live updates
 // ============================================
 
+// SSE event types to listen for
+const SSE_EVENT_TYPES = [
+  "input.message",
+  "output.message.started",
+  "output.message.delta",
+  "output.message.completed",
+  "turn.started",
+  "turn.completed",
+  "turn.failed",
+  "turn.cancelled",
+  "reason.started",
+  "reason.completed",
+  "act.started",
+  "act.completed",
+  "tool.started",
+  "tool.completed",
+  "llm.generation",
+  "session.started",
+  "session.activated",
+  "session.idled",
+  "reason.thinking.started",
+  "reason.thinking.delta",
+  "reason.thinking.completed",
+];
+
 /**
- * Fetch events for a session using SSE (Server-Sent Events)
+ * Fetch events for a session using REST + SSE.
  *
- * Uses SSE for real-time streaming with since_id for incremental updates.
- * Falls back to initial fetch + SSE reconnection for reliability.
- * The enabled option controls whether to connect to SSE (useful for inactive sessions).
+ * Strategy: REST first, SSE second.
+ * 1. Fetch all existing events via REST (single HTTP response → single setState)
+ * 2. Connect SSE with since_id from last REST event for live incremental updates
+ *
+ * This is critical for large sessions (1000+ turns, 30k+ events) where
+ * SSE-only would trigger one state update per event on initial load.
  */
 export function useEvents(sessionId: string | undefined, options?: { enabled?: boolean }) {
   const { currentOrg } = useOrg();
@@ -157,7 +185,10 @@ export function useEvents(sessionId: string | undefined, options?: { enabled?: b
   // Track events by ID to avoid duplicates
   const eventIdsRef = useRef<Set<string>>(new Set());
 
-  // Cleanup function
+  // Track whether initial REST fetch has completed
+  const [restLoaded, setRestLoaded] = useState(false);
+
+  // Cleanup SSE connection
   const cleanup = useCallback(() => {
     if (eventSourceRef.current) {
       eventSourceRef.current.close();
@@ -172,92 +203,87 @@ export function useEvents(sessionId: string | undefined, options?: { enabled?: b
     setError(null);
     lastEventIdRef.current = null;
     eventIdsRef.current.clear();
-  }, [org, sessionId]);
+    setRestLoaded(false);
+    cleanup();
+  }, [org, sessionId, cleanup]);
 
-  // SSE connection
+  // Step 1: REST batch load existing events
   useEffect(() => {
-    if (!org || !sessionId || !isEnabled) {
-      cleanup();
+    if (!org || !sessionId || !isEnabled) return;
+
+    let cancelled = false;
+
+    async function fetchInitialEvents() {
+      try {
+        const batch = await listEvents(sessionId!);
+        if (cancelled) return;
+
+        if (batch.length > 0) {
+          for (const e of batch) {
+            eventIdsRef.current.add(e.id);
+          }
+          lastEventIdRef.current = batch[batch.length - 1].id;
+          // Single state update for entire batch
+          setEvents(batch);
+        }
+      } catch (e) {
+        if (cancelled) return;
+        console.error("Failed to fetch initial events, falling back to SSE-only:", e);
+      }
+
+      if (!cancelled) {
+        setIsLoading(false);
+        setRestLoaded(true);
+      }
+    }
+
+    fetchInitialEvents();
+    return () => {
+      cancelled = true;
+    };
+  }, [org, sessionId, isEnabled]);
+
+  // Step 2: SSE for live updates (starts after REST completes)
+  useEffect(() => {
+    if (!org || !sessionId || !isEnabled || !restLoaded) {
       return;
     }
 
     const connectSSE = () => {
-      // Close existing connection
       cleanup();
 
       const sseUrl = getSseUrl(sessionId, lastEventIdRef.current ?? undefined);
       const eventSource = new EventSource(sseUrl, { withCredentials: true });
       eventSourceRef.current = eventSource;
 
-      // Listen for "connected" event to know SSE stream is ready
-      // This is sent immediately by the server when connection is established
       eventSource.addEventListener("connected", () => {
-        setIsLoading(false);
         setError(null);
       });
 
-      // Listen for "disconnecting" event for graceful connection cycling
-      // Server sends this before closing to allow immediate reconnect with since_id
       eventSource.addEventListener("disconnecting", (messageEvent) => {
         try {
           const data = JSON.parse(messageEvent.data);
           const retryMs = data.retry_ms ?? 100;
-          console.debug("SSE disconnecting event received, reconnecting in", retryMs, "ms");
           cleanup();
           setTimeout(() => {
-            if (isEnabled) {
-              connectSSE();
-            }
+            if (isEnabled) connectSSE();
           }, retryMs);
         } catch {
-          // Fallback: reconnect immediately
           cleanup();
-          if (isEnabled) {
-            connectSSE();
-          }
+          if (isEnabled) connectSSE();
         }
       });
 
-      // Fallback: onopen may fire, but "connected" event is more reliable
       eventSource.onopen = () => {
         setError(null);
       };
 
-      // Listen for typed events (the backend sends event type as SSE event name)
-      const eventTypes = [
-        "input.message",
-        "output.message.started",
-        "output.message.delta",
-        "output.message.completed",
-        "turn.started",
-        "turn.completed",
-        "turn.failed",
-        "turn.cancelled",
-        "reason.started",
-        "reason.completed",
-        "act.started",
-        "act.completed",
-        "tool.started",
-        "tool.completed",
-        "llm.generation",
-        "session.started",
-        "session.activated",
-        "session.idled",
-        // Streaming events for real-time text updates
-        "reason.thinking.started",
-        "reason.thinking.delta",
-        "reason.thinking.completed",
-      ];
-
-      for (const eventType of eventTypes) {
+      for (const eventType of SSE_EVENT_TYPES) {
         eventSource.addEventListener(eventType, (messageEvent) => {
           try {
             const event: Event = JSON.parse(messageEvent.data);
 
-            // Skip if we already have this event
-            if (eventIdsRef.current.has(event.id)) {
-              return;
-            }
+            if (eventIdsRef.current.has(event.id)) return;
 
             eventIdsRef.current.add(event.id);
             lastEventIdRef.current = event.id;
@@ -269,14 +295,10 @@ export function useEvents(sessionId: string | undefined, options?: { enabled?: b
       }
 
       eventSource.onerror = () => {
-        // SSE will auto-reconnect, but we track the error state
         setError(new Error("SSE connection error"));
-        // Reconnect after a delay if the connection was lost
         cleanup();
         setTimeout(() => {
-          if (isEnabled) {
-            connectSSE();
-          }
+          if (isEnabled) connectSSE();
         }, 2000);
       };
     };
@@ -284,7 +306,7 @@ export function useEvents(sessionId: string | undefined, options?: { enabled?: b
     connectSSE();
 
     return cleanup;
-  }, [org, sessionId, isEnabled, cleanup]);
+  }, [org, sessionId, isEnabled, restLoaded, cleanup]);
 
   return {
     data: events,


### PR DESCRIPTION
## What
New **Trajectory** tab in the session detail UI that visualizes agent work as an interactive flow diagram using React Flow.

## Why
Agent sessions can involve complex multi-turn reasoning with tool calls, but there was no visual way to understand the flow of work. This makes it hard to debug agent behavior or understand what happened during a session.

## How
- Added `@xyflow/react` (React Flow v12) for flow visualization
- `trajectory-utils.ts`: Transforms session events into React Flow nodes/edges with parent-child turn grouping
- `trajectory-nodes.tsx`: Custom node components (TurnGroup, UserMessage, AgentMessage, Reasoning, ToolGroup)
- `trajectory-view.tsx`: Main React Flow wrapper with MiniMap, Controls, stats bar
- Hybrid REST + SSE loading: batch-loads existing events via REST, then subscribes to SSE for live updates
- Performance: memoization gated on structural event count (skips high-frequency delta events), React Flow viewport culling handles 1000+ turns
- Turn grouping: each turn renders as a container box with child nodes inside, connected by bezier edges

## Risk
- Low
- New tab only, no changes to existing session functionality
- `use-sessions.ts` hook refactored to REST+SSE but maintains same public API

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered