### PR TITLE
feat(security): upgrade fetchkit to v0.1.2, mitigate SSRF threats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "fetchkit"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78234c85007f12632e64570a2f3fc3deb2526e7b6ca748f39d36ac2a90c67e39"
+checksum = "1613575f52ffed08a5d0149e2dfcffce17dde3f2359827daa270bfc894df5653"
 dependencies = [
  "async-trait",
  "bytes",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -51,7 +51,7 @@ base64.workspace = true
 url = "2"
 
 # Web fetching
-fetchkit = "0.1.1"
+fetchkit = "0.1.2"
 
 # Sandboxed bash interpreter
 bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.1.4" }

--- a/crates/core/src/capabilities/web_fetch.rs
+++ b/crates/core/src/capabilities/web_fetch.rs
@@ -12,7 +12,9 @@
 use super::{Capability, CapabilityStatus};
 use crate::tools::{Tool, ToolExecutionResult};
 use async_trait::async_trait;
-use fetchkit::{FetchError, FetchRequest, TOOL_DESCRIPTION, TOOL_LLMTXT, fetch};
+use fetchkit::{
+    FetchError, FetchOptions, FetchRequest, TOOL_DESCRIPTION, TOOL_LLMTXT, fetch_with_options,
+};
 use serde_json::Value;
 
 /// WebFetch capability - provides tools to fetch web content
@@ -50,7 +52,7 @@ impl Capability for WebFetchCapability {
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
-        vec![Box::new(WebFetchTool)]
+        vec![Box::new(WebFetchTool::default())]
     }
 }
 
@@ -59,7 +61,15 @@ impl Capability for WebFetchCapability {
 // ============================================================================
 
 /// Tool that fetches content from a URL using fetchkit
-pub struct WebFetchTool;
+///
+/// THREAT[TM-API-008]: SSRF protection via fetchkit DnsPolicy
+/// Mitigation: Default FetchOptions uses DnsPolicy::block_private_ips(),
+/// which blocks loopback, RFC1918, link-local (cloud metadata), and other
+/// reserved IP ranges via resolve-then-check with DNS pinning.
+#[derive(Default)]
+pub struct WebFetchTool {
+    options: FetchOptions,
+}
 
 #[async_trait]
 impl Tool for WebFetchTool {
@@ -124,8 +134,8 @@ impl Tool for WebFetchTool {
             as_text: if as_text { Some(true) } else { None },
         };
 
-        // Execute the fetch using fetchkit
-        match fetch(request).await {
+        // Execute the fetch using fetchkit with configured options (SSRF protection)
+        match fetch_with_options(request, self.options.clone()).await {
             Ok(response) => {
                 // Convert the fetchkit response to JSON
                 ToolExecutionResult::success(serde_json::to_value(&response).unwrap_or_else(|_| {
@@ -160,12 +170,24 @@ impl Tool for WebFetchTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use fetchkit::DnsPolicy;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
+    /// Create a WebFetchTool with permissive DNS policy for wiremock tests
+    /// (wiremock binds to 127.0.0.1 which is blocked by default).
+    fn tool_for_wiremock() -> WebFetchTool {
+        WebFetchTool {
+            options: FetchOptions {
+                dns_policy: DnsPolicy::allow_all(),
+                ..Default::default()
+            },
+        }
+    }
+
     #[test]
     fn test_web_fetch_tool_parameters() {
-        let tool = WebFetchTool;
+        let tool = WebFetchTool::default();
         let schema = tool.parameters_schema();
 
         assert_eq!(schema["type"], "object");
@@ -201,7 +223,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_web_fetch_missing_url() {
-        let tool = WebFetchTool;
+        let tool = WebFetchTool::default();
         let result = tool.execute(serde_json::json!({})).await;
 
         if let ToolExecutionResult::ToolError(msg) = result {
@@ -213,7 +235,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_web_fetch_invalid_url() {
-        let tool = WebFetchTool;
+        let tool = WebFetchTool::default();
         let result = tool
             .execute(serde_json::json!({"url": "not-a-valid-url"}))
             .await;
@@ -227,7 +249,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_web_fetch_invalid_method() {
-        let tool = WebFetchTool;
+        let tool = WebFetchTool::default();
         let result = tool
             .execute(serde_json::json!({"url": "https://example.com", "method": "POST"}))
             .await;
@@ -254,7 +276,7 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let tool = WebFetchTool;
+        let tool = tool_for_wiremock();
         let result = tool
             .execute(serde_json::json!({
                 "url": format!("{}/html", mock_server.uri()),
@@ -289,7 +311,7 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let tool = WebFetchTool;
+        let tool = tool_for_wiremock();
         let result = tool
             .execute(serde_json::json!({
                 "url": format!("{}/html", mock_server.uri()),
@@ -322,7 +344,7 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let tool = WebFetchTool;
+        let tool = tool_for_wiremock();
         let result = tool
             .execute(serde_json::json!({
                 "url": format!("{}/html", mock_server.uri())
@@ -354,7 +376,7 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let tool = WebFetchTool;
+        let tool = tool_for_wiremock();
         let result = tool
             .execute(serde_json::json!({
                 "url": format!("{}/image/png", mock_server.uri())
@@ -396,7 +418,7 @@ mod tests {
             .await;
 
         // Normal response should have truncated: false
-        let tool = WebFetchTool;
+        let tool = tool_for_wiremock();
         let result = tool
             .execute(serde_json::json!({
                 "url": format!("{}/html", mock_server.uri())
@@ -417,18 +439,31 @@ mod tests {
 
     #[tokio::test]
     async fn test_web_fetch_timeout_unreachable_host() {
-        // Use a non-routable IP address to trigger connection timeout
-        // 10.255.255.1 is typically non-routable and will timeout
-        let tool = WebFetchTool;
+        // Use TEST-NET-1 (192.0.2.0/24, RFC 5737) which is non-routable and will timeout.
+        // Note: fetchkit v0.1.2 blocks RFC1918 private IPs, but TEST-NET ranges
+        // are also blocked by DNS policy. Use a wiremock server with a delay instead.
+        let mock_server = MockServer::start().await;
+
+        // Mount a mock that takes 5 seconds to respond (exceeds 1s first-byte timeout)
+        Mock::given(method("GET"))
+            .and(path("/slow"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string("slow response")
+                    .set_delay(std::time::Duration::from_secs(5)),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let tool = tool_for_wiremock();
         let result = tool
             .execute(serde_json::json!({
-                "url": "http://10.255.255.1:12345/test"
+                "url": format!("{}/slow", mock_server.uri())
             }))
             .await;
 
         match result {
             ToolExecutionResult::ToolError(msg) => {
-                // Should timeout or fail to connect
                 assert!(
                     msg.contains("timed out") || msg.contains("connect") || msg.contains("failed"),
                     "Expected timeout or connection error, got: {}",
@@ -436,7 +471,7 @@ mod tests {
                 );
             }
             _ => {
-                // This is also acceptable - some networks may have different behavior
+                // Some environments may handle timeouts differently
             }
         }
     }
@@ -455,7 +490,7 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let tool = WebFetchTool;
+        let tool = tool_for_wiremock();
         let result = tool
             .execute(serde_json::json!({
                 "url": format!("{}/html", mock_server.uri())
@@ -494,7 +529,7 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let tool = WebFetchTool;
+        let tool = tool_for_wiremock();
         let result = tool
             .execute(serde_json::json!({
                 "url": format!("{}/html", mock_server.uri()),
@@ -531,7 +566,7 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let tool = WebFetchTool;
+        let tool = tool_for_wiremock();
         // No as_markdown needed - fetchkit returns markdown by default for HTML
         let result = tool
             .execute(serde_json::json!({
@@ -566,7 +601,7 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let tool = WebFetchTool;
+        let tool = tool_for_wiremock();
         let result = tool
             .execute(serde_json::json!({
                 "url": format!("{}/html", mock_server.uri()),
@@ -601,7 +636,7 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let tool = WebFetchTool;
+        let tool = tool_for_wiremock();
         let result = tool
             .execute(serde_json::json!({
                 "url": format!("{}/json", mock_server.uri())
@@ -626,7 +661,7 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let tool = WebFetchTool;
+        let tool = tool_for_wiremock();
         let result = tool
             .execute(serde_json::json!({
                 "url": format!("{}/status/404", mock_server.uri())
@@ -651,7 +686,7 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let tool = WebFetchTool;
+        let tool = tool_for_wiremock();
         let result = tool
             .execute(serde_json::json!({
                 "url": format!("{}/status/500", mock_server.uri())
@@ -668,21 +703,24 @@ mod tests {
 
     #[tokio::test]
     async fn test_web_fetch_dns_failure() {
-        let tool = WebFetchTool;
+        let tool = WebFetchTool::default();
         let result = tool
             .execute(serde_json::json!({
                 "url": "https://this-domain-definitely-does-not-exist-12345.com/test"
             }))
             .await;
 
-        // DNS failure should return a tool error
+        // DNS failure returns a tool error. With fetchkit v0.1.2's resolve-then-check,
+        // DNS resolution failures may surface as "blocked by policy" since the hostname
+        // cannot be validated against the DNS policy.
         if let ToolExecutionResult::ToolError(msg) = result {
             let msg_lower = msg.to_lowercase();
             assert!(
                 msg_lower.contains("failed")
                     || msg_lower.contains("error")
                     || msg_lower.contains("timed out")
-                    || msg_lower.contains("connect"),
+                    || msg_lower.contains("connect")
+                    || msg_lower.contains("blocked"),
                 "Expected error message about failure, got: {}",
                 msg
             );
@@ -693,7 +731,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_web_fetch_rejects_ftp_url() {
-        let tool = WebFetchTool;
+        let tool = WebFetchTool::default();
         let result = tool
             .execute(serde_json::json!({
                 "url": "ftp://example.com/file.txt"
@@ -709,7 +747,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_web_fetch_rejects_file_url() {
-        let tool = WebFetchTool;
+        let tool = WebFetchTool::default();
         let result = tool
             .execute(serde_json::json!({
                 "url": "file:///etc/passwd"
@@ -737,7 +775,7 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let tool = WebFetchTool;
+        let tool = tool_for_wiremock();
         // Note: mock_server.uri() returns http:// URL
         let result = tool
             .execute(serde_json::json!({
@@ -768,7 +806,7 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let tool = WebFetchTool;
+        let tool = tool_for_wiremock();
         let result = tool
             .execute(serde_json::json!({
                 "url": format!("{}/newlines", mock_server.uri())
@@ -790,87 +828,72 @@ mod tests {
     // ========================================================================
     // SSRF security tests (TM-API-008 through TM-API-012)
     //
-    // These tests verify that private/internal URLs are blocked by policy.
-    // Currently fetchkit block_prefixes are NOT configured, so private IPs
-    // are NOT blocked. Tests document the current behavior and will fail
-    // (alerting developers) once the fix is applied.
-    //
-    // When the fix lands (switching to fetchkit Tool::execute with
-    // block_prefixes), update these tests to assert:
-    //   matches!(result, ToolExecutionResult::ToolError(msg) if msg.contains("blocked"))
+    // fetchkit v0.1.2 blocks private/internal IPs by default via
+    // resolve-then-check with DNS pinning. These tests verify that
+    // private/internal URLs are blocked by policy.
     //
     // Run with: cargo test -p everruns-core --lib -- web_fetch::tests::test_ssrf
     // ========================================================================
 
-    // Helper: asserts that a private/internal URL is NOT currently blocked
-    // by fetchkit policy (documenting the TM-API-008 gap). The request will
-    // either succeed (if host reachable) or fail with a connect/timeout error,
-    // but NOT with "blocked by policy".
-    async fn assert_not_blocked_by_policy(url: &str) {
-        let tool = WebFetchTool;
+    // Helper: asserts that a private/internal URL IS blocked by fetchkit's
+    // DNS policy (SSRF protection). The tool should return a ToolError
+    // containing "blocked".
+    async fn assert_blocked_by_policy(url: &str) {
+        let tool = WebFetchTool::default();
         let result = tool.execute(serde_json::json!({"url": url})).await;
-        match &result {
-            ToolExecutionResult::ToolError(msg) if msg.contains("blocked") => {
-                panic!(
-                    "GOOD NEWS: URL {url} is now blocked by policy! \
-                     TM-API-008 mitigation is working. Update this test to \
-                     assert the blocked behavior."
-                );
-            }
-            _ => {
-                // Expected: either Success (host reachable) or ToolError (timeout/connect).
-                // Both confirm that fetchkit did NOT block the URL by policy.
-            }
-        }
+        assert!(
+            matches!(&result, ToolExecutionResult::ToolError(msg) if msg.contains("blocked")),
+            "Expected URL {url} to be blocked by policy, got: {:?}",
+            result
+        );
     }
 
-    /// THREAT[TM-API-009]: Cloud metadata endpoint is NOT blocked (vulnerability).
-    /// Once mitigated, this test should assert BlockedUrl error.
+    /// THREAT[TM-API-009]: Cloud metadata endpoint blocked by fetchkit DNS policy.
     #[tokio::test]
-    async fn test_ssrf_cloud_metadata_not_blocked() {
-        assert_not_blocked_by_policy("http://169.254.169.254/latest/meta-data/").await;
+    async fn test_ssrf_cloud_metadata_blocked() {
+        assert_blocked_by_policy("http://169.254.169.254/latest/meta-data/").await;
     }
 
-    /// THREAT[TM-API-008]: Localhost is NOT blocked (vulnerability).
+    /// THREAT[TM-API-008]: Localhost blocked by fetchkit DNS policy.
     #[tokio::test]
-    async fn test_ssrf_localhost_not_blocked() {
-        assert_not_blocked_by_policy("http://127.0.0.1:1/").await;
+    async fn test_ssrf_localhost_blocked() {
+        assert_blocked_by_policy("http://127.0.0.1:1/").await;
     }
 
-    /// THREAT[TM-API-008]: RFC1918 10.x.x.x is NOT blocked (vulnerability).
+    /// THREAT[TM-API-008]: RFC1918 10.x.x.x blocked by fetchkit DNS policy.
     #[tokio::test]
-    async fn test_ssrf_private_10_not_blocked() {
-        assert_not_blocked_by_policy("http://10.0.0.1:1/").await;
+    async fn test_ssrf_private_10_blocked() {
+        assert_blocked_by_policy("http://10.0.0.1:1/").await;
     }
 
-    /// THREAT[TM-API-008]: RFC1918 172.16.x.x is NOT blocked (vulnerability).
+    /// THREAT[TM-API-008]: RFC1918 172.16.x.x blocked by fetchkit DNS policy.
     #[tokio::test]
-    async fn test_ssrf_private_172_not_blocked() {
-        assert_not_blocked_by_policy("http://172.16.0.1:1/").await;
+    async fn test_ssrf_private_172_blocked() {
+        assert_blocked_by_policy("http://172.16.0.1:1/").await;
     }
 
-    /// THREAT[TM-API-008]: RFC1918 192.168.x.x is NOT blocked (vulnerability).
+    /// THREAT[TM-API-008]: RFC1918 192.168.x.x blocked by fetchkit DNS policy.
     #[tokio::test]
-    async fn test_ssrf_private_192_not_blocked() {
-        assert_not_blocked_by_policy("http://192.168.0.1:1/").await;
+    async fn test_ssrf_private_192_blocked() {
+        assert_blocked_by_policy("http://192.168.0.1:1/").await;
     }
 
-    /// THREAT[TM-API-008]: IPv6 localhost is NOT blocked (vulnerability).
+    /// THREAT[TM-API-008]: IPv6 localhost blocked by fetchkit DNS policy.
     #[tokio::test]
-    async fn test_ssrf_ipv6_localhost_not_blocked() {
-        assert_not_blocked_by_policy("http://[::1]:1/").await;
+    async fn test_ssrf_ipv6_localhost_blocked() {
+        assert_blocked_by_policy("http://[::1]:1/").await;
     }
 
-    /// THREAT[TM-API-008]: 0.0.0.0 is NOT blocked (vulnerability).
+    /// THREAT[TM-API-008]: 0.0.0.0 blocked by fetchkit DNS policy.
     #[tokio::test]
-    async fn test_ssrf_unspecified_not_blocked() {
-        assert_not_blocked_by_policy("http://0.0.0.0:1/").await;
+    async fn test_ssrf_unspecified_blocked() {
+        assert_blocked_by_policy("http://0.0.0.0:1/").await;
     }
 
     /// Verify file://, ftp://, gopher:// schemes are blocked (existing protection).
     #[tokio::test]
     async fn test_ssrf_non_http_schemes_blocked() {
-        let tool = WebFetchTool;
+        let tool = WebFetchTool::default();
 
         for (scheme, url) in [
             ("file://", "file:///etc/passwd"),
@@ -893,7 +916,7 @@ mod tests {
     #[tokio::test]
     #[ignore = "requires network access"]
     async fn test_real_wasmtime_docs_fetch() {
-        let tool = WebFetchTool;
+        let tool = WebFetchTool::default();
         let result = tool
             .execute(serde_json::json!({
                 "url": "https://docs.wasmtime.dev/"
@@ -925,7 +948,7 @@ mod tests {
     #[tokio::test]
     #[ignore = "requires network access"]
     async fn test_real_wasmtime_docs_as_text() {
-        let tool = WebFetchTool;
+        let tool = WebFetchTool::default();
         let result = tool
             .execute(serde_json::json!({
                 "url": "https://docs.wasmtime.dev/",
@@ -956,7 +979,7 @@ mod tests {
     #[tokio::test]
     #[ignore = "requires network access"]
     async fn test_real_wasmtime_docs_head_request() {
-        let tool = WebFetchTool;
+        let tool = WebFetchTool::default();
         let result = tool
             .execute(serde_json::json!({
                 "url": "https://docs.wasmtime.dev/",
@@ -983,7 +1006,7 @@ mod tests {
     #[tokio::test]
     #[ignore = "requires network access"]
     async fn test_real_wasmtime_docs_subpage() {
-        let tool = WebFetchTool;
+        let tool = WebFetchTool::default();
         // No as_markdown - fetchkit returns markdown by default
         let result = tool
             .execute(serde_json::json!({
@@ -1009,7 +1032,7 @@ mod tests {
     async fn test_real_github_wasm3_readme() {
         // GitHub READMEs may return HTML even though fetchkit tries to convert
         // Note: fetchkit has 1-second first-byte timeout which GitHub often exceeds
-        let tool = WebFetchTool;
+        let tool = WebFetchTool::default();
         let result = tool
             .execute(serde_json::json!({
                 "url": "https://github.com/wasm3/wasm3"
@@ -1047,7 +1070,7 @@ mod tests {
     async fn test_real_github_wasm3_as_text() {
         // Test as_text conversion on GitHub page
         // Note: fetchkit has 1-second first-byte timeout which GitHub often exceeds
-        let tool = WebFetchTool;
+        let tool = WebFetchTool::default();
         let result = tool
             .execute(serde_json::json!({
                 "url": "https://github.com/wasm3/wasm3",

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -431,7 +431,7 @@ impl ToolRegistry {
             .tool(DeleteFileTool)
             .tool(StatFileTool)
             // WebFetch capability tools
-            .tool(WebFetchTool)
+            .tool(WebFetchTool::default())
             .build()
     }
 

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -549,12 +549,13 @@ Binary content (images, PDFs, audio, video, etc.) cannot be fetched as textual c
 
 ##### Design Decision: fetchkit Library
 
-The capability uses the [fetchkit](https://github.com/everruns/fetchkit) library for all HTTP operations and HTML conversion. This provides:
+The capability uses the [fetchkit](https://github.com/everruns/fetchkit) library (v0.1.2) for all HTTP operations and HTML conversion. This provides:
 - Consistent behavior across deployments
 - Built-in HTML to markdown/text conversion optimized for LLM consumption
 - Automatic binary content detection
 - Timeout management with partial content on body timeout
 - Excessive newline filtering
+- **SSRF protection** via `DnsPolicy::block_private_ips()` (default): resolve-then-check validates resolved IPs against blocked ranges (loopback, RFC1918, link-local/cloud metadata, CGNAT, multicast) with DNS pinning to prevent rebinding attacks
 
 #### StatelessTodoList
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -208,11 +208,11 @@ ApiError::Forbidden("No access")         // ✗ Reveals resource exists
 | TM-API-005 | Internal error detail leakage | Medium | Generic `{"error": "Internal server error"}` for 500s; details logged server-side only | MITIGATED |
 | TM-API-006 | Missing auth on protected routes | Critical | All protected routes require `AuthUser` extractor; compile-time route registration | MITIGATED |
 | TM-API-007 | CORS misconfiguration | Medium | `CORS_ALLOWED_ORIGINS` not set by default (same-origin only); configurable for cross-origin | MITIGATED |
-| TM-API-008 | WebFetch SSRF to internal services | High | fetchkit `fetch()` used without block_prefixes; no private IP or metadata endpoint filtering | **OPEN** |
-| TM-API-009 | WebFetch cloud metadata access | Critical | `http://169.254.169.254/` not blocked; IAM credential theft possible in cloud deployments | **OPEN** |
-| TM-API-010 | WebFetch internal DNS probing | Medium | Agent can resolve internal service names via web_fetch; enables service topology discovery | **OPEN** |
-| TM-API-011 | WebFetch internal port scanning | Medium | Agent can probe ports on discovered hosts; 1s first-byte timeout enables slow scanning | **OPEN** |
-| TM-API-012 | WebFetch DNS rebinding | Medium | No resolve-then-check; attacker domain can rebind from public to internal IP mid-request | **OPEN** |
+| TM-API-008 | WebFetch SSRF to internal services | High | fetchkit v0.1.2 `DnsPolicy::block_private_ips()` blocks loopback, RFC1918, link-local, and reserved IPs via resolve-then-check | MITIGATED |
+| TM-API-009 | WebFetch cloud metadata access | Critical | fetchkit v0.1.2 blocks 169.254.0.0/16 (link-local) via DnsPolicy; infrastructure-level IMDSv2 recommended as defense-in-depth | MITIGATED |
+| TM-API-010 | WebFetch internal DNS probing | Medium | fetchkit v0.1.2 resolve-then-check validates resolved IPs against blocked ranges before connecting | MITIGATED |
+| TM-API-011 | WebFetch internal port scanning | Medium | fetchkit v0.1.2 blocks private IP ranges; agents cannot reach internal hosts | MITIGATED |
+| TM-API-012 | WebFetch DNS rebinding | Medium | fetchkit v0.1.2 DNS pinning: resolves hostname, validates IP, pins to resolved address for connection | MITIGATED |
 
 ### Mitigation Details
 
@@ -235,99 +235,42 @@ Returns `400 Bad Request: "Input exceeds allowed limits"` (generic, no detail le
 ```
 Enforced at both application layer and database constraint (`session_files_path_check`).
 
-**TM-API-008 — WebFetch SSRF (OPEN — reclassified from ACCEPTED):**
+**TM-API-008 — WebFetch SSRF (MITIGATED — fetchkit v0.1.2):**
 
-Previously classified as ACCEPTED on the basis that "agent-controlled, not user-controlled URLs; agents are semi-trusted within session scope." Investigation reveals this significantly understates the risk:
+Previously OPEN: Everruns called `fetchkit::fetch()` with no URL filtering configured. Reclassified from ACCEPTED after investigation revealed agents could reach internal services, cloud metadata, and arbitrary hosts from the worker container.
 
-1. **No URL filtering at all:** Everruns calls `fetchkit::fetch()` (standalone function), which creates `FetchOptions` with empty `allow_prefixes` and `block_prefixes`. The `BlockedUrl` error path in the web_fetch error handler can never trigger.
-2. **fetchkit supports filtering but it's unused:** The `fetchkit::Tool::execute()` method correctly passes configured `block_prefixes`/`allow_prefixes` to the fetcher, but Everruns bypasses this by using the standalone `fetch()` function.
-3. **Prompt injection compounds the risk:** While agents are "semi-trusted," indirect prompt injection via tool results (TM-AGENT-002) or MCP tool descriptions (TM-AGENT-003) can influence the agent to fetch attacker-chosen URLs. The agent is not truly in control of its own URL choices.
+**Mitigation (fetchkit v0.1.2):** Upgraded to fetchkit v0.1.2 which implements resolve-then-check with DNS pinning via `DnsPolicy::block_private_ips()` (enabled by default). The `WebFetchTool` uses `fetchkit::fetch_with_options()` with default `FetchOptions`, which blocks:
 
-Attack surface from within the worker container:
-- Internal services: `postgres:5432`, `server:9000`/`9001`, `jaeger:4317`/`4318`/`16686`
-- Other containers on the Docker bridge network
-- Cloud metadata endpoints (see TM-API-009)
-- Any host reachable from the container's network namespace
+| Range | CIDR | Purpose |
+|-------|------|---------|
+| Loopback | `127.0.0.0/8`, `::1` | Localhost |
+| Private | `10.0.0.0/8` | RFC1918 Class A |
+| Private | `172.16.0.0/12` | RFC1918 Class B |
+| Private | `192.168.0.0/16` | RFC1918 Class C |
+| Link-local | `169.254.0.0/16` | Cloud metadata |
+| Link-local IPv6 | `fe80::/10` | IPv6 link-local |
+| Carrier-grade NAT | `100.64.0.0/10` | CGNAT |
+| Unique local IPv6 | `fc00::/7` | IPv6 private |
+| Multicast | `224.0.0.0/4`, `ff00::/8` | Multicast |
+| Special | `0.0.0.0`, `::`, `255.255.255.255` | Broadcast/unspecified |
 
-**Recommendation:** Switch from `fetchkit::fetch()` to `fetchkit::Tool` with configured `block_prefixes`:
-```rust
-let tool = fetchkit::Tool::builder()
-    .block_prefix("http://169.254.")       // Cloud metadata (AWS/GCP/Azure)
-    .block_prefix("https://169.254.")
-    .block_prefix("http://metadata.")       // GCP metadata alias
-    .block_prefix("https://metadata.")
-    .block_prefix("http://127.0.0.1")       // Localhost
-    .block_prefix("https://127.0.0.1")
-    .block_prefix("http://[::1]")           // IPv6 localhost
-    .block_prefix("https://[::1]")
-    .block_prefix("http://localhost")       // Localhost by name
-    .block_prefix("https://localhost")
-    .block_prefix("http://10.")             // RFC 1918 private
-    .block_prefix("https://10.")
-    .block_prefix("http://172.16.")         // RFC 1918 private
-    .block_prefix("https://172.16.")
-    .block_prefix("http://192.168.")        // RFC 1918 private
-    .block_prefix("https://192.168.")
-    .block_prefix("http://0.0.0.0")         // Unspecified
-    .block_prefix("https://0.0.0.0")
-    .build();
-```
-**Priority:** Critical — this is the single highest-impact network security gap.
+IPv6-mapped IPv4 addresses (e.g., `::ffff:127.0.0.1`) are canonicalized before validation, preventing bypass via mapped addresses. DNS pinning resolves the hostname once and pins the connection to that IP, preventing DNS rebinding.
 
-**Limitations of prefix-based blocking:**
-- Does not block numeric IP variants (e.g., `http://2130706433` for 127.0.0.1 as decimal)
-- Does not block DNS names that resolve to private IPs (e.g., `http://internal.corp.com` → 10.0.0.5)
-- Does not prevent DNS rebinding attacks (see TM-API-012)
-- Prefix matching on `http://172.16.` misses `172.17.` through `172.31.` in the private range
+**Defense-in-depth:** Infrastructure-level controls (AWS IMDSv2, cloud firewall egress rules, worker network isolation) are still recommended as caller responsibilities.
 
-A robust long-term fix requires resolve-then-check: resolve the URL's hostname, then validate the resolved IP against blocked ranges before connecting. This requires changes in fetchkit itself.
+**TM-API-009 — Cloud Metadata Access (MITIGATED — fetchkit v0.1.2):**
+Cloud metadata at `http://169.254.169.254/` is blocked by fetchkit's DnsPolicy which blocks the entire `169.254.0.0/16` link-local range.
 
-**TM-API-009 — Cloud Metadata Access (OPEN):**
-Cloud providers expose instance metadata at `http://169.254.169.254/`. This endpoint returns:
-- AWS: IAM role credentials, instance identity, user data (may contain secrets)
-- GCP: Service account tokens, project metadata, SSH keys
-- Azure: Managed identity tokens, instance metadata
+- **Defense-in-depth:** Enable IMDSv2 (AWS), metadata concealment (GCP), or equivalent cloud-level protections. Block 169.254.0.0/16 egress at cloud firewall.
 
-An agent with `web_fetch` can call `http://169.254.169.254/latest/meta-data/iam/security-credentials/` to retrieve temporary AWS credentials, enabling lateral movement beyond the Everruns cluster.
+**TM-API-010 — Internal DNS Probing (MITIGATED — fetchkit v0.1.2):**
+Fetchkit's resolve-then-check validates all resolved IP addresses against blocked ranges before connecting. If an internal service name (e.g., `postgres`, `server`) resolves to a private IP, the request is blocked with `BlockedUrl` error. Error messages no longer distinguish between DNS failures and blocked addresses in a way that enables enumeration.
 
-- **Recommendation:** Block `169.254.0.0/16` at fetchkit level (see TM-API-008 recommendation) AND via infrastructure (AWS IMDSv2, GCP metadata concealment, cloud firewall egress rules).
-- **Priority:** Critical in cloud deployments.
+**TM-API-011 — Internal Port Scanning (MITIGATED — fetchkit v0.1.2):**
+Private IP ranges are blocked at the DNS resolution layer. Agents cannot reach internal hosts regardless of port, eliminating the port scanning attack vector.
 
-**TM-API-010 — Internal DNS Probing (OPEN):**
-An agent can use `web_fetch` to discover internal services by trying known names:
-```
-web_fetch("http://postgres:5432/")
-web_fetch("http://server:9000/health")
-web_fetch("http://jaeger:16686/")
-web_fetch("http://redis:6379/")
-```
-Error messages distinguish between DNS failures ("Failed to connect") and timeouts ("timed out"), enabling service enumeration.
-
-- **Recommendation:** Block private IP ranges (covers resolved addresses if using resolve-then-check). For DNS-level protection, use split-horizon DNS or restrict container DNS resolution.
-- **Priority:** Medium
-
-**TM-API-011 — Internal Port Scanning (OPEN):**
-With the 1-second first-byte timeout, an agent can probe ~60 ports per minute. Combined with DNS probing (TM-API-010), an attacker can map the internal network.
-- Open port: returns HTTP response or connection refused (fast)
-- Closed port: times out after 1 second
-- Non-existent host: DNS failure (fast)
-
-The agent iteration limit (default 100) and tool call limits constrain the scope, but a determined attacker can spread scanning across multiple sessions.
-
-- **Recommendation:** Block private IP ranges at fetchkit level. Consider per-session rate limiting on web_fetch calls.
-- **Priority:** Medium
-
-**TM-API-012 — DNS Rebinding (OPEN):**
-Fetchkit performs no resolve-then-check. An attacker can:
-1. Register a domain (e.g., `evil.example.com`) that initially resolves to a public IP
-2. Configure short DNS TTL
-3. After URL validation passes (if any), rebind the domain to an internal IP (e.g., `10.0.0.1`)
-4. The HTTP client connects to the internal IP
-
-This bypasses any URL-based prefix filtering since the domain looks public.
-
-- **Recommendation:** Implement resolve-then-check in fetchkit: resolve hostname → validate resolved IP → connect. This requires upstream changes to fetchkit.
-- **Priority:** Medium (defense-in-depth; prefix blocking mitigates most practical attacks).
+**TM-API-012 — DNS Rebinding (MITIGATED — fetchkit v0.1.2):**
+Fetchkit v0.1.2 implements DNS pinning: the hostname is resolved once, all resolved IPs are validated against blocked ranges, and the first non-blocked IP is pinned via `reqwest::resolve()`. A second DNS lookup cannot return a different IP because the connection is pinned to the validated address.
 
 ## 5. Session Filesystem (TM-FS)
 
@@ -721,11 +664,11 @@ When a bash script calls `bash` or `sh` or uses `eval`, bashkit re-invokes its o
 
 | ID | Threat | Severity | Recommendation |
 |----|--------|----------|----------------|
-| TM-API-008 | WebFetch SSRF to internal services | High | Use fetchkit `Tool::execute()` with block_prefixes for private IPs |
-| TM-API-009 | WebFetch cloud metadata access | Critical | Block 169.254.0.0/16; enforce IMDSv2; cloud firewall egress rules |
-| TM-API-010 | WebFetch internal DNS probing | Medium | Block private IP ranges via resolve-then-check |
-| TM-API-011 | WebFetch internal port scanning | Medium | Block private IPs; rate-limit web_fetch per session |
-| TM-API-012 | WebFetch DNS rebinding | Medium | Implement resolve-then-check in fetchkit |
+| ~~TM-API-008~~ | ~~WebFetch SSRF to internal services~~ | ~~High~~ | Mitigated: fetchkit v0.1.2 DnsPolicy blocks private IPs via resolve-then-check |
+| ~~TM-API-009~~ | ~~WebFetch cloud metadata access~~ | ~~Critical~~ | Mitigated: fetchkit v0.1.2 blocks 169.254.0.0/16; IMDSv2 recommended as defense-in-depth |
+| ~~TM-API-010~~ | ~~WebFetch internal DNS probing~~ | ~~Medium~~ | Mitigated: fetchkit v0.1.2 resolve-then-check blocks private IP resolution |
+| ~~TM-API-011~~ | ~~WebFetch internal port scanning~~ | ~~Medium~~ | Mitigated: fetchkit v0.1.2 blocks private IP ranges |
+| ~~TM-API-012~~ | ~~WebFetch DNS rebinding~~ | ~~Medium~~ | Mitigated: fetchkit v0.1.2 DNS pinning prevents rebinding |
 | TM-AUTH-001 | No rate limiting on login | High | Per-IP rate limiting on auth endpoints |
 | TM-AGENT-005 | No approval for dangerous capabilities | High | HITL approval for virtual_bash, docker |
 | TM-AGENT-007 | No per-iteration tool call limit | Medium | Cap tool calls per LLM response |
@@ -744,7 +687,7 @@ When a bash script calls `bash` or `sh` or uses `eval`, bashkit re-invokes its o
 |----|--------|-----------|
 | TM-AUTH-010 | Admin password in env var | Limited to development mode; documented |
 | TM-AUTH-011 | Auth bypass in none mode | By design for local development |
-| TM-API-008 | ~~WebFetch SSRF~~ | Reclassified to **OPEN** — no URL filtering in place; see TM-API-008 details |
+| ~~TM-API-008~~ | ~~WebFetch SSRF~~ | Reclassified to **MITIGATED** — fetchkit v0.1.2 DnsPolicy blocks private IPs |
 | TM-FS-006 | File content unencrypted at rest | Relies on infrastructure encryption |
 | TM-FS-007 | No file access audit log | Privacy tradeoff; not compliance-required |
 | TM-LLM-007 | Indirect prompt injection | Inherent LLM limitation; mitigated by role separation |
@@ -767,8 +710,8 @@ When a bash script calls `bash` or `sh` or uses `eval`, bashkit re-invokes its o
 | OAuth provider trust | TM-AUTH-012 | Verify email ownership at OAuth providers |
 | Review agent capabilities | TM-AGENT-005, TM-AGENT-013 | Audit capability assignments; avoid virtual_bash + web_fetch on untrusted agents |
 | System prompt review | TM-AGENT-004 | Review agent system prompts for jailbreak patterns before deployment |
-| Block cloud metadata | TM-API-009 | Enable IMDSv2 (AWS), metadata concealment (GCP), or equivalent; block 169.254.0.0/16 egress at cloud firewall |
-| Worker network isolation | TM-API-008, TM-API-010, TM-API-011 | Restrict worker container egress to LLM provider IPs and required external services only |
+| Block cloud metadata | TM-API-009 | Defense-in-depth: enable IMDSv2 (AWS), metadata concealment (GCP), or equivalent; fetchkit v0.1.2 blocks 169.254.0.0/16 at application level |
+| Worker network isolation | TM-API-008, TM-API-010, TM-API-011 | Defense-in-depth: restrict worker container egress; fetchkit v0.1.2 blocks private IPs at application level |
 
 ## Security Controls Matrix
 
@@ -807,4 +750,4 @@ When a bash script calls `bash` or `sh` or uses `eval`, bashkit re-invokes its o
 - `specs/apis.md` — HTTP API endpoints and error handling
 - `specs/capabilities.md` — Agent capabilities system
 - `specs/bashkit-requirements.md` — Bashkit integration requirements
-- [fetchkit v0.1.1 source](https://crates.io/crates/fetchkit) — URL prefix blocking, fetch options, fetcher registry
+- [fetchkit v0.1.2 source](https://crates.io/crates/fetchkit) — SSRF protection (resolve-then-check, DNS pinning, DnsPolicy), URL prefix blocking, fetch options, fetcher registry


### PR DESCRIPTION
## What
Upgrade fetchkit 0.1.1 → 0.1.2 and update threat model to reflect that all 5 WebFetch SSRF threats (TM-API-008 through TM-API-012) are now mitigated.

## Why
fetchkit v0.1.2 adds built-in SSRF protection via resolve-then-check with DNS pinning (`DnsPolicy::block_private_ips()`, enabled by default). This closes the single highest-impact network security gap identified in the threat model — agents could previously reach internal services, cloud metadata endpoints (IAM credential theft), and arbitrary hosts from worker containers.

## How
- **Dependency upgrade**: `fetchkit = "0.1.1"` → `"0.1.2"` in `crates/core/Cargo.toml`
- **WebFetchTool refactor**: Now holds `FetchOptions` and uses `fetch_with_options()` instead of standalone `fetch()`. Default `FetchOptions` blocks private IPs via `DnsPolicy::block_private_ips()`
- **SSRF tests updated**: 8 tests now assert private IPs are blocked (were: documenting the open vulnerability). Timeout test rewritten to use wiremock delay instead of non-routable private IP
- **Wiremock tests**: Use `tool_for_wiremock()` helper with `DnsPolicy::allow_all()` since wiremock binds to 127.0.0.1
- **Threat model updated**: TM-API-008 through TM-API-012 reclassified OPEN → MITIGATED with detailed mitigation documentation
- **Capabilities spec**: Documents SSRF protection in fetchkit library section
- **Linear**: EVE-25 (Urgent) and EVE-26 (High) marked Done

### Blocked IP ranges (fetchkit v0.1.2 DnsPolicy)
| Range | CIDR |
|-------|------|
| Loopback | 127.0.0.0/8, ::1 |
| Private | 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 |
| Link-local | 169.254.0.0/16 (cloud metadata), fe80::/10 |
| CGNAT | 100.64.0.0/10 |
| IPv6 private | fc00::/7 |
| Multicast | 224.0.0.0/4, ff00::/8 |
| Special | 0.0.0.0, ::, 255.255.255.255 |

## Risk
- Low
- fetchkit v0.1.2 is backward-compatible. The only breaking behavior is that private IPs are now blocked by default, which is the intended security improvement. Wiremock tests use `DnsPolicy::allow_all()` to keep localhost connectivity in tests.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered