### PR TITLE
fix(ui): fix workspace refresh button and auto-refresh on tab switch

### DIFF
--- a/apps/ui/src/__tests__/file-browser.test.tsx
+++ b/apps/ui/src/__tests__/file-browser.test.tsx
@@ -35,7 +35,7 @@ jest.mock("lucide-react", () => ({
 }));
 
 // Mock the file hooks
-const mockRefetch = jest.fn();
+const mockRefetch = jest.fn().mockResolvedValue({ data: [] });
 const mockCreateFile = jest.fn();
 const mockCreateDir = jest.fn();
 const mockDeleteFile = jest.fn();
@@ -545,6 +545,8 @@ describe("FileBrowser Directory Expansion", () => {
   });
 
   it("reloads expanded directories on refresh", async () => {
+    mockRefetch.mockResolvedValue({ data: [mockDirectory] });
+
     (useFiles as jest.Mock).mockReturnValue({
       data: [mockDirectory],
       isLoading: false,

--- a/apps/ui/src/components/files/file-browser.tsx
+++ b/apps/ui/src/components/files/file-browser.tsx
@@ -129,6 +129,11 @@ export function FileBrowser({ sessionId, onFileSelect, selectedPath }: FileBrows
     }
   }, [rootFiles]);
 
+  // Auto-refresh when Workspace tab becomes active (component remounts on tab switch)
+  useEffect(() => {
+    refetchRoot();
+  }, [refetchRoot]);
+
   const handleSelect = useCallback(
     (path: string) => {
       // Find the file info for this path
@@ -172,9 +177,14 @@ export function FileBrowser({ sessionId, onFileSelect, selectedPath }: FileBrows
     [loadedDirs, loadDirectory],
   );
 
-  const handleRefresh = useCallback(() => {
+  const handleRefresh = useCallback(async () => {
     setLoadedDirs(new Map());
-    refetchRoot();
+    // Await refetch and explicitly set data to handle React Query structural sharing
+    // (if server returns identical data, rootFiles ref won't change and the useEffect won't fire)
+    const { data } = await refetchRoot();
+    if (data) {
+      setLoadedDirs((prev) => new Map(prev).set("/workspace", data));
+    }
     // Reload expanded subdirectories
     for (const path of expandedPaths) {
       if (path !== "/workspace") {


### PR DESCRIPTION
## What
Fix the Workspace tab refresh button and add auto-refresh when switching to the tab.

## Why
The refresh button was non-functional: clicking it cleared the local directory cache (`loadedDirs`) then called `refetchRoot()`, but React Query structural sharing meant the `rootFiles` reference stayed the same when data was unchanged, so the `useEffect([rootFiles])` never re-fired and the file tree stayed permanently empty.

Users also had to manually refresh to see workspace changes made by the agent while on another tab.

## How
- **Refresh button**: `await refetchRoot()` and explicitly set the returned data into `loadedDirs`, bypassing the structural sharing issue.
- **Auto-refresh on tab switch**: Added a mount effect that calls `refetchRoot()`. Since the `FileBrowser` component remounts on tab navigation, this ensures workspace data is always fresh when the user switches to the Workspace tab.

## Risk
- Low
- UI-only change in one file. No backend changes. Worst case: an extra network request on tab switch.

## Checklist
- [x] Tests added or updated (pre-existing failure_injection_test failures are unrelated and reproduce on main)
- [x] Backward compatibility considered (N/A, internal UI code)
