### PR TITLE
fix(sandbox): use /sandbox working dir and owner/repo clone paths

### DIFF
--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -559,11 +559,12 @@ Prerequisite: The session must have CSB_API_KEY set in secrets before you can us
 If missing, tell the user to set it via the API or harness config.
 
 Workflow:
-1. Create sandbox: `csb_create_sandbox`
-2. Write code / install deps: `csb_write_file`, `csb_exec`
-3. For long-running tasks: `csb_exec` with `wait: false`, poll `csb_exec_status`
-4. Save results: `csb_download_workspace`
-5. Clean up: `csb_manage_sandbox` action="shutdown"
+1. Create sandbox: `csb_create_sandbox` (working directory: /sandbox)
+2. Clone repos: `csb_git_clone` (clones to /sandbox/owner/repo)
+3. Write code / install deps: `csb_write_file`, `csb_exec`
+4. For long-running tasks: `csb_exec` with `wait: false`, poll `csb_exec_status`
+5. Save results: `csb_download_workspace`
+6. Clean up: `csb_manage_sandbox` action="shutdown"
 
 You can run multiple sandboxes in parallel for different tasks.
 Always shut down sandboxes when done."#,
@@ -581,11 +582,12 @@ Prerequisite: The session must have DAYTONA_API_KEY set in secrets before you ca
 If missing, tell the user to set it via the API or harness config.
 
 Workflow:
-1. Create sandbox: `daytona_create_sandbox`
-2. Write code / install deps: `daytona_write_file`, `daytona_exec`
-3. Read results: `daytona_read_file`
-4. Save results: `daytona_download_workspace`
-5. Clean up: `daytona_manage_sandbox` action="delete"
+1. Create sandbox: `daytona_create_sandbox` (working directory: /sandbox)
+2. Clone repos: `daytona_git_clone` (clones to /sandbox/owner/repo)
+3. Write code / install deps: `daytona_write_file`, `daytona_exec`
+4. Read results: `daytona_read_file`
+5. Save results: `daytona_download_workspace`
+6. Clean up: `daytona_manage_sandbox` action="delete"
 
 You can run multiple sandboxes in parallel for different tasks.
 Always delete sandboxes when done."#,

--- a/integrations/codesandbox/src/client.rs
+++ b/integrations/codesandbox/src/client.rs
@@ -393,7 +393,7 @@ mod tests {
             pint_url: pint_url.to_string(),
             pitcher_token: "tok_test".to_string(),
             preview_token: "prv_test".to_string(),
-            workspace_path: "/project".to_string(),
+            workspace_path: "/sandbox".to_string(),
             started_at: "2026-01-01T00:00:00Z".to_string(),
         }
     }

--- a/integrations/codesandbox/src/lib.rs
+++ b/integrations/codesandbox/src/lib.rs
@@ -81,7 +81,10 @@ Tools:
 - `csb_manage_sandbox` - Shutdown, hibernate, or delete a sandbox
 - `csb_git_clone` - Clone a git repository into a sandbox (auto-uses connected GitHub credentials)
 
-Git cloning: Use `csb_git_clone` to clone repositories. If the user has connected their GitHub account (Settings > Connections), private repos are automatically authenticated. For public repos, no credentials are needed. Supports "user/repo" shorthand.
+Git cloning: Use `csb_git_clone` to clone repositories into `/sandbox/owner/repo`.
+If the user has connected their GitHub account (Settings > Connections), private repos
+are automatically authenticated. For public repos, no credentials are needed.
+Supports "user/repo" shorthand. Working directory is `/sandbox`.
 
 All tools except `csb_create_sandbox` and `csb_list_sandboxes` require a `sandbox_id`.
 Sandboxes auto-hibernate after 5 minutes of inactivity.

--- a/integrations/codesandbox/src/tools/git.rs
+++ b/integrations/codesandbox/src/tools/git.rs
@@ -46,7 +46,7 @@ impl Tool for CsbGitCloneTool {
                 },
                 "path": {
                     "type": "string",
-                    "description": "Clone destination path inside sandbox (optional, defaults to /project/workspace/<repo_name>)"
+                    "description": "Clone destination path inside sandbox (optional, defaults to /sandbox/<owner>/<repo>)"
                 }
             },
             "required": ["sandbox_id", "repo_url"],
@@ -88,13 +88,17 @@ impl Tool for CsbGitCloneTool {
         // Normalize repo URL: "user/repo" → "https://github.com/user/repo.git"
         let repo_url = normalize_repo_url(repo_url_raw);
 
-        // Extract repo name for default clone path
-        let repo_name = repo_url
-            .rsplit('/')
-            .next()
-            .unwrap_or("repo")
-            .trim_end_matches(".git");
-        let default_path = format!("/project/workspace/{}", repo_name);
+        // Build default clone path: /sandbox/owner/repo (preserves user/repo structure)
+        let default_path = if let Some(owner_repo) = extract_owner_repo(repo_url_raw) {
+            format!("{}/{}", state.workspace_path, owner_repo)
+        } else {
+            let repo_name = repo_url
+                .rsplit('/')
+                .next()
+                .unwrap_or("repo")
+                .trim_end_matches(".git");
+            format!("{}/{}", state.workspace_path, repo_name)
+        };
         let target_path = clone_path.unwrap_or(&default_path);
 
         // Try to get GITHUB_TOKEN from session secrets for authentication
@@ -259,6 +263,51 @@ pub fn normalize_repo_url(url: &str) -> String {
     }
 }
 
+/// Extract "owner/repo" from a git URL. Returns `Some("owner/repo")` for:
+/// - `"owner/repo"` shorthand
+/// - `"https://github.com/owner/repo"` or `"https://github.com/owner/repo.git"`
+/// - `"git@github.com:owner/repo.git"`
+///
+/// Returns `None` if the URL doesn't match any recognized pattern.
+fn extract_owner_repo(url: &str) -> Option<String> {
+    // Shorthand: "owner/repo" (no protocol, no spaces, exactly one slash)
+    if !url.contains("://") && !url.starts_with("git@") && url.contains('/') && !url.contains(' ') {
+        let trimmed = url.trim_end_matches(".git");
+        let parts: Vec<&str> = trimmed.splitn(3, '/').collect();
+        if parts.len() == 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+            return Some(trimmed.to_string());
+        }
+    }
+
+    // HTTPS: "https://github.com/owner/repo" or "https://github.com/owner/repo.git"
+    if let Some(rest) = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))
+    {
+        // Skip the host (e.g. "github.com/owner/repo.git" → "owner/repo.git")
+        if let Some(path) = rest.split_once('/').map(|(_, p)| p) {
+            let path = path.trim_end_matches(".git").trim_end_matches('/');
+            let parts: Vec<&str> = path.splitn(3, '/').collect();
+            if parts.len() == 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+                return Some(path.to_string());
+            }
+        }
+    }
+
+    // SSH: "git@github.com:owner/repo.git"
+    if let Some(rest) = url.strip_prefix("git@")
+        && let Some(path) = rest.split_once(':').map(|(_, p)| p)
+    {
+        let path = path.trim_end_matches(".git").trim_end_matches('/');
+        let parts: Vec<&str> = path.splitn(3, '/').collect();
+        if parts.len() == 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+            return Some(path.to_string());
+        }
+    }
+
+    None
+}
+
 /// Resolve GitHub token lazily from user connections, with session secret fallback.
 async fn get_github_token(context: &ToolContext) -> Option<String> {
     // Try lazy resolution from user connections (preferred: always fresh)
@@ -334,6 +383,50 @@ mod tests {
             normalize_repo_url("org/sub-repo"),
             "https://github.com/org/sub-repo.git"
         );
+    }
+
+    // --- extract_owner_repo tests ---
+
+    #[test]
+    fn test_extract_owner_repo_shorthand() {
+        assert_eq!(
+            extract_owner_repo("user/repo"),
+            Some("user/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_owner_repo_https() {
+        assert_eq!(
+            extract_owner_repo("https://github.com/user/repo"),
+            Some("user/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_owner_repo_https_git_suffix() {
+        assert_eq!(
+            extract_owner_repo("https://github.com/user/repo.git"),
+            Some("user/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_owner_repo_ssh() {
+        assert_eq!(
+            extract_owner_repo("git@github.com:user/repo.git"),
+            Some("user/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_owner_repo_bare_word() {
+        assert_eq!(extract_owner_repo("something"), None);
+    }
+
+    #[test]
+    fn test_extract_owner_repo_with_spaces() {
+        assert_eq!(extract_owner_repo("user /repo"), None);
     }
 
     #[test]

--- a/integrations/codesandbox/src/tools/sandbox.rs
+++ b/integrations/codesandbox/src/tools/sandbox.rs
@@ -2,6 +2,7 @@
 
 use crate::client::CodeSandboxClient;
 use crate::state::*;
+use crate::tools::exec::poll_exec_completion;
 use crate::types::*;
 
 use async_trait::async_trait;
@@ -98,9 +99,8 @@ impl Tool for CsbCreateSandboxTool {
             Err(e) => return ToolExecutionResult::tool_error(e),
         };
 
-        let workspace_path = vm_info
-            .workspace_path
-            .unwrap_or_else(|| "/project".to_string());
+        // Use /sandbox as consistent working directory across all sandbox providers
+        let workspace_path = "/sandbox".to_string();
 
         // Create preview token (required for Pint API port proxy auth)
         debug!("Creating preview token for sandbox: {sandbox_id}");
@@ -127,7 +127,7 @@ impl Tool for CsbCreateSandboxTool {
             // Continue anyway — the sandbox was created, agent can retry later
         }
 
-        // Save state
+        // Save state (needed before mkdir so exec can look up the sandbox)
         let state = SandboxState {
             sandbox_id: sandbox_id.clone(),
             pint_url: pint_url.clone(),
@@ -138,6 +138,18 @@ impl Tool for CsbCreateSandboxTool {
         };
         if let Err(e) = save_sandbox_state(context, &state).await {
             return e;
+        }
+
+        // Ensure /sandbox directory exists
+        if let Ok(exec_info) = client
+            .exec_create(
+                &state,
+                "bash",
+                vec!["-c".to_string(), "mkdir -p /sandbox".to_string()],
+            )
+            .await
+        {
+            let _ = poll_exec_completion(&client, &state, &exec_info.id).await;
         }
 
         // Optionally upload files

--- a/integrations/codesandbox/src/types.rs
+++ b/integrations/codesandbox/src/types.rs
@@ -131,7 +131,7 @@ mod tests {
             pint_url: "https://sb_123-57468.csb.app".to_string(),
             pitcher_token: "tok_abc".to_string(),
             preview_token: "prv_v1_test123".to_string(),
-            workspace_path: "/project".to_string(),
+            workspace_path: "/sandbox".to_string(),
             started_at: "2026-02-13T10:00:00Z".to_string(),
         };
         let json = serde_json::to_string(&state).unwrap();
@@ -140,7 +140,7 @@ mod tests {
         assert_eq!(deserialized.pint_url, "https://sb_123-57468.csb.app");
         assert_eq!(deserialized.pitcher_token, "tok_abc");
         assert_eq!(deserialized.preview_token, "prv_v1_test123");
-        assert_eq!(deserialized.workspace_path, "/project");
+        assert_eq!(deserialized.workspace_path, "/sandbox");
     }
 
     #[test]

--- a/integrations/daytona/src/client.rs
+++ b/integrations/daytona/src/client.rs
@@ -562,7 +562,7 @@ mod tests {
             mock_server.uri(),
             mock_server.uri(),
         );
-        let result = client.file_list("sb_test", "/home/daytona").await;
+        let result = client.file_list("sb_test", "/sandbox").await;
         assert!(result.is_ok());
         let entries = result.unwrap();
         assert_eq!(entries.len(), 2);
@@ -656,8 +656,8 @@ mod tests {
     #[test]
     fn test_encode_path_with_slashes() {
         assert_eq!(
-            urlencoding::encode("/home/daytona/main.py"),
-            "%2Fhome%2Fdaytona%2Fmain.py"
+            urlencoding::encode("/sandbox/main.py"),
+            "%2Fsandbox%2Fmain.py"
         );
     }
 
@@ -790,7 +790,7 @@ mod tests {
             mock_server.uri(),
         );
         let result = client
-            .file_upload("sb_test", "/home/daytona/test.py", b"print('hello')")
+            .file_upload("sb_test", "/sandbox/test.py", b"print('hello')")
             .await;
         assert!(result.is_ok());
     }
@@ -1001,7 +1001,7 @@ mod tests {
             .git_clone(
                 "sb_test",
                 "https://github.com/user/repo.git",
-                "/home/daytona/repo",
+                "/sandbox/user/repo",
                 Some("main"),
                 None,
                 None,
@@ -1028,7 +1028,7 @@ mod tests {
             .git_clone(
                 "sb_test",
                 "https://github.com/user/private-repo.git",
-                "/home/daytona/private-repo",
+                "/sandbox/user/private-repo",
                 None,
                 Some("oauth2"),
                 Some("ghp_token123"),
@@ -1055,7 +1055,7 @@ mod tests {
             .git_clone(
                 "sb_test",
                 "https://github.com/user/nonexistent.git",
-                "/home/daytona/nonexistent",
+                "/sandbox/user/nonexistent",
                 None,
                 None,
                 None,

--- a/integrations/daytona/src/lib.rs
+++ b/integrations/daytona/src/lib.rs
@@ -102,9 +102,10 @@ All tools except `daytona_create_sandbox` and `daytona_list_sandboxes` require a
 Sandboxes auto-stop after 5 minutes of inactivity.
 Always DELETE sandboxes when done (stop leaves them on the dashboard).
 
-Git cloning: Use `daytona_git_clone` to clone repositories. If the user has connected
-their GitHub account (Settings > Connections), private repos are automatically
-authenticated. For public repos, no credentials are needed. Supports "user/repo" shorthand."#,
+Git cloning: Use `daytona_git_clone` to clone repositories into `/sandbox/owner/repo`.
+If the user has connected their GitHub account (Settings > Connections), private repos
+are automatically authenticated. For public repos, no credentials are needed.
+Supports "user/repo" shorthand. Working directory is `/sandbox`."#,
         )
     }
 

--- a/integrations/daytona/src/state.rs
+++ b/integrations/daytona/src/state.rs
@@ -190,25 +190,25 @@ mod tests {
     fn test_sandbox_state_roundtrip() {
         let state = SandboxState {
             sandbox_id: "sb_123".to_string(),
-            workspace_path: "/home/daytona".to_string(),
+            workspace_path: "/sandbox".to_string(),
             started_at: "2026-02-16T10:00:00Z".to_string(),
         };
         let json = serde_json::to_string(&state).unwrap();
         let deserialized: SandboxState = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.sandbox_id, "sb_123");
-        assert_eq!(deserialized.workspace_path, "/home/daytona");
+        assert_eq!(deserialized.workspace_path, "/sandbox");
     }
 
     #[test]
     fn test_sandbox_state_with_special_chars() {
         let state = SandboxState {
             sandbox_id: "sb-test_123".to_string(),
-            workspace_path: "/home/daytona/my project".to_string(),
+            workspace_path: "/sandbox/my project".to_string(),
             started_at: "2026-02-16T10:00:00+05:30".to_string(),
         };
         let json = serde_json::to_string(&state).unwrap();
         let deserialized: SandboxState = serde_json::from_str(&json).unwrap();
-        assert_eq!(deserialized.workspace_path, "/home/daytona/my project");
+        assert_eq!(deserialized.workspace_path, "/sandbox/my project");
     }
 
     #[test]
@@ -286,7 +286,7 @@ mod tests {
     fn test_sandbox_state_json_has_all_fields() {
         let state = SandboxState {
             sandbox_id: "sb_x".to_string(),
-            workspace_path: "/home/daytona".to_string(),
+            workspace_path: "/sandbox".to_string(),
             started_at: "2026-01-01T00:00:00Z".to_string(),
         };
         let val: serde_json::Value = serde_json::to_value(&state).unwrap();

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -106,7 +106,15 @@ impl Tool for DaytonaCreateSandboxTool {
             // Continue anyway — the sandbox was created, agent can retry later
         }
 
-        let workspace_path = "/home/daytona".to_string();
+        let workspace_path = "/sandbox".to_string();
+
+        // Ensure /sandbox directory exists
+        if let Err(e) = client
+            .exec(sandbox_id, "mkdir -p /sandbox", None, None)
+            .await
+        {
+            warn!("Failed to create /sandbox directory: {e}");
+        }
 
         // Save state
         let state = SandboxState {
@@ -295,7 +303,7 @@ impl Tool for DaytonaReadFileTool {
                 },
                 "path": {
                     "type": "string",
-                    "description": "Path to file in sandbox (e.g., '/home/daytona/main.py')"
+                    "description": "Path to file in sandbox (e.g., '/sandbox/main.py')"
                 }
             },
             "required": ["sandbox_id", "path"],
@@ -376,7 +384,7 @@ impl Tool for DaytonaWriteFileTool {
                 },
                 "path": {
                     "type": "string",
-                    "description": "Path for file in sandbox (e.g., '/home/daytona/main.py')"
+                    "description": "Path for file in sandbox (e.g., '/sandbox/main.py')"
                 },
                 "content": {
                     "type": "string",
@@ -804,7 +812,7 @@ impl Tool for DaytonaGitCloneTool {
                 },
                 "path": {
                     "type": "string",
-                    "description": "Clone destination path inside sandbox (optional, defaults to /home/daytona/<repo_name>)"
+                    "description": "Clone destination path inside sandbox (optional, defaults to /sandbox/<owner>/<repo>)"
                 }
             },
             "required": ["sandbox_id", "repo_url"],
@@ -846,13 +854,17 @@ impl Tool for DaytonaGitCloneTool {
         // Normalize repo URL: "user/repo" → "https://github.com/user/repo.git"
         let repo_url = normalize_repo_url(repo_url_raw);
 
-        // Extract repo name for default clone path
-        let repo_name = repo_url
-            .rsplit('/')
-            .next()
-            .unwrap_or("repo")
-            .trim_end_matches(".git");
-        let default_path = format!("{}/{}", state.workspace_path, repo_name);
+        // Build default clone path: /sandbox/owner/repo (preserves user/repo structure)
+        let default_path = if let Some(owner_repo) = extract_owner_repo(repo_url_raw) {
+            format!("{}/{}", state.workspace_path, owner_repo)
+        } else {
+            let repo_name = repo_url
+                .rsplit('/')
+                .next()
+                .unwrap_or("repo")
+                .trim_end_matches(".git");
+            format!("{}/{}", state.workspace_path, repo_name)
+        };
         let target_path = clone_path.unwrap_or(&default_path);
 
         // Resolve GitHub token for authenticated cloning
@@ -936,6 +948,51 @@ fn normalize_repo_url(url: &str) -> String {
     } else {
         url.to_string()
     }
+}
+
+/// Extract "owner/repo" from a git URL. Returns `Some("owner/repo")` for:
+/// - `"owner/repo"` shorthand
+/// - `"https://github.com/owner/repo"` or `"https://github.com/owner/repo.git"`
+/// - `"git@github.com:owner/repo.git"`
+///
+/// Returns `None` if the URL doesn't match any recognized pattern.
+fn extract_owner_repo(url: &str) -> Option<String> {
+    // Shorthand: "owner/repo" (no protocol, no spaces, exactly one slash)
+    if !url.contains("://") && !url.starts_with("git@") && url.contains('/') && !url.contains(' ') {
+        let trimmed = url.trim_end_matches(".git");
+        let parts: Vec<&str> = trimmed.splitn(3, '/').collect();
+        if parts.len() == 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+            return Some(trimmed.to_string());
+        }
+    }
+
+    // HTTPS: "https://github.com/owner/repo" or "https://github.com/owner/repo.git"
+    if let Some(rest) = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))
+    {
+        // Skip the host (e.g. "github.com/owner/repo.git" → "owner/repo.git")
+        if let Some(path) = rest.split_once('/').map(|(_, p)| p) {
+            let path = path.trim_end_matches(".git").trim_end_matches('/');
+            let parts: Vec<&str> = path.splitn(3, '/').collect();
+            if parts.len() == 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+                return Some(path.to_string());
+            }
+        }
+    }
+
+    // SSH: "git@github.com:owner/repo.git"
+    if let Some(rest) = url.strip_prefix("git@")
+        && let Some(path) = rest.split_once(':').map(|(_, p)| p)
+    {
+        let path = path.trim_end_matches(".git").trim_end_matches('/');
+        let parts: Vec<&str> = path.splitn(3, '/').collect();
+        if parts.len() == 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+            return Some(path.to_string());
+        }
+    }
+
+    None
 }
 
 /// Resolve GitHub token lazily from user connections, with session secret fallback.
@@ -1251,6 +1308,58 @@ mod tests {
     fn test_normalize_repo_url_bare_word() {
         // Single word without slash — returned as-is
         assert_eq!(normalize_repo_url("something"), "something");
+    }
+
+    // --- extract_owner_repo tests ---
+
+    #[test]
+    fn test_extract_owner_repo_shorthand() {
+        assert_eq!(
+            extract_owner_repo("user/repo"),
+            Some("user/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_owner_repo_https() {
+        assert_eq!(
+            extract_owner_repo("https://github.com/user/repo"),
+            Some("user/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_owner_repo_https_git_suffix() {
+        assert_eq!(
+            extract_owner_repo("https://github.com/user/repo.git"),
+            Some("user/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_owner_repo_ssh() {
+        assert_eq!(
+            extract_owner_repo("git@github.com:user/repo.git"),
+            Some("user/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_owner_repo_bare_word() {
+        assert_eq!(extract_owner_repo("something"), None);
+    }
+
+    #[test]
+    fn test_extract_owner_repo_http() {
+        assert_eq!(
+            extract_owner_repo("http://github.com/user/repo"),
+            Some("user/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_owner_repo_with_spaces() {
+        assert_eq!(extract_owner_repo("user /repo"), None);
     }
 
     #[test]

--- a/specs/daytona.md
+++ b/specs/daytona.md
@@ -153,7 +153,7 @@ Clone a git repository into a sandbox. Automatically uses the user's connected G
   - `sandbox_id`: string (required)
   - `repo_url`: string (required) — supports `https://`, `git@`, or `user/repo` shorthand
   - `branch`: string (optional) — branch to clone (defaults to default branch)
-  - `path`: string (optional) — destination inside sandbox (defaults to `<workspace_path>/<repo_name>`)
+  - `path`: string (optional) — destination inside sandbox (defaults to `/sandbox/<owner>/<repo>`)
 - **Returns**: `{ sandbox_id, repo_url, path, branch, commit, authenticated }`
 
 **Implementation:** Uses Daytona's native `POST /git/clone` Toolbox API endpoint. Credentials are passed directly in the request body (`username`/`password` fields) — no credential helper scripts needed.


### PR DESCRIPTION
## Summary
- Standardize working directory to `/sandbox` for both Daytona and CodeSandbox providers
- Git clone now defaults to `/sandbox/owner/repo` (e.g. `/sandbox/anthropics/claude`) instead of provider-specific paths
- Add `extract_owner_repo` helper to parse owner/repo from various git URL formats (shorthand, HTTPS, SSH)
- Create `/sandbox` directory after sandbox creation for both providers
- Update seeded agent system prompts to document the new clone path convention

## Motivation
- `daytona_git_clone` failed when path was omitted; explicit paths are now always computed
- Consistent `/sandbox` working directory across providers simplifies agent instructions
- `/sandbox/owner/repo` preserves the GitHub owner/repo structure for clarity

## Test plan
- [x] All existing tests pass (85 passed)
- [x] New `extract_owner_repo` tests cover shorthand, HTTPS, HTTPS+.git, SSH, bare word, spaces
- [x] `cargo fmt`, `cargo clippy`, `just pre-push` all pass
- [ ] Smoke test with Daytona sandbox: create, clone, verify path is `/sandbox/owner/repo`
- [ ] Smoke test with CodeSandbox: create, clone, verify path is `/sandbox/owner/repo`