### PR TITLE
feat(harness): add skills capability to Generic harness

### DIFF
--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -2041,6 +2041,7 @@ mod tests {
             "virtual_bash".to_string(),
             "session_storage".to_string(),
             "session".to_string(),
+            "skills".to_string(),
         ];
 
         let registry = CapabilityRegistry::with_builtins();

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -286,7 +286,7 @@ const SEED_HARNESSES: &[SeedHarness] = &[
     SeedHarness {
         id: seed_ids::GENERIC_HARNESS,
         name: "Generic",
-        description: "General-purpose harness with file system, bash, secrets, and session management. Recommended default for most use cases.",
+        description: "General-purpose harness with file system, bash, secrets, session management, and agent skills. Recommended default for most use cases.",
         system_prompt: "You are a helpful assistant.",
         tags: &["generic", "default", "seed"],
         capabilities: &[
@@ -295,6 +295,7 @@ const SEED_HARNESSES: &[SeedHarness] = &[
             "session_storage",
             "session",
             "agent_instructions",
+            "skills",
         ],
     },
 ];
@@ -1523,12 +1524,13 @@ mod tests {
             .find(|h| h.name == "Generic")
             .expect("Generic harness should exist");
 
-        assert_eq!(generic.capabilities.len(), 5);
+        assert_eq!(generic.capabilities.len(), 6);
         assert!(generic.capabilities.contains(&"session_file_system"));
         assert!(generic.capabilities.contains(&"virtual_bash"));
         assert!(generic.capabilities.contains(&"session_storage"));
         assert!(generic.capabilities.contains(&"session"));
         assert!(generic.capabilities.contains(&"agent_instructions"));
+        assert!(generic.capabilities.contains(&"skills"));
         assert!(generic.tags.contains(&"generic"));
         assert!(generic.tags.contains(&"default"));
     }
@@ -1638,6 +1640,50 @@ mod tests {
             .map(|t| t.name())
             .collect();
         assert!(tool_names.contains(&"bash"), "must include bash tool");
+        assert!(
+            tool_names.contains(&"list_skills"),
+            "must include list_skills tool"
+        );
+        assert!(
+            tool_names.contains(&"activate_skill"),
+            "must include activate_skill tool"
+        );
+    }
+
+    /// Verify Generic Harness includes skills discovery tools.
+    #[tokio::test]
+    async fn test_generic_harness_capabilities_produce_skills_tools() {
+        use everruns_core::capabilities::{SystemPromptContext, collect_capabilities};
+
+        let registry = everruns_core::capabilities::CapabilityRegistry::with_builtins_for_grade(
+            everruns_core::DeploymentGrade::Dev,
+        );
+
+        let generic = SEED_HARNESSES
+            .iter()
+            .find(|h| h.name == "Generic")
+            .expect("Generic harness should exist");
+
+        let cap_ids: Vec<String> = generic.capabilities.iter().map(|s| s.to_string()).collect();
+        let ctx = SystemPromptContext::without_file_store(everruns_core::SessionId::new());
+        let collected = collect_capabilities(&cap_ids, &registry, &ctx).await;
+
+        let tool_names: Vec<&str> = collected
+            .tool_definitions
+            .iter()
+            .map(|t| t.name())
+            .collect();
+
+        assert!(
+            tool_names.contains(&"list_skills"),
+            "Generic Harness must include 'list_skills' tool from skills capability, got: {:?}",
+            tool_names
+        );
+        assert!(
+            tool_names.contains(&"activate_skill"),
+            "Generic Harness must include 'activate_skill' tool from skills capability, got: {:?}",
+            tool_names
+        );
     }
 
     // --- seed_all ---

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -832,7 +832,7 @@ async fn test_get_generic_harness() {
     assert!(harness.tags.contains(&"generic".to_string()));
     assert!(harness.tags.contains(&"default".to_string()));
 
-    // Verify Generic harness has the expected 5 capabilities
+    // Verify Generic harness has the expected 6 capabilities
     let cap_ids: Vec<&str> = harness
         .capabilities
         .iter()
@@ -840,8 +840,8 @@ async fn test_get_generic_harness() {
         .collect();
     assert_eq!(
         cap_ids.len(),
-        5,
-        "Generic harness should have 5 capabilities"
+        6,
+        "Generic harness should have 6 capabilities"
     );
     assert!(
         cap_ids.contains(&"session_file_system"),
@@ -863,6 +863,7 @@ async fn test_get_generic_harness() {
         cap_ids.contains(&"agent_instructions"),
         "Should have agent instructions"
     );
+    assert!(cap_ids.contains(&"skills"), "Should have skills discovery");
 }
 
 #[tokio::test]
@@ -1031,11 +1032,11 @@ async fn test_copy_seed_generic_harness() {
         .json();
 
     assert_eq!(copied.name, "Generic (copy)");
-    // Generic harness has 5 capabilities
+    // Generic harness has 6 capabilities
     assert_eq!(
         copied.capabilities.len(),
-        5,
-        "Copied harness should have same 5 capabilities"
+        6,
+        "Copied harness should have same 6 capabilities"
     );
 }
 

--- a/specs/harness-types.md
+++ b/specs/harness-types.md
@@ -43,6 +43,7 @@ The recommended default harness. Bundles the core capabilities needed for genera
 | `session_storage` | Session Storage | Key/value store and encrypted secret storage |
 | `session` | Session | Session info access and title management |
 | `agent_instructions` | Agent Instructions | Reads AGENTS.md from workspace and injects into system prompt |
+| `skills` | Agent Skills | Discover and activate skills from `/.agents/skills/` in session filesystem |
 
 **Use cases:**
 - Default harness for most agents
@@ -59,6 +60,7 @@ The recommended default harness. Bundles the core capabilities needed for genera
 | Why include `session_storage` in Generic? | Secret storage is needed for agents that interact with external APIs (API keys, tokens). KV storage is useful for persisting state. |
 | Why include `session` in Generic? | Session metadata (title, info) is commonly needed and has minimal overhead. |
 | Why include `agent_instructions` in Generic? | AGENTS.md is the standard way to provide project-level instructions. Including it by default means users get this functionality without extra configuration. |
+| Why include `skills` in Generic? | Skills extend agent abilities via portable instruction packages. Including discovery by default means agents can use skills uploaded to the session filesystem without extra capability setup. |
 | Can users create additional harnesses? | Yes, via `POST /v1/harnesses`. Built-in harnesses are seed data, not the only options. |
 
 ## Seed Data


### PR DESCRIPTION
## What
Add the `skills` capability to the Generic harness seed data. Sessions using the Generic harness now include `list_skills` and `activate_skill` tools by default.

## Why
Skills are portable instruction packages that extend agent abilities. Including skills discovery in the Generic harness means agents can use SKILL.md files uploaded to `/.agents/skills/` without requiring manual capability configuration.

## How
- Added skills to Generic harness capabilities in seed data
- Updated description to mention agent skills
- Updated spec with new capability row and design decision
- Updated all tests to expect 6 capabilities
- Added dedicated test verifying list_skills and activate_skill tools

## Risk
- Low
- The skills capability depends on session_file_system which Generic already includes.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered