### PR TITLE
docs: add concepts page with entity diagrams

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Fix root cause. Unsure: read more code; if stuck, ask w/ short options. Unrecogn
 
 `specs/` contains feature specifications. New code should comply with these or propose changes.
 
+- `specs/concepts.md` - Core entities, relationships, and concept diagram
 - `specs/architecture.md` - System architecture, crate structure, infrastructure
 - `specs/code-organization.md` - Naming conventions, type flow, testing, error handling
 - `specs/models.md` - Data models (Agent, Session, Message, etc.)

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -50,6 +50,7 @@ export default defineConfig({
           label: "Getting Started",
           items: [
             { label: "Introduction", slug: "getting-started/introduction" },
+            { label: "Concepts", slug: "getting-started/concepts" },
             { label: "Docker Compose Quickstart", slug: "getting-started/docker-compose" },
             { label: "Architecture", slug: "getting-started/architecture" },
           ],

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -1,6 +1,9 @@
-# Concepts
+---
+title: Concepts
+description: Core entities and relationships in Everruns
+---
 
-Everruns is a durable agentic harness engine. This document describes the core entities and how they relate to each other, split into three layers: high-level execution model, session internals, and settings.
+This page describes the core entities in Everruns and how they relate to each other, organized into three layers: the high-level execution model, session internals, and settings.
 
 ## High Level
 
@@ -32,36 +35,36 @@ graph LR
 
 ### Harness
 
-Top-level entity that represents a setup for agent execution. Defines infrastructure, defaults, and constraints under which sessions run. Configures how agents are invoked, which capabilities are available by default, and the execution environment.
+A Harness is the top-level entity that represents a setup for agent execution. It defines the infrastructure, defaults, and constraints under which sessions run — configuring how agents are invoked, which capabilities are available by default, and what execution environment is provided.
 
-- Many harnesses in the system
+- There can be many harnesses in the system
 - Each session has exactly one assigned harness
-- A harness can have capabilities attached
+- A harness can have capabilities attached to it
 
 ### Agent
 
-Domain-specific or task-specific configuration for the agentic loop. Defines system prompt, default LLM model, and enabled capabilities.
+An Agent is a domain-specific or task-specific configuration for the agentic loop. It defines the system prompt, the default LLM model, and which capabilities are enabled.
 
-- Many agents in the system
+- There can be many agents in the system
 - A session may or may not have an agent assigned
-- Agents can be assigned or changed during a session's lifetime
-- Agent has capabilities with position ordering
-- Agent references a default LLM model
+- Agents can be assigned or changed during the lifetime of a session
+- Each agent has capabilities with position ordering
+- Each agent references a default LLM model
 
 ### Session
 
-Working instance of an agentic loop. Configured by its harness and situationally by an agent. Primary execution context where conversations happen.
+A Session is a working instance of an agentic loop. It is configured by its harness and, optionally, by an agent. Sessions are the primary execution context where conversations happen.
 
-- Many sessions in the system
+- There can be many sessions in the system
 - Each session has an assigned harness
-- Agent is optional and can change over the session's lifetime
-- Sessions can have own capabilities, additive to agent capabilities
+- The agent is optional and can change over the session's lifetime
+- Sessions can have their own capabilities, which are additive to the agent's capabilities
 - Sessions can override the LLM model
-- Status: `started` → `active` → `idle` (sessions work indefinitely)
+- Status flow: `started` → `active` → `idle` (sessions work indefinitely)
 
 ### Capability
 
-Modular, reusable configuration unit that extends harness, agent, or session behavior. Contributes:
+A Capability is a modular, reusable configuration unit that extends the behavior of a harness, agent, or session. Each capability can contribute:
 
 1. **System prompt additions** — text prepended to the agent's prompt
 2. **Tools** — functions the agent can invoke
@@ -73,9 +76,11 @@ Modular, reusable configuration unit that extends harness, agent, or session beh
 - MCP servers appear as virtual capabilities with `mcp:{uuid}` IDs
 - Capabilities can depend on other capabilities, resolved in topological order
 
+See [Capabilities](/features/capabilities) for a full list and configuration details.
+
 ### Tool
 
-A function the agent can invoke during execution. Tools are provided by capabilities.
+A Tool is a function the agent can invoke during execution. Tools are provided by capabilities.
 
 - Built-in tools have no name prefix
 - MCP tools are prefixed: `mcp_{server_name}__{tool_name}`
@@ -103,15 +108,15 @@ erDiagram
 
 ### Turn
 
-One iteration of the agent loop: reason (call the LLM) then act (execute tools).
+A Turn is one iteration of the agent loop: reason (call the LLM) then act (execute tools).
 
 - Each turn belongs to a session
-- Produces messages and emits events
+- A turn produces messages and emits events
 - Lifecycle: `turn.started` → reason → act → `turn.completed` (or `turn.failed`)
 
 ### Message
 
-A conversation entry reconstructed from the event log. Messages are not stored in a separate table.
+A Message is a conversation entry reconstructed from the event log. Messages are not stored in a separate table.
 
 - Roles: `user`, `agent`, `tool_result`
 - Content is an array of parts: text, image, tool_call, tool_result
@@ -120,16 +125,18 @@ A conversation entry reconstructed from the event log. Messages are not stored i
 
 ### Event
 
-An immutable, append-only record. The primary data store for conversations and SSE notifications.
+An Event is an immutable, append-only record. Events are the primary data store for conversations and SSE notifications.
 
 - Atomic per-session sequence numbering
 - Types: input, output, turn, atom, tool, LLM, session lifecycle
 - Cannot be updated or deleted
 - Carries correlation context: turn ID, input message ID, execution ID
 
+See [Events](/features/events) for the full event reference.
+
 ### File System
 
-A per-session isolated virtual filesystem stored in PostgreSQL.
+Each session has an isolated virtual filesystem stored in PostgreSQL.
 
 - Paths are relative to `/workspace`
 - Capabilities can mount initial files and directories
@@ -138,7 +145,7 @@ A per-session isolated virtual filesystem stored in PostgreSQL.
 
 ### Key-Value Store
 
-Per-session scoped storage with two tiers:
+Each session has scoped storage with two tiers:
 
 - **Key/Value** — plain text storage for general data such as state, preferences, or intermediate results
 - **Secrets** — AES-256-GCM encrypted at rest for API keys, tokens, and credentials
@@ -163,15 +170,15 @@ erDiagram
 
 ### LLM Provider
 
-A configured API provider such as OpenAI or Anthropic. Stores encrypted API keys.
+An LLM Provider is a configured API provider such as OpenAI or Anthropic. Providers store encrypted API keys and contain models.
 
 - Provider types: `openai`, `openai_completions`, `anthropic`
 - Each provider contains many models
-- Default providers are seeded on startup
+- Default providers (OpenAI, Anthropic) are seeded on startup
 
 ### LLM Model
 
-A specific model within a provider (e.g., `gpt-4o`, `claude-sonnet-4`).
+An LLM Model is a specific model within a provider (e.g., `gpt-4o`, `claude-sonnet-4`).
 
 - Each model belongs to one provider
 - Sources: predefined, discovered from the provider API, or manually added
@@ -179,9 +186,9 @@ A specific model within a provider (e.g., `gpt-4o`, `claude-sonnet-4`).
 
 ### MCP Server
 
-A remote server that exposes tools via the Model Context Protocol. Integrated as a virtual capability.
+An MCP Server is a remote server that exposes tools via the Model Context Protocol. MCP servers are integrated as virtual capabilities.
 
-- Becomes a capability with ID `mcp:{server_uuid}`
+- Each server becomes a capability with ID `mcp:{server_uuid}`
 - Tools are discovered at runtime and cached with a 24-hour TTL
 - Tool names are prefixed to avoid conflicts: `mcp_{server}__{tool}`
 - Execution happens via HTTP JSON-RPC

--- a/specs/concepts.md
+++ b/specs/concepts.md
@@ -4,27 +4,23 @@ Everruns is a durable agentic harness engine. This document describes the core e
 
 ## High Level
 
-Harness and Agent are **configuration containers** — they hold capabilities and tools. Session is the **runtime consumer** that assembles configuration from its harness, optional agent, and own overrides.
+Harness and Agent are **configuration containers** — they hold capabilities and define behavior. At runtime, their configuration merges into a **RuntimeAgent** which executes inside a Session.
 
 ```mermaid
 graph LR
-    subgraph Configuration
-        subgraph Harness
-            HC[Capability] --> HT[Tool]
-        end
-        subgraph Agent
-            AC[Capability] --> AT[Tool]
-        end
-    end
+    Harness -->|has| Agent
+    Harness -->|has| Capability
+    Agent -->|has| Capability
 
-    subgraph Runtime
-        Session
-    end
+    Harness -.->|assembles| RuntimeAgent
+    Agent -.->|assembles| RuntimeAgent
+    Capability -.->|assembles| RuntimeAgent
 
-    Harness -- "configures" --> Session
-    Agent -. "optionally assigned" .-> Session
-    Session -- "own capabilities (additive)" --> SC[Capability] --> ST[Tool]
+    RuntimeAgent -.->|executes in| Session
 ```
+
+- **Solid arrows** (left): configuration ownership — Harness has Agents and Capabilities, Agent has Capabilities
+- **Dashed arrows** (right): runtime assembly — Harness, Agent, and Capability config merge into RuntimeAgent, which executes in a Session
 
 ### Harness
 

--- a/specs/concepts.md
+++ b/specs/concepts.md
@@ -4,20 +4,26 @@ Everruns is a durable agentic harness engine. This document describes the core e
 
 ## High Level
 
-The core execution model: how harnesses, agents, sessions, capabilities, and tools relate.
+Harness and Agent are **configuration containers** — they hold capabilities and tools. Session is the **runtime consumer** that assembles configuration from its harness, optional agent, and own overrides.
 
 ```mermaid
-erDiagram
-    Harness ||--o{ Session : "configures"
-    Harness }o--o{ Capability : "has"
+graph LR
+    subgraph Configuration
+        subgraph Harness
+            HC[Capability] --> HT[Tool]
+        end
+        subgraph Agent
+            AC[Capability] --> AT[Tool]
+        end
+    end
 
-    Agent }o--o{ Capability : "has"
+    subgraph Runtime
+        Session
+    end
 
-    Session }o--o| Harness : "belongs to"
-    Session }o--o| Agent : "optionally assigned"
-    Session }o--o{ Capability : "has (additive)"
-
-    Capability ||--o{ Tool : "provides"
+    Harness -- "configures" --> Session
+    Agent -. "optionally assigned" .-> Session
+    Session -- "own capabilities (additive)" --> SC[Capability] --> ST[Tool]
 ```
 
 ### Harness

--- a/specs/concepts.md
+++ b/specs/concepts.md
@@ -1,0 +1,162 @@
+# Concepts
+
+## Overview
+
+Everruns is a durable agentic harness engine. This document describes the core entities and how they relate to each other.
+
+## Entity Diagram
+
+```mermaid
+erDiagram
+    Organization ||--o{ Harness : contains
+    Organization ||--o{ Session : contains
+    Organization ||--o{ Agent : contains
+
+    Harness ||--o{ Session : "configures"
+    Harness }o--o{ Capability : "has"
+
+    Agent }o--o{ Capability : "has"
+    Agent }o--|| LlmModel : "default model"
+
+    Session }o--o| Agent : "optionally assigned"
+    Session }o--o| LlmModel : "override model"
+    Session }o--o{ Capability : "has (additive)"
+    Session ||--o{ Turn : contains
+    Session ||--o{ Message : contains
+    Session ||--o{ Event : contains
+
+    Turn ||--o{ Message : produces
+    Turn ||--o{ Event : emits
+
+    Message ||--o{ ContentPart : contains
+
+    Capability ||--o{ Tool : provides
+
+    LlmProvider ||--o{ LlmModel : contains
+
+    McpServer ||--o{ Tool : "exposes (virtual capability)"
+
+    ContentPart }o--o| Tool : "tool_call / tool_result"
+```
+
+## Entities
+
+### Harness
+
+The **Harness** is the top-level entity that represents a setup for agent execution. It defines the infrastructure, defaults, and constraints under which sessions run. A harness configures how agents are invoked, which capabilities are available by default, and what execution environment is provided.
+
+- There can be many harnesses in the system
+- Each session has exactly one assigned harness
+- A harness can have capabilities attached to it
+
+### Agent
+
+An **Agent** is a domain-specific or task-specific configuration for the agentic loop. It defines the system prompt, default LLM model, and which capabilities are enabled.
+
+- There can be many agents in the system
+- A session may or may not have an agent assigned
+- Agents can be assigned or changed during the lifetime of a session
+- An agent can have capabilities (via `agent_capabilities` junction with position ordering)
+- An agent references a default LLM model
+
+### Session
+
+A **Session** is a working instance of an agentic loop. It is configured by its harness and situationally by an agent. Sessions are the primary execution context where conversations happen.
+
+- There can be many sessions in the system
+- Each session has an assigned harness
+- A session may or may not have an agent, and the agent can change over the session's lifetime
+- Sessions can have their own capabilities (additive to agent capabilities)
+- Sessions can override the LLM model
+- Each session owns its messages, events, turns, filesystem, and storage
+- Status: `started` → `active` → `idle` (sessions work indefinitely)
+
+### Capability
+
+A **Capability** is a modular, reusable configuration unit that extends agent or harness behavior. Capabilities can contribute:
+
+1. **System prompt additions** — text prepended to the agent's prompt
+2. **Tools** — functions the agent can invoke
+3. **Mount points** — files/directories populated in the session filesystem
+
+- Capabilities can be attached to a harness, an agent, or a session
+- Session capabilities are additive to agent capabilities
+- Built-in capabilities use `snake_case` IDs (e.g., `current_time`, `web_fetch`)
+- MCP servers appear as virtual capabilities with `mcp:{uuid}` IDs
+- Capabilities can depend on other capabilities (resolved in topological order)
+- Defined in-memory (not in database); no migration needed to add new ones
+
+### Tool
+
+A **Tool** is a function that the agent can invoke during execution. Tools are provided by capabilities.
+
+- Built-in tools have no name prefix
+- MCP tools are prefixed: `mcp_{server_name}__{tool_name}` (double underscore)
+- Tools are executed by the `ActAtom` during a turn
+- Each tool can be context-aware (e.g., accessing session filesystem)
+
+### Turn
+
+A **Turn** is one iteration of the agent loop: reason (call LLM) then act (execute tools). A session consists of many turns.
+
+- Each turn belongs to a session
+- A turn produces messages and emits events
+- Turn lifecycle: `turn.started` → reason → act → `turn.completed` (or `turn.failed`)
+- Turns are tracked via `turn_id` in event context
+
+### Message
+
+A **Message** is a conversation entry stored as events. Messages are reconstructed from the event log.
+
+- Roles: `user`, `agent`, `tool_result`
+- Content is an array of parts: text, image, tool_call, tool_result
+- Agent messages may include `thinking` content from reasoning models
+- Messages support per-message controls (model override, reasoning effort)
+- Stored in the append-only events table, not a separate messages table
+
+### LLM Provider
+
+An **LLM Provider** represents a configured API provider (OpenAI, Anthropic). Providers store encrypted API keys and contain models.
+
+- Provider types: `openai`, `openai_completions`, `anthropic`
+- Each provider has many models
+- Default providers (OpenAI, Anthropic) are seeded on startup with well-known UUIDs
+
+### LLM Model
+
+An **LLM Model** is a specific model within a provider (e.g., `gpt-4o`, `claude-sonnet-4`).
+
+- Each model belongs to one provider
+- Models can be predefined, discovered (from provider API), or manually added
+- Model resolution priority: message controls → session override → agent default → system default
+- Runtime profiles (cost, limits, modalities) are computed from external data, not stored
+
+### MCP Server
+
+An **MCP Server** is a remote server that exposes tools via the Model Context Protocol. MCP servers are integrated as virtual capabilities.
+
+- Each MCP server becomes a capability with ID `mcp:{server_uuid}`
+- Tools are discovered at runtime and cached (24h TTL)
+- Tool names are prefixed to avoid conflicts: `mcp_{server}__{tool}`
+- Execution happens via HTTP JSON-RPC (not in-process)
+
+## Relationship Summary
+
+| Relationship | Cardinality | Notes |
+|---|---|---|
+| Organization → Harness | 1:N | Many harnesses per org |
+| Organization → Session | 1:N | Many sessions per org |
+| Organization → Agent | 1:N | Many agents per org |
+| Harness → Session | 1:N | Each session has one harness |
+| Session → Agent | N:0..1 | Optional, can change over time |
+| Agent → Capability | M:N | Via junction table with position |
+| Harness → Capability | M:N | Harness-level defaults |
+| Session → Capability | M:N | Additive to agent capabilities |
+| Agent → LlmModel | N:1 | Default model |
+| Session → LlmModel | N:0..1 | Optional override |
+| LlmProvider → LlmModel | 1:N | Provider owns models |
+| Session → Turn | 1:N | Many turns per session |
+| Session → Message | 1:N | Reconstructed from events |
+| Session → Event | 1:N | Append-only event log |
+| Capability → Tool | 1:N | Capability provides tools |
+| MCP Server → Tool | 1:N | Virtual capability |

--- a/specs/concepts.md
+++ b/specs/concepts.md
@@ -1,162 +1,182 @@
 # Concepts
 
-## Overview
+Everruns is a durable agentic harness engine. This document describes the core entities and how they relate to each other, split into three layers: high-level execution model, session internals, and settings.
 
-Everruns is a durable agentic harness engine. This document describes the core entities and how they relate to each other.
+## High Level
 
-## Entity Diagram
+The core execution model: how harnesses, agents, sessions, capabilities, and tools relate.
 
 ```mermaid
 erDiagram
-    Organization ||--o{ Harness : contains
-    Organization ||--o{ Session : contains
-    Organization ||--o{ Agent : contains
-
     Harness ||--o{ Session : "configures"
     Harness }o--o{ Capability : "has"
 
     Agent }o--o{ Capability : "has"
-    Agent }o--|| LlmModel : "default model"
 
+    Session }o--o| Harness : "belongs to"
     Session }o--o| Agent : "optionally assigned"
-    Session }o--o| LlmModel : "override model"
     Session }o--o{ Capability : "has (additive)"
-    Session ||--o{ Turn : contains
-    Session ||--o{ Message : contains
-    Session ||--o{ Event : contains
 
-    Turn ||--o{ Message : produces
-    Turn ||--o{ Event : emits
-
-    Message ||--o{ ContentPart : contains
-
-    Capability ||--o{ Tool : provides
-
-    LlmProvider ||--o{ LlmModel : contains
-
-    McpServer ||--o{ Tool : "exposes (virtual capability)"
-
-    ContentPart }o--o| Tool : "tool_call / tool_result"
+    Capability ||--o{ Tool : "provides"
 ```
-
-## Entities
 
 ### Harness
 
-The **Harness** is the top-level entity that represents a setup for agent execution. It defines the infrastructure, defaults, and constraints under which sessions run. A harness configures how agents are invoked, which capabilities are available by default, and what execution environment is provided.
+Top-level entity that represents a setup for agent execution. Defines infrastructure, defaults, and constraints under which sessions run. Configures how agents are invoked, which capabilities are available by default, and the execution environment.
 
-- There can be many harnesses in the system
+- Many harnesses in the system
 - Each session has exactly one assigned harness
-- A harness can have capabilities attached to it
+- A harness can have capabilities attached
 
 ### Agent
 
-An **Agent** is a domain-specific or task-specific configuration for the agentic loop. It defines the system prompt, default LLM model, and which capabilities are enabled.
+Domain-specific or task-specific configuration for the agentic loop. Defines system prompt, default LLM model, and enabled capabilities.
 
-- There can be many agents in the system
+- Many agents in the system
 - A session may or may not have an agent assigned
-- Agents can be assigned or changed during the lifetime of a session
-- An agent can have capabilities (via `agent_capabilities` junction with position ordering)
-- An agent references a default LLM model
+- Agents can be assigned or changed during a session's lifetime
+- Agent has capabilities (via junction table with position ordering)
+- Agent references a default LLM model
 
 ### Session
 
-A **Session** is a working instance of an agentic loop. It is configured by its harness and situationally by an agent. Sessions are the primary execution context where conversations happen.
+Working instance of an agentic loop. Configured by its harness and situationally by an agent. Primary execution context where conversations happen.
 
-- There can be many sessions in the system
+- Many sessions in the system
 - Each session has an assigned harness
-- A session may or may not have an agent, and the agent can change over the session's lifetime
-- Sessions can have their own capabilities (additive to agent capabilities)
+- Agent is optional and can change over the session's lifetime
+- Sessions can have own capabilities (additive to agent capabilities)
 - Sessions can override the LLM model
-- Each session owns its messages, events, turns, filesystem, and storage
 - Status: `started` → `active` → `idle` (sessions work indefinitely)
 
 ### Capability
 
-A **Capability** is a modular, reusable configuration unit that extends agent or harness behavior. Capabilities can contribute:
+Modular, reusable configuration unit that extends harness, agent, or session behavior. Contributes:
 
 1. **System prompt additions** — text prepended to the agent's prompt
 2. **Tools** — functions the agent can invoke
 3. **Mount points** — files/directories populated in the session filesystem
 
-- Capabilities can be attached to a harness, an agent, or a session
+- Attached to a harness, an agent, or a session
 - Session capabilities are additive to agent capabilities
-- Built-in capabilities use `snake_case` IDs (e.g., `current_time`, `web_fetch`)
-- MCP servers appear as virtual capabilities with `mcp:{uuid}` IDs
-- Capabilities can depend on other capabilities (resolved in topological order)
+- Built-in IDs: `snake_case` (e.g., `current_time`, `web_fetch`)
+- MCP servers appear as virtual capabilities: `mcp:{uuid}`
+- Can depend on other capabilities (resolved in topological order)
 - Defined in-memory (not in database); no migration needed to add new ones
 
 ### Tool
 
-A **Tool** is a function that the agent can invoke during execution. Tools are provided by capabilities.
+Function the agent can invoke during execution. Provided by capabilities.
 
-- Built-in tools have no name prefix
-- MCP tools are prefixed: `mcp_{server_name}__{tool_name}` (double underscore)
-- Tools are executed by the `ActAtom` during a turn
-- Each tool can be context-aware (e.g., accessing session filesystem)
+- Built-in tools: no name prefix
+- MCP tools: `mcp_{server_name}__{tool_name}` (double underscore)
+- Executed by `ActAtom` during a turn
+- Can be context-aware (e.g., accessing session filesystem)
+
+---
+
+## Session
+
+What lives inside a session: turns, messages, events, filesystem, and storage.
+
+```mermaid
+erDiagram
+    Session ||--o{ Turn : "contains"
+    Session ||--o{ Event : "append-only log"
+    Session ||--|{ FileSystem : "isolated"
+    Session ||--|{ KeyValueStore : "isolated"
+
+    Turn ||--o{ Event : "emits"
+
+    Event ||--o{ Message : "reconstructs"
+
+    Message ||--o{ ContentPart : "contains"
+```
 
 ### Turn
 
-A **Turn** is one iteration of the agent loop: reason (call LLM) then act (execute tools). A session consists of many turns.
+One iteration of the agent loop: reason (call LLM) then act (execute tools).
 
 - Each turn belongs to a session
-- A turn produces messages and emits events
-- Turn lifecycle: `turn.started` → reason → act → `turn.completed` (or `turn.failed`)
-- Turns are tracked via `turn_id` in event context
+- Produces messages and emits events
+- Lifecycle: `turn.started` → reason → act → `turn.completed` (or `turn.failed`)
+- Tracked via `turn_id` in event context
 
 ### Message
 
-A **Message** is a conversation entry stored as events. Messages are reconstructed from the event log.
+Conversation entry reconstructed from the event log. Not stored in a separate table.
 
 - Roles: `user`, `agent`, `tool_result`
 - Content is an array of parts: text, image, tool_call, tool_result
 - Agent messages may include `thinking` content from reasoning models
-- Messages support per-message controls (model override, reasoning effort)
-- Stored in the append-only events table, not a separate messages table
+- Supports per-message controls (model override, reasoning effort)
+- Stored as events: `input.message`, `output.message.completed`, `tool.completed`
+
+### Event
+
+Immutable, append-only record. Primary data store for conversations and SSE notifications.
+
+- Atomic per-session sequence numbering
+- Types: input, output, turn, atom, tool, LLM, session lifecycle
+- Cannot be updated or deleted (enforced by database triggers)
+- Carries correlation context: `turn_id`, `input_message_id`, `exec_id`
+
+### File System
+
+Per-session isolated virtual filesystem stored in PostgreSQL.
+
+- Paths relative to `/workspace`
+- Capabilities can mount initial files/directories
+- Shared between FileSystem and VirtualBash capabilities
+- Files have optional read-only flag
+
+### Key-Value Store
+
+Per-session scoped storage with two tiers:
+
+- **Key/Value** — plain text, general data (state, preferences, intermediate results)
+- **Secrets** — AES-256-GCM encrypted at rest (API keys, tokens, credentials)
+- Session-isolated; cannot access across sessions
+
+---
+
+## Settings
+
+System-wide configuration: LLM providers, models, and MCP servers.
+
+```mermaid
+erDiagram
+    LlmProvider ||--o{ LlmModel : "contains"
+
+    Agent }o--|| LlmModel : "default model"
+    Session }o--o| LlmModel : "override model"
+
+    McpServer ||--o{ Tool : "exposes"
+    McpServer ||--|| Capability : "virtual capability"
+```
 
 ### LLM Provider
 
-An **LLM Provider** represents a configured API provider (OpenAI, Anthropic). Providers store encrypted API keys and contain models.
+Configured API provider (OpenAI, Anthropic). Stores encrypted API keys.
 
-- Provider types: `openai`, `openai_completions`, `anthropic`
+- Types: `openai`, `openai_completions`, `anthropic`
 - Each provider has many models
-- Default providers (OpenAI, Anthropic) are seeded on startup with well-known UUIDs
+- Defaults seeded on startup with well-known UUIDs
 
 ### LLM Model
 
-An **LLM Model** is a specific model within a provider (e.g., `gpt-4o`, `claude-sonnet-4`).
+Specific model within a provider (e.g., `gpt-4o`, `claude-sonnet-4`).
 
-- Each model belongs to one provider
-- Models can be predefined, discovered (from provider API), or manually added
+- Belongs to one provider
+- Sources: `predefined`, `discovered` (from provider API), `manual`
 - Model resolution priority: message controls → session override → agent default → system default
-- Runtime profiles (cost, limits, modalities) are computed from external data, not stored
+- Runtime profiles (cost, limits, modalities) computed from external data, not stored
 
 ### MCP Server
 
-An **MCP Server** is a remote server that exposes tools via the Model Context Protocol. MCP servers are integrated as virtual capabilities.
+Remote server exposing tools via Model Context Protocol. Integrated as virtual capability.
 
-- Each MCP server becomes a capability with ID `mcp:{server_uuid}`
-- Tools are discovered at runtime and cached (24h TTL)
-- Tool names are prefixed to avoid conflicts: `mcp_{server}__{tool}`
-- Execution happens via HTTP JSON-RPC (not in-process)
-
-## Relationship Summary
-
-| Relationship | Cardinality | Notes |
-|---|---|---|
-| Organization → Harness | 1:N | Many harnesses per org |
-| Organization → Session | 1:N | Many sessions per org |
-| Organization → Agent | 1:N | Many agents per org |
-| Harness → Session | 1:N | Each session has one harness |
-| Session → Agent | N:0..1 | Optional, can change over time |
-| Agent → Capability | M:N | Via junction table with position |
-| Harness → Capability | M:N | Harness-level defaults |
-| Session → Capability | M:N | Additive to agent capabilities |
-| Agent → LlmModel | N:1 | Default model |
-| Session → LlmModel | N:0..1 | Optional override |
-| LlmProvider → LlmModel | 1:N | Provider owns models |
-| Session → Turn | 1:N | Many turns per session |
-| Session → Message | 1:N | Reconstructed from events |
-| Session → Event | 1:N | Append-only event log |
-| Capability → Tool | 1:N | Capability provides tools |
-| MCP Server → Tool | 1:N | Virtual capability |
+- Becomes capability with ID `mcp:{server_uuid}`
+- Tools discovered at runtime, cached (24h TTL)
+- Tool names prefixed: `mcp_{server}__{tool}`
+- Execution via HTTP JSON-RPC (not in-process)

--- a/specs/concepts.md
+++ b/specs/concepts.md
@@ -17,6 +17,14 @@ graph LR
     Capability -.->|assembles| RuntimeAgent
 
     RuntimeAgent -.->|executes in| Session
+
+    classDef config fill:#c7f0db,stroke:#2d6a4f,color:#1b4332
+    classDef assembly fill:#ffd6a5,stroke:#e07b39,color:#5a3000
+    classDef runtime fill:#bde0fe,stroke:#3a86a8,color:#023047
+
+    class Harness,Agent,Capability config
+    class RuntimeAgent assembly
+    class Session runtime
 ```
 
 - **Solid arrows** (left): configuration ownership — Harness has Agents and Capabilities, Agent has Capabilities


### PR DESCRIPTION
## What
Add a Concepts documentation page describing core Everruns entities and their relationships, with three focused Mermaid diagrams.

## Why
No single doc explained how Harness, Agent, Session, Capability, Tool, Turn, Message, Event, Provider, Model, and MCP Server relate. Needed a public-facing overview for onboarding.

## How
- `specs/concepts.md` — internal spec (source of truth)
- `docs/getting-started/concepts.md` — public Starlight page with polished prose
- Three diagrams split by concern:
  - **High Level** — Harness/Agent as config containers assembling into RuntimeAgent → Session (flowchart with color coding)
  - **Session Internals** — Turn, Message, Event, FileSystem, KeyValueStore (ER diagram)
  - **Settings** — LLM Provider/Model, MCP Server (ER diagram)
- Sidebar entry added under Getting Started, after Introduction
- `AGENTS.md` updated with spec reference

## Risk
- Low
- Docs-only change, no code modifications

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered