### PR TITLE
feat(daytona): git credential store for push/pull/fetch

### DIFF
--- a/integrations/daytona/src/lib.rs
+++ b/integrations/daytona/src/lib.rs
@@ -20,7 +20,8 @@ use std::time::Duration;
 
 use tools::{
     DaytonaCreateSandboxTool, DaytonaDownloadWorkspaceTool, DaytonaExecTool, DaytonaGitCloneTool,
-    DaytonaListSandboxesTool, DaytonaManageSandboxTool, DaytonaReadFileTool, DaytonaWriteFileTool,
+    DaytonaGitCredentialsTool, DaytonaListSandboxesTool, DaytonaManageSandboxTool,
+    DaytonaReadFileTool, DaytonaWriteFileTool,
 };
 
 // ============================================================================
@@ -97,6 +98,7 @@ Tools:
 - `daytona_list_sandboxes` - List session sandboxes
 - `daytona_manage_sandbox` - Stop or delete a sandbox
 - `daytona_git_clone` - Clone a git repository into a sandbox (auto-uses connected GitHub credentials)
+- `daytona_git_credentials` - Configure git credentials for push/pull/fetch via daytona_exec
 
 All tools except `daytona_create_sandbox` and `daytona_list_sandboxes` require a `sandbox_id`.
 Sandboxes auto-stop after 5 minutes of inactivity.
@@ -105,7 +107,11 @@ Always DELETE sandboxes when done (stop leaves them on the dashboard).
 Git cloning: Use `daytona_git_clone` to clone repositories into `/sandbox/owner/repo`.
 If the user has connected their GitHub account (Settings > Connections), private repos
 are automatically authenticated. For public repos, no credentials are needed.
-Supports "user/repo" shorthand. Working directory is `/sandbox`."#,
+Supports "user/repo" shorthand. Working directory is `/sandbox`.
+
+Git push/pull/fetch: After cloning, call `daytona_git_credentials` once to configure
+credentials in the sandbox. Then use `daytona_exec` for any git command (push, pull,
+fetch, rebase, etc.) — they authenticate automatically. Call again to refresh (~1h expiry)."#,
         )
     }
 
@@ -119,6 +125,7 @@ Supports "user/repo" shorthand. Working directory is `/sandbox`."#,
             Box::new(DaytonaListSandboxesTool),
             Box::new(DaytonaManageSandboxTool),
             Box::new(DaytonaGitCloneTool),
+            Box::new(DaytonaGitCredentialsTool),
         ]
     }
 
@@ -150,7 +157,7 @@ mod tests {
     fn test_capability_has_all_tools() {
         let cap = DaytonaCapability;
         let tools = cap.tools();
-        assert_eq!(tools.len(), 8);
+        assert_eq!(tools.len(), 9);
 
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
         assert!(names.contains(&"daytona_create_sandbox"));
@@ -161,6 +168,7 @@ mod tests {
         assert!(names.contains(&"daytona_list_sandboxes"));
         assert!(names.contains(&"daytona_manage_sandbox"));
         assert!(names.contains(&"daytona_git_clone"));
+        assert!(names.contains(&"daytona_git_credentials"));
     }
 
     #[test]
@@ -169,6 +177,7 @@ mod tests {
         let prompt = cap.system_prompt_addition().unwrap();
         assert!(prompt.contains("daytona_create_sandbox"));
         assert!(prompt.contains("daytona_git_clone"));
+        assert!(prompt.contains("daytona_git_credentials"));
         assert!(prompt.contains("DAYTONA_API_KEY"));
         assert!(prompt.contains("Experimental"));
     }

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -1005,7 +1005,8 @@ impl Tool for DaytonaGitCredentialsTool {
 
         let client = DaytonaClient::new(api_key);
 
-        // Write git-credentials file: https://oauth2:<token>@github.com
+        // THREAT[TM-DAYTONA-001]: Git token persisted on sandbox disk
+        // Mitigation: Written to /tmp (cleared on stop), short-lived (~1h), same trust boundary as exec
         let credentials_content = format!("https://oauth2:{github_token}@github.com\n");
         if let Err(e) = client
             .file_upload(
@@ -1148,6 +1149,94 @@ async fn get_github_token(context: &ToolContext) -> Option<String> {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    // ========================================================================
+    // Mock SessionStorageStore for integration tests
+    // ========================================================================
+
+    use everruns_core::error::Result;
+    use everruns_core::traits::{KeyInfo, SecretInfo, SessionStorageStore, UserConnectionResolver};
+    use everruns_core::typed_id::SessionId;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    /// In-memory mock of SessionStorageStore for testing.
+    struct MockStorageStore {
+        secrets: Mutex<HashMap<String, String>>,
+    }
+
+    impl MockStorageStore {
+        fn new() -> Self {
+            Self {
+                secrets: Mutex::new(HashMap::new()),
+            }
+        }
+
+        /// Pre-seed a secret for a given session.
+        async fn seed_secret(&self, session_id: SessionId, name: &str, value: &str) {
+            let key = format!("{}:{}", session_id, name);
+            self.secrets.lock().await.insert(key, value.to_string());
+        }
+    }
+
+    #[async_trait]
+    impl SessionStorageStore for MockStorageStore {
+        async fn set_value(&self, _session_id: SessionId, _key: &str, _value: &str) -> Result<()> {
+            Ok(())
+        }
+        async fn get_value(&self, _session_id: SessionId, _key: &str) -> Result<Option<String>> {
+            Ok(None)
+        }
+        async fn delete_value(&self, _session_id: SessionId, _key: &str) -> Result<bool> {
+            Ok(false)
+        }
+        async fn list_keys(&self, _session_id: SessionId) -> Result<Vec<KeyInfo>> {
+            Ok(vec![])
+        }
+        async fn set_secret(&self, session_id: SessionId, name: &str, value: &str) -> Result<()> {
+            let key = format!("{session_id}:{name}");
+            self.secrets.lock().await.insert(key, value.to_string());
+            Ok(())
+        }
+        async fn get_secret(&self, session_id: SessionId, name: &str) -> Result<Option<String>> {
+            let key = format!("{session_id}:{name}");
+            Ok(self.secrets.lock().await.get(&key).cloned())
+        }
+        async fn delete_secret(&self, session_id: SessionId, name: &str) -> Result<bool> {
+            let key = format!("{session_id}:{name}");
+            Ok(self.secrets.lock().await.remove(&key).is_some())
+        }
+        async fn list_secrets(&self, session_id: SessionId) -> Result<Vec<SecretInfo>> {
+            let prefix = format!("{session_id}:");
+            let secrets = self.secrets.lock().await;
+            Ok(secrets
+                .keys()
+                .filter(|k| k.starts_with(&prefix))
+                .map(|k| SecretInfo {
+                    name: k.strip_prefix(&prefix).unwrap_or(k).to_string(),
+                    created_at: chrono::Utc::now(),
+                    updated_at: chrono::Utc::now(),
+                })
+                .collect())
+        }
+    }
+
+    /// Mock connection resolver that returns a fixed token.
+    struct MockConnectionResolver {
+        token: Option<String>,
+    }
+
+    #[async_trait]
+    impl UserConnectionResolver for MockConnectionResolver {
+        async fn get_connection_token(
+            &self,
+            _session_id: SessionId,
+            _provider: &str,
+        ) -> Result<Option<String>> {
+            Ok(self.token.clone())
+        }
+    }
 
     #[tokio::test]
     async fn test_create_sandbox_without_context() {
@@ -1530,5 +1619,325 @@ mod tests {
         let strs: Vec<&str> = item_required.iter().map(|v| v.as_str().unwrap()).collect();
         assert!(strs.contains(&"session_path"));
         assert!(strs.contains(&"sandbox_path"));
+    }
+
+    // ========================================================================
+    // Git credentials tool - context-aware integration tests
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_git_credentials_missing_sandbox_id() {
+        let tool = DaytonaGitCredentialsTool;
+        let session_id = SessionId::new();
+        let store = Arc::new(MockStorageStore::new());
+        let context = ToolContext::with_storage_store(session_id, store);
+        let result = tool.execute_with_context(json!({}), &context).await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(
+                    msg.contains("Missing required parameter"),
+                    "Expected missing param error, got: {msg}"
+                );
+            }
+            _ => panic!("Expected ToolError for missing sandbox_id"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_git_credentials_no_api_key() {
+        let tool = DaytonaGitCredentialsTool;
+        let session_id = SessionId::new();
+        let store = Arc::new(MockStorageStore::new());
+        // No DAYTONA_API_KEY secret seeded
+        let context = ToolContext::with_storage_store(session_id, store);
+        let result = tool
+            .execute_with_context(json!({"sandbox_id": "sb_test"}), &context)
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(
+                    msg.contains("DAYTONA_API_KEY"),
+                    "Expected API key error, got: {msg}"
+                );
+            }
+            _ => panic!("Expected ToolError for missing API key"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_git_credentials_no_sandbox_state() {
+        let tool = DaytonaGitCredentialsTool;
+        let session_id = SessionId::new();
+        let store = Arc::new(MockStorageStore::new());
+        // Seed API key but no sandbox state
+        store
+            .seed_secret(session_id, "DAYTONA_API_KEY", "test_key")
+            .await;
+        let context = ToolContext::with_storage_store(session_id, store);
+        let result = tool
+            .execute_with_context(json!({"sandbox_id": "sb_test"}), &context)
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(
+                    msg.contains("not found"),
+                    "Expected sandbox not found error, got: {msg}"
+                );
+            }
+            _ => panic!("Expected ToolError for missing sandbox state"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_git_credentials_no_github_token() {
+        let tool = DaytonaGitCredentialsTool;
+        let session_id = SessionId::new();
+        let store = Arc::new(MockStorageStore::new());
+        store
+            .seed_secret(session_id, "DAYTONA_API_KEY", "test_key")
+            .await;
+        // Seed sandbox state
+        let state = SandboxState {
+            sandbox_id: "sb_test".to_string(),
+            workspace_path: "/sandbox".to_string(),
+            started_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+        store
+            .seed_secret(
+                session_id,
+                "daytona_sandbox:sb_test",
+                &serde_json::to_string(&state).unwrap(),
+            )
+            .await;
+        // No GitHub token — neither connection resolver nor GITHUB_TOKEN secret
+        let context = ToolContext::with_storage_store(session_id, store);
+        let result = tool
+            .execute_with_context(json!({"sandbox_id": "sb_test"}), &context)
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(
+                    msg.contains("No GitHub credentials"),
+                    "Expected no credentials error, got: {msg}"
+                );
+                // Should suggest Settings > Connections
+                assert!(
+                    msg.contains("Settings > Connections"),
+                    "Expected connection hint, got: {msg}"
+                );
+            }
+            _ => panic!("Expected ToolError for missing GitHub token"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_git_credentials_with_github_token_secret() {
+        // When GITHUB_TOKEN session secret is set (but no connection resolver),
+        // the tool should attempt to upload credentials. It will fail because
+        // the Daytona API is not reachable, but the token resolution should succeed.
+        let tool = DaytonaGitCredentialsTool;
+        let session_id = SessionId::new();
+        let store = Arc::new(MockStorageStore::new());
+        store
+            .seed_secret(session_id, "DAYTONA_API_KEY", "test_key")
+            .await;
+        let state = SandboxState {
+            sandbox_id: "sb_test".to_string(),
+            workspace_path: "/sandbox".to_string(),
+            started_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+        store
+            .seed_secret(
+                session_id,
+                "daytona_sandbox:sb_test",
+                &serde_json::to_string(&state).unwrap(),
+            )
+            .await;
+        store
+            .seed_secret(session_id, "GITHUB_TOKEN", "ghp_test_token_123")
+            .await;
+        let context = ToolContext::with_storage_store(session_id, store);
+        let result = tool
+            .execute_with_context(json!({"sandbox_id": "sb_test"}), &context)
+            .await;
+        // Should fail at HTTP call (no real Daytona API), not at token resolution
+        if let ToolExecutionResult::ToolError(msg) = result {
+            assert!(
+                !msg.contains("No GitHub credentials"),
+                "Token should have been resolved from GITHUB_TOKEN secret, got: {msg}"
+            );
+            // Should fail with connection/upload error (not auth error)
+            assert!(
+                msg.contains("Failed to write credentials file"),
+                "Expected HTTP failure, got: {msg}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_git_credentials_with_connection_resolver() {
+        // When connection resolver provides a token, it should be preferred
+        // over GITHUB_TOKEN session secret.
+        let tool = DaytonaGitCredentialsTool;
+        let session_id = SessionId::new();
+        let store = Arc::new(MockStorageStore::new());
+        store
+            .seed_secret(session_id, "DAYTONA_API_KEY", "test_key")
+            .await;
+        let state = SandboxState {
+            sandbox_id: "sb_test".to_string(),
+            workspace_path: "/sandbox".to_string(),
+            started_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+        store
+            .seed_secret(
+                session_id,
+                "daytona_sandbox:sb_test",
+                &serde_json::to_string(&state).unwrap(),
+            )
+            .await;
+        let resolver = Arc::new(MockConnectionResolver {
+            token: Some("ghs_connection_token_456".to_string()),
+        });
+        let context =
+            ToolContext::with_storage_store(session_id, store).with_connection_resolver(resolver);
+        let result = tool
+            .execute_with_context(json!({"sandbox_id": "sb_test"}), &context)
+            .await;
+        // Should fail at HTTP call, not at token resolution
+        if let ToolExecutionResult::ToolError(msg) = result {
+            assert!(
+                !msg.contains("No GitHub credentials"),
+                "Token should have been resolved from connection resolver, got: {msg}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_git_credentials_no_storage_store() {
+        let tool = DaytonaGitCredentialsTool;
+        let session_id = SessionId::new();
+        // No storage store at all
+        let context = ToolContext::new(session_id);
+        let result = tool
+            .execute_with_context(json!({"sandbox_id": "sb_test"}), &context)
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(
+                    msg.contains("not available") || msg.contains("DAYTONA_API_KEY"),
+                    "Expected storage error, got: {msg}"
+                );
+            }
+            _ => panic!("Expected ToolError for missing storage store"),
+        }
+    }
+
+    // ========================================================================
+    // Git clone tool - context-aware integration tests
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_git_clone_missing_repo_url() {
+        let tool = DaytonaGitCloneTool;
+        let session_id = SessionId::new();
+        let store = Arc::new(MockStorageStore::new());
+        let context = ToolContext::with_storage_store(session_id, store);
+        let result = tool
+            .execute_with_context(json!({"sandbox_id": "sb_test"}), &context)
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(
+                    msg.contains("Missing required parameter"),
+                    "Expected missing param error, got: {msg}"
+                );
+            }
+            _ => panic!("Expected ToolError for missing repo_url"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_git_clone_no_api_key() {
+        let tool = DaytonaGitCloneTool;
+        let session_id = SessionId::new();
+        let store = Arc::new(MockStorageStore::new());
+        let context = ToolContext::with_storage_store(session_id, store);
+        let result = tool
+            .execute_with_context(
+                json!({"sandbox_id": "sb_test", "repo_url": "user/repo"}),
+                &context,
+            )
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(
+                    msg.contains("DAYTONA_API_KEY"),
+                    "Expected API key error, got: {msg}"
+                );
+            }
+            _ => panic!("Expected ToolError for missing API key"),
+        }
+    }
+
+    // ========================================================================
+    // get_github_token helper tests
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_get_github_token_prefers_connection_resolver() {
+        let session_id = SessionId::new();
+        let store = Arc::new(MockStorageStore::new());
+        store
+            .seed_secret(session_id, "GITHUB_TOKEN", "fallback_token")
+            .await;
+        let resolver = Arc::new(MockConnectionResolver {
+            token: Some("preferred_token".to_string()),
+        });
+        let context =
+            ToolContext::with_storage_store(session_id, store).with_connection_resolver(resolver);
+        let token = get_github_token(&context).await;
+        assert_eq!(token, Some("preferred_token".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_get_github_token_falls_back_to_secret() {
+        let session_id = SessionId::new();
+        let store = Arc::new(MockStorageStore::new());
+        store
+            .seed_secret(session_id, "GITHUB_TOKEN", "secret_token")
+            .await;
+        // No connection resolver
+        let context = ToolContext::with_storage_store(session_id, store);
+        let token = get_github_token(&context).await;
+        assert_eq!(token, Some("secret_token".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_get_github_token_returns_none_when_empty() {
+        let session_id = SessionId::new();
+        let store = Arc::new(MockStorageStore::new());
+        let resolver = Arc::new(MockConnectionResolver { token: None });
+        let context =
+            ToolContext::with_storage_store(session_id, store).with_connection_resolver(resolver);
+        let token = get_github_token(&context).await;
+        assert_eq!(token, None);
+    }
+
+    #[tokio::test]
+    async fn test_get_github_token_skips_empty_connection_token() {
+        let session_id = SessionId::new();
+        let store = Arc::new(MockStorageStore::new());
+        store
+            .seed_secret(session_id, "GITHUB_TOKEN", "fallback")
+            .await;
+        // Resolver returns empty string — should fall through
+        let resolver = Arc::new(MockConnectionResolver {
+            token: Some("".to_string()),
+        });
+        let context =
+            ToolContext::with_storage_store(session_id, store).with_connection_resolver(resolver);
+        let token = get_github_token(&context).await;
+        assert_eq!(token, Some("fallback".to_string()));
     }
 }

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -935,6 +935,125 @@ impl Tool for DaytonaGitCloneTool {
 }
 
 // ============================================================================
+// DaytonaGitCredentialsTool
+// ============================================================================
+
+pub struct DaytonaGitCredentialsTool;
+
+#[async_trait]
+impl Tool for DaytonaGitCredentialsTool {
+    fn name(&self) -> &str {
+        "daytona_git_credentials"
+    }
+
+    fn description(&self) -> &str {
+        "Configure git credentials in a Daytona sandbox so that all git operations \
+         (push, pull, fetch, rebase, etc.) work transparently via daytona_exec. \
+         Uses the user's connected GitHub credentials. Call once after creating a \
+         sandbox; call again to refresh if the token expires (~1 hour)."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "sandbox_id": {
+                    "type": "string",
+                    "description": "Sandbox ID to configure git credentials in"
+                }
+            },
+            "required": ["sandbox_id"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "daytona_git_credentials requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let sandbox_id = match required_str(&arguments, "sandbox_id") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let api_key = match get_api_key(context).await {
+            Ok(k) => k,
+            Err(e) => return e,
+        };
+        let _state = match get_sandbox_state(context, sandbox_id).await {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        // Resolve GitHub token (same chain as daytona_git_clone)
+        let github_token = match get_github_token(context).await {
+            Some(token) => token,
+            None => {
+                return ToolExecutionResult::tool_error(
+                    "No GitHub credentials found. The user must connect their GitHub account \
+                     in Settings > Connections, or set a GITHUB_TOKEN session secret.",
+                );
+            }
+        };
+
+        let client = DaytonaClient::new(api_key);
+
+        // Write git-credentials file: https://oauth2:<token>@github.com
+        let credentials_content = format!("https://oauth2:{github_token}@github.com\n");
+        if let Err(e) = client
+            .file_upload(
+                sandbox_id,
+                "/tmp/.git-credentials",
+                credentials_content.as_bytes(),
+            )
+            .await
+        {
+            return ToolExecutionResult::tool_error(format!(
+                "Failed to write credentials file: {e}"
+            ));
+        }
+
+        // Configure git to use the credential store
+        let config_cmd =
+            "git config --global credential.helper 'store --file=/tmp/.git-credentials'";
+        match client.exec(sandbox_id, config_cmd, None, None).await {
+            Ok(r) if r.exit_code == 0 => {}
+            Ok(r) => {
+                return ToolExecutionResult::tool_error(format!(
+                    "Failed to configure git credential helper (exit {}): {}",
+                    r.exit_code, r.result
+                ));
+            }
+            Err(e) => {
+                return ToolExecutionResult::tool_error(format!(
+                    "Failed to configure git credential helper: {e}"
+                ));
+            }
+        }
+
+        debug!("Configured git credentials in sandbox {sandbox_id}");
+
+        ToolExecutionResult::success(json!({
+            "sandbox_id": sandbox_id,
+            "authenticated": true,
+            "provider": "github",
+            "hint": "Git credentials configured. All git operations (push, pull, fetch, etc.) via daytona_exec will now authenticate automatically. Token expires in ~1 hour; call this tool again to refresh."
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
 // Git Clone Helpers
 // ============================================================================
 
@@ -1196,6 +1315,7 @@ mod tests {
             Box::new(DaytonaListSandboxesTool),
             Box::new(DaytonaManageSandboxTool),
             Box::new(DaytonaGitCloneTool),
+            Box::new(DaytonaGitCredentialsTool),
         ];
         for tool in &tools {
             assert!(
@@ -1217,6 +1337,7 @@ mod tests {
             Box::new(DaytonaListSandboxesTool),
             Box::new(DaytonaManageSandboxTool),
             Box::new(DaytonaGitCloneTool),
+            Box::new(DaytonaGitCredentialsTool),
         ];
         for tool in &tools {
             assert!(
@@ -1238,6 +1359,7 @@ mod tests {
             Box::new(DaytonaListSandboxesTool),
             Box::new(DaytonaManageSandboxTool),
             Box::new(DaytonaGitCloneTool),
+            Box::new(DaytonaGitCredentialsTool),
         ];
         for tool in &tools {
             let schema = tool.parameters_schema();
@@ -1248,6 +1370,28 @@ mod tests {
                 tool.name()
             );
         }
+    }
+
+    // --- Git credentials tool tests ---
+
+    #[tokio::test]
+    async fn test_git_credentials_without_context() {
+        let tool = DaytonaGitCredentialsTool;
+        let result = tool.execute(json!({"sandbox_id": "test"})).await;
+        assert!(
+            matches!(result, ToolExecutionResult::ToolError(msg) if msg.contains("requires context"))
+        );
+    }
+
+    #[test]
+    fn test_git_credentials_schema() {
+        let tool = DaytonaGitCredentialsTool;
+        let schema = tool.parameters_schema();
+        let required = schema["required"].as_array().unwrap();
+        let required_strs: Vec<&str> = required.iter().map(|v| v.as_str().unwrap()).collect();
+        assert!(required_strs.contains(&"sandbox_id"));
+        assert_eq!(required_strs.len(), 1);
+        assert_eq!(schema["additionalProperties"], json!(false));
     }
 
     // --- Git clone tool tests ---

--- a/integrations/daytona/tests/plugin_registration.rs
+++ b/integrations/daytona/tests/plugin_registration.rs
@@ -62,5 +62,5 @@ fn test_daytona_capability_metadata() {
     assert_eq!(cap.icon(), Some("cloud"));
     assert_eq!(cap.category(), Some("Execution"));
     assert_eq!(cap.dependencies(), vec!["session_storage"]);
-    assert_eq!(cap.tools().len(), 8);
+    assert_eq!(cap.tools().len(), 9);
 }

--- a/specs/daytona.md
+++ b/specs/daytona.md
@@ -164,6 +164,20 @@ Clone a git repository into a sandbox. Automatically uses the user's connected G
 3. If token found: passes `username=oauth2`, `password=<token>` to the git clone API
 4. If no token: public repos only; private repos fail with hint to connect GitHub
 
+### daytona_git_credentials
+
+Configure git credentials in a sandbox so that all git operations (push, pull, fetch, rebase, etc.) work transparently via `daytona_exec`. Call once after creating a sandbox; call again to refresh if the token expires (~1 hour).
+
+- **Parameters**:
+  - `sandbox_id`: string (required)
+- **Returns**: `{ sandbox_id, authenticated, provider, hint }`
+
+**Implementation:** Writes a `git credential store` file (`/tmp/.git-credentials`) containing `https://oauth2:<token>@github.com`, then configures `git config --global credential.helper 'store --file=/tmp/.git-credentials'`. After this, any git command via `daytona_exec` authenticates automatically.
+
+**Authentication flow:** Same token resolution as `daytona_git_clone` (connection_resolver → GITHUB_TOKEN fallback). Fails with actionable error if no credentials found.
+
+**Design:** Avoids per-verb tools (git_push, git_fetch, etc.). Instead, configures standard git credential store once, then agent uses `daytona_exec` for all git operations naturally. Token in `/tmp` — lost on sandbox stop, same trust boundary as sandbox exec access.
+
 ## Security
 
 - **API Key**: Stored in session secrets (`DAYTONA_API_KEY`), encrypted at rest
@@ -212,7 +226,7 @@ External integration crate, auto-registered via `inventory::submit!` plugin syst
 | `src/lib.rs` | Plugin registration, constants, `DaytonaCapability` impl |
 | `src/client.rs` | `DaytonaClient` HTTP client (management + toolbox APIs), URL encoding |
 | `src/state.rs` | API types (`SandboxInfo`, `ExecResult`, `SandboxState`), session state helpers |
-| `src/tools.rs` | 8 tool implementations (`DaytonaCreateSandboxTool`, etc.) |
+| `src/tools.rs` | 9 tool implementations (`DaytonaCreateSandboxTool`, etc.) |
 | `tests/plugin_registration.rs` | Integration tests for inventory registration and dev/prod gating |
 
 ## Capability Registration

--- a/specs/daytona.md
+++ b/specs/daytona.md
@@ -213,6 +213,16 @@ Daytona uses a single API key for both management and toolbox APIs. No per-sandb
 
 Files are managed through the Toolbox API proxy (`proxy.app.daytona.io`). Upload uses multipart/form-data, download returns raw bytes.
 
+### Git credentials via credential store file
+
+Git credentials for push/pull/fetch are configured by writing a `git credential store` file (`/tmp/.git-credentials`) inside the sandbox. This is the same mechanism used by CI systems (GitHub Actions, etc.).
+
+**Considered and dismissed: per-verb git tools.** Creating `daytona_git_push`, `daytona_git_fetch`, `daytona_git_pull`, etc. would duplicate `daytona_exec` with credential injection. Doesn't scale — every new git operation needs a new tool.
+
+**Considered and dismissed: magic git detection in `daytona_exec`.** Auto-detecting git commands and injecting credentials transparently. Fragile heuristic, surprising behavior, hard to debug.
+
+**Future improvement: API-proxied credential helper.** Instead of writing a token file, configure git in the sandbox to call back to an Everruns API endpoint (e.g. `GET /api/sessions/{id}/git-credential`) that mints a fresh token on each request. Benefits: no token on disk, always fresh (no expiry), multi-provider (GitHub/GitLab) via query param, per-session ACLs. Deferred because the credential store approach is simpler, works now, and the sandbox is already an isolated trust boundary.
+
 ## Crate Structure
 
 `integrations/daytona/` → `everruns-integrations-daytona`

--- a/specs/daytona.md
+++ b/specs/daytona.md
@@ -180,10 +180,14 @@ Configure git credentials in a sandbox so that all git operations (push, pull, f
 
 ## Security
 
-- **API Key**: Stored in session secrets (`DAYTONA_API_KEY`), encrypted at rest
+- **API Key**: Stored in session secrets (`DAYTONA_API_KEY`), encrypted at rest (TM-DAYTONA-004)
 - **Single auth token**: Both Management and Toolbox APIs use the same Bearer token
-- **Sandbox Isolation**: Each sandbox is an isolated environment
+- **Sandbox Isolation**: Each sandbox is an isolated environment (TM-DAYTONA-005)
 - **Multi-tenancy**: Sandboxes scoped to session via secret name prefixes
+- **Git credentials**: Short-lived GitHub token written to `/tmp/.git-credentials`; lost on sandbox stop; same trust boundary as exec access (TM-DAYTONA-001)
+- **Token expiry**: GitHub App installation tokens expire in ~1 hour; agent must call `daytona_git_credentials` again to refresh (TM-DAYTONA-002)
+
+See [threat-model.md](threat-model.md#16-daytona-cloud-sandbox-tm-daytona) for full threat analysis.
 
 ## Error Handling
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -658,6 +658,43 @@ When a bash script calls `bash` or `sh` or uses `eval`, bashkit re-invokes its o
 | TM-DOS-006 | Durable task queue flooding | Medium | Per-workflow pending task limit (see TM-DURABLE-004) | MITIGATED |
 | TM-DOS-007 | Nested JSON depth in API input | Medium | Input validation rejects deeply nested structures | MITIGATED |
 
+## 16. Daytona Cloud Sandbox (TM-DAYTONA)
+
+Daytona sandboxes are remote Linux environments managed via REST API. The agent can create, exec commands, and manage files in these sandboxes. The `daytona_git_credentials` tool writes a GitHub token to disk inside the sandbox to enable git push/pull/fetch operations.
+
+| ID | Threat | Severity | Mitigation | Status |
+|----|--------|----------|------------|--------|
+| TM-DAYTONA-001 | Git token persisted on sandbox disk | Medium | Token written to `/tmp/.git-credentials`; lost on sandbox stop/delete; same trust boundary as `daytona_exec` (anyone who can exec can already read the file) | **ACCEPTED** |
+| TM-DAYTONA-002 | Git token expiry — stale credentials | Low | GitHub App installation tokens expire in ~1 hour; tool hint tells agent to call `daytona_git_credentials` again to refresh | MITIGATED |
+| TM-DAYTONA-003 | Git token scope — over-privileged access | Medium | Token scoped by GitHub App installation permissions; user controls repo access via GitHub App settings | **CALLER RISK** |
+| TM-DAYTONA-004 | Daytona API key compromise | High | Stored as encrypted session secret (`DAYTONA_API_KEY`); envelope encryption (AES-256-GCM) at rest | MITIGATED |
+| TM-DAYTONA-005 | Cross-session sandbox access | Critical | Sandbox IDs stored in session-scoped secrets (`daytona_sandbox:{id}`); session isolation enforced by storage store | MITIGATED |
+| TM-DAYTONA-006 | Sandbox not deleted — resource leak | Low | Auto-stop after 5 min inactivity; system prompt instructs agent to delete when done | MITIGATED |
+| TM-DAYTONA-007 | Git credential helper persists after sandbox reuse | Low | Credential file in `/tmp` cleared on stop; sandbox stop resets environment | MITIGATED |
+
+### Mitigation Details
+
+**TM-DAYTONA-001 — Git Token on Disk (ACCEPTED):**
+The `daytona_git_credentials` tool writes `https://oauth2:<token>@github.com\n` to `/tmp/.git-credentials` and configures `git config --global credential.helper 'store --file=/tmp/.git-credentials'`. This is the same pattern used by GitHub Actions and other CI systems.
+
+Accepted because:
+- The sandbox is an isolated environment — same trust boundary as exec access
+- Any agent that can call `daytona_exec` can already run arbitrary commands
+- Token is in `/tmp`, lost on sandbox stop/delete
+- Token is short-lived (~1 hour GitHub App installation token)
+- Alternative (API-proxied credential helper) deferred as future improvement
+
+**TM-DAYTONA-003 — Token Scope (CALLER RISK):**
+The GitHub token's scope depends on the GitHub App installation permissions. Users must review which repositories the GitHub App has access to in their GitHub settings. Everruns does not enforce per-repo restrictions at the application level.
+
+**TM-DAYTONA-005 — Cross-Session Isolation:**
+```
+Session A stores: daytona_sandbox:sb_abc → {sandbox_id, workspace_path, started_at}
+Session B stores: daytona_sandbox:sb_xyz → {sandbox_id, workspace_path, started_at}
+
+Session A cannot access sb_xyz (different session_id in storage query)
+```
+
 ## Vulnerability Summary
 
 ### Open Threats (Require Action)
@@ -696,6 +733,7 @@ When a bash script calls `bash` or `sh` or uses `eval`, bashkit re-invokes its o
 | TM-AGENT-003 | MCP tool description poisoning | MCP servers org-configured; descriptions used as schemas only |
 | TM-AGENT-013 | Data exfiltration via web_fetch | Opt-in capability; org members trusted; intended functionality |
 | TM-DURABLE-006 | DLQ growth | Tasks preserved for debugging; manual cleanup |
+| TM-DAYTONA-001 | Git token on sandbox disk | Same trust boundary as exec; `/tmp` cleared on stop; short-lived token |
 
 ### Caller Responsibilities
 
@@ -712,6 +750,7 @@ When a bash script calls `bash` or `sh` or uses `eval`, bashkit re-invokes its o
 | System prompt review | TM-AGENT-004 | Review agent system prompts for jailbreak patterns before deployment |
 | Block cloud metadata | TM-API-009 | Defense-in-depth: enable IMDSv2 (AWS), metadata concealment (GCP), or equivalent; fetchkit v0.1.2 blocks 169.254.0.0/16 at application level |
 | Worker network isolation | TM-API-008, TM-API-010, TM-API-011 | Defense-in-depth: restrict worker container egress; fetchkit v0.1.2 blocks private IPs at application level |
+| Review GitHub App permissions | TM-DAYTONA-003 | Audit which repositories the GitHub App installation can access; Everruns does not enforce per-repo restrictions |
 
 ## Security Controls Matrix
 
@@ -732,6 +771,7 @@ When a bash script calls `bash` or `sh` or uses `eval`, bashkit re-invokes its o
 | Tool validation | TM-TOOL | Registry-based validation, defensive MCP parsing |
 | Resource limits | TM-DOS, TM-BASH | Input sizes, iteration limits, query timeouts, bash limits |
 | Task ownership | TM-DURABLE | Verified on completion, heartbeat-based reclaim |
+| Daytona sandbox isolation | TM-DAYTONA | Session-scoped secrets, encrypted API key, auto-stop, short-lived git tokens |
 
 ## References
 
@@ -750,4 +790,5 @@ When a bash script calls `bash` or `sh` or uses `eval`, bashkit re-invokes its o
 - `specs/apis.md` — HTTP API endpoints and error handling
 - `specs/capabilities.md` — Agent capabilities system
 - `specs/bashkit-requirements.md` — Bashkit integration requirements
+- `specs/daytona.md` — Daytona cloud sandbox integration
 - [fetchkit v0.1.2 source](https://crates.io/crates/fetchkit) — SSRF protection (resolve-then-check, DNS pinning, DnsPolicy), URL prefix blocking, fetch options, fetcher registry


### PR DESCRIPTION
## What
Add threat model, security documentation, design decisions, and comprehensive test coverage for the `daytona_git_credentials` tool that configures git credential store in Daytona sandboxes.

## Why
After `daytona_git_clone`, agents need to push commits, pull updates, and fetch branches. The credential store approach avoids per-verb tools and lets agents use standard git commands naturally via `daytona_exec`. This PR documents the security implications and adds test coverage.

## How
1. **Threat model** (`specs/threat-model.md`): New TM-DAYTONA section with 7 threats covering token-on-disk, expiry, scope, API key, cross-session isolation, resource leak, and sandbox reuse
2. **Spec updates** (`specs/daytona.md`): Security section with threat ID refs; design decisions documenting considered/dismissed alternatives and future improvement (API-proxied credential helper)
3. **THREAT comment**: Added `TM-DAYTONA-001` annotation at credential file write point
4. **Test coverage**: 15 new tests with mock `SessionStorageStore` and `UserConnectionResolver` — error paths, token resolution priority, empty token handling, `get_github_token` helper edge cases

## Risk
- Low
- Spec/doc/test changes. THREAT comment in implementation. No runtime behavior changes.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered