### PR TITLE
chore(deps): update everruns-sdk to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,9 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-sdk"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d88d1f1e929b0282bc0a125b778aa397aa3863cf1c06574afd9de392103ad784"
+checksum = "19c1fcd224455d50b722c1578e563dba5d9a417e45e5725197fa35aa1774535c"
 dependencies = [
  "async-stream",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ time = "0.3"
 parking_lot = "0.12"
 
 # Everruns SDK
-everruns-sdk = "0.1.1"
+everruns-sdk = "0.1.2"
 
 # gRPC (tonic)
 tonic = "0.14"


### PR DESCRIPTION
## What
Update `everruns-sdk` dependency from 0.1.1 to 0.1.2.

## Why
Keep SDK dependency current with latest published version on crates.io.

## How
- Bumped version in workspace `Cargo.toml` from `0.1.1` to `0.1.2`
- Updated `Cargo.lock` via `cargo update everruns-sdk`

## Risk
- Low
- Patch version bump; no breaking changes expected

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered