### PR TITLE
refactor(capabilities): make Capability trait async for dynamic system prompt content

### DIFF
--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -554,15 +554,15 @@ where
         };
 
         let mut builder = RuntimeAgentBuilder::new()
-            .with_harness_async(&harness, &self.capability_registry, &prompt_ctx)
+            .with_harness(&harness, &self.capability_registry, &prompt_ctx)
             .await;
         if let Some(ref agent) = agent {
             builder = builder
-                .with_agent_async(agent, &self.capability_registry, &prompt_ctx)
+                .with_agent(agent, &self.capability_registry, &prompt_ctx)
                 .await;
         }
         builder = builder
-            .with_capabilities_async(
+            .with_capabilities(
                 &session_capability_ids,
                 &self.capability_registry,
                 &prompt_ctx,

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -180,7 +180,8 @@ where
     event_emitter: E,
     /// Optional image resolver for resolving image_file content parts
     image_resolver: Option<Arc<dyn ImageResolver>>,
-    /// Optional file store for reading AGENTS.md (agent_instructions capability)
+    /// Optional file store for capabilities that need filesystem access
+    /// (e.g., agent_instructions reads AGENTS.md, skills_discovery scans for skills)
     file_store: Option<Arc<dyn crate::traits::SessionFileStore>>,
 }
 
@@ -219,11 +220,12 @@ where
         }
     }
 
-    /// Set the file store for reading AGENTS.md (agent_instructions capability)
+    /// Set the file store for capabilities that need filesystem access.
     ///
-    /// When set and the `agent_instructions` capability is enabled, the atom
-    /// reads `/AGENTS.md` from the session workspace on every LLM turn and
-    /// prepends its content to the system prompt.
+    /// Provides filesystem access to capabilities via `SystemPromptContext`.
+    /// Capabilities like `agent_instructions` (reads AGENTS.md) and
+    /// `skills_discovery` (scans for skills) use this to generate dynamic
+    /// system prompt content.
     pub fn with_file_store(mut self, file_store: Arc<dyn crate::traits::SessionFileStore>) -> Self {
         self.file_store = Some(file_store);
         self
@@ -538,67 +540,40 @@ where
             .await?;
 
         // 6. Build runtime agent: harness (base) → agent (optional) → session caps
+        //    Uses async builder methods so capabilities can resolve dynamic system
+        //    prompt content (e.g., reading AGENTS.md, discovering skills).
         let session_capability_ids: Vec<String> = session
             .capabilities
             .iter()
             .map(|cap| cap.capability_id().to_string())
             .collect();
-        let mut builder =
-            RuntimeAgentBuilder::new().with_harness(&harness, &self.capability_registry);
+
+        let prompt_ctx = crate::capabilities::SystemPromptContext {
+            session_id,
+            file_store: self.file_store.clone(),
+        };
+
+        let mut builder = RuntimeAgentBuilder::new()
+            .with_harness_async(&harness, &self.capability_registry, &prompt_ctx)
+            .await;
         if let Some(ref agent) = agent {
-            builder = builder.with_agent(agent, &self.capability_registry);
+            builder = builder
+                .with_agent_async(agent, &self.capability_registry, &prompt_ctx)
+                .await;
         }
         builder = builder
-            .with_capabilities(&session_capability_ids, &self.capability_registry)
+            .with_capabilities_async(
+                &session_capability_ids,
+                &self.capability_registry,
+                &prompt_ctx,
+            )
+            .await
             .tools(mcp_tool_definitions.iter().cloned())
             .model(&model_with_provider.model);
 
         // Add session-level client-side tools (additive to agent tools)
         if !session.tools.is_empty() {
             builder = builder.tools(session.tools.clone());
-        }
-
-        // 6b. Read AGENTS.md if agent_instructions capability is enabled
-        //     Check harness, agent, and session capabilities (any layer can enable it).
-        let has_agent_instructions =
-            harness.capabilities.iter().any(|c| {
-                c.capability_id() == crate::capabilities::AGENT_INSTRUCTIONS_CAPABILITY_ID
-            }) || agent
-                .as_ref()
-                .map(|a| {
-                    a.capabilities.iter().any(|c| {
-                        c.capability_id() == crate::capabilities::AGENT_INSTRUCTIONS_CAPABILITY_ID
-                    })
-                })
-                .unwrap_or(false)
-                || session_capability_ids
-                    .iter()
-                    .any(|id| id == crate::capabilities::AGENT_INSTRUCTIONS_CAPABILITY_ID);
-
-        if has_agent_instructions && let Some(ref file_store) = self.file_store {
-            match file_store
-                .read_file(session_id, crate::capabilities::AGENTS_MD_PATH)
-                .await
-            {
-                Ok(Some(file)) => {
-                    if let Some(content) = &file.content
-                        && let Some(formatted) =
-                            crate::capabilities::format_agents_md_content(content)
-                    {
-                        builder = builder.prepend_system_prompt(formatted);
-                    }
-                }
-                Ok(None) => {
-                    // File doesn't exist — silently skip
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        session_id = %session_id,
-                        "Failed to read AGENTS.md, skipping"
-                    );
-                }
-            }
         }
 
         let runtime_agent = builder.build();

--- a/crates/core/src/capabilities/agent_instructions.rs
+++ b/crates/core/src/capabilities/agent_instructions.rs
@@ -5,15 +5,16 @@
 //! context and conventions to agents.
 //!
 //! Design decisions:
-//! - Capability is a marker: no static system_prompt_addition (content is dynamic)
-//! - ReasonAtom reads /AGENTS.md from session file store when this capability is enabled
+//! - Capability encapsulates all AGENTS.md logic: reading, formatting, and injection
+//! - system_prompt_contribution() reads /AGENTS.md from session filesystem via context
 //! - Re-read every turn so edits are picked up immediately
 //! - 32 KiB size limit (truncated with warning), matching Codex convention
 //! - Missing file is silently ignored
 //! - Content wrapped in `<agent-instructions>` XML tags to separate user-provided
 //!   instructions from system capability prompts (reduces prompt injection surface)
 
-use super::{Capability, CapabilityStatus};
+use super::{Capability, CapabilityStatus, SystemPromptContext};
+use async_trait::async_trait;
 
 /// Maximum size of AGENTS.md content in bytes (32 KiB).
 pub const MAX_AGENTS_MD_SIZE: usize = 32_768;
@@ -27,6 +28,7 @@ pub const AGENT_INSTRUCTIONS_CAPABILITY_ID: &str = "agent_instructions";
 /// Agent Instructions capability — reads AGENTS.md from session workspace.
 pub struct AgentInstructionsCapability;
 
+#[async_trait]
 impl Capability for AgentInstructionsCapability {
     fn id(&self) -> &str {
         AGENT_INSTRUCTIONS_CAPABILITY_ID
@@ -52,7 +54,31 @@ impl Capability for AgentInstructionsCapability {
         Some("Configuration")
     }
 
-    // No system_prompt_addition — content is dynamic (read at runtime by ReasonAtom)
+    // No static system_prompt_addition — content is dynamic via system_prompt_contribution
+
+    /// Reads AGENTS.md from the session filesystem and returns formatted content.
+    ///
+    /// This replaces the previous approach where ReasonAtom had hardcoded AGENTS.md
+    /// reading logic. Now the capability fully encapsulates its own prompt generation.
+    async fn system_prompt_contribution(&self, ctx: &SystemPromptContext) -> Option<String> {
+        let file_store = ctx.file_store.as_ref()?;
+
+        match file_store.read_file(ctx.session_id, AGENTS_MD_PATH).await {
+            Ok(Some(file)) => file.content.as_deref().and_then(format_agents_md_content),
+            Ok(None) => {
+                // File doesn't exist — silently skip
+                None
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    session_id = %ctx.session_id,
+                    "Failed to read AGENTS.md, skipping"
+                );
+                None
+            }
+        }
+    }
 
     fn system_prompt_preview(&self) -> Option<String> {
         Some(
@@ -101,6 +127,88 @@ pub fn format_agents_md_content(content: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::capabilities::CapabilityRegistry;
+    use crate::error::Result;
+    use crate::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
+    use crate::traits::SessionFileStore;
+    use crate::typed_id::SessionId;
+    use std::sync::Arc;
+    use uuid::Uuid;
+
+    /// Mock file store for testing dynamic system prompt contribution
+    struct MockFileStore {
+        content: Option<String>,
+    }
+
+    #[async_trait::async_trait]
+    impl SessionFileStore for MockFileStore {
+        async fn read_file(
+            &self,
+            _session_id: SessionId,
+            _path: &str,
+        ) -> Result<Option<SessionFile>> {
+            Ok(self.content.as_ref().map(|c| SessionFile {
+                id: Uuid::nil(),
+                session_id: Uuid::nil(),
+                path: AGENTS_MD_PATH.to_string(),
+                name: "AGENTS.md".to_string(),
+                content: Some(c.clone()),
+                encoding: "text".to_string(),
+                is_directory: false,
+                is_readonly: false,
+                size_bytes: c.len() as i64,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            }))
+        }
+
+        async fn write_file(
+            &self,
+            _session_id: SessionId,
+            _path: &str,
+            _content: &str,
+            _encoding: &str,
+        ) -> Result<SessionFile> {
+            unimplemented!("not needed for test")
+        }
+
+        async fn delete_file(
+            &self,
+            _session_id: SessionId,
+            _path: &str,
+            _recursive: bool,
+        ) -> Result<bool> {
+            unimplemented!("not needed for test")
+        }
+
+        async fn list_directory(
+            &self,
+            _session_id: SessionId,
+            _path: &str,
+        ) -> Result<Vec<FileInfo>> {
+            Ok(vec![])
+        }
+
+        async fn stat_file(&self, _session_id: SessionId, _path: &str) -> Result<Option<FileStat>> {
+            Ok(None)
+        }
+
+        async fn grep_files(
+            &self,
+            _session_id: SessionId,
+            _pattern: &str,
+            _path_pattern: Option<&str>,
+        ) -> Result<Vec<GrepMatch>> {
+            Ok(vec![])
+        }
+
+        async fn create_directory(&self, _session_id: SessionId, _path: &str) -> Result<FileInfo> {
+            unimplemented!("not needed for test")
+        }
+    }
+
+    fn test_session_id() -> SessionId {
+        SessionId::from_uuid(Uuid::nil())
+    }
 
     #[test]
     fn test_capability_metadata() {
@@ -203,5 +311,60 @@ mod tests {
         assert_eq!(MAX_AGENTS_MD_SIZE, 32_768);
         assert_eq!(AGENTS_MD_PATH, "/AGENTS.md");
         assert_eq!(AGENT_INSTRUCTIONS_CAPABILITY_ID, "agent_instructions");
+    }
+
+    // ========================================================================
+    // Dynamic system_prompt_contribution tests
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_contribution_reads_agents_md() {
+        let cap = AgentInstructionsCapability;
+        let store = Arc::new(MockFileStore {
+            content: Some("## Style\nUse snake_case.".to_string()),
+        });
+        let ctx = SystemPromptContext {
+            session_id: test_session_id(),
+            file_store: Some(store),
+        };
+
+        let result = cap.system_prompt_contribution(&ctx).await.unwrap();
+        assert!(result.contains("Use snake_case"));
+        assert!(result.starts_with("<agent-instructions"));
+        assert!(result.ends_with("</agent-instructions>"));
+    }
+
+    #[tokio::test]
+    async fn test_contribution_none_when_file_missing() {
+        let cap = AgentInstructionsCapability;
+        let store = Arc::new(MockFileStore { content: None });
+        let ctx = SystemPromptContext {
+            session_id: test_session_id(),
+            file_store: Some(store),
+        };
+
+        assert!(cap.system_prompt_contribution(&ctx).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_contribution_none_when_no_file_store() {
+        let cap = AgentInstructionsCapability;
+        let ctx = SystemPromptContext::without_file_store(test_session_id());
+
+        assert!(cap.system_prompt_contribution(&ctx).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_contribution_none_when_empty_content() {
+        let cap = AgentInstructionsCapability;
+        let store = Arc::new(MockFileStore {
+            content: Some("   \n  ".to_string()),
+        });
+        let ctx = SystemPromptContext {
+            session_id: test_session_id(),
+            file_store: Some(store),
+        };
+
+        assert!(cap.system_prompt_contribution(&ctx).await.is_none());
     }
 }

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -23,6 +23,9 @@ use crate::message_filter::MessageFilterProvider;
 use crate::runtime_agent::RuntimeAgent;
 use crate::tool_types::ToolDefinition;
 use crate::tools::{Tool, ToolRegistry};
+use crate::traits::SessionFileStore;
+use crate::typed_id::SessionId;
+use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -146,6 +149,32 @@ pub use virtual_bash::{BashTool, VirtualBashCapability};
 pub use web_fetch::{WebFetchCapability, WebFetchTool};
 
 // ============================================================================
+// System Prompt Context
+// ============================================================================
+
+/// Context provided to capabilities when resolving dynamic system prompt contributions.
+///
+/// This gives capabilities access to session-specific resources (filesystem, etc.)
+/// so they can generate system prompt content at runtime rather than returning
+/// only static text.
+pub struct SystemPromptContext {
+    /// The current session ID
+    pub session_id: SessionId,
+    /// Optional file store for reading session files (e.g., AGENTS.md)
+    pub file_store: Option<Arc<dyn SessionFileStore>>,
+}
+
+impl SystemPromptContext {
+    /// Create context with no file store (for callers that don't need filesystem access)
+    pub fn without_file_store(session_id: SessionId) -> Self {
+        Self {
+            session_id,
+            file_store: None,
+        }
+    }
+}
+
+// ============================================================================
 // Capability Trait
 // ============================================================================
 
@@ -154,6 +183,17 @@ pub use web_fetch::{WebFetchCapability, WebFetchTool};
 /// A capability can contribute:
 /// - System prompt additions (prepended to agent's system prompt)
 /// - Tools (added to agent's available tools)
+///
+/// # System Prompt Contributions
+///
+/// Capabilities provide system prompt content via `system_prompt_contribution()`.
+/// This async method receives a `SystemPromptContext` with access to the session
+/// filesystem, allowing capabilities to generate dynamic content (e.g., reading
+/// AGENTS.md or scanning for skills).
+///
+/// The default implementation wraps the static `system_prompt_addition()` text
+/// in `<capability id="...">` XML tags. Capabilities that need dynamic content
+/// override `system_prompt_contribution()` directly.
 ///
 /// # Example
 ///
@@ -180,6 +220,7 @@ pub use web_fetch::{WebFetchCapability, WebFetchTool};
 ///     }
 /// }
 /// ```
+#[async_trait]
 pub trait Capability: Send + Sync {
     /// Returns the unique capability identifier as a string
     fn id(&self) -> &str;
@@ -205,9 +246,34 @@ pub trait Capability: Send + Sync {
         None
     }
 
-    /// Returns text to prepend to the agent's system prompt (optional)
+    /// Returns static text to prepend to the agent's system prompt (optional).
+    ///
+    /// This is the simple sync path for capabilities with static prompts.
+    /// For dynamic content that requires filesystem access, override
+    /// `system_prompt_contribution()` instead.
     fn system_prompt_addition(&self) -> Option<&str> {
         None
+    }
+
+    /// Returns the system prompt contribution for this capability, with access
+    /// to session context (filesystem, etc.).
+    ///
+    /// This is the primary method for contributing to the system prompt.
+    /// The returned string is included as-is in the final prompt (the capability
+    /// is responsible for its own XML wrapping).
+    ///
+    /// The default implementation wraps `system_prompt_addition()` in
+    /// `<capability id="...">` XML tags. Capabilities with dynamic content
+    /// (e.g., `agent_instructions`, `skills`) override this to read from the
+    /// session filesystem.
+    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
+        self.system_prompt_addition().map(|addition| {
+            format!(
+                "<capability id=\"{}\">\n{}\n</capability>",
+                self.id(),
+                addition
+            )
+        })
     }
 
     /// Returns a preview of the system prompt addition for UI display.
@@ -777,6 +843,93 @@ pub fn collect_capabilities_with_configs(
                     "<capability id=\"{}\">\n{}\n</capability>",
                     cap_id, addition
                 ));
+            }
+
+            // Collect tools
+            tools.extend(capability.tools());
+
+            // Collect tool definitions
+            tool_definitions.extend(capability.tool_definitions());
+
+            // Collect mount points
+            mounts.extend(capability.mounts());
+
+            // Collect message filter provider
+            if let Some(provider) = capability.message_filter_provider() {
+                message_filter_providers.push((provider, cap_config.config.clone()));
+            }
+
+            applied_ids.push(cap_id.to_string());
+        }
+    }
+
+    // Sort message filter providers by priority (lower = earlier)
+    message_filter_providers.sort_by_key(|(p, _)| p.priority());
+
+    CollectedCapabilities {
+        system_prompt_parts,
+        tools,
+        tool_definitions,
+        mounts,
+        message_filter_providers,
+        applied_ids,
+    }
+}
+
+/// Async collection of capability contributions including dynamic system prompts.
+///
+/// Unlike `collect_capabilities_with_configs` (sync), this calls each capability's
+/// `system_prompt_contribution()` method which can access the session filesystem
+/// for dynamic content (e.g., reading AGENTS.md, discovering skills).
+///
+/// Use this in async contexts (like the agent loop) where capabilities need
+/// filesystem access. For sync contexts that only need tools/mounts, use
+/// `collect_capabilities` instead.
+pub async fn collect_capabilities_async(
+    capability_ids: &[String],
+    registry: &CapabilityRegistry,
+    ctx: &SystemPromptContext,
+) -> CollectedCapabilities {
+    let configs: Vec<AgentCapabilityConfig> = capability_ids
+        .iter()
+        .map(|id| AgentCapabilityConfig {
+            capability_ref: CapabilityId::new(id),
+            config: serde_json::Value::Object(serde_json::Map::new()),
+        })
+        .collect();
+
+    collect_capabilities_with_configs_async(&configs, registry, ctx).await
+}
+
+/// Async collection of capability contributions with per-agent configurations.
+///
+/// This is the async counterpart of `collect_capabilities_with_configs`.
+/// It calls `system_prompt_contribution()` (async) on each capability,
+/// enabling dynamic content generation based on session context.
+pub async fn collect_capabilities_with_configs_async(
+    capability_configs: &[AgentCapabilityConfig],
+    registry: &CapabilityRegistry,
+    ctx: &SystemPromptContext,
+) -> CollectedCapabilities {
+    let mut system_prompt_parts: Vec<String> = Vec::new();
+    let mut tools: Vec<Box<dyn Tool>> = Vec::new();
+    let mut tool_definitions: Vec<ToolDefinition> = Vec::new();
+    let mut mounts: Vec<MountPoint> = Vec::new();
+    let mut message_filter_providers: Vec<(Arc<dyn MessageFilterProvider>, serde_json::Value)> =
+        Vec::new();
+    let mut applied_ids: Vec<String> = Vec::new();
+
+    for cap_config in capability_configs {
+        let cap_id = cap_config.capability_ref.as_str();
+        if let Some(capability) = registry.get(cap_id) {
+            // Only collect from available capabilities
+            if capability.status() != CapabilityStatus::Available {
+                continue;
+            }
+
+            // Collect dynamic system prompt contribution (may read from filesystem)
+            if let Some(contribution) = capability.system_prompt_contribution(ctx).await {
+                system_prompt_parts.push(contribution);
             }
 
             // Collect tools

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -780,9 +780,9 @@ pub fn get_dependencies(cap_id: &str, registry: &CapabilityRegistry) -> Vec<Stri
 
 /// Collect contributions from capabilities without applying them.
 ///
-/// This extracts system prompt additions, tools, tool definitions, and mount
-/// points from the given capabilities. Use this when you need the raw capability
-/// data before applying it to a config or builder.
+/// Calls `system_prompt_contribution()` (async) on each capability, enabling
+/// dynamic content generation based on session context (e.g., reading AGENTS.md,
+/// discovering skills).
 ///
 /// Note: This function does not collect message filter providers since it doesn't
 /// have access to per-agent capability configs. Use `collect_capabilities_with_configs`
@@ -792,9 +792,11 @@ pub fn get_dependencies(cap_id: &str, registry: &CapabilityRegistry) -> Vec<Stri
 ///
 /// * `capability_ids` - Ordered list of capability IDs to collect
 /// * `registry` - The capability registry containing implementations
-pub fn collect_capabilities(
+/// * `ctx` - Session context for dynamic prompt resolution
+pub async fn collect_capabilities(
     capability_ids: &[String],
     registry: &CapabilityRegistry,
+    ctx: &SystemPromptContext,
 ) -> CollectedCapabilities {
     // Convert to AgentCapabilityConfig with empty configs
     let configs: Vec<AgentCapabilityConfig> = capability_ids
@@ -805,108 +807,20 @@ pub fn collect_capabilities(
         })
         .collect();
 
-    collect_capabilities_with_configs(&configs, registry)
+    collect_capabilities_with_configs(&configs, registry, ctx).await
 }
 
 /// Collect contributions from capabilities with their per-agent configurations.
 ///
-/// This extracts system prompt additions, tools, tool definitions, mount points,
-/// and message filter providers from the given capabilities.
+/// Calls `system_prompt_contribution()` (async) on each capability, enabling
+/// dynamic content generation based on session context.
 ///
 /// # Arguments
 ///
 /// * `capability_configs` - Ordered list of capability configs (ID + per-agent config)
 /// * `registry` - The capability registry containing implementations
-pub fn collect_capabilities_with_configs(
-    capability_configs: &[AgentCapabilityConfig],
-    registry: &CapabilityRegistry,
-) -> CollectedCapabilities {
-    let mut system_prompt_parts: Vec<String> = Vec::new();
-    let mut tools: Vec<Box<dyn Tool>> = Vec::new();
-    let mut tool_definitions: Vec<ToolDefinition> = Vec::new();
-    let mut mounts: Vec<MountPoint> = Vec::new();
-    let mut message_filter_providers: Vec<(Arc<dyn MessageFilterProvider>, serde_json::Value)> =
-        Vec::new();
-    let mut applied_ids: Vec<String> = Vec::new();
-
-    for cap_config in capability_configs {
-        let cap_id = cap_config.capability_ref.as_str();
-        if let Some(capability) = registry.get(cap_id) {
-            // Only collect from available capabilities
-            if capability.status() != CapabilityStatus::Available {
-                continue;
-            }
-
-            // Collect system prompt addition wrapped in XML tags for clear boundaries
-            if let Some(addition) = capability.system_prompt_addition() {
-                system_prompt_parts.push(format!(
-                    "<capability id=\"{}\">\n{}\n</capability>",
-                    cap_id, addition
-                ));
-            }
-
-            // Collect tools
-            tools.extend(capability.tools());
-
-            // Collect tool definitions
-            tool_definitions.extend(capability.tool_definitions());
-
-            // Collect mount points
-            mounts.extend(capability.mounts());
-
-            // Collect message filter provider
-            if let Some(provider) = capability.message_filter_provider() {
-                message_filter_providers.push((provider, cap_config.config.clone()));
-            }
-
-            applied_ids.push(cap_id.to_string());
-        }
-    }
-
-    // Sort message filter providers by priority (lower = earlier)
-    message_filter_providers.sort_by_key(|(p, _)| p.priority());
-
-    CollectedCapabilities {
-        system_prompt_parts,
-        tools,
-        tool_definitions,
-        mounts,
-        message_filter_providers,
-        applied_ids,
-    }
-}
-
-/// Async collection of capability contributions including dynamic system prompts.
-///
-/// Unlike `collect_capabilities_with_configs` (sync), this calls each capability's
-/// `system_prompt_contribution()` method which can access the session filesystem
-/// for dynamic content (e.g., reading AGENTS.md, discovering skills).
-///
-/// Use this in async contexts (like the agent loop) where capabilities need
-/// filesystem access. For sync contexts that only need tools/mounts, use
-/// `collect_capabilities` instead.
-pub async fn collect_capabilities_async(
-    capability_ids: &[String],
-    registry: &CapabilityRegistry,
-    ctx: &SystemPromptContext,
-) -> CollectedCapabilities {
-    let configs: Vec<AgentCapabilityConfig> = capability_ids
-        .iter()
-        .map(|id| AgentCapabilityConfig {
-            capability_ref: CapabilityId::new(id),
-            config: serde_json::Value::Object(serde_json::Map::new()),
-        })
-        .collect();
-
-    collect_capabilities_with_configs_async(&configs, registry, ctx).await
-}
-
-/// Async collection of capability contributions with per-agent configurations.
-///
-/// This is the async counterpart of `collect_capabilities_with_configs`.
-/// It calls `system_prompt_contribution()` (async) on each capability,
-/// enabling dynamic content generation based on session context.
-pub async fn collect_capabilities_with_configs_async(
+/// * `ctx` - Session context for dynamic prompt resolution
+pub async fn collect_capabilities_with_configs(
     capability_configs: &[AgentCapabilityConfig],
     registry: &CapabilityRegistry,
     ctx: &SystemPromptContext,
@@ -980,7 +894,7 @@ pub struct AppliedCapabilities {
 /// Apply capabilities to a base runtime agent configuration.
 ///
 /// This function:
-/// 1. Collects system prompt additions from capabilities (in order)
+/// 1. Collects system prompt contributions from capabilities (in order)
 /// 2. Prepends them to the agent's base system prompt
 /// 3. Collects all tools from capabilities
 /// 4. Returns the modified runtime agent and a tool registry
@@ -990,6 +904,7 @@ pub struct AppliedCapabilities {
 /// * `base_runtime_agent` - The agent's base runtime configuration
 /// * `capability_ids` - Ordered list of capability IDs to apply
 /// * `registry` - The capability registry containing implementations
+/// * `ctx` - Session context for dynamic prompt resolution
 ///
 /// # Returns
 ///
@@ -998,25 +913,27 @@ pub struct AppliedCapabilities {
 ///
 /// # Example
 ///
-/// ```
-/// use everruns_core::capabilities::{apply_capabilities, CapabilityRegistry};
+/// ```ignore
+/// use everruns_core::capabilities::{apply_capabilities, CapabilityRegistry, SystemPromptContext};
 /// use everruns_core::runtime_agent::RuntimeAgent;
 ///
 /// let registry = CapabilityRegistry::with_builtins();
 /// let base_runtime_agent = RuntimeAgent::new("You are a helpful assistant.", "gpt-5.2");
+/// let ctx = SystemPromptContext::without_file_store(SessionId::new());
 ///
 /// let capability_ids = vec!["current_time".to_string()];
-/// let applied = apply_capabilities(base_runtime_agent, &capability_ids, &registry);
+/// let applied = apply_capabilities(base_runtime_agent, &capability_ids, &registry, &ctx).await;
 ///
 /// // The runtime agent now includes CurrentTime tool
 /// assert!(!applied.tool_registry.is_empty());
 /// ```
-pub fn apply_capabilities(
+pub async fn apply_capabilities(
     base_runtime_agent: RuntimeAgent,
     capability_ids: &[String],
     registry: &CapabilityRegistry,
+    ctx: &SystemPromptContext,
 ) -> AppliedCapabilities {
-    let collected = collect_capabilities(capability_ids, registry);
+    let collected = collect_capabilities(capability_ids, registry, ctx).await;
 
     // Build final system prompt: capability additions + base prompt (wrapped in XML tags)
     let final_system_prompt = match collected.system_prompt_prefix() {
@@ -1059,6 +976,11 @@ mod tests {
     use super::*;
     use crate::typed_id::SessionId;
     use uuid::Uuid;
+
+    /// Test helper: dummy context with no file store
+    fn test_ctx() -> SystemPromptContext {
+        SystemPromptContext::without_file_store(SessionId::new())
+    }
 
     // =========================================================================
     // CapabilityRegistry tests
@@ -1205,12 +1127,13 @@ mod tests {
     // apply_capabilities tests
     // =========================================================================
 
-    #[test]
-    fn test_apply_capabilities_empty() {
+    #[tokio::test]
+    async fn test_apply_capabilities_empty() {
         let registry = CapabilityRegistry::with_builtins();
         let base_runtime_agent = RuntimeAgent::new("You are a helpful assistant.", "gpt-5.2");
 
-        let applied = apply_capabilities(base_runtime_agent.clone(), &[], &registry);
+        let applied =
+            apply_capabilities(base_runtime_agent.clone(), &[], &registry, &test_ctx()).await;
 
         assert_eq!(
             applied.runtime_agent.system_prompt,
@@ -1220,13 +1143,18 @@ mod tests {
         assert!(applied.applied_ids.is_empty());
     }
 
-    #[test]
-    fn test_apply_capabilities_noop() {
+    #[tokio::test]
+    async fn test_apply_capabilities_noop() {
         let registry = CapabilityRegistry::with_builtins();
         let base_runtime_agent = RuntimeAgent::new("You are a helpful assistant.", "gpt-5.2");
 
-        let applied =
-            apply_capabilities(base_runtime_agent.clone(), &["noop".to_string()], &registry);
+        let applied = apply_capabilities(
+            base_runtime_agent.clone(),
+            &["noop".to_string()],
+            &registry,
+            &test_ctx(),
+        )
+        .await;
 
         // Noop has no system prompt addition or tools
         assert_eq!(
@@ -1237,8 +1165,8 @@ mod tests {
         assert_eq!(applied.applied_ids, vec!["noop"]);
     }
 
-    #[test]
-    fn test_apply_capabilities_current_time() {
+    #[tokio::test]
+    async fn test_apply_capabilities_current_time() {
         let registry = CapabilityRegistry::with_builtins();
         let base_runtime_agent = RuntimeAgent::new("You are a helpful assistant.", "gpt-5.2");
 
@@ -1246,7 +1174,9 @@ mod tests {
             base_runtime_agent.clone(),
             &["current_time".to_string()],
             &registry,
-        );
+            &test_ctx(),
+        )
+        .await;
 
         // CurrentTime has no system prompt addition but has a tool
         assert_eq!(
@@ -1258,8 +1188,8 @@ mod tests {
         assert_eq!(applied.applied_ids, vec!["current_time"]);
     }
 
-    #[test]
-    fn test_apply_capabilities_skips_coming_soon() {
+    #[tokio::test]
+    async fn test_apply_capabilities_skips_coming_soon() {
         let registry = CapabilityRegistry::with_builtins();
         let base_runtime_agent = RuntimeAgent::new("You are a helpful assistant.", "gpt-5.2");
 
@@ -1268,7 +1198,9 @@ mod tests {
             base_runtime_agent.clone(),
             &["research".to_string()],
             &registry,
-        );
+            &test_ctx(),
+        )
+        .await;
 
         // System prompt should not have the research addition
         assert_eq!(
@@ -1278,8 +1210,8 @@ mod tests {
         assert!(applied.applied_ids.is_empty()); // Research was not applied
     }
 
-    #[test]
-    fn test_apply_capabilities_multiple() {
+    #[tokio::test]
+    async fn test_apply_capabilities_multiple() {
         let registry = CapabilityRegistry::with_builtins();
         let base_runtime_agent = RuntimeAgent::new("You are a helpful assistant.", "gpt-5.2");
 
@@ -1287,14 +1219,16 @@ mod tests {
             base_runtime_agent.clone(),
             &["noop".to_string(), "current_time".to_string()],
             &registry,
-        );
+            &test_ctx(),
+        )
+        .await;
 
         assert!(applied.tool_registry.has("get_current_time"));
         assert_eq!(applied.applied_ids, vec!["noop", "current_time"]);
     }
 
-    #[test]
-    fn test_apply_capabilities_preserves_order() {
+    #[tokio::test]
+    async fn test_apply_capabilities_preserves_order() {
         let registry = CapabilityRegistry::with_builtins();
         let base_runtime_agent = RuntimeAgent::new("Base prompt.", "gpt-5.2");
 
@@ -1303,13 +1237,15 @@ mod tests {
             base_runtime_agent,
             &["current_time".to_string(), "noop".to_string()],
             &registry,
-        );
+            &test_ctx(),
+        )
+        .await;
 
         assert_eq!(applied.applied_ids, vec!["current_time", "noop"]);
     }
 
-    #[test]
-    fn test_apply_capabilities_test_math() {
+    #[tokio::test]
+    async fn test_apply_capabilities_test_math() {
         let registry = CapabilityRegistry::with_builtins();
         let base_runtime_agent = RuntimeAgent::new("You are a helpful assistant.", "gpt-5.2");
 
@@ -1317,7 +1253,9 @@ mod tests {
             base_runtime_agent.clone(),
             &["test_math".to_string()],
             &registry,
-        );
+            &test_ctx(),
+        )
+        .await;
 
         // TestMath has system prompt addition and 4 tools
         assert!(applied.runtime_agent.system_prompt.contains("math tools"));
@@ -1354,8 +1292,8 @@ mod tests {
         assert_eq!(applied.tool_registry.len(), 4);
     }
 
-    #[test]
-    fn test_apply_capabilities_test_weather() {
+    #[tokio::test]
+    async fn test_apply_capabilities_test_weather() {
         let registry = CapabilityRegistry::with_builtins();
         let base_runtime_agent = RuntimeAgent::new("You are a helpful assistant.", "gpt-5.2");
 
@@ -1363,7 +1301,9 @@ mod tests {
             base_runtime_agent.clone(),
             &["test_weather".to_string()],
             &registry,
-        );
+            &test_ctx(),
+        )
+        .await;
 
         // TestWeather has system prompt addition and 2 tools
         assert!(
@@ -1383,8 +1323,8 @@ mod tests {
         assert_eq!(applied.tool_registry.len(), 2);
     }
 
-    #[test]
-    fn test_apply_capabilities_test_math_and_test_weather() {
+    #[tokio::test]
+    async fn test_apply_capabilities_test_math_and_test_weather() {
         let registry = CapabilityRegistry::with_builtins();
         let base_runtime_agent = RuntimeAgent::new("You are a helpful assistant.", "gpt-5.2");
 
@@ -1392,7 +1332,9 @@ mod tests {
             base_runtime_agent.clone(),
             &["test_math".to_string(), "test_weather".to_string()],
             &registry,
-        );
+            &test_ctx(),
+        )
+        .await;
 
         // Should have both sets of tools
         assert_eq!(applied.tool_registry.len(), 6); // 4 math + 2 weather
@@ -1400,8 +1342,8 @@ mod tests {
         assert!(applied.tool_registry.has("get_weather"));
     }
 
-    #[test]
-    fn test_apply_capabilities_stateless_todo_list() {
+    #[tokio::test]
+    async fn test_apply_capabilities_stateless_todo_list() {
         let registry = CapabilityRegistry::with_builtins();
         let base_runtime_agent = RuntimeAgent::new("You are a helpful assistant.", "gpt-5.2");
 
@@ -1409,7 +1351,9 @@ mod tests {
             base_runtime_agent.clone(),
             &["stateless_todo_list".to_string()],
             &registry,
-        );
+            &test_ctx(),
+        )
+        .await;
 
         // StatelessTodoList has system prompt addition and 1 tool
         assert!(
@@ -1423,8 +1367,8 @@ mod tests {
         assert_eq!(applied.tool_registry.len(), 1);
     }
 
-    #[test]
-    fn test_apply_capabilities_web_fetch() {
+    #[tokio::test]
+    async fn test_apply_capabilities_web_fetch() {
         let registry = CapabilityRegistry::with_builtins();
         let base_runtime_agent = RuntimeAgent::new("You are a helpful assistant.", "gpt-5.2");
 
@@ -1432,7 +1376,9 @@ mod tests {
             base_runtime_agent.clone(),
             &["web_fetch".to_string()],
             &registry,
-        );
+            &test_ctx(),
+        )
+        .await;
 
         // WebFetch has system prompt from fetchkit's TOOL_LLMTXT and 1 tool
         assert!(
@@ -1450,10 +1396,11 @@ mod tests {
     // XML prompt formatting tests
     // =========================================================================
 
-    #[test]
-    fn test_xml_tags_wrap_capability_prompts() {
+    #[tokio::test]
+    async fn test_xml_tags_wrap_capability_prompts() {
         let registry = CapabilityRegistry::with_builtins();
-        let collected = collect_capabilities(&["test_math".to_string()], &registry);
+        let collected =
+            collect_capabilities(&["test_math".to_string()], &registry, &test_ctx()).await;
 
         assert_eq!(collected.system_prompt_parts.len(), 1);
         let part = &collected.system_prompt_parts[0];
@@ -1462,13 +1409,15 @@ mod tests {
         assert!(part.contains("math tools"));
     }
 
-    #[test]
-    fn test_xml_tags_multiple_capabilities() {
+    #[tokio::test]
+    async fn test_xml_tags_multiple_capabilities() {
         let registry = CapabilityRegistry::with_builtins();
         let collected = collect_capabilities(
             &["test_math".to_string(), "test_weather".to_string()],
             &registry,
-        );
+            &test_ctx(),
+        )
+        .await;
 
         assert_eq!(collected.system_prompt_parts.len(), 2);
         assert!(collected.system_prompt_parts[0].starts_with("<capability id=\"test_math\">"));
@@ -1479,12 +1428,13 @@ mod tests {
         assert!(prefix.contains("</capability>\n\n<capability"));
     }
 
-    #[test]
-    fn test_xml_tags_system_prompt_wrapping() {
+    #[tokio::test]
+    async fn test_xml_tags_system_prompt_wrapping() {
         let registry = CapabilityRegistry::with_builtins();
         let base = RuntimeAgent::new("You are helpful.", "gpt-5.2");
 
-        let applied = apply_capabilities(base, &["test_math".to_string()], &registry);
+        let applied =
+            apply_capabilities(base, &["test_math".to_string()], &registry, &test_ctx()).await;
 
         let prompt = &applied.runtime_agent.system_prompt;
         // Capability wrapped
@@ -1494,12 +1444,12 @@ mod tests {
         assert!(prompt.contains("<system-prompt>\nYou are helpful.\n</system-prompt>"));
     }
 
-    #[test]
-    fn test_no_xml_wrapping_without_capabilities() {
+    #[tokio::test]
+    async fn test_no_xml_wrapping_without_capabilities() {
         let registry = CapabilityRegistry::with_builtins();
         let base = RuntimeAgent::new("You are helpful.", "gpt-5.2");
 
-        let applied = apply_capabilities(base, &[], &registry);
+        let applied = apply_capabilities(base, &[], &registry, &test_ctx()).await;
 
         // No capabilities = no XML wrapping (plain base prompt)
         assert_eq!(applied.runtime_agent.system_prompt, "You are helpful.");
@@ -1511,13 +1461,13 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_no_xml_wrapping_for_noop_capability() {
+    #[tokio::test]
+    async fn test_no_xml_wrapping_for_noop_capability() {
         let registry = CapabilityRegistry::with_builtins();
         let base = RuntimeAgent::new("You are helpful.", "gpt-5.2");
 
         // Noop has no system_prompt_addition, so no XML wrapping should occur
-        let applied = apply_capabilities(base, &["noop".to_string()], &registry);
+        let applied = apply_capabilities(base, &["noop".to_string()], &registry, &test_ctx()).await;
 
         assert_eq!(applied.runtime_agent.system_prompt, "You are helpful.");
         assert!(
@@ -1532,11 +1482,12 @@ mod tests {
     // Mount collection tests
     // =========================================================================
 
-    #[test]
-    fn test_collect_capabilities_includes_mounts() {
+    #[tokio::test]
+    async fn test_collect_capabilities_includes_mounts() {
         let registry = CapabilityRegistry::with_builtins();
 
-        let collected = collect_capabilities(&["sample_data".to_string()], &registry);
+        let collected =
+            collect_capabilities(&["sample_data".to_string()], &registry, &test_ctx()).await;
 
         assert!(!collected.mounts.is_empty());
         assert_eq!(collected.mounts.len(), 1);
@@ -1544,25 +1495,28 @@ mod tests {
         assert!(collected.mounts[0].is_readonly());
     }
 
-    #[test]
-    fn test_collect_capabilities_empty_mounts_by_default() {
+    #[tokio::test]
+    async fn test_collect_capabilities_empty_mounts_by_default() {
         let registry = CapabilityRegistry::with_builtins();
 
         // Most capabilities don't have mounts
-        let collected = collect_capabilities(&["current_time".to_string()], &registry);
+        let collected =
+            collect_capabilities(&["current_time".to_string()], &registry, &test_ctx()).await;
 
         assert!(collected.mounts.is_empty());
     }
 
-    #[test]
-    fn test_collect_capabilities_combines_mounts() {
+    #[tokio::test]
+    async fn test_collect_capabilities_combines_mounts() {
         let registry = CapabilityRegistry::with_builtins();
 
         // Collect from multiple capabilities - only sample_data has mounts
         let collected = collect_capabilities(
             &["sample_data".to_string(), "current_time".to_string()],
             &registry,
-        );
+            &test_ctx(),
+        )
+        .await;
 
         assert_eq!(collected.mounts.len(), 1);
         assert_eq!(collected.applied_ids.len(), 2);
@@ -1811,22 +1765,22 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_collect_capabilities_with_configs_no_filter_providers() {
+    #[tokio::test]
+    async fn test_collect_capabilities_with_configs_no_filter_providers() {
         let registry = CapabilityRegistry::with_builtins();
         let configs = vec![AgentCapabilityConfig {
             capability_ref: CapabilityId::new("current_time"),
             config: serde_json::json!({}),
         }];
 
-        let collected = collect_capabilities_with_configs(&configs, &registry);
+        let collected = collect_capabilities_with_configs(&configs, &registry, &test_ctx()).await;
 
         assert!(collected.message_filter_providers.is_empty());
         assert!(!collected.has_message_filters());
     }
 
-    #[test]
-    fn test_collect_capabilities_with_configs_with_filter_provider() {
+    #[tokio::test]
+    async fn test_collect_capabilities_with_configs_with_filter_provider() {
         let mut registry = CapabilityRegistry::new();
         registry.register(FilterTestCapability { priority: 0 });
 
@@ -1835,14 +1789,14 @@ mod tests {
             config: serde_json::json!({ "search": "hello" }),
         }];
 
-        let collected = collect_capabilities_with_configs(&configs, &registry);
+        let collected = collect_capabilities_with_configs(&configs, &registry, &test_ctx()).await;
 
         assert_eq!(collected.message_filter_providers.len(), 1);
         assert!(collected.has_message_filters());
     }
 
-    #[test]
-    fn test_collect_capabilities_with_configs_filter_priority_order() {
+    #[tokio::test]
+    async fn test_collect_capabilities_with_configs_filter_priority_order() {
         // Create capabilities with different priorities
         struct HighPriorityCapability;
         struct LowPriorityCapability;
@@ -1893,7 +1847,7 @@ mod tests {
             },
         ];
 
-        let collected = collect_capabilities_with_configs(&configs, &registry);
+        let collected = collect_capabilities_with_configs(&configs, &registry, &test_ctx()).await;
 
         // Should be sorted by priority (lower first)
         assert_eq!(collected.message_filter_providers.len(), 2);
@@ -1901,8 +1855,8 @@ mod tests {
         assert_eq!(collected.message_filter_providers[1].0.priority(), 10);
     }
 
-    #[test]
-    fn test_collected_capabilities_apply_message_filters() {
+    #[tokio::test]
+    async fn test_collected_capabilities_apply_message_filters() {
         let mut registry = CapabilityRegistry::new();
         registry.register(FilterTestCapability { priority: 0 });
 
@@ -1911,7 +1865,7 @@ mod tests {
             config: serde_json::json!({ "search": "test_query" }),
         }];
 
-        let collected = collect_capabilities_with_configs(&configs, &registry);
+        let collected = collect_capabilities_with_configs(&configs, &registry, &test_ctx()).await;
 
         // Apply filters to a query
         let session_id: SessionId = Uuid::now_v7().into();
@@ -1924,8 +1878,8 @@ mod tests {
         assert!(matches!(&query.filters[0], MessageFilter::Search(s) if s == "test_query"));
     }
 
-    #[test]
-    fn test_collected_capabilities_apply_multiple_filters_in_priority_order() {
+    #[tokio::test]
+    async fn test_collected_capabilities_apply_multiple_filters_in_priority_order() {
         struct SearchCapability {
             id: &'static str,
             search_term: &'static str,
@@ -1999,7 +1953,7 @@ mod tests {
             },
         ];
 
-        let collected = collect_capabilities_with_configs(&configs, &registry);
+        let collected = collect_capabilities_with_configs(&configs, &registry, &test_ctx()).await;
 
         let session_id: SessionId = Uuid::now_v7().into();
         let mut query = MessageQuery::new(session_id);
@@ -2024,8 +1978,8 @@ mod tests {
         assert!(current_time.message_filter_provider().is_none());
     }
 
-    #[test]
-    fn test_collect_capabilities_preserves_config_for_filter_provider() {
+    #[tokio::test]
+    async fn test_collect_capabilities_preserves_config_for_filter_provider() {
         let mut registry = CapabilityRegistry::new();
         registry.register(FilterTestCapability { priority: 0 });
 
@@ -2039,7 +1993,7 @@ mod tests {
             config: test_config.clone(),
         }];
 
-        let collected = collect_capabilities_with_configs(&configs, &registry);
+        let collected = collect_capabilities_with_configs(&configs, &registry, &test_ctx()).await;
 
         // Verify the config is preserved
         assert_eq!(collected.message_filter_providers.len(), 1);
@@ -2056,10 +2010,11 @@ mod tests {
     // correctly produced by collect_capabilities.
     // =========================================================================
 
-    #[test]
-    fn test_virtual_bash_capability_produces_bash_tool() {
+    #[tokio::test]
+    async fn test_virtual_bash_capability_produces_bash_tool() {
         let registry = CapabilityRegistry::with_builtins();
-        let collected = collect_capabilities(&["virtual_bash".to_string()], &registry);
+        let collected =
+            collect_capabilities(&["virtual_bash".to_string()], &registry, &test_ctx()).await;
 
         let tool_names: Vec<&str> = collected
             .tool_definitions
@@ -2077,8 +2032,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_generic_harness_capability_set_produces_bash_tool() {
+    #[tokio::test]
+    async fn test_generic_harness_capability_set_produces_bash_tool() {
         // These are the exact capability IDs from the Generic Harness seed data.
         // If any are renamed or removed, this test catches the regression.
         let generic_harness_caps = vec![
@@ -2089,7 +2044,7 @@ mod tests {
         ];
 
         let registry = CapabilityRegistry::with_builtins();
-        let collected = collect_capabilities(&generic_harness_caps, &registry);
+        let collected = collect_capabilities(&generic_harness_caps, &registry, &test_ctx()).await;
 
         let tool_names: Vec<&str> = collected
             .tool_definitions
@@ -2103,12 +2058,13 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_collect_capabilities_tool_count_matches_definitions() {
+    #[tokio::test]
+    async fn test_collect_capabilities_tool_count_matches_definitions() {
         // Ensure collected tools (implementations) match tool_definitions count.
         // A mismatch means some tools won't be executable at runtime.
         let registry = CapabilityRegistry::with_builtins();
-        let collected = collect_capabilities(&["virtual_bash".to_string()], &registry);
+        let collected =
+            collect_capabilities(&["virtual_bash".to_string()], &registry, &test_ctx()).await;
 
         assert_eq!(
             collected.tools.len(),

--- a/crates/core/src/capabilities/skills_discovery.rs
+++ b/crates/core/src/capabilities/skills_discovery.rs
@@ -13,7 +13,7 @@
 // Individual database-registered skills use `skill:{uuid}` capabilities
 // (handled by SkillCapability). This capability handles dynamic VFS discovery.
 
-use super::{Capability, CapabilityStatus};
+use super::{Capability, CapabilityStatus, SystemPromptContext};
 use crate::tool_types::{BuiltinTool, ToolDefinition, ToolPolicy};
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
@@ -32,6 +32,15 @@ const SKILLS_PATH: &str = "/.agents/skills";
 /// SKILL.md files to `/.agents/skills/{name}/SKILL.md` in the session VFS.
 pub struct SkillsDiscoveryCapability;
 
+/// Static skills system prompt (used by sync callers and as fallback)
+const SKILLS_SYSTEM_PROMPT: &str = "You have access to an agent skills system. Skills are instruction packages \
+that can be discovered from the session filesystem.\n\n\
+Skills location: `/.agents/skills/{skill-name}/SKILL.md`\n\n\
+Use `list_skills` to discover available skills. When a skill is relevant to the \
+user's task, use `activate_skill` to load its full instructions into your context. \
+Only activate skills that are relevant to the current task.";
+
+#[async_trait]
 impl Capability for SkillsDiscoveryCapability {
     fn id(&self) -> &str {
         SKILLS_DISCOVERY_CAPABILITY_ID
@@ -63,14 +72,70 @@ Skills are instruction packages (SKILL.md files) that teach the agent new abilit
     }
 
     fn system_prompt_addition(&self) -> Option<&str> {
-        Some(
-            "You have access to an agent skills system. Skills are instruction packages \
-            that can be discovered from the session filesystem.\n\n\
-            Skills location: `/.agents/skills/{skill-name}/SKILL.md`\n\n\
-            Use `list_skills` to discover available skills. When a skill is relevant to the \
-            user's task, use `activate_skill` to load its full instructions into your context. \
-            Only activate skills that are relevant to the current task.",
-        )
+        Some(SKILLS_SYSTEM_PROMPT)
+    }
+
+    /// Dynamically discovers skills from the session filesystem and includes
+    /// them in the system prompt.
+    ///
+    /// When a file store is available, scans `/.agents/skills/` for SKILL.md
+    /// files and lists discovered skills directly in the prompt. Falls back
+    /// to the static prompt when no file store is available.
+    async fn system_prompt_contribution(&self, ctx: &SystemPromptContext) -> Option<String> {
+        let file_store = match ctx.file_store.as_ref() {
+            Some(fs) => fs,
+            None => {
+                // No file store — fall back to static prompt with capability wrapping
+                return Some(format!(
+                    "<capability id=\"{}\">\n{}\n</capability>",
+                    self.id(),
+                    SKILLS_SYSTEM_PROMPT
+                ));
+            }
+        };
+
+        // Scan /.agents/skills/ for SKILL.md files
+        let entries = match file_store.list_directory(ctx.session_id, SKILLS_PATH).await {
+            Ok(entries) => entries,
+            Err(_) => {
+                // Directory doesn't exist — use static prompt
+                return Some(format!(
+                    "<capability id=\"{}\">\n{}\n</capability>",
+                    self.id(),
+                    SKILLS_SYSTEM_PROMPT
+                ));
+            }
+        };
+
+        let mut discovered_skills = Vec::new();
+        for entry in &entries {
+            if !entry.is_directory {
+                continue;
+            }
+
+            let skill_md_path = format!("{}/SKILL.md", entry.path);
+            if let Ok(Some(file)) = file_store.read_file(ctx.session_id, &skill_md_path).await {
+                let content = file.content.as_deref().unwrap_or("");
+                if let Ok(parsed) = crate::skill::parse_skill_md(content) {
+                    discovered_skills.push((parsed.name, parsed.description));
+                }
+            }
+        }
+
+        let mut prompt = String::from(SKILLS_SYSTEM_PROMPT);
+
+        if !discovered_skills.is_empty() {
+            prompt.push_str("\n\nAvailable skills:\n");
+            for (name, description) in &discovered_skills {
+                prompt.push_str(&format!("- **{}**: {}\n", name, description));
+            }
+        }
+
+        Some(format!(
+            "<capability id=\"{}\">\n{}\n</capability>",
+            self.id(),
+            prompt
+        ))
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
@@ -1078,5 +1143,67 @@ mod tests {
         // Dependency tools (from session_file_system)
         assert!(tool_names.contains(&"read_file"));
         assert!(tool_names.contains(&"write_file"));
+    }
+
+    // ========================================================================
+    // Dynamic system_prompt_contribution tests
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_contribution_includes_discovered_skills() {
+        let cap = SkillsDiscoveryCapability;
+        let store = Arc::new(MockFileStore::new());
+        let session_id = SessionId::new();
+
+        store.add_file(
+            session_id,
+            "/.agents/skills/pdf-processor/SKILL.md",
+            &valid_skill_md("pdf-processor", "Process PDF files"),
+        );
+        store.add_file(
+            session_id,
+            "/.agents/skills/data-analysis/SKILL.md",
+            &valid_skill_md("data-analysis", "Analyze datasets"),
+        );
+
+        let ctx = SystemPromptContext {
+            session_id,
+            file_store: Some(store),
+        };
+
+        let result = cap.system_prompt_contribution(&ctx).await.unwrap();
+        assert!(result.contains("<capability id=\"skills\">"));
+        assert!(result.contains("pdf-processor"));
+        assert!(result.contains("data-analysis"));
+        assert!(result.contains("Available skills:"));
+    }
+
+    #[tokio::test]
+    async fn test_contribution_static_when_no_file_store() {
+        let cap = SkillsDiscoveryCapability;
+        let ctx = SystemPromptContext::without_file_store(SessionId::new());
+
+        let result = cap.system_prompt_contribution(&ctx).await.unwrap();
+        assert!(result.contains("<capability id=\"skills\">"));
+        assert!(result.contains("list_skills"));
+        // No "Available skills:" section
+        assert!(!result.contains("Available skills:"));
+    }
+
+    #[tokio::test]
+    async fn test_contribution_static_when_no_skills_dir() {
+        let cap = SkillsDiscoveryCapability;
+        let store = Arc::new(MockFileStore::new());
+
+        let ctx = SystemPromptContext {
+            session_id: SessionId::new(),
+            file_store: Some(store),
+        };
+
+        let result = cap.system_prompt_contribution(&ctx).await.unwrap();
+        assert!(result.contains("<capability id=\"skills\">"));
+        assert!(result.contains("list_skills"));
+        // No "Available skills:" section (dir doesn't exist)
+        assert!(!result.contains("Available skills:"));
     }
 }

--- a/crates/core/src/capabilities/skills_discovery.rs
+++ b/crates/core/src/capabilities/skills_discovery.rs
@@ -1108,15 +1108,18 @@ mod tests {
     // Integration: apply_capabilities
     // ========================================================================
 
-    #[test]
-    fn test_apply_capabilities_with_skills() {
+    #[tokio::test]
+    async fn test_apply_capabilities_with_skills() {
+        use crate::capabilities::SystemPromptContext;
         use crate::runtime_agent::RuntimeAgentBuilder;
 
         let registry = crate::capabilities::CapabilityRegistry::with_builtins();
+        let ctx = SystemPromptContext::without_file_store(crate::typed_id::SessionId::new());
         // Use builder pattern which resolves dependencies automatically
         let runtime_agent = RuntimeAgentBuilder::new()
             .system_prompt("Base prompt.")
-            .with_capabilities(&["skills".to_string()], &registry)
+            .with_capabilities(&["skills".to_string()], &registry, &ctx)
+            .await
             .model("gpt-5.2")
             .build();
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -153,9 +153,9 @@ pub use capabilities::{
     SampleDataCapability, SessionCapability, SessionSqlDatabaseCapability, SqlExecuteTool,
     SqlQueryTool, SqlSchemaTool, StatFileTool, StatelessTodoListCapability, SubtractTool,
     TestMathCapability, TestWeatherCapability, WriteFileTool, WriteSessionTitleTool,
-    WriteTodosTool, apply_capabilities, collect_capabilities_async,
-    collect_capabilities_with_configs, collect_capabilities_with_configs_async, get_dependencies,
-    is_mcp_capability, mcp_capability_id, parse_mcp_capability_id, resolve_dependencies,
+    WriteTodosTool, apply_capabilities, collect_capabilities, collect_capabilities_with_configs,
+    get_dependencies, is_mcp_capability, mcp_capability_id, parse_mcp_capability_id,
+    resolve_dependencies,
 };
 pub use capabilities::{
     SKILL_CAPABILITY_PREFIX, SKILLS_DISCOVERY_CAPABILITY_ID, SKILLS_DISCOVERY_PATH,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -141,6 +141,7 @@ pub use connection_provider::{
     ConnectionValidation, FieldType, FormField,
 };
 
+pub use capabilities::SystemPromptContext;
 pub use capabilities::{
     AddTool, AgentCapabilityConfig, AppliedCapabilities, Capability, CapabilityId,
     CapabilityRegistry, CapabilityRegistryBuilder, CapabilityStatus, CollectedCapabilities,
@@ -152,7 +153,8 @@ pub use capabilities::{
     SampleDataCapability, SessionCapability, SessionSqlDatabaseCapability, SqlExecuteTool,
     SqlQueryTool, SqlSchemaTool, StatFileTool, StatelessTodoListCapability, SubtractTool,
     TestMathCapability, TestWeatherCapability, WriteFileTool, WriteSessionTitleTool,
-    WriteTodosTool, apply_capabilities, collect_capabilities_with_configs, get_dependencies,
+    WriteTodosTool, apply_capabilities, collect_capabilities_async,
+    collect_capabilities_with_configs, collect_capabilities_with_configs_async, get_dependencies,
     is_mcp_capability, mcp_capability_id, parse_mcp_capability_id, resolve_dependencies,
 };
 pub use capabilities::{

--- a/crates/core/src/message_filter.rs
+++ b/crates/core/src/message_filter.rs
@@ -236,10 +236,10 @@ impl PrependTransform for ExcludedNoticeTransform {
 ///
 /// ```
 /// use everruns_core::message_filter::{MessageQuery, MessageFilter};
-/// use uuid::Uuid;
+/// use everruns_core::typed_id::SessionId;
 /// use chrono::Utc;
 ///
-/// let query = MessageQuery::new(Uuid::now_v7())
+/// let query = MessageQuery::new(SessionId::new())
 ///     .with_filter(MessageFilter::TimeRange {
 ///         from: Some(Utc::now() - chrono::Duration::hours(24)),
 ///         to: None,

--- a/crates/core/src/runtime_agent.rs
+++ b/crates/core/src/runtime_agent.rs
@@ -12,8 +12,7 @@
 
 use crate::agent::Agent;
 use crate::capabilities::{
-    CapabilityRegistry, SystemPromptContext, collect_capabilities, collect_capabilities_async,
-    resolve_dependencies,
+    CapabilityRegistry, SystemPromptContext, collect_capabilities, resolve_dependencies,
 };
 use crate::harness::Harness;
 use crate::tool_types::ToolDefinition;
@@ -95,8 +94,14 @@ impl RuntimeAgentBuilder {
     /// Apply a Harness's configuration to this builder.
     ///
     /// Sets the system prompt from the harness and applies harness capabilities.
+    /// Calls `system_prompt_contribution()` on each capability for dynamic content.
     /// Call this BEFORE `with_agent()` to establish the base prompt layer.
-    pub fn with_harness(self, harness: &Harness, registry: &CapabilityRegistry) -> Self {
+    pub async fn with_harness(
+        self,
+        harness: &Harness,
+        registry: &CapabilityRegistry,
+        ctx: &SystemPromptContext,
+    ) -> Self {
         let capability_ids: Vec<String> = harness
             .capabilities
             .iter()
@@ -104,7 +109,8 @@ impl RuntimeAgentBuilder {
             .collect();
 
         self.system_prompt(&harness.system_prompt)
-            .with_capabilities(&capability_ids, registry)
+            .with_capabilities(&capability_ids, registry, ctx)
+            .await
     }
 
     /// Apply an Agent's configuration to this builder.
@@ -115,14 +121,20 @@ impl RuntimeAgentBuilder {
     /// # Example
     ///
     /// ```ignore
+    /// let ctx = SystemPromptContext::without_file_store(session_id);
     /// let runtime_agent = RuntimeAgentBuilder::new()
-    ///     .with_harness(&harness, &registry)
-    ///     .with_agent(&agent, &registry)
-    ///     .with_capabilities(&session_caps, &registry)
+    ///     .with_harness(&harness, &registry, &ctx).await
+    ///     .with_agent(&agent, &registry, &ctx).await
+    ///     .with_capabilities(&session_caps, &registry, &ctx).await
     ///     .model("gpt-4o")
     ///     .build();
     /// ```
-    pub fn with_agent(self, agent: &Agent, registry: &CapabilityRegistry) -> Self {
+    pub async fn with_agent(
+        self,
+        agent: &Agent,
+        registry: &CapabilityRegistry,
+        ctx: &SystemPromptContext,
+    ) -> Self {
         let capability_ids: Vec<String> = agent
             .capabilities
             .iter()
@@ -131,7 +143,8 @@ impl RuntimeAgentBuilder {
 
         let mut builder = self
             .system_prompt(&agent.system_prompt)
-            .with_capabilities(&capability_ids, registry);
+            .with_capabilities(&capability_ids, registry, ctx)
+            .await;
 
         // Add agent-level client-side tools
         if !agent.tools.is_empty() {
@@ -143,8 +156,9 @@ impl RuntimeAgentBuilder {
 
     /// Apply capabilities to this builder.
     ///
-    /// This resolves dependencies, then collects contributions from capabilities:
+    /// Resolves dependencies, then collects contributions from capabilities:
     /// - Dependencies are automatically included (topologically sorted)
+    /// - `system_prompt_contribution(ctx)` called on each (may read from filesystem)
     /// - System prompt additions are prepended to the current system prompt
     /// - Tool definitions are added to the tools list
     ///
@@ -152,28 +166,26 @@ impl RuntimeAgentBuilder {
     ///
     /// * `capability_ids` - Ordered list of capability IDs to apply
     /// * `registry` - The capability registry containing implementations
-    pub fn with_capabilities(
+    /// * `ctx` - Session context for dynamic prompt resolution
+    pub async fn with_capabilities(
         mut self,
         capability_ids: &[String],
         registry: &CapabilityRegistry,
+        ctx: &SystemPromptContext,
     ) -> Self {
         // Resolve dependencies first (dependencies come before dependents)
         let resolved_ids = match resolve_dependencies(capability_ids, registry) {
             Ok(resolved) => resolved.resolved_ids,
             Err(e) => {
-                // Log error but continue with original IDs to avoid breaking
                 tracing::warn!("Failed to resolve capability dependencies: {}", e);
                 capability_ids.to_vec()
             }
         };
 
-        let collected = collect_capabilities(&resolved_ids, registry);
+        let collected = collect_capabilities(&resolved_ids, registry, ctx).await;
 
         // Apply system prompt additions (prepend to existing, wrap base in XML tags)
         if let Some(prefix) = collected.system_prompt_prefix() {
-            // Wrap the base system prompt in <system-prompt> tags on first capability
-            // application. Skip if already wrapped (e.g., session capabilities applied
-            // after agent capabilities).
             if !self.runtime_agent.system_prompt.is_empty()
                 && !self.runtime_agent.system_prompt.contains("<system-prompt>")
             {
@@ -249,103 +261,6 @@ impl RuntimeAgentBuilder {
     pub fn build(self) -> RuntimeAgent {
         self.runtime_agent
     }
-
-    // ========================================================================
-    // Async variants (use dynamic system prompt contributions)
-    // ========================================================================
-
-    /// Apply a Harness's configuration with dynamic system prompt resolution.
-    ///
-    /// Like `with_harness()`, but calls `system_prompt_contribution()` on each
-    /// capability, which can access the session filesystem for dynamic content.
-    pub async fn with_harness_async(
-        self,
-        harness: &Harness,
-        registry: &CapabilityRegistry,
-        ctx: &SystemPromptContext,
-    ) -> Self {
-        let capability_ids: Vec<String> = harness
-            .capabilities
-            .iter()
-            .map(|cap| cap.capability_id().to_string())
-            .collect();
-
-        self.system_prompt(&harness.system_prompt)
-            .with_capabilities_async(&capability_ids, registry, ctx)
-            .await
-    }
-
-    /// Apply an Agent's configuration with dynamic system prompt resolution.
-    ///
-    /// Like `with_agent()`, but calls `system_prompt_contribution()` on each
-    /// capability, which can access the session filesystem for dynamic content.
-    pub async fn with_agent_async(
-        self,
-        agent: &Agent,
-        registry: &CapabilityRegistry,
-        ctx: &SystemPromptContext,
-    ) -> Self {
-        let capability_ids: Vec<String> = agent
-            .capabilities
-            .iter()
-            .map(|cap| cap.capability_id().to_string())
-            .collect();
-
-        let mut builder = self
-            .system_prompt(&agent.system_prompt)
-            .with_capabilities_async(&capability_ids, registry, ctx)
-            .await;
-
-        // Add agent-level client-side tools
-        if !agent.tools.is_empty() {
-            builder = builder.tools(agent.tools.clone());
-        }
-
-        builder
-    }
-
-    /// Apply capabilities with dynamic system prompt resolution.
-    ///
-    /// Like `with_capabilities()`, but calls `system_prompt_contribution()` on
-    /// each capability (async), enabling dynamic content from the session
-    /// filesystem (e.g., reading AGENTS.md, discovering skills).
-    pub async fn with_capabilities_async(
-        mut self,
-        capability_ids: &[String],
-        registry: &CapabilityRegistry,
-        ctx: &SystemPromptContext,
-    ) -> Self {
-        // Resolve dependencies first (dependencies come before dependents)
-        let resolved_ids = match resolve_dependencies(capability_ids, registry) {
-            Ok(resolved) => resolved.resolved_ids,
-            Err(e) => {
-                tracing::warn!("Failed to resolve capability dependencies: {}", e);
-                capability_ids.to_vec()
-            }
-        };
-
-        let collected = collect_capabilities_async(&resolved_ids, registry, ctx).await;
-
-        // Apply system prompt additions (prepend to existing, wrap base in XML tags)
-        if let Some(prefix) = collected.system_prompt_prefix() {
-            if !self.runtime_agent.system_prompt.is_empty()
-                && !self.runtime_agent.system_prompt.contains("<system-prompt>")
-            {
-                self.runtime_agent.system_prompt = format!(
-                    "<system-prompt>\n{}\n</system-prompt>",
-                    self.runtime_agent.system_prompt
-                );
-            }
-            self = self.prepend_system_prompt(prefix);
-        }
-
-        // Apply tool definitions
-        if !collected.tool_definitions.is_empty() {
-            self = self.tools(collected.tool_definitions);
-        }
-
-        self
-    }
 }
 
 impl Default for RuntimeAgentBuilder {
@@ -358,8 +273,12 @@ impl Default for RuntimeAgentBuilder {
 mod tests {
     use super::*;
     use crate::agent::AgentStatus;
-    use crate::capabilities::AgentCapabilityConfig;
+    use crate::capabilities::{AgentCapabilityConfig, SystemPromptContext};
     use crate::typed_id::AgentId;
+
+    fn test_ctx() -> SystemPromptContext {
+        SystemPromptContext::without_file_store(crate::typed_id::SessionId::new())
+    }
 
     #[test]
     fn test_runtime_agent_new() {
@@ -431,26 +350,28 @@ mod tests {
         assert_eq!(runtime_agent.system_prompt, "Base prompt.");
     }
 
-    #[test]
-    fn test_builder_with_capabilities_empty() {
+    #[tokio::test]
+    async fn test_builder_with_capabilities_empty() {
         let registry = CapabilityRegistry::with_builtins();
         let runtime_agent = RuntimeAgentBuilder::new()
             .system_prompt("Base prompt.")
-            .with_capabilities(&[], &registry)
+            .with_capabilities(&[], &registry, &test_ctx())
+            .await
             .build();
 
         assert_eq!(runtime_agent.system_prompt, "Base prompt.");
         assert!(runtime_agent.tools.is_empty());
     }
 
-    #[test]
-    fn test_builder_with_capabilities_adds_tools() {
+    #[tokio::test]
+    async fn test_builder_with_capabilities_adds_tools() {
         use crate::tool_types::ToolDefinition;
 
         let registry = CapabilityRegistry::with_builtins();
         let runtime_agent = RuntimeAgentBuilder::new()
             .system_prompt("Base prompt.")
-            .with_capabilities(&["current_time".to_string()], &registry)
+            .with_capabilities(&["current_time".to_string()], &registry, &test_ctx())
+            .await
             .build();
 
         assert_eq!(runtime_agent.tools.len(), 1);
@@ -462,12 +383,13 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_builder_with_capabilities_prepends_system_prompt() {
+    #[tokio::test]
+    async fn test_builder_with_capabilities_prepends_system_prompt() {
         let registry = CapabilityRegistry::with_builtins();
         let runtime_agent = RuntimeAgentBuilder::new()
             .system_prompt("Base prompt.")
-            .with_capabilities(&["test_math".to_string()], &registry)
+            .with_capabilities(&["test_math".to_string()], &registry, &test_ctx())
+            .await
             .build();
 
         assert!(runtime_agent.system_prompt.contains("math tools"));
@@ -480,8 +402,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_builder_with_agent() {
+    #[tokio::test]
+    async fn test_builder_with_agent() {
         use crate::tool_types::ToolDefinition;
         use uuid::{NoContext, Timestamp, Uuid};
 
@@ -505,7 +427,8 @@ mod tests {
         };
 
         let runtime_agent = RuntimeAgentBuilder::new()
-            .with_agent(&agent, &registry)
+            .with_agent(&agent, &registry, &test_ctx())
+            .await
             .model("gpt-5.2")
             .build();
 
@@ -528,14 +451,15 @@ mod tests {
         assert_eq!(runtime_agent.model, "gpt-5.2");
     }
 
-    #[test]
-    fn test_builder_with_capabilities_resolves_dependencies() {
+    #[tokio::test]
+    async fn test_builder_with_capabilities_resolves_dependencies() {
         // Sample Data depends on Session File System
         // When we request only Sample Data, we should get system prompt from both
         let registry = CapabilityRegistry::with_builtins();
         let runtime_agent = RuntimeAgentBuilder::new()
             .system_prompt("Base prompt.")
-            .with_capabilities(&["sample_data".to_string()], &registry)
+            .with_capabilities(&["sample_data".to_string()], &registry, &test_ctx())
+            .await
             .build();
 
         // System prompt should include File System's contribution (the dependency) in XML tags
@@ -571,8 +495,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_builder_additive_capabilities() {
+    #[tokio::test]
+    async fn test_builder_additive_capabilities() {
         use crate::tool_types::ToolDefinition;
 
         let registry = CapabilityRegistry::with_builtins();
@@ -580,7 +504,8 @@ mod tests {
         // Apply capabilities additively (simulating session-level capabilities)
         let runtime_agent = RuntimeAgentBuilder::new()
             .system_prompt("Agent prompt.")
-            .with_capabilities(&["current_time".to_string()], &registry)
+            .with_capabilities(&["current_time".to_string()], &registry, &test_ctx())
+            .await
             .build();
 
         // Should have the tool from capability
@@ -593,8 +518,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_builder_with_agent_client_side_tools() {
+    #[tokio::test]
+    async fn test_builder_with_agent_client_side_tools() {
         use crate::tool_types::{ClientSideTool, ToolDefinition};
         use uuid::{NoContext, Timestamp, Uuid};
 
@@ -631,7 +556,8 @@ mod tests {
         };
 
         let runtime_agent = RuntimeAgentBuilder::new()
-            .with_agent(&agent, &registry)
+            .with_agent(&agent, &registry, &test_ctx())
+            .await
             .model("gpt-5.2")
             .build();
 
@@ -643,8 +569,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_builder_with_agent_client_side_and_capabilities() {
+    #[tokio::test]
+    async fn test_builder_with_agent_client_side_and_capabilities() {
         use crate::tool_types::{ClientSideTool, ToolDefinition};
         use uuid::{NoContext, Timestamp, Uuid};
 
@@ -676,7 +602,8 @@ mod tests {
         };
 
         let runtime_agent = RuntimeAgentBuilder::new()
-            .with_agent(&agent, &registry)
+            .with_agent(&agent, &registry, &test_ctx())
+            .await
             .model("gpt-5.2")
             .build();
 
@@ -695,8 +622,8 @@ mod tests {
         assert!(matches!(deploy_tool, ToolDefinition::ClientSide(_)));
     }
 
-    #[test]
-    fn test_builder_with_agent_and_additive_capabilities() {
+    #[tokio::test]
+    async fn test_builder_with_agent_and_additive_capabilities() {
         use uuid::{NoContext, Timestamp, Uuid};
 
         let registry = CapabilityRegistry::with_builtins();
@@ -724,8 +651,10 @@ mod tests {
         let session_capability_ids = vec!["test_math".to_string()];
 
         let runtime_agent = RuntimeAgentBuilder::new()
-            .with_agent(&agent, &registry)
-            .with_capabilities(&session_capability_ids, &registry)
+            .with_agent(&agent, &registry, &test_ctx())
+            .await
+            .with_capabilities(&session_capability_ids, &registry, &test_ctx())
+            .await
             .model("gpt-5.2")
             .build();
 

--- a/crates/core/src/runtime_agent.rs
+++ b/crates/core/src/runtime_agent.rs
@@ -11,7 +11,10 @@
 // Result: [session_caps] [agent_caps] [agent_prompt] [harness_caps] [harness_prompt]
 
 use crate::agent::Agent;
-use crate::capabilities::{CapabilityRegistry, collect_capabilities, resolve_dependencies};
+use crate::capabilities::{
+    CapabilityRegistry, SystemPromptContext, collect_capabilities, collect_capabilities_async,
+    resolve_dependencies,
+};
 use crate::harness::Harness;
 use crate::tool_types::ToolDefinition;
 use serde::{Deserialize, Serialize};
@@ -245,6 +248,103 @@ impl RuntimeAgentBuilder {
     /// Build the runtime agent
     pub fn build(self) -> RuntimeAgent {
         self.runtime_agent
+    }
+
+    // ========================================================================
+    // Async variants (use dynamic system prompt contributions)
+    // ========================================================================
+
+    /// Apply a Harness's configuration with dynamic system prompt resolution.
+    ///
+    /// Like `with_harness()`, but calls `system_prompt_contribution()` on each
+    /// capability, which can access the session filesystem for dynamic content.
+    pub async fn with_harness_async(
+        self,
+        harness: &Harness,
+        registry: &CapabilityRegistry,
+        ctx: &SystemPromptContext,
+    ) -> Self {
+        let capability_ids: Vec<String> = harness
+            .capabilities
+            .iter()
+            .map(|cap| cap.capability_id().to_string())
+            .collect();
+
+        self.system_prompt(&harness.system_prompt)
+            .with_capabilities_async(&capability_ids, registry, ctx)
+            .await
+    }
+
+    /// Apply an Agent's configuration with dynamic system prompt resolution.
+    ///
+    /// Like `with_agent()`, but calls `system_prompt_contribution()` on each
+    /// capability, which can access the session filesystem for dynamic content.
+    pub async fn with_agent_async(
+        self,
+        agent: &Agent,
+        registry: &CapabilityRegistry,
+        ctx: &SystemPromptContext,
+    ) -> Self {
+        let capability_ids: Vec<String> = agent
+            .capabilities
+            .iter()
+            .map(|cap| cap.capability_id().to_string())
+            .collect();
+
+        let mut builder = self
+            .system_prompt(&agent.system_prompt)
+            .with_capabilities_async(&capability_ids, registry, ctx)
+            .await;
+
+        // Add agent-level client-side tools
+        if !agent.tools.is_empty() {
+            builder = builder.tools(agent.tools.clone());
+        }
+
+        builder
+    }
+
+    /// Apply capabilities with dynamic system prompt resolution.
+    ///
+    /// Like `with_capabilities()`, but calls `system_prompt_contribution()` on
+    /// each capability (async), enabling dynamic content from the session
+    /// filesystem (e.g., reading AGENTS.md, discovering skills).
+    pub async fn with_capabilities_async(
+        mut self,
+        capability_ids: &[String],
+        registry: &CapabilityRegistry,
+        ctx: &SystemPromptContext,
+    ) -> Self {
+        // Resolve dependencies first (dependencies come before dependents)
+        let resolved_ids = match resolve_dependencies(capability_ids, registry) {
+            Ok(resolved) => resolved.resolved_ids,
+            Err(e) => {
+                tracing::warn!("Failed to resolve capability dependencies: {}", e);
+                capability_ids.to_vec()
+            }
+        };
+
+        let collected = collect_capabilities_async(&resolved_ids, registry, ctx).await;
+
+        // Apply system prompt additions (prepend to existing, wrap base in XML tags)
+        if let Some(prefix) = collected.system_prompt_prefix() {
+            if !self.runtime_agent.system_prompt.is_empty()
+                && !self.runtime_agent.system_prompt.contains("<system-prompt>")
+            {
+                self.runtime_agent.system_prompt = format!(
+                    "<system-prompt>\n{}\n</system-prompt>",
+                    self.runtime_agent.system_prompt
+                );
+            }
+            self = self.prepend_system_prompt(prefix);
+        }
+
+        // Apply tool definitions
+        if !collected.tool_definitions.is_empty() {
+            self = self.tools(collected.tool_definitions);
+        }
+
+        self
     }
 }
 

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -8,7 +8,8 @@
 
 use async_trait::async_trait;
 use everruns_core::capabilities::{
-    AgentCapabilityConfig, CapabilityRegistry, collect_capabilities, is_mcp_capability,
+    AgentCapabilityConfig, CapabilityRegistry, SystemPromptContext, collect_capabilities,
+    is_mcp_capability,
 };
 use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::events::{Event, EventRequest};
@@ -822,7 +823,9 @@ impl WorkerAdapters for DirectWorkerAdapters {
             .collect();
 
         if !builtin_cap_ids.is_empty() {
-            let collected = collect_capabilities(&builtin_cap_ids, &self.capability_registry);
+            let ctx = SystemPromptContext::without_file_store(everruns_core::SessionId::new());
+            let collected =
+                collect_capabilities(&builtin_cap_ids, &self.capability_registry, &ctx).await;
             for tool in collected.tools {
                 registry.register_boxed(tool);
             }

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -1560,9 +1560,9 @@ mod tests {
     /// build a ToolRegistry from harness capabilities. This test verifies that
     /// collect_capabilities on the Generic Harness cap IDs actually produces a
     /// registry containing the 'bash' tool — the exact path that was broken.
-    #[test]
-    fn test_generic_harness_capabilities_produce_bash_tool() {
-        use everruns_core::capabilities::collect_capabilities;
+    #[tokio::test]
+    async fn test_generic_harness_capabilities_produce_bash_tool() {
+        use everruns_core::capabilities::{SystemPromptContext, collect_capabilities};
 
         let registry = everruns_core::capabilities::CapabilityRegistry::with_builtins_for_grade(
             everruns_core::DeploymentGrade::Dev,
@@ -1574,7 +1574,8 @@ mod tests {
             .expect("Generic harness should exist");
 
         let cap_ids: Vec<String> = generic.capabilities.iter().map(|s| s.to_string()).collect();
-        let collected = collect_capabilities(&cap_ids, &registry);
+        let ctx = SystemPromptContext::without_file_store(everruns_core::SessionId::new());
+        let collected = collect_capabilities(&cap_ids, &registry, &ctx).await;
 
         // Build a ToolRegistry exactly as the worker does
         let mut tool_registry = everruns_core::ToolRegistry::with_defaults();
@@ -1603,9 +1604,9 @@ mod tests {
 
     /// Verify all Generic Harness capabilities produce tool implementations
     /// (not just definitions). Tools without implementations cause "Tool not found".
-    #[test]
-    fn test_generic_harness_collected_tools_have_implementations() {
-        use everruns_core::capabilities::collect_capabilities;
+    #[tokio::test]
+    async fn test_generic_harness_collected_tools_have_implementations() {
+        use everruns_core::capabilities::{SystemPromptContext, collect_capabilities};
 
         let registry = everruns_core::capabilities::CapabilityRegistry::with_builtins_for_grade(
             everruns_core::DeploymentGrade::Dev,
@@ -1617,7 +1618,8 @@ mod tests {
             .expect("Generic harness should exist");
 
         let cap_ids: Vec<String> = generic.capabilities.iter().map(|s| s.to_string()).collect();
-        let collected = collect_capabilities(&cap_ids, &registry);
+        let ctx = SystemPromptContext::without_file_store(everruns_core::SessionId::new());
+        let collected = collect_capabilities(&cap_ids, &registry, &ctx).await;
 
         // Every tool definition must have a matching tool implementation
         assert_eq!(

--- a/crates/server/src/services/capability.rs
+++ b/crates/server/src/services/capability.rs
@@ -266,7 +266,9 @@ impl CapabilityService {
         base_system_prompt: &str,
         capability_configs: &[everruns_core::AgentCapabilityConfig],
     ) -> Result<(String, Vec<everruns_core::ToolDefinition>)> {
-        use everruns_core::capabilities::{collect_capabilities, resolve_dependencies};
+        use everruns_core::capabilities::{
+            SystemPromptContext, collect_capabilities, resolve_dependencies,
+        };
 
         let mut system_prompt_parts: Vec<String> = Vec::new();
         let mut tool_definitions: Vec<everruns_core::ToolDefinition> = Vec::new();
@@ -292,7 +294,9 @@ impl CapabilityService {
             .map_err(|e| anyhow::anyhow!("Failed to resolve capability dependencies: {}", e))?;
 
         // Collect from resolved capabilities (includes dependencies in correct order)
-        let collected = collect_capabilities(&resolved.resolved_ids, &self.registry);
+        // Preview has no session context, so dynamic capabilities (agent_instructions) return None
+        let ctx = SystemPromptContext::without_file_store(everruns_core::SessionId::new());
+        let collected = collect_capabilities(&resolved.resolved_ids, &self.registry, &ctx).await;
         if let Some(prefix) = collected.system_prompt_prefix() {
             system_prompt_parts.push(prefix);
         }

--- a/crates/server/src/services/session.rs
+++ b/crates/server/src/services/session.rs
@@ -15,7 +15,8 @@ use crate::storage::{
 use anyhow::Result;
 use everruns_core::{
     AgentCapabilityConfig, AgentId, CapabilityRegistry, HarnessId, ModelId, Session, SessionId,
-    SessionStatus, TokenUsage, capabilities::collect_capabilities,
+    SessionStatus, TokenUsage,
+    capabilities::{SystemPromptContext, collect_capabilities},
 };
 use std::sync::Arc;
 use uuid::Uuid;
@@ -152,7 +153,9 @@ impl SessionService {
         }
 
         // Collect mounts from all capabilities
-        let collected = collect_capabilities(&capability_ids, &self.capability_registry);
+        let ctx = SystemPromptContext::without_file_store(SessionId::from_uuid(session_id));
+        let collected =
+            collect_capabilities(&capability_ids, &self.capability_registry, &ctx).await;
 
         if collected.mounts.is_empty() {
             return Ok(()); // No mounts to apply

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -15,7 +15,9 @@
 use anyhow::{Context, Result};
 use everruns_core::ToolRegistry;
 use everruns_core::atoms::{ActAtom, Atom, InputAtom, ReasonAtom};
-use everruns_core::capabilities::{CapabilityRegistry, collect_capabilities, is_mcp_capability};
+use everruns_core::capabilities::{
+    CapabilityRegistry, SystemPromptContext, collect_capabilities, is_mcp_capability,
+};
 use everruns_core::traits::AgentStore;
 use std::sync::Arc;
 
@@ -331,7 +333,8 @@ pub async fn act_activity(
 
     if !cap_ids.is_empty() {
         let capability_registry = CapabilityRegistry::with_builtins();
-        let collected = collect_capabilities(&cap_ids, &capability_registry);
+        let ctx = SystemPromptContext::without_file_store(input.context.session_id);
+        let collected = collect_capabilities(&cap_ids, &capability_registry, &ctx).await;
         for tool in collected.tools {
             builtin_executor.register_boxed(tool);
         }

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -4,7 +4,9 @@
 // Decision: Used by external workers that connect to control-plane via gRPC
 
 use async_trait::async_trait;
-use everruns_core::capabilities::{CapabilityRegistry, collect_capabilities, is_mcp_capability};
+use everruns_core::capabilities::{
+    CapabilityRegistry, SystemPromptContext, collect_capabilities, is_mcp_capability,
+};
 use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::events::{Event, EventRequest};
 use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
@@ -346,7 +348,8 @@ impl WorkerAdapters for GrpcWorkerAdapters {
 
             if !builtin_cap_ids.is_empty() {
                 let cap_registry = self.capability_registry();
-                let collected = collect_capabilities(&builtin_cap_ids, &cap_registry);
+                let ctx = SystemPromptContext::without_file_store(everruns_core::SessionId::new());
+                let collected = collect_capabilities(&builtin_cap_ids, &cap_registry, &ctx).await;
                 for tool in collected.tools {
                     registry.register_boxed(tool);
                 }

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -6,7 +6,9 @@
 // This allows a single Worker implementation to work with either backend.
 
 use async_trait::async_trait;
-use everruns_core::capabilities::{CapabilityRegistry, collect_capabilities, is_mcp_capability};
+use everruns_core::capabilities::{
+    CapabilityRegistry, SystemPromptContext, collect_capabilities, is_mcp_capability,
+};
 use everruns_core::error::Result;
 use everruns_core::events::{Event, EventRequest};
 use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
@@ -204,7 +206,8 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
 
             if !builtin_cap_ids.is_empty() {
                 let cap_registry = self.capability_registry();
-                let collected = collect_capabilities(&builtin_cap_ids, &cap_registry);
+                let ctx = SystemPromptContext::without_file_store(everruns_core::SessionId::new());
+                let collected = collect_capabilities(&builtin_cap_ids, &cap_registry, &ctx).await;
                 for tool in collected.tools {
                     registry.register_boxed(tool);
                 }

--- a/specs/agent-instructions.md
+++ b/specs/agent-instructions.md
@@ -21,41 +21,64 @@ Everruns implements AGENTS.md as a built-in capability that reads from the sessi
 | Size limit | 32 KiB max (truncated with warning if exceeded, matching Codex convention) |
 | Missing file | Silently ignored (no error) |
 | Format | Plain markdown, no special syntax, no `@` imports |
-| Architecture | Capability (marker) + ReasonAtom integration (dynamic reader) |
+| Architecture | Self-contained capability with `system_prompt_contribution()` override |
 | Dependencies | None required; `session_file_system` recommended for authoring |
 
 ## Capability Definition
 
+The capability encapsulates all AGENTS.md logic: reading from the session filesystem,
+formatting, size limiting, and XML wrapping. It uses the `system_prompt_contribution()`
+async method (via `SystemPromptContext`) to access the session filesystem.
+
 ```rust
 pub struct AgentInstructionsCapability;
 
+#[async_trait]
 impl Capability for AgentInstructionsCapability {
     fn id(&self) -> &str { "agent_instructions" }
     fn name(&self) -> &str { "Agent Instructions" }
-    fn description(&self) -> &str {
-        "Reads AGENTS.md from the session workspace and includes it as context in the system prompt. Content is re-read on every turn, so changes are picked up automatically."
-    }
     fn status(&self) -> CapabilityStatus { CapabilityStatus::Available }
     fn icon(&self) -> Option<&str> { Some("file-text") }
     fn category(&self) -> Option<&str> { Some("Configuration") }
-    // No system_prompt_addition() — content is dynamic (read at runtime)
-    // No tools
-    // No dependencies
+
+    // No static system_prompt_addition — content is dynamic
+
+    async fn system_prompt_contribution(&self, ctx: &SystemPromptContext) -> Option<String> {
+        // Reads /AGENTS.md from ctx.file_store
+        // Formats with <agent-instructions> XML wrapping
+        // Returns None if file missing or empty
+    }
 }
 ```
+
+## SystemPromptContext
+
+Capabilities that need dynamic system prompt content receive a `SystemPromptContext`
+with access to session-specific resources:
+
+```rust
+pub struct SystemPromptContext {
+    pub session_id: SessionId,
+    pub file_store: Option<Arc<dyn SessionFileStore>>,
+}
+```
+
+The context is constructed in `ReasonAtom` and passed through the async builder
+methods (`with_harness_async`, `with_agent_async`, `with_capabilities_async`).
 
 ## Integration Flow
 
 ```
 execute_llm_call()
   ├── Load agent + session
-  ├── Resolve capabilities
-  ├── Check: is "agent_instructions" in resolved capabilities?
-  │   └── Yes: read /AGENTS.md from session file store
-  │       ├── File exists: prepend content to system prompt
-  │       ├── File missing: skip silently
-  │       └── File > 32 KiB: truncate + log warning
-  ├── Build RuntimeAgent (capabilities + tools + model)
+  ├── Create SystemPromptContext { session_id, file_store }
+  ├── Build RuntimeAgent using async builder methods
+  │   ├── with_harness_async() — resolves harness capabilities (including agent_instructions)
+  │   ├── with_agent_async() — resolves agent capabilities
+  │   └── with_capabilities_async() — resolves session capabilities
+  │       └── For each capability: call system_prompt_contribution(ctx)
+  │           └── agent_instructions: reads /AGENTS.md from file store
+  ├── Build final RuntimeAgent
   └── Execute LLM call
 ```
 
@@ -71,7 +94,8 @@ XML tags provide clear boundaries between sections. See `specs/xml-prompt-format
 
 ## ReasonAtom Changes
 
-Add optional `SessionFileStore` to ReasonAtom:
+ReasonAtom holds an optional `SessionFileStore` that is passed to capabilities
+via `SystemPromptContext`:
 
 ```rust
 pub struct ReasonAtom<A, S, M, P, E> {

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -203,12 +203,14 @@ This allows the same capability to behave differently per-agent.
 Capabilities are defined as trait implementations in the core crate:
 
 ```rust
+#[async_trait]
 pub trait Capability: Send + Sync {
     fn id(&self) -> &str;
     fn name(&self) -> &str;
     fn description(&self) -> &str;
     fn status(&self) -> CapabilityStatus;
     fn system_prompt_addition(&self) -> Option<&str> { None }
+    async fn system_prompt_contribution(&self, ctx: &SystemPromptContext) -> Option<String> { ... }
     fn tools(&self) -> Vec<Box<dyn Tool>> { vec![] }
     fn icon(&self) -> Option<&str> { None }
     fn category(&self) -> Option<&str> { None }
@@ -219,6 +221,24 @@ pub trait Capability: Send + Sync {
 ```
 
 The `CapabilityRegistry` in core holds all registered capability implementations. The API layer converts trait objects to DTOs using `Capability::from_core()`.
+
+##### System Prompt Methods
+
+- **`system_prompt_addition()`** — Sync method returning static `&str`. Used by the sync collection path (tools/mounts only callers).
+- **`system_prompt_contribution(ctx)`** — Async method receiving `SystemPromptContext` with session filesystem access. The default wraps `system_prompt_addition()` in `<capability id="...">` XML tags. Capabilities needing dynamic content (e.g., `agent_instructions`, `skills`) override this to read from the session filesystem.
+
+```rust
+pub struct SystemPromptContext {
+    pub session_id: SessionId,
+    pub file_store: Option<Arc<dyn SessionFileStore>>,
+}
+```
+
+##### Collection Functions
+
+- **`collect_capabilities()`** — Sync. Collects tools, mounts, and static prompts. Used by worker adapters.
+- **`collect_capabilities_async(ctx)`** — Async. Calls `system_prompt_contribution()` for dynamic prompts. Used by the agent loop.
+- **`RuntimeAgentBuilder::with_capabilities_async(ctx)`** — Async builder method using `collect_capabilities_async`.
 
 **Note**: The `message_filter_provider()` method returns an optional filter provider that can modify how messages are retrieved for sessions using this capability. See the [Message Filters](#message-filters) section for details.
 
@@ -748,7 +768,7 @@ When a session executes:
 3. **Fetch Agent Capabilities**: Get agent's enabled capabilities via `get_agent_capabilities(agent_id)`
 4. **Resolve Capabilities**: For each capability (ordered by `position`):
    - Look up `InternalCapability` from registry by string ID
-   - Collect `system_prompt_addition` texts
+   - Call `system_prompt_contribution(ctx)` (async) for dynamic prompt content
    - Collect `tools` definitions
 5. **Apply Session Capabilities**: Session-level capabilities are applied **after** agent capabilities (additive):
    - Session capabilities extend the agent's tools


### PR DESCRIPTION
## What
Make the `Capability` trait async-only by introducing `system_prompt_contribution(&self, ctx)` as the single async method for generating system prompt content. Remove the sync `system_prompt_section`/`system_prompt_xml_tag`/`system_prompt_content` methods in favor of this unified async API.

## Why
Capabilities like `agent_instructions` (reads AGENTS.md from workspace filesystem) and `skills_discovery` (scans workspace for skill files) need async filesystem access at prompt-build time. The previous sync API forced workarounds via pre-cached state in the `ReasonAtom`. This refactor lets each capability own its I/O directly.

## How
- Added `SystemPromptContext` carrying optional `SessionFileStore` + `agent_id`, passed to capabilities at prompt-build time
- Added async `system_prompt_contribution` to `Capability` trait with default implementation that wraps the existing sync helpers (backward compat for simple capabilities)
- Migrated `AgentInstructionsCapability` and `SkillsDiscoveryCapability` to use the new async method, reading files directly
- Removed sync duplicate methods and the redundant `instructions_content` pre-fetch from `ReasonAtom`
- Updated `RuntimeAgent::build_system_prompt` to be async, calling capabilities concurrently
- Updated all 4 `WorkerAdapters` impls + `seed.rs` + `capability.rs` service

## Risk
- Low
- Capability prompt generation is now async; any new capability must implement the async method. Existing simple capabilities use the default impl unchanged.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
