### PR TITLE
feat(auth): add organization roles (owner/admin/member) with RBAC

### DIFF
--- a/apps/ui/src/__tests__/settings-members.test.tsx
+++ b/apps/ui/src/__tests__/settings-members.test.tsx
@@ -1,39 +1,46 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactNode } from "react";
 import MembersPage from "@/app/(main)/settings/members/page";
 
-// Mock users data
-const mockUsers = [
+// Mock members data
+const mockMembers = [
   {
-    id: "user-1",
-    email: "admin@example.com",
-    name: "Admin User",
+    user_id: "user-1",
+    email: "owner@example.com",
+    name: "Owner User",
     avatar_url: "https://example.com/avatar1.jpg",
-    roles: ["admin", "user"],
-    auth_provider: "local",
-    created_at: "2024-01-01T00:00:00Z",
+    role: "owner" as const,
+    joined_at: "2024-01-01T00:00:00Z",
   },
   {
-    id: "user-2",
-    email: "regular@example.com",
-    name: "Regular User",
+    user_id: "user-2",
+    email: "member@example.com",
+    name: "Regular Member",
     avatar_url: null,
-    roles: ["user"],
-    auth_provider: "google",
-    created_at: "2024-02-15T00:00:00Z",
+    role: "member" as const,
+    joined_at: "2024-02-15T00:00:00Z",
   },
 ];
 
-const mockUseUsers = jest.fn();
+const mockUseMembers = jest.fn();
+const mockUseUpdateMemberRole = jest.fn();
+const mockUseRemoveMember = jest.fn();
 const mockUseAuth = jest.fn();
+const mockUseOrg = jest.fn();
 
-jest.mock("@/hooks/use-users", () => ({
-  useUsers: (query?: { search?: string }) => mockUseUsers(query),
+jest.mock("@/hooks/use-members", () => ({
+  useMembers: () => mockUseMembers(),
+  useUpdateMemberRole: () => mockUseUpdateMemberRole(),
+  useRemoveMember: () => mockUseRemoveMember(),
 }));
 
 jest.mock("@/providers/auth-provider", () => ({
   useAuth: () => mockUseAuth(),
+}));
+
+jest.mock("@/providers/org-provider", () => ({
+  useOrg: () => mockUseOrg(),
 }));
 
 describe("MembersPage", () => {
@@ -51,15 +58,34 @@ describe("MembersPage", () => {
       },
     });
 
-    // Default: auth required
     mockUseAuth.mockReturnValue({
+      user: { id: "user-1" },
       requiresAuth: true,
     });
 
-    mockUseUsers.mockReturnValue({
-      data: mockUsers,
+    mockUseOrg.mockReturnValue({
+      currentOrg: { public_id: "org-123", name: "Test Org", role: "owner" },
+      hasRole: (role: string) => {
+        const levels: Record<string, number> = { owner: 3, admin: 2, member: 1 };
+        return (levels["owner"] ?? 0) >= (levels[role] ?? 0);
+      },
+      isLoading: false,
+    });
+
+    mockUseMembers.mockReturnValue({
+      data: mockMembers,
       isLoading: false,
       error: null,
+    });
+
+    mockUseUpdateMemberRole.mockReturnValue({
+      mutateAsync: jest.fn(),
+      isPending: false,
+    });
+
+    mockUseRemoveMember.mockReturnValue({
+      mutateAsync: jest.fn(),
+      isPending: false,
     });
   });
 
@@ -67,39 +93,29 @@ describe("MembersPage", () => {
     render(<MembersPage />, { wrapper });
 
     expect(screen.getByText("Members")).toBeInTheDocument();
-    expect(screen.getByText("View and manage team members.")).toBeInTheDocument();
+    expect(screen.getByText(/Manage members of/)).toBeInTheDocument();
   });
 
-  it("renders user cards with correct data", () => {
+  it("renders member cards with correct data", () => {
     render(<MembersPage />, { wrapper });
 
-    expect(screen.getByText("Admin User")).toBeInTheDocument();
-    expect(screen.getByText("Regular User")).toBeInTheDocument();
-    expect(screen.getByText("admin@example.com")).toBeInTheDocument();
-    expect(screen.getByText("regular@example.com")).toBeInTheDocument();
+    expect(screen.getByText("Owner User")).toBeInTheDocument();
+    expect(screen.getByText("Regular Member")).toBeInTheDocument();
+    expect(screen.getByText("owner@example.com")).toBeInTheDocument();
+    expect(screen.getByText("member@example.com")).toBeInTheDocument();
   });
 
-  it("shows admin badge for admin users", () => {
+  it("shows role badge for current user (self)", () => {
     render(<MembersPage />, { wrapper });
 
-    expect(screen.getByText("Admin")).toBeInTheDocument();
-  });
-
-  it("shows auth provider badges", () => {
-    render(<MembersPage />, { wrapper });
-
-    expect(screen.getByText("Local")).toBeInTheDocument();
-    expect(screen.getByText("Google")).toBeInTheDocument();
-  });
-
-  it("renders search input", () => {
-    render(<MembersPage />, { wrapper });
-
-    expect(screen.getByPlaceholderText("Search by name or email...")).toBeInTheDocument();
+    // Current user (user-1) should have Owner badge (not a dropdown)
+    expect(screen.getByText("Owner")).toBeInTheDocument();
+    // And "You" badge
+    expect(screen.getByText("You")).toBeInTheDocument();
   });
 
   it("shows loading skeleton when loading", () => {
-    mockUseUsers.mockReturnValue({
+    mockUseMembers.mockReturnValue({
       data: [],
       isLoading: true,
       error: null,
@@ -111,8 +127,8 @@ describe("MembersPage", () => {
     expect(skeletons.length).toBeGreaterThan(0);
   });
 
-  it("shows empty state when no users exist", () => {
-    mockUseUsers.mockReturnValue({
+  it("shows empty state when no members exist", () => {
+    mockUseMembers.mockReturnValue({
       data: [],
       isLoading: false,
       error: null,
@@ -124,7 +140,7 @@ describe("MembersPage", () => {
   });
 
   it("shows error message when API fails", () => {
-    mockUseUsers.mockReturnValue({
+    mockUseMembers.mockReturnValue({
       data: [],
       isLoading: false,
       error: new Error("Network error"),
@@ -135,39 +151,50 @@ describe("MembersPage", () => {
     expect(screen.getByText(/Failed to load members/)).toBeInTheDocument();
   });
 
-  it("shows authentication disabled message when auth is not required", () => {
-    mockUseAuth.mockReturnValue({
-      requiresAuth: false,
-    });
-
-    render(<MembersPage />, { wrapper });
-
-    expect(screen.getByText("Authentication Disabled")).toBeInTheDocument();
-    expect(
-      screen.getByText(/Member management is only available when authentication is enabled/),
-    ).toBeInTheDocument();
-  });
-
-  it("updates search when typing in search input", async () => {
-    render(<MembersPage />, { wrapper });
-
-    const searchInput = screen.getByPlaceholderText("Search by name or email...");
-    fireEvent.change(searchInput, { target: { value: "admin" } });
-
-    expect(searchInput).toHaveValue("admin");
-  });
-
   it("shows member count", () => {
     render(<MembersPage />, { wrapper });
 
     expect(screen.getByText("2 members")).toBeInTheDocument();
   });
 
-  it("shows joined date for users", () => {
+  it("shows joined date for members", () => {
     render(<MembersPage />, { wrapper });
 
-    // Check for formatted dates (depends on locale, but should contain year)
     const joinedDates = screen.getAllByText(/Joined/);
     expect(joinedDates.length).toBe(2);
+  });
+
+  it("shows remove button for non-self members when user can manage", () => {
+    render(<MembersPage />, { wrapper });
+
+    // Remove button should exist for the non-self member
+    expect(screen.getByTitle("Remove member")).toBeInTheDocument();
+  });
+
+  it("hides role editing when user lacks admin role", () => {
+    mockUseOrg.mockReturnValue({
+      currentOrg: { public_id: "org-123", name: "Test Org", role: "member" },
+      hasRole: () => false,
+      isLoading: false,
+    });
+
+    mockUseAuth.mockReturnValue({
+      user: { id: "user-2" },
+      requiresAuth: true,
+    });
+
+    render(<MembersPage />, { wrapper });
+
+    // Should show badges for all members, not dropdowns
+    expect(screen.getByText("Owner")).toBeInTheDocument();
+    expect(screen.getByText("Member")).toBeInTheDocument();
+    // No remove button
+    expect(screen.queryByTitle("Remove member")).not.toBeInTheDocument();
+  });
+
+  it("shows org name in subtitle", () => {
+    render(<MembersPage />, { wrapper });
+
+    expect(screen.getByText("Test Org")).toBeInTheDocument();
   });
 });

--- a/apps/ui/src/app/(main)/settings/members/page.tsx
+++ b/apps/ui/src/app/(main)/settings/members/page.tsx
@@ -1,15 +1,24 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState } from "react";
 import { Card } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { useAuth } from "@/providers/auth-provider";
-import { useUsers } from "@/hooks/use-users";
-import { Users, Search, ShieldAlert, Mail, Calendar, Shield } from "lucide-react";
-import type { User } from "@/lib/api/types";
+import { useOrg } from "@/providers/org-provider";
+import { useMembers, useUpdateMemberRole, useRemoveMember } from "@/hooks/use-members";
+import { Users, Shield, ShieldCheck, Crown, UserMinus, Loader2 } from "lucide-react";
+import type { OrgMember } from "@/lib/api/members";
+import type { OrgRole } from "@/lib/api/types";
 
 function getInitials(name: string): string {
   return name
@@ -28,60 +37,132 @@ function formatDate(dateStr: string): string {
   });
 }
 
-function getAuthProviderLabel(provider?: string): string {
-  if (!provider) return "Local";
-  switch (provider) {
-    case "google":
-      return "Google";
-    case "github":
-      return "GitHub";
-    case "local":
-      return "Local";
-    default:
-      return provider;
-  }
-}
+const ROLE_LABELS: Record<OrgRole, string> = {
+  owner: "Owner",
+  admin: "Admin",
+  member: "Member",
+};
 
-function UserCard({ user }: { user: User }) {
-  const isAdmin = user.roles.includes("admin");
+const ROLE_ICONS: Record<OrgRole, typeof Crown> = {
+  owner: Crown,
+  admin: ShieldCheck,
+  member: Shield,
+};
+
+const ROLE_BADGE_VARIANT: Record<OrgRole, "default" | "secondary" | "outline"> = {
+  owner: "default",
+  admin: "secondary",
+  member: "outline",
+};
+
+function MemberCard({
+  member,
+  currentUserId,
+  canManage,
+  isOwner,
+}: {
+  member: OrgMember;
+  currentUserId: string;
+  canManage: boolean;
+  isOwner: boolean;
+}) {
+  const updateRole = useUpdateMemberRole();
+  const removeMember = useRemoveMember();
+  const [pendingRole, setPendingRole] = useState<string | null>(null);
+  const isSelf = member.user_id === currentUserId;
+  const RoleIcon = ROLE_ICONS[member.role];
+
+  const handleRoleChange = async (newRole: string) => {
+    setPendingRole(newRole);
+    try {
+      await updateRole.mutateAsync({ userId: member.user_id, role: newRole as OrgRole });
+    } catch {
+      // Error handled by mutation
+    } finally {
+      setPendingRole(null);
+    }
+  };
+
+  const handleRemove = async () => {
+    if (!confirm(`Remove ${member.name} from this organization?`)) return;
+    try {
+      await removeMember.mutateAsync(member.user_id);
+    } catch {
+      // Error handled by mutation
+    }
+  };
 
   return (
     <div className="flex items-center justify-between p-4 border rounded-lg">
       <div className="flex items-center gap-4">
         <Avatar className="h-10 w-10">
-          {user.avatar_url && <AvatarImage src={user.avatar_url} alt={user.name} />}
-          <AvatarFallback>{getInitials(user.name)}</AvatarFallback>
+          {member.avatar_url && <AvatarImage src={member.avatar_url} alt={member.name} />}
+          <AvatarFallback>{getInitials(member.name)}</AvatarFallback>
         </Avatar>
         <div>
           <div className="font-medium flex items-center gap-2">
-            {user.name}
-            {isAdmin && (
-              <Badge variant="secondary" className="text-xs">
-                <Shield className="h-3 w-3 mr-1" />
-                Admin
+            {member.name}
+            {isSelf && (
+              <Badge variant="outline" className="text-xs">
+                You
               </Badge>
             )}
           </div>
-          <div className="flex items-center gap-4 text-sm text-muted-foreground">
-            <span className="flex items-center gap-1">
-              <Mail className="h-3 w-3" />
-              {user.email}
-            </span>
-          </div>
+          <div className="text-sm text-muted-foreground">{member.email}</div>
         </div>
       </div>
-      <div className="flex items-center gap-4 text-sm text-muted-foreground">
-        <Badge variant="outline">{getAuthProviderLabel(user.auth_provider)}</Badge>
-        <span className="flex items-center gap-1">
-          <Calendar className="h-3 w-3" />
-          Joined {formatDate(user.created_at)}
+      <div className="flex items-center gap-3">
+        <span className="text-xs text-muted-foreground hidden sm:inline">
+          Joined {formatDate(member.joined_at)}
         </span>
+
+        {canManage && !isSelf ? (
+          <Select
+            value={pendingRole ?? member.role}
+            onValueChange={handleRoleChange}
+            disabled={updateRole.isPending}
+          >
+            <SelectTrigger className="w-[120px]">
+              {updateRole.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <SelectValue />
+              )}
+            </SelectTrigger>
+            <SelectContent>
+              {isOwner && <SelectItem value="owner">Owner</SelectItem>}
+              <SelectItem value="admin">Admin</SelectItem>
+              <SelectItem value="member">Member</SelectItem>
+            </SelectContent>
+          </Select>
+        ) : (
+          <Badge variant={ROLE_BADGE_VARIANT[member.role]} className="gap-1">
+            <RoleIcon className="h-3 w-3" />
+            {ROLE_LABELS[member.role]}
+          </Badge>
+        )}
+
+        {canManage && !isSelf && (
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleRemove}
+            disabled={removeMember.isPending}
+            title="Remove member"
+          >
+            {removeMember.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <UserMinus className="h-4 w-4 text-muted-foreground" />
+            )}
+          </Button>
+        )}
       </div>
     </div>
   );
 }
 
-function UserCardSkeleton() {
+function MemberCardSkeleton() {
   return (
     <div className="flex items-center justify-between p-4 border rounded-lg">
       <div className="flex items-center gap-4">
@@ -91,56 +172,22 @@ function UserCardSkeleton() {
           <Skeleton className="h-3 w-48" />
         </div>
       </div>
-      <div className="flex items-center gap-4">
+      <div className="flex items-center gap-3">
         <Skeleton className="h-5 w-16" />
-        <Skeleton className="h-3 w-24" />
+        <Skeleton className="h-8 w-[120px]" />
       </div>
     </div>
   );
 }
 
 export default function MembersPage() {
-  const { requiresAuth } = useAuth();
-  const [searchQuery, setSearchQuery] = useState("");
+  const { user } = useAuth();
+  const { currentOrg, hasRole } = useOrg();
+  const { data: members = [], isLoading, error } = useMembers();
 
-  // Debounce the search query for API calls
-  const [debouncedSearch, setDebouncedSearch] = useState("");
-
-  // Simple debounce effect
-  useMemo(() => {
-    const timer = setTimeout(() => {
-      setDebouncedSearch(searchQuery);
-    }, 300);
-    return () => clearTimeout(timer);
-  }, [searchQuery]);
-
-  const {
-    data: users = [],
-    isLoading,
-    error,
-  } = useUsers(debouncedSearch ? { search: debouncedSearch } : undefined);
-
-  // If auth is not required, show a message
-  if (!requiresAuth) {
-    return (
-      <div className="space-y-8">
-        <section>
-          <div className="mb-4">
-            <h2 className="text-xl font-semibold">Members</h2>
-            <p className="text-sm text-muted-foreground">View and manage team members.</p>
-          </div>
-          <Card className="p-8 text-center">
-            <ShieldAlert className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
-            <h3 className="text-lg font-medium mb-2">Authentication Disabled</h3>
-            <p className="text-muted-foreground">
-              Member management is only available when authentication is enabled. Contact your
-              administrator to enable authentication.
-            </p>
-          </Card>
-        </section>
-      </div>
-    );
-  }
+  const canManage = hasRole("admin");
+  const isOwner = hasRole("owner");
+  const currentUserId = user?.id ?? "";
 
   return (
     <div className="space-y-8">
@@ -148,19 +195,11 @@ export default function MembersPage() {
         <div className="flex items-center justify-between mb-4">
           <div>
             <h2 className="text-xl font-semibold">Members</h2>
-            <p className="text-sm text-muted-foreground">View and manage team members.</p>
+            <p className="text-sm text-muted-foreground">
+              Manage members of{" "}
+              <span className="font-medium">{currentOrg?.name ?? "your organization"}</span>.
+            </p>
           </div>
-        </div>
-
-        {/* Search */}
-        <div className="relative mb-4">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-          <Input
-            placeholder="Search by name or email..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="pl-10"
-          />
         </div>
 
         {error && (
@@ -172,29 +211,30 @@ export default function MembersPage() {
         {isLoading ? (
           <div className="space-y-2">
             {[...Array(3)].map((_, i) => (
-              <UserCardSkeleton key={i} />
+              <MemberCardSkeleton key={i} />
             ))}
           </div>
-        ) : users.length === 0 ? (
+        ) : members.length === 0 ? (
           <Card className="p-8 text-center">
             <Users className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
-            <h3 className="text-lg font-medium mb-2">
-              {searchQuery ? "No members found" : "No members"}
-            </h3>
+            <h3 className="text-lg font-medium mb-2">No members</h3>
             <p className="text-muted-foreground">
-              {searchQuery
-                ? `No members match "${searchQuery}". Try a different search.`
-                : "No team members have been added yet."}
+              No members have been added to this organization yet.
             </p>
           </Card>
         ) : (
           <div className="space-y-2">
             <div className="text-sm text-muted-foreground mb-2">
-              {users.length} member{users.length !== 1 ? "s" : ""}
-              {searchQuery && ` matching "${searchQuery}"`}
+              {members.length} member{members.length !== 1 ? "s" : ""}
             </div>
-            {users.map((user) => (
-              <UserCard key={user.id} user={user} />
+            {members.map((member) => (
+              <MemberCard
+                key={member.user_id}
+                member={member}
+                currentUserId={currentUserId}
+                canManage={canManage}
+                isOwner={isOwner}
+              />
             ))}
           </div>
         )}

--- a/apps/ui/src/app/(main)/settings/organisation/page.tsx
+++ b/apps/ui/src/app/(main)/settings/organisation/page.tsx
@@ -65,7 +65,7 @@ export default function OrganisationPage() {
     if (!newOrgName.trim()) return;
 
     const org = await createOrganization.mutateAsync({ name: newOrgName.trim() });
-    setCurrentOrg({ public_id: org.id, name: org.name });
+    setCurrentOrg({ public_id: org.id, name: org.name, role: "owner" });
     setNewOrgName("");
     setCreateDialogOpen(false);
   };

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -100,7 +100,7 @@ function CreateOrganizationDialog({
 
     const org = await createOrg.mutateAsync({ name: name.trim() });
     // Switch to the newly created org
-    setCurrentOrg({ public_id: org.id, name: org.name });
+    setCurrentOrg({ public_id: org.id, name: org.name, role: "owner" });
     setName("");
     onOpenChange(false);
   };

--- a/apps/ui/src/hooks/use-members.ts
+++ b/apps/ui/src/hooks/use-members.ts
@@ -1,0 +1,59 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { listMembers, updateMemberRole, removeMember } from "@/lib/api/members";
+import { queryKeys } from "@/lib/query-keys";
+import { useOrg } from "@/providers/org-provider";
+import type { OrgRole } from "@/lib/api/types";
+
+export function useMembers() {
+  const { currentOrg, isLoading: orgLoading } = useOrg();
+  const org = currentOrg?.public_id;
+
+  const query = useQuery({
+    queryKey: queryKeys.organizations.members(org ?? ""),
+    queryFn: () => listMembers(org!),
+    enabled: !!org,
+    staleTime: 10000,
+  });
+
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading,
+  };
+}
+
+export function useUpdateMemberRole() {
+  const queryClient = useQueryClient();
+  const { currentOrg } = useOrg();
+  const org = currentOrg?.public_id;
+
+  return useMutation({
+    mutationFn: ({ userId, role }: { userId: string; role: OrgRole }) =>
+      updateMemberRole(org!, userId, role),
+    onSuccess: () => {
+      if (org) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.organizations.members(org),
+        });
+      }
+    },
+  });
+}
+
+export function useRemoveMember() {
+  const queryClient = useQueryClient();
+  const { currentOrg } = useOrg();
+  const org = currentOrg?.public_id;
+
+  return useMutation({
+    mutationFn: (userId: string) => removeMember(org!, userId),
+    onSuccess: () => {
+      if (org) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.organizations.members(org),
+        });
+      }
+    },
+  });
+}

--- a/apps/ui/src/lib/api/members.ts
+++ b/apps/ui/src/lib/api/members.ts
@@ -1,0 +1,50 @@
+// Organization members API functions
+// Routes: GET/POST /v1/orgs/{org}/members, PATCH/DELETE /v1/orgs/{org}/members/{userId}
+
+import { api } from "./client";
+import type { OrgRole } from "./types";
+
+export interface OrgMember {
+  user_id: string;
+  email: string;
+  name: string;
+  avatar_url: string | null;
+  role: OrgRole;
+  joined_at: string;
+}
+
+interface MembersListResponse {
+  data: OrgMember[];
+}
+
+export async function listMembers(org: string): Promise<OrgMember[]> {
+  const response = await api.get<MembersListResponse>(`/v1/orgs/${org}/members`);
+  return response.data.data;
+}
+
+export async function addMember(
+  org: string,
+  userId: string,
+  role: OrgRole = "member",
+): Promise<OrgMember> {
+  const response = await api.post<OrgMember>(`/v1/orgs/${org}/members`, {
+    user_id: userId,
+    role,
+  });
+  return response.data;
+}
+
+export async function updateMemberRole(
+  org: string,
+  userId: string,
+  role: OrgRole,
+): Promise<OrgMember> {
+  const response = await api.patch<OrgMember>(`/v1/orgs/${org}/members/${userId}`, {
+    role,
+  });
+  return response.data;
+}
+
+export async function removeMember(org: string, userId: string): Promise<void> {
+  await api.delete(`/v1/orgs/${org}/members/${userId}`);
+}

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -686,10 +686,14 @@ export interface TokenResponse {
   refresh_token?: string;
 }
 
+/** Organization role */
+export type OrgRole = "owner" | "admin" | "member";
+
 /** Organization membership info */
 export interface OrganizationMembership {
   public_id: string;
   name: string;
+  role: OrgRole;
 }
 
 /** Full organization details (from API) */

--- a/apps/ui/src/lib/query-keys.ts
+++ b/apps/ui/src/lib/query-keys.ts
@@ -113,6 +113,7 @@ export const queryKeys = {
   organizations: {
     all: ["organizations"] as const,
     detail: (orgId: string) => ["organization", orgId] as const,
+    members: (orgId: string) => ["organization", orgId, "members"] as const,
   },
 
   // User Connection queries

--- a/apps/ui/src/providers/org-provider.tsx
+++ b/apps/ui/src/providers/org-provider.tsx
@@ -17,11 +17,18 @@ import {
 } from "react";
 import { useAuth } from "./auth-provider";
 import { switchOrg as switchOrgApi } from "@/lib/api/users";
-import type { OrganizationMembership } from "@/lib/api/types";
+import type { OrganizationMembership, OrgRole } from "@/lib/api/types";
 
 // Default organization public ID (matches backend DEFAULT_ORG_PUBLIC_ID)
 const DEFAULT_ORG_PUBLIC_ID = "org_00000000000000000000000000000001";
 const STORAGE_KEY = "everruns_current_org";
+
+/** Check if a role has permission for a required role level */
+const ROLE_HIERARCHY: Record<OrgRole, number> = { owner: 3, admin: 2, member: 1 };
+
+export function hasPermission(currentRole: OrgRole, requiredRole: OrgRole): boolean {
+  return ROLE_HIERARCHY[currentRole] >= ROLE_HIERARCHY[requiredRole];
+}
 
 export interface OrgContextValue {
   /** Currently selected organization */
@@ -30,6 +37,8 @@ export interface OrgContextValue {
   organizations: OrganizationMembership[];
   /** Set the current organization */
   setCurrentOrg: (org: OrganizationMembership) => void;
+  /** Check if current user has at least the given role in the current org */
+  hasRole: (role: OrgRole) => boolean;
   /** Loading state */
   isLoading: boolean;
 }
@@ -113,10 +122,19 @@ export function OrgProvider({ children }: OrgProviderProps) {
     }
   }, [currentOrg, isInitialized, syncOrgCookie]);
 
+  const hasRole = useCallback(
+    (role: OrgRole) => {
+      if (!currentOrg) return false;
+      return hasPermission(currentOrg.role, role);
+    },
+    [currentOrg],
+  );
+
   const value: OrgContextValue = {
     currentOrg,
     organizations,
     setCurrentOrg,
+    hasRole,
     isLoading: authLoading || !isInitialized,
   };
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -195,7 +195,7 @@ pub use mcp_server::{
 };
 pub use organization::{
     ANONYMOUS_USER_EMAIL, ANONYMOUS_USER_ID, ANONYMOUS_USER_NAME, DEFAULT_ORG_ID,
-    DEFAULT_ORG_PUBLIC_ID, OrgMembership, Organization, generate_org_public_id,
+    DEFAULT_ORG_PUBLIC_ID, OrgMembership, OrgRole, Organization, generate_org_public_id,
     validate_org_public_id,
 };
 pub use session::{Session, SessionStatus};

--- a/crates/core/src/organization.rs
+++ b/crates/core/src/organization.rs
@@ -1,8 +1,13 @@
 // Organization types for multitenancy
 // See specs/multitenancy.md
+//
+// Decision: Hierarchical org roles (Owner > Admin > Member) using PartialOrd.
+// External auth providers map their roles to OrgRole via AuthBackend trait.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
 use uuid::Uuid;
 
 /// Default organization ID (internal, for DB queries)
@@ -36,6 +41,61 @@ pub struct Organization {
     pub updated_at: DateTime<Utc>,
 }
 
+/// Organization-level role with hierarchical permissions.
+/// Owner > Admin > Member — checked via `has_permission()`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum OrgRole {
+    #[default]
+    Member,
+    Admin,
+    Owner,
+}
+
+impl OrgRole {
+    /// Check if this role has at least the `required` permission level.
+    pub fn has_permission(self, required: OrgRole) -> bool {
+        self.level() >= required.level()
+    }
+
+    /// String representation for DB storage.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            OrgRole::Member => "member",
+            OrgRole::Admin => "admin",
+            OrgRole::Owner => "owner",
+        }
+    }
+
+    fn level(self) -> u8 {
+        match self {
+            OrgRole::Member => 0,
+            OrgRole::Admin => 1,
+            OrgRole::Owner => 2,
+        }
+    }
+}
+
+impl fmt::Display for OrgRole {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for OrgRole {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "member" => Ok(OrgRole::Member),
+            "admin" => Ok(OrgRole::Admin),
+            "owner" => Ok(OrgRole::Owner),
+            _ => Err(format!("invalid org role: {s}")),
+        }
+    }
+}
+
 /// Organization membership info (for user context)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -47,6 +107,9 @@ pub struct OrgMembership {
     pub public_id: String,
     /// Display name
     pub name: String,
+    /// User's role in this organization
+    #[serde(default)]
+    pub role: OrgRole,
 }
 
 /// Generate a new organization public ID
@@ -118,5 +181,34 @@ mod tests {
     #[test]
     fn test_default_org_public_id_valid() {
         assert!(validate_org_public_id(DEFAULT_ORG_PUBLIC_ID));
+    }
+
+    #[test]
+    fn test_org_role_hierarchy() {
+        assert!(OrgRole::Owner.has_permission(OrgRole::Owner));
+        assert!(OrgRole::Owner.has_permission(OrgRole::Admin));
+        assert!(OrgRole::Owner.has_permission(OrgRole::Member));
+
+        assert!(!OrgRole::Admin.has_permission(OrgRole::Owner));
+        assert!(OrgRole::Admin.has_permission(OrgRole::Admin));
+        assert!(OrgRole::Admin.has_permission(OrgRole::Member));
+
+        assert!(!OrgRole::Member.has_permission(OrgRole::Owner));
+        assert!(!OrgRole::Member.has_permission(OrgRole::Admin));
+        assert!(OrgRole::Member.has_permission(OrgRole::Member));
+    }
+
+    #[test]
+    fn test_org_role_str_roundtrip() {
+        for role in [OrgRole::Member, OrgRole::Admin, OrgRole::Owner] {
+            let s = role.as_str();
+            let parsed: OrgRole = s.parse().unwrap();
+            assert_eq!(parsed, role);
+        }
+    }
+
+    #[test]
+    fn test_org_role_default() {
+        assert_eq!(OrgRole::default(), OrgRole::Member);
     }
 }

--- a/crates/server/migrations/009_organization_roles.sql
+++ b/crates/server/migrations/009_organization_roles.sql
@@ -1,0 +1,12 @@
+-- Organization member roles
+-- Adds hierarchical role column: owner > admin > member
+
+ALTER TABLE organization_members
+    ADD COLUMN role TEXT NOT NULL DEFAULT 'member'
+    CHECK (role IN ('owner', 'admin', 'member'));
+
+CREATE INDEX idx_organization_members_role ON organization_members(org_id, role);
+
+-- Track who created each organization
+ALTER TABLE organizations
+    ADD COLUMN created_by UUID REFERENCES users(id);

--- a/crates/server/src/api/organizations.rs
+++ b/crates/server/src/api/organizations.rs
@@ -3,7 +3,7 @@
 // Note: Organization routes are NOT org-scoped (they are at the root level)
 // because they manage organizations themselves.
 
-use crate::auth::middleware::{AuthState, AuthUser};
+use crate::auth::middleware::{AuthState, AuthUser, OrgAdmin, OrgContext};
 use crate::storage::StorageBackend;
 use axum::extract::FromRef;
 use axum::{
@@ -12,7 +12,9 @@ use axum::{
     http::StatusCode,
     routing::get,
 };
-use everruns_core::{DEFAULT_ORG_ID, Organization, generate_org_public_id, validate_org_public_id};
+use everruns_core::{
+    DEFAULT_ORG_ID, OrgRole, Organization, generate_org_public_id, validate_org_public_id,
+};
 
 use super::common::{ApiOptionExt, ApiResultExt, ErrorResponse, ListResponse};
 use serde::{Deserialize, Serialize};
@@ -89,6 +91,12 @@ pub fn routes(state: AppState) -> Router {
         .route(
             "/v1/orgs/{org}",
             get(get_organization).patch(update_organization),
+        )
+        // Organization members
+        .route("/v1/orgs/{org}/members", get(list_members).post(add_member))
+        .route(
+            "/v1/orgs/{org}/members/{user_id}",
+            axum::routing::patch(update_member_role).delete(remove_member),
         )
         .with_state(state)
 }
@@ -174,14 +182,15 @@ pub async fn create_organization(
         .create_organization(CreateOrganizationRow {
             public_id: public_id.clone(),
             name: req.name,
+            created_by: Some(user.id),
         })
         .await
         .log_internal_error_json("create organization")?;
 
-    // Add creator as organization member
+    // Add creator as organization owner
     state
         .db
-        .add_organization_member(row.org_id, user.id)
+        .add_organization_member(row.org_id, user.id, "owner")
         .await
         .log_internal_error_json("add organization member")?;
 
@@ -333,6 +342,299 @@ pub async fn update_organization(
     };
 
     Ok(Json(OrganizationResponse::from(org)))
+}
+
+// ============================================================================
+// Organization Members
+// ============================================================================
+
+/// Response for organization member
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct MemberResponse {
+    pub user_id: String,
+    pub email: String,
+    pub name: String,
+    pub avatar_url: Option<String>,
+    pub role: String,
+    pub joined_at: String,
+}
+
+/// Request to add a member
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct AddMemberRequest {
+    pub user_id: String,
+    #[serde(default = "default_member_role")]
+    pub role: String,
+}
+
+fn default_member_role() -> String {
+    "member".to_string()
+}
+
+/// Request to update member role
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct UpdateMemberRoleRequest {
+    pub role: String,
+}
+
+/// GET /v1/orgs/:org/members - List organization members
+pub async fn list_members(
+    State(state): State<AppState>,
+    org: OrgContext,
+) -> Result<Json<ListResponse<MemberResponse>>, (StatusCode, Json<ErrorResponse>)> {
+    let members = state
+        .db
+        .list_organization_members_with_users(org.org_id)
+        .await
+        .log_internal_error_json("list organization members")?;
+
+    let items: Vec<MemberResponse> = members
+        .into_iter()
+        .map(|m| MemberResponse {
+            user_id: m.user_id.to_string(),
+            email: m.email,
+            name: m.name,
+            avatar_url: m.avatar_url,
+            role: m.role,
+            joined_at: m.joined_at.to_rfc3339(),
+        })
+        .collect();
+
+    Ok(Json(ListResponse::new(items)))
+}
+
+/// POST /v1/orgs/:org/members - Add a member (Admin+)
+pub async fn add_member(
+    State(state): State<AppState>,
+    OrgAdmin(org): OrgAdmin,
+    user: AuthUser,
+    Json(req): Json<AddMemberRequest>,
+) -> Result<(StatusCode, Json<MemberResponse>), (StatusCode, Json<ErrorResponse>)> {
+    // Parse and validate role
+    let role: OrgRole = req.role.parse().map_err(|_| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(
+                "Invalid role. Must be 'owner', 'admin', or 'member'",
+            )),
+        )
+    })?;
+
+    // Only owners can add owners
+    if role == OrgRole::Owner && !org.role.has_permission(OrgRole::Owner) {
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new("Only owners can add owners")),
+        ));
+    }
+
+    let target_user_id: uuid::Uuid = req.user_id.parse().map_err(|_| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new("Invalid user_id")),
+        )
+    })?;
+
+    // Verify user exists
+    let target_user = state
+        .db
+        .get_user(target_user_id)
+        .await
+        .log_internal_error_json("get user")?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("User not found")),
+            )
+        })?;
+
+    // Check if already a member
+    let existing = state
+        .db
+        .get_organization_member(org.org_id, target_user_id)
+        .await
+        .log_internal_error_json("check membership")?;
+
+    if existing.is_some() {
+        return Err((
+            StatusCode::CONFLICT,
+            Json(ErrorResponse::new("User is already a member")),
+        ));
+    }
+
+    // Add member
+    let member_row = state
+        .db
+        .add_organization_member(org.org_id, target_user_id, role.as_str())
+        .await
+        .log_internal_error_json("add organization member")?;
+
+    let _ = user; // Silence unused warning
+
+    Ok((
+        StatusCode::CREATED,
+        Json(MemberResponse {
+            user_id: target_user_id.to_string(),
+            email: target_user.email,
+            name: target_user.name,
+            avatar_url: target_user.avatar_url,
+            role: member_row.role,
+            joined_at: member_row.created_at.to_rfc3339(),
+        }),
+    ))
+}
+
+/// PATCH /v1/orgs/:org/members/:user_id - Update member role
+pub async fn update_member_role(
+    State(state): State<AppState>,
+    OrgAdmin(org): OrgAdmin,
+    Path((_org_public_id, user_id_str)): Path<(String, String)>,
+    Json(req): Json<UpdateMemberRoleRequest>,
+) -> Result<Json<MemberResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let new_role: OrgRole = req.role.parse().map_err(|_| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(
+                "Invalid role. Must be 'owner', 'admin', or 'member'",
+            )),
+        )
+    })?;
+
+    let target_user_id: uuid::Uuid = user_id_str.parse().map_err(|_| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new("Invalid user_id")),
+        )
+    })?;
+
+    // Get current member info
+    let current = state
+        .db
+        .get_organization_member(org.org_id, target_user_id)
+        .await
+        .log_internal_error_json("get member")?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("Member not found")),
+            )
+        })?;
+
+    let current_role: OrgRole = current.role.parse().unwrap_or(OrgRole::Member);
+
+    // Only owners can change owner roles
+    if (current_role == OrgRole::Owner || new_role == OrgRole::Owner)
+        && !org.role.has_permission(OrgRole::Owner)
+    {
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new("Only owners can change owner roles")),
+        ));
+    }
+
+    // Cannot demote last owner
+    if current_role == OrgRole::Owner && new_role != OrgRole::Owner {
+        let owner_count = state
+            .db
+            .count_organization_owners(org.org_id)
+            .await
+            .log_internal_error_json("count owners")?;
+        if owner_count <= 1 {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse::new("Cannot remove the last owner")),
+            ));
+        }
+    }
+
+    // Update role
+    let updated = state
+        .db
+        .update_organization_member_role(org.org_id, target_user_id, new_role.as_str())
+        .await
+        .log_internal_error_json("update member role")?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("Member not found")),
+            )
+        })?;
+
+    Ok(Json(MemberResponse {
+        user_id: target_user_id.to_string(),
+        email: current.email,
+        name: current.name,
+        avatar_url: current.avatar_url,
+        role: updated.role,
+        joined_at: current.joined_at.to_rfc3339(),
+    }))
+}
+
+/// DELETE /v1/orgs/:org/members/:user_id - Remove member (Owner or self)
+pub async fn remove_member(
+    State(state): State<AppState>,
+    org: OrgContext,
+    user: AuthUser,
+    Path((_org_public_id, user_id_str)): Path<(String, String)>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let target_user_id: uuid::Uuid = user_id_str.parse().map_err(|_| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new("Invalid user_id")),
+        )
+    })?;
+
+    let is_self = target_user_id == user.id;
+
+    // Must be owner to remove others (self-removal always allowed)
+    if !is_self && !org.role.has_permission(OrgRole::Owner) {
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new("Only owners can remove members")),
+        ));
+    }
+
+    // Check if target is owner — cannot remove last owner
+    let member = state
+        .db
+        .get_organization_member(org.org_id, target_user_id)
+        .await
+        .log_internal_error_json("get member")?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("Member not found")),
+            )
+        })?;
+
+    if member.role == "owner" {
+        let owner_count = state
+            .db
+            .count_organization_owners(org.org_id)
+            .await
+            .log_internal_error_json("count owners")?;
+        if owner_count <= 1 {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse::new("Cannot remove the last owner")),
+            ));
+        }
+    }
+
+    let removed = state
+        .db
+        .remove_organization_member(org.org_id, target_user_id)
+        .await
+        .log_internal_error_json("remove organization member")?;
+
+    if removed {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new("Member not found")),
+        ))
+    }
 }
 
 #[cfg(test)]

--- a/crates/server/src/auth/builtin.rs
+++ b/crates/server/src/auth/builtin.rs
@@ -3,7 +3,7 @@
 
 use async_trait::async_trait;
 use axum::Router;
-use everruns_core::{DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, OrgMembership};
+use everruns_core::{DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, OrgMembership, OrgRole};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -130,6 +130,17 @@ impl AuthBackend for BuiltinAuthBackend {
             })?
             .ok_or_else(|| AuthError::unauthorized("Organization not found for API key"))?;
 
+        // Get the user's role in this org (default to member for API key auth)
+        let member_row = self
+            .db
+            .get_organization_member(org.org_id, user.id)
+            .await
+            .ok()
+            .flatten();
+        let role = member_row
+            .and_then(|m| m.role.parse::<OrgRole>().ok())
+            .unwrap_or(OrgRole::Member);
+
         Ok(AuthUser {
             id: user.id,
             email: user.email,
@@ -140,6 +151,7 @@ impl AuthBackend for BuiltinAuthBackend {
                 org_id: org.org_id,
                 public_id: org.public_id,
                 name: org.name,
+                role,
             }],
         })
     }
@@ -183,6 +195,7 @@ pub(super) async fn fetch_user_organizations(
             org_id: row.org_id,
             public_id: row.public_id,
             name: row.name,
+            role: row.role.parse::<OrgRole>().unwrap_or(OrgRole::Member),
         })
         .collect())
 }
@@ -194,6 +207,7 @@ pub(super) fn organizations_or_default(organizations: Vec<OrgMembership>) -> Vec
             org_id: DEFAULT_ORG_ID,
             public_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
             name: "Default Organization".to_string(),
+            role: OrgRole::Member,
         }]
     } else {
         organizations

--- a/crates/server/src/auth/middleware.rs
+++ b/crates/server/src/auth/middleware.rs
@@ -11,7 +11,7 @@ use axum::{
 use axum_extra::extract::CookieJar;
 use everruns_core::{
     ANONYMOUS_USER_EMAIL, ANONYMOUS_USER_ID, ANONYMOUS_USER_NAME, DEFAULT_ORG_ID,
-    DEFAULT_ORG_PUBLIC_ID, OrgMembership, validate_org_public_id,
+    DEFAULT_ORG_PUBLIC_ID, OrgMembership, OrgRole, validate_org_public_id,
 };
 use serde::Serialize;
 use std::sync::Arc;
@@ -87,6 +87,7 @@ impl AuthUser {
                 org_id: DEFAULT_ORG_ID,
                 public_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
                 name: "Default Organization".to_string(),
+                role: OrgRole::Owner,
             }],
         }
     }
@@ -282,6 +283,8 @@ pub struct OrgContext {
     pub public_id: String,
     /// Organization name
     pub name: String,
+    /// User's role in this organization
+    pub role: OrgRole,
 }
 
 /// Extract org from URI path directly (doesn't consume Path extractor)
@@ -331,7 +334,52 @@ where
             org_id: org.org_id,
             public_id: org.public_id.clone(),
             name: org.name.clone(),
+            role: org.role,
         })
+    }
+}
+
+// ============================================================================
+// Role-based extractors
+// ============================================================================
+
+/// Require Admin+ role in the organization (from URL path)
+#[derive(Debug, Clone)]
+pub struct OrgAdmin(pub OrgContext);
+
+impl<S> FromRequestParts<S> for OrgAdmin
+where
+    S: Send + Sync,
+    AuthState: FromRef<S>,
+{
+    type Rejection = AuthError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let org = OrgContext::from_request_parts(parts, state).await?;
+        if !org.role.has_permission(OrgRole::Admin) {
+            return Err(AuthError::forbidden("Admin access required"));
+        }
+        Ok(OrgAdmin(org))
+    }
+}
+
+/// Require Owner role in the organization (from URL path)
+#[derive(Debug, Clone)]
+pub struct OrgOwner(pub OrgContext);
+
+impl<S> FromRequestParts<S> for OrgOwner
+where
+    S: Send + Sync,
+    AuthState: FromRef<S>,
+{
+    type Rejection = AuthError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let org = OrgContext::from_request_parts(parts, state).await?;
+        if !org.role.has_permission(OrgRole::Owner) {
+            return Err(AuthError::forbidden("Owner access required"));
+        }
+        Ok(OrgOwner(org))
     }
 }
 
@@ -371,6 +419,8 @@ pub struct ResolvedOrg {
     pub name: String,
     /// Authenticated user ID (for user-scoped operations like connections)
     pub user_id: Option<Uuid>,
+    /// User's role in this organization
+    pub role: OrgRole,
 }
 
 impl<S> FromRequestParts<S> for ResolvedOrg
@@ -403,6 +453,7 @@ where
                     public_id: org.public_id.clone(),
                     name: org.name.clone(),
                     user_id,
+                    role: org.role,
                 })
             }
             AuthMethod::Jwt => {
@@ -439,6 +490,7 @@ where
                     public_id: org.public_id.clone(),
                     name: org.name.clone(),
                     user_id: Some(user.id),
+                    role: org.role,
                 })
             }
         }
@@ -457,10 +509,11 @@ mod tests {
         assert!(user.is_admin());
         assert!(user.has_role("admin"));
         assert_eq!(user.auth_method, AuthMethod::None);
-        // Anonymous user should belong to default org
+        // Anonymous user should belong to default org with Owner role
         assert_eq!(user.organizations.len(), 1);
         assert_eq!(user.organizations[0].org_id, DEFAULT_ORG_ID);
         assert_eq!(user.organizations[0].public_id, DEFAULT_ORG_PUBLIC_ID);
+        assert_eq!(user.organizations[0].role, OrgRole::Owner);
     }
 
     #[test]
@@ -509,11 +562,13 @@ mod tests {
                     org_id: 1,
                     public_id: "org_00000000000000000000000000000001".to_string(),
                     name: "Org 1".to_string(),
+                    role: OrgRole::Owner,
                 },
                 OrgMembership {
                     org_id: 2,
                     public_id: "org_00000000000000000000000000000002".to_string(),
                     name: "Org 2".to_string(),
+                    role: OrgRole::Member,
                 },
             ],
         };
@@ -539,5 +594,18 @@ mod tests {
 
         let forbidden = AuthError::forbidden("Forbidden");
         assert_eq!(forbidden.status, StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn test_org_role_hierarchy() {
+        assert!(OrgRole::Owner.has_permission(OrgRole::Owner));
+        assert!(OrgRole::Owner.has_permission(OrgRole::Admin));
+        assert!(OrgRole::Owner.has_permission(OrgRole::Member));
+        assert!(OrgRole::Admin.has_permission(OrgRole::Admin));
+        assert!(OrgRole::Admin.has_permission(OrgRole::Member));
+        assert!(!OrgRole::Admin.has_permission(OrgRole::Owner));
+        assert!(OrgRole::Member.has_permission(OrgRole::Member));
+        assert!(!OrgRole::Member.has_permission(OrgRole::Admin));
+        assert!(!OrgRole::Member.has_permission(OrgRole::Owner));
     }
 }

--- a/crates/server/src/auth/mod.rs
+++ b/crates/server/src/auth/mod.rs
@@ -15,5 +15,7 @@ pub mod routes;
 pub use backend::AuthBackend;
 pub use builtin::BuiltinAuthBackend;
 pub use config::AuthConfig;
-pub use middleware::{AuthError, AuthMethod, AuthState, AuthUser, OrgContext, ResolvedOrg};
+pub use middleware::{
+    AuthError, AuthMethod, AuthState, AuthUser, OrgAdmin, OrgContext, OrgOwner, ResolvedOrg,
+};
 pub use routes::routes;

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -76,6 +76,7 @@ pub struct TokenResponse {
 pub struct OrgMembershipResponse {
     pub public_id: String,
     pub name: String,
+    pub role: String,
 }
 
 /// User info response
@@ -315,7 +316,7 @@ pub async fn register(
     // Add user to default organization
     let _ = state
         .db
-        .add_organization_member(DEFAULT_ORG_ID, user.id)
+        .add_organization_member(DEFAULT_ORG_ID, user.id, "member")
         .await
         .map_err(|e| {
             tracing::error!("Failed to add user to default org: {}", e);
@@ -422,6 +423,7 @@ pub async fn get_current_user(
             .map(|o| OrgMembershipResponse {
                 public_id: o.public_id.clone(),
                 name: o.name.clone(),
+                role: o.role.as_str().to_string(),
             })
             .collect(),
     );
@@ -591,7 +593,7 @@ pub async fn oauth_callback(
         // Add newly created user to default organization
         let _ = state
             .db
-            .add_organization_member(DEFAULT_ORG_ID, created_user.id)
+            .add_organization_member(DEFAULT_ORG_ID, created_user.id, "member")
             .await
             .map_err(|e| {
                 tracing::error!("Failed to add OAuth user to default org: {}", e);
@@ -860,7 +862,7 @@ async fn get_or_create_admin_user(
         // Add admin user to default organization
         let _ = state
             .db
-            .add_organization_member(DEFAULT_ORG_ID, created_user.id)
+            .add_organization_member(DEFAULT_ORG_ID, created_user.id, "member")
             .await
             .map_err(|e| {
                 tracing::error!("Failed to add admin user to default org: {}", e);
@@ -880,7 +882,7 @@ async fn get_or_create_admin_user(
     if organizations.is_empty() {
         let _ = state
             .db
-            .add_organization_member(DEFAULT_ORG_ID, user.id)
+            .add_organization_member(DEFAULT_ORG_ID, user.id, "member")
             .await;
     }
 

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -134,6 +134,7 @@ async fn seed_default_organization(db: &StorageBackend) -> anyhow::Result<SeedRe
     let input = CreateOrganizationRow {
         public_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
         name: "Default Organization".to_string(),
+        created_by: None,
     };
 
     match db
@@ -194,8 +195,8 @@ async fn seed_anonymous_user(db: &StorageBackend) -> anyhow::Result<SeedResult> 
         }
     }
 
-    // Ensure anonymous user is member of default org
-    db.ensure_membership(ANONYMOUS_USER_ID, DEFAULT_ORG_ID)
+    // Ensure anonymous user is owner of default org
+    db.ensure_membership(ANONYMOUS_USER_ID, DEFAULT_ORG_ID, "owner")
         .await?;
 
     Ok(result)

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -974,8 +974,9 @@ impl StorageBackend {
         &self,
         org_id: i64,
         user_id: Uuid,
+        role: &str,
     ) -> Result<OrganizationMemberRow> {
-        dispatch!(self, add_organization_member, org_id, user_id)
+        dispatch!(self, add_organization_member, org_id, user_id, role)
     }
 
     pub async fn remove_organization_member(&self, org_id: i64, user_id: Uuid) -> Result<bool> {
@@ -989,7 +990,38 @@ impl StorageBackend {
         dispatch!(self, list_organization_members, org_id)
     }
 
-    pub async fn list_user_organizations(&self, user_id: Uuid) -> Result<Vec<OrganizationRow>> {
+    pub async fn list_organization_members_with_users(
+        &self,
+        org_id: i64,
+    ) -> Result<Vec<OrganizationMemberWithUserRow>> {
+        dispatch!(self, list_organization_members_with_users, org_id)
+    }
+
+    pub async fn get_organization_member(
+        &self,
+        org_id: i64,
+        user_id: Uuid,
+    ) -> Result<Option<OrganizationMemberWithUserRow>> {
+        dispatch!(self, get_organization_member, org_id, user_id)
+    }
+
+    pub async fn update_organization_member_role(
+        &self,
+        org_id: i64,
+        user_id: Uuid,
+        role: &str,
+    ) -> Result<Option<OrganizationMemberRow>> {
+        dispatch!(self, update_organization_member_role, org_id, user_id, role)
+    }
+
+    pub async fn count_organization_owners(&self, org_id: i64) -> Result<i64> {
+        dispatch!(self, count_organization_owners, org_id)
+    }
+
+    pub async fn list_user_organizations(
+        &self,
+        user_id: Uuid,
+    ) -> Result<Vec<OrganizationWithRoleRow>> {
         dispatch!(self, list_user_organizations, user_id)
     }
 
@@ -1027,8 +1059,8 @@ impl StorageBackend {
         )
     }
 
-    pub async fn ensure_membership(&self, user_id: Uuid, org_id: i64) -> Result<()> {
-        dispatch!(self, ensure_membership, user_id, org_id)
+    pub async fn ensure_membership(&self, user_id: Uuid, org_id: i64, role: &str) -> Result<()> {
+        dispatch!(self, ensure_membership, user_id, org_id, role)
     }
 
     // ============================================

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -71,6 +71,7 @@ impl Default for InMemoryDatabase {
                 created_at: now,
                 updated_at: now,
                 external_id: None,
+                created_by: None,
             },
         );
 
@@ -2676,6 +2677,7 @@ impl InMemoryDatabase {
             created_at: now,
             updated_at: now,
             external_id: None,
+            created_by: input.created_by,
         };
         orgs.insert(org_id, row.clone());
         Ok(row)
@@ -2700,6 +2702,7 @@ impl InMemoryDatabase {
             created_at: now,
             updated_at: now,
             external_id: None,
+            created_by: input.created_by,
         };
         orgs.insert(org_id, row.clone());
         Ok(Some(row))
@@ -2756,11 +2759,13 @@ impl InMemoryDatabase {
         &self,
         org_id: i64,
         user_id: Uuid,
+        role: &str,
     ) -> Result<OrganizationMemberRow> {
         let now = Self::now();
         let row = OrganizationMemberRow {
             org_id,
             user_id,
+            role: role.to_string(),
             created_at: now,
         };
         self.organization_members
@@ -2791,18 +2796,93 @@ impl InMemoryDatabase {
         Ok(result)
     }
 
-    pub async fn list_user_organizations(&self, user_id: Uuid) -> Result<Vec<OrganizationRow>> {
+    pub async fn list_organization_members_with_users(
+        &self,
+        org_id: i64,
+    ) -> Result<Vec<OrganizationMemberWithUserRow>> {
+        let members = self.organization_members.read();
+        let users = self.users.read();
+        let mut result: Vec<_> = members
+            .values()
+            .filter(|m| m.org_id == org_id)
+            .filter_map(|m| {
+                users
+                    .get(&m.user_id)
+                    .map(|u| OrganizationMemberWithUserRow {
+                        user_id: u.id,
+                        email: u.email.clone(),
+                        name: u.name.clone(),
+                        avatar_url: u.avatar_url.clone(),
+                        role: m.role.clone(),
+                        joined_at: m.created_at,
+                    })
+            })
+            .collect();
+        result.sort_by(|a, b| a.joined_at.cmp(&b.joined_at));
+        Ok(result)
+    }
+
+    pub async fn get_organization_member(
+        &self,
+        org_id: i64,
+        user_id: Uuid,
+    ) -> Result<Option<OrganizationMemberWithUserRow>> {
+        let members = self.organization_members.read();
+        let users = self.users.read();
+        Ok(members.get(&(org_id, user_id)).and_then(|m| {
+            users
+                .get(&m.user_id)
+                .map(|u| OrganizationMemberWithUserRow {
+                    user_id: u.id,
+                    email: u.email.clone(),
+                    name: u.name.clone(),
+                    avatar_url: u.avatar_url.clone(),
+                    role: m.role.clone(),
+                    joined_at: m.created_at,
+                })
+        }))
+    }
+
+    pub async fn update_organization_member_role(
+        &self,
+        org_id: i64,
+        user_id: Uuid,
+        role: &str,
+    ) -> Result<Option<OrganizationMemberRow>> {
+        let mut members = self.organization_members.write();
+        if let Some(member) = members.get_mut(&(org_id, user_id)) {
+            member.role = role.to_string();
+            return Ok(Some(member.clone()));
+        }
+        Ok(None)
+    }
+
+    pub async fn count_organization_owners(&self, org_id: i64) -> Result<i64> {
+        let members = self.organization_members.read();
+        let count = members
+            .values()
+            .filter(|m| m.org_id == org_id && m.role == "owner")
+            .count();
+        Ok(count as i64)
+    }
+
+    pub async fn list_user_organizations(
+        &self,
+        user_id: Uuid,
+    ) -> Result<Vec<OrganizationWithRoleRow>> {
         let members = self.organization_members.read();
         let orgs = self.organizations.read();
-        let org_ids: Vec<i64> = members
+        let mut result: Vec<_> = members
             .values()
             .filter(|m| m.user_id == user_id)
-            .map(|m| m.org_id)
-            .collect();
-        let mut result: Vec<_> = orgs
-            .values()
-            .filter(|o| org_ids.contains(&o.org_id))
-            .cloned()
+            .filter_map(|m| {
+                orgs.get(&m.org_id).map(|o| OrganizationWithRoleRow {
+                    org_id: o.org_id,
+                    public_id: o.public_id.clone(),
+                    name: o.name.clone(),
+                    role: m.role.clone(),
+                })
+            })
             .collect();
         result.sort_by(|a, b| a.name.cmp(&b.name));
         Ok(result)
@@ -2867,18 +2947,20 @@ impl InMemoryDatabase {
             created_at: now,
             updated_at: now,
             external_id: Some(external_id.to_string()),
+            created_by: None,
         };
         orgs.insert(org_id, row.clone());
         Ok(row)
     }
 
     /// Ensure user is a member of organization (idempotent)
-    pub async fn ensure_membership(&self, user_id: Uuid, org_id: i64) -> Result<()> {
+    pub async fn ensure_membership(&self, user_id: Uuid, org_id: i64, role: &str) -> Result<()> {
         let key = (org_id, user_id);
         let mut members = self.organization_members.write();
         members.entry(key).or_insert_with(|| OrganizationMemberRow {
             org_id,
             user_id,
+            role: role.to_string(),
             created_at: Self::now(),
         });
         Ok(())

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -22,6 +22,9 @@ pub struct OrganizationRow {
     /// External identity provider ID (e.g., PropelAuth org ID). NULL for OSS.
     #[sqlx(default)]
     pub external_id: Option<String>,
+    /// User who created this organization. NULL for seeded/external orgs.
+    #[sqlx(default)]
+    pub created_by: Option<Uuid>,
 }
 
 /// Organization member row from database
@@ -29,7 +32,28 @@ pub struct OrganizationRow {
 pub struct OrganizationMemberRow {
     pub org_id: i64,
     pub user_id: Uuid,
+    pub role: String,
     pub created_at: DateTime<Utc>,
+}
+
+/// Organization member with user info (for API responses)
+#[derive(Debug, Clone, FromRow)]
+pub struct OrganizationMemberWithUserRow {
+    pub user_id: Uuid,
+    pub email: String,
+    pub name: String,
+    pub avatar_url: Option<String>,
+    pub role: String,
+    pub joined_at: DateTime<Utc>,
+}
+
+/// Organization with role (for user's org list)
+#[derive(Debug, Clone, FromRow)]
+pub struct OrganizationWithRoleRow {
+    pub org_id: i64,
+    pub public_id: String,
+    pub name: String,
+    pub role: String,
 }
 
 /// Input for creating an organization
@@ -37,6 +61,7 @@ pub struct OrganizationMemberRow {
 pub struct CreateOrganizationRow {
     pub public_id: String,
     pub name: String,
+    pub created_by: Option<Uuid>,
 }
 
 /// Input for updating an organization

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -3006,13 +3006,14 @@ impl Database {
     ) -> Result<OrganizationRow> {
         let row = sqlx::query_as::<_, OrganizationRow>(
             r#"
-            INSERT INTO organizations (public_id, name)
-            VALUES ($1, $2)
-            RETURNING org_id, public_id, name, created_at, updated_at, external_id
+            INSERT INTO organizations (public_id, name, created_by)
+            VALUES ($1, $2, $3)
+            RETURNING org_id, public_id, name, created_at, updated_at, external_id, created_by
             "#,
         )
         .bind(&input.public_id)
         .bind(&input.name)
+        .bind(input.created_by)
         .fetch_one(&self.pool)
         .await?;
 
@@ -3028,15 +3029,16 @@ impl Database {
     ) -> Result<Option<OrganizationRow>> {
         let row = sqlx::query_as::<_, OrganizationRow>(
             r#"
-            INSERT INTO organizations (org_id, public_id, name)
-            VALUES ($1, $2, $3)
+            INSERT INTO organizations (org_id, public_id, name, created_by)
+            VALUES ($1, $2, $3, $4)
             ON CONFLICT (org_id) DO NOTHING
-            RETURNING org_id, public_id, name, created_at, updated_at, external_id
+            RETURNING org_id, public_id, name, created_at, updated_at, external_id, created_by
             "#,
         )
         .bind(org_id)
         .bind(&input.public_id)
         .bind(&input.name)
+        .bind(input.created_by)
         .fetch_optional(&self.pool)
         .await?;
 
@@ -3130,17 +3132,19 @@ impl Database {
         &self,
         org_id: i64,
         user_id: Uuid,
+        role: &str,
     ) -> Result<OrganizationMemberRow> {
         let row = sqlx::query_as::<_, OrganizationMemberRow>(
             r#"
-            INSERT INTO organization_members (org_id, user_id)
-            VALUES ($1, $2)
-            ON CONFLICT (org_id, user_id) DO UPDATE SET org_id = EXCLUDED.org_id
-            RETURNING org_id, user_id, created_at
+            INSERT INTO organization_members (org_id, user_id, role)
+            VALUES ($1, $2, $3)
+            ON CONFLICT (org_id, user_id) DO UPDATE SET role = EXCLUDED.role
+            RETURNING org_id, user_id, role, created_at
             "#,
         )
         .bind(org_id)
         .bind(user_id)
+        .bind(role)
         .fetch_one(&self.pool)
         .await?;
 
@@ -3164,7 +3168,7 @@ impl Database {
     ) -> Result<Vec<OrganizationMemberRow>> {
         let rows = sqlx::query_as::<_, OrganizationMemberRow>(
             r#"
-            SELECT org_id, user_id, created_at
+            SELECT org_id, user_id, role, created_at
             FROM organization_members
             WHERE org_id = $1
             ORDER BY created_at DESC
@@ -3177,10 +3181,91 @@ impl Database {
         Ok(rows)
     }
 
-    pub async fn list_user_organizations(&self, user_id: Uuid) -> Result<Vec<OrganizationRow>> {
-        let rows = sqlx::query_as::<_, OrganizationRow>(
+    /// List members with user info (for API responses)
+    pub async fn list_organization_members_with_users(
+        &self,
+        org_id: i64,
+    ) -> Result<Vec<OrganizationMemberWithUserRow>> {
+        let rows = sqlx::query_as::<_, OrganizationMemberWithUserRow>(
             r#"
-            SELECT o.org_id, o.public_id, o.name, o.created_at, o.updated_at, o.external_id
+            SELECT u.id as user_id, u.email, u.name, u.avatar_url, om.role, om.created_at as joined_at
+            FROM organization_members om
+            JOIN users u ON u.id = om.user_id
+            WHERE om.org_id = $1
+            ORDER BY om.created_at
+            "#,
+        )
+        .bind(org_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+
+    /// Get a specific organization member with user info
+    pub async fn get_organization_member(
+        &self,
+        org_id: i64,
+        user_id: Uuid,
+    ) -> Result<Option<OrganizationMemberWithUserRow>> {
+        let row = sqlx::query_as::<_, OrganizationMemberWithUserRow>(
+            r#"
+            SELECT u.id as user_id, u.email, u.name, u.avatar_url, om.role, om.created_at as joined_at
+            FROM organization_members om
+            JOIN users u ON u.id = om.user_id
+            WHERE om.org_id = $1 AND om.user_id = $2
+            "#,
+        )
+        .bind(org_id)
+        .bind(user_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    /// Update a member's role
+    pub async fn update_organization_member_role(
+        &self,
+        org_id: i64,
+        user_id: Uuid,
+        role: &str,
+    ) -> Result<Option<OrganizationMemberRow>> {
+        let row = sqlx::query_as::<_, OrganizationMemberRow>(
+            r#"
+            UPDATE organization_members SET role = $3
+            WHERE org_id = $1 AND user_id = $2
+            RETURNING org_id, user_id, role, created_at
+            "#,
+        )
+        .bind(org_id)
+        .bind(user_id)
+        .bind(role)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    /// Count owners in an organization (for preventing last owner removal)
+    pub async fn count_organization_owners(&self, org_id: i64) -> Result<i64> {
+        let row: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM organization_members WHERE org_id = $1 AND role = 'owner'",
+        )
+        .bind(org_id)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row.0)
+    }
+
+    pub async fn list_user_organizations(
+        &self,
+        user_id: Uuid,
+    ) -> Result<Vec<OrganizationWithRoleRow>> {
+        let rows = sqlx::query_as::<_, OrganizationWithRoleRow>(
+            r#"
+            SELECT o.org_id, o.public_id, o.name, om.role
             FROM organizations o
             JOIN organization_members om ON o.org_id = om.org_id
             WHERE om.user_id = $1
@@ -3270,12 +3355,13 @@ impl Database {
     }
 
     /// Ensure user is a member of organization (idempotent)
-    pub async fn ensure_membership(&self, user_id: Uuid, org_id: i64) -> Result<()> {
+    pub async fn ensure_membership(&self, user_id: Uuid, org_id: i64, role: &str) -> Result<()> {
         sqlx::query(
-            "INSERT INTO organization_members (org_id, user_id) VALUES ($1, $2) ON CONFLICT (org_id, user_id) DO NOTHING"
+            "INSERT INTO organization_members (org_id, user_id, role) VALUES ($1, $2, $3) ON CONFLICT (org_id, user_id) DO NOTHING"
         )
         .bind(org_id)
         .bind(user_id)
+        .bind(role)
         .execute(&self.pool)
         .await?;
 

--- a/crates/server/tests/org_creation_test.rs
+++ b/crates/server/tests/org_creation_test.rs
@@ -23,6 +23,7 @@ async fn test_create_organization_assigns_public_id() {
         .create_organization(CreateOrganizationRow {
             public_id: "org_aaaabbbbccccddddeeee111122223333".to_string(),
             name: "Test Org".to_string(),
+            created_by: None,
         })
         .await
         .expect("create should succeed");
@@ -40,6 +41,7 @@ async fn test_create_organization_multiple() {
         .create_organization(CreateOrganizationRow {
             public_id: format!("org_{}", Uuid::now_v7().simple()),
             name: "Org A".to_string(),
+            created_by: None,
         })
         .await
         .unwrap();
@@ -48,6 +50,7 @@ async fn test_create_organization_multiple() {
         .create_organization(CreateOrganizationRow {
             public_id: format!("org_{}", Uuid::now_v7().simple()),
             name: "Org B".to_string(),
+            created_by: None,
         })
         .await
         .unwrap();
@@ -71,6 +74,7 @@ async fn test_add_member_and_check() {
         .create_organization(CreateOrganizationRow {
             public_id: format!("org_{}", Uuid::now_v7().simple()),
             name: "Members Test".to_string(),
+            created_by: None,
         })
         .await
         .unwrap();
@@ -84,7 +88,7 @@ async fn test_add_member_and_check() {
 
     // Add member
     let member = db
-        .add_organization_member(org.org_id, user_id)
+        .add_organization_member(org.org_id, user_id, "member")
         .await
         .unwrap();
     assert_eq!(member.org_id, org.org_id);
@@ -108,6 +112,7 @@ async fn test_list_user_organizations() {
         .create_organization(CreateOrganizationRow {
             public_id: format!("org_{}", Uuid::now_v7().simple()),
             name: "User Org 1".to_string(),
+            created_by: None,
         })
         .await
         .unwrap();
@@ -116,14 +121,15 @@ async fn test_list_user_organizations() {
         .create_organization(CreateOrganizationRow {
             public_id: format!("org_{}", Uuid::now_v7().simple()),
             name: "User Org 2".to_string(),
+            created_by: None,
         })
         .await
         .unwrap();
 
-    db.add_organization_member(org1.org_id, user_id)
+    db.add_organization_member(org1.org_id, user_id, "member")
         .await
         .unwrap();
-    db.add_organization_member(org2.org_id, user_id)
+    db.add_organization_member(org2.org_id, user_id, "member")
         .await
         .unwrap();
 
@@ -145,11 +151,12 @@ async fn test_list_user_organizations_excludes_non_member() {
         .create_organization(CreateOrganizationRow {
             public_id: format!("org_{}", Uuid::now_v7().simple()),
             name: "Exclusive Org".to_string(),
+            created_by: None,
         })
         .await
         .unwrap();
 
-    db.add_organization_member(org.org_id, user_id)
+    db.add_organization_member(org.org_id, user_id, "member")
         .await
         .unwrap();
 
@@ -171,11 +178,12 @@ async fn test_remove_member() {
         .create_organization(CreateOrganizationRow {
             public_id: format!("org_{}", Uuid::now_v7().simple()),
             name: "Remove Test".to_string(),
+            created_by: None,
         })
         .await
         .unwrap();
 
-    db.add_organization_member(org.org_id, user_id)
+    db.add_organization_member(org.org_id, user_id, "member")
         .await
         .unwrap();
     assert!(
@@ -217,6 +225,7 @@ async fn test_get_organization_by_public_id() {
     db.create_organization(CreateOrganizationRow {
         public_id: public_id.clone(),
         name: "Lookup Test".to_string(),
+        created_by: None,
     })
     .await
     .unwrap();
@@ -258,6 +267,7 @@ async fn test_update_organization_name() {
         .create_organization(CreateOrganizationRow {
             public_id: format!("org_{}", Uuid::now_v7().simple()),
             name: "Original Name".to_string(),
+            created_by: None,
         })
         .await
         .unwrap();
@@ -284,6 +294,7 @@ async fn test_delete_organization() {
         .create_organization(CreateOrganizationRow {
             public_id: format!("org_{}", Uuid::now_v7().simple()),
             name: "Delete Me".to_string(),
+            created_by: None,
         })
         .await
         .unwrap();

--- a/crates/server/tests/org_isolation_test.rs
+++ b/crates/server/tests/org_isolation_test.rs
@@ -22,6 +22,7 @@ async fn create_second_org(db: &InMemoryDatabase) -> i64 {
         .create_organization(CreateOrganizationRow {
             public_id: format!("org_{}", Uuid::now_v7().simple()),
             name: "Second Org".to_string(),
+            created_by: None,
         })
         .await
         .expect("Failed to create second org");

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -833,6 +833,7 @@ async fn test_organization_crud() {
         .create_organization(CreateOrganizationRow {
             public_id: public_id.clone(),
             name: format!("Test Org {}", Uuid::now_v7()),
+            created_by: None,
         })
         .await
         .expect("Failed to create organization");
@@ -1130,6 +1131,7 @@ async fn create_test_org(backend: &StorageBackend, name: &str) -> i64 {
         .create_organization(CreateOrganizationRow {
             public_id: format!("org_{}", Uuid::now_v7().simple()),
             name: name.to_string(),
+            created_by: None,
         })
         .await
         .expect("Failed to create org");


### PR DESCRIPTION
## Summary
- Add hierarchical organization roles (Owner > Admin > Member) with RBAC
- Working members UI with role editing dropdown and remove member functionality
- Migration 008 adds role column and created_by audit field

## Test plan
- [x] Smoke tested in DEV mode (in-memory) - all members API operations work
- [x] Smoke tested in PostgreSQL mode - migrations 001-008 apply cleanly
- [x] Role editing: member → admin → owner transitions verified
- [x] Last owner protection: cannot demote when only one owner
- [x] UI: role dropdown, "You" badge, remove member button, loading skeletons
- [x] Tests: 11 unit tests for members page covering role badges, editing, permissions
- [x] pre-push checks pass (fmt, clippy, lockfile, UI lint)