### PR TITLE
feat(session): add session capability and worker/session plumbing

### DIFF
--- a/crates/core/examples/turn_based_execution.rs
+++ b/crates/core/examples/turn_based_execution.rs
@@ -295,6 +295,7 @@ async fn main() -> anyhow::Result<()> {
 
         let act_result = act_atom
             .execute(ActInput {
+                org_id: Some(0),
                 context: act_context,
                 harness_id,
                 agent_id: Some(AgentId::from_uuid(agent_id)),

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -36,7 +36,10 @@ use crate::events::{
 };
 use crate::message::ContentPart;
 use crate::tool_types::{ToolCall, ToolDefinition, ToolResult};
-use crate::traits::{EventEmitter, SessionFileStore, ToolContext, ToolExecutor};
+use crate::traits::{
+    AgentStore, EventEmitter, SessionFileStore, SessionMutator, SessionStore, ToolContext,
+    ToolExecutor,
+};
 use crate::typed_id::{AgentId, HarnessId};
 use uuid::Uuid;
 
@@ -47,6 +50,9 @@ use uuid::Uuid;
 /// Input for ActAtom
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ActInput {
+    /// Organization ID for scoped data access.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub org_id: Option<i64>,
     /// Atom execution context
     pub context: AtomContext,
     /// Harness ID (needed for scheduling follow-up reason activity)
@@ -116,6 +122,12 @@ where
     storage_store: Option<Arc<dyn crate::traits::SessionStorageStore>>,
     /// Optional resolver for user connection tokens
     connection_resolver: Option<Arc<dyn crate::traits::UserConnectionResolver>>,
+    /// Optional session store for session metadata reads
+    session_store: Option<Arc<dyn SessionStore>>,
+    /// Optional session mutator for session metadata updates
+    session_mutator: Option<Arc<dyn SessionMutator>>,
+    /// Optional agent store for agent metadata reads
+    agent_store: Option<Arc<dyn AgentStore>>,
 }
 
 impl<T, E> ActAtom<T, E>
@@ -132,6 +144,9 @@ where
             sqldb_store: None,
             storage_store: None,
             connection_resolver: None,
+            session_store: None,
+            session_mutator: None,
+            agent_store: None,
         }
     }
 
@@ -148,6 +163,9 @@ where
             sqldb_store: None,
             storage_store: None,
             connection_resolver: None,
+            session_store: None,
+            session_mutator: None,
+            agent_store: None,
         }
     }
 
@@ -174,6 +192,24 @@ where
         self.connection_resolver = Some(resolver);
         self
     }
+
+    /// Set session store for context-aware tools.
+    pub fn with_session_store(mut self, store: Arc<dyn SessionStore>) -> Self {
+        self.session_store = Some(store);
+        self
+    }
+
+    /// Set session mutator for context-aware tools.
+    pub fn with_session_mutator(mut self, mutator: Arc<dyn SessionMutator>) -> Self {
+        self.session_mutator = Some(mutator);
+        self
+    }
+
+    /// Set agent store for context-aware tools.
+    pub fn with_agent_store(mut self, store: Arc<dyn AgentStore>) -> Self {
+        self.agent_store = Some(store);
+        self
+    }
 }
 
 #[async_trait]
@@ -194,7 +230,7 @@ where
             context,
             tool_calls,
             tool_definitions,
-            .. // agent_id not needed here, just passed through workflow
+            .. // agent_id/org_id not needed here, just passed through workflow
         } = input;
 
         if tool_calls.is_empty() {
@@ -435,6 +471,9 @@ where
             || self.sqldb_store.is_some()
             || self.storage_store.is_some()
             || self.connection_resolver.is_some()
+            || self.session_store.is_some()
+            || self.session_mutator.is_some()
+            || self.agent_store.is_some()
         {
             let mut tool_context = if let Some(ref store) = self.file_store {
                 ToolContext::with_file_store(context.session_id, store.clone())
@@ -449,6 +488,15 @@ where
             }
             if let Some(ref resolver) = self.connection_resolver {
                 tool_context.connection_resolver = Some(resolver.clone());
+            }
+            if let Some(ref store) = self.session_store {
+                tool_context.session_store = Some(store.clone());
+            }
+            if let Some(ref mutator) = self.session_mutator {
+                tool_context.session_mutator = Some(mutator.clone());
+            }
+            if let Some(ref store) = self.agent_store {
+                tool_context.agent_store = Some(store.clone());
             }
             self.tool_executor
                 .execute_with_context(&tool_call, tool_def, &tool_context)
@@ -602,6 +650,7 @@ mod tests {
 
         let context = AtomContext::new(SessionId::new(), TurnId::new(), MessageId::new());
         let input = ActInput {
+            org_id: Some(1),
             context,
             harness_id: HarnessId::from_seed(1),
             agent_id: Some(AgentId::new()),
@@ -625,6 +674,7 @@ mod tests {
 
         let context = AtomContext::new(SessionId::new(), TurnId::new(), MessageId::new());
         let input = ActInput {
+            org_id: Some(1),
             context,
             harness_id: HarnessId::from_seed(1),
             agent_id: Some(AgentId::new()),

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -78,6 +78,7 @@ pub mod mcp;
 mod noop;
 mod research;
 mod sample_data;
+mod session;
 mod session_sql_database;
 mod session_storage;
 mod stateless_todo_list;
@@ -125,6 +126,7 @@ pub use mcp::{
 pub use noop::NoopCapability;
 pub use research::ResearchCapability;
 pub use sample_data::SampleDataCapability;
+pub use session::{GetSessionInfoTool, SessionCapability, WriteSessionTitleTool};
 pub use session_sql_database::{
     SessionSqlDatabaseCapability, SqlExecuteTool, SqlQueryTool, SqlSchemaTool,
 };
@@ -321,6 +323,7 @@ impl CapabilityRegistry {
         registry.register(ResearchCapability);
         registry.register(FileSystemCapability);
         registry.register(SessionStorageCapability);
+        registry.register(SessionCapability);
         registry.register(SessionSqlDatabaseCapability);
         registry.register(TestMathCapability);
         registry.register(TestWeatherCapability);
@@ -913,6 +916,7 @@ mod tests {
         assert!(registry.has("research"));
         assert!(registry.has("session_file_system"));
         assert!(registry.has("session_storage"));
+        assert!(registry.has("session"));
         assert!(registry.has("session_sql_database"));
         assert!(registry.has("test_math"));
         assert!(registry.has("test_weather"));
@@ -924,9 +928,9 @@ mod tests {
         assert!(registry.has("fake_aws"));
         assert!(registry.has("fake_crm"));
         assert!(registry.has("fake_financial"));
-        // 17 core built-in capabilities
+        // 18 core built-in capabilities
         // (integration plugins like docker_container, codesandbox add more when linked)
-        assert!(registry.len() >= 17);
+        assert!(registry.len() >= 18);
     }
 
     #[test]
@@ -940,6 +944,7 @@ mod tests {
         assert!(registry.has("research"));
         assert!(registry.has("session_file_system"));
         assert!(registry.has("session_storage"));
+        assert!(registry.has("session"));
         assert!(registry.has("session_sql_database"));
         assert!(registry.has("test_math"));
         assert!(registry.has("test_weather"));
@@ -953,7 +958,7 @@ mod tests {
         assert!(registry.has("fake_financial"));
         // Experimental capabilities NOT included in prod
         assert!(!registry.has("docker_container"));
-        assert_eq!(registry.len(), 17);
+        assert_eq!(registry.len(), 18);
     }
 
     #[test]

--- a/crates/core/src/capabilities/session.rs
+++ b/crates/core/src/capabilities/session.rs
@@ -1,0 +1,320 @@
+//! Session Capability
+//!
+//! Provides session metadata tools:
+//! - `write_session_title`: update session title
+//! - `get_session_info`: return session id, title, and agent name (if any)
+
+use super::{Capability, CapabilityStatus};
+use crate::tools::{Tool, ToolExecutionResult};
+use crate::traits::ToolContext;
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+/// Session capability - read/update session metadata.
+pub struct SessionCapability;
+
+impl Capability for SessionCapability {
+    fn id(&self) -> &str {
+        "session"
+    }
+
+    fn name(&self) -> &str {
+        "Session"
+    }
+
+    fn description(&self) -> &str {
+        "Read and update current session metadata like title and agent info."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("panel-left")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Session")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(
+            r#"You can manage session metadata with these tools:
+
+- `write_session_title`: Set/update the current session title
+- `get_session_info`: Get session ID, title, and assigned agent name (if present)"#,
+        )
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(WriteSessionTitleTool),
+            Box::new(GetSessionInfoTool),
+        ]
+    }
+}
+
+/// Tool: write_session_title
+pub struct WriteSessionTitleTool;
+
+#[async_trait]
+impl Tool for WriteSessionTitleTool {
+    fn name(&self) -> &str {
+        "write_session_title"
+    }
+
+    fn description(&self) -> &str {
+        "Update the current session title."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "description": "New session title"
+                }
+            },
+            "required": ["title"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "write_session_title requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let title = match arguments.get("title").and_then(|v| v.as_str()) {
+            Some(t) if !t.trim().is_empty() => t.trim().to_string(),
+            _ => return ToolExecutionResult::tool_error("Missing required parameter: title"),
+        };
+
+        let Some(mutator) = &context.session_mutator else {
+            return ToolExecutionResult::tool_error(
+                "Session mutator not available in this context",
+            );
+        };
+
+        match mutator
+            .update_session_title(context.session_id, title.clone())
+            .await
+        {
+            Ok(session) => ToolExecutionResult::success(json!({
+                "session_id": session.id.to_string(),
+                "title": session.title,
+                "updated": true,
+            })),
+            Err(e) => ToolExecutionResult::internal_error(e),
+        }
+    }
+}
+
+/// Tool: get_session_info
+pub struct GetSessionInfoTool;
+
+#[async_trait]
+impl Tool for GetSessionInfoTool {
+    fn name(&self) -> &str {
+        "get_session_info"
+    }
+
+    fn description(&self) -> &str {
+        "Get current session metadata: id, title, and agent name (if assigned)."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "get_session_info requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        _arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let Some(session_store) = &context.session_store else {
+            return ToolExecutionResult::tool_error("Session store not available in this context");
+        };
+
+        let session = match session_store.get_session(context.session_id).await {
+            Ok(Some(session)) => session,
+            Ok(None) => return ToolExecutionResult::tool_error("Session not found"),
+            Err(e) => return ToolExecutionResult::internal_error(e),
+        };
+
+        let agent_name =
+            if let (Some(agent_id), Some(agent_store)) = (session.agent_id, &context.agent_store) {
+                match agent_store.get_agent(agent_id).await {
+                    Ok(Some(agent)) => Some(agent.name),
+                    Ok(None) => None,
+                    Err(e) => return ToolExecutionResult::internal_error(e),
+                }
+            } else {
+                None
+            };
+
+        ToolExecutionResult::success(json!({
+            "session_id": session.id.to_string(),
+            "title": session.title,
+            "agent_name": agent_name,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::{Agent, AgentStatus};
+    use crate::error::Result;
+    use crate::session::{Session, SessionStatus};
+    use crate::typed_id::{AgentId, HarnessId, ModelId, SessionId};
+    use crate::{AgentCapabilityConfig, Tool};
+    use async_trait::async_trait;
+    use chrono::Utc;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone)]
+    struct MockSessionStore {
+        session: Arc<Mutex<Option<Session>>>,
+    }
+
+    #[async_trait]
+    impl crate::traits::SessionStore for MockSessionStore {
+        async fn get_session(&self, _session_id: SessionId) -> Result<Option<Session>> {
+            Ok(self.session.lock().expect("poisoned").clone())
+        }
+    }
+
+    #[derive(Clone)]
+    struct MockSessionMutator {
+        session: Arc<Mutex<Session>>,
+    }
+
+    #[async_trait]
+    impl crate::traits::SessionMutator for MockSessionMutator {
+        async fn update_session_title(
+            &self,
+            _session_id: SessionId,
+            title: String,
+        ) -> Result<Session> {
+            let mut session = self.session.lock().expect("poisoned");
+            session.title = Some(title);
+            Ok(session.clone())
+        }
+    }
+
+    struct MockAgentStore {
+        agent: Option<Agent>,
+    }
+
+    #[async_trait]
+    impl crate::traits::AgentStore for MockAgentStore {
+        async fn get_agent(&self, _agent_id: AgentId) -> Result<Option<Agent>> {
+            Ok(self.agent.clone())
+        }
+    }
+
+    fn build_session(agent_id: Option<AgentId>) -> Session {
+        Session {
+            id: SessionId::new(),
+            organization_id: "org_00000000000000000000000000000001".to_string(),
+            harness_id: HarnessId::new(),
+            agent_id,
+            title: Some("Old title".to_string()),
+            preview: None,
+            output_preview: None,
+            tags: vec![],
+            model_id: Some(ModelId::new()),
+            capabilities: vec![],
+            tools: vec![],
+            status: SessionStatus::Idle,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            started_at: None,
+            finished_at: None,
+            usage: None,
+            is_pinned: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn write_session_title_updates_title() {
+        let session = build_session(None);
+        let session_id = session.id;
+        let mut context = ToolContext::new(session_id);
+        context.session_mutator = Some(Arc::new(MockSessionMutator {
+            session: Arc::new(Mutex::new(session)),
+        }));
+
+        let tool = WriteSessionTitleTool;
+        let result = tool
+            .execute_with_context(json!({"title": "New title"}), &context)
+            .await;
+
+        match result {
+            ToolExecutionResult::Success(value) => {
+                assert_eq!(value["title"], "New title");
+                assert_eq!(value["updated"], true);
+            }
+            _ => panic!("expected success"),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_session_info_returns_agent_name_when_assigned() {
+        let agent_id = AgentId::new();
+        let session = build_session(Some(agent_id));
+        let session_id = session.id;
+
+        let agent = Agent {
+            public_id: agent_id,
+            internal_id: agent_id.uuid(),
+            name: "Research Agent".to_string(),
+            description: Some("desc".to_string()),
+            system_prompt: "prompt".to_string(),
+            default_model_id: None,
+            tags: vec![],
+            capabilities: vec![AgentCapabilityConfig::new("session")],
+            tools: vec![],
+            status: AgentStatus::Active,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            usage: None,
+        };
+
+        let context = ToolContext::new(session_id)
+            .with_session_store(Arc::new(MockSessionStore {
+                session: Arc::new(Mutex::new(Some(session))),
+            }))
+            .with_agent_store(Arc::new(MockAgentStore { agent: Some(agent) }));
+
+        let tool = GetSessionInfoTool;
+        let result = tool.execute_with_context(json!({}), &context).await;
+
+        match result {
+            ToolExecutionResult::Success(value) => {
+                assert_eq!(value["title"], "Old title");
+                assert_eq!(value["agent_name"], "Research Agent");
+            }
+            _ => panic!("expected success"),
+        }
+    }
+}

--- a/crates/core/src/in_memory_loop.rs
+++ b/crates/core/src/in_memory_loop.rs
@@ -651,6 +651,7 @@ impl InMemoryAgenticLoop {
                     );
                     self.act_atom
                         .execute(ActInput {
+                            org_id: Some(0),
                             context: base_context.next_exec(),
                             harness_id: self.harness_id,
                             agent_id: Some(self.agent_id),

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -97,8 +97,9 @@ pub use message_retriever::{InputMessage, MessageRetriever};
 pub use runtime_agent::{RuntimeAgent, RuntimeAgentBuilder};
 pub use traits::{
     EventEmitter, HarnessStore, ImageResolver, KeyInfo, LlmProviderStore, ModelWithProvider,
-    NoopEventEmitter, ResolvedImage, SecretInfo, SessionFileStore, SessionSqlDbStoreRef,
-    SessionStorageStore, SessionStore, ToolContext, ToolExecutor, UserConnectionResolver,
+    NoopEventEmitter, ResolvedImage, SecretInfo, SessionFileStore, SessionMutator,
+    SessionSqlDbStoreRef, SessionStorageStore, SessionStore, ToolContext, ToolExecutor,
+    UserConnectionResolver,
 };
 
 // Event listener re-exports
@@ -137,15 +138,15 @@ pub use capabilities::{
     AddTool, AgentCapabilityConfig, AppliedCapabilities, Capability, CapabilityId,
     CapabilityRegistry, CapabilityRegistryBuilder, CapabilityStatus, CollectedCapabilities,
     CurrentTimeCapability, DeleteFileTool, DependencyError, DivideTool, FileSystemCapability,
-    GetCurrentTimeTool, GetForecastTool, GetWeatherTool, GrepFilesTool, IntegrationPlugin,
-    ListDirectoryTool, MAX_RESOLVED_CAPABILITIES, MCP_CAPABILITY_PREFIX, McpCapability,
-    MountAccess, MountDirectoryBuilder, MountEntry, MountPoint, MountSource, MultiplyTool,
-    NoopCapability, ReadFileTool, ResearchCapability, ResolvedCapabilities, SampleDataCapability,
-    SessionSqlDatabaseCapability, SqlExecuteTool, SqlQueryTool, SqlSchemaTool, StatFileTool,
-    StatelessTodoListCapability, SubtractTool, TestMathCapability, TestWeatherCapability,
-    WriteFileTool, WriteTodosTool, apply_capabilities, collect_capabilities_with_configs,
-    get_dependencies, is_mcp_capability, mcp_capability_id, parse_mcp_capability_id,
-    resolve_dependencies,
+    GetCurrentTimeTool, GetForecastTool, GetSessionInfoTool, GetWeatherTool, GrepFilesTool,
+    IntegrationPlugin, ListDirectoryTool, MAX_RESOLVED_CAPABILITIES, MCP_CAPABILITY_PREFIX,
+    McpCapability, MountAccess, MountDirectoryBuilder, MountEntry, MountPoint, MountSource,
+    MultiplyTool, NoopCapability, ReadFileTool, ResearchCapability, ResolvedCapabilities,
+    SampleDataCapability, SessionCapability, SessionSqlDatabaseCapability, SqlExecuteTool,
+    SqlQueryTool, SqlSchemaTool, StatFileTool, StatelessTodoListCapability, SubtractTool,
+    TestMathCapability, TestWeatherCapability, WriteFileTool, WriteSessionTitleTool,
+    WriteTodosTool, apply_capabilities, collect_capabilities_with_configs, get_dependencies,
+    is_mcp_capability, mcp_capability_id, parse_mcp_capability_id, resolve_dependencies,
 };
 
 // Atoms re-exports (stateless atomic operations)

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -71,6 +71,13 @@ pub trait SessionStore: Send + Sync {
     async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>>;
 }
 
+/// Trait for updating mutable session metadata.
+#[async_trait]
+pub trait SessionMutator: Send + Sync {
+    /// Update a session's human-readable title.
+    async fn update_session_title(&self, session_id: SessionId, title: String) -> Result<Session>;
+}
+
 // ============================================================================
 // LlmProviderStore - For retrieving LLM provider configurations
 // ============================================================================
@@ -352,6 +359,15 @@ pub struct ToolContext {
     /// Optional message retriever for tools that need conversation history access
     pub message_retriever: Option<Arc<dyn crate::message_retriever::MessageRetriever>>,
 
+    /// Optional session store for tools that need session metadata access.
+    pub session_store: Option<Arc<dyn SessionStore>>,
+
+    /// Optional session mutator for tools that need to update session metadata.
+    pub session_mutator: Option<Arc<dyn SessionMutator>>,
+
+    /// Optional agent store for tools that need agent metadata access.
+    pub agent_store: Option<Arc<dyn AgentStore>>,
+
     /// Optional resolver for user connection tokens (lazy GitHub token lookup, etc.)
     pub connection_resolver: Option<Arc<dyn UserConnectionResolver>>,
 }
@@ -365,6 +381,9 @@ impl ToolContext {
             storage_store: None,
             sqldb_store: None,
             message_retriever: None,
+            session_store: None,
+            session_mutator: None,
+            agent_store: None,
             connection_resolver: None,
         }
     }
@@ -377,6 +396,9 @@ impl ToolContext {
             storage_store: None,
             sqldb_store: None,
             message_retriever: None,
+            session_store: None,
+            session_mutator: None,
+            agent_store: None,
             connection_resolver: None,
         }
     }
@@ -392,6 +414,9 @@ impl ToolContext {
             storage_store: Some(storage_store),
             sqldb_store: None,
             message_retriever: None,
+            session_store: None,
+            session_mutator: None,
+            agent_store: None,
             connection_resolver: None,
         }
     }
@@ -408,6 +433,9 @@ impl ToolContext {
             storage_store: Some(storage_store),
             sqldb_store: None,
             message_retriever: None,
+            session_store: None,
+            session_mutator: None,
+            agent_store: None,
             connection_resolver: None,
         }
     }
@@ -427,6 +455,24 @@ impl ToolContext {
         self
     }
 
+    /// Add a session store to this context.
+    pub fn with_session_store(mut self, store: Arc<dyn SessionStore>) -> Self {
+        self.session_store = Some(store);
+        self
+    }
+
+    /// Add a session mutator to this context.
+    pub fn with_session_mutator(mut self, mutator: Arc<dyn SessionMutator>) -> Self {
+        self.session_mutator = Some(mutator);
+        self
+    }
+
+    /// Add an agent store to this context.
+    pub fn with_agent_store(mut self, store: Arc<dyn AgentStore>) -> Self {
+        self.agent_store = Some(store);
+        self
+    }
+
     /// Add a connection resolver to this context
     pub fn with_connection_resolver(mut self, resolver: Arc<dyn UserConnectionResolver>) -> Self {
         self.connection_resolver = Some(resolver);
@@ -442,6 +488,9 @@ impl std::fmt::Debug for ToolContext {
             .field("storage_store", &self.storage_store.is_some())
             .field("sqldb_store", &self.sqldb_store.is_some())
             .field("message_retriever", &self.message_retriever.is_some())
+            .field("session_store", &self.session_store.is_some())
+            .field("session_mutator", &self.session_mutator.is_some())
+            .field("agent_store", &self.agent_store.is_some())
             .field("connection_resolver", &self.connection_resolver.is_some())
             .finish()
     }

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -32,6 +32,7 @@ service WorkerService {
     // Session operations
     rpc GetSession(GetSessionRequest) returns (GetSessionResponse);
     rpc SetSessionStatus(SetSessionStatusRequest) returns (SetSessionStatusResponse);
+    rpc SetSessionTitle(SetSessionTitleRequest) returns (SetSessionTitleResponse);
 
     // Message operations
     rpc LoadMessages(LoadMessagesRequest) returns (LoadMessagesResponse);
@@ -290,6 +291,17 @@ message SetSessionStatusRequest {
 }
 
 message SetSessionStatusResponse {
+    Session session = 1;
+}
+
+message SetSessionTitleRequest {
+    Uuid session_id = 1;
+    string title = 2;
+    // Organization ID for resource validation
+    int64 org_id = 3;
+}
+
+message SetSessionTitleResponse {
     Session session = 1;
 }
 

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -286,6 +286,31 @@ impl WorkerAdapters for DirectWorkerAdapters {
             .ok_or_else(|| store_error("Session not found after update"))
     }
 
+    async fn set_session_title(
+        &self,
+        org_id: i64,
+        session_id: Uuid,
+        title: String,
+    ) -> Result<Session> {
+        let session_id_typed = SessionId::from_uuid(session_id);
+        let update = UpdateSession {
+            title: Some(title),
+            ..Default::default()
+        };
+
+        self.db
+            .update_session(org_id, session_id_typed, update)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to update session title: {}", e);
+                store_error("Failed to update session title")
+            })?;
+
+        self.get_session(org_id, session_id)
+            .await?
+            .ok_or_else(|| store_error("Session not found after update"))
+    }
+
     // =========================================================================
     // Message Operations
     // =========================================================================

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -52,9 +52,9 @@ use everruns_internal_protocol::proto::{
     SessionStorageListSecretsRequest, SessionStorageListSecretsResponse,
     SessionStorageSetSecretRequest, SessionStorageSetSecretResponse, SessionStorageSetValueRequest,
     SessionStorageSetValueResponse, SessionWriteFileRequest, SessionWriteFileResponse,
-    SetSessionStatusRequest, SetSessionStatusResponse, SubscribeTaskNotificationsRequest,
-    TaskNotification, TaskNotificationType, UpdateDurableWorkflowStatusRequest,
-    UpdateDurableWorkflowStatusResponse,
+    SetSessionStatusRequest, SetSessionStatusResponse, SetSessionTitleRequest,
+    SetSessionTitleResponse, SubscribeTaskNotificationsRequest, TaskNotification,
+    TaskNotificationType, UpdateDurableWorkflowStatusRequest, UpdateDurableWorkflowStatusResponse,
 };
 use everruns_internal_protocol::{
     WorkerService, WorkerServiceServer, proto_event_request_to_schema, schema_agent_to_proto,
@@ -719,6 +719,56 @@ impl WorkerService for WorkerServiceImpl {
         };
 
         Ok(Response::new(SetSessionStatusResponse {
+            session: Some(proto_session),
+        }))
+    }
+
+    async fn set_session_title(
+        &self,
+        request: Request<SetSessionTitleRequest>,
+    ) -> Result<Response<SetSessionTitleResponse>, Status> {
+        use everruns_internal_protocol::{datetime_to_proto_timestamp, uuid_to_proto_uuid};
+
+        let req = request.into_inner();
+        let session_id = parse_uuid(req.session_id.as_ref())?;
+        let org_public_id = self.get_org_public_id(req.org_id).await?;
+
+        let session = self
+            .session_service
+            .update(
+                req.org_id,
+                &org_public_id,
+                session_id,
+                crate::api::sessions::UpdateSessionRequest {
+                    title: Some(req.title),
+                    tags: None,
+                },
+            )
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to update session title: {}", e);
+                Status::internal("Failed to update session title")
+            })?
+            .ok_or_else(|| Status::not_found("Session not found"))?;
+
+        let proto_session = proto::Session {
+            id: Some(uuid_to_proto_uuid(session.id.uuid())),
+            agent_id: session.agent_id.map(|id| uuid_to_proto_uuid(id.uuid())),
+            harness_id: Some(uuid_to_proto_uuid(session.harness_id.uuid())),
+            title: session.title.clone().unwrap_or_default(),
+            status: session.status.to_string(),
+            created_at: Some(datetime_to_proto_timestamp(session.created_at)),
+            updated_at: Some(datetime_to_proto_timestamp(session.updated_at)),
+            default_model_id: session.model_id.map(|id| uuid_to_proto_uuid(id.uuid())),
+            organization_id: session.organization_id.clone(),
+            capabilities: session
+                .capabilities
+                .iter()
+                .filter_map(|c| serde_json::to_string(c).ok())
+                .collect(),
+        };
+
+        Ok(Response::new(SetSessionTitleResponse {
             session: Some(proto_session),
         }))
     }

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -416,6 +416,7 @@ mod tests {
         let context = AtomContext::new(SessionId::new(), TurnId::new(), MessageId::new());
 
         let input = ActInput {
+            org_id: Some(1),
             context: context.clone(),
             agent_id: Some(AgentId::new()),
             harness_id: HarnessId::new(),

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -1026,6 +1026,7 @@ impl DurableWorker {
                     let act_task_input = ActTaskInput {
                         org_id: input.org_id,
                         act_input: ActInput {
+                            org_id: Some(input.org_id),
                             context: AtomContext {
                                 session_id: input.session_id,
                                 turn_id,

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -109,6 +109,33 @@ impl GrpcClient {
         proto_session_to_session(proto_session)
     }
 
+    /// Set session title.
+    pub async fn set_session_title(
+        &self,
+        org_id: i64,
+        session_id: SessionId,
+        title: &str,
+    ) -> Result<Session> {
+        let request = proto::SetSessionTitleRequest {
+            session_id: Some(uuid_to_proto(session_id.uuid())),
+            title: title.to_string(),
+            org_id,
+        };
+
+        let mut client = self.inner.lock().await;
+        let response = client
+            .set_session_title(request)
+            .await
+            .map_err(|e| grpc_error(format!("Failed to set session title: {}", e)))?;
+
+        let proto_session = response
+            .into_inner()
+            .session
+            .ok_or_else(|| grpc_error("No session in response"))?;
+
+        proto_session_to_session(proto_session)
+    }
+
     /// Get MCP server info by name prefix (for MCP tool execution)
     pub async fn get_mcp_server_by_prefix(
         &self,

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -90,6 +90,17 @@ impl WorkerAdapters for GrpcWorkerAdapters {
             .await
     }
 
+    async fn set_session_title(
+        &self,
+        org_id: i64,
+        session_id: Uuid,
+        title: String,
+    ) -> Result<Session> {
+        self.client
+            .set_session_title(org_id, SessionId::from_uuid(session_id), &title)
+            .await
+    }
+
     // =========================================================================
     // Message Operations
     // =========================================================================

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -31,8 +31,8 @@ use uuid::Uuid;
 use crate::durable_runner::DurableTurnInput;
 use crate::worker_adapters::{
     AdapterAgentStore, AdapterEventEmitter, AdapterHarnessStore, AdapterImageResolver,
-    AdapterLlmProviderStore, AdapterMessageRetriever, AdapterSessionFileStore, AdapterSessionStore,
-    WorkerAdapters,
+    AdapterLlmProviderStore, AdapterMessageRetriever, AdapterSessionFileStore,
+    AdapterSessionMutator, AdapterSessionStore, WorkerAdapters,
 };
 
 // Re-export atom types
@@ -768,8 +768,15 @@ async fn execute_act_activity<A: WorkerAdapters>(
 
     let event_emitter = AdapterEventEmitter::new(adapters.clone());
     let file_store = Arc::new(AdapterSessionFileStore::new(adapters.clone()));
+    let org_id = input.org_id.unwrap_or(1);
+    let session_store = Arc::new(AdapterSessionStore::new(adapters.clone(), org_id));
+    let session_mutator = Arc::new(AdapterSessionMutator::new(adapters.clone(), org_id));
+    let agent_store = Arc::new(AdapterAgentStore::new(adapters.clone(), org_id));
 
-    let mut atom = ActAtom::with_file_store(tool_registry, event_emitter, file_store);
+    let mut atom = ActAtom::with_file_store(tool_registry, event_emitter, file_store)
+        .with_session_store(session_store)
+        .with_session_mutator(session_mutator)
+        .with_agent_store(agent_store);
     if let Some(sqldb_store) = adapters.sqldb_store() {
         atom = atom.with_sqldb_store(sqldb_store);
     }
@@ -869,6 +876,7 @@ async fn schedule_next_activity<S: WorkflowEventStore>(
                     // Schedule act activity for server-side tools
                     // Client-side tools will be handled after act completes
                     let act_input = ActInput {
+                        org_id: Some(input.org_id),
                         context: AtomContext {
                             session_id: input.session_id,
                             turn_id,

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -58,6 +58,18 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
         status: &str,
     ) -> Result<Session>;
 
+    /// Set a session title.
+    async fn set_session_title(
+        &self,
+        _org_id: i64,
+        _session_id: Uuid,
+        _title: String,
+    ) -> Result<Session> {
+        Err(everruns_core::AgentLoopError::store(
+            "set_session_title not supported by this adapter",
+        ))
+    }
+
     // =========================================================================
     // Message Operations
     // =========================================================================
@@ -263,6 +275,27 @@ impl<A: WorkerAdapters> everruns_core::traits::HarnessStore for AdapterHarnessSt
 pub struct AdapterSessionStore<A: WorkerAdapters> {
     adapters: A,
     org_id: i64,
+}
+
+/// Adapter-based SessionMutator implementation.
+pub struct AdapterSessionMutator<A: WorkerAdapters> {
+    adapters: A,
+    org_id: i64,
+}
+
+impl<A: WorkerAdapters> AdapterSessionMutator<A> {
+    pub fn new(adapters: A, org_id: i64) -> Self {
+        Self { adapters, org_id }
+    }
+}
+
+#[async_trait]
+impl<A: WorkerAdapters> everruns_core::traits::SessionMutator for AdapterSessionMutator<A> {
+    async fn update_session_title(&self, session_id: SessionId, title: String) -> Result<Session> {
+        self.adapters
+            .set_session_title(self.org_id, session_id.uuid(), title)
+            .await
+    }
 }
 
 impl<A: WorkerAdapters> AdapterSessionStore<A> {

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -127,6 +127,7 @@ Capability IDs are string-based for extensibility. New capabilities can be added
 | `session_file_system` | File System | File Operations | Available |
 | `virtual_bash` | Virtual Bash | Execution | Available |
 | `session_storage` | Session Storage | Storage | Available |
+| `session` | Session | Session | Available |
 | `web_fetch` | Web Fetch | Network | Available |
 | `stateless_todo_list` | Task Management | Productivity | Available |
 | `sample_data` | Sample Data | Data | Available |


### PR DESCRIPTION
## What
- Add `session` capability with `write_session_title` and `get_session_info`.
- Wire session store/mutator + agent store into tool context and act execution.
- Add internal gRPC `SetSessionTitle` flow (proto, server handler, worker adapters).
- Update capability spec table and AGENTS cloud gh workflow docs.

## Why
- Let agents read/update session metadata during tool execution across direct + gRPC worker paths.

## How
- Core capability + tests in `crates/core/src/capabilities/session.rs`.
- Context/traits updates in `crates/core/src/traits.rs` and `crates/core/src/atoms/act.rs`.
- Worker/server/proto plumbing across `crates/worker`, `crates/server`, `crates/internal-protocol`.
- Docs updates in `specs/capabilities.md` and `AGENTS.md`.

## Risk
- Medium: touches tool execution context and worker protocol surfaces.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
