### PR TITLE
feat(ui): add frontmatter support to markdown file preview

### DIFF
--- a/apps/ui/src/__tests__/file-previews.test.tsx
+++ b/apps/ui/src/__tests__/file-previews.test.tsx
@@ -16,6 +16,8 @@ import {
   canPreview,
   CSVPreview,
   ImagePreview,
+  MarkdownPreview,
+  parseFrontmatter,
 } from "@/components/files/file-previews";
 
 // ============================================
@@ -325,5 +327,127 @@ describe("ImagePreview", () => {
       const img = screen.getByRole("img");
       expect(img).toHaveAttribute("src", `data:image/png;base64,${sampleBase64}`);
     });
+  });
+});
+
+// ============================================
+// parseFrontmatter Tests
+// ============================================
+
+describe("parseFrontmatter", () => {
+  it("returns no entries for content without frontmatter", () => {
+    const content = "# Hello\n\nSome content";
+    const result = parseFrontmatter(content);
+    expect(result.entries).toEqual([]);
+    expect(result.body).toBe(content);
+  });
+
+  it("parses simple key-value pairs", () => {
+    const content = "---\ntitle: My Page\ndate: 2025-01-15\n---\n\n# Hello";
+    const result = parseFrontmatter(content);
+    expect(result.entries).toEqual([
+      { key: "title", value: "My Page" },
+      { key: "date", value: "2025-01-15" },
+    ]);
+    expect(result.body).toBe("# Hello");
+  });
+
+  it("handles array values in bracket notation", () => {
+    const content = "---\ntags: [react, typescript]\n---\n\nBody";
+    const result = parseFrontmatter(content);
+    expect(result.entries).toEqual([{ key: "tags", value: "[react, typescript]" }]);
+    expect(result.body).toBe("Body");
+  });
+
+  it("handles empty frontmatter block", () => {
+    const content = "---\n---\n\n# Content";
+    const result = parseFrontmatter(content);
+    expect(result.entries).toEqual([]);
+    expect(result.body).toBe("# Content");
+  });
+
+  it("handles boolean values", () => {
+    const content = "---\ndraft: false\npublished: true\n---\nBody";
+    const result = parseFrontmatter(content);
+    expect(result.entries).toEqual([
+      { key: "draft", value: "false" },
+      { key: "published", value: "true" },
+    ]);
+  });
+
+  it("returns original content when no closing delimiter found", () => {
+    const content = "---\ntitle: Broken\n\n# Content";
+    const result = parseFrontmatter(content);
+    expect(result.entries).toEqual([]);
+    expect(result.body).toBe(content);
+  });
+
+  it("does not parse frontmatter that doesn't start at beginning", () => {
+    const content = "\n---\ntitle: Not frontmatter\n---\nBody";
+    const result = parseFrontmatter(content);
+    expect(result.entries).toEqual([]);
+    expect(result.body).toBe(content);
+  });
+
+  it("handles values with colons", () => {
+    const content = "---\nurl: https://example.com\n---\nBody";
+    const result = parseFrontmatter(content);
+    expect(result.entries).toEqual([{ key: "url", value: "https://example.com" }]);
+  });
+
+  it("handles empty values", () => {
+    const content = "---\ntitle:\n---\nBody";
+    const result = parseFrontmatter(content);
+    expect(result.entries).toEqual([{ key: "title", value: "" }]);
+  });
+
+  it("handles multiline values with indentation", () => {
+    const content = "---\ndescription: First line\n  continued here\ntitle: Test\n---\nBody";
+    const result = parseFrontmatter(content);
+    expect(result.entries).toEqual([
+      { key: "description", value: "First line\ncontinued here" },
+      { key: "title", value: "Test" },
+    ]);
+  });
+
+  it("handles keys with hyphens and underscores", () => {
+    const content = "---\nfull-title: Hello\nmy_key: World\n---\nBody";
+    const result = parseFrontmatter(content);
+    expect(result.entries).toEqual([
+      { key: "full-title", value: "Hello" },
+      { key: "my_key", value: "World" },
+    ]);
+  });
+});
+
+// ============================================
+// MarkdownPreview Tests
+// ============================================
+
+describe("MarkdownPreview", () => {
+  it("renders markdown content without frontmatter", () => {
+    render(<MarkdownPreview content="# Hello World" />);
+    expect(screen.getByTestId("streamdown-mock")).toHaveTextContent("# Hello World");
+  });
+
+  it("strips frontmatter and renders body", () => {
+    const content = "---\ntitle: Test\n---\n\n# Hello";
+    render(<MarkdownPreview content={content} />);
+    expect(screen.getByTestId("streamdown-mock")).toHaveTextContent("# Hello");
+  });
+
+  it("displays frontmatter entries as metadata", () => {
+    const content = "---\ntitle: My Page\nauthor: Jane\n---\n\n# Content";
+    render(<MarkdownPreview content={content} />);
+    expect(screen.getByText("title")).toBeInTheDocument();
+    expect(screen.getByText("My Page")).toBeInTheDocument();
+    expect(screen.getByText("author")).toBeInTheDocument();
+    expect(screen.getByText("Jane")).toBeInTheDocument();
+  });
+
+  it("does not render frontmatter block when none present", () => {
+    const content = "# Just Markdown";
+    const { container } = render(<MarkdownPreview content={content} />);
+    expect(container.querySelector(".file-preview-frontmatter")).not.toBeInTheDocument();
   });
 });

--- a/apps/ui/src/app/dev/file-previews/page.tsx
+++ b/apps/ui/src/app/dev/file-previews/page.tsx
@@ -281,6 +281,37 @@ function hello(name: string): string {
 This demonstrates all the markdown features supported by the preview component.
 `;
 
+const sampleMarkdownWithFrontmatter = `---
+title: Getting Started Guide
+description: A comprehensive guide to setting up and using the platform
+author: Jane Smith
+date: 2025-12-15
+tags: [guide, setup, tutorial]
+draft: false
+---
+
+# Getting Started
+
+Welcome to the platform! This guide walks you through the initial setup.
+
+## Prerequisites
+
+- Node.js 20 or later
+- A GitHub account
+- Basic command line knowledge
+
+## Installation
+
+\`\`\`bash
+npm install -g everruns
+everruns init my-project
+\`\`\`
+
+## Next Steps
+
+See the [full documentation](https://docs.example.com) for more details.
+`;
+
 // Base64 encoded 1x1 pixel PNG (red)
 const sampleImageBase64 =
   "iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAACXBIWXMAAAsTAAALEwEAmpwYAAABSklEQVR4nO3dwQ2DMBBFUdKROqAPrUOfpoO0YC9YJSJyYmbu3xhZT8ssPgAAAAAAAAAAAABgqftah2HYv8p6us4D0C5lPAAAAACAi5nZ+xWuZd2WMu1wLS2Eg/qjPAD4K89hqF8/R7bHOTQchYOCQMOVIBDwLqshqCEckJ4hdQ/pnKD3FwIAAAAAAAAAgB9qjlJlqThKCKC8tJZeRlDjLAEAAPi/3hdqSKPWhX68UEMaiW2dhkDDbWHbPwIAAAAA4Bfc96OktG7BuicIBNxTSwgH3U8IQAAAAAAAAAAAAAD4qOaofq8/anPUvD4OAO+YK/8V";
@@ -373,6 +404,10 @@ export default function DevFilePreviewsPage() {
           >
             <ShowcaseItem label="Documentation (.md)">
               <MarkdownPreview content={sampleMarkdown} />
+            </ShowcaseItem>
+
+            <ShowcaseItem label="With Frontmatter (.md)">
+              <MarkdownPreview content={sampleMarkdownWithFrontmatter} />
             </ShowcaseItem>
           </ShowcaseSection>
 

--- a/apps/ui/src/components/files/file-previews.tsx
+++ b/apps/ui/src/components/files/file-previews.tsx
@@ -43,6 +43,14 @@ const previewStyles = `
   .file-preview-streamdown h2 { font-size: 1.25em; font-weight: 600; margin: 1em 0 0.5em; }
   .file-preview-streamdown h3 { font-size: 1.1em; font-weight: 600; margin: 1em 0 0.5em; }
 
+  /* Frontmatter metadata block */
+  .file-preview-frontmatter { background: var(--color-muted); border: 1px solid var(--color-border); border-radius: 6px; padding: 0.75em 1em; margin-bottom: 1.5em; }
+  .file-preview-frontmatter table { width: 100%; border-collapse: collapse; }
+  .file-preview-frontmatter tr:not(:last-child) td { padding-bottom: 0.25em; }
+  .file-preview-frontmatter-key { color: var(--color-muted-foreground); font-weight: 500; white-space: nowrap; padding-right: 1em; vertical-align: top; width: 1%; font-size: 0.85em; }
+  .file-preview-frontmatter-value { color: var(--color-foreground); word-break: break-word; font-size: 0.85em; }
+  .file-preview-frontmatter-value .empty { color: var(--color-muted-foreground); }
+
   /* GitHub-style alerts */
   .file-preview-streamdown .markdown-alert { padding: 0.5em 1em; margin: 0.5em 0; border-left: 4px solid; }
   .file-preview-streamdown .markdown-alert-title { display: flex; align-items: center; gap: 0.5em; font-weight: 600; margin-bottom: 0.25em; }
@@ -282,12 +290,92 @@ export function JSONPreview({ content }: { content: string }) {
   );
 }
 
+/**
+ * Parse YAML frontmatter from markdown content.
+ * Returns the frontmatter entries (key-value pairs) and the remaining body.
+ * Only detects frontmatter that starts at the very beginning of the content.
+ */
+export function parseFrontmatter(content: string): {
+  entries: { key: string; value: string }[];
+  body: string;
+} {
+  // Frontmatter must start at the very beginning with ---
+  if (!content.startsWith("---")) {
+    return { entries: [], body: content };
+  }
+
+  // Find the closing ---
+  const endIndex = content.indexOf("\n---", 3);
+  if (endIndex === -1) {
+    return { entries: [], body: content };
+  }
+
+  const frontmatterBlock = content.slice(4, endIndex).trim();
+  const body = content.slice(endIndex + 4).trimStart();
+
+  if (!frontmatterBlock) {
+    return { entries: [], body };
+  }
+
+  // Parse simple YAML key: value pairs
+  // Handles multiline values by treating indented continuation lines as part of the previous value
+  const entries: { key: string; value: string }[] = [];
+  const lines = frontmatterBlock.split("\n");
+  let currentKey = "";
+  let currentValue = "";
+
+  for (const line of lines) {
+    // Check if this is a new key-value pair (not indented, has colon)
+    const match = line.match(/^([a-zA-Z0-9_-]+)\s*:\s*(.*)/);
+    if (match) {
+      // Save previous entry
+      if (currentKey) {
+        entries.push({ key: currentKey, value: currentValue.trim() });
+      }
+      currentKey = match[1];
+      currentValue = match[2];
+    } else if (currentKey && (line.startsWith("  ") || line.startsWith("\t"))) {
+      // Continuation line for multiline value
+      currentValue += "\n" + line.trimStart();
+    }
+  }
+
+  // Save last entry
+  if (currentKey) {
+    entries.push({ key: currentKey, value: currentValue.trim() });
+  }
+
+  return { entries, body };
+}
+
+function FrontmatterBlock({ entries }: { entries: { key: string; value: string }[] }) {
+  return (
+    <div className="file-preview-frontmatter">
+      <table>
+        <tbody>
+          {entries.map(({ key, value }) => (
+            <tr key={key}>
+              <td className="file-preview-frontmatter-key">{key}</td>
+              <td className="file-preview-frontmatter-value">
+                {value || <span className="empty">—</span>}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
 export function MarkdownPreview({ content }: { content: string }) {
+  const { entries, body } = useMemo(() => parseFrontmatter(content), [content]);
+
   return (
     <ScrollArea className="h-full">
       <style>{previewStyles}</style>
       <div className="file-preview-streamdown text-sm p-4">
-        <Streamdown plugins={{ code }}>{content}</Streamdown>
+        {entries.length > 0 && <FrontmatterBlock entries={entries} />}
+        <Streamdown plugins={{ code }}>{body}</Streamdown>
       </div>
     </ScrollArea>
   );


### PR DESCRIPTION
## What
Add YAML frontmatter parsing and rendering to the markdown file preview in Session > Workspace.

## Why
Markdown files with YAML frontmatter (the `---` delimited block at the top) rendered poorly — the `---` delimiters became horizontal rules and the YAML content appeared as unformatted text.

## How
- Added `parseFrontmatter()` utility that extracts YAML frontmatter from markdown content
- Added `FrontmatterBlock` component that renders metadata as a styled key-value table
- Updated `MarkdownPreview` to strip frontmatter before passing content to Streamdown
- Added CSS styles for the frontmatter metadata block
- Added dev showcase example with frontmatter

## Risk
- Low
- Only affects markdown file preview rendering; no backend changes

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered