### PR TITLE
chore(release): prepare v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.8.0] - 2026-02-21
+
+### Highlights
+
+- **Built-in Skills Discovery** — Skills capability with system prompt integration and Generic harness support ([#516](https://github.com/everruns/everruns/pull/516), [#532](https://github.com/everruns/everruns/pull/532), [#543](https://github.com/everruns/everruns/pull/543))
+- **Daytona Integration** — User connection with API key support and official branding ([#522](https://github.com/everruns/everruns/pull/522), [#533](https://github.com/everruns/everruns/pull/533))
+- **Generic Harness Type** — New Generic harness with skills, agent_instructions, and copy endpoints ([#512](https://github.com/everruns/everruns/pull/512), [#518](https://github.com/everruns/everruns/pull/518), [#524](https://github.com/everruns/everruns/pull/524))
+- **Claude Sonnet 4.6 & Opus 4.6** — New model profiles for latest Claude models ([#531](https://github.com/everruns/everruns/pull/531))
+- **Session-Scoped Task Scheduling** — Cron-based scheduled tasks scoped to sessions ([#536](https://github.com/everruns/everruns/pull/536))
+
+### What's Changed
+
+- docs: fix Daytona integration image ([#561](https://github.com/everruns/everruns/pull/561))
+- fix(bash): set executable file mode for script execution ([#559](https://github.com/everruns/everruns/pull/559))
+- fix(durable): optimize slow claim_due_schedules scheduler query ([#558](https://github.com/everruns/everruns/pull/558))
+- chore(deps): update bashkit v0.1.5 → v0.1.6 ([#556](https://github.com/everruns/everruns/pull/556))
+- docs: fix duplicate titles, dark-mode logos, and add Braintrust icon ([#557](https://github.com/everruns/everruns/pull/557))
+- docs: fix duplicate titles, logo visibility, and redesign home page ([#555](https://github.com/everruns/everruns/pull/555))
+- fix(docs): correct edit page link URL for all doc pages ([#554](https://github.com/everruns/everruns/pull/554))
+- chore(docs): add Google site verification meta tag ([#553](https://github.com/everruns/everruns/pull/553))
+- refactor(migrations): squash post-0.7.0 migrations into single 003_v0.8.0 ([#552](https://github.com/everruns/everruns/pull/552))
+- chore: pre-release maintenance — deps, specs, threat model, code cleanup ([#551](https://github.com/everruns/everruns/pull/551))
+- feat(capabilities): add features() for UI-driven tab rendering ([#550](https://github.com/everruns/everruns/pull/550))
+- fix(ui): fix llm.generation preview modal layout and rename button to View ([#549](https://github.com/everruns/everruns/pull/549))
+- refactor(skills): separate AttachSkillCapability (mount-only) from SkillsCapability (discovery+tools) ([#548](https://github.com/everruns/everruns/pull/548))
+- docs(skills): add overview video, split into skills + skills-registry ([#547](https://github.com/everruns/everruns/pull/547))
+- feat(ui): add frontmatter support to markdown file preview ([#546](https://github.com/everruns/everruns/pull/546))
+- chore(deps): bump devalue from 5.6.2 to 5.6.3 in /apps/docs ([#545](https://github.com/everruns/everruns/pull/545))
+- fix(durable): gate postgres integration tests behind feature flag ([#544](https://github.com/everruns/everruns/pull/544))
+- feat(skills): include first 15 skill descriptions in system prompt ([#543](https://github.com/everruns/everruns/pull/543))
+- fix(ui): fix chat input panel and sidebar layout alignment ([#542](https://github.com/everruns/everruns/pull/542))
+- feat: add `just start-production` command ([#541](https://github.com/everruns/everruns/pull/541))
+- fix(llm): detect model-not-found errors and surface user-friendly message ([#540](https://github.com/everruns/everruns/pull/540))
+- docs: add sitemap.xml with lastmod dates ([#539](https://github.com/everruns/everruns/pull/539))
+- feat(docs): add Bing meta validation tag, robots.txt with AI crawler rules ([#538](https://github.com/everruns/everruns/pull/538))
+- feat(ui): add drag-and-drop file upload to workspace ([#537](https://github.com/everruns/everruns/pull/537))
+- feat(schedules): add session-scoped task scheduling ([#536](https://github.com/everruns/everruns/pull/536))
+- fix(ui): rename Preview button to View and restore generation visualization ([#535](https://github.com/everruns/everruns/pull/535))
+- fix(capabilities): respect /workspace prefix in skills agent-facing paths ([#534](https://github.com/everruns/everruns/pull/534))
+- feat(daytona): add official Daytona logo icon and integration docs ([#533](https://github.com/everruns/everruns/pull/533))
+- feat(harness): add skills capability to Generic harness ([#532](https://github.com/everruns/everruns/pull/532))
+- feat(models): add Claude Sonnet 4.6 and Opus 4.6 model profiles ([#531](https://github.com/everruns/everruns/pull/531))
+- refactor(capabilities): make Capability trait async for dynamic system prompt content ([#530](https://github.com/everruns/everruns/pull/530))
+- feat(commands): add /ship command for automated ship flow ([#529](https://github.com/everruns/everruns/pull/529))
+- fix(auth): auto-refresh expired tokens and preserve page on re-login ([#528](https://github.com/everruns/everruns/pull/528))
+- fix(ui): render connection instructions as markdown ([#527](https://github.com/everruns/everruns/pull/527))
+- feat(ui): add llm.generation filter to session events ([#526](https://github.com/everruns/everruns/pull/526))
+- chore(agents): update pre-PR checklist and add shipping definition ([#525](https://github.com/everruns/everruns/pull/525))
+- fix(harness): include agent_instructions in Generic harness ([#524](https://github.com/everruns/everruns/pull/524))
+- fix(ui): fix workspace refresh button and auto-refresh on tab switch ([#523](https://github.com/everruns/everruns/pull/523))
+- feat(connections): add Daytona user connection with API key support ([#522](https://github.com/everruns/everruns/pull/522))
+- feat(ui): reorganize sidebar navigation ([#521](https://github.com/everruns/everruns/pull/521))
+- fix(worker): increase control-plane connection timeout from 5s to 30s ([#520](https://github.com/everruns/everruns/pull/520))
+- fix(ui): fix settings panel not filling full height ([#519](https://github.com/everruns/everruns/pull/519))
+- feat(agents,harnesses): add copy endpoints ([#518](https://github.com/everruns/everruns/pull/518))
+- fix(worker): register harness capability tools when agent_id is absent ([#517](https://github.com/everruns/everruns/pull/517))
+- feat(capabilities): add built-in skills discovery capability ([#516](https://github.com/everruns/everruns/pull/516))
+- feat(ui): add Schedules link to sidebar navigation ([#515](https://github.com/everruns/everruns/pull/515))
+- chore(deps): update bashkit from v0.1.4 to v0.1.5 ([#514](https://github.com/everruns/everruns/pull/514))
+- fix(seed): upsert seed data with change detection ([#513](https://github.com/everruns/everruns/pull/513))
+- feat(harness): rename Default to Base, add Generic harness type ([#512](https://github.com/everruns/everruns/pull/512))
+- test: remove 11 ineffective tests ([#511](https://github.com/everruns/everruns/pull/511))
+
+### Migration Notes
+
+**0.7.0 → 0.8.0:** This release includes database schema changes (session-scoped scheduling, Generic harness type, migration squash). A fresh database is required — no automatic migration is supported.
+
 ## [0.7.0] - 2026-02-13
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,7 +1119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-codesandbox"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1339,7 +1339,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1354,7 +1354,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -1371,7 +1371,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1410,7 +1410,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2516,9 +2516,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "93f0862381daaec758576dcc22eb7bbf4d7efd67328553f3b45a412a51a3fb21"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2823,9 +2823,9 @@ dependencies = [
 
 [[package]]
 name = "minijinja"
-version = "2.15.1"
+version = "2.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b479616bb6f0779fb0f3964246beda02d4b01144e1b0d5519616e012ccc2a245"
+checksum = "5c54f3bcc034dd74496b5ca929fd0b710186672d5ff0b0f255a9ceb259042ece"
 dependencies = [
  "serde",
 ]
@@ -2946,7 +2946,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3698,7 +3698,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4165,7 +4165,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4223,7 +4223,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4927,7 +4927,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5737,9 +5737,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "1de241cdc66a9d91bd84f097039eb140cdc6eec47e0cdbaf9d932a1dd6c35866"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5750,9 +5750,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "a42e96ea38f49b191e08a1bab66c7ffdba24b06f9995b39a9dd60222e5b6f1da"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -5764,9 +5764,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "e12fdf6649048f2e3de6d7d5ff3ced779cdedee0e0baffd7dff5cdfa3abc8a52"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5774,9 +5774,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "0e63d1795c565ac3462334c1e396fd46dbf481c40f51f5072c310717bc4fb309"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5787,9 +5787,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "e9f9cdac23a5ce71f6bf9f8824898a501e511892791ea2a0c6b8568c68b9cb53"
 dependencies = [
  "unicode-ident",
 ]
@@ -5843,9 +5843,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "f2c7c5718134e770ee62af3b6b4a84518ec10101aad610c024b64d6ff29bb1ff"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5998,7 +5998,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns Contributors"]

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "everruns-ui",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "everruns-ui",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@streamdown/code": "^1.0.3",
@@ -4462,6 +4462,70 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.0",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "exports": {
     "./providers/*": "./src/providers/*.tsx",


### PR DESCRIPTION
## What
Prepare the v0.8.0 release — bump version numbers, update CHANGELOG.md, regenerate lock files.

## Why
Release 50 changes since v0.7.0 including built-in skills discovery, Daytona integration, Generic harness type, Claude 4.6 model profiles, and session-scoped task scheduling.

## How
- Bump `workspace.package.version` in Cargo.toml to 0.8.0
- Bump `version` in apps/ui/package.json to 0.8.0
- Add v0.8.0 section to CHANGELOG.md with highlights and full commit list
- Regenerate Cargo.lock and package-lock.json

## Risk
- Low
- Version number and changelog only; no code changes

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

### Post-merge
After merging, the release workflow will automatically:
- Create git tag `v0.8.0`
- Create GitHub Release with notes from CHANGELOG.md
- Trigger Docker image build with version tag