### PR TITLE
refactor(capabilities): extract Docker container to integrations/docker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,6 +1306,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "everruns-integrations-docker"
+version = "0.7.0"
+dependencies = [
+ "async-trait",
+ "base64",
+ "everruns-core",
+ "inventory",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "everruns-internal-protocol"
 version = "0.7.0"
 dependencies = [
@@ -1379,6 +1394,7 @@ dependencies = [
  "everruns-core",
  "everruns-durable",
  "everruns-integrations-codesandbox",
+ "everruns-integrations-docker",
  "everruns-internal-protocol",
  "everruns-session-sqldb",
  "everruns-worker",
@@ -1443,6 +1459,7 @@ dependencies = [
  "everruns-durable",
  "everruns-gemini",
  "everruns-integrations-codesandbox",
+ "everruns-integrations-docker",
  "everruns-internal-protocol",
  "everruns-openai",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/durable",
     "crates/session-sqldb",
     "integrations/codesandbox",
+    "integrations/docker",
 ]
 
 [workspace.package]

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -69,7 +69,6 @@ pub use crate::capability_types::{
 
 mod agent_instructions;
 mod current_time;
-mod docker_container;
 mod fake_aws;
 mod fake_crm;
 mod fake_financial;
@@ -93,10 +92,6 @@ pub use agent_instructions::{
     MAX_AGENTS_MD_SIZE, format_agents_md_content,
 };
 pub use current_time::{CurrentTimeCapability, GetCurrentTimeTool};
-pub use docker_container::{
-    DockerContainerCapability, DockerContainerConfig, DockerExecTool, DockerReadFileTool,
-    DockerStopTool, DockerWriteFileTool,
-};
 pub use fake_aws::{
     AwsCreateEc2InstanceTool, AwsCreateIamUserTool, AwsCreateRdsDatabaseTool,
     AwsCreateS3BucketTool, AwsGetCloudWatchMetricsTool, AwsListEc2InstancesTool,
@@ -314,7 +309,7 @@ impl CapabilityRegistry {
 
     /// Create a registry with built-in capabilities for a specific deployment grade
     ///
-    /// Experimental capabilities (like DockerContainer) are only included in dev environments.
+    /// Experimental capabilities are included via integration plugins in dev environments.
     pub fn with_builtins_for_grade(grade: DeploymentGrade) -> Self {
         let mut registry = Self::new();
 
@@ -340,11 +335,6 @@ impl CapabilityRegistry {
         registry.register(FakeAwsCapability);
         registry.register(FakeCrmCapability);
         registry.register(FakeFinancialCapability);
-
-        // Experimental capabilities (dev only) — built-in
-        if grade.experimental_features_enabled() {
-            registry.register(DockerContainerCapability);
-        }
 
         // External integration plugins (registered via inventory::submit! in integration crates)
         for plugin in inventory::iter::<IntegrationPlugin>() {
@@ -913,7 +903,7 @@ mod tests {
 
     #[test]
     fn test_capability_registry_with_builtins_dev() {
-        // Dev mode includes all built-in capabilities including experimental
+        // Dev mode includes all built-in capabilities
         let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
 
         assert!(registry.has("agent_instructions"));
@@ -933,11 +923,9 @@ mod tests {
         assert!(registry.has("fake_aws"));
         assert!(registry.has("fake_crm"));
         assert!(registry.has("fake_financial"));
-        // Built-in experimental capabilities included in dev
-        assert!(registry.has("docker_container"));
-        // 17 core + 1 docker_container = 18 built-in
-        // (integration plugins add more when linked into the binary)
-        assert!(registry.len() >= 18);
+        // 17 core built-in capabilities
+        // (integration plugins like docker_container, codesandbox add more when linked)
+        assert!(registry.len() >= 17);
     }
 
     #[test]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -56,6 +56,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 
 everruns-core = { path = "../core", features = ["openapi", "sqlx"] }
 everruns-integrations-codesandbox = { path = "../../integrations/codesandbox" }
+everruns-integrations-docker = { path = "../../integrations/docker" }
 everruns-session-sqldb = { path = "../session-sqldb" }
 everruns-worker = { path = "../worker" }  # For AgentRunner trait
 everruns-internal-protocol = { path = "../internal-protocol" }

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -16,6 +16,7 @@ tracing-subscriber.workspace = true
 
 everruns-core = { path = "../core" }
 everruns-integrations-codesandbox = { path = "../../integrations/codesandbox" }
+everruns-integrations-docker = { path = "../../integrations/docker" }
 everruns-openai = { path = "../openai" }
 everruns-anthropic = { path = "../anthropic" }
 everruns-gemini = { path = "../gemini" }

--- a/docs/features/capabilities.md
+++ b/docs/features/capabilities.md
@@ -87,13 +87,13 @@ Enables fetching content from URLs and converting HTML to markdown or plain text
 
 ### Docker Container (Experimental)
 
-**Status**: Available (Development only)
+**Status**: Available (Development only, integration plugin)
 
 :::caution
 This capability is experimental and only available in development environments. It may change significantly or be removed.
 :::
 
-Provides tools to run commands and manage files in a Docker container tied to the session.
+Provides tools to run commands and manage files in a Docker container tied to the session. Registered as an external integration plugin via the `inventory` crate (`integrations/docker/`).
 
 - **Tools**:
   - `docker_exec` - Execute shell commands in the container

--- a/integrations/codesandbox/tests/plugin_registration.rs
+++ b/integrations/codesandbox/tests/plugin_registration.rs
@@ -71,6 +71,7 @@ fn test_codesandbox_capability_metadata() {
 #[test]
 fn test_dev_registry_count_with_integration() {
     let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
-    // 17 core + 1 docker_container (built-in experimental) + 1 codesandbox (integration plugin)
-    assert_eq!(registry.len(), 19);
+    // 17 core + integration plugins (codesandbox, docker_container when linked)
+    // This test only links codesandbox, so expect at least 18
+    assert!(registry.len() >= 18);
 }

--- a/integrations/docker/Cargo.toml
+++ b/integrations/docker/Cargo.toml
@@ -1,0 +1,31 @@
+# Docker Container Integration
+# Decision: External integration crate, auto-registered via inventory plugin system
+# Decision: Experimental-only (gated behind DeploymentGrade::Dev)
+
+[package]
+name = "everruns-integrations-docker"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Docker container integration for Everruns"
+
+[dependencies]
+everruns-core = { path = "../../crates/core" }
+inventory.workspace = true
+
+# Serialization
+serde.workspace = true
+serde_json.workspace = true
+
+# Async
+async-trait.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+
+# Base64 encoding for file writes
+base64 = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full", "test-util"] }
+uuid = { workspace = true }

--- a/integrations/docker/src/lib.rs
+++ b/integrations/docker/src/lib.rs
@@ -1,10 +1,13 @@
-//! Docker Container Capability (Experimental)
+//! Docker Container Integration (Experimental)
 //!
 //! This capability provides tools for running and interacting with a Docker container
 //! tied to the session lifecycle. The container is lazily started on first tool use
 //! and persists for the duration of the session.
 //!
-//! **EXPERIMENTAL**: This capability is experimental and may change significantly.
+//! Decision: External integration crate, auto-registered via inventory plugin system
+//! Decision: Experimental-only (gated behind DeploymentGrade::Dev)
+//! Decision: Single container per session, named everruns-{session_id}
+//! Decision: Lazy start on first tool use, host networking
 //!
 //! Configuration (via AgentCapabilityConfig.config):
 //! ```json
@@ -13,23 +16,32 @@
 //!   "working_dir": "/workspace"  // optional, defaults to /workspace
 //! }
 //! ```
-//!
-//! Tools provided:
-//! - `docker_exec`: Execute a command inside the container
-//! - `docker_read_file`: Read a file from the container
-//! - `docker_write_file`: Write a file to the container
-//! - `docker_logs`: Get logs from the container
-//! - `docker_stop`: Stop and remove the container
 
-use super::{Capability, CapabilityStatus};
-use crate::tools::{Tool, ToolExecutionResult};
-use crate::traits::ToolContext;
+use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin};
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::traits::ToolContext;
+
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::process::Stdio;
 use tokio::process::Command;
 use tracing::{debug, error, info, warn};
+
+// ============================================================================
+// Integration Plugin Registration
+// ============================================================================
+
+inventory::submit! {
+    IntegrationPlugin {
+        experimental_only: true,
+        factory: || Box::new(DockerContainerCapability),
+    }
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
 
 /// Default Docker image if none specified in config
 const DEFAULT_IMAGE: &str = "mcr.microsoft.com/devcontainers/python:3.11";
@@ -39,6 +51,10 @@ const DEFAULT_WORKING_DIR: &str = "/workspace";
 
 /// Container name prefix
 const CONTAINER_PREFIX: &str = "everruns";
+
+// ============================================================================
+// Configuration
+// ============================================================================
 
 /// Configuration schema for the Docker Container capability
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -69,7 +85,10 @@ impl Default for DockerContainerConfig {
     }
 }
 
-/// Docker Container capability - provides tools to interact with a Docker container
+// ============================================================================
+// DockerContainerCapability
+// ============================================================================
+
 pub struct DockerContainerCapability;
 
 impl Capability for DockerContainerCapability {
@@ -101,17 +120,19 @@ impl Capability for DockerContainerCapability {
 
     fn system_prompt_addition(&self) -> Option<&str> {
         Some(
-            r#"You have access to a Docker container for executing commands and managing files.
+            r#"## Docker Container (Experimental)
+
+You have access to a Docker container for executing commands and managing files.
 The container is tied to this session and persists across tool calls.
 
 IMPORTANT: This is an EXPERIMENTAL capability. The container uses host networking.
 
-Available tools:
-- `docker_exec`: Execute a shell command inside the container. Returns stdout, stderr, and exit code.
-- `docker_read_file`: Read a file from the container filesystem.
-- `docker_write_file`: Write content to a file in the container filesystem.
-- `docker_logs`: Get logs from the container. Useful for debugging long-running processes.
-- `docker_stop`: Stop and remove the container (for cleanup or to reset state).
+Tools:
+- `docker_exec` - Execute a shell command inside the container. Returns stdout, stderr, and exit code.
+- `docker_read_file` - Read a file from the container filesystem.
+- `docker_write_file` - Write content to a file in the container filesystem.
+- `docker_logs` - Get logs from the container. Useful for debugging long-running processes.
+- `docker_stop` - Stop and remove the container (for cleanup or to reset state).
 
 The container is lazily started on first tool use. Subsequent calls reuse the same container.
 
@@ -140,7 +161,7 @@ Best practices:
 // ============================================================================
 
 /// Generate container name from session ID
-fn container_name(session_id: &crate::typed_id::SessionId) -> String {
+fn container_name(session_id: &everruns_core::typed_id::SessionId) -> String {
     format!("{}-{}", CONTAINER_PREFIX, session_id.uuid())
 }
 
@@ -267,7 +288,6 @@ fn parse_config(config: &Value) -> DockerContainerConfig {
 // DockerExecTool
 // ============================================================================
 
-/// Tool to execute commands inside the Docker container
 pub struct DockerExecTool;
 
 #[async_trait]
@@ -388,7 +408,6 @@ impl Tool for DockerExecTool {
 // DockerReadFileTool
 // ============================================================================
 
-/// Tool to read a file from the Docker container
 pub struct DockerReadFileTool;
 
 #[async_trait]
@@ -493,7 +512,6 @@ impl Tool for DockerReadFileTool {
 // DockerWriteFileTool
 // ============================================================================
 
-/// Tool to write a file to the Docker container
 pub struct DockerWriteFileTool;
 
 #[async_trait]
@@ -585,8 +603,7 @@ impl Tool for DockerWriteFileTool {
             warn!("Failed to create parent directory: {}", e);
         }
 
-        // Write content using docker exec with heredoc-style input via stdin
-        // We use base64 encoding to handle special characters safely
+        // Write content using docker exec with base64 encoding to handle special characters
         let encoded = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, content);
 
         let output = match Command::new("docker")
@@ -631,7 +648,6 @@ impl Tool for DockerWriteFileTool {
 // DockerStopTool
 // ============================================================================
 
-/// Tool to stop and remove the Docker container
 pub struct DockerStopTool;
 
 #[async_trait]
@@ -762,7 +778,6 @@ impl Tool for DockerStopTool {
 // DockerLogsTool
 // ============================================================================
 
-/// Tool to get logs from the Docker container
 pub struct DockerLogsTool;
 
 #[async_trait]
@@ -896,6 +911,8 @@ impl Tool for DockerLogsTool {
 mod tests {
     use super::*;
 
+    // --- Capability metadata tests ---
+
     #[test]
     fn test_capability_metadata() {
         let cap = DockerContainerCapability;
@@ -907,18 +924,17 @@ mod tests {
     }
 
     #[test]
-    fn test_capability_has_tools() {
+    fn test_capability_has_all_tools() {
         let cap = DockerContainerCapability;
         let tools = cap.tools();
-
         assert_eq!(tools.len(), 5);
 
-        let tool_names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
-        assert!(tool_names.contains(&"docker_exec"));
-        assert!(tool_names.contains(&"docker_read_file"));
-        assert!(tool_names.contains(&"docker_write_file"));
-        assert!(tool_names.contains(&"docker_logs"));
-        assert!(tool_names.contains(&"docker_stop"));
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(names.contains(&"docker_exec"));
+        assert!(names.contains(&"docker_read_file"));
+        assert!(names.contains(&"docker_write_file"));
+        assert!(names.contains(&"docker_logs"));
+        assert!(names.contains(&"docker_stop"));
     }
 
     #[test]
@@ -934,13 +950,18 @@ mod tests {
     }
 
     #[test]
-    fn test_tools_require_context() {
-        assert!(DockerExecTool.requires_context());
-        assert!(DockerReadFileTool.requires_context());
-        assert!(DockerWriteFileTool.requires_context());
-        assert!(DockerLogsTool.requires_context());
-        assert!(DockerStopTool.requires_context());
+    fn test_all_tools_require_context() {
+        let cap = DockerContainerCapability;
+        for tool in cap.tools() {
+            assert!(
+                tool.requires_context(),
+                "Tool {} should require context",
+                tool.name()
+            );
+        }
     }
+
+    // --- Config tests ---
 
     #[test]
     fn test_config_default() {
@@ -973,20 +994,22 @@ mod tests {
     #[test]
     fn test_container_name() {
         let uuid = uuid::Uuid::parse_str("12345678-1234-1234-1234-123456789012").unwrap();
-        let session_id = crate::typed_id::SessionId::from_uuid(uuid);
+        let session_id = everruns_core::typed_id::SessionId::from_uuid(uuid);
         let name = container_name(&session_id);
         assert_eq!(name, "everruns-12345678-1234-1234-1234-123456789012");
     }
+
+    // --- Error path tests ---
 
     #[tokio::test]
     async fn test_docker_exec_without_context() {
         let tool = DockerExecTool;
         let result = tool.execute(json!({"command": "echo hello"})).await;
-
-        if let ToolExecutionResult::ToolError(msg) = result {
-            assert!(msg.contains("requires context"));
-        } else {
-            panic!("Expected tool error");
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("requires context"));
+            }
+            _ => panic!("Expected tool error"),
         }
     }
 
@@ -994,11 +1017,11 @@ mod tests {
     async fn test_docker_read_file_without_context() {
         let tool = DockerReadFileTool;
         let result = tool.execute(json!({"path": "/test.txt"})).await;
-
-        if let ToolExecutionResult::ToolError(msg) = result {
-            assert!(msg.contains("requires context"));
-        } else {
-            panic!("Expected tool error");
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("requires context"));
+            }
+            _ => panic!("Expected tool error"),
         }
     }
 
@@ -1008,65 +1031,11 @@ mod tests {
         let result = tool
             .execute(json!({"path": "/test.txt", "content": "hello"}))
             .await;
-
-        if let ToolExecutionResult::ToolError(msg) = result {
-            assert!(msg.contains("requires context"));
-        } else {
-            panic!("Expected tool error");
-        }
-    }
-
-    #[tokio::test]
-    async fn test_docker_exec_missing_command() {
-        let tool = DockerExecTool;
-        let context = ToolContext::new(crate::typed_id::SessionId::from_uuid(uuid::Uuid::nil()));
-
-        let result = tool.execute_with_context(json!({}), &context).await;
-
-        if let ToolExecutionResult::ToolError(msg) = result {
-            assert!(msg.contains("Missing required parameter"));
-        } else {
-            panic!("Expected tool error for missing command");
-        }
-    }
-
-    #[tokio::test]
-    async fn test_docker_read_file_missing_path() {
-        let tool = DockerReadFileTool;
-        let context = ToolContext::new(crate::typed_id::SessionId::from_uuid(uuid::Uuid::nil()));
-
-        let result = tool.execute_with_context(json!({}), &context).await;
-
-        if let ToolExecutionResult::ToolError(msg) = result {
-            assert!(msg.contains("Missing required parameter"));
-        } else {
-            panic!("Expected tool error for missing path");
-        }
-    }
-
-    #[tokio::test]
-    async fn test_docker_write_file_missing_params() {
-        let tool = DockerWriteFileTool;
-        let context = ToolContext::new(crate::typed_id::SessionId::from_uuid(uuid::Uuid::nil()));
-
-        // Missing path
-        let result = tool
-            .execute_with_context(json!({"content": "hello"}), &context)
-            .await;
-        if let ToolExecutionResult::ToolError(msg) = result {
-            assert!(msg.contains("Missing required parameter"));
-        } else {
-            panic!("Expected tool error for missing path");
-        }
-
-        // Missing content
-        let result = tool
-            .execute_with_context(json!({"path": "/test.txt"}), &context)
-            .await;
-        if let ToolExecutionResult::ToolError(msg) = result {
-            assert!(msg.contains("Missing required parameter"));
-        } else {
-            panic!("Expected tool error for missing content");
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("requires context"));
+            }
+            _ => panic!("Expected tool error"),
         }
     }
 
@@ -1074,11 +1043,11 @@ mod tests {
     async fn test_docker_stop_without_context() {
         let tool = DockerStopTool;
         let result = tool.execute(json!({})).await;
-
-        if let ToolExecutionResult::ToolError(msg) = result {
-            assert!(msg.contains("requires context"));
-        } else {
-            panic!("Expected tool error");
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("requires context"));
+            }
+            _ => panic!("Expected tool error"),
         }
     }
 
@@ -1086,11 +1055,71 @@ mod tests {
     async fn test_docker_logs_without_context() {
         let tool = DockerLogsTool;
         let result = tool.execute(json!({})).await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("requires context"));
+            }
+            _ => panic!("Expected tool error"),
+        }
+    }
 
-        if let ToolExecutionResult::ToolError(msg) = result {
-            assert!(msg.contains("requires context"));
-        } else {
-            panic!("Expected tool error");
+    #[tokio::test]
+    async fn test_docker_exec_missing_command() {
+        let tool = DockerExecTool;
+        let context = ToolContext::new(everruns_core::typed_id::SessionId::from_uuid(
+            uuid::Uuid::nil(),
+        ));
+        let result = tool.execute_with_context(json!({}), &context).await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("Missing required parameter"));
+            }
+            _ => panic!("Expected tool error for missing command"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_docker_read_file_missing_path() {
+        let tool = DockerReadFileTool;
+        let context = ToolContext::new(everruns_core::typed_id::SessionId::from_uuid(
+            uuid::Uuid::nil(),
+        ));
+        let result = tool.execute_with_context(json!({}), &context).await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("Missing required parameter"));
+            }
+            _ => panic!("Expected tool error for missing path"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_docker_write_file_missing_params() {
+        let tool = DockerWriteFileTool;
+        let context = ToolContext::new(everruns_core::typed_id::SessionId::from_uuid(
+            uuid::Uuid::nil(),
+        ));
+
+        // Missing path
+        let result = tool
+            .execute_with_context(json!({"content": "hello"}), &context)
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("Missing required parameter"));
+            }
+            _ => panic!("Expected tool error for missing path"),
+        }
+
+        // Missing content
+        let result = tool
+            .execute_with_context(json!({"path": "/test.txt"}), &context)
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("Missing required parameter"));
+            }
+            _ => panic!("Expected tool error for missing content"),
         }
     }
 }

--- a/integrations/docker/tests/plugin_registration.rs
+++ b/integrations/docker/tests/plugin_registration.rs
@@ -1,0 +1,68 @@
+//! Integration test: verify Docker Container plugin registers via inventory.
+
+use everruns_core::capabilities::{CapabilityRegistry, IntegrationPlugin};
+use everruns_core::deployment::DeploymentGrade;
+
+// Force linker to include the integration crate's inventory submissions.
+use everruns_integrations_docker as _;
+
+#[test]
+fn test_docker_plugin_is_submitted() {
+    let plugins: Vec<&IntegrationPlugin> = inventory::iter::<IntegrationPlugin>().collect();
+    assert!(
+        plugins.iter().any(|p| {
+            let cap = (p.factory)();
+            cap.id() == "docker_container"
+        }),
+        "Docker Container IntegrationPlugin should be submitted via inventory"
+    );
+}
+
+#[test]
+fn test_docker_plugin_is_experimental() {
+    let plugins: Vec<&IntegrationPlugin> = inventory::iter::<IntegrationPlugin>().collect();
+    let docker = plugins
+        .iter()
+        .find(|p| {
+            let cap = (p.factory)();
+            cap.id() == "docker_container"
+        })
+        .expect("Docker Container plugin not found");
+
+    assert!(
+        docker.experimental_only,
+        "Docker Container should be marked experimental_only"
+    );
+}
+
+#[test]
+fn test_docker_registered_in_dev_registry() {
+    let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
+    assert!(
+        registry.has("docker_container"),
+        "Docker Container should be in dev registry"
+    );
+}
+
+#[test]
+fn test_docker_not_registered_in_prod_registry() {
+    let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Prod);
+    assert!(
+        !registry.has("docker_container"),
+        "Docker Container should NOT be in prod registry"
+    );
+}
+
+#[test]
+fn test_docker_capability_metadata() {
+    let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
+    let cap = registry
+        .get("docker_container")
+        .expect("Docker Container capability not found");
+
+    assert_eq!(cap.id(), "docker_container");
+    assert_eq!(cap.name(), "[Experimental] Docker Container");
+    assert_eq!(cap.icon(), Some("container"));
+    assert_eq!(cap.category(), Some("Development"));
+    assert_eq!(cap.tools().len(), 5);
+}

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -57,6 +57,7 @@ graph TB
    - `openai/` → `everruns-openai` - OpenAI LLM provider implementation
    - `anthropic/` → `everruns-anthropic` - Anthropic LLM provider implementation
    - `integrations/codesandbox/` → `everruns-integrations-codesandbox` - CodeSandbox cloud sandbox integration (auto-registered via `inventory` plugin system)
+   - `integrations/docker/` → `everruns-integrations-docker` - Docker container integration (auto-registered via `inventory` plugin system)
 3. **Frontend**: Next.js application in `apps/ui/` for management and chat interfaces
    - Exports providers, components, hooks, and lib modules via `package.json` `exports` field for SaaS wrapper consumption
 4. **Documentation Site**: Astro Starlight in `apps/docs/` deployed to https://docs.everruns.com/
@@ -78,7 +79,8 @@ everruns/
 │   ├── openai/           # OpenAI provider
 │   └── anthropic/        # Anthropic provider
 ├── integrations/
-│   └── codesandbox/      # CodeSandbox cloud sandbox (inventory plugin)
+│   ├── codesandbox/      # CodeSandbox cloud sandbox (inventory plugin)
+│   └── docker/           # Docker container (inventory plugin)
 ├── docs/                 # Documentation content (symlinked to apps/docs)
 ├── specs/                # Feature specifications
 ├── test_cases/           # Manual test cases

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -130,7 +130,7 @@ Capability IDs are string-based for extensibility. New capabilities can be added
 | `web_fetch` | Web Fetch | Network | Available |
 | `stateless_todo_list` | Task Management | Productivity | Available |
 | `sample_data` | Sample Data | Data | Available |
-| `docker_container` | Docker Container | Development | Available (Dev only) |
+| `docker_container` | Docker Container | Development | Available (Dev only, integration plugin) |
 | `session_sql_database` | SQL Database | Data | Available |
 | `research` | Research | AI | Coming Soon |
 
@@ -1024,8 +1024,9 @@ Experimental capabilities are available in development environments only (`Deplo
 
 #### DockerContainer
 
-- **Status**: Available (Dev only)
+- **Status**: Available (Dev only, integration plugin)
 - **ID**: `docker_container`
+- **Crate**: `integrations/docker/` → `everruns-integrations-docker` (auto-registered via `inventory` plugin system)
 - **Purpose**: Run commands and manage files in a Docker container tied to the session
 - **System Prompt**: Guidance on using container tools, best practices for command execution
 - **Container Lifecycle**:


### PR DESCRIPTION
## What
Move DockerContainerCapability from built-in core capability to external integration crate (integrations/docker/), matching the same shape and location as the CodeSandbox integration.

## Why
Consistency. The CodeSandbox integration was recently extracted to integrations/codesandbox/ using the inventory plugin system. Docker container should follow the same pattern since both are experimental, external-service-backed capabilities.

## How
- Created integrations/docker/ crate with inventory::submit! plugin registration
- Removed docker_container module, re-exports, and direct registry.register() from crates/core
- Added crate to workspace members + server/worker dependencies
- Added tests/plugin_registration.rs (same pattern as codesandbox)
- Updated specs and docs to reflect new location

## Risk
- Low
- Capability ID, tools, behavior all unchanged — only location and registration mechanism changed
- All existing tests pass

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered