### PR TITLE
fix(ui): render connection instructions as markdown

### DIFF
--- a/apps/ui/src/__tests__/connections-markdown.test.tsx
+++ b/apps/ui/src/__tests__/connections-markdown.test.tsx
@@ -1,0 +1,174 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import ConnectionsPage from "@/app/(main)/settings/connections/page";
+
+// Mock streamdown-message to capture rendered markdown content
+jest.mock("@/components/chat/streamdown-message", () => ({
+  StreamdownMessage: ({ children, className }: { children: string; className?: string }) => (
+    <div data-testid="streamdown-message" className={className}>
+      {children}
+    </div>
+  ),
+  InlineStreamdownMessage: ({ children, className }: { children: string; className?: string }) => (
+    <div data-testid="inline-streamdown-message" className={className}>
+      {children}
+    </div>
+  ),
+}));
+
+// Mock next/navigation
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => ({
+    get: jest.fn().mockReturnValue(null),
+  }),
+}));
+
+const mockUseUserConnections = jest.fn();
+const mockUseDeleteUserConnection = jest.fn();
+const mockUseConnectionProviders = jest.fn();
+const mockUseCreateApiKeyConnection = jest.fn();
+
+jest.mock("@/hooks/use-user-connections", () => ({
+  useUserConnections: () => mockUseUserConnections(),
+  useDeleteUserConnection: () => mockUseDeleteUserConnection(),
+  useConnectionProviders: () => mockUseConnectionProviders(),
+  useCreateApiKeyConnection: () => mockUseCreateApiKeyConnection(),
+}));
+
+jest.mock("@/lib/api/client", () => ({
+  getBackendUrl: () => "http://localhost:8080",
+}));
+
+const mockDaytonaProvider = {
+  provider_id: "daytona",
+  display_name: "Daytona",
+  description: "Cloud development environment",
+  icon: "cloud",
+  connection_type: "api_key" as const,
+  form_schema: {
+    fields: [
+      {
+        name: "api_key",
+        label: "API Key",
+        field_type: "password",
+        required: true,
+        placeholder: "Enter your Daytona API key",
+        help_text: null,
+      },
+    ],
+    instructions_markdown:
+      "1. Go to [Daytona Dashboard](https://app.daytona.io)\n2. Navigate to **API Keys** in your account settings\n3. Click **Create New API Key**\n4. Copy the key and paste it below",
+  },
+};
+
+describe("ConnectionsPage - Markdown Instructions", () => {
+  let queryClient: QueryClient;
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    mockUseUserConnections.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    });
+
+    mockUseConnectionProviders.mockReturnValue({
+      data: [mockDaytonaProvider],
+    });
+
+    mockUseDeleteUserConnection.mockReturnValue({
+      mutateAsync: jest.fn(),
+      isPending: false,
+    });
+
+    mockUseCreateApiKeyConnection.mockReturnValue({
+      mutateAsync: jest.fn(),
+      isPending: false,
+    });
+  });
+
+  it("renders available provider in the list", () => {
+    render(<ConnectionsPage />, { wrapper });
+
+    expect(screen.getByText("Daytona")).toBeInTheDocument();
+    expect(screen.getByText("Cloud development environment")).toBeInTheDocument();
+  });
+
+  it("renders instructions_markdown via InlineStreamdownMessage when dialog opens", async () => {
+    render(<ConnectionsPage />, { wrapper });
+
+    // Click Connect button to open the API key dialog
+    const connectButton = screen.getByRole("button", { name: /Connect/i });
+    fireEvent.click(connectButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    // Verify InlineStreamdownMessage is used with the raw markdown instructions
+    const markdownEl = screen.getByTestId("inline-streamdown-message");
+    expect(markdownEl).toBeInTheDocument();
+    // Raw markdown is passed as children (component handles rendering)
+    expect(markdownEl).toHaveTextContent("[Daytona Dashboard](https://app.daytona.io)");
+    expect(markdownEl).toHaveTextContent("**API Keys**");
+    expect(markdownEl).toHaveTextContent("**Create New API Key**");
+  });
+
+  it("passes styling classes to InlineStreamdownMessage", async () => {
+    render(<ConnectionsPage />, { wrapper });
+
+    const connectButton = screen.getByRole("button", { name: /Connect/i });
+    fireEvent.click(connectButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    const markdownEl = screen.getByTestId("inline-streamdown-message");
+    expect(markdownEl.className).toContain("text-sm");
+    expect(markdownEl.className).toContain("text-muted-foreground");
+  });
+
+  it("does not render InlineStreamdownMessage when dialog is closed", () => {
+    render(<ConnectionsPage />, { wrapper });
+
+    expect(screen.queryByTestId("inline-streamdown-message")).not.toBeInTheDocument();
+  });
+
+  it("renders form fields alongside markdown instructions", async () => {
+    render(<ConnectionsPage />, { wrapper });
+
+    const connectButton = screen.getByRole("button", { name: /Connect/i });
+    fireEvent.click(connectButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    // Both markdown instructions and form fields should be present
+    expect(screen.getByTestId("inline-streamdown-message")).toBeInTheDocument();
+    expect(screen.getByLabelText("API Key")).toBeInTheDocument();
+  });
+
+  it("renders Connect button with provider name in dialog title", async () => {
+    render(<ConnectionsPage />, { wrapper });
+
+    const connectButton = screen.getByRole("button", { name: /Connect/i });
+    fireEvent.click(connectButton);
+
+    await waitFor(() => {
+      expect(screen.getByText("Connect Daytona")).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/ui/src/__tests__/streamdown-message.test.tsx
+++ b/apps/ui/src/__tests__/streamdown-message.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen } from "@testing-library/react";
+
+// Capture props passed to Streamdown to verify components/plugins
+let capturedStreamdownProps: Record<string, unknown> = {};
+
+jest.mock("streamdown", () => ({
+  Streamdown: (props: Record<string, unknown>) => {
+    capturedStreamdownProps = props;
+    // Render children as text so we can assert content
+    return <div data-testid="streamdown-mock">{props.children as string}</div>;
+  },
+}));
+
+jest.mock("@streamdown/code", () => ({
+  code: { name: "mock-code-plugin" },
+}));
+
+jest.mock("remark-github-blockquote-alert", () => jest.fn());
+
+import { StreamdownMessage, InlineStreamdownMessage } from "@/components/chat/streamdown-message";
+
+describe("StreamdownMessage", () => {
+  beforeEach(() => {
+    capturedStreamdownProps = {};
+  });
+
+  it("passes components with ExternalLink override for anchor tags", () => {
+    render(<StreamdownMessage>Hello **world**</StreamdownMessage>);
+
+    expect(capturedStreamdownProps.components).toBeDefined();
+    const components = capturedStreamdownProps.components as Record<string, unknown>;
+    expect(components.a).toBeDefined();
+  });
+
+  it("ExternalLink component renders links with target=_blank", () => {
+    render(<StreamdownMessage>test</StreamdownMessage>);
+
+    const components = capturedStreamdownProps.components as Record<
+      string,
+      React.ComponentType<React.AnchorHTMLAttributes<HTMLAnchorElement>>
+    >;
+    const AnchorComponent = components.a;
+
+    // Render the anchor component directly
+    const { container } = render(
+      <AnchorComponent href="https://example.com">Click me</AnchorComponent>,
+    );
+    const link = container.querySelector("a")!;
+
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    expect(link).toHaveAttribute("href", "https://example.com");
+    expect(link).toHaveTextContent("Click me");
+  });
+
+  it("ExternalLink preserves additional attributes", () => {
+    render(<StreamdownMessage>test</StreamdownMessage>);
+
+    const components = capturedStreamdownProps.components as Record<
+      string,
+      React.ComponentType<React.AnchorHTMLAttributes<HTMLAnchorElement>>
+    >;
+    const AnchorComponent = components.a;
+
+    const { container } = render(
+      <AnchorComponent href="https://example.com" className="custom-link" title="Example">
+        Link
+      </AnchorComponent>,
+    );
+    const link = container.querySelector("a")!;
+
+    expect(link).toHaveAttribute("class", "custom-link");
+    expect(link).toHaveAttribute("title", "Example");
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("renders with default variant (bg-muted p-4)", () => {
+    const { container } = render(<StreamdownMessage>Content</StreamdownMessage>);
+
+    const wrapper = container.querySelector(".streamdown");
+    expect(wrapper?.className).toContain("bg-muted");
+    expect(wrapper?.className).toContain("p-4");
+  });
+
+  it("renders inline variant without background", () => {
+    const { container } = render(<StreamdownMessage variant="inline">Content</StreamdownMessage>);
+
+    const wrapper = container.querySelector(".streamdown");
+    expect(wrapper?.className).toContain("bg-transparent");
+    expect(wrapper?.className).not.toContain("bg-muted");
+  });
+
+  it("passes children to Streamdown", () => {
+    render(<StreamdownMessage>Hello markdown</StreamdownMessage>);
+
+    expect(screen.getByTestId("streamdown-mock")).toHaveTextContent("Hello markdown");
+  });
+
+  it("enables code highlighting by default", () => {
+    render(<StreamdownMessage>code block</StreamdownMessage>);
+
+    const plugins = capturedStreamdownProps.plugins as Record<string, unknown>;
+    expect(plugins.code).toEqual({ name: "mock-code-plugin" });
+  });
+
+  it("disables code highlighting when prop is false", () => {
+    render(<StreamdownMessage enableCodeHighlighting={false}>code block</StreamdownMessage>);
+
+    const plugins = capturedStreamdownProps.plugins as Record<string, unknown>;
+    expect(plugins.code).toBeUndefined();
+  });
+});
+
+describe("InlineStreamdownMessage", () => {
+  beforeEach(() => {
+    capturedStreamdownProps = {};
+  });
+
+  it("renders with inline variant (no background)", () => {
+    const { container } = render(
+      <InlineStreamdownMessage>Instructions here</InlineStreamdownMessage>,
+    );
+
+    const wrapper = container.querySelector(".streamdown");
+    expect(wrapper?.className).toContain("bg-transparent");
+  });
+
+  it("disables code highlighting", () => {
+    render(<InlineStreamdownMessage>Instructions</InlineStreamdownMessage>);
+
+    const plugins = capturedStreamdownProps.plugins as Record<string, unknown>;
+    expect(plugins.code).toBeUndefined();
+  });
+
+  it("passes custom className", () => {
+    const { container } = render(
+      <InlineStreamdownMessage className="text-sm text-muted-foreground">
+        Content
+      </InlineStreamdownMessage>,
+    );
+
+    const wrapper = container.querySelector(".streamdown");
+    expect(wrapper?.className).toContain("text-sm");
+    expect(wrapper?.className).toContain("text-muted-foreground");
+  });
+
+  it("inherits ExternalLink component for links", () => {
+    render(<InlineStreamdownMessage>Content</InlineStreamdownMessage>);
+
+    const components = capturedStreamdownProps.components as Record<string, unknown>;
+    expect(components.a).toBeDefined();
+  });
+});

--- a/apps/ui/src/app/(main)/settings/connections/page.tsx
+++ b/apps/ui/src/app/(main)/settings/connections/page.tsx
@@ -26,6 +26,7 @@ import { getBackendUrl } from "@/lib/api/client";
 import { ExternalLink, Github, LinkIcon, Trash2, Check, Cloud, AlertCircle } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { UserConnection, ConnectionProvider as ConnectionProviderType } from "@/lib/api/types";
+import { InlineStreamdownMessage } from "@/components/chat/streamdown-message";
 
 /** Icon mapping — lucide icon name to component */
 const iconMap: Record<string, LucideIcon> = {
@@ -182,9 +183,9 @@ function ApiKeyDialog({
 
         <form onSubmit={handleSubmit}>
           {/* Instructions */}
-          <div className="text-sm text-muted-foreground whitespace-pre-line mb-4 leading-relaxed">
+          <InlineStreamdownMessage className="text-sm text-muted-foreground mb-4 leading-relaxed">
             {provider.form_schema.instructions_markdown}
-          </div>
+          </InlineStreamdownMessage>
 
           {/* Form fields */}
           <div className="space-y-4 mb-4">

--- a/apps/ui/src/components/chat/streamdown-message.tsx
+++ b/apps/ui/src/components/chat/streamdown-message.tsx
@@ -13,6 +13,19 @@ import { Streamdown, type StreamdownProps } from "streamdown";
 import { code } from "@streamdown/code";
 import remarkGithubAlerts from "remark-github-blockquote-alert";
 import { cn } from "@/lib/utils";
+import type { ComponentType, AnchorHTMLAttributes } from "react";
+
+/** Opens all markdown links in a new tab with noopener noreferrer. */
+const ExternalLink: ComponentType<AnchorHTMLAttributes<HTMLAnchorElement>> = ({
+  children,
+  ...props
+}) => (
+  <a {...props} target="_blank" rel="noopener noreferrer">
+    {children}
+  </a>
+);
+
+const markdownComponents = { a: ExternalLink };
 
 // Streamdown styling to match the design system
 const streamdownStyles = `
@@ -108,6 +121,7 @@ export function StreamdownMessage({
           plugins={plugins}
           isAnimating={isAnimating}
           remarkPlugins={[remarkGithubAlerts]}
+          components={markdownComponents}
         >
           {children}
         </Streamdown>


### PR DESCRIPTION
## What
Render `instructions_markdown` from connection providers as actual markdown instead of plain text. All markdown links now open in a new tab.

## Why
Connection provider instructions (e.g. Daytona) contain markdown syntax (links, bold, numbered lists) but were displayed as raw text in the API key dialog.

## How
- Replace plain `<div>` with `InlineStreamdownMessage` in the API key dialog
- Add `target="_blank" rel="noopener noreferrer"` to all Streamdown-rendered links via `components` prop override

## Risk
- Low
- All existing markdown rendering uses StreamdownMessage, so link behavior change is consistent globally

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered