### PR TITLE
chore(specs): clarify user connection visibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,8 @@ GRPC_ADDRESS=127.0.0.1:9001
 # AUTH_DISABLE_PASSWORD=false
 #
 # OAuth (optional) - requires AUTH_BASE_URL for callback URLs
-# AUTH_BASE_URL=http://localhost:9000
+# AUTH_BASE_URL=http://localhost:9300
+# API_PREFIX=/api
 # AUTH_GOOGLE_CLIENT_ID=your-google-client-id
 # AUTH_GOOGLE_CLIENT_SECRET=your-google-client-secret
 # AUTH_GITHUB_CLIENT_ID=your-github-client-id

--- a/.env.example
+++ b/.env.example
@@ -31,8 +31,7 @@ GRPC_ADDRESS=127.0.0.1:9001
 # AUTH_DISABLE_PASSWORD=false
 #
 # OAuth (optional) - requires AUTH_BASE_URL for callback URLs
-# AUTH_BASE_URL=http://localhost:9300
-# API_PREFIX=/api
+# AUTH_BASE_URL=http://localhost:9300/api
 # AUTH_GOOGLE_CLIENT_ID=your-google-client-id
 # AUTH_GOOGLE_CLIENT_SECRET=your-google-client-secret
 # AUTH_GITHUB_CLIENT_ID=your-github-client-id

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,7 @@ Fix root cause. Unsure: read more code; if stuck, ask w/ short options. Unrecogn
 - `specs/scheduled-tasks.md` - Cron-based scheduled tasks for durable engine
 - `specs/fail-rs-testing.md` - Failure injection testing with fail-rs
 - `specs/authentication.md` - Authentication modes and OAuth
+- `specs/user-connections.md` - User connections (GitHub, GitLab) for repo access
 - `specs/encryption.md` - Envelope encryption for sensitive data
 - `specs/session-filesystem.md` - Per-session virtual filesystem
 - `specs/usage-tracking.md` - LLM token usage tracking

--- a/apps/ui/src/__tests__/settings-layout.test.tsx
+++ b/apps/ui/src/__tests__/settings-layout.test.tsx
@@ -102,7 +102,7 @@ describe("SettingsLayout", () => {
     expect(membersLink).toHaveClass("border-accent");
   });
 
-  it("has exactly 5 navigation items", () => {
+  it("has exactly 6 navigation items", () => {
     render(
       <SettingsLayout>
         <div>Test Content</div>
@@ -110,6 +110,6 @@ describe("SettingsLayout", () => {
     );
 
     const navLinks = screen.getAllByRole("link");
-    expect(navLinks).toHaveLength(5);
+    expect(navLinks).toHaveLength(6);
   });
 });

--- a/apps/ui/src/app/(main)/settings/connections/page.tsx
+++ b/apps/ui/src/app/(main)/settings/connections/page.tsx
@@ -8,18 +8,27 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useUserConnections, useDeleteUserConnection } from "@/hooks/use-user-connections";
 import { getBackendUrl } from "@/lib/api/client";
-import { ExternalLink, LinkIcon, Trash2, Check } from "lucide-react";
+import { ExternalLink, Github, LinkIcon, Trash2, Check } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import type { UserConnection } from "@/lib/api/types";
-import Image from "next/image";
 
 /** Provider metadata for display */
-const providers: Record<string, { name: string; icon: string; description: string }> = {
+const providers: Record<string, { name: string; icon: LucideIcon; description: string }> = {
   github: {
     name: "GitHub",
-    icon: "/icons/github.svg",
+    icon: Github,
     description: "Access private repositories for agent sessions",
   },
 };
+
+function ProviderIcon({ provider, className }: { provider: string; className?: string }) {
+  const meta = providers[provider];
+  if (meta) {
+    const Icon = meta.icon;
+    return <Icon className={className} />;
+  }
+  return <LinkIcon className={className} />;
+}
 
 function ConnectionRow({
   connection,
@@ -36,11 +45,7 @@ function ConnectionRow({
   return (
     <div className="flex items-center justify-between p-4 border rounded-lg">
       <div className="flex items-center gap-3">
-        {meta?.icon ? (
-          <Image src={meta.icon} alt={displayName} width={20} height={20} className="dark:invert" />
-        ) : (
-          <LinkIcon className="h-5 w-5 text-muted-foreground" />
-        )}
+        <ProviderIcon provider={connection.provider} className="h-5 w-5" />
         <div>
           <div className="font-medium flex items-center gap-2">
             {displayName}
@@ -75,7 +80,7 @@ function AvailableProviderRow({
   meta,
 }: {
   provider: string;
-  meta: { name: string; icon: string; description: string };
+  meta: { name: string; icon: LucideIcon; description: string };
 }) {
   const handleConnect = () => {
     // Navigate to OAuth authorize endpoint through the API proxy
@@ -85,7 +90,7 @@ function AvailableProviderRow({
   return (
     <div className="flex items-center justify-between p-4 border rounded-lg">
       <div className="flex items-center gap-3">
-        <Image src={meta.icon} alt={meta.name} width={20} height={20} className="dark:invert" />
+        <ProviderIcon provider={provider} className="h-5 w-5" />
         <div>
           <div className="font-medium">{meta.name}</div>
           <div className="text-sm text-muted-foreground">{meta.description}</div>

--- a/apps/ui/src/app/(main)/settings/connections/page.tsx
+++ b/apps/ui/src/app/(main)/settings/connections/page.tsx
@@ -7,9 +7,8 @@ import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useUserConnections, useDeleteUserConnection } from "@/hooks/use-user-connections";
-import { useAuth } from "@/providers/auth-provider";
 import { getBackendUrl } from "@/lib/api/client";
-import { ExternalLink, LinkIcon, ShieldAlert, Trash2, Check } from "lucide-react";
+import { ExternalLink, LinkIcon, Trash2, Check } from "lucide-react";
 import type { UserConnection } from "@/lib/api/types";
 import Image from "next/image";
 
@@ -101,7 +100,6 @@ function AvailableProviderRow({
 }
 
 export default function ConnectionsPage() {
-  const { requiresAuth } = useAuth();
   const { data: connections = [], isLoading, error } = useUserConnections();
   const deleteConnection = useDeleteUserConnection();
   const searchParams = useSearchParams();
@@ -127,28 +125,6 @@ export default function ConnectionsPage() {
       await deleteConnection.mutateAsync(provider);
     }
   };
-
-  if (!requiresAuth) {
-    return (
-      <div className="space-y-8">
-        <section>
-          <div className="mb-4">
-            <h2 className="text-xl font-semibold">Connections</h2>
-            <p className="text-sm text-muted-foreground">
-              Connect external accounts for agent sessions.
-            </p>
-          </div>
-          <Card className="p-8 text-center">
-            <ShieldAlert className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
-            <h3 className="text-lg font-medium mb-2">Authentication Disabled</h3>
-            <p className="text-muted-foreground">
-              Connections are only available when authentication is enabled.
-            </p>
-          </Card>
-        </section>
-      </div>
-    );
-  }
 
   // Determine which providers are not yet connected
   const connectedProviders = new Set(connections.map((c) => c.provider));

--- a/apps/ui/src/app/(main)/settings/connections/page.tsx
+++ b/apps/ui/src/app/(main)/settings/connections/page.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useUserConnections, useDeleteUserConnection } from "@/hooks/use-user-connections";
+import { useAuth } from "@/providers/auth-provider";
+import { getBackendUrl } from "@/lib/api/client";
+import { ExternalLink, LinkIcon, ShieldAlert, Trash2, Check } from "lucide-react";
+import type { UserConnection } from "@/lib/api/types";
+import Image from "next/image";
+
+/** Provider metadata for display */
+const providers: Record<string, { name: string; icon: string; description: string }> = {
+  github: {
+    name: "GitHub",
+    icon: "/icons/github.svg",
+    description: "Access private repositories for agent sessions",
+  },
+};
+
+function ConnectionRow({
+  connection,
+  onDisconnect,
+  isDisconnecting,
+}: {
+  connection: UserConnection;
+  onDisconnect: (provider: string) => void;
+  isDisconnecting: boolean;
+}) {
+  const meta = providers[connection.provider];
+  const displayName = meta?.name ?? connection.provider;
+
+  return (
+    <div className="flex items-center justify-between p-4 border rounded-lg">
+      <div className="flex items-center gap-3">
+        {meta?.icon ? (
+          <Image src={meta.icon} alt={displayName} width={20} height={20} className="dark:invert" />
+        ) : (
+          <LinkIcon className="h-5 w-5 text-muted-foreground" />
+        )}
+        <div>
+          <div className="font-medium flex items-center gap-2">
+            {displayName}
+            {connection.provider_username && (
+              <Badge variant="outline" className="text-xs font-normal">
+                {connection.provider_username}
+              </Badge>
+            )}
+          </div>
+          <div className="text-sm text-muted-foreground">
+            Connected {new Date(connection.connected_at).toLocaleDateString()}
+            {connection.scopes && <span className="ml-2">({connection.scopes})</span>}
+          </div>
+        </div>
+      </div>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="text-destructive"
+        onClick={() => onDisconnect(connection.provider)}
+        disabled={isDisconnecting}
+      >
+        <Trash2 className="h-4 w-4 mr-1" />
+        Disconnect
+      </Button>
+    </div>
+  );
+}
+
+function AvailableProviderRow({
+  provider,
+  meta,
+}: {
+  provider: string;
+  meta: { name: string; icon: string; description: string };
+}) {
+  const handleConnect = () => {
+    // Navigate to OAuth authorize endpoint through the API proxy
+    window.location.href = `${getBackendUrl()}/v1/user/connections/${provider}/authorize`;
+  };
+
+  return (
+    <div className="flex items-center justify-between p-4 border rounded-lg">
+      <div className="flex items-center gap-3">
+        <Image src={meta.icon} alt={meta.name} width={20} height={20} className="dark:invert" />
+        <div>
+          <div className="font-medium">{meta.name}</div>
+          <div className="text-sm text-muted-foreground">{meta.description}</div>
+        </div>
+      </div>
+      <Button variant="outline" size="sm" onClick={handleConnect}>
+        <ExternalLink className="h-4 w-4 mr-1" />
+        Connect
+      </Button>
+    </div>
+  );
+}
+
+export default function ConnectionsPage() {
+  const { requiresAuth } = useAuth();
+  const { data: connections = [], isLoading, error } = useUserConnections();
+  const deleteConnection = useDeleteUserConnection();
+  const searchParams = useSearchParams();
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  // Show success toast when redirected back from OAuth
+  useEffect(() => {
+    const connected = searchParams.get("connected");
+    if (connected) {
+      const meta = providers[connected];
+      setSuccessMessage(`${meta?.name ?? connected} connected successfully`);
+      // Clear URL param without reload
+      window.history.replaceState({}, "", "/settings/connections");
+      const timer = setTimeout(() => setSuccessMessage(null), 4000);
+      return () => clearTimeout(timer);
+    }
+  }, [searchParams]);
+
+  const handleDisconnect = async (provider: string) => {
+    const meta = providers[provider];
+    const name = meta?.name ?? provider;
+    if (confirm(`Disconnect ${name}? New sessions will no longer have access to your ${name} account.`)) {
+      await deleteConnection.mutateAsync(provider);
+    }
+  };
+
+  if (!requiresAuth) {
+    return (
+      <div className="space-y-8">
+        <section>
+          <div className="mb-4">
+            <h2 className="text-xl font-semibold">Connections</h2>
+            <p className="text-sm text-muted-foreground">
+              Connect external accounts for agent sessions.
+            </p>
+          </div>
+          <Card className="p-8 text-center">
+            <ShieldAlert className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+            <h3 className="text-lg font-medium mb-2">Authentication Disabled</h3>
+            <p className="text-muted-foreground">
+              Connections are only available when authentication is enabled.
+            </p>
+          </Card>
+        </section>
+      </div>
+    );
+  }
+
+  // Determine which providers are not yet connected
+  const connectedProviders = new Set(connections.map((c) => c.provider));
+  const availableProviders = Object.entries(providers).filter(
+    ([key]) => !connectedProviders.has(key),
+  );
+
+  return (
+    <div className="space-y-8">
+      {/* Success banner */}
+      {successMessage && (
+        <div className="flex items-center gap-2 bg-green-500/10 text-green-700 dark:text-green-400 p-3 rounded-lg text-sm">
+          <Check className="h-4 w-4" />
+          {successMessage}
+        </div>
+      )}
+
+      {/* Connected accounts */}
+      <section>
+        <div className="mb-4">
+          <h2 className="text-xl font-semibold">Connections</h2>
+          <p className="text-sm text-muted-foreground">
+            Connected accounts are automatically available in agent sessions.
+          </p>
+        </div>
+
+        {error && (
+          <div className="bg-destructive/10 text-destructive p-4 rounded-lg mb-4">
+            Failed to load connections: {error.message}
+          </div>
+        )}
+
+        {isLoading ? (
+          <div className="space-y-2">
+            {[...Array(1)].map((_, i) => (
+              <Skeleton key={i} className="h-[72px] w-full" />
+            ))}
+          </div>
+        ) : connections.length === 0 && availableProviders.length === 0 ? (
+          <Card className="p-8 text-center">
+            <LinkIcon className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+            <h3 className="text-lg font-medium mb-2">No connections available</h3>
+            <p className="text-muted-foreground">
+              No connection providers are configured.
+            </p>
+          </Card>
+        ) : (
+          <div className="space-y-2">
+            {connections.map((conn) => (
+              <ConnectionRow
+                key={conn.provider}
+                connection={conn}
+                onDisconnect={handleDisconnect}
+                isDisconnecting={deleteConnection.isPending}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Available providers */}
+      {availableProviders.length > 0 && (
+        <section>
+          <div className="mb-4">
+            <h2 className="text-lg font-semibold">Available</h2>
+            <p className="text-sm text-muted-foreground">
+              Connect additional accounts to enable repository access in sessions.
+            </p>
+          </div>
+          <div className="space-y-2">
+            {availableProviders.map(([key, meta]) => (
+              <AvailableProviderRow key={key} provider={key} meta={meta} />
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/app/(main)/settings/connections/page.tsx
+++ b/apps/ui/src/app/(main)/settings/connections/page.tsx
@@ -126,7 +126,11 @@ export default function ConnectionsPage() {
   const handleDisconnect = async (provider: string) => {
     const meta = providers[provider];
     const name = meta?.name ?? provider;
-    if (confirm(`Disconnect ${name}? New sessions will no longer have access to your ${name} account.`)) {
+    if (
+      confirm(
+        `Disconnect ${name}? New sessions will no longer have access to your ${name} account.`,
+      )
+    ) {
       await deleteConnection.mutateAsync(provider);
     }
   };
@@ -172,9 +176,7 @@ export default function ConnectionsPage() {
           <Card className="p-8 text-center">
             <LinkIcon className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
             <h3 className="text-lg font-medium mb-2">No connections available</h3>
-            <p className="text-muted-foreground">
-              No connection providers are configured.
-            </p>
+            <p className="text-muted-foreground">No connection providers are configured.</p>
           </Card>
         ) : (
           <div className="space-y-2">

--- a/apps/ui/src/app/(main)/settings/layout.tsx
+++ b/apps/ui/src/app/(main)/settings/layout.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { Header } from "@/components/layout/header";
-import { Server, Key, Users, Plug, Building2 } from "lucide-react";
+import { Server, Key, Users, Plug, Building2, Cable } from "lucide-react";
 
 const settingsNavigation = [
   {
@@ -24,6 +24,12 @@ const settingsNavigation = [
     href: "/settings/mcp-servers",
     icon: Plug,
     description: "Manage MCP server connections",
+  },
+  {
+    name: "Connections",
+    href: "/settings/connections",
+    icon: Cable,
+    description: "Connect external accounts",
   },
   {
     name: "API Keys",

--- a/apps/ui/src/hooks/use-user-connections.ts
+++ b/apps/ui/src/hooks/use-user-connections.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { getUserConnections, deleteUserConnection } from "@/lib/api/user-connections";
+import { queryKeys } from "@/lib/query-keys";
+
+export function useUserConnections() {
+  return useQuery({
+    queryKey: queryKeys.userConnections.list(),
+    queryFn: () => getUserConnections(),
+    staleTime: 30000,
+  });
+}
+
+export function useDeleteUserConnection() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (provider: string) => deleteUserConnection(provider),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.userConnections.all });
+    },
+  });
+}

--- a/apps/ui/src/lib/api/client.ts
+++ b/apps/ui/src/lib/api/client.ts
@@ -102,3 +102,4 @@ export function getBackendUrl(): string {
   }
   return API_BASE;
 }
+

--- a/apps/ui/src/lib/api/client.ts
+++ b/apps/ui/src/lib/api/client.ts
@@ -102,4 +102,3 @@ export function getBackendUrl(): string {
   }
   return API_BASE;
 }
-

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -1517,3 +1517,14 @@ export interface ScheduleExecutionsResponse {
 export interface TriggerResponse {
   execution_id: string;
 }
+
+// ============================================
+// User Connection types
+// ============================================
+
+export interface UserConnection {
+  provider: string;
+  provider_username?: string;
+  scopes?: string;
+  connected_at: string;
+}

--- a/apps/ui/src/lib/api/user-connections.ts
+++ b/apps/ui/src/lib/api/user-connections.ts
@@ -1,0 +1,14 @@
+// User Connections API functions
+// User-scoped (not org-scoped) — connections represent user's identity
+
+import { api } from "./client";
+import type { UserConnection } from "./types";
+
+export async function getUserConnections(): Promise<UserConnection[]> {
+  const response = await api.get<UserConnection[]>("/v1/user/connections");
+  return response.data;
+}
+
+export async function deleteUserConnection(provider: string): Promise<void> {
+  await api.delete(`/v1/user/connections/${provider}`);
+}

--- a/apps/ui/src/lib/query-keys.ts
+++ b/apps/ui/src/lib/query-keys.ts
@@ -115,6 +115,12 @@ export const queryKeys = {
     detail: (orgId: string) => ["organization", orgId] as const,
   },
 
+  // User Connection queries
+  userConnections: {
+    all: ["user-connections"] as const,
+    list: () => ["user-connections"] as const,
+  },
+
   // Skill queries
   skills: {
     all: ["skills"] as const,

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -114,6 +114,8 @@ where
     sqldb_store: Option<crate::traits::SessionSqlDbStoreRef>,
     /// Optional session storage store for kv_store/secret_store tools
     storage_store: Option<Arc<dyn crate::traits::SessionStorageStore>>,
+    /// Optional resolver for user connection tokens
+    connection_resolver: Option<Arc<dyn crate::traits::UserConnectionResolver>>,
 }
 
 impl<T, E> ActAtom<T, E>
@@ -129,6 +131,7 @@ where
             file_store: None,
             sqldb_store: None,
             storage_store: None,
+            connection_resolver: None,
         }
     }
 
@@ -144,6 +147,7 @@ where
             file_store: Some(file_store),
             sqldb_store: None,
             storage_store: None,
+            connection_resolver: None,
         }
     }
 
@@ -159,6 +163,15 @@ where
         store: Arc<dyn crate::traits::SessionStorageStore>,
     ) -> Self {
         self.storage_store = Some(store);
+        self
+    }
+
+    /// Set the user connection resolver on this atom
+    pub fn with_connection_resolver(
+        mut self,
+        resolver: Arc<dyn crate::traits::UserConnectionResolver>,
+    ) -> Self {
+        self.connection_resolver = Some(resolver);
         self
     }
 }
@@ -421,6 +434,7 @@ where
         let result = if self.file_store.is_some()
             || self.sqldb_store.is_some()
             || self.storage_store.is_some()
+            || self.connection_resolver.is_some()
         {
             let mut tool_context = if let Some(ref store) = self.file_store {
                 ToolContext::with_file_store(context.session_id, store.clone())
@@ -432,6 +446,9 @@ where
             }
             if let Some(ref store) = self.storage_store {
                 tool_context.storage_store = Some(store.clone());
+            }
+            if let Some(ref resolver) = self.connection_resolver {
+                tool_context.connection_resolver = Some(resolver.clone());
             }
             self.tool_executor
                 .execute_with_context(&tool_call, tool_def, &tool_context)

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -310,6 +310,7 @@ impl CapabilityRegistry {
     /// Create a registry with built-in capabilities for a specific deployment grade
     ///
     /// Experimental capabilities are included via integration plugins in dev environments.
+    /// Non-experimental integration plugins (like CodeSandbox) are included in all environments.
     pub fn with_builtins_for_grade(grade: DeploymentGrade) -> Self {
         let mut registry = Self::new();
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -98,7 +98,7 @@ pub use runtime_agent::{RuntimeAgent, RuntimeAgentBuilder};
 pub use traits::{
     EventEmitter, HarnessStore, ImageResolver, KeyInfo, LlmProviderStore, ModelWithProvider,
     NoopEventEmitter, ResolvedImage, SecretInfo, SessionFileStore, SessionSqlDbStoreRef,
-    SessionStorageStore, SessionStore, ToolContext, ToolExecutor,
+    SessionStorageStore, SessionStore, ToolContext, ToolExecutor, UserConnectionResolver,
 };
 
 // Event listener re-exports

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -312,6 +312,21 @@ pub trait SessionStorageStore: Send + Sync {
 /// Type alias for the session SQL DB store trait object.
 pub type SessionSqlDbStoreRef = Arc<dyn crate::session_sqldb::SessionSqlDbStore>;
 
+/// Resolves user connection tokens (e.g. GitHub) lazily at tool execution time.
+///
+/// Instead of eagerly injecting tokens at session creation, tools call this
+/// resolver when they need a token. If the user hasn't connected, returns None.
+#[async_trait]
+pub trait UserConnectionResolver: Send + Sync {
+    /// Get a decrypted connection token for the given provider.
+    /// Returns None if the user has no connection for this provider.
+    async fn get_connection_token(
+        &self,
+        session_id: SessionId,
+        provider: &str,
+    ) -> Result<Option<String>>;
+}
+
 /// Runtime context provided to tools during execution.
 ///
 /// This context contains:
@@ -336,6 +351,9 @@ pub struct ToolContext {
 
     /// Optional message retriever for tools that need conversation history access
     pub message_retriever: Option<Arc<dyn crate::message_retriever::MessageRetriever>>,
+
+    /// Optional resolver for user connection tokens (lazy GitHub token lookup, etc.)
+    pub connection_resolver: Option<Arc<dyn UserConnectionResolver>>,
 }
 
 impl ToolContext {
@@ -347,6 +365,7 @@ impl ToolContext {
             storage_store: None,
             sqldb_store: None,
             message_retriever: None,
+            connection_resolver: None,
         }
     }
 
@@ -358,6 +377,7 @@ impl ToolContext {
             storage_store: None,
             sqldb_store: None,
             message_retriever: None,
+            connection_resolver: None,
         }
     }
 
@@ -372,6 +392,7 @@ impl ToolContext {
             storage_store: Some(storage_store),
             sqldb_store: None,
             message_retriever: None,
+            connection_resolver: None,
         }
     }
 
@@ -387,6 +408,7 @@ impl ToolContext {
             storage_store: Some(storage_store),
             sqldb_store: None,
             message_retriever: None,
+            connection_resolver: None,
         }
     }
 
@@ -404,6 +426,12 @@ impl ToolContext {
         self.message_retriever = Some(retriever);
         self
     }
+
+    /// Add a connection resolver to this context
+    pub fn with_connection_resolver(mut self, resolver: Arc<dyn UserConnectionResolver>) -> Self {
+        self.connection_resolver = Some(resolver);
+        self
+    }
 }
 
 impl std::fmt::Debug for ToolContext {
@@ -414,6 +442,7 @@ impl std::fmt::Debug for ToolContext {
             .field("storage_store", &self.storage_store.is_some())
             .field("sqldb_store", &self.sqldb_store.is_some())
             .field("message_retriever", &self.message_retriever.is_some())
+            .field("connection_resolver", &self.connection_resolver.is_some())
             .finish()
     }
 }

--- a/crates/server/migrations/006_user_connections.sql
+++ b/crates/server/migrations/006_user_connections.sql
@@ -1,0 +1,30 @@
+-- User Connections: external service accounts linked to user identity
+-- Decision: User-scoped (not org-scoped) — token represents user's identity on external service
+-- Decision: No unique constraint on (user_id, provider) — enforced in app code for future flexibility
+-- Decision: Same envelope encryption as session_secrets and mcp_servers.api_key_encrypted
+
+CREATE TABLE user_connections (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    -- Provider identifier: 'github', 'gitlab', 'bitbucket'
+    provider VARCHAR(50) NOT NULL,
+    -- Provider-side user identity
+    provider_user_id TEXT,
+    provider_username TEXT,
+    -- Encrypted credentials (AES-256-GCM envelope encryption)
+    access_token_encrypted BYTEA NOT NULL,
+    refresh_token_encrypted BYTEA,
+    -- What scopes were granted (e.g., 'repo,read:user')
+    scopes TEXT,
+    -- NULL = no expiry (GitHub OAuth App tokens don't expire)
+    expires_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_user_connections_user_id ON user_connections(user_id);
+CREATE INDEX idx_user_connections_provider ON user_connections(user_id, provider);
+
+CREATE TRIGGER update_user_connections_updated_at
+    BEFORE UPDATE ON user_connections
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -23,6 +23,7 @@ pub mod sessions;
 pub mod skills;
 pub mod sse;
 pub mod tool_results;
+pub mod user_connections;
 pub mod users;
 pub mod validation;
 

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -1,9 +1,9 @@
 // Session CRUD HTTP routes
 // Routes use ResolvedOrg: org derived from auth context (API key or cookie)
 
-use crate::auth::{AuthState, ResolvedOrg};
+use crate::auth::{AuthState, AuthUser, ResolvedOrg};
 use crate::services::{EventService, SessionService};
-use crate::storage::StorageBackend;
+use crate::storage::{EncryptionService, StorageBackend};
 use axum::extract::FromRef;
 use axum::{
     Json, Router,
@@ -116,16 +116,23 @@ pub struct AppState {
     pub event_service: EventService,
     pub runner: Arc<dyn AgentRunner>,
     pub auth: AuthState,
+    pub encryption: Option<Arc<EncryptionService>>,
 }
 
 impl AppState {
-    pub fn new(db: Arc<StorageBackend>, runner: Arc<dyn AgentRunner>, auth: AuthState) -> Self {
+    pub fn new(
+        db: Arc<StorageBackend>,
+        runner: Arc<dyn AgentRunner>,
+        auth: AuthState,
+        encryption: Option<Arc<EncryptionService>>,
+    ) -> Self {
         Self {
             session_service: Arc::new(SessionService::new(db.clone())),
             event_service: EventService::new(db.clone()),
             db,
             runner,
             auth,
+            encryption,
         }
     }
 }
@@ -166,6 +173,7 @@ pub fn routes(state: AppState) -> Router {
 )]
 pub async fn create_session(
     org: ResolvedOrg,
+    auth_user: Option<AuthUser>,
     State(state): State<AppState>,
     Json(req): Json<CreateSessionRequest>,
 ) -> Result<(StatusCode, Json<Session>), (StatusCode, Json<ErrorResponse>)> {
@@ -201,7 +209,66 @@ pub async fn create_session(
         .await
         .log_internal_error_json("create session")?;
 
+    // Auto-inject user connections as session secrets (e.g., GITHUB_TOKEN)
+    if let Some(ref user) = auth_user {
+        inject_user_connections(&state, user.id, session.id.uuid()).await;
+    }
+
     Ok((StatusCode::CREATED, Json(session)))
+}
+
+/// Inject user connection tokens as session secrets.
+/// Runs best-effort — failures are logged but don't block session creation.
+async fn inject_user_connections(state: &AppState, user_id: uuid::Uuid, session_id: uuid::Uuid) {
+    let Some(ref encryption) = state.encryption else {
+        return;
+    };
+
+    // Check for GitHub connection
+    let github_conn = match state.db.get_user_connection(user_id, "github").await {
+        Ok(Some(conn)) => conn,
+        Ok(None) => return,
+        Err(e) => {
+            tracing::warn!("Failed to check user connections: {}", e);
+            return;
+        }
+    };
+
+    // Decrypt the token, re-encrypt as session secret
+    let token = match encryption.decrypt_to_string(&github_conn.access_token_encrypted) {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::warn!("Failed to decrypt GitHub connection token: {}", e);
+            return;
+        }
+    };
+
+    let secret_encrypted = match encryption.encrypt_string(&token) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("Failed to encrypt session secret: {}", e);
+            return;
+        }
+    };
+
+    // Store as session secret
+    if let Err(e) = state
+        .db
+        .upsert_session_secret(crate::storage::models::UpsertSessionSecret {
+            session_id: SessionId::from_uuid(session_id),
+            name: "GITHUB_TOKEN".to_string(),
+            value_encrypted: secret_encrypted,
+        })
+        .await
+    {
+        tracing::warn!("Failed to inject GITHUB_TOKEN session secret: {}", e);
+    } else {
+        tracing::debug!(
+            session_id = %session_id,
+            provider_username = ?github_conn.provider_username,
+            "Injected GITHUB_TOKEN from user connection"
+        );
+    }
 }
 
 /// GET /v1/sessions - List sessions in organization

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -3,7 +3,7 @@
 
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::services::{EventService, SessionService};
-use crate::storage::{EncryptionService, StorageBackend};
+use crate::storage::StorageBackend;
 use axum::extract::FromRef;
 use axum::{
     Json, Router,
@@ -116,23 +116,16 @@ pub struct AppState {
     pub event_service: EventService,
     pub runner: Arc<dyn AgentRunner>,
     pub auth: AuthState,
-    pub encryption: Option<Arc<EncryptionService>>,
 }
 
 impl AppState {
-    pub fn new(
-        db: Arc<StorageBackend>,
-        runner: Arc<dyn AgentRunner>,
-        auth: AuthState,
-        encryption: Option<Arc<EncryptionService>>,
-    ) -> Self {
+    pub fn new(db: Arc<StorageBackend>, runner: Arc<dyn AgentRunner>, auth: AuthState) -> Self {
         Self {
             session_service: Arc::new(SessionService::new(db.clone())),
             event_service: EventService::new(db.clone()),
             db,
             runner,
             auth,
-            encryption,
         }
     }
 }
@@ -208,66 +201,7 @@ pub async fn create_session(
         .await
         .log_internal_error_json("create session")?;
 
-    // Auto-inject user connections as session secrets (e.g., GITHUB_TOKEN)
-    if let Some(user_id) = org.user_id {
-        inject_user_connections(&state, user_id, session.id.uuid()).await;
-    }
-
     Ok((StatusCode::CREATED, Json(session)))
-}
-
-/// Inject user connection tokens as session secrets.
-/// Runs best-effort — failures are logged but don't block session creation.
-async fn inject_user_connections(state: &AppState, user_id: uuid::Uuid, session_id: uuid::Uuid) {
-    let Some(ref encryption) = state.encryption else {
-        return;
-    };
-
-    // Check for GitHub connection
-    let github_conn = match state.db.get_user_connection(user_id, "github").await {
-        Ok(Some(conn)) => conn,
-        Ok(None) => return,
-        Err(e) => {
-            tracing::warn!("Failed to check user connections: {}", e);
-            return;
-        }
-    };
-
-    // Decrypt the token, re-encrypt as session secret
-    let token = match encryption.decrypt_to_string(&github_conn.access_token_encrypted) {
-        Ok(t) => t,
-        Err(e) => {
-            tracing::warn!("Failed to decrypt GitHub connection token: {}", e);
-            return;
-        }
-    };
-
-    let secret_encrypted = match encryption.encrypt_string(&token) {
-        Ok(v) => v,
-        Err(e) => {
-            tracing::warn!("Failed to encrypt session secret: {}", e);
-            return;
-        }
-    };
-
-    // Store as session secret
-    if let Err(e) = state
-        .db
-        .upsert_session_secret(crate::storage::models::UpsertSessionSecret {
-            session_id: SessionId::from_uuid(session_id),
-            name: "GITHUB_TOKEN".to_string(),
-            value_encrypted: secret_encrypted,
-        })
-        .await
-    {
-        tracing::warn!("Failed to inject GITHUB_TOKEN session secret: {}", e);
-    } else {
-        tracing::debug!(
-            session_id = %session_id,
-            provider_username = ?github_conn.provider_username,
-            "Injected GITHUB_TOKEN from user connection"
-        );
-    }
 }
 
 /// GET /v1/sessions - List sessions in organization

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -1,7 +1,7 @@
 // Session CRUD HTTP routes
 // Routes use ResolvedOrg: org derived from auth context (API key or cookie)
 
-use crate::auth::{AuthState, AuthUser, ResolvedOrg};
+use crate::auth::{AuthState, ResolvedOrg};
 use crate::services::{EventService, SessionService};
 use crate::storage::{EncryptionService, StorageBackend};
 use axum::extract::FromRef;
@@ -173,7 +173,6 @@ pub fn routes(state: AppState) -> Router {
 )]
 pub async fn create_session(
     org: ResolvedOrg,
-    auth_user: Option<AuthUser>,
     State(state): State<AppState>,
     Json(req): Json<CreateSessionRequest>,
 ) -> Result<(StatusCode, Json<Session>), (StatusCode, Json<ErrorResponse>)> {
@@ -210,8 +209,8 @@ pub async fn create_session(
         .log_internal_error_json("create session")?;
 
     // Auto-inject user connections as session secrets (e.g., GITHUB_TOKEN)
-    if let Some(ref user) = auth_user {
-        inject_user_connections(&state, user.id, session.id.uuid()).await;
+    if let Some(user_id) = org.user_id {
+        inject_user_connections(&state, user_id, session.id.uuid()).await;
     }
 
     Ok((StatusCode::CREATED, Json(session)))

--- a/crates/server/src/api/user_connections.rs
+++ b/crates/server/src/api/user_connections.rs
@@ -1,0 +1,327 @@
+// User Connections API routes
+// Decision: User-scoped (not org-scoped) — token represents user's GitHub identity
+// Decision: Separate GitHub OAuth App from login (different scopes: repo vs profile)
+
+use crate::auth::config::AuthConfig;
+use crate::auth::middleware::{AuthState, AuthUser};
+use crate::auth::oauth::GitHubConnectionService;
+use crate::storage::{EncryptionService, StorageBackend};
+use axum::{
+    Json, Router,
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::Redirect,
+    routing::{delete, get, post},
+};
+use chrono::{DateTime, Utc};
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use utoipa::ToSchema;
+
+use axum::extract::FromRef;
+
+use crate::storage::models::CreateUserConnectionRow;
+
+/// App state for user connections routes
+#[derive(Clone)]
+pub struct AppState {
+    pub db: Arc<StorageBackend>,
+    pub encryption: Option<Arc<EncryptionService>>,
+    pub auth: AuthState,
+    pub auth_config: AuthConfig,
+}
+
+impl FromRef<AppState> for AuthState {
+    fn from_ref(input: &AppState) -> Self {
+        input.auth.clone()
+    }
+}
+
+/// Connection info returned in API responses (never includes token)
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ConnectionResponse {
+    pub provider: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider_username: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scopes: Option<String>,
+    pub connected_at: DateTime<Utc>,
+}
+
+/// Request to add a connection via manual token
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct CreateConnectionRequest {
+    pub provider: String,
+    pub access_token: String,
+}
+
+/// OAuth callback query params
+#[derive(Debug, Deserialize)]
+pub struct OAuthCallbackQuery {
+    pub code: String,
+    #[allow(dead_code)]
+    pub state: String,
+}
+
+/// Create user connections routes
+pub fn routes(state: AppState) -> Router {
+    Router::new()
+        .route("/v1/user/connections", get(list_connections))
+        .route("/v1/user/connections", post(create_connection))
+        .route(
+            "/v1/user/connections/{provider}",
+            delete(delete_connection),
+        )
+        .route(
+            "/v1/user/connections/github/authorize",
+            get(github_authorize),
+        )
+        .route(
+            "/v1/user/connections/github/callback",
+            get(github_callback),
+        )
+        .with_state(state)
+}
+
+/// GET /v1/user/connections — List user's connected accounts
+pub async fn list_connections(
+    State(state): State<AppState>,
+    auth: AuthUser,
+) -> Result<Json<Vec<ConnectionResponse>>, StatusCode> {
+    let rows = state
+        .db
+        .list_user_connections(auth.user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to list user connections: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    let connections = rows
+        .into_iter()
+        .map(|r| ConnectionResponse {
+            provider: r.provider,
+            provider_username: r.provider_username,
+            scopes: r.scopes,
+            connected_at: r.created_at,
+        })
+        .collect();
+
+    Ok(Json(connections))
+}
+
+/// POST /v1/user/connections — Add connection via manual PAT
+pub async fn create_connection(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Json(req): Json<CreateConnectionRequest>,
+) -> Result<(StatusCode, Json<ConnectionResponse>), (StatusCode, String)> {
+    if req.provider != "github" {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("Unsupported provider: {}", req.provider),
+        ));
+    }
+
+    let encryption = state.encryption.as_ref().ok_or_else(|| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Encryption not configured".to_string(),
+        )
+    })?;
+
+    // Validate token against GitHub API
+    let client = reqwest::Client::new();
+    let user_info: serde_json::Value = client
+        .get("https://api.github.com/user")
+        .header("User-Agent", "Everruns")
+        .bearer_auth(&req.access_token)
+        .send()
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to validate GitHub token: {}", e);
+            (
+                StatusCode::BAD_REQUEST,
+                "Invalid token: could not authenticate with github".to_string(),
+            )
+        })?
+        .json()
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to parse GitHub response: {}", e);
+            (
+                StatusCode::BAD_REQUEST,
+                "Invalid token: could not authenticate with github".to_string(),
+            )
+        })?;
+
+    let provider_user_id = user_info["id"].as_i64().map(|id| id.to_string());
+    let provider_username = user_info["login"].as_str().map(|s| s.to_string());
+
+    if provider_user_id.is_none() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Invalid token: could not authenticate with github".to_string(),
+        ));
+    }
+
+    // Encrypt token
+    let access_token_encrypted = encryption.encrypt_string(&req.access_token).map_err(|e| {
+        tracing::error!("Failed to encrypt token: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to store connection".to_string(),
+        )
+    })?;
+
+    let row = state
+        .db
+        .upsert_user_connection(CreateUserConnectionRow {
+            user_id: auth.user_id,
+            provider: req.provider.clone(),
+            provider_user_id,
+            provider_username: provider_username.clone(),
+            access_token_encrypted,
+            refresh_token_encrypted: None,
+            scopes: None, // Manual PAT — scopes unknown
+            expires_at: None,
+        })
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to create connection: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to store connection".to_string(),
+            )
+        })?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(ConnectionResponse {
+            provider: row.provider,
+            provider_username: row.provider_username,
+            scopes: row.scopes,
+            connected_at: row.created_at,
+        }),
+    ))
+}
+
+/// DELETE /v1/user/connections/:provider — Disconnect
+pub async fn delete_connection(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Path(provider): Path<String>,
+) -> Result<StatusCode, StatusCode> {
+    let deleted = state
+        .db
+        .delete_user_connection(auth.user_id, &provider)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to delete connection: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    if deleted {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(StatusCode::NOT_FOUND)
+    }
+}
+
+/// GET /v1/user/connections/github/authorize — Start GitHub OAuth flow
+pub async fn github_authorize(
+    State(state): State<AppState>,
+    _auth: AuthUser,
+    Query(params): Query<std::collections::HashMap<String, String>>,
+) -> Result<Redirect, (StatusCode, String)> {
+    let config = state.auth_config.github_connection.as_ref().ok_or_else(|| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "GitHub connection not configured".to_string(),
+        )
+    })?;
+
+    let service = GitHubConnectionService::new(config);
+
+    // Generate state for CSRF protection
+    let mut rng = rand::rng();
+    let bytes: [u8; 16] = rng.random();
+    let oauth_state = hex::encode(bytes);
+
+    // TODO: Store state in session/cookie for validation in callback
+    // For now, include redirect_uri in state param
+    let _redirect_after = params.get("redirect_uri").cloned();
+
+    let auth_url = service.authorization_url(&oauth_state);
+    Ok(Redirect::to(&auth_url.url))
+}
+
+/// GET /v1/user/connections/github/callback — GitHub OAuth callback
+pub async fn github_callback(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Query(query): Query<OAuthCallbackQuery>,
+) -> Result<Redirect, (StatusCode, String)> {
+    let config = state.auth_config.github_connection.as_ref().ok_or_else(|| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "GitHub connection not configured".to_string(),
+        )
+    })?;
+
+    let encryption = state.encryption.as_ref().ok_or_else(|| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Encryption not configured".to_string(),
+        )
+    })?;
+
+    let service = GitHubConnectionService::new(config);
+
+    // Exchange code for token + user info
+    let result = service.exchange_code(&query.code).await.map_err(|e| {
+        tracing::error!("GitHub connection OAuth exchange failed: {}", e);
+        (
+            StatusCode::BAD_REQUEST,
+            "GitHub authentication failed".to_string(),
+        )
+    })?;
+
+    // Encrypt token
+    let access_token_encrypted =
+        encryption
+            .encrypt_string(&result.access_token)
+            .map_err(|e| {
+                tracing::error!("Failed to encrypt token: {}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Failed to store connection".to_string(),
+                )
+            })?;
+
+    // Upsert connection
+    state
+        .db
+        .upsert_user_connection(CreateUserConnectionRow {
+            user_id: auth.user_id,
+            provider: "github".to_string(),
+            provider_user_id: Some(result.user_id),
+            provider_username: Some(result.username),
+            access_token_encrypted,
+            refresh_token_encrypted: None,
+            scopes: Some(result.scopes),
+            expires_at: None,
+        })
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to store GitHub connection: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to store connection".to_string(),
+            )
+        })?;
+
+    // Redirect back to settings page
+    Ok(Redirect::to("/settings/connections?connected=github"))
+}

--- a/crates/server/src/api/user_connections.rs
+++ b/crates/server/src/api/user_connections.rs
@@ -69,18 +69,12 @@ pub fn routes(state: AppState) -> Router {
     Router::new()
         .route("/v1/user/connections", get(list_connections))
         .route("/v1/user/connections", post(create_connection))
-        .route(
-            "/v1/user/connections/{provider}",
-            delete(delete_connection),
-        )
+        .route("/v1/user/connections/{provider}", delete(delete_connection))
         .route(
             "/v1/user/connections/github/authorize",
             get(github_authorize),
         )
-        .route(
-            "/v1/user/connections/github/callback",
-            get(github_callback),
-        )
+        .route("/v1/user/connections/github/callback", get(github_callback))
         .with_state(state)
 }
 
@@ -89,14 +83,10 @@ pub async fn list_connections(
     State(state): State<AppState>,
     auth: AuthUser,
 ) -> Result<Json<Vec<ConnectionResponse>>, StatusCode> {
-    let rows = state
-        .db
-        .list_user_connections(auth.user_id)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to list user connections: {}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
+    let rows = state.db.list_user_connections(auth.id).await.map_err(|e| {
+        tracing::error!("Failed to list user connections: {}", e);
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
 
     let connections = rows
         .into_iter()
@@ -178,7 +168,7 @@ pub async fn create_connection(
     let row = state
         .db
         .upsert_user_connection(CreateUserConnectionRow {
-            user_id: auth.user_id,
+            user_id: auth.id,
             provider: req.provider.clone(),
             provider_user_id,
             provider_username: provider_username.clone(),
@@ -215,7 +205,7 @@ pub async fn delete_connection(
 ) -> Result<StatusCode, StatusCode> {
     let deleted = state
         .db
-        .delete_user_connection(auth.user_id, &provider)
+        .delete_user_connection(auth.id, &provider)
         .await
         .map_err(|e| {
             tracing::error!("Failed to delete connection: {}", e);
@@ -235,12 +225,16 @@ pub async fn github_authorize(
     _auth: AuthUser,
     Query(params): Query<std::collections::HashMap<String, String>>,
 ) -> Result<Redirect, (StatusCode, String)> {
-    let config = state.auth_config.github_connection.as_ref().ok_or_else(|| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "GitHub connection not configured".to_string(),
-        )
-    })?;
+    let config = state
+        .auth_config
+        .github_connection
+        .as_ref()
+        .ok_or_else(|| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "GitHub connection not configured".to_string(),
+            )
+        })?;
 
     let service = GitHubConnectionService::new(config);
 
@@ -263,12 +257,16 @@ pub async fn github_callback(
     auth: AuthUser,
     Query(query): Query<OAuthCallbackQuery>,
 ) -> Result<Redirect, (StatusCode, String)> {
-    let config = state.auth_config.github_connection.as_ref().ok_or_else(|| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "GitHub connection not configured".to_string(),
-        )
-    })?;
+    let config = state
+        .auth_config
+        .github_connection
+        .as_ref()
+        .ok_or_else(|| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "GitHub connection not configured".to_string(),
+            )
+        })?;
 
     let encryption = state.encryption.as_ref().ok_or_else(|| {
         (
@@ -289,22 +287,21 @@ pub async fn github_callback(
     })?;
 
     // Encrypt token
-    let access_token_encrypted =
-        encryption
-            .encrypt_string(&result.access_token)
-            .map_err(|e| {
-                tracing::error!("Failed to encrypt token: {}", e);
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "Failed to store connection".to_string(),
-                )
-            })?;
+    let access_token_encrypted = encryption
+        .encrypt_string(&result.access_token)
+        .map_err(|e| {
+            tracing::error!("Failed to encrypt token: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to store connection".to_string(),
+            )
+        })?;
 
     // Upsert connection
     state
         .db
         .upsert_user_connection(CreateUserConnectionRow {
-            user_id: auth.user_id,
+            user_id: auth.id,
             provider: "github".to_string(),
             provider_user_id: Some(result.user_id),
             provider_username: Some(result.username),

--- a/crates/server/src/api/user_connections.rs
+++ b/crates/server/src/api/user_connections.rs
@@ -215,6 +215,10 @@ pub async fn github_callback(
             )
         })?;
 
-    // Redirect back to settings page
-    Ok(Redirect::to("/settings/connections?connected=github"))
+    // Redirect back to settings page (frontend may be on a different origin in dev)
+    let frontend_url = state.auth_config.frontend_url.trim_end_matches('/');
+    Ok(Redirect::to(&format!(
+        "{}/settings/connections?connected=github",
+        frontend_url
+    )))
 }

--- a/crates/server/src/api/user_connections.rs
+++ b/crates/server/src/api/user_connections.rs
@@ -11,7 +11,7 @@ use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
     response::Redirect,
-    routing::{delete, get, post},
+    routing::{delete, get},
 };
 use chrono::{DateTime, Utc};
 use rand::Rng;
@@ -49,13 +49,6 @@ pub struct ConnectionResponse {
     pub connected_at: DateTime<Utc>,
 }
 
-/// Request to add a connection via manual token
-#[derive(Debug, Deserialize, ToSchema)]
-pub struct CreateConnectionRequest {
-    pub provider: String,
-    pub access_token: String,
-}
-
 /// OAuth callback query params
 #[derive(Debug, Deserialize)]
 pub struct OAuthCallbackQuery {
@@ -68,7 +61,6 @@ pub struct OAuthCallbackQuery {
 pub fn routes(state: AppState) -> Router {
     Router::new()
         .route("/v1/user/connections", get(list_connections))
-        .route("/v1/user/connections", post(create_connection))
         .route("/v1/user/connections/{provider}", delete(delete_connection))
         .route(
             "/v1/user/connections/github/authorize",
@@ -99,102 +91,6 @@ pub async fn list_connections(
         .collect();
 
     Ok(Json(connections))
-}
-
-/// POST /v1/user/connections — Add connection via manual PAT
-pub async fn create_connection(
-    State(state): State<AppState>,
-    auth: AuthUser,
-    Json(req): Json<CreateConnectionRequest>,
-) -> Result<(StatusCode, Json<ConnectionResponse>), (StatusCode, String)> {
-    if req.provider != "github" {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            format!("Unsupported provider: {}", req.provider),
-        ));
-    }
-
-    let encryption = state.encryption.as_ref().ok_or_else(|| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "Encryption not configured".to_string(),
-        )
-    })?;
-
-    // Validate token against GitHub API
-    let client = reqwest::Client::new();
-    let user_info: serde_json::Value = client
-        .get("https://api.github.com/user")
-        .header("User-Agent", "Everruns")
-        .bearer_auth(&req.access_token)
-        .send()
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to validate GitHub token: {}", e);
-            (
-                StatusCode::BAD_REQUEST,
-                "Invalid token: could not authenticate with github".to_string(),
-            )
-        })?
-        .json()
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to parse GitHub response: {}", e);
-            (
-                StatusCode::BAD_REQUEST,
-                "Invalid token: could not authenticate with github".to_string(),
-            )
-        })?;
-
-    let provider_user_id = user_info["id"].as_i64().map(|id| id.to_string());
-    let provider_username = user_info["login"].as_str().map(|s| s.to_string());
-
-    if provider_user_id.is_none() {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "Invalid token: could not authenticate with github".to_string(),
-        ));
-    }
-
-    // Encrypt token
-    let access_token_encrypted = encryption.encrypt_string(&req.access_token).map_err(|e| {
-        tracing::error!("Failed to encrypt token: {}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "Failed to store connection".to_string(),
-        )
-    })?;
-
-    let row = state
-        .db
-        .upsert_user_connection(CreateUserConnectionRow {
-            user_id: auth.id,
-            provider: req.provider.clone(),
-            provider_user_id,
-            provider_username: provider_username.clone(),
-            access_token_encrypted,
-            refresh_token_encrypted: None,
-            scopes: None, // Manual PAT — scopes unknown
-            expires_at: None,
-        })
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to create connection: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Failed to store connection".to_string(),
-            )
-        })?;
-
-    Ok((
-        StatusCode::CREATED,
-        Json(ConnectionResponse {
-            provider: row.provider,
-            provider_username: row.provider_username,
-            scopes: row.scopes,
-            connected_at: row.created_at,
-        }),
-    ))
 }
 
 /// DELETE /v1/user/connections/:provider — Disconnect

--- a/crates/server/src/auth/config.rs
+++ b/crates/server/src/auth/config.rs
@@ -119,8 +119,8 @@ impl Default for AuthConfig {
     fn default() -> Self {
         Self {
             mode: AuthMode::None,
-            base_url: "http://localhost:9000".to_string(),
-            frontend_url: "http://localhost:9100".to_string(),
+            base_url: "http://localhost:9300".to_string(),
+            frontend_url: "http://localhost:9300".to_string(),
             jwt: JwtConfig::default(),
             admin: None,
             google: None,
@@ -142,12 +142,11 @@ impl AuthConfig {
 
         let base_url = std::env::var("AUTH_BASE_URL")
             .or_else(|_| std::env::var("BASE_URL"))
-            .unwrap_or_else(|_| "http://localhost:9000".to_string());
+            .unwrap_or_else(|_| "http://localhost:9300".to_string());
 
-        // Frontend URL for post-auth redirects. In production, typically same origin.
-        // In dev, UI runs on a different port (9100).
+        // Frontend URL for post-auth redirects. In dev with Caddy proxy, same as base_url.
         let frontend_url =
-            std::env::var("FRONTEND_URL").unwrap_or_else(|_| "http://localhost:9100".to_string());
+            std::env::var("FRONTEND_URL").unwrap_or_else(|_| "http://localhost:9300".to_string());
 
         // API prefix for constructing OAuth callback URLs
         let api_prefix = std::env::var("API_PREFIX").unwrap_or_default();

--- a/crates/server/src/auth/config.rs
+++ b/crates/server/src/auth/config.rs
@@ -119,7 +119,7 @@ impl Default for AuthConfig {
     fn default() -> Self {
         Self {
             mode: AuthMode::None,
-            base_url: "http://localhost:9300".to_string(),
+            base_url: "http://localhost:9300/api".to_string(),
             frontend_url: "http://localhost:9300".to_string(),
             jwt: JwtConfig::default(),
             admin: None,
@@ -142,9 +142,9 @@ impl AuthConfig {
 
         let base_url = std::env::var("AUTH_BASE_URL")
             .or_else(|_| std::env::var("BASE_URL"))
-            .unwrap_or_else(|_| "http://localhost:9300".to_string());
+            .unwrap_or_else(|_| "http://localhost:9300/api".to_string());
 
-        // Frontend URL for post-auth redirects. In dev with Caddy proxy, same as base_url.
+        // Frontend URL for post-auth redirects. In dev with Caddy proxy, same origin without /api.
         let frontend_url =
             std::env::var("FRONTEND_URL").unwrap_or_else(|_| "http://localhost:9300".to_string());
 

--- a/crates/server/src/auth/config.rs
+++ b/crates/server/src/auth/config.rs
@@ -45,10 +45,18 @@ pub struct GoogleOAuthConfig {
     pub allowed_domains: Option<Vec<String>>,
 }
 
-/// GitHub OAuth configuration
+/// GitHub OAuth configuration (for login)
 #[derive(Debug, Clone)]
 pub struct GitHubOAuthConfig {
     pub base: OAuthProviderConfig,
+}
+
+/// GitHub Connection OAuth configuration (for repo access, separate OAuth App)
+#[derive(Debug, Clone)]
+pub struct GitHubConnectionConfig {
+    pub client_id: String,
+    pub client_secret: String,
+    pub redirect_uri: String,
 }
 
 /// Admin user configuration (for admin-only mode or initial setup)
@@ -93,8 +101,10 @@ pub struct AuthConfig {
     pub admin: Option<AdminConfig>,
     /// Google OAuth configuration
     pub google: Option<GoogleOAuthConfig>,
-    /// GitHub OAuth configuration
+    /// GitHub OAuth configuration (login)
     pub github: Option<GitHubOAuthConfig>,
+    /// GitHub Connection OAuth configuration (repo access, separate OAuth App)
+    pub github_connection: Option<GitHubConnectionConfig>,
     /// Whether to disable password authentication
     pub disable_password_auth: bool,
     /// Whether to disable signup (registration)
@@ -112,6 +122,7 @@ impl Default for AuthConfig {
             admin: None,
             google: None,
             github: None,
+            github_connection: None,
             disable_password_auth: false,
             disable_signup: false,
             session_max_age: Duration::from_secs(30 * 24 * 60 * 60), // 30 days
@@ -223,6 +234,30 @@ impl AuthConfig {
             _ => None,
         };
 
+        // GitHub Connection OAuth (separate app for repo access)
+        let github_connection = match (
+            std::env::var("GITHUB_CONNECTION_CLIENT_ID"),
+            std::env::var("GITHUB_CONNECTION_CLIENT_SECRET"),
+        ) {
+            (Ok(client_id), Ok(client_secret))
+                if !client_id.is_empty() && !client_secret.is_empty() =>
+            {
+                let redirect_uri =
+                    std::env::var("GITHUB_CONNECTION_REDIRECT_URI").unwrap_or_else(|_| {
+                        format!(
+                            "{}{}/v1/user/connections/github/callback",
+                            base_url, api_prefix
+                        )
+                    });
+                Some(GitHubConnectionConfig {
+                    client_id,
+                    client_secret,
+                    redirect_uri,
+                })
+            }
+            _ => None,
+        };
+
         let disable_password_auth = std::env::var("AUTH_DISABLE_PASSWORD")
             .map(|s| s.to_lowercase() == "true" || s == "1")
             .unwrap_or(false);
@@ -244,6 +279,7 @@ impl AuthConfig {
             admin,
             google,
             github,
+            github_connection,
             disable_password_auth,
             disable_signup,
             session_max_age,

--- a/crates/server/src/auth/config.rs
+++ b/crates/server/src/auth/config.rs
@@ -146,8 +146,8 @@ impl AuthConfig {
 
         // Frontend URL for post-auth redirects. In production, typically same origin.
         // In dev, UI runs on a different port (9100).
-        let frontend_url = std::env::var("FRONTEND_URL")
-            .unwrap_or_else(|_| "http://localhost:9100".to_string());
+        let frontend_url =
+            std::env::var("FRONTEND_URL").unwrap_or_else(|_| "http://localhost:9100".to_string());
 
         // API prefix for constructing OAuth callback URLs
         let api_prefix = std::env::var("API_PREFIX").unwrap_or_default();

--- a/crates/server/src/auth/config.rs
+++ b/crates/server/src/auth/config.rs
@@ -93,8 +93,10 @@ impl Default for JwtConfig {
 pub struct AuthConfig {
     /// Authentication mode
     pub mode: AuthMode,
-    /// Base URL for OAuth callbacks
+    /// Base URL for OAuth callbacks (backend origin)
     pub base_url: String,
+    /// Frontend URL for post-auth redirects (UI origin, same as base_url in production)
+    pub frontend_url: String,
     /// JWT configuration
     pub jwt: JwtConfig,
     /// Admin user (for admin mode or initial setup)
@@ -118,6 +120,7 @@ impl Default for AuthConfig {
         Self {
             mode: AuthMode::None,
             base_url: "http://localhost:9000".to_string(),
+            frontend_url: "http://localhost:9100".to_string(),
             jwt: JwtConfig::default(),
             admin: None,
             google: None,
@@ -140,6 +143,11 @@ impl AuthConfig {
         let base_url = std::env::var("AUTH_BASE_URL")
             .or_else(|_| std::env::var("BASE_URL"))
             .unwrap_or_else(|_| "http://localhost:9000".to_string());
+
+        // Frontend URL for post-auth redirects. In production, typically same origin.
+        // In dev, UI runs on a different port (9100).
+        let frontend_url = std::env::var("FRONTEND_URL")
+            .unwrap_or_else(|_| "http://localhost:9100".to_string());
 
         // API prefix for constructing OAuth callback URLs
         let api_prefix = std::env::var("API_PREFIX").unwrap_or_default();
@@ -275,6 +283,7 @@ impl AuthConfig {
         Self {
             mode,
             base_url,
+            frontend_url,
             jwt,
             admin,
             google,

--- a/crates/server/src/auth/middleware.rs
+++ b/crates/server/src/auth/middleware.rs
@@ -369,6 +369,8 @@ pub struct ResolvedOrg {
     pub public_id: String,
     /// Organization name
     pub name: String,
+    /// Authenticated user ID (for user-scoped operations like connections)
+    pub user_id: Option<Uuid>,
 }
 
 impl<S> FromRequestParts<S> for ResolvedOrg
@@ -391,10 +393,16 @@ where
                     .organizations
                     .first()
                     .ok_or_else(|| AuthError::unauthorized("No organization available"))?;
+                let user_id = if user.auth_method == AuthMethod::None {
+                    None
+                } else {
+                    Some(user.id)
+                };
                 Ok(ResolvedOrg {
                     org_id: org.org_id,
                     public_id: org.public_id.clone(),
                     name: org.name.clone(),
+                    user_id,
                 })
             }
             AuthMethod::Jwt => {
@@ -430,6 +438,7 @@ where
                     org_id: org.org_id,
                     public_id: org.public_id.clone(),
                     name: org.name.clone(),
+                    user_id: Some(user.id),
                 })
             }
         }

--- a/crates/server/src/auth/oauth.rs
+++ b/crates/server/src/auth/oauth.rs
@@ -5,7 +5,7 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
-use super::config::{GitHubOAuthConfig, GoogleOAuthConfig};
+use super::config::{GitHubConnectionConfig, GitHubOAuthConfig, GoogleOAuthConfig};
 
 /// OAuth provider type
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -267,6 +267,8 @@ struct GitHubTokenResponse {
     access_token: String,
     #[allow(dead_code)]
     token_type: String,
+    #[allow(dead_code)]
+    scope: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -284,6 +286,99 @@ struct GitHubEmail {
     primary: bool,
     #[allow(dead_code)]
     verified: bool,
+}
+
+/// Result of GitHub connection OAuth exchange (repo access, not login)
+#[derive(Debug, Clone)]
+pub struct GitHubConnectionResult {
+    /// GitHub access token (with repo scope)
+    pub access_token: String,
+    /// GitHub user ID
+    pub user_id: String,
+    /// GitHub username (login)
+    pub username: String,
+    /// Scopes granted
+    pub scopes: String,
+}
+
+/// GitHub Connection OAuth service (separate OAuth App for repo access)
+pub struct GitHubConnectionService {
+    client_id: String,
+    client_secret: String,
+    redirect_uri: String,
+}
+
+impl GitHubConnectionService {
+    pub fn new(config: &GitHubConnectionConfig) -> Self {
+        Self {
+            client_id: config.client_id.clone(),
+            client_secret: config.client_secret.clone(),
+            redirect_uri: config.redirect_uri.clone(),
+        }
+    }
+
+    /// Generate authorization URL with repo scope
+    pub fn authorization_url(&self, state: &str) -> OAuthAuthorizationUrl {
+        let params = [
+            ("client_id", self.client_id.as_str()),
+            ("redirect_uri", self.redirect_uri.as_str()),
+            ("scope", "repo read:user"),
+            ("state", state),
+        ];
+
+        let query = params
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
+            .collect::<Vec<_>>()
+            .join("&");
+
+        OAuthAuthorizationUrl {
+            url: format!("https://github.com/login/oauth/authorize?{}", query),
+            state: state.to_string(),
+        }
+    }
+
+    /// Exchange code for access token + user info
+    pub async fn exchange_code(&self, code: &str) -> Result<GitHubConnectionResult> {
+        let client = reqwest::Client::new();
+
+        let token_response: GitHubTokenResponse = client
+            .post("https://github.com/login/oauth/access_token")
+            .header("Accept", "application/json")
+            .form(&[
+                ("client_id", self.client_id.as_str()),
+                ("client_secret", self.client_secret.as_str()),
+                ("code", code),
+                ("redirect_uri", self.redirect_uri.as_str()),
+            ])
+            .send()
+            .await
+            .context("Failed to exchange code")?
+            .json()
+            .await
+            .context("Failed to parse token response")?;
+
+        let access_token = &token_response.access_token;
+
+        // Fetch user info to get username
+        let user_info: GitHubUserInfo = client
+            .get("https://api.github.com/user")
+            .header("User-Agent", "Everruns")
+            .bearer_auth(access_token)
+            .send()
+            .await
+            .context("Failed to fetch user info")?
+            .json()
+            .await
+            .context("Failed to parse user info")?;
+
+        Ok(GitHubConnectionResult {
+            access_token: token_response.access_token,
+            user_id: user_info.id.to_string(),
+            username: user_info.login,
+            scopes: token_response.scope.unwrap_or_default(),
+        })
+    }
 }
 
 /// URL encoding helper

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -676,8 +676,9 @@ pub async fn oauth_callback(
     // Generate tokens and set cookies
     let (jar, _) = generate_token_response(&state, jar, &auth_user).await?;
 
-    // Redirect to frontend
-    Ok((jar, Redirect::to("/")))
+    // Redirect to frontend (different origin in dev)
+    let redirect_url = format!("{}/", state.config.frontend_url.trim_end_matches('/'));
+    Ok((jar, Redirect::to(&redirect_url)))
 }
 
 /// GET /v1/auth/api-keys - List API keys for current user

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -62,6 +62,7 @@ pub struct DirectWorkerAdapters {
     capability_registry: CapabilityRegistry,
     sqldb_store: Option<everruns_core::traits::SessionSqlDbStoreRef>,
     storage_store: Option<Arc<dyn everruns_core::traits::SessionStorageStore>>,
+    connection_resolver: Option<Arc<dyn everruns_core::traits::UserConnectionResolver>>,
 }
 
 impl DirectWorkerAdapters {
@@ -81,6 +82,7 @@ impl DirectWorkerAdapters {
             capability_registry,
             sqldb_store: None,
             storage_store: None,
+            connection_resolver: None,
         }
     }
 
@@ -96,6 +98,15 @@ impl DirectWorkerAdapters {
         store: Arc<dyn everruns_core::traits::SessionStorageStore>,
     ) -> Self {
         self.storage_store = Some(store);
+        self
+    }
+
+    /// Set the user connection resolver for lazy token lookup
+    pub fn with_connection_resolver(
+        mut self,
+        resolver: Arc<dyn everruns_core::traits::UserConnectionResolver>,
+    ) -> Self {
+        self.connection_resolver = Some(resolver);
         self
     }
 
@@ -758,6 +769,12 @@ impl WorkerAdapters for DirectWorkerAdapters {
 
     fn storage_store(&self) -> Option<Arc<dyn everruns_core::traits::SessionStorageStore>> {
         self.storage_store.clone()
+    }
+
+    fn connection_resolver(
+        &self,
+    ) -> Option<Arc<dyn everruns_core::traits::UserConnectionResolver>> {
+        self.connection_resolver.clone()
     }
 
     async fn build_tool_registry(&self, agent_id: Uuid) -> Result<ToolRegistry> {

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -3,6 +3,11 @@
 // Decision: Pluggable auth backend for SaaS wrapper repos
 // Decision: Server entrypoint extracted into run() for SaaS binary reuse
 
+// Force-link integration crates so inventory::submit! registrations are included
+extern crate everruns_integrations_codesandbox;
+extern crate everruns_integrations_daytona;
+extern crate everruns_integrations_docker;
+
 // API routes and types (shared for OpenAPI generation)
 pub mod api;
 

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -568,7 +568,7 @@ You can run multiple sandboxes in parallel for different tasks.
 Always shut down sandboxes when done."#,
         tags: &["coding", "cloud", "sandbox", "codesandbox", "demo", "seed"],
         capabilities: &["codesandbox", "session_storage", "session_file_system"],
-        dev_only: true,
+        dev_only: false,
     },
     SeedAgent {
         id: seed_ids::DAYTONA_CODER_AGENT,
@@ -647,7 +647,17 @@ async fn seed_agents(db: &StorageBackend, grade: DeploymentGrade) -> anyhow::Res
                 result.created += 1;
             }
             None => {
-                tracing::debug!(name = seed.name, id = %seed.id, "Agent already exists, skipping");
+                // Agent exists — ensure capabilities stay in sync with seed definition
+                if !seed.capabilities.is_empty() {
+                    let cap_tuples: Vec<(String, i32, serde_json::Value)> = seed
+                        .capabilities
+                        .iter()
+                        .enumerate()
+                        .map(|(idx, cap)| (cap.to_string(), idx as i32, serde_json::json!({})))
+                        .collect();
+                    db.set_agent_capabilities(seed.id, cap_tuples).await?;
+                }
+                tracing::debug!(name = seed.name, id = %seed.id, "Agent already exists, updated capabilities");
                 result.skipped += 1;
             }
         }

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -185,8 +185,12 @@ pub async fn run(
     let auth_state = auth::AuthState::new(auth_config.clone(), auth_backend.clone());
 
     // Create module-specific states
-    let sessions_state =
-        api::sessions::AppState::new(db.clone(), runner.clone(), auth_state.clone());
+    let sessions_state = api::sessions::AppState::new(
+        db.clone(),
+        runner.clone(),
+        auth_state.clone(),
+        encryption.clone(),
+    );
     let messages_state =
         api::messages::AppState::new(db.clone(), runner.clone(), auth_state.clone());
     let tool_results_state =
@@ -274,6 +278,12 @@ pub async fn run(
     let skills_state = api::skills::AppState::new(db.clone(), auth_state.clone());
     let images_state = api::images::AppState::new(db.clone(), auth_state.clone());
     let organizations_state = api::organizations::AppState::new(db.clone(), auth_state.clone());
+    let user_connections_state = api::user_connections::AppState {
+        db: db.clone(),
+        encryption: encryption.clone(),
+        auth: auth_state.clone(),
+        auth_config: auth_config.clone(),
+    };
     let health_state = HealthState {
         auth_mode: format!("{:?}", auth_config.mode),
     };
@@ -308,7 +318,8 @@ pub async fn run(
         .merge(api::schedules::routes(schedules_state))
         .merge(api::images::routes(images_state))
         .merge(api::skills::routes(skills_state))
-        .merge(api::organizations::routes(organizations_state));
+        .merge(api::organizations::routes(organizations_state))
+        .merge(api::user_connections::routes(user_connections_state));
 
     // Add auth-specific routes if the backend provides them
     if let Some(auth_routes) = auth_backend.auth_routes() {

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -185,12 +185,8 @@ pub async fn run(
     let auth_state = auth::AuthState::new(auth_config.clone(), auth_backend.clone());
 
     // Create module-specific states
-    let sessions_state = api::sessions::AppState::new(
-        db.clone(),
-        runner.clone(),
-        auth_state.clone(),
-        encryption.clone(),
-    );
+    let sessions_state =
+        api::sessions::AppState::new(db.clone(), runner.clone(), auth_state.clone());
     let messages_state =
         api::messages::AppState::new(db.clone(), runner.clone(), auth_state.clone());
     let tool_results_state =
@@ -568,7 +564,7 @@ pub async fn run(
                     crate::storage::StorageBackend::InMemory(mem_db) => mem_db.clone(),
                 };
 
-            let adapters = DirectWorkerAdapters::new(
+            let mut adapters = DirectWorkerAdapters::new(
                 db.clone(),
                 event_service.clone(),
                 llm_resolver,
@@ -577,6 +573,15 @@ pub async fn run(
             )
             .with_sqldb_store(sqldb_store.clone())
             .with_storage_store(session_storage_store);
+
+            // Wire lazy connection resolver (requires encryption for token decryption)
+            if let Some(ref enc) = encryption {
+                let resolver = Arc::new(crate::storage::DbConnectionResolver::new(
+                    db.as_ref().clone(),
+                    enc.as_ref().clone(),
+                ));
+                adapters = adapters.with_connection_resolver(resolver);
+            }
 
             let worker_config = TaskWorkerConfig::dev_mode();
             tokio::spawn(async move {

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -1055,18 +1055,11 @@ impl StorageBackend {
         dispatch!(self, get_user_connection, user_id, provider)
     }
 
-    pub async fn list_user_connections(
-        &self,
-        user_id: Uuid,
-    ) -> Result<Vec<UserConnectionRow>> {
+    pub async fn list_user_connections(&self, user_id: Uuid) -> Result<Vec<UserConnectionRow>> {
         dispatch!(self, list_user_connections, user_id)
     }
 
-    pub async fn delete_user_connection(
-        &self,
-        user_id: Uuid,
-        provider: &str,
-    ) -> Result<bool> {
+    pub async fn delete_user_connection(&self, user_id: Uuid, provider: &str) -> Result<bool> {
         dispatch!(self, delete_user_connection, user_id, provider)
     }
 }

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -1062,4 +1062,12 @@ impl StorageBackend {
     pub async fn delete_user_connection(&self, user_id: Uuid, provider: &str) -> Result<bool> {
         dispatch!(self, delete_user_connection, user_id, provider)
     }
+
+    pub async fn get_connection_token_for_session(
+        &self,
+        session_id: SessionId,
+        provider: &str,
+    ) -> Result<Option<Vec<u8>>> {
+        dispatch!(self, get_connection_token_for_session, session_id, provider)
+    }
 }

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -1028,4 +1028,45 @@ impl StorageBackend {
     ) -> Result<Vec<SessionSecretInfoRow>> {
         dispatch!(self, list_session_secrets, session_id)
     }
+
+    pub async fn upsert_session_secret(
+        &self,
+        input: UpsertSessionSecret,
+    ) -> Result<SessionSecretRow> {
+        dispatch!(self, upsert_session_secret, input)
+    }
+
+    // ============================================
+    // User Connections
+    // ============================================
+
+    pub async fn upsert_user_connection(
+        &self,
+        input: CreateUserConnectionRow,
+    ) -> Result<UserConnectionRow> {
+        dispatch!(self, upsert_user_connection, input)
+    }
+
+    pub async fn get_user_connection(
+        &self,
+        user_id: Uuid,
+        provider: &str,
+    ) -> Result<Option<UserConnectionRow>> {
+        dispatch!(self, get_user_connection, user_id, provider)
+    }
+
+    pub async fn list_user_connections(
+        &self,
+        user_id: Uuid,
+    ) -> Result<Vec<UserConnectionRow>> {
+        dispatch!(self, list_user_connections, user_id)
+    }
+
+    pub async fn delete_user_connection(
+        &self,
+        user_id: Uuid,
+        provider: &str,
+    ) -> Result<bool> {
+        dispatch!(self, delete_user_connection, user_id, provider)
+    }
 }

--- a/crates/server/src/storage/connection_resolver.rs
+++ b/crates/server/src/storage/connection_resolver.rs
@@ -1,0 +1,57 @@
+// Lazy user connection token resolver
+//
+// Resolves connection tokens (e.g. GitHub) at tool execution time instead of
+// eagerly injecting at session creation. This means:
+// - Tokens are always fresh (reconnect mid-session works)
+// - Sessions created before connecting still get tokens
+// - Tools can show helpful guidance when not connected
+
+use async_trait::async_trait;
+use everruns_core::traits::UserConnectionResolver;
+use everruns_core::typed_id::SessionId;
+use everruns_core::{AgentLoopError, Result};
+
+use super::backend::StorageBackend;
+use super::encryption::EncryptionService;
+
+/// Resolves user connection tokens by looking up the session's org members.
+///
+/// Query path: session_id → org_id → org_members → user_connections.
+/// For single-member orgs (default dev mode), this is unambiguous.
+/// For multi-member orgs, returns the first match (future: track session creator).
+#[derive(Clone)]
+pub struct DbConnectionResolver {
+    db: StorageBackend,
+    encryption: EncryptionService,
+}
+
+impl DbConnectionResolver {
+    pub fn new(db: StorageBackend, encryption: EncryptionService) -> Self {
+        Self { db, encryption }
+    }
+}
+
+#[async_trait]
+impl UserConnectionResolver for DbConnectionResolver {
+    async fn get_connection_token(
+        &self,
+        session_id: SessionId,
+        provider: &str,
+    ) -> Result<Option<String>> {
+        let encrypted = self
+            .db
+            .get_connection_token_for_session(session_id, provider)
+            .await
+            .map_err(|e| AgentLoopError::store(format!("Failed to resolve connection: {e}")))?;
+
+        match encrypted {
+            Some(blob) => {
+                let token = self.encryption.decrypt_to_string(&blob).map_err(|e| {
+                    AgentLoopError::store(format!("Failed to decrypt connection token: {e}"))
+                })?;
+                Ok(Some(token))
+            }
+            None => Ok(None),
+        }
+    }
+}

--- a/crates/server/src/storage/encryption.rs
+++ b/crates/server/src/storage/encryption.rs
@@ -342,6 +342,18 @@ pub const ENCRYPTED_COLUMNS: &[EncryptedColumn] = &[
         column: "value_encrypted",
         id_column: "id",
     },
+    // User connection access tokens are encrypted at rest
+    EncryptedColumn {
+        table: "user_connections",
+        column: "access_token_encrypted",
+        id_column: "id",
+    },
+    // User connection refresh tokens are encrypted at rest
+    EncryptedColumn {
+        table: "user_connections",
+        column: "refresh_token_encrypted",
+        id_column: "id",
+    },
 ];
 
 #[cfg(test)]

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -3089,7 +3089,9 @@ impl everruns_core::traits::SessionStorageStore for InMemoryDatabase {
         secrets.sort_by(|a, b| a.name.cmp(&b.name));
         Ok(secrets)
     }
+}
 
+impl InMemoryDatabase {
     // ============================================
     // User Connections
     // ============================================
@@ -3135,10 +3137,7 @@ impl everruns_core::traits::SessionStorageStore for InMemoryDatabase {
             .cloned())
     }
 
-    pub async fn list_user_connections(
-        &self,
-        user_id: Uuid,
-    ) -> Result<Vec<UserConnectionRow>> {
+    pub async fn list_user_connections(&self, user_id: Uuid) -> Result<Vec<UserConnectionRow>> {
         let mut connections: Vec<_> = self
             .user_connections
             .read()
@@ -3150,11 +3149,7 @@ impl everruns_core::traits::SessionStorageStore for InMemoryDatabase {
         Ok(connections)
     }
 
-    pub async fn delete_user_connection(
-        &self,
-        user_id: Uuid,
-        provider: &str,
-    ) -> Result<bool> {
+    pub async fn delete_user_connection(&self, user_id: Uuid, provider: &str) -> Result<bool> {
         let mut connections = self.user_connections.write();
         let before = connections.len();
         connections.retain(|_, c| !(c.user_id == user_id && c.provider == provider));

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -47,6 +47,8 @@ pub struct InMemoryDatabase {
     // Session storage
     session_key_values: RwLock<HashMap<(SessionId, String), SessionKeyValueRow>>,
     session_secrets: RwLock<HashMap<(SessionId, String), SessionSecretRow>>,
+    // User connections (external service accounts)
+    user_connections: RwLock<HashMap<Uuid, UserConnectionRow>>,
 }
 
 impl Default for InMemoryDatabase {
@@ -89,6 +91,7 @@ impl Default for InMemoryDatabase {
             event_sequences: RwLock::new(HashMap::new()),
             session_key_values: RwLock::new(HashMap::new()),
             session_secrets: RwLock::new(HashMap::new()),
+            user_connections: RwLock::new(HashMap::new()),
         }
     }
 }
@@ -2926,6 +2929,34 @@ impl InMemoryDatabase {
         secrets.sort_by(|a, b| a.name.cmp(&b.name));
         Ok(secrets)
     }
+
+    pub async fn upsert_session_secret(
+        &self,
+        input: UpsertSessionSecret,
+    ) -> Result<SessionSecretRow> {
+        let now = Self::now();
+        let map_key = (input.session_id, input.name.clone());
+        let mut storage = self.session_secrets.write();
+
+        let row = if let Some(existing) = storage.get_mut(&map_key) {
+            existing.value_encrypted = input.value_encrypted;
+            existing.updated_at = now;
+            existing.clone()
+        } else {
+            let row = SessionSecretRow {
+                id: Uuid::now_v7(),
+                session_id: input.session_id,
+                name: input.name,
+                value_encrypted: input.value_encrypted,
+                created_at: now,
+                updated_at: now,
+            };
+            storage.insert(map_key, row.clone());
+            row
+        };
+
+        Ok(row)
+    }
 }
 
 // ============================================================================
@@ -3057,6 +3088,77 @@ impl everruns_core::traits::SessionStorageStore for InMemoryDatabase {
             .collect();
         secrets.sort_by(|a, b| a.name.cmp(&b.name));
         Ok(secrets)
+    }
+
+    // ============================================
+    // User Connections
+    // ============================================
+
+    pub async fn upsert_user_connection(
+        &self,
+        input: CreateUserConnectionRow,
+    ) -> Result<UserConnectionRow> {
+        let now = Self::now();
+        let id = Uuid::now_v7();
+
+        // Remove existing connection for same user+provider (app-level uniqueness)
+        let mut connections = self.user_connections.write();
+        connections.retain(|_, c| !(c.user_id == input.user_id && c.provider == input.provider));
+
+        let row = UserConnectionRow {
+            id,
+            user_id: input.user_id,
+            provider: input.provider,
+            provider_user_id: input.provider_user_id,
+            provider_username: input.provider_username,
+            access_token_encrypted: input.access_token_encrypted,
+            refresh_token_encrypted: input.refresh_token_encrypted,
+            scopes: input.scopes,
+            expires_at: input.expires_at,
+            created_at: now,
+            updated_at: now,
+        };
+        connections.insert(id, row.clone());
+        Ok(row)
+    }
+
+    pub async fn get_user_connection(
+        &self,
+        user_id: Uuid,
+        provider: &str,
+    ) -> Result<Option<UserConnectionRow>> {
+        Ok(self
+            .user_connections
+            .read()
+            .values()
+            .find(|c| c.user_id == user_id && c.provider == provider)
+            .cloned())
+    }
+
+    pub async fn list_user_connections(
+        &self,
+        user_id: Uuid,
+    ) -> Result<Vec<UserConnectionRow>> {
+        let mut connections: Vec<_> = self
+            .user_connections
+            .read()
+            .values()
+            .filter(|c| c.user_id == user_id)
+            .cloned()
+            .collect();
+        connections.sort_by(|a, b| a.provider.cmp(&b.provider));
+        Ok(connections)
+    }
+
+    pub async fn delete_user_connection(
+        &self,
+        user_id: Uuid,
+        provider: &str,
+    ) -> Result<bool> {
+        let mut connections = self.user_connections.write();
+        let before = connections.len();
+        connections.retain(|_, c| !(c.user_id == user_id && c.provider == provider));
+        Ok(connections.len() < before)
     }
 }
 

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -3149,6 +3149,43 @@ impl InMemoryDatabase {
         Ok(connections)
     }
 
+    /// Get encrypted connection token for a session's org member (in-memory equivalent).
+    pub async fn get_connection_token_for_session(
+        &self,
+        session_id: SessionId,
+        provider: &str,
+    ) -> Result<Option<Vec<u8>>> {
+        // Find the session to get org_id
+        let sessions = self.sessions.read();
+        let session = match sessions.get(&session_id) {
+            Some(s) => s,
+            None => return Ok(None),
+        };
+        let org_id = session.org_id;
+        drop(sessions);
+
+        // Find org members
+        let members = self.organization_members.read();
+        let user_ids: Vec<Uuid> = members
+            .iter()
+            .filter(|((oid, _), _)| *oid == org_id)
+            .map(|((_, uid), _)| *uid)
+            .collect();
+        drop(members);
+
+        // Find first matching connection
+        let connections = self.user_connections.read();
+        for uid in user_ids {
+            for conn in connections.values() {
+                if conn.user_id == uid && conn.provider == provider {
+                    return Ok(Some(conn.access_token_encrypted.clone()));
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
     pub async fn delete_user_connection(&self, user_id: Uuid, provider: &str) -> Result<bool> {
         let mut connections = self.user_connections.write();
         let before = connections.len();

--- a/crates/server/src/storage/mod.rs
+++ b/crates/server/src/storage/mod.rs
@@ -11,6 +11,7 @@
 
 pub mod agent_store;
 pub mod backend;
+pub mod connection_resolver;
 pub mod encryption;
 pub mod harness_store;
 pub mod llm_provider_store;
@@ -28,6 +29,7 @@ mod event_tests;
 
 pub use agent_store::{DbAgentStore, create_db_agent_store};
 pub use backend::StorageBackend;
+pub use connection_resolver::DbConnectionResolver;
 pub use encryption::{
     ENCRYPTED_COLUMNS, EncryptedColumn, EncryptedPayload, EncryptionService,
     generate_encryption_key,

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -811,3 +811,36 @@ pub struct CreateSkillFileRow {
     pub is_binary: bool,
     pub size_bytes: i64,
 }
+
+// ============================================
+// User Connection models
+// ============================================
+
+/// User connection row from database
+#[derive(Debug, Clone, FromRow)]
+pub struct UserConnectionRow {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub provider: String,
+    pub provider_user_id: Option<String>,
+    pub provider_username: Option<String>,
+    pub access_token_encrypted: Vec<u8>,
+    pub refresh_token_encrypted: Option<Vec<u8>>,
+    pub scopes: Option<String>,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Input for creating a user connection
+#[derive(Debug, Clone)]
+pub struct CreateUserConnectionRow {
+    pub user_id: Uuid,
+    pub provider: String,
+    pub provider_user_id: Option<String>,
+    pub provider_username: Option<String>,
+    pub access_token_encrypted: Vec<u8>,
+    pub refresh_token_encrypted: Option<Vec<u8>>,
+    pub scopes: Option<String>,
+    pub expires_at: Option<DateTime<Utc>>,
+}

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -3463,6 +3463,31 @@ impl Database {
         Ok(rows)
     }
 
+    /// Get the encrypted connection token for a session's org member.
+    /// Joins session → org_members → user_connections to resolve lazily.
+    pub async fn get_connection_token_for_session(
+        &self,
+        session_id: SessionId,
+        provider: &str,
+    ) -> Result<Option<Vec<u8>>> {
+        let row: Option<(Vec<u8>,)> = sqlx::query_as(
+            r#"
+            SELECT uc.access_token_encrypted
+            FROM sessions s
+            JOIN organization_members om ON om.org_id = s.org_id
+            JOIN user_connections uc ON uc.user_id = om.user_id AND uc.provider = $2
+            WHERE s.id = $1
+            LIMIT 1
+            "#,
+        )
+        .bind(session_id)
+        .bind(provider)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.map(|(blob,)| blob))
+    }
+
     /// Delete a user's connection for a specific provider
     pub async fn delete_user_connection(&self, user_id: Uuid, provider: &str) -> Result<bool> {
         let result =

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -3396,13 +3396,11 @@ impl Database {
         input: CreateUserConnectionRow,
     ) -> Result<UserConnectionRow> {
         // App-level uniqueness: delete existing connection for this user+provider
-        sqlx::query(
-            "DELETE FROM user_connections WHERE user_id = $1 AND provider = $2",
-        )
-        .bind(input.user_id)
-        .bind(&input.provider)
-        .execute(&self.pool)
-        .await?;
+        sqlx::query("DELETE FROM user_connections WHERE user_id = $1 AND provider = $2")
+            .bind(input.user_id)
+            .bind(&input.provider)
+            .execute(&self.pool)
+            .await?;
 
         let row = sqlx::query_as::<_, UserConnectionRow>(
             r#"
@@ -3449,10 +3447,7 @@ impl Database {
     }
 
     /// List all connections for a user
-    pub async fn list_user_connections(
-        &self,
-        user_id: Uuid,
-    ) -> Result<Vec<UserConnectionRow>> {
+    pub async fn list_user_connections(&self, user_id: Uuid) -> Result<Vec<UserConnectionRow>> {
         let rows = sqlx::query_as::<_, UserConnectionRow>(
             r#"
             SELECT id, user_id, provider, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, created_at, updated_at
@@ -3469,18 +3464,13 @@ impl Database {
     }
 
     /// Delete a user's connection for a specific provider
-    pub async fn delete_user_connection(
-        &self,
-        user_id: Uuid,
-        provider: &str,
-    ) -> Result<bool> {
-        let result = sqlx::query(
-            "DELETE FROM user_connections WHERE user_id = $1 AND provider = $2",
-        )
-        .bind(user_id)
-        .bind(provider)
-        .execute(&self.pool)
-        .await?;
+    pub async fn delete_user_connection(&self, user_id: Uuid, provider: &str) -> Result<bool> {
+        let result =
+            sqlx::query("DELETE FROM user_connections WHERE user_id = $1 AND provider = $2")
+                .bind(user_id)
+                .bind(provider)
+                .execute(&self.pool)
+                .await?;
 
         Ok(result.rows_affected() > 0)
     }

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -3384,6 +3384,106 @@ impl Database {
 
         Ok(result.rows_affected() > 0)
     }
+
+    // ============================================
+    // User Connections
+    // ============================================
+
+    /// Create or replace a user connection for a provider.
+    /// Deletes any existing connection for the same (user_id, provider) first.
+    pub async fn upsert_user_connection(
+        &self,
+        input: CreateUserConnectionRow,
+    ) -> Result<UserConnectionRow> {
+        // App-level uniqueness: delete existing connection for this user+provider
+        sqlx::query(
+            "DELETE FROM user_connections WHERE user_id = $1 AND provider = $2",
+        )
+        .bind(input.user_id)
+        .bind(&input.provider)
+        .execute(&self.pool)
+        .await?;
+
+        let row = sqlx::query_as::<_, UserConnectionRow>(
+            r#"
+            INSERT INTO user_connections (user_id, provider, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            RETURNING id, user_id, provider, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, created_at, updated_at
+            "#,
+        )
+        .bind(input.user_id)
+        .bind(&input.provider)
+        .bind(&input.provider_user_id)
+        .bind(&input.provider_username)
+        .bind(&input.access_token_encrypted)
+        .bind(&input.refresh_token_encrypted)
+        .bind(&input.scopes)
+        .bind(input.expires_at)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    /// Get a user's connection for a specific provider
+    pub async fn get_user_connection(
+        &self,
+        user_id: Uuid,
+        provider: &str,
+    ) -> Result<Option<UserConnectionRow>> {
+        let row = sqlx::query_as::<_, UserConnectionRow>(
+            r#"
+            SELECT id, user_id, provider, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, created_at, updated_at
+            FROM user_connections
+            WHERE user_id = $1 AND provider = $2
+            ORDER BY created_at DESC
+            LIMIT 1
+            "#,
+        )
+        .bind(user_id)
+        .bind(provider)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    /// List all connections for a user
+    pub async fn list_user_connections(
+        &self,
+        user_id: Uuid,
+    ) -> Result<Vec<UserConnectionRow>> {
+        let rows = sqlx::query_as::<_, UserConnectionRow>(
+            r#"
+            SELECT id, user_id, provider, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, created_at, updated_at
+            FROM user_connections
+            WHERE user_id = $1
+            ORDER BY provider ASC
+            "#,
+        )
+        .bind(user_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+
+    /// Delete a user's connection for a specific provider
+    pub async fn delete_user_connection(
+        &self,
+        user_id: Uuid,
+        provider: &str,
+    ) -> Result<bool> {
+        let result = sqlx::query(
+            "DELETE FROM user_connections WHERE user_id = $1 AND provider = $2",
+        )
+        .bind(user_id)
+        .bind(provider)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
 }
 
 #[cfg(test)]

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -135,7 +135,7 @@ impl TestServer {
 
         // Create module-specific states
         let sessions_state =
-            api::sessions::AppState::new(db.clone(), runner.clone(), auth_state.clone());
+            api::sessions::AppState::new(db.clone(), runner.clone(), auth_state.clone(), None);
         let messages_state =
             api::messages::AppState::new(db.clone(), runner.clone(), auth_state.clone());
         let sse_tracker = Arc::new(everruns_server::api::sse::SseConnectionTracker::new(

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -135,7 +135,7 @@ impl TestServer {
 
         // Create module-specific states
         let sessions_state =
-            api::sessions::AppState::new(db.clone(), runner.clone(), auth_state.clone(), None);
+            api::sessions::AppState::new(db.clone(), runner.clone(), auth_state.clone());
         let messages_state =
             api::messages::AppState::new(db.clone(), runner.clone(), auth_state.clone());
         let sse_tracker = Arc::new(everruns_server::api::sse::SseConnectionTracker::new(

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -1,3 +1,8 @@
+// Force-link integration crates so inventory::submit! registrations are included
+extern crate everruns_integrations_codesandbox;
+extern crate everruns_integrations_daytona;
+extern crate everruns_integrations_docker;
+
 pub mod activities;
 pub mod adapters;
 pub mod durable_runner;

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -776,6 +776,9 @@ async fn execute_act_activity<A: WorkerAdapters>(
     if let Some(storage_store) = adapters.storage_store() {
         atom = atom.with_storage_store(storage_store);
     }
+    if let Some(connection_resolver) = adapters.connection_resolver() {
+        atom = atom.with_connection_resolver(connection_resolver);
+    }
 
     let result = atom.execute(input.clone()).await?;
 

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -181,6 +181,14 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
     fn storage_store(&self) -> Option<Arc<dyn everruns_core::traits::SessionStorageStore>> {
         None
     }
+
+    /// Get the user connection resolver for lazy token lookup (if available).
+    /// Default returns None (not all backends support user connections).
+    fn connection_resolver(
+        &self,
+    ) -> Option<Arc<dyn everruns_core::traits::UserConnectionResolver>> {
+        None
+    }
 }
 
 // =============================================================================

--- a/docs/sre/runbooks/authentication.md
+++ b/docs/sre/runbooks/authentication.md
@@ -55,7 +55,7 @@ export AUTH_GITHUB_CLIENT_SECRET=your-github-client-secret
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `AUTH_MODE` | No | `none`, `admin`, or `full` (default: `none`) |
-| `AUTH_BASE_URL` | For OAuth | Base URL for callbacks (default: `http://localhost:9000`) |
+| `AUTH_BASE_URL` | For OAuth | Base URL for callbacks (default: `http://localhost:9300`) |
 | `AUTH_JWT_SECRET` | For admin/full | JWT signing secret (min 32 chars recommended) |
 
 ### Admin Mode Settings

--- a/docs/sre/runbooks/authentication.md
+++ b/docs/sre/runbooks/authentication.md
@@ -55,7 +55,7 @@ export AUTH_GITHUB_CLIENT_SECRET=your-github-client-secret
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `AUTH_MODE` | No | `none`, `admin`, or `full` (default: `none`) |
-| `AUTH_BASE_URL` | For OAuth | Base URL for callbacks (default: `http://localhost:9300`) |
+| `AUTH_BASE_URL` | For OAuth | Base URL for callbacks (default: `http://localhost:9300/api`) |
 | `AUTH_JWT_SECRET` | For admin/full | JWT signing secret (min 32 chars recommended) |
 
 ### Admin Mode Settings

--- a/integrations/codesandbox/src/lib.rs
+++ b/integrations/codesandbox/src/lib.rs
@@ -1853,9 +1853,18 @@ echo "password={token}""#
 
         // Check if clone succeeded (non-empty output usually means error)
         if output.contains("fatal:") || output.contains("error:") {
+            let error_lines: String = output.lines().take(5).collect::<Vec<_>>().join("\n");
+            let hint = if github_token.is_none()
+                && (output.contains("Authentication failed")
+                    || output.contains("could not read Username")
+                    || output.contains("Repository not found"))
+            {
+                "\n\nThis may be a private repository. The user can connect their GitHub account in Settings > Connections to enable authenticated cloning."
+            } else {
+                ""
+            };
             return ToolExecutionResult::tool_error(format!(
-                "Git clone failed: {}",
-                output.lines().take(5).collect::<Vec<_>>().join("\n")
+                "Git clone failed: {error_lines}{hint}"
             ));
         }
 
@@ -1886,17 +1895,30 @@ fn normalize_repo_url(url: &str) -> String {
     }
 }
 
-/// Read GITHUB_TOKEN from session secrets (injected from user connections)
+/// Resolve GitHub token lazily from user connections, with session secret fallback.
 async fn get_github_token(context: &ToolContext) -> Option<String> {
-    let storage = context.storage_store.as_ref()?;
-    match storage.get_secret(context.session_id, "GITHUB_TOKEN").await {
-        Ok(Some(token)) if !token.is_empty() => Some(token),
-        Ok(_) => None,
-        Err(e) => {
-            debug!("No GITHUB_TOKEN available: {e}");
-            None
+    // Try lazy resolution from user connections (preferred: always fresh)
+    if let Some(ref resolver) = context.connection_resolver {
+        match resolver
+            .get_connection_token(context.session_id, "github")
+            .await
+        {
+            Ok(Some(token)) if !token.is_empty() => return Some(token),
+            Ok(_) => {}
+            Err(e) => debug!("Connection resolver failed: {e}"),
         }
     }
+
+    // Fallback: session secret (for backward compat with pre-injected tokens)
+    if let Some(ref storage) = context.storage_store {
+        match storage.get_secret(context.session_id, "GITHUB_TOKEN").await {
+            Ok(Some(token)) if !token.is_empty() => return Some(token),
+            Ok(_) => {}
+            Err(e) => debug!("No GITHUB_TOKEN session secret: {e}"),
+        }
+    }
+
+    None
 }
 
 /// Poll exec completion and return output

--- a/integrations/codesandbox/src/lib.rs
+++ b/integrations/codesandbox/src/lib.rs
@@ -707,6 +707,9 @@ Tools:
 - `csb_download_workspace` - Download sandbox workspace to session storage
 - `csb_list_sandboxes` - List session sandboxes
 - `csb_manage_sandbox` - Shutdown, hibernate, or delete a sandbox
+- `csb_git_clone` - Clone a git repository into a sandbox (auto-uses connected GitHub credentials)
+
+Git cloning: Use `csb_git_clone` to clone repositories. If the user has connected their GitHub account (Settings > Connections), private repos are automatically authenticated. For public repos, no credentials are needed. Supports "user/repo" shorthand.
 
 All tools except `csb_create_sandbox` and `csb_list_sandboxes` require a `sandbox_id`.
 Sandboxes auto-hibernate after 5 minutes of inactivity.
@@ -724,6 +727,7 @@ Always DELETE sandboxes when done (shutdown/hibernate leave them on the dashboar
             Box::new(CsbDownloadWorkspaceTool),
             Box::new(CsbListSandboxesTool),
             Box::new(CsbManageSandboxTool),
+            Box::new(CsbGitCloneTool),
         ]
     }
 
@@ -1643,6 +1647,293 @@ impl Tool for CsbManageSandboxTool {
 }
 
 // ============================================================================
+// CsbGitCloneTool
+// ============================================================================
+
+pub struct CsbGitCloneTool;
+
+#[async_trait]
+impl Tool for CsbGitCloneTool {
+    fn name(&self) -> &str {
+        "csb_git_clone"
+    }
+
+    fn description(&self) -> &str {
+        "Clone a git repository into a CodeSandbox VM. Automatically uses the user's \
+         connected GitHub credentials (GITHUB_TOKEN) if available. For private repos, \
+         the user must have connected their GitHub account in Settings > Connections."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "sandbox_id": {
+                    "type": "string",
+                    "description": "Sandbox ID to clone into"
+                },
+                "repo_url": {
+                    "type": "string",
+                    "description": "Repository URL (e.g., 'https://github.com/user/repo' or 'user/repo' shorthand)"
+                },
+                "branch": {
+                    "type": "string",
+                    "description": "Branch to clone (optional, defaults to default branch)"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Clone destination path inside sandbox (optional, defaults to /project/workspace/<repo_name>)"
+                }
+            },
+            "required": ["sandbox_id", "repo_url"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "csb_git_clone requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let sandbox_id = match required_str(&arguments, "sandbox_id") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+        let repo_url_raw = match required_str(&arguments, "repo_url") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+        let branch = arguments.get("branch").and_then(|v| v.as_str());
+        let clone_path = arguments.get("path").and_then(|v| v.as_str());
+
+        let api_key = match get_api_key(context).await {
+            Ok(k) => k,
+            Err(e) => return e,
+        };
+        let state = match get_sandbox_state(context, sandbox_id).await {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        // Normalize repo URL: "user/repo" → "https://github.com/user/repo.git"
+        let repo_url = normalize_repo_url(repo_url_raw);
+
+        // Extract repo name for default clone path
+        let repo_name = repo_url
+            .rsplit('/')
+            .next()
+            .unwrap_or("repo")
+            .trim_end_matches(".git");
+        let default_path = format!("/project/workspace/{}", repo_name);
+        let target_path = clone_path.unwrap_or(&default_path);
+
+        // Try to get GITHUB_TOKEN from session secrets for authentication
+        let github_token = get_github_token(context).await;
+
+        let client = CodeSandboxClient::new(api_key);
+
+        // Step 1: Set up git credential helper if we have a token
+        if let Some(ref token) = github_token {
+            debug!("Setting up git credential helper for authenticated clone");
+            let credential_script = format!(
+                r#"#!/bin/sh
+echo "protocol=https"
+echo "host=github.com"
+echo "username=oauth2"
+echo "password={token}""#
+            );
+
+            // Write credential helper script
+            let write_helper = client
+                .exec_create(
+                    &state,
+                    "bash",
+                    vec![
+                        "-c".to_string(),
+                        format!(
+                            "mkdir -p /tmp && cat > /tmp/git-credential-helper.sh << 'CREDEOF'\n{credential_script}\nCREDEOF\nchmod +x /tmp/git-credential-helper.sh"
+                        ),
+                    ],
+                )
+                .await;
+
+            if let Err(e) = write_helper {
+                warn!("Failed to write credential helper: {e}");
+                // Continue without auth — will fail for private repos
+            } else if let Ok(exec_info) = write_helper {
+                let _ = poll_exec_completion(&client, &state, &exec_info.id).await;
+            }
+
+            // Configure git to use the credential helper
+            let configure_git = client
+                .exec_create(
+                    &state,
+                    "bash",
+                    vec![
+                        "-c".to_string(),
+                        "git config --global credential.helper '/tmp/git-credential-helper.sh'"
+                            .to_string(),
+                    ],
+                )
+                .await;
+
+            if let Ok(exec_info) = configure_git {
+                let _ = poll_exec_completion(&client, &state, &exec_info.id).await;
+            }
+        }
+
+        // Step 2: Build and run git clone command
+        let mut clone_cmd = format!("git clone --depth 1");
+        if let Some(b) = branch {
+            clone_cmd.push_str(&format!(" --branch {b}"));
+        }
+        clone_cmd.push_str(&format!(" {repo_url} {target_path}"));
+
+        debug!("Cloning repository: {clone_cmd}");
+        let exec_info = match client
+            .exec_create(&state, "bash", vec!["-c".to_string(), clone_cmd])
+            .await
+        {
+            Ok(info) => info,
+            Err(e) => return ToolExecutionResult::tool_error(e),
+        };
+
+        // Poll for completion
+        let output = match poll_exec_completion(&client, &state, &exec_info.id).await {
+            Ok(o) => o,
+            Err(e) => return e,
+        };
+
+        // Step 3: Get the HEAD commit SHA
+        let commit_sha = {
+            let sha_exec = client
+                .exec_create(
+                    &state,
+                    "bash",
+                    vec![
+                        "-c".to_string(),
+                        format!("cd {target_path} && git rev-parse --short HEAD"),
+                    ],
+                )
+                .await;
+            if let Ok(exec_info) = sha_exec {
+                if let Ok(sha_output) = poll_exec_completion(&client, &state, &exec_info.id).await {
+                    sha_output.trim().to_string()
+                } else {
+                    "unknown".to_string()
+                }
+            } else {
+                "unknown".to_string()
+            }
+        };
+
+        // Step 4: Clean up credential helper (security)
+        if github_token.is_some() {
+            let cleanup = client
+                .exec_create(
+                    &state,
+                    "bash",
+                    vec![
+                        "-c".to_string(),
+                        "rm -f /tmp/git-credential-helper.sh && git config --global --unset credential.helper"
+                            .to_string(),
+                    ],
+                )
+                .await;
+            if let Ok(exec_info) = cleanup {
+                let _ = poll_exec_completion(&client, &state, &exec_info.id).await;
+            }
+        }
+
+        // Check if clone succeeded (non-empty output usually means error)
+        if output.contains("fatal:") || output.contains("error:") {
+            return ToolExecutionResult::tool_error(format!(
+                "Git clone failed: {}",
+                output.lines().take(5).collect::<Vec<_>>().join("\n")
+            ));
+        }
+
+        ToolExecutionResult::success(json!({
+            "sandbox_id": sandbox_id,
+            "repo_url": repo_url,
+            "path": target_path,
+            "branch": branch.unwrap_or("default"),
+            "commit": commit_sha,
+            "authenticated": github_token.is_some()
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+/// Normalize repository URL: "user/repo" → "https://github.com/user/repo.git"
+fn normalize_repo_url(url: &str) -> String {
+    if url.starts_with("http://") || url.starts_with("https://") || url.starts_with("git@") {
+        url.to_string()
+    } else if url.contains('/') && !url.contains(' ') {
+        // Looks like "user/repo" shorthand
+        format!("https://github.com/{url}.git")
+    } else {
+        url.to_string()
+    }
+}
+
+/// Read GITHUB_TOKEN from session secrets (injected from user connections)
+async fn get_github_token(context: &ToolContext) -> Option<String> {
+    let storage = context.storage_store.as_ref()?;
+    match storage
+        .get_secret(context.session_id, "GITHUB_TOKEN")
+        .await
+    {
+        Ok(Some(token)) if !token.is_empty() => Some(token),
+        Ok(_) => None,
+        Err(e) => {
+            debug!("No GITHUB_TOKEN available: {e}");
+            None
+        }
+    }
+}
+
+/// Poll exec completion and return output
+async fn poll_exec_completion(
+    client: &CodeSandboxClient,
+    state: &SandboxState,
+    exec_id: &str,
+) -> Result<String, ToolExecutionResult> {
+    let start = std::time::Instant::now();
+    loop {
+        if start.elapsed() > EXEC_POLL_MAX_WAIT {
+            return Ok("(timed out waiting for completion)".to_string());
+        }
+
+        match client.exec_get(state, exec_id).await {
+            Ok(info) if info.status == "finished" => {
+                return match client.exec_get_output(state, exec_id).await {
+                    Ok(output) => Ok(output),
+                    Err(_) => Ok(String::new()),
+                };
+            }
+            Ok(_) => {
+                tokio::time::sleep(EXEC_POLL_INTERVAL).await;
+            }
+            Err(e) => {
+                return Err(ToolExecutionResult::tool_error(format!(
+                    "Failed to check exec status: {e}"
+                )));
+            }
+        }
+    }
+}
+
+// ============================================================================
 // Tests
 // ============================================================================
 
@@ -1666,7 +1957,7 @@ mod tests {
     fn test_capability_has_all_tools() {
         let cap = CodeSandboxCapability;
         let tools = cap.tools();
-        assert_eq!(tools.len(), 8);
+        assert_eq!(tools.len(), 9);
 
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
         assert!(names.contains(&"csb_create_sandbox"));
@@ -1677,6 +1968,7 @@ mod tests {
         assert!(names.contains(&"csb_download_workspace"));
         assert!(names.contains(&"csb_list_sandboxes"));
         assert!(names.contains(&"csb_manage_sandbox"));
+        assert!(names.contains(&"csb_git_clone"));
     }
 
     #[test]
@@ -1688,6 +1980,7 @@ mod tests {
         assert!(prompt.contains("Experimental"));
         assert!(prompt.contains("csb_exec"));
         assert!(prompt.contains("csb_download_workspace"));
+        assert!(prompt.contains("csb_git_clone"));
         assert!(prompt.contains("Prerequisite"));
         // Should NOT duplicate workflow steps (that's the agent's job)
         assert!(!prompt.contains("Set API key (once per session)"));

--- a/integrations/codesandbox/src/lib.rs
+++ b/integrations/codesandbox/src/lib.rs
@@ -1,4 +1,4 @@
-//! CodeSandbox Integration (Experimental)
+//! CodeSandbox Integration
 //!
 //! Cloud-based sandboxed code execution via CodeSandbox REST API.
 //! Supports multiple sandboxes per session, each identified by sandbox_id.
@@ -25,7 +25,7 @@ use tracing::{debug, error, warn};
 
 inventory::submit! {
     IntegrationPlugin {
-        experimental_only: true,
+        experimental_only: false,
         factory: || Box::new(CodeSandboxCapability),
     }
 }
@@ -670,7 +670,7 @@ impl Capability for CodeSandboxCapability {
     }
 
     fn name(&self) -> &str {
-        "[Experimental] CodeSandbox"
+        "CodeSandbox"
     }
 
     fn description(&self) -> &str {
@@ -1944,7 +1944,7 @@ mod tests {
     fn test_capability_metadata() {
         let cap = CodeSandboxCapability;
         assert_eq!(cap.id(), "codesandbox");
-        assert_eq!(cap.name(), "[Experimental] CodeSandbox");
+        assert_eq!(cap.name(), "CodeSandbox");
         assert_eq!(cap.status(), CapabilityStatus::Available);
         assert_eq!(cap.icon(), Some("cloud"));
         assert_eq!(cap.category(), Some("Execution"));

--- a/integrations/codesandbox/src/lib.rs
+++ b/integrations/codesandbox/src/lib.rs
@@ -1789,7 +1789,7 @@ echo "password={token}""#
         }
 
         // Step 2: Build and run git clone command
-        let mut clone_cmd = format!("git clone --depth 1");
+        let mut clone_cmd = "git clone --depth 1".to_string();
         if let Some(b) = branch {
             clone_cmd.push_str(&format!(" --branch {b}"));
         }
@@ -1889,10 +1889,7 @@ fn normalize_repo_url(url: &str) -> String {
 /// Read GITHUB_TOKEN from session secrets (injected from user connections)
 async fn get_github_token(context: &ToolContext) -> Option<String> {
     let storage = context.storage_store.as_ref()?;
-    match storage
-        .get_secret(context.session_id, "GITHUB_TOKEN")
-        .await
-    {
+    match storage.get_secret(context.session_id, "GITHUB_TOKEN").await {
         Ok(Some(token)) if !token.is_empty() => Some(token),
         Ok(_) => None,
         Err(e) => {

--- a/integrations/codesandbox/tests/plugin_registration.rs
+++ b/integrations/codesandbox/tests/plugin_registration.rs
@@ -19,7 +19,7 @@ fn test_codesandbox_plugin_is_submitted() {
 }
 
 #[test]
-fn test_codesandbox_plugin_is_experimental() {
+fn test_codesandbox_plugin_is_not_experimental() {
     let plugins: Vec<&IntegrationPlugin> = inventory::iter::<IntegrationPlugin>().collect();
     let csb = plugins
         .iter()
@@ -30,8 +30,8 @@ fn test_codesandbox_plugin_is_experimental() {
         .expect("CodeSandbox plugin not found");
 
     assert!(
-        csb.experimental_only,
-        "CodeSandbox should be marked experimental_only"
+        !csb.experimental_only,
+        "CodeSandbox should NOT be marked experimental_only"
     );
 }
 
@@ -45,11 +45,11 @@ fn test_codesandbox_registered_in_dev_registry() {
 }
 
 #[test]
-fn test_codesandbox_not_registered_in_prod_registry() {
+fn test_codesandbox_registered_in_prod_registry() {
     let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Prod);
     assert!(
-        !registry.has("codesandbox"),
-        "CodeSandbox should NOT be in prod registry"
+        registry.has("codesandbox"),
+        "CodeSandbox should be in prod registry"
     );
 }
 
@@ -61,11 +61,11 @@ fn test_codesandbox_capability_metadata() {
         .expect("CodeSandbox capability not found");
 
     assert_eq!(cap.id(), "codesandbox");
-    assert_eq!(cap.name(), "[Experimental] CodeSandbox");
+    assert_eq!(cap.name(), "CodeSandbox");
     assert_eq!(cap.icon(), Some("cloud"));
     assert_eq!(cap.category(), Some("Execution"));
     assert_eq!(cap.dependencies(), vec!["session_storage"]);
-    assert_eq!(cap.tools().len(), 8);
+    assert_eq!(cap.tools().len(), 9);
 }
 
 #[test]

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -121,7 +121,6 @@ print_doppler_secret_hint() {
 
   [ -n "${OPENAI_API_KEY:-}" ] || missing+=("OPENAI_API_KEY")
   [ -n "${ANTHROPIC_API_KEY:-}" ] || missing+=("ANTHROPIC_API_KEY")
-  [ -n "${GITHUB_TOKEN:-}" ] || missing+=("GITHUB_TOKEN")
 
   if [ ${#missing[@]} -eq 0 ]; then
     return 0
@@ -131,7 +130,7 @@ print_doppler_secret_hint() {
     echo "   ⚠️  Missing env: ${missing[*]}"
     echo "   ℹ️  Cloud agents use Doppler for secrets."
     echo "   ℹ️  Re-run with: doppler run -- <command>"
-    echo "   ℹ️  Quickcheck: doppler run -- env | rg 'OPENAI_API_KEY|ANTHROPIC_API_KEY|GITHUB_TOKEN'"
+    echo "   ℹ️  Quickcheck: doppler run -- env | rg 'OPENAI_API_KEY|ANTHROPIC_API_KEY'"
   fi
 }
 

--- a/scripts/lib/services.sh
+++ b/scripts/lib/services.sh
@@ -114,9 +114,8 @@ case "$cmd" in
     export DEV_MODE=true
     export DEPLOYMENT_GRADE=dev
     export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:9300}
-    export AUTH_BASE_URL=${AUTH_BASE_URL:-http://localhost:9300}
+    export AUTH_BASE_URL=${AUTH_BASE_URL:-http://localhost:9300/api}
     export FRONTEND_URL=${FRONTEND_URL:-http://localhost:9300}
-    export API_PREFIX=${API_PREFIX:-/api}
     export RUST_LOG=${RUST_LOG:-info}
 
     # Set encryption key if not provided (standard dev key from .env.example)
@@ -383,9 +382,8 @@ case "$cmd" in
 
     # Start API
     export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:9300}
-    export AUTH_BASE_URL=${AUTH_BASE_URL:-http://localhost:9300}
+    export AUTH_BASE_URL=${AUTH_BASE_URL:-http://localhost:9300/api}
     export FRONTEND_URL=${FRONTEND_URL:-http://localhost:9300}
-    export API_PREFIX=${API_PREFIX:-/api}
     export DEPLOYMENT_GRADE=dev
     export RUST_LOG=${RUST_LOG:-info}
     if [ "$NO_WATCH" = true ]; then

--- a/scripts/lib/services.sh
+++ b/scripts/lib/services.sh
@@ -114,6 +114,9 @@ case "$cmd" in
     export DEV_MODE=true
     export DEPLOYMENT_GRADE=dev
     export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:9300}
+    export AUTH_BASE_URL=${AUTH_BASE_URL:-http://localhost:9300}
+    export FRONTEND_URL=${FRONTEND_URL:-http://localhost:9300}
+    export API_PREFIX=${API_PREFIX:-/api}
     export RUST_LOG=${RUST_LOG:-info}
 
     # Set encryption key if not provided (standard dev key from .env.example)
@@ -380,6 +383,9 @@ case "$cmd" in
 
     # Start API
     export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:9300}
+    export AUTH_BASE_URL=${AUTH_BASE_URL:-http://localhost:9300}
+    export FRONTEND_URL=${FRONTEND_URL:-http://localhost:9300}
+    export API_PREFIX=${API_PREFIX:-/api}
     export DEPLOYMENT_GRADE=dev
     export RUST_LOG=${RUST_LOG:-info}
     if [ "$NO_WATCH" = true ]; then

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -297,6 +297,18 @@ Providers with custom base URLs or providers that don't support model listing re
 - `include_stale` - Include stale models (default: `true`)
 - `favorites_only` - Only return favorites (default: `false`)
 
+### User Connections
+
+User-scoped external service accounts (e.g., GitHub) for repo access. See [user-connections.md](user-connections.md) for full specification.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/user/connections` | List user's connected accounts |
+| POST | `/v1/user/connections` | Add connection via manual PAT |
+| DELETE | `/v1/user/connections/{provider}` | Disconnect (delete stored token) |
+| GET | `/v1/user/connections/github/authorize` | Start GitHub OAuth flow |
+| GET | `/v1/user/connections/github/callback` | GitHub OAuth callback |
+
 ### Agent Capabilities
 
 | Method | Path | Description |
@@ -480,6 +492,7 @@ These endpoints return all items wrapped in `{"data": [...], "total": N}`:
 - `GET /v1/durable/tasks` - Returns all tasks
 - `GET /v1/durable/dlq` - Returns all DLQ entries
 - `GET /v1/durable/circuit-breakers` - Returns all circuit breakers
+- `GET /v1/user/connections` - Returns all user connections (array, no wrapper)
 
 **Exception:** The `/v1/capabilities` endpoint uses `items` instead of `data` for historical reasons.
 

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -304,7 +304,6 @@ User-scoped external service accounts (e.g., GitHub) for repo access. See [user-
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/v1/user/connections` | List user's connected accounts |
-| POST | `/v1/user/connections` | Add connection via manual PAT |
 | DELETE | `/v1/user/connections/{provider}` | Disconnect (delete stored token) |
 | GET | `/v1/user/connections/github/authorize` | Start GitHub OAuth flow |
 | GET | `/v1/user/connections/github/callback` | GitHub OAuth callback |

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -58,6 +58,7 @@ graph TB
    - `anthropic/` → `everruns-anthropic` - Anthropic LLM provider implementation
    - `integrations/codesandbox/` → `everruns-integrations-codesandbox` - CodeSandbox cloud sandbox integration (auto-registered via `inventory` plugin system)
    - `integrations/docker/` → `everruns-integrations-docker` - Docker container integration (auto-registered via `inventory` plugin system)
+   - `integrations/daytona/` → `everruns-integrations-daytona` - Daytona cloud sandbox integration (auto-registered via `inventory` plugin system)
 3. **Frontend**: Next.js application in `apps/ui/` for management and chat interfaces
    - Exports providers, components, hooks, and lib modules via `package.json` `exports` field for SaaS wrapper consumption
 4. **Documentation Site**: Astro Starlight in `apps/docs/` deployed to https://docs.everruns.com/
@@ -80,7 +81,8 @@ everruns/
 │   └── anthropic/        # Anthropic provider
 ├── integrations/
 │   ├── codesandbox/      # CodeSandbox cloud sandbox (inventory plugin)
-│   └── docker/           # Docker container (inventory plugin)
+│   ├── docker/           # Docker container (inventory plugin)
+│   └── daytona/          # Daytona cloud sandbox (inventory plugin)
 ├── docs/                 # Documentation content (symlinked to apps/docs)
 ├── specs/                # Feature specifications
 ├── test_cases/           # Manual test cases
@@ -108,6 +110,25 @@ graph TD
     core --> server
     worker -.->|gRPC| server
 ```
+
+### Integration Plugin Force-Linking
+
+Integration crates (`codesandbox`, `docker`, `daytona`) register capabilities at startup via `inventory::submit!`. The `inventory` crate uses linker sections — if the crate is not explicitly referenced, Rust's linker will optimize it out and the `submit!` registrations silently disappear.
+
+**Both `crates/server/src/lib.rs` and `crates/worker/src/lib.rs` must have `extern crate` statements for every integration crate:**
+
+```rust
+extern crate everruns_integrations_codesandbox;
+extern crate everruns_integrations_daytona;
+extern crate everruns_integrations_docker;
+```
+
+Adding a new integration crate requires:
+1. Create the crate under `integrations/`
+2. Add it as a dependency in `crates/server/Cargo.toml` and `crates/worker/Cargo.toml`
+3. Add `extern crate` to both `crates/server/src/lib.rs` and `crates/worker/src/lib.rs`
+
+Without step 3, the crate compiles but its capabilities are never registered. There is no compile-time error — the integration simply does not appear at runtime.
 
 ### Server Entrypoint
 

--- a/specs/authentication.md
+++ b/specs/authentication.md
@@ -69,7 +69,7 @@ Account linking by email is supported (same email = same account).
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `AUTH_MODE` | Authentication mode: `none`, `admin`, `full`, `external` | `none` |
-| `AUTH_BASE_URL` | Base URL for OAuth callbacks | `http://localhost:9300` |
+| `AUTH_BASE_URL` | Base URL for OAuth callbacks (include path prefix if behind reverse proxy) | `http://localhost:9300/api` |
 | `AUTH_ADMIN_EMAIL` | Admin user email (admin mode) | - |
 | `AUTH_ADMIN_PASSWORD` | Admin user password (admin mode) | - |
 | `AUTH_JWT_SECRET` | JWT signing secret (required for admin/full) | - |

--- a/specs/authentication.md
+++ b/specs/authentication.md
@@ -84,6 +84,9 @@ Account linking by email is supported (same email = same account).
 | `AUTH_GITHUB_CLIENT_ID` | GitHub OAuth client ID | - |
 | `AUTH_GITHUB_CLIENT_SECRET` | GitHub OAuth client secret | - |
 | `AUTH_GITHUB_REDIRECT_URI` | GitHub OAuth redirect URI | `{base_url}{api_prefix}/v1/auth/callback/github` |
+| `GITHUB_CONNECTION_CLIENT_ID` | GitHub OAuth App client ID (for connections, NOT login) | - |
+| `GITHUB_CONNECTION_CLIENT_SECRET` | GitHub OAuth App client secret (for connections) | - |
+| `GITHUB_CONNECTION_REDIRECT_URI` | Callback URL for connections OAuth | `{AUTH_BASE_URL}/v1/user/connections/github/callback` |
 | `CORS_ALLOWED_ORIGINS` | Comma-separated allowed CORS origins (only if cross-origin) | Not set |
 
 ### Database Schema

--- a/specs/authentication.md
+++ b/specs/authentication.md
@@ -69,7 +69,7 @@ Account linking by email is supported (same email = same account).
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `AUTH_MODE` | Authentication mode: `none`, `admin`, `full`, `external` | `none` |
-| `AUTH_BASE_URL` | Base URL for OAuth callbacks | `http://localhost:9000` |
+| `AUTH_BASE_URL` | Base URL for OAuth callbacks | `http://localhost:9300` |
 | `AUTH_ADMIN_EMAIL` | Admin user email (admin mode) | - |
 | `AUTH_ADMIN_PASSWORD` | Admin user password (admin mode) | - |
 | `AUTH_JWT_SECRET` | JWT signing secret (required for admin/full) | - |
@@ -86,7 +86,7 @@ Account linking by email is supported (same email = same account).
 | `AUTH_GITHUB_REDIRECT_URI` | GitHub OAuth redirect URI | `{base_url}{api_prefix}/v1/auth/callback/github` |
 | `GITHUB_CONNECTION_CLIENT_ID` | GitHub OAuth App client ID (for connections, NOT login) | - |
 | `GITHUB_CONNECTION_CLIENT_SECRET` | GitHub OAuth App client secret (for connections) | - |
-| `GITHUB_CONNECTION_REDIRECT_URI` | Callback URL for connections OAuth | `{AUTH_BASE_URL}/v1/user/connections/github/callback` |
+| `GITHUB_CONNECTION_REDIRECT_URI` | Callback URL for connections OAuth | `{AUTH_BASE_URL}{API_PREFIX}/v1/user/connections/github/callback` |
 | `CORS_ALLOWED_ORIGINS` | Comma-separated allowed CORS origins (only if cross-origin) | Not set |
 
 ### Database Schema

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -1026,7 +1026,7 @@ Experimental capabilities are available in development environments only (`Deplo
 
 - **Status**: Available (Dev only, integration plugin)
 - **ID**: `docker_container`
-- **Crate**: `integrations/docker/` → `everruns-integrations-docker` (auto-registered via `inventory` plugin system)
+- **Crate**: `integrations/docker/` → `everruns-integrations-docker` (auto-registered via `inventory` plugin system, force-linked via `extern crate` in server and worker — see [architecture.md](architecture.md#integration-plugin-force-linking))
 - **Purpose**: Run commands and manage files in a Docker container tied to the session
 - **System Prompt**: Guidance on using container tools, best practices for command execution
 - **Container Lifecycle**:

--- a/specs/codesandbox.md
+++ b/specs/codesandbox.md
@@ -244,6 +244,8 @@ The capability declares `session_storage` as a dependency because it needs both 
 External integration crate, auto-registered via `inventory::submit!` plugin system.
 Core (`everruns-core`) has no compile-time knowledge of this crate.
 
+**Force-link required**: Both `crates/server/src/lib.rs` and `crates/worker/src/lib.rs` must contain `extern crate everruns_integrations_codesandbox;` — otherwise the linker optimizes out the crate and `inventory::submit!` registrations silently disappear. See [architecture.md](architecture.md#integration-plugin-force-linking).
+
 ## Capability Registration
 
 - **ID**: `codesandbox`

--- a/specs/concepts.md
+++ b/specs/concepts.md
@@ -185,3 +185,13 @@ A remote server that exposes tools via the Model Context Protocol. Integrated as
 - Tools are discovered at runtime and cached with a 24-hour TTL
 - Tool names are prefixed to avoid conflicts: `mcp_{server}__{tool}`
 - Execution happens via HTTP JSON-RPC
+
+### User Connection
+
+A linked external service account (GitHub, GitLab, etc.) associated with a user. Provides authenticated access to external services from agent sessions.
+
+- User-scoped (not org-scoped) — represents the user's identity on the external service
+- Tokens encrypted at rest via AES-256-GCM envelope encryption
+- Auto-injected into sessions as secrets (e.g., `GITHUB_TOKEN`) when sessions are created
+- Capabilities like `codesandbox` use injected tokens transparently (e.g., `csb_git_clone` for private repos)
+- See [user-connections.md](user-connections.md) for full specification

--- a/specs/daytona.md
+++ b/specs/daytona.md
@@ -185,6 +185,8 @@ Files are managed through the Toolbox API proxy (`proxy.app.daytona.io`). Upload
 
 External integration crate, auto-registered via `inventory::submit!` plugin system.
 
+**Force-link required**: Both `crates/server/src/lib.rs` and `crates/worker/src/lib.rs` must contain `extern crate everruns_integrations_daytona;` — otherwise the linker optimizes out the crate and `inventory::submit!` registrations silently disappear. See [architecture.md](architecture.md#integration-plugin-force-linking).
+
 | File | Purpose |
 |------|---------|
 | `src/lib.rs` | Plugin registration, constants, `DaytonaCapability` impl |

--- a/specs/models.md
+++ b/specs/models.md
@@ -613,6 +613,24 @@ Automatic discovery of available models from provider APIs.
 - `include_stale` - Include stale models (default: true)
 - `favorites_only` - Only return favorites (default: false)
 
+### UserConnection
+
+A linked external service account. User-scoped (not org-scoped). See [user-connections.md](user-connections.md) for full specification.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | UUID v7 | Internal primary key |
+| `user_id` | UUID | FK to users.id |
+| `provider` | string | `github`, `gitlab`, `bitbucket` |
+| `provider_user_id` | string? | Provider's user ID |
+| `provider_username` | string? | Display name (e.g., `octocat`) |
+| `access_token_encrypted` | bytes | Encrypted with envelope encryption |
+| `refresh_token_encrypted` | bytes? | For providers that support refresh |
+| `scopes` | string? | Granted scopes (e.g., `repo,read:user`) |
+| `expires_at` | timestamp? | NULL = no expiry (GitHub OAuth App tokens) |
+| `created_at` | timestamp | |
+| `updated_at` | timestamp | |
+
 ## Design Decisions
 
 | Question | Decision |

--- a/specs/user-connections.md
+++ b/specs/user-connections.md
@@ -48,6 +48,10 @@ A **separate** GitHub OAuth App from the login OAuth App. Different client_id/se
 
 Connections are **user-scoped**. The token represents the user's identity on the external service. It's usable in any org the user belongs to.
 
+**Visibility:** Connections are private to the user who created them. Other org members cannot list, view, or manage another user's connections via the API. The `GET /v1/user/connections` endpoint only returns the authenticated user's own connections.
+
+**Token resolution:** Although connections are private, the lazy token resolver (`UserConnectionResolver`) can resolve tokens across org members for tool execution. When a tool needs a GitHub token, the resolver finds any org member who has connected GitHub. This means a user's token may be used to serve tool requests in sessions belonging to the same org, but the connection itself remains invisible to other users.
+
 ### Lazy Token Resolution
 
 Connection tokens are resolved lazily at tool execution time via `UserConnectionResolver`:
@@ -145,7 +149,7 @@ The app requests `repo read:user` scopes (hardcoded in `GitHubConnectionService`
 | Question | Decision | Rationale |
 |----------|----------|-----------|
 | Separate OAuth App? | Yes | Different scopes (repo vs profile). Separation of concerns. User sees distinct authorization prompts. |
-| User-scoped not org-scoped? | Yes | Token represents user's GitHub identity, not org's. Different org members have different repo access. |
+| User-scoped not org-scoped? | Yes | Token represents user's GitHub identity, not org's. Different org members have different repo access. Connections are private — other org members cannot see them. |
 | No DB unique constraint? | Yes | Enforce in app code. Allows future multi-account per provider without migration. |
 | Auto-inject into sessions? | Yes | Seamless UX. User connects once, all sessions get access. |
 | Credential helper not URL-embedded token? | Yes | Token never appears in command line, process list, or exec output. Safer. |

--- a/specs/user-connections.md
+++ b/specs/user-connections.md
@@ -48,16 +48,21 @@ A **separate** GitHub OAuth App from the login OAuth App. Different client_id/se
 
 Connections are **user-scoped**. The token represents the user's identity on the external service. It's usable in any org the user belongs to.
 
-### Session Injection
+### Lazy Token Resolution
 
-When a session starts and the `codesandbox` capability is active:
+Connection tokens are resolved lazily at tool execution time via `UserConnectionResolver`:
 
-1. Resolve user from auth context (session creator)
-2. Query `user_connections` for user's `github` connection
-3. If found, decrypt token and set as session secret: `GITHUB_TOKEN`
-4. Also inject `GITHUB_USERNAME` and `GITHUB_EMAIL` as session KV values
+1. Tool (e.g. `csb_git_clone`) requests token via `context.connection_resolver`
+2. Resolver joins `sessions → org_members → user_connections` to find the token
+3. Token is decrypted and returned directly to the tool
+4. If no connection exists, tool returns guidance: "connect GitHub in Settings > Connections"
 
-Agent tools read `GITHUB_TOKEN` from session secrets internally. The token value never appears in tool arguments, tool results, or message history.
+Benefits over eager session injection:
+- Tokens are always fresh (reconnect mid-session works)
+- Sessions created before connecting still get tokens
+- No stale secrets in session storage
+
+The token value never appears in tool arguments, tool results, or message history.
 
 ### API Endpoints
 

--- a/specs/user-connections.md
+++ b/specs/user-connections.md
@@ -102,7 +102,7 @@ GitHub OAuth callback. Exchanges code, stores token, redirects to UI.
 |----------|-------------|
 | `GITHUB_CONNECTION_CLIENT_ID` | GitHub OAuth App client ID (for connections, NOT login) |
 | `GITHUB_CONNECTION_CLIENT_SECRET` | GitHub OAuth App client secret |
-| `GITHUB_CONNECTION_REDIRECT_URI` | Callback URL (default: `{AUTH_BASE_URL}/v1/user/connections/github/callback`) |
+| `GITHUB_CONNECTION_REDIRECT_URI` | Callback URL (default: `{AUTH_BASE_URL}{API_PREFIX}/v1/user/connections/github/callback`) |
 
 ### GitHub OAuth App Setup
 
@@ -111,8 +111,8 @@ Create a **separate** GitHub OAuth App for connections (not the login OAuth App)
 1. Go to **GitHub → Settings → Developer settings → OAuth Apps → New OAuth App**
 2. Configure:
    - **Application name:** `Everruns`
-   - **Homepage URL:** `https://everruns.com` (or `http://localhost:9000` for local dev)
-   - **Authorization callback URL:** `http://localhost:9000/v1/user/connections/github/callback` (local) or `https://<domain>/v1/user/connections/github/callback` (production)
+   - **Homepage URL:** `https://everruns.com` (or `http://localhost:9300` for local dev)
+   - **Authorization callback URL:** `http://localhost:9300/api/v1/user/connections/github/callback` (local) or `https://<domain>/v1/user/connections/github/callback` (production)
 3. Copy **Client ID** → `GITHUB_CONNECTION_CLIENT_ID`
 4. Generate **Client Secret** → `GITHUB_CONNECTION_CLIENT_SECRET`
 

--- a/specs/user-connections.md
+++ b/specs/user-connections.md
@@ -104,6 +104,20 @@ GitHub OAuth callback. Exchanges code, stores token, redirects to UI.
 | `GITHUB_CONNECTION_CLIENT_SECRET` | GitHub OAuth App client secret |
 | `GITHUB_CONNECTION_REDIRECT_URI` | Callback URL (default: `{AUTH_BASE_URL}/v1/user/connections/github/callback`) |
 
+### GitHub OAuth App Setup
+
+Create a **separate** GitHub OAuth App for connections (not the login OAuth App):
+
+1. Go to **GitHub → Settings → Developer settings → OAuth Apps → New OAuth App**
+2. Configure:
+   - **Application name:** `Everruns`
+   - **Homepage URL:** `https://everruns.com` (or `http://localhost:9000` for local dev)
+   - **Authorization callback URL:** `http://localhost:9000/v1/user/connections/github/callback` (local) or `https://<domain>/v1/user/connections/github/callback` (production)
+3. Copy **Client ID** → `GITHUB_CONNECTION_CLIENT_ID`
+4. Generate **Client Secret** → `GITHUB_CONNECTION_CLIENT_SECRET`
+
+The app requests `repo read:user` scopes (hardcoded in `GitHubConnectionService`).
+
 ### Security
 
 - Tokens encrypted at rest via AES-256-GCM envelope encryption (same as MCP server API keys, session secrets)

--- a/specs/user-connections.md
+++ b/specs/user-connections.md
@@ -1,0 +1,160 @@
+# User Connections Specification
+
+## Abstract
+
+User connections allow users to link external service accounts (GitHub, GitLab, etc.) to their Everruns account, independent of their authentication provider. A user who logged in via Google or email/password can still connect their GitHub account for repo access. Connected tokens are auto-injected into agent sessions, enabling tools like `csb_git_clone` to operate as the user without exposing credentials to the LLM.
+
+## Requirements
+
+### UserConnection
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | UUID v7 | Internal primary key |
+| `user_id` | UUID | FK to users.id |
+| `provider` | string | `github`, `gitlab`, `bitbucket` |
+| `provider_user_id` | string | Provider's user ID |
+| `provider_username` | string | Display name (e.g., `octocat`) |
+| `access_token_encrypted` | bytes | Encrypted with envelope encryption |
+| `refresh_token_encrypted` | bytes? | For providers that support refresh |
+| `scopes` | string? | Granted scopes (e.g., `repo,read:user`) |
+| `expires_at` | timestamp? | NULL = no expiry (GitHub OAuth App tokens) |
+| `created_at` | timestamp | |
+| `updated_at` | timestamp | |
+
+No unique DB constraint on (user_id, provider). Uniqueness enforced in application code. This allows future multi-account support per provider if needed.
+
+### Connection Methods
+
+#### 1. GitHub OAuth App (Browser Flow)
+
+A **separate** GitHub OAuth App from the login OAuth App. Different client_id/secret, different scopes.
+
+- Login OAuth App scopes: `user:email read:user` (profile only)
+- Connection OAuth App scopes: `repo read:user` (repo access + profile for username)
+
+**Flow:**
+1. User clicks "Connect GitHub" in settings UI
+2. `GET /v1/user/connections/github/authorize` → redirect to GitHub
+3. GitHub redirects back → `GET /v1/user/connections/github/callback?code=...&state=...`
+4. Server exchanges code for access_token
+5. Server calls GitHub API to get username/user_id
+6. Server encrypts token, upserts into `user_connections`
+7. Redirect to UI settings page with success
+
+**Token behavior:** GitHub OAuth App tokens do not expire by default. No refresh flow needed for v1.
+
+#### 2. Manual PAT (Fallback)
+
+For GitHub Enterprise, fine-grained tokens, or users who prefer explicit control:
+
+```
+POST /v1/user/connections
+{ "provider": "github", "access_token": "ghp_xxxxxxxxxxxx" }
+```
+
+Server validates the token against `GET https://api.github.com/user`, extracts username/id, stores encrypted.
+
+### Scoping
+
+Connections are **user-scoped**. The token represents the user's identity on the external service. It's usable in any org the user belongs to.
+
+### Session Injection
+
+When a session starts and the `codesandbox` capability is active:
+
+1. Resolve user from auth context (session creator)
+2. Query `user_connections` for user's `github` connection
+3. If found, decrypt token and set as session secret: `GITHUB_TOKEN`
+4. Also inject `GITHUB_USERNAME` and `GITHUB_EMAIL` as session KV values
+
+Agent tools read `GITHUB_TOKEN` from session secrets internally. The token value never appears in tool arguments, tool results, or message history.
+
+### API Endpoints
+
+#### GET /v1/user/connections
+
+List user's connected accounts. Token values never returned.
+
+**Response:**
+```json
+{
+  "data": [
+    {
+      "provider": "github",
+      "provider_username": "octocat",
+      "scopes": "repo,read:user",
+      "connected_at": "2026-02-15T10:00:00Z"
+    }
+  ]
+}
+```
+
+#### POST /v1/user/connections
+
+Add connection via manual token.
+
+**Request:**
+```json
+{
+  "provider": "github",
+  "access_token": "ghp_xxxxxxxxxxxx"
+}
+```
+
+**Response:** `201 Created` with connection info (no token in response).
+
+#### DELETE /v1/user/connections/{provider}
+
+Disconnect. Deletes the stored token.
+
+**Response:** `204 No Content`
+
+#### GET /v1/user/connections/github/authorize
+
+Start GitHub OAuth flow. Returns redirect to GitHub.
+
+**Query params:**
+- `redirect_uri` (optional): Where to redirect after callback (default: UI settings page)
+
+#### GET /v1/user/connections/github/callback
+
+GitHub OAuth callback. Exchanges code, stores token, redirects to UI.
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `GITHUB_CONNECTION_CLIENT_ID` | GitHub OAuth App client ID (for connections, NOT login) |
+| `GITHUB_CONNECTION_CLIENT_SECRET` | GitHub OAuth App client secret |
+| `GITHUB_CONNECTION_REDIRECT_URI` | Callback URL (default: `{AUTH_BASE_URL}/v1/user/connections/github/callback`) |
+
+### Security
+
+- Tokens encrypted at rest via AES-256-GCM envelope encryption (same as MCP server API keys, session secrets)
+- Token never returned in API responses
+- Token never appears in LLM message history or tool results
+- `csb_git_clone` tool uses credential helper approach: writes a temporary script inside the sandbox VM that supplies the token, avoiding it appearing in command lines or process lists
+- Revoking a connection immediately prevents new sessions from getting the token; existing sessions retain their injected copy until session ends
+
+### Error Handling
+
+| Scenario | Response |
+|----------|----------|
+| Provider not supported | 400: "Unsupported provider: {name}" |
+| Token validation fails | 400: "Invalid token: could not authenticate with {provider}" |
+| Already connected (app-level check) | 409: "Already connected to {provider}. Disconnect first." |
+| OAuth state mismatch | 400: "Invalid OAuth state" |
+| Connection not found on delete | 404 |
+| Missing connection config | 500 (logged): GitHub connection OAuth App not configured |
+
+## Design Decisions
+
+| Question | Decision | Rationale |
+|----------|----------|-----------|
+| Separate OAuth App? | Yes | Different scopes (repo vs profile). Separation of concerns. User sees distinct authorization prompts. |
+| User-scoped not org-scoped? | Yes | Token represents user's GitHub identity, not org's. Different org members have different repo access. |
+| No DB unique constraint? | Yes | Enforce in app code. Allows future multi-account per provider without migration. |
+| Auto-inject into sessions? | Yes | Seamless UX. User connects once, all sessions get access. |
+| Credential helper not URL-embedded token? | Yes | Token never appears in command line, process list, or exec output. Safer. |
+| Generic `user_connections` not `github_connections`? | Yes | Same pattern works for GitLab, Bitbucket. Provider-generic table + provider-specific OAuth code. |

--- a/specs/user-connections.md
+++ b/specs/user-connections.md
@@ -24,9 +24,9 @@ User connections allow users to link external service accounts (GitHub, GitLab, 
 
 No unique DB constraint on (user_id, provider). Uniqueness enforced in application code. This allows future multi-account support per provider if needed.
 
-### Connection Methods
+### Connection Method: GitHub OAuth App
 
-#### 1. GitHub OAuth App (Browser Flow)
+
 
 A **separate** GitHub OAuth App from the login OAuth App. Different client_id/secret, different scopes.
 
@@ -43,17 +43,6 @@ A **separate** GitHub OAuth App from the login OAuth App. Different client_id/se
 7. Redirect to UI settings page with success
 
 **Token behavior:** GitHub OAuth App tokens do not expire by default. No refresh flow needed for v1.
-
-#### 2. Manual PAT (Fallback)
-
-For GitHub Enterprise, fine-grained tokens, or users who prefer explicit control:
-
-```
-POST /v1/user/connections
-{ "provider": "github", "access_token": "ghp_xxxxxxxxxxxx" }
-```
-
-Server validates the token against `GET https://api.github.com/user`, extracts username/id, stores encrypted.
 
 ### Scoping
 
@@ -89,20 +78,6 @@ List user's connected accounts. Token values never returned.
   ]
 }
 ```
-
-#### POST /v1/user/connections
-
-Add connection via manual token.
-
-**Request:**
-```json
-{
-  "provider": "github",
-  "access_token": "ghp_xxxxxxxxxxxx"
-}
-```
-
-**Response:** `201 Created` with connection info (no token in response).
 
 #### DELETE /v1/user/connections/{provider}
 
@@ -141,8 +116,6 @@ GitHub OAuth callback. Exchanges code, stores token, redirects to UI.
 
 | Scenario | Response |
 |----------|----------|
-| Provider not supported | 400: "Unsupported provider: {name}" |
-| Token validation fails | 400: "Invalid token: could not authenticate with {provider}" |
 | Already connected (app-level check) | 409: "Already connected to {provider}. Disconnect first." |
 | OAuth state mismatch | 400: "Invalid OAuth state" |
 | Connection not found on delete | 404 |


### PR DESCRIPTION
## What
Clarify in specs/user-connections.md that user connections are private — other org members cannot list or view them via the API.

## Why
Spec documented user-scoped connections but did not explicitly state visibility rules. Could be misread as user-scoped storage but org-visible listing.

## How
- Added Visibility paragraph: API only returns the authenticated users own connections
- Added Token resolution paragraph: explains the cross-org-member resolution for tool execution (distinct from API visibility)
- Updated design decisions table with privacy note

## Risk
- Low
- Spec-only change, no code affected

## Checklist
- [x] Tests added or updated (N/A — spec only)
- [x] Backward compatibility considered (N/A)