### PR TITLE
fix(ci): trigger Docker Publish for release tags via workflow_dispatch

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,6 +4,14 @@ on:
   push:
     branches: [main]
     tags: ['v*']
+  # Triggered by Release workflow after creating tag (GITHUB_TOKEN tag pushes
+  # don't fire push events, so Release calls this via workflow_dispatch)
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag to build and publish (e.g., v0.8.0)'
+        required: true
+        type: string
   pull_request:
     types: [opened, synchronize, reopened]
 
@@ -44,9 +52,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # QEMU needed for UI ARM builds (runs npm on target platform)
+      # QEMU needed for multi-arch builds (ARM64 cross-compilation)
       - name: Set up QEMU
-        if: github.event_name == 'push'
+        if: github.event_name != 'pull_request'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
@@ -70,15 +78,30 @@ jobs:
             echo "sha_short=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
           fi
 
-      # Build ARM64 only on main push and version tags (cross-compiled)
+      - name: Determine release tag
+        id: release_tag
+        run: |
+          # workflow_dispatch passes the tag explicitly
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+            echo "is_release=true" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+            echo "is_release=true" >> $GITHUB_OUTPUT
+          else
+            echo "tag=" >> $GITHUB_OUTPUT
+            echo "is_release=false" >> $GITHUB_OUTPUT
+          fi
+
+      # Build ARM64 only on main push, version tags, and release dispatches
       # PRs only build amd64 for faster CI
       - name: Determine platforms
         id: platforms
         run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
-            echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
-          else
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
+          else
+            echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
           fi
 
       - name: Extract metadata for Docker
@@ -87,9 +110,10 @@ jobs:
         with:
           images: ${{ env.IMAGE_BASE }}/${{ matrix.image_name }}
           tags: |
-            # On version tags (v*): use the tag name + update latest
+            # On version tags (push or workflow_dispatch): use the tag name + update latest
             type=ref,event=tag
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=${{ steps.release_tag.outputs.tag }},enable=${{ steps.release_tag.outputs.is_release == 'true' }}
+            type=raw,value=latest,enable=${{ steps.release_tag.outputs.is_release == 'true' }}
             # On main push: tag as 'development' (mutable, tracks main branch)
             type=raw,value=development,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
             # Always tag with short and full SHA

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
 
     permissions:
       contents: write
+      actions: write
 
     steps:
       - name: Checkout
@@ -117,3 +118,14 @@ jobs:
             --target "${{ github.sha }}"
 
           echo "Created release v${{ steps.version.outputs.version }}"
+
+      # GITHUB_TOKEN tag pushes don't trigger other workflows (GitHub anti-recursion).
+      # Explicitly dispatch Docker Publish to build version-tagged images.
+      - name: Trigger Docker Publish for release tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ steps.version.outputs.version }}"
+          echo "Triggering Docker Publish for tag $TAG..."
+          gh workflow run docker-publish.yml --ref "$TAG" -f "tag=$TAG"
+          echo "Docker Publish triggered for $TAG"

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -61,7 +61,10 @@ The workflow will extract release notes from CHANGELOG.md and create the GitHub 
 1. Tag format: `vX.Y.Z` (e.g., `v0.4.0`)
 2. Release title: `vX.Y.Z`
 3. Release body: Extracted from CHANGELOG.md section for that version
-4. Docker images tagged with version (triggered by tag push)
+4. Docker images tagged with version (triggered via `workflow_dispatch` from Release workflow)
+
+> **Note:** Tags created by `GITHUB_TOKEN` don't trigger other workflows (GitHub anti-recursion).
+> The Release workflow explicitly dispatches Docker Publish after creating the release.
 
 ### Docker Image Tagging
 


### PR DESCRIPTION
## What
Fix Docker Publish workflow to correctly tag release images with version numbers (e.g., `v0.8.0`, `latest`).

## Why
Tags created by `GITHUB_TOKEN` do not trigger other workflows (GitHub anti-recursion policy). The Release workflow creates tags via `gh release create`, but those tag pushes never triggered Docker Publish. This meant **no Docker images were ever tagged with version numbers** — only `development` and SHA tags from main branch pushes.

## How
- **Docker Publish**: Added `workflow_dispatch` trigger that accepts a `tag` input. Added `Determine release tag` step to handle both tag-push and workflow_dispatch events. Updated metadata tags to use the resolved release tag.
- **Release**: Added a step after creating the GitHub Release that explicitly dispatches Docker Publish via `gh workflow run`. Added `actions: write` permission for the dispatch.
- Fixed QEMU/platform detection to use `!= pull_request` instead of `== push` so workflow_dispatch gets multi-arch builds.
- Updated `specs/release-process.md` to document the dispatch pattern.

## Risk
- Low
- Docker Publish for PRs and main pushes unchanged — only adds a new trigger path for releases

## Checklist
- [x] Tests added or updated (CI workflow change; verified via pre-push)
- [x] Backward compatibility considered (existing push/PR triggers unchanged)