### PR TITLE
feat(durable): add per-workflow pending task queue limit

### DIFF
--- a/crates/durable/src/persistence/memory.rs
+++ b/crates/durable/src/persistence/memory.rs
@@ -80,6 +80,7 @@ pub struct InMemoryWorkflowEventStore {
     scheduler_instances: RwLock<HashMap<String, SchedulerInstanceInfo>>,
     #[allow(dead_code)] // Reserved for future global sequence counter
     sequence_counter: AtomicI32,
+    max_pending_tasks_per_workflow: u32,
 }
 
 impl InMemoryWorkflowEventStore {
@@ -95,7 +96,16 @@ impl InMemoryWorkflowEventStore {
             schedule_executions: RwLock::new(HashMap::new()),
             scheduler_instances: RwLock::new(HashMap::new()),
             sequence_counter: AtomicI32::new(0),
+            max_pending_tasks_per_workflow: super::store::max_pending_tasks_per_workflow_from_env(),
         }
+    }
+
+    /// Create with a custom max pending tasks per workflow limit (for testing)
+    #[cfg(test)]
+    pub fn with_max_pending_tasks(limit: u32) -> Self {
+        let mut store = Self::new();
+        store.max_pending_tasks_per_workflow = limit;
+        store
     }
 
     /// Get the number of workflows
@@ -243,8 +253,27 @@ impl WorkflowEventStore for InMemoryWorkflowEventStore {
     }
 
     async fn enqueue_task(&self, task: TaskDefinition) -> Result<Uuid, StoreError> {
+        let limit = self.max_pending_tasks_per_workflow;
+
         let task_id = Uuid::now_v7();
         let mut tasks = self.tasks.write();
+
+        // Check per-workflow pending task count
+        let pending_count = tasks
+            .values()
+            .filter(|t| {
+                t.definition.workflow_id == task.workflow_id && t.status == TaskStatus::Pending
+            })
+            .count() as u32;
+
+        if pending_count >= limit {
+            return Err(StoreError::TaskQueueLimitExceeded {
+                workflow_id: task.workflow_id,
+                current: pending_count,
+                limit,
+            });
+        }
+
         tasks.insert(
             task_id,
             TaskState {
@@ -1942,5 +1971,105 @@ mod tests {
             stats.last_execution_status,
             Some(ScheduleExecutionStatus::Failed)
         );
+    }
+
+    #[tokio::test]
+    async fn test_task_queue_limit_per_workflow() {
+        let store = InMemoryWorkflowEventStore::with_max_pending_tasks(3);
+        let workflow_id = Uuid::now_v7();
+
+        store
+            .create_workflow(workflow_id, "test", serde_json::json!({}), None)
+            .await
+            .unwrap();
+
+        // Enqueue up to the limit
+        for i in 0..3 {
+            store
+                .enqueue_task(TaskDefinition {
+                    workflow_id,
+                    activity_id: format!("act_{i}"),
+                    activity_type: "test_activity".to_string(),
+                    input: serde_json::json!({}),
+                    options: ActivityOptions::default(),
+                })
+                .await
+                .unwrap();
+        }
+
+        // Fourth should fail
+        let result = store
+            .enqueue_task(TaskDefinition {
+                workflow_id,
+                activity_id: "act_overflow".to_string(),
+                activity_type: "test_activity".to_string(),
+                input: serde_json::json!({}),
+                options: ActivityOptions::default(),
+            })
+            .await;
+
+        assert!(
+            matches!(result, Err(StoreError::TaskQueueLimitExceeded { .. })),
+            "expected TaskQueueLimitExceeded, got: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_task_queue_limit_does_not_block_other_workflows() {
+        let store = InMemoryWorkflowEventStore::with_max_pending_tasks(2);
+        let workflow_a = Uuid::now_v7();
+        let workflow_b = Uuid::now_v7();
+
+        store
+            .create_workflow(workflow_a, "test", serde_json::json!({}), None)
+            .await
+            .unwrap();
+        store
+            .create_workflow(workflow_b, "test", serde_json::json!({}), None)
+            .await
+            .unwrap();
+
+        // Fill workflow A to limit
+        for i in 0..2 {
+            store
+                .enqueue_task(TaskDefinition {
+                    workflow_id: workflow_a,
+                    activity_id: format!("a_{i}"),
+                    activity_type: "test".to_string(),
+                    input: serde_json::json!({}),
+                    options: ActivityOptions::default(),
+                })
+                .await
+                .unwrap();
+        }
+
+        // Workflow B should still work
+        store
+            .enqueue_task(TaskDefinition {
+                workflow_id: workflow_b,
+                activity_id: "b_0".to_string(),
+                activity_type: "test".to_string(),
+                input: serde_json::json!({}),
+                options: ActivityOptions::default(),
+            })
+            .await
+            .unwrap();
+
+        // Workflow A should fail
+        let result = store
+            .enqueue_task(TaskDefinition {
+                workflow_id: workflow_a,
+                activity_id: "a_overflow".to_string(),
+                activity_type: "test".to_string(),
+                input: serde_json::json!({}),
+                options: ActivityOptions::default(),
+            })
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(StoreError::TaskQueueLimitExceeded { .. })
+        ));
     }
 }

--- a/crates/durable/src/persistence/mod.rs
+++ b/crates/durable/src/persistence/mod.rs
@@ -12,10 +12,11 @@ mod store;
 pub use memory::InMemoryWorkflowEventStore;
 pub use postgres::PostgresWorkflowEventStore;
 pub use store::{
-    CircuitBreakerState, ClaimedTask, CreateScheduleRow, DlqEntry, DlqFilter, HeartbeatResponse,
-    Pagination, ScheduleExecutionFilter, ScheduleExecutionRow, ScheduleExecutionStatus,
-    ScheduleFilter, ScheduleRow, ScheduleStats, ScheduleTargetType, SchedulerInstanceInfo,
-    StoreError, SystemHealth, TaskDefinition, TaskFailureOutcome, TaskFilter, TaskInfo, TaskStatus,
-    TraceContext, UpdateSchedule, WorkerFilter, WorkerInfo, WorkflowEventInfo, WorkflowEventStore,
-    WorkflowFilter, WorkflowInfo, WorkflowInfoExtended, WorkflowStatus, event_type_name,
+    CircuitBreakerState, ClaimedTask, CreateScheduleRow, DEFAULT_MAX_PENDING_TASKS_PER_WORKFLOW,
+    DlqEntry, DlqFilter, HeartbeatResponse, Pagination, ScheduleExecutionFilter,
+    ScheduleExecutionRow, ScheduleExecutionStatus, ScheduleFilter, ScheduleRow, ScheduleStats,
+    ScheduleTargetType, SchedulerInstanceInfo, StoreError, SystemHealth, TaskDefinition,
+    TaskFailureOutcome, TaskFilter, TaskInfo, TaskStatus, TraceContext, UpdateSchedule,
+    WorkerFilter, WorkerInfo, WorkflowEventInfo, WorkflowEventStore, WorkflowFilter, WorkflowInfo,
+    WorkflowInfoExtended, WorkflowStatus, event_type_name,
 };

--- a/crates/durable/src/persistence/postgres.rs
+++ b/crates/durable/src/persistence/postgres.rs
@@ -44,12 +44,16 @@ use fail::fail_point;
 #[derive(Clone)]
 pub struct PostgresWorkflowEventStore {
     pool: PgPool,
+    max_pending_tasks_per_workflow: u32,
 }
 
 impl PostgresWorkflowEventStore {
     /// Create a new PostgreSQL store with the given connection pool
     pub fn new(pool: PgPool) -> Self {
-        Self { pool }
+        Self {
+            pool,
+            max_pending_tasks_per_workflow: super::store::max_pending_tasks_per_workflow_from_env(),
+        }
     }
 
     /// Get a reference to the connection pool
@@ -322,6 +326,31 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
 
     #[instrument(skip(self, task))]
     async fn enqueue_task(&self, task: TaskDefinition) -> Result<Uuid, StoreError> {
+        let limit = self.max_pending_tasks_per_workflow;
+
+        // Check per-workflow pending task count before inserting
+        let pending_count: i64 = sqlx::query_scalar(
+            r#"
+            SELECT COUNT(*) FROM durable_task_queue
+            WHERE workflow_id = $1 AND status = 'pending'
+            "#,
+        )
+        .bind(task.workflow_id)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| {
+            error!("Failed to count pending tasks: {}", e);
+            StoreError::Database(e.to_string())
+        })?;
+
+        if pending_count >= limit as i64 {
+            return Err(StoreError::TaskQueueLimitExceeded {
+                workflow_id: task.workflow_id,
+                current: pending_count as u32,
+                limit,
+            });
+        }
+
         let task_id = Uuid::now_v7();
         let options_json = serde_json::to_value(&task.options)
             .map_err(|e| StoreError::Serialization(e.to_string()))?;

--- a/crates/durable/src/persistence/store.rs
+++ b/crates/durable/src/persistence/store.rs
@@ -9,6 +9,18 @@ use uuid::Uuid;
 
 use crate::workflow::{ActivityOptions, WorkflowEvent, WorkflowSignal};
 
+/// Default max pending (unclaimed) tasks per workflow.
+/// Prevents a single workflow from flooding the queue.
+pub const DEFAULT_MAX_PENDING_TASKS_PER_WORKFLOW: u32 = 100;
+
+/// Read max pending tasks per workflow from env, falling back to default.
+pub fn max_pending_tasks_per_workflow_from_env() -> u32 {
+    std::env::var("DURABLE_MAX_PENDING_TASKS_PER_WORKFLOW")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_MAX_PENDING_TASKS_PER_WORKFLOW)
+}
+
 /// Error type for store operations
 #[derive(Debug, thiserror::Error)]
 pub enum StoreError {
@@ -39,6 +51,16 @@ pub enum StoreError {
     /// Schedule limit exceeded
     #[error("schedule limit exceeded: {current}/{limit} schedules")]
     ScheduleLimitExceeded { current: u32, limit: u32 },
+
+    /// Task queue limit exceeded (per-workflow pending task cap)
+    #[error(
+        "task queue limit exceeded for workflow {workflow_id}: {current}/{limit} pending tasks"
+    )]
+    TaskQueueLimitExceeded {
+        workflow_id: Uuid,
+        current: u32,
+        limit: u32,
+    },
 
     /// Invalid cron expression
     #[error("invalid cron expression: {0}")]

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -1365,8 +1365,16 @@ impl WorkerService for WorkerServiceImpl {
         };
 
         let task_id = store.enqueue_task(task).await.map_err(|e| {
-            tracing::error!("Failed to enqueue task: {}", e);
-            Status::internal("Failed to enqueue task")
+            if matches!(
+                e,
+                everruns_durable::StoreError::TaskQueueLimitExceeded { .. }
+            ) {
+                tracing::warn!("Task queue limit exceeded: {}", e);
+                Status::resource_exhausted(e.to_string())
+            } else {
+                tracing::error!("Failed to enqueue task: {}", e);
+                Status::internal("Failed to enqueue task")
+            }
         })?;
 
         // Record ActivityScheduled event


### PR DESCRIPTION
## What
Adds per-workflow pending task queue limit to prevent queue flooding.

## Why
A single workflow could flood the durable task queue with unlimited pending tasks (TM-DOS-006). Workers must process them all with no backpressure at enqueue time.

Closes EVE-14.

## How
- Added `TaskQueueLimitExceeded` error variant to `StoreError`
- Per-workflow pending task count check before INSERT in both Postgres and InMemory stores
- Default limit: 100 pending tasks per workflow, configurable via `DURABLE_MAX_PENDING_TASKS_PER_WORKFLOW` env var
- gRPC handler returns `RESOURCE_EXHAUSTED` status when limit hit
- Limit is per-workflow scoped — workflow B is unaffected when workflow A hits its cap

## Risk
- Low
- Only adds a pre-INSERT count check. Existing tasks and workflows unaffected. Default limit (100) is generous for normal use.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered