### PR TITLE
chore(docs): remove redundant cloud legacy section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,17 +89,6 @@ Fix root cause. Unsure: read more code; if stuck, ask w/ short options. Unrecogn
 
 `test_cases/` - manual test cases by feature. Format in `specs/test-cases.md`.
 
-### Cloud Agent (legacy details)
-
-```bash
-./scripts/init-cloud-env.sh       # Install just + gh + doppler
-just start-dev --no-watch         # DEV MODE (no Docker)
-```
-
-Pre-configured cloud secrets are provided via Doppler: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`.
-
-Use `doppler run -- <command>` to inject them.
-
 ### Local Dev
 
 ```bash


### PR DESCRIPTION
## What
- Remove `Cloud Agent (legacy details)` section from `AGENTS.md`.
- Keep one canonical cloud guidance section: `Cloud Agent (start here)`.

## Why
- Legacy block is redundant and can confuse cloud-agent startup flow.
- Single source of truth improves readability and compliance.

## How
- Deleted duplicated legacy text above `Local Dev`.

## Risk
- Low
- Docs-only.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
