### PR TITLE
feat(ui): add organisation creation support

### DIFF
--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -51,6 +51,16 @@ jest.mock("@/providers/org-provider", () => ({
   }),
 }));
 
+// Mock organizations hooks
+jest.mock("@/hooks/use-organizations", () => ({
+  useCreateOrganization: () => ({
+    mutateAsync: jest.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+  }),
+}));
+
 describe("Sidebar", () => {
   beforeEach(() => {
     mockPathname.mockReturnValue("/dashboard");

--- a/apps/ui/src/app/(main)/settings/organisation/page.tsx
+++ b/apps/ui/src/app/(main)/settings/organisation/page.tsx
@@ -7,17 +7,32 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { CopyButton } from "@/components/ui/copy-button";
-import { useOrganization, useUpdateOrganization } from "@/hooks/use-organizations";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  useOrganization,
+  useUpdateOrganization,
+  useCreateOrganization,
+} from "@/hooks/use-organizations";
 import { useOrg } from "@/providers/org-provider";
-import { Building2, Save, AlertCircle } from "lucide-react";
+import { Building2, Save, AlertCircle, Plus, Check } from "lucide-react";
 
 export default function OrganisationPage() {
-  const { currentOrg } = useOrg();
+  const { currentOrg, organizations, setCurrentOrg } = useOrg();
   const { data: organization, isLoading, error } = useOrganization();
   const updateOrganization = useUpdateOrganization();
+  const createOrganization = useCreateOrganization();
 
   const [name, setName] = useState("");
   const [hasChanges, setHasChanges] = useState(false);
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [newOrgName, setNewOrgName] = useState("");
 
   // Sync name from fetched organization data
   useEffect(() => {
@@ -45,6 +60,16 @@ export default function OrganisationPage() {
     }
   };
 
+  const handleCreateOrg = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newOrgName.trim()) return;
+
+    const org = await createOrganization.mutateAsync({ name: newOrgName.trim() });
+    setCurrentOrg({ public_id: org.id, name: org.name });
+    setNewOrgName("");
+    setCreateDialogOpen(false);
+  };
+
   if (error) {
     return (
       <div className="space-y-8">
@@ -65,6 +90,7 @@ export default function OrganisationPage() {
 
   return (
     <div className="space-y-8">
+      {/* Current Organisation Settings */}
       <section>
         <div className="mb-6">
           <h2 className="text-xl font-semibold">Organisation</h2>
@@ -147,6 +173,104 @@ export default function OrganisationPage() {
           </Card>
         )}
       </section>
+
+      {/* All Organisations */}
+      <section>
+        <div className="mb-6 flex items-center justify-between">
+          <div>
+            <h2 className="text-xl font-semibold">Your Organisations</h2>
+            <p className="text-sm text-muted-foreground">
+              All organisations you are a member of.
+            </p>
+          </div>
+          <Button onClick={() => setCreateDialogOpen(true)}>
+            <Plus className="h-4 w-4 mr-2" />
+            Create Organisation
+          </Button>
+        </div>
+
+        <div className="space-y-3">
+          {organizations.map((org) => {
+            const isCurrent = currentOrg?.public_id === org.public_id;
+            return (
+              <Card
+                key={org.public_id}
+                className={`p-4 flex items-center justify-between ${isCurrent ? "border-primary/50" : ""}`}
+              >
+                <div className="flex items-center gap-3">
+                  <div
+                    className={`p-2 rounded-lg ${isCurrent ? "bg-primary/10" : "bg-muted"}`}
+                  >
+                    <Building2
+                      className={`h-4 w-4 ${isCurrent ? "text-primary" : "text-muted-foreground"}`}
+                    />
+                  </div>
+                  <div>
+                    <p className="font-medium">{org.name}</p>
+                    <p className="text-xs text-muted-foreground font-mono">{org.public_id}</p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  {isCurrent ? (
+                    <span className="flex items-center gap-1 text-sm text-primary">
+                      <Check className="h-4 w-4" />
+                      Current
+                    </span>
+                  ) : (
+                    <Button variant="outline" size="sm" onClick={() => setCurrentOrg(org)}>
+                      Switch
+                    </Button>
+                  )}
+                </div>
+              </Card>
+            );
+          })}
+        </div>
+      </section>
+
+      {/* Create Organisation Dialog */}
+      <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create Organisation</DialogTitle>
+            <DialogDescription>
+              Create a new organisation. You will be added as a member automatically.
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleCreateOrg} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="new-org-name">Name</Label>
+              <Input
+                id="new-org-name"
+                value={newOrgName}
+                onChange={(e) => setNewOrgName(e.target.value)}
+                placeholder="Organisation name"
+                required
+              />
+            </div>
+            {createOrganization.isError && (
+              <p className="text-sm text-destructive">
+                Failed to create: {createOrganization.error.message}
+              </p>
+            )}
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setCreateDialogOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                disabled={createOrganization.isPending || !newOrgName.trim()}
+              >
+                {createOrganization.isPending ? "Creating..." : "Create"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/apps/ui/src/app/(main)/settings/organisation/page.tsx
+++ b/apps/ui/src/app/(main)/settings/organisation/page.tsx
@@ -179,9 +179,7 @@ export default function OrganisationPage() {
         <div className="mb-6 flex items-center justify-between">
           <div>
             <h2 className="text-xl font-semibold">Your Organisations</h2>
-            <p className="text-sm text-muted-foreground">
-              All organisations you are a member of.
-            </p>
+            <p className="text-sm text-muted-foreground">All organisations you are a member of.</p>
           </div>
           <Button onClick={() => setCreateDialogOpen(true)}>
             <Plus className="h-4 w-4 mr-2" />
@@ -198,9 +196,7 @@ export default function OrganisationPage() {
                 className={`p-4 flex items-center justify-between ${isCurrent ? "border-primary/50" : ""}`}
               >
                 <div className="flex items-center gap-3">
-                  <div
-                    className={`p-2 rounded-lg ${isCurrent ? "bg-primary/10" : "bg-muted"}`}
-                  >
+                  <div className={`p-2 rounded-lg ${isCurrent ? "bg-primary/10" : "bg-muted"}`}>
                     <Building2
                       className={`h-4 w-4 ${isCurrent ? "text-primary" : "text-muted-foreground"}`}
                     />
@@ -254,17 +250,10 @@ export default function OrganisationPage() {
               </p>
             )}
             <DialogFooter>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => setCreateDialogOpen(false)}
-              >
+              <Button type="button" variant="outline" onClick={() => setCreateDialogOpen(false)}>
                 Cancel
               </Button>
-              <Button
-                type="submit"
-                disabled={createOrganization.isPending || !newOrgName.trim()}
-              >
+              <Button type="submit" disabled={createOrganization.isPending || !newOrgName.trim()}>
                 {createOrganization.isPending ? "Creating..." : "Create"}
               </Button>
             </DialogFooter>

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { version } from "../../../package.json";
 import Link from "next/link";
 import Image from "next/image";
@@ -8,7 +9,19 @@ import { cn } from "@/lib/utils";
 import { useAuth } from "@/providers/auth-provider";
 import { useOrg } from "@/providers/org-provider";
 import { useLogout } from "@/hooks/use-auth";
+import { useCreateOrganization } from "@/hooks/use-organizations";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -38,6 +51,7 @@ import {
   Check,
   Shield,
   BookOpen,
+  Plus,
 } from "lucide-react";
 
 const isDev = process.env.NODE_ENV === "development";
@@ -69,12 +83,74 @@ function getInitials(name: string): string {
     .slice(0, 2);
 }
 
+function CreateOrganizationDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [name, setName] = useState("");
+  const createOrg = useCreateOrganization();
+  const { setCurrentOrg } = useOrg();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+
+    const org = await createOrg.mutateAsync({ name: name.trim() });
+    // Switch to the newly created org
+    setCurrentOrg({ public_id: org.id, name: org.name });
+    setName("");
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create Organisation</DialogTitle>
+          <DialogDescription>
+            Create a new organisation. You will be added as a member automatically.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="org-name">Name</Label>
+            <Input
+              id="org-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Organisation name"
+              required
+            />
+          </div>
+          {createOrg.isError && (
+            <p className="text-sm text-destructive">
+              Failed to create organisation: {createOrg.error.message}
+            </p>
+          )}
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={createOrg.isPending || !name.trim()}>
+              {createOrg.isPending ? "Creating..." : "Create"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 export function Sidebar() {
   const pathname = usePathname();
   const router = useRouter();
   const { user, requiresAuth } = useAuth();
   const { currentOrg, organizations, setCurrentOrg } = useOrg();
   const logoutMutation = useLogout();
+  const [createOrgOpen, setCreateOrgOpen] = useState(false);
 
   const handleLogout = async () => {
     await logoutMutation.mutateAsync();
@@ -119,6 +195,11 @@ export function Sidebar() {
                     </DropdownMenuItem>
                   ))}
                 </DropdownMenuGroup>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={() => setCreateOrgOpen(true)}>
+                  <Plus className="mr-2 h-4 w-4" />
+                  Create Organisation
+                </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenuPositioner>
           </DropdownMenu>
@@ -241,6 +322,9 @@ export function Sidebar() {
           <p className="text-xs text-muted-foreground px-3">Everruns v{version}</p>
         )}
       </div>
+
+      {/* Create Organisation Dialog */}
+      <CreateOrganizationDialog open={createOrgOpen} onOpenChange={setCreateOrgOpen} />
     </div>
   );
 }

--- a/apps/ui/src/hooks/use-organizations.ts
+++ b/apps/ui/src/hooks/use-organizations.ts
@@ -1,9 +1,9 @@
 "use client";
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { getOrganization, updateOrganization } from "@/lib/api/organizations";
+import { createOrganization, getOrganization, updateOrganization } from "@/lib/api/organizations";
 import { queryKeys } from "@/lib/query-keys";
-import type { UpdateOrganizationRequest } from "@/lib/api/types";
+import type { CreateOrganizationRequest, UpdateOrganizationRequest } from "@/lib/api/types";
 import { useOrg } from "@/providers/org-provider";
 
 export function useOrganization() {
@@ -22,6 +22,19 @@ export function useOrganization() {
     ...query,
     isLoading: orgLoading || query.isLoading,
   };
+}
+
+export function useCreateOrganization() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: CreateOrganizationRequest) => createOrganization(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.organizations.all });
+      // Refresh user's org list so the new org appears in the dropdown
+      queryClient.invalidateQueries({ queryKey: queryKeys.users.me() });
+    },
+  });
 }
 
 export function useUpdateOrganization() {

--- a/apps/ui/src/lib/api/organizations.ts
+++ b/apps/ui/src/lib/api/organizations.ts
@@ -1,8 +1,13 @@
 // Organization API functions
-// Routes: GET/PATCH /v1/orgs/{org}
+// Routes: POST /v1/orgs, GET/PATCH /v1/orgs/{org}
 
 import { api } from "./client";
-import type { Organization, UpdateOrganizationRequest } from "./types";
+import type { CreateOrganizationRequest, Organization, UpdateOrganizationRequest } from "./types";
+
+export async function createOrganization(data: CreateOrganizationRequest): Promise<Organization> {
+  const response = await api.post<Organization>("/v1/orgs", data);
+  return response.data;
+}
 
 export async function getOrganization(org: string): Promise<Organization> {
   const response = await api.get<Organization>(`/v1/orgs/${org}`);

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -698,6 +698,11 @@ export interface Organization {
   updated_at: string;
 }
 
+/** Request to create an organization */
+export interface CreateOrganizationRequest {
+  name: string;
+}
+
 /** Request to update an organization */
 export interface UpdateOrganizationRequest {
   name?: string;

--- a/crates/server/src/api/organizations.rs
+++ b/crates/server/src/api/organizations.rs
@@ -352,4 +352,29 @@ mod tests {
         assert_eq!(response.id, org.public_id);
         assert_eq!(response.name, org.name);
     }
+
+    #[test]
+    fn test_create_request_deserialization() {
+        let json = r#"{"name": "Acme Corp"}"#;
+        let req: CreateOrganizationRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.name, "Acme Corp");
+    }
+
+    #[test]
+    fn test_create_request_empty_name() {
+        let json = r#"{"name": ""}"#;
+        let req: CreateOrganizationRequest = serde_json::from_str(json).unwrap();
+        assert!(req.name.is_empty());
+    }
+
+    #[test]
+    fn test_update_request_partial() {
+        let json = r#"{}"#;
+        let req: UpdateOrganizationRequest = serde_json::from_str(json).unwrap();
+        assert!(req.name.is_none());
+
+        let json = r#"{"name": "New Name"}"#;
+        let req: UpdateOrganizationRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.name.unwrap(), "New Name");
+    }
 }

--- a/crates/server/tests/org_creation_test.rs
+++ b/crates/server/tests/org_creation_test.rs
@@ -1,0 +1,336 @@
+//! Organization creation tests
+//!
+//! Verifies org creation, membership assignment, validation constraints,
+//! and listing of user organizations.
+//!
+//! Uses in-memory backend (no PostgreSQL required).
+//!
+//! Run with: cargo test -p everruns-server --test org_creation_test
+
+use uuid::Uuid;
+
+use everruns_server::storage::{CreateOrganizationRow, InMemoryDatabase};
+
+// ============================================
+// Creation Tests
+// ============================================
+
+#[tokio::test]
+async fn test_create_organization_assigns_public_id() {
+    let db = InMemoryDatabase::default();
+
+    let org = db
+        .create_organization(CreateOrganizationRow {
+            public_id: "org_aaaabbbbccccddddeeee111122223333".to_string(),
+            name: "Test Org".to_string(),
+        })
+        .await
+        .expect("create should succeed");
+
+    assert_eq!(org.public_id, "org_aaaabbbbccccddddeeee111122223333");
+    assert_eq!(org.name, "Test Org");
+    assert!(org.org_id > 1); // org_id=1 is default org
+}
+
+#[tokio::test]
+async fn test_create_organization_multiple() {
+    let db = InMemoryDatabase::default();
+
+    let org1 = db
+        .create_organization(CreateOrganizationRow {
+            public_id: format!("org_{}", Uuid::now_v7().simple()),
+            name: "Org A".to_string(),
+        })
+        .await
+        .unwrap();
+
+    let org2 = db
+        .create_organization(CreateOrganizationRow {
+            public_id: format!("org_{}", Uuid::now_v7().simple()),
+            name: "Org B".to_string(),
+        })
+        .await
+        .unwrap();
+
+    assert_ne!(org1.org_id, org2.org_id);
+    assert_ne!(org1.public_id, org2.public_id);
+    assert_eq!(org1.name, "Org A");
+    assert_eq!(org2.name, "Org B");
+}
+
+// ============================================
+// Membership Tests
+// ============================================
+
+#[tokio::test]
+async fn test_add_member_and_check() {
+    let db = InMemoryDatabase::default();
+    let user_id = Uuid::now_v7();
+
+    let org = db
+        .create_organization(CreateOrganizationRow {
+            public_id: format!("org_{}", Uuid::now_v7().simple()),
+            name: "Members Test".to_string(),
+        })
+        .await
+        .unwrap();
+
+    // Initially not a member
+    assert!(
+        !db.is_organization_member(org.org_id, user_id)
+            .await
+            .unwrap()
+    );
+
+    // Add member
+    let member = db
+        .add_organization_member(org.org_id, user_id)
+        .await
+        .unwrap();
+    assert_eq!(member.org_id, org.org_id);
+    assert_eq!(member.user_id, user_id);
+
+    // Now a member
+    assert!(
+        db.is_organization_member(org.org_id, user_id)
+            .await
+            .unwrap()
+    );
+}
+
+#[tokio::test]
+async fn test_list_user_organizations() {
+    let db = InMemoryDatabase::default();
+    let user_id = Uuid::now_v7();
+
+    // Create two orgs and add user to both
+    let org1 = db
+        .create_organization(CreateOrganizationRow {
+            public_id: format!("org_{}", Uuid::now_v7().simple()),
+            name: "User Org 1".to_string(),
+        })
+        .await
+        .unwrap();
+
+    let org2 = db
+        .create_organization(CreateOrganizationRow {
+            public_id: format!("org_{}", Uuid::now_v7().simple()),
+            name: "User Org 2".to_string(),
+        })
+        .await
+        .unwrap();
+
+    db.add_organization_member(org1.org_id, user_id)
+        .await
+        .unwrap();
+    db.add_organization_member(org2.org_id, user_id)
+        .await
+        .unwrap();
+
+    let user_orgs = db.list_user_organizations(user_id).await.unwrap();
+    assert_eq!(user_orgs.len(), 2);
+
+    let names: Vec<&str> = user_orgs.iter().map(|o| o.name.as_str()).collect();
+    assert!(names.contains(&"User Org 1"));
+    assert!(names.contains(&"User Org 2"));
+}
+
+#[tokio::test]
+async fn test_list_user_organizations_excludes_non_member() {
+    let db = InMemoryDatabase::default();
+    let user_id = Uuid::now_v7();
+    let other_user_id = Uuid::now_v7();
+
+    let org = db
+        .create_organization(CreateOrganizationRow {
+            public_id: format!("org_{}", Uuid::now_v7().simple()),
+            name: "Exclusive Org".to_string(),
+        })
+        .await
+        .unwrap();
+
+    db.add_organization_member(org.org_id, user_id)
+        .await
+        .unwrap();
+
+    // user_id can see it
+    let user_orgs = db.list_user_organizations(user_id).await.unwrap();
+    assert_eq!(user_orgs.len(), 1);
+
+    // other_user_id cannot
+    let other_orgs = db.list_user_organizations(other_user_id).await.unwrap();
+    assert!(other_orgs.is_empty());
+}
+
+#[tokio::test]
+async fn test_remove_member() {
+    let db = InMemoryDatabase::default();
+    let user_id = Uuid::now_v7();
+
+    let org = db
+        .create_organization(CreateOrganizationRow {
+            public_id: format!("org_{}", Uuid::now_v7().simple()),
+            name: "Remove Test".to_string(),
+        })
+        .await
+        .unwrap();
+
+    db.add_organization_member(org.org_id, user_id)
+        .await
+        .unwrap();
+    assert!(
+        db.is_organization_member(org.org_id, user_id)
+            .await
+            .unwrap()
+    );
+
+    // Remove member
+    let removed = db
+        .remove_organization_member(org.org_id, user_id)
+        .await
+        .unwrap();
+    assert!(removed);
+
+    // No longer a member
+    assert!(
+        !db.is_organization_member(org.org_id, user_id)
+            .await
+            .unwrap()
+    );
+    assert!(
+        db.list_user_organizations(user_id)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}
+
+// ============================================
+// Lookup Tests
+// ============================================
+
+#[tokio::test]
+async fn test_get_organization_by_public_id() {
+    let db = InMemoryDatabase::default();
+    let public_id = format!("org_{}", Uuid::now_v7().simple());
+
+    db.create_organization(CreateOrganizationRow {
+        public_id: public_id.clone(),
+        name: "Lookup Test".to_string(),
+    })
+    .await
+    .unwrap();
+
+    let found = db.get_organization_by_public_id(&public_id).await.unwrap();
+    assert!(found.is_some());
+    assert_eq!(found.unwrap().name, "Lookup Test");
+
+    let not_found = db
+        .get_organization_by_public_id("org_00000000000000000000000000009999")
+        .await
+        .unwrap();
+    assert!(not_found.is_none());
+}
+
+#[tokio::test]
+async fn test_default_org_exists() {
+    let db = InMemoryDatabase::default();
+
+    // Default org (org_id=1) should exist
+    let default_org = db.get_organization(1).await.unwrap();
+    assert!(default_org.is_some());
+
+    let org = default_org.unwrap();
+    assert_eq!(org.org_id, 1);
+    assert_eq!(org.public_id, "org_00000000000000000000000000000001");
+    assert_eq!(org.name, "Default Organization");
+}
+
+// ============================================
+// Update & Delete Tests
+// ============================================
+
+#[tokio::test]
+async fn test_update_organization_name() {
+    let db = InMemoryDatabase::default();
+
+    let org = db
+        .create_organization(CreateOrganizationRow {
+            public_id: format!("org_{}", Uuid::now_v7().simple()),
+            name: "Original Name".to_string(),
+        })
+        .await
+        .unwrap();
+
+    let updated = db
+        .update_organization(
+            org.org_id,
+            everruns_server::storage::UpdateOrganization {
+                name: Some("New Name".to_string()),
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(updated.is_some());
+    assert_eq!(updated.unwrap().name, "New Name");
+}
+
+#[tokio::test]
+async fn test_delete_organization() {
+    let db = InMemoryDatabase::default();
+
+    let org = db
+        .create_organization(CreateOrganizationRow {
+            public_id: format!("org_{}", Uuid::now_v7().simple()),
+            name: "Delete Me".to_string(),
+        })
+        .await
+        .unwrap();
+
+    let deleted = db.delete_organization(org.org_id).await.unwrap();
+    assert!(deleted);
+
+    let gone = db.get_organization(org.org_id).await.unwrap();
+    assert!(gone.is_none());
+}
+
+// ============================================
+// Validation Tests (core)
+// ============================================
+
+#[test]
+fn test_validate_org_public_id() {
+    use everruns_core::validate_org_public_id;
+
+    assert!(validate_org_public_id(
+        "org_00000000000000000000000000000001"
+    ));
+    assert!(validate_org_public_id(
+        "org_aaaabbbbccccddddeeee111122223333"
+    ));
+    assert!(!validate_org_public_id("org_"));
+    assert!(!validate_org_public_id("org_short"));
+    assert!(!validate_org_public_id(
+        "agent_00000000000000000000000000000001"
+    ));
+    assert!(!validate_org_public_id(""));
+    assert!(!validate_org_public_id(
+        "org_AAAABBBBCCCCDDDDEEEE111122223333"
+    )); // uppercase
+}
+
+#[test]
+fn test_generate_org_public_id_format() {
+    use everruns_core::{generate_org_public_id, validate_org_public_id};
+
+    for _ in 0..10 {
+        let id = generate_org_public_id();
+        assert!(
+            validate_org_public_id(&id),
+            "Generated ID should be valid: {id}"
+        );
+        assert!(id.starts_with("org_"));
+        assert_eq!(id.len(), 36); // "org_" + 32 hex chars
+    }
+}

--- a/specs/multitenancy.md
+++ b/specs/multitenancy.md
@@ -522,7 +522,9 @@ ApiError::Forbidden("You don't have access to this agent")
 - [x] Update all API calls with org path
 - [x] Add OrgProvider context with useOrg() hook
 - [x] Persist selected org in localStorage
-- [ ] Add org management page (view members) - deferred to future
+- [x] Add "Create Organisation" button in org dropdown
+- [x] Add org creation dialog (sidebar + settings page)
+- [x] Add organisation management section in settings (list all orgs, switch, create)
 
 ### Phase 8: Usage & Cleanup ✅
 - [x] Add `org_id` to usage tracking
@@ -632,7 +634,19 @@ Some resources remain system-wide (not org-scoped):
 - `/v1/auth/*` - Authentication endpoints
 
 ### UI Organization Selector
-Located in sidebar (`apps/ui/src/components/layout/sidebar.tsx`). Shows current org with dropdown to switch between user's organizations. Uses Base UI's `DropdownMenu` component.
+Located in sidebar (`apps/ui/src/components/layout/sidebar.tsx`). Shows current org with dropdown to switch between user's organizations. Uses Base UI's `DropdownMenu` component. Includes a "Create Organisation" button at the bottom of the dropdown.
+
+### UI Organization Creation
+Two entry points for creating organisations:
+1. **Sidebar dropdown:** "Create Organisation" menu item opens a dialog
+2. **Settings > Organisation page:** "Create Organisation" button in the "Your Organisations" section
+
+Both use the `useCreateOrganization` hook (`hooks/use-organizations.ts`) which calls `POST /v1/orgs`. On success, the new org is auto-selected as the current org via `setCurrentOrg()`.
+
+### UI Organisation Management
+The settings page (`/settings/organisation`) has two sections:
+1. **Current Organisation:** Edit name, view org ID (existing)
+2. **Your Organisations:** Lists all orgs the user belongs to with switch buttons. Current org highlighted with a "Current" badge.
 
 ## Future Considerations
 


### PR DESCRIPTION
## What
Add organisation creation support to the UI, including a Create Organisation button in the sidebar dropdown and an organisation management section on the settings page.

## Why
Users had no way to create new organisations from the UI. The backend POST /v1/orgs endpoint already existed but lacked UI integration.

## How
- Added CreateOrganizationRequest type and createOrganization API client function
- Added useCreateOrganization React Query mutation hook
- Added Create Organisation menu item in the sidebar org dropdown, opening a dialog
- Enhanced the Settings Organisation page with a Your Organisations section listing all orgs the user belongs to, with switch/create actions
- On creation, the new org is automatically selected as the current org
- Added 12 storage-level tests for org CRUD, membership, lookup, and ID validation
- Added handler-level request deserialization tests
- Updated specs/multitenancy.md with org creation UI documentation

## Risk
- Low
- The backend was already fully implemented and tested. This PR adds UI entry points to the existing POST /v1/orgs endpoint. No schema or backend logic changes.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered