### PR TITLE
fix(docs): correct edit page link URL for all doc pages

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -100,7 +100,7 @@ export default defineConfig({
         ...openAPISidebarGroups,
       ],
       editLink: {
-        baseUrl: "https://github.com/everruns/everruns/blob/main/docs/",
+        baseUrl: "https://github.com/everruns/everruns/edit/main/apps/docs/",
       },
       lastUpdated: true,
     }),


### PR DESCRIPTION
## Summary

- Fix broken Edit page links across all documentation pages (not just skills)
- The Starlight editLink.baseUrl pointed to docs/ but Starlight appends the file path relative to the Astro project root (src/content/docs/...), producing non-existent paths like docs/src/content/docs/features/skills.mdx
- Changed baseUrl to apps/docs/ so the path traverses the content symlink (src/content/docs -> ../../../../docs) and resolves correctly on GitHub
- Switched from blob to edit URL per Starlight convention (opens editor directly)

## Test plan

- [ ] Verify edit links on deployed docs resolve to valid GitHub pages
- [ ] Check multiple doc pages (skills, concepts, architecture) to confirm fix applies globally