### PR TITLE
feat(ui): add Schedules link to sidebar navigation

### DIFF
--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -44,6 +44,7 @@ import {
   ChevronUp,
   ChevronDown,
   FlaskConical,
+  Calendar,
   Cog,
   Server,
   Workflow,
@@ -70,6 +71,7 @@ const durableNavigation = [
   { name: "Overview", href: "/durable", icon: Cog, exact: true },
   { name: "Workers", href: "/durable/workers", icon: Server },
   { name: "Workflows", href: "/durable/workflows", icon: Workflow },
+  { name: "Schedules", href: "/durable/schedules", icon: Calendar },
 ];
 
 const devNavigation = [{ name: "Dev Tools", href: "/dev", icon: FlaskConical }];


### PR DESCRIPTION
## What
Add "Schedules" entry to the Durable Execution section in the sidebar navigation.

## Why
The schedules list and detail pages already exist (`/durable/schedules`, `/durable/schedules/{id}`) but were not reachable from the sidebar — users had to navigate via URL or the durable overview card.

## How
- Added `Calendar` icon import from lucide-react
- Added `{ name: "Schedules", href: "/durable/schedules", icon: Calendar }` to `durableNavigation` array

## Risk
- Low
- Purely additive UI change; no logic or API changes

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered