### PR TITLE
fix(durable): gate postgres integration tests behind feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,10 +210,10 @@ jobs:
         run: cargo test -p everruns-server --test repository_integration_test -- --test-threads=1
 
       - name: Run durable integration tests
-        run: cargo test -p everruns-durable --test postgres_integration_test -- --test-threads=1
+        run: cargo test -p everruns-durable --test postgres_integration_test --features postgres-tests -- --test-threads=1
 
       - name: Run durable repository tests
-        run: cargo test -p everruns-durable --test postgres_repository_test -- --test-threads=1
+        run: cargo test -p everruns-durable --test postgres_repository_test --features postgres-tests -- --test-threads=1
 
       - name: Run LLM integration tests (skips providers without API keys)
         timeout-minutes: 10

--- a/crates/durable/Cargo.toml
+++ b/crates/durable/Cargo.toml
@@ -69,6 +69,7 @@ fail = { workspace = true, optional = true }
 
 [features]
 failpoints = ["fail/failpoints"]
+postgres-tests = []
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/crates/durable/tests/postgres_integration_test.rs
+++ b/crates/durable/tests/postgres_integration_test.rs
@@ -1,10 +1,13 @@
 //! Integration tests for PostgresWorkflowEventStore
 //!
-//! Run with: cargo test -p everruns-durable --test postgres_integration_test -- --test-threads=1
+//! Run with: cargo test -p everruns-durable --test postgres_integration_test --features postgres-tests -- --test-threads=1
 //!
 //! Requirements:
+//! - `postgres-tests` feature enabled
 //! - PostgreSQL running with DATABASE_URL set or default postgres://localhost:5432/everruns_test
 //! - Migrations applied (run migrations from crates/server/migrations/)
+
+#![cfg(feature = "postgres-tests")]
 
 use std::time::Duration;
 

--- a/crates/durable/tests/postgres_repository_test.rs
+++ b/crates/durable/tests/postgres_repository_test.rs
@@ -8,11 +8,14 @@
 //! These tests focus on SQL query correctness and type mappings,
 //! covering queries used by the durable SSE endpoints.
 //!
-//! Run with: cargo test -p everruns-durable --test postgres_repository_test -- --test-threads=1
+//! Run with: cargo test -p everruns-durable --test postgres_repository_test --features postgres-tests -- --test-threads=1
 //!
 //! Requirements:
+//! - `postgres-tests` feature enabled
 //! - PostgreSQL running with DATABASE_URL set
 //! - Migrations applied (run migrations from crates/server/migrations/)
+
+#![cfg(feature = "postgres-tests")]
 
 use chrono::Utc;
 use serde_json::json;

--- a/justfile
+++ b/justfile
@@ -68,8 +68,8 @@ test-integration: start-docker
     cargo test -p everruns-server --lib
     cargo test -p everruns-server --test api_integration_test -- --test-threads=1
     cargo test -p everruns-server --test repository_integration_test -- --test-threads=1
-    cargo test -p everruns-durable --test postgres_integration_test -- --test-threads=1
-    cargo test -p everruns-durable --test postgres_repository_test -- --test-threads=1
+    cargo test -p everruns-durable --test postgres_integration_test --features postgres-tests -- --test-threads=1
+    cargo test -p everruns-durable --test postgres_repository_test --features postgres-tests -- --test-threads=1
 
 # Run workflow tests (requires running server + worker)
 test-workflow:


### PR DESCRIPTION
## What
Gate `postgres_integration_test.rs` and `postgres_repository_test.rs` behind a `postgres-tests` feature flag so they only compile and run when PostgreSQL is available.

## Why
These 41 integration tests require a running PostgreSQL instance and fail with connection errors in environments without a database (e.g., cloud coding agents, local dev without Docker). This blocks `cargo test -p everruns-durable` in those environments.

## How
- Added `postgres-tests = []` feature to `crates/durable/Cargo.toml`
- Added `#![cfg(feature = "postgres-tests")]` to both postgres test files
- Updated CI workflow and justfile `test-integration` to pass `--features postgres-tests`
- Follows the existing pattern: `failure_injection_test.rs` already uses `#![cfg(feature = "failpoints")]`

Behavior:
- `cargo test -p everruns-durable` — skips postgres tests (safe anywhere)
- `cargo test -p everruns-durable --features postgres-tests` — runs postgres tests (needs DB)
- `cargo test --all-features` — still runs everything (for full environments)

## Risk
- Low
- CI must pass `--features postgres-tests` to run these tests (updated in this PR)

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered