### PR TITLE
feat(agents,harnesses): add copy endpoints

### DIFF
--- a/apps/ui/src/__tests__/agent-detail-model.test.tsx
+++ b/apps/ui/src/__tests__/agent-detail-model.test.tsx
@@ -148,6 +148,7 @@ const mockUseCreateSession = jest.fn();
 const mockUseCapabilities = jest.fn();
 const mockUseLlmModels = jest.fn();
 const mockUseExportAgent = jest.fn();
+const mockUseCopyAgent = jest.fn();
 const mockUseHarnesses = jest.fn();
 
 jest.mock("@/hooks", () => ({
@@ -157,6 +158,7 @@ jest.mock("@/hooks", () => ({
   useCapabilities: () => mockUseCapabilities(),
   useLlmModels: () => mockUseLlmModels(),
   useExportAgent: () => mockUseExportAgent(),
+  useCopyAgent: () => mockUseCopyAgent(),
   useHarnesses: () => mockUseHarnesses(),
 }));
 
@@ -186,6 +188,7 @@ describe("AgentDetailPage - LLM Model Display in Sessions List", () => {
     mockUseCapabilities.mockReturnValue({ data: [] });
     mockUseLlmModels.mockReturnValue({ data: mockLlmModels });
     mockUseExportAgent.mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
+    mockUseCopyAgent.mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
     mockUseHarnesses.mockReturnValue({ data: [] });
   });
 
@@ -196,6 +199,20 @@ describe("AgentDetailPage - LLM Model Display in Sessions List", () => {
     expect(screen.getByText("Test Agent")).toBeInTheDocument();
     // Sessions section header should be visible
     expect(screen.getByText("Sessions")).toBeInTheDocument();
+  });
+
+  it("renders copy button", async () => {
+    await renderWithSuspense({ agentId: "agent-1" });
+
+    expect(screen.getByText("Copy")).toBeInTheDocument();
+  });
+
+  it("shows copying state when copy is pending", async () => {
+    mockUseCopyAgent.mockReturnValue({ mutateAsync: jest.fn(), isPending: true });
+
+    await renderWithSuspense({ agentId: "agent-1" });
+
+    expect(screen.getByText("Copying...")).toBeInTheDocument();
   });
 
   it("renders agent details correctly", async () => {
@@ -280,6 +297,7 @@ describe("AgentDetailPage - Default Model Display in Configuration", () => {
     mockUseCapabilities.mockReturnValue({ data: [] });
     mockUseLlmModels.mockReturnValue({ data: mockLlmModels });
     mockUseExportAgent.mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
+    mockUseCopyAgent.mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
     mockUseHarnesses.mockReturnValue({ data: [] });
   });
 

--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -9,6 +9,7 @@ import {
   useCapabilities,
   useLlmModels,
   useExportAgent,
+  useCopyAgent,
 } from "@/hooks";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
@@ -22,7 +23,7 @@ import { ProviderIcon } from "@/components/providers/provider-icon";
 import { SessionCard } from "@/components/session/session-card";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { AgentPreview } from "@/components/agents/agent-preview";
-import { ArrowLeft, Plus, Pencil, Download, Zap, Eye, LayoutDashboard } from "lucide-react";
+import { ArrowLeft, Plus, Pencil, Download, Copy, Zap, Eye, LayoutDashboard } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import type { Capability, LlmModelWithProvider, TokenUsage } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
@@ -59,6 +60,7 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
   const { data: llmModels } = useLlmModels();
   const createSession = useCreateSession();
   const exportAgent = useExportAgent();
+  const copyAgent = useCopyAgent();
   const { data: harnesses } = useHarnesses();
 
   // Create a map of model_id -> model for quick lookups
@@ -101,6 +103,15 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
       console.error("Failed to export agent:", error);
     }
   }, [agent, agentId, exportAgent]);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      const copied = await copyAgent.mutateAsync(agentId);
+      router.push(`/agents/${copied.id}`);
+    } catch (error) {
+      console.error("Failed to copy agent:", error);
+    }
+  }, [agentId, copyAgent, router]);
 
   const getCapabilityInfo = (capabilityId: string): Capability | undefined =>
     allCapabilities?.find((c) => c.id === capabilityId);
@@ -150,6 +161,10 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
           </h1>
         </div>
         <div className="flex gap-2">
+          <Button variant="outline" onClick={handleCopy} disabled={copyAgent.isPending}>
+            <Copy className="w-4 h-4 mr-2" />
+            {copyAgent.isPending ? "Copying..." : "Copy"}
+          </Button>
           <Button variant="outline" onClick={handleExport} disabled={exportAgent.isPending}>
             <Download className="w-4 h-4 mr-2" />
             {exportAgent.isPending ? "Exporting..." : "Export"}

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { use, useMemo } from "react";
-import { useHarness, useCapabilities, useLlmModels, useDeleteHarness } from "@/hooks";
+import { use, useMemo, useCallback } from "react";
+import { useHarness, useCapabilities, useLlmModels, useDeleteHarness, useCopyHarness } from "@/hooks";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
@@ -11,7 +11,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { MarkdownDisplay } from "@/components/ui/prompt-editor";
 import { InlineStreamdownMessage } from "@/components/chat/streamdown-message";
 import { ProviderIcon } from "@/components/providers/provider-icon";
-import { ArrowLeft, Pencil, Trash2 } from "lucide-react";
+import { ArrowLeft, Pencil, Copy, Trash2 } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import type { Capability, LlmModelWithProvider } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
@@ -23,6 +23,7 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
   const { data: allCapabilities } = useCapabilities();
   const { data: llmModels } = useLlmModels();
   const deleteHarness = useDeleteHarness();
+  const copyHarness = useCopyHarness();
 
   const modelMap = useMemo(() => {
     if (!llmModels) return new Map<string, LlmModelWithProvider>();
@@ -49,6 +50,15 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
       console.error("Failed to delete harness:", error);
     }
   };
+
+  const handleCopy = useCallback(async () => {
+    try {
+      const copied = await copyHarness.mutateAsync(harnessId);
+      router.push(`/harnesses/${copied.id}`);
+    } catch (error) {
+      console.error("Failed to copy harness:", error);
+    }
+  }, [harnessId, copyHarness, router]);
 
   if (harnessLoading) {
     return (
@@ -92,6 +102,10 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
           </h1>
         </div>
         <div className="flex gap-2">
+          <Button variant="outline" onClick={handleCopy} disabled={copyHarness.isPending}>
+            <Copy className="w-4 h-4 mr-2" />
+            {copyHarness.isPending ? "Copying..." : "Copy"}
+          </Button>
           <Link href={`/harnesses/${harnessId}/edit`}>
             <Button variant="outline">
               <Pencil className="w-4 h-4 mr-2" />

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { use, useMemo, useCallback } from "react";
-import { useHarness, useCapabilities, useLlmModels, useDeleteHarness, useCopyHarness } from "@/hooks";
+import {
+  useHarness,
+  useCapabilities,
+  useLlmModels,
+  useDeleteHarness,
+  useCopyHarness,
+} from "@/hooks";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";

--- a/apps/ui/src/hooks/use-agents.ts
+++ b/apps/ui/src/hooks/use-agents.ts
@@ -3,6 +3,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
+  copyAgent,
   createAgent,
   deleteAgent,
   exportAgent,
@@ -81,6 +82,17 @@ export function useDeleteAgent() {
 
   return useMutation({
     mutationFn: (agentId: string) => deleteAgent(agentId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.agents.all });
+    },
+  });
+}
+
+export function useCopyAgent() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (agentId: string) => copyAgent(agentId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.all });
     },

--- a/apps/ui/src/hooks/use-harnesses.ts
+++ b/apps/ui/src/hooks/use-harnesses.ts
@@ -3,6 +3,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
+  copyHarness,
   createHarness,
   deleteHarness,
   getHarness,
@@ -67,6 +68,17 @@ export function useUpdateHarness() {
       queryClient.invalidateQueries({
         queryKey: queryKeys.harnesses.detail(harnessId),
       });
+    },
+  });
+}
+
+export function useCopyHarness() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (harnessId: string) => copyHarness(harnessId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.harnesses.all });
     },
   });
 }

--- a/apps/ui/src/lib/api/agents.ts
+++ b/apps/ui/src/lib/api/agents.ts
@@ -65,6 +65,11 @@ export async function importAgent(markdown: string): Promise<Agent> {
   return response.json();
 }
 
+export async function copyAgent(agentId: string): Promise<Agent> {
+  const response = await api.post<Agent>(`/v1/agents/${agentId}/copy`, {});
+  return response.data;
+}
+
 export async function previewAgent(request: PreviewAgentRequest): Promise<AgentPreviewResponse> {
   const response = await api.post<AgentPreviewResponse>("/v1/agents/preview", request);
   return response.data;

--- a/apps/ui/src/lib/api/harnesses.ts
+++ b/apps/ui/src/lib/api/harnesses.ts
@@ -30,3 +30,8 @@ export async function updateHarness(
 export async function deleteHarness(harnessId: string): Promise<void> {
   await api.delete(`/v1/harnesses/${harnessId}`);
 }
+
+export async function copyHarness(harnessId: string): Promise<Harness> {
+  const response = await api.post<Harness>(`/v1/harnesses/${harnessId}/copy`, {});
+  return response.data;
+}

--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -212,6 +212,7 @@ pub fn routes(state: AppState) -> Router {
                 .delete(delete_agent),
         )
         .route("/v1/agents/{agent_id}/export", get(export_agent))
+        .route("/v1/agents/{agent_id}/copy", post(copy_agent))
         .with_state(state)
 }
 
@@ -412,6 +413,48 @@ pub async fn delete_agent(
             }),
         ))
     }
+}
+
+/// POST /v1/agents/{agent_id}/copy - Copy an agent
+///
+/// Creates a new agent with the same configuration as the source agent.
+/// The new agent's name will be "{original name} (copy)".
+#[utoipa::path(
+    post,
+    path = "/v1/agents/{agent_id}/copy",
+    params(
+        ("agent_id" = String, Path, description = "Source agent ID to copy")
+    ),
+    responses(
+        (status = 201, description = "Agent copied successfully", body = Agent),
+        (status = 400, description = "Invalid agent ID", body = ErrorResponse),
+        (status = 404, description = "Source agent not found", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "agents"
+)]
+pub async fn copy_agent(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(agent_id): Path<String>,
+) -> Result<(StatusCode, Json<Agent>), (StatusCode, Json<ErrorResponse>)> {
+    let agent_id: AgentId = agent_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid agent ID: {}", e),
+            }),
+        )
+    })?;
+
+    let agent = state
+        .service
+        .copy(org.org_id, &agent_id.to_string())
+        .await
+        .log_internal_error_json("copy agent")?
+        .ok_or_not_found_json("Agent")?;
+
+    Ok((StatusCode::CREATED, Json(agent)))
 }
 
 /// PUT /v1/agents/{agent_id} - Create or update agent (upsert)

--- a/crates/server/src/api/harnesses.rs
+++ b/crates/server/src/api/harnesses.rs
@@ -125,6 +125,7 @@ pub fn routes(state: AppState) -> Router {
                 .patch(update_harness)
                 .delete(delete_harness),
         )
+        .route("/v1/harnesses/{harness_id}/copy", post(copy_harness))
         .with_state(state)
 }
 
@@ -318,6 +319,48 @@ pub async fn delete_harness(
             }),
         ))
     }
+}
+
+/// POST /v1/harnesses/{harness_id}/copy - Copy a harness
+///
+/// Creates a new harness with the same configuration as the source harness.
+/// The new harness's name will be "{original name} (copy)".
+#[utoipa::path(
+    post,
+    path = "/v1/harnesses/{harness_id}/copy",
+    params(
+        ("harness_id" = String, Path, description = "Source harness ID to copy")
+    ),
+    responses(
+        (status = 201, description = "Harness copied successfully", body = Harness),
+        (status = 400, description = "Invalid harness ID", body = ErrorResponse),
+        (status = 404, description = "Source harness not found", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "harnesses"
+)]
+pub async fn copy_harness(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(harness_id): Path<String>,
+) -> Result<(StatusCode, Json<Harness>), (StatusCode, Json<ErrorResponse>)> {
+    let harness_id: HarnessId = harness_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid harness ID: {}", e),
+            }),
+        )
+    })?;
+
+    let harness = state
+        .service
+        .copy(org.org_id, harness_id.uuid())
+        .await
+        .log_internal_error_json("copy harness")?
+        .ok_or_not_found_json("Harness")?;
+
+    Ok((StatusCode::CREATED, Json(harness)))
 }
 
 /// POST /v1/harnesses/preview

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -92,6 +92,7 @@ use utoipa::OpenApi;
         // Agents - additional
         api::agents::preview_agent,
         api::agents::upsert_agent,
+        api::agents::copy_agent,
         // LLM Providers - additional
         api::llm_providers::sync_models,
         // Users - additional

--- a/crates/server/src/services/agent.rs
+++ b/crates/server/src/services/agent.rs
@@ -182,6 +182,29 @@ impl AgentService {
         }
     }
 
+    /// Copy an agent by public_id. Creates a new agent with "{name} (copy)" and
+    /// duplicates description, system_prompt, default_model_id, tags, capabilities, tools.
+    pub async fn copy(&self, org_id: i64, public_id: &str) -> Result<Option<Agent>> {
+        let source = self.get_by_public_id(org_id, public_id).await?;
+        let Some(source) = source else {
+            return Ok(None);
+        };
+
+        let req = CreateAgentRequest {
+            id: None,
+            name: format!("{} (copy)", source.name),
+            description: source.description,
+            system_prompt: source.system_prompt,
+            default_model_id: source.default_model_id,
+            tags: source.tags,
+            capabilities: source.capabilities,
+            tools: source.tools,
+        };
+
+        let agent = self.create(org_id, None, req).await?;
+        Ok(Some(agent))
+    }
+
     pub async fn delete(&self, org_id: i64, public_id: &str) -> Result<bool> {
         // Resolve public_id -> internal AgentId
         let row = self.db.get_agent_by_public_id(org_id, public_id).await?;

--- a/crates/server/src/services/harness.rs
+++ b/crates/server/src/services/harness.rs
@@ -128,6 +128,27 @@ impl HarnessService {
         }
     }
 
+    /// Copy a harness by UUID. Creates a new harness with "{name} (copy)" and
+    /// duplicates description, system_prompt, default_model_id, tags, capabilities.
+    pub async fn copy(&self, org_id: i64, id: Uuid) -> Result<Option<Harness>> {
+        let source = self.get(org_id, id).await?;
+        let Some(source) = source else {
+            return Ok(None);
+        };
+
+        let req = CreateHarnessRequest {
+            name: format!("{} (copy)", source.name),
+            description: source.description,
+            system_prompt: source.system_prompt,
+            default_model_id: source.default_model_id,
+            tags: source.tags,
+            capabilities: source.capabilities,
+        };
+
+        let harness = self.create(org_id, req).await?;
+        Ok(Some(harness))
+    }
+
     pub async fn delete(&self, org_id: i64, id: Uuid) -> Result<bool> {
         self.db
             .delete_harness(org_id, HarnessId::from_uuid(id))

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -937,7 +937,6 @@ async fn test_copy_agent() {
     assert_eq!(copied.capabilities[0].capability_id(), "current_time");
     // New ID
     assert_ne!(copied.public_id, agent.public_id);
-    assert_ne!(copied.internal_id, agent.internal_id);
 }
 
 #[tokio::test]

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -896,6 +896,147 @@ async fn test_create_session_with_generic_harness() {
 }
 
 // ============================================
+// Copy Agent Tests
+// ============================================
+
+#[tokio::test]
+async fn test_copy_agent() {
+    let server = TestServer::new().await;
+
+    // Create an agent with capabilities and tags
+    let agent: Agent = server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": "Original Agent",
+                "description": "Original description",
+                "system_prompt": "You are helpful",
+                "tags": ["tag1", "tag2"],
+                "capabilities": [
+                    {"ref": "current_time", "config": {}}
+                ]
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    // Copy the agent
+    let copied: Agent = server
+        .post(&format!("/v1/agents/{}/copy", agent.public_id), json!({}))
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    // Verify copy
+    assert_eq!(copied.name, "Original Agent (copy)");
+    assert_eq!(copied.description.as_deref(), Some("Original description"));
+    assert_eq!(copied.system_prompt, "You are helpful");
+    assert_eq!(copied.tags, vec!["tag1", "tag2"]);
+    assert_eq!(copied.capabilities.len(), 1);
+    assert_eq!(copied.capabilities[0].capability_id(), "current_time");
+    // New ID
+    assert_ne!(copied.public_id, agent.public_id);
+    assert_ne!(copied.internal_id, agent.internal_id);
+}
+
+#[tokio::test]
+async fn test_copy_agent_not_found() {
+    let server = TestServer::new().await;
+
+    server
+        .post(
+            "/v1/agents/agent_00000000000000000000000000000099/copy",
+            json!({}),
+        )
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+}
+
+// ============================================
+// Copy Harness Tests
+// ============================================
+
+#[tokio::test]
+async fn test_copy_harness() {
+    let server = TestServer::new().await;
+
+    // Create a harness with capabilities and tags
+    let harness: Harness = server
+        .post(
+            "/v1/harnesses",
+            json!({
+                "name": "Original Harness",
+                "description": "Original harness description",
+                "system_prompt": "Harness prompt",
+                "tags": ["harness-tag"],
+                "capabilities": [
+                    {"ref": "current_time", "config": {}}
+                ]
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    // Copy the harness
+    let copied: Harness = server
+        .post(&format!("/v1/harnesses/{}/copy", harness.id), json!({}))
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    // Verify copy
+    assert_eq!(copied.name, "Original Harness (copy)");
+    assert_eq!(
+        copied.description.as_deref(),
+        Some("Original harness description")
+    );
+    assert_eq!(copied.system_prompt, "Harness prompt");
+    assert_eq!(copied.tags, vec!["harness-tag"]);
+    assert_eq!(copied.capabilities.len(), 1);
+    assert_eq!(copied.capabilities[0].capability_id(), "current_time");
+    // New ID
+    assert_ne!(copied.id, harness.id);
+}
+
+#[tokio::test]
+async fn test_copy_harness_not_found() {
+    let server = TestServer::new().await;
+
+    server
+        .post(
+            "/v1/harnesses/harness_00000000000000000000000000000099/copy",
+            json!({}),
+        )
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_copy_seed_generic_harness() {
+    let server = TestServer::new().await;
+
+    // Copy the seed Generic harness
+    let copied: Harness = server
+        .post(
+            &format!("/v1/harnesses/{}/copy", SEED_GENERIC_HARNESS_ID),
+            json!({}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    assert_eq!(copied.name, "Generic (copy)");
+    // Generic harness has 4 capabilities
+    assert_eq!(
+        copied.capabilities.len(),
+        4,
+        "Copied harness should have same 4 capabilities"
+    );
+}
+
+// ============================================
 // Capabilities Tests
 // ============================================
 

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -397,6 +397,69 @@
         }
       }
     },
+    "/v1/agents/{agent_id}/copy": {
+      "post": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "POST /v1/agents/{agent_id}/copy - Copy an agent",
+        "description": "Creates a new agent with the same configuration as the source agent.\nThe new agent's name will be \"{original name} (copy)\".",
+        "operationId": "copy_agent",
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "path",
+            "description": "Source agent ID to copy",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Agent copied successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Agent"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid agent ID",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Source agent not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/agents/{agent_id}/export": {
       "get": {
         "tags": [

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -47,6 +47,7 @@ See [authentication.md](authentication.md) for full authentication specification
 | POST | `/v1/agents/import` | Import agent from file content |
 | GET | `/v1/agents/{id}/export` | Export agent as Markdown |
 | POST | `/v1/agents/preview` | Preview final agent shape |
+| POST | `/v1/agents/{id}/copy` | Copy agent (new ID, "{name} (copy)") |
 
 #### Agent Preview
 
@@ -85,6 +86,19 @@ The response shows:
 **Input Validation:**
 
 All agent create/update/import endpoints enforce input size limits as last-resort protection against abuse. See [models.md](models.md#agent) for limit details. Validation failures return `400 Bad Request` with generic message "Input exceeds allowed limits".
+
+### Harnesses
+
+Harnesses define the base environment and capabilities for sessions. See [harness-types.md](harness-types.md) for built-in types.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/v1/harnesses` | Create harness |
+| GET | `/v1/harnesses` | List harnesses |
+| GET | `/v1/harnesses/{id}` | Get harness |
+| PATCH | `/v1/harnesses/{id}` | Update harness |
+| DELETE | `/v1/harnesses/{id}` | Delete harness |
+| POST | `/v1/harnesses/{id}/copy` | Copy harness (new ID, "{name} (copy)") |
 
 ### Sessions
 


### PR DESCRIPTION
## What
Add copy functionality for both agents and harnesses. Users can duplicate an existing agent or harness with a single click.

## Why
Users need to create variations of existing agents/harnesses without manually re-entering all configuration (system prompt, capabilities, tags, etc.).

## How
- **Backend:** `POST /v1/agents/{id}/copy` and `POST /v1/harnesses/{id}/copy` endpoints. Service methods fetch the source, build a `CreateRequest` with `"{name} (copy)"`, and delegate to existing `create()`. All fields are copied: description, system_prompt, default_model_id, tags, capabilities, tools (agents only). New IDs are auto-generated.
- **Frontend:** API client functions, React Query hooks (`useCopyAgent`, `useCopyHarness`), and Copy buttons on both detail pages. Clicking Copy navigates to the new resource.
- **OpenAPI:** `copy_agent` registered.

## Risk
- Low
- Only additive new endpoints; no changes to existing behavior

## Checklist
- [x] Tests added or updated
  - 5 backend integration tests (copy agent, copy harness, 404 cases, seed harness copy)
  - 2 UI unit tests (copy button render, pending state)
- [x] Backward compatibility considered (purely additive, no breaking changes)
- [x] Specs updated (apis.md: harness CRUD table + copy endpoints for both)
- [x] Pre-push checks pass (fmt, clippy, UI lint)
- [x] Smoke tested (both endpoints verified via curl)