### PR TITLE
feat(capabilities): CodeSandbox cloud sandbox capability

### DIFF
--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -112,6 +112,8 @@ where
     file_store: Option<Arc<dyn SessionFileStore>>,
     /// Optional SQL database store for sql_execute/sql_query/sql_schema tools
     sqldb_store: Option<crate::traits::SessionSqlDbStoreRef>,
+    /// Optional session storage store for kv_store/secret_store tools
+    storage_store: Option<Arc<dyn crate::traits::SessionStorageStore>>,
 }
 
 impl<T, E> ActAtom<T, E>
@@ -126,6 +128,7 @@ where
             event_emitter,
             file_store: None,
             sqldb_store: None,
+            storage_store: None,
         }
     }
 
@@ -140,12 +143,22 @@ where
             event_emitter,
             file_store: Some(file_store),
             sqldb_store: None,
+            storage_store: None,
         }
     }
 
     /// Set the SQL database store on this atom
     pub fn with_sqldb_store(mut self, store: crate::traits::SessionSqlDbStoreRef) -> Self {
         self.sqldb_store = Some(store);
+        self
+    }
+
+    /// Set the session storage store on this atom
+    pub fn with_storage_store(
+        mut self,
+        store: Arc<dyn crate::traits::SessionStorageStore>,
+    ) -> Self {
+        self.storage_store = Some(store);
         self
     }
 }
@@ -405,7 +418,10 @@ where
         };
 
         // Execute the tool
-        let result = if self.file_store.is_some() || self.sqldb_store.is_some() {
+        let result = if self.file_store.is_some()
+            || self.sqldb_store.is_some()
+            || self.storage_store.is_some()
+        {
             let mut tool_context = if let Some(ref store) = self.file_store {
                 ToolContext::with_file_store(context.session_id, store.clone())
             } else {
@@ -413,6 +429,9 @@ where
             };
             if let Some(ref store) = self.sqldb_store {
                 tool_context.sqldb_store = Some(store.clone());
+            }
+            if let Some(ref store) = self.storage_store {
+                tool_context.storage_store = Some(store.clone());
             }
             self.tool_executor
                 .execute_with_context(&tool_call, tool_def, &tool_context)

--- a/crates/core/src/capabilities/codesandbox.rs
+++ b/crates/core/src/capabilities/codesandbox.rs
@@ -1,0 +1,2207 @@
+//! CodeSandbox Capability (Experimental)
+//!
+//! Cloud-based sandboxed code execution via CodeSandbox REST API.
+//! Supports multiple sandboxes per session, each identified by sandbox_id.
+//!
+//! Decision: Use secrets store for all state (API key + per-sandbox pitcher tokens)
+//! Decision: Two-tier API: Management API for lifecycle, Pint API for in-sandbox ops
+//! Decision: Sync+async exec modes via `wait` parameter
+//! Decision: session_storage dependency for API key and state persistence
+//!
+//! Tools provided:
+//! - `csb_create_sandbox`: Create a new sandbox VM
+//! - `csb_exec`: Execute a command in a sandbox
+//! - `csb_exec_status`: Check execution status and get output
+//! - `csb_read_file`: Read a file from sandbox
+//! - `csb_write_file`: Write a file to sandbox
+//! - `csb_download_workspace`: Download entire workspace to session storage
+//! - `csb_list_sandboxes`: List session sandboxes
+//! - `csb_manage_sandbox`: Shutdown/hibernate/delete sandbox
+
+use super::{Capability, CapabilityStatus};
+use crate::tools::{Tool, ToolExecutionResult};
+use crate::traits::ToolContext;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::time::Duration;
+use tracing::{debug, error, warn};
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const CSB_API_BASE: &str = "https://api.codesandbox.io";
+const CSB_API_KEY_SECRET: &str = "CSB_API_KEY";
+const CSB_SANDBOX_SECRET_PREFIX: &str = "csb_sandbox:";
+const EXEC_POLL_INTERVAL: Duration = Duration::from_millis(500);
+const EXEC_POLL_MAX_WAIT: Duration = Duration::from_secs(120);
+const SSE_READ_TIMEOUT: Duration = Duration::from_secs(5);
+
+// ============================================================================
+// API Response Types
+// ============================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SandboxInfo {
+    pub id: String,
+    pub title: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VmStartResponse {
+    pub pitcher_url: String,
+    pub pitcher_token: String,
+    pub workspace_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecInfo {
+    pub id: String,
+    pub status: String,
+    #[serde(rename = "exitCode")]
+    pub exit_code: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileContent {
+    pub path: String,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DirEntry {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub entry_type: Option<String>,
+}
+
+// ============================================================================
+// Persisted Sandbox State (stored in session secrets as JSON)
+// ============================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SandboxState {
+    pub sandbox_id: String,
+    pub pitcher_url: String,
+    pub pitcher_token: String,
+    pub workspace_path: String,
+    pub started_at: String,
+}
+
+// ============================================================================
+// CodeSandboxClient - HTTP client for CodeSandbox APIs
+// ============================================================================
+
+pub struct CodeSandboxClient {
+    http: reqwest::Client,
+    api_key: String,
+    base_url: String,
+}
+
+impl CodeSandboxClient {
+    pub fn new(api_key: String) -> Self {
+        Self::with_base_url(api_key, CSB_API_BASE.to_string())
+    }
+
+    pub fn with_base_url(api_key: String, base_url: String) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            api_key,
+            base_url,
+        }
+    }
+
+    // --- Generic request helpers ---
+
+    async fn management_request(
+        &self,
+        method: reqwest::Method,
+        path: &str,
+        body: Option<Value>,
+    ) -> Result<Value, String> {
+        let url = format!("{}{}", self.base_url, path);
+        let mut req = self
+            .http
+            .request(method, &url)
+            .bearer_auth(&self.api_key)
+            .header("Content-Type", "application/json");
+
+        if let Some(b) = body {
+            req = req.json(&b);
+        }
+
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| format!("Failed to connect to CodeSandbox API: {e}"))?;
+
+        let status = resp.status();
+        let body_text = resp
+            .text()
+            .await
+            .map_err(|e| format!("Failed to read response: {e}"))?;
+
+        if !status.is_success() {
+            return Err(format!("CodeSandbox API error ({status}): {body_text}"));
+        }
+
+        serde_json::from_str(&body_text).map_err(|e| format!("Invalid JSON from CodeSandbox: {e}"))
+    }
+
+    async fn pint_request(
+        &self,
+        method: reqwest::Method,
+        pitcher_url: &str,
+        path: &str,
+        pitcher_token: &str,
+        body: Option<Value>,
+    ) -> Result<Value, String> {
+        let url = format!("{}{}", pitcher_url, path);
+        let mut req = self
+            .http
+            .request(method, &url)
+            .bearer_auth(pitcher_token)
+            .header("Content-Type", "application/json");
+
+        if let Some(b) = body {
+            req = req.json(&b);
+        }
+
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| format!("Failed to connect to sandbox: {e}"))?;
+
+        let status = resp.status();
+        let body_text = resp
+            .text()
+            .await
+            .map_err(|e| format!("Failed to read sandbox response: {e}"))?;
+
+        if !status.is_success() {
+            return Err(format!("Sandbox API error ({status}): {body_text}"));
+        }
+
+        if body_text.is_empty() {
+            return Ok(json!({}));
+        }
+
+        serde_json::from_str(&body_text).map_err(|e| format!("Invalid JSON from sandbox: {e}"))
+    }
+
+    // --- Management API ---
+
+    pub async fn create_sandbox(&self, body: Value) -> Result<SandboxInfo, String> {
+        let resp = self
+            .management_request(reqwest::Method::POST, "/sandbox", Some(body))
+            .await?;
+        // Response wraps data in { data: { id, ... } }
+        let data = resp.get("data").cloned().unwrap_or(resp.clone());
+        serde_json::from_value(data).map_err(|e| format!("Failed to parse sandbox info: {e}"))
+    }
+
+    pub async fn start_vm(
+        &self,
+        sandbox_id: &str,
+        tier: Option<&str>,
+    ) -> Result<VmStartResponse, String> {
+        let body = tier.map(|t| json!({ "tier": t }));
+        let resp = self
+            .management_request(
+                reqwest::Method::POST,
+                &format!("/vm/{sandbox_id}/start"),
+                body,
+            )
+            .await?;
+        let data = resp.get("data").cloned().unwrap_or(resp.clone());
+        serde_json::from_value(data).map_err(|e| format!("Failed to parse VM start response: {e}"))
+    }
+
+    pub async fn shutdown_vm(&self, sandbox_id: &str) -> Result<(), String> {
+        self.management_request(
+            reqwest::Method::POST,
+            &format!("/vm/{sandbox_id}/shutdown"),
+            None,
+        )
+        .await?;
+        Ok(())
+    }
+
+    pub async fn hibernate_vm(&self, sandbox_id: &str) -> Result<(), String> {
+        self.management_request(
+            reqwest::Method::POST,
+            &format!("/vm/{sandbox_id}/hibernate"),
+            None,
+        )
+        .await?;
+        Ok(())
+    }
+
+    pub async fn delete_vm(&self, sandbox_id: &str) -> Result<(), String> {
+        self.management_request(reqwest::Method::DELETE, &format!("/vm/{sandbox_id}"), None)
+            .await?;
+        Ok(())
+    }
+
+    // --- Pint API: Exec ---
+
+    pub async fn exec_create(
+        &self,
+        pitcher_url: &str,
+        pitcher_token: &str,
+        command: Vec<String>,
+    ) -> Result<ExecInfo, String> {
+        let resp = self
+            .pint_request(
+                reqwest::Method::POST,
+                pitcher_url,
+                "/api/v1/execs",
+                pitcher_token,
+                Some(json!({ "command": command })),
+            )
+            .await?;
+        serde_json::from_value(resp).map_err(|e| format!("Failed to parse exec info: {e}"))
+    }
+
+    pub async fn exec_get(
+        &self,
+        pitcher_url: &str,
+        pitcher_token: &str,
+        exec_id: &str,
+    ) -> Result<ExecInfo, String> {
+        let resp = self
+            .pint_request(
+                reqwest::Method::GET,
+                pitcher_url,
+                &format!("/api/v1/execs/{exec_id}"),
+                pitcher_token,
+                None,
+            )
+            .await?;
+        serde_json::from_value(resp).map_err(|e| format!("Failed to parse exec info: {e}"))
+    }
+
+    pub async fn exec_get_output(
+        &self,
+        pitcher_url: &str,
+        pitcher_token: &str,
+        exec_id: &str,
+    ) -> Result<String, String> {
+        let url = format!("{pitcher_url}/api/v1/execs/{exec_id}/io");
+        let resp = self
+            .http
+            .get(&url)
+            .bearer_auth(pitcher_token)
+            .timeout(SSE_READ_TIMEOUT)
+            .send()
+            .await
+            .map_err(|e| format!("Failed to connect for exec output: {e}"))?;
+
+        if !resp.status().is_success() {
+            return Err(format!("Exec output error ({})", resp.status()));
+        }
+
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| format!("Failed to read exec output: {e}"))?;
+
+        Ok(parse_sse_output(&body))
+    }
+
+    pub async fn exec_kill(
+        &self,
+        pitcher_url: &str,
+        pitcher_token: &str,
+        exec_id: &str,
+    ) -> Result<(), String> {
+        self.pint_request(
+            reqwest::Method::DELETE,
+            pitcher_url,
+            &format!("/api/v1/execs/{exec_id}"),
+            pitcher_token,
+            None,
+        )
+        .await?;
+        Ok(())
+    }
+
+    // --- Pint API: Files ---
+
+    pub async fn file_read(
+        &self,
+        pitcher_url: &str,
+        pitcher_token: &str,
+        path: &str,
+    ) -> Result<FileContent, String> {
+        let encoded_path = encode_path(path);
+        let resp = self
+            .pint_request(
+                reqwest::Method::GET,
+                pitcher_url,
+                &format!("/api/v1/files/{encoded_path}"),
+                pitcher_token,
+                None,
+            )
+            .await?;
+        serde_json::from_value(resp).map_err(|e| format!("Failed to parse file content: {e}"))
+    }
+
+    pub async fn file_write(
+        &self,
+        pitcher_url: &str,
+        pitcher_token: &str,
+        path: &str,
+        content: &str,
+    ) -> Result<(), String> {
+        let encoded_path = encode_path(path);
+        self.pint_request(
+            reqwest::Method::POST,
+            pitcher_url,
+            &format!("/api/v1/files/{encoded_path}"),
+            pitcher_token,
+            Some(json!({ "content": content })),
+        )
+        .await?;
+        Ok(())
+    }
+
+    // --- Pint API: Directories ---
+
+    pub async fn dir_list(
+        &self,
+        pitcher_url: &str,
+        pitcher_token: &str,
+        path: &str,
+    ) -> Result<Vec<DirEntry>, String> {
+        let encoded_path = encode_path(path);
+        let resp = self
+            .pint_request(
+                reqwest::Method::GET,
+                pitcher_url,
+                &format!("/api/v1/directories/{encoded_path}"),
+                pitcher_token,
+                None,
+            )
+            .await?;
+        // Response may be an array directly or wrapped
+        if let Some(arr) = resp.as_array() {
+            serde_json::from_value(Value::Array(arr.clone()))
+                .map_err(|e| format!("Failed to parse directory listing: {e}"))
+        } else {
+            serde_json::from_value(resp)
+                .map_err(|e| format!("Failed to parse directory listing: {e}"))
+        }
+    }
+}
+
+// ============================================================================
+// Utility Functions
+// ============================================================================
+
+/// URL-encode a file path for use in Pint API URLs, preserving slash separators.
+fn encode_path(path: &str) -> String {
+    // Strip leading slash and pass through — CodeSandbox Pint API accepts
+    // unencoded paths in practice. Only encode spaces as %20.
+    path.trim_start_matches('/').replace(' ', "%20")
+}
+
+/// Parse SSE stream output, extracting data lines.
+fn parse_sse_output(raw: &str) -> String {
+    let mut output = String::new();
+    for line in raw.lines() {
+        if let Some(data) = line.strip_prefix("data: ") {
+            // Try to parse as JSON with "output" or "data" field
+            if let Ok(val) = serde_json::from_str::<Value>(data) {
+                if let Some(text) = val.get("output").and_then(|v| v.as_str()) {
+                    output.push_str(text);
+                } else if let Some(text) = val.get("data").and_then(|v| v.as_str()) {
+                    output.push_str(text);
+                } else {
+                    output.push_str(data);
+                    output.push('\n');
+                }
+            } else {
+                output.push_str(data);
+                output.push('\n');
+            }
+        }
+    }
+    output
+}
+
+// ============================================================================
+// Helper Functions for State Management
+// ============================================================================
+
+async fn get_api_key(context: &ToolContext) -> Result<String, ToolExecutionResult> {
+    let storage = context
+        .storage_store
+        .as_ref()
+        .ok_or_else(|| ToolExecutionResult::tool_error("Storage not available in this context"))?;
+
+    storage
+        .get_secret(context.session_id, CSB_API_KEY_SECRET)
+        .await
+        .map_err(|e| {
+            error!("Failed to read CSB_API_KEY secret: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Failed to read API key: {e}"))
+        })?
+        .ok_or_else(|| {
+            ToolExecutionResult::tool_error(
+                "CSB_API_KEY not set. Use `secret_store set CSB_API_KEY <your-key>` first. \
+                 Get your key at https://codesandbox.io/t/api",
+            )
+        })
+}
+
+async fn get_sandbox_state(
+    context: &ToolContext,
+    sandbox_id: &str,
+) -> Result<SandboxState, ToolExecutionResult> {
+    let storage = context
+        .storage_store
+        .as_ref()
+        .ok_or_else(|| ToolExecutionResult::tool_error("Storage not available in this context"))?;
+
+    let secret_name = format!("{CSB_SANDBOX_SECRET_PREFIX}{sandbox_id}");
+    let json_str = storage
+        .get_secret(context.session_id, &secret_name)
+        .await
+        .map_err(|e| {
+            error!("Failed to read sandbox state: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Failed to read sandbox state: {e}"))
+        })?
+        .ok_or_else(|| {
+            ToolExecutionResult::tool_error(format!(
+                "Sandbox '{sandbox_id}' not found. Create one first with csb_create_sandbox."
+            ))
+        })?;
+
+    serde_json::from_str(&json_str).map_err(|e| {
+        error!("Corrupt sandbox state for {sandbox_id}: {e}");
+        ToolExecutionResult::internal_error_msg(format!("Corrupt sandbox state: {e}"))
+    })
+}
+
+async fn save_sandbox_state(
+    context: &ToolContext,
+    state: &SandboxState,
+) -> Result<(), ToolExecutionResult> {
+    let storage = context
+        .storage_store
+        .as_ref()
+        .ok_or_else(|| ToolExecutionResult::tool_error("Storage not available in this context"))?;
+
+    let secret_name = format!("{CSB_SANDBOX_SECRET_PREFIX}{}", state.sandbox_id);
+    let json_str = serde_json::to_string(state).map_err(|e| {
+        ToolExecutionResult::internal_error_msg(format!("Failed to serialize sandbox state: {e}"))
+    })?;
+
+    storage
+        .set_secret(context.session_id, &secret_name, &json_str)
+        .await
+        .map_err(|e| {
+            error!("Failed to save sandbox state: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Failed to save sandbox state: {e}"))
+        })
+}
+
+async fn delete_sandbox_state(
+    context: &ToolContext,
+    sandbox_id: &str,
+) -> Result<(), ToolExecutionResult> {
+    let storage = context
+        .storage_store
+        .as_ref()
+        .ok_or_else(|| ToolExecutionResult::tool_error("Storage not available in this context"))?;
+
+    let secret_name = format!("{CSB_SANDBOX_SECRET_PREFIX}{sandbox_id}");
+    storage
+        .delete_secret(context.session_id, &secret_name)
+        .await
+        .map_err(|e| {
+            error!("Failed to delete sandbox state: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Failed to delete sandbox state: {e}"))
+        })?;
+    Ok(())
+}
+
+async fn list_sandbox_states(
+    context: &ToolContext,
+) -> Result<Vec<SandboxState>, ToolExecutionResult> {
+    let storage = context
+        .storage_store
+        .as_ref()
+        .ok_or_else(|| ToolExecutionResult::tool_error("Storage not available in this context"))?;
+
+    let secrets = storage
+        .list_secrets(context.session_id)
+        .await
+        .map_err(|e| {
+            error!("Failed to list secrets: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Failed to list secrets: {e}"))
+        })?;
+
+    let mut states = Vec::new();
+    for secret_info in secrets {
+        if let Some(sandbox_id) = secret_info.name.strip_prefix(CSB_SANDBOX_SECRET_PREFIX) {
+            match get_sandbox_state(context, sandbox_id).await {
+                Ok(state) => states.push(state),
+                Err(_) => {
+                    warn!("Skipping corrupt sandbox state: {}", sandbox_id);
+                }
+            }
+        }
+    }
+
+    Ok(states)
+}
+
+/// Extract a required string parameter from tool arguments.
+fn required_str<'a>(args: &'a Value, name: &str) -> Result<&'a str, ToolExecutionResult> {
+    args.get(name).and_then(|v| v.as_str()).ok_or_else(|| {
+        ToolExecutionResult::tool_error(format!("Missing required parameter: {name}"))
+    })
+}
+
+// ============================================================================
+// CodeSandboxCapability
+// ============================================================================
+
+pub struct CodeSandboxCapability;
+
+impl Capability for CodeSandboxCapability {
+    fn id(&self) -> &str {
+        "codesandbox"
+    }
+
+    fn name(&self) -> &str {
+        "[Experimental] CodeSandbox"
+    }
+
+    fn description(&self) -> &str {
+        "Run code in cloud-based sandbox VMs powered by CodeSandbox. \
+         Create multiple isolated Linux environments per session, execute commands, \
+         manage files, and download results. EXPERIMENTAL: This capability may change."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("cloud")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Execution")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(
+            r#"You have access to CodeSandbox for running code in cloud-based sandbox VMs.
+Each sandbox is an isolated Firecracker microVM with a full Linux environment and network access.
+
+IMPORTANT: This is an EXPERIMENTAL capability.
+
+## Setup
+
+Set your CodeSandbox API key first (get one at https://codesandbox.io/t/api):
+  secret_store set CSB_API_KEY <your-api-key>
+
+## Tools
+
+- `csb_create_sandbox` - Create a new sandbox VM. Optionally upload files from session storage.
+- `csb_exec` - Execute a shell command. Set `wait: true` (default) to get output, or `wait: false` for async.
+- `csb_exec_status` - Check async execution status and get output.
+- `csb_read_file` - Read a file from sandbox filesystem.
+- `csb_write_file` - Write a file to sandbox filesystem.
+- `csb_download_workspace` - Download entire sandbox workspace to session file storage.
+- `csb_list_sandboxes` - List all sandboxes in this session.
+- `csb_manage_sandbox` - Shutdown, hibernate, or delete a sandbox.
+
+## Workflow
+
+1. Set API key (once per session)
+2. Create sandbox: `csb_create_sandbox`
+3. Write files / execute commands using the sandbox_id
+4. For long-running commands: `csb_exec` with `wait: false`, then poll `csb_exec_status`
+5. Download results: `csb_download_workspace`
+6. Clean up: `csb_manage_sandbox` with action "shutdown"
+
+## Tips
+
+- All tools require a `sandbox_id` (except csb_create_sandbox and csb_list_sandboxes)
+- You can manage multiple sandboxes simultaneously
+- Use `bash -c "..."` for complex shell commands
+- Sandboxes persist until explicitly shut down or the session ends"#,
+        )
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(CsbCreateSandboxTool),
+            Box::new(CsbExecTool),
+            Box::new(CsbExecStatusTool),
+            Box::new(CsbReadFileTool),
+            Box::new(CsbWriteFileTool),
+            Box::new(CsbDownloadWorkspaceTool),
+            Box::new(CsbListSandboxesTool),
+            Box::new(CsbManageSandboxTool),
+        ]
+    }
+
+    fn dependencies(&self) -> Vec<&'static str> {
+        vec!["session_storage"]
+    }
+}
+
+// ============================================================================
+// CsbCreateSandboxTool
+// ============================================================================
+
+pub struct CsbCreateSandboxTool;
+
+#[async_trait]
+impl Tool for CsbCreateSandboxTool {
+    fn name(&self) -> &str {
+        "csb_create_sandbox"
+    }
+
+    fn description(&self) -> &str {
+        "Create a new CodeSandbox cloud VM. Optionally upload files from session storage."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "description": "Sandbox title (optional)"
+                },
+                "template": {
+                    "type": "string",
+                    "description": "Template ID to fork from (optional)"
+                },
+                "upload_files": {
+                    "type": "array",
+                    "description": "Files to upload from session storage (optional)",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "session_path": { "type": "string", "description": "Source path in session storage" },
+                            "sandbox_path": { "type": "string", "description": "Destination path in sandbox" }
+                        },
+                        "required": ["session_path", "sandbox_path"]
+                    }
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "csb_create_sandbox requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let api_key = match get_api_key(context).await {
+            Ok(k) => k,
+            Err(e) => return e,
+        };
+
+        let client = CodeSandboxClient::new(api_key);
+
+        // Build create request
+        let title = arguments
+            .get("title")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Everruns Sandbox");
+        let mut create_body = json!({
+            "title": title,
+            "privacy": 2,
+        });
+        if let Some(template) = arguments.get("template").and_then(|v| v.as_str()) {
+            create_body["template"] = json!(template);
+        }
+
+        // Create sandbox
+        debug!("Creating CodeSandbox: {title}");
+        let sandbox_info = match client.create_sandbox(create_body).await {
+            Ok(info) => info,
+            Err(e) => return ToolExecutionResult::tool_error(e),
+        };
+
+        let sandbox_id = &sandbox_info.id;
+
+        // Start VM
+        debug!("Starting VM for sandbox: {sandbox_id}");
+        let vm_info = match client.start_vm(sandbox_id, None).await {
+            Ok(info) => info,
+            Err(e) => return ToolExecutionResult::tool_error(e),
+        };
+
+        let workspace_path = vm_info
+            .workspace_path
+            .unwrap_or_else(|| "/project".to_string());
+
+        // Save state
+        let state = SandboxState {
+            sandbox_id: sandbox_id.clone(),
+            pitcher_url: vm_info.pitcher_url.clone(),
+            pitcher_token: vm_info.pitcher_token.clone(),
+            workspace_path: workspace_path.clone(),
+            started_at: chrono::Utc::now().to_rfc3339(),
+        };
+        if let Err(e) = save_sandbox_state(context, &state).await {
+            return e;
+        }
+
+        // Optionally upload files
+        let mut uploaded_count = 0;
+        if let Some(files) = arguments.get("upload_files").and_then(|v| v.as_array()) {
+            let file_store = match context.file_store.as_ref() {
+                Some(fs) => fs,
+                None => {
+                    return ToolExecutionResult::tool_error(
+                        "File store not available for file upload",
+                    );
+                }
+            };
+
+            for file_spec in files {
+                let session_path = match file_spec.get("session_path").and_then(|v| v.as_str()) {
+                    Some(p) => p,
+                    None => continue,
+                };
+                let sandbox_path = match file_spec.get("sandbox_path").and_then(|v| v.as_str()) {
+                    Some(p) => p,
+                    None => continue,
+                };
+
+                // Read from session storage
+                match file_store.read_file(context.session_id, session_path).await {
+                    Ok(Some(file)) => {
+                        // Write to sandbox
+                        let content = file.content.unwrap_or_default();
+                        if let Err(e) = client
+                            .file_write(
+                                &vm_info.pitcher_url,
+                                &vm_info.pitcher_token,
+                                sandbox_path,
+                                &content,
+                            )
+                            .await
+                        {
+                            warn!("Failed to upload {session_path} to sandbox: {e}");
+                        } else {
+                            uploaded_count += 1;
+                        }
+                    }
+                    Ok(None) => {
+                        warn!("File not found in session storage: {session_path}");
+                    }
+                    Err(e) => {
+                        warn!("Failed to read {session_path}: {e}");
+                    }
+                }
+            }
+        }
+
+        ToolExecutionResult::success(json!({
+            "sandbox_id": sandbox_id,
+            "status": "running",
+            "workspace_path": workspace_path,
+            "files_uploaded": uploaded_count
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// CsbExecTool
+// ============================================================================
+
+pub struct CsbExecTool;
+
+#[async_trait]
+impl Tool for CsbExecTool {
+    fn name(&self) -> &str {
+        "csb_exec"
+    }
+
+    fn description(&self) -> &str {
+        "Execute a shell command in a CodeSandbox VM. Set wait=true (default) to get output, \
+         or wait=false to get an exec_id for polling with csb_exec_status."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "sandbox_id": {
+                    "type": "string",
+                    "description": "Sandbox ID to execute in"
+                },
+                "command": {
+                    "type": "string",
+                    "description": "Shell command to execute (e.g., 'python app.py')"
+                },
+                "wait": {
+                    "type": "boolean",
+                    "description": "Wait for completion and return output (default: true). Set false for long-running commands."
+                }
+            },
+            "required": ["sandbox_id", "command"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "csb_exec requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let sandbox_id = match required_str(&arguments, "sandbox_id") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+        let command = match required_str(&arguments, "command") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+        let wait = arguments
+            .get("wait")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+
+        let api_key = match get_api_key(context).await {
+            Ok(k) => k,
+            Err(e) => return e,
+        };
+        let state = match get_sandbox_state(context, sandbox_id).await {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let client = CodeSandboxClient::new(api_key);
+
+        // Parse command into shell invocation
+        let cmd_parts = vec!["bash".to_string(), "-c".to_string(), command.to_string()];
+
+        debug!("Executing in sandbox {sandbox_id}: {command}");
+        let exec_info = match client
+            .exec_create(&state.pitcher_url, &state.pitcher_token, cmd_parts)
+            .await
+        {
+            Ok(info) => info,
+            Err(e) => return ToolExecutionResult::tool_error(e),
+        };
+
+        if !wait {
+            return ToolExecutionResult::success(json!({
+                "exec_id": exec_info.id,
+                "status": exec_info.status,
+                "message": "Command started. Use csb_exec_status to check progress."
+            }));
+        }
+
+        // Poll until completion
+        let start = std::time::Instant::now();
+        loop {
+            if start.elapsed() > EXEC_POLL_MAX_WAIT {
+                return ToolExecutionResult::success(json!({
+                    "exec_id": exec_info.id,
+                    "status": "timeout",
+                    "message": "Command still running after timeout. Use csb_exec_status to check."
+                }));
+            }
+
+            tokio::time::sleep(EXEC_POLL_INTERVAL).await;
+
+            match client
+                .exec_get(&state.pitcher_url, &state.pitcher_token, &exec_info.id)
+                .await
+            {
+                Ok(status) => {
+                    let is_done = status.status == "finished"
+                        || status.status == "exited"
+                        || status.status == "error"
+                        || status.exit_code.is_some();
+
+                    if is_done {
+                        // Get output
+                        let output = client
+                            .exec_get_output(
+                                &state.pitcher_url,
+                                &state.pitcher_token,
+                                &exec_info.id,
+                            )
+                            .await
+                            .unwrap_or_default();
+
+                        return ToolExecutionResult::success(json!({
+                            "exec_id": exec_info.id,
+                            "status": status.status,
+                            "exit_code": status.exit_code,
+                            "output": output
+                        }));
+                    }
+                }
+                Err(e) => {
+                    warn!("Error polling exec status: {e}");
+                }
+            }
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// CsbExecStatusTool
+// ============================================================================
+
+pub struct CsbExecStatusTool;
+
+#[async_trait]
+impl Tool for CsbExecStatusTool {
+    fn name(&self) -> &str {
+        "csb_exec_status"
+    }
+
+    fn description(&self) -> &str {
+        "Check execution status and get output for a command started with csb_exec (wait=false)."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "sandbox_id": {
+                    "type": "string",
+                    "description": "Sandbox ID"
+                },
+                "exec_id": {
+                    "type": "string",
+                    "description": "Execution ID returned by csb_exec"
+                }
+            },
+            "required": ["sandbox_id", "exec_id"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "csb_exec_status requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let sandbox_id = match required_str(&arguments, "sandbox_id") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+        let exec_id = match required_str(&arguments, "exec_id") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let api_key = match get_api_key(context).await {
+            Ok(k) => k,
+            Err(e) => return e,
+        };
+        let state = match get_sandbox_state(context, sandbox_id).await {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let client = CodeSandboxClient::new(api_key);
+
+        let exec_info = match client
+            .exec_get(&state.pitcher_url, &state.pitcher_token, exec_id)
+            .await
+        {
+            Ok(info) => info,
+            Err(e) => return ToolExecutionResult::tool_error(e),
+        };
+
+        let output = client
+            .exec_get_output(&state.pitcher_url, &state.pitcher_token, exec_id)
+            .await
+            .unwrap_or_default();
+
+        ToolExecutionResult::success(json!({
+            "exec_id": exec_info.id,
+            "status": exec_info.status,
+            "exit_code": exec_info.exit_code,
+            "output": output
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// CsbReadFileTool
+// ============================================================================
+
+pub struct CsbReadFileTool;
+
+#[async_trait]
+impl Tool for CsbReadFileTool {
+    fn name(&self) -> &str {
+        "csb_read_file"
+    }
+
+    fn description(&self) -> &str {
+        "Read a file from a CodeSandbox VM filesystem."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "sandbox_id": {
+                    "type": "string",
+                    "description": "Sandbox ID"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Absolute path to file in sandbox (e.g., '/project/main.py')"
+                }
+            },
+            "required": ["sandbox_id", "path"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "csb_read_file requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let sandbox_id = match required_str(&arguments, "sandbox_id") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+        let path = match required_str(&arguments, "path") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let api_key = match get_api_key(context).await {
+            Ok(k) => k,
+            Err(e) => return e,
+        };
+        let state = match get_sandbox_state(context, sandbox_id).await {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let client = CodeSandboxClient::new(api_key);
+
+        match client
+            .file_read(&state.pitcher_url, &state.pitcher_token, path)
+            .await
+        {
+            Ok(content) => ToolExecutionResult::success(json!({
+                "path": content.path,
+                "content": content.content
+            })),
+            Err(e) => ToolExecutionResult::tool_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// CsbWriteFileTool
+// ============================================================================
+
+pub struct CsbWriteFileTool;
+
+#[async_trait]
+impl Tool for CsbWriteFileTool {
+    fn name(&self) -> &str {
+        "csb_write_file"
+    }
+
+    fn description(&self) -> &str {
+        "Write content to a file in a CodeSandbox VM filesystem."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "sandbox_id": {
+                    "type": "string",
+                    "description": "Sandbox ID"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Absolute path for file in sandbox (e.g., '/project/main.py')"
+                },
+                "content": {
+                    "type": "string",
+                    "description": "File content to write"
+                }
+            },
+            "required": ["sandbox_id", "path", "content"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "csb_write_file requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let sandbox_id = match required_str(&arguments, "sandbox_id") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+        let path = match required_str(&arguments, "path") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+        let content = match required_str(&arguments, "content") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let api_key = match get_api_key(context).await {
+            Ok(k) => k,
+            Err(e) => return e,
+        };
+        let state = match get_sandbox_state(context, sandbox_id).await {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let client = CodeSandboxClient::new(api_key);
+
+        match client
+            .file_write(&state.pitcher_url, &state.pitcher_token, path, content)
+            .await
+        {
+            Ok(()) => ToolExecutionResult::success(json!({
+                "path": path,
+                "success": true
+            })),
+            Err(e) => ToolExecutionResult::tool_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// CsbDownloadWorkspaceTool
+// ============================================================================
+
+pub struct CsbDownloadWorkspaceTool;
+
+#[async_trait]
+impl Tool for CsbDownloadWorkspaceTool {
+    fn name(&self) -> &str {
+        "csb_download_workspace"
+    }
+
+    fn description(&self) -> &str {
+        "Download the entire sandbox workspace to session file storage."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "sandbox_id": {
+                    "type": "string",
+                    "description": "Sandbox ID"
+                },
+                "sandbox_path": {
+                    "type": "string",
+                    "description": "Root path in sandbox to download (default: workspace path)"
+                },
+                "session_path": {
+                    "type": "string",
+                    "description": "Destination path in session storage (default: /workspace)"
+                }
+            },
+            "required": ["sandbox_id"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "csb_download_workspace requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let sandbox_id = match required_str(&arguments, "sandbox_id") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let api_key = match get_api_key(context).await {
+            Ok(k) => k,
+            Err(e) => return e,
+        };
+        let state = match get_sandbox_state(context, sandbox_id).await {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let file_store = match context.file_store.as_ref() {
+            Some(fs) => fs,
+            None => {
+                return ToolExecutionResult::tool_error(
+                    "File store not available for workspace download",
+                );
+            }
+        };
+
+        let sandbox_root = arguments
+            .get("sandbox_path")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&state.workspace_path);
+        let session_root = arguments
+            .get("session_path")
+            .and_then(|v| v.as_str())
+            .unwrap_or("/workspace");
+
+        let client = CodeSandboxClient::new(api_key);
+
+        // Recursively list and download files
+        let mut downloaded = 0u64;
+        let mut skipped = 0u64;
+        let mut errors = Vec::new();
+
+        let mut dirs_to_visit = vec![sandbox_root.to_string()];
+
+        while let Some(dir_path) = dirs_to_visit.pop() {
+            let entries = match client
+                .dir_list(&state.pitcher_url, &state.pitcher_token, &dir_path)
+                .await
+            {
+                Ok(e) => e,
+                Err(e) => {
+                    errors.push(format!("Failed to list {dir_path}: {e}"));
+                    continue;
+                }
+            };
+
+            for entry in entries {
+                let full_path = if dir_path.ends_with('/') {
+                    format!("{}{}", dir_path, entry.name)
+                } else {
+                    format!("{}/{}", dir_path, entry.name)
+                };
+
+                let is_dir = entry
+                    .entry_type
+                    .as_deref()
+                    .map(|t| t == "directory" || t == "dir")
+                    .unwrap_or(false);
+
+                if is_dir {
+                    dirs_to_visit.push(full_path);
+                } else {
+                    // Download file
+                    match client
+                        .file_read(&state.pitcher_url, &state.pitcher_token, &full_path)
+                        .await
+                    {
+                        Ok(content) => {
+                            // Compute session destination path
+                            let relative =
+                                full_path.strip_prefix(sandbox_root).unwrap_or(&full_path);
+                            let session_dest = format!(
+                                "{}{}",
+                                session_root.trim_end_matches('/'),
+                                if relative.starts_with('/') {
+                                    relative.to_string()
+                                } else {
+                                    format!("/{relative}")
+                                }
+                            );
+
+                            match file_store
+                                .write_file(
+                                    context.session_id,
+                                    &session_dest,
+                                    &content.content,
+                                    "utf-8",
+                                )
+                                .await
+                            {
+                                Ok(_) => downloaded += 1,
+                                Err(e) => {
+                                    errors.push(format!("Failed to write {session_dest}: {e}"));
+                                    skipped += 1;
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            debug!("Skipping {full_path}: {e}");
+                            skipped += 1;
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut result = json!({
+            "files_downloaded": downloaded,
+            "files_skipped": skipped
+        });
+        if !errors.is_empty() {
+            result["errors"] = json!(errors);
+        }
+
+        ToolExecutionResult::success(result)
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// CsbListSandboxesTool
+// ============================================================================
+
+pub struct CsbListSandboxesTool;
+
+#[async_trait]
+impl Tool for CsbListSandboxesTool {
+    fn name(&self) -> &str {
+        "csb_list_sandboxes"
+    }
+
+    fn description(&self) -> &str {
+        "List all CodeSandbox VMs created in this session."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "csb_list_sandboxes requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        _arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let states = match list_sandbox_states(context).await {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let sandboxes: Vec<Value> = states
+            .iter()
+            .map(|s| {
+                json!({
+                    "sandbox_id": s.sandbox_id,
+                    "started_at": s.started_at,
+                    "workspace_path": s.workspace_path
+                })
+            })
+            .collect();
+
+        ToolExecutionResult::success(json!({
+            "sandboxes": sandboxes,
+            "count": sandboxes.len()
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// CsbManageSandboxTool
+// ============================================================================
+
+pub struct CsbManageSandboxTool;
+
+#[async_trait]
+impl Tool for CsbManageSandboxTool {
+    fn name(&self) -> &str {
+        "csb_manage_sandbox"
+    }
+
+    fn description(&self) -> &str {
+        "Manage sandbox lifecycle: shutdown, hibernate, or delete a CodeSandbox VM."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "sandbox_id": {
+                    "type": "string",
+                    "description": "Sandbox ID"
+                },
+                "action": {
+                    "type": "string",
+                    "enum": ["shutdown", "hibernate", "delete"],
+                    "description": "Action to perform: shutdown (stop VM), hibernate (save state), delete (remove permanently)"
+                }
+            },
+            "required": ["sandbox_id", "action"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "csb_manage_sandbox requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let sandbox_id = match required_str(&arguments, "sandbox_id") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+        let action = match required_str(&arguments, "action") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let api_key = match get_api_key(context).await {
+            Ok(k) => k,
+            Err(e) => return e,
+        };
+        // Verify sandbox exists in state
+        if let Err(e) = get_sandbox_state(context, sandbox_id).await {
+            return e;
+        }
+
+        let client = CodeSandboxClient::new(api_key);
+
+        let result = match action {
+            "shutdown" => client.shutdown_vm(sandbox_id).await,
+            "hibernate" => client.hibernate_vm(sandbox_id).await,
+            "delete" => {
+                let r = client.delete_vm(sandbox_id).await;
+                // Also remove state on delete
+                if r.is_ok() {
+                    let _ = delete_sandbox_state(context, sandbox_id).await;
+                }
+                r
+            }
+            _ => {
+                return ToolExecutionResult::tool_error(format!(
+                    "Invalid action: '{action}'. Must be one of: shutdown, hibernate, delete"
+                ));
+            }
+        };
+
+        match result {
+            Ok(()) => ToolExecutionResult::success(json!({
+                "sandbox_id": sandbox_id,
+                "action": action,
+                "success": true
+            })),
+            Err(e) => ToolExecutionResult::tool_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- Capability metadata tests ---
+
+    #[test]
+    fn test_capability_metadata() {
+        let cap = CodeSandboxCapability;
+        assert_eq!(cap.id(), "codesandbox");
+        assert_eq!(cap.name(), "[Experimental] CodeSandbox");
+        assert_eq!(cap.status(), CapabilityStatus::Available);
+        assert_eq!(cap.icon(), Some("cloud"));
+        assert_eq!(cap.category(), Some("Execution"));
+    }
+
+    #[test]
+    fn test_capability_has_all_tools() {
+        let cap = CodeSandboxCapability;
+        let tools = cap.tools();
+        assert_eq!(tools.len(), 8);
+
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(names.contains(&"csb_create_sandbox"));
+        assert!(names.contains(&"csb_exec"));
+        assert!(names.contains(&"csb_exec_status"));
+        assert!(names.contains(&"csb_read_file"));
+        assert!(names.contains(&"csb_write_file"));
+        assert!(names.contains(&"csb_download_workspace"));
+        assert!(names.contains(&"csb_list_sandboxes"));
+        assert!(names.contains(&"csb_manage_sandbox"));
+    }
+
+    #[test]
+    fn test_capability_has_system_prompt() {
+        let cap = CodeSandboxCapability;
+        let prompt = cap.system_prompt_addition().unwrap();
+        assert!(prompt.contains("csb_create_sandbox"));
+        assert!(prompt.contains("CSB_API_KEY"));
+        assert!(prompt.contains("EXPERIMENTAL"));
+        assert!(prompt.contains("csb_exec"));
+        assert!(prompt.contains("csb_download_workspace"));
+    }
+
+    #[test]
+    fn test_all_tools_require_context() {
+        let cap = CodeSandboxCapability;
+        for tool in cap.tools() {
+            assert!(
+                tool.requires_context(),
+                "Tool {} should require context",
+                tool.name()
+            );
+        }
+    }
+
+    #[test]
+    fn test_capability_dependencies() {
+        let cap = CodeSandboxCapability;
+        assert_eq!(cap.dependencies(), vec!["session_storage"]);
+    }
+
+    // --- State serialization tests ---
+
+    #[test]
+    fn test_sandbox_state_roundtrip() {
+        let state = SandboxState {
+            sandbox_id: "sb_123".to_string(),
+            pitcher_url: "https://pitcher-123.csb.app".to_string(),
+            pitcher_token: "tok_abc".to_string(),
+            workspace_path: "/project".to_string(),
+            started_at: "2026-02-13T10:00:00Z".to_string(),
+        };
+        let json = serde_json::to_string(&state).unwrap();
+        let deserialized: SandboxState = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.sandbox_id, "sb_123");
+        assert_eq!(deserialized.pitcher_url, "https://pitcher-123.csb.app");
+        assert_eq!(deserialized.pitcher_token, "tok_abc");
+        assert_eq!(deserialized.workspace_path, "/project");
+    }
+
+    #[test]
+    fn test_sandbox_state_with_special_chars() {
+        let state = SandboxState {
+            sandbox_id: "sb-test_123".to_string(),
+            pitcher_url: "https://pitcher.csb.app:8443/ws?token=abc&id=1".to_string(),
+            pitcher_token: "tok+abc/def==".to_string(),
+            workspace_path: "/home/user/my project".to_string(),
+            started_at: "2026-02-13T10:00:00+05:30".to_string(),
+        };
+        let json = serde_json::to_string(&state).unwrap();
+        let deserialized: SandboxState = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            deserialized.pitcher_url,
+            "https://pitcher.csb.app:8443/ws?token=abc&id=1"
+        );
+        assert_eq!(deserialized.pitcher_token, "tok+abc/def==");
+    }
+
+    // --- SSE parsing tests ---
+
+    #[test]
+    fn test_parse_sse_output_with_data_lines() {
+        let raw = "data: hello\ndata: world\n";
+        let output = parse_sse_output(raw);
+        assert_eq!(output, "hello\nworld\n");
+    }
+
+    #[test]
+    fn test_parse_sse_output_empty() {
+        let output = parse_sse_output("");
+        assert_eq!(output, "");
+    }
+
+    #[test]
+    fn test_parse_sse_output_json_with_output_field() {
+        let raw = r#"data: {"output":"line 1"}
+data: {"output":"line 2"}
+"#;
+        let output = parse_sse_output(raw);
+        assert_eq!(output, "line 1line 2");
+    }
+
+    #[test]
+    fn test_parse_sse_output_mixed_events() {
+        let raw = "event: message\ndata: first\n\nevent: done\ndata: second\n";
+        let output = parse_sse_output(raw);
+        assert_eq!(output, "first\nsecond\n");
+    }
+
+    #[test]
+    fn test_parse_sse_output_ignores_non_data_lines() {
+        let raw = "id: 1\nevent: test\nretry: 1000\ndata: actual data\n:comment\n";
+        let output = parse_sse_output(raw);
+        assert_eq!(output, "actual data\n");
+    }
+
+    // --- URL encoding tests ---
+
+    #[test]
+    fn test_encode_path_simple() {
+        assert_eq!(encode_path("/project/main.py"), "project/main.py");
+    }
+
+    #[test]
+    fn test_encode_path_with_spaces() {
+        let encoded = encode_path("/my project/file name.txt");
+        assert!(encoded.contains("my%20project"));
+        assert!(encoded.contains("file%20name.txt"));
+    }
+
+    #[test]
+    fn test_encode_path_preserves_slashes() {
+        assert_eq!(encode_path("/a/b/c/d.txt"), "a/b/c/d.txt");
+    }
+
+    // --- Error path tests ---
+
+    #[tokio::test]
+    async fn test_csb_exec_without_context() {
+        let tool = CsbExecTool;
+        let result = tool
+            .execute(json!({"sandbox_id": "test", "command": "ls"}))
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("requires context"));
+            }
+            _ => panic!("Expected tool error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_csb_create_sandbox_without_context() {
+        let tool = CsbCreateSandboxTool;
+        let result = tool.execute(json!({})).await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("requires context"));
+            }
+            _ => panic!("Expected tool error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_csb_exec_status_without_context() {
+        let tool = CsbExecStatusTool;
+        let result = tool
+            .execute(json!({"sandbox_id": "test", "exec_id": "e1"}))
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("requires context"));
+            }
+            _ => panic!("Expected tool error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_csb_read_file_without_context() {
+        let tool = CsbReadFileTool;
+        let result = tool
+            .execute(json!({"sandbox_id": "test", "path": "/test.txt"}))
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("requires context"));
+            }
+            _ => panic!("Expected tool error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_csb_write_file_without_context() {
+        let tool = CsbWriteFileTool;
+        let result = tool
+            .execute(json!({"sandbox_id": "test", "path": "/test.txt", "content": "hello"}))
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("requires context"));
+            }
+            _ => panic!("Expected tool error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_csb_download_workspace_without_context() {
+        let tool = CsbDownloadWorkspaceTool;
+        let result = tool.execute(json!({"sandbox_id": "test"})).await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("requires context"));
+            }
+            _ => panic!("Expected tool error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_csb_list_sandboxes_without_context() {
+        let tool = CsbListSandboxesTool;
+        let result = tool.execute(json!({})).await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("requires context"));
+            }
+            _ => panic!("Expected tool error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_csb_manage_sandbox_without_context() {
+        let tool = CsbManageSandboxTool;
+        let result = tool
+            .execute(json!({"sandbox_id": "test", "action": "shutdown"}))
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("requires context"));
+            }
+            _ => panic!("Expected tool error"),
+        }
+    }
+
+    // --- Parameter schema tests ---
+
+    #[test]
+    fn test_csb_exec_schema_has_required_fields() {
+        let tool = CsbExecTool;
+        let schema = tool.parameters_schema();
+        let required = schema["required"].as_array().unwrap();
+        let required_strs: Vec<&str> = required.iter().map(|v| v.as_str().unwrap()).collect();
+        assert!(required_strs.contains(&"sandbox_id"));
+        assert!(required_strs.contains(&"command"));
+    }
+
+    #[test]
+    fn test_csb_create_sandbox_schema_no_required() {
+        let tool = CsbCreateSandboxTool;
+        let schema = tool.parameters_schema();
+        // create has no required fields
+        assert!(schema.get("required").is_none());
+    }
+
+    #[test]
+    fn test_csb_manage_sandbox_schema_has_enum() {
+        let tool = CsbManageSandboxTool;
+        let schema = tool.parameters_schema();
+        let action_enum = &schema["properties"]["action"]["enum"];
+        let values: Vec<&str> = action_enum
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert!(values.contains(&"shutdown"));
+        assert!(values.contains(&"hibernate"));
+        assert!(values.contains(&"delete"));
+    }
+
+    // --- wiremock integration tests ---
+
+    mod client_tests {
+        use super::*;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        #[tokio::test]
+        async fn test_client_create_sandbox() {
+            let mock_server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/sandbox"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "data": {
+                        "id": "sb_test123",
+                        "title": "Test Sandbox"
+                    }
+                })))
+                .mount(&mock_server)
+                .await;
+
+            let client =
+                CodeSandboxClient::with_base_url("test_key".to_string(), mock_server.uri());
+            let result = client.create_sandbox(json!({"title": "Test"})).await;
+            assert!(result.is_ok());
+            let info = result.unwrap();
+            assert_eq!(info.id, "sb_test123");
+            assert_eq!(info.title, Some("Test Sandbox".to_string()));
+        }
+
+        #[tokio::test]
+        async fn test_client_start_vm() {
+            let mock_server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/vm/sb_test/start"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "data": {
+                        "pitcher_url": "https://pitcher.test.csb.app",
+                        "pitcher_token": "tok_test",
+                        "workspace_path": "/project"
+                    }
+                })))
+                .mount(&mock_server)
+                .await;
+
+            let client =
+                CodeSandboxClient::with_base_url("test_key".to_string(), mock_server.uri());
+            let result = client.start_vm("sb_test", None).await;
+            assert!(result.is_ok());
+            let info = result.unwrap();
+            assert_eq!(info.pitcher_url, "https://pitcher.test.csb.app");
+            assert_eq!(info.pitcher_token, "tok_test");
+            assert_eq!(info.workspace_path, Some("/project".to_string()));
+        }
+
+        #[tokio::test]
+        async fn test_client_shutdown_vm() {
+            let mock_server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/vm/sb_test/shutdown"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+                .mount(&mock_server)
+                .await;
+
+            let client =
+                CodeSandboxClient::with_base_url("test_key".to_string(), mock_server.uri());
+            let result = client.shutdown_vm("sb_test").await;
+            assert!(result.is_ok());
+        }
+
+        #[tokio::test]
+        async fn test_client_hibernate_vm() {
+            let mock_server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/vm/sb_test/hibernate"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+                .mount(&mock_server)
+                .await;
+
+            let client =
+                CodeSandboxClient::with_base_url("test_key".to_string(), mock_server.uri());
+            let result = client.hibernate_vm("sb_test").await;
+            assert!(result.is_ok());
+        }
+
+        #[tokio::test]
+        async fn test_client_delete_vm() {
+            let mock_server = MockServer::start().await;
+            Mock::given(method("DELETE"))
+                .and(path("/vm/sb_test"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+                .mount(&mock_server)
+                .await;
+
+            let client =
+                CodeSandboxClient::with_base_url("test_key".to_string(), mock_server.uri());
+            let result = client.delete_vm("sb_test").await;
+            assert!(result.is_ok());
+        }
+
+        #[tokio::test]
+        async fn test_client_exec_create() {
+            let mock_server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/api/v1/execs"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "id": "exec_1",
+                    "status": "running",
+                    "exitCode": null
+                })))
+                .mount(&mock_server)
+                .await;
+
+            let client =
+                CodeSandboxClient::with_base_url("test_key".to_string(), mock_server.uri());
+            let result = client
+                .exec_create(
+                    &mock_server.uri(),
+                    "tok_test",
+                    vec!["bash".into(), "-c".into(), "echo hi".into()],
+                )
+                .await;
+            assert!(result.is_ok());
+            let info = result.unwrap();
+            assert_eq!(info.id, "exec_1");
+            assert_eq!(info.status, "running");
+        }
+
+        #[tokio::test]
+        async fn test_client_exec_get() {
+            let mock_server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/api/v1/execs/exec_1"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "id": "exec_1",
+                    "status": "exited",
+                    "exitCode": 0
+                })))
+                .mount(&mock_server)
+                .await;
+
+            let client =
+                CodeSandboxClient::with_base_url("test_key".to_string(), mock_server.uri());
+            let result = client
+                .exec_get(&mock_server.uri(), "tok_test", "exec_1")
+                .await;
+            assert!(result.is_ok());
+            let info = result.unwrap();
+            assert_eq!(info.status, "exited");
+            assert_eq!(info.exit_code, Some(0));
+        }
+
+        #[tokio::test]
+        async fn test_client_exec_get_output() {
+            let mock_server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/api/v1/execs/exec_1/io"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_string("data: hello world\ndata: done\n"),
+                )
+                .mount(&mock_server)
+                .await;
+
+            let client =
+                CodeSandboxClient::with_base_url("test_key".to_string(), mock_server.uri());
+            let result = client
+                .exec_get_output(&mock_server.uri(), "tok_test", "exec_1")
+                .await;
+            assert!(result.is_ok());
+            let output = result.unwrap();
+            assert!(output.contains("hello world"));
+            assert!(output.contains("done"));
+        }
+
+        #[tokio::test]
+        async fn test_client_file_read() {
+            let mock_server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/api/v1/files/project/main.py"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "path": "/project/main.py",
+                    "content": "print('hello')"
+                })))
+                .mount(&mock_server)
+                .await;
+
+            let client =
+                CodeSandboxClient::with_base_url("test_key".to_string(), mock_server.uri());
+            let result = client
+                .file_read(&mock_server.uri(), "tok_test", "/project/main.py")
+                .await;
+            assert!(result.is_ok());
+            let content = result.unwrap();
+            assert_eq!(content.content, "print('hello')");
+        }
+
+        #[tokio::test]
+        async fn test_client_file_write() {
+            let mock_server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/api/v1/files/project/main.py"))
+                .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+                    "path": "/project/main.py",
+                    "content": "print('hello')"
+                })))
+                .mount(&mock_server)
+                .await;
+
+            let client =
+                CodeSandboxClient::with_base_url("test_key".to_string(), mock_server.uri());
+            let result = client
+                .file_write(
+                    &mock_server.uri(),
+                    "tok_test",
+                    "/project/main.py",
+                    "print('hello')",
+                )
+                .await;
+            assert!(result.is_ok());
+        }
+
+        #[tokio::test]
+        async fn test_client_dir_list() {
+            let mock_server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/api/v1/directories/project"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                    {"name": "main.py", "type": "file"},
+                    {"name": "src", "type": "directory"}
+                ])))
+                .mount(&mock_server)
+                .await;
+
+            let client =
+                CodeSandboxClient::with_base_url("test_key".to_string(), mock_server.uri());
+            let result = client
+                .dir_list(&mock_server.uri(), "tok_test", "/project")
+                .await;
+            assert!(result.is_ok());
+            let entries = result.unwrap();
+            assert_eq!(entries.len(), 2);
+            assert_eq!(entries[0].name, "main.py");
+            assert_eq!(entries[1].name, "src");
+        }
+
+        // --- Error response tests ---
+
+        #[tokio::test]
+        async fn test_client_404_error() {
+            let mock_server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/sandbox/nonexistent"))
+                .respond_with(
+                    ResponseTemplate::new(404).set_body_string("{\"error\":\"Sandbox not found\"}"),
+                )
+                .mount(&mock_server)
+                .await;
+
+            let client =
+                CodeSandboxClient::with_base_url("test_key".to_string(), mock_server.uri());
+            let result = client
+                .management_request(reqwest::Method::GET, "/sandbox/nonexistent", None)
+                .await;
+            assert!(result.is_err());
+            let err = result.unwrap_err();
+            assert!(err.contains("404"));
+        }
+
+        #[tokio::test]
+        async fn test_client_401_error() {
+            let mock_server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/sandbox"))
+                .respond_with(
+                    ResponseTemplate::new(401).set_body_string("{\"error\":\"Unauthorized\"}"),
+                )
+                .mount(&mock_server)
+                .await;
+
+            let client = CodeSandboxClient::with_base_url("bad_key".to_string(), mock_server.uri());
+            let result = client.create_sandbox(json!({"title": "Test"})).await;
+            assert!(result.is_err());
+            let err = result.unwrap_err();
+            assert!(err.contains("401"));
+        }
+
+        #[tokio::test]
+        async fn test_client_500_error() {
+            let mock_server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/vm/sb_test/start"))
+                .respond_with(ResponseTemplate::new(500).set_body_string("Internal Server Error"))
+                .mount(&mock_server)
+                .await;
+
+            let client =
+                CodeSandboxClient::with_base_url("test_key".to_string(), mock_server.uri());
+            let result = client.start_vm("sb_test", None).await;
+            assert!(result.is_err());
+            let err = result.unwrap_err();
+            assert!(err.contains("500"));
+        }
+
+        #[tokio::test]
+        async fn test_client_malformed_response() {
+            let mock_server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/sandbox"))
+                .respond_with(ResponseTemplate::new(200).set_body_string("not valid json"))
+                .mount(&mock_server)
+                .await;
+
+            let client =
+                CodeSandboxClient::with_base_url("test_key".to_string(), mock_server.uri());
+            let result = client.create_sandbox(json!({"title": "Test"})).await;
+            assert!(result.is_err());
+            let err = result.unwrap_err();
+            assert!(err.contains("Invalid JSON"));
+        }
+    }
+}

--- a/crates/core/src/capabilities/codesandbox.rs
+++ b/crates/core/src/capabilities/codesandbox.rs
@@ -113,28 +113,9 @@ pub struct SandboxState {
     pub started_at: String,
 }
 
-// ============================================================================
-// Template alias resolution
-// ============================================================================
-
-/// Map friendly template names to CodeSandbox template IDs.
-/// Not all templates resolve by name — some need their opaque ID.
-/// Source: https://codesandbox.io/docs/sdk/template-library
-fn resolve_template_alias(name: &str) -> &str {
-    match name {
-        "javascript" => "3l5fg9",
-        "node" | "node-http-server" => "node",
-        "nodejs" | "node.js" => "k8dsq1",
-        "python" => "in2qez",
-        "rust" => "rk69p3",
-        "universal" => "pcz35m",
-        "go" => "ej14tt",
-        "deno" => "kc6kgh",
-        "bun" => "0uzq6f",
-        "docker" => "hsd8ke",
-        other => other,
-    }
-}
+// NOTE: Template alias resolution was removed. The CodeSandbox `template` field
+// caused 500 errors from their API for most template IDs (tested 2026-02-15).
+// Sandboxes created without a template work fine. See specs/codesandbox.md for details.
 
 // ============================================================================
 // CodeSandboxClient - HTTP client for CodeSandbox APIs
@@ -777,10 +758,6 @@ impl Tool for CsbCreateSandboxTool {
                     "type": "string",
                     "description": "Sandbox title (optional)"
                 },
-                "template": {
-                    "type": "string",
-                    "description": "Template to fork from (optional, defaults to universal). Known: javascript, python, node, rust, go, deno, bun, docker, universal"
-                },
                 "upload_files": {
                     "type": "array",
                     "description": "Files to upload from session storage (optional)",
@@ -821,22 +798,13 @@ impl Tool for CsbCreateSandboxTool {
             .get("title")
             .and_then(|v| v.as_str())
             .unwrap_or("Everruns Sandbox");
-        let mut create_body = json!({
+        let create_body = json!({
             "title": title,
             "privacy": 2,
             "runtime": "vm",
             "settings": { "use_pint": true },
             "hibernationTimeoutSeconds": HIBERNATE_TIMEOUT_SECS,
         });
-        if let Some(template) = arguments
-            .get("template")
-            .and_then(|v| v.as_str())
-            .filter(|s| !s.is_empty())
-        {
-            // Some templates require their ID rather than name
-            let resolved = resolve_template_alias(template);
-            create_body["template"] = json!(resolved);
-        }
 
         // Create sandbox
         debug!("Creating CodeSandbox: {title}");
@@ -1728,21 +1696,6 @@ mod tests {
         assert!(prompt.contains("Prerequisite"));
         // Should NOT duplicate workflow steps (that's the agent's job)
         assert!(!prompt.contains("Set API key (once per session)"));
-    }
-
-    #[test]
-    fn test_resolve_template_alias() {
-        assert_eq!(resolve_template_alias("python"), "in2qez");
-        assert_eq!(resolve_template_alias("javascript"), "3l5fg9");
-        assert_eq!(resolve_template_alias("go"), "ej14tt");
-        assert_eq!(resolve_template_alias("rust"), "rk69p3");
-        assert_eq!(resolve_template_alias("universal"), "pcz35m");
-        assert_eq!(resolve_template_alias("deno"), "kc6kgh");
-        assert_eq!(resolve_template_alias("bun"), "0uzq6f");
-        assert_eq!(resolve_template_alias("node"), "node");
-        assert_eq!(resolve_template_alias("docker"), "hsd8ke");
-        // Unknown names pass through unchanged
-        assert_eq!(resolve_template_alias("custom-abc123"), "custom-abc123");
     }
 
     #[test]

--- a/crates/core/src/capabilities/codesandbox.rs
+++ b/crates/core/src/capabilities/codesandbox.rs
@@ -39,6 +39,8 @@ const EXEC_POLL_MAX_WAIT: Duration = Duration::from_secs(120);
 const SSE_READ_TIMEOUT: Duration = Duration::from_secs(5);
 const PINT_READY_POLL_INTERVAL: Duration = Duration::from_secs(2);
 const PINT_READY_MAX_WAIT: Duration = Duration::from_secs(30);
+/// Auto-hibernate after 5 minutes of inactivity (safety net)
+const HIBERNATE_TIMEOUT_SECS: u64 = 300;
 
 // ============================================================================
 // API Response Types
@@ -820,6 +822,7 @@ impl Tool for CsbCreateSandboxTool {
             "privacy": 2,
             "runtime": "vm",
             "settings": { "use_pint": true },
+            "hibernationTimeoutSeconds": HIBERNATE_TIMEOUT_SECS,
         });
         if let Some(template) = arguments
             .get("template")

--- a/crates/core/src/capabilities/codesandbox.rs
+++ b/crates/core/src/capabilities/codesandbox.rs
@@ -692,42 +692,23 @@ impl Capability for CodeSandboxCapability {
 
     fn system_prompt_addition(&self) -> Option<&str> {
         Some(
-            r#"You have access to CodeSandbox for running code in cloud-based sandbox VMs.
-Each sandbox is an isolated Firecracker microVM with a full Linux environment and network access.
+            r#"## CodeSandbox (Experimental)
 
-IMPORTANT: This is an EXPERIMENTAL capability.
+Cloud-based sandbox VMs via CodeSandbox. Each sandbox is an isolated Firecracker microVM with full Linux and network access.
 
-## Setup
+Prerequisite: CSB_API_KEY must be set in session secrets before using any sandbox tool.
 
-Set your CodeSandbox API key first (get one at https://codesandbox.io/t/api):
-  secret_store set CSB_API_KEY <your-api-key>
+Tools:
+- `csb_create_sandbox` - Create and start a new sandbox VM
+- `csb_exec` - Run a shell command (`wait: true` for output, `wait: false` for async)
+- `csb_exec_status` - Poll async execution status/output
+- `csb_read_file` / `csb_write_file` - Read/write files in sandbox
+- `csb_download_workspace` - Download sandbox workspace to session storage
+- `csb_list_sandboxes` - List session sandboxes
+- `csb_manage_sandbox` - Shutdown, hibernate, or delete a sandbox
 
-## Tools
-
-- `csb_create_sandbox` - Create a new sandbox VM. Optionally upload files from session storage.
-- `csb_exec` - Execute a shell command. Set `wait: true` (default) to get output, or `wait: false` for async.
-- `csb_exec_status` - Check async execution status and get output.
-- `csb_read_file` - Read a file from sandbox filesystem.
-- `csb_write_file` - Write a file to sandbox filesystem.
-- `csb_download_workspace` - Download entire sandbox workspace to session file storage.
-- `csb_list_sandboxes` - List all sandboxes in this session.
-- `csb_manage_sandbox` - Shutdown, hibernate, or delete a sandbox.
-
-## Workflow
-
-1. Set API key (once per session)
-2. Create sandbox: `csb_create_sandbox`
-3. Write files / execute commands using the sandbox_id
-4. For long-running commands: `csb_exec` with `wait: false`, then poll `csb_exec_status`
-5. Download results: `csb_download_workspace`
-6. Clean up: `csb_manage_sandbox` with action "shutdown"
-
-## Tips
-
-- All tools require a `sandbox_id` (except csb_create_sandbox and csb_list_sandboxes)
-- You can manage multiple sandboxes simultaneously
-- Use `bash -c "..."` for complex shell commands
-- Sandboxes persist until explicitly shut down or the session ends"#,
+All tools except `csb_create_sandbox` and `csb_list_sandboxes` require a `sandbox_id`.
+Sandboxes auto-hibernate after 5 minutes of inactivity. Always shut down when done."#,
         )
     }
 
@@ -1716,9 +1697,12 @@ mod tests {
         let prompt = cap.system_prompt_addition().unwrap();
         assert!(prompt.contains("csb_create_sandbox"));
         assert!(prompt.contains("CSB_API_KEY"));
-        assert!(prompt.contains("EXPERIMENTAL"));
+        assert!(prompt.contains("Experimental"));
         assert!(prompt.contains("csb_exec"));
         assert!(prompt.contains("csb_download_workspace"));
+        assert!(prompt.contains("Prerequisite"));
+        // Should NOT duplicate workflow steps (that's the agent's job)
+        assert!(!prompt.contains("Set API key (once per session)"));
     }
 
     #[test]

--- a/crates/core/src/capabilities/codesandbox.rs
+++ b/crates/core/src/capabilities/codesandbox.rs
@@ -690,7 +690,8 @@ Tools:
 - `csb_manage_sandbox` - Shutdown, hibernate, or delete a sandbox
 
 All tools except `csb_create_sandbox` and `csb_list_sandboxes` require a `sandbox_id`.
-Sandboxes auto-hibernate after 5 minutes of inactivity. Always shut down when done."#,
+Sandboxes auto-hibernate after 5 minutes of inactivity.
+Always DELETE sandboxes when done (shutdown/hibernate leave them on the dashboard)."#,
         )
     }
 
@@ -1553,7 +1554,7 @@ impl Tool for CsbManageSandboxTool {
                 "action": {
                     "type": "string",
                     "enum": ["shutdown", "hibernate", "delete"],
-                    "description": "Action to perform: shutdown (stop VM), hibernate (save state), delete (remove permanently)"
+                    "description": "Action to perform: shutdown (stop and delete VM), hibernate (save state, keeps on dashboard), delete (same as shutdown)"
                 }
             },
             "required": ["sandbox_id", "action"],
@@ -1593,16 +1594,17 @@ impl Tool for CsbManageSandboxTool {
         let client = CodeSandboxClient::new(api_key);
 
         let result = match action {
-            "shutdown" => client.shutdown_vm(sandbox_id).await,
-            "hibernate" => client.hibernate_vm(sandbox_id).await,
-            "delete" => {
+            "shutdown" | "delete" => {
+                // Both shutdown and delete fully remove the sandbox.
+                // Plain shutdown leaves sandboxes lingering on the dashboard,
+                // so we always delete to clean up.
                 let r = client.delete_vm(sandbox_id).await;
-                // Also remove state on delete
                 if r.is_ok() {
                     let _ = delete_sandbox_state(context, sandbox_id).await;
                 }
                 r
             }
+            "hibernate" => client.hibernate_vm(sandbox_id).await,
             _ => {
                 return ToolExecutionResult::tool_error(format!(
                     "Invalid action: '{action}'. Must be one of: shutdown, hibernate, delete"

--- a/crates/core/src/capabilities/codesandbox.rs
+++ b/crates/core/src/capabilities/codesandbox.rs
@@ -132,14 +132,6 @@ fn resolve_template_alias(name: &str) -> &str {
         "deno" => "kc6kgh",
         "bun" => "0uzq6f",
         "docker" => "hsd8ke",
-        "nextjs" | "next.js" => "fxis37",
-        "react" | "react-js" => "kd848j",
-        "react-ts" => "9qputt",
-        "vue" => "pb6sit",
-        "angular" => "angular",
-        "astro" => "j1qiqf",
-        "jupyter" => "29wlwy",
-        "flask" | "python-flask" => "4gppm4",
         other => other,
     }
 }
@@ -787,7 +779,7 @@ impl Tool for CsbCreateSandboxTool {
                 },
                 "template": {
                     "type": "string",
-                    "description": "Template to fork from (optional, defaults to universal). Known: javascript, python, node, rust, go, deno, bun, docker, nextjs, react, react-ts, vue, angular, astro, jupyter, flask"
+                    "description": "Template to fork from (optional, defaults to universal). Known: javascript, python, node, rust, go, deno, bun, docker, universal"
                 },
                 "upload_files": {
                     "type": "array",

--- a/crates/core/src/capabilities/codesandbox.rs
+++ b/crates/core/src/capabilities/codesandbox.rs
@@ -114,6 +114,37 @@ pub struct SandboxState {
 }
 
 // ============================================================================
+// Template alias resolution
+// ============================================================================
+
+/// Map friendly template names to CodeSandbox template IDs.
+/// Not all templates resolve by name — some need their opaque ID.
+/// Source: https://codesandbox.io/docs/sdk/template-library
+fn resolve_template_alias(name: &str) -> &str {
+    match name {
+        "javascript" => "3l5fg9",
+        "node" | "node-http-server" => "node",
+        "nodejs" | "node.js" => "k8dsq1",
+        "python" => "in2qez",
+        "rust" => "rk69p3",
+        "universal" => "pcz35m",
+        "go" => "ej14tt",
+        "deno" => "kc6kgh",
+        "bun" => "0uzq6f",
+        "docker" => "hsd8ke",
+        "nextjs" | "next.js" => "fxis37",
+        "react" | "react-js" => "kd848j",
+        "react-ts" => "9qputt",
+        "vue" => "pb6sit",
+        "angular" => "angular",
+        "astro" => "j1qiqf",
+        "jupyter" => "29wlwy",
+        "flask" | "python-flask" => "4gppm4",
+        other => other,
+    }
+}
+
+// ============================================================================
 // CodeSandboxClient - HTTP client for CodeSandbox APIs
 // ============================================================================
 
@@ -756,7 +787,7 @@ impl Tool for CsbCreateSandboxTool {
                 },
                 "template": {
                     "type": "string",
-                    "description": "Template ID to fork from (optional)"
+                    "description": "Template to fork from (optional, defaults to universal). Known: javascript, python, node, rust, go, deno, bun, docker, nextjs, react, react-ts, vue, angular, astro, jupyter, flask"
                 },
                 "upload_files": {
                     "type": "array",
@@ -810,7 +841,9 @@ impl Tool for CsbCreateSandboxTool {
             .and_then(|v| v.as_str())
             .filter(|s| !s.is_empty())
         {
-            create_body["template"] = json!(template);
+            // Some templates require their ID rather than name
+            let resolved = resolve_template_alias(template);
+            create_body["template"] = json!(resolved);
         }
 
         // Create sandbox
@@ -1703,6 +1736,21 @@ mod tests {
         assert!(prompt.contains("Prerequisite"));
         // Should NOT duplicate workflow steps (that's the agent's job)
         assert!(!prompt.contains("Set API key (once per session)"));
+    }
+
+    #[test]
+    fn test_resolve_template_alias() {
+        assert_eq!(resolve_template_alias("python"), "in2qez");
+        assert_eq!(resolve_template_alias("javascript"), "3l5fg9");
+        assert_eq!(resolve_template_alias("go"), "ej14tt");
+        assert_eq!(resolve_template_alias("rust"), "rk69p3");
+        assert_eq!(resolve_template_alias("universal"), "pcz35m");
+        assert_eq!(resolve_template_alias("deno"), "kc6kgh");
+        assert_eq!(resolve_template_alias("bun"), "0uzq6f");
+        assert_eq!(resolve_template_alias("node"), "node");
+        assert_eq!(resolve_template_alias("docker"), "hsd8ke");
+        // Unknown names pass through unchanged
+        assert_eq!(resolve_template_alias("custom-abc123"), "custom-abc123");
     }
 
     #[test]

--- a/crates/core/src/capabilities/codesandbox.rs
+++ b/crates/core/src/capabilities/codesandbox.rs
@@ -37,6 +37,8 @@ const CSB_SANDBOX_SECRET_PREFIX: &str = "csb_sandbox:";
 const EXEC_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const EXEC_POLL_MAX_WAIT: Duration = Duration::from_secs(120);
 const SSE_READ_TIMEOUT: Duration = Duration::from_secs(5);
+const PINT_READY_POLL_INTERVAL: Duration = Duration::from_secs(2);
+const PINT_READY_MAX_WAIT: Duration = Duration::from_secs(30);
 
 // ============================================================================
 // API Response Types
@@ -53,6 +55,12 @@ pub struct VmStartResponse {
     pub pitcher_url: String,
     pub pitcher_token: String,
     pub workspace_path: Option<String>,
+    /// Pint API URL (newer API, preferred when use_pint is true)
+    pub pint_url: Option<String>,
+    /// Pint API token (newer API, preferred when use_pint is true)
+    pub pint_token: Option<String>,
+    /// Whether to use pint_url/pint_token instead of pitcher_url/pitcher_token
+    pub use_pint: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -81,10 +89,24 @@ pub struct DirEntry {
 // ============================================================================
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PreviewTokenResponse {
+    pub token: PreviewTokenInfo,
+    pub sandbox_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PreviewTokenInfo {
+    pub token: String,
+    pub token_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SandboxState {
     pub sandbox_id: String,
-    pub pitcher_url: String,
+    /// Pint API base URL: https://{sandbox_id}-57468.csb.app
+    pub pint_url: String,
     pub pitcher_token: String,
+    pub preview_token: String,
     pub workspace_path: String,
     pub started_at: String,
 }
@@ -149,15 +171,24 @@ impl CodeSandboxClient {
         serde_json::from_str(&body_text).map_err(|e| format!("Invalid JSON from CodeSandbox: {e}"))
     }
 
+    /// Make a request to the Pint API (in-sandbox HTTP REST API).
+    /// pint_url: https://{sandbox_id}-57468.csb.app
+    /// preview_token: required for csb.app port proxy auth (query param)
+    /// pitcher_token: required for Pint API auth (Bearer header)
     async fn pint_request(
         &self,
         method: reqwest::Method,
-        pitcher_url: &str,
+        pint_url: &str,
         path: &str,
         pitcher_token: &str,
+        preview_token: &str,
         body: Option<Value>,
     ) -> Result<Value, String> {
-        let url = format!("{}{}", pitcher_url, path);
+        let separator = if path.contains('?') { '&' } else { '?' };
+        let url = format!(
+            "{}{}{separator}preview_token={preview_token}",
+            pint_url, path
+        );
         let mut req = self
             .http
             .request(method, &url)
@@ -218,6 +249,73 @@ impl CodeSandboxClient {
         serde_json::from_value(data).map_err(|e| format!("Failed to parse VM start response: {e}"))
     }
 
+    pub async fn create_preview_token(
+        &self,
+        sandbox_id: &str,
+    ) -> Result<PreviewTokenResponse, String> {
+        let resp = self
+            .management_request(
+                reqwest::Method::POST,
+                &format!("/sandbox/{sandbox_id}/tokens"),
+                None,
+            )
+            .await?;
+        let data = resp.get("data").cloned().unwrap_or(resp.clone());
+        serde_json::from_value(data)
+            .map_err(|e| format!("Failed to parse preview token response: {e}"))
+    }
+
+    /// Wait for the Pint API to become ready after VM start.
+    /// The VM may report as "RUNNING" before the internal Pint HTTP service has booted.
+    /// Polls the execs endpoint with backoff until it gets a non-502 response.
+    pub async fn wait_for_pint_ready(
+        &self,
+        pint_url: &str,
+        pitcher_token: &str,
+        preview_token: &str,
+    ) -> Result<(), String> {
+        let start = std::time::Instant::now();
+        let mut interval = PINT_READY_POLL_INTERVAL;
+
+        while start.elapsed() < PINT_READY_MAX_WAIT {
+            let url = format!("{pint_url}/api/v1/execs?preview_token={preview_token}");
+
+            match self
+                .http
+                .get(&url)
+                .bearer_auth(pitcher_token)
+                .timeout(Duration::from_secs(5))
+                .send()
+                .await
+            {
+                Ok(resp) => {
+                    let status = resp.status();
+                    // 502/503 = Pint service still booting; anything else means it's up
+                    if status.as_u16() != 502 && status.as_u16() != 503 {
+                        debug!(
+                            "Pint API ready (status: {status}) after {:?}",
+                            start.elapsed()
+                        );
+                        return Ok(());
+                    }
+                    debug!("Pint API not ready yet (status: {status}), retrying...");
+                }
+                Err(e) => {
+                    debug!("Pint API not reachable yet: {e}, retrying...");
+                }
+            }
+
+            tokio::time::sleep(interval).await;
+            // Cap backoff at 4s
+            interval = std::cmp::min(interval * 2, Duration::from_secs(4));
+        }
+
+        Err(format!(
+            "Pint API did not become ready within {}s",
+            PINT_READY_MAX_WAIT.as_secs()
+        ))
+    }
+
     pub async fn shutdown_vm(&self, sandbox_id: &str) -> Result<(), String> {
         self.management_request(
             reqwest::Method::POST,
@@ -248,34 +346,31 @@ impl CodeSandboxClient {
 
     pub async fn exec_create(
         &self,
-        pitcher_url: &str,
-        pitcher_token: &str,
-        command: Vec<String>,
+        state: &SandboxState,
+        command: &str,
+        args: Vec<String>,
     ) -> Result<ExecInfo, String> {
         let resp = self
             .pint_request(
                 reqwest::Method::POST,
-                pitcher_url,
+                &state.pint_url,
                 "/api/v1/execs",
-                pitcher_token,
-                Some(json!({ "command": command })),
+                &state.pitcher_token,
+                &state.preview_token,
+                Some(json!({ "command": command, "args": args })),
             )
             .await?;
         serde_json::from_value(resp).map_err(|e| format!("Failed to parse exec info: {e}"))
     }
 
-    pub async fn exec_get(
-        &self,
-        pitcher_url: &str,
-        pitcher_token: &str,
-        exec_id: &str,
-    ) -> Result<ExecInfo, String> {
+    pub async fn exec_get(&self, state: &SandboxState, exec_id: &str) -> Result<ExecInfo, String> {
         let resp = self
             .pint_request(
                 reqwest::Method::GET,
-                pitcher_url,
+                &state.pint_url,
                 &format!("/api/v1/execs/{exec_id}"),
-                pitcher_token,
+                &state.pitcher_token,
+                &state.preview_token,
                 None,
             )
             .await?;
@@ -284,15 +379,17 @@ impl CodeSandboxClient {
 
     pub async fn exec_get_output(
         &self,
-        pitcher_url: &str,
-        pitcher_token: &str,
+        state: &SandboxState,
         exec_id: &str,
     ) -> Result<String, String> {
-        let url = format!("{pitcher_url}/api/v1/execs/{exec_id}/io");
+        let url = format!(
+            "{}/api/v1/execs/{exec_id}/io?preview_token={}",
+            state.pint_url, state.preview_token
+        );
         let resp = self
             .http
             .get(&url)
-            .bearer_auth(pitcher_token)
+            .bearer_auth(&state.pitcher_token)
             .timeout(SSE_READ_TIMEOUT)
             .send()
             .await
@@ -310,17 +407,13 @@ impl CodeSandboxClient {
         Ok(parse_sse_output(&body))
     }
 
-    pub async fn exec_kill(
-        &self,
-        pitcher_url: &str,
-        pitcher_token: &str,
-        exec_id: &str,
-    ) -> Result<(), String> {
+    pub async fn exec_kill(&self, state: &SandboxState, exec_id: &str) -> Result<(), String> {
         self.pint_request(
             reqwest::Method::DELETE,
-            pitcher_url,
+            &state.pint_url,
             &format!("/api/v1/execs/{exec_id}"),
-            pitcher_token,
+            &state.pitcher_token,
+            &state.preview_token,
             None,
         )
         .await?;
@@ -329,19 +422,15 @@ impl CodeSandboxClient {
 
     // --- Pint API: Files ---
 
-    pub async fn file_read(
-        &self,
-        pitcher_url: &str,
-        pitcher_token: &str,
-        path: &str,
-    ) -> Result<FileContent, String> {
+    pub async fn file_read(&self, state: &SandboxState, path: &str) -> Result<FileContent, String> {
         let encoded_path = encode_path(path);
         let resp = self
             .pint_request(
                 reqwest::Method::GET,
-                pitcher_url,
+                &state.pint_url,
                 &format!("/api/v1/files/{encoded_path}"),
-                pitcher_token,
+                &state.pitcher_token,
+                &state.preview_token,
                 None,
             )
             .await?;
@@ -350,17 +439,17 @@ impl CodeSandboxClient {
 
     pub async fn file_write(
         &self,
-        pitcher_url: &str,
-        pitcher_token: &str,
+        state: &SandboxState,
         path: &str,
         content: &str,
     ) -> Result<(), String> {
         let encoded_path = encode_path(path);
         self.pint_request(
             reqwest::Method::POST,
-            pitcher_url,
+            &state.pint_url,
             &format!("/api/v1/files/{encoded_path}"),
-            pitcher_token,
+            &state.pitcher_token,
+            &state.preview_token,
             Some(json!({ "content": content })),
         )
         .await?;
@@ -371,17 +460,17 @@ impl CodeSandboxClient {
 
     pub async fn dir_list(
         &self,
-        pitcher_url: &str,
-        pitcher_token: &str,
+        state: &SandboxState,
         path: &str,
     ) -> Result<Vec<DirEntry>, String> {
         let encoded_path = encode_path(path);
         let resp = self
             .pint_request(
                 reqwest::Method::GET,
-                pitcher_url,
+                &state.pint_url,
                 &format!("/api/v1/directories/{encoded_path}"),
-                pitcher_token,
+                &state.pitcher_token,
+                &state.preview_token,
                 None,
             )
             .await?;
@@ -729,8 +818,14 @@ impl Tool for CsbCreateSandboxTool {
         let mut create_body = json!({
             "title": title,
             "privacy": 2,
+            "runtime": "vm",
+            "settings": { "use_pint": true },
         });
-        if let Some(template) = arguments.get("template").and_then(|v| v.as_str()) {
+        if let Some(template) = arguments
+            .get("template")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+        {
             create_body["template"] = json!(template);
         }
 
@@ -754,11 +849,37 @@ impl Tool for CsbCreateSandboxTool {
             .workspace_path
             .unwrap_or_else(|| "/project".to_string());
 
+        // Create preview token (required for Pint API port proxy auth)
+        debug!("Creating preview token for sandbox: {sandbox_id}");
+        let preview_token_resp = match client.create_preview_token(sandbox_id).await {
+            Ok(resp) => resp,
+            Err(e) => {
+                return ToolExecutionResult::tool_error(format!(
+                    "Failed to create preview token: {e}"
+                ));
+            }
+        };
+        let preview_token = preview_token_resp.token.token;
+
+        // Pint API is accessed via port forwarding: https://{sandbox_id}-57468.csb.app
+        let pint_url = format!("https://{sandbox_id}-57468.csb.app");
+
+        // Wait for Pint API to be ready (VM service may still be booting)
+        debug!("Waiting for Pint API to become ready...");
+        if let Err(e) = client
+            .wait_for_pint_ready(&pint_url, &vm_info.pitcher_token, &preview_token)
+            .await
+        {
+            warn!("Pint API readiness check failed: {e}");
+            // Continue anyway — the sandbox was created, agent can retry later
+        }
+
         // Save state
         let state = SandboxState {
             sandbox_id: sandbox_id.clone(),
-            pitcher_url: vm_info.pitcher_url.clone(),
+            pint_url: pint_url.clone(),
             pitcher_token: vm_info.pitcher_token.clone(),
+            preview_token: preview_token.clone(),
             workspace_path: workspace_path.clone(),
             started_at: chrono::Utc::now().to_rfc3339(),
         };
@@ -793,15 +914,7 @@ impl Tool for CsbCreateSandboxTool {
                     Ok(Some(file)) => {
                         // Write to sandbox
                         let content = file.content.unwrap_or_default();
-                        if let Err(e) = client
-                            .file_write(
-                                &vm_info.pitcher_url,
-                                &vm_info.pitcher_token,
-                                sandbox_path,
-                                &content,
-                            )
-                            .await
-                        {
+                        if let Err(e) = client.file_write(&state, sandbox_path, &content).await {
                             warn!("Failed to upload {session_path} to sandbox: {e}");
                         } else {
                             uploaded_count += 1;
@@ -904,12 +1017,10 @@ impl Tool for CsbExecTool {
 
         let client = CodeSandboxClient::new(api_key);
 
-        // Parse command into shell invocation
-        let cmd_parts = vec!["bash".to_string(), "-c".to_string(), command.to_string()];
-
+        // Exec API requires command and args split: {"command": "bash", "args": ["-c", "..."]}
         debug!("Executing in sandbox {sandbox_id}: {command}");
         let exec_info = match client
-            .exec_create(&state.pitcher_url, &state.pitcher_token, cmd_parts)
+            .exec_create(&state, "bash", vec!["-c".to_string(), command.to_string()])
             .await
         {
             Ok(info) => info,
@@ -937,12 +1048,10 @@ impl Tool for CsbExecTool {
 
             tokio::time::sleep(EXEC_POLL_INTERVAL).await;
 
-            match client
-                .exec_get(&state.pitcher_url, &state.pitcher_token, &exec_info.id)
-                .await
-            {
+            match client.exec_get(&state, &exec_info.id).await {
                 Ok(status) => {
                     let is_done = status.status == "finished"
+                        || status.status == "EXITED"
                         || status.status == "exited"
                         || status.status == "error"
                         || status.exit_code.is_some();
@@ -950,11 +1059,7 @@ impl Tool for CsbExecTool {
                     if is_done {
                         // Get output
                         let output = client
-                            .exec_get_output(
-                                &state.pitcher_url,
-                                &state.pitcher_token,
-                                &exec_info.id,
-                            )
+                            .exec_get_output(&state, &exec_info.id)
                             .await
                             .unwrap_or_default();
 
@@ -1043,16 +1148,13 @@ impl Tool for CsbExecStatusTool {
 
         let client = CodeSandboxClient::new(api_key);
 
-        let exec_info = match client
-            .exec_get(&state.pitcher_url, &state.pitcher_token, exec_id)
-            .await
-        {
+        let exec_info = match client.exec_get(&state, exec_id).await {
             Ok(info) => info,
             Err(e) => return ToolExecutionResult::tool_error(e),
         };
 
         let output = client
-            .exec_get_output(&state.pitcher_url, &state.pitcher_token, exec_id)
+            .exec_get_output(&state, exec_id)
             .await
             .unwrap_or_default();
 
@@ -1134,10 +1236,7 @@ impl Tool for CsbReadFileTool {
 
         let client = CodeSandboxClient::new(api_key);
 
-        match client
-            .file_read(&state.pitcher_url, &state.pitcher_token, path)
-            .await
-        {
+        match client.file_read(&state, path).await {
             Ok(content) => ToolExecutionResult::success(json!({
                 "path": content.path,
                 "content": content.content
@@ -1224,10 +1323,7 @@ impl Tool for CsbWriteFileTool {
 
         let client = CodeSandboxClient::new(api_key);
 
-        match client
-            .file_write(&state.pitcher_url, &state.pitcher_token, path, content)
-            .await
-        {
+        match client.file_write(&state, path, content).await {
             Ok(()) => ToolExecutionResult::success(json!({
                 "path": path,
                 "success": true
@@ -1332,10 +1428,7 @@ impl Tool for CsbDownloadWorkspaceTool {
         let mut dirs_to_visit = vec![sandbox_root.to_string()];
 
         while let Some(dir_path) = dirs_to_visit.pop() {
-            let entries = match client
-                .dir_list(&state.pitcher_url, &state.pitcher_token, &dir_path)
-                .await
-            {
+            let entries = match client.dir_list(&state, &dir_path).await {
                 Ok(e) => e,
                 Err(e) => {
                     errors.push(format!("Failed to list {dir_path}: {e}"));
@@ -1360,10 +1453,7 @@ impl Tool for CsbDownloadWorkspaceTool {
                     dirs_to_visit.push(full_path);
                 } else {
                     // Download file
-                    match client
-                        .file_read(&state.pitcher_url, &state.pitcher_token, &full_path)
-                        .await
-                    {
+                    match client.file_read(&state, &full_path).await {
                         Ok(content) => {
                             // Compute session destination path
                             let relative =
@@ -1652,16 +1742,18 @@ mod tests {
     fn test_sandbox_state_roundtrip() {
         let state = SandboxState {
             sandbox_id: "sb_123".to_string(),
-            pitcher_url: "https://pitcher-123.csb.app".to_string(),
+            pint_url: "https://sb_123-57468.csb.app".to_string(),
             pitcher_token: "tok_abc".to_string(),
+            preview_token: "prv_v1_test123".to_string(),
             workspace_path: "/project".to_string(),
             started_at: "2026-02-13T10:00:00Z".to_string(),
         };
         let json = serde_json::to_string(&state).unwrap();
         let deserialized: SandboxState = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.sandbox_id, "sb_123");
-        assert_eq!(deserialized.pitcher_url, "https://pitcher-123.csb.app");
+        assert_eq!(deserialized.pint_url, "https://sb_123-57468.csb.app");
         assert_eq!(deserialized.pitcher_token, "tok_abc");
+        assert_eq!(deserialized.preview_token, "prv_v1_test123");
         assert_eq!(deserialized.workspace_path, "/project");
     }
 
@@ -1669,17 +1761,15 @@ mod tests {
     fn test_sandbox_state_with_special_chars() {
         let state = SandboxState {
             sandbox_id: "sb-test_123".to_string(),
-            pitcher_url: "https://pitcher.csb.app:8443/ws?token=abc&id=1".to_string(),
+            pint_url: "https://sb-test_123-57468.csb.app".to_string(),
             pitcher_token: "tok+abc/def==".to_string(),
+            preview_token: "prv_v1_special+chars==".to_string(),
             workspace_path: "/home/user/my project".to_string(),
             started_at: "2026-02-13T10:00:00+05:30".to_string(),
         };
         let json = serde_json::to_string(&state).unwrap();
         let deserialized: SandboxState = serde_json::from_str(&json).unwrap();
-        assert_eq!(
-            deserialized.pitcher_url,
-            "https://pitcher.csb.app:8443/ws?token=abc&id=1"
-        );
+        assert_eq!(deserialized.pint_url, "https://sb-test_123-57468.csb.app");
         assert_eq!(deserialized.pitcher_token, "tok+abc/def==");
     }
 
@@ -1984,6 +2074,17 @@ data: {"output":"line 2"}
             assert!(result.is_ok());
         }
 
+        fn mock_state(pint_url: &str) -> SandboxState {
+            SandboxState {
+                sandbox_id: "sb_test".to_string(),
+                pint_url: pint_url.to_string(),
+                pitcher_token: "tok_test".to_string(),
+                preview_token: "prv_test".to_string(),
+                workspace_path: "/project".to_string(),
+                started_at: "2026-01-01T00:00:00Z".to_string(),
+            }
+        }
+
         #[tokio::test]
         async fn test_client_exec_create() {
             let mock_server = MockServer::start().await;
@@ -1999,12 +2100,9 @@ data: {"output":"line 2"}
 
             let client =
                 CodeSandboxClient::with_base_url("test_key".to_string(), mock_server.uri());
+            let state = mock_state(&mock_server.uri());
             let result = client
-                .exec_create(
-                    &mock_server.uri(),
-                    "tok_test",
-                    vec!["bash".into(), "-c".into(), "echo hi".into()],
-                )
+                .exec_create(&state, "bash", vec!["-c".into(), "echo hi".into()])
                 .await;
             assert!(result.is_ok());
             let info = result.unwrap();
@@ -2027,9 +2125,8 @@ data: {"output":"line 2"}
 
             let client =
                 CodeSandboxClient::with_base_url("test_key".to_string(), mock_server.uri());
-            let result = client
-                .exec_get(&mock_server.uri(), "tok_test", "exec_1")
-                .await;
+            let state = mock_state(&mock_server.uri());
+            let result = client.exec_get(&state, "exec_1").await;
             assert!(result.is_ok());
             let info = result.unwrap();
             assert_eq!(info.status, "exited");
@@ -2049,9 +2146,8 @@ data: {"output":"line 2"}
 
             let client =
                 CodeSandboxClient::with_base_url("test_key".to_string(), mock_server.uri());
-            let result = client
-                .exec_get_output(&mock_server.uri(), "tok_test", "exec_1")
-                .await;
+            let state = mock_state(&mock_server.uri());
+            let result = client.exec_get_output(&state, "exec_1").await;
             assert!(result.is_ok());
             let output = result.unwrap();
             assert!(output.contains("hello world"));
@@ -2072,9 +2168,8 @@ data: {"output":"line 2"}
 
             let client =
                 CodeSandboxClient::with_base_url("test_key".to_string(), mock_server.uri());
-            let result = client
-                .file_read(&mock_server.uri(), "tok_test", "/project/main.py")
-                .await;
+            let state = mock_state(&mock_server.uri());
+            let result = client.file_read(&state, "/project/main.py").await;
             assert!(result.is_ok());
             let content = result.unwrap();
             assert_eq!(content.content, "print('hello')");
@@ -2094,13 +2189,9 @@ data: {"output":"line 2"}
 
             let client =
                 CodeSandboxClient::with_base_url("test_key".to_string(), mock_server.uri());
+            let state = mock_state(&mock_server.uri());
             let result = client
-                .file_write(
-                    &mock_server.uri(),
-                    "tok_test",
-                    "/project/main.py",
-                    "print('hello')",
-                )
+                .file_write(&state, "/project/main.py", "print('hello')")
                 .await;
             assert!(result.is_ok());
         }
@@ -2119,9 +2210,8 @@ data: {"output":"line 2"}
 
             let client =
                 CodeSandboxClient::with_base_url("test_key".to_string(), mock_server.uri());
-            let result = client
-                .dir_list(&mock_server.uri(), "tok_test", "/project")
-                .await;
+            let state = mock_state(&mock_server.uri());
+            let result = client.dir_list(&state, "/project").await;
             assert!(result.is_ok());
             let entries = result.unwrap();
             assert_eq!(entries.len(), 2);

--- a/crates/core/src/capabilities/codesandbox.rs
+++ b/crates/core/src/capabilities/codesandbox.rs
@@ -410,7 +410,9 @@ impl CodeSandboxClient {
             .await
             .map_err(|e| format!("Failed to read exec output: {e}"))?;
 
-        Ok(parse_sse_output(&body))
+        // The /io endpoint returns plain text output, not SSE.
+        // Trim trailing whitespace but preserve internal newlines.
+        Ok(body.trim_end().to_string())
     }
 
     pub async fn exec_kill(&self, state: &SandboxState, exec_id: &str) -> Result<(), String> {
@@ -500,30 +502,6 @@ fn encode_path(path: &str) -> String {
     // Strip leading slash and pass through — CodeSandbox Pint API accepts
     // unencoded paths in practice. Only encode spaces as %20.
     path.trim_start_matches('/').replace(' ', "%20")
-}
-
-/// Parse SSE stream output, extracting data lines.
-fn parse_sse_output(raw: &str) -> String {
-    let mut output = String::new();
-    for line in raw.lines() {
-        if let Some(data) = line.strip_prefix("data: ") {
-            // Try to parse as JSON with "output" or "data" field
-            if let Ok(val) = serde_json::from_str::<Value>(data) {
-                if let Some(text) = val.get("output").and_then(|v| v.as_str()) {
-                    output.push_str(text);
-                } else if let Some(text) = val.get("data").and_then(|v| v.as_str()) {
-                    output.push_str(text);
-                } else {
-                    output.push_str(data);
-                    output.push('\n');
-                }
-            } else {
-                output.push_str(data);
-                output.push('\n');
-            }
-        }
-    }
-    output
 }
 
 // ============================================================================
@@ -1755,42 +1733,6 @@ mod tests {
 
     // --- SSE parsing tests ---
 
-    #[test]
-    fn test_parse_sse_output_with_data_lines() {
-        let raw = "data: hello\ndata: world\n";
-        let output = parse_sse_output(raw);
-        assert_eq!(output, "hello\nworld\n");
-    }
-
-    #[test]
-    fn test_parse_sse_output_empty() {
-        let output = parse_sse_output("");
-        assert_eq!(output, "");
-    }
-
-    #[test]
-    fn test_parse_sse_output_json_with_output_field() {
-        let raw = r#"data: {"output":"line 1"}
-data: {"output":"line 2"}
-"#;
-        let output = parse_sse_output(raw);
-        assert_eq!(output, "line 1line 2");
-    }
-
-    #[test]
-    fn test_parse_sse_output_mixed_events() {
-        let raw = "event: message\ndata: first\n\nevent: done\ndata: second\n";
-        let output = parse_sse_output(raw);
-        assert_eq!(output, "first\nsecond\n");
-    }
-
-    #[test]
-    fn test_parse_sse_output_ignores_non_data_lines() {
-        let raw = "id: 1\nevent: test\nretry: 1000\ndata: actual data\n:comment\n";
-        let output = parse_sse_output(raw);
-        assert_eq!(output, "actual data\n");
-    }
-
     // --- URL encoding tests ---
 
     #[test]
@@ -2119,7 +2061,8 @@ data: {"output":"line 2"}
             Mock::given(method("GET"))
                 .and(path("/api/v1/execs/exec_1/io"))
                 .respond_with(
-                    ResponseTemplate::new(200).set_body_string("data: hello world\ndata: done\n"),
+                    // The real CodeSandbox /io endpoint returns plain text, not SSE
+                    ResponseTemplate::new(200).set_body_string("hello world\n"),
                 )
                 .mount(&mock_server)
                 .await;
@@ -2130,8 +2073,7 @@ data: {"output":"line 2"}
             let result = client.exec_get_output(&state, "exec_1").await;
             assert!(result.is_ok());
             let output = result.unwrap();
-            assert!(output.contains("hello world"));
-            assert!(output.contains("done"));
+            assert_eq!(output, "hello world");
         }
 
         #[tokio::test]

--- a/crates/core/src/capabilities/codesandbox.rs
+++ b/crates/core/src/capabilities/codesandbox.rs
@@ -80,10 +80,24 @@ pub struct FileContent {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct DirEntry {
     pub name: String,
-    #[serde(rename = "type")]
-    pub entry_type: Option<String>,
+    /// Full path of the entry (e.g. "/workspace/src")
+    #[serde(default)]
+    pub path: String,
+    /// Whether this entry is a directory
+    #[serde(default)]
+    pub is_dir: bool,
+    /// File size in bytes
+    #[serde(default)]
+    pub size: u64,
+}
+
+/// Wrapper for the Pint directory listing response: `{"files": [...], "path": "..."}`
+#[derive(Debug, Clone, Deserialize)]
+struct DirListResponse {
+    files: Vec<DirEntry>,
 }
 
 // ============================================================================
@@ -482,13 +496,15 @@ impl CodeSandboxClient {
                 None,
             )
             .await?;
-        // Response may be an array directly or wrapped
-        if let Some(arr) = resp.as_array() {
-            serde_json::from_value(Value::Array(arr.clone()))
-                .map_err(|e| format!("Failed to parse directory listing: {e}"))
+        // Pint API returns {"files": [...], "path": "..."} or an error object
+        if resp.get("files").is_some() {
+            let listing: DirListResponse = serde_json::from_value(resp)
+                .map_err(|e| format!("Failed to parse directory listing: {e}"))?;
+            Ok(listing.files)
+        } else if let Some(msg) = resp.get("message").and_then(|m| m.as_str()) {
+            Err(format!("Directory listing error: {msg}"))
         } else {
-            serde_json::from_value(resp)
-                .map_err(|e| format!("Failed to parse directory listing: {e}"))
+            Err(format!("Unexpected directory listing response: {resp}"))
         }
     }
 }
@@ -1399,11 +1415,7 @@ impl Tool for CsbDownloadWorkspaceTool {
                     format!("{}/{}", dir_path, entry.name)
                 };
 
-                let is_dir = entry
-                    .entry_type
-                    .as_deref()
-                    .map(|t| t == "directory" || t == "dir")
-                    .unwrap_or(false);
+                let is_dir = entry.is_dir;
 
                 if is_dir {
                     dirs_to_visit.push(full_path);
@@ -2125,10 +2137,13 @@ mod tests {
             let mock_server = MockServer::start().await;
             Mock::given(method("GET"))
                 .and(path("/api/v1/directories/project"))
-                .respond_with(ResponseTemplate::new(200).set_body_json(json!([
-                    {"name": "main.py", "type": "file"},
-                    {"name": "src", "type": "directory"}
-                ])))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "files": [
+                        {"name": "main.py", "path": "/project/main.py", "isDir": false, "size": 42},
+                        {"name": "src", "path": "/project/src", "isDir": true, "size": 0}
+                    ],
+                    "path": "/project"
+                })))
                 .mount(&mock_server)
                 .await;
 
@@ -2140,7 +2155,9 @@ mod tests {
             let entries = result.unwrap();
             assert_eq!(entries.len(), 2);
             assert_eq!(entries[0].name, "main.py");
+            assert!(!entries[0].is_dir);
             assert_eq!(entries[1].name, "src");
+            assert!(entries[1].is_dir);
         }
 
         // --- Error response tests ---

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -37,6 +37,7 @@ pub use crate::capability_types::{
 // ============================================================================
 
 mod agent_instructions;
+mod codesandbox;
 mod current_time;
 mod docker_container;
 mod fake_aws;
@@ -60,6 +61,11 @@ mod web_fetch;
 pub use agent_instructions::{
     AGENT_INSTRUCTIONS_CAPABILITY_ID, AGENTS_MD_PATH, AgentInstructionsCapability,
     MAX_AGENTS_MD_SIZE, format_agents_md_content,
+};
+pub use codesandbox::{
+    CodeSandboxCapability, CodeSandboxClient, CsbCreateSandboxTool, CsbDownloadWorkspaceTool,
+    CsbExecStatusTool, CsbExecTool, CsbListSandboxesTool, CsbManageSandboxTool, CsbReadFileTool,
+    CsbWriteFileTool, SandboxState,
 };
 pub use current_time::{CurrentTimeCapability, GetCurrentTimeTool};
 pub use docker_container::{
@@ -312,6 +318,7 @@ impl CapabilityRegistry {
 
         // Experimental capabilities (dev only)
         if grade.experimental_features_enabled() {
+            registry.register(CodeSandboxCapability);
             registry.register(DockerContainerCapability);
         }
 
@@ -890,9 +897,10 @@ mod tests {
         assert!(registry.has("fake_aws"));
         assert!(registry.has("fake_crm"));
         assert!(registry.has("fake_financial"));
-        // Experimental capability included in dev
+        // Experimental capabilities included in dev
+        assert!(registry.has("codesandbox"));
         assert!(registry.has("docker_container"));
-        assert_eq!(registry.len(), 18);
+        assert_eq!(registry.len(), 19);
     }
 
     #[test]
@@ -917,7 +925,8 @@ mod tests {
         assert!(registry.has("fake_aws"));
         assert!(registry.has("fake_crm"));
         assert!(registry.has("fake_financial"));
-        // Experimental capability NOT included in prod
+        // Experimental capabilities NOT included in prod
+        assert!(!registry.has("codesandbox"));
         assert!(!registry.has("docker_container"));
         assert_eq!(registry.len(), 17);
     }

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -123,6 +123,33 @@ service WorkerService {
     // === MCP server operations ===
     // Get MCP server info by name prefix (for tool execution)
     rpc GetMcpServerByPrefix(GetMcpServerByPrefixRequest) returns (GetMcpServerByPrefixResponse);
+
+    // === Session storage operations ===
+    // Key/value and secret storage for session-scoped data
+
+    // Set a key/value pair (creates or updates)
+    rpc SessionStorageSetValue(SessionStorageSetValueRequest) returns (SessionStorageSetValueResponse);
+
+    // Get a value by key
+    rpc SessionStorageGetValue(SessionStorageGetValueRequest) returns (SessionStorageGetValueResponse);
+
+    // Delete a key/value pair
+    rpc SessionStorageDeleteValue(SessionStorageDeleteValueRequest) returns (SessionStorageDeleteValueResponse);
+
+    // List all keys in a session
+    rpc SessionStorageListKeys(SessionStorageListKeysRequest) returns (SessionStorageListKeysResponse);
+
+    // Set a secret (encrypted at rest)
+    rpc SessionStorageSetSecret(SessionStorageSetSecretRequest) returns (SessionStorageSetSecretResponse);
+
+    // Get a secret by name (decrypted)
+    rpc SessionStorageGetSecret(SessionStorageGetSecretRequest) returns (SessionStorageGetSecretResponse);
+
+    // Delete a secret
+    rpc SessionStorageDeleteSecret(SessionStorageDeleteSecretRequest) returns (SessionStorageDeleteSecretResponse);
+
+    // List all secret names in a session (without values)
+    rpc SessionStorageListSecrets(SessionStorageListSecretsRequest) returns (SessionStorageListSecretsResponse);
 }
 
 // ============================================================================
@@ -838,4 +865,94 @@ message GetMcpServerByPrefixRequest {
 
 message GetMcpServerByPrefixResponse {
     optional McpServerInfo server = 1;
+}
+
+// ============================================================================
+// Session storage types (key/value + secrets)
+// ============================================================================
+
+// Metadata for a stored key
+message StorageKeyInfo {
+    string key = 1;
+    Timestamp created_at = 2;
+    Timestamp updated_at = 3;
+}
+
+// Metadata for a stored secret (without value)
+message StorageSecretInfo {
+    string name = 1;
+    Timestamp created_at = 2;
+    Timestamp updated_at = 3;
+}
+
+// === Key/Value operations ===
+
+message SessionStorageSetValueRequest {
+    Uuid session_id = 1;
+    string key = 2;
+    string value = 3;
+}
+
+message SessionStorageSetValueResponse {}
+
+message SessionStorageGetValueRequest {
+    Uuid session_id = 1;
+    string key = 2;
+}
+
+message SessionStorageGetValueResponse {
+    optional string value = 1;
+}
+
+message SessionStorageDeleteValueRequest {
+    Uuid session_id = 1;
+    string key = 2;
+}
+
+message SessionStorageDeleteValueResponse {
+    bool deleted = 1;
+}
+
+message SessionStorageListKeysRequest {
+    Uuid session_id = 1;
+}
+
+message SessionStorageListKeysResponse {
+    repeated StorageKeyInfo keys = 1;
+}
+
+// === Secret operations ===
+
+message SessionStorageSetSecretRequest {
+    Uuid session_id = 1;
+    string name = 2;
+    string value = 3;
+}
+
+message SessionStorageSetSecretResponse {}
+
+message SessionStorageGetSecretRequest {
+    Uuid session_id = 1;
+    string name = 2;
+}
+
+message SessionStorageGetSecretResponse {
+    optional string value = 1;
+}
+
+message SessionStorageDeleteSecretRequest {
+    Uuid session_id = 1;
+    string name = 2;
+}
+
+message SessionStorageDeleteSecretResponse {
+    bool deleted = 1;
+}
+
+message SessionStorageListSecretsRequest {
+    Uuid session_id = 1;
+}
+
+message SessionStorageListSecretsResponse {
+    repeated StorageSecretInfo secrets = 1;
 }

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -61,6 +61,7 @@ pub struct DirectWorkerAdapters {
     mcp_server_service: Arc<McpServerService>,
     capability_registry: CapabilityRegistry,
     sqldb_store: Option<everruns_core::traits::SessionSqlDbStoreRef>,
+    storage_store: Option<Arc<dyn everruns_core::traits::SessionStorageStore>>,
 }
 
 impl DirectWorkerAdapters {
@@ -79,12 +80,22 @@ impl DirectWorkerAdapters {
             mcp_server_service,
             capability_registry,
             sqldb_store: None,
+            storage_store: None,
         }
     }
 
     /// Set the SQL database store for session-scoped SQL databases
     pub fn with_sqldb_store(mut self, store: everruns_core::traits::SessionSqlDbStoreRef) -> Self {
         self.sqldb_store = Some(store);
+        self
+    }
+
+    /// Set the session storage store for kv_store/secret_store tools
+    pub fn with_storage_store(
+        mut self,
+        store: Arc<dyn everruns_core::traits::SessionStorageStore>,
+    ) -> Self {
+        self.storage_store = Some(store);
         self
     }
 
@@ -743,6 +754,10 @@ impl WorkerAdapters for DirectWorkerAdapters {
 
     fn sqldb_store(&self) -> Option<everruns_core::traits::SessionSqlDbStoreRef> {
         self.sqldb_store.clone()
+    }
+
+    fn storage_store(&self) -> Option<Arc<dyn everruns_core::traits::SessionStorageStore>> {
+        self.storage_store.clone()
     }
 
     async fn build_tool_registry(&self, agent_id: Uuid) -> Result<ToolRegistry> {

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -45,9 +45,16 @@ use everruns_internal_protocol::proto::{
     SessionDeleteFileResponse, SessionGrepFilesRequest, SessionGrepFilesResponse,
     SessionListDirectoryRequest, SessionListDirectoryResponse, SessionReadFileRequest,
     SessionReadFileResponse, SessionStatFileRequest, SessionStatFileResponse,
-    SessionWriteFileRequest, SessionWriteFileResponse, SetSessionStatusRequest,
-    SetSessionStatusResponse, SubscribeTaskNotificationsRequest, TaskNotification,
-    TaskNotificationType, UpdateDurableWorkflowStatusRequest, UpdateDurableWorkflowStatusResponse,
+    SessionStorageDeleteSecretRequest, SessionStorageDeleteSecretResponse,
+    SessionStorageDeleteValueRequest, SessionStorageDeleteValueResponse,
+    SessionStorageGetSecretRequest, SessionStorageGetSecretResponse, SessionStorageGetValueRequest,
+    SessionStorageGetValueResponse, SessionStorageListKeysRequest, SessionStorageListKeysResponse,
+    SessionStorageListSecretsRequest, SessionStorageListSecretsResponse,
+    SessionStorageSetSecretRequest, SessionStorageSetSecretResponse, SessionStorageSetValueRequest,
+    SessionStorageSetValueResponse, SessionWriteFileRequest, SessionWriteFileResponse,
+    SetSessionStatusRequest, SetSessionStatusResponse, SubscribeTaskNotificationsRequest,
+    TaskNotification, TaskNotificationType, UpdateDurableWorkflowStatusRequest,
+    UpdateDurableWorkflowStatusResponse,
 };
 use everruns_internal_protocol::{
     WorkerService, WorkerServiceServer, proto_event_request_to_schema, schema_agent_to_proto,
@@ -117,6 +124,8 @@ pub struct WorkerServiceImpl {
     task_broadcaster: Option<Arc<TaskNotificationBroadcaster>>,
     /// Storage backend for image resolution
     db: Arc<StorageBackend>,
+    /// Session storage store for key/value and secret operations
+    session_storage_store: Option<Arc<dyn everruns_core::traits::SessionStorageStore>>,
 }
 
 impl WorkerServiceImpl {
@@ -130,13 +139,31 @@ impl WorkerServiceImpl {
         let session_service = SessionService::new(db.clone());
         let session_file_service = SessionFileService::new(db.clone());
         let llm_resolver_service = LlmResolverService::new(db.clone(), encryption.clone());
-        let mcp_server_service = McpServerService::new(db.clone(), encryption);
+        let mcp_server_service = McpServerService::new(db.clone(), encryption.clone());
 
         // Create durable store using the pool if available (PostgreSQL mode only)
         // In dev mode (in-memory), durable execution is handled differently
         let durable_store = db
             .pool()
             .map(|pool| Arc::new(PostgresWorkflowEventStore::new(pool.clone())));
+
+        // Create session storage store (PostgreSQL mode only)
+        let session_storage_store: Option<Arc<dyn everruns_core::traits::SessionStorageStore>> =
+            db.pool().map(|pool| {
+                let database = crate::storage::Database::new(pool.clone());
+                if let Some(enc) = &encryption {
+                    Arc::new(crate::storage::create_db_session_storage_store(
+                        database,
+                        enc.as_ref().clone(),
+                    )) as Arc<dyn everruns_core::traits::SessionStorageStore>
+                } else {
+                    Arc::new(
+                        crate::storage::create_db_session_storage_store_without_encryption(
+                            database,
+                        ),
+                    ) as Arc<dyn everruns_core::traits::SessionStorageStore>
+                }
+            });
 
         Self {
             event_service,
@@ -149,6 +176,7 @@ impl WorkerServiceImpl {
             durable_store,
             task_broadcaster: None, // Set via set_task_broadcaster() after async initialization
             db,
+            session_storage_store,
         }
     }
 
@@ -163,6 +191,16 @@ impl WorkerServiceImpl {
         self.durable_store
             .as_ref()
             .ok_or_else(|| Status::unavailable("Durable execution not enabled"))
+    }
+
+    /// Get session storage store or return unavailable error
+    #[allow(clippy::result_large_err)]
+    fn storage_store(
+        &self,
+    ) -> Result<&Arc<dyn everruns_core::traits::SessionStorageStore>, Status> {
+        self.session_storage_store
+            .as_ref()
+            .ok_or_else(|| Status::unavailable("Session storage not available"))
     }
 
     /// Get organization public_id from org_id
@@ -2088,6 +2126,184 @@ impl WorkerService for WorkerServiceImpl {
 
         Ok(Response::new(GetMcpServerByPrefixResponse {
             server: server_info,
+        }))
+    }
+
+    // =========================================================================
+    // Session Storage Operations
+    // =========================================================================
+
+    async fn session_storage_set_value(
+        &self,
+        request: Request<SessionStorageSetValueRequest>,
+    ) -> Result<Response<SessionStorageSetValueResponse>, Status> {
+        let req = request.into_inner();
+        let session_id = parse_uuid(req.session_id.as_ref())?;
+        let store = self.storage_store()?;
+
+        store
+            .set_value(session_id.into(), &req.key, &req.value)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to set storage value: {}", e);
+                Status::internal("Failed to set storage value")
+            })?;
+
+        Ok(Response::new(SessionStorageSetValueResponse {}))
+    }
+
+    async fn session_storage_get_value(
+        &self,
+        request: Request<SessionStorageGetValueRequest>,
+    ) -> Result<Response<SessionStorageGetValueResponse>, Status> {
+        let req = request.into_inner();
+        let session_id = parse_uuid(req.session_id.as_ref())?;
+        let store = self.storage_store()?;
+
+        let value = store
+            .get_value(session_id.into(), &req.key)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to get storage value: {}", e);
+                Status::internal("Failed to get storage value")
+            })?;
+
+        Ok(Response::new(SessionStorageGetValueResponse { value }))
+    }
+
+    async fn session_storage_delete_value(
+        &self,
+        request: Request<SessionStorageDeleteValueRequest>,
+    ) -> Result<Response<SessionStorageDeleteValueResponse>, Status> {
+        let req = request.into_inner();
+        let session_id = parse_uuid(req.session_id.as_ref())?;
+        let store = self.storage_store()?;
+
+        let deleted = store
+            .delete_value(session_id.into(), &req.key)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to delete storage value: {}", e);
+                Status::internal("Failed to delete storage value")
+            })?;
+
+        Ok(Response::new(SessionStorageDeleteValueResponse { deleted }))
+    }
+
+    async fn session_storage_list_keys(
+        &self,
+        request: Request<SessionStorageListKeysRequest>,
+    ) -> Result<Response<SessionStorageListKeysResponse>, Status> {
+        use everruns_internal_protocol::datetime_to_proto_timestamp;
+
+        let req = request.into_inner();
+        let session_id = parse_uuid(req.session_id.as_ref())?;
+        let store = self.storage_store()?;
+
+        let keys = store.list_keys(session_id.into()).await.map_err(|e| {
+            tracing::error!("Failed to list storage keys: {}", e);
+            Status::internal("Failed to list storage keys")
+        })?;
+
+        let proto_keys = keys
+            .into_iter()
+            .map(|k| proto::StorageKeyInfo {
+                key: k.key,
+                created_at: Some(datetime_to_proto_timestamp(k.created_at)),
+                updated_at: Some(datetime_to_proto_timestamp(k.updated_at)),
+            })
+            .collect();
+
+        Ok(Response::new(SessionStorageListKeysResponse {
+            keys: proto_keys,
+        }))
+    }
+
+    async fn session_storage_set_secret(
+        &self,
+        request: Request<SessionStorageSetSecretRequest>,
+    ) -> Result<Response<SessionStorageSetSecretResponse>, Status> {
+        let req = request.into_inner();
+        let session_id = parse_uuid(req.session_id.as_ref())?;
+        let store = self.storage_store()?;
+
+        store
+            .set_secret(session_id.into(), &req.name, &req.value)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to set secret: {}", e);
+                Status::internal("Failed to set secret")
+            })?;
+
+        Ok(Response::new(SessionStorageSetSecretResponse {}))
+    }
+
+    async fn session_storage_get_secret(
+        &self,
+        request: Request<SessionStorageGetSecretRequest>,
+    ) -> Result<Response<SessionStorageGetSecretResponse>, Status> {
+        let req = request.into_inner();
+        let session_id = parse_uuid(req.session_id.as_ref())?;
+        let store = self.storage_store()?;
+
+        let value = store
+            .get_secret(session_id.into(), &req.name)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to get secret: {}", e);
+                Status::internal("Failed to get secret")
+            })?;
+
+        Ok(Response::new(SessionStorageGetSecretResponse { value }))
+    }
+
+    async fn session_storage_delete_secret(
+        &self,
+        request: Request<SessionStorageDeleteSecretRequest>,
+    ) -> Result<Response<SessionStorageDeleteSecretResponse>, Status> {
+        let req = request.into_inner();
+        let session_id = parse_uuid(req.session_id.as_ref())?;
+        let store = self.storage_store()?;
+
+        let deleted = store
+            .delete_secret(session_id.into(), &req.name)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to delete secret: {}", e);
+                Status::internal("Failed to delete secret")
+            })?;
+
+        Ok(Response::new(SessionStorageDeleteSecretResponse {
+            deleted,
+        }))
+    }
+
+    async fn session_storage_list_secrets(
+        &self,
+        request: Request<SessionStorageListSecretsRequest>,
+    ) -> Result<Response<SessionStorageListSecretsResponse>, Status> {
+        use everruns_internal_protocol::datetime_to_proto_timestamp;
+
+        let req = request.into_inner();
+        let session_id = parse_uuid(req.session_id.as_ref())?;
+        let store = self.storage_store()?;
+
+        let secrets = store.list_secrets(session_id.into()).await.map_err(|e| {
+            tracing::error!("Failed to list secrets: {}", e);
+            Status::internal("Failed to list secrets")
+        })?;
+
+        let proto_secrets = secrets
+            .into_iter()
+            .map(|s| proto::StorageSecretInfo {
+                name: s.name,
+                created_at: Some(datetime_to_proto_timestamp(s.created_at)),
+                updated_at: Some(datetime_to_proto_timestamp(s.updated_at)),
+            })
+            .collect();
+
+        Ok(Response::new(SessionStorageListSecretsResponse {
+            secrets: proto_secrets,
         }))
     }
 }

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -508,32 +508,20 @@ sql_query(database="analytics", sql="SELECT product, SUM(amount) as total FROM s
         id: seed_ids::CLOUD_CODER_AGENT,
         name: "Cloud Coder",
         description: "A coding agent that runs code in cloud sandboxes powered by CodeSandbox",
-        system_prompt: r#"You are a Cloud Coder Agent with access to CodeSandbox cloud sandboxes.
-You can create isolated Linux VMs, write code, execute it, and manage multiple sandbox environments.
+        system_prompt: r#"You are a Cloud Coder Agent. You run code in cloud sandbox VMs powered by CodeSandbox.
 
-## Setup
+Prerequisite: The session must have CSB_API_KEY set in secrets before you can use sandbox tools.
+If missing, tell the user to set it via the API or harness config.
 
-Before using sandbox tools, set your CodeSandbox API key:
-  secret_store set CSB_API_KEY <your-api-key>
-Get your key at https://codesandbox.io/t/api
+Workflow:
+1. Create sandbox: `csb_create_sandbox`
+2. Write code / install deps: `csb_write_file`, `csb_exec`
+3. For long-running tasks: `csb_exec` with `wait: false`, poll `csb_exec_status`
+4. Save results: `csb_download_workspace`
+5. Clean up: `csb_manage_sandbox` action="shutdown"
 
-## Workflow
-
-1. Set API key (once per session)
-2. Create a sandbox: `csb_create_sandbox`
-3. Write files: `csb_write_file`
-4. Execute code: `csb_exec` with `wait: true` for quick commands
-5. For long-running tasks: `csb_exec` with `wait: false`, then poll `csb_exec_status`
-6. Download results: `csb_download_workspace`
-7. Clean up: `csb_manage_sandbox` with action "shutdown"
-
-## Tips
-
-- Each sandbox is a full Linux VM with network access
-- You can create multiple sandboxes for different tasks
-- Install packages with `csb_exec` (e.g., `apt-get install`, `pip install`)
-- Use `csb_download_workspace` to save all outputs to session storage
-- Sandboxes persist until explicitly shut down"#,
+You can run multiple sandboxes in parallel for different tasks.
+Always shut down sandboxes when done."#,
         tags: &["coding", "cloud", "sandbox", "codesandbox", "demo", "seed"],
         capabilities: &["codesandbox", "session_storage", "session_file_system"],
         dev_only: true,

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -41,6 +41,7 @@ mod seed_ids {
     pub const PYTHON_CODER_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000104);
     pub const SHELL_ASSISTANT_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000105);
     pub const DATA_ANALYST_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000106);
+    pub const CLOUD_CODER_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000107);
 
     // MCP Servers (0x500-0x5FF)
     pub const MS_LEARN_MCP: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000501);
@@ -502,6 +503,40 @@ sql_query(database="analytics", sql="SELECT product, SUM(amount) as total FROM s
             "stateless_todo_list",
         ],
         dev_only: false,
+    },
+    SeedAgent {
+        id: seed_ids::CLOUD_CODER_AGENT,
+        name: "Cloud Coder",
+        description: "A coding agent that runs code in cloud sandboxes powered by CodeSandbox",
+        system_prompt: r#"You are a Cloud Coder Agent with access to CodeSandbox cloud sandboxes.
+You can create isolated Linux VMs, write code, execute it, and manage multiple sandbox environments.
+
+## Setup
+
+Before using sandbox tools, set your CodeSandbox API key:
+  secret_store set CSB_API_KEY <your-api-key>
+Get your key at https://codesandbox.io/t/api
+
+## Workflow
+
+1. Set API key (once per session)
+2. Create a sandbox: `csb_create_sandbox`
+3. Write files: `csb_write_file`
+4. Execute code: `csb_exec` with `wait: true` for quick commands
+5. For long-running tasks: `csb_exec` with `wait: false`, then poll `csb_exec_status`
+6. Download results: `csb_download_workspace`
+7. Clean up: `csb_manage_sandbox` with action "shutdown"
+
+## Tips
+
+- Each sandbox is a full Linux VM with network access
+- You can create multiple sandboxes for different tasks
+- Install packages with `csb_exec` (e.g., `apt-get install`, `pip install`)
+- Use `csb_download_workspace` to save all outputs to session storage
+- Sandboxes persist until explicitly shut down"#,
+        tags: &["coding", "cloud", "sandbox", "codesandbox", "demo", "seed"],
+        capabilities: &["codesandbox", "session_storage", "session_file_system"],
+        dev_only: true,
     },
 ];
 

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -536,6 +536,25 @@ pub async fn run(
             ));
             let capability_registry = CapabilityRegistry::with_builtins();
 
+            let session_storage_store: Arc<dyn everruns_core::traits::SessionStorageStore> =
+                match db.as_ref() {
+                    crate::storage::StorageBackend::Postgres(database) => {
+                        if let Some(enc) = &encryption {
+                            Arc::new(crate::storage::create_db_session_storage_store(
+                                database.clone(),
+                                enc.as_ref().clone(),
+                            ))
+                        } else {
+                            Arc::new(
+                                crate::storage::create_db_session_storage_store_without_encryption(
+                                    database.clone(),
+                                ),
+                            )
+                        }
+                    }
+                    crate::storage::StorageBackend::InMemory(mem_db) => mem_db.clone(),
+                };
+
             let adapters = DirectWorkerAdapters::new(
                 db.clone(),
                 event_service.clone(),
@@ -543,7 +562,8 @@ pub async fn run(
                 mcp_server_service,
                 capability_registry,
             )
-            .with_sqldb_store(sqldb_store.clone());
+            .with_sqldb_store(sqldb_store.clone())
+            .with_storage_store(session_storage_store);
 
             let worker_config = TaskWorkerConfig::dev_mode();
             tokio::spawn(async move {

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -2898,6 +2898,138 @@ impl InMemoryDatabase {
     }
 }
 
+// ============================================================================
+// SessionStorageStore implementation for in-memory backend
+// ============================================================================
+
+#[async_trait::async_trait]
+impl everruns_core::traits::SessionStorageStore for InMemoryDatabase {
+    async fn set_value(
+        &self,
+        session_id: SessionId,
+        key: &str,
+        value: &str,
+    ) -> everruns_core::Result<()> {
+        let now = Self::now();
+        let mut storage = self.session_key_values.write();
+        let map_key = (session_id, key.to_string());
+        storage
+            .entry(map_key)
+            .and_modify(|row| {
+                row.value = value.to_string();
+                row.updated_at = now;
+            })
+            .or_insert_with(|| SessionKeyValueRow {
+                id: Uuid::now_v7(),
+                session_id,
+                key: key.to_string(),
+                value: value.to_string(),
+                created_at: now,
+                updated_at: now,
+            });
+        Ok(())
+    }
+
+    async fn get_value(
+        &self,
+        session_id: SessionId,
+        key: &str,
+    ) -> everruns_core::Result<Option<String>> {
+        let storage = self.session_key_values.read();
+        Ok(storage
+            .get(&(session_id, key.to_string()))
+            .map(|r| r.value.clone()))
+    }
+
+    async fn delete_value(&self, session_id: SessionId, key: &str) -> everruns_core::Result<bool> {
+        let mut storage = self.session_key_values.write();
+        Ok(storage.remove(&(session_id, key.to_string())).is_some())
+    }
+
+    async fn list_keys(
+        &self,
+        session_id: SessionId,
+    ) -> everruns_core::Result<Vec<everruns_core::KeyInfo>> {
+        let storage = self.session_key_values.read();
+        let mut keys: Vec<_> = storage
+            .iter()
+            .filter(|((sid, _), _)| *sid == session_id)
+            .map(|(_, row)| everruns_core::KeyInfo {
+                key: row.key.clone(),
+                created_at: row.created_at,
+                updated_at: row.updated_at,
+            })
+            .collect();
+        keys.sort_by(|a, b| a.key.cmp(&b.key));
+        Ok(keys)
+    }
+
+    async fn set_secret(
+        &self,
+        session_id: SessionId,
+        name: &str,
+        value: &str,
+    ) -> everruns_core::Result<()> {
+        let now = Self::now();
+        let mut storage = self.session_secrets.write();
+        let map_key = (session_id, name.to_string());
+        // In-memory: store plain text as bytes (no encryption in dev mode)
+        storage
+            .entry(map_key)
+            .and_modify(|row| {
+                row.value_encrypted = value.as_bytes().to_vec();
+                row.updated_at = now;
+            })
+            .or_insert_with(|| SessionSecretRow {
+                id: Uuid::now_v7(),
+                session_id,
+                name: name.to_string(),
+                value_encrypted: value.as_bytes().to_vec(),
+                created_at: now,
+                updated_at: now,
+            });
+        Ok(())
+    }
+
+    async fn get_secret(
+        &self,
+        session_id: SessionId,
+        name: &str,
+    ) -> everruns_core::Result<Option<String>> {
+        let storage = self.session_secrets.read();
+        Ok(storage
+            .get(&(session_id, name.to_string()))
+            .map(|r| String::from_utf8_lossy(&r.value_encrypted).to_string()))
+    }
+
+    async fn delete_secret(
+        &self,
+        session_id: SessionId,
+        name: &str,
+    ) -> everruns_core::Result<bool> {
+        let mut storage = self.session_secrets.write();
+        Ok(storage.remove(&(session_id, name.to_string())).is_some())
+    }
+
+    async fn list_secrets(
+        &self,
+        session_id: SessionId,
+    ) -> everruns_core::Result<Vec<everruns_core::SecretInfo>> {
+        let storage = self.session_secrets.read();
+        let mut secrets: Vec<_> = storage
+            .iter()
+            .filter(|((sid, _), _)| *sid == session_id)
+            .map(|(_, row)| everruns_core::SecretInfo {
+                name: row.name.clone(),
+                created_at: row.created_at,
+                updated_at: row.updated_at,
+            })
+            .collect();
+        secrets.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(secrets)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -22,7 +22,8 @@ use std::sync::Arc;
 use crate::adapters::create_driver_registry;
 use crate::grpc_adapters::{
     GrpcAgentStore, GrpcClient, GrpcEventEmitter, GrpcHarnessStore, GrpcImageResolver,
-    GrpcLlmProviderStore, GrpcMessageRetriever, GrpcSessionFileStore, GrpcSessionStore,
+    GrpcLlmProviderStore, GrpcMessageRetriever, GrpcSessionFileStore, GrpcSessionStorageStore,
+    GrpcSessionStore,
 };
 
 // Re-export atom types for activity callers
@@ -332,9 +333,12 @@ pub async fn act_activity(
         crate::mcp_executor::CompositeToolExecutor::new(builtin_executor, mcp_executor);
 
     let event_emitter = GrpcEventEmitter::new(grpc_client.clone());
-    let file_store = Arc::new(GrpcSessionFileStore::new(grpc_client));
+    let file_store = Arc::new(GrpcSessionFileStore::new(grpc_client.clone()));
+    let storage_store: Arc<dyn everruns_core::traits::SessionStorageStore> =
+        Arc::new(GrpcSessionStorageStore::new(grpc_client));
 
-    let atom = ActAtom::with_file_store(tool_executor, event_emitter, file_store);
+    let atom = ActAtom::with_file_store(tool_executor, event_emitter, file_store)
+        .with_storage_store(storage_store);
 
     atom.execute(input)
         .await

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -1041,7 +1041,9 @@ fn proto_mcp_tool_def_to_tool_definition(
 // ImageResolver implementation
 // ============================================================================
 
-use everruns_core::traits::{ImageResolver, ResolvedImage};
+use everruns_core::traits::{
+    ImageResolver, KeyInfo, ResolvedImage, SecretInfo, SessionStorageStore,
+};
 use std::collections::HashMap;
 
 /// gRPC-backed image resolver for resolving image_file content parts
@@ -1116,5 +1118,167 @@ impl ImageResolver for GrpcImageResolver {
         } else {
             Ok(None)
         }
+    }
+}
+
+// ============================================================================
+// SessionStorageStore implementation
+// ============================================================================
+
+/// gRPC-backed session storage store for key/value and secret operations
+pub struct GrpcSessionStorageStore {
+    client: GrpcClient,
+}
+
+impl GrpcSessionStorageStore {
+    pub fn new(client: GrpcClient) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl SessionStorageStore for GrpcSessionStorageStore {
+    async fn set_value(
+        &self,
+        session_id: everruns_core::SessionId,
+        key: &str,
+        value: &str,
+    ) -> Result<()> {
+        let mut client = self.client.inner.lock().await;
+        let request = proto::SessionStorageSetValueRequest {
+            session_id: Some(uuid_to_proto(session_id.uuid())),
+            key: key.to_string(),
+            value: value.to_string(),
+        };
+        client
+            .session_storage_set_value(request)
+            .await
+            .map_err(|e| grpc_error(format!("gRPC session_storage_set_value failed: {}", e)))?;
+        Ok(())
+    }
+
+    async fn get_value(
+        &self,
+        session_id: everruns_core::SessionId,
+        key: &str,
+    ) -> Result<Option<String>> {
+        let mut client = self.client.inner.lock().await;
+        let request = proto::SessionStorageGetValueRequest {
+            session_id: Some(uuid_to_proto(session_id.uuid())),
+            key: key.to_string(),
+        };
+        let response = client
+            .session_storage_get_value(request)
+            .await
+            .map_err(|e| grpc_error(format!("gRPC session_storage_get_value failed: {}", e)))?;
+        Ok(response.into_inner().value)
+    }
+
+    async fn delete_value(&self, session_id: everruns_core::SessionId, key: &str) -> Result<bool> {
+        let mut client = self.client.inner.lock().await;
+        let request = proto::SessionStorageDeleteValueRequest {
+            session_id: Some(uuid_to_proto(session_id.uuid())),
+            key: key.to_string(),
+        };
+        let response = client
+            .session_storage_delete_value(request)
+            .await
+            .map_err(|e| grpc_error(format!("gRPC session_storage_delete_value failed: {}", e)))?;
+        Ok(response.into_inner().deleted)
+    }
+
+    async fn list_keys(&self, session_id: everruns_core::SessionId) -> Result<Vec<KeyInfo>> {
+        let mut client = self.client.inner.lock().await;
+        let request = proto::SessionStorageListKeysRequest {
+            session_id: Some(uuid_to_proto(session_id.uuid())),
+        };
+        let response = client
+            .session_storage_list_keys(request)
+            .await
+            .map_err(|e| grpc_error(format!("gRPC session_storage_list_keys failed: {}", e)))?;
+        Ok(response
+            .into_inner()
+            .keys
+            .into_iter()
+            .map(|k| KeyInfo {
+                key: k.key,
+                created_at: proto_timestamp_or_now(k.created_at.as_ref()),
+                updated_at: proto_timestamp_or_now(k.updated_at.as_ref()),
+            })
+            .collect())
+    }
+
+    async fn set_secret(
+        &self,
+        session_id: everruns_core::SessionId,
+        name: &str,
+        value: &str,
+    ) -> Result<()> {
+        let mut client = self.client.inner.lock().await;
+        let request = proto::SessionStorageSetSecretRequest {
+            session_id: Some(uuid_to_proto(session_id.uuid())),
+            name: name.to_string(),
+            value: value.to_string(),
+        };
+        client
+            .session_storage_set_secret(request)
+            .await
+            .map_err(|e| grpc_error(format!("gRPC session_storage_set_secret failed: {}", e)))?;
+        Ok(())
+    }
+
+    async fn get_secret(
+        &self,
+        session_id: everruns_core::SessionId,
+        name: &str,
+    ) -> Result<Option<String>> {
+        let mut client = self.client.inner.lock().await;
+        let request = proto::SessionStorageGetSecretRequest {
+            session_id: Some(uuid_to_proto(session_id.uuid())),
+            name: name.to_string(),
+        };
+        let response = client
+            .session_storage_get_secret(request)
+            .await
+            .map_err(|e| grpc_error(format!("gRPC session_storage_get_secret failed: {}", e)))?;
+        Ok(response.into_inner().value)
+    }
+
+    async fn delete_secret(
+        &self,
+        session_id: everruns_core::SessionId,
+        name: &str,
+    ) -> Result<bool> {
+        let mut client = self.client.inner.lock().await;
+        let request = proto::SessionStorageDeleteSecretRequest {
+            session_id: Some(uuid_to_proto(session_id.uuid())),
+            name: name.to_string(),
+        };
+        let response = client
+            .session_storage_delete_secret(request)
+            .await
+            .map_err(|e| grpc_error(format!("gRPC session_storage_delete_secret failed: {}", e)))?;
+        Ok(response.into_inner().deleted)
+    }
+
+    async fn list_secrets(&self, session_id: everruns_core::SessionId) -> Result<Vec<SecretInfo>> {
+        let mut client = self.client.inner.lock().await;
+        let request = proto::SessionStorageListSecretsRequest {
+            session_id: Some(uuid_to_proto(session_id.uuid())),
+        };
+        let response = client
+            .session_storage_list_secrets(request)
+            .await
+            .map_err(|e| grpc_error(format!("gRPC session_storage_list_secrets failed: {}", e)))?;
+        Ok(response
+            .into_inner()
+            .secrets
+            .into_iter()
+            .map(|s| SecretInfo {
+                name: s.name,
+                created_at: proto_timestamp_or_now(s.created_at.as_ref()),
+                updated_at: proto_timestamp_or_now(s.updated_at.as_ref()),
+            })
+            .collect())
     }
 }

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -12,12 +12,14 @@ use everruns_core::traits::{AgentStore, ResolvedImage};
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, ModelId, SessionId};
 use everruns_core::{Agent, DriverRegistry, Harness, Message, Session, ToolRegistry};
 use std::collections::HashMap;
+use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::adapters::create_driver_registry;
 use crate::grpc_adapters::{
     GrpcAgentStore, GrpcClient, GrpcEventEmitter, GrpcHarnessStore, GrpcImageResolver,
-    GrpcLlmProviderStore, GrpcMessageRetriever, GrpcSessionFileStore, GrpcSessionStore,
+    GrpcLlmProviderStore, GrpcMessageRetriever, GrpcSessionFileStore, GrpcSessionStorageStore,
+    GrpcSessionStore,
 };
 use crate::mcp_executor::McpServerInfo;
 use crate::worker_adapters::{ModelWithProvider, TurnContext, WorkerAdapters};
@@ -308,6 +310,10 @@ impl WorkerAdapters for GrpcWorkerAdapters {
 
     fn driver_registry(&self) -> DriverRegistry {
         create_driver_registry()
+    }
+
+    fn storage_store(&self) -> Option<Arc<dyn everruns_core::traits::SessionStorageStore>> {
+        Some(Arc::new(GrpcSessionStorageStore::new(self.client.clone())))
     }
 
     async fn build_tool_registry(&self, agent_id: Uuid) -> Result<ToolRegistry> {

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -773,6 +773,9 @@ async fn execute_act_activity<A: WorkerAdapters>(
     if let Some(sqldb_store) = adapters.sqldb_store() {
         atom = atom.with_sqldb_store(sqldb_store);
     }
+    if let Some(storage_store) = adapters.storage_store() {
+        atom = atom.with_storage_store(storage_store);
+    }
 
     let result = atom.execute(input.clone()).await?;
 

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -16,6 +16,7 @@ use everruns_core::{
     Agent, DriverRegistry, Harness, LlmProviderType, Message, Session, ToolDefinition, ToolRegistry,
 };
 use std::collections::HashMap;
+use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::mcp_executor::McpServerInfo;
@@ -172,6 +173,12 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
     /// Get the session SQL database store (if available).
     /// Default returns None (not all backends support session SQL databases).
     fn sqldb_store(&self) -> Option<everruns_core::traits::SessionSqlDbStoreRef> {
+        None
+    }
+
+    /// Get the session storage store for kv_store/secret_store tools (if available).
+    /// Default returns None (not all backends support session storage).
+    fn storage_store(&self) -> Option<Arc<dyn everruns_core::traits::SessionStorageStore>> {
         None
     }
 }

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -1089,6 +1089,82 @@ This capability is experimental and only available in development environments d
 - Resource management considerations
 - API stability concerns
 
+#### CodeSandbox
+
+- **Status**: Available (Dev only)
+- **ID**: `codesandbox`
+- **Purpose**: Create and manage cloud-based sandbox VMs via CodeSandbox API for isolated code execution
+- **System Prompt**: Guidance on API key setup, sandbox lifecycle, tool usage, best practices
+- **Architecture**: Two-tier API — Management API for lifecycle, Pint API for in-sandbox operations
+- **State Management**: Sandbox connection info stored in session secrets (encrypted at rest)
+- **Configuration**: API key stored as session secret `CSB_API_KEY`
+- **Dependencies**: `session_storage`
+- **Tools**:
+  - `csb_create_sandbox` - Create a new sandbox VM, optionally upload files
+    - Parameters:
+      - `title`: string - Sandbox title
+      - `template`: string - Template ID to fork from
+      - `upload_files`: array - Files to upload from session storage `[{session_path, sandbox_path}]`
+    - Returns: sandbox_id, status, workspace_path
+    - Policy: Auto
+  - `csb_exec` - Execute shell command in a sandbox (sync or async)
+    - Parameters:
+      - `sandbox_id`: string (required) - Target sandbox
+      - `command`: string (required) - Shell command
+      - `wait`: boolean (default: true) - Wait for completion
+    - Returns: exec_id, status, exit_code, output
+    - Policy: Auto
+  - `csb_exec_status` - Check execution status and get output
+    - Parameters:
+      - `sandbox_id`: string (required) - Target sandbox
+      - `exec_id`: string (required) - Execution ID
+    - Returns: exec_id, status, exit_code, output
+    - Policy: Auto
+  - `csb_read_file` - Read file from sandbox filesystem
+    - Parameters:
+      - `sandbox_id`: string (required) - Target sandbox
+      - `path`: string (required) - File path
+    - Returns: path, content
+    - Policy: Auto
+  - `csb_write_file` - Write content to file in sandbox
+    - Parameters:
+      - `sandbox_id`: string (required) - Target sandbox
+      - `path`: string (required) - File path
+      - `content`: string (required) - File content
+    - Returns: path, success
+    - Policy: Auto
+  - `csb_download_workspace` - Download entire workspace to session storage
+    - Parameters:
+      - `sandbox_id`: string (required) - Target sandbox
+      - `sandbox_path`: string - Root path in sandbox (default: workspace_path)
+      - `session_path`: string - Destination in session storage (default: /workspace)
+    - Returns: files_downloaded, files_skipped, errors
+    - Policy: Auto
+  - `csb_list_sandboxes` - List all sandboxes in this session
+    - Parameters: none
+    - Returns: sandboxes array with sandbox_id, started_at
+    - Policy: Auto
+  - `csb_manage_sandbox` - Lifecycle management (shutdown, hibernate, delete)
+    - Parameters:
+      - `sandbox_id`: string (required) - Target sandbox
+      - `action`: string (required) - "shutdown", "hibernate", or "delete"
+    - Returns: sandbox_id, action, success
+    - Policy: Auto
+- **Icon**: "cloud"
+- **Category**: "Execution"
+
+##### Design Decision: Multiple Sandboxes Per Session
+
+Unlike DockerContainer (single container per session), CodeSandbox supports multiple sandboxes. This enables workflows like running frontend and backend in separate sandboxes, A/B testing configurations, or parallel execution.
+
+##### Design Decision: Encrypted State Storage
+
+Pitcher URL and token are persisted in session secrets (encrypted at rest) rather than plain-text KV store. The `pitcher_token` grants full access to the sandbox VM, so encryption is appropriate. This also avoids ~200ms+ latency per tool call from re-deriving connection info.
+
+##### Design Decision: Dev-Only Availability
+
+This capability is experimental and only available in development environments. The CodeSandbox API is external and requires an API key, and the integration is still being validated.
+
 ### Message Filters
 
 Capabilities can contribute message filters that modify how messages are retrieved from the database. This enables features like:

--- a/specs/codesandbox.md
+++ b/specs/codesandbox.md
@@ -70,7 +70,7 @@ All state is stored in session **secrets** (encrypted at rest via AES-256-GCM en
 
 | Method | Path | Purpose | Request Body |
 |--------|------|---------|-------------|
-| POST | `/sandbox` | Create sandbox | `{ title?, template?, runtime: "vm" }` |
+| POST | `/sandbox` | Create sandbox | `{ title?, runtime: "vm" }` |
 | GET | `/sandbox/{id}` | Get sandbox info | — |
 | POST | `/vm/{id}/start` | Start VM | `{ tier? }` |
 | POST | `/vm/{id}/shutdown` | Shutdown VM | — |
@@ -98,7 +98,6 @@ Creates a new sandbox VM. Optionally uploads files from session storage.
 
 - **Parameters**:
   - `title`: string (optional) — sandbox title
-  - `template`: string (optional) — template ID to fork from
   - `upload_files`: array (optional) — `[{session_path, sandbox_path}]`
 - **Returns**: `{ sandbox_id, status, workspace_path }`
 - **Policy**: Auto
@@ -229,6 +228,10 @@ The `csb_exec` tool supports both `wait: true` (blocks until completion, returns
 ### Workspace snapshot download
 
 The `csb_download_workspace` tool downloads the entire workspace directory tree rather than individual files. This supports the common workflow of running computations in a sandbox and bringing all results back to session storage.
+
+### Template field removed (2026-02-15)
+
+The `template` field on `csb_create_sandbox` was removed. The CodeSandbox API returns 500 Internal Server Error when a template ID is specified (tested with `python`/`in2qez` and others from their template library). Sandboxes created without a template work correctly — they get a universal VM with full Linux and network access. If CodeSandbox fixes their template API in the future, the field can be re-added.
 
 ### session_storage dependency
 

--- a/specs/codesandbox.md
+++ b/specs/codesandbox.md
@@ -62,7 +62,7 @@ All state is stored in session **secrets** (encrypted at rest via AES-256-GCM en
 | `VmStartResponse` | `pitcher_url`, `pitcher_token`, `workspace_path?` | `POST /vm/{id}/start` response |
 | `ExecInfo` | `id`, `status`, `exit_code?` | `GET /api/v1/execs/{id}` response |
 | `FileContent` | `path`, `content` | `GET /api/v1/files/{path}` response |
-| `DirEntry` | `name`, `entry_type?` | `GET /api/v1/directories/{path}` response |
+| `DirEntry` | `name`, `path`, `is_dir`, `size` | `GET /api/v1/directories/{path}` → `{files: [...]}` |
 
 ## API Integration
 

--- a/specs/codesandbox.md
+++ b/specs/codesandbox.md
@@ -1,0 +1,251 @@
+# CodeSandbox Capability Specification
+
+## Abstract
+
+The CodeSandbox capability integrates [CodeSandbox](https://codesandbox.io/) cloud-based sandbox VMs as an agent execution environment. Agents can create, manage, and interact with multiple isolated Firecracker microVMs per session via the CodeSandbox REST API. Unlike the Docker Container capability (single container per session), this supports multiple sandboxes per session, each identified by a `sandbox_id`.
+
+**Status**: Experimental (Dev only)
+
+## Architecture
+
+### Two-Tier API
+
+CodeSandbox exposes two API layers:
+
+1. **Management API** (`https://api.codesandbox.io`) — sandbox lifecycle (create, start, shutdown, hibernate, delete). Auth: `Bearer <CSB_API_KEY>`.
+2. **Pint API** (dynamic `pitcher_url` per sandbox) — in-sandbox operations (exec, files, directories). Auth: `Bearer <pitcher_token>`. The `pitcher_url` and `pitcher_token` are returned when starting a VM.
+
+```
+┌────────────────────────────────────────────┐
+│              Agent Session                  │
+│                                             │
+│  Tool Call (csb_exec, csb_read_file, etc.) │
+│         ↓                                   │
+│  Load SandboxState from session KV store   │
+│         ↓                                   │
+│  ┌─────────────────────────────────────┐   │
+│  │ CodeSandboxClient                    │   │
+│  │  - Management API (lifecycle)        │   │
+│  │  - Pint API (exec/files via pitcher) │   │
+│  └─────────────────────────────────────┘   │
+│         ↓                                   │
+│  Return result to agent                    │
+└────────────────────────────────────────────┘
+```
+
+### State Management
+
+All state is stored in session **secrets** (encrypted at rest via AES-256-GCM envelope encryption):
+
+- **API key**: secret name `CSB_API_KEY`
+- **Per-sandbox state**: secret name `csb_sandbox:{sandbox_id}`, value is JSON-serialized `SandboxState`
+
+**Why store connection info?** The `pitcher_url` and `pitcher_token` returned by `POST /vm/{id}/start` are needed for all subsequent Pint API calls. Tools are stateless structs with no shared memory between invocations. Without persistence, every tool call would require an extra HTTP roundtrip (~200ms+) to re-derive connection info. The `pitcher_token` grants full access to the sandbox VM, so encryption at rest is appropriate.
+
+## Data Model
+
+### SandboxState (persisted per sandbox)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sandbox_id` | String | CodeSandbox sandbox ID |
+| `pitcher_url` | String | Pint API base URL for this sandbox |
+| `pitcher_token` | String | Auth token for Pint API |
+| `workspace_path` | String | Default workspace path in sandbox |
+| `started_at` | String (ISO 8601) | When the sandbox was started |
+
+### API Response Types
+
+| Type | Fields | Source |
+|------|--------|--------|
+| `SandboxInfo` | `id`, `title?` | `POST /sandbox` response |
+| `VmStartResponse` | `pitcher_url`, `pitcher_token`, `workspace_path?` | `POST /vm/{id}/start` response |
+| `ExecInfo` | `id`, `status`, `exit_code?` | `GET /api/v1/execs/{id}` response |
+| `FileContent` | `path`, `content` | `GET /api/v1/files/{path}` response |
+| `DirEntry` | `name`, `entry_type?` | `GET /api/v1/directories/{path}` response |
+
+## API Integration
+
+### Management API Endpoints
+
+| Method | Path | Purpose | Request Body |
+|--------|------|---------|-------------|
+| POST | `/sandbox` | Create sandbox | `{ title?, template?, runtime: "vm" }` |
+| GET | `/sandbox/{id}` | Get sandbox info | — |
+| POST | `/vm/{id}/start` | Start VM | `{ tier? }` |
+| POST | `/vm/{id}/shutdown` | Shutdown VM | — |
+| POST | `/vm/{id}/hibernate` | Hibernate VM | — |
+| DELETE | `/vm/{id}` | Delete VM | — |
+
+### Pint API Endpoints (at `pitcher_url`)
+
+| Method | Path | Purpose | Request Body |
+|--------|------|---------|-------------|
+| POST | `/api/v1/execs` | Create execution | `{ command: string[] }` |
+| GET | `/api/v1/execs/{id}` | Get exec status | — |
+| GET | `/api/v1/execs/{id}/io` | SSE output stream | — |
+| DELETE | `/api/v1/execs/{id}` | Kill execution | — |
+| GET | `/api/v1/files/{path}` | Read file | — |
+| POST | `/api/v1/files/{path}` | Create/write file | `{ content? }` |
+| DELETE | `/api/v1/files/{path}` | Delete file | — |
+| GET | `/api/v1/directories/{path}` | List directory | — |
+
+## Tools
+
+### csb_create_sandbox
+
+Creates a new sandbox VM. Optionally uploads files from session storage.
+
+- **Parameters**:
+  - `title`: string (optional) — sandbox title
+  - `template`: string (optional) — template ID to fork from
+  - `upload_files`: array (optional) — `[{session_path, sandbox_path}]`
+- **Returns**: `{ sandbox_id, status, workspace_path }`
+- **Policy**: Auto
+
+### csb_exec
+
+Executes a shell command in a sandbox. Supports sync and async modes.
+
+- **Parameters**:
+  - `sandbox_id`: string (required)
+  - `command`: string (required) — shell command
+  - `wait`: boolean (optional, default: true) — wait for completion
+- **Returns**: `{ exec_id, status, exit_code?, output? }`
+- **Policy**: Auto
+
+### csb_exec_status
+
+Check execution status and get output.
+
+- **Parameters**:
+  - `sandbox_id`: string (required)
+  - `exec_id`: string (required)
+- **Returns**: `{ exec_id, status, exit_code?, output? }`
+- **Policy**: Auto
+
+### csb_read_file
+
+Read a file from sandbox filesystem.
+
+- **Parameters**: `sandbox_id` (required), `path` (required)
+- **Returns**: `{ path, content }`
+- **Policy**: Auto
+
+### csb_write_file
+
+Write content to a file in sandbox.
+
+- **Parameters**: `sandbox_id` (required), `path` (required), `content` (required)
+- **Returns**: `{ path, success }`
+- **Policy**: Auto
+
+### csb_download_workspace
+
+Downloads entire sandbox workspace to session file storage.
+
+- **Parameters**:
+  - `sandbox_id`: string (required)
+  - `sandbox_path`: string (optional, default: workspace_path)
+  - `session_path`: string (optional, default: `/workspace`)
+- **Returns**: `{ files_downloaded, files_skipped, errors? }`
+- **Policy**: Auto
+
+### csb_list_sandboxes
+
+Lists all sandboxes created in this session.
+
+- **Parameters**: none
+- **Returns**: `{ sandboxes: [{sandbox_id, started_at}] }`
+- **Policy**: Auto
+
+### csb_manage_sandbox
+
+Lifecycle management: shutdown, hibernate, or delete.
+
+- **Parameters**:
+  - `sandbox_id`: string (required)
+  - `action`: `"shutdown" | "hibernate" | "delete"` (required)
+- **Returns**: `{ sandbox_id, action, success }`
+- **Policy**: Auto
+
+## State Lifecycle
+
+```
+  csb_create_sandbox
+        │
+        ▼
+  ┌──────────┐   csb_exec, csb_read_file,    ┌──────────┐
+  │ Created   │──csb_write_file, etc.──────── │  Active   │
+  │ & Started │◄──────────────────────────────│          │
+  └──────────┘                                └──────────┘
+        │                                          │
+        │    csb_manage_sandbox                    │
+        │    action="hibernate"                    │
+        ▼                                          ▼
+  ┌──────────┐                              ┌──────────┐
+  │Hibernated│  (resume via csb_exec auto)  │ Shutdown │
+  └──────────┘                              └──────────┘
+        │                                          │
+        │    csb_manage_sandbox action="delete"    │
+        ▼                                          ▼
+  ┌──────────┐                              ┌──────────┐
+  │ Deleted   │                              │ Deleted   │
+  └──────────┘                              └──────────┘
+```
+
+## Security
+
+- **API Key**: Stored in session secrets (`CSB_API_KEY`), encrypted at rest via AES-256-GCM envelope encryption
+- **Pitcher Token**: Stored in session secrets (`csb_sandbox:{id}`), encrypted at rest. Ephemeral, short-lived, bound to a specific sandbox VM.
+- **Sandbox Isolation**: Each sandbox is a Firecracker microVM with complete isolation
+- **Multi-tenancy**: Sandboxes scoped to session via secret name prefixes
+
+## Error Handling
+
+| Scenario | Result Type | Message |
+|----------|-------------|---------|
+| Missing required param | `ToolError` | "Missing required parameter: {name}" |
+| Sandbox not found | `ToolError` | "Sandbox '{id}' not found. Create one first with csb_create_sandbox." |
+| API key not configured | `ToolError` | "CSB_API_KEY not set. Use secret_store to set it first." |
+| HTTP 4xx | `ToolError` | "CodeSandbox API error ({status}): {body}" |
+| HTTP 5xx / network | `InternalError` | Logged internally, generic message to LLM |
+| No context | `ToolError` | "{tool_name} requires context." |
+
+## Design Decisions
+
+### Multiple sandboxes per session
+
+Unlike Docker Container (single container per session), CodeSandbox supports multiple sandboxes. This enables workflows like running frontend and backend in separate sandboxes, A/B testing different configurations, or parallel execution.
+
+### KV store for connection state
+
+Pitcher URL and token are persisted in session KV store rather than re-derived on each call. This avoids ~200ms+ latency per tool call. The `pitcher_token` is ephemeral (short-lived, sandbox-scoped), so plain-text KV storage is appropriate.
+
+### Sync + async exec modes
+
+The `csb_exec` tool supports both `wait: true` (blocks until completion, returns output) and `wait: false` (returns immediately with exec_id for polling). Sync mode is convenient for simple commands; async mode is essential for long-running tasks.
+
+### Workspace snapshot download
+
+The `csb_download_workspace` tool downloads the entire workspace directory tree rather than individual files. This supports the common workflow of running computations in a sandbox and bringing all results back to session storage.
+
+### session_storage dependency
+
+The capability declares `session_storage` as a dependency because it needs both the secrets store (for `CSB_API_KEY`) and the KV store (for sandbox state persistence).
+
+## Capability Registration
+
+- **ID**: `codesandbox`
+- **Name**: `[Experimental] CodeSandbox`
+- **Status**: Available (Dev only, gated behind `experimental_features_enabled()`)
+- **Icon**: `cloud`
+- **Category**: `Execution`
+- **Dependencies**: `["session_storage"]`
+
+## Seeded Agent: Cloud Coder
+
+A pre-configured seed agent (`Cloud Coder`) demonstrates the capability:
+- **Capabilities**: `codesandbox`, `session_storage`, `session_file_system`
+- **Dev-only**: true
+- **System prompt**: Guides users through API key setup, sandbox creation, code execution, and result download


### PR DESCRIPTION
## What
Add CodeSandbox capability for cloud-based sandbox VMs. Agents can create, exec commands in, read/write files, download workspaces from, and manage CodeSandbox VMs.

## Why
Agents need isolated cloud execution environments for running code, installing dependencies, and building projects without affecting the host.

## How
- New `codesandbox` capability with tools: `csb_create_sandbox`, `csb_exec`, `csb_file_read`, `csb_file_write`, `csb_download_workspace`, `csb_manage_sandbox`
- Pint API integration for file/directory/exec operations via port-forwarded VM endpoints
- Management API for sandbox lifecycle (create, start VM, hibernate, shutdown/delete)
- Session secrets store sandbox state (pitcher token, preview token, pint URL)
- gRPC storage wiring for worker path
- Fixes: exec output parsing (plain text, not SSE), dir listing deserialization (`{files:[...]}` with `isDir`), shutdown deletes VM

## Risk
- Low
- New capability, no changes to existing tools. CodeSandbox API changes could break Pint integration.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered