### PR TITLE
feat(daytona): add git clone tool using native API

### DIFF
--- a/integrations/daytona/src/client.rs
+++ b/integrations/daytona/src/client.rs
@@ -375,11 +375,36 @@ impl DaytonaClient {
         .await?;
         Ok(())
     }
-}
+    // --- Toolbox API: Git ---
 
-// ============================================================================
-// URL encoding helper (inline, avoids extra dependency)
-// ============================================================================
+    /// Clone a git repository using Daytona's native git clone endpoint.
+    pub async fn git_clone(
+        &self,
+        sandbox_id: &str,
+        url: &str,
+        path: &str,
+        branch: Option<&str>,
+        username: Option<&str>,
+        password: Option<&str>,
+    ) -> Result<(), String> {
+        let mut body = json!({
+            "url": url,
+            "path": path,
+        });
+        if let Some(b) = branch {
+            body["branch"] = json!(b);
+        }
+        if let Some(u) = username {
+            body["username"] = json!(u);
+        }
+        if let Some(p) = password {
+            body["password"] = json!(p);
+        }
+        self.toolbox_request(reqwest::Method::POST, sandbox_id, "/git/clone", Some(body))
+            .await?;
+        Ok(())
+    }
+}
 
 pub(crate) mod urlencoding {
     /// Percent-encode a string for use in query parameters.
@@ -956,5 +981,87 @@ mod tests {
         let entries = client.file_list("sb_test", "/home").await.unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0]["name"], "only.txt");
+    }
+
+    #[tokio::test]
+    async fn test_client_git_clone() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/sb_test/git/clone"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(""))
+            .mount(&mock_server)
+            .await;
+
+        let client = DaytonaClient::with_base_urls(
+            "test_key".to_string(),
+            mock_server.uri(),
+            mock_server.uri(),
+        );
+        let result = client
+            .git_clone(
+                "sb_test",
+                "https://github.com/user/repo.git",
+                "/home/daytona/repo",
+                Some("main"),
+                None,
+                None,
+            )
+            .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_client_git_clone_with_auth() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/sb_test/git/clone"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(""))
+            .mount(&mock_server)
+            .await;
+
+        let client = DaytonaClient::with_base_urls(
+            "test_key".to_string(),
+            mock_server.uri(),
+            mock_server.uri(),
+        );
+        let result = client
+            .git_clone(
+                "sb_test",
+                "https://github.com/user/private-repo.git",
+                "/home/daytona/private-repo",
+                None,
+                Some("oauth2"),
+                Some("ghp_token123"),
+            )
+            .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_client_git_clone_error() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/sb_test/git/clone"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("Repository not found"))
+            .mount(&mock_server)
+            .await;
+
+        let client = DaytonaClient::with_base_urls(
+            "test_key".to_string(),
+            mock_server.uri(),
+            mock_server.uri(),
+        );
+        let result = client
+            .git_clone(
+                "sb_test",
+                "https://github.com/user/nonexistent.git",
+                "/home/daytona/nonexistent",
+                None,
+                None,
+                None,
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("500"));
     }
 }

--- a/integrations/daytona/src/lib.rs
+++ b/integrations/daytona/src/lib.rs
@@ -47,8 +47,6 @@ const SANDBOX_READY_POLL_INTERVAL: Duration = Duration::from_secs(2);
 const SANDBOX_READY_MAX_WAIT: Duration = Duration::from_secs(60);
 /// Auto-stop after 5 minutes of inactivity (safety net)
 const AUTO_STOP_INTERVAL_MINUTES: u64 = 5;
-/// Timeout for git clone operations (longer than default exec)
-const GIT_CLONE_TIMEOUT_MS: u64 = 300_000;
 
 // ============================================================================
 // DaytonaCapability

--- a/integrations/daytona/src/lib.rs
+++ b/integrations/daytona/src/lib.rs
@@ -19,7 +19,7 @@ use everruns_core::tools::Tool;
 use std::time::Duration;
 
 use tools::{
-    DaytonaCreateSandboxTool, DaytonaDownloadWorkspaceTool, DaytonaExecTool,
+    DaytonaCreateSandboxTool, DaytonaDownloadWorkspaceTool, DaytonaExecTool, DaytonaGitCloneTool,
     DaytonaListSandboxesTool, DaytonaManageSandboxTool, DaytonaReadFileTool, DaytonaWriteFileTool,
 };
 
@@ -47,6 +47,8 @@ const SANDBOX_READY_POLL_INTERVAL: Duration = Duration::from_secs(2);
 const SANDBOX_READY_MAX_WAIT: Duration = Duration::from_secs(60);
 /// Auto-stop after 5 minutes of inactivity (safety net)
 const AUTO_STOP_INTERVAL_MINUTES: u64 = 5;
+/// Timeout for git clone operations (longer than default exec)
+const GIT_CLONE_TIMEOUT_MS: u64 = 300_000;
 
 // ============================================================================
 // DaytonaCapability
@@ -96,10 +98,15 @@ Tools:
 - `daytona_download_workspace` - Download sandbox workspace to session storage
 - `daytona_list_sandboxes` - List session sandboxes
 - `daytona_manage_sandbox` - Stop or delete a sandbox
+- `daytona_git_clone` - Clone a git repository into a sandbox (auto-uses connected GitHub credentials)
 
 All tools except `daytona_create_sandbox` and `daytona_list_sandboxes` require a `sandbox_id`.
 Sandboxes auto-stop after 5 minutes of inactivity.
-Always DELETE sandboxes when done (stop leaves them on the dashboard)."#,
+Always DELETE sandboxes when done (stop leaves them on the dashboard).
+
+Git cloning: Use `daytona_git_clone` to clone repositories. If the user has connected
+their GitHub account (Settings > Connections), private repos are automatically
+authenticated. For public repos, no credentials are needed. Supports "user/repo" shorthand."#,
         )
     }
 
@@ -112,6 +119,7 @@ Always DELETE sandboxes when done (stop leaves them on the dashboard)."#,
             Box::new(DaytonaDownloadWorkspaceTool),
             Box::new(DaytonaListSandboxesTool),
             Box::new(DaytonaManageSandboxTool),
+            Box::new(DaytonaGitCloneTool),
         ]
     }
 
