### PR TITLE
fix(worker): increase control-plane connection timeout from 5s to 30s

### DIFF
--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -120,6 +120,8 @@ pub struct DurableWorkerConfig {
     pub heartbeat_interval: Duration,
     /// gRPC address for control-plane communication
     pub grpc_address: String,
+    /// Timeout for initial connection to control-plane gRPC
+    pub connect_timeout: Duration,
 }
 
 impl Default for DurableWorkerConfig {
@@ -135,6 +137,7 @@ impl Default for DurableWorkerConfig {
             poll_interval: Duration::from_millis(100), // Fallback when push notifications unavailable
             heartbeat_interval: Duration::from_secs(10),
             grpc_address: "127.0.0.1:9001".to_string(),
+            connect_timeout: Duration::from_secs(30),
         }
     }
 }
@@ -153,10 +156,16 @@ impl DurableWorkerConfig {
             .and_then(|s| s.parse().ok())
             .unwrap_or(10);
 
+        let connect_timeout_secs: u64 = std::env::var("GRPC_CONNECT_TIMEOUT")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(30);
+
         Self {
             worker_id,
             grpc_address,
             max_concurrent_tasks: max_concurrent,
+            connect_timeout: Duration::from_secs(connect_timeout_secs),
             ..Default::default()
         }
     }
@@ -189,7 +198,9 @@ impl DurableWorker {
             "Initializing durable worker (gRPC mode)"
         );
 
-        let store = GrpcDurableStore::connect(&config.grpc_address).await?;
+        let store =
+            GrpcDurableStore::connect_with_timeout(&config.grpc_address, config.connect_timeout)
+                .await?;
         let grpc_address = config.grpc_address.clone();
 
         let (shutdown_tx, shutdown_rx) = watch::channel(false);

--- a/crates/worker/src/grpc_durable_store.rs
+++ b/crates/worker/src/grpc_durable_store.rs
@@ -3,6 +3,8 @@
 // Decision: No direct database access from workers - all operations go through gRPC
 // Decision: Supports push-based task notifications with polling fallback
 
+use std::time::Duration;
+
 use anyhow::Result;
 use everruns_internal_protocol::proto::{
     self, CheckCircuitBreakerRequest, ClaimDurableTasksRequest, CompleteDurableTaskRequest,
@@ -60,16 +62,18 @@ pub struct GrpcDurableStore {
 
 impl GrpcDurableStore {
     /// Connect to the control-plane gRPC service with retry logic.
-    /// Retries with exponential backoff for up to 5 seconds total.
-    /// Fails fast to allow orchestrator/script-level restarts.
+    /// Retries with exponential backoff for up to `connect_timeout` (default 30s).
     pub async fn connect(address: &str) -> Result<Self> {
-        use std::time::Duration;
+        Self::connect_with_timeout(address, Duration::from_secs(30)).await
+    }
+
+    /// Connect with explicit timeout. Used by tests to avoid long waits.
+    pub async fn connect_with_timeout(address: &str, max_duration: Duration) -> Result<Self> {
         use tokio::time::sleep;
 
         let endpoint = format!("http://{}", address);
-        let max_duration = Duration::from_secs(5);
         let initial_backoff = Duration::from_millis(100);
-        let max_backoff = Duration::from_secs(1);
+        let max_backoff = Duration::from_secs(2);
 
         let start = std::time::Instant::now();
         let mut backoff = initial_backoff;
@@ -621,8 +625,9 @@ mod tests {
     async fn test_connect_fails_after_timeout_on_unavailable_server() {
         // Verify connection fails with clear error after retry timeout
         // when control-plane is unavailable
+        let timeout = Duration::from_secs(5);
         let start = std::time::Instant::now();
-        let result = GrpcDurableStore::connect("127.0.0.1:19999").await;
+        let result = GrpcDurableStore::connect_with_timeout("127.0.0.1:19999", timeout).await;
 
         assert!(result.is_err());
         let elapsed = start.elapsed();


### PR DESCRIPTION
## What
Increase the worker→control-plane gRPC connection timeout from 5s to 30s and make it configurable via `GRPC_CONNECT_TIMEOUT` env var.

## Why
During `just start-all`, the worker often fails with "Failed to connect to control-plane after 5.5s (9 attempts): transport error" because the gRPC server hasn't finished binding yet. The 5s timeout was too aggressive for startup scenarios.

## How
- `GrpcDurableStore::connect()` default timeout: 5s → 30s
- Max backoff between retries: 1s → 2s (fewer log-spam retries)
- Extracted `connect_with_timeout()` so tests use a short timeout (no 30s waits)
- Added `connect_timeout` field to `DurableWorkerConfig` with `GRPC_CONNECT_TIMEOUT` env var override
- Existing test updated to use `connect_with_timeout` with 5s explicit timeout

## Risk
- Low
- No behavior change for already-running systems (connects on first attempt). Only affects startup race condition where control-plane is slow to bind.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered