### PR TITLE
refactor: simplify auth code and add code-cleanup maintenance step

### DIFF
--- a/apps/ui/src/hooks/use-organizations.ts
+++ b/apps/ui/src/hooks/use-organizations.ts
@@ -3,7 +3,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { createOrganization, getOrganization, updateOrganization } from "@/lib/api/organizations";
 import { queryKeys } from "@/lib/query-keys";
-import type { CreateOrganizationRequest, UpdateOrganizationRequest } from "@/lib/api/types";
+import type { UpdateOrganizationRequest } from "@/lib/api/types";
 import { useOrg } from "@/providers/org-provider";
 
 export function useOrganization() {
@@ -11,7 +11,7 @@ export function useOrganization() {
   const org = currentOrg?.public_id;
 
   const query = useQuery({
-    queryKey: [...queryKeys.organizations.detail(org ?? ""), org],
+    queryKey: queryKeys.organizations.detail(org ?? ""),
     queryFn: () => getOrganization(org!),
     enabled: !!org,
     staleTime: 30000,
@@ -28,7 +28,7 @@ export function useCreateOrganization() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: CreateOrganizationRequest) => createOrganization(data),
+    mutationFn: createOrganization,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.organizations.all });
       // Refresh user's org list so the new org appears in the dropdown

--- a/apps/ui/src/lib/api/durable.ts
+++ b/apps/ui/src/lib/api/durable.ts
@@ -12,6 +12,14 @@ import type {
   DlqResponse,
   CircuitBreakersResponse,
   DurableSystemHealth,
+  DurableSchedule,
+  SchedulesResponse,
+  CreateScheduleRequest,
+  UpdateScheduleRequest,
+  ScheduleExecution,
+  ScheduleExecutionsResponse,
+  ScheduleStats,
+  TriggerResponse,
 } from "./types";
 
 // ============================================
@@ -211,17 +219,6 @@ export async function deleteCircuitBreaker(key: string): Promise<void> {
 // ============================================
 // Schedules
 // ============================================
-
-import type {
-  DurableSchedule,
-  SchedulesResponse,
-  CreateScheduleRequest,
-  UpdateScheduleRequest,
-  ScheduleExecution,
-  ScheduleExecutionsResponse,
-  ScheduleStats,
-  TriggerResponse,
-} from "./types";
 
 export interface ListSchedulesParams {
   enabled?: boolean;

--- a/crates/server/src/auth/builtin.rs
+++ b/crates/server/src/auth/builtin.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 
 use super::api_key::{ValidatedApiKey, hash_api_key, is_valid_api_key_format};
 use super::backend::AuthBackend;
-use super::config::{AuthConfig, AuthMode};
+use super::config::AuthConfig;
 use super::jwt::JwtService;
 use super::middleware::{AuthError, AuthMethod, AuthUser};
 use super::routes::{self, AuthConfigResponse};
@@ -50,19 +50,13 @@ impl AuthBackend for BuiltinAuthBackend {
         let organizations = fetch_user_organizations(&self.db, user_id).await?;
 
         // If user has no organizations, fall back to default organization
-        let organizations = if organizations.is_empty() {
+        if organizations.is_empty() {
             tracing::warn!(
                 user_id = %user_id,
                 "User has no organizations, falling back to default org"
             );
-            vec![OrgMembership {
-                org_id: DEFAULT_ORG_ID,
-                public_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
-                name: "Default Organization".to_string(),
-            }]
-        } else {
-            organizations
-        };
+        }
+        let organizations = organizations_or_default(organizations);
 
         Ok(AuthUser {
             id: user_id,
@@ -165,24 +159,16 @@ impl AuthBackend for BuiltinAuthBackend {
         }
 
         AuthConfigResponse {
-            mode: match self.config.mode {
-                AuthMode::None => "none".to_string(),
-                AuthMode::Admin => "admin".to_string(),
-                AuthMode::Full => "full".to_string(),
-                AuthMode::External => "external".to_string(),
-            },
+            mode: self.config.mode.as_str().to_string(),
             password_auth_enabled: self.config.password_auth_enabled(),
             oauth_providers,
-            // External mode: signup is managed by the external provider
-            signup_enabled: self.config.mode != AuthMode::Admin
-                && self.config.mode != AuthMode::External
-                && !self.config.disable_signup,
+            signup_enabled: self.config.signup_enabled(),
         }
     }
 }
 
 /// Fetch organization memberships for a user
-async fn fetch_user_organizations(
+pub(super) async fn fetch_user_organizations(
     db: &StorageBackend,
     user_id: Uuid,
 ) -> Result<Vec<OrgMembership>, AuthError> {
@@ -199,4 +185,17 @@ async fn fetch_user_organizations(
             name: row.name,
         })
         .collect())
+}
+
+/// Return organizations as-is, or fall back to default org membership if empty
+pub(super) fn organizations_or_default(organizations: Vec<OrgMembership>) -> Vec<OrgMembership> {
+    if organizations.is_empty() {
+        vec![OrgMembership {
+            org_id: DEFAULT_ORG_ID,
+            public_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
+            name: "Default Organization".to_string(),
+        }]
+    } else {
+        organizations
+    }
 }

--- a/crates/server/src/auth/config.rs
+++ b/crates/server/src/auth/config.rs
@@ -27,6 +27,15 @@ impl AuthMode {
             _ => AuthMode::None,
         }
     }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            AuthMode::None => "none",
+            AuthMode::Admin => "admin",
+            AuthMode::Full => "full",
+            AuthMode::External => "external",
+        }
+    }
 }
 
 /// OAuth provider configuration
@@ -269,6 +278,11 @@ impl AuthConfig {
         self.mode == AuthMode::Full && (self.google.is_some() || self.github.is_some())
     }
 
+    /// Check if user signup (registration) is enabled
+    pub fn signup_enabled(&self) -> bool {
+        self.mode != AuthMode::Admin && self.mode != AuthMode::External && !self.disable_signup
+    }
+
     /// Check if API key authentication is available
     #[allow(dead_code)]
     pub fn api_key_auth_enabled(&self) -> bool {
@@ -440,17 +454,14 @@ mod tests {
 
     #[test]
     fn test_admin_mode_signup_should_be_disabled() {
-        // In admin mode, signup should be disabled regardless of disable_signup setting
-        // (This is enforced in routes.rs, but we document the expected behavior here)
         let config = AuthConfig {
             mode: AuthMode::Admin,
             disable_signup: false, // Even if not explicitly disabled
             ..Default::default()
         };
-
-        // The signup_enabled check in routes.rs is:
-        // config.mode != AuthMode::Admin && !config.disable_signup
-        let signup_enabled = config.mode != AuthMode::Admin && !config.disable_signup;
-        assert!(!signup_enabled, "Admin mode should never allow signup");
+        assert!(
+            !config.signup_enabled(),
+            "Admin mode should never allow signup"
+        );
     }
 }

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -11,7 +11,7 @@ use axum::{
 };
 use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 use chrono::{Duration, Utc};
-use everruns_core::{DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, OrgMembership};
+use everruns_core::DEFAULT_ORG_ID;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -19,7 +19,7 @@ use uuid::Uuid;
 
 use super::{
     api_key::generate_api_key,
-    builtin::BuiltinAuthBackend,
+    builtin::{self, BuiltinAuthBackend},
     config::AuthMode,
     jwt::hash_token,
     middleware::{AuthError, AuthMethod, AuthState, AuthUser, ORG_COOKIE_NAME, ResolvedOrg},
@@ -182,19 +182,10 @@ pub async fn get_auth_config(State(state): State<BuiltinAuthBackend>) -> Json<Au
     }
 
     Json(AuthConfigResponse {
-        mode: match state.config.mode {
-            AuthMode::None => "none".to_string(),
-            AuthMode::Admin => "admin".to_string(),
-            AuthMode::Full => "full".to_string(),
-            AuthMode::External => "external".to_string(),
-        },
+        mode: state.config.mode.as_str().to_string(),
         password_auth_enabled: state.config.password_auth_enabled(),
         oauth_providers,
-        // Admin mode has a single predefined user, no signup allowed
-        // External mode: signup is managed by the external provider
-        signup_enabled: state.config.mode != AuthMode::Admin
-            && state.config.mode != AuthMode::External
-            && !state.config.disable_signup,
+        signup_enabled: state.config.signup_enabled(),
     })
 }
 
@@ -253,29 +244,17 @@ pub async fn login(
 
     let roles: Vec<String> = serde_json::from_value(user.roles.clone()).unwrap_or_default();
 
-    // Fetch organization memberships
-    let organizations = fetch_user_organizations(&state.db, user.id)
+    let organizations = builtin::fetch_user_organizations(&state.db, user.id)
         .await
         .unwrap_or_default();
-
-    // Fallback to default org if empty (add_organization_member may have failed silently)
-    let organizations = if organizations.is_empty() {
-        vec![OrgMembership {
-            org_id: DEFAULT_ORG_ID,
-            public_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
-            name: "Default Organization".to_string(),
-        }]
-    } else {
-        organizations
-    };
 
     let auth_user = AuthUser {
         id: user.id,
         email: user.email,
         name: user.name,
         roles,
-        auth_method: super::middleware::AuthMethod::Jwt,
-        organizations,
+        auth_method: AuthMethod::Jwt,
+        organizations: builtin::organizations_or_default(organizations),
     };
 
     generate_token_response(&state, jar, &auth_user).await
@@ -343,29 +322,17 @@ pub async fn register(
             // Continue anyway - user is created, they just might not have org membership
         });
 
-    // Fetch organization memberships (should include default org now)
-    let organizations = fetch_user_organizations(&state.db, user.id)
+    let organizations = builtin::fetch_user_organizations(&state.db, user.id)
         .await
         .unwrap_or_default();
-
-    // Fallback to default org if empty (add_organization_member may have failed silently)
-    let organizations = if organizations.is_empty() {
-        vec![OrgMembership {
-            org_id: DEFAULT_ORG_ID,
-            public_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
-            name: "Default Organization".to_string(),
-        }]
-    } else {
-        organizations
-    };
 
     let auth_user = AuthUser {
         id: user.id,
         email: user.email,
         name: user.name,
         roles: vec!["user".to_string()],
-        auth_method: super::middleware::AuthMethod::Jwt,
-        organizations,
+        auth_method: AuthMethod::Jwt,
+        organizations: builtin::organizations_or_default(organizations),
     };
 
     let (jar, json) = generate_token_response(&state, jar, &auth_user).await?;
@@ -420,29 +387,17 @@ pub async fn refresh_token(
 
     let roles: Vec<String> = serde_json::from_value(user.roles.clone()).unwrap_or_default();
 
-    // Fetch organization memberships
-    let organizations = fetch_user_organizations(&state.db, user.id)
+    let organizations = builtin::fetch_user_organizations(&state.db, user.id)
         .await
         .unwrap_or_default();
-
-    // Fallback to default org if empty (add_organization_member may have failed silently)
-    let organizations = if organizations.is_empty() {
-        vec![OrgMembership {
-            org_id: DEFAULT_ORG_ID,
-            public_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
-            name: "Default Organization".to_string(),
-        }]
-    } else {
-        organizations
-    };
 
     let auth_user = AuthUser {
         id: user.id,
         email: user.email,
         name: user.name,
         roles,
-        auth_method: super::middleware::AuthMethod::Jwt,
-        organizations,
+        auth_method: AuthMethod::Jwt,
+        organizations: builtin::organizations_or_default(organizations),
     };
 
     generate_token_response(&state, jar, &auth_user).await
@@ -648,29 +603,17 @@ pub async fn oauth_callback(
 
     let roles: Vec<String> = serde_json::from_value(user.roles.clone()).unwrap_or_default();
 
-    // Fetch organization memberships
-    let organizations = fetch_user_organizations(&state.db, user.id)
+    let organizations = builtin::fetch_user_organizations(&state.db, user.id)
         .await
         .unwrap_or_default();
-
-    // Fallback to default org if empty (add_organization_member may have failed silently)
-    let organizations = if organizations.is_empty() {
-        vec![OrgMembership {
-            org_id: DEFAULT_ORG_ID,
-            public_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
-            name: "Default Organization".to_string(),
-        }]
-    } else {
-        organizations
-    };
 
     let auth_user = AuthUser {
         id: user.id,
         email: user.email,
         name: user.name,
         roles,
-        auth_method: super::middleware::AuthMethod::Jwt,
-        organizations,
+        auth_method: AuthMethod::Jwt,
+        organizations: builtin::organizations_or_default(organizations),
     };
 
     // Generate tokens and set cookies
@@ -928,54 +871,24 @@ async fn get_or_create_admin_user(
 
     let roles: Vec<String> = serde_json::from_value(user.roles.clone()).unwrap_or_default();
 
-    // Fetch organization memberships
-    let organizations = fetch_user_organizations(&state.db, user.id)
+    let organizations = builtin::fetch_user_organizations(&state.db, user.id)
         .await
         .unwrap_or_default();
 
-    // Fallback to default org if empty (for existing admin users not in any org)
-    let organizations = if organizations.is_empty() {
-        // Try to add user to default org
+    // For existing admin users not in any org, try to add them
+    if organizations.is_empty() {
         let _ = state
             .db
             .add_organization_member(DEFAULT_ORG_ID, user.id)
             .await;
-
-        vec![OrgMembership {
-            org_id: DEFAULT_ORG_ID,
-            public_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
-            name: "Default Organization".to_string(),
-        }]
-    } else {
-        organizations
-    };
+    }
 
     Ok(AuthUser {
         id: user.id,
         email: user.email,
         name: user.name,
         roles,
-        auth_method: super::middleware::AuthMethod::Jwt,
-        organizations,
+        auth_method: AuthMethod::Jwt,
+        organizations: builtin::organizations_or_default(organizations),
     })
-}
-
-/// Fetch organization memberships for a user
-async fn fetch_user_organizations(
-    db: &crate::storage::StorageBackend,
-    user_id: Uuid,
-) -> Result<Vec<OrgMembership>, AuthError> {
-    let org_rows = db.list_user_organizations(user_id).await.map_err(|e| {
-        tracing::error!("Failed to fetch user organizations: {}", e);
-        AuthError::unauthorized("Failed to fetch organizations")
-    })?;
-
-    Ok(org_rows
-        .into_iter()
-        .map(|row| OrgMembership {
-            org_id: row.org_id,
-            public_id: row.public_id,
-            name: row.name,
-        })
-        .collect())
 }

--- a/specs/maintenance.md
+++ b/specs/maintenance.md
@@ -135,7 +135,21 @@ Verify [everruns/sdk](https://github.com/everruns/sdk) public documentation (`do
 5. No TODO/FIXME items that should be resolved before release
 6. CHANGELOG.md has entries for all changes since last release
 
-## Automation
+### 12. Code Simplification
+
+Run the [code-simplifier](https://github.com/anthropics/claude-plugins-official/blob/main/plugins/code-simplifier/agents/code-simplifier.md) agent against recently modified code to clean up clarity, consistency, and maintainability issues while preserving exact functionality.
+
+1. Review code changed since last release (`git diff <last-release-tag>..HEAD --stat`)
+2. Run code-simplifier agent on changed files — focuses on:
+   - Deduplicating repeated patterns into shared helpers
+   - Consolidating split/scattered imports
+   - Removing redundant code (unused imports, passthrough wrappers, duplicate logic)
+   - Applying project conventions consistently (naming, error handling, type annotations)
+   - Simplifying overly nested or complex expressions
+3. Verify all tests still pass after simplification
+4. Ensure no behavioral changes — only structural improvements
+
+
 
 Run `just pre-pr` to automate checks 1-9 where possible. Manual review needed for spec accuracy, threat model, SDK parity, and AGENTS.md content.
 


### PR DESCRIPTION
## What
Deduplicate auth org-fetch/fallback patterns, consolidate AuthMode/signup logic into methods, and clean up UI code. Add code-simplifier step to maintenance checklist.

## Why
5 near-identical org-fetch-and-fallback blocks in routes.rs, duplicated AuthMode-to-string match and signup condition across routes.rs and builtin.rs, redundant query key in use-organizations.ts, and split import block in durable.ts.

## How
- **config.rs**: Add `AuthMode::as_str()` and `AuthConfig::signup_enabled()` methods
- **builtin.rs**: Make `fetch_user_organizations` pub(super), add `organizations_or_default` helper
- **routes.rs**: Remove duplicate `fetch_user_organizations`, use shared helpers for org fallback and auth config (eliminates ~80 lines)
- **use-organizations.ts**: Fix redundant query key, simplify passthrough mutationFn
- **durable.ts**: Consolidate split import blocks into single top-level import
- **maintenance.md**: Add code-simplifier agent reference as section 12

## Risk
- Low
- Pure refactor (no behavioral changes). All existing tests pass. Auth flows unchanged.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered