### PR TITLE
feat(harness): rename Default to Base, add Generic harness type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,7 @@ Fix root cause. Unsure: read more code; if stuck, ask w/ short options. Unrecogn
 - `specs/linear-issues.md` - Linear issue processing workflow
 - `specs/daytona.md` - Daytona cloud sandbox integration
 - `specs/brave-search.md` - Brave Search web search integration
+- `specs/harness-types.md` - Built-in harness types (Base, Generic)
 
 ### Skills
 

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -52,7 +52,8 @@ mod seed_ids {
     pub const MS_LEARN_MCP: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000501);
 
     // Harnesses (0x600-0x6FF)
-    pub const DEFAULT_HARNESS: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000601);
+    pub const BASE_HARNESS: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000601);
+    pub const GENERIC_HARNESS: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000602);
 
     // OpenAI Models (0x200-0x2FF)
     pub const GPT_5_2: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000201);
@@ -217,14 +218,29 @@ struct SeedHarness {
 }
 
 /// Built-in seed harnesses
-const SEED_HARNESSES: &[SeedHarness] = &[SeedHarness {
-    id: seed_ids::DEFAULT_HARNESS,
-    name: "Default",
-    description: "Default harness with no special configuration. Provides a blank canvas for sessions.",
-    system_prompt: "You are a helpful assistant.",
-    tags: &["default", "seed"],
-    capabilities: &[],
-}];
+const SEED_HARNESSES: &[SeedHarness] = &[
+    SeedHarness {
+        id: seed_ids::BASE_HARNESS,
+        name: "Base",
+        description: "Empty harness with no capabilities. Provides a blank canvas for custom configurations.",
+        system_prompt: "You are a helpful assistant.",
+        tags: &["base", "seed"],
+        capabilities: &[],
+    },
+    SeedHarness {
+        id: seed_ids::GENERIC_HARNESS,
+        name: "Generic",
+        description: "General-purpose harness with file system, bash, secrets, and session management. Recommended default for most use cases.",
+        system_prompt: "You are a helpful assistant.",
+        tags: &["generic", "default", "seed"],
+        capabilities: &[
+            "session_file_system",
+            "virtual_bash",
+            "session_storage",
+            "session",
+        ],
+    },
+];
 
 /// Seed harnesses into the database
 async fn seed_harnesses(db: &StorageBackend) -> anyhow::Result<SeedResult> {
@@ -1364,4 +1380,85 @@ pub async fn seed_all(db: &StorageBackend, grade: DeploymentGrade) -> anyhow::Re
     result.merge(agent_result);
 
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_seed_harness_ids_are_unique() {
+        let ids: Vec<Uuid> = SEED_HARNESSES.iter().map(|h| h.id).collect();
+        let mut unique_ids = ids.clone();
+        unique_ids.sort();
+        unique_ids.dedup();
+        assert_eq!(
+            ids.len(),
+            unique_ids.len(),
+            "Seed harness IDs must be unique"
+        );
+    }
+
+    #[test]
+    fn test_seed_harness_names_are_unique() {
+        let names: Vec<&str> = SEED_HARNESSES.iter().map(|h| h.name).collect();
+        let mut unique_names = names.clone();
+        unique_names.sort();
+        unique_names.dedup();
+        assert_eq!(
+            names.len(),
+            unique_names.len(),
+            "Seed harness names must be unique"
+        );
+    }
+
+    #[test]
+    fn test_base_harness_has_no_capabilities() {
+        let base = SEED_HARNESSES
+            .iter()
+            .find(|h| h.name == "Base")
+            .expect("Base harness should exist");
+        assert!(
+            base.capabilities.is_empty(),
+            "Base harness must have no capabilities"
+        );
+        assert!(base.tags.contains(&"base"));
+    }
+
+    #[test]
+    fn test_generic_harness_has_expected_capabilities() {
+        let generic = SEED_HARNESSES
+            .iter()
+            .find(|h| h.name == "Generic")
+            .expect("Generic harness should exist");
+
+        assert_eq!(generic.capabilities.len(), 4);
+        assert!(generic.capabilities.contains(&"session_file_system"));
+        assert!(generic.capabilities.contains(&"virtual_bash"));
+        assert!(generic.capabilities.contains(&"session_storage"));
+        assert!(generic.capabilities.contains(&"session"));
+        assert!(generic.tags.contains(&"generic"));
+        assert!(generic.tags.contains(&"default"));
+    }
+
+    #[test]
+    fn test_generic_harness_capabilities_are_registered() {
+        // Verify all capability IDs referenced by Generic harness exist in the registry
+        let registry = everruns_core::capabilities::CapabilityRegistry::with_builtins_for_grade(
+            everruns_core::DeploymentGrade::Dev,
+        );
+
+        let generic = SEED_HARNESSES
+            .iter()
+            .find(|h| h.name == "Generic")
+            .expect("Generic harness should exist");
+
+        for cap_id in generic.capabilities {
+            assert!(
+                registry.has(cap_id),
+                "Capability '{}' referenced by Generic harness must be registered",
+                cap_id
+            );
+        }
+    }
 }

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -17,10 +17,12 @@ use serde_json::{Value, json};
 use test_harness::TestServer;
 
 use everruns_core::llm_models::LlmProvider;
-use everruns_core::{Agent, LlmModel, Session, SessionFile};
+use everruns_core::{Agent, Harness, LlmModel, Session, SessionFile};
 
-/// Seed harness ID from seed.rs (DEFAULT_HARNESS = 0x01933b5a_0000_7000_8000_000000000601)
-const SEED_HARNESS_ID: &str = "harness_01933b5a000070008000000000000601";
+/// Seed harness ID from seed.rs (BASE_HARNESS = 0x01933b5a_0000_7000_8000_000000000601)
+const SEED_BASE_HARNESS_ID: &str = "harness_01933b5a000070008000000000000601";
+/// Seed harness ID from seed.rs (GENERIC_HARNESS = 0x01933b5a_0000_7000_8000_000000000602)
+const SEED_GENERIC_HARNESS_ID: &str = "harness_01933b5a000070008000000000000602";
 
 // ============================================
 // Health Endpoint Tests
@@ -214,7 +216,7 @@ async fn test_create_session() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_HARNESS_ID,
+                "harness_id": SEED_BASE_HARNESS_ID,
                 "agent_id": agent.public_id,
                 "title": "Test Session"
             }),
@@ -248,7 +250,7 @@ async fn test_get_session() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_HARNESS_ID,
+                "harness_id": SEED_BASE_HARNESS_ID,
                 "agent_id": agent.public_id,
                 "title": "Get Test Session"
             }),
@@ -290,7 +292,7 @@ async fn test_sessions_pagination() {
             .post(
                 "/v1/sessions",
                 json!({
-                    "harness_id": SEED_HARNESS_ID,
+                    "harness_id": SEED_BASE_HARNESS_ID,
                     "agent_id": agent.public_id,
                     "title": format!("Session {}", i)
                 }),
@@ -358,7 +360,7 @@ async fn test_create_user_message() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_HARNESS_ID,
+                "harness_id": SEED_BASE_HARNESS_ID,
                 "agent_id": agent.public_id
             }),
         )
@@ -405,7 +407,7 @@ async fn test_list_messages() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_HARNESS_ID,
+                "harness_id": SEED_BASE_HARNESS_ID,
                 "agent_id": agent.public_id
             }),
         )
@@ -464,7 +466,7 @@ async fn test_list_events() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_HARNESS_ID,
+                "harness_id": SEED_BASE_HARNESS_ID,
                 "agent_id": agent.public_id
             }),
         )
@@ -642,7 +644,7 @@ async fn test_session_inherits_agent_default_model() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_HARNESS_ID,
+                "harness_id": SEED_BASE_HARNESS_ID,
                 "agent_id": agent.public_id,
                 "title": "Inheritance Test"
             }),
@@ -694,7 +696,7 @@ async fn test_session_filesystem() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_HARNESS_ID,
+                "harness_id": SEED_BASE_HARNESS_ID,
                 "agent_id": agent.public_id
             }),
         )
@@ -767,6 +769,130 @@ async fn test_session_filesystem() {
         .assert_status(StatusCode::OK)
         .json();
     assert_eq!(result["deleted"], true);
+}
+
+// ============================================
+// Harness Tests
+// ============================================
+
+#[tokio::test]
+async fn test_list_harnesses_includes_base_and_generic() {
+    let server = TestServer::new().await;
+
+    let data: Value = server
+        .get("/v1/harnesses")
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+
+    let harnesses = data["data"].as_array().expect("Expected array");
+    assert!(
+        harnesses.len() >= 2,
+        "Should have at least Base and Generic harnesses"
+    );
+
+    let names: Vec<&str> = harnesses
+        .iter()
+        .filter_map(|h| h["name"].as_str())
+        .collect();
+    assert!(names.contains(&"Base"), "Should have Base harness");
+    assert!(names.contains(&"Generic"), "Should have Generic harness");
+}
+
+#[tokio::test]
+async fn test_get_base_harness() {
+    let server = TestServer::new().await;
+
+    let harness: Harness = server
+        .get(&format!("/v1/harnesses/{}", SEED_BASE_HARNESS_ID))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+
+    assert_eq!(harness.name, "Base");
+    assert!(
+        harness.capabilities.is_empty(),
+        "Base harness should have no capabilities"
+    );
+    assert!(harness.tags.contains(&"base".to_string()));
+    assert!(harness.tags.contains(&"seed".to_string()));
+}
+
+#[tokio::test]
+async fn test_get_generic_harness() {
+    let server = TestServer::new().await;
+
+    let harness: Harness = server
+        .get(&format!("/v1/harnesses/{}", SEED_GENERIC_HARNESS_ID))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+
+    assert_eq!(harness.name, "Generic");
+    assert!(harness.tags.contains(&"generic".to_string()));
+    assert!(harness.tags.contains(&"default".to_string()));
+
+    // Verify Generic harness has the expected 4 capabilities
+    let cap_ids: Vec<&str> = harness
+        .capabilities
+        .iter()
+        .map(|c| c.capability_id())
+        .collect();
+    assert_eq!(
+        cap_ids.len(),
+        4,
+        "Generic harness should have 4 capabilities"
+    );
+    assert!(
+        cap_ids.contains(&"session_file_system"),
+        "Should have file system"
+    );
+    assert!(
+        cap_ids.contains(&"virtual_bash"),
+        "Should have virtual bash"
+    );
+    assert!(
+        cap_ids.contains(&"session_storage"),
+        "Should have session storage"
+    );
+    assert!(
+        cap_ids.contains(&"session"),
+        "Should have session capability"
+    );
+}
+
+#[tokio::test]
+async fn test_create_session_with_generic_harness() {
+    let server = TestServer::new().await;
+
+    // Create an agent
+    let agent: Agent = server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": "Generic Harness Test Agent",
+                "system_prompt": "Test"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    // Create session with Generic harness
+    let session: Session = server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": SEED_GENERIC_HARNESS_ID,
+                "agent_id": agent.public_id,
+                "title": "Generic Harness Session"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    assert_eq!(session.title.as_deref(), Some("Generic Harness Session"));
 }
 
 // ============================================
@@ -845,7 +971,7 @@ async fn test_session_databases_crud() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_HARNESS_ID,
+                "harness_id": SEED_BASE_HARNESS_ID,
                 "agent_id": agent.public_id.to_string()
             }),
         )
@@ -948,7 +1074,7 @@ async fn test_session_databases_schema() {
     let session: Session = server
         .post(
             "/v1/sessions",
-            json!({"harness_id": SEED_HARNESS_ID, "agent_id": agent.public_id.to_string()}),
+            json!({"harness_id": SEED_BASE_HARNESS_ID, "agent_id": agent.public_id.to_string()}),
         )
         .await
         .assert_status(StatusCode::CREATED)
@@ -1002,7 +1128,7 @@ async fn test_session_databases_invalid_name() {
     let session: Session = server
         .post(
             "/v1/sessions",
-            json!({"harness_id": SEED_HARNESS_ID, "agent_id": agent.public_id.to_string()}),
+            json!({"harness_id": SEED_BASE_HARNESS_ID, "agent_id": agent.public_id.to_string()}),
         )
         .await
         .assert_status(StatusCode::CREATED)

--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -23,7 +23,7 @@ const API_BASE_URL: &str = "http://localhost:9000";
 // Note: With AUTH_MODE=none, org is derived from the anonymous user's default org.
 // No cookie or header needed for integration tests.
 
-/// Seed harness ID from seed.rs (DEFAULT_HARNESS = 0x01933b5a_0000_7000_8000_000000000601)
+/// Seed harness ID from seed.rs (BASE_HARNESS = 0x01933b5a_0000_7000_8000_000000000601)
 const SEED_HARNESS_ID: &str = "harness_01933b5a000070008000000000000601";
 
 #[tokio::test]

--- a/docs/features/harnesses.md
+++ b/docs/features/harnesses.md
@@ -1,0 +1,131 @@
+---
+title: Harnesses
+description: Pre-configured environments that define base capabilities for sessions
+---
+
+A harness defines the base environment for sessions — the system prompt, default model, and capabilities that every session starts with. Think of a harness as a "starter kit" that agents and sessions build on top of.
+
+## Overview
+
+When you create a session, you assign it a harness. The harness provides:
+
+- **System Prompt**: The foundation of the prompt stack
+- **Capabilities**: Tools and behaviors available to the agent
+- **Default Model**: Optional default LLM model (lowest priority in the inheritance chain)
+
+Agents add their own system prompts and capabilities on top of the harness. Sessions can add even more capabilities. The final configuration is the merged result of all three layers.
+
+## Built-in Harnesses
+
+Everruns ships two built-in harnesses that cover the most common starting points.
+
+### Base
+
+An empty harness with no capabilities. Use this when you want full control over what tools and behaviors are available.
+
+- **Capabilities**: None
+- **System Prompt**: "You are a helpful assistant."
+- **Best for**: Custom configurations, testing, minimal-overhead sessions
+
+### Generic (Recommended)
+
+A general-purpose harness bundling the core capabilities most agents need. This is the recommended default for most use cases.
+
+- **System Prompt**: "You are a helpful assistant."
+- **Best for**: General-purpose agents, coding assistants, research workflows
+
+**Included Capabilities:**
+
+| Capability | What it provides |
+|------------|-----------------|
+| **File System** | Read, write, list, grep, and delete files in the session workspace (`/workspace`) |
+| **Virtual Bash** | Sandboxed bash shell for running commands, scripts, and text processing |
+| **Session Storage** | Key/value store for general data and encrypted secret storage for API keys and credentials |
+| **Session** | Access session metadata and manage session title |
+
+## Choosing a Harness
+
+| Scenario | Recommended Harness |
+|----------|-------------------|
+| General-purpose assistant | Generic |
+| Coding or scripting tasks | Generic |
+| Agent that needs API keys | Generic (includes secret storage) |
+| Minimal agent with one specific tool | Base + add only what you need |
+| Testing capability behavior | Base |
+| Custom tool composition | Base |
+
+## Managing Harnesses
+
+### Via API
+
+List available harnesses:
+
+```bash
+curl http://localhost:9300/api/v1/harnesses
+```
+
+Create a custom harness:
+
+```bash
+curl -X POST http://localhost:9300/api/v1/harnesses \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "My Custom Harness",
+    "description": "Harness with research capabilities",
+    "system_prompt": "You are a research assistant.",
+    "capabilities": [
+      {"ref": "session_file_system"},
+      {"ref": "web_fetch"},
+      {"ref": "stateless_todo_list"}
+    ]
+  }'
+```
+
+Use a harness when creating a session:
+
+```bash
+curl -X POST http://localhost:9300/api/v1/sessions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "harness_id": "harness_...",
+    "agent_id": "agent_..."
+  }'
+```
+
+### Preview a Harness
+
+See the merged system prompt and available tools before creating a session:
+
+```bash
+curl -X POST http://localhost:9300/api/v1/harnesses/preview \
+  -H "Content-Type: application/json" \
+  -d '{
+    "system_prompt": "You are a helpful assistant.",
+    "capabilities": [
+      {"ref": "session_file_system"},
+      {"ref": "virtual_bash"}
+    ]
+  }'
+```
+
+## How Harnesses Fit in the Prompt Stack
+
+The system prompt is built from three layers, each wrapped in XML tags for clarity:
+
+1. **Harness capabilities** — Foundation layer
+2. **Agent capabilities** — Domain-specific layer
+3. **Session capabilities** — Per-session additions
+
+The final system prompt merges all three, with the harness system prompt at the base.
+
+```
+┌──────────────────────────────┐
+│  Session Capabilities        │  (additive, per-session)
+├──────────────────────────────┤
+│  Agent Capabilities          │  (domain-specific)
+│  Agent System Prompt         │
+├──────────────────────────────┤
+│  Harness Capabilities        │  (foundation)
+│  Harness System Prompt       │
+└──────────────────────────────┘
+```

--- a/specs/harness-types.md
+++ b/specs/harness-types.md
@@ -1,0 +1,80 @@
+# Harness Types Specification
+
+## Abstract
+
+Harnesses define the base environment and capabilities for sessions. Everruns ships built-in harness types that cover common use cases. Users can also create custom harnesses via the API.
+
+## Built-in Harness Types
+
+### Base
+
+The empty harness. No capabilities, no opinions. Intended as a blank canvas for fully custom configurations where users attach capabilities manually.
+
+| Property | Value |
+|----------|-------|
+| Name | Base |
+| Seed ID | `harness_01933b5a000070008000000000000601` |
+| System Prompt | "You are a helpful assistant." |
+| Capabilities | _(none)_ |
+| Tags | `base`, `seed` |
+
+**Use cases:**
+- Custom agent configurations where only specific capabilities are needed
+- Testing capability behavior in isolation
+- Minimal-overhead sessions with no tools
+
+### Generic
+
+The recommended default harness. Bundles the core capabilities needed for general-purpose agent work: file system access, bash execution, secret management, and session metadata.
+
+| Property | Value |
+|----------|-------|
+| Name | Generic |
+| Seed ID | `harness_01933b5a000070008000000000000602` |
+| System Prompt | "You are a helpful assistant." |
+| Tags | `generic`, `default`, `seed` |
+
+**Capabilities:**
+
+| Capability ID | Name | Purpose |
+|---------------|------|---------|
+| `session_file_system` | File System | Read, write, list, grep, delete files in `/workspace` |
+| `virtual_bash` | Virtual Bash | Sandboxed bash shell for code execution and scripting |
+| `session_storage` | Session Storage | Key/value store and encrypted secret storage |
+| `session` | Session | Session info access and title management |
+
+**Use cases:**
+- Default harness for most agents
+- Agents that need file manipulation and code execution
+- Agents that store API keys or credentials in session secrets
+- General-purpose assistant workflows
+
+## Design Decisions
+
+| Question | Decision |
+|----------|----------|
+| Why separate Base and Generic? | Base provides a zero-capability starting point; Generic provides batteries-included defaults. Separating them lets users choose their starting point. |
+| Why is Generic the recommended default? | Most agents need file system and bash access. Bundling these in a harness avoids repetitive per-agent capability setup. |
+| Why include `session_storage` in Generic? | Secret storage is needed for agents that interact with external APIs (API keys, tokens). KV storage is useful for persisting state. |
+| Why include `session` in Generic? | Session metadata (title, info) is commonly needed and has minimal overhead. |
+| Can users create additional harnesses? | Yes, via `POST /v1/harnesses`. Built-in harnesses are seed data, not the only options. |
+
+## Seed Data
+
+Built-in harnesses are seeded on server startup using fixed UUIDs for idempotency. They use `ON CONFLICT DO NOTHING` to avoid overwriting user modifications.
+
+### UUID Allocation
+
+Harness UUIDs occupy the `0x600-0x6FF` range in the seed ID schema:
+
+| Harness | UUID (hex) |
+|---------|-----------|
+| Base | `0x01933b5a_0000_7000_8000_000000000601` |
+| Generic | `0x01933b5a_0000_7000_8000_000000000602` |
+
+## Future Harness Types
+
+The harness type system is designed for extension. Planned additions:
+- **Research** — Web fetch, todo list, file system for research workflows
+- **Data** — SQL database, file system, sample data for analytics
+- **Code** — Docker/sandbox execution with file system for coding tasks


### PR DESCRIPTION
## What
Rename the existing Default harness to Base and add a new Generic harness type with core capabilities (file system, virtual bash, secrets, session).

## Why
We need multiple built-in harness types as starting points. Base provides a blank canvas for custom configurations. Generic provides batteries-included defaults for most use cases — this is the recommended default going forward.

## How
- Renamed `DEFAULT_HARNESS` seed constant to `BASE_HARNESS`, updated name from "Default" to "Base"
- Added `GENERIC_HARNESS` seed (UUID `0x602`) with `session_file_system`, `virtual_bash`, `session_storage`, and `session` capabilities
- Added `specs/harness-types.md` documenting both harness types
- Added `docs/features/harnesses.md` public documentation
- Added 5 unit tests verifying seed data integrity (unique IDs/names, correct capabilities, registry validation)
- Added 4 integration tests verifying harness API endpoints (list, get base, get generic, create session with generic)

## Risk
- Low
- Existing sessions using the old Default harness UUID continue to work (Base keeps the same UUID)
- New Generic harness uses a new UUID so no conflicts
- Only seed data changes; no schema migration needed

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered