### PR TITLE
chore(specs): clarify GitHub App setup instructions

### DIFF
--- a/apps/ui/src/app/(main)/settings/connections/page.tsx
+++ b/apps/ui/src/app/(main)/settings/connections/page.tsx
@@ -17,7 +17,7 @@ const providers: Record<string, { name: string; icon: LucideIcon; description: s
   github: {
     name: "GitHub",
     icon: Github,
-    description: "Access private repositories for agent sessions",
+    description: "Install the GitHub App to grant access to selected repositories",
   },
 };
 
@@ -83,7 +83,7 @@ function AvailableProviderRow({
   meta: { name: string; icon: LucideIcon; description: string };
 }) {
   const handleConnect = () => {
-    // Navigate to OAuth authorize endpoint through the API proxy
+    // Navigate to GitHub App installation flow through the API proxy
     window.location.href = `${getBackendUrl()}/v1/user/connections/${provider}/authorize`;
   };
 
@@ -98,7 +98,7 @@ function AvailableProviderRow({
       </div>
       <Button variant="outline" size="sm" onClick={handleConnect}>
         <ExternalLink className="h-4 w-4 mr-1" />
-        Connect
+        Install
       </Button>
     </div>
   );

--- a/crates/server/migrations/008_github_app.sql
+++ b/crates/server/migrations/008_github_app.sql
@@ -1,0 +1,17 @@
+-- GitHub App migration: store installation_id instead of OAuth access token.
+--
+-- GitHub Apps use short-lived installation tokens minted on demand (1h TTL),
+-- so we no longer need to store a long-lived access token for GitHub connections.
+-- The installation_id identifies which GitHub App installation to mint tokens for.
+-- Other providers (GitLab, etc.) still use access_token_encrypted.
+
+ALTER TABLE user_connections
+    ALTER COLUMN access_token_encrypted DROP NOT NULL;
+
+ALTER TABLE user_connections
+    ADD COLUMN installation_id BIGINT;
+
+-- Partial index for installation-based lookups
+CREATE INDEX idx_user_connections_installation
+    ON user_connections(installation_id)
+    WHERE installation_id IS NOT NULL;

--- a/crates/server/src/api/user_connections.rs
+++ b/crates/server/src/api/user_connections.rs
@@ -1,10 +1,10 @@
 // User Connections API routes
 // Decision: User-scoped (not org-scoped) — token represents user's GitHub identity
-// Decision: Separate GitHub OAuth App from login (different scopes: repo vs profile)
+// Decision: GitHub App installation flow replaces OAuth App for repo access
 
 use crate::auth::config::AuthConfig;
 use crate::auth::middleware::{AuthState, AuthUser};
-use crate::auth::oauth::GitHubConnectionService;
+use crate::auth::oauth::GitHubAppService;
 use crate::storage::{EncryptionService, StorageBackend};
 use axum::{
     Json, Router,
@@ -49,12 +49,14 @@ pub struct ConnectionResponse {
     pub connected_at: DateTime<Utc>,
 }
 
-/// OAuth callback query params
+/// GitHub App installation callback query params
 #[derive(Debug, Deserialize)]
-pub struct OAuthCallbackQuery {
-    pub code: String,
+pub struct GitHubInstallationCallbackQuery {
+    pub installation_id: i64,
     #[allow(dead_code)]
-    pub state: String,
+    pub setup_action: Option<String>,
+    #[allow(dead_code)]
+    pub state: Option<String>,
 }
 
 /// Create user connections routes
@@ -115,11 +117,11 @@ pub async fn delete_connection(
     }
 }
 
-/// GET /v1/user/connections/github/authorize — Start GitHub OAuth flow
+/// GET /v1/user/connections/github/authorize — Redirect to GitHub App installation
 pub async fn github_authorize(
     State(state): State<AppState>,
     _auth: AuthUser,
-    Query(params): Query<std::collections::HashMap<String, String>>,
+    Query(_params): Query<std::collections::HashMap<String, String>>,
 ) -> Result<Redirect, (StatusCode, String)> {
     let config = state
         .auth_config
@@ -128,30 +130,30 @@ pub async fn github_authorize(
         .ok_or_else(|| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                "GitHub connection not configured".to_string(),
+                "GitHub App not configured".to_string(),
             )
         })?;
 
-    let service = GitHubConnectionService::new(config);
+    let service = GitHubAppService::new(config);
 
     // Generate state for CSRF protection
     let mut rng = rand::rng();
     let bytes: [u8; 16] = rng.random();
-    let oauth_state = hex::encode(bytes);
+    let install_state = hex::encode(bytes);
 
     // TODO: Store state in session/cookie for validation in callback
-    // For now, include redirect_uri in state param
-    let _redirect_after = params.get("redirect_uri").cloned();
-
-    let auth_url = service.authorization_url(&oauth_state);
+    let auth_url = service.installation_url(&install_state);
     Ok(Redirect::to(&auth_url.url))
 }
 
-/// GET /v1/user/connections/github/callback — GitHub OAuth callback
+/// GET /v1/user/connections/github/callback — GitHub App installation callback
+///
+/// After user installs the GitHub App on their repos, GitHub redirects here
+/// with the installation_id. We verify the installation and store the ID.
 pub async fn github_callback(
     State(state): State<AppState>,
     auth: AuthUser,
-    Query(query): Query<OAuthCallbackQuery>,
+    Query(query): Query<GitHubInstallationCallbackQuery>,
 ) -> Result<Redirect, (StatusCode, String)> {
     let config = state
         .auth_config
@@ -160,62 +162,48 @@ pub async fn github_callback(
         .ok_or_else(|| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                "GitHub connection not configured".to_string(),
+                "GitHub App not configured".to_string(),
             )
         })?;
 
-    let encryption = state.encryption.as_ref().ok_or_else(|| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "Encryption not configured".to_string(),
-        )
-    })?;
+    let service = GitHubAppService::new(config);
 
-    let service = GitHubConnectionService::new(config);
-
-    // Exchange code for token + user info
-    let result = service.exchange_code(&query.code).await.map_err(|e| {
-        tracing::error!("GitHub connection OAuth exchange failed: {}", e);
-        (
-            StatusCode::BAD_REQUEST,
-            "GitHub authentication failed".to_string(),
-        )
-    })?;
-
-    // Encrypt token
-    let access_token_encrypted = encryption
-        .encrypt_string(&result.access_token)
+    // Verify the installation exists and get account details
+    let result = service
+        .verify_installation(query.installation_id)
+        .await
         .map_err(|e| {
-            tracing::error!("Failed to encrypt token: {}", e);
+            tracing::error!("GitHub App installation verification failed: {}", e);
             (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Failed to store connection".to_string(),
+                StatusCode::BAD_REQUEST,
+                "GitHub App installation verification failed".to_string(),
             )
         })?;
 
-    // Upsert connection
+    // Store installation_id (no OAuth token needed — tokens minted on demand)
     state
         .db
         .upsert_user_connection(CreateUserConnectionRow {
             user_id: auth.id,
             provider: "github".to_string(),
-            provider_user_id: Some(result.user_id),
-            provider_username: Some(result.username),
-            access_token_encrypted,
+            provider_user_id: Some(result.account_id),
+            provider_username: Some(result.account_login),
+            access_token_encrypted: None,
             refresh_token_encrypted: None,
-            scopes: Some(result.scopes),
+            scopes: Some(result.permissions),
             expires_at: None,
+            installation_id: Some(result.installation_id),
         })
         .await
         .map_err(|e| {
-            tracing::error!("Failed to store GitHub connection: {}", e);
+            tracing::error!("Failed to store GitHub App installation: {}", e);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Failed to store connection".to_string(),
             )
         })?;
 
-    // Redirect back to settings page (frontend may be on a different origin in dev)
+    // Redirect back to settings page
     let frontend_url = state.auth_config.frontend_url.trim_end_matches('/');
     Ok(Redirect::to(&format!(
         "{}/settings/connections?connected=github",

--- a/crates/server/src/auth/config.rs
+++ b/crates/server/src/auth/config.rs
@@ -60,12 +60,17 @@ pub struct GitHubOAuthConfig {
     pub base: OAuthProviderConfig,
 }
 
-/// GitHub Connection OAuth configuration (for repo access, separate OAuth App)
+/// GitHub App configuration (for repo access via GitHub App installation tokens)
 #[derive(Debug, Clone)]
 pub struct GitHubConnectionConfig {
-    pub client_id: String,
-    pub client_secret: String,
-    pub redirect_uri: String,
+    /// GitHub App ID (numeric, from App settings page)
+    pub app_id: String,
+    /// PEM-encoded RSA private key for JWT signing
+    pub private_key: String,
+    /// App slug for constructing installation URLs (e.g. "everruns")
+    pub app_slug: String,
+    /// Callback URL after user installs the GitHub App
+    pub setup_url: String,
 }
 
 /// Admin user configuration (for admin-only mode or initial setup)
@@ -250,25 +255,27 @@ impl AuthConfig {
             _ => None,
         };
 
-        // GitHub Connection OAuth (separate app for repo access)
+        // GitHub App for repo access (installation-based tokens)
         let github_connection = match (
-            std::env::var("GITHUB_CONNECTION_CLIENT_ID"),
-            std::env::var("GITHUB_CONNECTION_CLIENT_SECRET"),
+            std::env::var("GITHUB_APP_ID"),
+            std::env::var("GITHUB_APP_PRIVATE_KEY"),
         ) {
-            (Ok(client_id), Ok(client_secret))
-                if !client_id.is_empty() && !client_secret.is_empty() =>
-            {
-                let redirect_uri =
-                    std::env::var("GITHUB_CONNECTION_REDIRECT_URI").unwrap_or_else(|_| {
-                        format!(
-                            "{}{}/v1/user/connections/github/callback",
-                            base_url, api_prefix
-                        )
-                    });
+            (Ok(app_id), Ok(private_key)) if !app_id.is_empty() && !private_key.is_empty() => {
+                // Support escaped newlines in env vars (common in Docker/CI)
+                let private_key = private_key.replace("\\n", "\n");
+                let app_slug =
+                    std::env::var("GITHUB_APP_SLUG").unwrap_or_else(|_| "everruns".to_string());
+                let setup_url = std::env::var("GITHUB_APP_SETUP_URL").unwrap_or_else(|_| {
+                    format!(
+                        "{}{}/v1/user/connections/github/callback",
+                        base_url, api_prefix
+                    )
+                });
                 Some(GitHubConnectionConfig {
-                    client_id,
-                    client_secret,
-                    redirect_uri,
+                    app_id,
+                    private_key,
+                    app_slug,
+                    setup_url,
                 })
             }
             _ => None,

--- a/crates/server/src/auth/oauth.rs
+++ b/crates/server/src/auth/oauth.rs
@@ -288,97 +288,178 @@ struct GitHubEmail {
     verified: bool,
 }
 
-/// Result of GitHub connection OAuth exchange (repo access, not login)
+/// Result of GitHub App installation verification
 #[derive(Debug, Clone)]
-pub struct GitHubConnectionResult {
-    /// GitHub access token (with repo scope)
-    pub access_token: String,
-    /// GitHub user ID
-    pub user_id: String,
-    /// GitHub username (login)
-    pub username: String,
-    /// Scopes granted
-    pub scopes: String,
+pub struct GitHubInstallationResult {
+    /// GitHub App installation ID
+    pub installation_id: i64,
+    /// Account (user/org) that installed the app
+    pub account_id: String,
+    /// Account login (username or org name)
+    pub account_login: String,
+    /// Permissions granted to the installation (e.g. "contents: read")
+    pub permissions: String,
 }
 
-/// GitHub Connection OAuth service (separate OAuth App for repo access)
-pub struct GitHubConnectionService {
-    client_id: String,
-    client_secret: String,
-    redirect_uri: String,
+/// GitHub App service for installation-based repo access.
+///
+/// Unlike OAuth Apps, GitHub Apps use:
+/// 1. App installation flow (user installs app on repos, not OAuth consent)
+/// 2. Short-lived installation access tokens (1h TTL, minted on demand)
+/// 3. Granular per-repo permissions instead of broad OAuth scopes
+pub struct GitHubAppService {
+    app_id: String,
+    private_key: String,
+    app_slug: String,
 }
 
-impl GitHubConnectionService {
+impl GitHubAppService {
     pub fn new(config: &GitHubConnectionConfig) -> Self {
         Self {
-            client_id: config.client_id.clone(),
-            client_secret: config.client_secret.clone(),
-            redirect_uri: config.redirect_uri.clone(),
+            app_id: config.app_id.clone(),
+            private_key: config.private_key.clone(),
+            app_slug: config.app_slug.clone(),
         }
     }
 
-    /// Generate authorization URL with repo scope
-    pub fn authorization_url(&self, state: &str) -> OAuthAuthorizationUrl {
-        let params = [
-            ("client_id", self.client_id.as_str()),
-            ("redirect_uri", self.redirect_uri.as_str()),
-            ("scope", "repo read:user"),
-            ("state", state),
-        ];
-
-        let query = params
-            .iter()
-            .map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
-            .collect::<Vec<_>>()
-            .join("&");
-
+    /// Generate URL for GitHub App installation.
+    /// User clicks this to install the app on their repos.
+    pub fn installation_url(&self, state: &str) -> OAuthAuthorizationUrl {
+        let url = format!(
+            "https://github.com/apps/{}/installations/new?state={}",
+            self.app_slug,
+            urlencoding::encode(state)
+        );
         OAuthAuthorizationUrl {
-            url: format!("https://github.com/login/oauth/authorize?{}", query),
+            url,
             state: state.to_string(),
         }
     }
 
-    /// Exchange code for access token + user info
-    pub async fn exchange_code(&self, code: &str) -> Result<GitHubConnectionResult> {
+    /// Create a JWT for authenticating as the GitHub App.
+    /// Valid for up to 10 minutes. Used to call GitHub API as the App.
+    pub fn create_app_jwt(&self) -> Result<String> {
+        use jsonwebtoken::{Algorithm, EncodingKey, Header};
+
+        let now = chrono::Utc::now().timestamp();
+        let claims = serde_json::json!({
+            "iat": now - 60,          // 60s in past for clock drift
+            "exp": now + (10 * 60),   // 10 minute max
+            "iss": self.app_id,
+        });
+
+        let key = EncodingKey::from_rsa_pem(self.private_key.as_bytes())
+            .context("Invalid GitHub App private key (must be PEM-encoded RSA)")?;
+        let header = Header::new(Algorithm::RS256);
+        let token = jsonwebtoken::encode(&header, &claims, &key)
+            .context("Failed to sign GitHub App JWT")?;
+        Ok(token)
+    }
+
+    /// Verify an installation exists and return its details.
+    /// Called during the installation callback to validate the installation_id.
+    pub async fn verify_installation(
+        &self,
+        installation_id: i64,
+    ) -> Result<GitHubInstallationResult> {
+        let jwt = self.create_app_jwt()?;
         let client = reqwest::Client::new();
 
-        let token_response: GitHubTokenResponse = client
-            .post("https://github.com/login/oauth/access_token")
-            .header("Accept", "application/json")
-            .form(&[
-                ("client_id", self.client_id.as_str()),
-                ("client_secret", self.client_secret.as_str()),
-                ("code", code),
-                ("redirect_uri", self.redirect_uri.as_str()),
-            ])
-            .send()
-            .await
-            .context("Failed to exchange code")?
-            .json()
-            .await
-            .context("Failed to parse token response")?;
-
-        let access_token = &token_response.access_token;
-
-        // Fetch user info to get username
-        let user_info: GitHubUserInfo = client
-            .get("https://api.github.com/user")
+        let response = client
+            .get(format!(
+                "https://api.github.com/app/installations/{installation_id}"
+            ))
+            .header("Authorization", format!("Bearer {jwt}"))
+            .header("Accept", "application/vnd.github+json")
             .header("User-Agent", "Everruns")
-            .bearer_auth(access_token)
+            .header("X-GitHub-Api-Version", "2022-11-28")
             .send()
             .await
-            .context("Failed to fetch user info")?
+            .context("Failed to verify GitHub App installation")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "GitHub API returned {status} verifying installation {installation_id}: {body}"
+            );
+        }
+
+        let installation: GitHubInstallation = response
             .json()
             .await
-            .context("Failed to parse user info")?;
+            .context("Failed to parse installation response")?;
 
-        Ok(GitHubConnectionResult {
-            access_token: token_response.access_token,
-            user_id: user_info.id.to_string(),
-            username: user_info.login,
-            scopes: token_response.scope.unwrap_or_default(),
+        // Format permissions as human-readable string
+        let permissions = installation
+            .permissions
+            .as_object()
+            .map(|obj| {
+                obj.iter()
+                    .map(|(k, v)| format!("{k}: {}", v.as_str().unwrap_or("unknown")))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            })
+            .unwrap_or_default();
+
+        Ok(GitHubInstallationResult {
+            installation_id,
+            account_id: installation.account.id.to_string(),
+            account_login: installation.account.login,
+            permissions,
         })
     }
+
+    /// Mint a short-lived installation access token (1h TTL).
+    /// Called at tool execution time to get a fresh token for git operations.
+    pub async fn mint_installation_token(&self, installation_id: i64) -> Result<String> {
+        let jwt = self.create_app_jwt()?;
+        let client = reqwest::Client::new();
+
+        let response = client
+            .post(format!(
+                "https://api.github.com/app/installations/{installation_id}/access_tokens"
+            ))
+            .header("Authorization", format!("Bearer {jwt}"))
+            .header("Accept", "application/vnd.github+json")
+            .header("User-Agent", "Everruns")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .send()
+            .await
+            .context("Failed to mint GitHub installation token")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "GitHub API returned {status} minting installation token for {installation_id}: {body}"
+            );
+        }
+
+        let token_response: GitHubInstallationTokenResponse = response
+            .json()
+            .await
+            .context("Failed to parse installation token response")?;
+
+        Ok(token_response.token)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubInstallation {
+    account: GitHubInstallationAccount,
+    permissions: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubInstallationAccount {
+    id: i64,
+    login: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubInstallationTokenResponse {
+    token: String,
 }
 
 /// URL encoding helper

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -576,9 +576,17 @@ pub async fn run(
 
             // Wire lazy connection resolver (requires encryption for token decryption)
             if let Some(ref enc) = encryption {
+                // Build GitHub App token minter if configured
+                let github_app_minter = auth_config.github_connection.as_ref().map(|config| {
+                    crate::storage::GitHubAppTokenMinter::new(
+                        config.app_id.clone(),
+                        config.private_key.clone(),
+                    )
+                });
                 let resolver = Arc::new(crate::storage::DbConnectionResolver::new(
                     db.as_ref().clone(),
                     enc.as_ref().clone(),
+                    github_app_minter,
                 ));
                 adapters = adapters.with_connection_resolver(resolver);
             }

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -1095,4 +1095,12 @@ impl StorageBackend {
     ) -> Result<Option<Vec<u8>>> {
         dispatch!(self, get_connection_token_for_session, session_id, provider)
     }
+
+    pub async fn get_installation_id_for_session(
+        &self,
+        session_id: SessionId,
+        provider: &str,
+    ) -> Result<Option<i64>> {
+        dispatch!(self, get_installation_id_for_session, session_id, provider)
+    }
 }

--- a/crates/server/src/storage/connection_resolver.rs
+++ b/crates/server/src/storage/connection_resolver.rs
@@ -5,6 +5,9 @@
 // - Tokens are always fresh (reconnect mid-session works)
 // - Sessions created before connecting still get tokens
 // - Tools can show helpful guidance when not connected
+//
+// GitHub App connections: mints a fresh 1h installation token on each request.
+// Legacy OAuth connections: decrypts the stored token.
 
 use async_trait::async_trait;
 use everruns_core::traits::UserConnectionResolver;
@@ -13,6 +16,7 @@ use everruns_core::{AgentLoopError, Result};
 
 use super::backend::StorageBackend;
 use super::encryption::EncryptionService;
+use crate::auth::oauth::GitHubAppService;
 
 /// Resolves user connection tokens by looking up the session's org members.
 ///
@@ -23,11 +27,56 @@ use super::encryption::EncryptionService;
 pub struct DbConnectionResolver {
     db: StorageBackend,
     encryption: EncryptionService,
+    /// GitHub App service for minting installation tokens (None = legacy OAuth only)
+    github_app: Option<GitHubAppTokenMinter>,
+}
+
+/// Handles GitHub App JWT signing and installation token minting.
+/// Cloneable so the resolver can be shared across tool executions.
+#[derive(Clone)]
+pub struct GitHubAppTokenMinter {
+    app_id: String,
+    private_key: String,
+}
+
+impl GitHubAppTokenMinter {
+    pub fn new(app_id: String, private_key: String) -> Self {
+        Self {
+            app_id,
+            private_key,
+        }
+    }
+
+    /// Mint a fresh installation access token (1h TTL).
+    async fn mint_token(&self, installation_id: i64) -> std::result::Result<String, String> {
+        use crate::auth::config::GitHubConnectionConfig;
+
+        // Build a minimal config for GitHubAppService
+        let config = GitHubConnectionConfig {
+            app_id: self.app_id.clone(),
+            private_key: self.private_key.clone(),
+            app_slug: String::new(),
+            setup_url: String::new(),
+        };
+        let service = GitHubAppService::new(&config);
+        service
+            .mint_installation_token(installation_id)
+            .await
+            .map_err(|e| format!("Failed to mint GitHub installation token: {e}"))
+    }
 }
 
 impl DbConnectionResolver {
-    pub fn new(db: StorageBackend, encryption: EncryptionService) -> Self {
-        Self { db, encryption }
+    pub fn new(
+        db: StorageBackend,
+        encryption: EncryptionService,
+        github_app: Option<GitHubAppTokenMinter>,
+    ) -> Self {
+        Self {
+            db,
+            encryption,
+            github_app,
+        }
     }
 }
 
@@ -38,6 +87,25 @@ impl UserConnectionResolver for DbConnectionResolver {
         session_id: SessionId,
         provider: &str,
     ) -> Result<Option<String>> {
+        // GitHub App path: mint a fresh installation token
+        if provider == "github"
+            && let Some(ref minter) = self.github_app
+        {
+            let installation_id = self
+                .db
+                .get_installation_id_for_session(session_id, provider)
+                .await
+                .map_err(|e| {
+                    AgentLoopError::store(format!("Failed to resolve GitHub installation: {e}"))
+                })?;
+
+            if let Some(id) = installation_id {
+                let token = minter.mint_token(id).await.map_err(AgentLoopError::store)?;
+                return Ok(Some(token));
+            }
+        }
+
+        // Legacy path: decrypt stored OAuth token
         let encrypted = self
             .db
             .get_connection_token_for_session(session_id, provider)

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -3123,6 +3123,7 @@ impl InMemoryDatabase {
             refresh_token_encrypted: input.refresh_token_encrypted,
             scopes: input.scopes,
             expires_at: input.expires_at,
+            installation_id: input.installation_id,
             created_at: now,
             updated_at: now,
         };
@@ -3179,12 +3180,52 @@ impl InMemoryDatabase {
             .collect();
         drop(members);
 
-        // Find first matching connection
+        // Find first matching connection with an encrypted token
+        let connections = self.user_connections.read();
+        for uid in user_ids.clone() {
+            for conn in connections.values() {
+                if conn.user_id == uid
+                    && conn.provider == provider
+                    && conn.access_token_encrypted.is_some()
+                {
+                    return Ok(conn.access_token_encrypted.clone());
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    pub async fn get_installation_id_for_session(
+        &self,
+        session_id: SessionId,
+        provider: &str,
+    ) -> Result<Option<i64>> {
+        // Look up session → org → members → connections (same join as token lookup)
+        let sessions = self.sessions.read();
+        let session = match sessions.get(&session_id) {
+            Some(s) => s,
+            None => return Ok(None),
+        };
+        let org_id = session.org_id;
+        drop(sessions);
+
+        let members = self.organization_members.read();
+        let user_ids: Vec<Uuid> = members
+            .iter()
+            .filter(|((oid, _), _)| *oid == org_id)
+            .map(|((_, uid), _)| *uid)
+            .collect();
+        drop(members);
+
         let connections = self.user_connections.read();
         for uid in user_ids {
             for conn in connections.values() {
-                if conn.user_id == uid && conn.provider == provider {
-                    return Ok(Some(conn.access_token_encrypted.clone()));
+                if conn.user_id == uid
+                    && conn.provider == provider
+                    && conn.installation_id.is_some()
+                {
+                    return Ok(conn.installation_id);
                 }
             }
         }

--- a/crates/server/src/storage/mod.rs
+++ b/crates/server/src/storage/mod.rs
@@ -29,7 +29,7 @@ mod event_tests;
 
 pub use agent_store::{DbAgentStore, create_db_agent_store};
 pub use backend::StorageBackend;
-pub use connection_resolver::DbConnectionResolver;
+pub use connection_resolver::{DbConnectionResolver, GitHubAppTokenMinter};
 pub use encryption::{
     ENCRYPTED_COLUMNS, EncryptedColumn, EncryptedPayload, EncryptionService,
     generate_encryption_key,

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -824,10 +824,13 @@ pub struct UserConnectionRow {
     pub provider: String,
     pub provider_user_id: Option<String>,
     pub provider_username: Option<String>,
-    pub access_token_encrypted: Vec<u8>,
+    /// Encrypted OAuth token (NULL for GitHub App connections)
+    pub access_token_encrypted: Option<Vec<u8>>,
     pub refresh_token_encrypted: Option<Vec<u8>>,
     pub scopes: Option<String>,
     pub expires_at: Option<DateTime<Utc>>,
+    /// GitHub App installation ID (tokens minted on demand)
+    pub installation_id: Option<i64>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -839,8 +842,11 @@ pub struct CreateUserConnectionRow {
     pub provider: String,
     pub provider_user_id: Option<String>,
     pub provider_username: Option<String>,
-    pub access_token_encrypted: Vec<u8>,
+    /// Encrypted OAuth token (None for GitHub App connections)
+    pub access_token_encrypted: Option<Vec<u8>>,
     pub refresh_token_encrypted: Option<Vec<u8>>,
     pub scopes: Option<String>,
     pub expires_at: Option<DateTime<Utc>>,
+    /// GitHub App installation ID (tokens minted on demand)
+    pub installation_id: Option<i64>,
 }

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -3466,9 +3466,9 @@ impl Database {
 
         let row = sqlx::query_as::<_, UserConnectionRow>(
             r#"
-            INSERT INTO user_connections (user_id, provider, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-            RETURNING id, user_id, provider, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, created_at, updated_at
+            INSERT INTO user_connections (user_id, provider, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            RETURNING id, user_id, provider, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id, created_at, updated_at
             "#,
         )
         .bind(input.user_id)
@@ -3479,6 +3479,7 @@ impl Database {
         .bind(&input.refresh_token_encrypted)
         .bind(&input.scopes)
         .bind(input.expires_at)
+        .bind(input.installation_id)
         .fetch_one(&self.pool)
         .await?;
 
@@ -3493,7 +3494,7 @@ impl Database {
     ) -> Result<Option<UserConnectionRow>> {
         let row = sqlx::query_as::<_, UserConnectionRow>(
             r#"
-            SELECT id, user_id, provider, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, created_at, updated_at
+            SELECT id, user_id, provider, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id, created_at, updated_at
             FROM user_connections
             WHERE user_id = $1 AND provider = $2
             ORDER BY created_at DESC
@@ -3512,7 +3513,7 @@ impl Database {
     pub async fn list_user_connections(&self, user_id: Uuid) -> Result<Vec<UserConnectionRow>> {
         let rows = sqlx::query_as::<_, UserConnectionRow>(
             r#"
-            SELECT id, user_id, provider, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, created_at, updated_at
+            SELECT id, user_id, provider, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id, created_at, updated_at
             FROM user_connections
             WHERE user_id = $1
             ORDER BY provider ASC
@@ -3527,18 +3528,20 @@ impl Database {
 
     /// Get the encrypted connection token for a session's org member.
     /// Joins session → org_members → user_connections to resolve lazily.
+    /// Returns None for GitHub App connections (use get_installation_id_for_session instead).
     pub async fn get_connection_token_for_session(
         &self,
         session_id: SessionId,
         provider: &str,
     ) -> Result<Option<Vec<u8>>> {
-        let row: Option<(Vec<u8>,)> = sqlx::query_as(
+        let row: Option<(Option<Vec<u8>>,)> = sqlx::query_as(
             r#"
             SELECT uc.access_token_encrypted
             FROM sessions s
             JOIN organization_members om ON om.org_id = s.org_id
             JOIN user_connections uc ON uc.user_id = om.user_id AND uc.provider = $2
             WHERE s.id = $1
+              AND uc.access_token_encrypted IS NOT NULL
             LIMIT 1
             "#,
         )
@@ -3547,7 +3550,33 @@ impl Database {
         .fetch_optional(&self.pool)
         .await?;
 
-        Ok(row.map(|(blob,)| blob))
+        Ok(row.and_then(|(blob,)| blob))
+    }
+
+    /// Get the GitHub App installation ID for a session's org member.
+    /// Used by the connection resolver to mint fresh installation tokens.
+    pub async fn get_installation_id_for_session(
+        &self,
+        session_id: SessionId,
+        provider: &str,
+    ) -> Result<Option<i64>> {
+        let row: Option<(i64,)> = sqlx::query_as(
+            r#"
+            SELECT uc.installation_id
+            FROM sessions s
+            JOIN organization_members om ON om.org_id = s.org_id
+            JOIN user_connections uc ON uc.user_id = om.user_id AND uc.provider = $2
+            WHERE s.id = $1
+              AND uc.installation_id IS NOT NULL
+            LIMIT 1
+            "#,
+        )
+        .bind(session_id)
+        .bind(provider)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.map(|(id,)| id))
     }
 
     /// Delete a user's connection for a specific provider

--- a/specs/user-connections.md
+++ b/specs/user-connections.md
@@ -136,17 +136,25 @@ Create a GitHub App:
 
 1. Go to **GitHub → Settings → Developer settings → GitHub Apps → New GitHub App**
 2. Configure:
-   - **GitHub App name:** `Everruns`
-   - **Homepage URL:** `https://everruns.com`
-   - **Setup URL:** `https://<domain>/v1/user/connections/github/callback` (or `http://localhost:9300/api/v1/user/connections/github/callback` for local dev)
-   - **Redirect on update:** checked
-   - **Webhook:** uncheck "Active" (not needed)
-   - **Repository permissions:** `Contents: Read & write` (or `Read-only` for clone-only)
-   - **Where can this GitHub App be installed?** `Any account`
+
+   | Field | Value |
+   |-------|-------|
+   | **GitHub App name** | `Everruns` (or `Everruns (Dev)` for local) |
+   | **Homepage URL** | `https://everruns.com` |
+   | **Callback URL** | _(leave blank — not used, we use installation flow, not OAuth)_ |
+   | **Setup URL** (Post installation) | `https://<domain>/api/v1/user/connections/github/callback` |
+   | **Redirect on update** | Checked |
+   | **Webhook → Active** | Unchecked |
+   | **Repository permissions** | `Contents: Read & write` (or `Read-only` for clone-only) |
+   | **Where can this be installed?** | `Any account` |
+
+   > **Setup URL vs Callback URL:** The Callback URL is for OAuth user-authorization flow — we don't use it. The Setup URL is where GitHub redirects after a user **installs** the app on their repos. The server receives the `installation_id` there, verifies it, stores it, then redirects to the UI.
+
 3. After creation:
    - Copy **App ID** → `GITHUB_APP_ID`
    - Note the **slug** from the URL → `GITHUB_APP_SLUG`
    - Generate a **private key** (.pem file) → `GITHUB_APP_PRIVATE_KEY`
+   - `GITHUB_APP_PRIVATE_KEY` supports literal `\n` in env vars (auto-converted at startup)
 
 #### Dev App: Everruns (Dev)
 
@@ -157,7 +165,7 @@ Pre-configured for local development: <https://github.com/settings/apps/everruns
 | **GitHub App name** | `Everruns (Dev)` |
 | **Homepage URL** | `http://localhost:9300` |
 | **Callback URL** | _(leave blank)_ |
-| **Setup URL** | `http://localhost:9300/api/v1/user/connections/github/callback` |
+| **Setup URL** (Post installation) | `http://localhost:9300/api/v1/user/connections/github/callback` |
 | **Redirect on update** | Checked |
 | **Webhook → Active** | Unchecked |
 

--- a/specs/user-connections.md
+++ b/specs/user-connections.md
@@ -148,6 +148,19 @@ Create a GitHub App:
    - Note the **slug** from the URL → `GITHUB_APP_SLUG`
    - Generate a **private key** (.pem file) → `GITHUB_APP_PRIVATE_KEY`
 
+#### Dev App: Everruns (Dev)
+
+Pre-configured for local development: <https://github.com/settings/apps/everruns-dev>
+
+| Field | Value |
+|-------|-------|
+| **GitHub App name** | `Everruns (Dev)` |
+| **Homepage URL** | `http://localhost:9300` |
+| **Callback URL** | _(leave blank)_ |
+| **Setup URL** | `http://localhost:9300/api/v1/user/connections/github/callback` |
+| **Redirect on update** | Checked |
+| **Webhook → Active** | Unchecked |
+
 ### Security
 
 - No long-lived tokens stored for GitHub (only `installation_id`, which is not a secret)

--- a/specs/user-connections.md
+++ b/specs/user-connections.md
@@ -2,7 +2,7 @@
 
 ## Abstract
 
-User connections allow users to link external service accounts (GitHub, GitLab, etc.) to their Everruns account, independent of their authentication provider. A user who logged in via Google or email/password can still connect their GitHub account for repo access. Connected tokens are auto-injected into agent sessions, enabling tools like `csb_git_clone` to operate as the user without exposing credentials to the LLM.
+User connections allow users to link external service accounts (GitHub, GitLab, etc.) to their Everruns account, independent of their authentication provider. A user who logged in via Google or email/password can still connect their GitHub account for repo access. Connection tokens are resolved lazily at tool execution time, enabling tools like `git_clone` to operate as the user without exposing credentials to the LLM.
 
 ## Requirements
 
@@ -13,58 +13,72 @@ User connections allow users to link external service accounts (GitHub, GitLab, 
 | `id` | UUID v7 | Internal primary key |
 | `user_id` | UUID | FK to users.id |
 | `provider` | string | `github`, `gitlab`, `bitbucket` |
-| `provider_user_id` | string | Provider's user ID |
+| `provider_user_id` | string | Provider's user/account ID |
 | `provider_username` | string | Display name (e.g., `octocat`) |
-| `access_token_encrypted` | bytes | Encrypted with envelope encryption |
+| `access_token_encrypted` | bytes? | Encrypted OAuth token (NULL for GitHub App) |
 | `refresh_token_encrypted` | bytes? | For providers that support refresh |
-| `scopes` | string? | Granted scopes (e.g., `repo,read:user`) |
-| `expires_at` | timestamp? | NULL = no expiry (GitHub OAuth App tokens) |
+| `scopes` | string? | Granted permissions (e.g., `contents: read`) |
+| `installation_id` | bigint? | GitHub App installation ID |
+| `expires_at` | timestamp? | NULL = no expiry |
 | `created_at` | timestamp | |
 | `updated_at` | timestamp | |
 
 No unique DB constraint on (user_id, provider). Uniqueness enforced in application code. This allows future multi-account support per provider if needed.
 
-### Connection Method: GitHub OAuth App
+### Connection Method: GitHub App
 
+A **GitHub App** (not an OAuth App) provides granular, per-repo permissions with short-lived tokens.
 
-
-A **separate** GitHub OAuth App from the login OAuth App. Different client_id/secret, different scopes.
-
-- Login OAuth App scopes: `user:email read:user` (profile only)
-- Connection OAuth App scopes: `repo read:user` (repo access + profile for username)
+| Property | OAuth App (old) | GitHub App (current) |
+|----------|----------------|---------------------|
+| Token lifetime | Forever | 1 hour (installation access token) |
+| Scope | `repo` = all repos | Per-repo (user selects which repos to install on) |
+| Permissions | Coarse (`repo` = read+write+admin) | Granular (e.g., `contents: read` for clone only) |
+| Revocation | User must manually revoke | Token expires automatically |
+| Blast radius | All user's repos, forever | Selected repos only, 1 hour window |
 
 **Flow:**
-1. User clicks "Connect GitHub" in settings UI
-2. `GET /v1/user/connections/github/authorize` → redirect to GitHub
-3. GitHub redirects back → `GET /v1/user/connections/github/callback?code=...&state=...`
-4. Server exchanges code for access_token
-5. Server calls GitHub API to get username/user_id
-6. Server encrypts token, upserts into `user_connections`
+1. User clicks "Install" in Settings > Connections
+2. `GET /v1/user/connections/github/authorize` → redirect to GitHub App installation page
+3. User selects which repos to grant access to
+4. GitHub redirects back → `GET /v1/user/connections/github/callback?installation_id=...&setup_action=install`
+5. Server verifies installation via GitHub API (`GET /app/installations/{id}`)
+6. Server stores `installation_id` in `user_connections`
 7. Redirect to UI settings page with success
 
-**Token behavior:** GitHub OAuth App tokens do not expire by default. No refresh flow needed for v1.
+**Token minting:** At tool execution time, the server:
+1. Reads `installation_id` from `user_connections`
+2. Creates a JWT signed with the App's RSA private key (RS256, 10min TTL)
+3. Calls `POST /app/installations/{id}/access_tokens` to mint a 1-hour token
+4. Returns the token to the tool
+
+**Permissions requested in App manifest:**
+- Clone-only: `contents: read`
+- Clone+push: `contents: write` (includes read)
+- No admin, no webhooks, no issues, no PRs — unless needed
 
 ### Scoping
 
-Connections are **user-scoped**. The token represents the user's identity on the external service. It's usable in any org the user belongs to.
+Connections are **user-scoped**. The installation represents the user's/org's grant of access. It's usable in any Everruns org the user belongs to.
 
 **Visibility:** Connections are private to the user who created them. Other org members cannot list, view, or manage another user's connections via the API. The `GET /v1/user/connections` endpoint only returns the authenticated user's own connections.
 
-**Token resolution:** Although connections are private, the lazy token resolver (`UserConnectionResolver`) can resolve tokens across org members for tool execution. When a tool needs a GitHub token, the resolver finds any org member who has connected GitHub. This means a user's token may be used to serve tool requests in sessions belonging to the same org, but the connection itself remains invisible to other users.
+**Token resolution:** Although connections are private, the lazy token resolver (`UserConnectionResolver`) can resolve tokens across org members for tool execution. When a tool needs a GitHub token, the resolver finds any org member who has connected GitHub. This means a user's installation may be used to serve tool requests in sessions belonging to the same org, but the connection itself remains invisible to other users.
 
 ### Lazy Token Resolution
 
 Connection tokens are resolved lazily at tool execution time via `UserConnectionResolver`:
 
-1. Tool (e.g. `csb_git_clone`) requests token via `context.connection_resolver`
-2. Resolver joins `sessions → org_members → user_connections` to find the token
-3. Token is decrypted and returned directly to the tool
+1. Tool (e.g. `git_clone`) requests token via `context.connection_resolver`
+2. For GitHub App: resolver reads `installation_id`, mints a fresh 1h token via GitHub API
+3. For legacy OAuth: resolver decrypts stored `access_token_encrypted`
 4. If no connection exists, tool returns guidance: "connect GitHub in Settings > Connections"
 
-Benefits over eager session injection:
-- Tokens are always fresh (reconnect mid-session works)
+Benefits:
+- Tokens are always fresh (1h TTL, minted on demand)
 - Sessions created before connecting still get tokens
-- No stale secrets in session storage
+- No long-lived secrets stored for GitHub
+- Token scope is limited to installed repos only
 
 The token value never appears in tool arguments, tool results, or message history.
 
@@ -81,7 +95,7 @@ List user's connected accounts. Token values never returned.
     {
       "provider": "github",
       "provider_username": "octocat",
-      "scopes": "repo,read:user",
+      "scopes": "contents: write, metadata: read",
       "connected_at": "2026-02-15T10:00:00Z"
     }
   ]
@@ -90,67 +104,79 @@ List user's connected accounts. Token values never returned.
 
 #### DELETE /v1/user/connections/{provider}
 
-Disconnect. Deletes the stored token.
+Disconnect. Deletes the stored installation_id/token.
 
 **Response:** `204 No Content`
 
 #### GET /v1/user/connections/github/authorize
 
-Start GitHub OAuth flow. Returns redirect to GitHub.
-
-**Query params:**
-- `redirect_uri` (optional): Where to redirect after callback (default: UI settings page)
+Start GitHub App installation flow. Redirects to `https://github.com/apps/{slug}/installations/new`.
 
 #### GET /v1/user/connections/github/callback
 
-GitHub OAuth callback. Exchanges code, stores token, redirects to UI.
+GitHub App installation callback. Receives `installation_id`, verifies it, stores it, redirects to UI.
+
+**Query params (from GitHub):**
+- `installation_id`: The numeric installation ID
+- `setup_action`: `install` or `update`
+- `state`: CSRF token (if passed during redirect)
 
 ### Environment Variables
 
 | Variable | Description |
 |----------|-------------|
-| `GITHUB_CONNECTION_CLIENT_ID` | GitHub OAuth App client ID (for connections, NOT login) |
-| `GITHUB_CONNECTION_CLIENT_SECRET` | GitHub OAuth App client secret |
-| `GITHUB_CONNECTION_REDIRECT_URI` | Callback URL (default: `{AUTH_BASE_URL}{API_PREFIX}/v1/user/connections/github/callback`) |
+| `GITHUB_APP_ID` | GitHub App ID (numeric, from App settings page) |
+| `GITHUB_APP_PRIVATE_KEY` | PEM-encoded RSA private key for JWT signing |
+| `GITHUB_APP_SLUG` | App slug for installation URL (default: `everruns`) |
+| `GITHUB_APP_SETUP_URL` | Post-install callback URL (default: `{AUTH_BASE_URL}{API_PREFIX}/v1/user/connections/github/callback`) |
 
-### GitHub OAuth App Setup
+### GitHub App Setup
 
-Create a **separate** GitHub OAuth App for connections (not the login OAuth App):
+Create a GitHub App:
 
-1. Go to **GitHub → Settings → Developer settings → OAuth Apps → New OAuth App**
+1. Go to **GitHub → Settings → Developer settings → GitHub Apps → New GitHub App**
 2. Configure:
-   - **Application name:** `Everruns`
-   - **Homepage URL:** `https://everruns.com` (or `http://localhost:9300` for local dev)
-   - **Authorization callback URL:** `http://localhost:9300/api/v1/user/connections/github/callback` (local) or `https://<domain>/v1/user/connections/github/callback` (production)
-3. Copy **Client ID** → `GITHUB_CONNECTION_CLIENT_ID`
-4. Generate **Client Secret** → `GITHUB_CONNECTION_CLIENT_SECRET`
-
-The app requests `repo read:user` scopes (hardcoded in `GitHubConnectionService`).
+   - **GitHub App name:** `Everruns`
+   - **Homepage URL:** `https://everruns.com`
+   - **Setup URL:** `https://<domain>/v1/user/connections/github/callback` (or `http://localhost:9300/api/v1/user/connections/github/callback` for local dev)
+   - **Redirect on update:** checked
+   - **Webhook:** uncheck "Active" (not needed)
+   - **Repository permissions:** `Contents: Read & write` (or `Read-only` for clone-only)
+   - **Where can this GitHub App be installed?** `Any account`
+3. After creation:
+   - Copy **App ID** → `GITHUB_APP_ID`
+   - Note the **slug** from the URL → `GITHUB_APP_SLUG`
+   - Generate a **private key** (.pem file) → `GITHUB_APP_PRIVATE_KEY`
 
 ### Security
 
-- Tokens encrypted at rest via AES-256-GCM envelope encryption (same as MCP server API keys, session secrets)
+- No long-lived tokens stored for GitHub (only `installation_id`, which is not a secret)
+- Installation tokens are minted on demand with 1h TTL
+- App private key stored as server-side env var, never in database
 - Token never returned in API responses
 - Token never appears in LLM message history or tool results
-- `csb_git_clone` tool uses credential helper approach: writes a temporary script inside the sandbox VM that supplies the token, avoiding it appearing in command lines or process lists
-- Revoking a connection immediately prevents new sessions from getting the token; existing sessions retain their injected copy until session ends
+- Git tools use credential helper approach: writes a temporary script inside the sandbox that supplies the token, avoiding it appearing in command lines or process lists
+- Revoking (uninstalling) the GitHub App immediately prevents new token minting
+- Other providers (GitLab) still use encrypted OAuth tokens at rest
 
 ### Error Handling
 
 | Scenario | Response |
 |----------|----------|
-| Already connected (app-level check) | 409: "Already connected to {provider}. Disconnect first." |
-| OAuth state mismatch | 400: "Invalid OAuth state" |
+| Already connected (app-level check) | Upsert replaces existing connection |
+| Installation verification failed | 400: "GitHub App installation verification failed" |
 | Connection not found on delete | 404 |
-| Missing connection config | 500 (logged): GitHub connection OAuth App not configured |
+| Missing GitHub App config | 500 (logged): "GitHub App not configured" |
 
 ## Design Decisions
 
 | Question | Decision | Rationale |
 |----------|----------|-----------|
-| Separate OAuth App? | Yes | Different scopes (repo vs profile). Separation of concerns. User sees distinct authorization prompts. |
-| User-scoped not org-scoped? | Yes | Token represents user's GitHub identity, not org's. Different org members have different repo access. Connections are private — other org members cannot see them. |
+| GitHub App instead of OAuth App? | Yes | Short-lived tokens (1h vs forever), per-repo permissions, smaller blast radius. See security comparison table above. |
+| User-scoped not org-scoped? | Yes | Installation represents user's GitHub identity/access, not Everruns org's. Different org members have different repo access. Connections are private. |
+| Store installation_id not token? | Yes | Tokens minted on demand via App private key. No long-lived secrets in database. |
 | No DB unique constraint? | Yes | Enforce in app code. Allows future multi-account per provider without migration. |
-| Auto-inject into sessions? | Yes | Seamless UX. User connects once, all sessions get access. |
+| Auto-inject into sessions? | Yes | Seamless UX. User installs once, all sessions get access. |
 | Credential helper not URL-embedded token? | Yes | Token never appears in command line, process list, or exec output. Safer. |
-| Generic `user_connections` not `github_connections`? | Yes | Same pattern works for GitLab, Bitbucket. Provider-generic table + provider-specific OAuth code. |
+| Generic `user_connections` not `github_connections`? | Yes | Same pattern works for GitLab, Bitbucket. Provider-generic table + provider-specific connection code. |
+| Backward-compatible resolver? | Yes | Resolver checks `installation_id` first (GitHub App path), falls back to `access_token_encrypted` (legacy OAuth path). Supports migration period. |


### PR DESCRIPTION
## What
Improve GitHub App setup instructions in `specs/user-connections.md`.

## Why
Setup URL vs Callback URL distinction was unclear, causing misconfiguration.

## How
- Restructured setup fields as a table for clarity
- Added explicit note: Callback URL is for OAuth (unused), Setup URL is for installation flow
- Noted `\n` support in `GITHUB_APP_PRIVATE_KEY` env var
- Added dev app (Everruns (Dev)) reference with link

## Risk
- Low
- Spec-only change, no code affected

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered