### PR TITLE
docs(ecosystem): add bashkit overview and hide SRE sidebar

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -76,16 +76,21 @@ export default defineConfig({
           label: "Features",
           autogenerate: { directory: "features" },
         },
+        // SRE Guide hidden for now
+        // {
+        //   label: "SRE Guide",
+        //   items: [
+        //     { label: "Environment Variables", slug: "sre/environment-variables" },
+        //     { label: "Admin Container", slug: "sre/admin-container" },
+        //     {
+        //       label: "Runbooks",
+        //       autogenerate: { directory: "sre/runbooks" },
+        //     },
+        //   ],
+        // },
         {
-          label: "SRE Guide",
-          items: [
-            { label: "Environment Variables", slug: "sre/environment-variables" },
-            { label: "Admin Container", slug: "sre/admin-container" },
-            {
-              label: "Runbooks",
-              autogenerate: { directory: "sre/runbooks" },
-            },
-          ],
+          label: "Ecosystem",
+          autogenerate: { directory: "ecosystem" },
         },
         {
           label: "Integrations",

--- a/docs/ecosystem/bashkit.md
+++ b/docs/ecosystem/bashkit.md
@@ -1,0 +1,72 @@
+---
+title: Bashkit
+description: Sandboxed virtual Bash interpreter for multi-tenant agent environments.
+---
+
+[Bashkit](https://github.com/everruns/bashkit) is a virtual Bash interpreter written in Rust. It provides sandboxed, in-process execution with no real filesystem access by default — purpose-built for running untrusted bash scripts in multi-tenant agent environments.
+
+## Why Bashkit?
+
+Agents need shell access to be effective — installing packages, running builds, inspecting files. But spawning real bash processes in a shared environment creates isolation, security, and resource control problems. Bashkit solves this by interpreting bash in-process against a virtual filesystem, giving agents a full shell experience without host access.
+
+## Core Capabilities
+
+- **POSIX-compliant shell language** — variables, parameter expansion, command substitution, arithmetic, pipelines, redirections, control flow, functions, arrays, globs, here-documents
+- **85 built-in commands** — core I/O (`echo`, `cat`, `printf`), navigation (`cd`, `ls`, `find`), text processing (`grep`, `sed`, `awk`, `jq`, `sort`), file operations (`mkdir`, `rm`, `cp`, `mv`), archives (`tar`, `gzip`), network (`curl`, `wget` with domain allowlist), and more
+- **Virtual filesystem** — pluggable backends: `InMemoryFs`, `OverlayFs`, `MountableFs`
+- **Resource limits** — configurable caps on command count, loop iterations, and function call depth
+- **Network allowlist** — HTTP requests via `curl`/`wget` require explicit per-domain authorization
+- **Async-native** — built on tokio
+
+### Experimental Features
+
+- **Git** — virtual git operations within the VFS (no host access)
+- **Python** — embedded Monty interpreter (pure Rust, Python 3.12 compatible) with VFS bridging
+
+## How Everruns Uses Bashkit
+
+Everruns integrates bashkit as the execution backend for the **virtual bash** agent capability. When an agent runs shell commands, they execute inside bashkit rather than a real shell.
+
+### Session Filesystem Bridge
+
+The key integration point is `SessionFileSystemAdapter` — a custom `FileSystem` implementation that bridges bashkit to the Everruns session file store. This gives agents:
+
+- **Live file visibility** — files written by other tools during bash execution are immediately visible
+- **No sync overhead** — eliminates pre/post execution sync of the entire filesystem
+- **Memory efficiency** — files read on-demand instead of loading all into memory
+- **Single source of truth** — consistent file state across all agent capabilities
+
+Session files are mounted at `/workspace` in the bash environment, with path normalization shared between the `virtual_bash` and `session_file_system` capabilities.
+
+```rust
+use bashkit::{DirEntry, FileSystem, FileType, Metadata};
+
+pub struct SessionFileSystemAdapter {
+    session_id: SessionId,
+    store: Arc<dyn SessionFileStore>,
+}
+
+#[async_trait]
+impl FileSystem for SessionFileSystemAdapter {
+    async fn read_file(&self, path: &Path) -> Result<Vec<u8>> {
+        // Delegates to SessionFileStore::read_file
+    }
+
+    async fn stat(&self, path: &Path) -> Result<Metadata> {
+        // Builds Metadata from SessionFile info
+    }
+
+    async fn read_dir(&self, path: &Path) -> Result<Vec<DirEntry>> {
+        // Maps SessionFileStore::list_directory to Vec<DirEntry>
+    }
+    // ...
+}
+```
+
+### Resource Controls
+
+Bashkit's execution limits map directly to Everruns' per-session resource constraints — preventing runaway scripts from consuming shared infrastructure. The network allowlist ensures agents can only reach explicitly authorized domains.
+
+## Links
+
+- [GitHub repository](https://github.com/everruns/bashkit)

--- a/docs/ecosystem/bashkit.md
+++ b/docs/ecosystem/bashkit.md
@@ -29,39 +29,12 @@ Everruns integrates bashkit as the execution backend for the **virtual bash** ag
 
 ### Session Filesystem Bridge
 
-The key integration point is `SessionFileSystemAdapter` — a custom `FileSystem` implementation that bridges bashkit to the Everruns session file store. This gives agents:
+Bashkit's pluggable filesystem trait lets Everruns bridge the interpreter directly to the session file store. Files created by other tools are immediately visible inside bash, and vice versa — no pre/post sync needed. Session files are mounted at `/workspace` in the bash environment.
 
 - **Live file visibility** — files written by other tools during bash execution are immediately visible
 - **No sync overhead** — eliminates pre/post execution sync of the entire filesystem
 - **Memory efficiency** — files read on-demand instead of loading all into memory
 - **Single source of truth** — consistent file state across all agent capabilities
-
-Session files are mounted at `/workspace` in the bash environment, with path normalization shared between the `virtual_bash` and `session_file_system` capabilities.
-
-```rust
-use bashkit::{DirEntry, FileSystem, FileType, Metadata};
-
-pub struct SessionFileSystemAdapter {
-    session_id: SessionId,
-    store: Arc<dyn SessionFileStore>,
-}
-
-#[async_trait]
-impl FileSystem for SessionFileSystemAdapter {
-    async fn read_file(&self, path: &Path) -> Result<Vec<u8>> {
-        // Delegates to SessionFileStore::read_file
-    }
-
-    async fn stat(&self, path: &Path) -> Result<Metadata> {
-        // Builds Metadata from SessionFile info
-    }
-
-    async fn read_dir(&self, path: &Path) -> Result<Vec<DirEntry>> {
-        // Maps SessionFileStore::list_directory to Vec<DirEntry>
-    }
-    // ...
-}
-```
 
 ### Resource Controls
 


### PR DESCRIPTION
## What
Add a new **Ecosystem** section to the docs site with a Bashkit overview page. Hide the SRE Guide from the sidebar.

## Why
Bashkit is a core part of the Everruns ecosystem and needs user-facing documentation. The SRE Guide should be hidden from the public sidebar for now.

## How
- Created `docs/ecosystem/bashkit.md` — covers what bashkit is, core capabilities (85 built-in commands, POSIX shell, virtual FS, resource limits, network allowlist), and how Everruns integrates it via the session filesystem bridge
- Added `Ecosystem` sidebar section with autogenerate in `astro.config.mjs`
- Commented out the `SRE Guide` sidebar entry

## Risk
- Low
- Docs-only change, no runtime impact

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered