### PR TITLE
feat(capabilities): add features() for UI-driven tab rendering

### DIFF
--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -40,7 +40,7 @@
         "playwright": "^1.58.0",
         "tailwindcss": "^4",
         "ts-jest": "^29.4.6",
-        "typescript": "^5"
+        "typescript": "5.9.3"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -55,6 +55,6 @@
     "playwright": "^1.58.0",
     "tailwindcss": "^4",
     "ts-jest": "^29.4.6",
-    "typescript": "^5"
+    "typescript": "5.9.3"
   }
 }

--- a/apps/ui/src/__tests__/session-layout.test.tsx
+++ b/apps/ui/src/__tests__/session-layout.test.tsx
@@ -96,6 +96,7 @@ const mockSessionContext = {
     status: "idle",
     created_at: "2025-01-01T00:00:00Z",
     active_schedule_count: 0,
+    features: ["file_system", "secrets", "key_value", "schedules"],
   } as Record<string, unknown> | null,
   llmModel: { display_name: "GPT-4" } as Record<string, unknown> | null,
   sessionLoading: false,
@@ -127,6 +128,7 @@ describe("SessionLayout", () => {
       status: "idle",
       created_at: "2025-01-01T00:00:00Z",
       active_schedule_count: 0,
+      features: ["file_system", "secrets", "key_value", "schedules"],
     };
   });
 
@@ -296,6 +298,55 @@ describe("SessionLayout", () => {
     await waitFor(() => {
       expect(screen.getByText("Session not found")).toBeInTheDocument();
     });
+  });
+
+  it("hides feature-gated tabs when features are empty", async () => {
+    mockSessionContext.session = {
+      ...mockSessionContext.session,
+      features: [],
+    };
+    await renderLayout();
+
+    await waitFor(() => {
+      // Chat, Events, Trajectory are always present
+      expect(screen.getByRole("link", { name: /chat/i })).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /events/i })).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /trajectory/i })).toBeInTheDocument();
+    });
+
+    // Feature-gated tabs should NOT be present
+    expect(screen.queryByRole("link", { name: /workspace/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /storage/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /schedules/i })).not.toBeInTheDocument();
+  });
+
+  it("shows only workspace tab when only file_system feature is present", async () => {
+    mockSessionContext.session = {
+      ...mockSessionContext.session,
+      features: ["file_system"],
+    };
+    await renderLayout();
+
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: /workspace/i })).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole("link", { name: /storage/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /schedules/i })).not.toBeInTheDocument();
+  });
+
+  it("shows schedules tab when schedules feature is present", async () => {
+    mockSessionContext.session = {
+      ...mockSessionContext.session,
+      features: ["schedules"],
+    };
+    await renderLayout();
+
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: /schedules/i })).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole("link", { name: /workspace/i })).not.toBeInTheDocument();
   });
 
   it("has flex-col layout for proper content stacking", async () => {

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
@@ -160,10 +160,7 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
   const basePath = `/sessions/${sessionId}`;
 
   // Compute active feature set from session capabilities
-  const features = useMemo(
-    () => new Set(session?.features ?? []),
-    [session?.features],
-  );
+  const features = useMemo(() => new Set(session?.features ?? []), [session?.features]);
   const hasFeature = (feature: string) => features.has(feature);
 
   if (sessionLoading) {

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useEffect, useRef, useState } from "react";
+import { use, useEffect, useMemo, useRef, useState } from "react";
 import { usePathname } from "next/navigation";
 import Link from "next/link";
 import { buttonVariants } from "@/components/ui/button";
@@ -159,6 +159,13 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
 
   const basePath = `/sessions/${sessionId}`;
 
+  // Compute active feature set from session capabilities
+  const features = useMemo(
+    () => new Set(session?.features ?? []),
+    [session?.features],
+  );
+  const hasFeature = (feature: string) => features.has(feature);
+
   if (sessionLoading) {
     return (
       <div className="container mx-auto p-6">
@@ -278,50 +285,56 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
             <MessageSquare className="h-4 w-4" />
             Chat
           </Link>
-          <Link
-            href={`${basePath}/files`}
-            className={cn(
-              buttonVariants({
-                variant: activeTab === "files" ? "default" : "ghost",
-                size: "sm",
-              }),
-              "gap-2",
-            )}
-          >
-            <Folder className="h-4 w-4" />
-            Workspace
-          </Link>
-          <Link
-            href={`${basePath}/storage`}
-            className={cn(
-              buttonVariants({
-                variant: activeTab === "storage" ? "default" : "ghost",
-                size: "sm",
-              }),
-              "gap-2",
-            )}
-          >
-            <Database className="h-4 w-4" />
-            Storage
-          </Link>
-          <Link
-            href={`${basePath}/schedules`}
-            className={cn(
-              buttonVariants({
-                variant: activeTab === "schedules" ? "default" : "ghost",
-                size: "sm",
-              }),
-              "gap-2",
-            )}
-          >
-            <CalendarClock className="h-4 w-4" />
-            Schedules
-            {(session.active_schedule_count ?? 0) > 0 && (
-              <Badge variant="secondary" className="h-5 min-w-5 px-1 text-xs">
-                {session.active_schedule_count}
-              </Badge>
-            )}
-          </Link>
+          {hasFeature("file_system") && (
+            <Link
+              href={`${basePath}/files`}
+              className={cn(
+                buttonVariants({
+                  variant: activeTab === "files" ? "default" : "ghost",
+                  size: "sm",
+                }),
+                "gap-2",
+              )}
+            >
+              <Folder className="h-4 w-4" />
+              Workspace
+            </Link>
+          )}
+          {(hasFeature("secrets") || hasFeature("key_value")) && (
+            <Link
+              href={`${basePath}/storage`}
+              className={cn(
+                buttonVariants({
+                  variant: activeTab === "storage" ? "default" : "ghost",
+                  size: "sm",
+                }),
+                "gap-2",
+              )}
+            >
+              <Database className="h-4 w-4" />
+              Storage
+            </Link>
+          )}
+          {hasFeature("schedules") && (
+            <Link
+              href={`${basePath}/schedules`}
+              className={cn(
+                buttonVariants({
+                  variant: activeTab === "schedules" ? "default" : "ghost",
+                  size: "sm",
+                }),
+                "gap-2",
+              )}
+            >
+              <CalendarClock className="h-4 w-4" />
+              Schedules
+              {(session.active_schedule_count ?? 0) > 0 && (
+                <Badge variant="secondary" className="h-5 min-w-5 px-1 text-xs">
+                  {session.active_schedule_count}
+                </Badge>
+              )}
+            </Link>
+          )}
           <Link
             href={`${basePath}/events`}
             className={cn(

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -161,6 +161,8 @@ export interface Session {
   is_pinned?: boolean;
   /** Number of active schedules for this session */
   active_schedule_count?: number;
+  /** Aggregated UI features from all active capabilities (harness + agent + session) */
+  features?: string[];
 }
 
 export interface CreateSessionRequest {
@@ -982,6 +984,8 @@ export interface Capability {
   is_mcp?: boolean;
   /** IDs of capabilities that this capability depends on */
   dependencies?: CapabilityId[];
+  /** UI feature strings this capability contributes to */
+  features?: string[];
 }
 
 // ============================================

--- a/crates/core/examples/turn_based_execution.rs
+++ b/crates/core/examples/turn_based_execution.rs
@@ -166,6 +166,7 @@ async fn main() -> anyhow::Result<()> {
         usage: None,
         is_pinned: None,
         active_schedule_count: None,
+        features: vec![],
     };
     session_store.add_session(session).await;
 

--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -142,6 +142,10 @@ Best practices:
             Box::new(StatFileTool),
         ]
     }
+
+    fn features(&self) -> Vec<&'static str> {
+        vec!["file_system"]
+    }
 }
 
 // ============================================================================

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -324,6 +324,24 @@ pub trait Capability: Send + Sync {
         vec![]
     }
 
+    /// Returns UI feature strings that this capability contributes to.
+    ///
+    /// Features are open-ended strings indicating what user-facing functionality
+    /// this capability enables. Multiple capabilities can contribute the same
+    /// feature (e.g., both `session_schedule` and a future `signals` capability
+    /// might contribute `"schedules"`).
+    ///
+    /// The UI uses the aggregated set of features from all active capabilities
+    /// to decide which tabs/sections to render.
+    ///
+    /// Known features: `"file_system"`, `"schedules"`, `"secrets"`,
+    /// `"key_value"`, `"sql_database"`.
+    ///
+    /// By default, returns an empty vector (no features).
+    fn features(&self) -> Vec<&'static str> {
+        vec![]
+    }
+
     /// Returns a message filter provider if this capability modifies message retrieval.
     ///
     /// Capabilities can contribute filters that modify how messages are loaded
@@ -773,6 +791,32 @@ fn resolve_single_capability(
     }
 
     Ok(())
+}
+
+/// Compute the aggregated set of UI features from a list of capability IDs.
+///
+/// Resolves dependencies, collects features from all resolved capabilities,
+/// and returns deduplicated feature strings.
+pub fn compute_features(capability_ids: &[String], registry: &CapabilityRegistry) -> Vec<String> {
+    use std::collections::HashSet;
+
+    let resolved_ids = match resolve_dependencies(capability_ids, registry) {
+        Ok(resolved) => resolved.resolved_ids,
+        Err(_) => capability_ids.to_vec(),
+    };
+
+    let mut seen = HashSet::new();
+    let mut features = Vec::new();
+    for cap_id in &resolved_ids {
+        if let Some(cap) = registry.get(cap_id) {
+            for feature in cap.features() {
+                if seen.insert(feature) {
+                    features.push(feature.to_string());
+                }
+            }
+        }
+    }
+    features
 }
 
 /// Get direct dependencies for a capability ID.
@@ -2093,5 +2137,162 @@ mod tests {
             !registry.has("bash"),
             "with_defaults() must not include 'bash' — it comes from virtual_bash capability"
         );
+    }
+
+    // =========================================================================
+    // Feature tests
+    // =========================================================================
+
+    #[test]
+    fn test_capability_features_default_empty() {
+        let registry = CapabilityRegistry::with_builtins();
+
+        // Most capabilities have no features
+        let noop = registry.get("noop").unwrap();
+        assert!(noop.features().is_empty());
+
+        let current_time = registry.get("current_time").unwrap();
+        assert!(current_time.features().is_empty());
+    }
+
+    #[test]
+    fn test_file_system_capability_features() {
+        let registry = CapabilityRegistry::with_builtins();
+
+        let fs = registry.get("session_file_system").unwrap();
+        assert_eq!(fs.features(), vec!["file_system"]);
+    }
+
+    #[test]
+    fn test_virtual_bash_capability_features() {
+        let registry = CapabilityRegistry::with_builtins();
+
+        let bash = registry.get("virtual_bash").unwrap();
+        assert_eq!(bash.features(), vec!["file_system"]);
+    }
+
+    #[test]
+    fn test_session_storage_capability_features() {
+        let registry = CapabilityRegistry::with_builtins();
+
+        let storage = registry.get("session_storage").unwrap();
+        let features = storage.features();
+        assert!(features.contains(&"secrets"));
+        assert!(features.contains(&"key_value"));
+    }
+
+    #[test]
+    fn test_session_schedule_capability_features() {
+        let registry = CapabilityRegistry::with_builtins();
+
+        let schedule = registry.get("session_schedule").unwrap();
+        assert_eq!(schedule.features(), vec!["schedules"]);
+    }
+
+    #[test]
+    fn test_session_sql_database_capability_features() {
+        let registry = CapabilityRegistry::with_builtins();
+
+        let sql = registry.get("session_sql_database").unwrap();
+        assert_eq!(sql.features(), vec!["sql_database"]);
+    }
+
+    #[test]
+    fn test_sample_data_capability_features() {
+        let registry = CapabilityRegistry::with_builtins();
+
+        let sample = registry.get("sample_data").unwrap();
+        assert_eq!(sample.features(), vec!["file_system"]);
+    }
+
+    #[test]
+    fn test_compute_features_empty() {
+        let registry = CapabilityRegistry::with_builtins();
+
+        let features = compute_features(&[], &registry);
+        assert!(features.is_empty());
+    }
+
+    #[test]
+    fn test_compute_features_single_capability() {
+        let registry = CapabilityRegistry::with_builtins();
+
+        let features = compute_features(&["session_schedule".to_string()], &registry);
+        assert_eq!(features, vec!["schedules"]);
+    }
+
+    #[test]
+    fn test_compute_features_multiple_capabilities() {
+        let registry = CapabilityRegistry::with_builtins();
+
+        let features = compute_features(
+            &[
+                "session_file_system".to_string(),
+                "session_storage".to_string(),
+                "session_schedule".to_string(),
+            ],
+            &registry,
+        );
+        assert!(features.contains(&"file_system".to_string()));
+        assert!(features.contains(&"secrets".to_string()));
+        assert!(features.contains(&"key_value".to_string()));
+        assert!(features.contains(&"schedules".to_string()));
+    }
+
+    #[test]
+    fn test_compute_features_deduplicates() {
+        let registry = CapabilityRegistry::with_builtins();
+
+        // Both session_file_system and virtual_bash contribute "file_system"
+        let features = compute_features(
+            &[
+                "session_file_system".to_string(),
+                "virtual_bash".to_string(),
+            ],
+            &registry,
+        );
+        let file_system_count = features.iter().filter(|f| *f == "file_system").count();
+        assert_eq!(file_system_count, 1, "file_system should appear only once");
+    }
+
+    #[test]
+    fn test_compute_features_includes_dependency_features() {
+        let registry = CapabilityRegistry::with_builtins();
+
+        // virtual_bash depends on session_file_system; both contribute "file_system"
+        let features = compute_features(&["virtual_bash".to_string()], &registry);
+        assert!(features.contains(&"file_system".to_string()));
+    }
+
+    #[test]
+    fn test_compute_features_generic_harness_set() {
+        let registry = CapabilityRegistry::with_builtins();
+
+        // Typical Generic Harness capabilities
+        let features = compute_features(
+            &[
+                "session_file_system".to_string(),
+                "virtual_bash".to_string(),
+                "session_storage".to_string(),
+                "session".to_string(),
+                "session_schedule".to_string(),
+            ],
+            &registry,
+        );
+        assert!(features.contains(&"file_system".to_string()));
+        assert!(features.contains(&"secrets".to_string()));
+        assert!(features.contains(&"key_value".to_string()));
+        assert!(features.contains(&"schedules".to_string()));
+    }
+
+    #[test]
+    fn test_compute_features_unknown_capability_ignored() {
+        let registry = CapabilityRegistry::with_builtins();
+
+        let features = compute_features(
+            &["unknown_cap".to_string(), "session_schedule".to_string()],
+            &registry,
+        );
+        assert_eq!(features, vec!["schedules"]);
     }
 }

--- a/crates/core/src/capabilities/sample_data.rs
+++ b/crates/core/src/capabilities/sample_data.rs
@@ -147,6 +147,10 @@ These files are read-only and can be used for learning, testing, or as templates
         // Sample Data depends on Session File System for file operations
         vec!["session_file_system"]
     }
+
+    fn features(&self) -> Vec<&'static str> {
+        vec!["file_system"]
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/capabilities/session.rs
+++ b/crates/core/src/capabilities/session.rs
@@ -261,6 +261,7 @@ mod tests {
             usage: None,
             is_pinned: None,
             active_schedule_count: None,
+            features: vec![],
         }
     }
 

--- a/crates/core/src/capabilities/session_schedule.rs
+++ b/crates/core/src/capabilities/session_schedule.rs
@@ -65,6 +65,10 @@ Maximum 5 active schedules per session."#,
             Box::new(ListSchedulesTool),
         ]
     }
+
+    fn features(&self) -> Vec<&'static str> {
+        vec!["schedules"]
+    }
 }
 
 // ============================================================================

--- a/crates/core/src/capabilities/session_sql_database.rs
+++ b/crates/core/src/capabilities/session_sql_database.rs
@@ -65,6 +65,10 @@ impl Capability for SessionSqlDatabaseCapability {
             Box::new(SqlSchemaTool),
         ]
     }
+
+    fn features(&self) -> Vec<&'static str> {
+        vec!["sql_database"]
+    }
 }
 
 // ============================================================================

--- a/crates/core/src/capabilities/session_storage.rs
+++ b/crates/core/src/capabilities/session_storage.rs
@@ -73,6 +73,10 @@ Best practices:
     fn tools(&self) -> Vec<Box<dyn Tool>> {
         vec![Box::new(KvStoreTool), Box::new(SecretStoreTool)]
     }
+
+    fn features(&self) -> Vec<&'static str> {
+        vec!["secrets", "key_value"]
+    }
 }
 
 // ============================================================================

--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -108,6 +108,10 @@ impl Capability for VirtualBashCapability {
         // Depends on session filesystem for file access
         vec!["session_file_system"]
     }
+
+    fn features(&self) -> Vec<&'static str> {
+        vec!["file_system"]
+    }
 }
 
 // ============================================================================

--- a/crates/core/src/capability_dto.rs
+++ b/crates/core/src/capability_dto.rs
@@ -50,6 +50,10 @@ pub struct CapabilityInfo {
     /// When this capability is selected, its dependencies are automatically included.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub dependencies: Vec<String>,
+    /// UI feature strings this capability contributes to.
+    /// Multiple capabilities can contribute the same feature.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub features: Vec<String>,
 }
 
 impl CapabilityInfo {
@@ -73,6 +77,7 @@ impl CapabilityInfo {
             is_mcp,
             is_skill,
             dependencies: cap.dependencies().iter().map(|s| s.to_string()).collect(),
+            features: cap.features().iter().map(|s| s.to_string()).collect(),
         }
     }
 }
@@ -106,6 +111,7 @@ mod tests {
             is_mcp: false,
             is_skill: false,
             dependencies: vec![],
+            features: vec![],
         };
 
         let json = serde_json::to_string(&cap).unwrap();
@@ -118,6 +124,8 @@ mod tests {
         assert!(!json.contains("\"is_skill\""));
         // Empty dependencies should be skipped in serialization
         assert!(!json.contains("\"dependencies\""));
+        // Empty features should be skipped in serialization
+        assert!(!json.contains("\"features\""));
     }
 
     #[test]
@@ -134,6 +142,7 @@ mod tests {
             is_mcp: true,
             is_skill: false,
             dependencies: vec![],
+            features: vec![],
         };
 
         let json = serde_json::to_string(&cap).unwrap();
@@ -154,6 +163,7 @@ mod tests {
             is_mcp: false,
             is_skill: false,
             dependencies: vec!["session_file_system".to_string()],
+            features: vec![],
         };
 
         let json = serde_json::to_string(&cap).unwrap();
@@ -190,5 +200,45 @@ mod tests {
 
         let json = serde_json::to_string(&custom).unwrap();
         assert_eq!(json, "\"my_custom_capability\"");
+    }
+
+    #[test]
+    fn test_capability_with_features_serialization() {
+        let cap = CapabilityInfo {
+            id: CapabilityId::new("session_storage"),
+            name: "Session Storage".to_string(),
+            description: "Storage capability".to_string(),
+            status: CapabilityStatus::Available,
+            icon: None,
+            category: None,
+            system_prompt: None,
+            tool_definitions: vec![],
+            is_mcp: false,
+            is_skill: false,
+            dependencies: vec![],
+            features: vec!["secrets".to_string(), "key_value".to_string()],
+        };
+
+        let json = serde_json::to_string(&cap).unwrap();
+        assert!(json.contains("\"features\":[\"secrets\",\"key_value\"]"));
+    }
+
+    #[test]
+    fn test_from_core_populates_features() {
+        let registry = crate::capabilities::CapabilityRegistry::with_builtins();
+
+        let schedule_cap = registry.get("session_schedule").unwrap();
+        let info = CapabilityInfo::from_core(schedule_cap.as_ref());
+        assert_eq!(info.features, vec!["schedules"]);
+
+        let storage_cap = registry.get("session_storage").unwrap();
+        let info = CapabilityInfo::from_core(storage_cap.as_ref());
+        assert!(info.features.contains(&"secrets".to_string()));
+        assert!(info.features.contains(&"key_value".to_string()));
+
+        // Capability with no features
+        let noop_cap = registry.get("noop").unwrap();
+        let info = CapabilityInfo::from_core(noop_cap.as_ref());
+        assert!(info.features.is_empty());
     }
 }

--- a/crates/core/src/in_memory_loop.rs
+++ b/crates/core/src/in_memory_loop.rs
@@ -382,6 +382,7 @@ impl InMemoryAgenticLoopBuilder {
             usage: None,
             is_pinned: None,
             active_schedule_count: None,
+            features: vec![],
         };
         session_store.add_session(session).await;
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -155,8 +155,8 @@ pub use capabilities::{
     SqlQueryTool, SqlSchemaTool, StatFileTool, StatelessTodoListCapability, SubtractTool,
     TestMathCapability, TestWeatherCapability, WriteFileTool, WriteSessionTitleTool,
     WriteTodosTool, apply_capabilities, collect_capabilities, collect_capabilities_with_configs,
-    get_dependencies, is_mcp_capability, mcp_capability_id, parse_mcp_capability_id,
-    resolve_dependencies,
+    compute_features, get_dependencies, is_mcp_capability, mcp_capability_id,
+    parse_mcp_capability_id, resolve_dependencies,
 };
 pub use capabilities::{
     AttachSkillCapability, SKILL_CAPABILITY_PREFIX, SKILLS_CAPABILITY_ID, SKILLS_DISCOVERY_PATH,

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -122,4 +122,9 @@ pub struct Session {
     /// Populated when the session is fetched for API responses.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub active_schedule_count: Option<u32>,
+    /// Aggregated UI features from all active capabilities (harness + agent + session).
+    /// Computed at read time from the capability registry.
+    /// Known features: "file_system", "schedules", "secrets", "key_value", "sql_database".
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub features: Vec<String>,
 }

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -100,6 +100,7 @@ async fn setup_test_environment() -> (
         usage: None,
         is_pinned: None,
         active_schedule_count: None,
+        features: vec![],
     };
     session_store.add_session(session).await;
 
@@ -410,6 +411,7 @@ async fn test_reason_atom_with_different_configs() {
         usage: None,
         is_pinned: None,
         active_schedule_count: None,
+        features: vec![],
     };
     session_store.add_session(session2).await;
     message_retriever

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -269,6 +269,7 @@ impl WorkerAdapters for DirectWorkerAdapters {
                 usage: None,
                 is_pinned: None,
                 active_schedule_count: None,
+                features: vec![],
             }
         }))
     }

--- a/crates/server/src/services/capability.rs
+++ b/crates/server/src/services/capability.rs
@@ -80,6 +80,7 @@ impl CapabilityService {
                 is_mcp: true,
                 is_skill: false,
                 dependencies: vec![], // MCP capabilities have no dependencies
+                features: vec![],
             });
         }
 
@@ -102,6 +103,7 @@ impl CapabilityService {
                 is_mcp: false,
                 is_skill: true,
                 dependencies: vec!["session_file_system".to_string()],
+                features: vec![],
             });
         }
 
@@ -146,6 +148,7 @@ impl CapabilityService {
                     is_mcp: true,
                     is_skill: false,
                     dependencies: vec![], // MCP capabilities have no dependencies
+                    features: vec![],
                 }));
             }
             return Ok(None);
@@ -167,6 +170,7 @@ impl CapabilityService {
                     is_mcp: false,
                     is_skill: true,
                     dependencies: vec!["session_file_system".to_string()],
+                    features: vec![],
                 }));
             }
             return Ok(None);

--- a/crates/server/src/services/session.rs
+++ b/crates/server/src/services/session.rs
@@ -16,7 +16,7 @@ use anyhow::Result;
 use everruns_core::{
     AgentCapabilityConfig, AgentId, CapabilityRegistry, HarnessId, ModelId, Session, SessionId,
     SessionStatus, TokenUsage,
-    capabilities::{SystemPromptContext, collect_capabilities},
+    capabilities::{SystemPromptContext, collect_capabilities, compute_features},
 };
 use std::sync::Arc;
 use uuid::Uuid;
@@ -96,6 +96,10 @@ impl SessionService {
         };
         let row = self.db.create_session(input).await?;
         let mut session = Self::row_to_session(row, org_public_id);
+
+        // Populate features before overriding agent_id (needs internal UUID)
+        self.populate_features(&mut session).await?;
+
         // Override agent_id with public_id (DB stores internal UUID as FK)
         session.agent_id = agent_public_id;
 
@@ -123,30 +127,9 @@ impl SessionService {
     ) -> Result<()> {
         let session_id = session_id.into();
 
-        // Collect capability IDs: harness caps first, then agent, then session
-        let harness_cap_rows = self.db.get_harness_capabilities(harness_id).await?;
-        let mut capability_ids: Vec<String> = harness_cap_rows
-            .iter()
-            .map(|r| r.capability_id.clone())
-            .collect();
-
-        // Add agent's capability IDs
-        if let Some(agent_id) = agent_id {
-            let agent_cap_rows = self.db.get_agent_capabilities(agent_id).await?;
-            for r in &agent_cap_rows {
-                if !capability_ids.contains(&r.capability_id) {
-                    capability_ids.push(r.capability_id.clone());
-                }
-            }
-        }
-
-        // Add session-level capabilities (additive)
-        for cap in session_capabilities {
-            let cap_id = cap.capability_id().to_string();
-            if !capability_ids.contains(&cap_id) {
-                capability_ids.push(cap_id);
-            }
-        }
+        let capability_ids = self
+            .collect_session_capability_ids(harness_id, agent_id, session_capabilities)
+            .await?;
 
         if capability_ids.is_empty() {
             return Ok(()); // No capabilities, nothing to mount
@@ -202,6 +185,8 @@ impl SessionService {
         match row {
             Some(r) => {
                 let mut session = Self::row_to_session(r, org_public_id);
+                // Populate features before resolving agent_id (needs internal UUID)
+                self.populate_features(&mut session).await?;
                 self.resolve_session_agent_id(org_id, &mut session).await?;
                 // Populate is_pinned if user context available
                 if let Some(uid) = user_id {
@@ -231,6 +216,11 @@ impl SessionService {
             .into_iter()
             .map(|r| Self::row_to_session(r, org_public_id))
             .collect();
+
+        // Populate features before resolving agent IDs (needs internal UUIDs)
+        for session in &mut sessions {
+            self.populate_features(session).await?;
+        }
 
         // Resolve agent internal UUIDs to public IDs
         for session in &mut sessions {
@@ -349,6 +339,56 @@ impl SessionService {
         Ok(())
     }
 
+    /// Collect all capability IDs for a session (harness + agent + session-level).
+    /// Deduplicates while preserving order: harness first, then agent, then session.
+    async fn collect_session_capability_ids(
+        &self,
+        harness_id: Uuid,
+        agent_id: Option<Uuid>,
+        session_capabilities: &[AgentCapabilityConfig],
+    ) -> Result<Vec<String>> {
+        let harness_cap_rows = self.db.get_harness_capabilities(harness_id).await?;
+        let mut capability_ids: Vec<String> = harness_cap_rows
+            .iter()
+            .map(|r| r.capability_id.clone())
+            .collect();
+
+        if let Some(agent_id) = agent_id {
+            let agent_cap_rows = self.db.get_agent_capabilities(agent_id).await?;
+            for r in &agent_cap_rows {
+                if !capability_ids.contains(&r.capability_id) {
+                    capability_ids.push(r.capability_id.clone());
+                }
+            }
+        }
+
+        for cap in session_capabilities {
+            let cap_id = cap.capability_id().to_string();
+            if !capability_ids.contains(&cap_id) {
+                capability_ids.push(cap_id);
+            }
+        }
+
+        Ok(capability_ids)
+    }
+
+    /// Populate the `features` field on a session by aggregating features from
+    /// all active capabilities (harness + agent + session-level).
+    ///
+    /// Must be called BEFORE `resolve_session_agent_id()` because the session's
+    /// agent_id at that point is still the internal UUID needed for DB lookups.
+    async fn populate_features(&self, session: &mut Session) -> Result<()> {
+        let harness_id = session.harness_id.uuid();
+        let agent_internal_id = session.agent_id.map(|a| a.uuid());
+
+        let capability_ids = self
+            .collect_session_capability_ids(harness_id, agent_internal_id, &session.capabilities)
+            .await?;
+
+        session.features = compute_features(&capability_ids, &self.capability_registry);
+        Ok(())
+    }
+
     fn row_to_session(row: crate::storage::SessionRow, org_public_id: &str) -> Session {
         // Convert database usage columns to TokenUsage
         let usage = if row.total_input_tokens > 0 || row.total_output_tokens > 0 {
@@ -394,6 +434,7 @@ impl SessionService {
             usage,
             is_pinned: None,             // Populated by caller with user context
             active_schedule_count: None, // Populated by caller
+            features: vec![],            // Populated by caller via populate_features()
         }
     }
 }

--- a/crates/server/src/storage/session_store.rs
+++ b/crates/server/src/storage/session_store.rs
@@ -87,6 +87,7 @@ impl SessionStore for DbSessionStore {
                     usage,
                     is_pinned: None,
                     active_schedule_count: None,
+                    features: vec![],
                 }))
             }
             None => Ok(None),

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -1457,10 +1457,10 @@ async fn test_session_features_in_list() {
         .assert_success()
         .json_value();
 
-    let items = list_body["items"].as_array().expect("items array");
-    assert!(!items.is_empty());
+    let data = list_body["data"].as_array().expect("data array");
+    assert!(!data.is_empty());
 
-    let first = &items[0];
+    let first = &data[0];
     let features = first["features"]
         .as_array()
         .expect("features should be an array");
@@ -1590,10 +1590,10 @@ async fn test_capability_info_includes_features() {
         .assert_success()
         .json_value();
 
-    let items = body["items"].as_array().expect("items array");
+    let data = body["data"].as_array().expect("data array");
 
     // Find session_storage capability — should have secrets and key_value features
-    let storage = items
+    let storage = data
         .iter()
         .find(|c| c["id"] == "session_storage")
         .expect("session_storage capability should exist");
@@ -1611,7 +1611,7 @@ async fn test_capability_info_includes_features() {
     );
 
     // Find session_schedule — should have schedules feature
-    let schedule = items
+    let schedule = data
         .iter()
         .find(|c| c["id"] == "session_schedule")
         .expect("session_schedule capability should exist");
@@ -1625,7 +1625,7 @@ async fn test_capability_info_includes_features() {
     );
 
     // Find noop — should have no features (empty or absent)
-    let noop = items
+    let noop = data
         .iter()
         .find(|c| c["id"] == "noop")
         .expect("noop capability should exist");

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -1299,3 +1299,341 @@ async fn test_session_databases_invalid_name() {
         .await
         .assert_status(StatusCode::BAD_REQUEST);
 }
+
+// ============================================================================
+// Session Features Tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_session_features_base_harness_empty() {
+    let server = TestServer::new().await;
+
+    let agent: Agent = server
+        .post(
+            "/v1/agents",
+            json!({"name": "Base Features Agent", "system_prompt": "Test"}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    // Base harness has no capabilities → no features
+    let session: Session = server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": SEED_BASE_HARNESS_ID,
+                "agent_id": agent.public_id,
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    assert!(
+        session.features.is_empty(),
+        "Base harness session should have no features, got: {:?}",
+        session.features,
+    );
+}
+
+#[tokio::test]
+async fn test_session_features_generic_harness() {
+    let server = TestServer::new().await;
+
+    let agent: Agent = server
+        .post(
+            "/v1/agents",
+            json!({"name": "Generic Features Agent", "system_prompt": "Test"}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    // Generic harness has session_file_system, virtual_bash, session_storage, etc.
+    let session: Session = server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": SEED_GENERIC_HARNESS_ID,
+                "agent_id": agent.public_id,
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    assert!(
+        session.features.contains(&"file_system".to_string()),
+        "Generic harness should include file_system feature, got: {:?}",
+        session.features,
+    );
+    assert!(
+        session.features.contains(&"secrets".to_string()),
+        "Generic harness should include secrets feature, got: {:?}",
+        session.features,
+    );
+    assert!(
+        session.features.contains(&"key_value".to_string()),
+        "Generic harness should include key_value feature, got: {:?}",
+        session.features,
+    );
+    // file_system should only appear once despite session_file_system + virtual_bash
+    let fs_count = session
+        .features
+        .iter()
+        .filter(|f| *f == "file_system")
+        .count();
+    assert_eq!(fs_count, 1, "file_system should appear exactly once");
+}
+
+#[tokio::test]
+async fn test_session_features_persisted_in_get() {
+    let server = TestServer::new().await;
+
+    let agent: Agent = server
+        .post(
+            "/v1/agents",
+            json!({"name": "Get Features Agent", "system_prompt": "Test"}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let session: Session = server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": SEED_GENERIC_HARNESS_ID,
+                "agent_id": agent.public_id,
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    // Features should also appear in GET response
+    let fetched: Session = server
+        .get(&format!("/v1/sessions/{}", session.id))
+        .await
+        .assert_success()
+        .json();
+
+    assert_eq!(
+        fetched.features, session.features,
+        "GET session should return same features as POST",
+    );
+}
+
+#[tokio::test]
+async fn test_session_features_in_list() {
+    let server = TestServer::new().await;
+
+    let agent: Agent = server
+        .post(
+            "/v1/agents",
+            json!({"name": "List Features Agent", "system_prompt": "Test"}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let _session: Session = server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": SEED_GENERIC_HARNESS_ID,
+                "agent_id": agent.public_id,
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    // Features should appear in list response
+    let list_body: Value = server
+        .get(&format!("/v1/sessions?agent_id={}", agent.public_id))
+        .await
+        .assert_success()
+        .json_value();
+
+    let items = list_body["items"].as_array().expect("items array");
+    assert!(!items.is_empty());
+
+    let first = &items[0];
+    let features = first["features"]
+        .as_array()
+        .expect("features should be an array");
+    assert!(
+        features.contains(&json!("file_system")),
+        "List should include file_system feature",
+    );
+}
+
+#[tokio::test]
+async fn test_session_features_with_session_capabilities() {
+    let server = TestServer::new().await;
+
+    let agent: Agent = server
+        .post(
+            "/v1/agents",
+            json!({"name": "Session Cap Features Agent", "system_prompt": "Test"}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    // Base harness has no caps, but add session_schedule at session level
+    let session: Session = server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": SEED_BASE_HARNESS_ID,
+                "agent_id": agent.public_id,
+                "capabilities": [{"ref": "session_schedule"}],
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    assert!(
+        session.features.contains(&"schedules".to_string()),
+        "Session-level capability should contribute features, got: {:?}",
+        session.features,
+    );
+}
+
+#[tokio::test]
+async fn test_session_features_with_agent_capabilities() {
+    let server = TestServer::new().await;
+
+    // Create agent with session_schedule capability
+    let agent: Agent = server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": "Agent Cap Features Agent",
+                "system_prompt": "Test",
+                "capabilities": [{"ref": "session_schedule"}],
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    // Base harness (no caps) + agent has session_schedule
+    let body: Value = server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": SEED_BASE_HARNESS_ID,
+                "agent_id": agent.public_id,
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json_value();
+
+    let features = body["features"]
+        .as_array()
+        .expect("features should be an array");
+    assert!(
+        features.contains(&json!("schedules")),
+        "Agent capability should contribute features, got: {:?}",
+        features,
+    );
+}
+
+#[tokio::test]
+async fn test_session_features_sql_database() {
+    let server = TestServer::new().await;
+
+    let agent: Agent = server
+        .post(
+            "/v1/agents",
+            json!({"name": "SqlDb Features Agent", "system_prompt": "Test"}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    // Add session_sql_database via session-level capability
+    let session: Session = server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": SEED_BASE_HARNESS_ID,
+                "agent_id": agent.public_id,
+                "capabilities": [{"ref": "session_sql_database"}],
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    assert!(
+        session.features.contains(&"sql_database".to_string()),
+        "session_sql_database should contribute sql_database feature, got: {:?}",
+        session.features,
+    );
+}
+
+#[tokio::test]
+async fn test_capability_info_includes_features() {
+    let server = TestServer::new().await;
+
+    // Check that the capabilities endpoint returns features
+    let body: Value = server
+        .get("/v1/capabilities")
+        .await
+        .assert_success()
+        .json_value();
+
+    let items = body["items"].as_array().expect("items array");
+
+    // Find session_storage capability — should have secrets and key_value features
+    let storage = items
+        .iter()
+        .find(|c| c["id"] == "session_storage")
+        .expect("session_storage capability should exist");
+
+    let features = storage["features"]
+        .as_array()
+        .expect("features should be an array");
+    assert!(
+        features.contains(&json!("secrets")),
+        "session_storage should have secrets feature",
+    );
+    assert!(
+        features.contains(&json!("key_value")),
+        "session_storage should have key_value feature",
+    );
+
+    // Find session_schedule — should have schedules feature
+    let schedule = items
+        .iter()
+        .find(|c| c["id"] == "session_schedule")
+        .expect("session_schedule capability should exist");
+
+    let schedule_features = schedule["features"]
+        .as_array()
+        .expect("features should be an array");
+    assert!(
+        schedule_features.contains(&json!("schedules")),
+        "session_schedule should have schedules feature",
+    );
+
+    // Find noop — should have no features (empty or absent)
+    let noop = items
+        .iter()
+        .find(|c| c["id"] == "noop")
+        .expect("noop capability should exist");
+    let noop_features = noop.get("features");
+    assert!(
+        noop_features
+            .and_then(|v| v.as_array())
+            .is_none_or(|a| a.is_empty()),
+        "noop should have no features",
+    );
+}

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -600,6 +600,7 @@ fn proto_session_to_session(proto_session: proto::Session) -> Result<Session> {
         usage: None, // Usage not tracked in worker context
         is_pinned: None,
         active_schedule_count: None,
+        features: vec![], // Computed at API read time, not in worker
     })
 }
 

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -4307,6 +4307,13 @@
             "type": "string",
             "description": "Description of what this capability provides"
           },
+          "features": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "UI feature strings this capability contributes to.\nMultiple capabilities can contribute the same feature."
+          },
           "icon": {
             "type": [
               "string",
@@ -5855,6 +5862,13 @@
                 "description": {
                   "type": "string",
                   "description": "Description of what this capability provides"
+                },
+                "features": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "UI feature strings this capability contributes to.\nMultiple capabilities can contribute the same feature."
                 },
                 "icon": {
                   "type": [
@@ -7828,6 +7842,13 @@
                   "format": "date-time",
                   "description": "Timestamp when the session was created."
                 },
+                "features": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Aggregated UI features from all active capabilities (harness + agent + session).\nComputed at read time from the capability registry.\nKnown features: \"file_system\", \"schedules\", \"secrets\", \"key_value\", \"sql_database\"."
+                },
                 "finished_at": {
                   "type": [
                     "string",
@@ -8567,6 +8588,13 @@
             "type": "string",
             "format": "date-time",
             "description": "Timestamp when the session was created."
+          },
+          "features": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Aggregated UI features from all active capabilities (harness + agent + session).\nComputed at read time from the capability registry.\nKnown features: \"file_system\", \"schedules\", \"secrets\", \"key_value\", \"sql_database\"."
           },
           "finished_at": {
             "type": [

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -60,6 +60,7 @@ Capabilities are defined in **everruns-core** and resolved at the **API layer**:
 | `category` | string? | Category for grouping in UI |
 | `is_mcp` | boolean | True if this is an MCP virtual capability |
 | `dependencies` | string[] | IDs of capabilities this capability depends on |
+| `features` | string[] | UI feature strings this capability contributes to |
 
 ##### Description Markdown Support
 
@@ -216,6 +217,7 @@ pub trait Capability: Send + Sync {
     fn category(&self) -> Option<&str> { None }
     fn mounts(&self) -> Vec<MountPoint> { vec![] }
     fn dependencies(&self) -> Vec<&'static str> { vec![] }
+    fn features(&self) -> Vec<&'static str> { vec![] }
     fn message_filter_provider(&self) -> Option<Arc<dyn MessageFilterProvider>> { None }
 }
 ```
@@ -302,10 +304,71 @@ pub fn resolve_dependencies(
 
 #### Built-in Capabilities with Dependencies
 
-| Capability | Depends On |
-|------------|-----------|
-| `sample_data` | `session_file_system` |
-| `skills` | `session_file_system` |
+| Capability | Depends On | Features |
+|------------|-----------|----------|
+| `sample_data` | `session_file_system` | `file_system` |
+| `skills` | `session_file_system` | *(none)* |
+| `virtual_bash` | `session_file_system` | `file_system` |
+
+### Capability Features
+
+Capabilities declare UI features they contribute to via `features()`. Features are open-ended strings indicating what user-facing functionality a capability enables. The Session DTO aggregates features from all active capabilities (harness + agent + session-level) at read time, and the UI uses the aggregated set to decide which tabs/sections to render.
+
+#### How Features Work
+
+1. **Declaration**: Capabilities implement `features()` returning a list of feature strings
+2. **Aggregation**: `compute_features()` resolves dependencies and collects features from all resolved capabilities
+3. **Deduplication**: Features are deduplicated — multiple capabilities contributing the same feature produce one entry
+4. **Session DTO**: The `Session.features` field is computed at read time (not stored in the database)
+5. **UI Rendering**: The UI conditionally renders tabs based on the feature set (e.g., Workspace tab only appears when `"file_system"` is present)
+
+#### Built-in Feature Mapping
+
+| Capability | Features |
+|------------|----------|
+| `session_file_system` | `file_system` |
+| `virtual_bash` | `file_system` |
+| `sample_data` | `file_system` |
+| `session_storage` | `secrets`, `key_value` |
+| `session_schedule` | `schedules` |
+| `session_sql_database` | `sql_database` |
+
+MCP and Skill virtual capabilities currently declare no features.
+
+#### Known Feature Strings
+
+| Feature | UI Element | Description |
+|---------|------------|-------------|
+| `file_system` | Workspace tab | Session has file system access |
+| `secrets` | Storage tab | Session can store encrypted secrets |
+| `key_value` | Storage tab | Session can store key/value pairs |
+| `schedules` | Schedules tab | Session can create/manage schedules |
+| `sql_database` | *(reserved)* | Session has SQL database access |
+
+#### Example
+
+```rust
+impl Capability for SessionScheduleCapability {
+    fn id(&self) -> &str { "session_schedule" }
+
+    fn features(&self) -> Vec<&'static str> {
+        vec!["schedules"]
+    }
+}
+```
+
+When `session_schedule` is selected, the session's `features` will include `"schedules"`, and the UI will render the Schedules tab.
+
+#### compute_features()
+
+```rust
+/// Compute aggregated features from capability IDs.
+/// Resolves dependencies, collects features, deduplicates.
+pub fn compute_features(
+    capability_ids: &[String],
+    registry: &CapabilityRegistry,
+) -> Vec<String>;
+```
 
 ### Built-in Capabilities
 

--- a/specs/models.md
+++ b/specs/models.md
@@ -56,6 +56,9 @@ An instance of agentic loop execution. Sessions are top-level entities under org
 | `updated_at` | timestamp | Last modification time (auto-updated on any change) |
 | `started_at` | timestamp? | Execution start time |
 | `finished_at` | timestamp? | Completion time |
+| `features` | string[] | Aggregated UI features (computed at read time, not stored) |
+
+**Session Features:** The `features` field is computed at read time by aggregating `features()` from all active capabilities (harness + agent + session-level), after resolving dependencies. It is not stored in the database. See `specs/capabilities.md#capability-features`.
 
 **Session Capabilities:** The `capabilities` field allows setting session-level capabilities that are additive to the agent's capabilities. When building the RuntimeAgent, agent capabilities are applied first, then session capabilities are applied after. This enables temporarily extending an agent's capabilities for specific sessions.
 


### PR DESCRIPTION
## What

Add a `features()` method to the `Capability` trait that declares UI feature strings each capability contributes. The Session DTO aggregates these at read time from all active capabilities (harness + agent + session-level). The UI conditionally renders session tabs based on the computed feature set.

## Why

Previously, session tabs (Workspace, Storage, Schedules) were always rendered regardless of which capabilities were active. This made the UI cluttered for sessions using minimal harnesses. Features provide a clean, extensible mechanism for capabilities to signal what UI elements should be shown.

## How

**Backend:**
- `Capability` trait: new `fn features() -> Vec<&'static str>` (default: empty)
- `CapabilityInfo` DTO: new `features: Vec<String>` field
- 6 capabilities implement `features()`:
  - `session_file_system`, `virtual_bash`, `sample_data` -> `"file_system"`
  - `session_storage` -> `"secrets"`, `"key_value"`
  - `session_schedule` -> `"schedules"`
  - `session_sql_database` -> `"sql_database"`
- `Session` struct: new `features: Vec<String>` computed at read time
- `compute_features()`: resolves deps, aggregates, deduplicates
- `SessionService`: populates features in `get()`, `list()`, `create()`
- Refactored `collect_session_capability_ids()` shared helper

**Frontend:**
- `Session.features?: string[]` and `Capability.features?: string[]` types
- Workspace tab: shown when `file_system` present
- Storage tab: shown when `secrets` or `key_value` present
- Schedules tab: shown when `schedules` present

## Risk
- Low
- Additive change. No existing behavior removed. Features default to empty.

## Checklist
- [x] Tests added or updated
  - 16 unit tests in everruns-core (features declarations, compute_features, dedup, deps)
  - 8 integration tests in server (base/generic harness, session/agent caps, GET/list, capabilities endpoint)
- [x] Backward compatibility considered (features field omitted when empty via skip_serializing_if)
- [x] Specs updated (capabilities.md, models.md)
