### PR TITLE
docs: add sitemap.xml with lastmod dates

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -2,6 +2,7 @@ import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
 import starlightOpenAPI, { openAPISidebarGroups } from "starlight-openapi";
 import starlightClientMermaid from "@pasqal-io/starlight-client-mermaid";
+import sitemapEnhance from "./integrations/sitemap-enhance.mjs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
@@ -96,5 +97,6 @@ export default defineConfig({
       },
       lastUpdated: true,
     }),
+    sitemapEnhance(),
   ],
 });

--- a/apps/docs/integrations/sitemap-enhance.mjs
+++ b/apps/docs/integrations/sitemap-enhance.mjs
@@ -1,0 +1,52 @@
+// Post-processes Starlight's sitemap to produce /sitemap.xml with <lastmod>.
+// Uses build date (not git history) — works on Cloudflare Pages shallow clones.
+import { readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export default function sitemapEnhance() {
+  return {
+    name: "sitemap-enhance",
+    hooks: {
+      "astro:build:done": async ({ dir }) => {
+        const outDir = fileURLToPath(dir);
+        const sitemapSrc = join(outDir, "sitemap-0.xml");
+
+        let content;
+        try {
+          content = readFileSync(sitemapSrc, "utf-8");
+        } catch {
+          console.warn(
+            "[sitemap-enhance] sitemap-0.xml not found, skipping"
+          );
+          return;
+        }
+
+        const lastmod = new Date().toISOString().split("T")[0];
+
+        // Add <lastmod> to each <url> entry
+        const enhanced = content.replace(
+          /<url><loc>(.*?)<\/loc><\/url>/g,
+          (_match, url) =>
+            `<url><loc>${url}</loc><lastmod>${lastmod}</lastmod></url>`
+        );
+
+        const sitemapDest = join(outDir, "sitemap.xml");
+        writeFileSync(sitemapDest, enhanced);
+
+        // Remove Starlight's intermediate sitemap files
+        unlinkSync(sitemapSrc);
+        try {
+          unlinkSync(join(outDir, "sitemap-index.xml"));
+        } catch {
+          // may not exist
+        }
+
+        const entryCount = (enhanced.match(/<url>/g) || []).length;
+        console.log(
+          `[sitemap-enhance] sitemap.xml written with ${entryCount} entries (lastmod: ${lastmod})`
+        );
+      },
+    },
+  };
+}

--- a/apps/docs/public/robots.txt
+++ b/apps/docs/public/robots.txt
@@ -36,4 +36,4 @@ Allow: /
 User-agent: *
 Allow: /
 
-Sitemap: https://docs.everruns.com/sitemap-index.xml
+Sitemap: https://docs.everruns.com/sitemap.xml


### PR DESCRIPTION
## What
Add `/sitemap.xml` generation with `<lastmod>` dates for the docs site. Updates `robots.txt` to reference the canonical sitemap URL.

## Why
SEO: search engines need `https://docs.everruns.com/sitemap.xml` (served directly, no redirects) with per-entry `<lastmod>` dates.

## How
Custom Astro integration (`sitemap-enhance`) that post-processes Starlight's built-in sitemap output:
1. Reads `sitemap-0.xml` generated by Starlight's `@astrojs/sitemap`
2. Adds `<lastmod>` (build date) to every entry
3. Writes as `sitemap.xml` and removes intermediate files (`sitemap-0.xml`, `sitemap-index.xml`)

Uses build date rather than git history — compatible with Cloudflare Pages shallow clones.

Also updates `robots.txt` Sitemap directive from `sitemap-index.xml` to `sitemap.xml`.

## Risk
- Low
- Only affects static docs build output; no backend changes

## Checklist
- [x] Tests added or updated (verified via `npm run build` — 126 entries with lastmod)
- [x] Backward compatibility considered (robots.txt updated to new URL)