### PR TITLE
feat(ui): add llm.generation filter to session events

### DIFF
--- a/apps/ui/src/app/(main)/sessions/[sessionId]/events/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/events/page.tsx
@@ -54,14 +54,16 @@ export default function EventsPage() {
   const [currentPage, setCurrentPage] = useState(1);
   const [hasNewEvents, setHasNewEvents] = useState(false);
   const [hideDeltaEvents, setHideDeltaEvents] = useState(true);
+  const [onlyLlmGeneration, setOnlyLlmGeneration] = useState(false);
   const lastKnownCountRef = useRef(0);
 
-  // Filter out delta events if hideDeltaEvents is enabled
+  // Filter events based on active filters
   const filteredEvents = useMemo(() => {
     if (!events) return [];
+    if (onlyLlmGeneration) return events.filter((e) => e.type === "llm.generation");
     if (!hideDeltaEvents) return events;
     return events.filter((e) => !DEFAULT_EXCLUDED_EVENTS.includes(e.type));
-  }, [events, hideDeltaEvents]);
+  }, [events, hideDeltaEvents, onlyLlmGeneration]);
 
   // Sort events by sequence descending (newest first)
   const sortedEvents = useMemo(() => {
@@ -108,7 +110,7 @@ export default function EventsPage() {
   useEffect(() => {
     setCurrentPage(1);
     lastKnownCountRef.current = filteredEvents.length;
-  }, [hideDeltaEvents, filteredEvents.length]);
+  }, [hideDeltaEvents, onlyLlmGeneration, filteredEvents.length]);
 
   const handleRefresh = () => {
     setCurrentPage(1);
@@ -142,6 +144,8 @@ export default function EventsPage() {
               <EventFilter
                 hideDeltaEvents={hideDeltaEvents}
                 onHideDeltaEventsChange={setHideDeltaEvents}
+                onlyLlmGeneration={onlyLlmGeneration}
+                onOnlyLlmGenerationChange={setOnlyLlmGeneration}
               />
               {hasNewEvents && (
                 <Button

--- a/apps/ui/src/components/events/event-filter.tsx
+++ b/apps/ui/src/components/events/event-filter.tsx
@@ -16,10 +16,17 @@ import { cn } from "@/lib/utils";
 interface EventFilterProps {
   hideDeltaEvents: boolean;
   onHideDeltaEventsChange: (hide: boolean) => void;
+  onlyLlmGeneration: boolean;
+  onOnlyLlmGenerationChange: (only: boolean) => void;
 }
 
-export function EventFilter({ hideDeltaEvents, onHideDeltaEventsChange }: EventFilterProps) {
-  const activeFilterCount = hideDeltaEvents ? 1 : 0;
+export function EventFilter({
+  hideDeltaEvents,
+  onHideDeltaEventsChange,
+  onlyLlmGeneration,
+  onOnlyLlmGenerationChange,
+}: EventFilterProps) {
+  const activeFilterCount = (hideDeltaEvents ? 1 : 0) + (onlyLlmGeneration ? 1 : 0);
 
   return (
     <DropdownMenu>
@@ -43,6 +50,12 @@ export function EventFilter({ hideDeltaEvents, onHideDeltaEventsChange }: EventF
               onCheckedChange={onHideDeltaEventsChange}
             >
               Hide streaming events
+            </DropdownMenuCheckboxItem>
+            <DropdownMenuCheckboxItem
+              checked={onlyLlmGeneration}
+              onCheckedChange={onOnlyLlmGenerationChange}
+            >
+              Only llm.generation events
             </DropdownMenuCheckboxItem>
           </DropdownMenuGroup>
         </DropdownMenuContent>


### PR DESCRIPTION
## What
Add "Only llm.generation events" checkbox filter to the Sessions > Events page filter dropdown.

## Why
When debugging LLM calls, the events list contains many event types (turn lifecycle, streaming deltas, tool execution, etc). A dedicated filter to show only `llm.generation` events makes it easy to inspect LLM API calls without noise.

## How
- Added `onlyLlmGeneration` boolean state to EventsPage
- Extended EventFilter component with new checkbox prop
- When enabled, filters client-side to `e.type === "llm.generation"` (same pattern as existing "Hide streaming events" filter)
- Page resets to 1 when filter toggles; active filter count badge updated

## Risk
- Low
- UI-only change, no backend modifications. Worst case: filter shows empty list if no llm.generation events exist.

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered