### PR TITLE
feat(sessions): add per-user session pinning

### DIFF
--- a/apps/ui/src/app/(main)/sessions/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/page.tsx
@@ -1,7 +1,15 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { useAgents, useHarnesses, useSessions, useCreateSession, useLlmModels } from "@/hooks";
+import {
+  useAgents,
+  useHarnesses,
+  useSessions,
+  useCreateSession,
+  useLlmModels,
+  usePinSession,
+  useUnpinSession,
+} from "@/hooks";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -41,8 +49,18 @@ export default function SessionsPage() {
   );
   const { data: llmModels } = useLlmModels();
   const createSession = useCreateSession();
+  const pinSessionMutation = usePinSession();
+  const unpinSessionMutation = useUnpinSession();
 
-  const sessions = sessionsResponse?.data ?? [];
+  // Sort pinned sessions first, preserving server order within each group
+  const sessions = useMemo(() => {
+    const data = sessionsResponse?.data ?? [];
+    return [...data].sort((a, b) => {
+      const aPinned = a.is_pinned === true ? 1 : 0;
+      const bPinned = b.is_pinned === true ? 1 : 0;
+      return bPinned - aPinned;
+    });
+  }, [sessionsResponse?.data]);
   const totalSessions = sessionsResponse?.total ?? 0;
   const totalPages = Math.ceil(totalSessions / PAGE_SIZE);
 
@@ -99,6 +117,14 @@ export default function SessionsPage() {
     setPage(0); // Reset pagination when filter changes
   };
 
+  const handleTogglePin = (sessionId: string, pinned: boolean) => {
+    if (pinned) {
+      pinSessionMutation.mutate({ sessionId });
+    } else {
+      unpinSessionMutation.mutate({ sessionId });
+    }
+  };
+
   return (
     <div className="container mx-auto p-6">
       <div className="flex items-center justify-between mb-6">
@@ -142,6 +168,7 @@ export default function SessionsPage() {
                     session={session}
                     agentName={agent?.name}
                     model={session.model_id ? modelMap.get(session.model_id) : undefined}
+                    onTogglePin={handleTogglePin}
                   />
                 );
               })}

--- a/apps/ui/src/components/session/session-card.tsx
+++ b/apps/ui/src/components/session/session-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { Info, MessageSquare, Loader2, Zap } from "lucide-react";
+import { Info, MessageSquare, Loader2, Zap, Pin, PinOff } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { ProviderIcon } from "@/components/providers/provider-icon";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
@@ -29,6 +29,8 @@ export interface SessionCardProps {
   summary?: string;
   /** Whether to show the delete button (if provided with onDelete) */
   onDelete?: (sessionId: string, sessionTitle: string) => void;
+  /** Callback to toggle pin state */
+  onTogglePin?: (sessionId: string, pinned: boolean) => void;
 }
 
 /**
@@ -118,7 +120,7 @@ function SessionInfoIcon({ session }: { session: Session }) {
  * SessionCard displays a session with status, summary, and metadata.
  * Designed for use in session lists and overview pages.
  */
-export function SessionCard({ session, agentName, model, summary }: SessionCardProps) {
+export function SessionCard({ session, agentName, model, summary, onTogglePin }: SessionCardProps) {
   const statusInfo = getStatusInfo(session.status);
   const displayTitle = session.title || `Session ${shortenId(session.id)}`;
   // Show preview from session (first user message), explicit summary prop, or nothing
@@ -127,6 +129,7 @@ export function SessionCard({ session, agentName, model, summary }: SessionCardP
   const outputPreview = session.output_preview;
   // Sessions are org-level entities
   const sessionUrl = `/sessions/${session.id}`;
+  const isPinned = session.is_pinned === true;
 
   return (
     <Link
@@ -184,6 +187,26 @@ export function SessionCard({ session, agentName, model, summary }: SessionCardP
             <ProviderIcon providerType={model.provider_type} size="sm" showBackground={false} />
             {model.display_name}
           </Badge>
+        )}
+        {onTogglePin && (
+          <Tooltip>
+            <TooltipTrigger
+              className={cn(
+                "p-0.5 rounded transition-colors flex-shrink-0",
+                isPinned
+                  ? "text-primary hover:text-primary/80 hover:bg-muted/80"
+                  : "text-muted-foreground/50 hover:text-muted-foreground hover:bg-muted/80",
+              )}
+              aria-label={isPinned ? "Unpin session" : "Pin session"}
+              onClick={(e) => {
+                e.preventDefault();
+                onTogglePin(session.id, !isPinned);
+              }}
+            >
+              {isPinned ? <PinOff className="w-3.5 h-3.5" /> : <Pin className="w-3.5 h-3.5" />}
+            </TooltipTrigger>
+            <TooltipContent>{isPinned ? "Unpin session" : "Pin session"}</TooltipContent>
+          </Tooltip>
         )}
         <SessionInfoIcon session={session} />
       </div>

--- a/apps/ui/src/hooks/use-sessions.ts
+++ b/apps/ui/src/hooks/use-sessions.ts
@@ -10,6 +10,8 @@ import {
   listSessions,
   updateSession,
   sendUserMessage,
+  pinSession,
+  unpinSession,
 } from "@/lib/api/sessions";
 import { getSseUrl, listEvents } from "@/lib/api/events";
 import { queryKeys } from "@/lib/query-keys";
@@ -106,6 +108,38 @@ export function useDeleteSession() {
     mutationFn: ({ sessionId }: { sessionId: string }) => deleteSession(sessionId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.sessions.all() });
+    },
+  });
+}
+
+export function usePinSession() {
+  const queryClient = useQueryClient();
+  const { currentOrg } = useOrg();
+  const org = currentOrg?.public_id;
+
+  return useMutation({
+    mutationFn: ({ sessionId }: { sessionId: string }) => pinSession(sessionId),
+    onSuccess: (_, { sessionId }) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.sessions.all() });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.sessions.detail(org, sessionId),
+      });
+    },
+  });
+}
+
+export function useUnpinSession() {
+  const queryClient = useQueryClient();
+  const { currentOrg } = useOrg();
+  const org = currentOrg?.public_id;
+
+  return useMutation({
+    mutationFn: ({ sessionId }: { sessionId: string }) => unpinSession(sessionId),
+    onSuccess: (_, { sessionId }) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.sessions.all() });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.sessions.detail(org, sessionId),
+      });
     },
   });
 }

--- a/apps/ui/src/lib/api/sessions.ts
+++ b/apps/ui/src/lib/api/sessions.ts
@@ -81,3 +81,17 @@ export async function deleteSession(sessionId: string): Promise<void> {
 export async function cancelTurn(sessionId: string): Promise<void> {
   await api.post(`/v1/sessions/${sessionId}/cancel`);
 }
+
+// ============================================
+// Session Pinning
+// ============================================
+
+/** Pin a session for the current user */
+export async function pinSession(sessionId: string): Promise<void> {
+  await api.put(`/v1/sessions/${sessionId}/pin`);
+}
+
+/** Unpin a session for the current user */
+export async function unpinSession(sessionId: string): Promise<void> {
+  await api.delete(`/v1/sessions/${sessionId}/pin`);
+}

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -157,6 +157,8 @@ export interface Session {
   finished_at: string | null;
   /** Cumulative token usage for all LLM calls in this session */
   usage?: TokenUsage;
+  /** Whether this session is pinned by the current user */
+  is_pinned?: boolean;
 }
 
 export interface CreateSessionRequest {

--- a/crates/core/examples/turn_based_execution.rs
+++ b/crates/core/examples/turn_based_execution.rs
@@ -164,6 +164,7 @@ async fn main() -> anyhow::Result<()> {
         started_at: None,
         finished_at: None,
         usage: None,
+        is_pinned: None,
     };
     session_store.add_session(session).await;
 

--- a/crates/core/src/in_memory_loop.rs
+++ b/crates/core/src/in_memory_loop.rs
@@ -380,6 +380,7 @@ impl InMemoryAgenticLoopBuilder {
             started_at: None,
             finished_at: None,
             usage: None,
+            is_pinned: None,
         };
         session_store.add_session(session).await;
 

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -114,4 +114,8 @@ pub struct Session {
     /// Cumulative token usage for all LLM calls in this session.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub usage: Option<TokenUsage>,
+    /// Whether this session is pinned by the current user.
+    /// Only populated when the request has an authenticated user context.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_pinned: Option<bool>,
 }

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -98,6 +98,7 @@ async fn setup_test_environment() -> (
         started_at: None,
         finished_at: None,
         usage: None,
+        is_pinned: None,
     };
     session_store.add_session(session).await;
 
@@ -406,6 +407,7 @@ async fn test_reason_atom_with_different_configs() {
         started_at: None,
         finished_at: None,
         usage: None,
+        is_pinned: None,
     };
     session_store.add_session(session2).await;
     message_retriever

--- a/crates/server/migrations/007_pinned_sessions.sql
+++ b/crates/server/migrations/007_pinned_sessions.sql
@@ -1,0 +1,13 @@
+-- Per-user pinned sessions
+-- Users can pin sessions for quick access. Pins are scoped per-user per-org.
+
+CREATE TABLE pinned_sessions (
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    session_id UUID NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    org_id BIGINT NOT NULL REFERENCES organizations(org_id) ON DELETE CASCADE,
+    pinned_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (user_id, session_id)
+);
+
+-- Index for listing a user's pinned sessions in an org
+CREATE INDEX idx_pinned_sessions_user_org ON pinned_sessions(user_id, org_id);

--- a/crates/server/src/api/events.rs
+++ b/crates/server/src/api/events.rs
@@ -177,7 +177,7 @@ pub async fn stream_sse(
     // Verify session exists
     let _session = state
         .session_service
-        .get(org.org_id, &org.public_id, session_id.uuid())
+        .get(org.org_id, &org.public_id, session_id.uuid(), None)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get session: {}", e);
@@ -497,7 +497,7 @@ pub async fn list_events(
     // Verify session exists
     let _session = state
         .session_service
-        .get(org.org_id, &org.public_id, session_id.uuid())
+        .get(org.org_id, &org.public_id, session_id.uuid(), None)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get session: {}", e);

--- a/crates/server/src/api/messages.rs
+++ b/crates/server/src/api/messages.rs
@@ -219,7 +219,7 @@ pub async fn create_message(
     // Get session to retrieve agent_id
     let session = state
         .session_service
-        .get(org.org_id, &org.public_id, session_id.uuid())
+        .get(org.org_id, &org.public_id, session_id.uuid(), None)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get session: {}", e);
@@ -315,7 +315,7 @@ pub async fn list_messages(
     // Verify session exists
     let _session = state
         .session_service
-        .get(org.org_id, &org.public_id, session_id.uuid())
+        .get(org.org_id, &org.public_id, session_id.uuid(), None)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get session: {}", e);

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -147,6 +147,11 @@ pub fn routes(state: AppState) -> Router {
                 .patch(update_session)
                 .delete(delete_session),
         )
+        // Pin/unpin
+        .route(
+            "/v1/sessions/{session_id}/pin",
+            axum::routing::put(pin_session).delete(unpin_session),
+        )
         // Cancel turn endpoint
         .route("/v1/sessions/{session_id}/cancel", post(cancel_turn))
         .with_state(state)
@@ -238,7 +243,13 @@ pub async fn list_sessions(
 
     let (sessions, total) = state
         .session_service
-        .list(org.org_id, &org.public_id, agent_internal_id, pagination)
+        .list(
+            org.org_id,
+            &org.public_id,
+            agent_internal_id,
+            org.user_id,
+            pagination,
+        )
         .await
         .log_internal_error_json("list sessions")?;
 
@@ -276,7 +287,7 @@ pub async fn get_session(
 
     let session = state
         .session_service
-        .get(org.org_id, &org.public_id, session_id.uuid())
+        .get(org.org_id, &org.public_id, session_id.uuid(), org.user_id)
         .await
         .log_internal_error_json("get session")?
         .ok_or_not_found_json("Session")?;
@@ -372,6 +383,108 @@ pub async fn delete_session(
     }
 }
 
+/// PUT /v1/sessions/{session_id}/pin - Pin session for current user
+#[utoipa::path(
+    put,
+    path = "/v1/sessions/{session_id}/pin",
+    params(
+        ("session_id" = String, Path, description = "Session ID (prefixed, e.g., session_...)")
+    ),
+    responses(
+        (status = 204, description = "Session pinned successfully"),
+        (status = 400, description = "Invalid session ID"),
+        (status = 401, description = "Authentication required"),
+        (status = 404, description = "Session not found"),
+        (status = 500, description = "Internal server error")
+    ),
+    tag = "sessions"
+)]
+pub async fn pin_session(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let user_id = org.user_id.ok_or_else(|| {
+        (
+            StatusCode::UNAUTHORIZED,
+            Json(ErrorResponse {
+                error: "Authentication required to pin sessions".to_string(),
+            }),
+        )
+    })?;
+    let session_id: SessionId = session_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid session ID: {}", e),
+            }),
+        )
+    })?;
+
+    // Verify session exists in this org
+    state
+        .session_service
+        .get(org.org_id, &org.public_id, session_id.uuid(), None)
+        .await
+        .log_internal_error_json("get session for pin")?
+        .ok_or_not_found_json("Session")?;
+
+    state
+        .session_service
+        .pin(user_id, session_id.uuid(), org.org_id)
+        .await
+        .log_internal_error_json("pin session")?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// DELETE /v1/sessions/{session_id}/pin - Unpin session for current user
+#[utoipa::path(
+    delete,
+    path = "/v1/sessions/{session_id}/pin",
+    params(
+        ("session_id" = String, Path, description = "Session ID (prefixed, e.g., session_...)")
+    ),
+    responses(
+        (status = 204, description = "Session unpinned successfully"),
+        (status = 400, description = "Invalid session ID"),
+        (status = 401, description = "Authentication required"),
+        (status = 404, description = "Session not found"),
+        (status = 500, description = "Internal server error")
+    ),
+    tag = "sessions"
+)]
+pub async fn unpin_session(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let user_id = org.user_id.ok_or_else(|| {
+        (
+            StatusCode::UNAUTHORIZED,
+            Json(ErrorResponse {
+                error: "Authentication required to unpin sessions".to_string(),
+            }),
+        )
+    })?;
+    let session_id: SessionId = session_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid session ID: {}", e),
+            }),
+        )
+    })?;
+
+    state
+        .session_service
+        .unpin(user_id, session_id.uuid())
+        .await
+        .log_internal_error_json("unpin session")?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
 /// POST /v1/sessions/{session_id}/cancel - Cancel current turn
 ///
 /// Cancels the currently running turn in the session. If no turn is running,
@@ -404,7 +517,7 @@ pub async fn cancel_turn(
     // Verify session exists
     let session = state
         .session_service
-        .get(org.org_id, &org.public_id, session_id.uuid())
+        .get(org.org_id, &org.public_id, session_id.uuid(), None)
         .await
         .log_internal_error("get session for cancel")?
         .ok_or_not_found()?;

--- a/crates/server/src/api/tool_results.rs
+++ b/crates/server/src/api/tool_results.rs
@@ -143,7 +143,7 @@ pub async fn submit_tool_results(
     // Get session and verify status
     let session = state
         .session_service
-        .get(org.org_id, &org.public_id, session_id.uuid())
+        .get(org.org_id, &org.public_id, session_id.uuid(), None)
         .await
         .log_internal_error_json("get session")?
         .ok_or_not_found_json("Session")?;

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -255,6 +255,7 @@ impl WorkerAdapters for DirectWorkerAdapters {
                 started_at: r.started_at,
                 finished_at: r.finished_at,
                 usage: None,
+                is_pinned: None,
             }
         }))
     }

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -372,7 +372,7 @@ impl WorkerService for WorkerServiceImpl {
         // Get session via SessionService
         let session = self
             .session_service
-            .get(req.org_id, &org_public_id, session_id)
+            .get(req.org_id, &org_public_id, session_id, None)
             .await
             .map_err(|e| {
                 tracing::error!("Failed to get session: {}", e);
@@ -641,7 +641,7 @@ impl WorkerService for WorkerServiceImpl {
         // Get session via SessionService
         let session = self
             .session_service
-            .get(req.org_id, &org_public_id, session_id)
+            .get(req.org_id, &org_public_id, session_id, None)
             .await
             .map_err(|e| {
                 tracing::error!("Failed to get session: {}", e);

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -42,6 +42,8 @@ use utoipa::OpenApi;
         api::sessions::get_session,
         api::sessions::update_session,
         api::sessions::delete_session,
+        api::sessions::pin_session,
+        api::sessions::unpin_session,
         api::sessions::cancel_turn,
         api::messages::create_message,
         api::messages::list_messages,

--- a/crates/server/src/services/session.rs
+++ b/crates/server/src/services/session.rs
@@ -185,7 +185,13 @@ impl SessionService {
         Ok(())
     }
 
-    pub async fn get(&self, org_id: i64, org_public_id: &str, id: Uuid) -> Result<Option<Session>> {
+    pub async fn get(
+        &self,
+        org_id: i64,
+        org_public_id: &str,
+        id: Uuid,
+        user_id: Option<Uuid>,
+    ) -> Result<Option<Session>> {
         let row = self
             .db
             .get_session(org_id, SessionId::from_uuid(id))
@@ -194,6 +200,11 @@ impl SessionService {
             Some(r) => {
                 let mut session = Self::row_to_session(r, org_public_id);
                 self.resolve_session_agent_id(org_id, &mut session).await?;
+                // Populate is_pinned if user context available
+                if let Some(uid) = user_id {
+                    let pinned = self.db.list_pinned_session_ids(uid, org_id).await?;
+                    session.is_pinned = Some(pinned.iter().any(|s| s.uuid() == id));
+                }
                 Ok(Some(session))
             }
             None => Ok(None),
@@ -208,6 +219,7 @@ impl SessionService {
         org_id: i64,
         org_public_id: &str,
         agent_id: Option<Uuid>,
+        user_id: Option<Uuid>,
         pagination: Pagination,
     ) -> Result<(Vec<Session>, u32)> {
         let agent_id = agent_id.map(AgentId::from_uuid);
@@ -234,6 +246,16 @@ impl SessionService {
             }
             if let Some(preview) = output_previews.get(&session.id.uuid()) {
                 session.output_preview = Some(preview.clone());
+            }
+        }
+
+        // Populate is_pinned if user context available
+        if let Some(uid) = user_id {
+            let pinned_ids = self.db.list_pinned_session_ids(uid, org_id).await?;
+            let pinned_set: std::collections::HashSet<Uuid> =
+                pinned_ids.iter().map(|id| id.uuid()).collect();
+            for session in &mut sessions {
+                session.is_pinned = Some(pinned_set.contains(&session.id.uuid()));
             }
         }
 
@@ -298,6 +320,20 @@ impl SessionService {
             .await
     }
 
+    /// Pin a session for a user
+    pub async fn pin(&self, user_id: Uuid, session_id: Uuid, org_id: i64) -> Result<()> {
+        self.db
+            .pin_session(user_id, SessionId::from_uuid(session_id), org_id)
+            .await
+    }
+
+    /// Unpin a session for a user
+    pub async fn unpin(&self, user_id: Uuid, session_id: Uuid) -> Result<bool> {
+        self.db
+            .unpin_session(user_id, SessionId::from_uuid(session_id))
+            .await
+    }
+
     /// Resolve a session's agent_id from internal UUID to the agent's public_id.
     /// The DB stores the internal UUID as FK; the API should return the public_id.
     async fn resolve_session_agent_id(&self, org_id: i64, session: &mut Session) -> Result<()> {
@@ -353,6 +389,7 @@ impl SessionService {
             started_at: row.started_at,
             finished_at: row.finished_at,
             usage,
+            is_pinned: None, // Populated by caller with user context
         }
     }
 }

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -303,6 +303,31 @@ impl StorageBackend {
     }
 
     // ============================================
+    // Pinned Sessions
+    // ============================================
+
+    pub async fn pin_session(
+        &self,
+        user_id: Uuid,
+        session_id: SessionId,
+        org_id: i64,
+    ) -> Result<()> {
+        dispatch!(self, pin_session, user_id, session_id, org_id)
+    }
+
+    pub async fn unpin_session(&self, user_id: Uuid, session_id: SessionId) -> Result<bool> {
+        dispatch!(self, unpin_session, user_id, session_id)
+    }
+
+    pub async fn list_pinned_session_ids(
+        &self,
+        user_id: Uuid,
+        org_id: i64,
+    ) -> Result<Vec<SessionId>> {
+        dispatch!(self, list_pinned_session_ids, user_id, org_id)
+    }
+
+    // ============================================
     // Events
     // ============================================
 

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -18,6 +18,9 @@ use uuid::Uuid;
 
 use super::models::*;
 
+/// Stored data for a pinned session: (org_id, pinned_at)
+type PinnedSessionData = (i64, DateTime<Utc>);
+
 /// In-memory database for dev mode
 /// All data is stored in memory and lost on restart
 pub struct InMemoryDatabase {
@@ -49,6 +52,8 @@ pub struct InMemoryDatabase {
     session_secrets: RwLock<HashMap<(SessionId, String), SessionSecretRow>>,
     // User connections (external service accounts)
     user_connections: RwLock<HashMap<Uuid, UserConnectionRow>>,
+    // Pinned sessions: (user_id, session_id) -> (org_id, pinned_at)
+    pinned_sessions: RwLock<HashMap<(Uuid, SessionId), PinnedSessionData>>,
 }
 
 impl Default for InMemoryDatabase {
@@ -92,6 +97,7 @@ impl Default for InMemoryDatabase {
             session_key_values: RwLock::new(HashMap::new()),
             session_secrets: RwLock::new(HashMap::new()),
             user_connections: RwLock::new(HashMap::new()),
+            pinned_sessions: RwLock::new(HashMap::new()),
         }
     }
 }
@@ -3191,6 +3197,42 @@ impl InMemoryDatabase {
         let before = connections.len();
         connections.retain(|_, c| !(c.user_id == user_id && c.provider == provider));
         Ok(connections.len() < before)
+    }
+
+    // ============================================
+    // Pinned Sessions
+    // ============================================
+
+    pub async fn pin_session(
+        &self,
+        user_id: Uuid,
+        session_id: SessionId,
+        org_id: i64,
+    ) -> Result<()> {
+        let mut pins = self.pinned_sessions.write();
+        pins.entry((user_id, session_id))
+            .or_insert((org_id, Self::now()));
+        Ok(())
+    }
+
+    pub async fn unpin_session(&self, user_id: Uuid, session_id: SessionId) -> Result<bool> {
+        let mut pins = self.pinned_sessions.write();
+        Ok(pins.remove(&(user_id, session_id)).is_some())
+    }
+
+    pub async fn list_pinned_session_ids(
+        &self,
+        user_id: Uuid,
+        org_id: i64,
+    ) -> Result<Vec<SessionId>> {
+        let pins = self.pinned_sessions.read();
+        let mut entries: Vec<_> = pins
+            .iter()
+            .filter(|((uid, _), (oid, _))| *uid == user_id && *oid == org_id)
+            .map(|((_, sid), (_, pinned_at))| (*sid, *pinned_at))
+            .collect();
+        entries.sort_by(|a, b| b.1.cmp(&a.1)); // Most recently pinned first
+        Ok(entries.into_iter().map(|(sid, _)| sid).collect())
     }
 }
 

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -964,6 +964,68 @@ impl Database {
     }
 
     // ============================================
+    // Pinned Sessions
+    // ============================================
+
+    /// Pin a session for a user
+    pub async fn pin_session(
+        &self,
+        user_id: Uuid,
+        session_id: SessionId,
+        org_id: i64,
+    ) -> Result<()> {
+        sqlx::query(
+            r#"
+            INSERT INTO pinned_sessions (user_id, session_id, org_id)
+            VALUES ($1, $2, $3)
+            ON CONFLICT (user_id, session_id) DO NOTHING
+            "#,
+        )
+        .bind(user_id)
+        .bind(session_id)
+        .bind(org_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Unpin a session for a user
+    pub async fn unpin_session(&self, user_id: Uuid, session_id: SessionId) -> Result<bool> {
+        let result = sqlx::query(
+            r#"
+            DELETE FROM pinned_sessions
+            WHERE user_id = $1 AND session_id = $2
+            "#,
+        )
+        .bind(user_id)
+        .bind(session_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Get the set of pinned session IDs for a user in an org
+    pub async fn list_pinned_session_ids(
+        &self,
+        user_id: Uuid,
+        org_id: i64,
+    ) -> Result<Vec<SessionId>> {
+        let rows: Vec<(SessionId,)> = sqlx::query_as(
+            r#"
+            SELECT session_id
+            FROM pinned_sessions
+            WHERE user_id = $1 AND org_id = $2
+            ORDER BY pinned_at DESC
+            "#,
+        )
+        .bind(user_id)
+        .bind(org_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().map(|(id,)| id).collect())
+    }
+
+    // ============================================
     // Events (source of truth for messages)
     // ============================================
     //

--- a/crates/server/src/storage/session_store.rs
+++ b/crates/server/src/storage/session_store.rs
@@ -85,6 +85,7 @@ impl SessionStore for DbSessionStore {
                     started_at: row.started_at,
                     finished_at: row.finished_at,
                     usage,
+                    is_pinned: None,
                 }))
             }
             None => Ok(None),

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -571,6 +571,7 @@ fn proto_session_to_session(proto_session: proto::Session) -> Result<Session> {
         started_at: None,
         finished_at: None,
         usage: None, // Usage not tracked in worker context
+        is_pinned: None,
     })
 }
 


### PR DESCRIPTION
## What
Add ability to pin sessions per user on the session page. Pinned sessions are sorted to the top of the list for quick access.

## Why
Users with many sessions need a way to keep important ones easily accessible without scrolling or searching.

## How

**Backend:**
- New `pinned_sessions` table (migration 007) with `(user_id, session_id)` PK and org_id FK
- `pin_session`/`unpin_session`/`list_pinned_session_ids` in both PostgreSQL and in-memory storage
- `PUT /v1/sessions/{session_id}/pin` and `DELETE /v1/sessions/{session_id}/pin` endpoints
- `is_pinned` field on Session, populated when user context is available
- Requires authentication (returns 401 in anonymous mode)

**Frontend:**
- Pin/unpin API client functions and React Query hooks
- Pin toggle button (Pin/PinOff icons) on each SessionCard
- Pinned sessions sorted to top of list on sessions page

## Risk
- Low
- New table + endpoints only, no changes to existing data. `is_pinned` uses `skip_serializing_if` so omitted when not populated (backward compatible).

## Checklist
- [x] Tests added or updated (227 server unit tests pass, 700 core tests pass)
- [x] Backward compatibility considered (`is_pinned` omitted from JSON when None)