### PR TITLE
fix(auth): auto-refresh expired tokens and preserve page on re-login

### DIFF
--- a/apps/ui/src/app/(auth)/layout.tsx
+++ b/apps/ui/src/app/(auth)/layout.tsx
@@ -1,8 +1,14 @@
+import { Suspense } from "react";
+import { Loader2 } from "lucide-react";
+
 // Auth pages layout - centered, no sidebar
+// Suspense boundary required for useSearchParams() in login/register pages
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="min-h-screen flex items-center justify-center bg-background bg-brand-dots p-4">
-      {children}
+      <Suspense fallback={<Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />}>
+        {children}
+      </Suspense>
     </div>
   );
 }

--- a/apps/ui/src/app/(auth)/login/page.tsx
+++ b/apps/ui/src/app/(auth)/login/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import Image from "next/image";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -20,6 +20,9 @@ import { useAuthConfig, useLogin } from "@/hooks/use-auth";
 import { getOAuthUrl } from "@/lib/api/auth";
 import { Loader2 } from "lucide-react";
 
+// Session storage key for preserving return_to across OAuth redirects
+const RETURN_TO_KEY = "everruns_return_to";
+
 // OAuth provider icons/names
 const oauthProviders: Record<string, { name: string; icon: string }> = {
   google: { name: "Google", icon: "/icons/google.svg" },
@@ -28,12 +31,15 @@ const oauthProviders: Record<string, { name: string; icon: string }> = {
 
 export default function LoginPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { data: config, isLoading: configLoading } = useAuthConfig();
   const loginMutation = useLogin();
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
+
+  const returnTo = searchParams.get("return_to");
 
   // Redirect to dashboard if auth is not required
   useEffect(() => {
@@ -42,13 +48,20 @@ export default function LoginPage() {
     }
   }, [config, router]);
 
+  const getRedirectTarget = (): string => {
+    // Check URL param first, then sessionStorage (for OAuth flow)
+    const target = returnTo || sessionStorage.getItem(RETURN_TO_KEY);
+    sessionStorage.removeItem(RETURN_TO_KEY);
+    return target || "/dashboard";
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
 
     try {
       await loginMutation.mutateAsync({ email, password });
-      router.push("/dashboard");
+      router.push(getRedirectTarget());
     } catch (err) {
       if (err instanceof Error) {
         setError(err.message);
@@ -59,6 +72,11 @@ export default function LoginPage() {
   };
 
   const handleOAuthLogin = (provider: string) => {
+    // Persist return_to in sessionStorage so it survives the OAuth redirect chain
+    const target = returnTo || sessionStorage.getItem(RETURN_TO_KEY);
+    if (target) {
+      sessionStorage.setItem(RETURN_TO_KEY, target);
+    }
     window.location.assign(getOAuthUrl(provider));
   };
 
@@ -188,7 +206,10 @@ export default function LoginPage() {
         <CardFooter className="flex justify-center">
           <p className="text-sm text-muted-foreground">
             Don&apos;t have an account?{" "}
-            <Link href="/register" className="text-primary hover:underline">
+            <Link
+              href={returnTo ? `/register?return_to=${encodeURIComponent(returnTo)}` : "/register"}
+              className="text-primary hover:underline"
+            >
               Sign up
             </Link>
           </p>

--- a/apps/ui/src/app/(auth)/register/page.tsx
+++ b/apps/ui/src/app/(auth)/register/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import Image from "next/image";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -20,6 +20,7 @@ import { Loader2 } from "lucide-react";
 
 export default function RegisterPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { data: config, isLoading: configLoading } = useAuthConfig();
   const registerMutation = useRegister();
 
@@ -28,6 +29,8 @@ export default function RegisterPage() {
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
+
+  const returnTo = searchParams.get("return_to");
 
   // Redirect if auth is not required or signup is disabled
   useEffect(() => {
@@ -58,7 +61,7 @@ export default function RegisterPage() {
 
     try {
       await registerMutation.mutateAsync({ name, email, password });
-      router.push("/dashboard");
+      router.push(returnTo || "/dashboard");
     } catch (err) {
       if (err instanceof Error) {
         setError(err.message);
@@ -160,7 +163,10 @@ export default function RegisterPage() {
       <CardFooter className="flex justify-center">
         <p className="text-sm text-muted-foreground">
           Already have an account?{" "}
-          <Link href="/login" className="text-primary hover:underline">
+          <Link
+            href={returnTo ? `/login?return_to=${encodeURIComponent(returnTo)}` : "/login"}
+            className="text-primary hover:underline"
+          >
             Sign in
           </Link>
         </p>

--- a/apps/ui/src/app/(main)/layout.tsx
+++ b/apps/ui/src/app/(main)/layout.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 // Main app layout with sidebar and auth guard
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { Suspense, useEffect } from "react";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { Sidebar } from "@/components/layout/sidebar";
 import { useAuth } from "@/providers/auth-provider";
 import { useOrg } from "@/providers/org-provider";
@@ -12,8 +12,10 @@ interface MainLayoutProps {
   children: React.ReactNode;
 }
 
-export default function MainLayout({ children }: MainLayoutProps) {
+function MainLayoutInner({ children }: MainLayoutProps) {
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const { isAuthenticated, isLoading: authLoading, requiresAuth } = useAuth();
   const { isLoading: orgLoading } = useOrg();
 
@@ -23,9 +25,24 @@ export default function MainLayout({ children }: MainLayoutProps) {
   // Redirect to login if auth is required but user is not authenticated
   useEffect(() => {
     if (!authLoading && requiresAuth && !isAuthenticated) {
-      router.replace("/login");
+      // Preserve current location so login can redirect back
+      const currentUrl = pathname + (searchParams.toString() ? `?${searchParams.toString()}` : "");
+      const returnTo =
+        currentUrl !== "/dashboard" ? `?return_to=${encodeURIComponent(currentUrl)}` : "";
+      router.replace(`/login${returnTo}`);
     }
-  }, [authLoading, requiresAuth, isAuthenticated, router]);
+  }, [authLoading, requiresAuth, isAuthenticated, router, pathname, searchParams]);
+
+  // After OAuth login, check sessionStorage for a pending return_to redirect
+  useEffect(() => {
+    if (!authLoading && isAuthenticated) {
+      const pendingReturnTo = sessionStorage.getItem("everruns_return_to");
+      if (pendingReturnTo) {
+        sessionStorage.removeItem("everruns_return_to");
+        router.replace(pendingReturnTo);
+      }
+    }
+  }, [authLoading, isAuthenticated, router]);
 
   // Show loading state while checking auth and initializing org
   if (isLoading) {
@@ -46,5 +63,19 @@ export default function MainLayout({ children }: MainLayoutProps) {
       <Sidebar />
       <main className="flex-1 overflow-auto bg-background bg-brand-dots">{children}</main>
     </div>
+  );
+}
+
+export default function MainLayout({ children }: MainLayoutProps) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex h-screen items-center justify-center">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      }
+    >
+      <MainLayoutInner>{children}</MainLayoutInner>
+    </Suspense>
   );
 }

--- a/apps/ui/src/lib/api/auth.ts
+++ b/apps/ui/src/lib/api/auth.ts
@@ -53,12 +53,11 @@ export async function logout(): Promise<void> {
 }
 
 /**
- * Refresh the access token using the refresh token
+ * Refresh the access token using the refresh token cookie.
+ * The HttpOnly refresh_token cookie is sent automatically by the browser.
  */
-export async function refreshToken(token: string): Promise<TokenResponse> {
-  const { data } = await api.post<TokenResponse>("/v1/auth/refresh", {
-    refresh_token: token,
-  });
+export async function refreshToken(): Promise<TokenResponse> {
+  const { data } = await api.post<TokenResponse>("/v1/auth/refresh");
   return data;
 }
 

--- a/apps/ui/src/lib/api/client.ts
+++ b/apps/ui/src/lib/api/client.ts
@@ -18,17 +18,50 @@ export class ApiError extends Error {
   }
 }
 
+// Token refresh state: deduplicates concurrent refresh attempts so multiple
+// 401 responses don't each consume a refresh token.
+let refreshPromise: Promise<boolean> | null = null;
+
+async function tryRefreshToken(): Promise<boolean> {
+  try {
+    // POST with no body — backend reads refresh_token from HttpOnly cookie
+    const response = await fetch(`${API_BASE}/v1/auth/refresh`, {
+      method: "POST",
+      credentials: "include",
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
 async function request<T>(endpoint: string, options: RequestInit = {}): Promise<{ data: T }> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     ...(options.headers as Record<string, string>),
   };
 
-  const response = await fetch(`${API_BASE}${endpoint}`, {
-    ...options,
-    credentials: "include", // Include cookies for auth (access_token, everruns_org)
-    headers,
-  });
+  const doFetch = () =>
+    fetch(`${API_BASE}${endpoint}`, {
+      ...options,
+      credentials: "include", // Include cookies for auth (access_token, everruns_org)
+      headers,
+    });
+
+  let response = await doFetch();
+
+  // On 401, try refreshing the access token once (skip for auth endpoints to avoid loops)
+  if (response.status === 401 && !endpoint.startsWith("/v1/auth/")) {
+    if (!refreshPromise) {
+      refreshPromise = tryRefreshToken().finally(() => {
+        refreshPromise = null;
+      });
+    }
+    const refreshed = await refreshPromise;
+    if (refreshed) {
+      response = await doFetch();
+    }
+  }
 
   if (!response.ok) {
     // Try to get error details from response body

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -341,19 +341,32 @@ pub async fn register(
 }
 
 /// POST /v1/auth/refresh - Refresh access token
+///
+/// Accepts the refresh token from either the JSON body (`{ "refresh_token": "..." }`)
+/// or the `refresh_token` HttpOnly cookie (set at login). Cookie-based is the
+/// primary flow for browser clients since the cookie is HttpOnly.
 pub async fn refresh_token(
     State(state): State<BuiltinAuthBackend>,
     jar: CookieJar,
-    Json(req): Json<RefreshTokenRequest>,
+    body: Option<Json<RefreshTokenRequest>>,
 ) -> Result<(CookieJar, Json<TokenResponse>), AuthError> {
+    // Prefer JSON body, fall back to cookie
+    let refresh_token_value = if let Some(Json(req)) = body {
+        req.refresh_token
+    } else if let Some(cookie) = jar.get("refresh_token") {
+        cookie.value().to_string()
+    } else {
+        return Err(AuthError::unauthorized("Missing refresh token"));
+    };
+
     // Validate refresh token
     let claims = state
         .jwt_service
-        .validate_refresh_token(&req.refresh_token)
+        .validate_refresh_token(&refresh_token_value)
         .map_err(|_| AuthError::unauthorized("Invalid refresh token"))?;
 
     // Check if token is in database (not revoked)
-    let token_hash = hash_token(&req.refresh_token);
+    let token_hash = hash_token(&refresh_token_value);
     let token_row = state
         .db
         .get_refresh_token_by_hash(&token_hash)
@@ -783,8 +796,10 @@ async fn generate_token_response(
         .max_age(time::Duration::seconds(token_pair.expires_in))
         .build();
 
+    // Path must be "/" so the cookie is sent through the /api proxy.
+    // "/v1/auth" doesn't match the browser-side path "/api/v1/auth".
     let refresh_cookie = Cookie::build(("refresh_token", token_pair.refresh_token.clone()))
-        .path("/v1/auth")
+        .path("/")
         .http_only(true)
         .secure(true)
         .same_site(SameSite::Strict)

--- a/crates/server/tests/auth_integration_test.rs
+++ b/crates/server/tests/auth_integration_test.rs
@@ -1,0 +1,510 @@
+//! Auth integration tests for refresh token flows
+//!
+//! Tests the refresh token endpoint with both JSON body and HttpOnly cookie sources,
+//! verifying the fix for cookie path (/ vs /v1/auth) and the new cookie-based refresh flow.
+//!
+//! Run with: cargo test -p everruns-server --test auth_integration_test
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use everruns_server::auth::config::{AuthConfig, AuthMode, JwtConfig};
+use everruns_server::auth::{self, BuiltinAuthBackend};
+use everruns_server::seed;
+use everruns_server::storage::StorageBackend;
+
+/// Build a mini router with auth routes backed by in-memory storage.
+async fn auth_router() -> (Router, Arc<StorageBackend>) {
+    let db = Arc::new(StorageBackend::in_memory());
+    let grade = everruns_core::DeploymentGrade::from_env();
+    seed::seed_all(&db, grade).await.expect("seed failed");
+
+    let config = AuthConfig {
+        mode: AuthMode::Full,
+        jwt: JwtConfig {
+            secret: "test-secret-for-auth-integration-tests".to_string(),
+            access_token_lifetime: Duration::from_secs(900),
+            refresh_token_lifetime: Duration::from_secs(86400),
+        },
+        ..Default::default()
+    };
+
+    let backend = BuiltinAuthBackend::new(config, db.clone());
+    let router = auth::routes(backend);
+    (router, db)
+}
+
+/// Helper: issue a request and return (status, body_json, set-cookie headers).
+async fn send(
+    router: &Router,
+    method: &str,
+    uri: &str,
+    body: Option<Value>,
+    cookies: Option<&str>,
+) -> (StatusCode, Value, Vec<String>) {
+    let mut builder = Request::builder().method(method).uri(uri);
+
+    if body.is_some() {
+        builder = builder.header("content-type", "application/json");
+    }
+    if let Some(c) = cookies {
+        builder = builder.header("cookie", c);
+    }
+
+    let request = if let Some(b) = body {
+        builder
+            .body(Body::from(serde_json::to_string(&b).unwrap()))
+            .unwrap()
+    } else {
+        builder.body(Body::empty()).unwrap()
+    };
+
+    let response = router.clone().oneshot(request).await.unwrap();
+    let status = response.status();
+
+    let set_cookies: Vec<String> = response
+        .headers()
+        .get_all("set-cookie")
+        .iter()
+        .map(|v| v.to_str().unwrap().to_string())
+        .collect();
+
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+
+    let json: Value = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+    };
+
+    (status, json, set_cookies)
+}
+
+/// Extract a named cookie value from Set-Cookie headers.
+fn extract_cookie_value(set_cookies: &[String], name: &str) -> Option<String> {
+    for header in set_cookies {
+        if header.starts_with(&format!("{name}=")) {
+            let value = header
+                .split(';')
+                .next()
+                .unwrap()
+                .trim_start_matches(&format!("{name}="));
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+/// Register a test user and return (access_token, refresh_token, set_cookies).
+async fn register_user(
+    router: &Router,
+    email: &str,
+    password: &str,
+) -> (String, String, Vec<String>) {
+    let (status, body, cookies) = send(
+        router,
+        "POST",
+        "/v1/auth/register",
+        Some(json!({
+            "email": email,
+            "password": password,
+            "name": "Test User"
+        })),
+        None,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::CREATED, "register failed: {body}");
+    let access_token = body["access_token"].as_str().unwrap().to_string();
+    let refresh_token = body["refresh_token"].as_str().unwrap().to_string();
+    (access_token, refresh_token, cookies)
+}
+
+// ============================================
+// Positive path tests
+// ============================================
+
+#[tokio::test]
+async fn test_refresh_via_json_body() {
+    let (router, _db) = auth_router().await;
+
+    let (_access, refresh, _cookies) =
+        register_user(&router, "body@example.com", "password123").await;
+
+    // Refresh using JSON body (the original flow)
+    let (status, body, new_cookies) = send(
+        &router,
+        "POST",
+        "/v1/auth/refresh",
+        Some(json!({ "refresh_token": refresh })),
+        None,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "refresh via body failed: {body}");
+    assert!(body["access_token"].is_string());
+    assert!(body["refresh_token"].is_string());
+    assert_eq!(body["token_type"], "Bearer");
+
+    // New tokens should be different (token rotation)
+    assert_ne!(body["refresh_token"].as_str().unwrap(), refresh);
+
+    // Should also set cookies
+    assert!(
+        extract_cookie_value(&new_cookies, "access_token").is_some(),
+        "access_token cookie missing"
+    );
+    assert!(
+        extract_cookie_value(&new_cookies, "refresh_token").is_some(),
+        "refresh_token cookie missing"
+    );
+}
+
+#[tokio::test]
+async fn test_refresh_via_cookie() {
+    let (router, _db) = auth_router().await;
+
+    let (_access, refresh, _cookies) =
+        register_user(&router, "cookie@example.com", "password123").await;
+
+    // Refresh using cookie (no JSON body) — the new browser flow
+    let cookie_header = format!("refresh_token={refresh}");
+    let (status, body, _new_cookies) = send(
+        &router,
+        "POST",
+        "/v1/auth/refresh",
+        None,
+        Some(&cookie_header),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "refresh via cookie failed: {body}");
+    assert!(body["access_token"].is_string());
+    assert!(body["refresh_token"].is_string());
+    // Token rotation: new refresh token must differ from old one
+    assert_ne!(body["refresh_token"].as_str().unwrap(), refresh);
+}
+
+#[tokio::test]
+async fn test_refresh_body_takes_precedence_over_cookie() {
+    let (router, _db) = auth_router().await;
+
+    // Register two users
+    let (_a1, refresh1, _c1) = register_user(&router, "user1@example.com", "password123").await;
+    let (_a2, refresh2, _c2) = register_user(&router, "user2@example.com", "password123").await;
+
+    // Send body with user1's token, cookie with user2's token
+    // Body should take precedence
+    let cookie_header = format!("refresh_token={refresh2}");
+    let (status, body, _cookies) = send(
+        &router,
+        "POST",
+        "/v1/auth/refresh",
+        Some(json!({ "refresh_token": refresh1 })),
+        Some(&cookie_header),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "refresh failed: {body}");
+
+    // Verify the user2 token is still valid (wasn't consumed)
+    let cookie_header2 = format!("refresh_token={refresh2}");
+    let (status2, body2, _) = send(
+        &router,
+        "POST",
+        "/v1/auth/refresh",
+        None,
+        Some(&cookie_header2),
+    )
+    .await;
+    assert_eq!(
+        status2,
+        StatusCode::OK,
+        "user2 refresh should still work: {body2}"
+    );
+}
+
+#[tokio::test]
+async fn test_refresh_sets_cookie_with_root_path() {
+    let (router, _db) = auth_router().await;
+
+    let (_access, refresh, _cookies) =
+        register_user(&router, "path@example.com", "password123").await;
+
+    let (status, _body, new_cookies) = send(
+        &router,
+        "POST",
+        "/v1/auth/refresh",
+        Some(json!({ "refresh_token": refresh })),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    // Verify the refresh_token cookie has Path=/
+    let refresh_cookie = new_cookies
+        .iter()
+        .find(|c| c.starts_with("refresh_token="))
+        .expect("refresh_token cookie not set");
+    assert!(
+        refresh_cookie.contains("Path=/;") || refresh_cookie.ends_with("Path=/"),
+        "refresh_token cookie should have Path=/, got: {refresh_cookie}"
+    );
+
+    // Verify it's HttpOnly
+    let lower = refresh_cookie.to_lowercase();
+    assert!(lower.contains("httponly"), "should be HttpOnly");
+}
+
+// ============================================
+// Negative path tests
+// ============================================
+
+#[tokio::test]
+async fn test_refresh_no_token_returns_401() {
+    let (router, _db) = auth_router().await;
+
+    // No body, no cookie
+    let (status, body, _cookies) = send(&router, "POST", "/v1/auth/refresh", None, None).await;
+
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap()
+            .contains("Missing refresh token")
+    );
+}
+
+#[tokio::test]
+async fn test_refresh_invalid_token_returns_401() {
+    let (router, _db) = auth_router().await;
+
+    let (status, body, _cookies) = send(
+        &router,
+        "POST",
+        "/v1/auth/refresh",
+        Some(json!({ "refresh_token": "this-is-not-a-valid-jwt" })),
+        None,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap()
+            .contains("Invalid refresh token")
+    );
+}
+
+#[tokio::test]
+async fn test_refresh_invalid_cookie_returns_401() {
+    let (router, _db) = auth_router().await;
+
+    let (status, body, _cookies) = send(
+        &router,
+        "POST",
+        "/v1/auth/refresh",
+        None,
+        Some("refresh_token=garbage-jwt-value"),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap()
+            .contains("Invalid refresh token")
+    );
+}
+
+#[tokio::test]
+async fn test_refresh_reuse_revoked_token_returns_401() {
+    let (router, _db) = auth_router().await;
+
+    let (_access, refresh, _cookies) =
+        register_user(&router, "revoke@example.com", "password123").await;
+
+    // First refresh succeeds (consumes the token)
+    let (status1, _body1, _) = send(
+        &router,
+        "POST",
+        "/v1/auth/refresh",
+        Some(json!({ "refresh_token": refresh })),
+        None,
+    )
+    .await;
+    assert_eq!(status1, StatusCode::OK);
+
+    // Second refresh with the same token should fail (token was rotated/deleted)
+    let (status2, body2, _) = send(
+        &router,
+        "POST",
+        "/v1/auth/refresh",
+        Some(json!({ "refresh_token": refresh })),
+        None,
+    )
+    .await;
+    assert_eq!(
+        status2,
+        StatusCode::UNAUTHORIZED,
+        "reused token should be rejected: {body2}"
+    );
+}
+
+#[tokio::test]
+async fn test_refresh_with_access_token_returns_401() {
+    let (router, _db) = auth_router().await;
+
+    let (access, _refresh, _cookies) =
+        register_user(&router, "wrong-type@example.com", "password123").await;
+
+    // Try refreshing with an access token (wrong token type)
+    let (status, body, _cookies) = send(
+        &router,
+        "POST",
+        "/v1/auth/refresh",
+        Some(json!({ "refresh_token": access })),
+        None,
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "access token should not work as refresh: {body}"
+    );
+}
+
+// ============================================
+// Login flow tests
+// ============================================
+
+#[tokio::test]
+async fn test_login_sets_cookies_with_root_path() {
+    let (router, _db) = auth_router().await;
+
+    // Register first
+    register_user(&router, "login@example.com", "password123").await;
+
+    // Login
+    let (status, body, cookies) = send(
+        &router,
+        "POST",
+        "/v1/auth/login",
+        Some(json!({
+            "email": "login@example.com",
+            "password": "password123"
+        })),
+        None,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "login failed: {body}");
+
+    // Verify refresh_token cookie has Path=/
+    let refresh_cookie = cookies
+        .iter()
+        .find(|c| c.starts_with("refresh_token="))
+        .expect("refresh_token cookie not set");
+    assert!(
+        refresh_cookie.contains("Path=/;") || refresh_cookie.ends_with("Path=/"),
+        "refresh_token cookie should have Path=/, got: {refresh_cookie}"
+    );
+}
+
+#[tokio::test]
+async fn test_full_flow_register_login_refresh_cookie_refresh() {
+    let (router, _db) = auth_router().await;
+
+    // 1. Register
+    let (_access, _refresh, _reg_cookies) =
+        register_user(&router, "flow@example.com", "password123").await;
+
+    // 2. Login
+    let (status, _body, login_cookies) = send(
+        &router,
+        "POST",
+        "/v1/auth/login",
+        Some(json!({
+            "email": "flow@example.com",
+            "password": "password123"
+        })),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    // 3. Refresh via cookie (simulating browser behavior)
+    let refresh_val = extract_cookie_value(&login_cookies, "refresh_token")
+        .expect("no refresh cookie from login");
+    let (status, body, refresh_cookies) = send(
+        &router,
+        "POST",
+        "/v1/auth/refresh",
+        None,
+        Some(&format!("refresh_token={refresh_val}")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "cookie refresh failed: {body}");
+
+    // 4. Refresh again with the new cookie (chained rotation)
+    let new_refresh_val = extract_cookie_value(&refresh_cookies, "refresh_token")
+        .expect("no refresh cookie after refresh");
+    let (status2, body2, _) = send(
+        &router,
+        "POST",
+        "/v1/auth/refresh",
+        None,
+        Some(&format!("refresh_token={new_refresh_val}")),
+    )
+    .await;
+    assert_eq!(
+        status2,
+        StatusCode::OK,
+        "chained cookie refresh failed: {body2}"
+    );
+
+    // 5. Old registration refresh token should be revoked already (used during register)
+    // Actually register returns a fresh token, and login creates a new one.
+    // The register refresh_token in reg_cookies was never used for refresh,
+    // but let's verify the old login token is consumed after step 3.
+    let (status3, _, _) = send(
+        &router,
+        "POST",
+        "/v1/auth/refresh",
+        None,
+        Some(&format!("refresh_token={refresh_val}")),
+    )
+    .await;
+    assert_eq!(
+        status3,
+        StatusCode::UNAUTHORIZED,
+        "old login refresh token should be consumed"
+    );
+}
+
+// ============================================
+// Auth config endpoint test
+// ============================================
+
+#[tokio::test]
+async fn test_auth_config_returns_full_mode() {
+    let (router, _db) = auth_router().await;
+
+    let (status, body, _cookies) = send(&router, "GET", "/v1/auth/config", None, None).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["mode"], "full");
+    assert_eq!(body["password_auth_enabled"], true);
+    assert_eq!(body["signup_enabled"], true);
+}

--- a/specs/authentication.md
+++ b/specs/authentication.md
@@ -145,10 +145,11 @@ The anonymous user is added to the default organization (`org_id = 1`) via `ensu
 ### Security Considerations
 
 1. **JWT Secret**: Must be a secure random string (minimum 32 bytes recommended)
-2. **Cookie Security**: Refresh tokens use HTTP-only, Secure (in production), SameSite=Lax cookies
+2. **Cookie Security**: Refresh tokens use HTTP-only, Secure (in production), SameSite=Strict cookies with `Path=/` so the cookie is sent through the UI's `/api` proxy
 3. **API Key Storage**: Only hash is stored, full key shown once at creation
 4. **Password Storage**: Argon2id with secure defaults
 5. **Token Revocation**: Refresh tokens can be revoked by deleting from database
+6. **Token Auto-Refresh**: The UI API client intercepts 401 responses and attempts a silent token refresh before failing (skips `/v1/auth/` endpoints to avoid loops; concurrent 401s are deduplicated into a single refresh request)
 
 ### Error Responses
 
@@ -198,17 +199,29 @@ Based on `mode`:
 1. App loads, fetches `/v1/auth/config`
 2. If `mode === "none"`, render app without auth
 3. Otherwise, check if user is authenticated via `/v1/auth/me`
-4. If not authenticated, redirect to `/login`
-5. After login, cookies are set automatically (HTTP-only)
+4. If not authenticated, redirect to `/login?return_to=<current_path>` (preserving the user's location)
+5. After login, cookies are set automatically (HTTP-only) and the user is redirected back to `return_to` (default: `/dashboard`)
 6. Subsequent requests include cookies via `credentials: "include"`
+7. On 401 response, the API client silently attempts `POST /v1/auth/refresh` (using the HttpOnly `refresh_token` cookie) and retries the request
+
+### Token Refresh
+
+The `POST /v1/auth/refresh` endpoint accepts the refresh token from two sources (checked in order):
+
+1. **JSON body** `{ "refresh_token": "..." }` — for programmatic clients
+2. **HttpOnly cookie** `refresh_token` — primary flow for browser clients (cookie is set at login with `Path=/`)
+
+On success, the old refresh token is deleted (rotation) and a new token pair is returned (both in JSON body and Set-Cookie headers).
 
 ### OAuth Flow
 
 1. User clicks OAuth button (e.g., "Continue with Google")
-2. Browser redirects to `GET /v1/auth/oauth/{provider}`
-3. API redirects to provider's authorization page
-4. After user authorizes, provider redirects to callback
-5. API handles callback, sets cookies, redirects to `/`
+2. If a `return_to` URL is present, the UI persists it in `sessionStorage` (key: `everruns_return_to`) so it survives the redirect chain
+3. Browser redirects to `GET /v1/auth/oauth/{provider}`
+4. API redirects to provider's authorization page
+5. After user authorizes, provider redirects to callback
+6. API handles callback, sets cookies, redirects to `/`
+7. The main layout checks `sessionStorage` for a pending `return_to` and redirects the user back
 
 ### Protected Routes
 


### PR DESCRIPTION
## What
Fix two auth UX issues: silent token expiration kicking users to login, and losing the current page after re-login.

## Why
1. Access tokens (15min TTL) expired silently because the `refresh_token` cookie had `path=/v1/auth` which didn't match the browser proxy path `/api/v1/auth`, so the cookie was never sent on refresh requests.
2. After re-login, users always landed on `/dashboard` instead of the page they were on.

## How
- **Cookie path fix**: Change refresh_token cookie path from `/v1/auth` to `/` so the browser sends it through the `/api` proxy.
- **Auto-refresh interceptor**: Add a 401 interceptor in the API client that attempts a token refresh before failing. Concurrent 401s are deduplicated so only one refresh request fires.
- **Backend flexibility**: Accept refresh token from either the JSON body or the HttpOnly cookie (cookie is primary for browser clients).
- **return_to flow**: When redirecting to login, pass `return_to` query param with the current URL. After login, redirect back. For OAuth, persist `return_to` in sessionStorage across the redirect chain.
- **Suspense boundaries**: Wrap layouts using `useSearchParams()` in Suspense (required by Next.js).

## Risk
- Low
- Cookie path change is broader (`/`) but the cookie is already HttpOnly, Secure, SameSite=Strict
- Auto-refresh skips `/v1/auth/` endpoints to avoid loops

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
