### PR TITLE
chore(deps): upgrade fetchkit to 0.1.1 from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,7 +394,7 @@ dependencies = [
  "jaq-json",
  "jaq-std",
  "regex",
- "schemars 1.2.1",
+ "schemars",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1501,17 +1501,18 @@ dependencies = [
 
 [[package]]
 name = "fetchkit"
-version = "0.1.0"
-source = "git+https://github.com/everruns/fetchkit#959708a2ce3526d7444b82f4ebdf4ddaa2ef8551"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78234c85007f12632e64570a2f3fc3deb2526e7b6ca748f39d36ac2a90c67e39"
 dependencies = [
  "async-trait",
  "bytes",
  "futures",
  "reqwest 0.13.1",
- "schemars 0.8.22",
+ "schemars",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -4233,39 +4234,15 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
-dependencies = [
- "dyn-clone",
- "schemars_derive 0.8.22",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
- "schemars_derive 1.2.1",
+ "schemars_derive",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn 2.0.114",
 ]
 
 [[package]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -50,7 +50,7 @@ base64.workspace = true
 url = "2"
 
 # Web fetching
-fetchkit = { git = "https://github.com/everruns/fetchkit" }
+fetchkit = "0.1.1"
 
 # Sandboxed bash interpreter
 bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.1.4" }


### PR DESCRIPTION
## What
Upgrade fetchkit from git dependency to crates.io published version 0.1.1. Verified everruns-sdk is already at latest (0.1.1).

## Why
Using published crates.io versions is preferred over git dependencies for reproducibility, caching, and version clarity.

## How
- Changed `fetchkit = { git = "..." }` to `fetchkit = "0.1.1"` in `crates/core/Cargo.toml`
- This also removes the transitive `schemars 0.8` dependency (fetchkit 0.1.1 uses schemars 1.x) and upgrades fetchkit's thiserror from 1.x to 2.x
- everruns-sdk was already at latest (0.1.1), no change needed

## Risk
- Low
- API is unchanged; fetchkit 0.1.1 is the published version of the same code that was on the git default branch

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered