### PR TITLE
feat(ui): split settings sidebar into Organisation and Personal sections

### DIFF
--- a/apps/ui/src/__tests__/settings-layout.test.tsx
+++ b/apps/ui/src/__tests__/settings-layout.test.tsx
@@ -34,9 +34,23 @@ describe("SettingsLayout", () => {
       </SettingsLayout>,
     );
 
+    expect(screen.getByText("General")).toBeInTheDocument();
     expect(screen.getByText("LLM Providers")).toBeInTheDocument();
-    expect(screen.getByText("API Keys")).toBeInTheDocument();
+    expect(screen.getByText("MCP Servers")).toBeInTheDocument();
     expect(screen.getByText("Members")).toBeInTheDocument();
+    expect(screen.getByText("Connections")).toBeInTheDocument();
+    expect(screen.getByText("API Keys")).toBeInTheDocument();
+  });
+
+  it("renders section labels for Organisation and Personal", () => {
+    render(
+      <SettingsLayout>
+        <div>Test Content</div>
+      </SettingsLayout>,
+    );
+
+    expect(screen.getByText("Organisation")).toBeInTheDocument();
+    expect(screen.getByText("Personal")).toBeInTheDocument();
   });
 
   it("renders correct navigation links", () => {

--- a/apps/ui/src/__tests__/settings-layout.test.tsx
+++ b/apps/ui/src/__tests__/settings-layout.test.tsx
@@ -60,13 +60,19 @@ describe("SettingsLayout", () => {
       </SettingsLayout>,
     );
 
+    const generalLink = screen.getByRole("link", { name: /General/i });
     const providersLink = screen.getByRole("link", { name: /LLM Providers/i });
-    const apiKeysLink = screen.getByRole("link", { name: /API Keys/i });
+    const mcpServersLink = screen.getByRole("link", { name: /MCP Servers/i });
     const membersLink = screen.getByRole("link", { name: /Members/i });
+    const connectionsLink = screen.getByRole("link", { name: /Connections/i });
+    const apiKeysLink = screen.getByRole("link", { name: /API Keys/i });
 
+    expect(generalLink).toHaveAttribute("href", "/settings/organisation");
     expect(providersLink).toHaveAttribute("href", "/settings/providers");
-    expect(apiKeysLink).toHaveAttribute("href", "/settings/api-keys");
+    expect(mcpServersLink).toHaveAttribute("href", "/settings/mcp-servers");
     expect(membersLink).toHaveAttribute("href", "/settings/members");
+    expect(connectionsLink).toHaveAttribute("href", "/settings/connections");
+    expect(apiKeysLink).toHaveAttribute("href", "/settings/api-keys");
   });
 
   it("highlights the active navigation item for providers", () => {
@@ -125,5 +131,105 @@ describe("SettingsLayout", () => {
 
     const navLinks = screen.getAllByRole("link");
     expect(navLinks).toHaveLength(6);
+  });
+
+  it("groups items under correct sections", () => {
+    render(
+      <SettingsLayout>
+        <div>Test Content</div>
+      </SettingsLayout>,
+    );
+
+    const orgLabel = screen.getByText("Organisation");
+    const personalLabel = screen.getByText("Personal");
+
+    // Organisation section contains its items
+    const orgSection = orgLabel.closest("div[class]")!.parentElement!;
+    expect(orgSection).toHaveTextContent("General");
+    expect(orgSection).toHaveTextContent("LLM Providers");
+    expect(orgSection).toHaveTextContent("MCP Servers");
+    expect(orgSection).toHaveTextContent("Members");
+    expect(orgSection).not.toHaveTextContent("Connections");
+    expect(orgSection).not.toHaveTextContent("API Keys");
+
+    // Personal section contains its items
+    const personalSection = personalLabel.closest("div[class]")!.parentElement!;
+    expect(personalSection).toHaveTextContent("Connections");
+    expect(personalSection).toHaveTextContent("API Keys");
+    expect(personalSection).not.toHaveTextContent("General");
+    expect(personalSection).not.toHaveTextContent("Members");
+  });
+
+  it("renders section labels with uppercase styling", () => {
+    render(
+      <SettingsLayout>
+        <div>Test Content</div>
+      </SettingsLayout>,
+    );
+
+    const orgLabel = screen.getByText("Organisation");
+    const personalLabel = screen.getByText("Personal");
+
+    expect(orgLabel).toHaveClass("uppercase");
+    expect(orgLabel).toHaveClass("tracking-wider");
+    expect(orgLabel).toHaveClass("text-xs");
+    expect(orgLabel).toHaveClass("font-semibold");
+
+    expect(personalLabel).toHaveClass("uppercase");
+    expect(personalLabel).toHaveClass("tracking-wider");
+  });
+
+  it("applies inactive styles to non-active items", () => {
+    mockPathname.mockReturnValue("/settings/providers");
+    render(
+      <SettingsLayout>
+        <div>Test Content</div>
+      </SettingsLayout>,
+    );
+
+    const generalLink = screen.getByRole("link", { name: /General/i });
+    const membersLink = screen.getByRole("link", { name: /Members/i });
+    const apiKeysLink = screen.getByRole("link", { name: /API Keys/i });
+
+    expect(generalLink).toHaveClass("border-transparent");
+    expect(generalLink).not.toHaveClass("border-accent");
+    expect(membersLink).toHaveClass("border-transparent");
+    expect(apiKeysLink).toHaveClass("border-transparent");
+  });
+
+  it("highlights active item for General page", () => {
+    mockPathname.mockReturnValue("/settings/organisation");
+    render(
+      <SettingsLayout>
+        <div>Test Content</div>
+      </SettingsLayout>,
+    );
+
+    const generalLink = screen.getByRole("link", { name: /General/i });
+    expect(generalLink).toHaveClass("border-accent");
+  });
+
+  it("highlights active item for MCP Servers page", () => {
+    mockPathname.mockReturnValue("/settings/mcp-servers");
+    render(
+      <SettingsLayout>
+        <div>Test Content</div>
+      </SettingsLayout>,
+    );
+
+    const mcpLink = screen.getByRole("link", { name: /MCP Servers/i });
+    expect(mcpLink).toHaveClass("border-accent");
+  });
+
+  it("highlights active item for Connections page", () => {
+    mockPathname.mockReturnValue("/settings/connections");
+    render(
+      <SettingsLayout>
+        <div>Test Content</div>
+      </SettingsLayout>,
+    );
+
+    const connectionsLink = screen.getByRole("link", { name: /Connections/i });
+    expect(connectionsLink).toHaveClass("border-accent");
   });
 });

--- a/apps/ui/src/app/(main)/settings/layout.tsx
+++ b/apps/ui/src/app/(main)/settings/layout.tsx
@@ -6,42 +6,64 @@ import { cn } from "@/lib/utils";
 import { Header } from "@/components/layout/header";
 import { Server, Key, Users, Plug, Building2, Cable } from "lucide-react";
 
-const settingsNavigation = [
+interface NavItem {
+  name: string;
+  href: string;
+  icon: React.ComponentType<{ className?: string }>;
+  description: string;
+}
+
+interface NavSection {
+  label: string;
+  items: NavItem[];
+}
+
+const settingsSections: NavSection[] = [
   {
-    name: "Organisation",
-    href: "/settings/organisation",
-    icon: Building2,
-    description: "Manage organisation settings",
+    label: "Organisation",
+    items: [
+      {
+        name: "General",
+        href: "/settings/organisation",
+        icon: Building2,
+        description: "Manage organisation settings",
+      },
+      {
+        name: "LLM Providers",
+        href: "/settings/providers",
+        icon: Server,
+        description: "Manage LLM providers and models",
+      },
+      {
+        name: "MCP Servers",
+        href: "/settings/mcp-servers",
+        icon: Plug,
+        description: "Manage MCP server connections",
+      },
+      {
+        name: "Members",
+        href: "/settings/members",
+        icon: Users,
+        description: "View and manage team members",
+      },
+    ],
   },
   {
-    name: "LLM Providers",
-    href: "/settings/providers",
-    icon: Server,
-    description: "Manage LLM providers and models",
-  },
-  {
-    name: "MCP Servers",
-    href: "/settings/mcp-servers",
-    icon: Plug,
-    description: "Manage MCP server connections",
-  },
-  {
-    name: "Connections",
-    href: "/settings/connections",
-    icon: Cable,
-    description: "Connect external accounts",
-  },
-  {
-    name: "API Keys",
-    href: "/settings/api-keys",
-    icon: Key,
-    description: "Manage API keys for programmatic access",
-  },
-  {
-    name: "Members",
-    href: "/settings/members",
-    icon: Users,
-    description: "View and manage team members",
+    label: "Personal",
+    items: [
+      {
+        name: "Connections",
+        href: "/settings/connections",
+        icon: Cable,
+        description: "Connect external accounts",
+      },
+      {
+        name: "API Keys",
+        href: "/settings/api-keys",
+        icon: Key,
+        description: "Manage API keys for programmatic access",
+      },
+    ],
   },
 ];
 
@@ -58,27 +80,36 @@ export default function SettingsLayout({ children }: SettingsLayoutProps) {
       <div className="flex flex-1 overflow-hidden">
         {/* Settings Sidebar */}
         <nav className="w-64 border-r bg-card p-4 overflow-y-auto">
-          <div className="space-y-1">
-            {settingsNavigation.map((item) => {
-              const isActive = pathname === item.href;
-              return (
-                <Link
-                  key={item.name}
-                  href={item.href}
-                  className={cn(
-                    "flex items-center gap-3 px-3 py-2 text-sm transition-colors border-l-2",
-                    isActive
-                      ? "bg-accent/10 text-accent-foreground border-accent"
-                      : "text-muted-foreground hover:bg-muted hover:text-foreground border-transparent",
-                  )}
-                >
-                  <item.icon className="h-4 w-4" />
-                  <div>
-                    <div className="font-medium">{item.name}</div>
-                  </div>
-                </Link>
-              );
-            })}
+          <div className="space-y-6">
+            {settingsSections.map((section) => (
+              <div key={section.label}>
+                <div className="px-3 pb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground/70">
+                  {section.label}
+                </div>
+                <div className="space-y-1">
+                  {section.items.map((item) => {
+                    const isActive = pathname === item.href;
+                    return (
+                      <Link
+                        key={item.name}
+                        href={item.href}
+                        className={cn(
+                          "flex items-center gap-3 px-3 py-2 text-sm transition-colors border-l-2",
+                          isActive
+                            ? "bg-accent/10 text-accent-foreground border-accent"
+                            : "text-muted-foreground hover:bg-muted hover:text-foreground border-transparent",
+                        )}
+                      >
+                        <item.icon className="h-4 w-4" />
+                        <div>
+                          <div className="font-medium">{item.name}</div>
+                        </div>
+                      </Link>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
           </div>
         </nav>
 

--- a/specs/multitenancy.md
+++ b/specs/multitenancy.md
@@ -643,6 +643,22 @@ Two entry points for creating organisations:
 
 Both use the `useCreateOrganization` hook (`hooks/use-organizations.ts`) which calls `POST /v1/orgs`. On success, the new org is auto-selected as the current org via `setCurrentOrg()`.
 
+### UI Settings Navigation
+
+The settings sidebar (`/settings/*`) is organized into two labeled sections:
+
+**Organisation** (org-scoped settings):
+- **General** (`/settings/organisation`) — Org name, ID, "Your Organisations" list
+- **LLM Providers** (`/settings/providers`) — Provider configs and API keys
+- **MCP Servers** (`/settings/mcp-servers`) — MCP server connections
+- **Members** (`/settings/members`) — Team member list
+
+**Personal** (user-scoped settings):
+- **Connections** (`/settings/connections`) — External account links (GitHub, etc.)
+- **API Keys** (`/settings/api-keys`) — Personal API keys
+
+Section labels are rendered as uppercase headers (`text-xs font-semibold uppercase tracking-wider`). Active nav item highlighted with accent left border.
+
 ### UI Organisation Management
 The settings page (`/settings/organisation`) has two sections:
 1. **Current Organisation:** Edit name, view org ID (existing)


### PR DESCRIPTION
## What
Split the settings sidebar navigation into two visually distinct sections: **Organisation** and **Personal**.

## Why
The settings page mixed org-level settings (LLM Providers, MCP Servers, Members) with user-level settings (Connections, API Keys). This made it unclear which settings affect the whole org vs. just the current user.

## How
- Restructured the flat `settingsNavigation` array into a `settingsSections` array with labeled groups
- **Organisation** section: General, LLM Providers, MCP Servers, Members
- **Personal** section: Connections, API Keys
- Renamed "Organisation" nav item to "General" (section header already provides that context)
- Added uppercase section labels (`text-xs font-semibold uppercase tracking-wider`)
- Updated tests to cover new section labels

## Risk
- Low
- Visual-only change to sidebar navigation; no routing or data changes

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered