### PR TITLE
feat(tools): add human-readable display names to all tools

### DIFF
--- a/apps/ui/src/components/chat/client-tool-call-card.tsx
+++ b/apps/ui/src/components/chat/client-tool-call-card.tsx
@@ -42,7 +42,9 @@ export function ClientToolCallCard({ toolCall, toolResult }: ClientToolCallCardP
       <div className="flex items-center gap-1">
         {statusIcon}
         <MonitorSmartphone className="h-3 w-3 text-amber-500/70" />
-        <span className="font-mono text-amber-700 dark:text-amber-400">{toolCall.name}</span>
+        <span className="font-mono text-amber-700 dark:text-amber-400">
+          {toolResult?.display_name ?? toolCall.display_name ?? toolCall.name}
+        </span>
         {!isComplete && (
           <span className="text-amber-500/70 italic text-[10px] ml-1">Waiting for client...</span>
         )}

--- a/apps/ui/src/components/chat/tool-call-card-from-event.tsx
+++ b/apps/ui/src/components/chat/tool-call-card-from-event.tsx
@@ -68,7 +68,9 @@ export function ToolCallCardFromEvent({
       {/* Tool name with status icon */}
       <div className="flex items-center gap-1">
         {statusIcon}
-        <span className="font-mono">{toolCall.name}</span>
+        <span className="font-mono">
+          {toolResult?.display_name ?? toolCall.display_name ?? toolCall.name}
+        </span>
         {argsPreview && <span className="opacity-60">{argsPreview}</span>}
       </div>
 

--- a/apps/ui/src/components/chat/tool-call-card.tsx
+++ b/apps/ui/src/components/chat/tool-call-card.tsx
@@ -61,7 +61,7 @@ export function ToolCallCard({ toolCall, toolResult }: ToolCallCardProps) {
     <div className="w-full space-y-0.5 text-sm text-muted-foreground">
       {/* Tool name and arguments */}
       <div>
-        <span className="font-medium">{content.name}:</span>
+        <span className="font-medium">{content.display_name ?? content.name}:</span>
         {argsPreview && <span className="ml-1">{argsPreview}</span>}
       </div>
 

--- a/apps/ui/src/components/chat/tool-call-utils.ts
+++ b/apps/ui/src/components/chat/tool-call-utils.ts
@@ -11,6 +11,8 @@ import { isToolCallPart, isToolResultPart } from "@/lib/api/types";
 export interface ToolCallContent {
   id: string;
   name: string;
+  /** Human-readable display name for UI rendering */
+  display_name?: string;
   arguments: Record<string, unknown>;
 }
 

--- a/apps/ui/src/components/trajectory/trajectory-nodes.tsx
+++ b/apps/ui/src/components/trajectory/trajectory-nodes.tsx
@@ -180,7 +180,7 @@ export const ToolGroupNode = memo(function ToolGroupNode({
             ) : (
               <XCircle className="w-2.5 h-2.5" />
             )}
-            {tool.name}
+            {tool.displayName ?? tool.name}
           </span>
         ))}
       </div>

--- a/apps/ui/src/components/trajectory/trajectory-utils.ts
+++ b/apps/ui/src/components/trajectory/trajectory-utils.ts
@@ -56,6 +56,8 @@ export interface ToolGroupNodeData {
   tools: Array<{
     id: string;
     name: string;
+    /** Human-readable display name for UI rendering */
+    displayName?: string;
     success: boolean;
     status: string;
     durationMs?: number;
@@ -254,6 +256,7 @@ function buildTurns(events: Event[]): TurnAccumulator[] {
             return {
               id: tc.id,
               name: tc.name,
+              displayName: tc.display_name ?? result?.display_name,
               success: result?.success ?? true,
               status: result?.status ?? "pending",
               durationMs: result?.duration_ms,

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -449,6 +449,8 @@ export interface ReasonCompletedData {
 export interface ToolCallSummary {
   id: string;
   name: string;
+  /** Human-readable display name for UI rendering */
+  display_name?: string;
 }
 
 /** Data for act.started event */
@@ -474,6 +476,8 @@ export interface ToolCall {
 /** Data for tool.started event */
 export interface ToolStartedData {
   tool_call: ToolCall;
+  /** Human-readable display name for UI rendering */
+  display_name?: string;
 }
 
 /** Data for tool.call_requested event (client-side tool calls awaiting results) */
@@ -489,6 +493,8 @@ export interface ToolCallRequestedData {
 export interface ToolCompletedData {
   tool_call_id: string;
   tool_name: string;
+  /** Human-readable display name for UI rendering */
+  display_name?: string;
   success: boolean;
   status: "success" | "error" | "timeout" | "cancelled";
   result?: ContentPart[];
@@ -623,6 +629,8 @@ export interface BuiltinTool {
   type: "builtin";
   /** Tool name (used by LLM and for registry lookup) */
   name: string;
+  /** Human-readable display name for UI rendering */
+  display_name?: string;
   /** Tool description for LLM */
   description: string;
   /** JSON schema for tool parameters */
@@ -636,6 +644,8 @@ export interface ClientSideTool {
   type: "client_side";
   /** Tool name (used by LLM and for registry lookup) */
   name: string;
+  /** Human-readable display name for UI rendering */
+  display_name?: string;
   /** Tool description for LLM */
   description: string;
   /** JSON schema for tool parameters */

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -271,13 +271,22 @@ where
         // Track act phase timing for Braintrust observability
         let act_start = Instant::now();
 
-        // Emit act.started event
+        // Build tool name to definition map
+        let tool_map: std::collections::HashMap<&str, &ToolDefinition> = tool_definitions
+            .iter()
+            .map(|def| {
+                let name = def.name();
+                (name, def)
+            })
+            .collect();
+
+        // Emit act.started event (with display names from tool definitions)
         if let Err(e) = self
             .event_emitter
             .emit(EventRequest::new(
                 context.session_id,
                 event_context.clone(),
-                ActStartedData::new(&tool_calls),
+                ActStartedData::with_definitions(&tool_calls, &tool_definitions),
             ))
             .await
         {
@@ -287,15 +296,6 @@ where
                 "ActAtom: failed to emit act.started event"
             );
         }
-
-        // Build tool name to definition map
-        let tool_map: std::collections::HashMap<&str, &ToolDefinition> = tool_definitions
-            .iter()
-            .map(|def| {
-                let name = def.name();
-                (name, def)
-            })
-            .collect();
 
         // Execute all tool calls in parallel (each tool event references act span as parent)
         let futures: Vec<_> = tool_calls
@@ -404,6 +404,9 @@ where
         // Track tool call timing for Braintrust observability
         let tool_start = Instant::now();
 
+        // Resolve display name from tool definition
+        let display_name = tool_def.and_then(|d| d.display_name().map(|s| s.to_string()));
+
         // Emit tool.started event (child of act.started)
         if let Err(e) = self
             .event_emitter
@@ -412,6 +415,7 @@ where
                 event_context.clone(),
                 ToolStartedData {
                     tool_call: tool_call.clone(),
+                    display_name: display_name.clone(),
                 },
             ))
             .await
@@ -536,6 +540,7 @@ where
                         result_content,
                         Some(tool_duration_ms),
                     )
+                    .with_display_name(display_name.clone())
                 } else {
                     ToolCompletedData::failure(
                         tool_call.id.clone(),
@@ -544,6 +549,7 @@ where
                         tool_result.error.clone().unwrap_or_default(),
                         Some(tool_duration_ms),
                     )
+                    .with_display_name(display_name.clone())
                 };
 
                 if let Err(e) = self
@@ -594,7 +600,8 @@ where
                             "error".to_string(),
                             error_msg.clone(),
                             Some(tool_duration_ms),
-                        ),
+                        )
+                        .with_display_name(display_name.clone()),
                     ))
                     .await
                 {

--- a/crates/core/src/capabilities/current_time.rs
+++ b/crates/core/src/capabilities/current_time.rs
@@ -51,6 +51,10 @@ impl Tool for GetCurrentTimeTool {
         "get_current_time"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("Get Current Time")
+    }
+
     fn description(&self) -> &str {
         "Get the current date and time. Can return time in different formats and timezones."
     }

--- a/crates/core/src/capabilities/fake_aws.rs
+++ b/crates/core/src/capabilities/fake_aws.rs
@@ -173,6 +173,10 @@ impl Tool for AwsListEc2InstancesTool {
         "aws_list_ec2_instances"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("List EC2 Instances")
+    }
+
     fn description(&self) -> &str {
         "List all EC2 instances with their current status, IPs, and configuration."
     }
@@ -310,6 +314,10 @@ impl Tool for AwsCreateEc2InstanceTool {
         "aws_create_ec2_instance"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("Create EC2 Instance")
+    }
+
     fn description(&self) -> &str {
         "Launch a new EC2 instance with specified configuration."
     }
@@ -445,6 +453,10 @@ impl Tool for AwsStopEc2InstanceTool {
         "aws_stop_ec2_instance"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("Stop EC2 Instance")
+    }
+
     fn description(&self) -> &str {
         "Stop a running EC2 instance."
     }
@@ -546,6 +558,10 @@ impl Tool for AwsListRdsDatabasesTool {
         "aws_list_rds_databases"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("List RDS Databases")
+    }
+
     fn description(&self) -> &str {
         "List all RDS database instances."
     }
@@ -606,6 +622,10 @@ impl Tool for AwsCreateRdsDatabaseTool {
         "aws_create_rds_database"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("Create RDS Database")
+    }
+
     fn description(&self) -> &str {
         "Create a new RDS database instance."
     }
@@ -658,6 +678,10 @@ impl Tool for AwsListS3BucketsTool {
         "aws_list_s3_buckets"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("List S3 Buckets")
+    }
+
     fn description(&self) -> &str {
         "List all S3 buckets in the account."
     }
@@ -706,6 +730,10 @@ pub struct AwsCreateS3BucketTool;
 impl Tool for AwsCreateS3BucketTool {
     fn name(&self) -> &str {
         "aws_create_s3_bucket"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Create S3 Bucket")
     }
 
     fn description(&self) -> &str {
@@ -760,6 +788,10 @@ impl Tool for AwsListIamUsersTool {
         "aws_list_iam_users"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("List IAM Users")
+    }
+
     fn description(&self) -> &str {
         "List all IAM users in the account."
     }
@@ -808,6 +840,10 @@ pub struct AwsCreateIamUserTool;
 impl Tool for AwsCreateIamUserTool {
     fn name(&self) -> &str {
         "aws_create_iam_user"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Create IAM User")
     }
 
     fn description(&self) -> &str {
@@ -862,6 +898,10 @@ pub struct AwsListSecurityGroupsTool;
 impl Tool for AwsListSecurityGroupsTool {
     fn name(&self) -> &str {
         "aws_list_security_groups"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("List Security Groups")
     }
 
     fn description(&self) -> &str {
@@ -921,6 +961,10 @@ pub struct AwsGetCloudWatchMetricsTool;
 impl Tool for AwsGetCloudWatchMetricsTool {
     fn name(&self) -> &str {
         "aws_get_cloudwatch_metrics"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Get CloudWatch Metrics")
     }
 
     fn description(&self) -> &str {

--- a/crates/core/src/capabilities/fake_crm.rs
+++ b/crates/core/src/capabilities/fake_crm.rs
@@ -132,6 +132,10 @@ impl Tool for CrmListCustomersTool {
         "crm_list_customers"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("List Customers")
+    }
+
     fn description(&self) -> &str {
         "List all customers. Optionally filter by customer tier."
     }
@@ -248,6 +252,10 @@ impl Tool for CrmGetCustomerTool {
         "crm_get_customer"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("Get Customer")
+    }
+
     fn description(&self) -> &str {
         "Get detailed customer information by customer ID."
     }
@@ -320,6 +328,10 @@ pub struct CrmCreateCustomerTool;
 impl Tool for CrmCreateCustomerTool {
     fn name(&self) -> &str {
         "crm_create_customer"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Create Customer")
     }
 
     fn description(&self) -> &str {
@@ -441,6 +453,10 @@ impl Tool for CrmListTicketsTool {
         "crm_list_tickets"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("List Tickets")
+    }
+
     fn description(&self) -> &str {
         "List support tickets. Filter by status or priority."
     }
@@ -520,6 +536,10 @@ pub struct CrmCreateTicketTool;
 impl Tool for CrmCreateTicketTool {
     fn name(&self) -> &str {
         "crm_create_ticket"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Create Ticket")
     }
 
     fn description(&self) -> &str {
@@ -643,6 +663,10 @@ impl Tool for CrmUpdateTicketTool {
         "crm_update_ticket"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("Update Ticket")
+    }
+
     fn description(&self) -> &str {
         "Update ticket status or assignment."
     }
@@ -728,6 +752,10 @@ impl Tool for CrmAddInteractionTool {
         "crm_add_interaction"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("Add Interaction")
+    }
+
     fn description(&self) -> &str {
         "Add a customer interaction note (call, email, meeting, chat)."
     }
@@ -774,6 +802,10 @@ pub struct CrmSearchCustomersTool;
 impl Tool for CrmSearchCustomersTool {
     fn name(&self) -> &str {
         "crm_search_customers"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Search Customers")
     }
 
     fn description(&self) -> &str {

--- a/crates/core/src/capabilities/fake_financial.rs
+++ b/crates/core/src/capabilities/fake_financial.rs
@@ -122,6 +122,10 @@ impl Tool for FinanceListTransactionsTool {
         "finance_list_transactions"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("List Transactions")
+    }
+
     fn description(&self) -> &str {
         "List financial transactions. Filter by type (income/expense) or category."
     }
@@ -248,6 +252,10 @@ pub struct FinanceCreateTransactionTool;
 impl Tool for FinanceCreateTransactionTool {
     fn name(&self) -> &str {
         "finance_create_transaction"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Create Transaction")
     }
 
     fn description(&self) -> &str {
@@ -382,6 +390,10 @@ impl Tool for FinanceGetBalanceTool {
         "finance_get_balance"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("Get Balance")
+    }
+
     fn description(&self) -> &str {
         "Get current account balances."
     }
@@ -460,6 +472,10 @@ impl Tool for FinanceListBudgetsTool {
         "finance_list_budgets"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("List Budgets")
+    }
+
     fn description(&self) -> &str {
         "List all budgets by category."
     }
@@ -506,6 +522,10 @@ pub struct FinanceCreateBudgetTool;
 impl Tool for FinanceCreateBudgetTool {
     fn name(&self) -> &str {
         "finance_create_budget"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Create Budget")
     }
 
     fn description(&self) -> &str {
@@ -560,6 +580,10 @@ pub struct FinanceGetExpenseReportTool;
 impl Tool for FinanceGetExpenseReportTool {
     fn name(&self) -> &str {
         "finance_get_expense_report"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Get Expense Report")
     }
 
     fn description(&self) -> &str {
@@ -622,6 +646,10 @@ impl Tool for FinanceGetRevenueReportTool {
         "finance_get_revenue_report"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("Get Revenue Report")
+    }
+
     fn description(&self) -> &str {
         "Generate revenue report for a time period."
     }
@@ -679,6 +707,10 @@ pub struct FinanceForecastCashFlowTool;
 impl Tool for FinanceForecastCashFlowTool {
     fn name(&self) -> &str {
         "finance_forecast_cash_flow"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Forecast Cash Flow")
     }
 
     fn description(&self) -> &str {

--- a/crates/core/src/capabilities/fake_warehouse.rs
+++ b/crates/core/src/capabilities/fake_warehouse.rs
@@ -138,6 +138,10 @@ impl Tool for WarehouseGetInventoryTool {
         "warehouse_get_inventory"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("Get Inventory")
+    }
+
     fn description(&self) -> &str {
         "Get current inventory levels. Optionally filter by SKU or show only low stock items."
     }
@@ -289,6 +293,10 @@ impl Tool for WarehouseUpdateInventoryTool {
         "warehouse_update_inventory"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("Update Inventory")
+    }
+
     fn description(&self) -> &str {
         "Update inventory quantity for a product. Use positive numbers to add stock, negative to remove."
     }
@@ -415,6 +423,10 @@ impl Tool for WarehouseCreateShipmentTool {
         "warehouse_create_shipment"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("Create Shipment")
+    }
+
     fn description(&self) -> &str {
         "Create a new shipment. Automatically updates inventory levels."
     }
@@ -539,6 +551,10 @@ impl Tool for WarehouseListShipmentsTool {
         "warehouse_list_shipments"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("List Shipments")
+    }
+
     fn description(&self) -> &str {
         "List all shipments. Optionally filter by status."
     }
@@ -615,6 +631,10 @@ pub struct WarehouseUpdateShipmentStatusTool;
 impl Tool for WarehouseUpdateShipmentStatusTool {
     fn name(&self) -> &str {
         "warehouse_update_shipment_status"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Update Shipment Status")
     }
 
     fn description(&self) -> &str {
@@ -731,6 +751,10 @@ impl Tool for WarehouseCreateOrderTool {
         "warehouse_create_order"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("Create Order")
+    }
+
     fn description(&self) -> &str {
         "Create a new customer order."
     }
@@ -827,6 +851,10 @@ impl Tool for WarehouseListOrdersTool {
         "warehouse_list_orders"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("List Orders")
+    }
+
     fn description(&self) -> &str {
         "List all customer orders."
     }
@@ -873,6 +901,10 @@ pub struct WarehouseCreateInvoiceTool;
 impl Tool for WarehouseCreateInvoiceTool {
     fn name(&self) -> &str {
         "warehouse_create_invoice"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Create Invoice")
     }
 
     fn description(&self) -> &str {
@@ -924,6 +956,10 @@ pub struct WarehouseProcessReturnTool;
 impl Tool for WarehouseProcessReturnTool {
     fn name(&self) -> &str {
         "warehouse_process_return"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Process Return")
     }
 
     fn description(&self) -> &str {
@@ -978,6 +1014,10 @@ pub struct WarehouseInventoryReportTool;
 impl Tool for WarehouseInventoryReportTool {
     fn name(&self) -> &str {
         "warehouse_inventory_report"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Inventory Report")
     }
 
     fn description(&self) -> &str {

--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -157,6 +157,10 @@ impl Tool for ReadFileTool {
         "read_file"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("Read File")
+    }
+
     fn description(&self) -> &str {
         "Read the content of a file. Returns text content directly. For image files (PNG, JPEG, GIF, WebP), the image is returned as a native image so you can see it visually."
     }
@@ -269,6 +273,10 @@ impl Tool for WriteFileTool {
         "write_file"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("Write File")
+    }
+
     fn description(&self) -> &str {
         "Create a new file or update an existing file's content. Parent directories are created automatically."
     }
@@ -375,6 +383,10 @@ impl Tool for ListDirectoryTool {
         "list_directory"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("List Directory")
+    }
+
     fn description(&self) -> &str {
         "List files and directories at a given path. Returns file metadata including size and type."
     }
@@ -473,6 +485,10 @@ pub struct GrepFilesTool;
 impl Tool for GrepFilesTool {
     fn name(&self) -> &str {
         "grep_files"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Grep Files")
     }
 
     fn description(&self) -> &str {
@@ -575,6 +591,10 @@ impl Tool for DeleteFileTool {
         "delete_file"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("Delete File")
+    }
+
     fn description(&self) -> &str {
         "Delete a file or directory. Use recursive=true to delete non-empty directories."
     }
@@ -673,6 +693,10 @@ pub struct StatFileTool;
 impl Tool for StatFileTool {
     fn name(&self) -> &str {
         "stat_file"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("File Info")
     }
 
     fn description(&self) -> &str {

--- a/crates/core/src/capabilities/mcp.rs
+++ b/crates/core/src/capabilities/mcp.rs
@@ -83,6 +83,7 @@ impl McpCapability {
 
         ToolDefinition::Builtin(BuiltinTool {
             name: prefixed_name,
+            display_name: None,
             description: mcp_tool
                 .description
                 .clone()

--- a/crates/core/src/capabilities/session.rs
+++ b/crates/core/src/capabilities/session.rs
@@ -64,6 +64,10 @@ impl Tool for WriteSessionTitleTool {
         "write_session_title"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("Write Session Title")
+    }
+
     fn description(&self) -> &str {
         "Update the current session title."
     }
@@ -125,6 +129,10 @@ pub struct GetSessionInfoTool;
 impl Tool for GetSessionInfoTool {
     fn name(&self) -> &str {
         "get_session_info"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Get Session Info")
     }
 
     fn description(&self) -> &str {

--- a/crates/core/src/capabilities/session_sql_database.rs
+++ b/crates/core/src/capabilities/session_sql_database.rs
@@ -91,6 +91,10 @@ impl Tool for SqlExecuteTool {
         "sql_execute"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("SQL Execute")
+    }
+
     fn description(&self) -> &str {
         "Execute DDL/DML SQL (CREATE TABLE, INSERT, UPDATE, DELETE). Auto-creates database if it doesn't exist."
     }
@@ -172,6 +176,10 @@ pub struct SqlQueryTool;
 impl Tool for SqlQueryTool {
     fn name(&self) -> &str {
         "sql_query"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("SQL Query")
     }
 
     fn description(&self) -> &str {
@@ -262,6 +270,10 @@ pub struct SqlSchemaTool;
 impl Tool for SqlSchemaTool {
     fn name(&self) -> &str {
         "sql_schema"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("SQL Schema")
     }
 
     fn description(&self) -> &str {

--- a/crates/core/src/capabilities/session_storage.rs
+++ b/crates/core/src/capabilities/session_storage.rs
@@ -88,6 +88,10 @@ impl Tool for KvStoreTool {
         "kv_store"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("Key-Value Store")
+    }
+
     fn description(&self) -> &str {
         "Key/value storage operations: set, get, delete, or list keys."
     }
@@ -259,6 +263,10 @@ pub struct SecretStoreTool;
 impl Tool for SecretStoreTool {
     fn name(&self) -> &str {
         "secret_store"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Secret Store")
     }
 
     fn description(&self) -> &str {

--- a/crates/core/src/capabilities/skill.rs
+++ b/crates/core/src/capabilities/skill.rs
@@ -276,6 +276,7 @@ impl Capability for SkillCapability {
 
         vec![ToolDefinition::Builtin(BuiltinTool {
             name: "activate_skill".to_string(),
+            display_name: Some("Activate Skill".to_string()),
             description: format!(
                 "Activate an agent skill by name to load its full instructions. \
                 Available skills: {names_list}"
@@ -318,6 +319,10 @@ impl std::fmt::Debug for ActivateSkillTool {
 impl Tool for ActivateSkillTool {
     fn name(&self) -> &str {
         "activate_skill"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Activate Skill")
     }
 
     fn description(&self) -> &str {

--- a/crates/core/src/capabilities/stateless_todo_list.rs
+++ b/crates/core/src/capabilities/stateless_todo_list.rs
@@ -146,6 +146,10 @@ impl Tool for WriteTodosTool {
         "write_todos"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("Write Todos")
+    }
+
     fn description(&self) -> &str {
         "Create or update a task list for tracking multi-step work. Each task must have 'content' (imperative form like 'Run tests'), 'activeForm' (present continuous like 'Running tests'), and 'status' (pending/in_progress/completed). Exactly one task should be 'in_progress' at a time."
     }

--- a/crates/core/src/capabilities/test_math.rs
+++ b/crates/core/src/capabilities/test_math.rs
@@ -62,6 +62,10 @@ impl Tool for AddTool {
         "add"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("Add")
+    }
+
     fn description(&self) -> &str {
         "Add two numbers together and return the result."
     }
@@ -109,6 +113,10 @@ pub struct SubtractTool;
 impl Tool for SubtractTool {
     fn name(&self) -> &str {
         "subtract"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Subtract")
     }
 
     fn description(&self) -> &str {
@@ -160,6 +168,10 @@ impl Tool for MultiplyTool {
         "multiply"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("Multiply")
+    }
+
     fn description(&self) -> &str {
         "Multiply two numbers together and return the result."
     }
@@ -207,6 +219,10 @@ pub struct DivideTool;
 impl Tool for DivideTool {
     fn name(&self) -> &str {
         "divide"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Divide")
     }
 
     fn description(&self) -> &str {

--- a/crates/core/src/capabilities/test_weather.rs
+++ b/crates/core/src/capabilities/test_weather.rs
@@ -57,6 +57,10 @@ impl Tool for GetWeatherTool {
         "get_weather"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("Get Weather")
+    }
+
     fn description(&self) -> &str {
         "Get the current weather for a location. Returns temperature, conditions, humidity, and wind speed."
     }
@@ -136,6 +140,10 @@ pub struct GetForecastTool;
 impl Tool for GetForecastTool {
     fn name(&self) -> &str {
         "get_forecast"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Get Forecast")
     }
 
     fn description(&self) -> &str {

--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -123,6 +123,10 @@ impl Tool for BashTool {
         "bash"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("Bash")
+    }
+
     fn description(&self) -> &str {
         &TOOL_DESCRIPTION
     }

--- a/crates/core/src/capabilities/web_fetch.rs
+++ b/crates/core/src/capabilities/web_fetch.rs
@@ -77,6 +77,10 @@ impl Tool for WebFetchTool {
         "web_fetch"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("Web Fetch")
+    }
+
     fn description(&self) -> &str {
         // Use the description from fetchkit library
         TOOL_DESCRIPTION

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -592,6 +592,9 @@ impl ReasonCompletedData {
 pub struct ToolCallSummary {
     pub id: String,
     pub name: String,
+    /// Human-readable display name for UI rendering
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
 }
 
 impl From<&ToolCall> for ToolCallSummary {
@@ -599,6 +602,7 @@ impl From<&ToolCall> for ToolCallSummary {
         Self {
             id: tc.id.clone(),
             name: tc.name.clone(),
+            display_name: None,
         }
     }
 }
@@ -609,6 +613,9 @@ impl From<&ToolCall> for ToolCallSummary {
 pub struct ToolDefinitionSummary {
     /// Tool name
     pub name: String,
+    /// Human-readable display name for UI rendering
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
     /// Tool description
     pub description: String,
 }
@@ -617,6 +624,7 @@ impl From<&crate::tool_types::ToolDefinition> for ToolDefinitionSummary {
     fn from(tool: &crate::tool_types::ToolDefinition) -> Self {
         Self {
             name: tool.name().to_string(),
+            display_name: tool.display_name().map(|s| s.to_string()),
             description: tool.description().to_string(),
         }
     }
@@ -634,6 +642,30 @@ impl ActStartedData {
     pub fn new(tool_calls: &[ToolCall]) -> Self {
         Self {
             tool_calls: tool_calls.iter().map(ToolCallSummary::from).collect(),
+        }
+    }
+
+    /// Create with display names resolved from tool definitions
+    pub fn with_definitions(
+        tool_calls: &[ToolCall],
+        tool_defs: &[crate::tool_types::ToolDefinition],
+    ) -> Self {
+        let def_map: std::collections::HashMap<&str, &crate::tool_types::ToolDefinition> =
+            tool_defs.iter().map(|d| (d.name(), d)).collect();
+        Self {
+            tool_calls: tool_calls
+                .iter()
+                .map(|tc| {
+                    let display_name = def_map
+                        .get(tc.name.as_str())
+                        .and_then(|d| d.display_name().map(|s| s.to_string()));
+                    ToolCallSummary {
+                        id: tc.id.clone(),
+                        name: tc.name.clone(),
+                        display_name,
+                    }
+                })
+                .collect(),
         }
     }
 }
@@ -662,6 +694,9 @@ pub struct ActCompletedData {
 pub struct ToolStartedData {
     /// The tool call being executed
     pub tool_call: ToolCall,
+    /// Human-readable display name for UI rendering
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
 }
 
 /// Data for tool.completed event
@@ -673,6 +708,10 @@ pub struct ToolCompletedData {
 
     /// Tool name
     pub tool_name: String,
+
+    /// Human-readable display name for UI rendering
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
 
     /// Whether the tool call succeeded
     pub success: bool,
@@ -703,6 +742,7 @@ impl ToolCompletedData {
         Self {
             tool_call_id,
             tool_name,
+            display_name: None,
             success: true,
             status: "success".to_string(),
             result: Some(result),
@@ -721,12 +761,19 @@ impl ToolCompletedData {
         Self {
             tool_call_id,
             tool_name,
+            display_name: None,
             success: false,
             status,
             result: None,
             error: Some(error),
             duration_ms,
         }
+    }
+
+    /// Set display name on this event data
+    pub fn with_display_name(mut self, display_name: Option<String>) -> Self {
+        self.display_name = display_name;
+        self
     }
 }
 
@@ -1769,6 +1816,7 @@ mod tests {
         let messages = vec![Message::user("Hello"), Message::assistant("Hi there!")];
         let tools = vec![ToolDefinitionSummary {
             name: "get_weather".to_string(),
+            display_name: None,
             description: "Get weather for a city".to_string(),
         }];
         let tool_calls = vec![];
@@ -2337,6 +2385,7 @@ mod contract_tests {
             tool_calls: vec![ToolCallSummary {
                 id: "tc_1".to_string(),
                 name: "get_weather".to_string(),
+                display_name: None,
             }],
         };
         with_settings!({
@@ -2369,6 +2418,7 @@ mod contract_tests {
                 name: "get_weather".to_string(),
                 arguments: serde_json::json!({"city": "London"}),
             },
+            display_name: None,
         };
         with_settings!({
             sort_maps => true,
@@ -2398,6 +2448,7 @@ mod contract_tests {
             vec![Message::user("Hello")],
             vec![ToolDefinitionSummary {
                 name: "tool1".to_string(),
+                display_name: None,
                 description: "A tool".to_string(),
             }],
             Some("Hi there!".to_string()),
@@ -2498,6 +2549,128 @@ mod contract_tests {
         }, {
             assert_json_snapshot!("event_data_session_idled", data);
         });
+    }
+
+    // ========================================================================
+    // Display Name Tests
+    // ========================================================================
+    // Verify display_name propagation through event data types.
+
+    #[test]
+    fn tool_call_summary_with_display_name() {
+        let summary = ToolCallSummary {
+            id: "tc_1".to_string(),
+            name: "get_weather".to_string(),
+            display_name: Some("Get Weather".to_string()),
+        };
+        let json = serde_json::to_value(&summary).unwrap();
+        assert_eq!(json["display_name"], "Get Weather");
+
+        // Round-trip
+        let deserialized: ToolCallSummary = serde_json::from_value(json).unwrap();
+        assert_eq!(deserialized.display_name.as_deref(), Some("Get Weather"));
+    }
+
+    #[test]
+    fn tool_call_summary_without_display_name_omits_field() {
+        let summary = ToolCallSummary {
+            id: "tc_1".to_string(),
+            name: "get_weather".to_string(),
+            display_name: None,
+        };
+        let json = serde_json::to_string(&summary).unwrap();
+        assert!(!json.contains("display_name"));
+
+        // Deserialize without display_name field present
+        let json_without = r#"{"id":"tc_1","name":"get_weather"}"#;
+        let deserialized: ToolCallSummary = serde_json::from_str(json_without).unwrap();
+        assert_eq!(deserialized.display_name, None);
+    }
+
+    #[test]
+    fn act_started_with_definitions_populates_display_names() {
+        use crate::tool_types::{BuiltinTool, ToolPolicy};
+
+        let tool_calls = vec![
+            ToolCall {
+                id: "tc_1".to_string(),
+                name: "get_weather".to_string(),
+                arguments: serde_json::json!({}),
+            },
+            ToolCall {
+                id: "tc_2".to_string(),
+                name: "unknown_tool".to_string(),
+                arguments: serde_json::json!({}),
+            },
+        ];
+        let tool_defs = vec![crate::tool_types::ToolDefinition::Builtin(BuiltinTool {
+            name: "get_weather".to_string(),
+            display_name: Some("Get Weather".to_string()),
+            description: "Gets weather".to_string(),
+            parameters: serde_json::json!({}),
+            policy: ToolPolicy::Auto,
+        })];
+
+        let data = ActStartedData::with_definitions(&tool_calls, &tool_defs);
+        assert_eq!(data.tool_calls.len(), 2);
+        assert_eq!(
+            data.tool_calls[0].display_name.as_deref(),
+            Some("Get Weather")
+        );
+        assert_eq!(data.tool_calls[1].display_name, None);
+    }
+
+    #[test]
+    fn tool_completed_with_display_name_roundtrip() {
+        let data = ToolCompletedData::success(
+            "tc_1".to_string(),
+            "get_weather".to_string(),
+            vec![crate::message::ContentPart::text("Sunny")],
+            Some(100),
+        )
+        .with_display_name(Some("Get Weather".to_string()));
+
+        assert_eq!(data.display_name.as_deref(), Some("Get Weather"));
+
+        let json = serde_json::to_value(&data).unwrap();
+        assert_eq!(json["display_name"], "Get Weather");
+
+        let deserialized: ToolCompletedData = serde_json::from_value(json).unwrap();
+        assert_eq!(deserialized.display_name.as_deref(), Some("Get Weather"));
+    }
+
+    #[test]
+    fn tool_started_display_name_serialization() {
+        let data = ToolStartedData {
+            tool_call: ToolCall {
+                id: "tc_1".to_string(),
+                name: "bash".to_string(),
+                arguments: serde_json::json!({"command": "ls"}),
+            },
+            display_name: Some("Bash".to_string()),
+        };
+
+        let json = serde_json::to_value(&data).unwrap();
+        assert_eq!(json["display_name"], "Bash");
+    }
+
+    #[test]
+    fn tool_definition_summary_display_name() {
+        use crate::tool_types::{BuiltinTool, ToolPolicy};
+
+        let def = crate::tool_types::ToolDefinition::Builtin(BuiltinTool {
+            name: "read_file".to_string(),
+            display_name: Some("Read File".to_string()),
+            description: "Reads a file".to_string(),
+            parameters: serde_json::json!({}),
+            policy: ToolPolicy::Auto,
+        });
+
+        let summary = ToolDefinitionSummary::from(&def);
+        assert_eq!(summary.display_name.as_deref(), Some("Read File"));
+
+        let json = serde_json::to_value(&summary).unwrap();
+        assert_eq!(json["display_name"], "Read File");
     }
 
     // ========================================================================

--- a/crates/core/src/memory.rs
+++ b/crates/core/src/memory.rs
@@ -891,6 +891,7 @@ mod tests {
 
         let tool_def = ToolDefinition::Builtin(crate::tool_types::BuiltinTool {
             name: "get_weather".to_string(),
+            display_name: None,
             description: "Get weather".to_string(),
             parameters: serde_json::json!({}),
             policy: crate::tool_types::ToolPolicy::Auto,

--- a/crates/core/src/observation/braintrust.rs
+++ b/crates/core/src/observation/braintrust.rs
@@ -1683,10 +1683,12 @@ mod tests {
                 ToolCallSummary {
                     id: "call_1".to_string(),
                     name: "search".to_string(),
+                    display_name: None,
                 },
                 ToolCallSummary {
                     id: "call_2".to_string(),
                     name: "fetch".to_string(),
+                    display_name: None,
                 },
             ],
         };
@@ -1733,6 +1735,7 @@ mod tests {
         let data = ToolCompletedData {
             tool_call_id: "call_123".to_string(),
             tool_name: "search".to_string(),
+            display_name: None,
             success: true,
             status: "success".to_string(),
             result: None,
@@ -1924,6 +1927,7 @@ mod tests {
             tool_calls: vec![ToolCallSummary {
                 id: "call_1".to_string(),
                 name: "search".to_string(),
+                display_name: None,
             }],
         };
         let act_event = Event::new(
@@ -1947,6 +1951,7 @@ mod tests {
         let tool_data = ToolCompletedData {
             tool_call_id: "call_1".to_string(),
             tool_name: "search".to_string(),
+            display_name: None,
             success: true,
             status: "success".to_string(),
             result: None,
@@ -2118,6 +2123,7 @@ mod tests {
             tool_calls: vec![ToolCallSummary {
                 id: "call_1".to_string(),
                 name: "search".to_string(),
+                display_name: None,
             }],
         };
         let started_event = Event::new(
@@ -2176,6 +2182,7 @@ mod tests {
                 name: "search".to_string(),
                 arguments: serde_json::json!({"query": "test"}),
             },
+            display_name: None,
         };
         let started_event = Event::new(
             SessionId::new(),
@@ -2194,6 +2201,7 @@ mod tests {
         let completed_data = ToolCompletedData {
             tool_call_id: "call_1".to_string(),
             tool_name: "search".to_string(),
+            display_name: None,
             success: true,
             status: "success".to_string(),
             result: None,

--- a/crates/core/src/observation/otel.rs
+++ b/crates/core/src/observation/otel.rs
@@ -1169,6 +1169,7 @@ mod tests {
                 name: "calculate".to_string(),
                 arguments: json!({"x": 42}),
             },
+            display_name: None,
         };
         listener
             .on_event(&Event::new(
@@ -1182,6 +1183,7 @@ mod tests {
         let completed = ToolCompletedData {
             tool_call_id: "call_abc".to_string(),
             tool_name: "calculate".to_string(),
+            display_name: None,
             success: true,
             status: "success".to_string(),
             result: None,
@@ -1205,6 +1207,7 @@ mod tests {
         let completed = ToolCompletedData {
             tool_call_id: "orphan_call".to_string(),
             tool_name: "unknown_tool".to_string(),
+            display_name: None,
             success: false,
             status: "error".to_string(),
             result: None,
@@ -1234,6 +1237,7 @@ mod tests {
                     name: format!("tool_{}", i),
                     arguments: json!({}),
                 },
+                display_name: None,
             };
             listener
                 .on_event(&Event::new(
@@ -1250,6 +1254,7 @@ mod tests {
             let completed = ToolCompletedData {
                 tool_call_id: format!("call_{}", i),
                 tool_name: format!("tool_{}", i),
+                display_name: None,
                 success: true,
                 status: "success".to_string(),
                 result: None,
@@ -1549,6 +1554,7 @@ mod tests {
                 name: "search".to_string(),
                 arguments: json!({"query": "rust programming", "limit": 10}),
             },
+            display_name: None,
         };
         listener
             .on_event(&Event::new(
@@ -1561,6 +1567,7 @@ mod tests {
         let completed = ToolCompletedData {
             tool_call_id: "call_with_args".to_string(),
             tool_name: "search".to_string(),
+            display_name: None,
             success: true,
             status: "success".to_string(),
             result: None,
@@ -1940,6 +1947,7 @@ mod tests {
                         name: "web_search".to_string(),
                         arguments: json!({"query": "rust documentation"}),
                     },
+                    display_name: None,
                 }),
             ))
             .await;
@@ -1954,6 +1962,7 @@ mod tests {
                 EventData::ToolCompleted(ToolCompletedData {
                     tool_call_id: "call_search".to_string(),
                     tool_name: "web_search".to_string(),
+                    display_name: None,
                     success: true,
                     status: "success".to_string(),
                     result: None,

--- a/crates/core/src/runtime_agent.rs
+++ b/crates/core/src/runtime_agent.rs
@@ -504,6 +504,7 @@ mod tests {
 
         let client_tool = ToolDefinition::ClientSide(ClientSideTool {
             name: "browser_click".to_string(),
+            display_name: None,
             description: "Click an element in the browser".to_string(),
             parameters: serde_json::json!({
                 "type": "object",
@@ -553,6 +554,7 @@ mod tests {
 
         let client_tool = ToolDefinition::ClientSide(ClientSideTool {
             name: "deploy_staging".to_string(),
+            display_name: None,
             description: "Deploy to staging".to_string(),
             parameters: serde_json::json!({"type": "object"}),
         });

--- a/crates/core/src/tool_types.rs
+++ b/crates/core/src/tool_types.rs
@@ -45,6 +45,9 @@ pub enum ToolDefinition {
 pub struct BuiltinTool {
     /// Tool name (used by LLM and for registry lookup)
     pub name: String,
+    /// Human-readable display name for UI rendering (e.g., "Get Current Time" for `get_current_time`)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
     /// Tool description for LLM
     pub description: String,
     /// JSON schema for tool parameters
@@ -61,6 +64,9 @@ pub struct BuiltinTool {
 pub struct ClientSideTool {
     /// Tool name (used by LLM and for correlation)
     pub name: String,
+    /// Human-readable display name for UI rendering
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
     /// Tool description for LLM
     pub description: String,
     /// JSON schema for tool parameters
@@ -73,6 +79,14 @@ impl ToolDefinition {
         match self {
             ToolDefinition::Builtin(b) => &b.name,
             ToolDefinition::ClientSide(c) => &c.name,
+        }
+    }
+
+    /// Get the tool display name regardless of variant
+    pub fn display_name(&self) -> Option<&str> {
+        match self {
+            ToolDefinition::Builtin(b) => b.display_name.as_deref(),
+            ToolDefinition::ClientSide(c) => c.display_name.as_deref(),
         }
     }
 
@@ -223,15 +237,60 @@ mod tests {
     fn test_tool_definition_accessor_methods() {
         let tool = ToolDefinition::Builtin(BuiltinTool {
             name: "test_tool".to_string(),
+            display_name: None,
             description: "A test tool".to_string(),
             parameters: serde_json::json!({"type": "object"}),
             policy: ToolPolicy::RequiresApproval,
         });
 
         assert_eq!(tool.name(), "test_tool");
+        assert_eq!(tool.display_name(), None);
         assert_eq!(tool.description(), "A test tool");
         assert_eq!(tool.parameters(), &serde_json::json!({"type": "object"}));
         assert_eq!(tool.policy(), &ToolPolicy::RequiresApproval);
+    }
+
+    #[test]
+    fn test_tool_definition_display_name_accessor() {
+        let builtin = ToolDefinition::Builtin(BuiltinTool {
+            name: "get_weather".to_string(),
+            display_name: Some("Get Weather".to_string()),
+            description: "Gets weather".to_string(),
+            parameters: serde_json::json!({}),
+            policy: ToolPolicy::Auto,
+        });
+        assert_eq!(builtin.display_name(), Some("Get Weather"));
+
+        let client = ToolDefinition::ClientSide(ClientSideTool {
+            name: "deploy".to_string(),
+            display_name: Some("Deploy".to_string()),
+            description: "Deploys".to_string(),
+            parameters: serde_json::json!({}),
+        });
+        assert_eq!(client.display_name(), Some("Deploy"));
+    }
+
+    #[test]
+    fn test_display_name_serialization_skip_none() {
+        let tool = BuiltinTool {
+            name: "test".to_string(),
+            display_name: None,
+            description: "test".to_string(),
+            parameters: serde_json::json!({}),
+            policy: ToolPolicy::Auto,
+        };
+        let json = serde_json::to_string(&tool).unwrap();
+        assert!(!json.contains("display_name"));
+
+        let tool_with = BuiltinTool {
+            name: "test".to_string(),
+            display_name: Some("Test".to_string()),
+            description: "test".to_string(),
+            parameters: serde_json::json!({}),
+            policy: ToolPolicy::Auto,
+        };
+        let json = serde_json::to_string(&tool_with).unwrap();
+        assert!(json.contains("\"display_name\":\"Test\""));
     }
 
     #[test]
@@ -295,6 +354,7 @@ mod tests {
     fn test_client_side_tool_roundtrip() {
         let tool = ToolDefinition::ClientSide(ClientSideTool {
             name: "run_test".to_string(),
+            display_name: None,
             description: "Run a test suite".to_string(),
             parameters: serde_json::json!({"type": "object"}),
         });
@@ -311,6 +371,7 @@ mod tests {
     fn test_client_side_tool_accessor_methods() {
         let tool = ToolDefinition::ClientSide(ClientSideTool {
             name: "deploy_app".to_string(),
+            display_name: None,
             description: "Deploy application to staging".to_string(),
             parameters: serde_json::json!({
                 "type": "object",
@@ -332,6 +393,7 @@ mod tests {
         // ClientSide variant always returns ClientSide policy regardless of content
         let tool = ToolDefinition::ClientSide(ClientSideTool {
             name: "any_tool".to_string(),
+            display_name: None,
             description: "".to_string(),
             parameters: serde_json::json!({}),
         });
@@ -359,12 +421,14 @@ mod tests {
         let tools = vec![
             ToolDefinition::Builtin(BuiltinTool {
                 name: "server_tool".to_string(),
+                display_name: None,
                 description: "A server tool".to_string(),
                 parameters: serde_json::json!({"type": "object"}),
                 policy: ToolPolicy::Auto,
             }),
             ToolDefinition::ClientSide(ClientSideTool {
                 name: "client_tool".to_string(),
+                display_name: None,
                 description: "A client tool".to_string(),
                 parameters: serde_json::json!({"type": "object"}),
             }),

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -274,6 +274,16 @@ pub trait Tool: Send + Sync {
     /// within a ToolRegistry.
     fn name(&self) -> &str;
 
+    /// Returns a human-readable display name for UI rendering.
+    ///
+    /// This name is shown to users in the UI instead of the technical tool name.
+    /// For example, "Get Current Time" instead of "get_current_time".
+    /// Returns None if no display name is set, in which case the UI may
+    /// fall back to the technical name.
+    fn display_name(&self) -> Option<&str> {
+        None
+    }
+
     /// Returns a description of what the tool does.
     ///
     /// This description is provided to the LLM to help it understand
@@ -347,6 +357,7 @@ pub trait Tool: Send + Sync {
     fn to_definition(&self) -> ToolDefinition {
         ToolDefinition::Builtin(BuiltinTool {
             name: self.name().to_string(),
+            display_name: self.display_name().map(|s| s.to_string()),
             description: self.description().to_string(),
             parameters: self.parameters_schema(),
             policy: self.policy(),
@@ -612,6 +623,10 @@ impl Tool for EchoTool {
         "echo"
     }
 
+    fn display_name(&self) -> Option<&str> {
+        Some("Echo")
+    }
+
     fn description(&self) -> &str {
         "Echo back the provided message. Useful for testing tool execution."
     }
@@ -677,6 +692,10 @@ impl Default for FailingTool {
 impl Tool for FailingTool {
     fn name(&self) -> &str {
         "failing_tool"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Failing Tool")
     }
 
     fn description(&self) -> &str {
@@ -804,6 +823,39 @@ mod tests {
             .build();
 
         assert_eq!(registry.len(), 2);
+    }
+
+    #[test]
+    fn test_tool_display_name_in_definition() {
+        // GetCurrentTimeTool has display_name "Get Current Time"
+        let tool = GetCurrentTimeTool;
+        assert_eq!(tool.display_name(), Some("Get Current Time"));
+
+        let def = tool.to_definition();
+        assert_eq!(def.display_name(), Some("Get Current Time"));
+    }
+
+    #[test]
+    fn test_echo_tool_display_name() {
+        let tool = EchoTool;
+        assert_eq!(tool.display_name(), Some("Echo"));
+
+        let def = tool.to_definition();
+        assert_eq!(def.display_name(), Some("Echo"));
+    }
+
+    #[test]
+    fn test_all_default_tools_have_display_names() {
+        let registry = ToolRegistry::with_defaults();
+        let definitions = registry.tool_definitions();
+
+        for def in &definitions {
+            assert!(
+                def.display_name().is_some(),
+                "Tool '{}' should have a display_name",
+                def.name()
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/core/tests/tool_calling_test.rs
+++ b/crates/core/tests/tool_calling_test.rs
@@ -37,6 +37,7 @@ async fn test_tool_registry_as_executor() {
 
     let tool_def = ToolDefinition::Builtin(BuiltinTool {
         name: "echo".to_string(),
+        display_name: None,
         description: "Echo".to_string(),
         parameters: json!({}),
         policy: ToolPolicy::Auto,
@@ -61,6 +62,7 @@ async fn test_get_current_time_tool() {
 
     let tool_def = ToolDefinition::Builtin(BuiltinTool {
         name: "get_current_time".to_string(),
+        display_name: None,
         description: "Get time".to_string(),
         parameters: json!({}),
         policy: ToolPolicy::Auto,
@@ -89,6 +91,7 @@ async fn test_tool_error_handling() {
 
     let tool_def = ToolDefinition::Builtin(BuiltinTool {
         name: "failing_tool".to_string(),
+        display_name: None,
         description: "A tool that fails".to_string(),
         parameters: json!({}),
         policy: ToolPolicy::Auto,
@@ -119,6 +122,7 @@ async fn test_internal_error_is_hidden() {
 
     let tool_def = ToolDefinition::Builtin(BuiltinTool {
         name: "failing_tool".to_string(),
+        display_name: None,
         description: "A tool that fails internally".to_string(),
         parameters: json!({}),
         policy: ToolPolicy::Auto,
@@ -147,6 +151,7 @@ async fn test_tool_not_found_error() {
 
     let tool_def = ToolDefinition::Builtin(BuiltinTool {
         name: "nonexistent_tool".to_string(),
+        display_name: None,
         description: "Does not exist".to_string(),
         parameters: json!({}),
         policy: ToolPolicy::Auto,
@@ -211,6 +216,7 @@ async fn test_custom_tool_execution() {
 
     let tool_def = ToolDefinition::Builtin(BuiltinTool {
         name: "counter".to_string(),
+        display_name: None,
         description: "Counter".to_string(),
         parameters: json!({}),
         policy: ToolPolicy::Auto,
@@ -249,6 +255,7 @@ async fn test_multiple_tools_in_registry() {
 
     let time_def = ToolDefinition::Builtin(BuiltinTool {
         name: "get_current_time".to_string(),
+        display_name: None,
         description: "Get time".to_string(),
         parameters: json!({}),
         policy: ToolPolicy::Auto,
@@ -267,6 +274,7 @@ async fn test_multiple_tools_in_registry() {
 
     let echo_def = ToolDefinition::Builtin(BuiltinTool {
         name: "echo".to_string(),
+        display_name: None,
         description: "Echo".to_string(),
         parameters: json!({}),
         policy: ToolPolicy::Auto,

--- a/crates/gemini/src/driver.rs
+++ b/crates/gemini/src/driver.rs
@@ -1045,6 +1045,7 @@ mod tests {
         use everruns_core::tool_types::{BuiltinTool, ToolPolicy};
         let tools = vec![ToolDefinition::Builtin(BuiltinTool {
             name: "get_weather".to_string(),
+            display_name: None,
             description: "Get the weather for a city".to_string(),
             parameters: json!({
                 "type": "object",
@@ -1069,6 +1070,7 @@ mod tests {
         use everruns_core::tool_types::{BuiltinTool, ToolPolicy};
         let tools = vec![ToolDefinition::Builtin(BuiltinTool {
             name: "search".to_string(),
+            display_name: None,
             description: "Search".to_string(),
             parameters: json!({
                 "type": "object",

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -940,6 +940,7 @@ impl DirectWorkerAdapters {
 
                 mcp_tools.push(ToolDefinition::Builtin(BuiltinTool {
                     name: prefixed_name,
+                    display_name: None,
                     description,
                     parameters: tool.input_schema,
                     policy: ToolPolicy::Auto,

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -427,6 +427,7 @@ mod tests {
             }],
             tool_definitions: vec![ToolDefinition::Builtin(BuiltinTool {
                 name: "get_weather".to_string(),
+                display_name: None,
                 description: "Get weather".to_string(),
                 parameters: json!({}),
                 policy: ToolPolicy::Auto,

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -1059,6 +1059,7 @@ fn proto_mcp_tool_def_to_tool_definition(
 
     ToolDefinition::Builtin(BuiltinTool {
         name: proto_tool.name,
+        display_name: None,
         description: proto_tool.description,
         parameters,
         policy: ToolPolicy::Auto, // MCP tools are auto-executed

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -1040,6 +1040,7 @@ mod tests {
     fn test_partition_all_server_tools() {
         let tool_definitions = vec![ToolDefinition::Builtin(BuiltinTool {
             name: "get_weather".to_string(),
+            display_name: None,
             description: "Get weather".to_string(),
             parameters: serde_json::json!({"type": "object"}),
             policy: ToolPolicy::Auto,
@@ -1061,6 +1062,7 @@ mod tests {
     fn test_partition_all_client_tools() {
         let tool_definitions = vec![ToolDefinition::ClientSide(ClientSideTool {
             name: "browser_click".to_string(),
+            display_name: None,
             description: "Click element".to_string(),
             parameters: serde_json::json!({"type": "object"}),
         })];
@@ -1082,22 +1084,26 @@ mod tests {
         let tool_definitions = vec![
             ToolDefinition::Builtin(BuiltinTool {
                 name: "get_time".to_string(),
+                display_name: None,
                 description: "Get current time".to_string(),
                 parameters: serde_json::json!({"type": "object"}),
                 policy: ToolPolicy::Auto,
             }),
             ToolDefinition::ClientSide(ClientSideTool {
                 name: "browser_click".to_string(),
+                display_name: None,
                 description: "Click element".to_string(),
                 parameters: serde_json::json!({"type": "object"}),
             }),
             ToolDefinition::ClientSide(ClientSideTool {
                 name: "browser_type".to_string(),
+                display_name: None,
                 description: "Type text".to_string(),
                 parameters: serde_json::json!({"type": "object"}),
             }),
             ToolDefinition::Builtin(BuiltinTool {
                 name: "read_file".to_string(),
+                display_name: None,
                 description: "Read a file".to_string(),
                 parameters: serde_json::json!({"type": "object"}),
                 policy: ToolPolicy::Auto,
@@ -1146,6 +1152,7 @@ mod tests {
         // Unknown tools (not in definitions) default to server-side
         let tool_definitions = vec![ToolDefinition::ClientSide(ClientSideTool {
             name: "known_client".to_string(),
+            display_name: None,
             description: "Known client tool".to_string(),
             parameters: serde_json::json!({"type": "object"}),
         })];
@@ -1175,6 +1182,7 @@ mod tests {
     fn test_partition_empty_tool_calls() {
         let tool_definitions = vec![ToolDefinition::ClientSide(ClientSideTool {
             name: "some_tool".to_string(),
+            display_name: None,
             description: "A tool".to_string(),
             parameters: serde_json::json!({"type": "object"}),
         })];
@@ -1207,12 +1215,14 @@ mod tests {
             tool_definitions: vec![
                 ToolDefinition::Builtin(BuiltinTool {
                     name: "get_current_time".to_string(),
+                    display_name: None,
                     description: "Get current time".to_string(),
                     parameters: serde_json::json!({"type": "object"}),
                     policy: ToolPolicy::Auto,
                 }),
                 ToolDefinition::ClientSide(ClientSideTool {
                     name: "deploy_app".to_string(),
+                    display_name: None,
                     description: "Deploy application".to_string(),
                     parameters: serde_json::json!({"type": "object"}),
                 }),
@@ -1245,12 +1255,14 @@ mod tests {
         let tool_definitions = vec![
             ToolDefinition::Builtin(BuiltinTool {
                 name: "delete_file".to_string(),
+                display_name: None,
                 description: "Delete a file".to_string(),
                 parameters: serde_json::json!({"type": "object"}),
                 policy: ToolPolicy::RequiresApproval,
             }),
             ToolDefinition::ClientSide(ClientSideTool {
                 name: "browser_click".to_string(),
+                display_name: None,
                 description: "Click element".to_string(),
                 parameters: serde_json::json!({"type": "object"}),
             }),

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -4169,6 +4169,13 @@
             "type": "string",
             "description": "Tool description for LLM"
           },
+          "display_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable display name for UI rendering (e.g., \"Get Current Time\" for `get_current_time`)"
+          },
           "name": {
             "type": "string",
             "description": "Tool name (used by LLM and for registry lookup)"
@@ -4292,6 +4299,13 @@
           "description": {
             "type": "string",
             "description": "Tool description for LLM"
+          },
+          "display_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable display name for UI rendering"
           },
           "name": {
             "type": "string",
@@ -9137,6 +9151,13 @@
           "name"
         ],
         "properties": {
+          "display_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable display name for UI rendering"
+          },
           "id": {
             "type": "string"
           },
@@ -9155,6 +9176,13 @@
           "status"
         ],
         "properties": {
+          "display_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable display name for UI rendering"
+          },
           "duration_ms": {
             "type": [
               "integer",
@@ -9262,6 +9290,13 @@
             "type": "string",
             "description": "Tool description"
           },
+          "display_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable display name for UI rendering"
+          },
           "name": {
             "type": "string",
             "description": "Tool name"
@@ -9304,6 +9339,13 @@
           "tool_call"
         ],
         "properties": {
+          "display_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable display name for UI rendering"
+          },
           "tool_call": {
             "$ref": "#/components/schemas/ToolCall",
             "description": "The tool call being executed"

--- a/specs/events.md
+++ b/specs/events.md
@@ -481,7 +481,7 @@ ActAtom lifecycle - tool batch execution.
   "context": { "turn_id": "...", "exec_id": "..." },
   "data": {
     "tool_calls": [
-      { "id": "call_123", "name": "get_weather" }
+      { "id": "call_123", "name": "get_weather", "display_name": "Get Weather" }
     ]
   }
 }
@@ -514,7 +514,8 @@ Individual tool execution within ActAtom.
       "id": "call_123",
       "name": "get_weather",
       "arguments": { "city": "Tokyo" }
-    }
+    },
+    "display_name": "Get Weather"
   }
 }
 ```
@@ -527,6 +528,7 @@ Individual tool execution within ActAtom.
   "data": {
     "tool_call_id": "call_123",
     "tool_name": "get_weather",
+    "display_name": "Get Weather",
     "success": true,
     "status": "success",
     "result": [
@@ -546,6 +548,7 @@ For failed tool calls:
   "data": {
     "tool_call_id": "call_456",
     "tool_name": "search_db",
+    "display_name": "Search Database",
     "success": false,
     "status": "error",
     "error": "Connection timeout"

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -16,12 +16,20 @@ System-provided tools implemented via the `Tool` trait in `everruns-core`.
 #[async_trait]
 pub trait Tool: Send + Sync {
     fn name(&self) -> &str;
+    fn display_name(&self) -> Option<&str> { None }
     fn description(&self) -> &str;
     fn parameters_schema(&self) -> Value;
     async fn execute(&self, arguments: Value) -> ToolExecutionResult;
     fn policy(&self) -> ToolPolicy { ToolPolicy::Auto }
 }
 ```
+
+**Display Names:**
+All tools should provide a human-readable `display_name` for UI rendering (e.g., "Get Current Time" for `get_current_time`). The display name is:
+- Returned by `fn display_name(&self) -> Option<&str>` on the `Tool` trait
+- Included in `BuiltinTool` and `ClientSideTool` as `display_name: Option<String>`
+- Propagated through events (`act.started`, `tool.started`, `tool.completed`) so the UI can render it
+- The UI falls back to the technical `name` if `display_name` is absent
 
 **Error Handling Contract:**
 - `ToolExecutionResult::Success(Value)` - Successful result returned to LLM as `result` field
@@ -80,6 +88,7 @@ let agent_loop = AgentLoop::new(config, emitter, store, llm, registry);
 {
   "type": "builtin",
   "name": "tool_name",
+  "display_name": "Tool Name",
   "description": "What the tool does",
   "parameters": {
     "type": "object",
@@ -91,7 +100,6 @@ let agent_loop = AgentLoop::new(config, emitter, store, llm, registry);
     },
     "required": ["param1"]
   },
-  "kind": "current_time",
   "policy": "auto"
 }
 ```


### PR DESCRIPTION
## What
Add `display_name` field to all tools, propagated through events to the UI. Tools now have human-readable names (e.g., "Get Current Time" for `get_current_time`, "Read File" for `read_file`) that the UI renders instead of technical snake_case identifiers.

## Why
Technical tool names like `get_current_time` or `warehouse_create_shipment` are not user-friendly. Display names improve readability in the chat view, trajectory visualization, and tool call cards.

## How
- Added `display_name() -> Option<&str>` to the `Tool` trait (default: `None`)
- Added `display_name: Option<String>` to `BuiltinTool`, `ClientSideTool`, and event data types (`ToolCallSummary`, `ToolStartedData`, `ToolCompletedData`, `ToolDefinitionSummary`)
- `ActAtom` resolves display names from tool definitions when emitting events
- All 60 tool implementations now return a display name
- UI components (tool-call-card, tool-call-card-from-event, client-tool-call-card, trajectory-nodes) render display_name with graceful fallback to technical name
- All new fields are `Option` with `skip_serializing_if` -- fully backward-compatible per events-contract.md

## Risk
- Low
- Adding optional fields is explicitly non-breaking per specs/events-contract.md. Old consumers that don't know about display_name simply ignore it. UI falls back to technical name if absent.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
