### PR TITLE
refactor(ui,server): remove SSE dev hacks and swagger-ui

### DIFF
--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -68,7 +68,7 @@ curl -s -X POST "http://localhost:9300/api/v1/agents" \
 
 ## Full API Reference
 
-See http://localhost:9300/swagger-ui/ for complete API documentation.
+See https://docs.everruns.com for complete API documentation.
 
 ## Troubleshooting
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,6 @@ just start-all
 Services available at:
 - **App**: http://localhost:9300
 - **API**: http://localhost:9300/api/...
-- **API Docs**: http://localhost:9300/swagger-ui/
 - **Jaeger**: http://localhost:16686
 
 ### Quick Start (DEV_MODE - No Database)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1440,9 +1440,8 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "utoipa",
- "utoipa-swagger-ui",
  "uuid",
- "zip 2.4.2",
+ "zip",
 ]
 
 [[package]]
@@ -1617,7 +1616,6 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
- "zlib-rs",
 ]
 
 [[package]]
@@ -4118,40 +4116,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-embed"
-version = "8.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
-dependencies = [
- "rust-embed-impl",
- "rust-embed-utils",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-impl"
-version = "8.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
-dependencies = [
- "proc-macro2",
- "quote",
- "rust-embed-utils",
- "syn 2.0.116",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-utils"
-version = "8.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
-dependencies = [
- "sha2",
- "walkdir",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5664,24 +5628,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utoipa-swagger-ui"
-version = "9.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
-dependencies = [
- "axum",
- "base64",
- "mime_guess",
- "regex",
- "rust-embed",
- "serde",
- "serde_json",
- "url",
- "utoipa",
- "zip 3.0.0",
-]
-
-[[package]]
 name = "uuid"
 version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6714,26 +6660,6 @@ dependencies = [
  "thiserror 2.0.18",
  "zopfli",
 ]
-
-[[package]]
-name = "zip"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
-dependencies = [
- "arbitrary",
- "crc32fast",
- "flate2",
- "indexmap",
- "memchr",
- "zopfli",
-]
-
-[[package]]
-name = "zlib-rs"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7948af682ccbc3342b6e9420e8c51c1fe5d7bf7756002b4a3c6cabfe96a7e3c"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,9 +66,8 @@ opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.31", features = ["http-proto", "reqwest-client"] }
 tracing-opentelemetry = "0.32"
 
-# OpenAPI documentation
+# OpenAPI documentation (used by export-openapi binary for spec generation)
 utoipa = { version = "5.4", features = ["axum_extras", "chrono", "uuid"] }
-utoipa-swagger-ui = { version = "9.0", features = ["axum"] }
 
 # Encryption
 aes-gcm = "0.10"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ docker compose up -d
 
 Access the platform:
 - **Web UI**: http://localhost:9300
-- **API Docs**: http://localhost:9300/swagger-ui/
+- **API**: http://localhost:9300/api/...
 
 For detailed setup instructions, see the [Docker Compose Quickstart](https://docs.everruns.com/getting-started/docker-compose/).
 

--- a/apps/ui/next.config.ts
+++ b/apps/ui/next.config.ts
@@ -2,18 +2,8 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: 'standalone',
-  // Proxy /api/* requests to backend in development
-  // Strips the /api prefix and forwards to backend (e.g., /api/v1/agents -> http://localhost:9000/v1/agents)
-  // In production, configure your reverse proxy to do the same
-  async rewrites() {
-    const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:9000';
-    return [
-      {
-        source: '/api/:path*',
-        destination: `${apiUrl}/:path*`,
-      },
-    ];
-  },
+  // API routing handled by Caddy reverse proxy (strips /api prefix, forwards to backend)
+  // No Next.js rewrites needed
 };
 
 export default nextConfig;

--- a/apps/ui/src/lib/api/client.ts
+++ b/apps/ui/src/lib/api/client.ts
@@ -102,4 +102,3 @@ export function getBackendUrl(): string {
   }
   return API_BASE;
 }
-

--- a/apps/ui/src/lib/api/client.ts
+++ b/apps/ui/src/lib/api/client.ts
@@ -1,7 +1,6 @@
 // API base URL configuration:
-// All API requests use /api prefix which is either:
-// - Proxied by Next.js rewrites in development (strips /api, forwards to backend)
-// - Handled by reverse proxy in production (strips /api, forwards to backend)
+// All API requests (including SSE) use /api prefix.
+// Caddy reverse proxy strips /api and forwards to backend in all environments.
 const API_BASE = "/api";
 
 // Org selection is handled via server-side cookie (everruns_org), set by
@@ -104,27 +103,3 @@ export function getBackendUrl(): string {
   return API_BASE;
 }
 
-/**
- * Get the direct backend URL for SSE connections.
- *
- * In development: Connect directly to backend at localhost:9000
- *                 (Next.js rewrites don't handle SSE streaming properly)
- * In production: Uses origin + /api (reverse proxies like Caddy stream SSE correctly)
- *
- * Override with NEXT_PUBLIC_API_URL if needed.
- */
-export function getDirectBackendUrl(): string {
-  // Use NEXT_PUBLIC_API_URL if explicitly set
-  if (typeof window !== "undefined" && process.env.NEXT_PUBLIC_API_URL) {
-    return process.env.NEXT_PUBLIC_API_URL;
-  }
-  // In development, connect directly to backend (Next.js rewrites buffer SSE)
-  if (process.env.NODE_ENV === "development") {
-    return "http://localhost:9000";
-  }
-  // In production, use origin + /api (reverse proxy handles SSE correctly)
-  if (typeof window !== "undefined") {
-    return window.location.origin + "/api";
-  }
-  return "/api";
-}

--- a/apps/ui/src/lib/api/durable.ts
+++ b/apps/ui/src/lib/api/durable.ts
@@ -1,6 +1,6 @@
 // Durable Execution API functions
 
-import { api, getDirectBackendUrl } from "./client";
+import { api, getApiBaseUrl } from "./client";
 import type {
   WorkersResponse,
   WorkflowsResponse,
@@ -15,7 +15,7 @@ import type {
 } from "./types";
 
 // ============================================
-// SSE URLs (bypasses Next.js proxy buffering)
+// SSE URLs
 // ============================================
 
 /**
@@ -23,8 +23,7 @@ import type {
  * Returns health, workers, workflows, tasks, DLQ, and circuit breakers.
  */
 export function getDurableSseUrl(): string {
-  const baseUrl = getDirectBackendUrl();
-  return `${baseUrl}/v1/durable/sse`;
+  return `${getApiBaseUrl()}/v1/durable/sse`;
 }
 
 /**
@@ -32,8 +31,7 @@ export function getDurableSseUrl(): string {
  * Returns workflow details and events.
  */
 export function getWorkflowSseUrl(workflowId: string): string {
-  const baseUrl = getDirectBackendUrl();
-  return `${baseUrl}/v1/durable/workflows/${workflowId}/sse`;
+  return `${getApiBaseUrl()}/v1/durable/workflows/${workflowId}/sse`;
 }
 
 // ============================================

--- a/apps/ui/src/lib/api/events.ts
+++ b/apps/ui/src/lib/api/events.ts
@@ -2,7 +2,7 @@
 // Events are SSE notifications for real-time updates
 // Org is sent via everruns_org cookie (set by OrgProvider via /v1/users/me/switch-org)
 
-import { api, getDirectBackendUrl } from "./client";
+import { api, getApiBaseUrl } from "./client";
 import type { Event, ListResponse } from "./types";
 
 // Default event types to exclude in UI contexts (streaming delta events are noise)
@@ -25,12 +25,11 @@ export async function listEvents(sessionId: string, exclude?: string[]): Promise
 }
 
 // Get SSE URL for real-time event streaming
-// Uses direct backend URL to bypass Next.js proxy (proxies buffer SSE)
 // Uses since_id for incremental updates (UUID v7 monotonically increasing)
 // Optional exclude parameter to filter out event types (e.g., delta events)
 // Note: Org is sent via everruns_org cookie (EventSource sends cookies automatically)
 export function getSseUrl(sessionId: string, sinceId?: string, exclude?: string[]): string {
-  const baseUrl = getDirectBackendUrl();
+  const baseUrl = getApiBaseUrl();
   const params = new URLSearchParams();
   if (sinceId) {
     params.set("since_id", sinceId);

--- a/apps/ui/src/lib/api/images.ts
+++ b/apps/ui/src/lib/api/images.ts
@@ -4,7 +4,7 @@
 // API functions for uploading, retrieving, and deleting images.
 // Images can be attached to messages as image_file content parts.
 
-import { getApiBaseUrl, getDirectBackendUrl } from "./client";
+import { getApiBaseUrl } from "./client";
 import type { ImageUploadResponse, ImageInfo } from "./types";
 import { ALLOWED_IMAGE_TYPES, MAX_IMAGE_SIZE } from "./types";
 
@@ -49,9 +49,7 @@ export async function uploadImage(file: File, sessionId?: string): Promise<Image
   const formData = new FormData();
   formData.append("file", file);
 
-  // Use direct backend URL for multipart uploads
-  // Next.js rewrites don't handle streaming/multipart properly (causes EPIPE errors)
-  const baseUrl = getDirectBackendUrl();
+  const baseUrl = getApiBaseUrl();
   const params = sessionId ? `?session_id=${sessionId}` : "";
   const url = `${baseUrl}/v1/images${params}`;
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -34,7 +34,6 @@ thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 utoipa.workspace = true
-utoipa-swagger-ui.workspace = true
 sqlx.workspace = true
 chrono.workspace = true
 dotenvy.workspace = true

--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -23,10 +23,9 @@ Migrations are applied automatically on server startup.
 
 The API will be available at `http://localhost:9000`
 
-### 3. View API Documentation
+### 3. Access the API
 
-Open your browser to:
-- **Swagger UI**: http://localhost:9000/swagger-ui/
+- **API**: http://localhost:9000/v1/...
 - **OpenAPI Spec**: http://localhost:9000/api-doc/openapi.json
 
 ## Examples
@@ -105,7 +104,6 @@ See [specs/apis.md](../../specs/apis.md) for the complete API reference.
 ### System
 
 - `GET /health` - Health check (includes version and runner mode)
-- `GET /swagger-ui/` - Interactive API documentation
 - `GET /api-doc/openapi.json` - OpenAPI specification
 
 Organization context is derived from authentication (API key or session cookie).

--- a/crates/server/examples/create_agent.rs
+++ b/crates/server/examples/create_agent.rs
@@ -74,7 +74,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\nNext steps:");
     println!("   - Create a session: POST /v1/sessions (with agent_id in body)");
     println!("   - Send a message: POST /v1/sessions/<session_id>/messages");
-    println!("   - View API docs: http://localhost:9000/swagger-ui/");
+    println!("   - View API docs: https://docs.everruns.com");
 
     Ok(())
 }

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -27,7 +27,6 @@ use std::sync::Arc;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::trace::TraceLayer;
 use utoipa::OpenApi;
-use utoipa_swagger_ui::SwaggerUi;
 
 /// Server configuration loaded from environment
 pub struct ServerConfig {
@@ -322,10 +321,13 @@ pub async fn run(
     }
 
     // Build main router
-    let mut app = Router::new().route("/health", get(health).with_state(health_state));
-    app = app.merge(build_router_with_prefix(api_routes, &config.api_prefix));
-    let app =
-        app.merge(SwaggerUi::new("/swagger-ui").url("/api-doc/openapi.json", ApiDoc::openapi()));
+    let app = Router::new()
+        .route("/health", get(health).with_state(health_state))
+        .route(
+            "/api-doc/openapi.json",
+            get(|| async { Json(ApiDoc::openapi()) }),
+        )
+        .merge(build_router_with_prefix(api_routes, &config.api_prefix));
 
     // CORS
     let app = if !config.cors_origins.is_empty() {

--- a/docs/getting-started/docker-compose.md
+++ b/docs/getting-started/docker-compose.md
@@ -63,7 +63,7 @@ This starts:
 | Service | URL |
 |---------|-----|
 | **Web UI** | http://localhost:9300 |
-| **Swagger API Docs** | http://localhost:9300/swagger-ui/ |
+| **API** | http://localhost:9300/api/... |
 | **Health Check** | http://localhost:9300/health |
 | **Jaeger Tracing** | http://localhost:16686 |
 

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -53,17 +53,16 @@ See [Capabilities](/features/capabilities) for more details.
 
 ### API Access
 
-The API is available at your deployment URL with full OpenAPI documentation:
+The API is available at your deployment URL:
 
-- **API Base**: `https://your-domain.com/v1/`
-- **Swagger UI**: `https://your-domain.com/swagger-ui/`
+- **API Base**: `https://your-domain.com/api/v1/`
 - **OpenAPI Spec**: `https://your-domain.com/api-doc/openapi.json`
 
 ## Architecture
 
 Everruns uses a layered architecture:
 
-- **API Layer**: HTTP endpoints (axum), SSE streaming, Swagger UI
+- **API Layer**: HTTP endpoints (axum), SSE streaming
 - **Core Layer**: Agent abstractions, capabilities, tools
 - **Worker Layer**: Durable workflows for reliable execution
 - **Storage Layer**: PostgreSQL with encrypted secrets and durable execution state

--- a/docs/sre/environment-variables.md
+++ b/docs/sre/environment-variables.md
@@ -88,7 +88,7 @@ API_PREFIX=/api
 ```
 
 **Notes:**
-- `/health`, `/swagger-ui`, and `/api-doc/openapi.json` are not affected by this prefix
+- `/health` and `/api-doc/openapi.json` are not affected by this prefix
 - All API routes including auth (`/v1/auth/*`) are affected by this prefix
 - OAuth callback URLs automatically include this prefix when using defaults
 - Use when running behind a reverse proxy or API gateway that expects a path prefix

--- a/docs/sre/environment-variables.md
+++ b/docs/sre/environment-variables.md
@@ -113,7 +113,7 @@ CORS_ALLOWED_ORIGINS=https://app.example.com,https://admin.example.com
 ```
 
 **Notes:**
-- Not needed for local development (Next.js proxy handles `/api/*` requests)
+- Not needed for local development (Caddy reverse proxy handles `/api/*` requests)
 - Not needed in production if using a reverse proxy on the same domain
 - If set, credentials are allowed (`Access-Control-Allow-Credentials: true`)
 - Wildcard (`*`) is not supported when using credentials
@@ -169,23 +169,19 @@ DEFAULT_GEMINI_API_KEY=AIza...
 
 ## UI API Proxy Architecture
 
-The UI makes all API requests to `/api/*` paths. These are handled differently in each environment:
+The UI makes all API requests (including SSE) to `/api/*` paths. Caddy reverse proxy strips `/api` and forwards to the backend.
 
 **Local Development:**
-- Next.js rewrites proxy `/api/*` to `http://localhost:9000/*`
+- Caddy on `:9300` routes `/api/*` to backend at `:9000` (strips `/api` prefix)
 - Example: `/api/v1/agents` → `http://localhost:9000/v1/agents`
-- No CORS needed (same-origin)
+- SSE streaming works via `flush_interval -1` in Caddy config
+- No CORS needed (same-origin through Caddy)
 
-**Production (recommended):**
+**Production:**
 - Configure your reverse proxy (nginx, Caddy, etc.) to route `/api/*` to the API server
 - Strip the `/api` prefix when forwarding
-- Example nginx config:
-  ```nginx
-  location /api/ {
-    proxy_pass http://api-server:9000/;
-  }
-  ```
-- No CORS needed (same-origin)
+- Disable response buffering for SSE endpoints
+- Example Caddy config: see `local/Caddyfile`
 
 ## Worker Configuration
 

--- a/examples/docker-compose-full.yaml
+++ b/examples/docker-compose-full.yaml
@@ -171,20 +171,16 @@ configs:
   caddyfile:
     content: |
       # Reverse proxy routes:
-      #   /api/*        -> API (strips prefix)
-      #   /swagger-ui/* -> API
-      #   /api-doc/*    -> API
-      #   /health       -> API
-      #   /*            -> UI
+      #   /api/*     -> API (strips prefix)
+      #   /api-doc/* -> API
+      #   /health    -> API
+      #   /*         -> UI
       :9300 {
         handle_path /api/* {
           reverse_proxy server:9000 {
             # Disable response buffering for SSE streaming
             flush_interval -1
           }
-        }
-        handle /swagger-ui/* {
-          reverse_proxy server:9000
         }
         handle /api-doc/* {
           reverse_proxy server:9000

--- a/local/Caddyfile
+++ b/local/Caddyfile
@@ -2,20 +2,16 @@
 # Unifies API (9000) and UI (9100) behind a single port (9300)
 #
 # Routes:
-#   /api/*        -> API server at :9000 (strips /api prefix)
-#   /swagger-ui/* -> API server at :9000
-#   /api-doc/*    -> API server at :9000
-#   /health       -> API server at :9000
-#   /*            -> UI dev server at :9100
+#   /api/*     -> API server at :9000 (strips /api prefix)
+#   /api-doc/* -> API server at :9000
+#   /health    -> API server at :9000
+#   /*         -> UI dev server at :9100
 :9300 {
 	handle_path /api/* {
 		reverse_proxy localhost:9000 {
 			# Disable response buffering for SSE streaming
 			flush_interval -1
 		}
-	}
-	handle /swagger-ui/* {
-		reverse_proxy localhost:9000
 	}
 	handle /api-doc/* {
 		reverse_proxy localhost:9000

--- a/scripts/lib/services.sh
+++ b/scripts/lib/services.sh
@@ -201,7 +201,6 @@ case "$cmd" in
     echo "✅ DEV MODE started (fully functional, in-memory storage)!"
     echo ""
     echo "   🌐 App:           http://localhost:9300"
-    echo "   📖 API Docs:      http://localhost:9300/swagger-ui/"
     echo "   🔌 API:           http://localhost:9300/api/..."
     echo "   ⚙️  Worker:        Running in-process (no separate process)"
     echo ""
@@ -492,11 +491,9 @@ case "$cmd" in
     echo ""
     if [ "$NO_UI" = false ]; then
       echo "   🌐 App:         http://localhost:9300"
-      echo "   📖 API Docs:    http://localhost:9300/swagger-ui/"
       echo "   🔌 API:         http://localhost:9300/api/..."
     else
       echo "   🌐 API:         http://localhost:9000"
-      echo "   📖 API Docs:    http://localhost:9000/swagger-ui/"
     fi
     if [ "$NO_WATCH" = false ]; then
       echo "   ⚙️ Worker:      running (auto-reload)"

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -362,7 +362,6 @@ GET /v1/agents/{agent_id}
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/swagger-ui/` | Swagger UI for OpenAPI docs |
 | GET | `/api-doc/openapi.json` | OpenAPI specification |
 
 ### OpenAPI Spec Generation

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -401,7 +401,7 @@ Capabilities are modular functionality units that extend Agent behavior. See [sp
 
 1. **RESTful**: Standard REST conventions for CRUD operations
 2. **Versioning**: API versioned under `/v1/` prefix
-3. **Documentation**: OpenAPI 3.0 with Swagger UI at `/swagger-ui/`
+3. **Documentation**: OpenAPI 3.0 spec generated via `./scripts/export-openapi.sh`
 
 ### Infrastructure
 

--- a/specs/maintenance.md
+++ b/specs/maintenance.md
@@ -71,10 +71,9 @@ Identify and fill gaps.
 ### 5. API Documentation
 
 1. Run `./scripts/export-openapi.sh` — must succeed
-2. Verify OpenAPI spec at `docs/api/openapi.json` matches running server
+2. Verify OpenAPI spec at `docs/api/openapi.json` is up to date
 3. Check all endpoints have descriptions and response types in utoipa annotations
-4. Verify Swagger UI loads without errors
-5. Cross-check `specs/apis.md` with actual routes
+4. Cross-check `specs/apis.md` with actual routes
 
 ### 6. Examples
 


### PR DESCRIPTION
## Summary
- **Remove SSE dev hacks**: All requests (REST, SSE, uploads) now route through `/api` via Caddy instead of bypassing to `localhost:9000` directly. Fixes cross-origin cookie/CORS issues with `start-all`.
- **Remove swagger-ui**: Drop `utoipa-swagger-ui` dependency and `/swagger-ui` route. Keep `/api-doc/openapi.json` as a plain axum endpoint. The docs site is the canonical API reference.
- Remove Next.js rewrites (Caddy handles all routing)

## Test plan
- [ ] `just start-dev` — app loads at `:9300`, SSE streaming works in chat
- [ ] `just start-all` — same, no cross-origin errors in browser console
- [ ] Image upload works (no EPIPE or CORS errors)
- [ ] `/api-doc/openapi.json` returns valid spec
- [ ] `/swagger-ui/` returns 404
- [ ] Durable dashboard SSE works (`/durable`)