### PR TITLE
chore(specs): add SDK doc check to maintenance checklist

### DIFF
--- a/docs/features/sdk.mdx
+++ b/docs/features/sdk.mdx
@@ -226,12 +226,19 @@ All SDKs provide access to the full Everruns API:
 
 | Resource | Operations |
 |----------|------------|
-| **Agents** | Create, list, get, update, archive |
+| **Agents** | Create, list, get, update, upsert, archive, import, export, preview |
 | **Sessions** | Create, list, get, update, delete, cancel |
 | **Messages** | Create, list |
 | **Events** | Poll, stream (SSE) |
-| **Filesystem** | Session file operations |
-| **Images** | Upload, retrieve |
+| **Capabilities** | List, get |
+| **LLM Providers** | Create, list, get, update, delete, sync models |
+| **LLM Models** | Create, list, get, update, delete |
+| **MCP Servers** | Create, list, get, update, delete |
+| **Filesystem** | List, read, create, update, delete, move, copy, grep, stat |
+| **Session Databases** | Create, list, get, delete, schema |
+| **Images** | Upload, list, get, thumbnail, delete |
+| **Organizations** | Create, list, get, update |
+| **Scheduled Tasks** | Create, list, get, update, delete, pause, resume, trigger |
 
 ## Error Handling
 
@@ -295,7 +302,12 @@ The SDKs support all event types from the Everruns API:
 | **Input** | `input.message` |
 | **Output** | `output.message.started`, `output.message.delta`, `output.message.completed` |
 | **Turn** | `turn.started`, `turn.completed`, `turn.failed`, `turn.cancelled` |
-| **Tool** | `tool.started`, `tool.completed` |
+| **Reasoning** | `reason.started`, `reason.completed` |
+| **Thinking** | `reason.thinking.started`, `reason.thinking.delta`, `reason.thinking.completed` |
+| **Act** | `act.started`, `act.completed` |
+| **Tool** | `tool.started`, `tool.completed`, `tool.call_requested` |
+| **LLM** | `llm.generation` |
+| **Session** | `session.started`, `session.activated`, `session.idled` |
 
 See the [Events documentation](/features/events) for detailed information about event streaming.
 

--- a/specs/maintenance.md
+++ b/specs/maintenance.md
@@ -91,14 +91,31 @@ Identify and fill gaps.
 4. Verify API example matches current API shape
 5. Check Docker Compose instructions match `examples/docker-compose-full.yaml`
 
-### 8. Rust Documentation
+### 8. SDK Documentation and Feature Parity
+
+Verify [everruns/sdk](https://github.com/everruns/sdk) public documentation (`docs/features/sdk.mdx`) is current and the SDK supports latest main API features.
+
+**Documentation accuracy:**
+1. Compare SDK docs API coverage table against actual endpoints in `specs/apis.md`
+2. Verify documented sub-clients (agents, sessions, messages, events) match server routes
+3. Check documented event types match `specs/events.md`
+4. Verify code examples use current request/response shapes (compare against OpenAPI spec)
+5. Confirm installation instructions and version references are current
+
+**Feature parity:**
+6. Compare SDK version in `Cargo.toml` (`everruns-sdk`) against latest published release
+7. Check if new API resources added since last SDK release are missing from SDK (e.g., MCP servers, LLM providers, scheduled tasks, session databases, organizations)
+8. Verify CLI crate (`crates/cli/`) can exercise all SDK sub-clients without errors
+9. File issues or PRs on [everruns/sdk](https://github.com/everruns/sdk) for any gaps found
+
+### 9. Rust Documentation
 
 1. Run `cargo doc --no-deps --all-features` — must compile without warnings
 2. Verify public types have doc comments
 3. Check crate-level documentation (`//!` comments in `lib.rs`)
 4. Fix any broken intra-doc links
 
-### 9. AGENTS.md (CLAUDE.md)
+### 10. AGENTS.md (CLAUDE.md)
 
 `AGENTS.md` is the primary agent instruction file (`CLAUDE.md` references it).
 
@@ -110,7 +127,7 @@ Identify and fill gaps.
 6. Check commit convention matches `commitlint.config.js`
 7. Ensure tone/style guidance is clear and consistent
 
-### 10. Additional Checks
+### 11. Additional Checks
 
 1. `cargo deny check` — license compliance passes
 2. `cargo fmt --check` — formatting passes
@@ -121,7 +138,7 @@ Identify and fill gaps.
 
 ## Automation
 
-Run `just pre-pr` to automate checks 1-8 where possible. Manual review needed for spec accuracy, threat model, and AGENTS.md content.
+Run `just pre-pr` to automate checks 1-9 where possible. Manual review needed for spec accuracy, threat model, SDK parity, and AGENTS.md content.
 
 ## Frequency
 


### PR DESCRIPTION
## What
Add SDK documentation and feature parity check as section 8 to the pre-release maintenance spec. Update SDK docs page with missing API resources and event types.

## Why
SDK public docs were out of date — missing coverage of capabilities, LLM providers/models, MCP servers, session databases, organizations, scheduled tasks, and several event types (reasoning, thinking, act, session lifecycle, llm.generation). No maintenance step existed to catch this drift.

## How
- Added section 8 "SDK Documentation and Feature Parity" to specs/maintenance.md with 9 sub-checks covering doc accuracy and feature parity
- Renumbered subsequent sections (9, 10, 11)
- Updated docs/features/sdk.mdx API coverage table from 6 to 13 resource groups
- Updated event types table from 4 to 10 categories (23 event types total)
- Verified docs build passes

## Risk
- Low
- Docs-only change, no code affected

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered