### PR TITLE
fix(capabilities): respect /workspace prefix in skills agent-facing paths

### DIFF
--- a/crates/core/src/capabilities/skill.rs
+++ b/crates/core/src/capabilities/skill.rs
@@ -30,6 +30,9 @@ pub const SKILL_CAPABILITY_PREFIX: &str = "skill:";
 /// Default path for filesystem-based skill discovery
 pub const SKILLS_DISCOVERY_PATH: &str = "/.agents/skills";
 
+/// Workspace prefix for agent-facing paths (matches file_system capability convention)
+const WORKSPACE_PREFIX: &str = "/workspace";
+
 /// Maximum number of skills in a single capability
 pub const MAX_SKILLS_PER_CAPABILITY: usize = 50;
 
@@ -168,7 +171,10 @@ impl SkillCapability {
                 skill.description
             ));
             if let SkillSource::Filesystem { ref path } = skill.source {
-                xml.push_str(&format!("    <location>{}/SKILL.md</location>\n", path));
+                xml.push_str(&format!(
+                    "    <location>{}{}/SKILL.md</location>\n",
+                    WORKSPACE_PREFIX, path
+                ));
             }
             xml.push_str("  </skill>\n");
         }
@@ -376,10 +382,10 @@ impl Tool for ActivateSkillTool {
                     let file_list: Vec<&str> =
                         skill.files.iter().map(|(path, _)| path.as_str()).collect();
                     result.push_str(&format!(
-                        "\n\nBundled files are available at /skills/{name}/:\n{}",
+                        "\n\nBundled files are available at {WORKSPACE_PREFIX}/skills/{name}/:\n{}",
                         file_list
                             .iter()
-                            .map(|f| format!("- /skills/{name}/{f}"))
+                            .map(|f| format!("- {WORKSPACE_PREFIX}/skills/{name}/{f}"))
                             .collect::<Vec<_>>()
                             .join("\n")
                     ));
@@ -547,8 +553,11 @@ mod tests {
         assert!(prompt.contains("<description>Extract text from PDFs</description>"));
         assert!(prompt.contains("activate_skill"));
         assert!(prompt.contains("</available_skills>"));
-        // Filesystem skills include location
-        assert!(prompt.contains("<location>/.agents/skills/data-analysis/SKILL.md</location>"));
+        // Filesystem skills include location with workspace prefix
+        assert!(
+            prompt
+                .contains("<location>/workspace/.agents/skills/data-analysis/SKILL.md</location>")
+        );
     }
 
     #[test]
@@ -644,7 +653,7 @@ mod tests {
             ToolExecutionResult::Success(value) => {
                 assert_eq!(value["files_mounted"], true);
                 let instr = value["instructions"].as_str().unwrap();
-                assert!(instr.contains("/skills/data-skill/scripts/run.py"));
+                assert!(instr.contains("/workspace/skills/data-skill/scripts/run.py"));
             }
             other => panic!("Expected Success, got: {:?}", other),
         }
@@ -759,7 +768,7 @@ mod tests {
         assert!(xml.ends_with("</available_skills>"));
         assert!(xml.contains("<name>my-skill</name>"));
         assert!(xml.contains("<description>Does cool things</description>"));
-        // Registry skills don't have location
+        // Registry skills don't have location (only filesystem skills do)
         assert!(!xml.contains("<location>"));
     }
 

--- a/crates/core/src/capabilities/skills_discovery.rs
+++ b/crates/core/src/capabilities/skills_discovery.rs
@@ -26,6 +26,18 @@ pub const SKILLS_DISCOVERY_CAPABILITY_ID: &str = "skills";
 /// Path in session VFS where skills are discovered
 const SKILLS_PATH: &str = "/.agents/skills";
 
+/// Workspace prefix for agent-facing paths (matches file_system capability convention)
+const WORKSPACE_PREFIX: &str = "/workspace";
+
+/// Add workspace prefix for display paths shown to the agent
+fn workspace_path(path: &str) -> String {
+    if path.starts_with('/') {
+        format!("{}{}", WORKSPACE_PREFIX, path)
+    } else {
+        format!("{}/{}", WORKSPACE_PREFIX, path)
+    }
+}
+
 /// Built-in Skills Discovery Capability
 ///
 /// Provides the generic skills mechanism. No skills are bundled — users upload
@@ -35,7 +47,7 @@ pub struct SkillsDiscoveryCapability;
 /// Static skills system prompt (used by sync callers and as fallback)
 const SKILLS_SYSTEM_PROMPT: &str = "You have access to an agent skills system. Skills are instruction packages \
 that can be discovered from the session filesystem.\n\n\
-Skills location: `/.agents/skills/{skill-name}/SKILL.md`\n\n\
+Skills location: `/workspace/.agents/skills/{skill-name}/SKILL.md`\n\n\
 Use `list_skills` to discover available skills. When a skill is relevant to the \
 user's task, use `activate_skill` to load its full instructions into your context. \
 Only activate skills that are relevant to the current task.";
@@ -53,7 +65,7 @@ impl Capability for SkillsDiscoveryCapability {
     fn description(&self) -> &str {
         r#"Discover and activate skills from the session filesystem.
 
-Skills are instruction packages (SKILL.md files) that teach the agent new abilities. Upload skills to `/.agents/skills/{name}/SKILL.md` and the agent will discover them automatically.
+Skills are instruction packages (SKILL.md files) that teach the agent new abilities. Upload skills to `/workspace/.agents/skills/{name}/SKILL.md` and the agent will discover them automatically.
 
 > [!TIP]
 > Use the `list_skills` tool to see available skills, then `activate_skill` to load one."#
@@ -148,7 +160,7 @@ Skills are instruction packages (SKILL.md files) that teach the agent new abilit
                 name: "list_skills".to_string(),
                 display_name: Some("List Skills".to_string()),
                 description: "Discover available skills from the session filesystem. \
-                    Scans /.agents/skills/ for SKILL.md files and returns their names \
+                    Scans /workspace/.agents/skills/ for SKILL.md files and returns their names \
                     and descriptions."
                     .to_string(),
                 parameters: serde_json::json!({
@@ -162,7 +174,7 @@ Skills are instruction packages (SKILL.md files) that teach the agent new abilit
                 name: "activate_skill".to_string(),
                 display_name: Some("Activate Skill".to_string()),
                 description: "Activate a skill by name to load its full instructions. \
-                    The skill must exist at /.agents/skills/{name}/SKILL.md in the \
+                    The skill must exist at /workspace/.agents/skills/{name}/SKILL.md in the \
                     session filesystem."
                     .to_string(),
                 parameters: serde_json::json!({
@@ -249,7 +261,7 @@ impl Tool for ListSkillsTool {
                 // Directory doesn't exist yet — no skills available
                 return ToolExecutionResult::success(serde_json::json!({
                     "skills": [],
-                    "message": "No skills found. Upload skills to /.agents/skills/{name}/SKILL.md"
+                    "message": "No skills found. Upload skills to /workspace/.agents/skills/{name}/SKILL.md"
                 }));
             }
         };
@@ -272,14 +284,14 @@ impl Tool for ListSkillsTool {
                         skills.push(serde_json::json!({
                             "name": parsed.name,
                             "description": parsed.description,
-                            "path": skill_md_path,
+                            "path": workspace_path(&skill_md_path),
                             "version": parsed.version,
                         }));
                     }
                     Err(errors) => {
                         skills.push(serde_json::json!({
                             "name": entry.name,
-                            "path": skill_md_path,
+                            "path": workspace_path(&skill_md_path),
                             "error": format!("Invalid SKILL.md: {}", errors.join(", ")),
                         }));
                     }
@@ -290,7 +302,7 @@ impl Tool for ListSkillsTool {
         ToolExecutionResult::success(serde_json::json!({
             "skills": skills,
             "count": skills.len(),
-            "skills_path": SKILLS_PATH,
+            "skills_path": workspace_path(SKILLS_PATH),
         }))
     }
 }
@@ -378,8 +390,9 @@ impl Tool for ActivateSkillFromVfsTool {
             Ok(Some(f)) => f,
             Ok(None) => {
                 return ToolExecutionResult::tool_error(format!(
-                    "Skill '{name}' not found at {skill_md_path}. \
-                     Use list_skills to see available skills."
+                    "Skill '{name}' not found at {}. \
+                     Use list_skills to see available skills.",
+                    workspace_path(&skill_md_path)
                 ));
             }
             Err(e) => {
@@ -407,7 +420,7 @@ impl Tool for ActivateSkillFromVfsTool {
                     Ok(entries) => entries
                         .iter()
                         .filter(|e| !e.is_directory && e.name != "SKILL.md")
-                        .map(|e| e.path.clone())
+                        .map(|e| workspace_path(&e.path))
                         .collect::<Vec<_>>(),
                     Err(_) => vec![],
                 };
@@ -425,7 +438,8 @@ impl Tool for ActivateSkillFromVfsTool {
                 ToolExecutionResult::success(result)
             }
             Err(errors) => ToolExecutionResult::tool_error(format!(
-                "Invalid SKILL.md at {skill_md_path}: {}",
+                "Invalid SKILL.md at {}: {}",
+                workspace_path(&skill_md_path),
                 errors.join(", ")
             )),
         }
@@ -666,7 +680,7 @@ mod tests {
         let cap = SkillsDiscoveryCapability;
         let prompt = cap.system_prompt_addition().unwrap();
 
-        assert!(prompt.contains("/.agents/skills/"));
+        assert!(prompt.contains("/workspace/.agents/skills/"));
         assert!(prompt.contains("list_skills"));
         assert!(prompt.contains("activate_skill"));
     }
@@ -1052,7 +1066,7 @@ mod tests {
                 // Should have the extra files (not SKILL.md)
                 assert!(!bundled.is_empty());
                 let paths: Vec<&str> = bundled.iter().map(|f| f.as_str().unwrap()).collect();
-                assert!(paths.contains(&"/.agents/skills/data-tool/README.md"));
+                assert!(paths.contains(&"/workspace/.agents/skills/data-tool/README.md"));
                 // scripts/run.py is nested so won't be a direct child
             }
             other => panic!("Expected Success, got: {:?}", other),
@@ -1129,8 +1143,10 @@ mod tests {
             "System prompt should mention list_skills tool"
         );
         assert!(
-            runtime_agent.system_prompt.contains("/.agents/skills/"),
-            "System prompt should mention skills path"
+            runtime_agent
+                .system_prompt
+                .contains("/workspace/.agents/skills/"),
+            "System prompt should mention skills path with workspace prefix"
         );
         assert!(
             runtime_agent


### PR DESCRIPTION
## What

Skills capabilities now use `/workspace` prefix for all agent-facing paths, matching the `file_system` capability convention.

## Why

The `file_system` capability presents all paths under `/workspace` to agents (e.g., `/workspace/src/main.rs`). The skills capabilities (`skills_discovery.rs` and `skill.rs`) were bypassing this convention, showing raw VFS paths like `/.agents/skills/...` and `/skills/{name}/...` directly to agents. This created an inconsistency — agents saw skills at `/.agents/skills/` but all other files under `/workspace`.

## How

- `skills_discovery.rs`: Added `workspace_path()` helper; prefixed all agent-facing paths (system prompt, tool descriptions, tool output, error messages) with `/workspace`
- `skill.rs`: Prefixed filesystem skill locations in `<available_skills>` XML and bundled file paths in `activate_skill` output with `/workspace`
- Internal VFS access paths remain unchanged (`/.agents/skills/`)

## Risk
- Low
- All existing tests updated and passing. Only changes are to display strings shown to agents — no logic or VFS access path changes.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered