### PR TITLE
feat(core): wrap system prompt sections in XML tags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ Fix root cause. Unsure: read more code; if stuck, ask w/ short options. Unrecogn
 - `specs/bashkit-requirements.md` - Bash sandbox capabilities and requirements
 - `specs/events-contract.md` - SSE event format contract
 - `specs/maintenance.md` - Pre-release maintenance checklist
+- `specs/xml-prompt-formatting.md` - XML tags for system prompt structure
 
 ### Skills
 

--- a/crates/core/src/capabilities/agent_instructions.rs
+++ b/crates/core/src/capabilities/agent_instructions.rs
@@ -10,6 +10,8 @@
 //! - Re-read every turn so edits are picked up immediately
 //! - 32 KiB size limit (truncated with warning), matching Codex convention
 //! - Missing file is silently ignored
+//! - Content wrapped in `<agent-instructions>` XML tags to separate user-provided
+//!   instructions from system capability prompts (reduces prompt injection surface)
 
 use super::{Capability, CapabilityStatus};
 
@@ -54,8 +56,9 @@ impl Capability for AgentInstructionsCapability {
 
     fn system_prompt_preview(&self) -> Option<String> {
         Some(
-            "# Instructions (AGENTS.md)\n\n\
-             <contents of /workspace/AGENTS.md, re-read every turn>"
+            "<agent-instructions source=\"AGENTS.md\">\n\
+             (contents of /workspace/AGENTS.md, re-read every turn)\n\
+             </agent-instructions>"
                 .to_string(),
         )
     }
@@ -86,10 +89,11 @@ pub fn format_agents_md_content(content: &str) -> Option<String> {
         (content, false)
     };
 
-    let mut result = format!("# Instructions (AGENTS.md)\n\n{}", body);
+    let mut result = format!("<agent-instructions source=\"AGENTS.md\">\n{}", body);
     if was_truncated {
         result.push_str("\n\n[AGENTS.md was truncated — content exceeds 32 KiB limit]");
     }
+    result.push_str("\n</agent-instructions>");
     Some(result)
 }
 
@@ -121,6 +125,8 @@ mod tests {
         let preview = cap.system_prompt_preview().unwrap();
         assert!(preview.contains("AGENTS.md"));
         assert!(preview.contains("re-read every turn"));
+        assert!(preview.starts_with("<agent-instructions"));
+        assert!(preview.ends_with("</agent-instructions>"));
     }
 
     #[test]
@@ -146,7 +152,8 @@ mod tests {
         let content = "## Style\nUse snake_case for variables.";
         let result = format_agents_md_content(content).unwrap();
 
-        assert!(result.starts_with("# Instructions (AGENTS.md)"));
+        assert!(result.starts_with("<agent-instructions source=\"AGENTS.md\">"));
+        assert!(result.ends_with("</agent-instructions>"));
         assert!(result.contains("Use snake_case"));
     }
 
@@ -162,11 +169,15 @@ mod tests {
         let content = "x".repeat(MAX_AGENTS_MD_SIZE + 1000);
         let result = format_agents_md_content(&content).unwrap();
 
-        let header = "# Instructions (AGENTS.md)\n\n";
-        let suffix = "\n\n[AGENTS.md was truncated — content exceeds 32 KiB limit]";
-        let expected_len = header.len() + MAX_AGENTS_MD_SIZE + suffix.len();
+        let header = "<agent-instructions source=\"AGENTS.md\">\n";
+        let truncation_notice = "\n\n[AGENTS.md was truncated — content exceeds 32 KiB limit]";
+        let closing = "\n</agent-instructions>";
+        let expected_len =
+            header.len() + MAX_AGENTS_MD_SIZE + truncation_notice.len() + closing.len();
         assert_eq!(result.len(), expected_len);
-        assert!(result.ends_with(suffix));
+        assert!(result.starts_with("<agent-instructions"));
+        assert!(result.ends_with("</agent-instructions>"));
+        assert!(result.contains("truncated"));
     }
 
     #[test]

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -11,6 +11,10 @@
 //! - CapabilityRegistry holds all available capability implementations
 //! - apply_capabilities() merges capability contributions into RuntimeAgent
 //! - The agent-loop remains execution-focused; capabilities are applied before execution
+//! - System prompt sections use XML tags for clear boundaries between components.
+//!   This follows Anthropic's recommendation for multi-component prompts and reduces
+//!   misattribution between capability instructions, user-provided AGENTS.md, and the
+//!   agent's base system prompt. See specs/xml-prompt-formatting.md for rationale.
 //!
 //! Each capability is in its own file with collocated tools.
 
@@ -727,9 +731,12 @@ pub fn collect_capabilities_with_configs(
                 continue;
             }
 
-            // Collect system prompt addition
+            // Collect system prompt addition wrapped in XML tags for clear boundaries
             if let Some(addition) = capability.system_prompt_addition() {
-                system_prompt_parts.push(addition.to_string());
+                system_prompt_parts.push(format!(
+                    "<capability id=\"{}\">\n{}\n</capability>",
+                    cap_id, addition
+                ));
             }
 
             // Collect tools
@@ -818,9 +825,12 @@ pub fn apply_capabilities(
 ) -> AppliedCapabilities {
     let collected = collect_capabilities(capability_ids, registry);
 
-    // Build final system prompt: capability additions + base prompt
+    // Build final system prompt: capability additions + base prompt (wrapped in XML tags)
     let final_system_prompt = match collected.system_prompt_prefix() {
-        Some(prefix) => format!("{}\n\n{}", prefix, base_runtime_agent.system_prompt),
+        Some(prefix) => format!(
+            "{}\n\n<system-prompt>\n{}\n</system-prompt>",
+            prefix, base_runtime_agent.system_prompt
+        ),
         None => base_runtime_agent.system_prompt,
     };
 
@@ -1111,6 +1121,32 @@ mod tests {
 
         // TestMath has system prompt addition and 4 tools
         assert!(applied.runtime_agent.system_prompt.contains("math tools"));
+        // Capability prompt wrapped in XML tags
+        assert!(
+            applied
+                .runtime_agent
+                .system_prompt
+                .contains("<capability id=\"test_math\">")
+        );
+        assert!(
+            applied
+                .runtime_agent
+                .system_prompt
+                .contains("</capability>")
+        );
+        // Base prompt wrapped in <system-prompt> tags
+        assert!(
+            applied
+                .runtime_agent
+                .system_prompt
+                .contains("<system-prompt>")
+        );
+        assert!(
+            applied
+                .runtime_agent
+                .system_prompt
+                .contains("</system-prompt>")
+        );
         assert!(applied.tool_registry.has("add"));
         assert!(applied.tool_registry.has("subtract"));
         assert!(applied.tool_registry.has("multiply"));
@@ -1135,6 +1171,12 @@ mod tests {
                 .runtime_agent
                 .system_prompt
                 .contains("weather tools")
+        );
+        assert!(
+            applied
+                .runtime_agent
+                .system_prompt
+                .contains("<capability id=\"test_weather\">")
         );
         assert!(applied.tool_registry.has("get_weather"));
         assert!(applied.tool_registry.has("get_forecast"));
@@ -1202,6 +1244,88 @@ mod tests {
         assert!(applied.runtime_agent.system_prompt.contains("FetchKit"));
         assert!(applied.tool_registry.has("web_fetch"));
         assert_eq!(applied.tool_registry.len(), 1);
+    }
+
+    // =========================================================================
+    // XML prompt formatting tests
+    // =========================================================================
+
+    #[test]
+    fn test_xml_tags_wrap_capability_prompts() {
+        let registry = CapabilityRegistry::with_builtins();
+        let collected = collect_capabilities(&["test_math".to_string()], &registry);
+
+        assert_eq!(collected.system_prompt_parts.len(), 1);
+        let part = &collected.system_prompt_parts[0];
+        assert!(part.starts_with("<capability id=\"test_math\">"));
+        assert!(part.ends_with("</capability>"));
+        assert!(part.contains("math tools"));
+    }
+
+    #[test]
+    fn test_xml_tags_multiple_capabilities() {
+        let registry = CapabilityRegistry::with_builtins();
+        let collected = collect_capabilities(
+            &["test_math".to_string(), "test_weather".to_string()],
+            &registry,
+        );
+
+        assert_eq!(collected.system_prompt_parts.len(), 2);
+        assert!(collected.system_prompt_parts[0].starts_with("<capability id=\"test_math\">"));
+        assert!(collected.system_prompt_parts[1].starts_with("<capability id=\"test_weather\">"));
+
+        let prefix = collected.system_prompt_prefix().unwrap();
+        // Both capability sections separated by double newline
+        assert!(prefix.contains("</capability>\n\n<capability"));
+    }
+
+    #[test]
+    fn test_xml_tags_system_prompt_wrapping() {
+        let registry = CapabilityRegistry::with_builtins();
+        let base = RuntimeAgent::new("You are helpful.", "gpt-5.2");
+
+        let applied = apply_capabilities(base, &["test_math".to_string()], &registry);
+
+        let prompt = &applied.runtime_agent.system_prompt;
+        // Capability wrapped
+        assert!(prompt.contains("<capability id=\"test_math\">"));
+        assert!(prompt.contains("</capability>"));
+        // Base prompt wrapped
+        assert!(prompt.contains("<system-prompt>\nYou are helpful.\n</system-prompt>"));
+    }
+
+    #[test]
+    fn test_no_xml_wrapping_without_capabilities() {
+        let registry = CapabilityRegistry::with_builtins();
+        let base = RuntimeAgent::new("You are helpful.", "gpt-5.2");
+
+        let applied = apply_capabilities(base, &[], &registry);
+
+        // No capabilities = no XML wrapping (plain base prompt)
+        assert_eq!(applied.runtime_agent.system_prompt, "You are helpful.");
+        assert!(
+            !applied
+                .runtime_agent
+                .system_prompt
+                .contains("<system-prompt>")
+        );
+    }
+
+    #[test]
+    fn test_no_xml_wrapping_for_noop_capability() {
+        let registry = CapabilityRegistry::with_builtins();
+        let base = RuntimeAgent::new("You are helpful.", "gpt-5.2");
+
+        // Noop has no system_prompt_addition, so no XML wrapping should occur
+        let applied = apply_capabilities(base, &["noop".to_string()], &registry);
+
+        assert_eq!(applied.runtime_agent.system_prompt, "You are helpful.");
+        assert!(
+            !applied
+                .runtime_agent
+                .system_prompt
+                .contains("<system-prompt>")
+        );
     }
 
     // =========================================================================

--- a/crates/core/src/runtime_agent.rs
+++ b/crates/core/src/runtime_agent.rs
@@ -152,8 +152,19 @@ impl RuntimeAgentBuilder {
 
         let collected = collect_capabilities(&resolved_ids, registry);
 
-        // Apply system prompt additions (prepend to existing)
+        // Apply system prompt additions (prepend to existing, wrap base in XML tags)
         if let Some(prefix) = collected.system_prompt_prefix() {
+            // Wrap the base system prompt in <system-prompt> tags on first capability
+            // application. Skip if already wrapped (e.g., session capabilities applied
+            // after agent capabilities).
+            if !self.runtime_agent.system_prompt.is_empty()
+                && !self.runtime_agent.system_prompt.contains("<system-prompt>")
+            {
+                self.runtime_agent.system_prompt = format!(
+                    "<system-prompt>\n{}\n</system-prompt>",
+                    self.runtime_agent.system_prompt
+                );
+            }
             self = self.prepend_system_prompt(prefix);
         }
 
@@ -346,7 +357,13 @@ mod tests {
             .build();
 
         assert!(runtime_agent.system_prompt.contains("math tools"));
-        assert!(runtime_agent.system_prompt.ends_with("Base prompt."));
+        // Base prompt wrapped in <system-prompt> tags
+        assert!(runtime_agent.system_prompt.contains("<system-prompt>"));
+        assert!(
+            runtime_agent
+                .system_prompt
+                .ends_with("<system-prompt>\nBase prompt.\n</system-prompt>")
+        );
     }
 
     #[test]
@@ -407,24 +424,36 @@ mod tests {
             .with_capabilities(&["sample_data".to_string()], &registry)
             .build();
 
-        // System prompt should include File System's contribution (the dependency)
+        // System prompt should include File System's contribution (the dependency) in XML tags
+        assert!(
+            runtime_agent
+                .system_prompt
+                .contains("<capability id=\"session_file_system\">"),
+            "Should include File System capability in XML tags"
+        );
         assert!(
             runtime_agent.system_prompt.contains("read_file"),
             "Should include File System system prompt (mentions read_file tool)"
         );
+        // Should also include Sample Data's contribution in XML tags
         assert!(
-            runtime_agent.system_prompt.contains("write_file"),
-            "Should include File System system prompt (mentions write_file tool)"
+            runtime_agent
+                .system_prompt
+                .contains("<capability id=\"sample_data\">"),
+            "Should include Sample Data capability in XML tags"
         );
-        // Should also include Sample Data's contribution
         assert!(
             runtime_agent.system_prompt.contains("/samples"),
             "Should include Sample Data system prompt (mentions /samples path)"
         );
-        // Base prompt should still be there
+        // Base prompt should still be there, wrapped
         assert!(
             runtime_agent.system_prompt.contains("Base prompt."),
             "Should preserve base prompt"
+        );
+        assert!(
+            runtime_agent.system_prompt.contains("<system-prompt>"),
+            "Base prompt should be wrapped in system-prompt tags"
         );
     }
 
@@ -557,7 +586,7 @@ mod tests {
         let registry = CapabilityRegistry::with_builtins();
         let ts = Timestamp::now(NoContext);
 
-        // Agent has current_time capability
+        // Agent has current_time capability (no system prompt addition)
         let uuid = Uuid::new_v7(ts);
         let agent = Agent {
             public_id: AgentId::from_uuid(uuid),
@@ -575,7 +604,7 @@ mod tests {
             usage: None,
         };
 
-        // Session adds test_math capability (additive)
+        // Session adds test_math capability (additive — has system prompt addition)
         let session_capability_ids = vec!["test_math".to_string()];
 
         let runtime_agent = RuntimeAgentBuilder::new()
@@ -593,5 +622,19 @@ mod tests {
         // System prompt should contain both capability additions and agent prompt
         assert!(runtime_agent.system_prompt.contains("Agent prompt."));
         assert!(runtime_agent.system_prompt.contains("math tools"));
+        assert!(
+            runtime_agent
+                .system_prompt
+                .contains("<capability id=\"test_math\">")
+        );
+        // Base prompt should be wrapped in <system-prompt> tags (no double wrapping)
+        let system_prompt_count = runtime_agent
+            .system_prompt
+            .matches("<system-prompt>")
+            .count();
+        assert_eq!(
+            system_prompt_count, 1,
+            "Should have exactly one <system-prompt> tag, not double-wrapped"
+        );
     }
 }

--- a/crates/server/src/services/capability.rs
+++ b/crates/server/src/services/capability.rs
@@ -224,12 +224,12 @@ impl CapabilityService {
             }
         }
 
-        // Build final system prompt
+        // Build final system prompt (XML-wrapped when capabilities contribute prompts)
         let final_system_prompt = if system_prompt_parts.is_empty() {
             base_system_prompt.to_string()
         } else {
             format!(
-                "{}\n\n{}",
+                "{}\n\n<system-prompt>\n{}\n</system-prompt>",
                 system_prompt_parts.join("\n\n"),
                 base_system_prompt
             )

--- a/specs/agent-instructions.md
+++ b/specs/agent-instructions.md
@@ -63,11 +63,11 @@ execute_llm_call()
 
 After injection, system prompt order (top to bottom):
 
-1. **AGENTS.md content** (project instructions)
-2. **Capability system prompt additions** (tool guidance, etc.)
-3. **Agent's base system prompt** (agent-specific behavior)
+1. **AGENTS.md content** — wrapped in `<agent-instructions source="AGENTS.md">` tags
+2. **Capability system prompt additions** — each wrapped in `<capability id="...">` tags
+3. **Agent's base system prompt** — wrapped in `<system-prompt>` tags (only when capabilities are present)
 
-This ensures project-level context comes first, then capability-specific instructions, then the agent's own personality/role.
+XML tags provide clear boundaries between sections. See `specs/xml-prompt-formatting.md` for rationale.
 
 ## ReasonAtom Changes
 

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -728,6 +728,10 @@ When a session executes:
    - This allows temporarily extending capabilities without modifying the agent
 6. **Build RuntimeAgent**:
    - System prompt = session cap additions + agent cap additions + agent's base prompt
+   - Each section is wrapped in XML tags for clear boundaries (see `specs/xml-prompt-formatting.md`):
+     - AGENTS.md content: `<agent-instructions source="AGENTS.md">`
+     - Each capability's addition: `<capability id="{cap_id}">`
+     - Base prompt: `<system-prompt>` (only when capabilities contribute prompt additions)
    - Tools = merged tool list from agent capabilities + session capabilities
 7. **Execute**: Run Agent Loop with fully configured RuntimeAgent
 

--- a/specs/xml-prompt-formatting.md
+++ b/specs/xml-prompt-formatting.md
@@ -1,0 +1,146 @@
+# XML Prompt Formatting
+
+## Abstract
+
+System prompts use XML tags to create clear boundaries between capability instructions, user-provided project instructions (AGENTS.md), and the agent's base system prompt. This follows Anthropic's recommendation for multi-component prompts and is the cross-provider consensus for structured prompt formatting.
+
+## Rationale
+
+### Problem
+
+When multiple capabilities are enabled, the LLM receives a wall of text where:
+- Boundaries between capability sections are ambiguous (only `\n\n` separators)
+- User-provided AGENTS.md content bleeds into system capability instructions
+- Tool guidance for one capability can be misattributed to another
+- The distinction between platform instructions and agent-level behavior is unclear
+
+### Why XML Tags
+
+Anthropic's prompt engineering docs recommend XML tags for multi-component prompts:
+> "XML tags can be a game-changer. They help Claude parse your prompts more accurately, leading to higher-quality outputs."
+
+Key advantages over markdown-only formatting:
+- **Clear boundaries**: Unambiguous section delimiters reduce misattribution
+- **Cross-model support**: XML tags are recommended by Anthropic, Google, and OpenAI
+- **Prompt injection resistance**: XML boundaries make it harder for injected content in AGENTS.md to impersonate system instructions
+- **Parseability**: Tags enable referencing sections by name (e.g., "the instructions in `<agent-instructions>`")
+
+Trade-offs accepted:
+- ~15% more tokens for tags (negligible vs. conversation length)
+- Slightly reduced human readability in raw form (mitigated: markdown preserved inside tags)
+
+## Design
+
+### Tag Schema
+
+Three XML tags wrap the three logical sections of the assembled system prompt:
+
+| Tag | Purpose | Content |
+|-----|---------|---------|
+| `<agent-instructions source="AGENTS.md">` | User-provided project instructions | AGENTS.md file content (markdown) |
+| `<capability id="{cap_id}">` | Per-capability tool guidance | Capability's `system_prompt_addition()` (markdown) |
+| `<system-prompt>` | Agent's core behavior prompt | Agent's base `system_prompt` field |
+
+### Assembled Prompt Structure
+
+```xml
+<agent-instructions source="AGENTS.md">
+## Style
+Use snake_case for variables.
+</agent-instructions>
+
+<capability id="session_file_system">
+You have access to file system tools...
+</capability>
+
+<capability id="test_math">
+You have access to math tools...
+</capability>
+
+<system-prompt>
+You are a helpful assistant.
+</system-prompt>
+```
+
+### Ordering
+
+Top to bottom (matches existing order, unchanged):
+
+1. **AGENTS.md** — user-provided project instructions (if `agent_instructions` capability enabled)
+2. **Capability prompts** — in capability application order (agent caps, then session caps)
+3. **Base system prompt** — agent's core behavior prompt
+
+### Conditional Wrapping
+
+- `<system-prompt>` tags only appear when at least one capability contributes a `system_prompt_addition`. If no capabilities add prompts, the base prompt is used unwrapped.
+- `<capability>` tags only appear for capabilities that have a non-None `system_prompt_addition()`.
+- `<agent-instructions>` tags only appear when AGENTS.md exists and is non-empty.
+- Capabilities without `system_prompt_addition` (e.g., `current_time`, `noop`) add no XML to the prompt.
+
+### Implementation
+
+#### `collect_capabilities_with_configs()` (mod.rs)
+
+Wraps each capability's `system_prompt_addition()` in `<capability id="...">` tags during collection:
+
+```rust
+if let Some(addition) = capability.system_prompt_addition() {
+    system_prompt_parts.push(format!(
+        "<capability id=\"{}\">\n{}\n</capability>",
+        cap_id, addition
+    ));
+}
+```
+
+#### `format_agents_md_content()` (agent_instructions.rs)
+
+Wraps AGENTS.md content in `<agent-instructions>` tags:
+
+```rust
+let mut result = format!("<agent-instructions source=\"AGENTS.md\">\n{}", body);
+// ... truncation handling ...
+result.push_str("\n</agent-instructions>");
+```
+
+#### `RuntimeAgentBuilder::with_capabilities()` (runtime_agent.rs)
+
+Wraps the base system prompt in `<system-prompt>` tags when capabilities contribute prompts:
+
+```rust
+if let Some(prefix) = collected.system_prompt_prefix() {
+    if !self.runtime_agent.system_prompt.contains("<system-prompt>") {
+        self.runtime_agent.system_prompt = format!(
+            "<system-prompt>\n{}\n</system-prompt>",
+            self.runtime_agent.system_prompt
+        );
+    }
+    self = self.prepend_system_prompt(prefix);
+}
+```
+
+Double-wrapping is prevented by checking for existing `<system-prompt>` tag (relevant when session capabilities are applied after agent capabilities).
+
+#### `apply_capabilities()` (mod.rs)
+
+Same wrapping in the standalone `apply_capabilities` path:
+
+```rust
+let final_system_prompt = match collected.system_prompt_prefix() {
+    Some(prefix) => format!(
+        "{}\n\n<system-prompt>\n{}\n</system-prompt>",
+        prefix, base_runtime_agent.system_prompt
+    ),
+    None => base_runtime_agent.system_prompt,
+};
+```
+
+### UI Impact
+
+- **Agent Preview** (Full System Prompt card): Shows raw assembled prompt including XML tags. Uses monospace `<pre>` rendering — XML tags display naturally.
+- **Capability Detail** (System Prompt Addition card): Shows the raw `system_prompt_addition()` via `MarkdownDisplay` — no XML tags (wrapping is at collection time, not in the trait).
+- **Prompt Editor**: No change — users edit the base system prompt without XML.
+
+### Future Considerations
+
+- If capability prompts need to reference each other, the `id` attribute on `<capability>` tags enables this.
+- Tags could be extended with metadata (e.g., `<capability id="..." version="1.0">`) for capability versioning.


### PR DESCRIPTION
## What
Wrap the three logical sections of assembled system prompts in XML tags:
- `<capability id="{cap_id}">` for each capability's `system_prompt_addition()`
- `<agent-instructions source="AGENTS.md">` for user-provided project instructions
- `<system-prompt>` for the agent's base system prompt

## Why
When multiple capabilities are enabled, the LLM receives a concatenated wall of text where boundaries between sections are ambiguous (only `\n\n` separators). This causes:
- Misattribution of instructions between capabilities
- Blurred boundary between user-provided AGENTS.md and system capability prompts
- Potential prompt injection via AGENTS.md impersonating system instructions

Anthropic explicitly recommends XML tags for multi-component system prompts. This is also the cross-provider consensus (Google, OpenAI).

## How
- **`collect_capabilities_with_configs()`** (mod.rs): wraps each capability's prompt in `<capability id="...">` tags during collection
- **`format_agents_md_content()`** (agent_instructions.rs): wraps AGENTS.md in `<agent-instructions>` tags
- **`RuntimeAgentBuilder::with_capabilities()`** (runtime_agent.rs): wraps base prompt in `<system-prompt>` tags when capabilities contribute additions
- **`CapabilityService::preview()`** (capability.rs): same wrapping in the API preview path
- Conditional: no XML wrapping when no capabilities contribute prompt additions
- Double-wrapping prevention for additive session capabilities
- New spec: `specs/xml-prompt-formatting.md` with full rationale and design

## Risk
- Low
- Prompt text changes could theoretically alter LLM behavior, but XML tags are well-understood by all major models and the internal content is unchanged

## Checklist
- [x] Tests added or updated (5 new XML formatting tests + updated existing tests)
- [x] Backward compatibility considered (no breaking API changes, prompt-only change)