### PR TITLE
fix(worker): register harness capability tools when agent_id is absent

### DIFF
--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -1886,4 +1886,87 @@ mod tests {
         let (_, stored_config) = &collected.message_filter_providers[0];
         assert_eq!(*stored_config, test_config);
     }
+
+    // =========================================================================
+    // Harness capability tool registration tests
+    //
+    // Regression tests for the "Tool not found: bash" bug where harness
+    // capabilities were not used for tool registration when agent_id was absent.
+    // These tests verify that capability-provided tools (especially bash) are
+    // correctly produced by collect_capabilities.
+    // =========================================================================
+
+    #[test]
+    fn test_virtual_bash_capability_produces_bash_tool() {
+        let registry = CapabilityRegistry::with_builtins();
+        let collected = collect_capabilities(&["virtual_bash".to_string()], &registry);
+
+        let tool_names: Vec<&str> = collected
+            .tool_definitions
+            .iter()
+            .map(|t| t.name())
+            .collect();
+        assert!(
+            tool_names.contains(&"bash"),
+            "virtual_bash capability must produce 'bash' tool, got: {:?}",
+            tool_names
+        );
+        assert!(
+            !collected.tools.is_empty(),
+            "virtual_bash must provide tool implementations"
+        );
+    }
+
+    #[test]
+    fn test_generic_harness_capability_set_produces_bash_tool() {
+        // These are the exact capability IDs from the Generic Harness seed data.
+        // If any are renamed or removed, this test catches the regression.
+        let generic_harness_caps = vec![
+            "session_file_system".to_string(),
+            "virtual_bash".to_string(),
+            "session_storage".to_string(),
+            "session".to_string(),
+        ];
+
+        let registry = CapabilityRegistry::with_builtins();
+        let collected = collect_capabilities(&generic_harness_caps, &registry);
+
+        let tool_names: Vec<&str> = collected
+            .tool_definitions
+            .iter()
+            .map(|t| t.name())
+            .collect();
+        assert!(
+            tool_names.contains(&"bash"),
+            "Generic Harness capabilities must produce 'bash' tool, got: {:?}",
+            tool_names
+        );
+    }
+
+    #[test]
+    fn test_collect_capabilities_tool_count_matches_definitions() {
+        // Ensure collected tools (implementations) match tool_definitions count.
+        // A mismatch means some tools won't be executable at runtime.
+        let registry = CapabilityRegistry::with_builtins();
+        let collected = collect_capabilities(&["virtual_bash".to_string()], &registry);
+
+        assert_eq!(
+            collected.tools.len(),
+            collected.tool_definitions.len(),
+            "tool implementations ({}) must match tool definitions ({})",
+            collected.tools.len(),
+            collected.tool_definitions.len(),
+        );
+    }
+
+    #[test]
+    fn test_defaults_do_not_include_bash() {
+        // ToolRegistry::with_defaults() must NOT include bash — it comes from
+        // capabilities only. This documents the invariant that the bug violated.
+        let registry = crate::ToolRegistry::with_defaults();
+        assert!(
+            !registry.has("bash"),
+            "with_defaults() must not include 'bash' — it comes from virtual_bash capability"
+        );
+    }
 }

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -963,4 +963,23 @@ mod tests {
         // AddTool returns floats, so compare as f64
         assert_eq!(result.result.unwrap()["result"].as_f64().unwrap(), 8.0);
     }
+
+    /// Regression: with_defaults() must NOT include capability-provided tools like
+    /// 'bash'. These tools come from capabilities and must be registered separately.
+    /// If bash were in defaults, the harness capability fallback would be masked.
+    #[test]
+    fn test_with_defaults_excludes_capability_only_tools() {
+        let registry = ToolRegistry::with_defaults();
+
+        // bash comes from virtual_bash capability, not defaults
+        assert!(
+            !registry.has("bash"),
+            "bash must not be in defaults — it comes from virtual_bash capability"
+        );
+        // kv_store/secret_store come from session_storage capability
+        assert!(
+            !registry.has("kv_store"),
+            "kv_store must not be in defaults — it comes from session_storage capability"
+        );
+    }
 }

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -1552,6 +1552,90 @@ mod tests {
         }
     }
 
+    /// Regression test for "Tool not found: bash" bug.
+    ///
+    /// When a session uses the Generic Harness without an agent, the worker must
+    /// build a ToolRegistry from harness capabilities. This test verifies that
+    /// collect_capabilities on the Generic Harness cap IDs actually produces a
+    /// registry containing the 'bash' tool — the exact path that was broken.
+    #[test]
+    fn test_generic_harness_capabilities_produce_bash_tool() {
+        use everruns_core::capabilities::collect_capabilities;
+
+        let registry = everruns_core::capabilities::CapabilityRegistry::with_builtins_for_grade(
+            everruns_core::DeploymentGrade::Dev,
+        );
+
+        let generic = SEED_HARNESSES
+            .iter()
+            .find(|h| h.name == "Generic")
+            .expect("Generic harness should exist");
+
+        let cap_ids: Vec<String> = generic.capabilities.iter().map(|s| s.to_string()).collect();
+        let collected = collect_capabilities(&cap_ids, &registry);
+
+        // Build a ToolRegistry exactly as the worker does
+        let mut tool_registry = everruns_core::ToolRegistry::with_defaults();
+        for tool in collected.tools {
+            tool_registry.register_boxed(tool);
+        }
+
+        assert!(
+            tool_registry.has("bash"),
+            "ToolRegistry built from Generic Harness capabilities must include 'bash' tool. \
+             This was the root cause of the 'Tool not found: bash' bug."
+        );
+    }
+
+    /// Verify that ToolRegistry::with_defaults() alone does NOT include 'bash'.
+    /// This documents why harness capability registration is necessary.
+    #[test]
+    fn test_defaults_alone_miss_bash_tool() {
+        let registry = everruns_core::ToolRegistry::with_defaults();
+        assert!(
+            !registry.has("bash"),
+            "with_defaults() must NOT include 'bash' — it comes from virtual_bash capability. \
+             If this fails, the tool was added to defaults and the harness fallback is moot."
+        );
+    }
+
+    /// Verify all Generic Harness capabilities produce tool implementations
+    /// (not just definitions). Tools without implementations cause "Tool not found".
+    #[test]
+    fn test_generic_harness_collected_tools_have_implementations() {
+        use everruns_core::capabilities::collect_capabilities;
+
+        let registry = everruns_core::capabilities::CapabilityRegistry::with_builtins_for_grade(
+            everruns_core::DeploymentGrade::Dev,
+        );
+
+        let generic = SEED_HARNESSES
+            .iter()
+            .find(|h| h.name == "Generic")
+            .expect("Generic harness should exist");
+
+        let cap_ids: Vec<String> = generic.capabilities.iter().map(|s| s.to_string()).collect();
+        let collected = collect_capabilities(&cap_ids, &registry);
+
+        // Every tool definition must have a matching tool implementation
+        assert_eq!(
+            collected.tools.len(),
+            collected.tool_definitions.len(),
+            "tool implementations ({}) must match tool definitions ({}) — \
+             mismatches cause 'Tool not found' at runtime",
+            collected.tools.len(),
+            collected.tool_definitions.len(),
+        );
+
+        // Verify specific tools that Generic Harness users expect
+        let tool_names: Vec<&str> = collected
+            .tool_definitions
+            .iter()
+            .map(|t| t.name())
+            .collect();
+        assert!(tool_names.contains(&"bash"), "must include bash tool");
+    }
+
     // --- seed_all ---
 
     #[tokio::test]

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -297,31 +297,49 @@ pub async fn act_activity(
     // Create tool registry with default built-in tools
     let mut builtin_executor = ToolRegistry::with_defaults();
 
-    // Load agent capabilities and register their tools
-    let agent_store = GrpcAgentStore::new(grpc_client.clone(), org_id);
-    if let Some(agent_id) = input.agent_id
-        && let Ok(Some(agent)) = agent_store.get_agent(agent_id).await
-    {
-        // Extract capability IDs, filtering out MCP capabilities (handled separately)
-        let builtin_cap_ids: Vec<String> = agent
-            .capabilities
-            .iter()
-            .map(|c| c.capability_id().to_string())
-            .filter(|id| !is_mcp_capability(id))
-            .collect();
-
-        if !builtin_cap_ids.is_empty() {
-            let capability_registry = CapabilityRegistry::with_builtins();
-            let collected = collect_capabilities(&builtin_cap_ids, &capability_registry);
-            for tool in collected.tools {
-                builtin_executor.register_boxed(tool);
-            }
-            tracing::debug!(
-                capability_count = builtin_cap_ids.len(),
-                tool_count = collected.tool_definitions.len(),
-                "Registered capability tools for act_activity"
-            );
+    // Load capabilities and register their tools.
+    // When agent_id is present, use agent capabilities.
+    // When agent_id is absent, fall back to harness capabilities so that
+    // harness-provided tools (e.g. bash) are still registered.
+    let cap_ids: Vec<String> = if let Some(agent_id) = input.agent_id {
+        let agent_store = GrpcAgentStore::new(grpc_client.clone(), org_id);
+        if let Ok(Some(agent)) = agent_store.get_agent(agent_id).await {
+            agent
+                .capabilities
+                .iter()
+                .map(|c| c.capability_id().to_string())
+                .filter(|id| !is_mcp_capability(id))
+                .collect()
+        } else {
+            vec![]
         }
+    } else {
+        let harness_store = GrpcHarnessStore::new(grpc_client.clone(), org_id);
+        if let Ok(Some(harness)) =
+            everruns_core::traits::HarnessStore::get_harness(&harness_store, input.harness_id).await
+        {
+            harness
+                .capabilities
+                .iter()
+                .map(|c| c.capability_id().to_string())
+                .filter(|id| !is_mcp_capability(id))
+                .collect()
+        } else {
+            vec![]
+        }
+    };
+
+    if !cap_ids.is_empty() {
+        let capability_registry = CapabilityRegistry::with_builtins();
+        let collected = collect_capabilities(&cap_ids, &capability_registry);
+        for tool in collected.tools {
+            builtin_executor.register_boxed(tool);
+        }
+        tracing::debug!(
+            capability_count = cap_ids.len(),
+            tool_count = collected.tool_definitions.len(),
+            "Registered capability tools for act_activity"
+        );
     }
 
     // Create composite tool executor that handles both built-in and MCP tools

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -11,7 +11,6 @@
 use anyhow::Result;
 use everruns_core::ActInput;
 use everruns_core::atoms::{ActAtom, Atom, AtomContext, InputAtom, ReasonAtom};
-use everruns_core::capabilities::{collect_capabilities, is_mcp_capability};
 use everruns_core::events::{
     EventContext, EventRequest, SessionActivatedData, SessionIdledData, TurnCompletedData,
     TurnFailedData, TurnStartedData,
@@ -767,30 +766,10 @@ async fn execute_act_activity<A: WorkerAdapters>(
     let tool_registry = if let Some(agent_id) = input.agent_id {
         adapters.build_tool_registry(agent_id.uuid()).await?
     } else {
-        let mut registry = everruns_core::ToolRegistry::with_defaults();
         let org_id = input.org_id.unwrap_or(1);
-        if let Ok(Some(harness)) = adapters.get_harness(org_id, input.harness_id.uuid()).await {
-            let builtin_cap_ids: Vec<String> = harness
-                .capabilities
-                .iter()
-                .map(|c| c.capability_id().to_string())
-                .filter(|id| !is_mcp_capability(id))
-                .collect();
-
-            if !builtin_cap_ids.is_empty() {
-                let cap_registry = adapters.capability_registry();
-                let collected = collect_capabilities(&builtin_cap_ids, &cap_registry);
-                for tool in collected.tools {
-                    registry.register_boxed(tool);
-                }
-                debug!(
-                    capability_count = builtin_cap_ids.len(),
-                    tool_count = collected.tool_definitions.len(),
-                    "Registered harness capability tools (no agent)"
-                );
-            }
-        }
-        registry
+        adapters
+            .build_tool_registry_for_harness(org_id, input.harness_id.uuid())
+            .await?
     };
 
     let event_emitter = AdapterEventEmitter::new(adapters.clone());

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -11,6 +11,7 @@
 use anyhow::Result;
 use everruns_core::ActInput;
 use everruns_core::atoms::{ActAtom, Atom, AtomContext, InputAtom, ReasonAtom};
+use everruns_core::capabilities::{collect_capabilities, is_mcp_capability};
 use everruns_core::events::{
     EventContext, EventRequest, SessionActivatedData, SessionIdledData, TurnCompletedData,
     TurnFailedData, TurnStartedData,
@@ -759,11 +760,37 @@ async fn execute_act_activity<A: WorkerAdapters>(
         "Executing act activity"
     );
 
-    // Build tool registry with defaults and capability tools
+    // Build tool registry with defaults and capability tools.
+    // When agent_id is present, use agent capabilities.
+    // When agent_id is absent, fall back to harness capabilities so that
+    // harness-provided tools (e.g. bash) are still registered.
     let tool_registry = if let Some(agent_id) = input.agent_id {
         adapters.build_tool_registry(agent_id.uuid()).await?
     } else {
-        everruns_core::ToolRegistry::with_defaults()
+        let mut registry = everruns_core::ToolRegistry::with_defaults();
+        let org_id = input.org_id.unwrap_or(1);
+        if let Ok(Some(harness)) = adapters.get_harness(org_id, input.harness_id.uuid()).await {
+            let builtin_cap_ids: Vec<String> = harness
+                .capabilities
+                .iter()
+                .map(|c| c.capability_id().to_string())
+                .filter(|id| !is_mcp_capability(id))
+                .collect();
+
+            if !builtin_cap_ids.is_empty() {
+                let cap_registry = adapters.capability_registry();
+                let collected = collect_capabilities(&builtin_cap_ids, &cap_registry);
+                for tool in collected.tools {
+                    registry.register_boxed(tool);
+                }
+                debug!(
+                    capability_count = builtin_cap_ids.len(),
+                    tool_count = collected.tool_definitions.len(),
+                    "Registered harness capability tools (no agent)"
+                );
+            }
+        }
+        registry
     };
 
     let event_emitter = AdapterEventEmitter::new(adapters.clone());

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -6,7 +6,7 @@
 // This allows a single Worker implementation to work with either backend.
 
 use async_trait::async_trait;
-use everruns_core::capabilities::CapabilityRegistry;
+use everruns_core::capabilities::{CapabilityRegistry, collect_capabilities, is_mcp_capability};
 use everruns_core::error::Result;
 use everruns_core::events::{Event, EventRequest};
 use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
@@ -181,6 +181,37 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
 
     /// Create a tool registry with defaults and agent capabilities
     async fn build_tool_registry(&self, agent_id: Uuid) -> Result<ToolRegistry>;
+
+    /// Create a tool registry with defaults and harness capabilities.
+    ///
+    /// Fallback for sessions without an agent — builds the registry from the
+    /// harness's capability list so harness-provided tools (e.g. bash) are
+    /// available. Without this, only `ToolRegistry::with_defaults()` would be
+    /// used, which doesn't include capability-provided tools.
+    async fn build_tool_registry_for_harness(
+        &self,
+        org_id: i64,
+        harness_id: Uuid,
+    ) -> Result<ToolRegistry> {
+        let mut registry = ToolRegistry::with_defaults();
+        if let Ok(Some(harness)) = self.get_harness(org_id, harness_id).await {
+            let builtin_cap_ids: Vec<String> = harness
+                .capabilities
+                .iter()
+                .map(|c| c.capability_id().to_string())
+                .filter(|id| !is_mcp_capability(id))
+                .collect();
+
+            if !builtin_cap_ids.is_empty() {
+                let cap_registry = self.capability_registry();
+                let collected = collect_capabilities(&builtin_cap_ids, &cap_registry);
+                for tool in collected.tools {
+                    registry.register_boxed(tool);
+                }
+            }
+        }
+        Ok(registry)
+    }
 
     /// Get the session SQL database store (if available).
     /// Default returns None (not all backends support session SQL databases).


### PR DESCRIPTION
## What
Fix "Tool not found: bash" error when running sessions against the Generic Harness without an agent.

## Why
When a session uses a harness without an agent (`agent_id = None`), `execute_act_activity` built the tool registry using only `ToolRegistry::with_defaults()`, which does not include capability-provided tools like `bash`. The Generic Harness defines `virtual_bash` as a capability, but this was never translated into a registered tool implementation at execution time.

**Root cause:** The `if let Some(agent_id)` / `else` branch in both `unified_worker.rs` and `activities.rs` only loaded capabilities from the agent. The else branch fell through to bare defaults, silently dropping all harness capabilities.

**Why it happened:** The Generic Harness type was added in #512, which introduced the first harness with capabilities but no mandatory agent. The tool registration code was written when only agent-based capability loading existed, and the harness fallback path was never implemented.

## How

1. **Trait mitigation:** Added `build_tool_registry_for_harness()` default method to `WorkerAdapters` trait. This provides a single canonical implementation that fetches the harness, extracts its capabilities, and registers them in the tool registry. Future code paths cannot forget to handle this case.

2. **Fix in `unified_worker.rs`:** The `execute_act_activity` function now calls `build_tool_registry_for_harness()` when `agent_id` is `None` instead of falling back to bare defaults.

3. **Fix in `activities.rs`:** The legacy `act_activity` function (used by `durable_worker.rs`) now loads harness capabilities via `GrpcHarnessStore` when `agent_id` is absent.

4. **8 regression tests** across 3 crates:
   - `crates/core`: virtual_bash produces bash tool, Generic Harness cap set produces bash, tool count matches definitions, defaults exclude capability-only tools
   - `crates/server/seed.rs`: Generic Harness caps produce bash in full registry, defaults alone miss bash, collected tools have implementations
   - `crates/core/tools.rs`: defaults exclude capability-only tools (bash, kv_store)

## Risk
- Low
- Change is additive: the agent-based path is unchanged; only the `None` agent path now loads harness capabilities instead of bare defaults. All existing tests pass.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
