### PR TITLE
feat(ui): reorganize sidebar navigation

### DIFF
--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -69,9 +69,7 @@ const buildingBlocksNavigation = [
   { name: "Capabilities", href: "/capabilities", icon: Puzzle },
 ];
 
-const bottomNavigation = [
-  { name: "Settings", href: "/settings", icon: Settings },
-];
+const bottomNavigation = [{ name: "Settings", href: "/settings", icon: Settings }];
 
 const durableNavigation = [
   { name: "Overview", href: "/durable", icon: Cog, exact: true },

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -57,13 +57,19 @@ import {
 
 const isDev = process.env.NODE_ENV === "development";
 
-const navigation = [
+const topNavigation = [
   { name: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
+  { name: "Sessions", href: "/sessions", icon: MessageSquare },
+];
+
+const buildingBlocksNavigation = [
   { name: "Harnesses", href: "/harnesses", icon: Shield },
   { name: "Agents", href: "/agents", icon: Boxes },
   { name: "Skills", href: "/skills", icon: BookOpen },
-  { name: "Sessions", href: "/sessions", icon: MessageSquare },
   { name: "Capabilities", href: "/capabilities", icon: Puzzle },
+];
+
+const bottomNavigation = [
   { name: "Settings", href: "/settings", icon: Settings },
 ];
 
@@ -210,7 +216,50 @@ export function Sidebar() {
 
       {/* Navigation */}
       <nav className="flex-1 space-y-1 py-4">
-        {navigation.map((item) => {
+        {topNavigation.map((item) => {
+          const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
+          return (
+            <Link
+              key={item.name}
+              href={item.href}
+              className={cn(
+                "flex items-center gap-3 px-3 py-2 text-sm font-medium transition-colors",
+                isActive
+                  ? "bg-accent/10 text-accent-foreground border-l-2 border-accent"
+                  : "text-muted-foreground hover:bg-muted hover:text-foreground border-l-2 border-transparent",
+              )}
+            >
+              <item.icon className="h-5 w-5" />
+              {item.name}
+            </Link>
+          );
+        })}
+
+        {/* Building Blocks section */}
+        <div className="my-3 border-t" />
+        <p className="px-3 py-1 text-xs font-medium text-muted-foreground">Building Blocks</p>
+        {buildingBlocksNavigation.map((item) => {
+          const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
+          return (
+            <Link
+              key={item.name}
+              href={item.href}
+              className={cn(
+                "flex items-center gap-3 px-3 py-2 text-sm font-medium transition-colors",
+                isActive
+                  ? "bg-accent/10 text-accent-foreground border-l-2 border-accent"
+                  : "text-muted-foreground hover:bg-muted hover:text-foreground border-l-2 border-transparent",
+              )}
+            >
+              <item.icon className="h-5 w-5" />
+              {item.name}
+            </Link>
+          );
+        })}
+
+        {/* Settings */}
+        <div className="my-3 border-t" />
+        {bottomNavigation.map((item) => {
           const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
           return (
             <Link


### PR DESCRIPTION
## Summary
- Reorganize sidebar navigation into logical sections: Dashboard/Sessions at top, Building Blocks (Harnesses, Agents, Skills, Capabilities) grouped under a section header, and Settings separated below
- Matches the requested navigation structure for better discoverability

## Test plan
- [ ] Verify sidebar renders with correct order: Dashboard, Sessions, Building Blocks section, Settings
- [ ] Verify active state highlighting works for all nav items
- [ ] Verify Durable Execution and Dev sections still render correctly