### PR TITLE
fix(ui): fix chat input panel and sidebar layout alignment

### DIFF
--- a/apps/ui/src/__tests__/session-layout.test.tsx
+++ b/apps/ui/src/__tests__/session-layout.test.tsx
@@ -10,6 +10,7 @@ jest.mock("next/navigation", () => ({
 // Mock next/link
 jest.mock("next/link", () => ({
   __esModule: true,
+  // eslint-disable-next-line nextjs/no-html-link-for-pages
   default: ({
     children,
     href,
@@ -19,6 +20,7 @@ jest.mock("next/link", () => ({
     href: string;
     className?: string;
   }) => (
+    // eslint-disable-next-line nextjs/no-html-link-for-pages
     <a href={href} className={className}>
       {children}
     </a>
@@ -300,7 +302,9 @@ describe("SessionLayout", () => {
     const { container } = await renderLayout();
 
     await waitFor(() => {
-      const layoutDiv = container.querySelector('[class*="flex"][class*="flex-col"][class*="h-full"]');
+      const layoutDiv = container.querySelector(
+        '[class*="flex"][class*="flex-col"][class*="h-full"]',
+      );
       expect(layoutDiv).toBeInTheDocument();
     });
   });

--- a/apps/ui/src/__tests__/session-layout.test.tsx
+++ b/apps/ui/src/__tests__/session-layout.test.tsx
@@ -1,0 +1,307 @@
+import { render, screen, act, waitFor } from "@testing-library/react";
+import { Suspense } from "react";
+
+// Mock next/navigation
+const mockPathname = jest.fn();
+jest.mock("next/navigation", () => ({
+  usePathname: () => mockPathname(),
+}));
+
+// Mock next/link
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    className,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+// Mock UI components
+jest.mock("@/components/ui/button", () => ({
+  buttonVariants: ({ variant }: { variant: string; size: string }) =>
+    variant === "default" ? "btn-default" : "btn-ghost",
+  Button: ({ children, ...props }: { children: React.ReactNode }) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+jest.mock("@/components/ui/badge", () => ({
+  Badge: ({
+    children,
+    variant,
+    className,
+  }: {
+    children: React.ReactNode;
+    variant?: string;
+    className?: string;
+  }) => (
+    <span data-variant={variant} className={className}>
+      {children}
+    </span>
+  ),
+}));
+
+jest.mock("@/components/ui/skeleton", () => ({
+  Skeleton: ({ className }: { className?: string }) => (
+    <div data-testid="skeleton" className={className} />
+  ),
+}));
+
+jest.mock("@/components/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("@/components/ui/input", () => ({
+  Input: (props: Record<string, unknown>) => <input {...props} />,
+}));
+
+jest.mock("@/components/ui/copy-button", () => ({
+  CopyButton: () => <button aria-label="Copy" />,
+}));
+
+jest.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+  shortenId: (id: string) => id.slice(0, 8),
+}));
+
+// Mock session hooks
+jest.mock("@/hooks/use-sessions", () => ({
+  useUpdateSession: () => ({
+    mutate: jest.fn(),
+    isPending: false,
+  }),
+}));
+
+// Mock the SessionProvider to skip data fetching
+const mockSessionContext = {
+  agent: { name: "Test Agent", id: "agent-123" } as Record<string, unknown>,
+  session: {
+    id: "ses-abc12345",
+    title: "Test Session",
+    agent_id: "agent-123",
+    status: "idle",
+    created_at: "2025-01-01T00:00:00Z",
+    active_schedule_count: 0,
+  } as Record<string, unknown> | null,
+  llmModel: { display_name: "GPT-4" } as Record<string, unknown> | null,
+  sessionLoading: false,
+  effectiveStatus: "idle" as string | undefined,
+  liveUsage: null as Record<string, unknown> | null,
+  agentId: "agent-123",
+};
+
+jest.mock("@/app/(main)/sessions/[sessionId]/session-context", () => ({
+  SessionProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useSessionContext: () => mockSessionContext,
+}));
+
+// Import after mocks
+import SessionLayout from "@/app/(main)/sessions/[sessionId]/layout";
+
+describe("SessionLayout", () => {
+  beforeEach(() => {
+    mockPathname.mockReturnValue("/sessions/ses-abc12345/chat");
+    mockSessionContext.sessionLoading = false;
+    mockSessionContext.effectiveStatus = "idle";
+    mockSessionContext.liveUsage = null;
+    mockSessionContext.llmModel = { display_name: "GPT-4" };
+    mockSessionContext.agent = { name: "Test Agent", id: "agent-123" };
+    mockSessionContext.session = {
+      id: "ses-abc12345",
+      title: "Test Session",
+      agent_id: "agent-123",
+      status: "idle",
+      created_at: "2025-01-01T00:00:00Z",
+      active_schedule_count: 0,
+    };
+  });
+
+  async function renderLayout(children?: React.ReactNode) {
+    let result: ReturnType<typeof render> | undefined;
+    await act(async () => {
+      result = render(
+        <Suspense fallback={<div data-testid="suspense-fallback">Loading...</div>}>
+          <SessionLayout params={Promise.resolve({ sessionId: "ses-abc12345" })}>
+            {children ?? <div data-testid="child-content">Chat Content</div>}
+          </SessionLayout>
+        </Suspense>,
+      );
+    });
+    return result!;
+  }
+
+  it("uses h-full for proper height (not calc-based)", async () => {
+    const { container } = await renderLayout();
+
+    await waitFor(() => {
+      // The main wrapper div should use h-full, not h-[calc(100vh-4rem)]
+      const layoutDiv = container.querySelector('[class*="h-full"]');
+      expect(layoutDiv).toBeInTheDocument();
+    });
+
+    // Ensure the old broken calc-based height is NOT present
+    const calcDiv = container.querySelector('[class*="calc"]');
+    expect(calcDiv).not.toBeInTheDocument();
+  });
+
+  it("renders children content", async () => {
+    await renderLayout();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("child-content")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Chat Content")).toBeInTheDocument();
+  });
+
+  it("renders session title", async () => {
+    await renderLayout();
+
+    await waitFor(() => {
+      expect(screen.getByText("Test Session")).toBeInTheDocument();
+    });
+  });
+
+  it("renders all tab navigation links", async () => {
+    await renderLayout();
+
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: /chat/i })).toBeInTheDocument();
+    });
+    expect(screen.getByRole("link", { name: /workspace/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /storage/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /events/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /trajectory/i })).toBeInTheDocument();
+  });
+
+  it("renders correct tab hrefs", async () => {
+    await renderLayout();
+
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: /chat/i })).toHaveAttribute(
+        "href",
+        "/sessions/ses-abc12345/chat",
+      );
+    });
+    expect(screen.getByRole("link", { name: /workspace/i })).toHaveAttribute(
+      "href",
+      "/sessions/ses-abc12345/files",
+    );
+    expect(screen.getByRole("link", { name: /storage/i })).toHaveAttribute(
+      "href",
+      "/sessions/ses-abc12345/storage",
+    );
+    expect(screen.getByRole("link", { name: /events/i })).toHaveAttribute(
+      "href",
+      "/sessions/ses-abc12345/events",
+    );
+    expect(screen.getByRole("link", { name: /trajectory/i })).toHaveAttribute(
+      "href",
+      "/sessions/ses-abc12345/trajectory",
+    );
+  });
+
+  it("highlights active chat tab", async () => {
+    mockPathname.mockReturnValue("/sessions/ses-abc12345/chat");
+    await renderLayout();
+
+    await waitFor(() => {
+      const chatLink = screen.getByRole("link", { name: /chat/i });
+      expect(chatLink).toHaveClass("btn-default");
+    });
+  });
+
+  it("highlights active files tab", async () => {
+    mockPathname.mockReturnValue("/sessions/ses-abc12345/files");
+    await renderLayout();
+
+    await waitFor(() => {
+      const filesLink = screen.getByRole("link", { name: /workspace/i });
+      expect(filesLink).toHaveClass("btn-default");
+    });
+  });
+
+  it("shows inactive style for non-active tabs", async () => {
+    mockPathname.mockReturnValue("/sessions/ses-abc12345/chat");
+    await renderLayout();
+
+    await waitFor(() => {
+      const eventsLink = screen.getByRole("link", { name: /events/i });
+      expect(eventsLink).toHaveClass("btn-ghost");
+    });
+  });
+
+  it("renders Back to Sessions link", async () => {
+    await renderLayout();
+
+    await waitFor(() => {
+      const backLink = screen.getByRole("link", { name: /back to sessions/i });
+      expect(backLink).toHaveAttribute("href", "/sessions");
+    });
+  });
+
+  it("renders agent name with link", async () => {
+    await renderLayout();
+
+    await waitFor(() => {
+      const agentLink = screen.getByRole("link", { name: /test agent/i });
+      expect(agentLink).toHaveAttribute("href", "/agents/agent-123");
+    });
+  });
+
+  it("renders Ready badge for idle session", async () => {
+    await renderLayout();
+
+    await waitFor(() => {
+      expect(screen.getByText("Ready")).toBeInTheDocument();
+    });
+  });
+
+  it("renders LLM model badge", async () => {
+    await renderLayout();
+
+    await waitFor(() => {
+      expect(screen.getByText("GPT-4")).toBeInTheDocument();
+    });
+  });
+
+  it("shows loading skeletons when session is loading", async () => {
+    mockSessionContext.sessionLoading = true;
+    await renderLayout();
+
+    await waitFor(() => {
+      const skeletons = screen.getAllByTestId("skeleton");
+      expect(skeletons.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("shows error state when session is not found", async () => {
+    mockSessionContext.sessionLoading = false;
+    mockSessionContext.session = null;
+    await renderLayout();
+
+    await waitFor(() => {
+      expect(screen.getByText("Session not found")).toBeInTheDocument();
+    });
+  });
+
+  it("has flex-col layout for proper content stacking", async () => {
+    const { container } = await renderLayout();
+
+    await waitFor(() => {
+      const layoutDiv = container.querySelector('[class*="flex"][class*="flex-col"][class*="h-full"]');
+      expect(layoutDiv).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -146,4 +146,36 @@ describe("Sidebar", () => {
     );
     expect(foundNavLinks).toHaveLength(5);
   });
+
+  it("renders section labels for Building Blocks and Durable Execution", () => {
+    render(<Sidebar />);
+
+    expect(screen.getByText("Building Blocks")).toBeInTheDocument();
+    expect(screen.getByText("Durable Execution")).toBeInTheDocument();
+  });
+
+  it("renders Durable Execution navigation items", () => {
+    render(<Sidebar />);
+
+    expect(screen.getByText("Overview")).toBeInTheDocument();
+    expect(screen.getByText("Workers")).toBeInTheDocument();
+    expect(screen.getByText("Workflows")).toBeInTheDocument();
+    expect(screen.getByText("Schedules")).toBeInTheDocument();
+  });
+
+  it("nav element has overflow-y-auto and min-h-0 to prevent sidebar overflow", () => {
+    render(<Sidebar />);
+
+    const nav = screen.getByRole("navigation");
+    expect(nav).toHaveClass("min-h-0");
+    expect(nav).toHaveClass("overflow-y-auto");
+  });
+
+  it("highlights durable navigation for nested routes", () => {
+    mockPathname.mockReturnValue("/durable/workers");
+    render(<Sidebar />);
+
+    const workersLink = screen.getByRole("link", { name: /workers/i });
+    expect(workersLink).toHaveClass("border-accent");
+  });
 });

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
@@ -181,7 +181,7 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
   }
 
   return (
-    <div className="flex flex-col h-[calc(100vh-4rem)]">
+    <div className="flex flex-col h-full">
       {/* Header */}
       <div className="border-b p-4">
         <Link

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -213,7 +213,7 @@ export function Sidebar() {
       )}
 
       {/* Navigation */}
-      <nav className="flex-1 space-y-1 py-4">
+      <nav className="flex-1 min-h-0 overflow-y-auto space-y-1 py-4">
         {topNavigation.map((item) => {
           const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
           return (


### PR DESCRIPTION
## What
Fix two layout alignment regressions: the chat input panel had a gap at the bottom, and the sidebar nav could overflow into the user footer when many sections are present.

## Why
The session layout used `h-[calc(100vh-4rem)]` which subtracted 4rem for a non-existent top header bar (the layout is a horizontal sidebar + main flex, not vertical with a top nav). The sidebar `<nav>` element lacked overflow constraints, so after adding Building Blocks and Durable Execution sections it could overflow into the user footer area.

## How
- `layout.tsx`: Changed `h-[calc(100vh-4rem)]` to `h-full` so the session panel fills its flex parent correctly
- `sidebar.tsx`: Added `min-h-0 overflow-y-auto` to the `<nav>` element so it scrolls when content exceeds available space
- Added 15 new tests for session layout (new test file) and 4 new tests for sidebar covering the fixes

## Risk
- Low
- CSS-only changes to two components with full test coverage

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered