### PR TITLE
fix(multitenancy): enforce org_id authorization on all org-level entities

### DIFF
--- a/crates/server/migrations/003_images_org_id.sql
+++ b/crates/server/migrations/003_images_org_id.sql
@@ -1,0 +1,3 @@
+-- Add org_id column to images table for multi-tenant isolation
+ALTER TABLE images ADD COLUMN org_id BIGINT NOT NULL REFERENCES organizations(org_id) DEFAULT 1;
+CREATE INDEX idx_images_org_id ON images(org_id);

--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -734,13 +734,13 @@ fn slugify(s: &str) -> String {
     tag = "agents"
 )]
 pub async fn preview_agent(
-    _org: ResolvedOrg,
+    org: ResolvedOrg,
     State(state): State<AppState>,
     Json(req): Json<PreviewAgentRequest>,
 ) -> Result<Json<AgentPreviewResponse>, (StatusCode, Json<ErrorResponse>)> {
     let (system_prompt, tools) = state
         .capability_service
-        .preview(&req.system_prompt, &req.capabilities)
+        .preview(org.org_id, &req.system_prompt, &req.capabilities)
         .await
         .map_err(|e| {
             tracing::error!("Failed to generate agent preview: {}", e);

--- a/crates/server/src/api/capabilities.rs
+++ b/crates/server/src/api/capabilities.rs
@@ -59,10 +59,10 @@ pub fn routes(state: AppState) -> Router {
     tag = "capabilities"
 )]
 pub async fn list_capabilities(
-    _org: ResolvedOrg,
+    org: ResolvedOrg,
     State(state): State<AppState>,
 ) -> Result<Json<ListResponse<CapabilityInfo>>, StatusCode> {
-    let capabilities = state.service.list_all().await.map_err(|e| {
+    let capabilities = state.service.list_all(org.org_id).await.map_err(|e| {
         tracing::error!("Failed to list capabilities: {}", e);
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
@@ -83,7 +83,7 @@ pub async fn list_capabilities(
     tag = "capabilities"
 )]
 pub async fn get_capability(
-    _org: ResolvedOrg,
+    org: ResolvedOrg,
     State(state): State<AppState>,
     Path(capability_id): Path<String>,
 ) -> Result<Json<CapabilityInfo>, StatusCode> {
@@ -91,7 +91,7 @@ pub async fn get_capability(
 
     let capability = state
         .service
-        .get(&cap_id)
+        .get(org.org_id, &cap_id)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get capability: {}", e);

--- a/crates/server/src/api/harnesses.rs
+++ b/crates/server/src/api/harnesses.rs
@@ -332,13 +332,13 @@ pub async fn delete_harness(
     tag = "harnesses"
 )]
 pub async fn preview_harness(
-    _org: ResolvedOrg,
+    org: ResolvedOrg,
     State(state): State<AppState>,
     Json(req): Json<PreviewHarnessRequest>,
 ) -> Result<Json<HarnessPreviewResponse>, (StatusCode, Json<ErrorResponse>)> {
     let (system_prompt, tools) = state
         .capability_service
-        .preview(&req.system_prompt, &req.capabilities)
+        .preview(org.org_id, &req.system_prompt, &req.capabilities)
         .await
         .map_err(|e| {
             tracing::error!("Failed to generate harness preview: {}", e);

--- a/crates/server/src/api/images.rs
+++ b/crates/server/src/api/images.rs
@@ -179,7 +179,7 @@ fn generate_thumbnail(data: &[u8], content_type: &str) -> Option<(Vec<u8>, Strin
     tag = "images"
 )]
 pub async fn upload_image(
-    _org: ResolvedOrg,
+    org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<UploadImageQuery>,
     mut multipart: Multipart,
@@ -259,15 +259,19 @@ pub async fn upload_image(
     let size_bytes = data.len() as i64;
     let row = state
         .db
-        .create_image(CreateImageRow {
-            filename: filename.clone(),
-            content_type: content_type.clone(),
-            size_bytes,
-            data,
-            thumbnail_data,
-            thumbnail_content_type,
-            metadata,
-        })
+        .create_image(
+            org.org_id,
+            CreateImageRow {
+                org_id: org.org_id,
+                filename: filename.clone(),
+                content_type: content_type.clone(),
+                size_bytes,
+                data,
+                thumbnail_data,
+                thumbnail_content_type,
+                metadata,
+            },
+        )
         .await
         .map_err(|e| {
             tracing::error!("Failed to store image: {}", e);
@@ -304,13 +308,13 @@ pub async fn upload_image(
     tag = "images"
 )]
 pub async fn list_images(
-    _org: ResolvedOrg,
+    org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListImagesQuery>,
 ) -> Result<Json<Vec<ImageInfo>>, StatusCode> {
     let rows = state
         .db
-        .list_images(query.limit, query.offset)
+        .list_images(org.org_id, query.limit, query.offset)
         .await
         .map_err(|e| {
             tracing::error!("Failed to list images: {}", e);
@@ -348,7 +352,7 @@ pub async fn list_images(
     tag = "images"
 )]
 pub async fn get_image(
-    _org: ResolvedOrg,
+    org: ResolvedOrg,
     State(state): State<AppState>,
     Path(image_id): Path<String>,
 ) -> Result<Response, (StatusCode, String)> {
@@ -358,7 +362,7 @@ pub async fn get_image(
 
     let row = state
         .db
-        .get_image(image_id.uuid())
+        .get_image(org.org_id, image_id.uuid())
         .await
         .map_err(|e| {
             tracing::error!("Failed to get image: {}", e);
@@ -399,7 +403,7 @@ pub async fn get_image(
     tag = "images"
 )]
 pub async fn get_thumbnail(
-    _org: ResolvedOrg,
+    org: ResolvedOrg,
     State(state): State<AppState>,
     Path(image_id): Path<String>,
 ) -> Result<Response, (StatusCode, String)> {
@@ -409,7 +413,7 @@ pub async fn get_thumbnail(
 
     let row = state
         .db
-        .get_image(image_id.uuid())
+        .get_image(org.org_id, image_id.uuid())
         .await
         .map_err(|e| {
             tracing::error!("Failed to get image: {}", e);
@@ -452,7 +456,7 @@ pub async fn get_thumbnail(
     tag = "images"
 )]
 pub async fn delete_image(
-    _org: ResolvedOrg,
+    org: ResolvedOrg,
     State(state): State<AppState>,
     Path(image_id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, String)> {
@@ -460,13 +464,17 @@ pub async fn delete_image(
         .parse()
         .map_err(|e| (StatusCode::BAD_REQUEST, format!("Invalid image ID: {}", e)))?;
 
-    let deleted = state.db.delete_image(image_id.uuid()).await.map_err(|e| {
-        tracing::error!("Failed to delete image: {}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "Internal server error".to_string(),
-        )
-    })?;
+    let deleted = state
+        .db
+        .delete_image(org.org_id, image_id.uuid())
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to delete image: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal server error".to_string(),
+            )
+        })?;
 
     if deleted {
         Ok(StatusCode::NO_CONTENT)

--- a/crates/server/src/api/llm_models.rs
+++ b/crates/server/src/api/llm_models.rs
@@ -125,7 +125,7 @@ pub struct UpdateLlmModelRequest {
     tag = "llm-models"
 )]
 pub async fn create_model(
-    _org: ResolvedOrg,
+    org: ResolvedOrg,
     State(state): State<AppState>,
     Path(provider_id): Path<String>,
     Json(req): Json<CreateLlmModelRequest>,
@@ -141,7 +141,7 @@ pub async fn create_model(
 
     let model = state
         .service
-        .create(provider_id.uuid(), req)
+        .create(org.org_id, provider_id.uuid(), req)
         .await
         .map_err(|e| {
             tracing::error!("Failed to create LLM model: {}", e);
@@ -170,7 +170,7 @@ pub async fn create_model(
     tag = "llm-models"
 )]
 pub async fn list_provider_models(
-    _org: ResolvedOrg,
+    org: ResolvedOrg,
     State(state): State<AppState>,
     Path(provider_id): Path<String>,
 ) -> Result<Json<ListResponse<LlmModel>>, (StatusCode, Json<ErrorResponse>)> {
@@ -185,7 +185,7 @@ pub async fn list_provider_models(
 
     let models = state
         .service
-        .list_for_provider(provider_id.uuid())
+        .list_for_provider(org.org_id, provider_id.uuid())
         .await
         .map_err(|e| {
             tracing::error!("Failed to list LLM models for provider: {}", e);
@@ -213,13 +213,18 @@ pub async fn list_provider_models(
     tag = "llm-models"
 )]
 pub async fn list_all_models(
-    _org: ResolvedOrg,
+    org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListModelsQuery>,
 ) -> Result<Json<ListResponse<LlmModelWithProvider>>, (StatusCode, Json<ErrorResponse>)> {
     let models = state
         .service
-        .list_all_with_filters(query.source, query.include_stale, query.favorites_only)
+        .list_all_with_filters(
+            org.org_id,
+            query.source,
+            query.include_stale,
+            query.favorites_only,
+        )
         .await
         .map_err(|e| {
             tracing::error!("Failed to list all LLM models: {}", e);
@@ -249,7 +254,7 @@ pub async fn list_all_models(
     tag = "llm-models"
 )]
 pub async fn get_model(
-    _org: ResolvedOrg,
+    org: ResolvedOrg,
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Result<Json<LlmModelWithProvider>, (StatusCode, Json<ErrorResponse>)> {
@@ -264,7 +269,7 @@ pub async fn get_model(
 
     let model = state
         .service
-        .get_with_provider(model_id.uuid())
+        .get_with_provider(org.org_id, model_id.uuid())
         .await
         .map_err(|e| {
             tracing::error!("Failed to get LLM model: {}", e);
@@ -303,7 +308,7 @@ pub async fn get_model(
     tag = "llm-models"
 )]
 pub async fn update_model(
-    _org: ResolvedOrg,
+    org: ResolvedOrg,
     State(state): State<AppState>,
     Path(id): Path<String>,
     Json(req): Json<UpdateLlmModelRequest>,
@@ -319,7 +324,7 @@ pub async fn update_model(
 
     let model = state
         .service
-        .update(model_id.uuid(), req)
+        .update(org.org_id, model_id.uuid(), req)
         .await
         .map_err(|e| {
             tracing::error!("Failed to update LLM model: {}", e);
@@ -357,7 +362,7 @@ pub async fn update_model(
     tag = "llm-models"
 )]
 pub async fn delete_model(
-    _org: ResolvedOrg,
+    org: ResolvedOrg,
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
@@ -370,15 +375,19 @@ pub async fn delete_model(
         )
     })?;
 
-    let deleted = state.service.delete(model_id.uuid()).await.map_err(|e| {
-        tracing::error!("Failed to delete LLM model: {}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse {
-                error: "Internal server error".to_string(),
-            }),
-        )
-    })?;
+    let deleted = state
+        .service
+        .delete(org.org_id, model_id.uuid())
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to delete LLM model: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "Internal server error".to_string(),
+                }),
+            )
+        })?;
 
     if deleted {
         Ok(StatusCode::NO_CONTENT)

--- a/crates/server/src/api/llm_providers.rs
+++ b/crates/server/src/api/llm_providers.rs
@@ -120,11 +120,11 @@ pub struct UpdateLlmProviderRequest {
     tag = "llm-providers"
 )]
 pub async fn create_provider(
-    _org: ResolvedOrg,
+    org: ResolvedOrg,
     State(state): State<AppState>,
     Json(req): Json<CreateLlmProviderRequest>,
 ) -> Result<(StatusCode, Json<LlmProvider>), (StatusCode, Json<ErrorResponse>)> {
-    let provider = state.service.create(req).await.map_err(|e| {
+    let provider = state.service.create(org.org_id, req).await.map_err(|e| {
         let error_msg = e.to_string();
         if error_msg.contains("Encryption not configured") {
             (
@@ -155,10 +155,10 @@ pub async fn create_provider(
     tag = "llm-providers"
 )]
 pub async fn list_providers(
-    _org: ResolvedOrg,
+    org: ResolvedOrg,
     State(state): State<AppState>,
 ) -> Result<Json<ListResponse<LlmProvider>>, (StatusCode, Json<ErrorResponse>)> {
-    let providers = state.service.list().await.map_err(|e| {
+    let providers = state.service.list(org.org_id).await.map_err(|e| {
         tracing::error!("Failed to list LLM providers: {}", e);
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -186,7 +186,7 @@ pub async fn list_providers(
     tag = "llm-providers"
 )]
 pub async fn get_provider(
-    _org: ResolvedOrg,
+    org: ResolvedOrg,
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Result<Json<LlmProvider>, (StatusCode, Json<ErrorResponse>)> {
@@ -201,7 +201,7 @@ pub async fn get_provider(
 
     let provider = state
         .service
-        .get(provider_id.uuid())
+        .get(org.org_id, provider_id.uuid())
         .await
         .map_err(|e| {
             tracing::error!("Failed to get LLM provider: {}", e);
@@ -240,7 +240,7 @@ pub async fn get_provider(
     tag = "llm-providers"
 )]
 pub async fn update_provider(
-    _org: ResolvedOrg,
+    org: ResolvedOrg,
     State(state): State<AppState>,
     Path(id): Path<String>,
     Json(req): Json<UpdateLlmProviderRequest>,
@@ -256,7 +256,7 @@ pub async fn update_provider(
 
     let provider = state
         .service
-        .update(provider_id.uuid(), req)
+        .update(org.org_id, provider_id.uuid(), req)
         .await
         .map_err(|e| {
             let error_msg = e.to_string();
@@ -302,7 +302,7 @@ pub async fn update_provider(
     tag = "llm-providers"
 )]
 pub async fn delete_provider(
-    _org: ResolvedOrg,
+    org: ResolvedOrg,
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
@@ -317,7 +317,7 @@ pub async fn delete_provider(
 
     let deleted = state
         .service
-        .delete(provider_id.uuid())
+        .delete(org.org_id, provider_id.uuid())
         .await
         .map_err(|e| {
             tracing::error!("Failed to delete LLM provider: {}", e);
@@ -360,7 +360,7 @@ pub async fn delete_provider(
     tag = "llm-providers"
 )]
 pub async fn sync_models(
-    _org: ResolvedOrg,
+    org: ResolvedOrg,
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Result<Json<SyncModelsResponse>, (StatusCode, Json<ErrorResponse>)> {
@@ -375,7 +375,7 @@ pub async fn sync_models(
 
     let result = state
         .sync_service
-        .sync_provider(provider_id.uuid())
+        .sync_provider(org.org_id, provider_id.uuid())
         .await
         .map_err(|e| {
             let error_msg = e.to_string();

--- a/crates/server/src/api/mcp_servers.rs
+++ b/crates/server/src/api/mcp_servers.rs
@@ -142,7 +142,7 @@ pub fn routes(state: AppState) -> Router {
     tag = "mcp-servers"
 )]
 pub async fn create_mcp_server(
-    _org: ResolvedOrg,
+    org: ResolvedOrg,
     State(state): State<AppState>,
     Json(req): Json<CreateMcpServerRequest>,
 ) -> Result<(StatusCode, Json<McpServer>), (StatusCode, Json<ErrorResponse>)> {
@@ -160,7 +160,7 @@ pub async fn create_mcp_server(
         );
     }
 
-    let server = state.service.create(req).await.map_err(|e| {
+    let server = state.service.create(org.org_id, req).await.map_err(|e| {
         // Check if it's a duplicate name error
         let msg = e.to_string();
         if msg.contains("already exists") {
@@ -185,12 +185,12 @@ pub async fn create_mcp_server(
     tag = "mcp-servers"
 )]
 pub async fn list_mcp_servers(
-    _org: ResolvedOrg,
+    org: ResolvedOrg,
     State(state): State<AppState>,
 ) -> Result<Json<ListResponse<McpServer>>, StatusCode> {
     let servers = state
         .service
-        .list()
+        .list(org.org_id)
         .await
         .log_internal_error("list MCP servers")?;
 
@@ -213,7 +213,7 @@ pub async fn list_mcp_servers(
     tag = "mcp-servers"
 )]
 pub async fn get_mcp_server(
-    _org: ResolvedOrg,
+    org: ResolvedOrg,
     State(state): State<AppState>,
     Path(server_id): Path<String>,
 ) -> Result<Json<McpServer>, (StatusCode, Json<ErrorResponse>)> {
@@ -228,7 +228,7 @@ pub async fn get_mcp_server(
 
     let server = state
         .service
-        .get(server_id.uuid())
+        .get(org.org_id, server_id.uuid())
         .await
         .log_internal_error_json("get MCP server")?
         .ok_or_not_found_json("MCP server")?;
@@ -253,7 +253,7 @@ pub async fn get_mcp_server(
     tag = "mcp-servers"
 )]
 pub async fn update_mcp_server(
-    _org: ResolvedOrg,
+    org: ResolvedOrg,
     State(state): State<AppState>,
     Path(server_id): Path<String>,
     Json(req): Json<UpdateMcpServerRequest>,
@@ -287,7 +287,7 @@ pub async fn update_mcp_server(
 
     let server = state
         .service
-        .update(server_id.uuid(), req)
+        .update(org.org_id, server_id.uuid(), req)
         .await
         .log_internal_error_json("update MCP server")?
         .ok_or_not_found_json("MCP server")?;
@@ -311,7 +311,7 @@ pub async fn update_mcp_server(
     tag = "mcp-servers"
 )]
 pub async fn delete_mcp_server(
-    _org: ResolvedOrg,
+    org: ResolvedOrg,
     State(state): State<AppState>,
     Path(server_id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
@@ -326,7 +326,7 @@ pub async fn delete_mcp_server(
 
     let deleted = state
         .service
-        .delete(server_id.uuid())
+        .delete(org.org_id, server_id.uuid())
         .await
         .log_internal_error_json("delete MCP server")?;
 

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -16,9 +16,9 @@ use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
 use everruns_core::traits::ResolvedImage;
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId};
 use everruns_core::{
-    Agent, AgentStatus, ContentPart, DEFAULT_ORG_PUBLIC_ID, DriverRegistry, EventData, Harness,
-    HarnessStatus, LlmProviderType, Message, MessageRole, Session, SessionStatus, ToolDefinition,
-    ToolRegistry, ToolResultContentPart,
+    Agent, AgentStatus, ContentPart, DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, DriverRegistry,
+    EventData, Harness, HarnessStatus, LlmProviderType, Message, MessageRole, Session,
+    SessionStatus, ToolDefinition, ToolRegistry, ToolResultContentPart,
 };
 use everruns_worker::create_driver_registry;
 use everruns_worker::mcp_executor::McpServerInfo;
@@ -347,10 +347,15 @@ impl WorkerAdapters for DirectWorkerAdapters {
 
     async fn resolve_image(&self, image_id: Uuid) -> Result<Option<ResolvedImage>> {
         // Get the image from storage
-        let image_row = self.db.get_image(image_id).await.map_err(|e| {
-            tracing::error!("Failed to get image: {}", e);
-            store_error("Failed to get image")
-        })?;
+        // TODO: Thread org_id through WorkerAdapters trait for image resolution
+        let image_row = self
+            .db
+            .get_image(DEFAULT_ORG_ID, image_id)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to get image: {}", e);
+                store_error("Failed to get image")
+            })?;
 
         match image_row {
             Some(row) => {
@@ -617,12 +622,12 @@ impl WorkerAdapters for DirectWorkerAdapters {
 
     async fn get_mcp_server_by_prefix(
         &self,
-        _org_id: i64,
+        org_id: i64,
         server_prefix: &str,
     ) -> Result<McpServerInfo> {
         // Search for MCP server by name prefix (using sanitized name matching)
         let server_prefix_lower = server_prefix.to_lowercase();
-        let servers = self.mcp_server_service.list().await.map_err(|e| {
+        let servers = self.mcp_server_service.list(org_id).await.map_err(|e| {
             tracing::error!("Failed to list MCP servers: {}", e);
             store_error("Failed to get MCP server")
         })?;
@@ -708,7 +713,7 @@ impl WorkerAdapters for DirectWorkerAdapters {
 
         // Build MCP tool definitions from agent capabilities (if agent present)
         let mcp_tool_definitions = if let Some(ref a) = agent {
-            self.build_mcp_tool_definitions(a.internal_id)
+            self.build_mcp_tool_definitions(org_id, a.internal_id)
                 .await
                 .unwrap_or_default()
         } else {
@@ -818,7 +823,11 @@ impl DirectWorkerAdapters {
     }
 
     /// Build MCP tool definitions from agent's MCP capabilities
-    async fn build_mcp_tool_definitions(&self, agent_id: Uuid) -> Result<Vec<ToolDefinition>> {
+    async fn build_mcp_tool_definitions(
+        &self,
+        org_id: i64,
+        agent_id: Uuid,
+    ) -> Result<Vec<ToolDefinition>> {
         use everruns_core::capabilities::mcp::parse_mcp_capability_id;
         use everruns_core::mcp_server::mcp_tool_name;
         use everruns_core::tool_types::{BuiltinTool, ToolPolicy};
@@ -841,7 +850,11 @@ impl DirectWorkerAdapters {
                 None => continue,
             };
 
-            let tools = match self.mcp_server_service.get_tools(server_id, false).await {
+            let tools = match self
+                .mcp_server_service
+                .get_tools(org_id, server_id, false)
+                .await
+            {
                 Ok(t) => t,
                 Err(e) => {
                     tracing::warn!(
@@ -853,7 +866,7 @@ impl DirectWorkerAdapters {
                 }
             };
 
-            let server_name = match self.mcp_server_service.get(server_id).await {
+            let server_name = match self.mcp_server_service.get(org_id, server_id).await {
                 Ok(Some(s)) => s.name,
                 _ => {
                     tracing::warn!(server_id = %server_id, "MCP server not found, skipping");

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -13,6 +13,7 @@ use crate::services::{
 use crate::storage::{EncryptionService, StorageBackend};
 use crate::task_notifications::TaskNotificationBroadcaster;
 use base64::Engine;
+use everruns_core::DEFAULT_ORG_ID;
 use everruns_durable::{
     ActivityOptions, CircuitBreakerConfig, CircuitState, DistributedCircuitBreaker,
     PostgresWorkflowEventStore, StoreError, TaskDefinition, TaskFailureOutcome, WorkerInfo,
@@ -167,7 +168,11 @@ impl WorkerServiceImpl {
     /// Extracts MCP server UUIDs from capability IDs (format: "mcp:{uuid}"),
     /// batch-fetches all servers with cached tools in a single query,
     /// and converts to proto McpToolDef.
-    async fn build_mcp_tool_definitions(&self, agent: &everruns_core::Agent) -> Vec<McpToolDef> {
+    async fn build_mcp_tool_definitions(
+        &self,
+        org_id: i64,
+        agent: &everruns_core::Agent,
+    ) -> Vec<McpToolDef> {
         use everruns_core::capabilities::mcp::parse_mcp_capability_id;
         use everruns_core::mcp_server::mcp_tool_name;
 
@@ -444,7 +449,7 @@ impl WorkerService for WorkerServiceImpl {
         // Build MCP tool definitions from agent's MCP capabilities
         // This resolves MCP tools so the worker doesn't need to look them up
         let mcp_tool_definitions = if let Some(ref a) = agent {
-            self.build_mcp_tool_definitions(a).await
+            self.build_mcp_tool_definitions(req.org_id, a).await
         } else {
             vec![]
         };
@@ -1916,7 +1921,8 @@ impl WorkerService for WorkerServiceImpl {
         let image_id = parse_uuid(req.image_id.as_ref())?;
 
         // Get image from storage
-        let image_row = match self.db.get_image(image_id).await {
+        // TODO: Thread org_id through image resolution proto messages
+        let image_row = match self.db.get_image(DEFAULT_ORG_ID, image_id).await {
             Ok(Some(row)) => row,
             Ok(None) => {
                 return Ok(Response::new(ResolveImageResponse {
@@ -1957,7 +1963,7 @@ impl WorkerService for WorkerServiceImpl {
             let image_id = parse_uuid(Some(&proto_id))?;
 
             // Get image from storage
-            match self.db.get_image(image_id).await {
+            match self.db.get_image(DEFAULT_ORG_ID, image_id).await {
                 Ok(Some(row)) => {
                     let base64_data = base64::engine::general_purpose::STANDARD.encode(&row.data);
                     images.insert(
@@ -1994,7 +2000,7 @@ impl WorkerService for WorkerServiceImpl {
         // List active MCP servers and find one matching the prefix
         let servers = self
             .mcp_server_service
-            .list_active_with_tools()
+            .list_active_with_tools(req.org_id)
             .await
             .map_err(|e| {
                 tracing::error!("Failed to list MCP servers: {}", e);

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -170,7 +170,7 @@ impl WorkerServiceImpl {
     /// and converts to proto McpToolDef.
     async fn build_mcp_tool_definitions(
         &self,
-        org_id: i64,
+        _org_id: i64,
         agent: &everruns_core::Agent,
     ) -> Vec<McpToolDef> {
         use everruns_core::capabilities::mcp::parse_mcp_capability_id;

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -170,7 +170,7 @@ impl WorkerServiceImpl {
     /// and converts to proto McpToolDef.
     async fn build_mcp_tool_definitions(
         &self,
-        _org_id: i64,
+        org_id: i64,
         agent: &everruns_core::Agent,
     ) -> Vec<McpToolDef> {
         use everruns_core::capabilities::mcp::parse_mcp_capability_id;
@@ -192,7 +192,7 @@ impl WorkerServiceImpl {
         // Batch fetch all MCP servers with cached tools in one query
         let servers = match self
             .mcp_server_service
-            .get_batch_with_tools(&server_ids)
+            .get_batch_with_tools(org_id, &server_ids)
             .await
         {
             Ok(s) => s,

--- a/crates/server/src/services/capability.rs
+++ b/crates/server/src/services/capability.rs
@@ -34,7 +34,7 @@ impl CapabilityService {
     }
 
     /// List all available capabilities including MCP servers (public info only)
-    pub async fn list_all(&self) -> Result<Vec<CapabilityInfo>> {
+    pub async fn list_all(&self, org_id: i64) -> Result<Vec<CapabilityInfo>> {
         // Get built-in capabilities
         let mut capabilities: Vec<CapabilityInfo> = self
             .registry
@@ -44,7 +44,7 @@ impl CapabilityService {
             .collect();
 
         // Get MCP server capabilities
-        let mcp_servers = self.mcp_service.list_active_with_tools().await?;
+        let mcp_servers = self.mcp_service.list_active_with_tools(org_id).await?;
         for server_with_tools in mcp_servers {
             let mcp_cap = McpCapability::new(
                 server_with_tools.server.id.uuid(),
@@ -83,12 +83,12 @@ impl CapabilityService {
     /// For MCP capabilities, uses cached tools only (no external refresh).
     /// This ensures viewing a capability doesn't fail if the MCP server is unreachable.
     /// Use the refresh tools endpoint to explicitly update cached tools.
-    pub async fn get(&self, id: &CapabilityId) -> Result<Option<CapabilityInfo>> {
+    pub async fn get(&self, org_id: i64, id: &CapabilityId) -> Result<Option<CapabilityInfo>> {
         // Check if it's an MCP capability
         if let Some(server_id) = id.mcp_server_id() {
             // Use cached tools only - no external refresh on read
-            let tools = self.mcp_service.get_cached_tools(server_id).await;
-            let server = self.mcp_service.get(server_id).await?;
+            let tools = self.mcp_service.get_cached_tools(org_id, server_id).await;
+            let server = self.mcp_service.get(org_id, server_id).await?;
 
             if let Some(server) = server {
                 let mcp_cap = McpCapability::new(
@@ -131,16 +131,23 @@ impl CapabilityService {
     #[allow(dead_code)]
     pub async fn get_mcp_tools(
         &self,
+        org_id: i64,
         server_id: uuid::Uuid,
         force_refresh: bool,
     ) -> Result<Vec<McpToolDefinition>> {
-        self.mcp_service.get_tools(server_id, force_refresh).await
+        self.mcp_service
+            .get_tools(org_id, server_id, force_refresh)
+            .await
     }
 
     /// Refresh tools for an MCP server
     #[allow(dead_code)]
-    pub async fn refresh_mcp_tools(&self, server_id: uuid::Uuid) -> Result<Vec<McpToolDefinition>> {
-        self.mcp_service.refresh_tools(server_id).await
+    pub async fn refresh_mcp_tools(
+        &self,
+        org_id: i64,
+        server_id: uuid::Uuid,
+    ) -> Result<Vec<McpToolDefinition>> {
+        self.mcp_service.refresh_tools(org_id, server_id).await
     }
 
     /// Get the built-in capability registry
@@ -175,6 +182,7 @@ impl CapabilityService {
     /// A tuple of (final_system_prompt, tool_definitions)
     pub async fn preview(
         &self,
+        org_id: i64,
         base_system_prompt: &str,
         capability_configs: &[everruns_core::AgentCapabilityConfig],
     ) -> Result<(String, Vec<everruns_core::ToolDefinition>)> {
@@ -210,8 +218,8 @@ impl CapabilityService {
         // Collect from MCP capabilities using cached tools only (no refresh)
         // Note: MCP capabilities don't have dependencies
         for server_id in mcp_cap_ids {
-            let tools = self.mcp_service.get_cached_tools(server_id).await;
-            let server = self.mcp_service.get(server_id).await?;
+            let tools = self.mcp_service.get_cached_tools(org_id, server_id).await;
+            let server = self.mcp_service.get(org_id, server_id).await?;
 
             if let Some(server) = server {
                 let mcp_cap = McpCapability::new(

--- a/crates/server/src/services/llm_model.rs
+++ b/crates/server/src/services/llm_model.rs
@@ -6,8 +6,8 @@ use crate::storage::{
 };
 use anyhow::Result;
 use everruns_core::{
-    DEFAULT_ORG_ID, LlmModel, LlmModelSource, LlmModelStatus, LlmModelWithProvider,
-    LlmProviderType, get_model_profile,
+    LlmModel, LlmModelSource, LlmModelStatus, LlmModelWithProvider, LlmProviderType,
+    get_model_profile,
 };
 use std::sync::Arc;
 use uuid::Uuid;
@@ -23,11 +23,15 @@ impl LlmModelService {
         Self { db }
     }
 
-    pub async fn create(&self, provider_id: Uuid, req: CreateLlmModelRequest) -> Result<LlmModel> {
+    pub async fn create(
+        &self,
+        org_id: i64,
+        provider_id: Uuid,
+        req: CreateLlmModelRequest,
+    ) -> Result<LlmModel> {
         // If setting this model as default, clear all other defaults first ("last wins")
-        // TODO: Get org_id from context after Phase 3
         if req.is_default {
-            self.db.clear_all_model_defaults(DEFAULT_ORG_ID).await?;
+            self.db.clear_all_model_defaults(org_id).await?;
         }
 
         let input = CreateLlmModelRow {
@@ -41,38 +45,44 @@ impl LlmModelService {
             provider_metadata: None,
         };
 
-        let row = self.db.create_llm_model(DEFAULT_ORG_ID, input).await?;
+        let row = self.db.create_llm_model(org_id, input).await?;
         Ok(Self::row_to_model(&row))
     }
 
-    pub async fn get_with_provider(&self, id: Uuid) -> Result<Option<LlmModelWithProvider>> {
-        let row = self.db.get_llm_model_with_provider(id).await?;
+    pub async fn get_with_provider(
+        &self,
+        org_id: i64,
+        id: Uuid,
+    ) -> Result<Option<LlmModelWithProvider>> {
+        let row = self.db.get_llm_model_with_provider(org_id, id).await?;
         Ok(row.as_ref().map(Self::row_to_model_with_provider))
     }
 
-    pub async fn list_for_provider(&self, provider_id: Uuid) -> Result<Vec<LlmModel>> {
-        let rows = self.db.list_llm_models_for_provider(provider_id).await?;
+    pub async fn list_for_provider(&self, org_id: i64, provider_id: Uuid) -> Result<Vec<LlmModel>> {
+        let rows = self
+            .db
+            .list_llm_models_for_provider(org_id, provider_id)
+            .await?;
         Ok(rows.iter().map(Self::row_to_model).collect())
     }
 
-    pub async fn list_all(&self) -> Result<Vec<LlmModelWithProvider>> {
-        // TODO: Get org_id from context after Phase 3
-        let rows = self.db.list_all_llm_models(DEFAULT_ORG_ID).await?;
+    pub async fn list_all(&self, org_id: i64) -> Result<Vec<LlmModelWithProvider>> {
+        let rows = self.db.list_all_llm_models(org_id).await?;
         Ok(rows.iter().map(Self::row_to_model_with_provider).collect())
     }
 
     /// List all models with optional filters
     pub async fn list_all_with_filters(
         &self,
+        org_id: i64,
         source: Option<LlmModelSource>,
         include_stale: bool,
         favorites_only: bool,
     ) -> Result<Vec<LlmModelWithProvider>> {
-        // TODO: Get org_id from context after Phase 3
-        let rows = self.db.list_all_llm_models(DEFAULT_ORG_ID).await?;
+        let rows = self.db.list_all_llm_models(org_id).await?;
 
         // Get provider last_synced_at timestamps for stale detection
-        let providers = self.db.list_llm_providers().await?;
+        let providers = self.db.list_llm_providers(org_id).await?;
         let provider_sync_times: std::collections::HashMap<
             Uuid,
             Option<chrono::DateTime<chrono::Utc>>,
@@ -124,11 +134,15 @@ impl LlmModelService {
         Ok(models)
     }
 
-    pub async fn update(&self, id: Uuid, req: UpdateLlmModelRequest) -> Result<Option<LlmModel>> {
+    pub async fn update(
+        &self,
+        org_id: i64,
+        id: Uuid,
+        req: UpdateLlmModelRequest,
+    ) -> Result<Option<LlmModel>> {
         // If setting this model as default, clear all other defaults first ("last wins")
-        // TODO: Get org_id from context after Phase 3
         if req.is_default == Some(true) {
-            self.db.clear_all_model_defaults(DEFAULT_ORG_ID).await?;
+            self.db.clear_all_model_defaults(org_id).await?;
         }
 
         let input = UpdateLlmModel {
@@ -145,18 +159,17 @@ impl LlmModelService {
             provider_metadata: None,
         };
 
-        let row = self.db.update_llm_model(id, input).await?;
+        let row = self.db.update_llm_model(org_id, id, input).await?;
         Ok(row.as_ref().map(Self::row_to_model))
     }
 
-    pub async fn delete(&self, id: Uuid) -> Result<bool> {
-        self.db.delete_llm_model(id).await
+    pub async fn delete(&self, org_id: i64, id: Uuid) -> Result<bool> {
+        self.db.delete_llm_model(org_id, id).await
     }
 
     /// Get the default model
-    pub async fn get_default(&self) -> Result<Option<LlmModelWithProvider>> {
-        // TODO: Get org_id from context after Phase 3
-        let row = self.db.get_default_llm_model(DEFAULT_ORG_ID).await?;
+    pub async fn get_default(&self, org_id: i64) -> Result<Option<LlmModelWithProvider>> {
+        let row = self.db.get_default_llm_model(org_id).await?;
         Ok(row.as_ref().map(Self::row_to_model_with_provider))
     }
 

--- a/crates/server/src/services/llm_provider.rs
+++ b/crates/server/src/services/llm_provider.rs
@@ -6,7 +6,7 @@ use crate::storage::{
 };
 use anyhow::{Result, anyhow};
 use everruns_core::llm_models::LlmProvider;
-use everruns_core::{DEFAULT_ORG_ID, LlmProviderStatus, LlmProviderType};
+use everruns_core::{LlmProviderStatus, LlmProviderType};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -22,7 +22,7 @@ impl LlmProviderService {
         Self { db, encryption }
     }
 
-    pub async fn create(&self, req: CreateLlmProviderRequest) -> Result<LlmProvider> {
+    pub async fn create(&self, org_id: i64, req: CreateLlmProviderRequest) -> Result<LlmProvider> {
         // Encrypt API key if provided
         let api_key_encrypted = if let Some(api_key) = &req.api_key {
             let encryption = self
@@ -42,22 +42,23 @@ impl LlmProviderService {
             settings: None,
         };
 
-        let row = self.db.create_llm_provider(DEFAULT_ORG_ID, input).await?; // TODO: Get org_id from context after Phase 3
+        let row = self.db.create_llm_provider(org_id, input).await?;
         Ok(Self::row_to_provider(&row))
     }
 
-    pub async fn get(&self, id: Uuid) -> Result<Option<LlmProvider>> {
-        let row = self.db.get_llm_provider(id).await?;
+    pub async fn get(&self, org_id: i64, id: Uuid) -> Result<Option<LlmProvider>> {
+        let row = self.db.get_llm_provider(org_id, id).await?;
         Ok(row.as_ref().map(Self::row_to_provider))
     }
 
-    pub async fn list(&self) -> Result<Vec<LlmProvider>> {
-        let rows = self.db.list_llm_providers().await?;
+    pub async fn list(&self, org_id: i64) -> Result<Vec<LlmProvider>> {
+        let rows = self.db.list_llm_providers(org_id).await?;
         Ok(rows.iter().map(Self::row_to_provider).collect())
     }
 
     pub async fn update(
         &self,
+        org_id: i64,
         id: Uuid,
         req: UpdateLlmProviderRequest,
     ) -> Result<Option<LlmProvider>> {
@@ -84,12 +85,12 @@ impl LlmProviderService {
             settings: None,
         };
 
-        let row = self.db.update_llm_provider(id, input).await?;
+        let row = self.db.update_llm_provider(org_id, id, input).await?;
         Ok(row.as_ref().map(Self::row_to_provider))
     }
 
-    pub async fn delete(&self, id: Uuid) -> Result<bool> {
-        self.db.delete_llm_provider(id).await
+    pub async fn delete(&self, org_id: i64, id: Uuid) -> Result<bool> {
+        self.db.delete_llm_provider(org_id, id).await
     }
 
     fn row_to_provider(row: &LlmProviderRow) -> LlmProvider {

--- a/crates/server/src/services/llm_resolver.rs
+++ b/crates/server/src/services/llm_resolver.rs
@@ -70,7 +70,8 @@ impl LlmResolverService {
     /// Resolve a model by ID with decrypted provider credentials
     pub async fn resolve_model(&self, model_id: Uuid) -> Result<Option<ResolvedModel>> {
         // Look up the model
-        let model_row = self.db.get_llm_model(model_id).await?;
+        // TODO: Get org_id from context after Phase 3
+        let model_row = self.db.get_llm_model(DEFAULT_ORG_ID, model_id).await?;
 
         let model_row = match model_row {
             Some(row) => row,
@@ -80,7 +81,7 @@ impl LlmResolverService {
         // Look up the provider
         let provider_row = self
             .db
-            .get_llm_provider(model_row.provider_id.uuid())
+            .get_llm_provider(DEFAULT_ORG_ID, model_row.provider_id.uuid())
             .await?;
 
         let provider_row = match provider_row {
@@ -113,7 +114,7 @@ impl LlmResolverService {
         // Look up the provider
         let provider_row = self
             .db
-            .get_llm_provider(model_row.provider_id.uuid())
+            .get_llm_provider(DEFAULT_ORG_ID, model_row.provider_id.uuid())
             .await?;
 
         let provider_row = match provider_row {

--- a/crates/server/src/services/mcp_server.rs
+++ b/crates/server/src/services/mcp_server.rs
@@ -8,8 +8,8 @@ use crate::storage::{
 use anyhow::{Result, anyhow};
 use chrono::{DateTime, Utc};
 use everruns_core::{
-    DEFAULT_ORG_ID, McpServer, McpServerStatus, McpServerTransportType, McpToolDefinition,
-    McpToolsListRequest, McpToolsListResponse,
+    McpServer, McpServerStatus, McpServerTransportType, McpToolDefinition, McpToolsListRequest,
+    McpToolsListResponse,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -34,7 +34,7 @@ impl McpServerService {
         Self { db, encryption }
     }
 
-    pub async fn create(&self, req: CreateMcpServerRequest) -> Result<McpServer> {
+    pub async fn create(&self, org_id: i64, req: CreateMcpServerRequest) -> Result<McpServer> {
         // Encrypt API key if provided
         let api_key_encrypted = if let Some(api_key) = &req.api_key {
             let encryption = self
@@ -58,12 +58,12 @@ impl McpServerService {
             settings: None,
         };
 
-        let row = self.db.create_mcp_server(DEFAULT_ORG_ID, input).await?; // TODO: Get org_id from context after Phase 3
+        let row = self.db.create_mcp_server(org_id, input).await?;
         Ok(Self::row_to_mcp_server(&row))
     }
 
-    pub async fn get(&self, id: Uuid) -> Result<Option<McpServer>> {
-        let row = self.db.get_mcp_server(id).await?;
+    pub async fn get(&self, org_id: i64, id: Uuid) -> Result<Option<McpServer>> {
+        let row = self.db.get_mcp_server(org_id, id).await?;
         Ok(row.as_ref().map(Self::row_to_mcp_server))
     }
 
@@ -85,12 +85,17 @@ impl McpServerService {
             .collect())
     }
 
-    pub async fn list(&self) -> Result<Vec<McpServer>> {
-        let rows = self.db.list_mcp_servers().await?;
+    pub async fn list(&self, org_id: i64) -> Result<Vec<McpServer>> {
+        let rows = self.db.list_mcp_servers(org_id).await?;
         Ok(rows.iter().map(Self::row_to_mcp_server).collect())
     }
 
-    pub async fn update(&self, id: Uuid, req: UpdateMcpServerRequest) -> Result<Option<McpServer>> {
+    pub async fn update(
+        &self,
+        org_id: i64,
+        id: Uuid,
+        req: UpdateMcpServerRequest,
+    ) -> Result<Option<McpServer>> {
         // Encrypt API key if provided
         let api_key_encrypted = if let Some(api_key) = &req.api_key {
             let encryption = self
@@ -115,23 +120,23 @@ impl McpServerService {
             settings: None,
         };
 
-        let row = self.db.update_mcp_server(id, input).await?;
+        let row = self.db.update_mcp_server(org_id, id, input).await?;
         Ok(row.as_ref().map(Self::row_to_mcp_server))
     }
 
-    pub async fn delete(&self, id: Uuid) -> Result<bool> {
-        self.db.delete_mcp_server(id).await
+    pub async fn delete(&self, org_id: i64, id: Uuid) -> Result<bool> {
+        self.db.delete_mcp_server(org_id, id).await
     }
 
     /// List active MCP servers (for capability listing)
-    pub async fn list_active(&self) -> Result<Vec<McpServer>> {
-        let rows = self.db.list_active_mcp_servers().await?;
+    pub async fn list_active(&self, org_id: i64) -> Result<Vec<McpServer>> {
+        let rows = self.db.list_active_mcp_servers(org_id).await?;
         Ok(rows.iter().map(Self::row_to_mcp_server).collect())
     }
 
     /// List active MCP servers with their cached tools
-    pub async fn list_active_with_tools(&self) -> Result<Vec<McpServerWithTools>> {
-        let rows = self.db.list_active_mcp_servers().await?;
+    pub async fn list_active_with_tools(&self, org_id: i64) -> Result<Vec<McpServerWithTools>> {
+        let rows = self.db.list_active_mcp_servers(org_id).await?;
         Ok(rows
             .iter()
             .map(Self::row_to_mcp_server_with_tools)
@@ -139,11 +144,11 @@ impl McpServerService {
     }
 
     /// Refresh cached tools for an MCP server by calling tools/list
-    pub async fn refresh_tools(&self, id: Uuid) -> Result<Vec<McpToolDefinition>> {
+    pub async fn refresh_tools(&self, org_id: i64, id: Uuid) -> Result<Vec<McpToolDefinition>> {
         // Get the MCP server
         let row = self
             .db
-            .get_mcp_server(id)
+            .get_mcp_server(org_id, id)
             .await?
             .ok_or_else(|| anyhow!("MCP server not found"))?;
 
@@ -172,17 +177,22 @@ impl McpServerService {
         // Cache tools in database
         let cached_tools = serde_json::to_value(&tools)?;
         self.db
-            .update_mcp_server_tools(id, UpdateMcpServerTools { cached_tools })
+            .update_mcp_server_tools(org_id, id, UpdateMcpServerTools { cached_tools })
             .await?;
 
         Ok(tools)
     }
 
     /// Get cached tools for an MCP server, refreshing if stale
-    pub async fn get_tools(&self, id: Uuid, force_refresh: bool) -> Result<Vec<McpToolDefinition>> {
+    pub async fn get_tools(
+        &self,
+        org_id: i64,
+        id: Uuid,
+        force_refresh: bool,
+    ) -> Result<Vec<McpToolDefinition>> {
         let row = self
             .db
-            .get_mcp_server(id)
+            .get_mcp_server(org_id, id)
             .await?
             .ok_or_else(|| anyhow!("MCP server not found"))?;
 
@@ -202,13 +212,13 @@ impl McpServerService {
         }
 
         // Refresh tools
-        self.refresh_tools(id).await
+        self.refresh_tools(org_id, id).await
     }
 
     /// Get cached tools for an MCP server without refreshing (for preview)
     /// Returns empty vec if server not found or no cached tools
-    pub async fn get_cached_tools(&self, id: Uuid) -> Vec<McpToolDefinition> {
-        match self.db.get_mcp_server(id).await {
+    pub async fn get_cached_tools(&self, org_id: i64, id: Uuid) -> Vec<McpToolDefinition> {
+        match self.db.get_mcp_server(org_id, id).await {
             Ok(Some(row)) => serde_json::from_value(row.cached_tools.clone()).unwrap_or_default(),
             _ => Vec::new(),
         }

--- a/crates/server/src/services/mcp_server.rs
+++ b/crates/server/src/services/mcp_server.rs
@@ -71,9 +71,10 @@ impl McpServerService {
     /// Returns a map of server_id -> (McpServer, Vec<McpToolDefinition>).
     pub async fn get_batch_with_tools(
         &self,
+        org_id: i64,
         ids: &[Uuid],
     ) -> Result<HashMap<Uuid, (McpServer, Vec<McpToolDefinition>)>> {
-        let rows = self.db.get_mcp_servers_batch(ids).await?;
+        let rows = self.db.get_mcp_servers_batch(org_id, ids).await?;
         Ok(rows
             .iter()
             .map(|row| {

--- a/crates/server/src/services/model_sync.rs
+++ b/crates/server/src/services/model_sync.rs
@@ -10,8 +10,8 @@ use crate::storage::{
 use anyhow::{Context, Result};
 use chrono::Utc;
 use everruns_core::{
-    DiscoveredModel, DriverRegistry, LlmProviderType, ProviderConfig, ProviderId, ProviderType,
-    get_model_profile,
+    DEFAULT_ORG_ID, DiscoveredModel, DriverRegistry, LlmProviderType, ProviderConfig, ProviderId,
+    ProviderType, get_model_profile,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -50,11 +50,11 @@ impl ModelSyncService {
     }
 
     /// Sync models for a single provider
-    pub async fn sync_provider(&self, provider_id: Uuid) -> Result<SyncResult> {
+    pub async fn sync_provider(&self, org_id: i64, provider_id: Uuid) -> Result<SyncResult> {
         // Get the provider
         let provider_row = self
             .db
-            .get_llm_provider(provider_id)
+            .get_llm_provider(org_id, provider_id)
             .await?
             .context("Provider not found")?;
 
@@ -137,7 +137,7 @@ impl ModelSyncService {
 
         // Update provider's last_synced_at
         self.db
-            .update_provider_last_synced(provider_id, Utc::now())
+            .update_provider_last_synced(org_id, provider_id, Utc::now())
             .await?;
 
         Ok(sync_result)
@@ -145,12 +145,13 @@ impl ModelSyncService {
 
     /// Sync all providers (called by background job)
     pub async fn sync_all(&self) -> Result<Vec<(ProviderId, SyncResult)>> {
-        let providers = self.db.list_llm_providers().await?;
+        // TODO: List providers across all orgs for true multi-org background sync
+        let providers = self.db.list_llm_providers(DEFAULT_ORG_ID).await?;
         let mut results = Vec::with_capacity(providers.len());
 
         for provider in providers {
             let result = self
-                .sync_provider(provider.id.uuid())
+                .sync_provider(provider.org_id, provider.id.uuid())
                 .await
                 .unwrap_or_else(|e| SyncResult::Failed {
                     error: e.to_string(),
@@ -180,7 +181,7 @@ impl ModelSyncService {
         // Get existing models for this provider
         let existing = self
             .db
-            .list_llm_models_for_provider(provider.id.uuid())
+            .list_llm_models_for_provider(provider.org_id, provider.id.uuid())
             .await?;
         let existing_ids: std::collections::HashSet<_> =
             existing.iter().map(|m| m.model_id.as_str()).collect();
@@ -209,7 +210,7 @@ impl ModelSyncService {
                         ..Default::default()
                     };
                     self.db
-                        .update_llm_model(existing_model.id.uuid(), update)
+                        .update_llm_model(provider.org_id, existing_model.id.uuid(), update)
                         .await?;
                     updated += 1;
                 }

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -385,33 +385,41 @@ impl StorageBackend {
         dispatch!(self, create_llm_provider_with_id, org_id, id, input)
     }
 
-    pub async fn get_llm_provider(&self, id: Uuid) -> Result<Option<LlmProviderRow>> {
-        dispatch!(self, get_llm_provider, id)
+    pub async fn get_llm_provider(&self, org_id: i64, id: Uuid) -> Result<Option<LlmProviderRow>> {
+        dispatch!(self, get_llm_provider, org_id, id)
     }
 
-    pub async fn list_llm_providers(&self) -> Result<Vec<LlmProviderRow>> {
-        dispatch!(self, list_llm_providers)
+    pub async fn list_llm_providers(&self, org_id: i64) -> Result<Vec<LlmProviderRow>> {
+        dispatch!(self, list_llm_providers, org_id)
     }
 
     pub async fn update_llm_provider(
         &self,
+        org_id: i64,
         id: Uuid,
         input: UpdateLlmProvider,
     ) -> Result<Option<LlmProviderRow>> {
-        dispatch!(self, update_llm_provider, id, input)
+        dispatch!(self, update_llm_provider, org_id, id, input)
     }
 
-    pub async fn delete_llm_provider(&self, id: Uuid) -> Result<bool> {
-        dispatch!(self, delete_llm_provider, id)
+    pub async fn delete_llm_provider(&self, org_id: i64, id: Uuid) -> Result<bool> {
+        dispatch!(self, delete_llm_provider, org_id, id)
     }
 
     /// Update provider's last_synced_at timestamp
     pub async fn update_provider_last_synced(
         &self,
+        org_id: i64,
         id: Uuid,
         last_synced_at: chrono::DateTime<chrono::Utc>,
     ) -> Result<()> {
-        dispatch!(self, update_provider_last_synced, id, last_synced_at)
+        dispatch!(
+            self,
+            update_provider_last_synced,
+            org_id,
+            id,
+            last_synced_at
+        )
     }
 
     /// Get a provider with its decrypted API key
@@ -461,22 +469,24 @@ impl StorageBackend {
         dispatch!(self, create_llm_model_with_id, org_id, id, input)
     }
 
-    pub async fn get_llm_model(&self, id: Uuid) -> Result<Option<LlmModelRow>> {
-        dispatch!(self, get_llm_model, id)
+    pub async fn get_llm_model(&self, org_id: i64, id: Uuid) -> Result<Option<LlmModelRow>> {
+        dispatch!(self, get_llm_model, org_id, id)
     }
 
     pub async fn get_llm_model_with_provider(
         &self,
+        org_id: i64,
         id: Uuid,
     ) -> Result<Option<LlmModelWithProviderRow>> {
-        dispatch!(self, get_llm_model_with_provider, id)
+        dispatch!(self, get_llm_model_with_provider, org_id, id)
     }
 
     pub async fn list_llm_models_for_provider(
         &self,
+        org_id: i64,
         provider_id: Uuid,
     ) -> Result<Vec<LlmModelRow>> {
-        dispatch!(self, list_llm_models_for_provider, provider_id)
+        dispatch!(self, list_llm_models_for_provider, org_id, provider_id)
     }
 
     pub async fn list_all_llm_models(&self, org_id: i64) -> Result<Vec<LlmModelWithProviderRow>> {
@@ -485,14 +495,15 @@ impl StorageBackend {
 
     pub async fn update_llm_model(
         &self,
+        org_id: i64,
         id: Uuid,
         input: UpdateLlmModel,
     ) -> Result<Option<LlmModelRow>> {
-        dispatch!(self, update_llm_model, id, input)
+        dispatch!(self, update_llm_model, org_id, id, input)
     }
 
-    pub async fn delete_llm_model(&self, id: Uuid) -> Result<bool> {
-        dispatch!(self, delete_llm_model, id)
+    pub async fn delete_llm_model(&self, org_id: i64, id: Uuid) -> Result<bool> {
+        dispatch!(self, delete_llm_model, org_id, id)
     }
 
     pub async fn get_llm_model_by_model_id(
@@ -665,8 +676,8 @@ impl StorageBackend {
         dispatch!(self, create_mcp_server_with_id, org_id, id, input)
     }
 
-    pub async fn get_mcp_server(&self, id: Uuid) -> Result<Option<McpServerRow>> {
-        dispatch!(self, get_mcp_server, id)
+    pub async fn get_mcp_server(&self, org_id: i64, id: Uuid) -> Result<Option<McpServerRow>> {
+        dispatch!(self, get_mcp_server, org_id, id)
     }
 
     /// Batch fetch multiple MCP servers by IDs in a single query.
@@ -674,36 +685,42 @@ impl StorageBackend {
         dispatch!(self, get_mcp_servers_batch, ids)
     }
 
-    pub async fn get_mcp_server_by_name(&self, name: &str) -> Result<Option<McpServerRow>> {
-        dispatch!(self, get_mcp_server_by_name, name)
+    pub async fn get_mcp_server_by_name(
+        &self,
+        org_id: i64,
+        name: &str,
+    ) -> Result<Option<McpServerRow>> {
+        dispatch!(self, get_mcp_server_by_name, org_id, name)
     }
 
-    pub async fn list_mcp_servers(&self) -> Result<Vec<McpServerRow>> {
-        dispatch!(self, list_mcp_servers)
+    pub async fn list_mcp_servers(&self, org_id: i64) -> Result<Vec<McpServerRow>> {
+        dispatch!(self, list_mcp_servers, org_id)
     }
 
-    pub async fn list_active_mcp_servers(&self) -> Result<Vec<McpServerRow>> {
-        dispatch!(self, list_active_mcp_servers)
+    pub async fn list_active_mcp_servers(&self, org_id: i64) -> Result<Vec<McpServerRow>> {
+        dispatch!(self, list_active_mcp_servers, org_id)
     }
 
     pub async fn update_mcp_server(
         &self,
+        org_id: i64,
         id: Uuid,
         input: UpdateMcpServer,
     ) -> Result<Option<McpServerRow>> {
-        dispatch!(self, update_mcp_server, id, input)
+        dispatch!(self, update_mcp_server, org_id, id, input)
     }
 
     pub async fn update_mcp_server_tools(
         &self,
+        org_id: i64,
         id: Uuid,
         input: UpdateMcpServerTools,
     ) -> Result<Option<McpServerRow>> {
-        dispatch!(self, update_mcp_server_tools, id, input)
+        dispatch!(self, update_mcp_server_tools, org_id, id, input)
     }
 
-    pub async fn delete_mcp_server(&self, id: Uuid) -> Result<bool> {
-        dispatch!(self, delete_mcp_server, id)
+    pub async fn delete_mcp_server(&self, org_id: i64, id: Uuid) -> Result<bool> {
+        dispatch!(self, delete_mcp_server, org_id, id)
     }
 
     // ============================================
@@ -837,24 +854,29 @@ impl StorageBackend {
     // Images
     // ============================================
 
-    pub async fn create_image(&self, input: CreateImageRow) -> Result<ImageRow> {
-        dispatch!(self, create_image, input)
+    pub async fn create_image(&self, org_id: i64, input: CreateImageRow) -> Result<ImageRow> {
+        dispatch!(self, create_image, org_id, input)
     }
 
-    pub async fn get_image(&self, id: Uuid) -> Result<Option<ImageRow>> {
-        dispatch!(self, get_image, id)
+    pub async fn get_image(&self, org_id: i64, id: Uuid) -> Result<Option<ImageRow>> {
+        dispatch!(self, get_image, org_id, id)
     }
 
-    pub async fn get_image_info(&self, id: Uuid) -> Result<Option<ImageInfoRow>> {
-        dispatch!(self, get_image_info, id)
+    pub async fn get_image_info(&self, org_id: i64, id: Uuid) -> Result<Option<ImageInfoRow>> {
+        dispatch!(self, get_image_info, org_id, id)
     }
 
-    pub async fn delete_image(&self, id: Uuid) -> Result<bool> {
-        dispatch!(self, delete_image, id)
+    pub async fn delete_image(&self, org_id: i64, id: Uuid) -> Result<bool> {
+        dispatch!(self, delete_image, org_id, id)
     }
 
-    pub async fn list_images(&self, limit: i64, offset: i64) -> Result<Vec<ImageInfoRow>> {
-        dispatch!(self, list_images, limit, offset)
+    pub async fn list_images(
+        &self,
+        org_id: i64,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<ImageInfoRow>> {
+        dispatch!(self, list_images, org_id, limit, offset)
     }
 
     // ============================================

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -681,8 +681,8 @@ impl StorageBackend {
     }
 
     /// Batch fetch multiple MCP servers by IDs in a single query.
-    pub async fn get_mcp_servers_batch(&self, ids: &[Uuid]) -> Result<Vec<McpServerRow>> {
-        dispatch!(self, get_mcp_servers_batch, ids)
+    pub async fn get_mcp_servers_batch(&self, org_id: i64, ids: &[Uuid]) -> Result<Vec<McpServerRow>> {
+        dispatch!(self, get_mcp_servers_batch, org_id, ids)
     }
 
     pub async fn get_mcp_server_by_name(

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -681,7 +681,11 @@ impl StorageBackend {
     }
 
     /// Batch fetch multiple MCP servers by IDs in a single query.
-    pub async fn get_mcp_servers_batch(&self, org_id: i64, ids: &[Uuid]) -> Result<Vec<McpServerRow>> {
+    pub async fn get_mcp_servers_batch(
+        &self,
+        org_id: i64,
+        ids: &[Uuid],
+    ) -> Result<Vec<McpServerRow>> {
         dispatch!(self, get_mcp_servers_batch, org_id, ids)
     }
 

--- a/crates/server/src/storage/llm_provider_store.rs
+++ b/crates/server/src/storage/llm_provider_store.rs
@@ -43,7 +43,7 @@ impl LlmProviderStore for DbLlmProviderStore {
         // Look up the model
         let model_row = self
             .db
-            .get_llm_model(model_id.uuid())
+            .get_llm_model(DEFAULT_ORG_ID, model_id.uuid())
             .await
             .map_err(|e| AgentLoopError::store(e.to_string()))?;
 
@@ -55,7 +55,7 @@ impl LlmProviderStore for DbLlmProviderStore {
         // Look up the provider
         let provider_row = self
             .db
-            .get_llm_provider(model_row.provider_id.uuid())
+            .get_llm_provider(DEFAULT_ORG_ID, model_row.provider_id.uuid())
             .await
             .map_err(|e| AgentLoopError::store(e.to_string()))?;
 
@@ -98,7 +98,7 @@ impl LlmProviderStore for DbLlmProviderStore {
         // Look up the provider
         let provider_row = self
             .db
-            .get_llm_provider(model_row.provider_id.uuid())
+            .get_llm_provider(DEFAULT_ORG_ID, model_row.provider_id.uuid())
             .await
             .map_err(|e| AgentLoopError::store(e.to_string()))?;
 

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -2153,11 +2153,20 @@ impl InMemoryDatabase {
     }
 
     /// Batch fetch multiple MCP servers by IDs.
-    pub async fn get_mcp_servers_batch(&self, ids: &[Uuid]) -> Result<Vec<McpServerRow>> {
+    pub async fn get_mcp_servers_batch(
+        &self,
+        org_id: i64,
+        ids: &[Uuid],
+    ) -> Result<Vec<McpServerRow>> {
         let servers = self.mcp_servers.read();
         Ok(ids
             .iter()
-            .filter_map(|id| servers.get(&McpServerId::from_uuid(*id)).cloned())
+            .filter_map(|id| {
+                servers
+                    .get(&McpServerId::from_uuid(*id))
+                    .filter(|s| s.org_id == org_id)
+                    .cloned()
+            })
             .collect())
     }
 

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -1185,29 +1185,38 @@ impl InMemoryDatabase {
         Ok(Some(row))
     }
 
-    pub async fn get_llm_provider(&self, id: Uuid) -> Result<Option<LlmProviderRow>> {
+    pub async fn get_llm_provider(&self, org_id: i64, id: Uuid) -> Result<Option<LlmProviderRow>> {
         Ok(self
             .llm_providers
             .read()
             .get(&ProviderId::from_uuid(id))
+            .filter(|p| p.org_id == org_id)
             .cloned())
     }
 
-    pub async fn list_llm_providers(&self) -> Result<Vec<LlmProviderRow>> {
+    pub async fn list_llm_providers(&self, org_id: i64) -> Result<Vec<LlmProviderRow>> {
         let providers = self.llm_providers.read();
-        let mut result: Vec<_> = providers.values().cloned().collect();
+        let mut result: Vec<_> = providers
+            .values()
+            .filter(|p| p.org_id == org_id)
+            .cloned()
+            .collect();
         result.sort_by(|a, b| a.name.cmp(&b.name));
         Ok(result)
     }
 
     pub async fn update_llm_provider(
         &self,
+        org_id: i64,
         id: Uuid,
         input: UpdateLlmProvider,
     ) -> Result<Option<LlmProviderRow>> {
         let id = ProviderId::from_uuid(id);
         let mut providers = self.llm_providers.write();
         if let Some(provider) = providers.get_mut(&id) {
+            if provider.org_id != org_id {
+                return Ok(None);
+            }
             if let Some(name) = input.name {
                 provider.name = name;
             }
@@ -1230,8 +1239,19 @@ impl InMemoryDatabase {
         Ok(None)
     }
 
-    pub async fn delete_llm_provider(&self, id: Uuid) -> Result<bool> {
+    pub async fn delete_llm_provider(&self, org_id: i64, id: Uuid) -> Result<bool> {
         let id = ProviderId::from_uuid(id);
+        // Check org_id before deletion
+        {
+            let providers = self.llm_providers.read();
+            if let Some(provider) = providers.get(&id) {
+                if provider.org_id != org_id {
+                    return Ok(false);
+                }
+            } else {
+                return Ok(false);
+            }
+        }
         // Delete models first
         {
             let mut models = self.llm_models.write();
@@ -1250,11 +1270,15 @@ impl InMemoryDatabase {
     /// Update provider's last_synced_at timestamp
     pub async fn update_provider_last_synced(
         &self,
+        org_id: i64,
         id: Uuid,
         last_synced_at: chrono::DateTime<chrono::Utc>,
     ) -> Result<()> {
         let id = ProviderId::from_uuid(id);
         if let Some(provider) = self.llm_providers.write().get_mut(&id) {
+            if provider.org_id != org_id {
+                return Ok(());
+            }
             provider.last_synced_at = Some(last_synced_at);
             provider.updated_at = Self::now();
         }
@@ -1416,13 +1440,19 @@ impl InMemoryDatabase {
         Ok(Some(row))
     }
 
-    pub async fn get_llm_model(&self, id: Uuid) -> Result<Option<LlmModelRow>> {
+    pub async fn get_llm_model(&self, org_id: i64, id: Uuid) -> Result<Option<LlmModelRow>> {
         let id = ModelId::from_uuid(id);
-        Ok(self.llm_models.read().get(&id).cloned())
+        Ok(self
+            .llm_models
+            .read()
+            .get(&id)
+            .filter(|m| m.org_id == org_id)
+            .cloned())
     }
 
     pub async fn get_llm_model_with_provider(
         &self,
+        org_id: i64,
         id: Uuid,
     ) -> Result<Option<LlmModelWithProviderRow>> {
         let id = ModelId::from_uuid(id);
@@ -1430,6 +1460,7 @@ impl InMemoryDatabase {
         let providers = self.llm_providers.read();
 
         if let Some(model) = models.get(&id)
+            && model.org_id == org_id
             && let Some(provider) = providers.get(&model.provider_id)
         {
             return Ok(Some(LlmModelWithProviderRow {
@@ -1456,13 +1487,14 @@ impl InMemoryDatabase {
 
     pub async fn list_llm_models_for_provider(
         &self,
+        org_id: i64,
         provider_id: Uuid,
     ) -> Result<Vec<LlmModelRow>> {
         let provider_id = ProviderId::from_uuid(provider_id);
         let models = self.llm_models.read();
         let mut result: Vec<_> = models
             .values()
-            .filter(|m| m.provider_id == provider_id)
+            .filter(|m| m.provider_id == provider_id && m.org_id == org_id)
             .cloned()
             .collect();
         result.sort_by(|a, b| a.display_name.cmp(&b.display_name));
@@ -1510,12 +1542,16 @@ impl InMemoryDatabase {
 
     pub async fn update_llm_model(
         &self,
+        org_id: i64,
         id: Uuid,
         input: UpdateLlmModel,
     ) -> Result<Option<LlmModelRow>> {
         let id = ModelId::from_uuid(id);
         let mut models = self.llm_models.write();
         if let Some(model) = models.get_mut(&id) {
+            if model.org_id != org_id {
+                return Ok(None);
+            }
             if let Some(display_name) = input.display_name {
                 model.display_name = display_name;
             }
@@ -1537,9 +1573,17 @@ impl InMemoryDatabase {
         Ok(None)
     }
 
-    pub async fn delete_llm_model(&self, id: Uuid) -> Result<bool> {
+    pub async fn delete_llm_model(&self, org_id: i64, id: Uuid) -> Result<bool> {
         let id = ModelId::from_uuid(id);
-        Ok(self.llm_models.write().remove(&id).is_some())
+        let mut models = self.llm_models.write();
+        if let Some(model) = models.get(&id) {
+            if model.org_id != org_id {
+                return Ok(false);
+            }
+        } else {
+            return Ok(false);
+        }
+        Ok(models.remove(&id).is_some())
     }
 
     pub async fn get_llm_model_by_model_id(
@@ -2098,9 +2142,14 @@ impl InMemoryDatabase {
         Ok(Some(row))
     }
 
-    pub async fn get_mcp_server(&self, id: Uuid) -> Result<Option<McpServerRow>> {
+    pub async fn get_mcp_server(&self, org_id: i64, id: Uuid) -> Result<Option<McpServerRow>> {
         let id = McpServerId::from_uuid(id);
-        Ok(self.mcp_servers.read().get(&id).cloned())
+        Ok(self
+            .mcp_servers
+            .read()
+            .get(&id)
+            .filter(|s| s.org_id == org_id)
+            .cloned())
     }
 
     /// Batch fetch multiple MCP servers by IDs.
@@ -2112,27 +2161,37 @@ impl InMemoryDatabase {
             .collect())
     }
 
-    pub async fn get_mcp_server_by_name(&self, name: &str) -> Result<Option<McpServerRow>> {
+    pub async fn get_mcp_server_by_name(
+        &self,
+        org_id: i64,
+        name: &str,
+    ) -> Result<Option<McpServerRow>> {
         Ok(self
             .mcp_servers
             .read()
             .values()
-            .find(|s| s.name == name)
+            .find(|s| s.name == name && s.org_id == org_id)
             .cloned())
     }
 
-    pub async fn list_mcp_servers(&self) -> Result<Vec<McpServerRow>> {
-        let mut servers: Vec<_> = self.mcp_servers.read().values().cloned().collect();
-        servers.sort_by(|a, b| b.created_at.cmp(&a.created_at));
-        Ok(servers)
-    }
-
-    pub async fn list_active_mcp_servers(&self) -> Result<Vec<McpServerRow>> {
+    pub async fn list_mcp_servers(&self, org_id: i64) -> Result<Vec<McpServerRow>> {
         let mut servers: Vec<_> = self
             .mcp_servers
             .read()
             .values()
-            .filter(|s| s.status == "active")
+            .filter(|s| s.org_id == org_id)
+            .cloned()
+            .collect();
+        servers.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(servers)
+    }
+
+    pub async fn list_active_mcp_servers(&self, org_id: i64) -> Result<Vec<McpServerRow>> {
+        let mut servers: Vec<_> = self
+            .mcp_servers
+            .read()
+            .values()
+            .filter(|s| s.status == "active" && s.org_id == org_id)
             .cloned()
             .collect();
         servers.sort_by(|a, b| a.name.cmp(&b.name));
@@ -2141,11 +2200,15 @@ impl InMemoryDatabase {
 
     pub async fn update_mcp_server(
         &self,
+        org_id: i64,
         id: Uuid,
         input: UpdateMcpServer,
     ) -> Result<Option<McpServerRow>> {
         let mut servers = self.mcp_servers.write();
         if let Some(server) = servers.get_mut(&id) {
+            if server.org_id != org_id {
+                return Ok(None);
+            }
             if let Some(name) = input.name {
                 server.name = name;
             }
@@ -2177,8 +2240,16 @@ impl InMemoryDatabase {
         Ok(None)
     }
 
-    pub async fn delete_mcp_server(&self, id: Uuid) -> Result<bool> {
-        Ok(self.mcp_servers.write().remove(&id).is_some())
+    pub async fn delete_mcp_server(&self, org_id: i64, id: Uuid) -> Result<bool> {
+        let mut servers = self.mcp_servers.write();
+        if let Some(server) = servers.get(&id) {
+            if server.org_id != org_id {
+                return Ok(false);
+            }
+        } else {
+            return Ok(false);
+        }
+        Ok(servers.remove(&id).is_some())
     }
 
     // ============================================
@@ -2253,11 +2324,12 @@ impl InMemoryDatabase {
     // Images
     // ============================================
 
-    pub async fn create_image(&self, input: CreateImageRow) -> Result<ImageRow> {
+    pub async fn create_image(&self, org_id: i64, input: CreateImageRow) -> Result<ImageRow> {
         let now = Self::now();
         let id = ImageId::new();
         let row = ImageRow {
             id,
+            org_id,
             filename: input.filename,
             content_type: input.content_type,
             size_bytes: input.size_bytes,
@@ -2271,34 +2343,60 @@ impl InMemoryDatabase {
         Ok(row)
     }
 
-    pub async fn get_image(&self, id: Uuid) -> Result<Option<ImageRow>> {
+    pub async fn get_image(&self, org_id: i64, id: Uuid) -> Result<Option<ImageRow>> {
         let id = ImageId::from_uuid(id);
-        Ok(self.images.read().get(&id).cloned())
+        Ok(self
+            .images
+            .read()
+            .get(&id)
+            .filter(|img| img.org_id == org_id)
+            .cloned())
     }
 
-    pub async fn get_image_info(&self, id: Uuid) -> Result<Option<ImageInfoRow>> {
+    pub async fn get_image_info(&self, org_id: i64, id: Uuid) -> Result<Option<ImageInfoRow>> {
         let id = ImageId::from_uuid(id);
-        Ok(self.images.read().get(&id).map(|img| ImageInfoRow {
-            id: img.id,
-            filename: img.filename.clone(),
-            content_type: img.content_type.clone(),
-            size_bytes: img.size_bytes,
-            metadata: img.metadata.clone(),
-            created_at: img.created_at,
-        }))
+        Ok(self
+            .images
+            .read()
+            .get(&id)
+            .filter(|img| img.org_id == org_id)
+            .map(|img| ImageInfoRow {
+                id: img.id,
+                org_id: img.org_id,
+                filename: img.filename.clone(),
+                content_type: img.content_type.clone(),
+                size_bytes: img.size_bytes,
+                metadata: img.metadata.clone(),
+                created_at: img.created_at,
+            }))
     }
 
-    pub async fn delete_image(&self, id: Uuid) -> Result<bool> {
+    pub async fn delete_image(&self, org_id: i64, id: Uuid) -> Result<bool> {
         let id = ImageId::from_uuid(id);
-        Ok(self.images.write().remove(&id).is_some())
+        let mut images = self.images.write();
+        if let Some(img) = images.get(&id) {
+            if img.org_id != org_id {
+                return Ok(false);
+            }
+        } else {
+            return Ok(false);
+        }
+        Ok(images.remove(&id).is_some())
     }
 
-    pub async fn list_images(&self, limit: i64, offset: i64) -> Result<Vec<ImageInfoRow>> {
+    pub async fn list_images(
+        &self,
+        org_id: i64,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<ImageInfoRow>> {
         let images = self.images.read();
         let mut result: Vec<_> = images
             .values()
+            .filter(|img| img.org_id == org_id)
             .map(|img| ImageInfoRow {
                 id: img.id,
+                org_id: img.org_id,
                 filename: img.filename.clone(),
                 content_type: img.content_type.clone(),
                 size_bytes: img.size_bytes,
@@ -2317,12 +2415,16 @@ impl InMemoryDatabase {
 
     pub async fn update_mcp_server_tools(
         &self,
+        org_id: i64,
         id: Uuid,
         input: UpdateMcpServerTools,
     ) -> Result<Option<McpServerRow>> {
         let id = McpServerId::from_uuid(id);
         let mut servers = self.mcp_servers.write();
         if let Some(server) = servers.get_mut(&id) {
+            if server.org_id != org_id {
+                return Ok(None);
+            }
             server.cached_tools = input.cached_tools;
             server.tools_cached_at = Some(Self::now());
             server.updated_at = Self::now();

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -627,6 +627,7 @@ pub struct UpdateMcpServer {
 #[derive(Debug, Clone, FromRow)]
 pub struct ImageRow {
     pub id: ImageId,
+    pub org_id: i64,
     pub filename: String,
     pub content_type: String,
     pub size_bytes: i64,
@@ -641,6 +642,7 @@ pub struct ImageRow {
 #[derive(Debug, Clone, FromRow)]
 pub struct ImageInfoRow {
     pub id: ImageId,
+    pub org_id: i64,
     pub filename: String,
     pub content_type: String,
     pub size_bytes: i64,
@@ -651,6 +653,7 @@ pub struct ImageInfoRow {
 /// Input for creating an image
 #[derive(Debug, Clone)]
 pub struct CreateImageRow {
+    pub org_id: i64,
     pub filename: String,
     pub content_type: String,
     pub size_bytes: i64,

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -2364,7 +2364,11 @@ impl Database {
     }
 
     /// Batch fetch multiple MCP servers by IDs in a single query.
-    pub async fn get_mcp_servers_batch(&self, ids: &[Uuid]) -> Result<Vec<McpServerRow>> {
+    pub async fn get_mcp_servers_batch(
+        &self,
+        org_id: i64,
+        ids: &[Uuid],
+    ) -> Result<Vec<McpServerRow>> {
         if ids.is_empty() {
             return Ok(vec![]);
         }
@@ -2372,9 +2376,10 @@ impl Database {
             r#"
             SELECT id, org_id, name, description, url, transport_type, status, api_key_encrypted, api_key_set, headers, settings, cached_tools, tools_cached_at, created_at, updated_at
             FROM mcp_servers
-            WHERE id = ANY($1)
+            WHERE org_id = $1 AND id = ANY($2)
             "#,
         )
+        .bind(org_id)
         .bind(ids)
         .fetch_all(&self.pool)
         .await?;

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -1382,14 +1382,15 @@ impl Database {
         Ok(row)
     }
 
-    pub async fn get_llm_provider(&self, id: Uuid) -> Result<Option<LlmProviderRow>> {
+    pub async fn get_llm_provider(&self, org_id: i64, id: Uuid) -> Result<Option<LlmProviderRow>> {
         let row = sqlx::query_as::<_, LlmProviderRow>(
             r#"
             SELECT id, org_id, name, provider_type, base_url, api_key_encrypted, api_key_set, status, settings, last_synced_at, created_at, updated_at
             FROM llm_providers
-            WHERE id = $1
+            WHERE org_id = $1 AND id = $2
             "#,
         )
+        .bind(org_id)
         .bind(id)
         .fetch_optional(&self.pool)
         .await?;
@@ -1397,14 +1398,16 @@ impl Database {
         Ok(row)
     }
 
-    pub async fn list_llm_providers(&self) -> Result<Vec<LlmProviderRow>> {
+    pub async fn list_llm_providers(&self, org_id: i64) -> Result<Vec<LlmProviderRow>> {
         let rows = sqlx::query_as::<_, LlmProviderRow>(
             r#"
             SELECT id, org_id, name, provider_type, base_url, api_key_encrypted, api_key_set, status, settings, last_synced_at, created_at, updated_at
             FROM llm_providers
+            WHERE org_id = $1
             ORDER BY created_at DESC
             "#,
         )
+        .bind(org_id)
         .fetch_all(&self.pool)
         .await?;
 
@@ -1413,6 +1416,7 @@ impl Database {
 
     pub async fn update_llm_provider(
         &self,
+        org_id: i64,
         id: Uuid,
         input: UpdateLlmProvider,
     ) -> Result<Option<LlmProviderRow>> {
@@ -1423,18 +1427,19 @@ impl Database {
             r#"
             UPDATE llm_providers
             SET
-                name = COALESCE($2, name),
-                provider_type = COALESCE($3, provider_type),
-                base_url = COALESCE($4, base_url),
-                api_key_encrypted = COALESCE($5, api_key_encrypted),
-                api_key_set = COALESCE($6, api_key_set),
-                status = COALESCE($7, status),
-                settings = COALESCE($8, settings),
+                name = COALESCE($3, name),
+                provider_type = COALESCE($4, provider_type),
+                base_url = COALESCE($5, base_url),
+                api_key_encrypted = COALESCE($6, api_key_encrypted),
+                api_key_set = COALESCE($7, api_key_set),
+                status = COALESCE($8, status),
+                settings = COALESCE($9, settings),
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE org_id = $1 AND id = $2
             RETURNING id, org_id, name, provider_type, base_url, api_key_encrypted, api_key_set, status, settings, last_synced_at, created_at, updated_at
             "#,
         )
+        .bind(org_id)
         .bind(id)
         .bind(&input.name)
         .bind(&input.provider_type)
@@ -1449,8 +1454,9 @@ impl Database {
         Ok(row)
     }
 
-    pub async fn delete_llm_provider(&self, id: Uuid) -> Result<bool> {
-        let result = sqlx::query("DELETE FROM llm_providers WHERE id = $1")
+    pub async fn delete_llm_provider(&self, org_id: i64, id: Uuid) -> Result<bool> {
+        let result = sqlx::query("DELETE FROM llm_providers WHERE org_id = $1 AND id = $2")
+            .bind(org_id)
             .bind(id)
             .execute(&self.pool)
             .await?;
@@ -1461,12 +1467,14 @@ impl Database {
     /// Update provider's last_synced_at timestamp
     pub async fn update_provider_last_synced(
         &self,
+        org_id: i64,
         id: Uuid,
         last_synced_at: chrono::DateTime<chrono::Utc>,
     ) -> Result<()> {
         sqlx::query(
-            "UPDATE llm_providers SET last_synced_at = $2, updated_at = NOW() WHERE id = $1",
+            "UPDATE llm_providers SET last_synced_at = $3, updated_at = NOW() WHERE org_id = $1 AND id = $2",
         )
+        .bind(org_id)
         .bind(id)
         .bind(last_synced_at)
         .execute(&self.pool)
@@ -1610,14 +1618,15 @@ impl Database {
         Ok(row)
     }
 
-    pub async fn get_llm_model(&self, id: Uuid) -> Result<Option<LlmModelRow>> {
+    pub async fn get_llm_model(&self, org_id: i64, id: Uuid) -> Result<Option<LlmModelRow>> {
         let row = sqlx::query_as::<_, LlmModelRow>(
             r#"
             SELECT id, org_id, provider_id, model_id, display_name, capabilities, is_default, is_favorite, status, source, last_seen_at, provider_metadata, created_at, updated_at
             FROM llm_models
-            WHERE id = $1
+            WHERE org_id = $1 AND id = $2
             "#,
         )
+        .bind(org_id)
         .bind(id)
         .fetch_optional(&self.pool)
         .await?;
@@ -1627,6 +1636,7 @@ impl Database {
 
     pub async fn get_llm_model_with_provider(
         &self,
+        org_id: i64,
         id: Uuid,
     ) -> Result<Option<LlmModelWithProviderRow>> {
         let row = sqlx::query_as::<_, LlmModelWithProviderRow>(
@@ -1635,9 +1645,10 @@ impl Database {
                    p.name as provider_name, p.provider_type
             FROM llm_models m
             JOIN llm_providers p ON m.provider_id = p.id
-            WHERE m.id = $1
+            WHERE m.org_id = $1 AND m.id = $2
             "#,
         )
+        .bind(org_id)
         .bind(id)
         .fetch_optional(&self.pool)
         .await?;
@@ -1647,16 +1658,18 @@ impl Database {
 
     pub async fn list_llm_models_for_provider(
         &self,
+        org_id: i64,
         provider_id: Uuid,
     ) -> Result<Vec<LlmModelRow>> {
         let rows = sqlx::query_as::<_, LlmModelRow>(
             r#"
             SELECT id, org_id, provider_id, model_id, display_name, capabilities, is_default, is_favorite, status, source, last_seen_at, provider_metadata, created_at, updated_at
             FROM llm_models
-            WHERE provider_id = $1
+            WHERE org_id = $1 AND provider_id = $2
             ORDER BY display_name ASC
             "#,
         )
+        .bind(org_id)
         .bind(provider_id)
         .fetch_all(&self.pool)
         .await?;
@@ -1684,6 +1697,7 @@ impl Database {
 
     pub async fn update_llm_model(
         &self,
+        org_id: i64,
         id: Uuid,
         input: UpdateLlmModel,
     ) -> Result<Option<LlmModelRow>> {
@@ -1696,19 +1710,20 @@ impl Database {
             r#"
             UPDATE llm_models
             SET
-                model_id = COALESCE($2, model_id),
-                display_name = COALESCE($3, display_name),
-                capabilities = COALESCE($4, capabilities),
-                is_default = COALESCE($5, is_default),
-                is_favorite = COALESCE($6, is_favorite),
-                status = COALESCE($7, status),
-                last_seen_at = COALESCE($8, last_seen_at),
-                provider_metadata = COALESCE($9, provider_metadata),
+                model_id = COALESCE($3, model_id),
+                display_name = COALESCE($4, display_name),
+                capabilities = COALESCE($5, capabilities),
+                is_default = COALESCE($6, is_default),
+                is_favorite = COALESCE($7, is_favorite),
+                status = COALESCE($8, status),
+                last_seen_at = COALESCE($9, last_seen_at),
+                provider_metadata = COALESCE($10, provider_metadata),
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE org_id = $1 AND id = $2
             RETURNING id, org_id, provider_id, model_id, display_name, capabilities, is_default, is_favorite, status, source, last_seen_at, provider_metadata, created_at, updated_at
             "#,
         )
+        .bind(org_id)
         .bind(id)
         .bind(&input.model_id)
         .bind(&input.display_name)
@@ -1724,8 +1739,9 @@ impl Database {
         Ok(row)
     }
 
-    pub async fn delete_llm_model(&self, id: Uuid) -> Result<bool> {
-        let result = sqlx::query("DELETE FROM llm_models WHERE id = $1")
+    pub async fn delete_llm_model(&self, org_id: i64, id: Uuid) -> Result<bool> {
+        let result = sqlx::query("DELETE FROM llm_models WHERE org_id = $1 AND id = $2")
+            .bind(org_id)
             .bind(id)
             .execute(&self.pool)
             .await?;
@@ -2331,14 +2347,15 @@ impl Database {
         Ok(row)
     }
 
-    pub async fn get_mcp_server(&self, id: Uuid) -> Result<Option<McpServerRow>> {
+    pub async fn get_mcp_server(&self, org_id: i64, id: Uuid) -> Result<Option<McpServerRow>> {
         let row = sqlx::query_as::<_, McpServerRow>(
             r#"
             SELECT id, org_id, name, description, url, transport_type, status, api_key_encrypted, api_key_set, headers, settings, cached_tools, tools_cached_at, created_at, updated_at
             FROM mcp_servers
-            WHERE id = $1
+            WHERE org_id = $1 AND id = $2
             "#,
         )
+        .bind(org_id)
         .bind(id)
         .fetch_optional(&self.pool)
         .await?;
@@ -2365,14 +2382,19 @@ impl Database {
         Ok(rows)
     }
 
-    pub async fn get_mcp_server_by_name(&self, name: &str) -> Result<Option<McpServerRow>> {
+    pub async fn get_mcp_server_by_name(
+        &self,
+        org_id: i64,
+        name: &str,
+    ) -> Result<Option<McpServerRow>> {
         let row = sqlx::query_as::<_, McpServerRow>(
             r#"
             SELECT id, org_id, name, description, url, transport_type, status, api_key_encrypted, api_key_set, headers, settings, cached_tools, tools_cached_at, created_at, updated_at
             FROM mcp_servers
-            WHERE name = $1
+            WHERE org_id = $1 AND name = $2
             "#,
         )
+        .bind(org_id)
         .bind(name)
         .fetch_optional(&self.pool)
         .await?;
@@ -2380,14 +2402,16 @@ impl Database {
         Ok(row)
     }
 
-    pub async fn list_mcp_servers(&self) -> Result<Vec<McpServerRow>> {
+    pub async fn list_mcp_servers(&self, org_id: i64) -> Result<Vec<McpServerRow>> {
         let rows = sqlx::query_as::<_, McpServerRow>(
             r#"
             SELECT id, org_id, name, description, url, transport_type, status, api_key_encrypted, api_key_set, headers, settings, cached_tools, tools_cached_at, created_at, updated_at
             FROM mcp_servers
+            WHERE org_id = $1
             ORDER BY created_at DESC
             "#,
         )
+        .bind(org_id)
         .fetch_all(&self.pool)
         .await?;
 
@@ -2395,15 +2419,16 @@ impl Database {
     }
 
     /// List only active MCP servers (for capability listing)
-    pub async fn list_active_mcp_servers(&self) -> Result<Vec<McpServerRow>> {
+    pub async fn list_active_mcp_servers(&self, org_id: i64) -> Result<Vec<McpServerRow>> {
         let rows = sqlx::query_as::<_, McpServerRow>(
             r#"
             SELECT id, org_id, name, description, url, transport_type, status, api_key_encrypted, api_key_set, headers, settings, cached_tools, tools_cached_at, created_at, updated_at
             FROM mcp_servers
-            WHERE status = 'active'
+            WHERE org_id = $1 AND status = 'active'
             ORDER BY name ASC
             "#,
         )
+        .bind(org_id)
         .fetch_all(&self.pool)
         .await?;
 
@@ -2412,6 +2437,7 @@ impl Database {
 
     pub async fn update_mcp_server(
         &self,
+        org_id: i64,
         id: Uuid,
         input: UpdateMcpServer,
     ) -> Result<Option<McpServerRow>> {
@@ -2422,19 +2448,20 @@ impl Database {
             r#"
             UPDATE mcp_servers
             SET
-                name = COALESCE($2, name),
-                description = COALESCE($3, description),
-                url = COALESCE($4, url),
-                transport_type = COALESCE($5, transport_type),
-                status = COALESCE($6, status),
-                api_key_encrypted = COALESCE($7, api_key_encrypted),
-                api_key_set = COALESCE($8, api_key_set),
-                headers = COALESCE($9, headers),
-                settings = COALESCE($10, settings)
-            WHERE id = $1
+                name = COALESCE($3, name),
+                description = COALESCE($4, description),
+                url = COALESCE($5, url),
+                transport_type = COALESCE($6, transport_type),
+                status = COALESCE($7, status),
+                api_key_encrypted = COALESCE($8, api_key_encrypted),
+                api_key_set = COALESCE($9, api_key_set),
+                headers = COALESCE($10, headers),
+                settings = COALESCE($11, settings)
+            WHERE org_id = $1 AND id = $2
             RETURNING id, org_id, name, description, url, transport_type, status, api_key_encrypted, api_key_set, headers, settings, cached_tools, tools_cached_at, created_at, updated_at
             "#,
         )
+        .bind(org_id)
         .bind(id)
         .bind(&input.name)
         .bind(&input.description)
@@ -2454,6 +2481,7 @@ impl Database {
     /// Update cached tools for an MCP server
     pub async fn update_mcp_server_tools(
         &self,
+        org_id: i64,
         id: Uuid,
         input: UpdateMcpServerTools,
     ) -> Result<Option<McpServerRow>> {
@@ -2461,12 +2489,13 @@ impl Database {
             r#"
             UPDATE mcp_servers
             SET
-                cached_tools = $2,
+                cached_tools = $3,
                 tools_cached_at = NOW()
-            WHERE id = $1
+            WHERE org_id = $1 AND id = $2
             RETURNING id, org_id, name, description, url, transport_type, status, api_key_encrypted, api_key_set, headers, settings, cached_tools, tools_cached_at, created_at, updated_at
             "#,
         )
+        .bind(org_id)
         .bind(id)
         .bind(&input.cached_tools)
         .fetch_optional(&self.pool)
@@ -2475,8 +2504,9 @@ impl Database {
         Ok(row)
     }
 
-    pub async fn delete_mcp_server(&self, id: Uuid) -> Result<bool> {
-        let result = sqlx::query("DELETE FROM mcp_servers WHERE id = $1")
+    pub async fn delete_mcp_server(&self, org_id: i64, id: Uuid) -> Result<bool> {
+        let result = sqlx::query("DELETE FROM mcp_servers WHERE org_id = $1 AND id = $2")
+            .bind(org_id)
             .bind(id)
             .execute(&self.pool)
             .await?;
@@ -2778,14 +2808,15 @@ impl Database {
     // Images
     // ============================================
 
-    pub async fn create_image(&self, input: CreateImageRow) -> Result<ImageRow> {
+    pub async fn create_image(&self, org_id: i64, input: CreateImageRow) -> Result<ImageRow> {
         let row = sqlx::query_as::<_, ImageRow>(
             r#"
-            INSERT INTO images (filename, content_type, size_bytes, data, thumbnail_data, thumbnail_content_type, metadata)
-            VALUES ($1, $2, $3, $4, $5, $6, $7)
-            RETURNING id, filename, content_type, size_bytes, data, thumbnail_data, thumbnail_content_type, metadata, created_at
+            INSERT INTO images (org_id, filename, content_type, size_bytes, data, thumbnail_data, thumbnail_content_type, metadata)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            RETURNING id, org_id, filename, content_type, size_bytes, data, thumbnail_data, thumbnail_content_type, metadata, created_at
             "#,
         )
+        .bind(org_id)
         .bind(&input.filename)
         .bind(&input.content_type)
         .bind(input.size_bytes)
@@ -2799,14 +2830,15 @@ impl Database {
         Ok(row)
     }
 
-    pub async fn get_image(&self, id: Uuid) -> Result<Option<ImageRow>> {
+    pub async fn get_image(&self, org_id: i64, id: Uuid) -> Result<Option<ImageRow>> {
         let row = sqlx::query_as::<_, ImageRow>(
             r#"
-            SELECT id, filename, content_type, size_bytes, data, thumbnail_data, thumbnail_content_type, metadata, created_at
+            SELECT id, org_id, filename, content_type, size_bytes, data, thumbnail_data, thumbnail_content_type, metadata, created_at
             FROM images
-            WHERE id = $1
+            WHERE org_id = $1 AND id = $2
             "#,
         )
+        .bind(org_id)
         .bind(id)
         .fetch_optional(&self.pool)
         .await?;
@@ -2814,14 +2846,15 @@ impl Database {
         Ok(row)
     }
 
-    pub async fn get_image_info(&self, id: Uuid) -> Result<Option<ImageInfoRow>> {
+    pub async fn get_image_info(&self, org_id: i64, id: Uuid) -> Result<Option<ImageInfoRow>> {
         let row = sqlx::query_as::<_, ImageInfoRow>(
             r#"
-            SELECT id, filename, content_type, size_bytes, metadata, created_at
+            SELECT id, org_id, filename, content_type, size_bytes, metadata, created_at
             FROM images
-            WHERE id = $1
+            WHERE org_id = $1 AND id = $2
             "#,
         )
+        .bind(org_id)
         .bind(id)
         .fetch_optional(&self.pool)
         .await?;
@@ -2829,8 +2862,9 @@ impl Database {
         Ok(row)
     }
 
-    pub async fn delete_image(&self, id: Uuid) -> Result<bool> {
-        let result = sqlx::query("DELETE FROM images WHERE id = $1")
+    pub async fn delete_image(&self, org_id: i64, id: Uuid) -> Result<bool> {
+        let result = sqlx::query("DELETE FROM images WHERE org_id = $1 AND id = $2")
+            .bind(org_id)
             .bind(id)
             .execute(&self.pool)
             .await?;
@@ -2838,15 +2872,22 @@ impl Database {
         Ok(result.rows_affected() > 0)
     }
 
-    pub async fn list_images(&self, limit: i64, offset: i64) -> Result<Vec<ImageInfoRow>> {
+    pub async fn list_images(
+        &self,
+        org_id: i64,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<ImageInfoRow>> {
         let rows = sqlx::query_as::<_, ImageInfoRow>(
             r#"
-            SELECT id, filename, content_type, size_bytes, metadata, created_at
+            SELECT id, org_id, filename, content_type, size_bytes, metadata, created_at
             FROM images
+            WHERE org_id = $1
             ORDER BY created_at DESC
-            LIMIT $1 OFFSET $2
+            LIMIT $2 OFFSET $3
             "#,
         )
+        .bind(org_id)
         .bind(limit)
         .bind(offset)
         .fetch_all(&self.pool)

--- a/crates/server/tests/org_isolation_test.rs
+++ b/crates/server/tests/org_isolation_test.rs
@@ -1,0 +1,823 @@
+//! Organization isolation tests
+//!
+//! Verifies that all org-scoped entities enforce proper tenant isolation:
+//! resources created in one org are invisible to another org.
+//!
+//! Uses in-memory backend (no PostgreSQL required).
+//!
+//! Run with: cargo test -p everruns-server --test org_isolation_test
+
+use serde_json::json;
+use uuid::Uuid;
+
+use everruns_server::storage::{
+    CreateImageRow, CreateLlmModelRow, CreateLlmProviderRow, CreateMcpServerRow,
+    CreateOrganizationRow, InMemoryDatabase, UpdateLlmModel, UpdateLlmProvider, UpdateMcpServer,
+};
+
+/// Helper: create a second org in the in-memory database.
+/// The default org (org_id=1) already exists.
+async fn create_second_org(db: &InMemoryDatabase) -> i64 {
+    let org = db
+        .create_organization(CreateOrganizationRow {
+            public_id: format!("org_{}", Uuid::now_v7().simple()),
+            name: "Second Org".to_string(),
+        })
+        .await
+        .expect("Failed to create second org");
+    org.org_id
+}
+
+const ORG1: i64 = 1; // Default org
+
+// ============================================
+// MCP Server Isolation Tests
+// ============================================
+
+#[tokio::test]
+async fn test_mcp_server_positive_own_org() {
+    let db = InMemoryDatabase::default();
+
+    let server = db
+        .create_mcp_server(
+            ORG1,
+            CreateMcpServerRow {
+                name: "My Server".to_string(),
+                description: None,
+                url: "https://mcp.example.com".to_string(),
+                transport_type: "http".to_string(),
+                api_key_encrypted: None,
+                headers: None,
+                settings: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    // Positive: own org can get, list, update, delete
+    assert!(
+        db.get_mcp_server(ORG1, server.id.uuid())
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        db.get_mcp_server_by_name(ORG1, "My Server")
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert_eq!(db.list_mcp_servers(ORG1).await.unwrap().len(), 1);
+    assert_eq!(db.list_active_mcp_servers(ORG1).await.unwrap().len(), 1);
+
+    let updated = db
+        .update_mcp_server(
+            ORG1,
+            server.id.uuid(),
+            UpdateMcpServer {
+                name: Some("Renamed".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert!(updated.is_some());
+    assert_eq!(updated.unwrap().name, "Renamed");
+
+    assert!(db.delete_mcp_server(ORG1, server.id.uuid()).await.unwrap());
+}
+
+#[tokio::test]
+async fn test_mcp_server_negative_cross_org() {
+    let db = InMemoryDatabase::default();
+    let org2 = create_second_org(&db).await;
+
+    let server = db
+        .create_mcp_server(
+            ORG1,
+            CreateMcpServerRow {
+                name: "Org1 Server".to_string(),
+                description: None,
+                url: "https://mcp.example.com".to_string(),
+                transport_type: "http".to_string(),
+                api_key_encrypted: None,
+                headers: None,
+                settings: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    // Negative: other org cannot see, update, or delete
+    assert!(
+        db.get_mcp_server(org2, server.id.uuid())
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        db.get_mcp_server_by_name(org2, "Org1 Server")
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(db.list_mcp_servers(org2).await.unwrap().is_empty());
+    assert!(db.list_active_mcp_servers(org2).await.unwrap().is_empty());
+    assert!(
+        db.update_mcp_server(
+            org2,
+            server.id.uuid(),
+            UpdateMcpServer {
+                name: Some("Hacked".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap()
+        .is_none()
+    );
+    assert!(!db.delete_mcp_server(org2, server.id.uuid()).await.unwrap());
+
+    // Verify original is untouched
+    let original = db
+        .get_mcp_server(ORG1, server.id.uuid())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(original.name, "Org1 Server");
+}
+
+// ============================================
+// LLM Provider Isolation Tests
+// ============================================
+
+#[tokio::test]
+async fn test_llm_provider_positive_own_org() {
+    let db = InMemoryDatabase::default();
+
+    let provider = db
+        .create_llm_provider(
+            ORG1,
+            CreateLlmProviderRow {
+                name: "My Provider".to_string(),
+                provider_type: "openai".to_string(),
+                base_url: None,
+                api_key_encrypted: None,
+                settings: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    // Positive: own org can get, list, update, delete
+    assert!(
+        db.get_llm_provider(ORG1, provider.id.uuid())
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert_eq!(db.list_llm_providers(ORG1).await.unwrap().len(), 1);
+
+    let updated = db
+        .update_llm_provider(
+            ORG1,
+            provider.id.uuid(),
+            UpdateLlmProvider {
+                name: Some("Renamed Provider".to_string()),
+                provider_type: None,
+                base_url: None,
+                api_key_encrypted: None,
+                status: None,
+                settings: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert!(updated.is_some());
+    assert_eq!(updated.unwrap().name, "Renamed Provider");
+
+    assert!(
+        db.delete_llm_provider(ORG1, provider.id.uuid())
+            .await
+            .unwrap()
+    );
+}
+
+#[tokio::test]
+async fn test_llm_provider_negative_cross_org() {
+    let db = InMemoryDatabase::default();
+    let org2 = create_second_org(&db).await;
+
+    let provider = db
+        .create_llm_provider(
+            ORG1,
+            CreateLlmProviderRow {
+                name: "Org1 Provider".to_string(),
+                provider_type: "openai".to_string(),
+                base_url: None,
+                api_key_encrypted: None,
+                settings: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    // Negative: other org cannot see, update, or delete
+    assert!(
+        db.get_llm_provider(org2, provider.id.uuid())
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(db.list_llm_providers(org2).await.unwrap().is_empty());
+    assert!(
+        db.update_llm_provider(
+            org2,
+            provider.id.uuid(),
+            UpdateLlmProvider {
+                name: Some("Hacked".to_string()),
+                provider_type: None,
+                base_url: None,
+                api_key_encrypted: None,
+                status: None,
+                settings: None,
+            },
+        )
+        .await
+        .unwrap()
+        .is_none()
+    );
+    assert!(
+        !db.delete_llm_provider(org2, provider.id.uuid())
+            .await
+            .unwrap()
+    );
+
+    // Verify original is untouched
+    let original = db
+        .get_llm_provider(ORG1, provider.id.uuid())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(original.name, "Org1 Provider");
+}
+
+// ============================================
+// LLM Model Isolation Tests
+// ============================================
+
+#[tokio::test]
+async fn test_llm_model_positive_own_org() {
+    let db = InMemoryDatabase::default();
+
+    let provider = db
+        .create_llm_provider(
+            ORG1,
+            CreateLlmProviderRow {
+                name: "Provider".to_string(),
+                provider_type: "openai".to_string(),
+                base_url: None,
+                api_key_encrypted: None,
+                settings: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let model = db
+        .create_llm_model(
+            ORG1,
+            CreateLlmModelRow {
+                provider_id: provider.id,
+                model_id: "gpt-4".to_string(),
+                display_name: "GPT-4".to_string(),
+                capabilities: vec![],
+                is_default: false,
+                is_favorite: false,
+                source: "manual".to_string(),
+                provider_metadata: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    // Positive: own org can get, list, update, delete
+    assert!(
+        db.get_llm_model(ORG1, model.id.uuid())
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        db.get_llm_model_with_provider(ORG1, model.id.uuid())
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert_eq!(
+        db.list_llm_models_for_provider(ORG1, provider.id.uuid())
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(db.list_all_llm_models(ORG1).await.unwrap().len(), 1);
+
+    let updated = db
+        .update_llm_model(
+            ORG1,
+            model.id.uuid(),
+            UpdateLlmModel {
+                display_name: Some("GPT-4 Turbo".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert!(updated.is_some());
+    assert_eq!(updated.unwrap().display_name, "GPT-4 Turbo");
+
+    assert!(db.delete_llm_model(ORG1, model.id.uuid()).await.unwrap());
+}
+
+#[tokio::test]
+async fn test_llm_model_negative_cross_org() {
+    let db = InMemoryDatabase::default();
+    let org2 = create_second_org(&db).await;
+
+    let provider = db
+        .create_llm_provider(
+            ORG1,
+            CreateLlmProviderRow {
+                name: "Provider".to_string(),
+                provider_type: "openai".to_string(),
+                base_url: None,
+                api_key_encrypted: None,
+                settings: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let model = db
+        .create_llm_model(
+            ORG1,
+            CreateLlmModelRow {
+                provider_id: provider.id,
+                model_id: "gpt-4".to_string(),
+                display_name: "GPT-4".to_string(),
+                capabilities: vec![],
+                is_default: false,
+                is_favorite: false,
+                source: "manual".to_string(),
+                provider_metadata: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    // Negative: other org cannot see, update, or delete
+    assert!(
+        db.get_llm_model(org2, model.id.uuid())
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        db.get_llm_model_with_provider(org2, model.id.uuid())
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        db.list_llm_models_for_provider(org2, provider.id.uuid())
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    assert!(db.list_all_llm_models(org2).await.unwrap().is_empty());
+    assert!(
+        db.update_llm_model(
+            org2,
+            model.id.uuid(),
+            UpdateLlmModel {
+                display_name: Some("Hacked".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap()
+        .is_none()
+    );
+    assert!(!db.delete_llm_model(org2, model.id.uuid()).await.unwrap());
+
+    // Verify original is untouched
+    let original = db
+        .get_llm_model(ORG1, model.id.uuid())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(original.display_name, "GPT-4");
+}
+
+// ============================================
+// Image Isolation Tests
+// ============================================
+
+#[tokio::test]
+async fn test_image_positive_own_org() {
+    let db = InMemoryDatabase::default();
+
+    let image = db
+        .create_image(
+            ORG1,
+            CreateImageRow {
+                org_id: ORG1,
+                filename: "test.png".to_string(),
+                content_type: "image/png".to_string(),
+                size_bytes: 1024,
+                data: vec![0u8; 1024],
+                thumbnail_data: None,
+                thumbnail_content_type: None,
+                metadata: json!({}),
+            },
+        )
+        .await
+        .unwrap();
+
+    // Positive: own org can get, list, delete
+    assert!(db.get_image(ORG1, image.id.uuid()).await.unwrap().is_some());
+    assert!(
+        db.get_image_info(ORG1, image.id.uuid())
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert_eq!(db.list_images(ORG1, 50, 0).await.unwrap().len(), 1);
+    assert!(db.delete_image(ORG1, image.id.uuid()).await.unwrap());
+}
+
+#[tokio::test]
+async fn test_image_negative_cross_org() {
+    let db = InMemoryDatabase::default();
+    let org2 = create_second_org(&db).await;
+
+    let image = db
+        .create_image(
+            ORG1,
+            CreateImageRow {
+                org_id: ORG1,
+                filename: "secret.png".to_string(),
+                content_type: "image/png".to_string(),
+                size_bytes: 1024,
+                data: vec![0u8; 1024],
+                thumbnail_data: None,
+                thumbnail_content_type: None,
+                metadata: json!({}),
+            },
+        )
+        .await
+        .unwrap();
+
+    // Negative: other org cannot see or delete
+    assert!(db.get_image(org2, image.id.uuid()).await.unwrap().is_none());
+    assert!(
+        db.get_image_info(org2, image.id.uuid())
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(db.list_images(org2, 50, 0).await.unwrap().is_empty());
+    assert!(!db.delete_image(org2, image.id.uuid()).await.unwrap());
+
+    // Verify original still accessible to owner
+    assert!(db.get_image(ORG1, image.id.uuid()).await.unwrap().is_some());
+}
+
+// ============================================
+// Cross-Entity Isolation: Multi-org scenario
+// ============================================
+
+#[tokio::test]
+async fn test_multi_org_full_isolation() {
+    let db = InMemoryDatabase::default();
+    let org2 = create_second_org(&db).await;
+
+    // Create resources in org1
+    let org1_provider = db
+        .create_llm_provider(
+            ORG1,
+            CreateLlmProviderRow {
+                name: "Org1 Provider".to_string(),
+                provider_type: "openai".to_string(),
+                base_url: None,
+                api_key_encrypted: None,
+                settings: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let org1_model = db
+        .create_llm_model(
+            ORG1,
+            CreateLlmModelRow {
+                provider_id: org1_provider.id,
+                model_id: "gpt-4".to_string(),
+                display_name: "GPT-4".to_string(),
+                capabilities: vec![],
+                is_default: true,
+                is_favorite: false,
+                source: "manual".to_string(),
+                provider_metadata: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let org1_server = db
+        .create_mcp_server(
+            ORG1,
+            CreateMcpServerRow {
+                name: "Org1 MCP".to_string(),
+                description: None,
+                url: "https://mcp1.example.com".to_string(),
+                transport_type: "http".to_string(),
+                api_key_encrypted: None,
+                headers: None,
+                settings: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let org1_image = db
+        .create_image(
+            ORG1,
+            CreateImageRow {
+                org_id: ORG1,
+                filename: "org1.png".to_string(),
+                content_type: "image/png".to_string(),
+                size_bytes: 100,
+                data: vec![1u8; 100],
+                thumbnail_data: None,
+                thumbnail_content_type: None,
+                metadata: json!({}),
+            },
+        )
+        .await
+        .unwrap();
+
+    // Create resources in org2
+    let org2_provider = db
+        .create_llm_provider(
+            org2,
+            CreateLlmProviderRow {
+                name: "Org2 Provider".to_string(),
+                provider_type: "anthropic".to_string(),
+                base_url: None,
+                api_key_encrypted: None,
+                settings: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let org2_model = db
+        .create_llm_model(
+            org2,
+            CreateLlmModelRow {
+                provider_id: org2_provider.id,
+                model_id: "claude-3".to_string(),
+                display_name: "Claude 3".to_string(),
+                capabilities: vec![],
+                is_default: true,
+                is_favorite: false,
+                source: "manual".to_string(),
+                provider_metadata: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let org2_server = db
+        .create_mcp_server(
+            org2,
+            CreateMcpServerRow {
+                name: "Org2 MCP".to_string(),
+                description: None,
+                url: "https://mcp2.example.com".to_string(),
+                transport_type: "http".to_string(),
+                api_key_encrypted: None,
+                headers: None,
+                settings: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    // Verify org1 sees only its own resources
+    let org1_providers = db.list_llm_providers(ORG1).await.unwrap();
+    assert_eq!(org1_providers.len(), 1);
+    assert_eq!(org1_providers[0].name, "Org1 Provider");
+
+    let org1_models = db.list_all_llm_models(ORG1).await.unwrap();
+    assert_eq!(org1_models.len(), 1);
+    assert_eq!(org1_models[0].model_id, "gpt-4");
+
+    let org1_servers = db.list_mcp_servers(ORG1).await.unwrap();
+    assert_eq!(org1_servers.len(), 1);
+    assert_eq!(org1_servers[0].name, "Org1 MCP");
+
+    let org1_images = db.list_images(ORG1, 50, 0).await.unwrap();
+    assert_eq!(org1_images.len(), 1);
+    assert_eq!(org1_images[0].filename, "org1.png");
+
+    // Verify org2 sees only its own resources
+    let org2_providers = db.list_llm_providers(org2).await.unwrap();
+    assert_eq!(org2_providers.len(), 1);
+    assert_eq!(org2_providers[0].name, "Org2 Provider");
+
+    let org2_models = db.list_all_llm_models(org2).await.unwrap();
+    assert_eq!(org2_models.len(), 1);
+    assert_eq!(org2_models[0].model_id, "claude-3");
+
+    let org2_servers = db.list_mcp_servers(org2).await.unwrap();
+    assert_eq!(org2_servers.len(), 1);
+    assert_eq!(org2_servers[0].name, "Org2 MCP");
+
+    // Verify cross-org access is denied for all entity types
+    assert!(
+        db.get_llm_provider(org2, org1_provider.id.uuid())
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        db.get_llm_model(org2, org1_model.id.uuid())
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        db.get_mcp_server(org2, org1_server.id.uuid())
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        db.get_image(org2, org1_image.id.uuid())
+            .await
+            .unwrap()
+            .is_none()
+    );
+
+    assert!(
+        db.get_llm_provider(ORG1, org2_provider.id.uuid())
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        db.get_llm_model(ORG1, org2_model.id.uuid())
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        db.get_mcp_server(ORG1, org2_server.id.uuid())
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+// ============================================
+// Default model isolation
+// ============================================
+
+#[tokio::test]
+async fn test_default_model_org_isolation() {
+    let db = InMemoryDatabase::default();
+    let org2 = create_second_org(&db).await;
+
+    let provider = db
+        .create_llm_provider(
+            ORG1,
+            CreateLlmProviderRow {
+                name: "Provider".to_string(),
+                provider_type: "openai".to_string(),
+                base_url: None,
+                api_key_encrypted: None,
+                settings: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    // Set default model in org1
+    let _model = db
+        .create_llm_model(
+            ORG1,
+            CreateLlmModelRow {
+                provider_id: provider.id,
+                model_id: "gpt-4".to_string(),
+                display_name: "GPT-4".to_string(),
+                capabilities: vec![],
+                is_default: true,
+                is_favorite: false,
+                source: "manual".to_string(),
+                provider_metadata: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    // Positive: org1 has a default model
+    assert!(db.get_default_llm_model(ORG1).await.unwrap().is_some());
+
+    // Negative: org2 does not see org1's default model
+    assert!(db.get_default_llm_model(org2).await.unwrap().is_none());
+}
+
+// ============================================
+// Update does not leak across orgs
+// ============================================
+
+#[tokio::test]
+async fn test_update_mcp_server_tools_cross_org() {
+    let db = InMemoryDatabase::default();
+    let org2 = create_second_org(&db).await;
+
+    let server = db
+        .create_mcp_server(
+            ORG1,
+            CreateMcpServerRow {
+                name: "Server".to_string(),
+                description: None,
+                url: "https://example.com".to_string(),
+                transport_type: "http".to_string(),
+                api_key_encrypted: None,
+                headers: None,
+                settings: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    // Negative: org2 cannot update cached tools
+    let result = db
+        .update_mcp_server_tools(
+            org2,
+            server.id.uuid(),
+            everruns_server::storage::UpdateMcpServerTools {
+                cached_tools: json!([{"name": "hacked_tool"}]),
+            },
+        )
+        .await
+        .unwrap();
+    assert!(result.is_none());
+
+    // Verify original tools untouched (empty array from creation)
+    let original = db
+        .get_mcp_server(ORG1, server.id.uuid())
+        .await
+        .unwrap()
+        .unwrap();
+    let tools: Vec<serde_json::Value> =
+        serde_json::from_value(original.cached_tools.clone()).unwrap_or_default();
+    assert!(tools.is_empty());
+}
+
+#[tokio::test]
+async fn test_provider_last_synced_cross_org() {
+    let db = InMemoryDatabase::default();
+    let org2 = create_second_org(&db).await;
+
+    let provider = db
+        .create_llm_provider(
+            ORG1,
+            CreateLlmProviderRow {
+                name: "Provider".to_string(),
+                provider_type: "openai".to_string(),
+                base_url: None,
+                api_key_encrypted: None,
+                settings: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    // Negative: org2 cannot update last_synced_at
+    db.update_provider_last_synced(org2, provider.id.uuid(), chrono::Utc::now())
+        .await
+        .unwrap();
+
+    // Verify original last_synced_at is still None
+    let original = db
+        .get_llm_provider(ORG1, provider.id.uuid())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(original.last_synced_at.is_none());
+}

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -423,7 +423,7 @@ async fn test_llm_provider_crud() {
 
     // Get provider
     let fetched = backend
-        .get_llm_provider(provider.id.into())
+        .get_llm_provider(TEST_ORG_ID, provider.id.into())
         .await
         .expect("Failed to get provider")
         .expect("Provider not found");
@@ -432,6 +432,7 @@ async fn test_llm_provider_crud() {
     // Update provider
     let updated = backend
         .update_llm_provider(
+            TEST_ORG_ID,
             provider.id.into(),
             UpdateLlmProvider {
                 name: Some("Updated Provider".to_string()),
@@ -449,14 +450,14 @@ async fn test_llm_provider_crud() {
 
     // List providers
     let providers = backend
-        .list_llm_providers()
+        .list_llm_providers(TEST_ORG_ID)
         .await
         .expect("Failed to list providers");
     assert!(providers.iter().any(|p| p.id == provider.id));
 
     // Delete provider
     let deleted = backend
-        .delete_llm_provider(provider.id.into())
+        .delete_llm_provider(TEST_ORG_ID, provider.id.into())
         .await
         .expect("Failed to delete provider");
     assert!(deleted);
@@ -507,7 +508,7 @@ async fn test_llm_model_crud() {
 
     // Get model
     let fetched = backend
-        .get_llm_model(model.id.into())
+        .get_llm_model(TEST_ORG_ID, model.id.into())
         .await
         .expect("Failed to get model")
         .expect("Model not found");
@@ -515,7 +516,7 @@ async fn test_llm_model_crud() {
 
     // Get model with provider
     let with_provider = backend
-        .get_llm_model_with_provider(model.id.into())
+        .get_llm_model_with_provider(TEST_ORG_ID, model.id.into())
         .await
         .expect("Failed to get model with provider")
         .expect("Model not found");
@@ -524,6 +525,7 @@ async fn test_llm_model_crud() {
     // Update model
     let updated = backend
         .update_llm_model(
+            TEST_ORG_ID,
             model.id.into(),
             UpdateLlmModel {
                 display_name: Some("Updated GPT-4".to_string()),
@@ -537,15 +539,18 @@ async fn test_llm_model_crud() {
 
     // List models for provider
     let models = backend
-        .list_llm_models_for_provider(provider.id.into())
+        .list_llm_models_for_provider(TEST_ORG_ID, provider.id.into())
         .await
         .expect("Failed to list models");
     assert!(models.iter().any(|m| m.id == model.id));
 
     // Cleanup
-    backend.delete_llm_model(model.id.into()).await.unwrap();
     backend
-        .delete_llm_provider(provider.id.into())
+        .delete_llm_model(TEST_ORG_ID, model.id.into())
+        .await
+        .unwrap();
+    backend
+        .delete_llm_provider(TEST_ORG_ID, provider.id.into())
         .await
         .unwrap();
 }
@@ -694,7 +699,7 @@ async fn test_mcp_server_crud() {
 
     // Get MCP server
     let fetched = backend
-        .get_mcp_server(server.id.into())
+        .get_mcp_server(TEST_ORG_ID, server.id.uuid())
         .await
         .expect("Failed to get MCP server")
         .expect("MCP server not found");
@@ -702,7 +707,7 @@ async fn test_mcp_server_crud() {
 
     // Get by name
     let by_name = backend
-        .get_mcp_server_by_name(&unique_name)
+        .get_mcp_server_by_name(TEST_ORG_ID, &unique_name)
         .await
         .expect("Failed to get MCP server by name")
         .expect("MCP server not found");
@@ -710,14 +715,14 @@ async fn test_mcp_server_crud() {
 
     // List MCP servers
     let servers = backend
-        .list_mcp_servers()
+        .list_mcp_servers(TEST_ORG_ID)
         .await
         .expect("Failed to list MCP servers");
     assert!(servers.iter().any(|s| s.id == server.id));
 
     // Delete MCP server
     let deleted = backend
-        .delete_mcp_server(server.id.into())
+        .delete_mcp_server(TEST_ORG_ID, server.id.uuid())
         .await
         .expect("Failed to delete MCP server");
     assert!(deleted);
@@ -874,15 +879,19 @@ async fn test_image_crud() {
 
     // Create image
     let image = backend
-        .create_image(CreateImageRow {
-            filename: "test.png".to_string(),
-            content_type: "image/png".to_string(),
-            size_bytes: 4,
-            data: vec![0x89, 0x50, 0x4E, 0x47], // PNG header
-            thumbnail_data: None,
-            thumbnail_content_type: None,
-            metadata: json!({}),
-        })
+        .create_image(
+            TEST_ORG_ID,
+            CreateImageRow {
+                org_id: TEST_ORG_ID,
+                filename: "test.png".to_string(),
+                content_type: "image/png".to_string(),
+                size_bytes: 4,
+                data: vec![0x89, 0x50, 0x4E, 0x47], // PNG header
+                thumbnail_data: None,
+                thumbnail_content_type: None,
+                metadata: json!({}),
+            },
+        )
         .await
         .expect("Failed to create image");
 
@@ -891,7 +900,7 @@ async fn test_image_crud() {
 
     // Get image
     let fetched = backend
-        .get_image(image.id.into())
+        .get_image(TEST_ORG_ID, image.id.uuid())
         .await
         .expect("Failed to get image")
         .expect("Image not found");
@@ -900,7 +909,7 @@ async fn test_image_crud() {
 
     // Get image info (without data)
     let info = backend
-        .get_image_info(image.id.into())
+        .get_image_info(TEST_ORG_ID, image.id.uuid())
         .await
         .expect("Failed to get image info")
         .expect("Image not found");
@@ -909,14 +918,14 @@ async fn test_image_crud() {
 
     // List images
     let images = backend
-        .list_images(10, 0)
+        .list_images(TEST_ORG_ID, 10, 0)
         .await
         .expect("Failed to list images");
     assert!(images.iter().any(|i| i.id == image.id));
 
     // Delete image
     let deleted = backend
-        .delete_image(image.id.into())
+        .delete_image(TEST_ORG_ID, image.id.uuid())
         .await
         .expect("Failed to delete image");
     assert!(deleted);

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -1105,3 +1105,324 @@ async fn test_session_previews() {
 
     // Note: No cleanup - events are append-only so sessions with events cannot be deleted
 }
+
+// ============================================
+// Organization Isolation Tests (PostgreSQL)
+// ============================================
+
+/// Helper to create a new org for isolation testing
+async fn create_test_org(backend: &StorageBackend, name: &str) -> i64 {
+    let org = backend
+        .create_organization(CreateOrganizationRow {
+            public_id: format!("org_{}", Uuid::now_v7().simple()),
+            name: name.to_string(),
+        })
+        .await
+        .expect("Failed to create org");
+    org.org_id
+}
+
+#[tokio::test]
+async fn test_mcp_server_org_isolation_postgres() {
+    let backend = create_test_backend().await;
+    let org2 = create_test_org(&backend, "Isolation Test Org").await;
+
+    let unique_name = format!("MCP-Iso-{}", Uuid::now_v7());
+    let server = backend
+        .create_mcp_server(
+            TEST_ORG_ID,
+            CreateMcpServerRow {
+                name: unique_name.clone(),
+                description: None,
+                url: "https://mcp.example.com".to_string(),
+                transport_type: "http".to_string(),
+                api_key_encrypted: None,
+                headers: None,
+                settings: None,
+            },
+        )
+        .await
+        .expect("create server");
+
+    // Positive: own org sees the server
+    assert!(
+        backend
+            .get_mcp_server(TEST_ORG_ID, server.id.uuid())
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        backend
+            .get_mcp_server_by_name(TEST_ORG_ID, &unique_name)
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        backend
+            .list_mcp_servers(TEST_ORG_ID)
+            .await
+            .unwrap()
+            .iter()
+            .any(|s| s.id == server.id)
+    );
+
+    // Negative: other org cannot see it
+    assert!(
+        backend
+            .get_mcp_server(org2, server.id.uuid())
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        backend
+            .get_mcp_server_by_name(org2, &unique_name)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        !backend
+            .list_mcp_servers(org2)
+            .await
+            .unwrap()
+            .iter()
+            .any(|s| s.id == server.id)
+    );
+
+    // Negative: other org cannot delete
+    assert!(
+        !backend
+            .delete_mcp_server(org2, server.id.uuid())
+            .await
+            .unwrap()
+    );
+
+    // Cleanup
+    backend
+        .delete_mcp_server(TEST_ORG_ID, server.id.uuid())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_llm_provider_org_isolation_postgres() {
+    let backend = create_test_backend().await;
+    let org2 = create_test_org(&backend, "Provider Isolation Org").await;
+
+    let provider = backend
+        .create_llm_provider(
+            TEST_ORG_ID,
+            CreateLlmProviderRow {
+                name: format!("Provider-{}", Uuid::now_v7()),
+                provider_type: "openai".to_string(),
+                base_url: None,
+                api_key_encrypted: None,
+                settings: None,
+            },
+        )
+        .await
+        .expect("create provider");
+
+    // Positive
+    assert!(
+        backend
+            .get_llm_provider(TEST_ORG_ID, provider.id.uuid())
+            .await
+            .unwrap()
+            .is_some()
+    );
+
+    // Negative
+    assert!(
+        backend
+            .get_llm_provider(org2, provider.id.uuid())
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        !backend
+            .list_llm_providers(org2)
+            .await
+            .unwrap()
+            .iter()
+            .any(|p| p.id == provider.id)
+    );
+    assert!(
+        !backend
+            .delete_llm_provider(org2, provider.id.uuid())
+            .await
+            .unwrap()
+    );
+
+    // Cleanup
+    backend
+        .delete_llm_provider(TEST_ORG_ID, provider.id.uuid())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_llm_model_org_isolation_postgres() {
+    let backend = create_test_backend().await;
+    let org2 = create_test_org(&backend, "Model Isolation Org").await;
+
+    let provider = backend
+        .create_llm_provider(
+            TEST_ORG_ID,
+            CreateLlmProviderRow {
+                name: format!("Prov-{}", Uuid::now_v7()),
+                provider_type: "openai".to_string(),
+                base_url: None,
+                api_key_encrypted: None,
+                settings: None,
+            },
+        )
+        .await
+        .expect("create provider");
+
+    let model = backend
+        .create_llm_model(
+            TEST_ORG_ID,
+            CreateLlmModelRow {
+                provider_id: provider.id,
+                model_id: format!("model-{}", Uuid::now_v7()),
+                display_name: "Test Model".to_string(),
+                capabilities: vec![],
+                is_default: false,
+                is_favorite: false,
+                source: "manual".to_string(),
+                provider_metadata: None,
+            },
+        )
+        .await
+        .expect("create model");
+
+    // Positive
+    assert!(
+        backend
+            .get_llm_model(TEST_ORG_ID, model.id.uuid())
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        backend
+            .get_llm_model_with_provider(TEST_ORG_ID, model.id.uuid())
+            .await
+            .unwrap()
+            .is_some()
+    );
+
+    // Negative
+    assert!(
+        backend
+            .get_llm_model(org2, model.id.uuid())
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        backend
+            .get_llm_model_with_provider(org2, model.id.uuid())
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        backend
+            .list_llm_models_for_provider(org2, provider.id.uuid())
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    assert!(
+        !backend
+            .delete_llm_model(org2, model.id.uuid())
+            .await
+            .unwrap()
+    );
+
+    // Cleanup
+    backend
+        .delete_llm_model(TEST_ORG_ID, model.id.uuid())
+        .await
+        .unwrap();
+    backend
+        .delete_llm_provider(TEST_ORG_ID, provider.id.uuid())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_image_org_isolation_postgres() {
+    let backend = create_test_backend().await;
+    let org2 = create_test_org(&backend, "Image Isolation Org").await;
+
+    let image = backend
+        .create_image(
+            TEST_ORG_ID,
+            CreateImageRow {
+                org_id: TEST_ORG_ID,
+                filename: format!("iso-{}.png", Uuid::now_v7()),
+                content_type: "image/png".to_string(),
+                size_bytes: 4,
+                data: vec![0x89, 0x50, 0x4E, 0x47],
+                thumbnail_data: None,
+                thumbnail_content_type: None,
+                metadata: json!({}),
+            },
+        )
+        .await
+        .expect("create image");
+
+    // Positive
+    assert!(
+        backend
+            .get_image(TEST_ORG_ID, image.id.uuid())
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        backend
+            .get_image_info(TEST_ORG_ID, image.id.uuid())
+            .await
+            .unwrap()
+            .is_some()
+    );
+
+    // Negative
+    assert!(
+        backend
+            .get_image(org2, image.id.uuid())
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        backend
+            .get_image_info(org2, image.id.uuid())
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        !backend
+            .list_images(org2, 50, 0)
+            .await
+            .unwrap()
+            .iter()
+            .any(|i| i.id == image.id)
+    );
+    assert!(!backend.delete_image(org2, image.id.uuid()).await.unwrap());
+
+    // Cleanup
+    backend
+        .delete_image(TEST_ORG_ID, image.id.uuid())
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
## What
Enforce org_id filtering at the repository layer for MCP servers, LLM providers, LLM models, and images. Previously these entities accepted but ignored the org context, allowing cross-org data access.

## Why
Multitenancy audit found that 4 entity types had API handlers accepting `ResolvedOrg` but not passing it through to the storage layer. Any authenticated user could access another org's providers, models, MCP servers, and images by ID.

## How
- Added `org_id: i64` parameter to all repository, backend, service, and handler methods for the 4 affected entity types (22+ methods across 3 layers)
- Added `WHERE org_id = $N` clauses to all PostgreSQL queries
- Added `.filter(|s| s.org_id == org_id)` guards to all in-memory storage methods
- Added `org_id` column to `images` table via migration (only entity missing it at schema level)
- Internal callers without org context (worker stores, resolver, background sync) use `DEFAULT_ORG_ID` with TODO comments for Phase 3
- Changed `_org: ResolvedOrg` to `org: ResolvedOrg` in all API handlers and pass `org.org_id` through

## Risk
- Medium
- Breaking change for internal callers that don't pass org_id yet (mitigated by DEFAULT_ORG_ID fallback)
- Images migration adds NOT NULL column with default — safe for existing data

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

### Test coverage
- 12 in-memory org isolation tests (always runnable, no PostgreSQL needed)
- 4 PostgreSQL-backed org isolation tests in repository_integration_test.rs
- Tests cover positive (own org CRUD) and negative (cross-org denied) for all 4 entity types
- Dev mode smoke tested: health, providers, models, MCP servers, images endpoints all pass with org scoping