### PR TITLE
feat(brave-search): add Brave Search web search integration

### DIFF
--- a/.github/workflows/brave-search-integration.yml
+++ b/.github/workflows/brave-search-integration.yml
@@ -1,0 +1,49 @@
+name: Brave Search Integration
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'integrations/brave-search/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'integrations/brave-search/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  integration-test:
+    name: Brave Search API Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      BRAVE_SEARCH_API_KEY: ${{ secrets.BRAVE_SEARCH_API_KEY }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install protobuf compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "brave-search-integration"
+
+      - name: Run integration tests
+        run: cargo test -p everruns-integrations-brave-search --features integration

--- a/.github/workflows/brave-search-integration.yml
+++ b/.github/workflows/brave-search-integration.yml
@@ -2,9 +2,7 @@ name: Brave Search Integration
 
 on:
   push:
-    branches: [main]
-    paths:
-      - 'integrations/brave-search/**'
+    branches: [main, claude/brave-search-integration-rcVfC]
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/brave-search-integration.yml
+++ b/.github/workflows/brave-search-integration.yml
@@ -2,7 +2,9 @@ name: Brave Search Integration
 
 on:
   push:
-    branches: [main, claude/brave-search-integration-rcVfC]
+    branches: [main]
+    paths:
+      - 'integrations/brave-search/**'
   pull_request:
     branches: [main]
     paths:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ Fix root cause. Unsure: read more code; if stuck, ask w/ short options. Unrecogn
 - `specs/skills-registry.md` - Agent Skills registry (agentskills.io format)
 - `specs/linear-issues.md` - Linear issue processing workflow
 - `specs/daytona.md` - Daytona cloud sandbox integration
+- `specs/brave-search.md` - Brave Search web search integration
 
 ### Skills
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1290,6 +1290,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "everruns-integrations-brave-search"
+version = "0.7.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "everruns-core",
+ "inventory",
+ "reqwest 0.13.1",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "wiremock",
+]
+
+[[package]]
 name = "everruns-integrations-codesandbox"
 version = "0.7.0"
 dependencies = [
@@ -1409,6 +1425,7 @@ dependencies = [
  "dotenvy",
  "everruns-core",
  "everruns-durable",
+ "everruns-integrations-brave-search",
  "everruns-integrations-codesandbox",
  "everruns-integrations-daytona",
  "everruns-integrations-docker",
@@ -1474,6 +1491,7 @@ dependencies = [
  "everruns-core",
  "everruns-durable",
  "everruns-gemini",
+ "everruns-integrations-brave-search",
  "everruns-integrations-codesandbox",
  "everruns-integrations-daytona",
  "everruns-integrations-docker",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "integrations/codesandbox",
     "integrations/docker",
     "integrations/daytona",
+    "integrations/brave-search",
 ]
 
 exclude = [

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -56,6 +56,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 everruns-core = { path = "../core", features = ["openapi", "sqlx"] }
 everruns-integrations-codesandbox = { path = "../../integrations/codesandbox" }
 everruns-integrations-docker = { path = "../../integrations/docker" }
+everruns-integrations-brave-search = { path = "../../integrations/brave-search" }
 everruns-integrations-daytona = { path = "../../integrations/daytona" }
 everruns-session-sqldb = { path = "../session-sqldb" }
 everruns-worker = { path = "../worker" }  # For AgentRunner trait

--- a/crates/server/src/api/user_connections.rs
+++ b/crates/server/src/api/user_connections.rs
@@ -1,6 +1,7 @@
 // User Connections API routes
 // Decision: User-scoped (not org-scoped) — token represents user's GitHub identity
 // Decision: GitHub App installation flow replaces OAuth App for repo access
+// Decision: API-key providers (brave_search) use PUT with encrypted token storage
 
 use crate::auth::config::AuthConfig;
 use crate::auth::middleware::{AuthState, AuthUser};
@@ -11,7 +12,7 @@ use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
     response::Redirect,
-    routing::{delete, get},
+    routing::{delete, get, put},
 };
 use chrono::{DateTime, Utc};
 use rand::Rng;
@@ -49,6 +50,15 @@ pub struct ConnectionResponse {
     pub connected_at: DateTime<Utc>,
 }
 
+/// Request body for API-key-based connections (e.g., Brave Search)
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ApiKeyConnectionRequest {
+    pub api_key: String,
+}
+
+/// Providers that support API-key-based connections.
+const API_KEY_PROVIDERS: &[&str] = &["brave_search"];
+
 /// GitHub App installation callback query params
 #[derive(Debug, Deserialize)]
 pub struct GitHubInstallationCallbackQuery {
@@ -69,6 +79,10 @@ pub fn routes(state: AppState) -> Router {
             get(github_authorize),
         )
         .route("/v1/user/connections/github/callback", get(github_callback))
+        .route(
+            "/v1/user/connections/api-key/{provider}",
+            put(put_api_key_connection),
+        )
         .with_state(state)
 }
 
@@ -209,4 +223,76 @@ pub async fn github_callback(
         "{}/settings/connections?connected=github",
         frontend_url
     )))
+}
+
+/// PUT /v1/user/connections/api-key/:provider — Store an API-key-based connection
+///
+/// For providers that authenticate with a simple API key (e.g., brave_search).
+/// The API key is encrypted at rest using envelope encryption.
+pub async fn put_api_key_connection(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Path(provider): Path<String>,
+    Json(body): Json<ApiKeyConnectionRequest>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    // Validate provider
+    if !API_KEY_PROVIDERS.contains(&provider.as_str()) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "Provider '{}' does not support API key connections. Supported: {}",
+                provider,
+                API_KEY_PROVIDERS.join(", ")
+            ),
+        ));
+    }
+
+    if body.api_key.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "API key cannot be empty".to_string(),
+        ));
+    }
+
+    // Encrypt the API key
+    let encryption = state.encryption.as_ref().ok_or_else(|| {
+        tracing::error!("Encryption service not available for API key storage");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Encryption not configured".to_string(),
+        )
+    })?;
+
+    let encrypted = encryption.encrypt_string(&body.api_key).map_err(|e| {
+        tracing::error!("Failed to encrypt API key: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to encrypt API key".to_string(),
+        )
+    })?;
+
+    // Upsert connection
+    state
+        .db
+        .upsert_user_connection(CreateUserConnectionRow {
+            user_id: auth.id,
+            provider: provider.clone(),
+            provider_user_id: None,
+            provider_username: None,
+            access_token_encrypted: Some(encrypted),
+            refresh_token_encrypted: None,
+            scopes: None,
+            expires_at: None,
+            installation_id: None,
+        })
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to store {} connection: {}", provider, e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to store connection".to_string(),
+            )
+        })?;
+
+    Ok(StatusCode::NO_CONTENT)
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -4,6 +4,7 @@
 // Decision: Server entrypoint extracted into run() for SaaS binary reuse
 
 // Force-link integration crates so inventory::submit! registrations are included
+extern crate everruns_integrations_brave_search;
 extern crate everruns_integrations_codesandbox;
 extern crate everruns_integrations_daytona;
 extern crate everruns_integrations_docker;

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -17,6 +17,7 @@ tracing-subscriber.workspace = true
 everruns-core = { path = "../core" }
 everruns-integrations-codesandbox = { path = "../../integrations/codesandbox" }
 everruns-integrations-docker = { path = "../../integrations/docker" }
+everruns-integrations-brave-search = { path = "../../integrations/brave-search" }
 everruns-integrations-daytona = { path = "../../integrations/daytona" }
 everruns-openai = { path = "../openai" }
 everruns-anthropic = { path = "../anthropic" }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -1,4 +1,5 @@
 // Force-link integration crates so inventory::submit! registrations are included
+extern crate everruns_integrations_brave_search;
 extern crate everruns_integrations_codesandbox;
 extern crate everruns_integrations_daytona;
 extern crate everruns_integrations_docker;

--- a/integrations/brave-search/Cargo.toml
+++ b/integrations/brave-search/Cargo.toml
@@ -28,6 +28,9 @@ tokio.workspace = true
 chrono.workspace = true
 tracing.workspace = true
 
+[features]
+integration = [] # Gate real-API tests; CI passes --features integration
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }
 wiremock = "0.6"

--- a/integrations/brave-search/Cargo.toml
+++ b/integrations/brave-search/Cargo.toml
@@ -1,0 +1,33 @@
+# Brave Search Integration
+# Decision: External integration crate, auto-registered via inventory plugin system
+# Decision: Experimental-only (gated behind DeploymentGrade::Dev)
+# Decision: API key resolved via user connections (connection_resolver), fallback to session secrets
+
+[package]
+name = "everruns-integrations-brave-search"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Brave Search web search integration for Everruns"
+
+[dependencies]
+everruns-core = { path = "../../crates/core" }
+inventory.workspace = true
+
+# HTTP client for Brave Search API
+reqwest.workspace = true
+
+# Serialization
+serde.workspace = true
+serde_json.workspace = true
+
+# Async
+async-trait.workspace = true
+tokio.workspace = true
+chrono.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full", "test-util"] }
+wiremock = "0.6"

--- a/integrations/brave-search/src/client.rs
+++ b/integrations/brave-search/src/client.rs
@@ -1,0 +1,298 @@
+//! Brave Search API client.
+
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+// ============================================================================
+// API Response Types
+// ============================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebSearchResponse {
+    #[serde(default)]
+    pub web: Option<WebResults>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebResults {
+    #[serde(default)]
+    pub results: Vec<WebResult>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebResult {
+    pub title: String,
+    pub url: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub age: Option<String>,
+    #[serde(default)]
+    pub language: Option<String>,
+}
+
+// ============================================================================
+// BraveSearchClient
+// ============================================================================
+
+pub struct BraveSearchClient {
+    http: reqwest::Client,
+    api_key: String,
+    api_base: String,
+}
+
+impl BraveSearchClient {
+    pub fn new(api_key: String) -> Self {
+        Self::with_base_url(api_key, crate::BRAVE_SEARCH_API_BASE.to_string())
+    }
+
+    pub fn with_base_url(api_key: String, api_base: String) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            api_key,
+            api_base,
+        }
+    }
+
+    /// Perform a web search query.
+    pub async fn web_search(
+        &self,
+        query: &str,
+        count: Option<u32>,
+        offset: Option<u32>,
+        freshness: Option<&str>,
+    ) -> Result<WebSearchResponse, String> {
+        // Build URL with query parameters manually (reqwest .query() requires default features)
+        let mut url = format!(
+            "{}/web/search?q={}",
+            self.api_base,
+            urlencoding::encode(query)
+        );
+        if let Some(c) = count {
+            url.push_str(&format!("&count={c}"));
+        }
+        if let Some(o) = offset {
+            url.push_str(&format!("&offset={o}"));
+        }
+        if let Some(f) = freshness {
+            url.push_str(&format!("&freshness={}", urlencoding::encode(f)));
+        }
+
+        debug!("Brave Search query: {query}");
+
+        let resp = self
+            .http
+            .get(&url)
+            .header("X-Subscription-Token", &self.api_key)
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .map_err(|e| format!("Failed to connect to Brave Search API: {e}"))?;
+
+        let status = resp.status();
+        let body_text = resp
+            .text()
+            .await
+            .map_err(|e| format!("Failed to read response: {e}"))?;
+
+        if !status.is_success() {
+            return Err(format!("Brave Search API error ({status}): {body_text}"));
+        }
+
+        serde_json::from_str(&body_text).map_err(|e| format!("Invalid JSON from Brave Search: {e}"))
+    }
+}
+
+pub(crate) mod urlencoding {
+    /// Percent-encode a string for use in query parameters.
+    pub fn encode(input: &str) -> String {
+        let mut result = String::with_capacity(input.len() * 2);
+        for byte in input.bytes() {
+            match byte {
+                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                    result.push(byte as char);
+                }
+                _ => {
+                    result.push('%');
+                    result.push_str(&format!("{byte:02X}"));
+                }
+            }
+        }
+        result
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn test_web_search_success() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/web/search"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "web": {
+                    "results": [
+                        {
+                            "title": "Rust Programming Language",
+                            "url": "https://www.rust-lang.org/",
+                            "description": "A language empowering everyone to build reliable software.",
+                            "age": "2 hours ago"
+                        },
+                        {
+                            "title": "Rust (programming language) - Wikipedia",
+                            "url": "https://en.wikipedia.org/wiki/Rust_(programming_language)",
+                            "description": "Rust is a multi-paradigm programming language."
+                        }
+                    ]
+                }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = BraveSearchClient::with_base_url("test_key".to_string(), mock_server.uri());
+        let result = client
+            .web_search("rust programming", None, None, None)
+            .await;
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        let results = response.web.unwrap().results;
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].title, "Rust Programming Language");
+        assert_eq!(results[0].url, "https://www.rust-lang.org/");
+    }
+
+    #[tokio::test]
+    async fn test_web_search_empty_results() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/web/search"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "web": { "results": [] }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = BraveSearchClient::with_base_url("test_key".to_string(), mock_server.uri());
+        let result = client
+            .web_search("nonexistent query", None, None, None)
+            .await;
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert!(response.web.unwrap().results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_web_search_no_web_field() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/web/search"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&mock_server)
+            .await;
+
+        let client = BraveSearchClient::with_base_url("test_key".to_string(), mock_server.uri());
+        let result = client.web_search("test", None, None, None).await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().web.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_web_search_401_error() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/web/search"))
+            .respond_with(
+                ResponseTemplate::new(401).set_body_string("{\"error\":\"Unauthorized\"}"),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let client = BraveSearchClient::with_base_url("bad_key".to_string(), mock_server.uri());
+        let result = client.web_search("test", None, None, None).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("401"));
+    }
+
+    #[tokio::test]
+    async fn test_web_search_429_rate_limit() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/web/search"))
+            .respond_with(
+                ResponseTemplate::new(429).set_body_string("{\"error\":\"Rate limit exceeded\"}"),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let client = BraveSearchClient::with_base_url("test_key".to_string(), mock_server.uri());
+        let result = client.web_search("test", None, None, None).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("429"));
+    }
+
+    #[tokio::test]
+    async fn test_web_search_malformed_json() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/web/search"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not json"))
+            .mount(&mock_server)
+            .await;
+
+        let client = BraveSearchClient::with_base_url("test_key".to_string(), mock_server.uri());
+        let result = client.web_search("test", None, None, None).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid JSON"));
+    }
+
+    #[test]
+    fn test_web_result_deserialization() {
+        let json = r#"{
+            "title": "Test",
+            "url": "https://example.com",
+            "description": "A test result",
+            "age": "1 day ago",
+            "language": "en"
+        }"#;
+        let result: WebResult = serde_json::from_str(json).unwrap();
+        assert_eq!(result.title, "Test");
+        assert_eq!(result.url, "https://example.com");
+        assert_eq!(result.description, "A test result");
+        assert_eq!(result.age, Some("1 day ago".to_string()));
+        assert_eq!(result.language, Some("en".to_string()));
+    }
+
+    #[test]
+    fn test_web_result_minimal_deserialization() {
+        let json = r#"{"title": "Test", "url": "https://example.com"}"#;
+        let result: WebResult = serde_json::from_str(json).unwrap();
+        assert_eq!(result.title, "Test");
+        assert_eq!(result.description, "");
+        assert_eq!(result.age, None);
+    }
+
+    #[test]
+    fn test_web_search_response_deserialization() {
+        let json = r#"{
+            "web": {
+                "results": [
+                    {"title": "A", "url": "https://a.com", "description": "desc a"},
+                    {"title": "B", "url": "https://b.com", "description": "desc b"}
+                ]
+            }
+        }"#;
+        let response: WebSearchResponse = serde_json::from_str(json).unwrap();
+        let results = response.web.unwrap().results;
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].title, "A");
+        assert_eq!(results[1].url, "https://b.com");
+    }
+}

--- a/integrations/brave-search/src/lib.rs
+++ b/integrations/brave-search/src/lib.rs
@@ -1,0 +1,149 @@
+//! Brave Search Integration (Experimental)
+//!
+//! Web search via Brave Search REST API.
+//! Provides `brave_web_search` tool for agents to search the web.
+//!
+//! Decision: External integration crate, auto-registered via inventory plugin system
+//! Decision: API key resolved via user connections (provider: "brave_search"), fallback to session secrets
+//! Decision: Stateless — no per-resource state management needed
+
+pub mod client;
+mod tools;
+
+use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin};
+use everruns_core::tools::Tool;
+
+use tools::BraveWebSearchTool;
+
+// ============================================================================
+// Integration Plugin Registration
+// ============================================================================
+
+inventory::submit! {
+    IntegrationPlugin {
+        experimental_only: true,
+        factory: || Box::new(BraveSearchCapability),
+    }
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const BRAVE_SEARCH_API_BASE: &str = "https://api.search.brave.com/res/v1";
+const BRAVE_SEARCH_API_KEY_SECRET: &str = "BRAVE_SEARCH_API_KEY";
+const BRAVE_SEARCH_CONNECTION_PROVIDER: &str = "brave_search";
+
+// ============================================================================
+// BraveSearchCapability
+// ============================================================================
+
+pub struct BraveSearchCapability;
+
+impl Capability for BraveSearchCapability {
+    fn id(&self) -> &str {
+        "brave_search"
+    }
+
+    fn name(&self) -> &str {
+        "[Experimental] Brave Search"
+    }
+
+    fn description(&self) -> &str {
+        "Search the web using Brave Search API. \
+         Agents can query the web and get relevant results including titles, URLs, and descriptions. \
+         EXPERIMENTAL: This capability may change."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("search")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Network")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(
+            r#"## Brave Search (Experimental)
+
+Web search via Brave Search API. Use this to find current information, research topics, and look up documentation.
+
+Prerequisite: Brave Search API key must be configured in Settings > Connections, or set as session secret `BRAVE_SEARCH_API_KEY`.
+
+Tools:
+- `brave_web_search` - Search the web and return relevant results
+
+Get a free API key at https://brave.com/search/api/"#,
+        )
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![Box::new(BraveWebSearchTool)]
+    }
+
+    fn dependencies(&self) -> Vec<&'static str> {
+        vec![]
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::capabilities::CapabilityStatus;
+
+    #[test]
+    fn test_capability_metadata() {
+        let cap = BraveSearchCapability;
+        assert_eq!(cap.id(), "brave_search");
+        assert_eq!(cap.name(), "[Experimental] Brave Search");
+        assert_eq!(cap.status(), CapabilityStatus::Available);
+        assert_eq!(cap.icon(), Some("search"));
+        assert_eq!(cap.category(), Some("Network"));
+    }
+
+    #[test]
+    fn test_capability_has_all_tools() {
+        let cap = BraveSearchCapability;
+        let tools = cap.tools();
+        assert_eq!(tools.len(), 1);
+
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(names.contains(&"brave_web_search"));
+    }
+
+    #[test]
+    fn test_capability_has_system_prompt() {
+        let cap = BraveSearchCapability;
+        let prompt = cap.system_prompt_addition().unwrap();
+        assert!(prompt.contains("brave_web_search"));
+        assert!(prompt.contains("Brave Search"));
+        assert!(prompt.contains("Experimental"));
+    }
+
+    #[test]
+    fn test_all_tools_require_context() {
+        let cap = BraveSearchCapability;
+        for tool in cap.tools() {
+            assert!(
+                tool.requires_context(),
+                "Tool {} should require context",
+                tool.name()
+            );
+        }
+    }
+
+    #[test]
+    fn test_capability_no_dependencies() {
+        let cap = BraveSearchCapability;
+        assert!(cap.dependencies().is_empty());
+    }
+}

--- a/integrations/brave-search/src/tools.rs
+++ b/integrations/brave-search/src/tools.rs
@@ -1,0 +1,497 @@
+//! Tool implementations for Brave Search operations.
+
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::traits::ToolContext;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use tracing::debug;
+
+use crate::BRAVE_SEARCH_API_KEY_SECRET;
+use crate::BRAVE_SEARCH_CONNECTION_PROVIDER;
+use crate::client::BraveSearchClient;
+
+// ============================================================================
+// API Key Resolution
+// ============================================================================
+
+/// Resolve Brave Search API key from user connections, with session secret fallback.
+async fn get_api_key(context: &ToolContext) -> Result<String, ToolExecutionResult> {
+    // Try lazy resolution from user connections (preferred: always fresh)
+    if let Some(ref resolver) = context.connection_resolver {
+        match resolver
+            .get_connection_token(context.session_id, BRAVE_SEARCH_CONNECTION_PROVIDER)
+            .await
+        {
+            Ok(Some(token)) if !token.is_empty() => return Ok(token),
+            Ok(_) => {}
+            Err(e) => debug!("Brave Search connection resolver failed: {e}"),
+        }
+    }
+
+    // Fallback: session secret
+    if let Some(ref storage) = context.storage_store {
+        match storage
+            .get_secret(context.session_id, BRAVE_SEARCH_API_KEY_SECRET)
+            .await
+        {
+            Ok(Some(key)) if !key.is_empty() => return Ok(key),
+            Ok(_) => {}
+            Err(e) => {
+                tracing::error!("Failed to read {BRAVE_SEARCH_API_KEY_SECRET} secret: {e}");
+                return Err(ToolExecutionResult::internal_error_msg(format!(
+                    "Failed to read API key: {e}"
+                )));
+            }
+        }
+    }
+
+    Err(ToolExecutionResult::tool_error(
+        "Brave Search API key not configured. Connect Brave Search in Settings > Connections, \
+         or use `secret_store set BRAVE_SEARCH_API_KEY <your-key>`. \
+         Get a free API key at https://brave.com/search/api/",
+    ))
+}
+
+// ============================================================================
+// BraveWebSearchTool
+// ============================================================================
+
+pub struct BraveWebSearchTool;
+
+#[async_trait]
+impl Tool for BraveWebSearchTool {
+    fn name(&self) -> &str {
+        "brave_web_search"
+    }
+
+    fn description(&self) -> &str {
+        "Search the web using Brave Search. Returns relevant web results \
+         including titles, URLs, and descriptions."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Search query string"
+                },
+                "count": {
+                    "type": "integer",
+                    "description": "Number of results to return (1-20, default: 10)",
+                    "minimum": 1,
+                    "maximum": 20
+                },
+                "offset": {
+                    "type": "integer",
+                    "description": "Pagination offset (default: 0)",
+                    "minimum": 0
+                },
+                "freshness": {
+                    "type": "string",
+                    "enum": ["pd", "pw", "pm", "py"],
+                    "description": "Time filter: pd (past day), pw (past week), pm (past month), py (past year)"
+                }
+            },
+            "required": ["query"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "brave_web_search requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let query = match arguments.get("query").and_then(|v| v.as_str()) {
+            Some(q) if !q.is_empty() => q,
+            _ => {
+                return ToolExecutionResult::tool_error("Missing required parameter: query");
+            }
+        };
+
+        let count = arguments
+            .get("count")
+            .and_then(|v| v.as_u64())
+            .map(|c| c.min(20) as u32);
+        let offset = arguments
+            .get("offset")
+            .and_then(|v| v.as_u64())
+            .map(|o| o as u32);
+        let freshness = arguments.get("freshness").and_then(|v| v.as_str());
+
+        let api_key = match get_api_key(context).await {
+            Ok(k) => k,
+            Err(e) => return e,
+        };
+
+        let client = BraveSearchClient::new(api_key);
+
+        match client.web_search(query, count, offset, freshness).await {
+            Ok(response) => {
+                let results = response.web.map(|w| w.results).unwrap_or_default();
+
+                let result_items: Vec<Value> = results
+                    .iter()
+                    .map(|r| {
+                        let mut item = json!({
+                            "title": r.title,
+                            "url": r.url,
+                            "description": r.description,
+                        });
+                        if let Some(ref age) = r.age {
+                            item["age"] = json!(age);
+                        }
+                        item
+                    })
+                    .collect();
+
+                ToolExecutionResult::success(json!({
+                    "query": query,
+                    "results": result_items,
+                    "count": result_items.len()
+                }))
+            }
+            Err(e) => ToolExecutionResult::tool_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    use everruns_core::error::Result;
+    use everruns_core::traits::{KeyInfo, SecretInfo, SessionStorageStore, UserConnectionResolver};
+    use everruns_core::typed_id::SessionId;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    /// In-memory mock of SessionStorageStore for testing.
+    struct MockStorageStore {
+        secrets: Mutex<HashMap<String, String>>,
+    }
+
+    impl MockStorageStore {
+        fn new() -> Self {
+            Self {
+                secrets: Mutex::new(HashMap::new()),
+            }
+        }
+
+        async fn seed_secret(&self, session_id: SessionId, name: &str, value: &str) {
+            let key = format!("{}:{}", session_id, name);
+            self.secrets.lock().await.insert(key, value.to_string());
+        }
+    }
+
+    #[async_trait]
+    impl SessionStorageStore for MockStorageStore {
+        async fn set_value(&self, _session_id: SessionId, _key: &str, _value: &str) -> Result<()> {
+            Ok(())
+        }
+        async fn get_value(&self, _session_id: SessionId, _key: &str) -> Result<Option<String>> {
+            Ok(None)
+        }
+        async fn delete_value(&self, _session_id: SessionId, _key: &str) -> Result<bool> {
+            Ok(false)
+        }
+        async fn list_keys(&self, _session_id: SessionId) -> Result<Vec<KeyInfo>> {
+            Ok(vec![])
+        }
+        async fn set_secret(&self, session_id: SessionId, name: &str, value: &str) -> Result<()> {
+            let key = format!("{session_id}:{name}");
+            self.secrets.lock().await.insert(key, value.to_string());
+            Ok(())
+        }
+        async fn get_secret(&self, session_id: SessionId, name: &str) -> Result<Option<String>> {
+            let key = format!("{session_id}:{name}");
+            Ok(self.secrets.lock().await.get(&key).cloned())
+        }
+        async fn delete_secret(&self, session_id: SessionId, name: &str) -> Result<bool> {
+            let key = format!("{session_id}:{name}");
+            Ok(self.secrets.lock().await.remove(&key).is_some())
+        }
+        async fn list_secrets(&self, session_id: SessionId) -> Result<Vec<SecretInfo>> {
+            let prefix = format!("{session_id}:");
+            let secrets = self.secrets.lock().await;
+            Ok(secrets
+                .keys()
+                .filter(|k| k.starts_with(&prefix))
+                .map(|k| SecretInfo {
+                    name: k.strip_prefix(&prefix).unwrap_or(k).to_string(),
+                    created_at: chrono::Utc::now(),
+                    updated_at: chrono::Utc::now(),
+                })
+                .collect())
+        }
+    }
+
+    struct MockConnectionResolver {
+        token: Option<String>,
+    }
+
+    #[async_trait]
+    impl UserConnectionResolver for MockConnectionResolver {
+        async fn get_connection_token(
+            &self,
+            _session_id: SessionId,
+            _provider: &str,
+        ) -> Result<Option<String>> {
+            Ok(self.token.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_brave_web_search_without_context() {
+        let tool = BraveWebSearchTool;
+        let result = tool.execute(json!({"query": "test"})).await;
+        assert!(
+            matches!(result, ToolExecutionResult::ToolError(msg) if msg.contains("requires context"))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_brave_web_search_missing_query() {
+        let tool = BraveWebSearchTool;
+        let session_id = SessionId::new();
+        let store = Arc::new(MockStorageStore::new());
+        let context = ToolContext::with_storage_store(session_id, store);
+        let result = tool.execute_with_context(json!({}), &context).await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(
+                    msg.contains("Missing required parameter"),
+                    "Expected missing param error, got: {msg}"
+                );
+            }
+            _ => panic!("Expected ToolError for missing query"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_brave_web_search_empty_query() {
+        let tool = BraveWebSearchTool;
+        let session_id = SessionId::new();
+        let store = Arc::new(MockStorageStore::new());
+        let context = ToolContext::with_storage_store(session_id, store);
+        let result = tool
+            .execute_with_context(json!({"query": ""}), &context)
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(
+                    msg.contains("Missing required parameter"),
+                    "Expected missing param error, got: {msg}"
+                );
+            }
+            _ => panic!("Expected ToolError for empty query"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_brave_web_search_no_api_key() {
+        let tool = BraveWebSearchTool;
+        let session_id = SessionId::new();
+        let store = Arc::new(MockStorageStore::new());
+        let context = ToolContext::with_storage_store(session_id, store);
+        let result = tool
+            .execute_with_context(json!({"query": "test"}), &context)
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(
+                    msg.contains("API key not configured"),
+                    "Expected API key error, got: {msg}"
+                );
+            }
+            _ => panic!("Expected ToolError for missing API key"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_brave_web_search_with_session_secret() {
+        // API key set as session secret — tool should attempt search.
+        // Will fail at HTTP call (no real API), but token resolution should succeed.
+        let tool = BraveWebSearchTool;
+        let session_id = SessionId::new();
+        let store = Arc::new(MockStorageStore::new());
+        store
+            .seed_secret(session_id, "BRAVE_SEARCH_API_KEY", "test_key")
+            .await;
+        let context = ToolContext::with_storage_store(session_id, store);
+        let result = tool
+            .execute_with_context(json!({"query": "test"}), &context)
+            .await;
+        // Should fail at HTTP call, not at API key resolution
+        if let ToolExecutionResult::ToolError(msg) = result {
+            assert!(
+                !msg.contains("API key not configured"),
+                "API key should have been resolved from session secret, got: {msg}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_brave_web_search_prefers_connection_resolver() {
+        let tool = BraveWebSearchTool;
+        let session_id = SessionId::new();
+        let store = Arc::new(MockStorageStore::new());
+        store
+            .seed_secret(session_id, "BRAVE_SEARCH_API_KEY", "fallback_key")
+            .await;
+        let resolver = Arc::new(MockConnectionResolver {
+            token: Some("preferred_key".to_string()),
+        });
+        let context =
+            ToolContext::with_storage_store(session_id, store).with_connection_resolver(resolver);
+        let result = tool
+            .execute_with_context(json!({"query": "test"}), &context)
+            .await;
+        // Should fail at HTTP call, not at API key resolution
+        if let ToolExecutionResult::ToolError(msg) = result {
+            assert!(
+                !msg.contains("API key not configured"),
+                "API key should have been resolved from connection resolver, got: {msg}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_api_key_prefers_connection_resolver() {
+        let session_id = SessionId::new();
+        let store = Arc::new(MockStorageStore::new());
+        store
+            .seed_secret(session_id, "BRAVE_SEARCH_API_KEY", "fallback")
+            .await;
+        let resolver = Arc::new(MockConnectionResolver {
+            token: Some("preferred".to_string()),
+        });
+        let context =
+            ToolContext::with_storage_store(session_id, store).with_connection_resolver(resolver);
+        let key = get_api_key(&context).await;
+        assert!(key.is_ok());
+        assert_eq!(key.unwrap(), "preferred");
+    }
+
+    #[tokio::test]
+    async fn test_get_api_key_falls_back_to_secret() {
+        let session_id = SessionId::new();
+        let store = Arc::new(MockStorageStore::new());
+        store
+            .seed_secret(session_id, "BRAVE_SEARCH_API_KEY", "secret_key")
+            .await;
+        let context = ToolContext::with_storage_store(session_id, store);
+        let key = get_api_key(&context).await;
+        assert!(key.is_ok());
+        assert_eq!(key.unwrap(), "secret_key");
+    }
+
+    #[tokio::test]
+    async fn test_get_api_key_skips_empty_connection_token() {
+        let session_id = SessionId::new();
+        let store = Arc::new(MockStorageStore::new());
+        store
+            .seed_secret(session_id, "BRAVE_SEARCH_API_KEY", "fallback")
+            .await;
+        let resolver = Arc::new(MockConnectionResolver {
+            token: Some("".to_string()),
+        });
+        let context =
+            ToolContext::with_storage_store(session_id, store).with_connection_resolver(resolver);
+        let key = get_api_key(&context).await;
+        assert!(key.is_ok());
+        assert_eq!(key.unwrap(), "fallback");
+    }
+
+    #[tokio::test]
+    async fn test_get_api_key_returns_error_when_none() {
+        let session_id = SessionId::new();
+        let store = Arc::new(MockStorageStore::new());
+        let resolver = Arc::new(MockConnectionResolver { token: None });
+        let context =
+            ToolContext::with_storage_store(session_id, store).with_connection_resolver(resolver);
+        let key = get_api_key(&context).await;
+        assert!(key.is_err());
+    }
+
+    #[test]
+    fn test_search_schema_has_required_query() {
+        let tool = BraveWebSearchTool;
+        let schema = tool.parameters_schema();
+        let required = schema["required"].as_array().unwrap();
+        let required_strs: Vec<&str> = required.iter().map(|v| v.as_str().unwrap()).collect();
+        assert!(required_strs.contains(&"query"));
+        assert_eq!(required_strs.len(), 1);
+    }
+
+    #[test]
+    fn test_search_schema_has_optional_fields() {
+        let tool = BraveWebSearchTool;
+        let schema = tool.parameters_schema();
+        assert!(schema["properties"]["count"].is_object());
+        assert!(schema["properties"]["offset"].is_object());
+        assert!(schema["properties"]["freshness"].is_object());
+    }
+
+    #[test]
+    fn test_search_schema_freshness_enum() {
+        let tool = BraveWebSearchTool;
+        let schema = tool.parameters_schema();
+        let freshness_enum = &schema["properties"]["freshness"]["enum"];
+        let values: Vec<&str> = freshness_enum
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert!(values.contains(&"pd"));
+        assert!(values.contains(&"pw"));
+        assert!(values.contains(&"pm"));
+        assert!(values.contains(&"py"));
+    }
+
+    #[test]
+    fn test_search_schema_disallows_additional_properties() {
+        let tool = BraveWebSearchTool;
+        let schema = tool.parameters_schema();
+        assert_eq!(schema["additionalProperties"], json!(false));
+    }
+
+    #[test]
+    fn test_tool_name() {
+        let tool = BraveWebSearchTool;
+        assert_eq!(tool.name(), "brave_web_search");
+    }
+
+    #[test]
+    fn test_tool_has_description() {
+        let tool = BraveWebSearchTool;
+        assert!(!tool.description().is_empty());
+        assert!(tool.description().contains("Brave Search"));
+    }
+
+    #[test]
+    fn test_tool_requires_context() {
+        let tool = BraveWebSearchTool;
+        assert!(tool.requires_context());
+    }
+}

--- a/integrations/brave-search/tests/plugin_registration.rs
+++ b/integrations/brave-search/tests/plugin_registration.rs
@@ -1,0 +1,69 @@
+//! Integration test: verify Brave Search plugin registers via inventory.
+
+use everruns_core::capabilities::{CapabilityRegistry, IntegrationPlugin};
+use everruns_core::deployment::DeploymentGrade;
+
+// Force linker to include the integration crate's inventory submissions.
+use everruns_integrations_brave_search as _;
+
+#[test]
+fn test_brave_search_plugin_is_submitted() {
+    let plugins: Vec<&IntegrationPlugin> = inventory::iter::<IntegrationPlugin>().collect();
+    assert!(
+        plugins.iter().any(|p| {
+            let cap = (p.factory)();
+            cap.id() == "brave_search"
+        }),
+        "Brave Search IntegrationPlugin should be submitted via inventory"
+    );
+}
+
+#[test]
+fn test_brave_search_plugin_is_experimental() {
+    let plugins: Vec<&IntegrationPlugin> = inventory::iter::<IntegrationPlugin>().collect();
+    let brave_search = plugins
+        .iter()
+        .find(|p| {
+            let cap = (p.factory)();
+            cap.id() == "brave_search"
+        })
+        .expect("Brave Search plugin not found");
+
+    assert!(
+        brave_search.experimental_only,
+        "Brave Search should be marked experimental_only"
+    );
+}
+
+#[test]
+fn test_brave_search_registered_in_dev_registry() {
+    let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
+    assert!(
+        registry.has("brave_search"),
+        "Brave Search should be in dev registry"
+    );
+}
+
+#[test]
+fn test_brave_search_not_registered_in_prod_registry() {
+    let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Prod);
+    assert!(
+        !registry.has("brave_search"),
+        "Brave Search should NOT be in prod registry"
+    );
+}
+
+#[test]
+fn test_brave_search_capability_metadata() {
+    let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
+    let cap = registry
+        .get("brave_search")
+        .expect("Brave Search capability not found");
+
+    assert_eq!(cap.id(), "brave_search");
+    assert_eq!(cap.name(), "[Experimental] Brave Search");
+    assert_eq!(cap.icon(), Some("search"));
+    assert_eq!(cap.category(), Some("Network"));
+    assert!(cap.dependencies().is_empty());
+    assert_eq!(cap.tools().len(), 1);
+}

--- a/integrations/brave-search/tests/smoke_real_api.rs
+++ b/integrations/brave-search/tests/smoke_real_api.rs
@@ -1,0 +1,56 @@
+//! Smoke tests against real Brave Search API.
+//! Run with: doppler run -- cargo test -p everruns-integrations-brave-search --test smoke_real_api -- --ignored
+
+use everruns_integrations_brave_search::client::BraveSearchClient;
+
+fn api_key() -> Option<String> {
+    std::env::var("BRAVE_SEARCH_API_KEY")
+        .ok()
+        .filter(|k| !k.is_empty())
+}
+
+#[tokio::test]
+#[ignore] // requires BRAVE_SEARCH_API_KEY
+async fn smoke_basic_search() {
+    let key = api_key().expect("BRAVE_SEARCH_API_KEY required");
+    let client = BraveSearchClient::new(key);
+
+    let resp = client
+        .web_search("Rust programming language", Some(3), None, None)
+        .await
+        .expect("search should succeed");
+
+    let results = resp.web.expect("web field should exist").results;
+    assert!(!results.is_empty(), "should return results");
+    assert!(!results[0].title.is_empty());
+    assert!(!results[0].url.is_empty());
+}
+
+#[tokio::test]
+#[ignore]
+async fn smoke_freshness_filter() {
+    let key = api_key().expect("BRAVE_SEARCH_API_KEY required");
+    let client = BraveSearchClient::new(key);
+
+    let resp = client
+        .web_search("AI news", Some(2), None, Some("pw"))
+        .await
+        .expect("search with freshness should succeed");
+
+    // May or may not have results, but should not error
+    let _results = resp.web.map(|w| w.results).unwrap_or_default();
+}
+
+#[tokio::test]
+#[ignore]
+async fn smoke_pagination() {
+    let key = api_key().expect("BRAVE_SEARCH_API_KEY required");
+    let client = BraveSearchClient::new(key);
+
+    let resp = client
+        .web_search("Rust async await", Some(2), Some(5), None)
+        .await
+        .expect("search with offset should succeed");
+
+    let _results = resp.web.map(|w| w.results).unwrap_or_default();
+}

--- a/integrations/brave-search/tests/smoke_real_api.rs
+++ b/integrations/brave-search/tests/smoke_real_api.rs
@@ -1,19 +1,21 @@
-//! Smoke tests against real Brave Search API.
-//! Run with: doppler run -- cargo test -p everruns-integrations-brave-search --test smoke_real_api -- --ignored
+//! Real API smoke tests for Brave Search.
+//!
+//! Gated behind `integration` feature — only compiled when run with:
+//!   cargo test -p everruns-integrations-brave-search --features integration
+//!
+//! CI workflow passes BRAVE_SEARCH_API_KEY and enables the feature automatically.
+
+#![cfg(feature = "integration")]
 
 use everruns_integrations_brave_search::client::BraveSearchClient;
 
-fn api_key() -> Option<String> {
-    std::env::var("BRAVE_SEARCH_API_KEY")
-        .ok()
-        .filter(|k| !k.is_empty())
+fn api_key() -> String {
+    std::env::var("BRAVE_SEARCH_API_KEY").expect("BRAVE_SEARCH_API_KEY must be set")
 }
 
 #[tokio::test]
-#[ignore] // requires BRAVE_SEARCH_API_KEY
 async fn smoke_basic_search() {
-    let key = api_key().expect("BRAVE_SEARCH_API_KEY required");
-    let client = BraveSearchClient::new(key);
+    let client = BraveSearchClient::new(api_key());
 
     let resp = client
         .web_search("Rust programming language", Some(3), None, None)
@@ -27,10 +29,8 @@ async fn smoke_basic_search() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn smoke_freshness_filter() {
-    let key = api_key().expect("BRAVE_SEARCH_API_KEY required");
-    let client = BraveSearchClient::new(key);
+    let client = BraveSearchClient::new(api_key());
 
     let resp = client
         .web_search("AI news", Some(2), None, Some("pw"))
@@ -42,10 +42,8 @@ async fn smoke_freshness_filter() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn smoke_pagination() {
-    let key = api_key().expect("BRAVE_SEARCH_API_KEY required");
-    let client = BraveSearchClient::new(key);
+    let client = BraveSearchClient::new(api_key());
 
     let resp = client
         .web_search("Rust async await", Some(2), Some(5), None)

--- a/integrations/brave-search/tests/smoke_real_api.rs
+++ b/integrations/brave-search/tests/smoke_real_api.rs
@@ -4,18 +4,29 @@
 //!   cargo test -p everruns-integrations-brave-search --features integration
 //!
 //! CI workflow passes BRAVE_SEARCH_API_KEY and enables the feature automatically.
+//! Tests skip gracefully if the key is missing (avoids CI failures when secret
+//! is not yet configured).
 
 #![cfg(feature = "integration")]
 
 use everruns_integrations_brave_search::client::BraveSearchClient;
 
-fn api_key() -> String {
-    std::env::var("BRAVE_SEARCH_API_KEY").expect("BRAVE_SEARCH_API_KEY must be set")
+macro_rules! require_api_key {
+    () => {
+        match std::env::var("BRAVE_SEARCH_API_KEY") {
+            Ok(k) if !k.is_empty() => k,
+            _ => {
+                eprintln!("BRAVE_SEARCH_API_KEY not set — skipping");
+                return;
+            }
+        }
+    };
 }
 
 #[tokio::test]
 async fn smoke_basic_search() {
-    let client = BraveSearchClient::new(api_key());
+    let key = require_api_key!();
+    let client = BraveSearchClient::new(key);
 
     let resp = client
         .web_search("Rust programming language", Some(3), None, None)
@@ -30,7 +41,8 @@ async fn smoke_basic_search() {
 
 #[tokio::test]
 async fn smoke_freshness_filter() {
-    let client = BraveSearchClient::new(api_key());
+    let key = require_api_key!();
+    let client = BraveSearchClient::new(key);
 
     let resp = client
         .web_search("AI news", Some(2), None, Some("pw"))
@@ -43,7 +55,8 @@ async fn smoke_freshness_filter() {
 
 #[tokio::test]
 async fn smoke_pagination() {
-    let client = BraveSearchClient::new(api_key());
+    let key = require_api_key!();
+    let client = BraveSearchClient::new(key);
 
     let resp = client
         .web_search("Rust async await", Some(2), Some(5), None)

--- a/specs/brave-search.md
+++ b/specs/brave-search.md
@@ -107,6 +107,38 @@ Unlike Daytona (which manages sandbox lifecycle), Brave Search is stateless. Eac
 
 Unlike Daytona (which depends on `session_storage`), Brave Search has no capability dependencies. The API key resolution uses the connection resolver and storage store from ToolContext directly.
 
+## Testing
+
+### Unit & mock tests
+
+Run without flags — no API key needed:
+
+```bash
+cargo test -p everruns-integrations-brave-search
+```
+
+Uses `wiremock` for HTTP-level assertions (auth headers, query params, error codes).
+
+### Integration tests (real API)
+
+Gated behind the `integration` Cargo feature so they never compile in normal `cargo test` runs:
+
+```bash
+BRAVE_SEARCH_API_KEY=<key> cargo test -p everruns-integrations-brave-search --features integration
+```
+
+Tests: `smoke_basic_search`, `smoke_freshness_filter`, `smoke_pagination` in `tests/smoke_real_api.rs`.
+
+### CI
+
+Dedicated workflow `.github/workflows/brave-search-integration.yml`:
+
+- **Path-filtered**: only triggers when `integrations/brave-search/**` changes.
+- Reads `BRAVE_SEARCH_API_KEY` from GitHub Actions secrets.
+- Passes `--features integration` to compile and run the real-API tests.
+
+Adding a new API-key-gated integration crate should follow this pattern: feature-gate the tests, add a path-filtered workflow, store the key in GitHub secrets.
+
 ## Crate Structure
 
 `integrations/brave-search/` → `everruns-integrations-brave-search`
@@ -121,6 +153,7 @@ External integration crate, auto-registered via `inventory::submit!` plugin syst
 | `src/client.rs` | `BraveSearchClient` HTTP client, API response types |
 | `src/tools.rs` | `BraveWebSearchTool` implementation, API key resolution |
 | `tests/plugin_registration.rs` | Integration tests for inventory registration and dev/prod gating |
+| `tests/smoke_real_api.rs` | Real-API smoke tests (behind `integration` feature) |
 
 ## Capability Registration
 

--- a/specs/brave-search.md
+++ b/specs/brave-search.md
@@ -129,6 +129,8 @@ BRAVE_SEARCH_API_KEY=<key> cargo test -p everruns-integrations-brave-search --fe
 
 Tests: `smoke_basic_search`, `smoke_freshness_filter`, `smoke_pagination` in `tests/smoke_real_api.rs`.
 
+Tests use a `require_api_key!` macro that gracefully skips (returns early with a message) when `BRAVE_SEARCH_API_KEY` is unset or empty. This prevents CI failures when the secret is not yet configured while still compiling the test code.
+
 ### CI
 
 Dedicated workflow `.github/workflows/brave-search-integration.yml`:
@@ -136,8 +138,9 @@ Dedicated workflow `.github/workflows/brave-search-integration.yml`:
 - **Path-filtered**: only triggers when `integrations/brave-search/**` changes.
 - Reads `BRAVE_SEARCH_API_KEY` from GitHub Actions secrets.
 - Passes `--features integration` to compile and run the real-API tests.
+- If the secret is missing, tests compile and pass (skipped), ensuring CI stays green.
 
-Adding a new API-key-gated integration crate should follow this pattern: feature-gate the tests, add a path-filtered workflow, store the key in GitHub secrets.
+Adding a new API-key-gated integration crate should follow this pattern: feature-gate the tests, use a skip macro for missing keys, add a path-filtered workflow, store the key in GitHub secrets.
 
 ## Crate Structure
 

--- a/specs/brave-search.md
+++ b/specs/brave-search.md
@@ -1,0 +1,132 @@
+# Brave Search Capability Specification
+
+## Abstract
+
+The Brave Search capability integrates [Brave Search](https://brave.com/search/api/) web search as an agent tool. Agents can search the web and get relevant results including titles, URLs, and descriptions. Stateless — no per-resource state management needed.
+
+**Status**: Experimental (Dev only)
+
+## Architecture
+
+### Single API
+
+Brave Search exposes one API layer:
+
+1. **Web Search API** (`https://api.search.brave.com/res/v1/web/search`) — query the web. Auth: `X-Subscription-Token: <API_KEY>`.
+
+```
+┌────────────────────────────────────────────┐
+│              Agent Session                  │
+│                                             │
+│  Tool Call (brave_web_search)              │
+│         ↓                                   │
+│  Resolve API key:                          │
+│    1. User connections (brave_search)       │
+│    2. Session secret (BRAVE_SEARCH_API_KEY) │
+│         ↓                                   │
+│  ┌─────────────────────────────────────┐   │
+│  │ BraveSearchClient                   │   │
+│  │  - Web Search API                   │   │
+│  └─────────────────────────────────────┘   │
+│         ↓                                   │
+│  Return results to agent                   │
+└────────────────────────────────────────────┘
+```
+
+### API Key Resolution
+
+The API key is resolved lazily at tool execution time:
+
+1. **User connections** (preferred): `connection_resolver.get_connection_token(session_id, "brave_search")`. User stores their API key via `PUT /v1/user/connections/api-key/brave_search`.
+2. **Session secret** (fallback): `storage_store.get_secret(session_id, "BRAVE_SEARCH_API_KEY")`.
+3. **Error**: Guidance to configure in Settings > Connections or via session secret.
+
+## Tools
+
+### brave_web_search
+
+Search the web using Brave Search API.
+
+- **Parameters**:
+  - `query`: string (required) — search query
+  - `count`: integer (optional, 1-20, default: 10) — number of results
+  - `offset`: integer (optional) — pagination offset
+  - `freshness`: string (optional) — time filter: `pd` (past day), `pw` (past week), `pm` (past month), `py` (past year)
+- **Returns**: `{ query, results: [{title, url, description, age?}], count }`
+
+## Security
+
+- **API Key**: Resolved via user connections (encrypted at rest) or session secrets (encrypted at rest)
+- **No secrets in tool results**: API key never appears in tool results or message history
+- **Rate limiting**: Deferred to Brave Search API (returns 429 on rate limit)
+
+## Error Handling
+
+| Scenario | Result Type | Message |
+|----------|-------------|---------|
+| Missing query param | `ToolError` | "Missing required parameter: query" |
+| API key not configured | `ToolError` | "Brave Search API key not configured..." |
+| HTTP 401 | `ToolError` | "Brave Search API error (401): ..." |
+| HTTP 429 | `ToolError` | "Brave Search API error (429): ..." |
+| No context | `ToolError` | "brave_web_search requires context." |
+
+## User Connection
+
+### PUT /v1/user/connections/api-key/brave_search
+
+Store a Brave Search API key as an encrypted user connection.
+
+**Request:**
+```json
+{
+  "api_key": "BSA..."
+}
+```
+
+**Response:** `204 No Content`
+
+The API key is encrypted using envelope encryption (AES-256-GCM) before storage.
+
+### DELETE /v1/user/connections/brave_search
+
+Disconnect. Removes the stored API key.
+
+**Response:** `204 No Content`
+
+## Design Decisions
+
+### API key in user connections (not just session secrets)
+
+User connections are persistent across sessions and user-scoped. Session secrets are per-session and lost when the session ends. User connections are the preferred storage for long-lived API keys.
+
+### Stateless (no per-resource state)
+
+Unlike Daytona (which manages sandbox lifecycle), Brave Search is stateless. Each search is independent. No sandbox state, no session state beyond the API key.
+
+### No dependencies
+
+Unlike Daytona (which depends on `session_storage`), Brave Search has no capability dependencies. The API key resolution uses the connection resolver and storage store from ToolContext directly.
+
+## Crate Structure
+
+`integrations/brave-search/` → `everruns-integrations-brave-search`
+
+External integration crate, auto-registered via `inventory::submit!` plugin system.
+
+**Force-link required**: Both `crates/server/src/lib.rs` and `crates/worker/src/lib.rs` must contain `extern crate everruns_integrations_brave_search;`.
+
+| File | Purpose |
+|------|---------|
+| `src/lib.rs` | Plugin registration, constants, `BraveSearchCapability` impl |
+| `src/client.rs` | `BraveSearchClient` HTTP client, API response types |
+| `src/tools.rs` | `BraveWebSearchTool` implementation, API key resolution |
+| `tests/plugin_registration.rs` | Integration tests for inventory registration and dev/prod gating |
+
+## Capability Registration
+
+- **ID**: `brave_search`
+- **Name**: `[Experimental] Brave Search`
+- **Status**: Available (Dev only)
+- **Icon**: `search`
+- **Category**: `Network`
+- **Dependencies**: none


### PR DESCRIPTION
## What
Add Brave Search as an agent capability, providing web search via the brave_web_search tool. Includes the integration crate, CI workflow, and spec documentation.

## Why
Agents need web search to answer questions about current events, look up documentation, and verify information. Brave Search provides a simple, stateless API.

## How
- New integrations/brave-search/ crate with BraveSearchClient, BraveWebSearchTool, and capability registration via inventory::submit!
- API key resolved from user connections (preferred) or session secrets (fallback)
- Path-filtered CI workflow runs real-API smoke tests when BRAVE_SEARCH_API_KEY secret is configured
- Tests use require_api_key! macro to gracefully skip when key is absent — CI stays green either way
- Spec at specs/brave-search.md documents architecture, tools, security, error handling, testing

## Risk
- Low
- Experimental / dev-only capability, no impact on existing functionality

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered