### PR TITLE
fix(ui): fix llm.generation preview modal layout and rename button to View

### DIFF
--- a/apps/ui/src/app/(main)/sessions/[sessionId]/events/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/events/page.tsx
@@ -202,7 +202,7 @@ export default function EventsPage() {
                               onClick={() => setSelectedGeneration(event)}
                             >
                               <Eye className="w-3 h-3 mr-1" />
-                              Preview
+                              View
                             </Button>
                           )}
                           <CopyButton data={event.data} />

--- a/apps/ui/src/components/llm/llm-history-viewer.tsx
+++ b/apps/ui/src/components/llm/llm-history-viewer.tsx
@@ -391,10 +391,10 @@ export function LlmHistoryViewer({
   }
 
   return (
-    <div className="flex flex-col min-h-0 gap-4">
+    <div className="space-y-4">
       {/* Header */}
       {(eventId || timestamp) && (
-        <div className="flex items-center justify-between shrink-0">
+        <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <Badge variant="outline" className="font-mono">
               llm.generation
@@ -414,17 +414,15 @@ export function LlmHistoryViewer({
       )}
 
       {/* Metadata */}
-      <div className="shrink-0">
-        <MetadataSection metadata={metadata} />
-      </div>
+      <MetadataSection metadata={metadata} />
 
-      {/* Messages - scrollable, takes remaining space */}
-      <Card className="flex flex-col min-h-0 flex-1">
-        <CardHeader className="pb-2 shrink-0">
+      {/* Input Messages - capped height with internal scroll */}
+      <Card>
+        <CardHeader className="pb-2">
           <CardTitle className="text-sm">Input Messages ({messages.length})</CardTitle>
         </CardHeader>
-        <CardContent className="p-0 min-h-0 flex-1">
-          <ScrollArea className="h-full max-h-[40vh] p-4">
+        <CardContent className="p-0">
+          <ScrollArea className="max-h-[50vh] p-4">
             <div className="space-y-3">
               {messages.map((message, index) => (
                 <MessageCard key={message.id || index} message={message} index={index} />
@@ -434,10 +432,8 @@ export function LlmHistoryViewer({
         </CardContent>
       </Card>
 
-      {/* Output - always visible */}
-      <div className="shrink-0">
-        <OutputSection output={output} />
-      </div>
+      {/* Output */}
+      <OutputSection output={output} />
     </div>
   );
 }


### PR DESCRIPTION
## What
Fix the LLM generation preview modal so large input messages render correctly without overlapping the output section. Rename the "Preview" button to "View".

## Why
When an llm.generation event had many input messages, the flex layout in the modal caused the input section to overlap or push the output section out of view. The button label "Preview" was inconsistent with the action (viewing details).

## How
- Replaced the flex column layout in `LlmHistoryViewer` with simple `space-y-4` stacking — the parent dialog scroll container provides overall scrolling, so nested flex with `flex-1`/`shrink-0` was unnecessary and broken (no height constraint from the scrollable parent)
- Removed `h-full` from the ScrollArea (was causing height resolution issues) and increased `max-h` from `40vh` to `50vh` for better visibility of large inputs
- Renamed button text from "Preview" to "View" in the events page

## Risk
- Low
- Only affects the events page LLM generation detail modal; no data changes

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered