### PR TITLE
refactor(test): remove capability count assertions

### DIFF
--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -1592,12 +1592,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_max_capabilities_limit() {
-        // This test verifies the constant is set correctly
-        assert_eq!(MAX_RESOLVED_CAPABILITIES, 100);
-    }
-
     // =========================================================================
     // Message filter provider tests
     // =========================================================================

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -1055,7 +1055,6 @@ mod tests {
         let proto_agent = schema_agent_to_proto(&agent);
 
         // Verify capability_ids are preserved
-        assert_eq!(proto_agent.capability_ids.len(), 2);
         assert!(
             proto_agent
                 .capability_ids
@@ -1071,7 +1070,6 @@ mod tests {
         let schema_agent = proto_agent_to_schema(proto_agent).unwrap();
 
         // Verify capabilities survive roundtrip
-        assert_eq!(schema_agent.capabilities.len(), 2);
         // Check capability IDs are preserved (config defaults to empty)
         let cap_ids: Vec<&str> = schema_agent
             .capabilities

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -554,7 +554,6 @@ mod tests {
             TEST_HARNESS_ID, TEST_AGENT_ID
         );
         let req: CreateSessionRequest = serde_json::from_str(&json).unwrap();
-        assert_eq!(req.capabilities.len(), 2);
         assert_eq!(req.capabilities[0].capability_id(), "current_time");
         assert_eq!(req.capabilities[1].capability_id(), "web_fetch");
     }

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -771,7 +771,11 @@ async fn test_agent_capabilities() {
         .get_agent_capabilities(agent.id.into())
         .await
         .expect("Failed to get capabilities");
-    assert!(capabilities.iter().any(|c| c.capability_id == "current_time"));
+    assert!(
+        capabilities
+            .iter()
+            .any(|c| c.capability_id == "current_time")
+    );
 
     // Set capabilities (replace all)
     let new_caps = backend
@@ -784,7 +788,11 @@ async fn test_agent_capabilities() {
         )
         .await
         .expect("Failed to set capabilities");
-    assert!(new_caps.iter().any(|c| c.capability_id == "session_file_system"));
+    assert!(
+        new_caps
+            .iter()
+            .any(|c| c.capability_id == "session_file_system")
+    );
     assert!(new_caps.iter().any(|c| c.capability_id == "web_search"));
 
     // Verify capabilities replaced
@@ -792,7 +800,11 @@ async fn test_agent_capabilities() {
         .get_agent_capabilities(agent.id.into())
         .await
         .expect("Failed to get capabilities");
-    assert!(capabilities.iter().any(|c| c.capability_id == "session_file_system"));
+    assert!(
+        capabilities
+            .iter()
+            .any(|c| c.capability_id == "session_file_system")
+    );
     assert!(capabilities.iter().any(|c| c.capability_id == "web_search"));
 
     // Remove capability

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -771,7 +771,7 @@ async fn test_agent_capabilities() {
         .get_agent_capabilities(agent.id.into())
         .await
         .expect("Failed to get capabilities");
-    assert_eq!(capabilities.len(), 1);
+    assert!(capabilities.iter().any(|c| c.capability_id == "current_time"));
 
     // Set capabilities (replace all)
     let new_caps = backend
@@ -784,14 +784,16 @@ async fn test_agent_capabilities() {
         )
         .await
         .expect("Failed to set capabilities");
-    assert_eq!(new_caps.len(), 2);
+    assert!(new_caps.iter().any(|c| c.capability_id == "session_file_system"));
+    assert!(new_caps.iter().any(|c| c.capability_id == "web_search"));
 
     // Verify capabilities replaced
     let capabilities = backend
         .get_agent_capabilities(agent.id.into())
         .await
         .expect("Failed to get capabilities");
-    assert_eq!(capabilities.len(), 2);
+    assert!(capabilities.iter().any(|c| c.capability_id == "session_file_system"));
+    assert!(capabilities.iter().any(|c| c.capability_id == "web_search"));
 
     // Remove capability
     let removed = backend


### PR DESCRIPTION
## What
Remove all assertions that rely on capability collection counts in tests.

## Why
Count-based assertions are brittle — they break whenever capabilities are added or removed, even when the test's actual intent is to verify specific capabilities are present.

## How
- Removed `assert_eq!(capabilities.len(), N)` from 4 test files
- Replaced with `assert!(collection.iter().any(|c| c.capability_id == "..."))` where the test needs to verify specific capabilities exist
- Removed `test_max_capabilities_limit` test that only asserted a constant value
- Kept `validate_agent_capabilities_count` tests since those test validation logic, not collection sizes

## Risk
- Low
- No production code changed; only test assertions modified

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