@@ -143,7 +151,7 @@ mod tests {
     fn test_capability_has_all_tools() {
         let cap = DaytonaCapability;
         let tools = cap.tools();
-        assert_eq!(tools.len(), 7);
+        assert_eq!(tools.len(), 8);
 
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
         assert!(names.contains(&"daytona_create_sandbox"));
@@ -153,6 +161,7 @@ mod tests {
         assert!(names.contains(&"daytona_download_workspace"));
         assert!(names.contains(&"daytona_list_sandboxes"));
         assert!(names.contains(&"daytona_manage_sandbox"));
+        assert!(names.contains(&"daytona_git_clone"));
     }
 
     #[test]
@@ -160,6 +169,7 @@ mod tests {
         let cap = DaytonaCapability;
         let prompt = cap.system_prompt_addition().unwrap();
         assert!(prompt.contains("daytona_create_sandbox"));
+        assert!(prompt.contains("daytona_git_clone"));
         assert!(prompt.contains("DAYTONA_API_KEY"));
         assert!(prompt.contains("Experimental"));
     }

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -12,7 +12,7 @@ use crate::state::{
     SandboxState, delete_sandbox_state, get_api_key, get_sandbox_state, list_sandbox_states,
     required_str, save_sandbox_state,
 };
-use crate::{AUTO_STOP_INTERVAL_MINUTES, EXEC_TIMEOUT_MS};
+use crate::{AUTO_STOP_INTERVAL_MINUTES, EXEC_TIMEOUT_MS, GIT_CLONE_TIMEOUT_MS};
 
 // ============================================================================
 // DaytonaCreateSandboxTool
@@ -769,6 +769,249 @@ impl Tool for DaytonaManageSandboxTool {
 }
 
 // ============================================================================
+// DaytonaGitCloneTool
+// ============================================================================
+
+pub struct DaytonaGitCloneTool;
+
+#[async_trait]
+impl Tool for DaytonaGitCloneTool {
+    fn name(&self) -> &str {
+        "daytona_git_clone"
+    }
+
+    fn description(&self) -> &str {
+        "Clone a git repository into a Daytona sandbox. Automatically uses the user's \
+         connected GitHub credentials if available. For private repos, \
+         the user must have connected their GitHub account in Settings > Connections."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "sandbox_id": {
+                    "type": "string",
+                    "description": "Sandbox ID to clone into"
+                },
+                "repo_url": {
+                    "type": "string",
+                    "description": "Repository URL (e.g., 'https://github.com/user/repo' or 'user/repo' shorthand)"
+                },
+                "branch": {
+                    "type": "string",
+                    "description": "Branch to clone (optional, defaults to default branch)"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Clone destination path inside sandbox (optional, defaults to /home/daytona/<repo_name>)"
+                }
+            },
+            "required": ["sandbox_id", "repo_url"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "daytona_git_clone requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let sandbox_id = match required_str(&arguments, "sandbox_id") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+        let repo_url_raw = match required_str(&arguments, "repo_url") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+        let branch = arguments.get("branch").and_then(|v| v.as_str());
+        let clone_path = arguments.get("path").and_then(|v| v.as_str());
+
+        let api_key = match get_api_key(context).await {
+            Ok(k) => k,
+            Err(e) => return e,
+        };
+        let state = match get_sandbox_state(context, sandbox_id).await {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        // Normalize repo URL: "user/repo" → "https://github.com/user/repo.git"
+        let repo_url = normalize_repo_url(repo_url_raw);
+
+        // Extract repo name for default clone path
+        let repo_name = repo_url
+            .rsplit('/')
+            .next()
+            .unwrap_or("repo")
+            .trim_end_matches(".git");
+        let default_path = format!("{}/{}", state.workspace_path, repo_name);
+        let target_path = clone_path.unwrap_or(&default_path);
+
+        // Resolve GitHub token for authenticated cloning
+        let github_token = get_github_token(context).await;
+
+        let client = DaytonaClient::new(api_key);
+
+        // Step 1: Set up git credential helper if we have a token
+        if let Some(ref token) = github_token {
+            debug!("Setting up git credential helper for authenticated clone");
+            let credential_script = format!(
+                r#"#!/bin/sh
+echo "protocol=https"
+echo "host=github.com"
+echo "username=oauth2"
+echo "password={token}""#
+            );
+
+            // Write credential helper script and configure git
+            let setup_cmd = format!(
+                "mkdir -p /tmp && cat > /tmp/git-credential-helper.sh << 'CREDEOF'\n{credential_script}\nCREDEOF\nchmod +x /tmp/git-credential-helper.sh && git config --global credential.helper '/tmp/git-credential-helper.sh'"
+            );
+
+            match client.exec(sandbox_id, &setup_cmd, None, None).await {
+                Ok(result) if result.exit_code != 0 => {
+                    warn!(
+                        "Credential helper setup failed (exit {}): {}",
+                        result.exit_code, result.result
+                    );
+                    // Continue without auth — will fail for private repos
+                }
+                Err(e) => {
+                    warn!("Failed to set up credential helper: {e}");
+                }
+                Ok(_) => {}
+            }
+        }
+
+        // Step 2: Build and run git clone command
+        let mut clone_cmd = "git clone --depth 1".to_string();
+        if let Some(b) = branch {
+            clone_cmd.push_str(&format!(" --branch {b}"));
+        }
+        clone_cmd.push_str(&format!(" {repo_url} {target_path}"));
+
+        debug!("Cloning repository: {clone_cmd}");
+        let clone_result = match client
+            .exec(sandbox_id, &clone_cmd, None, Some(GIT_CLONE_TIMEOUT_MS))
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                return ToolExecutionResult::tool_error(format!("Git clone exec failed: {e}"));
+            }
+        };
+
+        let output = &clone_result.result;
+
+        // Step 3: Get the HEAD commit SHA (only if clone succeeded)
+        let commit_sha = if clone_result.exit_code == 0 {
+            match client
+                .exec(
+                    sandbox_id,
+                    &format!("cd {target_path} && git rev-parse --short HEAD"),
+                    None,
+                    None,
+                )
+                .await
+            {
+                Ok(r) if r.exit_code == 0 => r.result.trim().to_string(),
+                _ => "unknown".to_string(),
+            }
+        } else {
+            "unknown".to_string()
+        };
+
+        // Step 4: Clean up credential helper (security)
+        if github_token.is_some() {
+            let cleanup_cmd = "rm -f /tmp/git-credential-helper.sh && git config --global --unset credential.helper";
+            if let Err(e) = client.exec(sandbox_id, cleanup_cmd, None, None).await {
+                warn!("Credential cleanup failed: {e}");
+            }
+        }
+
+        // Check if clone failed
+        if clone_result.exit_code != 0 || output.contains("fatal:") || output.contains("error:") {
+            let error_lines: String = output.lines().take(5).collect::<Vec<_>>().join("\n");
+            let hint = if github_token.is_none()
+                && (output.contains("Authentication failed")
+                    || output.contains("could not read Username")
+                    || output.contains("Repository not found"))
+            {
+                "\n\nThis may be a private repository. The user can connect their GitHub account in Settings > Connections to enable authenticated cloning."
+            } else {
+                ""
+            };
+            return ToolExecutionResult::tool_error(format!(
+                "Git clone failed: {error_lines}{hint}"
+            ));
+        }
+
+        ToolExecutionResult::success(json!({
+            "sandbox_id": sandbox_id,
+            "repo_url": repo_url,
+            "path": target_path,
+            "branch": branch.unwrap_or("default"),
+            "commit": commit_sha,
+            "authenticated": github_token.is_some()
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// Git Clone Helpers
+// ============================================================================
+
+/// Normalize repository URL: "user/repo" → "https://github.com/user/repo.git"
+fn normalize_repo_url(url: &str) -> String {
+    if url.starts_with("http://") || url.starts_with("https://") || url.starts_with("git@") {
+        url.to_string()
+    } else if url.contains('/') && !url.contains(' ') {
+        // Looks like "user/repo" shorthand
+        format!("https://github.com/{url}.git")
+    } else {
+        url.to_string()
+    }
+}
+
+/// Resolve GitHub token lazily from user connections, with session secret fallback.
+async fn get_github_token(context: &ToolContext) -> Option<String> {
+    // Try lazy resolution from user connections (preferred: always fresh)
+    if let Some(ref resolver) = context.connection_resolver {
+        match resolver
+            .get_connection_token(context.session_id, "github")
+            .await
+        {
+            Ok(Some(token)) if !token.is_empty() => return Some(token),
+            Ok(_) => {}
+            Err(e) => debug!("Connection resolver failed: {e}"),
+        }
+    }
+
+    // Fallback: session secret (for backward compat with pre-injected tokens)
+    if let Some(ref storage) = context.storage_store {
+        match storage.get_secret(context.session_id, "GITHUB_TOKEN").await {
+            Ok(Some(token)) if !token.is_empty() => return Some(token),
+            Ok(_) => {}
+            Err(e) => debug!("No GITHUB_TOKEN session secret: {e}"),
+        }
+    }
+
+    None
+}
+
+// ============================================================================
 // Tests
 // ============================================================================
 
@@ -942,6 +1185,7 @@ mod tests {
             Box::new(DaytonaDownloadWorkspaceTool),
             Box::new(DaytonaListSandboxesTool),
             Box::new(DaytonaManageSandboxTool),
+            Box::new(DaytonaGitCloneTool),
         ];
         for tool in &tools {
             assert!(
@@ -962,6 +1206,7 @@ mod tests {
             Box::new(DaytonaDownloadWorkspaceTool),
             Box::new(DaytonaListSandboxesTool),
             Box::new(DaytonaManageSandboxTool),
+            Box::new(DaytonaGitCloneTool),
         ];
         for tool in &tools {
             assert!(
@@ -982,6 +1227,7 @@ mod tests {
             Box::new(DaytonaDownloadWorkspaceTool),
             Box::new(DaytonaListSandboxesTool),
             Box::new(DaytonaManageSandboxTool),
+            Box::new(DaytonaGitCloneTool),
         ];
         for tool in &tools {
             let schema = tool.parameters_schema();
@@ -992,6 +1238,66 @@ mod tests {
                 tool.name()
             );
         }
+    }
+
+    // --- Git clone tool tests ---
+
+    #[tokio::test]
+    async fn test_git_clone_without_context() {
+        let tool = DaytonaGitCloneTool;
+        let result = tool
+            .execute(json!({"sandbox_id": "test", "repo_url": "user/repo"}))
+            .await;
+        assert!(
+            matches!(result, ToolExecutionResult::ToolError(msg) if msg.contains("requires context"))
+        );
+    }
+
+    #[test]
+    fn test_git_clone_schema() {
+        let tool = DaytonaGitCloneTool;
+        let schema = tool.parameters_schema();
+        let required = schema["required"].as_array().unwrap();
+        let required_strs: Vec<&str> = required.iter().map(|v| v.as_str().unwrap()).collect();
+        assert!(required_strs.contains(&"sandbox_id"));
+        assert!(required_strs.contains(&"repo_url"));
+        // branch and path are optional
+        assert!(!required_strs.contains(&"branch"));
+        assert!(!required_strs.contains(&"path"));
+        assert!(schema["properties"]["branch"].is_object());
+        assert!(schema["properties"]["path"].is_object());
+    }
+
+    #[test]
+    fn test_normalize_repo_url_shorthand() {
+        assert_eq!(
+            normalize_repo_url("user/repo"),
+            "https://github.com/user/repo.git"
+        );
+    }
+
+    #[test]
+    fn test_normalize_repo_url_https() {
+        let url = "https://github.com/user/repo.git";
+        assert_eq!(normalize_repo_url(url), url);
+    }
+
+    #[test]
+    fn test_normalize_repo_url_ssh() {
+        let url = "git@github.com:user/repo.git";
+        assert_eq!(normalize_repo_url(url), url);
+    }
+
+    #[test]
+    fn test_normalize_repo_url_http() {
+        let url = "http://github.com/user/repo";
+        assert_eq!(normalize_repo_url(url), url);
+    }
+
+    #[test]
+    fn test_normalize_repo_url_bare_word() {
+        // Single word without slash — returned as-is
+        assert_eq!(normalize_repo_url("something"), "something");
     }
 
     #[test]

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -12,7 +12,7 @@ use crate::state::{
     SandboxState, delete_sandbox_state, get_api_key, get_sandbox_state, list_sandbox_states,
     required_str, save_sandbox_state,
 };
-use crate::{AUTO_STOP_INTERVAL_MINUTES, EXEC_TIMEOUT_MS, GIT_CLONE_TIMEOUT_MS};
+use crate::{AUTO_STOP_INTERVAL_MINUTES, EXEC_TIMEOUT_MS};
 
 // ============================================================================
 // DaytonaCreateSandboxTool
@@ -860,99 +860,52 @@ impl Tool for DaytonaGitCloneTool {
 
         let client = DaytonaClient::new(api_key);
 
-        // Step 1: Set up git credential helper if we have a token
-        if let Some(ref token) = github_token {
-            debug!("Setting up git credential helper for authenticated clone");
-            let credential_script = format!(
-                r#"#!/bin/sh
-echo "protocol=https"
-echo "host=github.com"
-echo "username=oauth2"
-echo "password={token}""#
-            );
+        // Use Daytona's native git clone API (POST /git/clone).
+        // Passes credentials directly via API body — no credential helper scripts needed.
+        let (username, password) = if let Some(ref token) = github_token {
+            (Some("oauth2"), Some(token.as_str()))
+        } else {
+            (None, None)
+        };
 
-            // Write credential helper script and configure git
-            let setup_cmd = format!(
-                "mkdir -p /tmp && cat > /tmp/git-credential-helper.sh << 'CREDEOF'\n{credential_script}\nCREDEOF\nchmod +x /tmp/git-credential-helper.sh && git config --global credential.helper '/tmp/git-credential-helper.sh'"
-            );
-
-            match client.exec(sandbox_id, &setup_cmd, None, None).await {
-                Ok(result) if result.exit_code != 0 => {
-                    warn!(
-                        "Credential helper setup failed (exit {}): {}",
-                        result.exit_code, result.result
-                    );
-                    // Continue without auth — will fail for private repos
-                }
-                Err(e) => {
-                    warn!("Failed to set up credential helper: {e}");
-                }
-                Ok(_) => {}
-            }
-        }
-
-        // Step 2: Build and run git clone command
-        let mut clone_cmd = "git clone --depth 1".to_string();
-        if let Some(b) = branch {
-            clone_cmd.push_str(&format!(" --branch {b}"));
-        }
-        clone_cmd.push_str(&format!(" {repo_url} {target_path}"));
-
-        debug!("Cloning repository: {clone_cmd}");
-        let clone_result = match client
-            .exec(sandbox_id, &clone_cmd, None, Some(GIT_CLONE_TIMEOUT_MS))
+        debug!("Cloning repository via Daytona git API: {repo_url} → {target_path}");
+        if let Err(e) = client
+            .git_clone(
+                sandbox_id,
+                &repo_url,
+                target_path,
+                branch,
+                username,
+                password,
+            )
             .await
         {
-            Ok(r) => r,
-            Err(e) => {
-                return ToolExecutionResult::tool_error(format!("Git clone exec failed: {e}"));
-            }
-        };
-
-        let output = &clone_result.result;
-
-        // Step 3: Get the HEAD commit SHA (only if clone succeeded)
-        let commit_sha = if clone_result.exit_code == 0 {
-            match client
-                .exec(
-                    sandbox_id,
-                    &format!("cd {target_path} && git rev-parse --short HEAD"),
-                    None,
-                    None,
-                )
-                .await
-            {
-                Ok(r) if r.exit_code == 0 => r.result.trim().to_string(),
-                _ => "unknown".to_string(),
-            }
-        } else {
-            "unknown".to_string()
-        };
-
-        // Step 4: Clean up credential helper (security)
-        if github_token.is_some() {
-            let cleanup_cmd = "rm -f /tmp/git-credential-helper.sh && git config --global --unset credential.helper";
-            if let Err(e) = client.exec(sandbox_id, cleanup_cmd, None, None).await {
-                warn!("Credential cleanup failed: {e}");
-            }
-        }
-
-        // Check if clone failed
-        if clone_result.exit_code != 0 || output.contains("fatal:") || output.contains("error:") {
-            let error_lines: String = output.lines().take(5).collect::<Vec<_>>().join("\n");
             let hint = if github_token.is_none()
-                && (output.contains("Authentication failed")
-                    || output.contains("could not read Username")
-                    || output.contains("Repository not found"))
+                && (e.contains("Authentication")
+                    || e.contains("not found")
+                    || e.contains("401")
+                    || e.contains("403"))
             {
                 "\n\nThis may be a private repository. The user can connect their GitHub account in Settings > Connections to enable authenticated cloning."
             } else {
                 ""
             };
-            return ToolExecutionResult::tool_error(format!(
-                "Git clone failed: {error_lines}{hint}"
-            ));
+            return ToolExecutionResult::tool_error(format!("Git clone failed: {e}{hint}"));
         }
+
+        // Get the HEAD commit SHA
+        let commit_sha = match client
+            .exec(
+                sandbox_id,
+                &format!("cd {target_path} && git rev-parse --short HEAD"),
+                None,
+                None,
+            )
+            .await
+        {
+            Ok(r) if r.exit_code == 0 => r.result.trim().to_string(),
+            _ => "unknown".to_string(),
+        };
 
         ToolExecutionResult::success(json!({
             "sandbox_id": sandbox_id,

--- a/integrations/daytona/tests/plugin_registration.rs
+++ b/integrations/daytona/tests/plugin_registration.rs
@@ -62,5 +62,5 @@ fn test_daytona_capability_metadata() {
     assert_eq!(cap.icon(), Some("cloud"));
     assert_eq!(cap.category(), Some("Execution"));
     assert_eq!(cap.dependencies(), vec!["session_storage"]);
-    assert_eq!(cap.tools().len(), 7);
+    assert_eq!(cap.tools().len(), 8);
 }

--- a/specs/daytona.md
+++ b/specs/daytona.md
@@ -75,6 +75,7 @@ All state is stored in session **secrets** (encrypted at rest via AES-256-GCM en
 | Method | Path | Purpose | Request Body |
 |--------|------|---------|-------------|
 | POST | `/process/execute` | Execute command (sync) | `{ command, cwd?, timeout? }` |
+| POST | `/git/clone` | Clone git repository | `{ url, path, branch?, username?, password? }` |
 | GET | `/files?path=` | List directory | — |
 | GET | `/files/download?path=` | Download file | — |
 | POST | `/files/upload?path=` | Upload file (multipart) | multipart/form-data |
@@ -155,10 +156,12 @@ Clone a git repository into a sandbox. Automatically uses the user's connected G
   - `path`: string (optional) — destination inside sandbox (defaults to `<workspace_path>/<repo_name>`)
 - **Returns**: `{ sandbox_id, repo_url, path, branch, commit, authenticated }`
 
+**Implementation:** Uses Daytona's native `POST /git/clone` Toolbox API endpoint. Credentials are passed directly in the request body (`username`/`password` fields) — no credential helper scripts needed.
+
 **Authentication flow:**
 1. Lazily resolves GitHub token from user connections (`connection_resolver`)
 2. Falls back to `GITHUB_TOKEN` session secret
-3. If token found: writes temporary credential helper script, configures git, clones, then cleans up
+3. If token found: passes `username=oauth2`, `password=<token>` to the git clone API
 4. If no token: public repos only; private repos fail with hint to connect GitHub
 
 ## Security

--- a/specs/daytona.md
+++ b/specs/daytona.md
@@ -144,6 +144,23 @@ Lifecycle management: stop or delete.
   - `action`: `"stop" | "delete"` (required)
 - **Returns**: `{ sandbox_id, action, success }`
 
+### daytona_git_clone
+
+Clone a git repository into a sandbox. Automatically uses the user's connected GitHub credentials for private repos.
+
+- **Parameters**:
+  - `sandbox_id`: string (required)
+  - `repo_url`: string (required) — supports `https://`, `git@`, or `user/repo` shorthand
+  - `branch`: string (optional) — branch to clone (defaults to default branch)
+  - `path`: string (optional) — destination inside sandbox (defaults to `<workspace_path>/<repo_name>`)
+- **Returns**: `{ sandbox_id, repo_url, path, branch, commit, authenticated }`
+
+**Authentication flow:**
+1. Lazily resolves GitHub token from user connections (`connection_resolver`)
+2. Falls back to `GITHUB_TOKEN` session secret
+3. If token found: writes temporary credential helper script, configures git, clones, then cleans up
+4. If no token: public repos only; private repos fail with hint to connect GitHub
+
 ## Security
 
 - **API Key**: Stored in session secrets (`DAYTONA_API_KEY`), encrypted at rest
@@ -192,7 +209,7 @@ External integration crate, auto-registered via `inventory::submit!` plugin syst
 | `src/lib.rs` | Plugin registration, constants, `DaytonaCapability` impl |
 | `src/client.rs` | `DaytonaClient` HTTP client (management + toolbox APIs), URL encoding |
 | `src/state.rs` | API types (`SandboxInfo`, `ExecResult`, `SandboxState`), session state helpers |
-| `src/tools.rs` | 7 tool implementations (`DaytonaCreateSandboxTool`, etc.) |
+| `src/tools.rs` | 8 tool implementations (`DaytonaCreateSandboxTool`, etc.) |
 | `tests/plugin_registration.rs` | Integration tests for inventory registration and dev/prod gating |
 
 ## Capability Registration


### PR DESCRIPTION
## What
Add `daytona_git_clone` tool to the Daytona integration. Uses Daytona's native `POST /git/clone` Toolbox API endpoint for repository cloning with automatic GitHub authentication.

## Why
Agents using Daytona sandboxes need to clone repositories into sandboxes. The CodeSandbox integration already has `csb_git_clone`; this brings parity to Daytona.

## How
- Added `git_clone()` method to `DaytonaClient` calling `POST /toolbox/{sandboxId}/git/clone`
- Added `DaytonaGitCloneTool` with GitHub token resolution (user connections + session secret fallback)
- Credentials passed directly in API request body (`username`/`password`) — no credential helper scripts
- Supports `user/repo` shorthand, optional branch, custom path
- 8 tools total (was 7)

## Risk
- Low
- Experimental/dev-only capability. No impact on existing tools.

## Checklist
- [x] Tests added or updated (83 unit + 5 integration tests pass)
- [x] Backward compatibility considered (additive only, no breaking changes)