### PR TITLE
refactor(capabilities): extract CodeSandbox to integrations/codesandbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1213,6 +1213,7 @@ dependencies = [
  "fetchkit",
  "futures",
  "insta",
+ "inventory",
  "llmsim",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -1289,6 +1290,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "everruns-integrations-codesandbox"
+version = "0.7.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "everruns-core",
+ "inventory",
+ "reqwest 0.13.1",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "wiremock",
+]
+
+[[package]]
 name = "everruns-internal-protocol"
 version = "0.7.0"
 dependencies = [
@@ -1361,6 +1378,7 @@ dependencies = [
  "dotenvy",
  "everruns-core",
  "everruns-durable",
+ "everruns-integrations-codesandbox",
  "everruns-internal-protocol",
  "everruns-session-sqldb",
  "everruns-worker",
@@ -1424,6 +1442,7 @@ dependencies = [
  "everruns-core",
  "everruns-durable",
  "everruns-gemini",
+ "everruns-integrations-codesandbox",
  "everruns-internal-protocol",
  "everruns-openai",
  "futures",
@@ -2323,6 +2342,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.115",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/cli",
     "crates/durable",
     "crates/session-sqldb",
+    "integrations/codesandbox",
 ]
 
 [workspace.package]
@@ -105,6 +106,9 @@ image = { version = "0.25", default-features = false, features = ["jpeg", "png",
 # Fault injection testing
 fail = "0.5"
 rstest = "0.25"
+
+# Plugin system for external integrations
+inventory = "0.3"
 
 [profile.dev]
 opt-level = 0

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -70,6 +70,9 @@ sqlx = { workspace = true, optional = true }
 reqwest = { version = "0.13", features = ["json", "stream", "rustls-native-certs", "blocking"] }
 eventsource-stream = "0.2"
 
+# Plugin system for external integrations
+inventory.workspace = true
+
 # LLM simulation for testing
 llmsim = "0.2.1"
 

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -26,6 +26,37 @@ use crate::tools::{Tool, ToolRegistry};
 use std::collections::HashMap;
 use std::sync::Arc;
 
+// ============================================================================
+// Integration Plugin System
+// ============================================================================
+
+/// Plugin registration point for external integration crates.
+///
+/// Integration crates use `inventory::submit!` to register their capabilities
+/// without requiring `everruns-core` to know about them at compile time.
+/// The `CapabilityRegistry::with_builtins_for_grade()` method iterates all
+/// registered plugins and includes those matching the current deployment grade.
+///
+/// # Example
+///
+/// ```ignore
+/// // In integrations/codesandbox/src/lib.rs:
+/// inventory::submit! {
+///     everruns_core::capabilities::IntegrationPlugin {
+///         experimental_only: true,
+///         factory: || Box::new(CodeSandboxCapability),
+///     }
+/// }
+/// ```
+pub struct IntegrationPlugin {
+    /// If true, only registered when `DeploymentGrade::experimental_features_enabled()` is true.
+    pub experimental_only: bool,
+    /// Factory function that creates the capability instance.
+    pub factory: fn() -> Box<dyn Capability>,
+}
+
+inventory::collect!(IntegrationPlugin);
+
 // Re-export capability types from capability_types module
 pub use crate::capability_types::{
     AgentCapabilityConfig, CapabilityId, CapabilityStatus, MountAccess, MountDirectoryBuilder,
@@ -37,7 +68,6 @@ pub use crate::capability_types::{
 // ============================================================================
 
 mod agent_instructions;
-mod codesandbox;
 mod current_time;
 mod docker_container;
 mod fake_aws;
@@ -61,11 +91,6 @@ mod web_fetch;
 pub use agent_instructions::{
     AGENT_INSTRUCTIONS_CAPABILITY_ID, AGENTS_MD_PATH, AgentInstructionsCapability,
     MAX_AGENTS_MD_SIZE, format_agents_md_content,
-};
-pub use codesandbox::{
-    CodeSandboxCapability, CodeSandboxClient, CsbCreateSandboxTool, CsbDownloadWorkspaceTool,
-    CsbExecStatusTool, CsbExecTool, CsbListSandboxesTool, CsbManageSandboxTool, CsbReadFileTool,
-    CsbWriteFileTool, SandboxState,
 };
 pub use current_time::{CurrentTimeCapability, GetCurrentTimeTool};
 pub use docker_container::{
@@ -316,10 +341,16 @@ impl CapabilityRegistry {
         registry.register(FakeCrmCapability);
         registry.register(FakeFinancialCapability);
 
-        // Experimental capabilities (dev only)
+        // Experimental capabilities (dev only) — built-in
         if grade.experimental_features_enabled() {
-            registry.register(CodeSandboxCapability);
             registry.register(DockerContainerCapability);
+        }
+
+        // External integration plugins (registered via inventory::submit! in integration crates)
+        for plugin in inventory::iter::<IntegrationPlugin>() {
+            if !plugin.experimental_only || grade.experimental_features_enabled() {
+                registry.register_boxed((plugin.factory)());
+            }
         }
 
         registry
@@ -875,9 +906,14 @@ mod tests {
     // CapabilityRegistry tests
     // =========================================================================
 
+    // Note: Integration plugins (codesandbox, etc.) are registered via inventory::submit!
+    // in external crates. They only appear in the registry when the integration crate is
+    // linked into the final binary. Core tests verify only built-in capabilities.
+    // Integration crates have their own tests for plugin registration.
+
     #[test]
     fn test_capability_registry_with_builtins_dev() {
-        // Dev mode includes all capabilities including experimental
+        // Dev mode includes all built-in capabilities including experimental
         let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
 
         assert!(registry.has("agent_instructions"));
@@ -897,10 +933,11 @@ mod tests {
         assert!(registry.has("fake_aws"));
         assert!(registry.has("fake_crm"));
         assert!(registry.has("fake_financial"));
-        // Experimental capabilities included in dev
-        assert!(registry.has("codesandbox"));
+        // Built-in experimental capabilities included in dev
         assert!(registry.has("docker_container"));
-        assert_eq!(registry.len(), 19);
+        // 17 core + 1 docker_container = 18 built-in
+        // (integration plugins add more when linked into the binary)
+        assert!(registry.len() >= 18);
     }
 
     #[test]
@@ -926,7 +963,6 @@ mod tests {
         assert!(registry.has("fake_crm"));
         assert!(registry.has("fake_financial"));
         // Experimental capabilities NOT included in prod
-        assert!(!registry.has("codesandbox"));
         assert!(!registry.has("docker_container"));
         assert_eq!(registry.len(), 17);
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -2,6 +2,7 @@
 //
 // This crate provides a DB-agnostic, streamable, and decomposable implementation
 // of an agentic loop (LLM call → tool execution → repeat).
+
 //
 // Key design decisions:
 // - Uses traits (MessageRetriever, ToolExecutor) for pluggable backends
@@ -135,10 +136,10 @@ pub use capabilities::{
     AddTool, AgentCapabilityConfig, AppliedCapabilities, Capability, CapabilityId,
     CapabilityRegistry, CapabilityRegistryBuilder, CapabilityStatus, CollectedCapabilities,
     CurrentTimeCapability, DeleteFileTool, DependencyError, DivideTool, FileSystemCapability,
-    GetCurrentTimeTool, GetForecastTool, GetWeatherTool, GrepFilesTool, ListDirectoryTool,
-    MAX_RESOLVED_CAPABILITIES, MCP_CAPABILITY_PREFIX, McpCapability, MountAccess,
-    MountDirectoryBuilder, MountEntry, MountPoint, MountSource, MultiplyTool, NoopCapability,
-    ReadFileTool, ResearchCapability, ResolvedCapabilities, SampleDataCapability,
+    GetCurrentTimeTool, GetForecastTool, GetWeatherTool, GrepFilesTool, IntegrationPlugin,
+    ListDirectoryTool, MAX_RESOLVED_CAPABILITIES, MCP_CAPABILITY_PREFIX, McpCapability,
+    MountAccess, MountDirectoryBuilder, MountEntry, MountPoint, MountSource, MultiplyTool,
+    NoopCapability, ReadFileTool, ResearchCapability, ResolvedCapabilities, SampleDataCapability,
     SessionSqlDatabaseCapability, SqlExecuteTool, SqlQueryTool, SqlSchemaTool, StatFileTool,
     StatelessTodoListCapability, SubtractTool, TestMathCapability, TestWeatherCapability,
     WriteFileTool, WriteTodosTool, apply_capabilities, collect_capabilities_with_configs,

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -55,6 +55,7 @@ cron = "0.15"
 zip = { version = "2", default-features = false, features = ["deflate"] }
 
 everruns-core = { path = "../core", features = ["openapi", "sqlx"] }
+everruns-integrations-codesandbox = { path = "../../integrations/codesandbox" }
 everruns-session-sqldb = { path = "../session-sqldb" }
 everruns-worker = { path = "../worker" }  # For AgentRunner trait
 everruns-internal-protocol = { path = "../internal-protocol" }

--- a/crates/server/Dockerfile
+++ b/crates/server/Dockerfile
@@ -25,6 +25,7 @@ FROM chef AS planner
 
 COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
 COPY crates crates
+COPY integrations integrations
 
 RUN cargo chef prepare --recipe-path recipe.json
 
@@ -40,6 +41,7 @@ RUN cargo chef cook --release --recipe-path recipe.json
 # Copy source and build application
 COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
 COPY crates crates
+COPY integrations integrations
 
 RUN cargo build --release -p everruns-server
 

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -15,6 +15,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 everruns-core = { path = "../core" }
+everruns-integrations-codesandbox = { path = "../../integrations/codesandbox" }
 everruns-openai = { path = "../openai" }
 everruns-anthropic = { path = "../anthropic" }
 everruns-gemini = { path = "../gemini" }

--- a/crates/worker/Dockerfile
+++ b/crates/worker/Dockerfile
@@ -25,6 +25,7 @@ FROM chef AS planner
 
 COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
 COPY crates crates
+COPY integrations integrations
 
 RUN cargo chef prepare --recipe-path recipe.json
 
@@ -40,6 +41,7 @@ RUN cargo chef cook --release --recipe-path recipe.json
 # Copy source and build application
 COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
 COPY crates crates
+COPY integrations integrations
 
 RUN cargo build --release -p everruns-worker
 

--- a/docker/Dockerfile.unified
+++ b/docker/Dockerfile.unified
@@ -49,6 +49,7 @@ WORKDIR /app
 # Copy source
 COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
 COPY crates crates
+COPY integrations integrations
 
 # ============================================================================
 # Stage 2a: Build Server binary

--- a/integrations/codesandbox/Cargo.toml
+++ b/integrations/codesandbox/Cargo.toml
@@ -1,0 +1,32 @@
+# CodeSandbox Integration
+# Decision: External integration crate, auto-registered via inventory plugin system
+# Decision: Experimental-only (gated behind DeploymentGrade::Dev)
+
+[package]
+name = "everruns-integrations-codesandbox"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "CodeSandbox cloud sandbox integration for Everruns"
+
+[dependencies]
+everruns-core = { path = "../../crates/core" }
+inventory.workspace = true
+
+# HTTP client for CodeSandbox API
+reqwest = { workspace = true }
+
+# Serialization
+serde.workspace = true
+serde_json.workspace = true
+
+# Async
+async-trait.workspace = true
+tokio.workspace = true
+chrono.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full", "test-util"] }
+wiremock = "0.6"

--- a/integrations/codesandbox/src/lib.rs
+++ b/integrations/codesandbox/src/lib.rs
@@ -1,31 +1,34 @@
-//! CodeSandbox Capability (Experimental)
+//! CodeSandbox Integration (Experimental)
 //!
 //! Cloud-based sandboxed code execution via CodeSandbox REST API.
 //! Supports multiple sandboxes per session, each identified by sandbox_id.
 //!
+//! Decision: External integration crate, auto-registered via inventory plugin system
 //! Decision: Use secrets store for all state (API key + per-sandbox pitcher tokens)
 //! Decision: Two-tier API: Management API for lifecycle, Pint API for in-sandbox ops
 //! Decision: Sync+async exec modes via `wait` parameter
 //! Decision: session_storage dependency for API key and state persistence
-//!
-//! Tools provided:
-//! - `csb_create_sandbox`: Create a new sandbox VM
-//! - `csb_exec`: Execute a command in a sandbox
-//! - `csb_exec_status`: Check execution status and get output
-//! - `csb_read_file`: Read a file from sandbox
-//! - `csb_write_file`: Write a file to sandbox
-//! - `csb_download_workspace`: Download entire workspace to session storage
-//! - `csb_list_sandboxes`: List session sandboxes
-//! - `csb_manage_sandbox`: Shutdown/hibernate/delete sandbox
 
-use super::{Capability, CapabilityStatus};
-use crate::tools::{Tool, ToolExecutionResult};
-use crate::traits::ToolContext;
+use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin};
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::traits::ToolContext;
+
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::time::Duration;
 use tracing::{debug, error, warn};
+
+// ============================================================================
+// Integration Plugin Registration
+// ============================================================================
+
+inventory::submit! {
+    IntegrationPlugin {
+        experimental_only: true,
+        factory: || Box::new(CodeSandboxCapability),
+    }
+}
 
 // ============================================================================
 // Constants

--- a/integrations/codesandbox/tests/plugin_registration.rs
+++ b/integrations/codesandbox/tests/plugin_registration.rs
@@ -1,0 +1,76 @@
+//! Integration test: verify CodeSandbox plugin registers via inventory.
+
+use everruns_core::capabilities::{CapabilityRegistry, IntegrationPlugin};
+use everruns_core::deployment::DeploymentGrade;
+
+// Force linker to include the integration crate's inventory submissions.
+use everruns_integrations_codesandbox as _;
+
+#[test]
+fn test_codesandbox_plugin_is_submitted() {
+    let plugins: Vec<&IntegrationPlugin> = inventory::iter::<IntegrationPlugin>().collect();
+    assert!(
+        plugins.iter().any(|p| {
+            let cap = (p.factory)();
+            cap.id() == "codesandbox"
+        }),
+        "CodeSandbox IntegrationPlugin should be submitted via inventory"
+    );
+}
+
+#[test]
+fn test_codesandbox_plugin_is_experimental() {
+    let plugins: Vec<&IntegrationPlugin> = inventory::iter::<IntegrationPlugin>().collect();
+    let csb = plugins
+        .iter()
+        .find(|p| {
+            let cap = (p.factory)();
+            cap.id() == "codesandbox"
+        })
+        .expect("CodeSandbox plugin not found");
+
+    assert!(
+        csb.experimental_only,
+        "CodeSandbox should be marked experimental_only"
+    );
+}
+
+#[test]
+fn test_codesandbox_registered_in_dev_registry() {
+    let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
+    assert!(
+        registry.has("codesandbox"),
+        "CodeSandbox should be in dev registry"
+    );
+}
+
+#[test]
+fn test_codesandbox_not_registered_in_prod_registry() {
+    let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Prod);
+    assert!(
+        !registry.has("codesandbox"),
+        "CodeSandbox should NOT be in prod registry"
+    );
+}
+
+#[test]
+fn test_codesandbox_capability_metadata() {
+    let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
+    let cap = registry
+        .get("codesandbox")
+        .expect("CodeSandbox capability not found");
+
+    assert_eq!(cap.id(), "codesandbox");
+    assert_eq!(cap.name(), "[Experimental] CodeSandbox");
+    assert_eq!(cap.icon(), Some("cloud"));
+    assert_eq!(cap.category(), Some("Execution"));
+    assert_eq!(cap.dependencies(), vec!["session_storage"]);
+    assert_eq!(cap.tools().len(), 8);
+}
+
+#[test]
+fn test_dev_registry_count_with_integration() {
+    let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
+    // 17 core + 1 docker_container (built-in experimental) + 1 codesandbox (integration plugin)
+    assert_eq!(registry.len(), 19);
+}

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -56,6 +56,7 @@ graph TB
    - `durable/` → `everruns-durable` - PostgreSQL-backed durable execution engine
    - `openai/` → `everruns-openai` - OpenAI LLM provider implementation
    - `anthropic/` → `everruns-anthropic` - Anthropic LLM provider implementation
+   - `integrations/codesandbox/` → `everruns-integrations-codesandbox` - CodeSandbox cloud sandbox integration (auto-registered via `inventory` plugin system)
 3. **Frontend**: Next.js application in `apps/ui/` for management and chat interfaces
    - Exports providers, components, hooks, and lib modules via `package.json` `exports` field for SaaS wrapper consumption
 4. **Documentation Site**: Astro Starlight in `apps/docs/` deployed to https://docs.everruns.com/
@@ -76,6 +77,8 @@ everruns/
 │   ├── durable/          # Durable execution engine
 │   ├── openai/           # OpenAI provider
 │   └── anthropic/        # Anthropic provider
+├── integrations/
+│   └── codesandbox/      # CodeSandbox cloud sandbox (inventory plugin)
 ├── docs/                 # Documentation content (symlinked to apps/docs)
 ├── specs/                # Feature specifications
 ├── test_cases/           # Manual test cases

--- a/specs/codesandbox.md
+++ b/specs/codesandbox.md
@@ -237,6 +237,13 @@ The `template` field on `csb_create_sandbox` was removed. The CodeSandbox API re
 
 The capability declares `session_storage` as a dependency because it needs both the secrets store (for `CSB_API_KEY`) and the KV store (for sandbox state persistence).
 
+## Crate Location
+
+`integrations/codesandbox/` → `everruns-integrations-codesandbox`
+
+External integration crate, auto-registered via `inventory::submit!` plugin system.
+Core (`everruns-core`) has no compile-time knowledge of this crate.
+
 ## Capability Registration
 
 - **ID**: `codesandbox`
@@ -245,6 +252,7 @@ The capability declares `session_storage` as a dependency because it needs both 
 - **Icon**: `cloud`
 - **Category**: `Execution`
 - **Dependencies**: `["session_storage"]`
+- **Registration**: `IntegrationPlugin` via `inventory::submit!` (experimental_only: true)
 
 ## Seeded Agent: Cloud Coder
 


### PR DESCRIPTION
## What
Move CodeSandbox capability from `crates/core/src/capabilities/codesandbox.rs` to a standalone integration crate at `integrations/codesandbox/` (`everruns-integrations-codesandbox`).

Introduce `IntegrationPlugin` + `inventory` crate for auto-registration — core no longer imports or knows about CodeSandbox at compile time.

## Why
Core should not own external integrations. This is the first step toward a plugin-based integration architecture where each integration is a self-contained crate that registers itself via `inventory::submit!`.

## How
- `IntegrationPlugin` struct in `core/capabilities/mod.rs` with `experimental_only: bool` + `factory: fn() -> Box<dyn Capability>`
- `inventory::collect!` in core, `inventory::submit!` in integration crate
- `CapabilityRegistry::with_builtins_for_grade()` iterates plugins and filters by grade
- Server + worker depend on the integration crate to ensure linker includes it
- Core tests verify only built-in capabilities; integration tests in the codesandbox crate verify plugin registration

### Files changed
- **New**: `integrations/codesandbox/` — crate with moved code + inventory registration + integration tests
- **Modified**: `crates/core/src/capabilities/mod.rs` — `IntegrationPlugin`, removed `mod codesandbox`, inventory iteration
- **Modified**: `Cargo.toml` — workspace member, `inventory` dep
- **Modified**: `crates/server/Cargo.toml`, `crates/worker/Cargo.toml` — integration crate dependency
- **Modified**: `specs/architecture.md`, `specs/codesandbox.md` — updated docs

## Risk
- Low
- All 36 existing CodeSandbox unit tests pass in the new location
- 6 new integration tests verify plugin registration (dev/prod grade, metadata, count)
- Core capability registry tests updated to not assert codesandbox presence (linker-dependent)
- Zero clippy warnings, clean fmt

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (N/A — internal code, no public API change)