### PR TITLE
feat(connections): add Daytona user connection with API key support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,6 +1436,7 @@ dependencies = [
  "hex",
  "http-body-util",
  "image",
+ "inventory",
  "jsonwebtoken",
  "parking_lot",
  "prost",

--- a/apps/ui/src/app/(main)/settings/connections/page.tsx
+++ b/apps/ui/src/app/(main)/settings/connections/page.tsx
@@ -5,47 +5,57 @@ import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useUserConnections, useDeleteUserConnection } from "@/hooks/use-user-connections";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  useUserConnections,
+  useDeleteUserConnection,
+  useConnectionProviders,
+  useCreateApiKeyConnection,
+} from "@/hooks/use-user-connections";
 import { getBackendUrl } from "@/lib/api/client";
-import { ExternalLink, Github, LinkIcon, Trash2, Check } from "lucide-react";
+import { ExternalLink, Github, LinkIcon, Trash2, Check, Cloud, AlertCircle } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
-import type { UserConnection } from "@/lib/api/types";
+import type { UserConnection, ConnectionProvider as ConnectionProviderType } from "@/lib/api/types";
 
-/** Provider metadata for display */
-const providers: Record<string, { name: string; icon: LucideIcon; description: string }> = {
-  github: {
-    name: "GitHub",
-    icon: Github,
-    description: "Install the GitHub App to grant access to selected repositories",
-  },
+/** Icon mapping — lucide icon name to component */
+const iconMap: Record<string, LucideIcon> = {
+  github: Github,
+  cloud: Cloud,
 };
 
-function ProviderIcon({ provider, className }: { provider: string; className?: string }) {
-  const meta = providers[provider];
-  if (meta) {
-    const Icon = meta.icon;
-    return <Icon className={className} />;
-  }
-  return <LinkIcon className={className} />;
+function ProviderIcon({ iconName, className }: { iconName: string; className?: string }) {
+  const Icon = iconMap[iconName] ?? LinkIcon;
+  return <Icon className={className} />;
 }
 
 function ConnectionRow({
   connection,
+  provider,
   onDisconnect,
   isDisconnecting,
 }: {
   connection: UserConnection;
+  provider?: ConnectionProviderType;
   onDisconnect: (provider: string) => void;
   isDisconnecting: boolean;
 }) {
-  const meta = providers[connection.provider];
-  const displayName = meta?.name ?? connection.provider;
+  const displayName = provider?.display_name ?? connection.provider;
+  const icon = provider?.icon ?? "link";
 
   return (
     <div className="flex items-center justify-between p-4 border rounded-lg">
       <div className="flex items-center gap-3">
-        <ProviderIcon provider={connection.provider} className="h-5 w-5" />
+        <ProviderIcon iconName={icon} className="h-5 w-5" />
         <div>
           <div className="font-medium flex items-center gap-2">
             {displayName}
@@ -77,55 +87,176 @@ function ConnectionRow({
 
 function AvailableProviderRow({
   provider,
-  meta,
+  onConnectApiKey,
 }: {
-  provider: string;
-  meta: { name: string; icon: LucideIcon; description: string };
+  provider: ConnectionProviderType;
+  onConnectApiKey: (provider: ConnectionProviderType) => void;
 }) {
   const handleConnect = () => {
-    // Navigate to GitHub App installation flow through the API proxy
-    window.location.href = `${getBackendUrl()}/v1/user/connections/${provider}/authorize`;
+    if (provider.connection_type === "oauth") {
+      window.location.href = `${getBackendUrl()}/v1/user/connections/${provider.provider_id}/authorize`;
+    } else {
+      onConnectApiKey(provider);
+    }
   };
 
   return (
     <div className="flex items-center justify-between p-4 border rounded-lg">
       <div className="flex items-center gap-3">
-        <ProviderIcon provider={provider} className="h-5 w-5" />
+        <ProviderIcon iconName={provider.icon} className="h-5 w-5" />
         <div>
-          <div className="font-medium">{meta.name}</div>
-          <div className="text-sm text-muted-foreground">{meta.description}</div>
+          <div className="font-medium">{provider.display_name}</div>
+          <div className="text-sm text-muted-foreground">{provider.description}</div>
         </div>
       </div>
       <Button variant="outline" size="sm" onClick={handleConnect}>
-        <ExternalLink className="h-4 w-4 mr-1" />
-        Install
+        {provider.connection_type === "oauth" ? (
+          <ExternalLink className="h-4 w-4 mr-1" />
+        ) : (
+          <LinkIcon className="h-4 w-4 mr-1" />
+        )}
+        Connect
       </Button>
     </div>
   );
 }
 
+/** Dialog for entering an API key */
+function ApiKeyDialog({
+  provider,
+  open,
+  onOpenChange,
+}: {
+  provider: ConnectionProviderType | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [formValues, setFormValues] = useState<Record<string, string>>({});
+  const [error, setError] = useState<string | null>(null);
+  const createConnection = useCreateApiKeyConnection();
+
+  // Reset form when dialog opens/closes
+  useEffect(() => {
+    if (open) {
+      setFormValues({});
+      setError(null);
+    }
+  }, [open]);
+
+  if (!provider?.form_schema) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    const apiKey = formValues["api_key"] ?? "";
+    if (!apiKey.trim()) {
+      setError("API key is required");
+      return;
+    }
+
+    try {
+      await createConnection.mutateAsync({
+        provider: provider.provider_id,
+        apiKey,
+      });
+      onOpenChange(false);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to save connection";
+      // Extract error message from API response if available
+      const apiError = (err as { response?: { data?: string } })?.response?.data;
+      setError(typeof apiError === "string" ? apiError : message);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <ProviderIcon iconName={provider.icon} className="h-5 w-5" />
+            Connect {provider.display_name}
+          </DialogTitle>
+          <DialogDescription>{provider.description}</DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit}>
+          {/* Instructions */}
+          <div className="text-sm text-muted-foreground whitespace-pre-line mb-4 leading-relaxed">
+            {provider.form_schema.instructions_markdown}
+          </div>
+
+          {/* Form fields */}
+          <div className="space-y-4 mb-4">
+            {provider.form_schema.fields.map((field) => (
+              <div key={field.name} className="space-y-2">
+                <Label htmlFor={field.name}>{field.label}</Label>
+                <Input
+                  id={field.name}
+                  type={field.field_type}
+                  required={field.required}
+                  placeholder={field.placeholder}
+                  value={formValues[field.name] ?? ""}
+                  onChange={(e) =>
+                    setFormValues((prev) => ({
+                      ...prev,
+                      [field.name]: e.target.value,
+                    }))
+                  }
+                  autoComplete="off"
+                />
+                {field.help_text && (
+                  <p className="text-xs text-muted-foreground">{field.help_text}</p>
+                )}
+              </div>
+            ))}
+          </div>
+
+          {/* Error */}
+          {error && (
+            <div className="flex items-center gap-2 text-destructive text-sm mb-4">
+              <AlertCircle className="h-4 w-4 flex-shrink-0" />
+              {error}
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={createConnection.isPending}>
+              {createConnection.isPending ? "Validating..." : "Connect"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 export default function ConnectionsPage() {
   const { data: connections = [], isLoading, error } = useUserConnections();
+  const { data: providers = [] } = useConnectionProviders();
   const deleteConnection = useDeleteUserConnection();
   const searchParams = useSearchParams();
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [apiKeyProvider, setApiKeyProvider] = useState<ConnectionProviderType | null>(null);
 
   // Show success toast when redirected back from OAuth
   useEffect(() => {
     const connected = searchParams.get("connected");
     if (connected) {
-      const meta = providers[connected];
-      setSuccessMessage(`${meta?.name ?? connected} connected successfully`);
-      // Clear URL param without reload
+      const provider = providers.find((p) => p.provider_id === connected);
+      setSuccessMessage(`${provider?.display_name ?? connected} connected successfully`);
       window.history.replaceState({}, "", "/settings/connections");
       const timer = setTimeout(() => setSuccessMessage(null), 4000);
       return () => clearTimeout(timer);
     }
-  }, [searchParams]);
+  }, [searchParams, providers]);
 
   const handleDisconnect = async (provider: string) => {
-    const meta = providers[provider];
-    const name = meta?.name ?? provider;
+    const meta = providers.find((p) => p.provider_id === provider);
+    const name = meta?.display_name ?? provider;
     if (
       confirm(
         `Disconnect ${name}? New sessions will no longer have access to your ${name} account.`,
@@ -135,11 +266,12 @@ export default function ConnectionsPage() {
     }
   };
 
-  // Determine which providers are not yet connected
+  // Providers not yet connected
   const connectedProviders = new Set(connections.map((c) => c.provider));
-  const availableProviders = Object.entries(providers).filter(
-    ([key]) => !connectedProviders.has(key),
-  );
+  const availableProviders = providers.filter((p) => !connectedProviders.has(p.provider_id));
+
+  // Build provider lookup for connected rows
+  const providerMap = new Map(providers.map((p) => [p.provider_id, p]));
 
   return (
     <div className="space-y-8">
@@ -184,6 +316,7 @@ export default function ConnectionsPage() {
               <ConnectionRow
                 key={conn.provider}
                 connection={conn}
+                provider={providerMap.get(conn.provider)}
                 onDisconnect={handleDisconnect}
                 isDisconnecting={deleteConnection.isPending}
               />
@@ -198,16 +331,29 @@ export default function ConnectionsPage() {
           <div className="mb-4">
             <h2 className="text-lg font-semibold">Available</h2>
             <p className="text-sm text-muted-foreground">
-              Connect additional accounts to enable repository access in sessions.
+              Connect additional accounts to enable access in sessions.
             </p>
           </div>
           <div className="space-y-2">
-            {availableProviders.map(([key, meta]) => (
-              <AvailableProviderRow key={key} provider={key} meta={meta} />
+            {availableProviders.map((provider) => (
+              <AvailableProviderRow
+                key={provider.provider_id}
+                provider={provider}
+                onConnectApiKey={setApiKeyProvider}
+              />
             ))}
           </div>
         </section>
       )}
+
+      {/* API Key entry dialog */}
+      <ApiKeyDialog
+        provider={apiKeyProvider}
+        open={apiKeyProvider !== null}
+        onOpenChange={(open) => {
+          if (!open) setApiKeyProvider(null);
+        }}
+      />
     </div>
   );
 }

--- a/apps/ui/src/hooks/use-user-connections.ts
+++ b/apps/ui/src/hooks/use-user-connections.ts
@@ -1,7 +1,12 @@
 "use client";
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { getUserConnections, deleteUserConnection } from "@/lib/api/user-connections";
+import {
+  getUserConnections,
+  getConnectionProviders,
+  createApiKeyConnection,
+  deleteUserConnection,
+} from "@/lib/api/user-connections";
 import { queryKeys } from "@/lib/query-keys";
 
 export function useUserConnections() {
@@ -12,13 +17,37 @@ export function useUserConnections() {
   });
 }
 
+export function useConnectionProviders() {
+  return useQuery({
+    queryKey: ["connection-providers"],
+    queryFn: () => getConnectionProviders(),
+    staleTime: 60000,
+  });
+}
+
+export function useCreateApiKeyConnection() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ provider, apiKey }: { provider: string; apiKey: string }) =>
+      createApiKeyConnection(provider, apiKey),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.userConnections.all,
+      });
+    },
+  });
+}
+
 export function useDeleteUserConnection() {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (provider: string) => deleteUserConnection(provider),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.userConnections.all });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.userConnections.all,
+      });
     },
   });
 }

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -1540,7 +1540,31 @@ export interface TriggerResponse {
 
 export interface UserConnection {
   provider: string;
+  connection_type: string;
   provider_username?: string;
   scopes?: string;
   connected_at: string;
+}
+
+export interface ConnectionProvider {
+  provider_id: string;
+  display_name: string;
+  description: string;
+  icon: string;
+  connection_type: "oauth" | "api_key";
+  form_schema?: ConnectionFormSchema;
+}
+
+export interface ConnectionFormSchema {
+  fields: ConnectionFormField[];
+  instructions_markdown: string;
+}
+
+export interface ConnectionFormField {
+  name: string;
+  label: string;
+  field_type: "password" | "text" | "url";
+  required: boolean;
+  placeholder?: string;
+  help_text?: string;
 }

--- a/apps/ui/src/lib/api/user-connections.ts
+++ b/apps/ui/src/lib/api/user-connections.ts
@@ -2,10 +2,25 @@
 // User-scoped (not org-scoped) — connections represent user's identity
 
 import { api } from "./client";
-import type { UserConnection } from "./types";
+import type { UserConnection, ConnectionProvider } from "./types";
 
 export async function getUserConnections(): Promise<UserConnection[]> {
   const response = await api.get<UserConnection[]>("/v1/user/connections");
+  return response.data;
+}
+
+export async function getConnectionProviders(): Promise<ConnectionProvider[]> {
+  const response = await api.get<ConnectionProvider[]>("/v1/user/connections/providers");
+  return response.data;
+}
+
+export async function createApiKeyConnection(
+  provider: string,
+  apiKey: string,
+): Promise<UserConnection> {
+  const response = await api.post<UserConnection>(`/v1/user/connections/${provider}`, {
+    api_key: apiKey,
+  });
   return response.data;
 }
 

--- a/crates/core/src/connection_provider.rs
+++ b/crates/core/src/connection_provider.rs
@@ -1,0 +1,130 @@
+// Connection Provider Plugin System
+//
+// Decision: Parallel to IntegrationPlugin, allows integration crates to register
+// connection providers via inventory::submit! without core knowing about them.
+// Decision: Form schema is backend-driven — providers define their own UI fields
+// and instructions, frontend renders generically.
+// Decision: Validation is async — providers can call external APIs to verify credentials.
+
+use async_trait::async_trait;
+use serde::Serialize;
+
+// ============================================================================
+// Plugin Registration
+// ============================================================================
+
+/// Plugin registration point for connection provider crates.
+///
+/// Integration crates use `inventory::submit!` to register their connection
+/// providers. The server discovers them at runtime to serve form schemas
+/// and handle credential submission.
+///
+/// # Example
+///
+/// ```ignore
+/// inventory::submit! {
+///     ConnectionProviderPlugin {
+///         experimental_only: true,
+///         factory: || Box::new(DaytonaConnectionProvider),
+///     }
+/// }
+/// ```
+pub struct ConnectionProviderPlugin {
+    /// If true, only registered when experimental features are enabled.
+    pub experimental_only: bool,
+    /// Factory function that creates the provider instance.
+    pub factory: fn() -> Box<dyn ConnectionProvider>,
+}
+
+inventory::collect!(ConnectionProviderPlugin);
+
+// ============================================================================
+// ConnectionProvider Trait
+// ============================================================================
+
+/// How the user provides credentials for this connection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectionType {
+    /// OAuth flow (redirect-based, e.g. GitHub)
+    OAuth,
+    /// Direct API key entry (form-based, e.g. Daytona)
+    ApiKey,
+}
+
+/// A connection provider that can validate credentials and describe its UI form.
+#[async_trait]
+pub trait ConnectionProvider: Send + Sync {
+    /// Unique provider identifier (e.g. "daytona"). Must match `user_connections.provider`.
+    fn provider_id(&self) -> &str;
+
+    /// Human-readable name (e.g. "Daytona").
+    fn display_name(&self) -> &str;
+
+    /// Short description for the connections UI.
+    fn description(&self) -> &str;
+
+    /// Lucide icon name (e.g. "cloud", "github").
+    fn icon(&self) -> &str;
+
+    /// Whether this provider uses OAuth or direct API key entry.
+    fn connection_type(&self) -> ConnectionType;
+
+    /// Form schema for API key providers. OAuth providers return None.
+    fn form_schema(&self) -> Option<ConnectionFormSchema>;
+
+    /// Validate a credential before saving. Called for API key providers.
+    /// Returns Ok with optional metadata on success, Err with user-facing message on failure.
+    async fn validate(&self, credential: &str) -> Result<ConnectionValidation, String>;
+}
+
+// ============================================================================
+// Form Schema Types
+// ============================================================================
+
+/// Describes the form fields and instructions for an API key connection.
+#[derive(Debug, Clone, Serialize)]
+pub struct ConnectionFormSchema {
+    /// Input fields to render.
+    pub fields: Vec<FormField>,
+    /// Markdown instructions shown above the form (how to get the key, etc.).
+    pub instructions_markdown: String,
+}
+
+/// A single form field.
+#[derive(Debug, Clone, Serialize)]
+pub struct FormField {
+    /// Field name used as the key when submitting (e.g. "api_key").
+    pub name: String,
+    /// Label shown next to the input.
+    pub label: String,
+    /// Input type.
+    pub field_type: FieldType,
+    /// Whether the field is required.
+    pub required: bool,
+    /// Placeholder text inside the input.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub placeholder: Option<String>,
+    /// Help text shown below the input.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub help_text: Option<String>,
+}
+
+/// Input field type for rendering.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FieldType {
+    /// Masked password/secret input.
+    Password,
+    /// Plain text input.
+    Text,
+    /// URL input.
+    Url,
+}
+
+/// Result of credential validation.
+#[derive(Debug, Clone)]
+pub struct ConnectionValidation {
+    /// Display name from the provider (e.g. organization name, username).
+    pub provider_username: Option<String>,
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -40,6 +40,7 @@ pub mod typed_id;
 // These are DB-agnostic entity types used by both API and worker
 pub mod agent;
 pub mod capability_dto;
+pub mod connection_provider;
 pub mod events;
 pub mod harness;
 pub mod llm_model_profiles;
@@ -134,6 +135,12 @@ pub use tools::{
 };
 
 // Capability re-exports
+// Connection provider plugin system (API key connections like Daytona)
+pub use connection_provider::{
+    ConnectionFormSchema, ConnectionProvider, ConnectionProviderPlugin, ConnectionType,
+    ConnectionValidation, FieldType, FormField,
+};
+
 pub use capabilities::{
     AddTool, AgentCapabilityConfig, AppliedCapabilities, Capability, CapabilityId,
     CapabilityRegistry, CapabilityRegistryBuilder, CapabilityStatus, CollectedCapabilities,

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -51,6 +51,7 @@ aes-gcm.workspace = true
 argon2.workspace = true
 parking_lot.workspace = true
 cron = "0.15"
+inventory.workspace = true
 zip = { version = "2", default-features = false, features = ["deflate"] }
 
 everruns-core = { path = "../core", features = ["openapi", "sqlx"] }

--- a/crates/server/migrations/010_user_connection_types.sql
+++ b/crates/server/migrations/010_user_connection_types.sql
@@ -1,0 +1,5 @@
+-- Add connection_type to user_connections to distinguish OAuth vs API key connections.
+-- Existing rows default to 'oauth'. New API-key connections (e.g. Daytona) use 'api_key'.
+
+ALTER TABLE user_connections
+  ADD COLUMN connection_type VARCHAR(20) NOT NULL DEFAULT 'oauth';

--- a/crates/server/src/api/user_connections.rs
+++ b/crates/server/src/api/user_connections.rs
@@ -1,7 +1,8 @@
 // User Connections API routes
-// Decision: User-scoped (not org-scoped) — token represents user's GitHub identity
+// Decision: User-scoped (not org-scoped) — token represents user's identity
 // Decision: GitHub App installation flow replaces OAuth App for repo access
-// Decision: API-key providers (brave_search) use PUT with encrypted token storage
+// Decision: API-key providers (Daytona etc.) register via ConnectionProviderPlugin
+//   and define their own form schema + validation. Server discovers them at runtime.
 
 use crate::auth::config::AuthConfig;
 use crate::auth::middleware::{AuthState, AuthUser};
@@ -9,18 +10,20 @@ use crate::auth::oauth::GitHubAppService;
 use crate::storage::{EncryptionService, StorageBackend};
 use axum::{
     Json, Router,
-    extract::{Path, Query, State},
+    extract::{FromRef, Path, Query, State},
     http::StatusCode,
     response::Redirect,
     routing::{delete, get, put},
 };
 use chrono::{DateTime, Utc};
+use everruns_core::connection_provider::{
+    ConnectionFormSchema as CoreFormSchema, ConnectionProviderPlugin, ConnectionType,
+};
+use everruns_core::deployment::DeploymentGrade;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
-
-use axum::extract::FromRef;
 
 use crate::storage::models::CreateUserConnectionRow;
 
@@ -39,15 +42,58 @@ impl FromRef<AppState> for AuthState {
     }
 }
 
+// ============================================================================
+// Response / Request Types
+// ============================================================================
+
 /// Connection info returned in API responses (never includes token)
 #[derive(Debug, Serialize, ToSchema)]
 pub struct ConnectionResponse {
     pub provider: String,
+    pub connection_type: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider_username: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scopes: Option<String>,
     pub connected_at: DateTime<Utc>,
+}
+
+/// Provider info for the connections UI
+#[derive(Debug, Serialize)]
+pub struct ProviderResponse {
+    pub provider_id: String,
+    pub display_name: String,
+    pub description: String,
+    pub icon: String,
+    pub connection_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub form_schema: Option<FormSchemaResponse>,
+}
+
+/// Form schema for API-key providers
+#[derive(Debug, Serialize)]
+pub struct FormSchemaResponse {
+    pub fields: Vec<FormFieldResponse>,
+    pub instructions_markdown: String,
+}
+
+/// Single form field
+#[derive(Debug, Serialize)]
+pub struct FormFieldResponse {
+    pub name: String,
+    pub label: String,
+    pub field_type: String,
+    pub required: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub placeholder: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub help_text: Option<String>,
+}
+
+/// Request body for API-key connection creation (plugin-based providers)
+#[derive(Debug, Deserialize)]
+pub struct CreateApiKeyConnectionRequest {
+    pub api_key: String,
 }
 
 /// Request body for API-key-based connections (e.g., Brave Search)
@@ -69,11 +115,22 @@ pub struct GitHubInstallationCallbackQuery {
     pub state: Option<String>,
 }
 
+// ============================================================================
+// Routes
+// ============================================================================
+
 /// Create user connections routes
 pub fn routes(state: AppState) -> Router {
     Router::new()
         .route("/v1/user/connections", get(list_connections))
-        .route("/v1/user/connections/{provider}", delete(delete_connection))
+        .route(
+            "/v1/user/connections/providers",
+            get(list_connection_providers),
+        )
+        .route(
+            "/v1/user/connections/{provider}",
+            delete(delete_connection).post(create_api_key_connection),
+        )
         .route(
             "/v1/user/connections/github/authorize",
             get(github_authorize),
@@ -85,6 +142,10 @@ pub fn routes(state: AppState) -> Router {
         )
         .with_state(state)
 }
+
+// ============================================================================
+// Handlers
+// ============================================================================
 
 /// GET /v1/user/connections — List user's connected accounts
 pub async fn list_connections(
@@ -100,6 +161,7 @@ pub async fn list_connections(
         .into_iter()
         .map(|r| ConnectionResponse {
             provider: r.provider,
+            connection_type: r.connection_type,
             provider_username: r.provider_username,
             scopes: r.scopes,
             connected_at: r.created_at,
@@ -107,6 +169,148 @@ pub async fn list_connections(
         .collect();
 
     Ok(Json(connections))
+}
+
+/// GET /v1/user/connections/providers — List available connection providers
+///
+/// Returns both hardcoded providers (GitHub/OAuth) and plugin-registered
+/// providers (Daytona/API-key). Frontend uses this to render connection forms.
+pub async fn list_connection_providers(
+    State(state): State<AppState>,
+    _auth: AuthUser,
+) -> Json<Vec<ProviderResponse>> {
+    let grade = DeploymentGrade::from_env();
+    let mut providers = Vec::new();
+
+    // Hardcoded GitHub OAuth provider (only if configured)
+    if state.auth_config.github_connection.is_some() {
+        providers.push(ProviderResponse {
+            provider_id: "github".to_string(),
+            display_name: "GitHub".to_string(),
+            description: "Access private repositories for agent sessions".to_string(),
+            icon: "github".to_string(),
+            connection_type: "oauth".to_string(),
+            form_schema: None,
+        });
+    }
+
+    // Plugin-registered providers (API-key based)
+    for plugin in inventory::iter::<ConnectionProviderPlugin> {
+        if plugin.experimental_only && !grade.experimental_features_enabled() {
+            continue;
+        }
+        let provider = (plugin.factory)();
+        let form_schema = provider.form_schema().map(|s| form_schema_to_response(&s));
+        let conn_type = match provider.connection_type() {
+            ConnectionType::OAuth => "oauth",
+            ConnectionType::ApiKey => "api_key",
+        };
+        providers.push(ProviderResponse {
+            provider_id: provider.provider_id().to_string(),
+            display_name: provider.display_name().to_string(),
+            description: provider.description().to_string(),
+            icon: provider.icon().to_string(),
+            connection_type: conn_type.to_string(),
+            form_schema,
+        });
+    }
+
+    Json(providers)
+}
+
+/// POST /v1/user/connections/:provider — Create API-key connection
+///
+/// For providers that use direct API key entry (not OAuth).
+/// Validates the key via the provider's validate() method before saving.
+pub async fn create_api_key_connection(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Path(provider_id): Path<String>,
+    Json(body): Json<CreateApiKeyConnectionRequest>,
+) -> Result<(StatusCode, Json<ConnectionResponse>), (StatusCode, String)> {
+    let grade = DeploymentGrade::from_env();
+
+    // Find the registered ConnectionProvider for this provider_id
+    let provider: Option<Box<dyn everruns_core::connection_provider::ConnectionProvider>> =
+        inventory::iter::<ConnectionProviderPlugin>
+            .into_iter()
+            .filter(|p| !p.experimental_only || grade.experimental_features_enabled())
+            .map(|p| (p.factory)())
+            .find(|p| p.provider_id() == provider_id);
+
+    let provider = provider.ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            format!("Unknown connection provider: {provider_id}"),
+        )
+    })?;
+
+    // Only API-key providers support direct creation
+    if provider.connection_type() != ConnectionType::ApiKey {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("Provider '{provider_id}' uses OAuth, not API key"),
+        ));
+    }
+
+    let encryption = state.encryption.as_ref().ok_or_else(|| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Encryption not configured".to_string(),
+        )
+    })?;
+
+    // Validate the API key
+    let validation: everruns_core::connection_provider::ConnectionValidation =
+        provider.validate(&body.api_key).await.map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                format!("API key validation failed: {e}"),
+            )
+        })?;
+
+    // Encrypt and store
+    let access_token_encrypted = encryption.encrypt_string(&body.api_key).map_err(|e| {
+        tracing::error!("Failed to encrypt API key: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to store connection".to_string(),
+        )
+    })?;
+
+    let row = state
+        .db
+        .upsert_user_connection(CreateUserConnectionRow {
+            user_id: auth.id,
+            provider: provider_id.clone(),
+            connection_type: "api_key".to_string(),
+            provider_user_id: None,
+            provider_username: validation.provider_username.clone(),
+            access_token_encrypted: Some(access_token_encrypted),
+            installation_id: None,
+            refresh_token_encrypted: None,
+            scopes: None,
+            expires_at: None,
+        })
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to store {provider_id} connection: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to store connection".to_string(),
+            )
+        })?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(ConnectionResponse {
+            provider: row.provider,
+            connection_type: row.connection_type,
+            provider_username: row.provider_username,
+            scopes: row.scopes,
+            connected_at: row.created_at,
+        }),
+    ))
 }
 
 /// DELETE /v1/user/connections/:provider — Disconnect
@@ -200,6 +404,7 @@ pub async fn github_callback(
         .upsert_user_connection(CreateUserConnectionRow {
             user_id: auth.id,
             provider: "github".to_string(),
+            connection_type: "oauth".to_string(),
             provider_user_id: Some(result.account_id),
             provider_username: Some(result.account_login),
             access_token_encrypted: None,
@@ -277,6 +482,7 @@ pub async fn put_api_key_connection(
         .upsert_user_connection(CreateUserConnectionRow {
             user_id: auth.id,
             provider: provider.clone(),
+            connection_type: "api_key".to_string(),
             provider_user_id: None,
             provider_username: None,
             access_token_encrypted: Some(encrypted),
@@ -295,4 +501,33 @@ pub async fn put_api_key_connection(
         })?;
 
     Ok(StatusCode::NO_CONTENT)
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn form_schema_to_response(schema: &CoreFormSchema) -> FormSchemaResponse {
+    FormSchemaResponse {
+        instructions_markdown: schema.instructions_markdown.clone(),
+        fields: schema
+            .fields
+            .iter()
+            .map(|f| {
+                let field_type = match f.field_type {
+                    everruns_core::connection_provider::FieldType::Password => "password",
+                    everruns_core::connection_provider::FieldType::Text => "text",
+                    everruns_core::connection_provider::FieldType::Url => "url",
+                };
+                FormFieldResponse {
+                    name: f.name.clone(),
+                    label: f.label.clone(),
+                    field_type: field_type.to_string(),
+                    required: f.required,
+                    placeholder: f.placeholder.clone(),
+                    help_text: f.help_text.clone(),
+                }
+            })
+            .collect(),
+    }
 }

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -3274,6 +3274,7 @@ impl InMemoryDatabase {
             id,
             user_id: input.user_id,
             provider: input.provider,
+            connection_type: input.connection_type,
             provider_user_id: input.provider_user_id,
             provider_username: input.provider_username,
             access_token_encrypted: input.access_token_encrypted,

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -847,6 +847,7 @@ pub struct UserConnectionRow {
     pub id: Uuid,
     pub user_id: Uuid,
     pub provider: String,
+    pub connection_type: String,
     pub provider_user_id: Option<String>,
     pub provider_username: Option<String>,
     /// Encrypted OAuth token (NULL for GitHub App connections)
@@ -865,6 +866,7 @@ pub struct UserConnectionRow {
 pub struct CreateUserConnectionRow {
     pub user_id: Uuid,
     pub provider: String,
+    pub connection_type: String,
     pub provider_user_id: Option<String>,
     pub provider_username: Option<String>,
     /// Encrypted OAuth token (None for GitHub App connections)

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -3600,13 +3600,14 @@ impl Database {
 
         let row = sqlx::query_as::<_, UserConnectionRow>(
             r#"
-            INSERT INTO user_connections (user_id, provider, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-            RETURNING id, user_id, provider, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id, created_at, updated_at
+            INSERT INTO user_connections (user_id, provider, connection_type, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            RETURNING id, user_id, provider, connection_type, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id, created_at, updated_at
             "#,
         )
         .bind(input.user_id)
         .bind(&input.provider)
+        .bind(&input.connection_type)
         .bind(&input.provider_user_id)
         .bind(&input.provider_username)
         .bind(&input.access_token_encrypted)
@@ -3628,7 +3629,7 @@ impl Database {
     ) -> Result<Option<UserConnectionRow>> {
         let row = sqlx::query_as::<_, UserConnectionRow>(
             r#"
-            SELECT id, user_id, provider, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id, created_at, updated_at
+            SELECT id, user_id, provider, connection_type, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id, created_at, updated_at
             FROM user_connections
             WHERE user_id = $1 AND provider = $2
             ORDER BY created_at DESC
@@ -3647,7 +3648,7 @@ impl Database {
     pub async fn list_user_connections(&self, user_id: Uuid) -> Result<Vec<UserConnectionRow>> {
         let rows = sqlx::query_as::<_, UserConnectionRow>(
             r#"
-            SELECT id, user_id, provider, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id, created_at, updated_at
+            SELECT id, user_id, provider, connection_type, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id, created_at, updated_at
             FROM user_connections
             WHERE user_id = $1
             ORDER BY provider ASC

--- a/integrations/daytona/src/connection.rs
+++ b/integrations/daytona/src/connection.rs
@@ -1,0 +1,102 @@
+// Daytona Connection Provider
+//
+// Decision: API-key-based connection (not OAuth). User enters key from Daytona dashboard.
+// Decision: Validate key by calling GET /sandbox — 200 means valid, 401 means invalid.
+// Decision: All Daytona-specific connection config (form schema, instructions, validation)
+//   lives in this crate, not in the server crate.
+
+use async_trait::async_trait;
+use everruns_core::connection_provider::{
+    ConnectionFormSchema, ConnectionProvider, ConnectionType, ConnectionValidation, FieldType,
+    FormField,
+};
+
+use crate::DAYTONA_API_BASE;
+
+pub struct DaytonaConnectionProvider;
+
+#[async_trait]
+impl ConnectionProvider for DaytonaConnectionProvider {
+    fn provider_id(&self) -> &str {
+        "daytona"
+    }
+
+    fn display_name(&self) -> &str {
+        "Daytona"
+    }
+
+    fn description(&self) -> &str {
+        "Cloud sandbox environments for code execution"
+    }
+
+    fn icon(&self) -> &str {
+        "cloud"
+    }
+
+    fn connection_type(&self) -> ConnectionType {
+        ConnectionType::ApiKey
+    }
+
+    fn form_schema(&self) -> Option<ConnectionFormSchema> {
+        Some(ConnectionFormSchema {
+            fields: vec![FormField {
+                name: "api_key".to_string(),
+                label: "API Key".to_string(),
+                field_type: FieldType::Password,
+                required: true,
+                placeholder: Some("your-daytona-api-key".to_string()),
+                help_text: None,
+            }],
+            instructions_markdown: "\
+1. Go to [Daytona Dashboard](https://app.daytona.io)\n\
+2. Navigate to **API Keys** in your account settings\n\
+3. Click **Create New API Key**\n\
+4. Copy the key and paste it below"
+                .to_string(),
+        })
+    }
+
+    async fn validate(&self, credential: &str) -> Result<ConnectionValidation, String> {
+        let client = reqwest::Client::new();
+        let response = client
+            .get(format!("{DAYTONA_API_BASE}/sandbox"))
+            .bearer_auth(credential)
+            .send()
+            .await
+            .map_err(|e| format!("Failed to reach Daytona API: {e}"))?;
+
+        match response.status().as_u16() {
+            200 => Ok(ConnectionValidation {
+                provider_username: None,
+            }),
+            401 | 403 => Err("Invalid API key. Check that the key is correct and active.".into()),
+            status => Err(format!(
+                "Unexpected response from Daytona API (HTTP {status})"
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_provider_metadata() {
+        let p = DaytonaConnectionProvider;
+        assert_eq!(p.provider_id(), "daytona");
+        assert_eq!(p.display_name(), "Daytona");
+        assert_eq!(p.connection_type(), ConnectionType::ApiKey);
+        assert_eq!(p.icon(), "cloud");
+    }
+
+    #[test]
+    fn test_form_schema() {
+        let p = DaytonaConnectionProvider;
+        let schema = p.form_schema().expect("should have form schema");
+        assert_eq!(schema.fields.len(), 1);
+        assert_eq!(schema.fields[0].name, "api_key");
+        assert!(schema.fields[0].required);
+        assert!(schema.instructions_markdown.contains("app.daytona.io"));
+    }
+}

--- a/integrations/daytona/src/lib.rs
+++ b/integrations/daytona/src/lib.rs
@@ -10,12 +10,15 @@
 //! Decision: session_storage dependency for API key and state persistence
 
 pub mod client;
+pub mod connection;
 pub mod state;
 mod tools;
 
 use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin};
+use everruns_core::connection_provider::ConnectionProviderPlugin;
 use everruns_core::tools::Tool;
 
+use connection::DaytonaConnectionProvider;
 use std::time::Duration;
 
 use tools::{
@@ -25,13 +28,20 @@ use tools::{
 };
 
 // ============================================================================
-// Integration Plugin Registration
+// Plugin Registration
 // ============================================================================
 
 inventory::submit! {
     IntegrationPlugin {
         experimental_only: false,
         factory: || Box::new(DaytonaCapability),
+    }
+}
+
+inventory::submit! {
+    ConnectionProviderPlugin {
+        experimental_only: true,
+        factory: || Box::new(DaytonaConnectionProvider),
     }
 }
 
@@ -88,7 +98,10 @@ impl Capability for DaytonaCapability {
 
 Cloud-based sandboxes via Daytona. Each sandbox is an isolated environment with full Linux and network access.
 
-Prerequisite: DAYTONA_API_KEY must be set in session secrets before using any sandbox tool.
+Authentication: Daytona API key is resolved automatically:
+1. Session secret `DAYTONA_API_KEY` (if set for this session)
+2. User connection (if configured in Settings > Connections > Daytona)
+If neither is available, guide the user to set up their key in Settings > Connections.
 
 Tools:
 - `daytona_create_sandbox` - Create and start a new sandbox
@@ -180,6 +193,7 @@ mod tests {
         assert!(prompt.contains("daytona_git_credentials"));
         assert!(prompt.contains("DAYTONA_API_KEY"));
         assert!(prompt.contains("Daytona"));
+        assert!(prompt.contains("Settings > Connections"));
     }
 
     #[test]

--- a/integrations/daytona/src/state.rs
+++ b/integrations/daytona/src/state.rs
@@ -47,25 +47,50 @@ pub struct SandboxState {
 // State Management Helpers
 // ============================================================================
 
+/// Resolve Daytona API key with fallback chain:
+/// 1. Session secret DAYTONA_API_KEY (highest priority — most local)
+/// 2. User connection for "daytona" provider (Settings > Connections)
+/// 3. Error with guidance to set up in Settings
 pub async fn get_api_key(context: &ToolContext) -> Result<String, ToolExecutionResult> {
-    let storage = context
-        .storage_store
-        .as_ref()
-        .ok_or_else(|| ToolExecutionResult::tool_error("Storage not available in this context"))?;
+    // 1. Session secret (highest priority)
+    if let Some(storage) = context.storage_store.as_ref() {
+        match storage
+            .get_secret(context.session_id, DAYTONA_API_KEY_SECRET)
+            .await
+        {
+            Ok(Some(key)) => return Ok(key),
+            Ok(None) => {} // fall through
+            Err(e) => {
+                error!("Failed to read DAYTONA_API_KEY secret: {e}");
+                // Fall through to try user connection
+            }
+        }
+    }
 
-    storage
-        .get_secret(context.session_id, DAYTONA_API_KEY_SECRET)
-        .await
-        .map_err(|e| {
-            error!("Failed to read DAYTONA_API_KEY secret: {e}");
-            ToolExecutionResult::internal_error_msg(format!("Failed to read API key: {e}"))
-        })?
-        .ok_or_else(|| {
-            ToolExecutionResult::tool_error(
-                "DAYTONA_API_KEY not set. Use `secret_store set DAYTONA_API_KEY <your-key>` first. \
-                 Get your key at https://app.daytona.io/ under API Keys.",
-            )
-        })
+    // 2. User connection
+    if let Some(resolver) = context.connection_resolver.as_ref() {
+        match resolver
+            .get_connection_token(context.session_id, "daytona")
+            .await
+        {
+            Ok(Some(key)) => return Ok(key),
+            Ok(None) => {} // fall through
+            Err(e) => {
+                error!("Failed to resolve Daytona user connection: {e}");
+                // Fall through to error
+            }
+        }
+    }
+
+    // 3. Not found — guide to Settings
+    // THREAT[TM-AGENT-016]: Asking secrets in chat stores them plaintext in events.
+    // Prefer Settings UI for credential entry.
+    Err(ToolExecutionResult::tool_error(
+        "Daytona API key not configured.\n\n\
+         Set up your API key in **Settings > Connections > Daytona**, \
+         or use `secret_store set DAYTONA_API_KEY <key>` for this session only.\n\n\
+         Get your key at https://app.daytona.io/ under API Keys.",
+    ))
 }
 
 pub async fn get_sandbox_state(

--- a/specs/daytona.md
+++ b/specs/daytona.md
@@ -35,10 +35,27 @@ Daytona exposes two API layers:
 
 ### State Management
 
-All state is stored in session **secrets** (encrypted at rest via AES-256-GCM envelope encryption):
+Per-sandbox state is stored in session **secrets** (encrypted at rest via AES-256-GCM envelope encryption):
 
-- **API key**: secret name `DAYTONA_API_KEY`
 - **Per-sandbox state**: secret name `daytona_sandbox:{sandbox_id}`, value is JSON-serialized `SandboxState`
+
+### API Key Resolution
+
+The Daytona API key is resolved with fallback chain:
+
+1. **Session secret** `DAYTONA_API_KEY` — highest priority, local to session
+2. **User connection** for `daytona` provider — persistent, set up via Settings > Connections
+3. **Error** — guides user to Settings > Connections
+
+### User Connection
+
+Daytona registers as a `ConnectionProviderPlugin` (API-key type). Users configure their key in **Settings > Connections > Daytona**:
+
+1. User enters API key (from [Daytona Dashboard](https://app.daytona.io) > API Keys)
+2. Key validated via `GET /sandbox` endpoint
+3. Key encrypted and stored in `user_connections` table
+
+This avoids entering the key in chat (see TM-AGENT-016).
 
 ## Data Model
 
@@ -180,7 +197,7 @@ Configure git credentials in a sandbox so that all git operations (push, pull, f
 
 ## Security
 
-- **API Key**: Stored in session secrets (`DAYTONA_API_KEY`), encrypted at rest (TM-DAYTONA-004)
+- **API Key**: Stored in user connections (preferred) or session secrets (`DAYTONA_API_KEY`), encrypted at rest (TM-DAYTONA-004)
 - **Single auth token**: Both Management and Toolbox APIs use the same Bearer token
 - **Sandbox Isolation**: Each sandbox is an isolated environment (TM-DAYTONA-005)
 - **Multi-tenancy**: Sandboxes scoped to session via secret name prefixes
@@ -239,6 +256,7 @@ External integration crate, auto-registered via `inventory::submit!` plugin syst
 |------|---------|
 | `src/lib.rs` | Plugin registration, constants, `DaytonaCapability` impl |
 | `src/client.rs` | `DaytonaClient` HTTP client (management + toolbox APIs), URL encoding |
+| `src/connection.rs` | `DaytonaConnectionProvider` — API-key connection plugin |
 | `src/state.rs` | API types (`SandboxInfo`, `ExecResult`, `SandboxState`), session state helpers |
 | `src/tools.rs` | 9 tool implementations (`DaytonaCreateSandboxTool`, etc.) |
 | `tests/plugin_registration.rs` | Integration tests for inventory registration |

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -532,6 +532,7 @@ The agent loop is a core trust boundary: an LLM decides which tools to call with
 | TM-AGENT-013 | Exfiltration via web_fetch | Medium | Agent with web_fetch capability can send session data to arbitrary URLs | **ACCEPTED** |
 | TM-AGENT-014 | Confused deputy — tool call with wrong session | Low | Tool context includes session_id; tools scoped to active session only | MITIGATED |
 | TM-AGENT-015 | Dangling tool calls cause LLM confusion | Low | Patched with synthetic "cancelled" results before LLM call; prevents API errors | MITIGATED |
+| TM-AGENT-016 | Plaintext secrets in chat history | Medium | When agent asks user for API key in chat, plaintext value stored in events table as message content; session secrets encrypt separately but chat retains plaintext | **OPEN** |
 
 ### Mitigation Details
 
@@ -585,6 +586,13 @@ This is accepted because:
 - `web_fetch` is an opt-in capability, not default
 - The intended use case requires external HTTP access
 - Removing this would break legitimate functionality
+
+**TM-AGENT-016 — Plaintext Secrets in Chat History (OPEN):**
+When an agent tool (e.g., Daytona) doesn't find an API key, it may instruct the user to provide one in chat. The user types the key as a chat message, which is stored as plaintext in the `events` table (message content). The `session_secrets` table encrypts the value separately, but the original chat message retains plaintext indefinitely.
+
+- **Impact:** API keys visible in session history, event exports, and any observability pipeline that captures events.
+- **Recommendation:** Prefer Settings UI for credential entry (user connections). Phase out in-chat secret collection. For tools that need credentials, guide users to Settings > Connections instead of requesting secrets in chat. See also TM-CRYPTO-007.
+- **Priority:** High
 
 ## 14. Bash Sandbox (TM-BASH)
 
@@ -733,6 +741,7 @@ Session A cannot access sb_xyz (different session_id in storage query)
 | TM-TOOL-008 | Tool approval not enforced | Low | Implement HITL approval for requires_approval policy |
 | TM-TOOL-009 | No tool rate limiting | Medium | Per-agent tool execution rate limits |
 | TM-DOS-003 | SSE connection exhaustion | Medium | Global SSE connection limit with per-user cap |
+| TM-AGENT-016 | Plaintext secrets in chat history | Medium | Prefer Settings UI; phase out in-chat secret collection |
 
 ### Accepted Risks
 

--- a/specs/user-connections.md
+++ b/specs/user-connections.md
@@ -2,7 +2,7 @@
 
 ## Abstract
 
-User connections allow users to link external service accounts (GitHub, GitLab, etc.) to their Everruns account, independent of their authentication provider. A user who logged in via Google or email/password can still connect their GitHub account for repo access. Connection tokens are resolved lazily at tool execution time, enabling tools like `git_clone` to operate as the user without exposing credentials to the LLM.
+User connections allow users to link external service accounts (GitHub, GitLab, Daytona, etc.) to their Everruns account, independent of their authentication provider. A user who logged in via Google or email/password can still connect their GitHub account for repo access, or their Daytona API key for sandbox access. Connection tokens are resolved lazily at tool execution time, enabling tools like `git_clone` or Daytona sandbox tools to operate as the user without exposing credentials to the LLM.
 
 ## Requirements
 
@@ -12,7 +12,8 @@ User connections allow users to link external service accounts (GitHub, GitLab, 
 |-------|------|-------------|
 | `id` | UUID v7 | Internal primary key |
 | `user_id` | UUID | FK to users.id |
-| `provider` | string | `github`, `gitlab`, `bitbucket` |
+| `provider` | string | `github`, `gitlab`, `bitbucket`, `daytona` |
+| `connection_type` | string | `oauth` or `api_key` |
 | `provider_user_id` | string | Provider's user/account ID |
 | `provider_username` | string | Display name (e.g., `octocat`) |
 | `access_token_encrypted` | bytes? | Encrypted OAuth token (NULL for GitHub App) |
@@ -24,6 +25,43 @@ User connections allow users to link external service accounts (GitHub, GitLab, 
 | `updated_at` | timestamp | |
 
 No unique DB constraint on (user_id, provider). Uniqueness enforced in application code. This allows future multi-account support per provider if needed.
+
+### Connection Types
+
+Two connection types:
+
+| Type | Flow | Example Providers |
+|------|------|-------------------|
+| `oauth` | Redirect to provider for authorization | GitHub, GitLab |
+| `api_key` | User enters API key in Settings UI dialog | Daytona |
+
+For `api_key` connections, OAuth-specific fields (`provider_user_id`, `scopes`, `refresh_token_encrypted`, `expires_at`) are NULL. The API key is stored in `access_token_encrypted`.
+
+### Connection Provider Plugin System
+
+API-key providers register themselves via `ConnectionProviderPlugin` (parallel to `IntegrationPlugin`). Each provider defines:
+- `provider_id`, `display_name`, `description`, `icon`
+- `connection_type` (OAuth vs ApiKey)
+- `form_schema` — fields and instructions for the UI dialog
+- `validate()` — async validation of credential before saving
+
+Registration uses `inventory::submit!`. Server discovers providers at runtime via `GET /v1/user/connections/providers`.
+
+### API Key Connection Flow
+
+1. User clicks "Connect" for an API-key provider in Settings > Connections
+2. Dialog renders the provider's `form_schema` (fields + instructions)
+3. User enters API key and submits
+4. `POST /v1/user/connections/{provider}` with `{ api_key: "..." }`
+5. Server validates key via `provider.validate()`
+6. Key encrypted and upserted into `user_connections` with `connection_type = 'api_key'`
+
+**Resolution priority** (for tools like Daytona):
+1. Session secret (highest priority — local to session)
+2. User connection (persistent, configured in Settings)
+3. Error with guidance to Settings > Connections
+
+**Security:** API keys should be entered via the Settings UI, not in chat. Secrets typed in chat are stored plaintext in the events table (see TM-AGENT-016).
 
 ### Connection Method: GitHub App
 
@@ -84,6 +122,37 @@ The token value never appears in tool arguments, tool results, or message histor
 
 ### API Endpoints
 
+#### GET /v1/user/connections/providers
+
+List available connection providers. Includes hardcoded OAuth providers and plugin-registered API-key providers.
+
+**Response:**
+```json
+{
+  "data": [
+    {
+      "provider_id": "github",
+      "display_name": "GitHub",
+      "description": "Access private repositories for agent sessions",
+      "icon": "github",
+      "connection_type": "oauth",
+      "form_schema": null
+    },
+    {
+      "provider_id": "daytona",
+      "display_name": "Daytona",
+      "description": "Cloud sandbox environments for code execution",
+      "icon": "cloud",
+      "connection_type": "api_key",
+      "form_schema": {
+        "fields": [{"name": "api_key", "label": "API Key", "field_type": "password", "required": true}],
+        "instructions_markdown": "1. Go to Daytona Dashboard..."
+      }
+    }
+  ]
+}
+```
+
 #### GET /v1/user/connections
 
 List user's connected accounts. Token values never returned.
@@ -94,6 +163,7 @@ List user's connected accounts. Token values never returned.
   "data": [
     {
       "provider": "github",
+      "connection_type": "oauth",
       "provider_username": "octocat",
       "scopes": "contents: write, metadata: read",
       "connected_at": "2026-02-15T10:00:00Z"
@@ -101,6 +171,21 @@ List user's connected accounts. Token values never returned.
   ]
 }
 ```
+
+#### POST /v1/user/connections/{provider}
+
+Create an API-key connection. Validates the key, encrypts, and stores.
+
+**Request:**
+```json
+{ "api_key": "your-api-key" }
+```
+
+**Response:** `201 Created` with `ConnectionResponse`
+
+**Errors:**
+- `404` — Unknown provider
+- `400` — Provider uses OAuth (not API key), or validation failed
 
 #### DELETE /v1/user/connections/{provider}
 


### PR DESCRIPTION
## What
Add API-key-based user connection support, starting with Daytona. Users can configure their Daytona API key in Settings > Connections instead of entering it in chat.

## Why
Previously, Daytona required `secret_store set DAYTONA_API_KEY` in chat, which stores the plaintext key in the events table (TM-AGENT-016). A persistent user connection via Settings UI is more secure and convenient.

## How
- **Connection Provider Plugin System** (`crates/core/src/connection_provider.rs`): New `ConnectionProvider` trait + `ConnectionProviderPlugin` registry via `inventory`. Providers define form schema and async `validate()`.
- **Daytona provider** (`integrations/daytona/src/connection.rs`): Registers as API-key provider, validates via `GET /sandbox`, defines form fields.
- **API endpoints**: `GET /v1/user/connections/providers` (list available providers), `POST /v1/user/connections/{provider}` (create API-key connection with validation+encryption).
- **DB migration** (`010_user_connection_types.sql`): Adds `connection_type` column to `user_connections`.
- **API key fallback chain**: Session secret → User connection → Error with Settings guidance.
- **UI**: Connections page now server-driven via providers endpoint. New `ApiKeyDialog` for form-based credential entry.
- **Specs**: Updated `user-connections.md`, `daytona.md`, `threat-model.md` (TM-AGENT-016).

## Risk
- Low
- Migration adds a column with default — safe for existing rows
- Plugin system is additive; existing GitHub OAuth/App flow unchanged

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered