### PR TITLE
feat(core): native image support in tool results

### DIFF
--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -184,13 +184,64 @@ impl AnthropicLlmDriver {
                     system_prompt = Some(msg.content.to_text());
                 }
                 LlmMessageRole::Tool => {
-                    // Tool results in Anthropic are user messages with tool_result content blocks
+                    // Tool results in Anthropic are user messages with tool_result content blocks.
+                    // When the message contains images, we use the array form with content blocks.
                     if let Some(tool_call_id) = &msg.tool_call_id {
+                        let has_images = match &msg.content {
+                            LlmMessageContent::Parts(parts) => parts
+                                .iter()
+                                .any(|p| matches!(p, LlmContentPart::Image { .. })),
+                            _ => false,
+                        };
+
+                        let content = if has_images {
+                            // Build array of text + image content blocks
+                            let blocks = match &msg.content {
+                                LlmMessageContent::Parts(parts) => parts
+                                    .iter()
+                                    .filter_map(|p| match p {
+                                        LlmContentPart::Text { text } => {
+                                            Some(AnthropicToolResultBlock::Text {
+                                                text: text.clone(),
+                                            })
+                                        }
+                                        LlmContentPart::Image { url } => {
+                                            let source = if url.starts_with("data:") {
+                                                let parts: Vec<&str> = url.splitn(2, ',').collect();
+                                                if parts.len() == 2 {
+                                                    let media_type = parts[0]
+                                                        .trim_start_matches("data:")
+                                                        .trim_end_matches(";base64")
+                                                        .to_string();
+                                                    AnthropicImageSource::Base64 {
+                                                        media_type,
+                                                        data: parts[1].to_string(),
+                                                    }
+                                                } else {
+                                                    AnthropicImageSource::Url { url: url.clone() }
+                                                }
+                                            } else {
+                                                AnthropicImageSource::Url { url: url.clone() }
+                                            };
+                                            Some(AnthropicToolResultBlock::Image { source })
+                                        }
+                                        _ => None,
+                                    })
+                                    .collect(),
+                                LlmMessageContent::Text(text) => {
+                                    vec![AnthropicToolResultBlock::Text { text: text.clone() }]
+                                }
+                            };
+                            AnthropicToolResultContent::Blocks(blocks)
+                        } else {
+                            AnthropicToolResultContent::Text(msg.content.to_text())
+                        };
+
                         converted.push(AnthropicMessage {
                             role: "user".to_string(),
                             content: vec![AnthropicContentBlock::ToolResult {
                                 tool_use_id: tool_call_id.clone(),
-                                content: msg.content.to_text(),
+                                content,
                                 is_error: None,
                             }],
                         });
@@ -877,10 +928,31 @@ enum AnthropicContentBlock {
     #[serde(rename = "tool_result")]
     ToolResult {
         tool_use_id: String,
-        content: String,
+        content: AnthropicToolResultContent,
         #[serde(skip_serializing_if = "Option::is_none")]
         is_error: Option<bool>,
     },
+}
+
+/// Content of a tool_result block - either a simple string or array of content blocks.
+/// Anthropic API accepts both forms; we use the array form when images are present.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+enum AnthropicToolResultContent {
+    /// Simple text content
+    Text(String),
+    /// Array of content blocks (text + images)
+    Blocks(Vec<AnthropicToolResultBlock>),
+}
+
+/// A content block inside a tool_result (text or image)
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+enum AnthropicToolResultBlock {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "image")]
+    Image { source: AnthropicImageSource },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1250,8 +1322,97 @@ mod tests {
                 ..
             } => {
                 assert_eq!(tool_use_id, "call_123");
-                assert_eq!(content, "{\"temp\": 20}");
+                match content {
+                    AnthropicToolResultContent::Text(text) => {
+                        assert_eq!(text, "{\"temp\": 20}");
+                    }
+                    _ => panic!("Expected text content in tool result"),
+                }
             }
+            _ => panic!("Expected ToolResult block"),
+        }
+    }
+
+    #[test]
+    fn test_tool_result_with_images_conversion() {
+        // Tool result with text + image content
+        let msg = LlmMessage {
+            role: LlmMessageRole::Tool,
+            content: LlmMessageContent::Parts(vec![
+                LlmContentPart::Text {
+                    text: "{\"status\": \"ok\"}".to_string(),
+                },
+                LlmContentPart::Image {
+                    url: "data:image/png;base64,AAAA".to_string(),
+                },
+            ]),
+            tool_calls: None,
+            tool_call_id: Some("call_img".to_string()),
+            thinking: None,
+            thinking_signature: None,
+        };
+
+        let (_, converted) = AnthropicLlmDriver::convert_messages(&[msg]);
+
+        assert_eq!(converted.len(), 1);
+        assert_eq!(converted[0].role, "user");
+        assert_eq!(converted[0].content.len(), 1);
+
+        match &converted[0].content[0] {
+            AnthropicContentBlock::ToolResult {
+                tool_use_id,
+                content,
+                ..
+            } => {
+                assert_eq!(tool_use_id, "call_img");
+                match content {
+                    AnthropicToolResultContent::Blocks(blocks) => {
+                        assert_eq!(blocks.len(), 2);
+                        match &blocks[0] {
+                            AnthropicToolResultBlock::Text { text } => {
+                                assert_eq!(text, "{\"status\": \"ok\"}");
+                            }
+                            _ => panic!("Expected text block"),
+                        }
+                        match &blocks[1] {
+                            AnthropicToolResultBlock::Image { source } => match source {
+                                AnthropicImageSource::Base64 { media_type, data } => {
+                                    assert_eq!(media_type, "image/png");
+                                    assert_eq!(data, "AAAA");
+                                }
+                                _ => panic!("Expected base64 image source"),
+                            },
+                            _ => panic!("Expected image block"),
+                        }
+                    }
+                    _ => panic!("Expected Blocks content for multimodal tool result"),
+                }
+            }
+            _ => panic!("Expected ToolResult block"),
+        }
+    }
+
+    #[test]
+    fn test_tool_result_text_only_stays_simple() {
+        // Tool result with text-only content should use simple Text form
+        let msg = LlmMessage {
+            role: LlmMessageRole::Tool,
+            content: LlmMessageContent::Text("result text".to_string()),
+            tool_calls: None,
+            tool_call_id: Some("call_txt".to_string()),
+            thinking: None,
+            thinking_signature: None,
+        };
+
+        let (_, converted) = AnthropicLlmDriver::convert_messages(&[msg]);
+
+        match &converted[0].content[0] {
+            AnthropicContentBlock::ToolResult { content, .. } => match content {
+                AnthropicToolResultContent::Text(text) => {
+                    assert_eq!(text, "result text");
+                }
+                _ => panic!("Expected simple Text content for text-only tool result"),
+            },
             _ => panic!("Expected ToolResult block"),
         }
     }

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -395,6 +395,7 @@ where
                 result: ToolResult {
                     tool_call_id: tool_call.id.clone(),
                     result: None,
+                    images: None,
                     error: Some(error_msg),
                 },
                 success: false,
@@ -427,12 +428,23 @@ where
 
                 // Emit tool.completed event
                 let completed_data = if success {
-                    // Convert result to ContentPart (text representation of JSON)
-                    let result_content = tool_result
+                    // Convert result to ContentPart (text + optional images)
+                    let mut result_content = tool_result
                         .result
                         .as_ref()
                         .map(|r| vec![ContentPart::text(r.to_string())])
                         .unwrap_or_default();
+                    // Append images as native Image content parts
+                    if let Some(ref images) = tool_result.images {
+                        for img in images {
+                            result_content.push(ContentPart::Image(
+                                crate::message::ImageContentPart::from_base64(
+                                    &img.base64,
+                                    &img.media_type,
+                                ),
+                            ));
+                        }
+                    }
                     ToolCompletedData::success(
                         tool_call.id.clone(),
                         tool_call.name.clone(),
@@ -522,6 +534,7 @@ where
                     result: ToolResult {
                         tool_call_id: tool_call.id.clone(),
                         result: None,
+                        images: None,
                         error: Some(error_msg),
                     },
                     success: false,

--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -12,10 +12,28 @@
 //! - `stat_file`: Get file metadata
 
 use super::{Capability, CapabilityStatus};
-use crate::tools::{Tool, ToolExecutionResult};
+use crate::tools::{Tool, ToolExecutionResult, ToolResultImage};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
 use serde_json::{Value, json};
+
+/// Image MIME types recognized by LLM vision APIs (OpenAI, Anthropic)
+const IMAGE_EXTENSIONS: &[(&str, &str)] = &[
+    (".png", "image/png"),
+    (".jpg", "image/jpeg"),
+    (".jpeg", "image/jpeg"),
+    (".gif", "image/gif"),
+    (".webp", "image/webp"),
+];
+
+/// Get the image MIME type if the path has a known image extension
+fn image_media_type(path: &str) -> Option<&'static str> {
+    let lower = path.to_lowercase();
+    IMAGE_EXTENSIONS
+        .iter()
+        .find(|(ext, _)| lower.ends_with(ext))
+        .map(|(_, mime)| *mime)
+}
 
 /// Workspace prefix used in file paths
 const WORKSPACE_PREFIX: &str = "/workspace";
@@ -140,7 +158,7 @@ impl Tool for ReadFileTool {
     }
 
     fn description(&self) -> &str {
-        "Read the content of a file. Returns the file content as text or base64-encoded binary."
+        "Read the content of a file. Returns text content directly. For image files (PNG, JPEG, GIF, WebP), the image is returned as a native image so you can see it visually."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -192,18 +210,39 @@ impl Tool for ReadFileTool {
         {
             Ok(Some(file)) => {
                 if file.is_directory {
-                    ToolExecutionResult::tool_error(format!(
+                    return ToolExecutionResult::tool_error(format!(
                         "Path '{}' is a directory, not a file. Use list_directory instead.",
                         display_path
-                    ))
-                } else {
-                    ToolExecutionResult::success(json!({
-                        "path": display_path,
-                        "content": file.content,
-                        "encoding": file.encoding,
-                        "size_bytes": file.size_bytes
-                    }))
+                    ));
                 }
+
+                // Check if this is an image file that should be returned as native image content
+                if let Some(media_type) = image_media_type(&normalized_path) {
+                    // For base64-encoded files, return as image
+                    if file.encoding == "base64"
+                        && let Some(ref content) = file.content
+                    {
+                        return ToolExecutionResult::success_with_images(
+                            json!({
+                                "path": display_path,
+                                "media_type": media_type,
+                                "size_bytes": file.size_bytes
+                            }),
+                            vec![ToolResultImage {
+                                base64: content.clone(),
+                                media_type: media_type.to_string(),
+                            }],
+                        );
+                    }
+                    // Text-encoded image paths still get returned as text (unusual case)
+                }
+
+                ToolExecutionResult::success(json!({
+                    "path": display_path,
+                    "content": file.content,
+                    "encoding": file.encoding,
+                    "size_bytes": file.size_bytes
+                }))
             }
             Ok(None) => {
                 ToolExecutionResult::tool_error(format!("File not found: {}", display_path))
@@ -867,5 +906,46 @@ mod tests {
         } else {
             panic!("Expected tool error for missing file store");
         }
+    }
+
+    // Image detection tests
+    #[test]
+    fn test_image_media_type_png() {
+        assert_eq!(
+            image_media_type("/workspace/screenshot.png"),
+            Some("image/png")
+        );
+    }
+
+    #[test]
+    fn test_image_media_type_jpeg() {
+        assert_eq!(image_media_type("/workspace/photo.jpg"), Some("image/jpeg"));
+        assert_eq!(
+            image_media_type("/workspace/photo.jpeg"),
+            Some("image/jpeg")
+        );
+    }
+
+    #[test]
+    fn test_image_media_type_gif() {
+        assert_eq!(image_media_type("/data/anim.gif"), Some("image/gif"));
+    }
+
+    #[test]
+    fn test_image_media_type_webp() {
+        assert_eq!(image_media_type("/images/art.webp"), Some("image/webp"));
+    }
+
+    #[test]
+    fn test_image_media_type_case_insensitive() {
+        assert_eq!(image_media_type("/workspace/PHOTO.PNG"), Some("image/png"));
+        assert_eq!(image_media_type("/workspace/image.JPG"), Some("image/jpeg"));
+    }
+
+    #[test]
+    fn test_image_media_type_not_image() {
+        assert_eq!(image_media_type("/workspace/readme.txt"), None);
+        assert_eq!(image_media_type("/workspace/data.json"), None);
+        assert_eq!(image_media_type("/workspace/script.py"), None);
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -125,7 +125,7 @@ pub use openresponses_protocol::{
 // Tool abstraction re-exports
 pub use tools::{
     EchoTool, FailingTool, Tool, ToolExecutionResult, ToolInternalError, ToolRegistry,
-    ToolRegistryBuilder,
+    ToolRegistryBuilder, ToolResultImage,
 };
 
 // Capability re-exports

--- a/crates/core/src/memory.rs
+++ b/crates/core/src/memory.rs
@@ -388,6 +388,7 @@ impl ToolExecutor for MockToolExecutor {
         Ok(ToolResult {
             tool_call_id: tool_call.id.clone(),
             result: Some(result),
+            images: None,
             error: None,
         })
     }
@@ -422,6 +423,7 @@ impl ToolExecutor for EchoToolExecutor {
                 "echoed_tool": tool_call.name,
                 "echoed_arguments": tool_call.arguments
             })),
+            images: None,
             error: None,
         })
     }
@@ -463,6 +465,7 @@ impl ToolExecutor for FailingToolExecutor {
         Ok(ToolResult {
             tool_call_id: tool_call.id.clone(),
             result: None,
+            images: None,
             error: Some(self.error_message.clone()),
         })
     }

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -577,6 +577,40 @@ impl Message {
         }
     }
 
+    /// Create a tool result message with images.
+    ///
+    /// Images are included as `ContentPart::Image` alongside the `ToolResult` part.
+    /// When converted to `LlmMessage`, images become native image content blocks
+    /// that the LLM can see visually (not just stringified base64).
+    pub fn tool_result_with_images(
+        tool_call_id: impl Into<String>,
+        result: Option<serde_json::Value>,
+        images: Vec<crate::tools::ToolResultImage>,
+    ) -> Self {
+        let tool_call_id = tool_call_id.into();
+        let mut content = vec![ContentPart::ToolResult(ToolResultContentPart::new(
+            tool_call_id,
+            result,
+            None,
+        ))];
+        for img in images {
+            content.push(ContentPart::Image(ImageContentPart::from_base64(
+                img.base64,
+                img.media_type,
+            )));
+        }
+        Self {
+            id: MessageId::new(),
+            role: MessageRole::ToolResult,
+            content,
+            thinking: None,
+            thinking_signature: None,
+            controls: None,
+            metadata: None,
+            created_at: Utc::now(),
+        }
+    }
+
     /// Get the tool_call_id from a tool result message
     ///
     /// Returns the tool_call_id from the first ToolResult content part, if any.

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -138,20 +138,34 @@ impl OpenResponsesProtocolLlmDriver {
 
     fn convert_message(msg: &LlmMessage) -> ResponsesInputItem {
         // Handle tool result messages differently
+        // Note: OpenAI Responses API function_call_output only supports text output.
+        // Images in tool results are dropped with a warning.
         if msg.role == LlmMessageRole::Tool
             && let Some(tool_call_id) = &msg.tool_call_id
         {
+            let mut has_images = false;
             let output = match &msg.content {
                 LlmMessageContent::Text(text) => text.clone(),
-                LlmMessageContent::Parts(parts) => parts
-                    .iter()
-                    .filter_map(|p| match p {
-                        LlmContentPart::Text { text } => Some(text.clone()),
-                        _ => None,
-                    })
-                    .collect::<Vec<_>>()
-                    .join(""),
+                LlmMessageContent::Parts(parts) => {
+                    has_images = parts
+                        .iter()
+                        .any(|p| matches!(p, LlmContentPart::Image { .. }));
+                    parts
+                        .iter()
+                        .filter_map(|p| match p {
+                            LlmContentPart::Text { text } => Some(text.clone()),
+                            _ => None,
+                        })
+                        .collect::<Vec<_>>()
+                        .join("")
+                }
             };
+            if has_images {
+                tracing::warn!(
+                    tool_call_id = %tool_call_id,
+                    "OpenResponses API does not support images in tool results; images dropped"
+                );
+            }
             return ResponsesInputItem::FunctionCallOutput {
                 r#type: "function_call_output".to_string(),
                 call_id: tool_call_id.clone(),

--- a/crates/core/src/tool_types.rs
+++ b/crates/core/src/tool_types.rs
@@ -114,6 +114,9 @@ pub struct ToolResult {
     pub tool_call_id: String,
     /// Result data (success)
     pub result: Option<serde_json::Value>,
+    /// Images returned by the tool (sent as native image content to LLM)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub images: Option<Vec<crate::tools::ToolResultImage>>,
     /// Error message (failure)
     pub error: Option<String>,
 }
@@ -178,6 +181,7 @@ mod tests {
         let result = ToolResult {
             tool_call_id: "call_123".to_string(),
             result: Some(serde_json::json!({"temperature": 72})),
+            images: None,
             error: None,
         };
 

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -11,6 +11,7 @@
 // - Internal errors are logged but not exposed to the LLM (security)
 
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -26,10 +27,23 @@ use crate::traits::ToolExecutor;
 // Tool Execution Result - Error Handling Contract
 // ============================================================================
 
+/// Image data returned by a tool alongside text results.
+///
+/// This allows tools (built-in or MCP) to return images that are sent
+/// to the LLM as native image content blocks, not stringified JSON.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolResultImage {
+    /// Base64-encoded image data
+    pub base64: String,
+    /// MIME type (e.g., "image/png", "image/jpeg")
+    pub media_type: String,
+}
+
 /// Result of a tool execution.
 ///
 /// This enum distinguishes between different outcomes:
 /// - `Success`: Tool executed successfully, result is returned to LLM
+/// - `SuccessWithImages`: Successful execution with JSON result plus images
 /// - `ToolError`: Tool-level error that should be shown to the LLM
 ///   (e.g., "City not found", "Invalid date format")
 /// - `InternalError`: System-level error that should NOT be exposed to the LLM
@@ -44,6 +58,14 @@ use crate::traits::ToolExecutor;
 pub enum ToolExecutionResult {
     /// Successful execution with a JSON result
     Success(Value),
+
+    /// Successful execution with a JSON result and images.
+    /// Images are sent to the LLM as native image content blocks
+    /// (not stringified JSON), enabling visual understanding.
+    SuccessWithImages {
+        result: Value,
+        images: Vec<ToolResultImage>,
+    },
 
     /// Tool-level error that is safe to show to the LLM
     ///
@@ -65,6 +87,14 @@ impl ToolExecutionResult {
         ToolExecutionResult::Success(value.into())
     }
 
+    /// Create a successful result with images
+    pub fn success_with_images(value: impl Into<Value>, images: Vec<ToolResultImage>) -> Self {
+        ToolExecutionResult::SuccessWithImages {
+            result: value.into(),
+            images,
+        }
+    }
+
     /// Create a tool-level error (safe to show to LLM)
     pub fn tool_error(message: impl Into<String>) -> Self {
         ToolExecutionResult::ToolError(message.into())
@@ -82,7 +112,10 @@ impl ToolExecutionResult {
 
     /// Check if this is a successful result
     pub fn is_success(&self) -> bool {
-        matches!(self, ToolExecutionResult::Success(_))
+        matches!(
+            self,
+            ToolExecutionResult::Success(_) | ToolExecutionResult::SuccessWithImages { .. }
+        )
     }
 
     /// Check if this is an error (either tool error or internal error)
@@ -102,11 +135,23 @@ impl ToolExecutionResult {
             ToolExecutionResult::Success(value) => ToolResult {
                 tool_call_id: tool_call_id.to_string(),
                 result: Some(value),
+                images: None,
+                error: None,
+            },
+            ToolExecutionResult::SuccessWithImages { result, images } => ToolResult {
+                tool_call_id: tool_call_id.to_string(),
+                result: Some(result),
+                images: if images.is_empty() {
+                    None
+                } else {
+                    Some(images)
+                },
                 error: None,
             },
             ToolExecutionResult::ToolError(message) => ToolResult {
                 tool_call_id: tool_call_id.to_string(),
                 result: Some(serde_json::json!({ "error": message })),
+                images: None,
                 error: None,
             },
             ToolExecutionResult::InternalError(err) => {
@@ -124,6 +169,7 @@ impl ToolExecutionResult {
                     result: Some(serde_json::json!({
                         "error": "An internal error occurred while executing the tool"
                     })),
+                    images: None,
                     error: None,
                 }
             }

--- a/crates/core/tests/tool_calling_test.rs
+++ b/crates/core/tests/tool_calling_test.rs
@@ -4,7 +4,7 @@
 // the ToolExecutor trait work correctly together.
 
 use async_trait::async_trait;
-use everruns_core::{BuiltinTool, ToolCall, ToolDefinition, ToolPolicy};
+use everruns_core::{BuiltinTool, ToolCall, ToolDefinition, ToolPolicy, ToolResultImage};
 use everruns_core::{
     GetCurrentTimeTool, Message, MessageRetriever, MessageRole, SessionId,
     memory::InMemoryMessageRetriever,
@@ -452,4 +452,261 @@ async fn test_message_retriever_parallel_tool_calls() {
     for (i, expected_city) in ["Tokyo", "London", "New York"].iter().enumerate() {
         assert_eq!(loaded_calls[i].arguments["city"], *expected_city);
     }
+}
+
+// =============================================================================
+// Image Tool Result Tests
+// =============================================================================
+
+/// Tool that returns an image alongside JSON
+struct ImageTool;
+
+#[async_trait]
+impl Tool for ImageTool {
+    fn name(&self) -> &str {
+        "screenshot"
+    }
+
+    fn description(&self) -> &str {
+        "Take a screenshot and return it as an image"
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "region": { "type": "string" }
+            },
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, arguments: serde_json::Value) -> ToolExecutionResult {
+        let region = arguments
+            .get("region")
+            .and_then(|v| v.as_str())
+            .unwrap_or("full");
+
+        // Tiny 1x1 red PNG (base64)
+        let tiny_png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==";
+
+        ToolExecutionResult::success_with_images(
+            json!({ "region": region, "width": 1, "height": 1 }),
+            vec![ToolResultImage {
+                base64: tiny_png.to_string(),
+                media_type: "image/png".to_string(),
+            }],
+        )
+    }
+}
+
+#[tokio::test]
+async fn test_image_tool_execution_result() {
+    let tool = ImageTool;
+    let result = tool.execute(json!({"region": "header"})).await;
+
+    match result {
+        ToolExecutionResult::SuccessWithImages { result, images } => {
+            assert_eq!(result["region"], "header");
+            assert_eq!(images.len(), 1);
+            assert_eq!(images[0].media_type, "image/png");
+            assert!(!images[0].base64.is_empty());
+        }
+        _ => panic!("Expected SuccessWithImages"),
+    }
+}
+
+#[tokio::test]
+async fn test_image_tool_into_tool_result() {
+    let result = ToolExecutionResult::success_with_images(
+        json!({"status": "ok"}),
+        vec![ToolResultImage {
+            base64: "AAAA".to_string(),
+            media_type: "image/jpeg".to_string(),
+        }],
+    );
+
+    let tool_result = result.into_tool_result("call_img", "screenshot");
+
+    assert!(tool_result.error.is_none());
+    assert_eq!(tool_result.result.unwrap()["status"], "ok");
+    let images = tool_result.images.unwrap();
+    assert_eq!(images.len(), 1);
+    assert_eq!(images[0].media_type, "image/jpeg");
+    assert_eq!(images[0].base64, "AAAA");
+}
+
+#[tokio::test]
+async fn test_image_tool_empty_images_gives_none() {
+    let result = ToolExecutionResult::success_with_images(json!({"ok": true}), vec![]);
+
+    let tool_result = result.into_tool_result("call_1", "tool");
+
+    assert!(tool_result.images.is_none(), "empty images should be None");
+}
+
+#[tokio::test]
+async fn test_image_tool_via_registry() {
+    let registry = ToolRegistry::builder().tool(ImageTool).build();
+
+    let tool_call = ToolCall {
+        id: "call_img".to_string(),
+        name: "screenshot".to_string(),
+        arguments: json!({"region": "viewport"}),
+    };
+
+    let tool_def = registry.get("screenshot").unwrap().to_definition();
+    let result = registry.execute(&tool_call, &tool_def).await.unwrap();
+
+    assert!(result.error.is_none());
+    assert_eq!(result.result.unwrap()["region"], "viewport");
+    let images = result.images.unwrap();
+    assert_eq!(images.len(), 1);
+    assert_eq!(images[0].media_type, "image/png");
+}
+
+#[tokio::test]
+async fn test_tool_result_with_images_message() {
+    let images = vec![ToolResultImage {
+        base64: "AAAA".to_string(),
+        media_type: "image/png".to_string(),
+    }];
+
+    let msg = Message::tool_result_with_images("call_123", Some(json!({"ok": true})), images);
+
+    assert_eq!(msg.role, MessageRole::ToolResult);
+    assert_eq!(msg.tool_call_id(), Some("call_123"));
+
+    // Should have ToolResult + Image content parts
+    assert_eq!(msg.content.len(), 2);
+    assert!(matches!(
+        msg.content[0],
+        everruns_core::ContentPart::ToolResult(_)
+    ));
+    assert!(matches!(
+        msg.content[1],
+        everruns_core::ContentPart::Image(_)
+    ));
+}
+
+#[tokio::test]
+async fn test_tool_result_with_images_llm_conversion() {
+    use everruns_core::llm_driver_registry::LlmMessage;
+    use std::collections::HashMap;
+
+    let images = vec![
+        ToolResultImage {
+            base64: "AAAA".to_string(),
+            media_type: "image/png".to_string(),
+        },
+        ToolResultImage {
+            base64: "BBBB".to_string(),
+            media_type: "image/jpeg".to_string(),
+        },
+    ];
+
+    let msg = Message::tool_result_with_images("call_456", Some(json!({"info": "test"})), images);
+
+    let resolved = HashMap::new();
+    let llm_msg = LlmMessage::from_message_with_images(&msg, &resolved);
+
+    // Should be Tool role with tool_call_id
+    assert_eq!(
+        llm_msg.role,
+        everruns_core::llm_driver_registry::LlmMessageRole::Tool
+    );
+    assert_eq!(llm_msg.tool_call_id, Some("call_456".to_string()));
+
+    // Content should have text (JSON result) + 2 images
+    match &llm_msg.content {
+        everruns_core::llm_driver_registry::LlmMessageContent::Parts(parts) => {
+            assert_eq!(parts.len(), 3, "should have 1 text + 2 images");
+            assert!(matches!(
+                &parts[0],
+                everruns_core::llm_driver_registry::LlmContentPart::Text { .. }
+            ));
+            match &parts[1] {
+                everruns_core::llm_driver_registry::LlmContentPart::Image { url } => {
+                    assert!(url.starts_with("data:image/png;base64,"));
+                    assert!(url.contains("AAAA"));
+                }
+                _ => panic!("Expected Image part"),
+            }
+            match &parts[2] {
+                everruns_core::llm_driver_registry::LlmContentPart::Image { url } => {
+                    assert!(url.starts_with("data:image/jpeg;base64,"));
+                    assert!(url.contains("BBBB"));
+                }
+                _ => panic!("Expected Image part"),
+            }
+        }
+        _ => panic!("Expected Parts content"),
+    }
+}
+
+#[tokio::test]
+async fn test_tool_result_with_images_store_roundtrip() {
+    let store = InMemoryMessageRetriever::new();
+    let session_id: SessionId = Uuid::now_v7().into();
+
+    let images = vec![ToolResultImage {
+        base64: "AAAA".to_string(),
+        media_type: "image/png".to_string(),
+    }];
+
+    let msg = Message::tool_result_with_images("call_rt", Some(json!({"ok": true})), images);
+
+    store.store(session_id, msg).await.unwrap();
+
+    let loaded = store.load(session_id).await.unwrap();
+    assert_eq!(loaded.len(), 1);
+
+    let loaded_msg = &loaded[0];
+    assert_eq!(loaded_msg.role, MessageRole::ToolResult);
+    assert_eq!(loaded_msg.tool_call_id(), Some("call_rt"));
+    // Should preserve both ToolResult and Image content parts
+    assert_eq!(loaded_msg.content.len(), 2);
+}
+
+#[test]
+fn test_tool_result_image_serialization() {
+    let img = ToolResultImage {
+        base64: "AAAA".to_string(),
+        media_type: "image/png".to_string(),
+    };
+
+    let json = serde_json::to_string(&img).unwrap();
+    let parsed: ToolResultImage = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(parsed.base64, "AAAA");
+    assert_eq!(parsed.media_type, "image/png");
+}
+
+#[test]
+fn test_tool_result_with_images_serialization() {
+    let result = everruns_core::ToolResult {
+        tool_call_id: "call_1".to_string(),
+        result: Some(json!({"ok": true})),
+        images: Some(vec![ToolResultImage {
+            base64: "AAAA".to_string(),
+            media_type: "image/png".to_string(),
+        }]),
+        error: None,
+    };
+
+    let json_str = serde_json::to_string(&result).unwrap();
+    let parsed: everruns_core::ToolResult = serde_json::from_str(&json_str).unwrap();
+
+    assert_eq!(parsed.images.as_ref().unwrap().len(), 1);
+    assert_eq!(parsed.images.unwrap()[0].media_type, "image/png");
+}
+
+#[test]
+fn test_tool_result_without_images_backward_compat() {
+    // Ensure old JSON without `images` field still deserializes
+    let json_str = r#"{"tool_call_id":"call_1","result":{"ok":true},"error":null}"#;
+    let parsed: everruns_core::ToolResult = serde_json::from_str(json_str).unwrap();
+
+    assert!(parsed.images.is_none());
+    assert_eq!(parsed.tool_call_id, "call_1");
 }

--- a/crates/server/src/services/message.rs
+++ b/crates/server/src/services/message.rs
@@ -172,23 +172,49 @@ impl MessageService {
                     everruns_core::EventData::InputMessage(data) => &data.message,
                     everruns_core::EventData::OutputMessageCompleted(data) => &data.message,
                     everruns_core::EventData::ToolCompleted(data) => {
-                        // Convert tool result to message
+                        // Separate text and image parts from the result content
+                        let mut images: Vec<everruns_core::tools::ToolResultImage> = Vec::new();
                         let result: Option<serde_json::Value> =
                             data.result
                                 .as_ref()
                                 .map(|parts: &Vec<everruns_core::ContentPart>| {
-                                    if parts.len() == 1
-                                        && let everruns_core::ContentPart::Text(t) = &parts[0]
+                                    for part in parts {
+                                        if let everruns_core::ContentPart::Image(img) = part
+                                            && let (Some(b64), Some(mt)) =
+                                                (&img.base64, &img.media_type)
+                                        {
+                                            images.push(everruns_core::tools::ToolResultImage {
+                                                base64: b64.clone(),
+                                                media_type: mt.clone(),
+                                            });
+                                        }
+                                    }
+                                    let text_parts: Vec<&everruns_core::ContentPart> = parts
+                                        .iter()
+                                        .filter(|p| {
+                                            matches!(p, everruns_core::ContentPart::Text(_))
+                                        })
+                                        .collect();
+                                    if text_parts.len() == 1
+                                        && let everruns_core::ContentPart::Text(t) = text_parts[0]
                                     {
                                         return serde_json::Value::String(t.text.clone());
                                     }
-                                    serde_json::to_value(parts).unwrap_or_default()
+                                    serde_json::to_value(&text_parts).unwrap_or_default()
                                 });
-                        let msg = everruns_core::Message::tool_result(
-                            &data.tool_call_id,
-                            result,
-                            data.error.clone(),
-                        );
+                        let msg = if images.is_empty() {
+                            everruns_core::Message::tool_result(
+                                &data.tool_call_id,
+                                result,
+                                data.error.clone(),
+                            )
+                        } else {
+                            everruns_core::Message::tool_result_with_images(
+                                &data.tool_call_id,
+                                result,
+                                images,
+                            )
+                        };
                         return Ok(Message {
                             id: msg.id,
                             session_id: SessionId::from_uuid(session_id),

--- a/crates/server/src/storage/message_store.rs
+++ b/crates/server/src/storage/message_store.rs
@@ -223,18 +223,43 @@ fn event_to_message(
 
 /// Convert ToolCompletedData to a ToolResult message
 fn tool_completed_to_message(data: ToolCompletedData) -> Message {
-    // Extract result as JSON value
+    // Separate text and image parts from the result content
+    let mut images: Vec<everruns_core::tools::ToolResultImage> = Vec::new();
     let result: Option<serde_json::Value> = data.result.map(|parts| {
+        // Collect image parts
+        for part in &parts {
+            if let ContentPart::Image(img) = part
+                && let (Some(b64), Some(mt)) = (&img.base64, &img.media_type)
+            {
+                images.push(everruns_core::tools::ToolResultImage {
+                    base64: b64.clone(),
+                    media_type: mt.clone(),
+                });
+            }
+        }
         // For simple text results, extract just the text
-        if parts.len() == 1
-            && let ContentPart::Text(t) = &parts[0]
+        let text_parts: Vec<&ContentPart> = parts
+            .iter()
+            .filter(|p| matches!(p, ContentPart::Text(_)))
+            .collect();
+        if text_parts.len() == 1
+            && let ContentPart::Text(t) = text_parts[0]
         {
             return serde_json::Value::String(t.text.clone());
         }
-        serde_json::to_value(&parts).unwrap_or_default()
+        // Fall back to serializing text parts only (images handled separately)
+        if !text_parts.is_empty() {
+            serde_json::to_value(&text_parts).unwrap_or_default()
+        } else {
+            serde_json::Value::Null
+        }
     });
 
-    Message::tool_result(&data.tool_call_id, result, data.error)
+    if images.is_empty() {
+        Message::tool_result(&data.tool_call_id, result, data.error)
+    } else {
+        Message::tool_result_with_images(&data.tool_call_id, result, images)
+    }
 }
 
 // ============================================================================

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -453,6 +453,7 @@ mod tests {
                 result: everruns_core::ToolResult {
                     tool_call_id: "call_1".to_string(),
                     result: Some(json!({"temp": 72})),
+                    images: None,
                     error: None,
                 },
                 success: true,

--- a/crates/worker/src/mcp_executor.rs
+++ b/crates/worker/src/mcp_executor.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use everruns_core::traits::{ToolContext, ToolExecutor};
 use everruns_core::{
     McpContent, McpToolCallRequest, McpToolCallResponse, ToolCall, ToolDefinition, ToolResult,
-    is_mcp_tool, parse_mcp_tool_name,
+    ToolResultImage, is_mcp_tool, parse_mcp_tool_name,
 };
 use serde_json::json;
 use std::collections::HashMap;
@@ -57,7 +57,7 @@ impl McpToolExecutor {
         let server_info = self.get_server_info(&server_prefix).await?;
 
         // Call the MCP server
-        let result = call_mcp_tool(
+        let (result, images) = call_mcp_tool(
             &server_info,
             &original_tool_name,
             tool_call.arguments.clone(),
@@ -67,6 +67,11 @@ impl McpToolExecutor {
         Ok(ToolResult {
             tool_call_id: tool_call.id.clone(),
             result: Some(result),
+            images: if images.is_empty() {
+                None
+            } else {
+                Some(images)
+            },
             error: None,
         })
     }
@@ -102,12 +107,13 @@ impl McpToolExecutor {
     }
 }
 
-/// Call an MCP server's tools/call endpoint
+/// Call an MCP server's tools/call endpoint.
+/// Returns (json_result, images) where images are extracted from MCP image content.
 async fn call_mcp_tool(
     server_info: &McpServerInfo,
     tool_name: &str,
     arguments: serde_json::Value,
-) -> Result<serde_json::Value> {
+) -> Result<(serde_json::Value, Vec<ToolResultImage>)> {
     let client = reqwest::Client::builder()
         .timeout(MCP_TOOL_TIMEOUT)
         .build()?;
@@ -210,40 +216,62 @@ async fn call_mcp_tool(
             })
             .collect::<Vec<_>>()
             .join("\n");
-        return Ok(json!({ "error": error_text }));
+        return Ok((json!({ "error": error_text }), vec![]));
     }
 
-    // Convert MCP content to JSON
-    let content_json: Vec<serde_json::Value> = result
-        .content
-        .iter()
-        .map(|c| match c {
-            McpContent::Text { text } => json!({ "type": "text", "text": text }),
-            McpContent::Image { data, mime_type } => json!({
-                "type": "image",
-                "data": data,
-                "mime_type": mime_type
-            }),
+    // Separate images from other content types.
+    // Images are returned as ToolResultImage for native LLM image support.
+    let mut images = Vec::new();
+    let mut text_parts = Vec::new();
+    let mut resource_parts = Vec::new();
+
+    for c in &result.content {
+        match c {
+            McpContent::Text { text } => {
+                text_parts.push(text.clone());
+            }
+            McpContent::Image { data, mime_type } => {
+                images.push(ToolResultImage {
+                    base64: data.clone(),
+                    media_type: mime_type.clone(),
+                });
+            }
             McpContent::Resource {
                 uri,
                 mime_type,
                 text,
-            } => json!({
-                "type": "resource",
-                "uri": uri,
-                "mime_type": mime_type,
-                "text": text
-            }),
-        })
-        .collect();
-
-    // Return simplified result for single text content
-    if content_json.len() == 1 && content_json[0].get("text").is_some() {
-        let text = &content_json[0]["text"];
-        return Ok(json!({ "result": text }));
+            } => {
+                resource_parts.push(json!({
+                    "type": "resource",
+                    "uri": uri,
+                    "mime_type": mime_type,
+                    "text": text
+                }));
+            }
+        }
     }
 
-    Ok(json!({ "content": content_json }))
+    // Build JSON result from text and resource content (images are separate)
+    let json_result = if resource_parts.is_empty() {
+        if text_parts.len() == 1 {
+            json!({ "result": text_parts[0] })
+        } else if text_parts.is_empty() && !images.is_empty() {
+            // Image-only response
+            json!({ "result": format!("[{} image(s)]", images.len()) })
+        } else {
+            json!({ "result": text_parts.join("\n") })
+        }
+    } else {
+        // Mix of text and resources
+        let mut content = Vec::new();
+        for t in &text_parts {
+            content.push(json!({ "type": "text", "text": t }));
+        }
+        content.extend(resource_parts);
+        json!({ "content": content })
+    };
+
+    Ok((json_result, images))
 }
 
 /// Composite Tool Executor that handles both built-in tools and MCP tools
@@ -369,5 +397,93 @@ data: {"result":{"tools":[{"name":"search","description":"Search docs"}]},"id":1
         let response = "some text\ndata: {\"key\": \"value\"}";
         let result = extract_json_from_response(response);
         assert_eq!(result, Some("{\"key\": \"value\"}"));
+    }
+
+    // MCP image content extraction tests
+
+    #[test]
+    fn test_mcp_text_only_result() {
+        let content = vec![McpContent::Text {
+            text: "Hello world".to_string(),
+        }];
+        let result = everruns_core::McpToolCallResult {
+            content,
+            is_error: false,
+        };
+
+        // Simulate what call_mcp_tool does after getting the result
+        let mut images = Vec::new();
+        let mut text_parts = Vec::new();
+        for c in &result.content {
+            match c {
+                McpContent::Text { text } => text_parts.push(text.clone()),
+                McpContent::Image { data, mime_type } => images.push(ToolResultImage {
+                    base64: data.clone(),
+                    media_type: mime_type.clone(),
+                }),
+                _ => {}
+            }
+        }
+        assert!(images.is_empty());
+        assert_eq!(text_parts, vec!["Hello world"]);
+    }
+
+    #[test]
+    fn test_mcp_image_extraction() {
+        let content = vec![
+            McpContent::Text {
+                text: "Here's the chart".to_string(),
+            },
+            McpContent::Image {
+                data: "iVBORw0KGgo=".to_string(),
+                mime_type: "image/png".to_string(),
+            },
+        ];
+
+        let mut images = Vec::new();
+        let mut text_parts = Vec::new();
+        for c in &content {
+            match c {
+                McpContent::Text { text } => text_parts.push(text.clone()),
+                McpContent::Image { data, mime_type } => images.push(ToolResultImage {
+                    base64: data.clone(),
+                    media_type: mime_type.clone(),
+                }),
+                _ => {}
+            }
+        }
+
+        assert_eq!(images.len(), 1);
+        assert_eq!(images[0].media_type, "image/png");
+        assert_eq!(images[0].base64, "iVBORw0KGgo=");
+        assert_eq!(text_parts, vec!["Here's the chart"]);
+    }
+
+    #[test]
+    fn test_mcp_multiple_images() {
+        let content = vec![
+            McpContent::Image {
+                data: "AAA=".to_string(),
+                mime_type: "image/png".to_string(),
+            },
+            McpContent::Image {
+                data: "BBB=".to_string(),
+                mime_type: "image/jpeg".to_string(),
+            },
+        ];
+
+        let mut images = Vec::new();
+        for c in &content {
+            if let McpContent::Image { data, mime_type } = c {
+                images.push(ToolResultImage {
+                    base64: data.clone(),
+                    media_type: mime_type.clone(),
+                });
+            }
+        }
+
+        assert_eq!(images.len(), 2);
+        assert_eq!(images[0].base64, "AAA=");
+        assert_eq!(images[1].media_type, "image/jpeg");
     }
 }

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -355,10 +355,10 @@ pub fn resolve_dependencies(
 - **System Prompt**: Guidance on using file system tools, best practices for exploration and file operations. Explains the `/workspace` mount point.
 - **Workspace Mount**: All paths are relative to `/workspace` (e.g., `/workspace/src/main.rs`). Paths are normalized internally to enable seamless integration with virtual_bash.
 - **Tools**:
-  - `read_file` - Read file content by path
+  - `read_file` - Read file content by path. For image files (PNG, JPEG, GIF, WebP), the image is returned as a native image content block so the LLM can see it visually.
     - Parameters:
       - `path`: string (required) - Absolute path to the file (e.g., '/workspace/docs/readme.txt')
-    - Returns: Object containing path, content, encoding, size_bytes
+    - Returns: Object containing path, content, encoding, size_bytes. For base64-encoded image files, returns `SuccessWithImages` with the image as a native `ToolResultImage`.
     - Policy: Auto
   - `write_file` - Create or update a file
     - Parameters:

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -120,6 +120,11 @@ Detect `RequestTooLarge` for:
    - `tool_calls`: Optional tool calls (assistant messages)
    - `tool_call_id`: Optional tool call reference (tool messages)
 
+   **Image Content in Tool Results**: When a tool returns images (via `ToolResultImage`), they become `LlmContentPart::Image` entries in the Tool message's content. Provider-specific handling:
+   - **Anthropic**: Tool results with images use array `content` in `tool_result` block (text + image blocks)
+   - **OpenAI Chat Completions**: Tool messages include `image_url` content parts alongside text
+   - **OpenAI Responses API**: Images not supported in `function_call_output` (text only, images dropped with warning)
+
 2. **LlmCallConfig**: Configuration for LLM calls
    - `model`: Model identifier
    - `temperature`: Optional sampling temperature

--- a/specs/mcp-servers.md
+++ b/specs/mcp-servers.md
@@ -249,7 +249,9 @@ MCP tool results can contain various content types:
 
 The executor converts MCP content to the internal format:
 - Single text content → simplified `{ "result": "text" }`
-- Multiple content blocks → `{ "content": [...] }`
+- Multiple text/resource blocks → `{ "content": [...] }`
+- **Image content → extracted as `ToolResultImage`** and sent to the LLM as native image content blocks (not embedded in JSON). This enables the LLM to visually analyze images returned by MCP tools.
+- Image-only responses → `{ "result": "[N image(s)]" }` with images as separate `ToolResult.images`
 - Errors → `{ "error": "message" }`
 
 ### LLM Provider Compatibility

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -25,10 +25,24 @@ pub trait Tool: Send + Sync {
 
 **Error Handling Contract:**
 - `ToolExecutionResult::Success(Value)` - Successful result returned to LLM as `result` field
+- `ToolExecutionResult::SuccessWithImages { result, images }` - Successful result with images. Images are sent as native image content blocks to the LLM, enabling visual understanding (not stringified JSON).
 - `ToolExecutionResult::ToolError(String)` - User-visible error packaged as `{"error": "..."}` in `result` field (e.g., `{"error": "City not found"}`)
 - `ToolExecutionResult::InternalError` - System error logged, generic message packaged as `{"error": "..."}` in `result` field (security)
 
 All error types continue the agent loop the same way as success - they are all packaged in the `result` field with no `error` field set. The LLM can interpret the `{"error": "..."}` payload and decide how to proceed.
+
+**Image Support in Tool Results:**
+
+Tools can return images alongside JSON results via `ToolExecutionResult::success_with_images()`. Images are represented as `ToolResultImage { base64, media_type }` and flow through the system as native image content:
+
+1. `ToolExecutionResult::SuccessWithImages` → `ToolResult` with `images: Option<Vec<ToolResultImage>>`
+2. `ToolResult.images` → `ContentPart::Image` in tool result messages
+3. `ContentPart::Image` → `LlmContentPart::Image` in LLM messages
+4. Provider-specific formatting: Anthropic uses array content blocks in `tool_result`, OpenAI uses `image_url` content parts
+
+Supported image formats: PNG, JPEG, GIF, WebP (matching LLM vision API support).
+
+Note: OpenAI Responses API (`function_call_output`) does not support images in tool results - images are dropped with a warning in that path.
 
 **Provided Tools:**
 - `GetCurrentTime` - Returns current timestamp in various formats (iso8601, unix, human)


### PR DESCRIPTION
## What
Add native image content support in tool results. Tools (built-in and MCP) can now return images that the LLM sees as actual image content blocks, not stringified base64 JSON.

## Why
Previously, MCP image results and filesystem image reads were embedded as JSON text in tool results. The LLM received base64 strings it could not visually interpret. This blocked use cases like:
- MCP tools returning charts, screenshots, or diagrams
- Agents reading image files from the session workspace
- Any tool-based visual analysis workflow

## How
- New `ToolResultImage { base64, media_type }` type and `SuccessWithImages` variant on `ToolExecutionResult`
- `ToolResult` gains `images: Option<Vec<ToolResultImage>>` field
- Images flow through: `ToolResult` → `ContentPart::Image` in messages → `LlmContentPart::Image` in LLM calls
- **Anthropic**: `tool_result` content uses array form with text + image blocks
- **OpenAI Chat Completions**: `image_url` content parts alongside text (already worked)
- **OpenAI Responses API**: Warning logged, images dropped (API limitation)
- **MCP executor**: Extracts `McpContent::Image` as `ToolResultImage` instead of embedding in JSON
- **ReadFileTool**: Detects image files (PNG, JPEG, GIF, WebP) and returns them as native images
- Specs updated: tool-execution.md, mcp-servers.md, capabilities.md, llm-drivers.md

## Risk
- Low
- Backward compatible: `images` field is `Option` with `#[serde(default)]`
- OpenResponses API path gracefully degrades (images dropped with warning)
- No breaking changes to existing tool implementations

## Checklist
- [x] Tests added or updated (20+ new tests covering full pipeline)
- [x] Backward compatibility considered (serde default, Option field)