### PR TITLE
fix(harness): include agent_instructions in Generic harness

### DIFF
--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -559,17 +559,21 @@ where
         }
 
         // 6b. Read AGENTS.md if agent_instructions capability is enabled
-        let has_agent_instructions = agent
-            .as_ref()
-            .map(|a| {
-                a.capabilities.iter().any(|c| {
-                    c.capability_id() == crate::capabilities::AGENT_INSTRUCTIONS_CAPABILITY_ID
+        //     Check harness, agent, and session capabilities (any layer can enable it).
+        let has_agent_instructions =
+            harness.capabilities.iter().any(|c| {
+                c.capability_id() == crate::capabilities::AGENT_INSTRUCTIONS_CAPABILITY_ID
+            }) || agent
+                .as_ref()
+                .map(|a| {
+                    a.capabilities.iter().any(|c| {
+                        c.capability_id() == crate::capabilities::AGENT_INSTRUCTIONS_CAPABILITY_ID
+                    })
                 })
-            })
-            .unwrap_or(false)
-            || session_capability_ids
-                .iter()
-                .any(|id| id == crate::capabilities::AGENT_INSTRUCTIONS_CAPABILITY_ID);
+                .unwrap_or(false)
+                || session_capability_ids
+                    .iter()
+                    .any(|id| id == crate::capabilities::AGENT_INSTRUCTIONS_CAPABILITY_ID);
 
         if has_agent_instructions && let Some(ref file_store) = self.file_store {
             match file_store

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -294,6 +294,7 @@ const SEED_HARNESSES: &[SeedHarness] = &[
             "virtual_bash",
             "session_storage",
             "session",
+            "agent_instructions",
         ],
     },
 ];
@@ -1522,11 +1523,12 @@ mod tests {
             .find(|h| h.name == "Generic")
             .expect("Generic harness should exist");
 
-        assert_eq!(generic.capabilities.len(), 4);
+        assert_eq!(generic.capabilities.len(), 5);
         assert!(generic.capabilities.contains(&"session_file_system"));
         assert!(generic.capabilities.contains(&"virtual_bash"));
         assert!(generic.capabilities.contains(&"session_storage"));
         assert!(generic.capabilities.contains(&"session"));
+        assert!(generic.capabilities.contains(&"agent_instructions"));
         assert!(generic.tags.contains(&"generic"));
         assert!(generic.tags.contains(&"default"));
     }

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -1027,11 +1027,11 @@ async fn test_copy_seed_generic_harness() {
         .json();
 
     assert_eq!(copied.name, "Generic (copy)");
-    // Generic harness has 4 capabilities
+    // Generic harness has 5 capabilities
     assert_eq!(
         copied.capabilities.len(),
-        4,
-        "Copied harness should have same 4 capabilities"
+        5,
+        "Copied harness should have same 5 capabilities"
     );
 }
 

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -832,7 +832,7 @@ async fn test_get_generic_harness() {
     assert!(harness.tags.contains(&"generic".to_string()));
     assert!(harness.tags.contains(&"default".to_string()));
 
-    // Verify Generic harness has the expected 4 capabilities
+    // Verify Generic harness has the expected 5 capabilities
     let cap_ids: Vec<&str> = harness
         .capabilities
         .iter()
@@ -840,8 +840,8 @@ async fn test_get_generic_harness() {
         .collect();
     assert_eq!(
         cap_ids.len(),
-        4,
-        "Generic harness should have 4 capabilities"
+        5,
+        "Generic harness should have 5 capabilities"
     );
     assert!(
         cap_ids.contains(&"session_file_system"),
@@ -858,6 +858,10 @@ async fn test_get_generic_harness() {
     assert!(
         cap_ids.contains(&"session"),
         "Should have session capability"
+    );
+    assert!(
+        cap_ids.contains(&"agent_instructions"),
+        "Should have agent instructions"
     );
 }
 

--- a/specs/harness-types.md
+++ b/specs/harness-types.md
@@ -25,7 +25,7 @@ The empty harness. No capabilities, no opinions. Intended as a blank canvas for 
 
 ### Generic
 
-The recommended default harness. Bundles the core capabilities needed for general-purpose agent work: file system access, bash execution, secret management, and session metadata.
+The recommended default harness. Bundles the core capabilities needed for general-purpose agent work: file system access, bash execution, secret management, session metadata, and project instructions.
 
 | Property | Value |
 |----------|-------|
@@ -42,6 +42,7 @@ The recommended default harness. Bundles the core capabilities needed for genera
 | `virtual_bash` | Virtual Bash | Sandboxed bash shell for code execution and scripting |
 | `session_storage` | Session Storage | Key/value store and encrypted secret storage |
 | `session` | Session | Session info access and title management |
+| `agent_instructions` | Agent Instructions | Reads AGENTS.md from workspace and injects into system prompt |
 
 **Use cases:**
 - Default harness for most agents
@@ -57,6 +58,7 @@ The recommended default harness. Bundles the core capabilities needed for genera
 | Why is Generic the recommended default? | Most agents need file system and bash access. Bundling these in a harness avoids repetitive per-agent capability setup. |
 | Why include `session_storage` in Generic? | Secret storage is needed for agents that interact with external APIs (API keys, tokens). KV storage is useful for persisting state. |
 | Why include `session` in Generic? | Session metadata (title, info) is commonly needed and has minimal overhead. |
+| Why include `agent_instructions` in Generic? | AGENTS.md is the standard way to provide project-level instructions. Including it by default means users get this functionality without extra configuration. |
 | Can users create additional harnesses? | Yes, via `POST /v1/harnesses`. Built-in harnesses are seed data, not the only options. |
 
 ## Seed Data

--- a/test_cases/agent_instructions/TC001_agents_md_applied_via_harness.md
+++ b/test_cases/agent_instructions/TC001_agents_md_applied_via_harness.md
@@ -1,0 +1,57 @@
+# TC001: AGENTS.md Applied via Generic Harness
+
+## Description
+
+Verify that AGENTS.md instructions are automatically applied when using the Generic harness (which includes `agent_instructions` capability by default). The agent should follow instructions written to AGENTS.md on subsequent turns.
+
+## Preconditions
+
+- Control-plane running (DEV_MODE or full mode)
+- LLM API key configured (non-simulated model required to verify instruction following)
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Harness | Generic (`harness_01933b5a000070008000000000000602`) |
+| AGENTS.md Content | `# Instructions\n\nAlways end your response with "-- Agent X"` |
+| User Message | `What is 2+2?` |
+
+## Steps
+
+1. Create session with Generic harness:
+   ```bash
+   curl -s -X POST "http://localhost:9000/v1/sessions" \
+     -H "Content-Type: application/json" \
+     -d '{"harness_id": "harness_01933b5a000070008000000000000602"}'
+   ```
+   Save `session_id` from response.
+
+2. Write AGENTS.md to session filesystem:
+   ```bash
+   curl -s -X POST "http://localhost:9000/v1/sessions/{session_id}/fs/AGENTS.md" \
+     -H "Content-Type: application/json" \
+     -d '{"content": "# Instructions\n\nAlways end your response with \"-- Agent X\""}'
+   ```
+
+3. Send a message:
+   ```bash
+   curl -s -X POST "http://localhost:9000/v1/sessions/{session_id}/messages" \
+     -H "Content-Type: application/json" \
+     -d '{"message": {"content": [{"type": "text", "text": "What is 2+2?"}]}}'
+   ```
+
+4. Wait for response (10-30 seconds).
+
+5. Retrieve messages:
+   ```bash
+   curl -s "http://localhost:9000/v1/sessions/{session_id}/messages"
+   ```
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Agent responds | `data` contains message with `role: "agent"` |
+| Instructions followed | Agent response ends with `-- Agent X` |
+| AGENTS.md readable | `GET /v1/sessions/{id}/fs/AGENTS.md` returns 200 with correct content |

--- a/test_cases/agent_instructions/TC002_agents_md_missing_file_silent.md
+++ b/test_cases/agent_instructions/TC002_agents_md_missing_file_silent.md
@@ -1,0 +1,47 @@
+# TC002: Missing AGENTS.md Silently Ignored
+
+## Description
+
+Verify that when no AGENTS.md file exists in the session filesystem, the agent operates normally without errors.
+
+## Preconditions
+
+- Control-plane running (DEV_MODE or full mode)
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Harness | Generic (`harness_01933b5a000070008000000000000602`) |
+| AGENTS.md | Not created |
+| User Message | `Say hello` |
+
+## Steps
+
+1. Create session with Generic harness:
+   ```bash
+   curl -s -X POST "http://localhost:9000/v1/sessions" \
+     -H "Content-Type: application/json" \
+     -d '{"harness_id": "harness_01933b5a000070008000000000000602"}'
+   ```
+
+2. Do NOT create an AGENTS.md file.
+
+3. Send a message:
+   ```bash
+   curl -s -X POST "http://localhost:9000/v1/sessions/{session_id}/messages" \
+     -H "Content-Type: application/json" \
+     -d '{"message": {"content": [{"type": "text", "text": "Say hello"}]}}'
+   ```
+
+4. Wait for response.
+
+5. Retrieve messages.
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Agent responds | `data` contains message with `role: "agent"` |
+| No errors | No error events in session events |
+| Turn completed | `turn.completed` event exists |

--- a/test_cases/agent_instructions/TC003_agents_md_dynamic_update.md
+++ b/test_cases/agent_instructions/TC003_agents_md_dynamic_update.md
@@ -1,0 +1,51 @@
+# TC003: AGENTS.md Dynamic Update Between Turns
+
+## Description
+
+Verify that changes to AGENTS.md are picked up on the next turn without restarting the session. The spec requires re-reading on every LLM turn.
+
+## Preconditions
+
+- Control-plane running with a real LLM (not LlmSim)
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Harness | Generic |
+| Initial AGENTS.md | `Always respond in uppercase.` |
+| Updated AGENTS.md | `Always respond in French.` |
+
+## Steps
+
+1. Create session with Generic harness.
+
+2. Write initial AGENTS.md:
+   ```bash
+   curl -s -X POST "http://localhost:9000/v1/sessions/{session_id}/fs/AGENTS.md" \
+     -H "Content-Type: application/json" \
+     -d '{"content": "Always respond in uppercase."}'
+   ```
+
+3. Send first message: `What color is the sky?`
+
+4. Wait for response. Verify response follows initial instructions.
+
+5. Update AGENTS.md:
+   ```bash
+   curl -s -X PUT "http://localhost:9000/v1/sessions/{session_id}/fs/AGENTS.md" \
+     -H "Content-Type: application/json" \
+     -d '{"content": "Always respond in French."}'
+   ```
+
+6. Send second message: `What color is the sky?`
+
+7. Wait for response. Verify response follows updated instructions.
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| First response | Follows initial AGENTS.md instructions (uppercase) |
+| Second response | Follows updated AGENTS.md instructions (French) |
+| No restart needed | Both responses come from the same session |

--- a/test_cases/agent_instructions/TC004_agents_md_base_harness_no_effect.md
+++ b/test_cases/agent_instructions/TC004_agents_md_base_harness_no_effect.md
@@ -1,0 +1,38 @@
+# TC004: AGENTS.md Has No Effect with Base Harness
+
+## Description
+
+Verify that AGENTS.md is not read when using the Base harness, which does not include the `agent_instructions` capability.
+
+## Preconditions
+
+- Control-plane running
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Harness | Base (`harness_01933b5a000070008000000000000601`) |
+| AGENTS.md Content | `Always respond with exactly one word.` |
+
+## Steps
+
+1. Create session with Base harness:
+   ```bash
+   curl -s -X POST "http://localhost:9000/v1/sessions" \
+     -H "Content-Type: application/json" \
+     -d '{"harness_id": "harness_01933b5a000070008000000000000601"}'
+   ```
+
+2. Write AGENTS.md (requires adding `session_file_system` capability to session first, or use direct storage).
+
+3. Send a message.
+
+4. Verify agent response does NOT follow AGENTS.md instructions (responds normally, not one word).
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Agent responds | Normal response, not constrained by AGENTS.md |
+| Capability absent | Base harness capabilities do not include `agent_instructions` |

--- a/test_cases/agent_instructions/TC005_agents_md_size_limit.md
+++ b/test_cases/agent_instructions/TC005_agents_md_size_limit.md
@@ -1,0 +1,43 @@
+# TC005: AGENTS.md Size Limit (32 KiB)
+
+## Description
+
+Verify that AGENTS.md content exceeding 32 KiB is truncated with a warning, not rejected.
+
+## Preconditions
+
+- Control-plane running
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Harness | Generic |
+| AGENTS.md Size | > 32,768 bytes |
+
+## Steps
+
+1. Create session with Generic harness.
+
+2. Write oversized AGENTS.md (> 32 KiB):
+   ```bash
+   # Generate content > 32 KiB
+   CONTENT=$(python3 -c "print('x' * 40000)")
+   curl -s -X POST "http://localhost:9000/v1/sessions/{session_id}/fs/AGENTS.md" \
+     -H "Content-Type: application/json" \
+     -d "{\"content\": \"$CONTENT\"}"
+   ```
+
+3. Send a message.
+
+4. Verify agent responds (no crash or error).
+
+5. Check server logs for truncation warning.
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Agent responds | Session continues normally |
+| Content truncated | Server logs contain truncation warning |
+| No crash | Turn completes successfully |


### PR DESCRIPTION
## What
Add `agent_instructions` capability to the Generic harness and fix the capability check in ReasonAtom to also inspect harness capabilities.

## Why
AGENTS.md files written to a session were silently ignored because:
1. The Generic harness did not include `agent_instructions` in its seed capabilities
2. The `has_agent_instructions` check in ReasonAtom only looked at agent and session capabilities, not harness capabilities

This meant users creating AGENTS.md via the agent instructions skill would see the file created but instructions never applied.

## How
1. Added `agent_instructions` to Generic harness seed data (`crates/server/src/seed.rs`)
2. Extended the `has_agent_instructions` check in `ReasonAtom::execute()` to also check `harness.capabilities` (`crates/core/src/atoms/reason.rs`)
3. Updated `specs/harness-types.md` to document the new capability
4. Updated unit and integration test assertions for the new capability count (4 → 5)
5. Added 5 manual test cases for AGENTS.md support

## Risk
- Low
- Existing sessions on the Generic harness will pick up the new capability on next server restart (seed sync). No migration needed.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered