### PR TITLE
refactor(seed): rename Cloud Coder to CodeSandbox Coder

### DIFF
--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -44,7 +44,8 @@ mod seed_ids {
     pub const PYTHON_CODER_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000104);
     pub const SHELL_ASSISTANT_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000105);
     pub const DATA_ANALYST_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000106);
-    pub const CLOUD_CODER_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000107);
+    pub const CODESANDBOX_CODER_AGENT: Uuid =
+        Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000107);
     pub const DAYTONA_CODER_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000108);
 
     // MCP Servers (0x500-0x5FF)
@@ -549,10 +550,10 @@ sql_query(database="analytics", sql="SELECT product, SUM(amount) as total FROM s
         dev_only: false,
     },
     SeedAgent {
-        id: seed_ids::CLOUD_CODER_AGENT,
-        name: "Cloud Coder",
+        id: seed_ids::CODESANDBOX_CODER_AGENT,
+        name: "CodeSandbox Coder",
         description: "A coding agent that runs code in cloud sandboxes powered by CodeSandbox",
-        system_prompt: r#"You are a Cloud Coder Agent. You run code in cloud sandbox VMs powered by CodeSandbox.
+        system_prompt: r#"You are a CodeSandbox Coder Agent. You run code in cloud sandbox VMs powered by CodeSandbox.
 
 Prerequisite: The session must have CSB_API_KEY set in secrets before you can use sandbox tools.
 If missing, tell the user to set it via the API or harness config.

--- a/specs/codesandbox.md
+++ b/specs/codesandbox.md
@@ -254,9 +254,9 @@ Core (`everruns-core`) has no compile-time knowledge of this crate.
 - **Dependencies**: `["session_storage"]`
 - **Registration**: `IntegrationPlugin` via `inventory::submit!` (experimental_only: true)
 
-## Seeded Agent: Cloud Coder
+## Seeded Agent: CodeSandbox Coder
 
-A pre-configured seed agent (`Cloud Coder`) demonstrates the capability:
+A pre-configured seed agent (`CodeSandbox Coder`) demonstrates the capability:
 - **Capabilities**: `codesandbox`, `session_storage`, `session_file_system`
 - **Dev-only**: true
 - **System prompt**: Guides users through API key setup, sandbox creation, code execution, and result download


### PR DESCRIPTION
## What
Rename the "Cloud Coder" seed agent to "CodeSandbox Coder".

## Why
Better reflects the CodeSandbox branding. Aligns naming with the pattern used by "Daytona Coder".

## How
- Renamed `CLOUD_CODER_AGENT` constant to `CODESANDBOX_CODER_AGENT` in `seed.rs`
- Updated agent name from "Cloud Coder" to "CodeSandbox Coder"
- Updated system prompt intro accordingly
- Updated `specs/codesandbox.md` references

## Risk
- Low
- Seed agent ID (UUID) unchanged, so existing data unaffected. Only display name and constant name changed.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered