### PR TITLE
fix(ci): handle multiline commit messages in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,13 @@ jobs:
     steps:
       - name: Check if release commit
         id: check
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
+          # Use env var to safely handle multiline commit messages
+          FIRST_LINE=$(echo "$COMMIT_MSG" | head -n1)
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || \
-             [[ "${{ github.event.head_commit.message }}" == chore\(release\):\ prepare\ v* ]]; then
+             [[ "$FIRST_LINE" == chore\(release\):\ prepare\ v* ]]; then
             echo "is_release=true" >> $GITHUB_OUTPUT
             echo "This is a release commit, proceeding with release"
           else
@@ -49,13 +53,15 @@ jobs:
 
       - name: Extract version from commit message or input
         id: version
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
           # Use input version if manual trigger, otherwise extract from commit message
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             VERSION="${{ github.event.inputs.version }}"
           else
             # Extract version from commit message like "chore(release): prepare v0.4.0"
-            VERSION=$(echo "${{ github.event.head_commit.message }}" | grep -oP 'prepare v\K[0-9]+\.[0-9]+\.[0-9]+')
+            VERSION=$(echo "$COMMIT_MSG" | head -n1 | grep -oP 'prepare v\K[0-9]+\.[0-9]+\.[0-9]+')
           fi
           if [ -z "$VERSION" ]; then
             echo "::error::Could not extract version from commit message or input"


### PR DESCRIPTION
## Summary
- Fix Release workflow crash when squash-merged PRs have multiline commit messages
- Pass commit message via `env` block instead of direct `${{ }}` interpolation to avoid bash syntax errors
- Extract only the first line (`head -n1`) for pattern matching — release check only needs the commit title

## Test plan
- [x] Verify the `check-release` step no longer fails with `conditional binary operator expected` on non-release commits
- [ ] Verify release commits (`chore(release): prepare vX.Y.Z`) still trigger the release job
- [ ] Verify `workflow_dispatch` trigger still works