### PR TITLE
feat(infra): add Caddy reverse proxy to unify local dev on :9300

### DIFF
--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -51,7 +51,7 @@ Integration tests cover: API endpoints, tool calling (OpenAI/Anthropic/LLMSim), 
 ### 4. UI Check
 
 ```bash
-curl -s -o /dev/null -w "%{http_code}" http://localhost:9100
+curl -s -o /dev/null -w "%{http_code}" http://localhost:9300
 # Expected: 200 or 307
 ```
 
@@ -61,21 +61,22 @@ curl -s -o /dev/null -w "%{http_code}" http://localhost:9100
 ORG="org_00000000000000000000000000000001"
 
 # Create agent
-curl -s -X POST "http://localhost:9000/v1/agents" \
+curl -s -X POST "http://localhost:9300/api/v1/agents" \
   -H "Content-Type: application/json" \
   -d '{"name": "Test", "system_prompt": "You are helpful."}' | jq '.id'
 ```
 
 ## Full API Reference
 
-See http://localhost:9000/swagger-ui/ for complete API documentation.
+See http://localhost:9300/swagger-ui/ for complete API documentation.
 
 ## Troubleshooting
 
 ```bash
 # Check ports
-lsof -i :9000  # API
-lsof -i :9100  # UI
+lsof -i :9300  # Caddy reverse proxy
+lsof -i :9000  # API (direct)
+lsof -i :9100  # UI (direct)
 
 # View logs (DEV MODE runs in foreground)
 # Ctrl+C to stop, then restart with: just start-dev

--- a/.claude/skills/ui-screenshots/SKILL.md
+++ b/.claude/skills/ui-screenshots/SKILL.md
@@ -42,7 +42,7 @@ Use the take-screenshot script:
 Example:
 ```bash
 .claude/skills/ui-screenshots/scripts/take-screenshot.sh \
-  http://localhost:9100/dev/components \
+  http://localhost:9300/dev/components \
   screenshot.png
 ```
 
@@ -52,7 +52,7 @@ For more control, use agent-browser CLI commands:
 
 ```bash
 # Open a page
-agent-browser open http://localhost:9100/dev/components
+agent-browser open http://localhost:9300/dev/components
 
 # Take full-page screenshot
 agent-browser screenshot screenshot.png --full
@@ -127,7 +127,7 @@ sleep 10  # Wait for server
 agent-browser uses sessions to isolate browser instances:
 ```bash
 # Use a named session
-agent-browser --session screenshots open http://localhost:9100
+agent-browser --session screenshots open http://localhost:9300
 
 # List sessions
 agent-browser session list
@@ -152,7 +152,7 @@ Take a screenshot of a URL using agent-browser:
 Example:
 ```bash
 .claude/skills/ui-screenshots/scripts/take-screenshot.sh \
-  http://localhost:9100/dev/components \
+  http://localhost:9300/dev/components \
   /tmp/screenshot.png
 ```
 

--- a/.claude/skills/ui-screenshots/scripts/take-screenshot.sh
+++ b/.claude/skills/ui-screenshots/scripts/take-screenshot.sh
@@ -6,13 +6,13 @@ set -euo pipefail
 # Usage: take-screenshot.sh <URL> <OUTPUT_PATH>
 #
 # Example:
-#   ./take-screenshot.sh http://localhost:9100/dev/components screenshot.png
+#   ./take-screenshot.sh http://localhost:9300/dev/components screenshot.png
 #
 # Requires: agent-browser >= 0.8.5 (npm install -g agent-browser && agent-browser install)
 #
 # Supports containerized environments via --args flag for sandbox-disabling.
 
-URL="${1:-http://localhost:9100/dev/components}"
+URL="${1:-http://localhost:9300/dev/components}"
 OUTPUT_PATH="${2:-screenshot.png}"
 
 # Check if agent-browser is installed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,9 +29,9 @@ just start-all
 ```
 
 Services available at:
-- **UI**: http://localhost:9100
-- **API**: http://localhost:9000
-- **API Docs**: http://localhost:9000/swagger-ui/
+- **App**: http://localhost:9300
+- **API**: http://localhost:9300/api/...
+- **API Docs**: http://localhost:9300/swagger-ui/
 - **Jaeger**: http://localhost:16686
 
 ### Quick Start (DEV_MODE - No Database)

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ docker compose up -d
 ```
 
 Access the platform:
-- **Web UI**: http://localhost:8080
-- **API Docs**: http://localhost:8080/swagger-ui/
+- **Web UI**: http://localhost:9300
+- **API Docs**: http://localhost:9300/swagger-ui/
 
 For detailed setup instructions, see the [Docker Compose Quickstart](https://docs.everruns.com/getting-started/docker-compose/).
 
@@ -58,17 +58,17 @@ For detailed setup instructions, see the [Docker Compose Quickstart](https://doc
 
 ```bash
 # Create an agent
-curl -X POST http://localhost:8080/api/v1/agents \
+curl -X POST http://localhost:9300/api/v1/agents \
   -H "Content-Type: application/json" \
   -d '{"name": "Assistant", "system_prompt": "You are a helpful assistant."}'
 
 # Create a session (agent_id in request body)
-curl -X POST http://localhost:8080/api/v1/sessions \
+curl -X POST http://localhost:9300/api/v1/sessions \
   -H "Content-Type: application/json" \
   -d '{"agent_id": "{agent_id}"}'
 
 # Send a message
-curl -X POST http://localhost:8080/api/v1/sessions/{session_id}/messages \
+curl -X POST http://localhost:9300/api/v1/sessions/{session_id}/messages \
   -H "Content-Type: application/json" \
   -d '{"message": {"role": "user", "content": [{"type": "text", "text": "Hello!"}]}}'
 ```

--- a/docs/features/agent-instructions.md
+++ b/docs/features/agent-instructions.md
@@ -21,7 +21,7 @@ Everruns implements `AGENTS.md` as a built-in capability. When enabled:
 1. **Enable the capability** on your agent:
 
 ```bash
-curl -X PATCH http://localhost:9000/v1/agents/{agent_id} \
+curl -X PATCH http://localhost:9300/api/v1/agents/{agent_id} \
   -H "Content-Type: application/json" \
   -d '{ "capabilities": [{ "ref": "agent_instructions" }] }'
 ```
@@ -112,7 +112,7 @@ Then write an `AGENTS.md` file to the session workspace using the file tools or 
 Enable the capability:
 
 ```bash
-curl -X PATCH http://localhost:9000/v1/agents/{agent_id} \
+curl -X PATCH http://localhost:9300/api/v1/agents/{agent_id} \
   -H "Content-Type: application/json" \
   -d '{
     "capabilities": [

--- a/docs/features/capabilities.md
+++ b/docs/features/capabilities.md
@@ -128,7 +128,7 @@ The order of capabilities matters - capabilities are applied in the order shown,
 Create agent with capabilities:
 
 ```bash
-curl -X POST http://localhost:9000/v1/agents \
+curl -X POST http://localhost:9300/api/v1/agents \
   -H "Content-Type: application/json" \
   -d '{
     "name": "My Agent",
@@ -140,7 +140,7 @@ curl -X POST http://localhost:9000/v1/agents \
 Update agent capabilities:
 
 ```bash
-curl -X PATCH http://localhost:9000/v1/agents/{agent_id} \
+curl -X PATCH http://localhost:9300/api/v1/agents/{agent_id} \
   -H "Content-Type: application/json" \
   -d '{
     "capabilities": ["current_time", "session_file_system"]
@@ -150,13 +150,13 @@ curl -X PATCH http://localhost:9000/v1/agents/{agent_id} \
 Get agent (includes capabilities):
 
 ```bash
-curl -X GET http://localhost:9000/v1/agents/{agent_id}
+curl -X GET http://localhost:9300/api/v1/agents/{agent_id}
 ```
 
 List all available capabilities:
 
 ```bash
-curl -X GET http://localhost:9000/v1/capabilities
+curl -X GET http://localhost:9300/api/v1/capabilities
 ```
 
 ## Capability Application Flow

--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -35,10 +35,10 @@ For local development, configure the API URL:
 
 ```bash
 # Via command-line flag
-everruns --api-url http://localhost:9000 agents list
+everruns --api-url http://localhost:9300/api agents list
 
 # Via environment variable
-export EVERRUNS_API_URL=http://localhost:9000
+export EVERRUNS_API_URL=http://localhost:9300/api
 everruns agents list
 ```
 

--- a/docs/features/ui.md
+++ b/docs/features/ui.md
@@ -15,7 +15,7 @@ The management UI is a Next.js application that provides:
 - Settings management (LLM providers, API keys, team members)
 - Dashboard with system statistics
 
-Access the UI at `http://localhost:9100` when running locally.
+Access the UI at `http://localhost:9300` when running locally.
 
 ## Navigation
 

--- a/docs/getting-started/docker-compose.md
+++ b/docs/getting-started/docker-compose.md
@@ -62,9 +62,9 @@ This starts:
 
 | Service | URL |
 |---------|-----|
-| **Web UI** | http://localhost:8080 |
-| **Swagger API Docs** | http://localhost:8080/swagger-ui/ |
-| **Health Check** | http://localhost:8080/health |
+| **Web UI** | http://localhost:9300 |
+| **Swagger API Docs** | http://localhost:9300/swagger-ui/ |
+| **Health Check** | http://localhost:9300/health |
 | **Jaeger Tracing** | http://localhost:16686 |
 
 ## Configuration
@@ -73,7 +73,7 @@ This starts:
 
 If you didn't set LLM API keys (`DEFAULT_OPENAI_API_KEY`, `DEFAULT_ANTHROPIC_API_KEY`, or `DEFAULT_GEMINI_API_KEY`) in your `.env` file, configure via UI:
 
-1. Open http://localhost:8080
+1. Open http://localhost:9300
 2. Navigate to **Settings** > **Providers**
 3. Add your OpenAI or Anthropic API key
 4. Save and verify connection
@@ -90,12 +90,12 @@ If you didn't set LLM API keys (`DEFAULT_OPENAI_API_KEY`, `DEFAULT_ANTHROPIC_API
 
 ```bash
 # Create a session (agent_id in request body)
-curl -X POST http://localhost:8080/api/v1/sessions \
+curl -X POST http://localhost:9300/api/v1/sessions \
   -H "Content-Type: application/json" \
   -d '{"agent_id": "{agent_id}"}'
 
 # Send a message
-curl -X POST http://localhost:8080/api/v1/sessions/{session_id}/messages \
+curl -X POST http://localhost:9300/api/v1/sessions/{session_id}/messages \
   -H "Content-Type: application/json" \
   -d '{"message": {"role": "user", "content": [{"type": "text", "text": "Hello!"}]}}'
 ```

--- a/docs/sre/runbooks/authentication.md
+++ b/docs/sre/runbooks/authentication.md
@@ -112,13 +112,13 @@ python3 -c "import secrets; print(secrets.token_hex(32))"
 
 ```bash
 # Check auth config endpoint
-curl http://localhost:9000/v1/auth/config
+curl http://localhost:9300/api/v1/auth/config
 
 # Should return:
 # {"mode":"none","password_auth_enabled":false,"oauth_providers":[],"signup_enabled":false}
 
 # For admin mode:
-curl -X POST http://localhost:9000/v1/auth/login \
+curl -X POST http://localhost:9300/api/v1/auth/login \
   -H "Content-Type: application/json" \
   -d '{"email":"admin@example.com","password":"your-password"}'
 ```
@@ -127,12 +127,12 @@ curl -X POST http://localhost:9000/v1/auth/login \
 
 ```bash
 # Login first to get access token
-TOKEN=$(curl -s -X POST http://localhost:9000/v1/auth/login \
+TOKEN=$(curl -s -X POST http://localhost:9300/api/v1/auth/login \
   -H "Content-Type: application/json" \
   -d '{"email":"user@example.com","password":"password"}' | jq -r '.access_token')
 
 # Create API key
-curl -X POST http://localhost:9000/v1/auth/api-keys \
+curl -X POST http://localhost:9300/api/v1/auth/api-keys \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"name":"my-api-key"}'
@@ -143,7 +143,7 @@ curl -X POST http://localhost:9000/v1/auth/api-keys \
 ### Revoke API Key
 
 ```bash
-curl -X DELETE http://localhost:9000/v1/auth/api-keys/{key_id} \
+curl -X DELETE http://localhost:9300/api/v1/auth/api-keys/{key_id} \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -197,7 +197,7 @@ docker run --rm -e DATABASE_URL="$DATABASE_URL" everruns-admin migrate-info
 The `/health` endpoint shows current auth mode:
 
 ```bash
-curl http://localhost:9000/health
+curl http://localhost:9300/health
 # {"status":"ok","version":"0.2.0","auth_mode":"None"}
 ```
 

--- a/example.just
+++ b/example.just
@@ -37,7 +37,7 @@ start tag="latest":
     cd examples
     docker compose -f docker-compose-full.yaml up -d
     echo "✅ Example full stack started!"
-    echo "   - UI: http://localhost:8080"
+    echo "   - UI: http://localhost:9300"
     echo "   - Jaeger UI: http://localhost:16686"
 
 # Stop example docker-compose-full

--- a/examples/docker-compose-full.yaml
+++ b/examples/docker-compose-full.yaml
@@ -21,10 +21,10 @@
 #   3. Start everything:
 #      docker compose -f docker-compose-full.yaml up -d
 #
-#   4. Open UI at: http://localhost:8080
+#   4. Open UI at: http://localhost:9300
 #
 # Ports:
-#   - 8080: Web UI (Caddy)
+#   - 9300: Web UI (Caddy)
 #   - 16686: Jaeger UI (optional)
 #
 # Note: Images are from ghcr.io/everruns - ensure you have access or build locally
@@ -136,7 +136,7 @@ services:
     image: caddy:2-alpine
     container_name: everruns-caddy
     ports:
-      - "8080:8080"
+      - "9300:9300"
     configs:
       - source: caddyfile
         target: /etc/caddy/Caddyfile
@@ -176,7 +176,7 @@ configs:
       #   /api-doc/*    -> API
       #   /health       -> API
       #   /*            -> UI
-      :8080 {
+      :9300 {
         handle_path /api/* {
           reverse_proxy server:9000 {
             # Disable response buffering for SSE streaming

--- a/local/Caddyfile
+++ b/local/Caddyfile
@@ -1,0 +1,29 @@
+# Local development reverse proxy
+# Unifies API (9000) and UI (9100) behind a single port (9300)
+#
+# Routes:
+#   /api/*        -> API server at :9000 (strips /api prefix)
+#   /swagger-ui/* -> API server at :9000
+#   /api-doc/*    -> API server at :9000
+#   /health       -> API server at :9000
+#   /*            -> UI dev server at :9100
+:9300 {
+	handle_path /api/* {
+		reverse_proxy localhost:9000 {
+			# Disable response buffering for SSE streaming
+			flush_interval -1
+		}
+	}
+	handle /swagger-ui/* {
+		reverse_proxy localhost:9000
+	}
+	handle /api-doc/* {
+		reverse_proxy localhost:9000
+	}
+	handle /health {
+		reverse_proxy localhost:9000
+	}
+	handle {
+		reverse_proxy localhost:9100
+	}
+}

--- a/scripts/init-cloud-env.sh
+++ b/scripts/init-cloud-env.sh
@@ -147,6 +147,46 @@ install_doppler() {
     fi
 }
 
+install_caddy() {
+    if command -v caddy &> /dev/null; then
+        info "caddy already installed: $(caddy version 2>/dev/null)"
+        return 0
+    fi
+
+    info "Installing Caddy (pre-built binary)..."
+
+    # Detect architecture
+    ARCH=$(uname -m)
+    case "$ARCH" in
+        x86_64)  CADDY_ARCH="amd64" ;;
+        aarch64) CADDY_ARCH="arm64" ;;
+        *)       error "Unsupported architecture: $ARCH" ;;
+    esac
+
+    CADDY_VERSION="2.9.1"
+    CADDY_TARBALL="caddy_${CADDY_VERSION}_linux_${CADDY_ARCH}.tar.gz"
+    CADDY_URL="https://github.com/caddyserver/caddy/releases/download/v${CADDY_VERSION}/${CADDY_TARBALL}"
+
+    # Download and extract
+    TEMP_DIR=$(mktemp -d)
+    trap "rm -rf $TEMP_DIR" EXIT
+
+    info "Downloading caddy v${CADDY_VERSION}..."
+    curl -sSL "$CADDY_URL" -o "$TEMP_DIR/$CADDY_TARBALL"
+
+    tar -xzf "$TEMP_DIR/$CADDY_TARBALL" -C "$TEMP_DIR" caddy
+
+    # Install binary
+    cp "$TEMP_DIR/caddy" "$INSTALL_DIR/caddy"
+    chmod +x "$INSTALL_DIR/caddy"
+
+    if command -v caddy &> /dev/null; then
+        info "caddy installed: $(caddy version 2>/dev/null)"
+    else
+        error "Failed to install caddy"
+    fi
+}
+
 configure_gh_repo() {
     # Set default repo for gh CLI (needed when git remote uses local proxy)
     # Extract repo from git remote URL (handles both github.com and proxy URLs)
@@ -260,6 +300,7 @@ main() {
     install_just
     install_gh
     install_doppler
+    install_caddy
     configure_gh_repo
     configure_doppler
     configure_gh_auth
@@ -275,6 +316,7 @@ main() {
     echo "  - just $(just --version 2>/dev/null || echo '(not in PATH)')"
     echo "  - gh $(gh --version 2>/dev/null | head -1 || echo '(not in PATH)')"
     echo "  - doppler $(doppler --version 2>/dev/null || echo '(not in PATH)')"
+    echo "  - caddy $(caddy version 2>/dev/null || echo '(not in PATH)')"
     echo ""
     echo "Next steps:"
     echo "  just --list              # See available commands"

--- a/scripts/init-cloud-env.sh
+++ b/scripts/init-cloud-env.sh
@@ -172,7 +172,7 @@ install_caddy() {
     trap "rm -rf $TEMP_DIR" EXIT
 
     info "Downloading caddy v${CADDY_VERSION}..."
-    curl -sSL "$CADDY_URL" -o "$TEMP_DIR/$CADDY_TARBALL"
+    curl -fsSL "$CADDY_URL" -o "$TEMP_DIR/$CADDY_TARBALL"
 
     tar -xzf "$TEMP_DIR/$CADDY_TARBALL" -C "$TEMP_DIR" caddy
 

--- a/scripts/lib/services.sh
+++ b/scripts/lib/services.sh
@@ -23,7 +23,7 @@ done
 case "$cmd" in
   server)
     echo "🌐 Starting server..."
-    export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:9100}
+    export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:9300}
     cargo run -p everruns-server
     ;;
 
@@ -35,7 +35,7 @@ case "$cmd" in
   watch-server)
     echo "👀 Starting server with auto-reload..."
     require_command cargo-watch "Run: just init"
-    export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:9100}
+    export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:9300}
     cargo watch -w crates -x 'run -p everruns-server'
     ;;
 
@@ -53,6 +53,7 @@ case "$cmd" in
       require_command cargo-watch "Run: just init (or use --no-watch)"
     fi
     require_command npm "Install Node.js/npm to start the UI."
+    require_command caddy "Run: just init"
 
     # Track child PIDs for cleanup
     CHILD_PIDS=()
@@ -80,6 +81,7 @@ case "$cmd" in
       done
 
       # Kill by name (catches any child processes we didn't track directly)
+      pkill -TERM -f "caddy run" 2>/dev/null || true
       pkill -TERM -f "cargo-watch" 2>/dev/null || true
       pkill -TERM -f "everruns-server" 2>/dev/null || true
       pkill -TERM -f "next dev" 2>/dev/null || true
@@ -94,6 +96,7 @@ case "$cmd" in
           kill -KILL "$pid" 2>/dev/null || true
         fi
       done
+      pkill -KILL -f "caddy run" 2>/dev/null || true
       pkill -KILL -f "cargo-watch" 2>/dev/null || true
       pkill -KILL -f "everruns-server" 2>/dev/null || true
       pkill -KILL -f "next dev" 2>/dev/null || true
@@ -110,7 +113,7 @@ case "$cmd" in
     # Enable dev mode
     export DEV_MODE=true
     export DEPLOYMENT_GRADE=dev
-    export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:9100}
+    export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:9300}
     export RUST_LOG=${RUST_LOG:-info}
 
     # Set encryption key if not provided (standard dev key from .env.example)
@@ -185,18 +188,22 @@ case "$cmd" in
     sleep 5
     echo "   ✅ UI is starting (PID: $UI_PID)"
 
+    # Start Caddy reverse proxy
+    echo "6️⃣  Starting reverse proxy (Caddy)..."
+    caddy run --config "$PROJECT_ROOT/local/Caddyfile" --adapter caddyfile &
+    CADDY_PID=$!
+    CHILD_PIDS+=("$CADDY_PID")
+    sleep 1
+    echo "   ✅ Reverse proxy is running on :9300 (PID: $CADDY_PID)"
+
     echo ""
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     echo "✅ DEV MODE started (fully functional, in-memory storage)!"
     echo ""
-    if [ "$NO_WATCH" = true ]; then
-      echo "   🌐 Server:        http://localhost:9000"
-    else
-      echo "   🌐 Server:        http://localhost:9000 (auto-reload)"
-    fi
-    echo "   📖 API Docs:      http://localhost:9000/swagger-ui/"
+    echo "   🌐 App:           http://localhost:9300"
+    echo "   📖 API Docs:      http://localhost:9300/swagger-ui/"
+    echo "   🔌 API:           http://localhost:9300/api/..."
     echo "   ⚙️  Worker:        Running in-process (no separate process)"
-    echo "   🖥️  UI:            http://localhost:9100 (hot reload)"
     echo ""
     echo "⚠️  DEV MODE notes:"
     echo "   - Data is stored in memory (lost on restart)"
@@ -222,6 +229,7 @@ case "$cmd" in
     require_command sqlx "Run: just init"
     if [ "$NO_UI" = false ]; then
       require_command npm "Install Node.js/npm to start the UI (or use --no-ui)"
+      require_command caddy "Run: just init"
     fi
 
     CHILD_PIDS=()
@@ -250,6 +258,7 @@ case "$cmd" in
       done
 
       # Kill by name (catches any child processes we didn't track directly)
+      pkill -TERM -f "caddy run" 2>/dev/null || true
       pkill -TERM -f "cargo-watch" 2>/dev/null || true
       pkill -TERM -f "everruns-server" 2>/dev/null || true
       pkill -TERM -f "everruns-worker" 2>/dev/null || true
@@ -265,6 +274,7 @@ case "$cmd" in
           kill -KILL "$pid" 2>/dev/null || true
         fi
       done
+      pkill -KILL -f "caddy run" 2>/dev/null || true
       pkill -KILL -f "cargo-watch" 2>/dev/null || true
       pkill -KILL -f "everruns-server" 2>/dev/null || true
       pkill -KILL -f "everruns-worker" 2>/dev/null || true
@@ -370,7 +380,7 @@ case "$cmd" in
     fi
 
     # Start API
-    export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:9100}
+    export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:9300}
     export DEPLOYMENT_GRADE=dev
     export RUST_LOG=${RUST_LOG:-info}
     if [ "$NO_WATCH" = true ]; then
@@ -460,6 +470,14 @@ case "$cmd" in
       cd "$PROJECT_ROOT"
       sleep 5
       echo "   ✅ UI is starting (PID: $UI_PID)"
+
+      # Start Caddy reverse proxy
+      echo "9️⃣  Starting reverse proxy (Caddy)..."
+      caddy run --config "$PROJECT_ROOT/local/Caddyfile" --adapter caddyfile &
+      CADDY_PID=$!
+      CHILD_PIDS+=("$CADDY_PID")
+      sleep 1
+      echo "   ✅ Reverse proxy is running on :9300 (PID: $CADDY_PID)"
     else
       echo "7️⃣  Skipping UI (--no-ui)"
     fi
@@ -472,17 +490,18 @@ case "$cmd" in
       echo "✅ All services started with auto-reload!"
     fi
     echo ""
-    if [ "$NO_WATCH" = true ]; then
+    if [ "$NO_UI" = false ]; then
+      echo "   🌐 App:         http://localhost:9300"
+      echo "   📖 API Docs:    http://localhost:9300/swagger-ui/"
+      echo "   🔌 API:         http://localhost:9300/api/..."
+    else
       echo "   🌐 API:         http://localhost:9000"
       echo "   📖 API Docs:    http://localhost:9000/swagger-ui/"
-      echo "   ⚙️ Worker:      running"
-    else
-      echo "   🌐 API:         http://localhost:9000 (auto-reload)"
-      echo "   📖 API Docs:    http://localhost:9000/swagger-ui/"
-      echo "   ⚙️ Worker:      running (auto-reload)"
     fi
-    if [ "$NO_UI" = false ]; then
-      echo "   🖥️ UI:          http://localhost:9100 (hot reload)"
+    if [ "$NO_WATCH" = false ]; then
+      echo "   ⚙️ Worker:      running (auto-reload)"
+    else
+      echo "   ⚙️ Worker:      running"
     fi
     if [ "$JAEGER_STARTED" = true ]; then
       echo "   🔍 Jaeger UI:   http://localhost:16686"
@@ -502,6 +521,7 @@ case "$cmd" in
   stop-all)
     echo "🛑 Stopping all Everruns services..."
 
+    pkill -f "caddy run" 2>/dev/null || true
     pkill -f "everruns-server" 2>/dev/null || true
     pkill -f "everruns-worker" 2>/dev/null || true
     pkill -f "next dev" 2>/dev/null || true

--- a/scripts/lib/setup.sh
+++ b/scripts/lib/setup.sh
@@ -15,6 +15,34 @@ case "$cmd" in
 
     echo "🧪 Preflight checks..."
 
+    # Caddy reverse proxy
+    echo "🔀 Reverse proxy:"
+    if ! command -v caddy &> /dev/null; then
+      echo "  Installing caddy..."
+      ARCH=$(uname -m)
+      case "$ARCH" in
+        x86_64)  CADDY_ARCH="amd64" ;;
+        aarch64) CADDY_ARCH="arm64" ;;
+        arm64)   CADDY_ARCH="arm64" ;;
+        *)       echo "  ⚠️  Unsupported architecture: $ARCH, skipping caddy"; CADDY_ARCH="" ;;
+      esac
+      if [ -n "$CADDY_ARCH" ]; then
+        OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+        CADDY_VERSION="2.9.1"
+        CADDY_URL="https://github.com/caddyserver/caddy/releases/download/v${CADDY_VERSION}/caddy_${CADDY_VERSION}_${OS}_${CADDY_ARCH}.tar.gz"
+        TEMP_DIR=$(mktemp -d)
+        curl -sSL "$CADDY_URL" -o "$TEMP_DIR/caddy.tar.gz"
+        tar -xzf "$TEMP_DIR/caddy.tar.gz" -C "$TEMP_DIR" caddy
+        mkdir -p "$HOME/.cargo/bin"
+        mv "$TEMP_DIR/caddy" "$HOME/.cargo/bin/caddy"
+        chmod +x "$HOME/.cargo/bin/caddy"
+        rm -rf "$TEMP_DIR"
+        echo "  ✅ caddy installed: $(caddy version 2>/dev/null || echo 'installed')"
+      fi
+    else
+      echo "  ✅ caddy already installed: $(caddy version 2>/dev/null)"
+    fi
+
     # Rust tools
     echo "📦 Rust tools:"
     if ! command -v sqlx &> /dev/null; then

--- a/scripts/lib/setup.sh
+++ b/scripts/lib/setup.sh
@@ -27,11 +27,15 @@ case "$cmd" in
         *)       echo "  ⚠️  Unsupported architecture: $ARCH, skipping caddy"; CADDY_ARCH="" ;;
       esac
       if [ -n "$CADDY_ARCH" ]; then
-        OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+        # Caddy uses "mac" not "darwin" in release asset names
+        case "$(uname -s)" in
+          Darwin) CADDY_OS="mac" ;;
+          *)      CADDY_OS=$(uname -s | tr '[:upper:]' '[:lower:]') ;;
+        esac
         CADDY_VERSION="2.9.1"
-        CADDY_URL="https://github.com/caddyserver/caddy/releases/download/v${CADDY_VERSION}/caddy_${CADDY_VERSION}_${OS}_${CADDY_ARCH}.tar.gz"
+        CADDY_URL="https://github.com/caddyserver/caddy/releases/download/v${CADDY_VERSION}/caddy_${CADDY_VERSION}_${CADDY_OS}_${CADDY_ARCH}.tar.gz"
         TEMP_DIR=$(mktemp -d)
-        curl -sSL "$CADDY_URL" -o "$TEMP_DIR/caddy.tar.gz"
+        curl -fsSL "$CADDY_URL" -o "$TEMP_DIR/caddy.tar.gz"
         tar -xzf "$TEMP_DIR/caddy.tar.gz" -C "$TEMP_DIR" caddy
         mkdir -p "$HOME/.cargo/bin"
         mv "$TEMP_DIR/caddy" "$HOME/.cargo/bin/caddy"

--- a/specs/code-organization.md
+++ b/specs/code-organization.md
@@ -205,7 +205,7 @@ just test-llm  # Run against real LLM APIs
 - Capabilities listing
 
 **Requirements:**
-- Server running at `localhost:9000` (use `just start-dev --no-watch` or DEV_MODE in CI)
+- Server running at `localhost:9300` (use `just start-dev --no-watch` or DEV_MODE in CI)
 - `DEFAULT_OPENAI_API_KEY` or `DEFAULT_ANTHROPIC_API_KEY` for chat tests
 - Use `--skip-chat` flag to skip chat tests when no LLM keys available
 

--- a/test_cases/research_agent/TC001_research_agent_full_workflow.md
+++ b/test_cases/research_agent/TC001_research_agent_full_workflow.md
@@ -22,7 +22,7 @@ Verify that the research agent completes a full research workflow: receives a qu
 
 1. Create research agent:
    ```bash
-   curl -s -X POST "http://localhost:9000/v1/agents" \
+   curl -s -X POST "http://localhost:9300/api/v1/agents" \
      -H "Content-Type: application/json" \
      -d '{
        "name": "Research Agent",
@@ -34,7 +34,7 @@ Verify that the research agent completes a full research workflow: receives a qu
 
 2. Create session:
    ```bash
-   curl -s -X POST "http://localhost:9000/v1/sessions" \
+   curl -s -X POST "http://localhost:9300/api/v1/sessions" \
      -H "Content-Type: application/json" \
      -d '{"agent_id": "{agent_id}"}'
    ```
@@ -42,7 +42,7 @@ Verify that the research agent completes a full research workflow: receives a qu
 
 3. Send research request:
    ```bash
-   curl -s -X POST "http://localhost:9000/v1/sessions/{session_id}/messages" \
+   curl -s -X POST "http://localhost:9300/api/v1/sessions/{session_id}/messages" \
      -H "Content-Type: application/json" \
      -d '{
        "message": {
@@ -57,13 +57,13 @@ Verify that the research agent completes a full research workflow: receives a qu
 5. Retrieve all data for assertions:
    ```bash
    # Events
-   curl -s "http://localhost:9000/v1/sessions/{session_id}/events"
+   curl -s "http://localhost:9300/api/v1/sessions/{session_id}/events"
 
    # Files
-   curl -s "http://localhost:9000/v1/sessions/{session_id}/fs?recursive=true"
+   curl -s "http://localhost:9300/api/v1/sessions/{session_id}/fs?recursive=true"
 
    # Report content
-   curl -s "http://localhost:9000/v1/sessions/{session_id}/fs/research/report.md"
+   curl -s "http://localhost:9300/api/v1/sessions/{session_id}/fs/research/report.md"
    ```
 
 ## Expected Result

--- a/test_cases/scheduled-tasks/TC006_api_crud.md
+++ b/test_cases/scheduled-tasks/TC006_api_crud.md
@@ -13,7 +13,7 @@ Verify all CRUD operations work correctly via the REST API.
 
 | Field | Value |
 |-------|-------|
-| API Base URL | http://localhost:9000 |
+| API Base URL | http://localhost:9300/api |
 | Schedule Name | api-test-schedule |
 
 ## Steps


### PR DESCRIPTION
## What
Add a Caddy reverse proxy as the unified entry point for local development on port 9300. All user-facing URLs now go through `http://localhost:9300`:
- `/api/*` → API server (:9000, prefix stripped)
- `/swagger-ui/*`, `/api-doc/*`, `/health` → API server (:9000)
- `/*` → UI dev server (:9100)

## Why
Previously, developers had to remember separate ports for UI (9100) and API (9000), and docker-compose used 8080. This unifies everything behind a single port (9300) that matches the docker-compose experience, simplifying onboarding and documentation.

## How
- New `local/Caddyfile` with reverse proxy rules and SSE streaming support (`flush_interval -1`)
- Caddy installed via `just init` (setup.sh) and `init-cloud-env.sh`
- Caddy started/stopped as part of `start-dev` and `start-all` lifecycle
- All docs, specs, test cases, examples, and skills updated from old ports to `:9300`
- CORS origin updated from `:9100` to `:9300`
- Docker-compose Caddy port updated from 8080 to 9300

## Risk
- Low
- Caddy binary download URL could change in future releases
- Existing developer muscle memory for `:9000` / `:9100` (both still work directly)

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered