### PR TITLE
feat(auth): add external AuthMode for third-party auth providers

### DIFF
--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -657,7 +657,7 @@ export interface HealthResponse {
 // Authentication types
 // ============================================
 
-export type AuthMode = "none" | "admin" | "full";
+export type AuthMode = "none" | "admin" | "full" | "external";
 
 export interface AuthConfigResponse {
   mode: AuthMode;

--- a/crates/server/src/auth/builtin.rs
+++ b/crates/server/src/auth/builtin.rs
@@ -169,10 +169,14 @@ impl AuthBackend for BuiltinAuthBackend {
                 AuthMode::None => "none".to_string(),
                 AuthMode::Admin => "admin".to_string(),
                 AuthMode::Full => "full".to_string(),
+                AuthMode::External => "external".to_string(),
             },
             password_auth_enabled: self.config.password_auth_enabled(),
             oauth_providers,
-            signup_enabled: self.config.mode != AuthMode::Admin && !self.config.disable_signup,
+            // External mode: signup is managed by the external provider
+            signup_enabled: self.config.mode != AuthMode::Admin
+                && self.config.mode != AuthMode::External
+                && !self.config.disable_signup,
         }
     }
 }

--- a/crates/server/src/auth/config.rs
+++ b/crates/server/src/auth/config.rs
@@ -14,6 +14,8 @@ pub enum AuthMode {
     Admin,
     /// Full authentication (password + OAuth + API keys)
     Full,
+    /// External authentication (third-party provider like PropelAuth, Auth0, Clerk)
+    External,
 }
 
 impl AuthMode {
@@ -21,6 +23,7 @@ impl AuthMode {
         match s.to_lowercase().as_str() {
             "admin" => AuthMode::Admin,
             "full" => AuthMode::Full,
+            "external" => AuthMode::External,
             _ => AuthMode::None,
         }
     }
@@ -257,6 +260,7 @@ impl AuthConfig {
     pub fn password_auth_enabled(&self) -> bool {
         // Admin mode always has password auth (that's how you log in with admin credentials)
         // Full mode has password auth unless explicitly disabled
+        // External mode: password auth is managed by the external provider, not us
         self.mode == AuthMode::Admin || (self.mode == AuthMode::Full && !self.disable_password_auth)
     }
 
@@ -268,7 +272,9 @@ impl AuthConfig {
     /// Check if API key authentication is available
     #[allow(dead_code)]
     pub fn api_key_auth_enabled(&self) -> bool {
-        self.mode == AuthMode::Full || self.mode == AuthMode::Admin
+        self.mode == AuthMode::Full
+            || self.mode == AuthMode::Admin
+            || self.mode == AuthMode::External
     }
 }
 
@@ -284,6 +290,8 @@ mod tests {
         assert_eq!(AuthMode::parse("ADMIN"), AuthMode::Admin);
         assert_eq!(AuthMode::parse("full"), AuthMode::Full);
         assert_eq!(AuthMode::parse("FULL"), AuthMode::Full);
+        assert_eq!(AuthMode::parse("external"), AuthMode::External);
+        assert_eq!(AuthMode::parse("EXTERNAL"), AuthMode::External);
         assert_eq!(AuthMode::parse("invalid"), AuthMode::None);
     }
 
@@ -407,6 +415,27 @@ mod tests {
         let admin = config_with_admin.admin.unwrap();
         assert_eq!(admin.email, "admin@example.com");
         assert_eq!(admin.password, "changeme");
+    }
+
+    #[test]
+    fn test_external_mode() {
+        let config = AuthConfig {
+            mode: AuthMode::External,
+            ..Default::default()
+        };
+        assert!(config.is_enabled());
+        assert!(
+            !config.password_auth_enabled(),
+            "External mode should not have password auth (managed by external provider)"
+        );
+        assert!(
+            !config.oauth_enabled(),
+            "External mode should not have built-in OAuth"
+        );
+        assert!(
+            config.api_key_auth_enabled(),
+            "External mode should support API keys"
+        );
     }
 
     #[test]

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -186,11 +186,15 @@ pub async fn get_auth_config(State(state): State<BuiltinAuthBackend>) -> Json<Au
             AuthMode::None => "none".to_string(),
             AuthMode::Admin => "admin".to_string(),
             AuthMode::Full => "full".to_string(),
+            AuthMode::External => "external".to_string(),
         },
         password_auth_enabled: state.config.password_auth_enabled(),
         oauth_providers,
         // Admin mode has a single predefined user, no signup allowed
-        signup_enabled: state.config.mode != AuthMode::Admin && !state.config.disable_signup,
+        // External mode: signup is managed by the external provider
+        signup_enabled: state.config.mode != AuthMode::Admin
+            && state.config.mode != AuthMode::External
+            && !state.config.disable_signup,
     })
 }
 

--- a/specs/authentication.md
+++ b/specs/authentication.md
@@ -8,13 +8,15 @@ This document defines the authentication system for Everruns, supporting flexibl
 
 ### Authentication Modes
 
-Everruns supports three authentication modes:
+Everruns supports four authentication modes:
 
 1. **None** (`AUTH_MODE=none`): No authentication required. All requests use a well-known anonymous user (`ANONYMOUS_USER_ID = 00000000-0000-0000-0000-000000000001`). This is a real database user seeded at startup, so all code paths (org membership, API keys, etc.) work uniformly without special-casing. The anonymous user has admin role and belongs to the default organization. Suitable for local development.
 
 2. **Admin** (`AUTH_MODE=admin`): Single admin user via environment variables. Suitable for local development with basic access control.
 
 3. **Full** (`AUTH_MODE=full`): Complete authentication with user registration, OAuth, and API keys. Suitable for production deployments.
+
+4. **External** (`AUTH_MODE=external`): Authentication managed by a third-party provider (e.g., PropelAuth, Auth0, Clerk). The external provider handles login, registration, and user management. Built-in password auth, OAuth, and signup are disabled. API key authentication is supported. Suitable for SaaS deployments with external identity providers.
 
 ### Authentication Methods
 
@@ -66,7 +68,7 @@ Account linking by email is supported (same email = same account).
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `AUTH_MODE` | Authentication mode: `none`, `admin`, `full` | `none` |
+| `AUTH_MODE` | Authentication mode: `none`, `admin`, `full`, `external` | `none` |
 | `AUTH_BASE_URL` | Base URL for OAuth callbacks | `http://localhost:9000` |
 | `AUTH_ADMIN_EMAIL` | Admin user email (admin mode) | - |
 | `AUTH_ADMIN_PASSWORD` | Admin user password (admin mode) | - |
@@ -164,7 +166,7 @@ The UI fetches authentication configuration from `GET /v1/auth/config` on startu
 
 ```typescript
 interface AuthConfigResponse {
-  mode: "none" | "admin" | "full";
+  mode: "none" | "admin" | "full" | "external";
   password_auth_enabled: boolean;
   oauth_providers: string[];  // ["google", "github"]
   signup_enabled: boolean;
@@ -177,6 +179,7 @@ Based on `mode`:
 
 - **none**: Skip authentication entirely, show app directly
 - **admin/full**: Require login before accessing protected routes
+- **external**: Auth required (like full), but login/signup managed by external provider
 
 ### UI Components
 


### PR DESCRIPTION
## Summary

- Adds `External` variant to `AuthMode` enum in Rust and `"external"` to the TypeScript `AuthMode` type
- External mode signals that authentication is managed by a third-party provider (PropelAuth, Auth0, Clerk)
- In external mode: built-in password auth, OAuth, and signup are disabled; API key auth remains supported
- Updates authentication spec to document the new mode

## Test plan

- [x] New `test_external_mode` unit test verifies external mode behavior (auth enabled, no password auth, no OAuth, API keys supported)
- [x] Existing `test_auth_mode_parsing` updated to cover `"external"` / `"EXTERNAL"` parsing
- [x] `cargo test` passes all auth config tests
- [x] `just pre-push` passes (fmt, clippy, lockfile)

Closes #489