### PR TITLE
chore(dev): clarify doppler cloud-secret workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,29 @@
 ## Coding-agent guidance
 
+### Cloud Agent (start here)
+
+Use Doppler for all secret-backed commands in cloud agents.
+
+```bash
+./scripts/init-cloud-env.sh
+doppler run -- just start-dev --no-watch
+```
+
+All cloud secrets are in Doppler (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`).
+
+For GitHub CLI, map token explicitly:
+
+```bash
+doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" gh auth status'
+```
+
+Quickcheck:
+
+```bash
+doppler run -- env | rg 'OPENAI_API_KEY|ANTHROPIC_API_KEY|GITHUB_TOKEN'
+doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" gh auth status'
+```
+
 ### Style
 
 Telegraph. Drop filler/grammar. Min tokens.
@@ -65,16 +89,16 @@ Fix root cause. Unsure: read more code; if stuck, ask w/ short options. Unrecogn
 
 `test_cases/` - manual test cases by feature. Format in `specs/test-cases.md`.
 
-### Cloud Agent Start
+### Cloud Agent (legacy details)
 
 ```bash
 ./scripts/init-cloud-env.sh       # Install just + gh + doppler
 just start-dev --no-watch         # DEV MODE (no Docker)
 ```
 
-Pre-configured: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`
+Pre-configured cloud secrets are provided via Doppler: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`.
 
-Doppler CLI is available in cloud environments for secrets management. Use `doppler run -- <command>` to inject secrets.
+Use `doppler run -- <command>` to inject them.
 
 ### Local Dev
 

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -115,6 +115,26 @@ check_postgres_ready() {
   return 0
 }
 
+
+print_doppler_secret_hint() {
+  local missing=()
+
+  [ -n "${OPENAI_API_KEY:-}" ] || missing+=("OPENAI_API_KEY")
+  [ -n "${ANTHROPIC_API_KEY:-}" ] || missing+=("ANTHROPIC_API_KEY")
+  [ -n "${GITHUB_TOKEN:-}" ] || missing+=("GITHUB_TOKEN")
+
+  if [ ${#missing[@]} -eq 0 ]; then
+    return 0
+  fi
+
+  if command -v doppler &> /dev/null; then
+    echo "   ⚠️  Missing env: ${missing[*]}"
+    echo "   ℹ️  Cloud agents use Doppler for secrets."
+    echo "   ℹ️  Re-run with: doppler run -- <command>"
+    echo "   ℹ️  Quickcheck: doppler run -- env | rg 'OPENAI_API_KEY|ANTHROPIC_API_KEY|GITHUB_TOKEN'"
+  fi
+}
+
 # Backward-compatible wrappers
 check_ui_deps() {
   check_npm_deps "UI" "cd apps/ui && npm install"

--- a/scripts/lib/services.sh
+++ b/scripts/lib/services.sh
@@ -119,6 +119,8 @@ case "$cmd" in
       echo "   ✅ Using default encryption key"
     fi
 
+    print_doppler_secret_hint
+
     # Configure LLM API keys
     if [ -n "${OPENAI_API_KEY:-}" ]; then
       export DEFAULT_OPENAI_API_KEY="$OPENAI_API_KEY"
@@ -343,6 +345,8 @@ case "$cmd" in
       echo "   ⚠️  Jaeger not available, disabling OpenTelemetry tracing"
       export OTEL_SDK_DISABLED=true
     fi
+
+    print_doppler_secret_hint
 
     # Configure LLM API keys
     echo "2️⃣  Configuring LLM API keys from environment..."


### PR DESCRIPTION
## What
- Renamed and elevated cloud guidance in `AGENTS.md` with a new **Cloud Agent (start here)** section.
- Made explicit that cloud secrets are in Doppler and secret-backed commands should run with `doppler run -- ...`.
- Added explicit GitHub CLI token mapping example (`GH_TOKEN="$GITHUB_TOKEN" gh ...`).
- Added quickcheck commands for cloud secrets + GH auth.
- Added startup hints in scripts when required env vars are missing.

## Why
- Guidance existed but was easy to miss.
- Running commands outside Doppler causes false negatives for auth/secrets.
- Startup should show corrective action immediately.

## How
- `AGENTS.md`: new top-level cloud section + quickchecks; clarified legacy cloud block.
- `scripts/lib/common.sh`: new `print_doppler_secret_hint()` helper.
- `scripts/lib/services.sh`: invoke hint helper in `start-dev` and `start-all`.

## Risk
- Low
- Docs + startup messaging only.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
