### PR TITLE
feat(skills): add SkillCapability for agentskills.io support

### DIFF
--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -81,6 +81,7 @@ mod sample_data;
 mod session;
 mod session_sql_database;
 mod session_storage;
+pub mod skill;
 mod stateless_todo_list;
 mod test_math;
 mod test_weather;
@@ -131,6 +132,11 @@ pub use session_sql_database::{
     SessionSqlDatabaseCapability, SqlExecuteTool, SqlQueryTool, SqlSchemaTool,
 };
 pub use session_storage::{KvStoreTool, SecretStoreTool, SessionStorageCapability};
+pub use skill::{
+    SKILL_CAPABILITY_PREFIX, SKILLS_DISCOVERY_PATH, SkillCapability, SkillInstructions, SkillMeta,
+    SkillSource, discover_skills_from_entries, is_skill_capability, parse_skill_capability_id,
+    skill_capability_id,
+};
 pub use stateless_todo_list::{StatelessTodoListCapability, WriteTodosTool};
 pub use test_math::{AddTool, DivideTool, MultiplyTool, SubtractTool, TestMathCapability};
 pub use test_weather::{GetForecastTool, GetWeatherTool, TestWeatherCapability};

--- a/crates/core/src/capabilities/skill.rs
+++ b/crates/core/src/capabilities/skill.rs
@@ -1,0 +1,787 @@
+// Skill Virtual Capability
+//
+// Implements the Capability trait for Agent Skills (agentskills.io format).
+// Skills are discoverable instruction packages loaded from:
+// 1. The database-backed skills registry (via API)
+// 2. The session filesystem at `.agents/skills/` (filesystem-based discovery)
+//
+// Design decisions:
+// - Follows MCP capability pattern: virtual capability wrapping external resources
+// - Capability ID format: "skill:{skill_uuid}" for registry-based skills
+// - Progressive disclosure: names/descriptions in system prompt, full content on activation
+// - `activate_skill` tool loads full SKILL.md into context on demand
+// - Depends on `session_file_system` for reading skill files after activation
+// - Bundled files (archive skills) mounted into VFS at `/skills/{name}/`
+
+use crate::capability_types::{CapabilityId, CapabilityStatus, MountDirectoryBuilder, MountPoint};
+use crate::tool_types::{BuiltinTool, ToolDefinition, ToolPolicy};
+use crate::tools::{Tool, ToolExecutionResult};
+
+use super::Capability;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::sync::{Arc, Mutex};
+use uuid::Uuid;
+
+/// Skill capability ID prefix
+pub const SKILL_CAPABILITY_PREFIX: &str = "skill:";
+
+/// Default path for filesystem-based skill discovery
+pub const SKILLS_DISCOVERY_PATH: &str = "/.agents/skills";
+
+/// Maximum number of skills in a single capability
+pub const MAX_SKILLS_PER_CAPABILITY: usize = 50;
+
+/// Generate capability ID for a skill
+pub fn skill_capability_id(skill_id: Uuid) -> String {
+    format!("{}{}", SKILL_CAPABILITY_PREFIX, skill_id)
+}
+
+/// Check if a capability ID is a skill capability
+pub fn is_skill_capability(capability_id: &str) -> bool {
+    capability_id.starts_with(SKILL_CAPABILITY_PREFIX)
+}
+
+/// Parse skill UUID from capability ID
+pub fn parse_skill_capability_id(capability_id: &str) -> Option<Uuid> {
+    if !capability_id.starts_with(SKILL_CAPABILITY_PREFIX) {
+        return None;
+    }
+    let uuid_str = &capability_id[SKILL_CAPABILITY_PREFIX.len()..];
+    Uuid::parse_str(uuid_str).ok()
+}
+
+/// Metadata for a discovered skill (lightweight, for system prompt injection)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillMeta {
+    /// Skill name (from SKILL.md frontmatter)
+    pub name: String,
+    /// Skill description (from SKILL.md frontmatter)
+    pub description: String,
+    /// Source location (filesystem path or "registry")
+    pub source: SkillSource,
+}
+
+/// Where a skill was discovered from
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum SkillSource {
+    /// Discovered from `.agents/skills/` in session filesystem
+    Filesystem { path: String },
+    /// Loaded from the database-backed registry
+    Registry { skill_id: String },
+}
+
+/// Skill Virtual Capability.
+///
+/// Wraps one or more discovered skills, providing:
+/// - System prompt with `<available_skills>` XML listing skill names/descriptions
+/// - `activate_skill` tool for loading full instructions on demand
+#[derive(Debug, Clone)]
+pub struct SkillCapability {
+    /// Unique capability ID (for single-skill: "skill:{uuid}", for aggregate: "skills")
+    capability_id: String,
+    /// Display name
+    display_name: String,
+    /// Available skills metadata (lightweight, for progressive disclosure)
+    skills: Vec<SkillMeta>,
+    /// Full SKILL.md instructions indexed by name (populated on discovery)
+    skill_instructions: Arc<Mutex<std::collections::HashMap<String, SkillInstructions>>>,
+}
+
+/// Full skill content loaded on activation
+#[derive(Debug, Clone)]
+pub struct SkillInstructions {
+    /// Full SKILL.md body (markdown instructions)
+    pub instructions: String,
+    /// Bundled files (path -> content), for VFS mounting
+    pub files: Vec<(String, String)>,
+}
+
+impl SkillCapability {
+    /// Create a skill capability for a single registry-based skill
+    pub fn from_registry(
+        skill_id: Uuid,
+        name: String,
+        description: String,
+        instructions: String,
+        files: Vec<(String, String)>,
+    ) -> Self {
+        let cap_id = skill_capability_id(skill_id);
+        let mut skill_instructions = std::collections::HashMap::new();
+        skill_instructions.insert(
+            name.clone(),
+            SkillInstructions {
+                instructions,
+                files,
+            },
+        );
+
+        Self {
+            capability_id: cap_id,
+            display_name: name.clone(),
+            skills: vec![SkillMeta {
+                name,
+                description,
+                source: SkillSource::Registry {
+                    skill_id: skill_id.to_string(),
+                },
+            }],
+            skill_instructions: Arc::new(Mutex::new(skill_instructions)),
+        }
+    }
+
+    /// Create a skill capability from multiple discovered skills
+    pub fn from_discovered(skills: Vec<SkillMeta>) -> Self {
+        Self {
+            capability_id: "skills".to_string(),
+            display_name: "Agent Skills".to_string(),
+            skills,
+            skill_instructions: Arc::new(Mutex::new(std::collections::HashMap::new())),
+        }
+    }
+
+    /// Register a skill's full instructions (called after discovery/loading)
+    pub fn register_instructions(&self, name: &str, instructions: SkillInstructions) {
+        let mut map = self.skill_instructions.lock().unwrap();
+        map.insert(name.to_string(), instructions);
+    }
+
+    /// Get the number of registered skills
+    pub fn skill_count(&self) -> usize {
+        self.skills.len()
+    }
+
+    /// Get the list of skill names
+    pub fn skill_names(&self) -> Vec<&str> {
+        self.skills.iter().map(|s| s.name.as_str()).collect()
+    }
+
+    /// Build the `<available_skills>` XML block for the system prompt
+    fn build_available_skills_xml(&self) -> String {
+        let mut xml = String::from("<available_skills>\n");
+        for skill in &self.skills {
+            xml.push_str("  <skill>\n");
+            xml.push_str(&format!("    <name>{}</name>\n", skill.name));
+            xml.push_str(&format!(
+                "    <description>{}</description>\n",
+                skill.description
+            ));
+            if let SkillSource::Filesystem { ref path } = skill.source {
+                xml.push_str(&format!("    <location>{}/SKILL.md</location>\n", path));
+            }
+            xml.push_str("  </skill>\n");
+        }
+        xml.push_str("</available_skills>");
+        xml
+    }
+
+    /// Get skill instructions by name (for tool execution)
+    pub fn get_instructions(&self, name: &str) -> Option<SkillInstructions> {
+        let map = self.skill_instructions.lock().unwrap();
+        map.get(name).cloned()
+    }
+
+    /// Build mount points for activated skill files
+    pub fn mount_points_for_skill(
+        name: &str,
+        files: &[(String, String)],
+        capability_id: &str,
+    ) -> Vec<MountPoint> {
+        if files.is_empty() {
+            return vec![];
+        }
+
+        let mut builder = MountDirectoryBuilder::new();
+        for (path, content) in files {
+            // Handle nested paths by flattening into directory structure
+            builder = builder.file(path, content);
+        }
+
+        vec![MountPoint::readonly(
+            format!("/skills/{name}"),
+            builder.build(),
+            capability_id,
+        )]
+    }
+}
+
+impl Capability for SkillCapability {
+    fn id(&self) -> &str {
+        Box::leak(self.capability_id.clone().into_boxed_str())
+    }
+
+    fn name(&self) -> &str {
+        Box::leak(self.display_name.clone().into_boxed_str())
+    }
+
+    fn description(&self) -> &str {
+        let desc = if self.skills.len() == 1 {
+            self.skills[0].description.clone()
+        } else {
+            format!(
+                "Agent Skills: {} skill(s) available for on-demand activation",
+                self.skills.len()
+            )
+        };
+        Box::leak(desc.into_boxed_str())
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("wand")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Skills")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        if self.skills.is_empty() {
+            return None;
+        }
+
+        let prompt = format!(
+            "{}\n\n\
+            When a user's task matches an available skill, activate it by using the \
+            `activate_skill` tool with the skill name. This loads the full instructions \
+            into your context. Only activate skills that are relevant to the current task.",
+            self.build_available_skills_xml()
+        );
+
+        Some(Box::leak(prompt.into_boxed_str()))
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        if self.skills.is_empty() {
+            return vec![];
+        }
+
+        vec![Box::new(ActivateSkillTool {
+            skill_instructions: self.skill_instructions.clone(),
+            available_skills: self.skills.iter().map(|s| s.name.clone()).collect(),
+        })]
+    }
+
+    fn tool_definitions(&self) -> Vec<ToolDefinition> {
+        if self.skills.is_empty() {
+            return vec![];
+        }
+
+        let skill_names: Vec<&str> = self.skills.iter().map(|s| s.name.as_str()).collect();
+        let names_list = skill_names.join(", ");
+
+        vec![ToolDefinition::Builtin(BuiltinTool {
+            name: "activate_skill".to_string(),
+            description: format!(
+                "Activate an agent skill by name to load its full instructions. \
+                Available skills: {names_list}"
+            ),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The name of the skill to activate",
+                        "enum": skill_names
+                    }
+                },
+                "required": ["name"]
+            }),
+            policy: ToolPolicy::Auto,
+        })]
+    }
+
+    fn dependencies(&self) -> Vec<&'static str> {
+        vec!["session_file_system"]
+    }
+}
+
+/// Tool for activating a skill (loading full instructions into context)
+pub struct ActivateSkillTool {
+    skill_instructions: Arc<Mutex<std::collections::HashMap<String, SkillInstructions>>>,
+    available_skills: Vec<String>,
+}
+
+impl std::fmt::Debug for ActivateSkillTool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ActivateSkillTool")
+            .field("available_skills", &self.available_skills)
+            .finish()
+    }
+}
+
+#[async_trait]
+impl Tool for ActivateSkillTool {
+    fn name(&self) -> &str {
+        "activate_skill"
+    }
+
+    fn description(&self) -> &str {
+        "Activate an agent skill by name to load its full instructions into context."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the skill to activate"
+                }
+            },
+            "required": ["name"]
+        })
+    }
+
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let name = match arguments.get("name").and_then(|v| v.as_str()) {
+            Some(n) => n,
+            None => {
+                return ToolExecutionResult::ToolError(
+                    "Missing required parameter: name".to_string(),
+                );
+            }
+        };
+
+        // Validate skill exists
+        if !self.available_skills.contains(&name.to_string()) {
+            let available = self.available_skills.join(", ");
+            return ToolExecutionResult::ToolError(format!(
+                "Unknown skill: '{name}'. Available skills: {available}"
+            ));
+        }
+
+        // Look up instructions
+        let instructions = {
+            let map = self.skill_instructions.lock().unwrap();
+            map.get(name).cloned()
+        };
+
+        match instructions {
+            Some(skill) => {
+                let mut result =
+                    format!("<skill name=\"{name}\">\n{}\n</skill>", skill.instructions);
+
+                // Note mounted files if present
+                if !skill.files.is_empty() {
+                    let file_list: Vec<&str> =
+                        skill.files.iter().map(|(path, _)| path.as_str()).collect();
+                    result.push_str(&format!(
+                        "\n\nBundled files are available at /skills/{name}/:\n{}",
+                        file_list
+                            .iter()
+                            .map(|f| format!("- /skills/{name}/{f}"))
+                            .collect::<Vec<_>>()
+                            .join("\n")
+                    ));
+                }
+
+                ToolExecutionResult::success(serde_json::json!({
+                    "skill": name,
+                    "instructions": result,
+                    "files_mounted": !skill.files.is_empty()
+                }))
+            }
+            None => ToolExecutionResult::ToolError(format!(
+                "Skill '{name}' instructions not loaded. The skill may not have been fully initialized."
+            )),
+        }
+    }
+}
+
+/// Parse SKILL.md files from a list of (path, content) entries discovered in the session VFS.
+///
+/// Each entry represents a directory under `.agents/skills/` containing a SKILL.md file.
+/// Returns parsed skill metadata and instructions for registration.
+pub fn discover_skills_from_entries(
+    entries: &[(String, String)],
+) -> Vec<(SkillMeta, SkillInstructions)> {
+    let mut results = Vec::new();
+
+    for (path, content) in entries {
+        match crate::skill::parse_skill_md(content) {
+            Ok(parsed) => {
+                let meta = SkillMeta {
+                    name: parsed.name.clone(),
+                    description: parsed.description.clone(),
+                    source: SkillSource::Filesystem { path: path.clone() },
+                };
+                let instructions = SkillInstructions {
+                    instructions: parsed.instructions,
+                    files: vec![], // Filesystem skills don't bundle files via this path
+                };
+                results.push((meta, instructions));
+            }
+            Err(errors) => {
+                tracing::warn!(
+                    path = %path,
+                    errors = ?errors,
+                    "Skipping invalid SKILL.md"
+                );
+            }
+        }
+    }
+
+    results
+}
+
+/// CapabilityId helpers for skill capabilities
+impl CapabilityId {
+    /// Check if this capability ID is for a skill
+    pub fn is_skill(&self) -> bool {
+        is_skill_capability(self.as_str())
+    }
+
+    /// Create a capability ID for a skill
+    pub fn skill(skill_id: Uuid) -> Self {
+        Self::new(skill_capability_id(skill_id))
+    }
+
+    /// Parse skill UUID from this capability ID
+    pub fn skill_id(&self) -> Option<Uuid> {
+        parse_skill_capability_id(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_skill_capability_id() {
+        let skill_id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let cap_id = skill_capability_id(skill_id);
+        assert_eq!(cap_id, "skill:550e8400-e29b-41d4-a716-446655440000");
+    }
+
+    #[test]
+    fn test_is_skill_capability() {
+        assert!(is_skill_capability(
+            "skill:550e8400-e29b-41d4-a716-446655440000"
+        ));
+        assert!(!is_skill_capability("current_time"));
+        assert!(!is_skill_capability(
+            "mcp:550e8400-e29b-41d4-a716-446655440000"
+        ));
+        assert!(!is_skill_capability("skills")); // aggregate ID
+    }
+
+    #[test]
+    fn test_parse_skill_capability_id() {
+        let skill_id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let cap_id = skill_capability_id(skill_id);
+        let parsed = parse_skill_capability_id(&cap_id);
+        assert_eq!(parsed, Some(skill_id));
+
+        assert_eq!(parse_skill_capability_id("current_time"), None);
+        assert_eq!(parse_skill_capability_id("skill:invalid"), None);
+    }
+
+    #[test]
+    fn test_capability_id_skill_methods() {
+        let skill_id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let cap_id = CapabilityId::skill(skill_id);
+
+        assert!(cap_id.is_skill());
+        assert_eq!(cap_id.skill_id(), Some(skill_id));
+
+        let regular_cap = CapabilityId::new("current_time");
+        assert!(!regular_cap.is_skill());
+        assert_eq!(regular_cap.skill_id(), None);
+    }
+
+    #[test]
+    fn test_skill_capability_from_registry() {
+        let skill_id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let cap = SkillCapability::from_registry(
+            skill_id,
+            "pdf-processing".to_string(),
+            "Extract text from PDFs".to_string(),
+            "# Instructions\nUse pdfplumber.".to_string(),
+            vec![(
+                "scripts/extract.py".to_string(),
+                "print('hello')".to_string(),
+            )],
+        );
+
+        assert_eq!(cap.id(), "skill:550e8400-e29b-41d4-a716-446655440000");
+        assert_eq!(cap.name(), "pdf-processing");
+        assert_eq!(cap.status(), CapabilityStatus::Available);
+        assert_eq!(cap.icon(), Some("wand"));
+        assert_eq!(cap.category(), Some("Skills"));
+        assert_eq!(cap.skill_count(), 1);
+    }
+
+    #[test]
+    fn test_skill_capability_system_prompt() {
+        let cap = SkillCapability::from_discovered(vec![
+            SkillMeta {
+                name: "pdf-processing".to_string(),
+                description: "Extract text from PDFs".to_string(),
+                source: SkillSource::Registry {
+                    skill_id: "test".to_string(),
+                },
+            },
+            SkillMeta {
+                name: "data-analysis".to_string(),
+                description: "Analyze datasets".to_string(),
+                source: SkillSource::Filesystem {
+                    path: "/.agents/skills/data-analysis".to_string(),
+                },
+            },
+        ]);
+
+        let prompt = cap.system_prompt_addition().unwrap();
+        assert!(prompt.contains("<available_skills>"));
+        assert!(prompt.contains("<name>pdf-processing</name>"));
+        assert!(prompt.contains("<name>data-analysis</name>"));
+        assert!(prompt.contains("<description>Extract text from PDFs</description>"));
+        assert!(prompt.contains("activate_skill"));
+        assert!(prompt.contains("</available_skills>"));
+        // Filesystem skills include location
+        assert!(prompt.contains("<location>/.agents/skills/data-analysis/SKILL.md</location>"));
+    }
+
+    #[test]
+    fn test_skill_capability_no_system_prompt_when_empty() {
+        let cap = SkillCapability::from_discovered(vec![]);
+        assert!(cap.system_prompt_addition().is_none());
+        assert!(cap.tools().is_empty());
+    }
+
+    #[test]
+    fn test_skill_capability_tool_definitions() {
+        let cap = SkillCapability::from_discovered(vec![SkillMeta {
+            name: "test-skill".to_string(),
+            description: "A test skill".to_string(),
+            source: SkillSource::Registry {
+                skill_id: "test".to_string(),
+            },
+        }]);
+
+        let defs = cap.tool_definitions();
+        assert_eq!(defs.len(), 1);
+
+        let ToolDefinition::Builtin(builtin) = &defs[0] else {
+            panic!("expected Builtin variant");
+        };
+        assert_eq!(builtin.name, "activate_skill");
+        assert!(builtin.description.contains("test-skill"));
+    }
+
+    #[test]
+    fn test_skill_capability_dependencies() {
+        let cap = SkillCapability::from_discovered(vec![]);
+        assert_eq!(cap.dependencies(), vec!["session_file_system"]);
+    }
+
+    #[tokio::test]
+    async fn test_activate_skill_tool_success() {
+        let instructions = Arc::new(Mutex::new(std::collections::HashMap::new()));
+        instructions.lock().unwrap().insert(
+            "test-skill".to_string(),
+            SkillInstructions {
+                instructions: "# Test Instructions\nDo the thing.".to_string(),
+                files: vec![],
+            },
+        );
+
+        let tool = ActivateSkillTool {
+            skill_instructions: instructions,
+            available_skills: vec!["test-skill".to_string()],
+        };
+
+        let result = tool
+            .execute(serde_json::json!({"name": "test-skill"}))
+            .await;
+
+        match result {
+            ToolExecutionResult::Success(value) => {
+                assert_eq!(value["skill"], "test-skill");
+                let instr = value["instructions"].as_str().unwrap();
+                assert!(instr.contains("<skill name=\"test-skill\">"));
+                assert!(instr.contains("# Test Instructions"));
+                assert!(instr.contains("</skill>"));
+                assert_eq!(value["files_mounted"], false);
+            }
+            other => panic!("Expected Success, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_activate_skill_tool_with_files() {
+        let instructions = Arc::new(Mutex::new(std::collections::HashMap::new()));
+        instructions.lock().unwrap().insert(
+            "data-skill".to_string(),
+            SkillInstructions {
+                instructions: "# Data Skill".to_string(),
+                files: vec![
+                    ("scripts/run.py".to_string(), "print('hi')".to_string()),
+                    ("references/REFERENCE.md".to_string(), "# Ref".to_string()),
+                ],
+            },
+        );
+
+        let tool = ActivateSkillTool {
+            skill_instructions: instructions,
+            available_skills: vec!["data-skill".to_string()],
+        };
+
+        let result = tool
+            .execute(serde_json::json!({"name": "data-skill"}))
+            .await;
+
+        match result {
+            ToolExecutionResult::Success(value) => {
+                assert_eq!(value["files_mounted"], true);
+                let instr = value["instructions"].as_str().unwrap();
+                assert!(instr.contains("/skills/data-skill/scripts/run.py"));
+            }
+            other => panic!("Expected Success, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_activate_skill_tool_unknown_skill() {
+        let instructions = Arc::new(Mutex::new(std::collections::HashMap::new()));
+
+        let tool = ActivateSkillTool {
+            skill_instructions: instructions,
+            available_skills: vec!["known-skill".to_string()],
+        };
+
+        let result = tool.execute(serde_json::json!({"name": "unknown"})).await;
+
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("Unknown skill"));
+                assert!(msg.contains("known-skill"));
+            }
+            other => panic!("Expected ToolError, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_activate_skill_tool_missing_name() {
+        let tool = ActivateSkillTool {
+            skill_instructions: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            available_skills: vec![],
+        };
+
+        let result = tool.execute(serde_json::json!({})).await;
+
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("Missing required parameter"));
+            }
+            other => panic!("Expected ToolError, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_discover_skills_from_entries() {
+        let entries = vec![
+            (
+                "/.agents/skills/test-skill".to_string(),
+                "---\nname: test-skill\ndescription: A test.\n---\n\n# Instructions\nDo things."
+                    .to_string(),
+            ),
+            (
+                "/.agents/skills/bad-skill".to_string(),
+                "no frontmatter here".to_string(),
+            ),
+        ];
+
+        let results = discover_skills_from_entries(&entries);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0.name, "test-skill");
+        assert_eq!(results[0].0.description, "A test.");
+        assert!(results[0].1.instructions.contains("# Instructions"));
+    }
+
+    #[test]
+    fn test_mount_points_for_skill() {
+        let files = vec![
+            ("scripts/run.py".to_string(), "print('hi')".to_string()),
+            ("references/REFERENCE.md".to_string(), "# Ref".to_string()),
+        ];
+
+        let mounts = SkillCapability::mount_points_for_skill("test-skill", &files, "skills");
+        assert_eq!(mounts.len(), 1);
+        assert_eq!(mounts[0].path, "/skills/test-skill");
+        assert!(mounts[0].is_readonly());
+    }
+
+    #[test]
+    fn test_mount_points_empty_files() {
+        let mounts = SkillCapability::mount_points_for_skill("test-skill", &[], "skills");
+        assert!(mounts.is_empty());
+    }
+
+    #[test]
+    fn test_skill_meta_serialization() {
+        let meta = SkillMeta {
+            name: "test-skill".to_string(),
+            description: "A test".to_string(),
+            source: SkillSource::Registry {
+                skill_id: "abc".to_string(),
+            },
+        };
+
+        let json = serde_json::to_string(&meta).unwrap();
+        assert!(json.contains("test-skill"));
+
+        let parsed: SkillMeta = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.name, "test-skill");
+    }
+
+    #[test]
+    fn test_build_available_skills_xml() {
+        let cap = SkillCapability::from_discovered(vec![SkillMeta {
+            name: "my-skill".to_string(),
+            description: "Does cool things".to_string(),
+            source: SkillSource::Registry {
+                skill_id: "id".to_string(),
+            },
+        }]);
+
+        let xml = cap.build_available_skills_xml();
+        assert!(xml.starts_with("<available_skills>"));
+        assert!(xml.ends_with("</available_skills>"));
+        assert!(xml.contains("<name>my-skill</name>"));
+        assert!(xml.contains("<description>Does cool things</description>"));
+        // Registry skills don't have location
+        assert!(!xml.contains("<location>"));
+    }
+
+    #[test]
+    fn test_register_instructions_after_creation() {
+        let cap = SkillCapability::from_discovered(vec![SkillMeta {
+            name: "lazy-skill".to_string(),
+            description: "Lazily loaded".to_string(),
+            source: SkillSource::Filesystem {
+                path: "/.agents/skills/lazy-skill".to_string(),
+            },
+        }]);
+
+        // Initially no instructions
+        assert!(cap.get_instructions("lazy-skill").is_none());
+
+        // Register instructions
+        cap.register_instructions(
+            "lazy-skill",
+            SkillInstructions {
+                instructions: "# Do stuff".to_string(),
+                files: vec![],
+            },
+        );
+
+        // Now instructions are available
+        let instr = cap.get_instructions("lazy-skill").unwrap();
+        assert!(instr.instructions.contains("# Do stuff"));
+    }
+}

--- a/crates/core/src/capability_dto.rs
+++ b/crates/core/src/capability_dto.rs
@@ -43,6 +43,9 @@ pub struct CapabilityInfo {
     /// Whether this is an MCP server capability (for UI badge)
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub is_mcp: bool,
+    /// Whether this is an Agent Skill capability (for UI badge)
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub is_skill: bool,
     /// IDs of capabilities that this capability depends on.
     /// When this capability is selected, its dependencies are automatically included.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
@@ -52,9 +55,11 @@ pub struct CapabilityInfo {
 impl CapabilityInfo {
     /// Create a CapabilityInfo DTO from a core Capability trait object
     pub fn from_core(cap: &dyn crate::capabilities::Capability) -> Self {
-        // Check if this is an MCP capability by checking the ID prefix
+        // Check if this is an MCP or skill capability by checking the ID prefix
         let id_str = cap.id();
         let is_mcp = id_str.starts_with("mcp:");
+        let is_skill =
+            id_str.starts_with("skill:") || id_str == "skills" || cap.category() == Some("Skills");
 
         Self {
             id: CapabilityId::new(id_str),
@@ -66,6 +71,7 @@ impl CapabilityInfo {
             system_prompt: cap.system_prompt_preview(),
             tool_definitions: cap.tool_definitions(),
             is_mcp,
+            is_skill,
             dependencies: cap.dependencies().iter().map(|s| s.to_string()).collect(),
         }
     }
@@ -98,6 +104,7 @@ mod tests {
             system_prompt: Some("You have research capabilities.".to_string()),
             tool_definitions: vec![],
             is_mcp: false,
+            is_skill: false,
             dependencies: vec![],
         };
 
@@ -107,6 +114,8 @@ mod tests {
         assert!(json.contains("\"system_prompt\":\"You have research capabilities.\""));
         // is_mcp: false should be skipped in serialization
         assert!(!json.contains("\"is_mcp\""));
+        // is_skill: false should be skipped in serialization
+        assert!(!json.contains("\"is_skill\""));
         // Empty dependencies should be skipped in serialization
         assert!(!json.contains("\"dependencies\""));
     }
@@ -123,6 +132,7 @@ mod tests {
             system_prompt: None,
             tool_definitions: vec![],
             is_mcp: true,
+            is_skill: false,
             dependencies: vec![],
         };
 
@@ -142,6 +152,7 @@ mod tests {
             system_prompt: None,
             tool_definitions: vec![],
             is_mcp: false,
+            is_skill: false,
             dependencies: vec!["session_file_system".to_string()],
         };
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -148,6 +148,11 @@ pub use capabilities::{
     WriteTodosTool, apply_capabilities, collect_capabilities_with_configs, get_dependencies,
     is_mcp_capability, mcp_capability_id, parse_mcp_capability_id, resolve_dependencies,
 };
+pub use capabilities::{
+    SKILL_CAPABILITY_PREFIX, SKILLS_DISCOVERY_PATH, SkillCapability, SkillInstructions, SkillMeta,
+    SkillSource, discover_skills_from_entries, is_skill_capability, parse_skill_capability_id,
+    skill_capability_id,
+};
 
 // Atoms re-exports (stateless atomic operations)
 pub use atoms::{

--- a/crates/server/src/services/capability.rs
+++ b/crates/server/src/services/capability.rs
@@ -6,15 +6,20 @@
 // MCP servers are integrated as "virtual capabilities" that appear alongside
 // built-in capabilities. Their tools are prefixed with "mcp_{server_name}_".
 //
+// Skills from the database registry are integrated as virtual capabilities,
+// following the same pattern as MCP servers.
+//
 // Note: Agent-specific capability management is handled by AgentService.
 
 use crate::services::mcp_server::McpServerService;
+use crate::services::skill::SkillService;
 use crate::storage::{EncryptionService, StorageBackend};
 use anyhow::Result;
 use everruns_core::capabilities::{Capability, CapabilityRegistry};
 use everruns_core::{
     CapabilityId, CapabilityInfo, CapabilityStatus, McpCapability, McpToolDefinition,
-    mcp_capability_id,
+    SkillCapability, SkillInstructions, SkillMeta, SkillSource, mcp_capability_id,
+    skill_capability_id,
 };
 use std::sync::Arc;
 
@@ -22,6 +27,7 @@ pub struct CapabilityService {
     db: Arc<StorageBackend>,
     registry: CapabilityRegistry,
     mcp_service: McpServerService,
+    skill_service: Arc<SkillService>,
 }
 
 impl CapabilityService {
@@ -29,11 +35,12 @@ impl CapabilityService {
         Self {
             db: db.clone(),
             registry: CapabilityRegistry::with_builtins(),
-            mcp_service: McpServerService::new(db, encryption),
+            mcp_service: McpServerService::new(db.clone(), encryption),
+            skill_service: Arc::new(SkillService::new(db)),
         }
     }
 
-    /// List all available capabilities including MCP servers (public info only)
+    /// List all available capabilities including MCP servers and skills (public info only)
     pub async fn list_all(&self, org_id: i64) -> Result<Vec<CapabilityInfo>> {
         // Get built-in capabilities
         let mut capabilities: Vec<CapabilityInfo> = self
@@ -71,7 +78,38 @@ impl CapabilityService {
                 system_prompt: None,
                 tool_definitions: mcp_cap.tool_definitions(),
                 is_mcp: true,
+                is_skill: false,
                 dependencies: vec![], // MCP capabilities have no dependencies
+            });
+        }
+
+        // Get skill capabilities from the registry
+        let skills = self.skill_service.list(org_id).await?;
+        for skill in &skills {
+            if skill.status != everruns_core::SkillStatus::Active {
+                continue;
+            }
+
+            let skill_cap = SkillCapability::from_registry(
+                skill.id.uuid(),
+                skill.name.clone(),
+                skill.description.clone(),
+                String::new(), // Instructions not needed for listing
+                vec![],
+            );
+
+            capabilities.push(CapabilityInfo {
+                id: CapabilityId::new(skill_capability_id(skill.id.uuid())),
+                name: skill.name.clone(),
+                description: skill.description.clone(),
+                status: CapabilityStatus::Available,
+                icon: Some("wand".to_string()),
+                category: Some("Skills".to_string()),
+                system_prompt: skill_cap.system_prompt_preview(),
+                tool_definitions: skill_cap.tool_definitions(),
+                is_mcp: false,
+                is_skill: true,
+                dependencies: vec!["session_file_system".to_string()],
             });
         }
 
@@ -114,7 +152,49 @@ impl CapabilityService {
                     system_prompt: None,
                     tool_definitions: mcp_cap.tool_definitions(),
                     is_mcp: true,
+                    is_skill: false,
                     dependencies: vec![], // MCP capabilities have no dependencies
+                }));
+            }
+            return Ok(None);
+        }
+
+        // Check if it's a skill capability
+        if let Some(skill_uuid) = id.skill_id() {
+            let skill = self.skill_service.get(org_id, skill_uuid).await?;
+            if let Some(skill) = skill {
+                let content = self.skill_service.get_content(org_id, skill_uuid).await?;
+
+                let files: Vec<(String, String)> = content
+                    .as_ref()
+                    .map(|c| {
+                        c.files
+                            .iter()
+                            .map(|f| (f.path.clone(), f.content.clone()))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                let skill_cap = SkillCapability::from_registry(
+                    skill.id.uuid(),
+                    skill.name.clone(),
+                    skill.description.clone(),
+                    content.map(|c| c.skill_md).unwrap_or_default(),
+                    files,
+                );
+
+                return Ok(Some(CapabilityInfo {
+                    id: CapabilityId::new(skill_capability_id(skill.id.uuid())),
+                    name: skill.name.clone(),
+                    description: skill.description.clone(),
+                    status: CapabilityStatus::Available,
+                    icon: Some("wand".to_string()),
+                    category: Some("Skills".to_string()),
+                    system_prompt: skill_cap.system_prompt_preview(),
+                    tool_definitions: skill_cap.tool_definitions(),
+                    is_mcp: false,
+                    is_skill: true,
+                    dependencies: vec!["session_file_system".to_string()],
                 }));
             }
             return Ok(None);
@@ -191,14 +271,17 @@ impl CapabilityService {
         let mut system_prompt_parts: Vec<String> = Vec::new();
         let mut tool_definitions: Vec<everruns_core::ToolDefinition> = Vec::new();
 
-        // Separate built-in capabilities from MCP capabilities
+        // Separate built-in capabilities from MCP and skill capabilities
         let mut builtin_cap_ids: Vec<String> = Vec::new();
         let mut mcp_cap_ids: Vec<uuid::Uuid> = Vec::new();
+        let mut skill_cap_ids: Vec<uuid::Uuid> = Vec::new();
 
         for cap_config in capability_configs {
             let cap_ref = &cap_config.capability_ref;
             if let Some(server_id) = cap_ref.mcp_server_id() {
                 mcp_cap_ids.push(server_id);
+            } else if let Some(skill_id) = cap_ref.skill_id() {
+                skill_cap_ids.push(skill_id);
             } else {
                 builtin_cap_ids.push(cap_ref.to_string());
             }
@@ -230,6 +313,52 @@ impl CapabilityService {
                 );
                 tool_definitions.extend(mcp_cap.tool_definitions());
             }
+        }
+
+        // Collect from skill capabilities
+        let mut skill_metas: Vec<SkillMeta> = Vec::new();
+        for skill_uuid in &skill_cap_ids {
+            if let Some(skill) = self.skill_service.get(org_id, *skill_uuid).await? {
+                skill_metas.push(SkillMeta {
+                    name: skill.name,
+                    description: skill.description,
+                    source: SkillSource::Registry {
+                        skill_id: skill_uuid.to_string(),
+                    },
+                });
+            }
+        }
+
+        if !skill_metas.is_empty() {
+            let skill_cap = SkillCapability::from_discovered(skill_metas);
+
+            // Load instructions for each skill
+            for skill_uuid in &skill_cap_ids {
+                if let Some(content) = self.skill_service.get_content(org_id, *skill_uuid).await?
+                    && let Ok(parsed) = everruns_core::parse_skill_md(&content.skill_md)
+                {
+                    let files: Vec<(String, String)> = content
+                        .files
+                        .into_iter()
+                        .map(|f| (f.path, f.content))
+                        .collect();
+                    skill_cap.register_instructions(
+                        &parsed.name,
+                        SkillInstructions {
+                            instructions: parsed.instructions,
+                            files,
+                        },
+                    );
+                }
+            }
+
+            if let Some(prompt) = skill_cap.system_prompt_addition() {
+                system_prompt_parts.push(format!(
+                    "<capability id=\"skills\">\n{}\n</capability>",
+                    prompt
+                ));
+            }
+            tool_definitions.extend(skill_cap.tool_definitions());
         }
 
         // Build final system prompt (XML-wrapped when capabilities contribute prompts)

--- a/crates/server/tests/skills_integration_test.rs
+++ b/crates/server/tests/skills_integration_test.rs
@@ -1,0 +1,376 @@
+//! Skills integration tests
+//!
+//! Tests the skills CRUD API and the integration of skills as virtual capabilities.
+
+mod test_harness;
+
+use axum::http::StatusCode;
+use serde_json::json;
+use test_harness::TestServer;
+
+const VALID_SKILL_MD: &str = "---\nname: test-skill\ndescription: A test skill for integration testing.\n---\n\n# Test Skill\n\n## Instructions\n\n1. Read the input data\n2. Process it according to the rules\n3. Return the result\n";
+
+const VALID_SKILL_MD_2: &str = "---\nname: data-analysis\ndescription: Analyze datasets and generate reports.\n---\n\n# Data Analysis\n\nUse pandas to analyze the provided dataset.\n";
+
+// ============================================================
+// Skill CRUD Tests
+// ============================================================
+
+#[tokio::test]
+async fn test_create_skill() {
+    let server = TestServer::new().await;
+
+    let resp = server
+        .post("/v1/skills", json!({ "skill_md": VALID_SKILL_MD }))
+        .await;
+
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let body = resp.json_value();
+    assert_eq!(body["name"], "test-skill");
+    assert_eq!(body["description"], "A test skill for integration testing.");
+    assert_eq!(body["source_type"], "markdown");
+    assert_eq!(body["status"], "active");
+    assert!(body["id"].as_str().unwrap().starts_with("skill_"));
+}
+
+#[tokio::test]
+async fn test_list_skills() {
+    let server = TestServer::new().await;
+
+    // Create two skills
+    server
+        .post("/v1/skills", json!({ "skill_md": VALID_SKILL_MD }))
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    server
+        .post("/v1/skills", json!({ "skill_md": VALID_SKILL_MD_2 }))
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    // List skills
+    let resp = server.get("/v1/skills").await.assert_success();
+    let body = resp.json_value();
+    let skills = body["data"].as_array().unwrap();
+    assert!(skills.len() >= 2);
+
+    let names: Vec<&str> = skills.iter().filter_map(|s| s["name"].as_str()).collect();
+    assert!(names.contains(&"test-skill"));
+    assert!(names.contains(&"data-analysis"));
+}
+
+#[tokio::test]
+async fn test_get_skill() {
+    let server = TestServer::new().await;
+
+    let create_resp = server
+        .post("/v1/skills", json!({ "skill_md": VALID_SKILL_MD }))
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    let skill_id = create_resp.json_value()["id"].as_str().unwrap().to_string();
+
+    let get_resp = server
+        .get(&format!("/v1/skills/{skill_id}"))
+        .await
+        .assert_success();
+
+    let body = get_resp.json_value();
+    assert_eq!(body["name"], "test-skill");
+    assert_eq!(body["id"], skill_id);
+}
+
+#[tokio::test]
+async fn test_get_skill_content() {
+    let server = TestServer::new().await;
+
+    let create_resp = server
+        .post("/v1/skills", json!({ "skill_md": VALID_SKILL_MD }))
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    let skill_id = create_resp.json_value()["id"].as_str().unwrap().to_string();
+
+    let content_resp = server
+        .get(&format!("/v1/skills/{skill_id}/content"))
+        .await
+        .assert_success();
+
+    let body = content_resp.json_value();
+    assert!(body["skill_md"].as_str().unwrap().contains("# Test Skill"));
+}
+
+#[tokio::test]
+async fn test_update_skill() {
+    let server = TestServer::new().await;
+
+    let create_resp = server
+        .post("/v1/skills", json!({ "skill_md": VALID_SKILL_MD }))
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    let skill_id = create_resp.json_value()["id"].as_str().unwrap().to_string();
+
+    let updated_md = "---\nname: test-skill\ndescription: Updated description.\n---\n\n# Updated\n";
+    let update_resp = server
+        .patch(
+            &format!("/v1/skills/{skill_id}"),
+            json!({ "skill_md": updated_md }),
+        )
+        .await
+        .assert_success();
+
+    let body = update_resp.json_value();
+    assert_eq!(body["description"], "Updated description.");
+}
+
+#[tokio::test]
+async fn test_update_skill_status() {
+    let server = TestServer::new().await;
+
+    let create_resp = server
+        .post("/v1/skills", json!({ "skill_md": VALID_SKILL_MD }))
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    let skill_id = create_resp.json_value()["id"].as_str().unwrap().to_string();
+
+    let update_resp = server
+        .patch(
+            &format!("/v1/skills/{skill_id}"),
+            json!({ "status": "disabled" }),
+        )
+        .await
+        .assert_success();
+
+    let body = update_resp.json_value();
+    assert_eq!(body["status"], "disabled");
+}
+
+#[tokio::test]
+async fn test_delete_skill() {
+    let server = TestServer::new().await;
+
+    let create_resp = server
+        .post("/v1/skills", json!({ "skill_md": VALID_SKILL_MD }))
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    let skill_id = create_resp.json_value()["id"].as_str().unwrap().to_string();
+
+    // Delete the skill
+    server
+        .delete(&format!("/v1/skills/{skill_id}"))
+        .await
+        .assert_status(StatusCode::NO_CONTENT);
+
+    // Verify it's gone
+    let get_resp = server.get(&format!("/v1/skills/{skill_id}")).await;
+    assert_eq!(get_resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_validate_skill() {
+    let server = TestServer::new().await;
+
+    // Valid skill
+    let resp = server
+        .post("/v1/skills/validate", json!({ "skill_md": VALID_SKILL_MD }))
+        .await
+        .assert_success();
+
+    let body = resp.json_value();
+    assert_eq!(body["valid"], true);
+    assert_eq!(body["name"], "test-skill");
+
+    // Invalid skill (no frontmatter)
+    let resp = server
+        .post(
+            "/v1/skills/validate",
+            json!({ "skill_md": "no frontmatter here" }),
+        )
+        .await
+        .assert_success();
+
+    let body = resp.json_value();
+    assert_eq!(body["valid"], false);
+}
+
+// ============================================================
+// Error Cases
+// ============================================================
+
+#[tokio::test]
+async fn test_create_skill_duplicate_name() {
+    let server = TestServer::new().await;
+
+    server
+        .post("/v1/skills", json!({ "skill_md": VALID_SKILL_MD }))
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    // Duplicate name should fail
+    let resp = server
+        .post("/v1/skills", json!({ "skill_md": VALID_SKILL_MD }))
+        .await;
+
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn test_create_skill_invalid_md() {
+    let server = TestServer::new().await;
+
+    let resp = server
+        .post("/v1/skills", json!({ "skill_md": "no valid frontmatter" }))
+        .await;
+
+    assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test]
+async fn test_create_skill_invalid_name() {
+    let server = TestServer::new().await;
+
+    let invalid_md = "---\nname: INVALID_NAME\ndescription: Bad name format.\n---\n\n# Bad\n";
+    let resp = server
+        .post("/v1/skills", json!({ "skill_md": invalid_md }))
+        .await;
+
+    assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test]
+async fn test_get_nonexistent_skill() {
+    let server = TestServer::new().await;
+
+    let resp = server
+        .get("/v1/skills/skill_00000000000000000000000000000000")
+        .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+// ============================================================
+// Skills as Capabilities Integration
+// ============================================================
+
+#[tokio::test]
+async fn test_skill_appears_in_capabilities_listing() {
+    let server = TestServer::new().await;
+
+    // Create a skill
+    server
+        .post("/v1/skills", json!({ "skill_md": VALID_SKILL_MD }))
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    // List capabilities - skill should appear
+    let resp = server.get("/v1/capabilities").await.assert_success();
+    let body = resp.json_value();
+    let capabilities = body["data"].as_array().unwrap();
+
+    let skill_caps: Vec<&serde_json::Value> = capabilities
+        .iter()
+        .filter(|c| c["is_skill"].as_bool() == Some(true))
+        .collect();
+
+    assert!(
+        !skill_caps.is_empty(),
+        "Skill should appear in capabilities"
+    );
+    let skill_cap = skill_caps
+        .iter()
+        .find(|c| c["name"].as_str() == Some("test-skill"))
+        .expect("Should find test-skill in capabilities");
+
+    assert_eq!(skill_cap["category"], "Skills");
+    assert!(skill_cap["id"].as_str().unwrap().starts_with("skill:"));
+    assert_eq!(
+        skill_cap["description"],
+        "A test skill for integration testing."
+    );
+}
+
+#[tokio::test]
+async fn test_disabled_skill_hidden_from_capabilities() {
+    let server = TestServer::new().await;
+
+    // Create and disable a skill
+    let create_resp = server
+        .post("/v1/skills", json!({ "skill_md": VALID_SKILL_MD }))
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    let skill_id = create_resp.json_value()["id"].as_str().unwrap().to_string();
+
+    server
+        .patch(
+            &format!("/v1/skills/{skill_id}"),
+            json!({ "status": "disabled" }),
+        )
+        .await
+        .assert_success();
+
+    // List capabilities - disabled skill should NOT appear
+    let resp = server.get("/v1/capabilities").await.assert_success();
+    let body = resp.json_value();
+    let capabilities = body["data"].as_array().unwrap();
+
+    let skill_caps: Vec<&serde_json::Value> = capabilities
+        .iter()
+        .filter(|c| c["name"].as_str() == Some("test-skill"))
+        .collect();
+
+    assert!(
+        skill_caps.is_empty(),
+        "Disabled skill should not appear in capabilities"
+    );
+}
+
+#[tokio::test]
+async fn test_agent_with_skill_capability() {
+    let server = TestServer::new().await;
+
+    // Create a skill
+    let create_resp = server
+        .post("/v1/skills", json!({ "skill_md": VALID_SKILL_MD }))
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    let _skill = create_resp.json_value();
+    // The ID from the skills API is the public_id (skill_xxx format)
+    // But capability IDs use skill:{uuid} format
+    // We need to extract the UUID from the listing
+    let caps_resp = server.get("/v1/capabilities").await.assert_success();
+    let capabilities = caps_resp.json_value()["data"].as_array().unwrap().clone();
+    let skill_cap = capabilities
+        .iter()
+        .find(|c| c["name"].as_str() == Some("test-skill"))
+        .expect("Skill capability should exist");
+    let cap_id = skill_cap["id"].as_str().unwrap();
+
+    // Create agent with skill capability
+    let agent_resp = server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": "Skill Agent",
+                "system_prompt": "You are a helpful assistant.",
+                "capabilities": [
+                    { "ref": cap_id, "config": {} }
+                ]
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    let agent = agent_resp.json_value();
+    assert_eq!(agent["name"], "Skill Agent");
+
+    // Verify capabilities include the skill
+    let agent_caps = agent["capabilities"].as_array().unwrap();
+    assert!(
+        agent_caps.iter().any(|c| c["ref"].as_str() == Some(cap_id)),
+        "Agent should have skill capability assigned"
+    );
+}

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -185,6 +185,7 @@ impl TestServer {
             auth: auth_state.clone(),
         };
         let durable_state = api::durable::AppState::new(Some(durable_store));
+        let skills_state = api::skills::AppState::new(db.clone(), auth_state.clone());
         let images_state = api::images::AppState::new(db.clone(), auth_state.clone());
         let organizations_state = api::organizations::AppState::new(db.clone(), auth_state.clone());
 
@@ -204,6 +205,7 @@ impl TestServer {
             .merge(api::session_databases::routes(session_databases_state))
             .merge(api::users::routes(users_state))
             .merge(api::durable::routes(durable_state))
+            .merge(api::skills::routes(skills_state))
             .merge(api::images::routes(images_state))
             .merge(api::organizations::routes(organizations_state))
             .merge(auth::routes(auth_backend));

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -4252,6 +4252,10 @@
             "type": "boolean",
             "description": "Whether this is an MCP server capability (for UI badge)"
           },
+          "is_skill": {
+            "type": "boolean",
+            "description": "Whether this is an Agent Skill capability (for UI badge)"
+          },
           "name": {
             "type": "string",
             "description": "Display name"
@@ -5789,6 +5793,10 @@
                 "is_mcp": {
                   "type": "boolean",
                   "description": "Whether this is an MCP server capability (for UI badge)"
+                },
+                "is_skill": {
+                  "type": "boolean",
+                  "description": "Whether this is an Agent Skill capability (for UI badge)"
                 },
                 "name": {
                   "type": "string",

--- a/docs/features/skills.md
+++ b/docs/features/skills.md
@@ -1,0 +1,196 @@
+---
+title: Agent Skills
+description: Portable instruction packages that extend agent capabilities with specialized knowledge and workflows
+---
+
+Agent Skills are portable instruction packages following the [Agent Skills](https://agentskills.io/) open specification. They enable agents to discover and activate specialized knowledge on demand, keeping the agent's context efficient through progressive disclosure.
+
+## Overview
+
+Skills work through a three-stage progressive disclosure model:
+
+1. **Discovery** (~100 tokens): Only skill names and descriptions are loaded at startup
+2. **Activation** (<5000 tokens): Full instructions loaded when the agent calls `activate_skill`
+3. **Resources** (on-demand): Bundled files accessed through the session filesystem
+
+## SKILL.md Format
+
+Every skill contains a `SKILL.md` file with YAML frontmatter and markdown instructions:
+
+```yaml
+---
+name: csv-analyzer
+description: Analyze CSV files and generate summary reports.
+license: MIT
+compatibility: Python 3.10+
+metadata:
+  category: data-processing
+  version: "1.0"
+allowed-tools: read_file write_file virtual_bash
+---
+
+# CSV Analyzer
+
+## When to Use
+
+Activate this skill when a user provides a CSV file and wants summary statistics.
+
+## Instructions
+
+1. Read the CSV file using the `read_file` tool
+2. Run the analysis script
+3. Present findings to the user
+```
+
+### Required Fields
+
+| Field | Description |
+|-------|-------------|
+| `name` | 1-64 characters, lowercase alphanumeric + hyphens only |
+| `description` | 1-1024 characters describing when to use the skill |
+
+### Optional Fields
+
+| Field | Description |
+|-------|-------------|
+| `license` | License identifier (e.g., MIT, Apache-2.0) |
+| `compatibility` | Environment requirements (e.g., Python 3.10+) |
+| `metadata` | Arbitrary key-value pairs |
+| `allowed-tools` | Space-delimited tool names (experimental) |
+
+## Creating Skills
+
+### Via API (Registry-Based)
+
+Create a skill from a SKILL.md file:
+
+```bash
+curl -X POST http://localhost:9000/v1/skills \
+  -H "Content-Type: application/json" \
+  -d '{
+    "skill_md": "---\nname: hello-world\ndescription: A simple greeting skill.\n---\n\n# Hello World\n\nGreet the user warmly."
+  }'
+```
+
+### Via ZIP Archive
+
+For skills with bundled scripts, references, or assets:
+
+```bash
+curl -X POST http://localhost:9000/v1/skills/upload \
+  -F "file=@csv-analyzer.zip"
+```
+
+Archive structure:
+```
+csv-analyzer/
+├── SKILL.md
+├── scripts/analyze.py
+└── references/REFERENCE.md
+```
+
+### Filesystem Discovery
+
+Skills placed in the session filesystem at `/.agents/skills/` are automatically discovered:
+
+```
+/.agents/skills/
+├── hello-world/
+│   └── SKILL.md
+├── csv-analyzer/
+│   ├── SKILL.md
+│   └── scripts/analyze.py
+```
+
+## Skills as Capabilities
+
+Skills integrate into the capability system as virtual capabilities, appearing alongside built-in and MCP capabilities.
+
+### Capability ID Format
+
+- **Registry skills**: `skill:{uuid}` (e.g., `skill:550e8400-e29b-41d4-a716-446655440000`)
+- **Filesystem skills**: Aggregated under `skills` capability ID
+
+### Assigning to Agents
+
+```bash
+curl -X POST http://localhost:9000/v1/agents \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Analyst Agent",
+    "capabilities": [
+      { "ref": "skill:550e8400-e29b-41d4-a716-446655440000", "config": {} },
+      { "ref": "session_file_system", "config": {} }
+    ]
+  }'
+```
+
+Skills automatically depend on `session_file_system` for reading bundled files.
+
+## How Activation Works
+
+When a skill is assigned to an agent, the system prompt includes an `<available_skills>` XML block:
+
+```xml
+<available_skills>
+  <skill>
+    <name>csv-analyzer</name>
+    <description>Analyze CSV files and generate summary reports.</description>
+  </skill>
+</available_skills>
+
+When a user's task matches an available skill, activate it by using the
+`activate_skill` tool with the skill name.
+```
+
+The agent then uses the `activate_skill` tool to load full instructions:
+
+```json
+{
+  "name": "activate_skill",
+  "arguments": { "name": "csv-analyzer" }
+}
+```
+
+The tool returns the complete SKILL.md instructions wrapped in `<skill>` tags. For archive-based skills, bundled files are mounted into the session VFS at `/skills/{name}/`.
+
+## API Reference
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/v1/skills` | Create skill from SKILL.md |
+| POST | `/v1/skills/upload` | Create skill from ZIP archive |
+| GET | `/v1/skills` | List all skills |
+| GET | `/v1/skills/{id}` | Get skill metadata |
+| GET | `/v1/skills/{id}/content` | Get full skill content |
+| PATCH | `/v1/skills/{id}` | Update skill |
+| DELETE | `/v1/skills/{id}` | Delete skill |
+| POST | `/v1/skills/validate` | Validate SKILL.md without creating |
+
+## Validation
+
+Use the validation endpoint to check a SKILL.md before creating:
+
+```bash
+curl -X POST http://localhost:9000/v1/skills/validate \
+  -H "Content-Type: application/json" \
+  -d '{"skill_md": "---\nname: my-skill\ndescription: Does things.\n---\n\n# Instructions"}'
+```
+
+Response:
+```json
+{
+  "valid": true,
+  "name": "my-skill",
+  "description": "Does things.",
+  "warnings": []
+}
+```
+
+## Security
+
+- Archive uploads are validated for path traversal, zip bombs, and size limits
+- Skill instructions are returned as tool results (not injected into system prompt)
+- Skill names are unique per organization
+- Disabled skills are hidden from capability listings
+- See the [Threat Model](/specs/threat-model/) for detailed security analysis (TM-TOOL-010 through TM-TOOL-014)

--- a/examples/skills/csv-analyzer/SKILL.md
+++ b/examples/skills/csv-analyzer/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: csv-analyzer
+description: Analyze CSV files to generate summary statistics, detect data quality issues, and produce formatted reports.
+license: MIT
+compatibility: Python 3.10+
+metadata:
+  category: data-processing
+  version: "1.0"
+allowed-tools: read_file write_file virtual_bash
+---
+
+# CSV Analyzer
+
+Analyze CSV data files to produce summary statistics and quality reports.
+
+## When to Use
+
+Activate this skill when a user provides a CSV file and wants:
+- Summary statistics (row count, column types, missing values)
+- Data quality analysis (duplicates, outliers, formatting issues)
+- A formatted report
+
+## Instructions
+
+1. Read the CSV file using the `read_file` tool
+2. Run the analysis script at `/skills/csv-analyzer/scripts/analyze.py`
+3. Review the output and present findings to the user
+
+## Analysis Steps
+
+### Step 1: Load Data
+```bash
+python3 /skills/csv-analyzer/scripts/analyze.py /workspace/data.csv
+```
+
+### Step 2: Review Output
+The script outputs a JSON report with:
+- `row_count`: Total number of rows
+- `column_count`: Number of columns
+- `columns`: Array of column metadata (name, type, null_count, unique_count)
+- `quality_issues`: Array of detected problems
+
+### Step 3: Present Results
+Format the results as a readable summary table for the user.
+
+## References
+
+See `/skills/csv-analyzer/references/` for additional documentation on CSV analysis best practices.

--- a/examples/skills/csv-analyzer/references/REFERENCE.md
+++ b/examples/skills/csv-analyzer/references/REFERENCE.md
@@ -1,0 +1,16 @@
+# CSV Analysis Reference
+
+## Common Data Quality Issues
+
+1. **Missing values**: Null or empty cells that may need imputation
+2. **Duplicate rows**: Exact copies that may indicate data collection errors
+3. **Type mismatches**: Columns with mixed data types (e.g., numbers stored as strings)
+4. **Constant columns**: Columns with only one unique value (likely not useful for analysis)
+5. **Outliers**: Values far from the mean that may be errors or genuine anomalies
+
+## Best Practices
+
+- Always check for missing values before analysis
+- Verify column types match expectations
+- Look for duplicate rows early
+- Document any data cleaning steps performed

--- a/examples/skills/csv-analyzer/scripts/analyze.py
+++ b/examples/skills/csv-analyzer/scripts/analyze.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""CSV analysis script for the csv-analyzer skill.
+
+Usage: python3 analyze.py <csv_file_path>
+
+Outputs a JSON report with summary statistics and data quality issues.
+"""
+
+import csv
+import json
+import sys
+from collections import Counter
+
+
+def analyze_csv(filepath: str) -> dict:
+    """Analyze a CSV file and return a summary report."""
+    with open(filepath, "r", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    if not rows:
+        return {
+            "row_count": 0,
+            "column_count": 0,
+            "columns": [],
+            "quality_issues": ["File is empty or has no data rows"],
+        }
+
+    columns = list(rows[0].keys())
+    column_stats = []
+    quality_issues = []
+
+    for col in columns:
+        values = [row.get(col, "") for row in rows]
+        null_count = sum(1 for v in values if v is None or v.strip() == "")
+        unique_count = len(set(v for v in values if v and v.strip()))
+
+        # Detect column type
+        col_type = detect_type(values)
+
+        column_stats.append(
+            {
+                "name": col,
+                "type": col_type,
+                "null_count": null_count,
+                "unique_count": unique_count,
+                "null_percentage": round(null_count / len(values) * 100, 1),
+            }
+        )
+
+        # Quality checks
+        if null_count > len(values) * 0.5:
+            quality_issues.append(
+                f"Column '{col}' has {null_count}/{len(values)} missing values ({round(null_count/len(values)*100, 1)}%)"
+            )
+
+        if unique_count == 1 and len(values) > 1:
+            quality_issues.append(
+                f"Column '{col}' has only one unique value (constant column)"
+            )
+
+    # Check for duplicate rows
+    row_strs = ["|".join(row.get(c, "") for c in columns) for row in rows]
+    dupes = len(row_strs) - len(set(row_strs))
+    if dupes > 0:
+        quality_issues.append(f"Found {dupes} duplicate row(s)")
+
+    return {
+        "row_count": len(rows),
+        "column_count": len(columns),
+        "columns": column_stats,
+        "quality_issues": quality_issues if quality_issues else ["No issues detected"],
+    }
+
+
+def detect_type(values: list) -> str:
+    """Detect the most likely type for a column's values."""
+    non_empty = [v for v in values if v and v.strip()]
+    if not non_empty:
+        return "empty"
+
+    int_count = sum(1 for v in non_empty if is_int(v))
+    float_count = sum(1 for v in non_empty if is_float(v))
+
+    if int_count == len(non_empty):
+        return "integer"
+    if float_count == len(non_empty):
+        return "float"
+    return "string"
+
+
+def is_int(s: str) -> bool:
+    try:
+        int(s.strip())
+        return True
+    except ValueError:
+        return False
+
+
+def is_float(s: str) -> bool:
+    try:
+        float(s.strip())
+        return True
+    except ValueError:
+        return False
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(json.dumps({"error": "Usage: analyze.py <csv_file_path>"}))
+        sys.exit(1)
+
+    report = analyze_csv(sys.argv[1])
+    print(json.dumps(report, indent=2))

--- a/examples/skills/hello-world/SKILL.md
+++ b/examples/skills/hello-world/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: hello-world
+description: A simple example skill that demonstrates the Agent Skills format. Use this as a template for creating new skills.
+license: MIT
+metadata:
+  category: examples
+  version: "1.0"
+---
+
+# Hello World Skill
+
+This is an example skill following the [Agent Skills](https://agentskills.io/) open specification.
+
+## When to Use
+
+Activate this skill when a user asks for a greeting, welcome message, or wants to see how skills work.
+
+## Instructions
+
+1. Greet the user warmly
+2. Explain that you are using the "hello-world" skill
+3. Describe the Agent Skills format briefly
+4. Offer to help with any other tasks
+
+## Response Format
+
+Respond in a friendly, conversational tone. Include:
+
+- A greeting appropriate to the context
+- A brief mention that this response was powered by the hello-world skill
+- An invitation to explore other available skills
+
+## Example
+
+**User**: Hi, can you show me how skills work?
+
+**Agent**: Hello! I'm using the **hello-world** skill right now to respond to you. Agent Skills are portable instruction packages that extend what I can do. Each skill has a `SKILL.md` file with instructions I follow when the skill is activated. You can create your own skills by following the [agentskills.io](https://agentskills.io/) specification!

--- a/specs/skills-registry.md
+++ b/specs/skills-registry.md
@@ -419,9 +419,18 @@ CREATE INDEX idx_skill_files_skill_id ON skill_files(skill_id);
 - Returns structured `ParsedSkillMd` with metadata and body
 
 **SkillCapability** (`crates/core/src/capabilities/skill.rs`):
-- Implements `Capability` trait
-- Returns `activate_skill` and `read_skill_file` tool definitions
-- System prompt adds `<available_skills>` XML block
+- Implements `Capability` trait as a virtual capability
+- Returns `activate_skill` tool definition (no separate `read_skill_file` — uses existing VFS tools)
+- System prompt adds `<available_skills>` XML block listing discovered skills
+- Supports two construction modes:
+  - `from_registry(skill_id, name, description, instructions, files)` — single registry-based skill
+  - `from_discovered(skills: Vec<SkillMeta>)` — aggregate capability from filesystem discovery
+- Progressive disclosure: names/descriptions in system prompt, full content on `activate_skill`
+- Dependencies: `["session_file_system"]` (for VFS access after activation)
+- `ActivateSkillTool` returns full SKILL.md wrapped in `<skill name="...">` XML tags
+- Archive files mounted into VFS at `/skills/{name}/` on activation
+- `discover_skills_from_entries()` helper parses SKILL.md files from `.agents/skills/` path
+- `is_skill` flag on `CapabilityInfo` DTO for UI badge rendering
 
 **SkillService** (`crates/server/src/services/skill.rs`):
 - Business logic for CRUD operations
@@ -509,6 +518,46 @@ Optional: A "getting started" skill could be provided:
 ## Migration Strategy
 
 New migration file: `NNN_add_skills.sql` (next available number after current migrations).
+
+## Filesystem Discovery
+
+Skills can also be discovered from the session filesystem at `/.agents/skills/`. Each subdirectory containing a `SKILL.md` file is treated as a skill.
+
+### Discovery Path
+
+```
+/.agents/skills/
+├── hello-world/
+│   └── SKILL.md
+├── csv-analyzer/
+│   ├── SKILL.md
+│   ├── scripts/analyze.py
+│   └── references/REFERENCE.md
+```
+
+### Discovery Flow
+
+1. On session startup (when `skills` capability is enabled), scan `/.agents/skills/` for subdirectories
+2. For each directory containing a `SKILL.md`, parse the frontmatter
+3. Valid skills are registered as available skills in the `SkillCapability`
+4. Invalid `SKILL.md` files are logged as warnings and skipped
+5. Discovered skills appear in the `<available_skills>` system prompt block alongside registry-based skills
+
+### Discovery vs Registry
+
+| Feature | Registry (API) | Filesystem (`.agents/skills/`) |
+|---------|---------------|-------------------------------|
+| Storage | PostgreSQL | Session VFS |
+| Persistence | Org-wide, cross-session | Per-session |
+| Upload | API endpoints | Write files to VFS |
+| Capability ID | `skill:{uuid}` | `skills` (aggregate) |
+| Best for | Shared/reusable skills | Project-specific skills |
+
+## Example Skills
+
+Example skills are provided in `examples/skills/`:
+- `hello-world/` — Minimal skill demonstrating the SKILL.md format
+- `csv-analyzer/` — Complex skill with scripts and references (archive-based)
 
 ## Design Decisions
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -357,6 +357,11 @@ fn authorizer(action: AuthAction) -> Authorization {
 | TM-TOOL-007 | MCP API key exposure | High | API keys encrypted at rest via envelope encryption; decrypted only at runtime | MITIGATED |
 | TM-TOOL-008 | Tool policy bypass | Low | `requires_approval` policy planned but not yet enforced (all tools auto-execute) | **OPEN** |
 | TM-TOOL-009 | No per-agent tool rate limiting | Medium | All tools execute without rate limits | **OPEN** |
+| TM-TOOL-010 | Skill SKILL.md prompt injection | Medium | Skill instructions returned as `tool_result` role (not system prompt); `<skill>` XML wrapper provides clear boundary | MITIGATED |
+| TM-TOOL-011 | Skill archive path traversal | High | ZIP extraction validates all paths; rejects `../`, absolute paths, symlinks; max 100 files, 1 MB each, 10 MB total | MITIGATED |
+| TM-TOOL-012 | Skill archive zip bomb | High | Decompressed size capped at 10 MB; file count capped at 100; individual file size capped at 1 MB | MITIGATED |
+| TM-TOOL-013 | Skill name collision across orgs | Medium | Skill names are unique per organization; capability IDs include UUID for global uniqueness | MITIGATED |
+| TM-TOOL-014 | Disabled skill still activatable | Medium | `CapabilityService.list_all()` filters out disabled skills; disabled skills not included in `<available_skills>` | MITIGATED |
 
 ### Mitigation Details
 
@@ -371,6 +376,17 @@ MCP tool execution flow:
 
 **TM-TOOL-005 — Prompt Injection Boundary:**
 Tool results occupy the `tool_result` message role in the conversation. They are not concatenated into the system prompt. The LLM processes them as structured tool outputs, not instructions. However, LLMs may still be influenced by adversarial content in tool results (inherent limitation of current LLM architecture).
+
+**TM-TOOL-010 — Skill Instruction Injection Boundary:**
+When `activate_skill` is called, the full SKILL.md body is returned as a tool result wrapped in `<skill name="...">` XML tags. This maintains the tool_result role boundary. Only skill names and descriptions appear in the system prompt (via `<available_skills>` XML block), limiting the injection surface to metadata validated during upload.
+
+**TM-TOOL-011/012 — Skill Archive Validation:**
+ZIP archive extraction in `SkillService::create_from_archive()` enforces:
+1. No path traversal: paths checked for `../`, absolute paths, and symlinks
+2. File count limit: max 100 files per archive
+3. Per-file size limit: 1 MB per individual file
+4. Total decompressed size limit: 10 MB
+5. Files extracted into `skill_files` table as individual rows (no runtime ZIP extraction)
 
 ## 8. LLM Integration (TM-LLM)
 
@@ -768,7 +784,7 @@ Session A cannot access sb_xyz (different session_id in storage query)
 | Agent loop controls | TM-AGENT | Max iterations, tool registry, session-scoped tools, no self-modification |
 | Error sanitization | TM-API, TM-OBS | Generic error messages, server-side logging only |
 | Cookie security | TM-WEB | HTTP-only, SameSite=Lax, Secure flag in production |
-| Tool validation | TM-TOOL | Registry-based validation, defensive MCP parsing |
+| Tool validation | TM-TOOL | Registry-based validation, defensive MCP parsing, skill archive validation |
 | Resource limits | TM-DOS, TM-BASH | Input sizes, iteration limits, query timeouts, bash limits |
 | Task ownership | TM-DURABLE | Verified on completion, heartbeat-based reclaim |
 | Daytona sandbox isolation | TM-DAYTONA | Session-scoped secrets, encrypted API key, auto-stop, short-lived git tokens |


### PR DESCRIPTION
## Summary

- Implement `SkillCapability` as a virtual capability following the MCP server pattern, enabling [agentskills.io](https://agentskills.io/) skill support
- Skills appear in capabilities listing with `is_skill` flag, provide `activate_skill` tool for progressive disclosure
- Add integration tests for skills CRUD and capabilities integration, example skills, public documentation, spec updates, and threat model entries (TM-TOOL-010 through TM-TOOL-014)

## Test plan

- [x] Unit tests: 20+ tests in `crates/core/src/capabilities/skill.rs` covering capability metadata, tool execution, filesystem discovery, mount points
- [x] Integration tests: `crates/server/tests/skills_integration_test.rs` covering full CRUD, validation, capabilities listing, agent assignment
- [x] Pre-push checks: `cargo fmt`, `cargo clippy -- -D warnings` pass cleanly
- [x] Smoke tests: skills API endpoints tested manually (create, list, get, content, validate, update, delete, capabilities integration)
- [ ] CI green