### PR TITLE
feat(core): add agent_instructions capability (AGENTS.md support)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Fix root cause. Unsure: read more code; if stuck, ask w/ short options. Unrecogn
 - `specs/markdown-messages.md` - Chat message markdown rendering with llm-ui
 - `specs/tool-execution.md` - Tool types and execution flow
 - `specs/capabilities.md` - Agent capabilities system
+- `specs/agent-instructions.md` - AGENTS.md support (dynamic project instructions)
 - `specs/mcp-servers.md` - MCP server registration
 - `specs/llm-drivers.md` - LLM driver trait, provider implementations
 - `specs/durable-execution-engine.md` - PostgreSQL-backed durable workflow engine

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -175,6 +175,8 @@ where
     event_emitter: E,
     /// Optional image resolver for resolving image_file content parts
     image_resolver: Option<Arc<dyn ImageResolver>>,
+    /// Optional file store for reading AGENTS.md (agent_instructions capability)
+    file_store: Option<Arc<dyn crate::traits::SessionFileStore>>,
 }
 
 impl<A, S, M, P, E> ReasonAtom<A, S, M, P, E>
@@ -204,7 +206,18 @@ where
             driver_registry,
             event_emitter,
             image_resolver: None,
+            file_store: None,
         }
+    }
+
+    /// Set the file store for reading AGENTS.md (agent_instructions capability)
+    ///
+    /// When set and the `agent_instructions` capability is enabled, the atom
+    /// reads `/AGENTS.md` from the session workspace on every LLM turn and
+    /// prepends its content to the system prompt.
+    pub fn with_file_store(mut self, file_store: Arc<dyn crate::traits::SessionFileStore>) -> Self {
+        self.file_store = Some(file_store);
+        self
     }
 
     /// Set the image resolver for resolving image_file content parts
@@ -507,6 +520,40 @@ where
         // Add session-level client-side tools (additive to agent tools)
         if !session.tools.is_empty() {
             builder = builder.tools(session.tools.clone());
+        }
+
+        // 6b. Read AGENTS.md if agent_instructions capability is enabled
+        let has_agent_instructions =
+            agent.capabilities.iter().any(|c| {
+                c.capability_id() == crate::capabilities::AGENT_INSTRUCTIONS_CAPABILITY_ID
+            }) || session_capability_ids
+                .iter()
+                .any(|id| id == crate::capabilities::AGENT_INSTRUCTIONS_CAPABILITY_ID);
+
+        if has_agent_instructions && let Some(ref file_store) = self.file_store {
+            match file_store
+                .read_file(session_id, crate::capabilities::AGENTS_MD_PATH)
+                .await
+            {
+                Ok(Some(file)) => {
+                    if let Some(content) = &file.content
+                        && let Some(formatted) =
+                            crate::capabilities::format_agents_md_content(content)
+                    {
+                        builder = builder.prepend_system_prompt(formatted);
+                    }
+                }
+                Ok(None) => {
+                    // File doesn't exist — silently skip
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        session_id = %session_id,
+                        "Failed to read AGENTS.md, skipping"
+                    );
+                }
+            }
         }
 
         let runtime_agent = builder.build();

--- a/crates/core/src/capabilities/agent_instructions.rs
+++ b/crates/core/src/capabilities/agent_instructions.rs
@@ -66,21 +66,22 @@ pub fn format_agents_md_content(content: &str) -> Option<String> {
         return None;
     }
 
-    let truncated = if content.len() > MAX_AGENTS_MD_SIZE {
+    let (body, was_truncated) = if content.len() > MAX_AGENTS_MD_SIZE {
         tracing::warn!(
             content_size = content.len(),
             max_size = MAX_AGENTS_MD_SIZE,
             "AGENTS.md exceeds size limit, truncating"
         );
-        &content[..MAX_AGENTS_MD_SIZE]
+        (&content[..MAX_AGENTS_MD_SIZE], true)
     } else {
-        content
+        (content, false)
     };
 
-    Some(format!(
-        "# Project Instructions (AGENTS.md)\n\n{}",
-        truncated
-    ))
+    let mut result = format!("# Instructions (AGENTS.md)\n\n{}", body);
+    if was_truncated {
+        result.push_str("\n\n[AGENTS.md was truncated — content exceeds 32 KiB limit]");
+    }
+    Some(result)
 }
 
 #[cfg(test)]
@@ -128,7 +129,7 @@ mod tests {
         let content = "## Style\nUse snake_case for variables.";
         let result = format_agents_md_content(content).unwrap();
 
-        assert!(result.starts_with("# Project Instructions (AGENTS.md)"));
+        assert!(result.starts_with("# Instructions (AGENTS.md)"));
         assert!(result.contains("Use snake_case"));
     }
 
@@ -144,9 +145,11 @@ mod tests {
         let content = "x".repeat(MAX_AGENTS_MD_SIZE + 1000);
         let result = format_agents_md_content(&content).unwrap();
 
-        // Header + \n\n + truncated content
-        let expected_len = "# Project Instructions (AGENTS.md)\n\n".len() + MAX_AGENTS_MD_SIZE;
+        let header = "# Instructions (AGENTS.md)\n\n";
+        let suffix = "\n\n[AGENTS.md was truncated — content exceeds 32 KiB limit]";
+        let expected_len = header.len() + MAX_AGENTS_MD_SIZE + suffix.len();
         assert_eq!(result.len(), expected_len);
+        assert!(result.ends_with(suffix));
     }
 
     #[test]

--- a/crates/core/src/capabilities/agent_instructions.rs
+++ b/crates/core/src/capabilities/agent_instructions.rs
@@ -51,6 +51,15 @@ impl Capability for AgentInstructionsCapability {
     }
 
     // No system_prompt_addition — content is dynamic (read at runtime by ReasonAtom)
+
+    fn system_prompt_preview(&self) -> Option<String> {
+        Some(
+            "# Instructions (AGENTS.md)\n\n\
+             <contents of /workspace/AGENTS.md, re-read every turn>"
+                .to_string(),
+        )
+    }
+
     // No tools
     // No dependencies
     // No mounts
@@ -104,6 +113,14 @@ mod tests {
     fn test_no_static_system_prompt() {
         let cap = AgentInstructionsCapability;
         assert!(cap.system_prompt_addition().is_none());
+    }
+
+    #[test]
+    fn test_system_prompt_preview() {
+        let cap = AgentInstructionsCapability;
+        let preview = cap.system_prompt_preview().unwrap();
+        assert!(preview.contains("AGENTS.md"));
+        assert!(preview.contains("re-read every turn"));
     }
 
     #[test]

--- a/crates/core/src/capabilities/agent_instructions.rs
+++ b/crates/core/src/capabilities/agent_instructions.rs
@@ -1,0 +1,176 @@
+//! Agent Instructions Capability (AGENTS.md)
+//!
+//! Reads AGENTS.md from the session workspace and dynamically injects its
+//! content into the system prompt on every LLM turn. This provides project-level
+//! context and conventions to agents.
+//!
+//! Design decisions:
+//! - Capability is a marker: no static system_prompt_addition (content is dynamic)
+//! - ReasonAtom reads /AGENTS.md from session file store when this capability is enabled
+//! - Re-read every turn so edits are picked up immediately
+//! - 32 KiB size limit (truncated with warning), matching Codex convention
+//! - Missing file is silently ignored
+
+use super::{Capability, CapabilityStatus};
+
+/// Maximum size of AGENTS.md content in bytes (32 KiB).
+pub const MAX_AGENTS_MD_SIZE: usize = 32_768;
+
+/// Path to AGENTS.md in the session filesystem.
+pub const AGENTS_MD_PATH: &str = "/AGENTS.md";
+
+/// Capability ID constant.
+pub const AGENT_INSTRUCTIONS_CAPABILITY_ID: &str = "agent_instructions";
+
+/// Agent Instructions capability — reads AGENTS.md from session workspace.
+pub struct AgentInstructionsCapability;
+
+impl Capability for AgentInstructionsCapability {
+    fn id(&self) -> &str {
+        AGENT_INSTRUCTIONS_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Agent Instructions"
+    }
+
+    fn description(&self) -> &str {
+        "Reads AGENTS.md from the session workspace and includes it as context in the system prompt. Content is re-read on every turn, so changes are picked up automatically.\n\n> [!TIP]\n> Write an `AGENTS.md` file to your session workspace with project conventions, coding style, or any instructions you want the agent to follow."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("file-text")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Configuration")
+    }
+
+    // No system_prompt_addition — content is dynamic (read at runtime by ReasonAtom)
+    // No tools
+    // No dependencies
+    // No mounts
+}
+
+/// Format AGENTS.md content for injection into the system prompt.
+///
+/// Truncates to `MAX_AGENTS_MD_SIZE` if content exceeds the limit.
+/// Returns `None` if content is empty.
+pub fn format_agents_md_content(content: &str) -> Option<String> {
+    let content = content.trim();
+    if content.is_empty() {
+        return None;
+    }
+
+    let truncated = if content.len() > MAX_AGENTS_MD_SIZE {
+        tracing::warn!(
+            content_size = content.len(),
+            max_size = MAX_AGENTS_MD_SIZE,
+            "AGENTS.md exceeds size limit, truncating"
+        );
+        &content[..MAX_AGENTS_MD_SIZE]
+    } else {
+        content
+    };
+
+    Some(format!(
+        "# Project Instructions (AGENTS.md)\n\n{}",
+        truncated
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capabilities::CapabilityRegistry;
+
+    #[test]
+    fn test_capability_metadata() {
+        let cap = AgentInstructionsCapability;
+
+        assert_eq!(cap.id(), "agent_instructions");
+        assert_eq!(cap.name(), "Agent Instructions");
+        assert_eq!(cap.status(), CapabilityStatus::Available);
+        assert_eq!(cap.icon(), Some("file-text"));
+        assert_eq!(cap.category(), Some("Configuration"));
+    }
+
+    #[test]
+    fn test_no_static_system_prompt() {
+        let cap = AgentInstructionsCapability;
+        assert!(cap.system_prompt_addition().is_none());
+    }
+
+    #[test]
+    fn test_no_tools() {
+        let cap = AgentInstructionsCapability;
+        assert!(cap.tools().is_empty());
+    }
+
+    #[test]
+    fn test_no_dependencies() {
+        let cap = AgentInstructionsCapability;
+        assert!(cap.dependencies().is_empty());
+    }
+
+    #[test]
+    fn test_no_mounts() {
+        let cap = AgentInstructionsCapability;
+        assert!(cap.mounts().is_empty());
+    }
+
+    #[test]
+    fn test_format_agents_md_content_normal() {
+        let content = "## Style\nUse snake_case for variables.";
+        let result = format_agents_md_content(content).unwrap();
+
+        assert!(result.starts_with("# Project Instructions (AGENTS.md)"));
+        assert!(result.contains("Use snake_case"));
+    }
+
+    #[test]
+    fn test_format_agents_md_content_empty() {
+        assert!(format_agents_md_content("").is_none());
+        assert!(format_agents_md_content("   ").is_none());
+        assert!(format_agents_md_content("\n\n").is_none());
+    }
+
+    #[test]
+    fn test_format_agents_md_content_truncation() {
+        let content = "x".repeat(MAX_AGENTS_MD_SIZE + 1000);
+        let result = format_agents_md_content(&content).unwrap();
+
+        // Header + \n\n + truncated content
+        let expected_len = "# Project Instructions (AGENTS.md)\n\n".len() + MAX_AGENTS_MD_SIZE;
+        assert_eq!(result.len(), expected_len);
+    }
+
+    #[test]
+    fn test_format_agents_md_content_trims_whitespace() {
+        let content = "  \n  Hello  \n  ";
+        let result = format_agents_md_content(content).unwrap();
+        assert!(result.contains("Hello"));
+        // Should not contain leading/trailing whitespace from original
+        assert!(!result.ends_with("  "));
+    }
+
+    #[test]
+    fn test_capability_in_registry() {
+        let registry = CapabilityRegistry::with_builtins();
+        let cap = registry.get("agent_instructions").unwrap();
+
+        assert_eq!(cap.id(), "agent_instructions");
+        assert_eq!(cap.name(), "Agent Instructions");
+    }
+
+    #[test]
+    fn test_constants() {
+        assert_eq!(MAX_AGENTS_MD_SIZE, 32_768);
+        assert_eq!(AGENTS_MD_PATH, "/AGENTS.md");
+        assert_eq!(AGENT_INSTRUCTIONS_CAPABILITY_ID, "agent_instructions");
+    }
+}

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -172,6 +172,15 @@ pub trait Capability: Send + Sync {
         None
     }
 
+    /// Returns a preview of the system prompt addition for UI display.
+    ///
+    /// For most capabilities this is identical to `system_prompt_addition()`.
+    /// Capabilities with dynamic content (e.g. `agent_instructions` which reads
+    /// AGENTS.md at runtime) override this to return a representative preview.
+    fn system_prompt_preview(&self) -> Option<String> {
+        self.system_prompt_addition().map(|s| s.to_string())
+    }
+
     /// Returns tool implementations provided by this capability
     fn tools(&self) -> Vec<Box<dyn Tool>> {
         vec![]
@@ -952,6 +961,34 @@ mod tests {
         let current_time = registry.get("current_time").unwrap();
         assert_eq!(current_time.icon(), Some("clock"));
         assert_eq!(current_time.category(), Some("Utilities"));
+    }
+
+    #[test]
+    fn test_system_prompt_preview_default_delegates_to_addition() {
+        let registry = CapabilityRegistry::with_builtins();
+
+        // test_math has a static system_prompt_addition — preview should match
+        let test_math = registry.get("test_math").unwrap();
+        assert_eq!(
+            test_math.system_prompt_preview().as_deref(),
+            test_math.system_prompt_addition()
+        );
+
+        // current_time has no system_prompt_addition — preview should be None
+        let current_time = registry.get("current_time").unwrap();
+        assert!(current_time.system_prompt_preview().is_none());
+        assert!(current_time.system_prompt_addition().is_none());
+    }
+
+    #[test]
+    fn test_system_prompt_preview_dynamic_capability() {
+        let registry = CapabilityRegistry::with_builtins();
+        let cap = registry.get("agent_instructions").unwrap();
+
+        // No static addition, but preview exists
+        assert!(cap.system_prompt_addition().is_none());
+        assert!(cap.system_prompt_preview().is_some());
+        assert!(cap.system_prompt_preview().unwrap().contains("AGENTS.md"));
     }
 
     // =========================================================================

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -32,6 +32,7 @@ pub use crate::capability_types::{
 // Capability Modules
 // ============================================================================
 
+mod agent_instructions;
 mod current_time;
 mod docker_container;
 mod fake_aws;
@@ -53,6 +54,10 @@ mod virtual_bash;
 mod web_fetch;
 
 // Re-export capabilities
+pub use agent_instructions::{
+    AGENT_INSTRUCTIONS_CAPABILITY_ID, AGENTS_MD_PATH, AgentInstructionsCapability,
+    MAX_AGENTS_MD_SIZE, format_agents_md_content,
+};
 pub use current_time::{CurrentTimeCapability, GetCurrentTimeTool};
 pub use docker_container::{
     DockerContainerCapability, DockerContainerConfig, DockerExecTool, DockerReadFileTool,
@@ -272,6 +277,7 @@ impl CapabilityRegistry {
         let mut registry = Self::new();
 
         // Core capabilities (all environments)
+        registry.register(AgentInstructionsCapability);
         registry.register(NoopCapability);
         registry.register(CurrentTimeCapability);
         registry.register(ResearchCapability);
@@ -851,6 +857,7 @@ mod tests {
         // Dev mode includes all capabilities including experimental
         let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
 
+        assert!(registry.has("agent_instructions"));
         assert!(registry.has("noop"));
         assert!(registry.has("current_time"));
         assert!(registry.has("research"));
@@ -870,7 +877,7 @@ mod tests {
         assert!(registry.has("fake_financial"));
         // Experimental capability included in dev
         assert!(registry.has("docker_container"));
-        assert_eq!(registry.len(), 18);
+        assert_eq!(registry.len(), 19);
     }
 
     #[test]
@@ -878,6 +885,7 @@ mod tests {
         // Prod mode excludes experimental capabilities
         let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Prod);
 
+        assert!(registry.has("agent_instructions"));
         assert!(registry.has("noop"));
         assert!(registry.has("current_time"));
         assert!(registry.has("research"));
@@ -897,7 +905,7 @@ mod tests {
         assert!(registry.has("fake_financial"));
         // Experimental capability NOT included in prod
         assert!(!registry.has("docker_container"));
-        assert_eq!(registry.len(), 17);
+        assert_eq!(registry.len(), 18);
     }
 
     #[test]

--- a/crates/core/src/capability_dto.rs
+++ b/crates/core/src/capability_dto.rs
@@ -63,7 +63,7 @@ impl CapabilityInfo {
             status: cap.status(),
             icon: cap.icon().map(|s| s.to_string()),
             category: cap.category().map(|s| s.to_string()),
-            system_prompt: cap.system_prompt_addition().map(|s| s.to_string()),
+            system_prompt: cap.system_prompt_preview(),
             tool_definitions: cap.tool_definitions(),
             is_mcp,
             dependencies: cap.dependencies().iter().map(|s| s.to_string()).collect(),

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -170,6 +170,9 @@ pub async fn reason_activity(
     // Create image resolver for multimodal image support
     let image_resolver = Arc::new(GrpcImageResolver::new(grpc_client.clone()));
 
+    // Create file store for AGENTS.md reading (agent_instructions capability)
+    let file_store = Arc::new(GrpcSessionFileStore::new(grpc_client.clone()));
+
     let atom = ReasonAtom::new(
         agent_store,
         session_store,
@@ -179,7 +182,8 @@ pub async fn reason_activity(
         driver_registry,
         event_emitter,
     )
-    .with_image_resolver(image_resolver);
+    .with_image_resolver(image_resolver)
+    .with_file_store(file_store);
 
     let result = atom
         .execute(input)

--- a/docs/features/agent-instructions.md
+++ b/docs/features/agent-instructions.md
@@ -1,0 +1,130 @@
+---
+title: Agent Instructions (AGENTS.md)
+description: Provide project-level instructions to agents via AGENTS.md
+---
+
+The **Agent Instructions** capability reads an `AGENTS.md` file from the session workspace and automatically includes it in the agent's system prompt on every turn. This gives you a simple, standard way to provide project-level context — coding conventions, style guides, build instructions, or any other guidance — to your agents.
+
+## Overview
+
+`AGENTS.md` is an emerging open standard for providing project-level instructions to AI coding agents. It is backed by organizations including OpenAI, Google, Cursor, Sourcegraph, and the Linux Foundation.
+
+Everruns implements `AGENTS.md` as a built-in capability. When enabled:
+
+- The agent reads `/workspace/AGENTS.md` from the session filesystem on every turn
+- Changes to the file are picked up automatically (no restart needed)
+- Content is prepended to the system prompt, before capability additions and the agent's own prompt
+- If the file doesn't exist, the agent operates normally without it
+
+## Quick Start
+
+1. **Enable the capability** on your agent:
+
+```bash
+curl -X PATCH http://localhost:9000/v1/agents/{agent_id} \
+  -H "Content-Type: application/json" \
+  -d '{ "capabilities": [{ "ref": "agent_instructions" }] }'
+```
+
+2. **Write an AGENTS.md file** to your session workspace:
+
+```bash
+# Via the file system tools during a session
+write_file("/workspace/AGENTS.md", "## Style\n\nUse snake_case for all variables.\nPrefer composition over inheritance.\n")
+```
+
+3. The agent will automatically read and follow the instructions on every turn.
+
+## What to Put in AGENTS.md
+
+`AGENTS.md` is plain Markdown. There are no required sections or special syntax. Common contents include:
+
+- **Project overview** — what the project does, key concepts
+- **Coding conventions** — naming, formatting, patterns to follow or avoid
+- **Build and test commands** — how to build, run tests, lint
+- **Architecture notes** — key directories, data flow, important modules
+- **PR and commit conventions** — branching strategy, commit message format
+- **Security considerations** — auth patterns, data handling rules
+
+### Example
+
+```markdown
+## Project: Acme API
+
+REST API built with Rust + Axum. PostgreSQL for storage.
+
+## Style
+
+- snake_case for variables and functions
+- PascalCase for types
+- Keep functions under 50 lines
+- Write tests for all public functions
+
+## Build & Test
+
+    cargo build
+    cargo test --all-features
+    cargo clippy -- -D warnings
+
+## Architecture
+
+- `src/api/` — HTTP handlers
+- `src/domain/` — Business logic
+- `src/db/` — Database queries
+- `src/models/` — Data types
+
+## Commits
+
+Use conventional commits: `feat(scope): description`
+```
+
+## How It Works
+
+### System Prompt Order
+
+When `AGENTS.md` is present, the system prompt is composed in this order (top to bottom):
+
+1. **AGENTS.md content** — project-level instructions
+2. **Capability system prompt additions** — tool guidance from enabled capabilities
+3. **Agent's base system prompt** — the agent's own role and personality
+
+This ensures project context comes first, then capability-specific guidance, then agent behavior.
+
+### Size Limit
+
+`AGENTS.md` content is capped at **32 KiB** (32,768 bytes). Content exceeding this limit is silently truncated. This matches the convention used by other tools like OpenAI Codex.
+
+### Dynamic Updates
+
+The file is re-read on every LLM turn. You can edit `AGENTS.md` at any point during a session and the agent will use the updated content on the next turn. No need to restart the session or re-enable the capability.
+
+## Managing via UI
+
+1. Navigate to the Agent detail page
+2. Find **Capabilities** in the sidebar
+3. Enable **Agent Instructions**
+4. Save changes
+
+Then write an `AGENTS.md` file to the session workspace using the file tools or bash.
+
+## Managing via API
+
+Enable the capability:
+
+```bash
+curl -X PATCH http://localhost:9000/v1/agents/{agent_id} \
+  -H "Content-Type: application/json" \
+  -d '{
+    "capabilities": [
+      { "ref": "agent_instructions" },
+      { "ref": "session_file_system" },
+      { "ref": "current_time" }
+    ]
+  }'
+```
+
+The `session_file_system` capability is recommended (but not required) alongside `agent_instructions` — it provides the file tools needed to create and edit `AGENTS.md` within the session.
+
+## Compatibility
+
+Everruns reads only `AGENTS.md`. Other tool-specific files (`.cursorrules`, `CLAUDE.md`, `.github/copilot-instructions.md`) are not read. If you maintain multiple instruction files, you can symlink or copy the content into `AGENTS.md`.

--- a/docs/features/capabilities.md
+++ b/docs/features/capabilities.md
@@ -15,6 +15,17 @@ When you assign capabilities to an agent, those capabilities enhance what the ag
 
 ## Available Capabilities
 
+### Agent Instructions
+
+**Status**: Available
+
+Reads `AGENTS.md` from the session workspace and includes it in the system prompt. Content is re-read on every turn, so changes are picked up automatically.
+
+- **No tools** — this capability only injects context into the system prompt
+- **File**: `/workspace/AGENTS.md` (plain Markdown, max 32 KiB)
+- **Use cases**: Project conventions, coding style, build instructions, architecture notes
+- See [Agent Instructions](/features/agent-instructions/) for full documentation
+
 ### Current Time
 
 **Status**: Available

--- a/specs/agent-instructions.md
+++ b/specs/agent-instructions.md
@@ -1,0 +1,135 @@
+# Agent Instructions (AGENTS.md) Specification
+
+## Abstract
+
+The Agent Instructions capability reads an `AGENTS.md` file from the session workspace and dynamically injects its content into the system prompt on every LLM turn. This provides project-level context and coding conventions to agents without modifying the agent's system prompt directly.
+
+## Background
+
+`AGENTS.md` is an emerging open standard (backed by OpenAI, Google, Cursor, Sourcegraph, Linux Foundation) for providing project-level instructions to AI coding agents. There is no formal specification beyond "plain markdown in a file named AGENTS.md." Each tool defines its own discovery and injection semantics.
+
+Everruns implements AGENTS.md as a built-in capability that reads from the session workspace filesystem. This integrates naturally with the existing capability system—users enable/disable it per agent, and the content is picked up dynamically (no restart needed).
+
+## Design Decisions
+
+| Question | Decision |
+|----------|----------|
+| File name | `AGENTS.md` only (not CLAUDE.md, .cursorrules, etc.) |
+| Discovery | Single file at workspace root (`/AGENTS.md`) — no upward walk (session filesystem is flat) |
+| Injection point | Prepended to system prompt, before capability additions |
+| Dynamic reading | Re-read on every LLM turn (picks up changes immediately) |
+| Size limit | 32 KiB max (truncated with warning if exceeded, matching Codex convention) |
+| Missing file | Silently ignored (no error) |
+| Format | Plain markdown, no special syntax, no `@` imports |
+| Architecture | Capability (marker) + ReasonAtom integration (dynamic reader) |
+| Dependencies | None required; `session_file_system` recommended for authoring |
+
+## Capability Definition
+
+```rust
+pub struct AgentInstructionsCapability;
+
+impl Capability for AgentInstructionsCapability {
+    fn id(&self) -> &str { "agent_instructions" }
+    fn name(&self) -> &str { "Agent Instructions" }
+    fn description(&self) -> &str {
+        "Reads AGENTS.md from the session workspace and includes it as context in the system prompt. Content is re-read on every turn, so changes are picked up automatically."
+    }
+    fn status(&self) -> CapabilityStatus { CapabilityStatus::Available }
+    fn icon(&self) -> Option<&str> { Some("file-text") }
+    fn category(&self) -> Option<&str> { Some("Configuration") }
+    // No system_prompt_addition() — content is dynamic (read at runtime)
+    // No tools
+    // No dependencies
+}
+```
+
+## Integration Flow
+
+```
+execute_llm_call()
+  ├── Load agent + session
+  ├── Resolve capabilities
+  ├── Check: is "agent_instructions" in resolved capabilities?
+  │   └── Yes: read /AGENTS.md from session file store
+  │       ├── File exists: prepend content to system prompt
+  │       ├── File missing: skip silently
+  │       └── File > 32 KiB: truncate + log warning
+  ├── Build RuntimeAgent (capabilities + tools + model)
+  └── Execute LLM call
+```
+
+### System Prompt Order
+
+After injection, system prompt order (top to bottom):
+
+1. **AGENTS.md content** (project instructions)
+2. **Capability system prompt additions** (tool guidance, etc.)
+3. **Agent's base system prompt** (agent-specific behavior)
+
+This ensures project-level context comes first, then capability-specific instructions, then the agent's own personality/role.
+
+## ReasonAtom Changes
+
+Add optional `SessionFileStore` to ReasonAtom:
+
+```rust
+pub struct ReasonAtom<A, S, M, P, E> {
+    // ... existing fields ...
+    file_store: Option<Arc<dyn SessionFileStore>>,
+}
+```
+
+With builder method:
+
+```rust
+pub fn with_file_store(mut self, file_store: Arc<dyn SessionFileStore>) -> Self {
+    self.file_store = Some(file_store);
+    self
+}
+```
+
+## Constants
+
+```rust
+/// Maximum size of AGENTS.md content (32 KiB)
+pub const MAX_AGENTS_MD_SIZE: usize = 32_768;
+
+/// File path in the session filesystem
+pub const AGENTS_MD_PATH: &str = "/AGENTS.md";
+
+/// Capability ID
+pub const AGENT_INSTRUCTIONS_CAPABILITY_ID: &str = "agent_instructions";
+```
+
+## API
+
+The capability appears in standard capability endpoints:
+
+```http
+GET /v1/capabilities
+
+Response includes:
+{
+  "id": "agent_instructions",
+  "name": "Agent Instructions",
+  "description": "Reads AGENTS.md from the session workspace...",
+  "status": "available",
+  "icon": "file-text",
+  "category": "Configuration"
+}
+```
+
+Enable on an agent:
+
+```http
+PATCH /v1/agents/{id}
+{ "capabilities": [{ "ref": "agent_instructions" }, ...] }
+```
+
+## Usage
+
+1. Enable the `agent_instructions` capability on an agent
+2. Write an `AGENTS.md` file to the session workspace (via file tools, bash, or API)
+3. The agent automatically reads it on every turn
+4. Edit the file anytime — changes take effect on the next turn

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -119,6 +119,7 @@ Capability IDs are string-based for extensibility. New capabilities can be added
 
 | ID | Name | Category | Status |
 |----|------|----------|--------|
+| `agent_instructions` | Agent Instructions | Configuration | Available |
 | `noop` | No-Op | Testing | Available |
 | `current_time` | Current Time | Utilities | Available |
 | `test_math` | Test Math | Testing | Available |


### PR DESCRIPTION
## What
Add `agent_instructions` capability that reads AGENTS.md from the session workspace and injects it into the system prompt dynamically on every LLM turn. Also adds `system_prompt_preview()` to the Capability trait for UI previews of dynamic capabilities.

## Why
AGENTS.md is an emerging open standard for providing project-level instructions to AI coding agents. This gives users a simple, standard way to provide coding conventions, style guides, and project context to agents without editing the agent's system prompt directly.

## How
- **Capability as marker**: `AgentInstructionsCapability` registers in the capability system (UI/API visible, enable/disable per agent) but has no static `system_prompt_addition()`
- **Dynamic reading in ReasonAtom**: Added optional `file_store: Option<Arc<dyn SessionFileStore>>` to ReasonAtom (same pattern as `image_resolver`). When `agent_instructions` is in the resolved capabilities, reads `/AGENTS.md` from the session file store and prepends to system prompt
- **`system_prompt_preview()`**: New trait method with default delegating to `system_prompt_addition()`. `AgentInstructionsCapability` overrides to return a representative preview. `CapabilityInfo` DTO now uses this for the API
- 32 KiB size limit with truncation notice appended to formatted output
- Missing file silently ignored; read errors logged and skipped

## Risk
- Low
- No changes to existing capability behavior (default `system_prompt_preview()` delegates to `system_prompt_addition()`)
- `file_store` is `Option` — `None` in in-memory loop (no regression), wired in worker via existing `GrpcSessionFileStore`

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered