### PR TITLE
docs: fix SEO issues across docs site

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -28,8 +28,12 @@ export default defineConfig({
   integrations: [
     starlight({
       title: "Everruns",
+      description:
+        "Documentation for Everruns, a durable agentic harness engine for AI agents",
+      routeMiddleware: "./src/routeData.ts",
       logo: {
         src: "./src/assets/logo.svg",
+        alt: "Everruns",
       },
       favicon: "/favicon.svg",
       head: [

--- a/apps/docs/src/routeData.ts
+++ b/apps/docs/src/routeData.ts
@@ -1,0 +1,130 @@
+// Route middleware for SEO improvements on auto-generated pages.
+//
+// 1. Generates fallback meta descriptions for pages without explicit ones
+//    (primarily API reference pages from starlight-openapi).
+// 2. Strips "METHOD /path - " prefix from API operation page titles to keep
+//    <title> tags under 70 chars. The method and path are already shown
+//    separately on the page by the starlight-openapi Operation component.
+//
+// Head entries are already computed before middleware runs, so we modify
+// route.head directly (not just route.entry.data).
+
+import { defineRouteMiddleware } from "@astrojs/starlight/route-data";
+
+// Matches "GET /v1/foo - Description" or "POST /v1/foo/{id}/bar - Description"
+const methodPathPrefix =
+  /^(?:GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s+\S+\s+-\s+/;
+
+export const onRequest = defineRouteMiddleware((context) => {
+  const route = context.locals.starlightRoute;
+  if (!route.entry?.id) return;
+
+  const slug = route.entry.id;
+  const isApiOperation =
+    slug.startsWith("api/operations/") &&
+    !slug.startsWith("api/operations/tags/");
+
+  // Strip method+path prefix from API operation titles for shorter <title> tags.
+  // Update both entry.data.title (affects h1) and the <title> head entry.
+  if (isApiOperation) {
+    const cleanTitle = route.entry.data.title.replace(methodPathPrefix, "");
+    route.entry.data.title = cleanTitle;
+
+    // Update the <title> head entry
+    const titleEntry = route.head.find((e) => e.tag === "title");
+    if (titleEntry) {
+      titleEntry.content = titleEntry.content?.replace(methodPathPrefix, "");
+    }
+
+    // Update og:title
+    const ogTitle = route.head.find(
+      (e) =>
+        e.tag === "meta" &&
+        e.attrs &&
+        "property" in e.attrs &&
+        e.attrs.property === "og:title",
+    );
+    if (ogTitle?.attrs) {
+      ogTitle.attrs.content = cleanTitle;
+    }
+  }
+
+  // Generate meta description for pages without one.
+  // Check if a page-specific description already exists in the head.
+  const hasDescription = route.head.some(
+    (e) =>
+      e.tag === "meta" &&
+      e.attrs &&
+      "name" in e.attrs &&
+      e.attrs.name === "description",
+  );
+
+  if (!hasDescription || !route.entry.data.description) {
+    const description = deriveDescription(slug, route.entry.data.title);
+    route.entry.data.description = description;
+
+    // Replace or add meta description in head
+    const descIdx = route.head.findIndex(
+      (e) =>
+        e.tag === "meta" &&
+        e.attrs &&
+        "name" in e.attrs &&
+        e.attrs.name === "description",
+    );
+    const descEntry = {
+      tag: "meta" as const,
+      attrs: { name: "description", content: description },
+      content: "",
+    };
+    if (descIdx >= 0) {
+      route.head[descIdx] = descEntry;
+    } else {
+      route.head.push(descEntry);
+    }
+
+    // Also update/add og:description
+    const ogDescIdx = route.head.findIndex(
+      (e) =>
+        e.tag === "meta" &&
+        e.attrs &&
+        "property" in e.attrs &&
+        e.attrs.property === "og:description",
+    );
+    const ogDescEntry = {
+      tag: "meta" as const,
+      attrs: { property: "og:description", content: description },
+      content: "",
+    };
+    if (ogDescIdx >= 0) {
+      route.head[ogDescIdx] = ogDescEntry;
+    } else {
+      route.head.push(ogDescEntry);
+    }
+  }
+});
+
+function deriveDescription(slug: string, title: string): string {
+  // API tag group pages: derive tag name from slug (e.g. "api/operations/tags/agents" → "agents")
+  if (slug.startsWith("api/operations/tags/")) {
+    const tagName = slug.split("/").pop() ?? title;
+    return `Everruns API ${tagName} endpoints`;
+  }
+
+  // API operation pages (title is already cleaned of method+path prefix)
+  if (slug.startsWith("api/operations/")) {
+    return `${title} - Everruns API reference`;
+  }
+
+  // API overview page
+  if (slug === "api") {
+    return "Complete API reference for Everruns, including endpoints, schemas, and authentication";
+  }
+
+  // API schema pages
+  if (slug.startsWith("api/schemas/")) {
+    return `${title} schema - Everruns API reference`;
+  }
+
+  // Generic fallback
+  return `${title} - Everruns documentation`;
+}

--- a/docs/features/events.md
+++ b/docs/features/events.md
@@ -235,16 +235,8 @@ Events follow semantic versioning. The contract is defined in `specs/events-cont
 
 All events in API responses are well-defined types. The server filters out any internal or unsupported events before transmission.
 
-## OpenAPI Schema
-
-Full event schemas are documented in the OpenAPI specification:
-
-- [Event Schema](/api/schemas/Event)
-- [EventData Variants](/api/schemas/EventData)
-- [EventContext](/api/schemas/EventContext)
-
 ## Related Resources
 
-- [Event Reference](/features/event-reference) - Complete reference for all event types
+- [Event Reference](/event-reference/) - Complete reference for all event types
 - [specs/events.md](https://github.com/everruns/everruns/blob/main/specs/events.md) - Internal specification
 - [specs/events-contract.md](https://github.com/everruns/everruns/blob/main/specs/events-contract.md) - Contract specification

--- a/docs/features/skills-registry.md
+++ b/docs/features/skills-registry.md
@@ -102,4 +102,4 @@ Response:
 - Skill instructions are returned as tool results (not injected into system prompt)
 - Skill names are unique per organization
 - Disabled skills are hidden from capability listings
-- See the [Threat Model](/specs/threat-model/) for detailed security analysis (TM-TOOL-010 through TM-TOOL-014)
+- See the [Threat Model](https://github.com/everruns/everruns/blob/main/specs/threat-model.md) for detailed security analysis (TM-TOOL-010 through TM-TOOL-014)

--- a/specs/documentation.md
+++ b/specs/documentation.md
@@ -172,6 +172,50 @@ The OpenAPI spec should be regenerated and committed when API endpoints change:
 
 This ensures developers cannot forget to regenerate the spec after API changes.
 
+### SEO Requirements
+
+The docs site must maintain good SEO hygiene to ensure discoverability.
+
+#### Meta Descriptions
+
+Every page must have a `<meta name="description">` tag.
+
+- **Content pages**: Set `description` in YAML frontmatter (required for all `docs/*.md` files)
+- **API pages**: Auto-generated via route middleware (`apps/docs/src/routeData.ts`)
+- **Fallback**: Starlight `description` config provides a site-level fallback
+
+#### Page Titles
+
+Page titles (rendered as `<title>Title | Everruns</title>`) must not exceed 70 characters total.
+
+- Starlight appends ` | Everruns` (12 chars), so page titles must be ≤57 chars
+- For API pages, route middleware strips the `METHOD /path - ` prefix from OpenAPI summaries to shorten titles
+- When writing OpenAPI `summary` doc comments in Rust, the description after the `METHOD /path - ` prefix should be ≤57 chars
+
+#### Images
+
+All `<img>` tags must have an `alt` attribute.
+
+- The Starlight logo config must include `alt: "Everruns"`
+- Markdown images: `![descriptive alt text](path/to/image.png)`
+- HTML images: `<img src="..." alt="descriptive text" />`
+
+#### Links
+
+No internal links should produce 404 errors.
+
+- Content pages under `docs/` should link using root-relative paths matching the sidebar structure (e.g. `/event-reference/`, not `/features/event-reference`)
+- Links to internal specs (`specs/*.md`) should use absolute GitHub URLs since specs aren't published as docs pages
+- The `starlight-openapi` plugin does not generate individual schema pages — do not link to `/api/schemas/{SchemaName}`
+
+#### Route Middleware (`apps/docs/src/routeData.ts`)
+
+SEO improvements for auto-generated pages are handled by Starlight route middleware:
+
+1. Strips `METHOD /path - ` prefix from API operation titles for shorter `<title>` tags
+2. Generates per-page meta descriptions for API reference pages that lack frontmatter descriptions
+3. Updates `og:title` and `og:description` to match
+
 ### Future Enhancements
 
 1. **Versioned Documentation**: Support for multiple documentation versions


### PR DESCRIPTION
## Summary

- Add Starlight route middleware to auto-generate meta descriptions and shorten page titles for all API reference pages
- Fix broken internal links (wrong paths, non-existent schema pages, internal spec references)
- Add alt attribute to logo config (fixes missing alt on every page)
- Add SEO requirements section to specs/documentation.md to prevent regressions

## Issues Fixed

| Issue | Before | After |
|-------|--------|-------|
| Meta description missing | 104 pages | 0 pages |
| Title too long (>70 chars) | 20 pages | 0 pages |
| Alt attribute missing | 126 pages | 0 pages |
| HTTP 4xx broken links | 7 pages | 2 (Cloudflare email obfuscation, unfixable from docs) |

## Details

**Route middleware** (apps/docs/src/routeData.ts):
- Strips METHOD /path prefix from API operation titles
- Generates per-page meta description for API pages based on slug and title
- Updates og:title and og:description head entries to match

**Broken links fixed**:
- /features/event-reference to /event-reference/ (wrong path)
- Removed links to non-existent /api/schemas/ pages
- /specs/threat-model/ to absolute GitHub URL (specs are not published)

**SEO spec** (specs/documentation.md):
- Documents meta description, title length, image alt, and link requirements
- Documents the route middleware behavior

## Test plan

- [x] npm run build succeeds in apps/docs/
- [x] npm run check passes (0 errors)
- [x] All 128 pages have meta description tags
- [x] No page titles exceed 70 characters
- [x] Logo img has alt=Everruns on all pages
- [ ] CI green