### PR TITLE
feat(test): add SKIP_LLM_INTEGRATION_TESTS_PROVIDERS env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,11 @@ GRPC_ADDRESS=127.0.0.1:9001
 # OTEL_SERVICE_NAME=everruns
 # OTEL_ENVIRONMENT=development
 
+# Skip LLM integration tests for specific providers (comma-separated)
+# Useful when API keys are set but inaccessible from the current environment.
+# Example: SKIP_LLM_PROVIDERS=gemini,openai
+# SKIP_LLM_PROVIDERS=gemini
+
 # Braintrust (optional - for LLM observability)
 # Set BRAINTRUST_API_KEY to enable Braintrust integration
 # BRAINTRUST_API_KEY=your-braintrust-api-key

--- a/.env.example
+++ b/.env.example
@@ -45,8 +45,8 @@ GRPC_ADDRESS=127.0.0.1:9001
 
 # Skip LLM integration tests for specific providers (comma-separated)
 # Useful when API keys are set but inaccessible from the current environment.
-# Example: SKIP_LLM_PROVIDERS=gemini,openai
-# SKIP_LLM_PROVIDERS=gemini
+# Example: SKIP_LLM_INTEGRATION_TESTS_PROVIDERS=gemini,openai
+# SKIP_LLM_INTEGRATION_TESTS_PROVIDERS=gemini
 
 # Braintrust (optional - for LLM observability)
 # Set BRAINTRUST_API_KEY to enable Braintrust integration

--- a/crates/core/tests/agent_run_basic.rs
+++ b/crates/core/tests/agent_run_basic.rs
@@ -12,6 +12,8 @@
 //
 // Required env vars (tests skip gracefully if missing):
 //   ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY
+//
+// Skip specific providers: SKIP_LLM_PROVIDERS=gemini,openai
 #![cfg(feature = "llm-tests")]
 
 mod llm_test_matrix;

--- a/crates/core/tests/agent_run_basic.rs
+++ b/crates/core/tests/agent_run_basic.rs
@@ -13,7 +13,7 @@
 // Required env vars (tests skip gracefully if missing):
 //   ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY
 //
-// Skip specific providers: SKIP_LLM_PROVIDERS=gemini,openai
+// Skip specific providers: SKIP_LLM_INTEGRATION_TESTS_PROVIDERS=gemini,openai
 #![cfg(feature = "llm-tests")]
 
 mod llm_test_matrix;

--- a/crates/core/tests/llm_test_matrix/mod.rs
+++ b/crates/core/tests/llm_test_matrix/mod.rs
@@ -37,10 +37,11 @@ impl ProviderModelConfig {
     }
 
     /// Build a `ModelWithProvider` from env, returning `None` if the key is
-    /// missing or empty, or if the provider appears in `SKIP_LLM_PROVIDERS`
-    /// (comma-separated list, e.g. `SKIP_LLM_PROVIDERS=gemini,openai`).
+    /// missing or empty, or if the provider appears in
+    /// `SKIP_LLM_INTEGRATION_TESTS_PROVIDERS` (comma-separated, e.g.
+    /// `SKIP_LLM_INTEGRATION_TESTS_PROVIDERS=gemini,openai`).
     pub fn model(&self) -> Option<ModelWithProvider> {
-        if let Ok(skip) = std::env::var("SKIP_LLM_PROVIDERS") {
+        if let Ok(skip) = std::env::var("SKIP_LLM_INTEGRATION_TESTS_PROVIDERS") {
             let provider = self.provider_type.to_string().to_lowercase();
             if skip.split(',').any(|s| s.trim().to_lowercase() == provider) {
                 return None;

--- a/crates/core/tests/llm_test_matrix/mod.rs
+++ b/crates/core/tests/llm_test_matrix/mod.rs
@@ -37,8 +37,15 @@ impl ProviderModelConfig {
     }
 
     /// Build a `ModelWithProvider` from env, returning `None` if the key is
-    /// missing or empty (test should skip).
+    /// missing or empty, or if the provider appears in `SKIP_LLM_PROVIDERS`
+    /// (comma-separated list, e.g. `SKIP_LLM_PROVIDERS=gemini,openai`).
     pub fn model(&self) -> Option<ModelWithProvider> {
+        if let Ok(skip) = std::env::var("SKIP_LLM_PROVIDERS") {
+            let provider = self.provider_type.to_string().to_lowercase();
+            if skip.split(',').any(|s| s.trim().to_lowercase() == provider) {
+                return None;
+            }
+        }
         let api_key = std::env::var(self.env_var).ok().filter(|k| !k.is_empty())?;
         Some(ModelWithProvider {
             model: self.model_name.to_string(),

--- a/justfile
+++ b/justfile
@@ -76,7 +76,7 @@ test-workflow:
     cargo test -p everruns-server --test workflow_test -- --test-threads=1
 
 # Run LLM tests against real APIs (requires ANTHROPIC_API_KEY, OPENAI_API_KEY)
-# Skip providers: SKIP_LLM_PROVIDERS=gemini just test-llm
+# Skip providers: SKIP_LLM_INTEGRATION_TESTS_PROVIDERS=gemini just test-llm
 test-llm:
     cargo test -p everruns-core --test agent_run_basic
     cargo test -p everruns-core --test agent_run_with_thinking

--- a/justfile
+++ b/justfile
@@ -76,6 +76,7 @@ test-workflow:
     cargo test -p everruns-server --test workflow_test -- --test-threads=1
 
 # Run LLM tests against real APIs (requires ANTHROPIC_API_KEY, OPENAI_API_KEY)
+# Skip providers: SKIP_LLM_PROVIDERS=gemini just test-llm
 test-llm:
     cargo test -p everruns-core --test agent_run_basic
     cargo test -p everruns-core --test agent_run_with_thinking


### PR DESCRIPTION
## What
Add `SKIP_LLM_INTEGRATION_TESTS_PROVIDERS` env var to skip LLM integration tests by provider name.

## Why
In cloud agent environments, API keys (e.g. `GEMINI_API_KEY`) may be set but inaccessible (403 Forbidden), causing integration tests to panic instead of skipping. The existing skip logic only checks if the env var is empty/missing.

## How
Check `SKIP_LLM_INTEGRATION_TESTS_PROVIDERS` (comma-separated) in `ProviderModelConfig::model()` before building the model config. Returns `None` to trigger the existing skip path. No changes needed in individual test files.

Usage: `SKIP_LLM_INTEGRATION_TESTS_PROVIDERS=gemini cargo test`

## Risk
- Low
- Only affects test infrastructure, no runtime code changes. Unit tests unaffected. CI unaffected (doesn't set the var).

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered