### PR TITLE
feat(load-test): add load testing infrastructure with llmsim and durable race fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,8 @@ build/
 # AI
 .claude/*.local.json
 
+# Load test checkpoints
+crates/server/benches/checkpoints/
+
 # Tools
 .sqlx.envrc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ Fix root cause. Unsure: read more code; if stuck, ask w/ short options. Unrecogn
 - `specs/client-side-tools.md` - Client-side tools for API/SDK consumers
 - `specs/codesandbox.md` - CodeSandbox cloud sandbox integration
 - `specs/infinity-context.md` - Unlimited conversation length via context management
+- `specs/load-testing.md` - End-to-end load testing framework and benchmarking process
 
 ### Skills
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,7 +702,6 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.2",
  "windows-sys 0.59.0",
 ]
 
@@ -1269,7 +1268,7 @@ dependencies = [
  "fail",
  "futures",
  "hostname",
- "indicatif 0.18.4",
+ "indicatif",
  "minijinja",
  "opentelemetry",
  "opentelemetry_sdk",
@@ -1450,13 +1449,13 @@ dependencies = [
  "everruns-integrations-daytona",
  "everruns-integrations-docker",
  "everruns-internal-protocol",
+ "everruns-sdk",
  "everruns-session-sqldb",
  "everruns-worker",
  "futures",
  "hex",
  "http-body-util",
  "image",
- "indicatif 0.17.11",
  "inventory",
  "jsonwebtoken",
  "parking_lot",
@@ -2360,19 +2359,6 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
-dependencies = [
- "console 0.15.11",
- "number_prefix",
- "portable-atomic",
- "unicode-width 0.2.2",
- "web-time",
-]
-
-[[package]]
-name = "indicatif"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
@@ -3075,12 +3061,6 @@ checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "objc2-core-foundation"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,6 +702,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
+ "unicode-width 0.2.2",
  "windows-sys 0.59.0",
 ]
 
@@ -1218,6 +1219,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "rand 0.9.2",
  "reqwest 0.13.1",
  "rstest",
  "serde",
@@ -1249,7 +1251,7 @@ dependencies = [
  "fail",
  "futures",
  "hostname",
- "indicatif",
+ "indicatif 0.18.4",
  "minijinja",
  "opentelemetry",
  "opentelemetry_sdk",
@@ -1436,6 +1438,7 @@ dependencies = [
  "hex",
  "http-body-util",
  "image",
+ "indicatif 0.17.11",
  "inventory",
  "jsonwebtoken",
  "parking_lot",
@@ -2338,6 +2341,19 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console 0.15.11",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width 0.2.2",
+ "web-time",
+]
+
+[[package]]
+name = "indicatif"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
@@ -3040,6 +3056,12 @@ checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "objc2-core-foundation"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,6 +816,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1219,7 +1238,6 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "rand 0.9.2",
  "reqwest 0.13.1",
  "rstest",
  "serde",
@@ -1260,7 +1278,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "sysinfo",
+ "sysinfo 0.38.2",
  "test-log",
  "thiserror 2.0.18",
  "tokio",
@@ -1451,6 +1469,7 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "sqlx",
+ "sysinfo 0.33.1",
  "thiserror 2.0.18",
  "time",
  "tokio",
@@ -2173,7 +2192,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3893,6 +3912,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4906,6 +4945,20 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows 0.57.0",
+]
+
+[[package]]
+name = "sysinfo"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efc19935b4b66baa6f654ac7924c192f55b175c00a7ab72410fc24284dacda8"
@@ -4915,7 +4968,7 @@ dependencies = [
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -6031,12 +6084,22 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.62.2",
  "windows-future",
  "windows-numerics",
 ]
@@ -6047,7 +6110,19 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6056,10 +6131,10 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
 ]
 
@@ -6069,9 +6144,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
  "windows-link",
  "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6079,6 +6165,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6108,7 +6205,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
  "windows-link",
 ]
 
@@ -6119,8 +6216,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/crates/durable/src/persistence/memory.rs
+++ b/crates/durable/src/persistence/memory.rs
@@ -246,9 +246,17 @@ impl WorkflowEventStore for InMemoryWorkflowEventStore {
             .get_mut(&workflow_id)
             .ok_or(StoreError::WorkflowNotFound(workflow_id))?;
 
-        workflow.status = status;
-        workflow.result = result;
-        workflow.error = error;
+        workflow.status = status.clone();
+        if matches!(status, WorkflowStatus::Pending) {
+            // Clear transient fields when resetting for a new turn
+            workflow.result = None;
+            workflow.error = None;
+            workflow.started_at = None;
+            workflow.completed_at = None;
+        } else {
+            workflow.result = result;
+            workflow.error = error;
+        }
         Ok(())
     }
 

--- a/crates/durable/src/persistence/memory.rs
+++ b/crates/durable/src/persistence/memory.rs
@@ -246,7 +246,7 @@ impl WorkflowEventStore for InMemoryWorkflowEventStore {
             .get_mut(&workflow_id)
             .ok_or(StoreError::WorkflowNotFound(workflow_id))?;
 
-        workflow.status = status.clone();
+        workflow.status = status;
         if matches!(status, WorkflowStatus::Pending) {
             // Clear transient fields when resetting for a new turn
             workflow.result = None;

--- a/crates/durable/src/persistence/postgres.rs
+++ b/crates/durable/src/persistence/postgres.rs
@@ -325,18 +325,18 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
         };
 
         sqlx::query(query)
-        .bind(workflow_id)
-        .bind(&status_str)
-        .bind(&result)
-        .bind(&error_json)
-        .bind(started_at)
-        .bind(completed_at)
-        .execute(&self.pool)
-        .await
-        .map_err(|e| {
-            error!("Failed to update workflow status: {}", e);
-            StoreError::Database(e.to_string())
-        })?;
+            .bind(workflow_id)
+            .bind(&status_str)
+            .bind(&result)
+            .bind(&error_json)
+            .bind(started_at)
+            .bind(completed_at)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| {
+                error!("Failed to update workflow status: {}", e);
+                StoreError::Database(e.to_string())
+            })?;
 
         debug!(%workflow_id, %status_str, "updated workflow status");
         Ok(())

--- a/crates/durable/src/persistence/postgres.rs
+++ b/crates/durable/src/persistence/postgres.rs
@@ -287,6 +287,11 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
             .transpose()
             .map_err(|e| StoreError::Serialization(e.to_string()))?;
 
+        // When resetting to Pending (for multi-turn reuse), clear timestamps,
+        // result, and error so the workflow starts clean. For other transitions,
+        // use COALESCE to preserve existing values.
+        let reset_to_pending = matches!(status, WorkflowStatus::Pending);
+
         let (started_at, completed_at): (Option<DateTime<Utc>>, Option<DateTime<Utc>>) =
             match status {
                 WorkflowStatus::Running => (Some(Utc::now()), None),
@@ -296,7 +301,18 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
                 WorkflowStatus::Pending => (None, None),
             };
 
-        sqlx::query(
+        let query = if reset_to_pending {
+            // Clear all transient fields when resetting for a new turn
+            r#"
+            UPDATE durable_workflow_instances
+            SET status = $2,
+                result = NULL,
+                error = NULL,
+                started_at = NULL,
+                completed_at = NULL
+            WHERE id = $1
+            "#
+        } else {
             r#"
             UPDATE durable_workflow_instances
             SET status = $2,
@@ -305,8 +321,10 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
                 started_at = COALESCE($5, started_at),
                 completed_at = COALESCE($6, completed_at)
             WHERE id = $1
-            "#,
-        )
+            "#
+        };
+
+        sqlx::query(query)
         .bind(workflow_id)
         .bind(&status_str)
         .bind(&result)

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -72,3 +72,10 @@ prost.workspace = true
 [dev-dependencies]
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-native-certs", "blocking"] }
 http-body-util = "0.1"
+
+[[bench]]
+name = "load_test"
+harness = false
+
+[dev-dependencies.indicatif]
+version = "0.17"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -70,13 +70,11 @@ tonic.workspace = true
 prost.workspace = true
 
 [dev-dependencies]
-reqwest.workspace = true
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-native-certs", "blocking"] }
 http-body-util = "0.1"
 sysinfo = "0.33"
+everruns-sdk.workspace = true
 
 [[bench]]
 name = "load_test"
 harness = false
-
-[dev-dependencies.indicatif]
-version = "0.17"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -70,8 +70,9 @@ tonic.workspace = true
 prost.workspace = true
 
 [dev-dependencies]
-reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-native-certs", "blocking"] }
+reqwest.workspace = true
 http-body-util = "0.1"
+sysinfo = "0.33"
 
 [[bench]]
 name = "load_test"

--- a/crates/server/benches/checkpoints/.gitkeep
+++ b/crates/server/benches/checkpoints/.gitkeep
@@ -1,0 +1,2 @@
+# This directory stores load test checkpoints for historical comparison.
+# Checkpoints are committed to track performance over time.

--- a/crates/server/benches/load_test.rs
+++ b/crates/server/benches/load_test.rs
@@ -1,14 +1,11 @@
 //! Everruns Load Test
 //!
-//! Massive load testing for Everruns with llmsim. Supports:
-//! - Parallel session execution
-//! - Thousands of messages per session
-//! - Realistic LLM timing simulation
-//! - Chaos scenarios (timeouts, errors, rate limits)
-//! - Result checkpointing with --save
+//! Uses everruns-sdk for agent/message operations. Raw reqwest for:
+//! - Session creation (SDK lacks harness_id field)
+//! - Event polling (SDK lacks offset/limit pagination)
 //!
 //! Usage:
-//!   cargo run --release -p everruns-server --bench load_test
+//!   cargo bench --package everruns-server --bench load_test
 //!   # Or via just:
 //!   just load-test
 //!
@@ -26,12 +23,16 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
+use everruns_sdk::{CreateAgentRequest, Everruns};
 use futures::stream::{self, StreamExt};
 use parking_lot::Mutex;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use sysinfo::{CpuRefreshKind, MemoryRefreshKind, RefreshKind, System};
 use tokio::sync::Semaphore;
+
+/// Seed harness ID from seed.rs (DEFAULT_HARNESS = 0x01933b5a_0000_7000_8000_000000000601)
+const DEFAULT_HARNESS_ID: &str = "harness_01933b5a000070008000000000000601";
 
 // ============================================================================
 // Configuration
@@ -306,9 +307,7 @@ impl CheckpointStore {
                 && let Ok(file) = fs::File::open(&path)
             {
                 let reader = BufReader::new(file);
-                if let Ok(checkpoint) =
-                    serde_json::from_reader::<_, LoadTestCheckpoint>(reader)
-                {
+                if let Ok(checkpoint) = serde_json::from_reader::<_, LoadTestCheckpoint>(reader) {
                     checkpoints.push(checkpoint);
                 }
             }
@@ -323,34 +322,10 @@ impl CheckpointStore {
 }
 
 // ============================================================================
-// API Types
+// API Types (for raw reqwest calls where SDK lacks support)
 // ============================================================================
 
-#[derive(Debug, Serialize)]
-struct CreateHarnessRequest {
-    name: String,
-    system_prompt: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    default_model_id: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct Harness {
-    id: String,
-}
-
-#[derive(Debug, Serialize)]
-struct CreateAgentRequest {
-    name: String,
-    system_prompt: String,
-    default_model_id: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct Agent {
-    id: String,
-}
-
+/// Session creation requires harness_id which the SDK doesn't support yet
 #[derive(Debug, Serialize)]
 struct CreateSessionRequest {
     harness_id: String,
@@ -367,29 +342,7 @@ struct Session {
     id: String,
 }
 
-#[derive(Debug, Serialize)]
-struct CreateMessageRequest {
-    message: InputMessage,
-}
-
-#[derive(Debug, Serialize)]
-struct InputMessage {
-    content: Vec<ContentPart>,
-}
-
-#[derive(Debug, Serialize)]
-struct ContentPart {
-    #[serde(rename = "type")]
-    content_type: String,
-    text: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct Message {
-    #[allow(dead_code)]
-    id: String,
-}
-
+/// Event polling requires offset/limit which the SDK doesn't support yet
 #[derive(Debug, Deserialize)]
 struct Event {
     #[serde(rename = "type")]
@@ -514,88 +467,58 @@ impl MetricsSummary {
 
 struct LoadTestRunner {
     config: LoadTestConfig,
-    client: Client,
+    /// SDK client for agent/message operations
+    sdk: Everruns,
+    /// Raw reqwest for session creation (needs harness_id) and event polling (needs pagination)
+    http: Client,
     metrics: Arc<Metrics>,
 }
 
 impl LoadTestRunner {
     fn new(config: LoadTestConfig) -> Self {
-        let client = Client::builder()
+        let http = Client::builder()
             .timeout(Duration::from_secs(config.timeout_secs))
             .pool_max_idle_per_host(100)
             .build()
             .expect("Failed to create HTTP client");
 
+        // SDK client - uses dummy API key (AUTH_MODE=none ignores it)
+        let sdk = Everruns::with_base_url("load-test", &config.api_url)
+            .expect("Failed to create SDK client");
+
         Self {
             config,
-            client,
+            sdk,
+            http,
             metrics: Arc::new(Metrics::default()),
         }
     }
 
-    async fn create_load_test_harness(&self) -> anyhow::Result<String> {
-        let url = format!("{}/v1/harnesses", self.config.api_url);
-
-        let req = CreateHarnessRequest {
-            name: format!("Load Test Harness {}", chrono::Utc::now().timestamp()),
-            system_prompt: "You are a helpful assistant for load testing. Respond concisely."
-                .to_string(),
-            default_model_id: Some(self.config.model_id.clone()),
-        };
-
-        let resp = self
-            .client
-            .post(&url)
-            .json(&req)
-            .send()
-            .await?
-            .error_for_status()?
-            .json::<Harness>()
-            .await?;
-
-        Ok(resp.id)
-    }
-
+    /// Create agent via SDK
     async fn create_load_test_agent(&self) -> anyhow::Result<String> {
-        let url = format!("{}/v1/agents", self.config.api_url);
+        let req = CreateAgentRequest::new(
+            format!("Load Test Agent {}", chrono::Utc::now().timestamp()),
+            "You are a helpful assistant for load testing. Respond concisely.",
+        )
+        .default_model_id(&self.config.model_id);
 
-        let req = CreateAgentRequest {
-            name: format!("Load Test Agent {}", chrono::Utc::now().timestamp()),
-            system_prompt: "You are a helpful assistant for load testing. Respond concisely."
-                .to_string(),
-            default_model_id: self.config.model_id.clone(),
-        };
-
-        let resp = self
-            .client
-            .post(&url)
-            .json(&req)
-            .send()
-            .await?
-            .error_for_status()?
-            .json::<Agent>()
-            .await?;
-
-        Ok(resp.id)
+        let agent = self.sdk.agents().create_with_options(req).await?;
+        Ok(agent.id)
     }
 
-    async fn create_session(
-        &self,
-        harness_id: &str,
-        agent_id: &str,
-        session_num: usize,
-    ) -> anyhow::Result<String> {
+    /// Create session via raw reqwest (SDK lacks harness_id support)
+    async fn create_session(&self, agent_id: &str, session_num: usize) -> anyhow::Result<String> {
         let url = format!("{}/v1/sessions", self.config.api_url);
 
         let req = CreateSessionRequest {
-            harness_id: harness_id.to_string(),
+            harness_id: DEFAULT_HARNESS_ID.to_string(),
             agent_id: Some(agent_id.to_string()),
             title: Some(format!("Load Test Session {}", session_num)),
             model_id: Some(self.config.model_id.clone()),
         };
 
         let resp = self
-            .client
+            .http
             .post(&url)
             .json(&req)
             .send()
@@ -610,44 +533,21 @@ impl LoadTestRunner {
         Ok(resp.id)
     }
 
-    async fn send_message(
-        &self,
-        session_id: &str,
-        message_num: usize,
-    ) -> anyhow::Result<Duration> {
-        let url = format!(
-            "{}/v1/sessions/{}/messages",
-            self.config.api_url, session_id
-        );
-
+    /// Send message via SDK and poll for completion via raw reqwest
+    async fn send_message(&self, session_id: &str, message_num: usize) -> anyhow::Result<Duration> {
         let start = Instant::now();
 
-        let req = CreateMessageRequest {
-            message: InputMessage {
-                content: vec![ContentPart {
-                    content_type: "text".to_string(),
-                    text: format!(
-                        "Load test message {} of {}. Please respond briefly.",
-                        message_num + 1,
-                        self.config.messages_per_session
-                    ),
-                }],
-            },
-        };
+        let text = format!(
+            "Load test message {} of {}. Please respond briefly.",
+            message_num + 1,
+            self.config.messages_per_session
+        );
 
         self.metrics.messages_sent.fetch_add(1, Ordering::Relaxed);
 
-        let _msg = self
-            .client
-            .post(&url)
-            .json(&req)
-            .send()
-            .await?
-            .error_for_status()?
-            .json::<Message>()
-            .await?;
+        self.sdk.messages().create(session_id, &text).await?;
 
-        // Wait for turn completion by polling events
+        // Wait for turn completion by polling events (needs offset/limit)
         self.wait_for_turn_completion(session_id).await?;
 
         let duration = start.elapsed();
@@ -659,11 +559,9 @@ impl LoadTestRunner {
         Ok(duration)
     }
 
+    /// Poll events via raw reqwest (SDK lacks offset/limit pagination)
     async fn wait_for_turn_completion(&self, session_id: &str) -> anyhow::Result<()> {
-        let base_url = format!(
-            "{}/v1/sessions/{}/events",
-            self.config.api_url, session_id
-        );
+        let base_url = format!("{}/v1/sessions/{}/events", self.config.api_url, session_id);
 
         let timeout = Duration::from_secs(60);
         let start = Instant::now();
@@ -676,7 +574,7 @@ impl LoadTestRunner {
 
             let url = format!("{}?limit=100&offset={}", base_url, last_event_count);
             let resp = self
-                .client
+                .http
                 .get(&url)
                 .send()
                 .await?
@@ -701,14 +599,9 @@ impl LoadTestRunner {
         }
     }
 
-    async fn run_session(
-        &self,
-        harness_id: &str,
-        agent_id: &str,
-        session_num: usize,
-    ) -> anyhow::Result<()> {
+    async fn run_session(&self, agent_id: &str, session_num: usize) -> anyhow::Result<()> {
         // Create session
-        let session_id = match self.create_session(harness_id, agent_id, session_num).await {
+        let session_id = match self.create_session(agent_id, session_num).await {
             Ok(id) => id,
             Err(e) => {
                 self.metrics.sessions_failed.fetch_add(1, Ordering::Relaxed);
@@ -760,14 +653,13 @@ impl LoadTestRunner {
             "  Total messages:       {}",
             self.config.sessions * self.config.messages_per_session
         );
+        println!("  Harness:              {} (default)", DEFAULT_HARNESS_ID);
         println!();
 
-        // Create load test harness + agent
-        println!("🚀 Creating load test harness and agent...");
-        let harness_id = self.create_load_test_harness().await?;
-        println!("   Harness ID: {}", harness_id);
+        // Create agent via SDK
+        println!("Creating load test agent...");
         let agent_id = self.create_load_test_agent().await?;
-        println!("   Agent ID:   {}", agent_id);
+        println!("  Agent ID: {}", agent_id);
         println!();
 
         // Semaphore for concurrent session limit
@@ -777,7 +669,7 @@ impl LoadTestRunner {
         let total_messages = self.config.sessions * self.config.messages_per_session;
 
         println!(
-            "🔥 Starting load test with {} sessions ({} total messages)...",
+            "Starting load test with {} sessions ({} total messages)...",
             self.config.sessions, total_messages
         );
         println!();
@@ -804,15 +696,12 @@ impl LoadTestRunner {
         let session_futures: Vec<_> = (0..self.config.sessions)
             .map(|session_num| {
                 let runner = self.clone();
-                let harness_id = harness_id.clone();
                 let agent_id = agent_id.clone();
                 let semaphore = semaphore.clone();
 
                 async move {
                     let _permit = semaphore.acquire().await.unwrap();
-                    runner
-                        .run_session(&harness_id, &agent_id, session_num)
-                        .await
+                    runner.run_session(&agent_id, session_num).await
                 }
             })
             .collect();
@@ -875,7 +764,8 @@ impl Clone for LoadTestRunner {
     fn clone(&self) -> Self {
         Self {
             config: self.config.clone(),
-            client: self.client.clone(),
+            sdk: self.sdk.clone(),
+            http: self.http.clone(),
             metrics: self.metrics.clone(),
         }
     }
@@ -929,7 +819,10 @@ fn print_comparison(current: &MetricsSnapshot, previous: &[LoadTestCheckpoint]) 
     let baseline_metrics = &baseline.metrics;
 
     println!();
-    println!("📊 Comparison with previous run ({}):", baseline.environment.moniker);
+    println!(
+        "Comparison with previous run ({}):",
+        baseline.environment.moniker
+    );
     println!(
         "   Previous: {} @ {}",
         baseline.config.sessions * baseline.config.messages_per_session,
@@ -945,36 +838,43 @@ fn print_comparison(current: &MetricsSnapshot, previous: &[LoadTestCheckpoint]) 
     };
 
     let arrow = |pct: f64, higher_is_better: bool| -> &'static str {
-        let is_better = if higher_is_better { pct > 0.0 } else { pct < 0.0 };
-        if pct.abs() < 1.0 {
-            "≈"
-        } else if is_better {
-            "✅"
+        let is_better = if higher_is_better {
+            pct > 0.0
         } else {
-            "❌"
+            pct < 0.0
+        };
+        if pct.abs() < 1.0 {
+            "~"
+        } else if is_better {
+            "BETTER"
+        } else {
+            "WORSE"
         }
     };
 
-    let throughput_pct = pct_change(current.throughput_msg_per_sec, baseline_metrics.throughput_msg_per_sec);
+    let throughput_pct = pct_change(
+        current.throughput_msg_per_sec,
+        baseline_metrics.throughput_msg_per_sec,
+    );
     let p50_pct = pct_change(current.latency_p50_ms, baseline_metrics.latency_p50_ms);
     let p99_pct = pct_change(current.latency_p99_ms, baseline_metrics.latency_p99_ms);
 
     println!(
-        "   Throughput: {:>8.1} → {:>8.1} msg/sec ({:+.1}%) {}",
+        "   Throughput: {:>8.1} -> {:>8.1} msg/sec ({:+.1}%) {}",
         baseline_metrics.throughput_msg_per_sec,
         current.throughput_msg_per_sec,
         throughput_pct,
         arrow(throughput_pct, true)
     );
     println!(
-        "   P50:        {:>8.1} → {:>8.1} ms       ({:+.1}%) {}",
+        "   P50:        {:>8.1} -> {:>8.1} ms       ({:+.1}%) {}",
         baseline_metrics.latency_p50_ms,
         current.latency_p50_ms,
         p50_pct,
         arrow(p50_pct, false)
     );
     println!(
-        "   P99:        {:>8.1} → {:>8.1} ms       ({:+.1}%) {}",
+        "   P99:        {:>8.1} -> {:>8.1} ms       ({:+.1}%) {}",
         baseline_metrics.latency_p99_ms,
         current.latency_p99_ms,
         p99_pct,
@@ -1023,10 +923,10 @@ async fn main() -> anyhow::Result<()> {
         match store.save(&checkpoint) {
             Ok(path) => {
                 println!();
-                println!("💾 Results saved to: {}", path.display());
+                println!("Results saved to: {}", path.display());
             }
             Err(e) => {
-                eprintln!("⚠️  Failed to save results: {}", e);
+                eprintln!("Failed to save results: {}", e);
             }
         }
     }

--- a/crates/server/benches/load_test.rs
+++ b/crates/server/benches/load_test.rs
@@ -1,0 +1,610 @@
+//! Everruns Load Test
+//!
+//! Massive load testing for Everruns with llmsim. Supports:
+//! - Parallel session execution
+//! - Thousands of messages per session
+//! - Realistic LLM timing simulation
+//! - Chaos scenarios (timeouts, errors, rate limits)
+//!
+//! Usage:
+//!   cargo run --release -p everruns-control-plane --example load_test
+//!   # Or via just:
+//!   just load-test
+//!
+//! Configuration via environment:
+//!   API_URL=http://localhost:9000   # API endpoint
+//!   SESSIONS=100                    # Number of parallel sessions
+//!   MESSAGES_PER_SESSION=50         # Messages per session
+//!   MODEL_ID=llmsim                 # Model to use (llmsim, llmsim-ttft-500, etc.)
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use futures::stream::{self, StreamExt};
+use parking_lot::Mutex;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Semaphore;
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+#[derive(Clone)]
+struct LoadTestConfig {
+    api_url: String,
+    org: String,
+    sessions: usize,
+    messages_per_session: usize,
+    model_id: String,
+    max_concurrent_sessions: usize,
+    timeout_secs: u64,
+}
+
+impl Default for LoadTestConfig {
+    fn default() -> Self {
+        Self {
+            api_url: std::env::var("API_URL")
+                .unwrap_or_else(|_| "http://localhost:9000".to_string()),
+            org: std::env::var("ORG").unwrap_or_else(|_| "default".to_string()),
+            sessions: std::env::var("SESSIONS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(100),
+            messages_per_session: std::env::var("MESSAGES_PER_SESSION")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(50),
+            model_id: std::env::var("MODEL_ID").unwrap_or_else(|_| "llmsim".to_string()),
+            max_concurrent_sessions: std::env::var("MAX_CONCURRENT")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(50),
+            timeout_secs: std::env::var("TIMEOUT_SECS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(300),
+        }
+    }
+}
+
+// ============================================================================
+// API Types
+// ============================================================================
+
+#[derive(Debug, Serialize)]
+struct CreateAgentRequest {
+    name: String,
+    system_prompt: String,
+    default_model_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct Agent {
+    id: String,
+}
+
+#[derive(Debug, Serialize)]
+struct CreateSessionRequest {
+    title: Option<String>,
+    model_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Session {
+    id: String,
+}
+
+#[derive(Debug, Serialize)]
+struct CreateMessageRequest {
+    message: InputMessage,
+}
+
+#[derive(Debug, Serialize)]
+struct InputMessage {
+    content: Vec<ContentPart>,
+}
+
+#[derive(Debug, Serialize)]
+struct ContentPart {
+    #[serde(rename = "type")]
+    content_type: String,
+    text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct Message {
+    #[allow(dead_code)]
+    id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct Event {
+    #[serde(rename = "type")]
+    event_type: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct EventsResponse {
+    items: Vec<Event>,
+}
+
+// ============================================================================
+// Metrics
+// ============================================================================
+
+#[derive(Default)]
+struct Metrics {
+    sessions_created: AtomicU64,
+    sessions_completed: AtomicU64,
+    sessions_failed: AtomicU64,
+    messages_sent: AtomicU64,
+    messages_completed: AtomicU64,
+    messages_failed: AtomicU64,
+    latencies: Mutex<Vec<Duration>>,
+    errors: Mutex<Vec<String>>,
+}
+
+impl Metrics {
+    fn record_latency(&self, duration: Duration) {
+        self.latencies.lock().push(duration);
+    }
+
+    fn record_error(&self, error: String) {
+        let mut errors = self.errors.lock();
+        if errors.len() < 100 {
+            // Cap error collection
+            errors.push(error);
+        }
+    }
+
+    fn summary(&self) -> MetricsSummary {
+        let mut latencies = self.latencies.lock().clone();
+        latencies.sort();
+
+        let p50 = latencies
+            .get(latencies.len() / 2)
+            .copied()
+            .unwrap_or_default();
+        let p95 = latencies
+            .get(latencies.len() * 95 / 100)
+            .copied()
+            .unwrap_or_default();
+        let p99 = latencies
+            .get(latencies.len() * 99 / 100)
+            .copied()
+            .unwrap_or_default();
+        let avg = if latencies.is_empty() {
+            Duration::ZERO
+        } else {
+            latencies.iter().sum::<Duration>() / latencies.len() as u32
+        };
+
+        MetricsSummary {
+            sessions_created: self.sessions_created.load(Ordering::Relaxed),
+            sessions_completed: self.sessions_completed.load(Ordering::Relaxed),
+            sessions_failed: self.sessions_failed.load(Ordering::Relaxed),
+            messages_sent: self.messages_sent.load(Ordering::Relaxed),
+            messages_completed: self.messages_completed.load(Ordering::Relaxed),
+            messages_failed: self.messages_failed.load(Ordering::Relaxed),
+            latency_p50: p50,
+            latency_p95: p95,
+            latency_p99: p99,
+            latency_avg: avg,
+            errors: self.errors.lock().clone(),
+        }
+    }
+}
+
+struct MetricsSummary {
+    sessions_created: u64,
+    sessions_completed: u64,
+    sessions_failed: u64,
+    messages_sent: u64,
+    messages_completed: u64,
+    messages_failed: u64,
+    latency_p50: Duration,
+    latency_p95: Duration,
+    latency_p99: Duration,
+    latency_avg: Duration,
+    errors: Vec<String>,
+}
+
+// ============================================================================
+// Load Test Runner
+// ============================================================================
+
+struct LoadTestRunner {
+    config: LoadTestConfig,
+    client: Client,
+    metrics: Arc<Metrics>,
+}
+
+impl LoadTestRunner {
+    fn new(config: LoadTestConfig) -> Self {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(config.timeout_secs))
+            .pool_max_idle_per_host(100)
+            .build()
+            .expect("Failed to create HTTP client");
+
+        Self {
+            config,
+            client,
+            metrics: Arc::new(Metrics::default()),
+        }
+    }
+
+    async fn create_load_test_agent(&self) -> anyhow::Result<String> {
+        let url = format!("{}/v1/orgs/{}/agents", self.config.api_url, self.config.org);
+
+        let req = CreateAgentRequest {
+            name: format!("Load Test Agent {}", chrono::Utc::now().timestamp()),
+            system_prompt: "You are a helpful assistant for load testing. Respond concisely."
+                .to_string(),
+            default_model_id: self.config.model_id.clone(),
+        };
+
+        let resp = self
+            .client
+            .post(&url)
+            .json(&req)
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<Agent>()
+            .await?;
+
+        Ok(resp.id)
+    }
+
+    async fn create_session(&self, agent_id: &str, session_num: usize) -> anyhow::Result<String> {
+        let url = format!(
+            "{}/v1/orgs/{}/agents/{}/sessions",
+            self.config.api_url, self.config.org, agent_id
+        );
+
+        let req = CreateSessionRequest {
+            title: Some(format!("Load Test Session {}", session_num)),
+            model_id: Some(self.config.model_id.clone()),
+        };
+
+        let resp = self
+            .client
+            .post(&url)
+            .json(&req)
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<Session>()
+            .await?;
+
+        self.metrics
+            .sessions_created
+            .fetch_add(1, Ordering::Relaxed);
+        Ok(resp.id)
+    }
+
+    async fn send_message(
+        &self,
+        agent_id: &str,
+        session_id: &str,
+        message_num: usize,
+    ) -> anyhow::Result<Duration> {
+        let url = format!(
+            "{}/v1/orgs/{}/agents/{}/sessions/{}/messages",
+            self.config.api_url, self.config.org, agent_id, session_id
+        );
+
+        let start = Instant::now();
+
+        let req = CreateMessageRequest {
+            message: InputMessage {
+                content: vec![ContentPart {
+                    content_type: "text".to_string(),
+                    text: format!(
+                        "Load test message {} of {}. Please respond briefly.",
+                        message_num + 1,
+                        self.config.messages_per_session
+                    ),
+                }],
+            },
+        };
+
+        self.metrics.messages_sent.fetch_add(1, Ordering::Relaxed);
+
+        let _msg = self
+            .client
+            .post(&url)
+            .json(&req)
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<Message>()
+            .await?;
+
+        // Wait for turn completion by polling events
+        self.wait_for_turn_completion(agent_id, session_id).await?;
+
+        let duration = start.elapsed();
+        self.metrics.record_latency(duration);
+        self.metrics
+            .messages_completed
+            .fetch_add(1, Ordering::Relaxed);
+
+        Ok(duration)
+    }
+
+    async fn wait_for_turn_completion(
+        &self,
+        agent_id: &str,
+        session_id: &str,
+    ) -> anyhow::Result<()> {
+        let base_url = format!(
+            "{}/v1/orgs/{}/agents/{}/sessions/{}/events",
+            self.config.api_url, self.config.org, agent_id, session_id
+        );
+
+        let timeout = Duration::from_secs(60);
+        let start = Instant::now();
+        let mut last_event_count = 0;
+
+        loop {
+            if start.elapsed() > timeout {
+                return Err(anyhow::anyhow!("Timeout waiting for turn completion"));
+            }
+
+            let url = format!("{}?limit=100&offset={}", base_url, last_event_count);
+            let resp = self
+                .client
+                .get(&url)
+                .send()
+                .await?
+                .error_for_status()?
+                .json::<EventsResponse>()
+                .await?;
+
+            last_event_count += resp.items.len();
+
+            // Check for session.idled or session.completed
+            let completed = resp.items.iter().any(|e| {
+                e.event_type == "session.idled"
+                    || e.event_type == "session.completed"
+                    || e.event_type == "session.failed"
+            });
+
+            if completed {
+                return Ok(());
+            }
+
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    async fn run_session(&self, agent_id: &str, session_num: usize) -> anyhow::Result<()> {
+        // Create session
+        let session_id = match self.create_session(agent_id, session_num).await {
+            Ok(id) => id,
+            Err(e) => {
+                self.metrics.sessions_failed.fetch_add(1, Ordering::Relaxed);
+                self.metrics
+                    .record_error(format!("Session {} create failed: {}", session_num, e));
+                return Err(e);
+            }
+        };
+
+        // Send messages sequentially within session
+        for msg_num in 0..self.config.messages_per_session {
+            match self.send_message(agent_id, &session_id, msg_num).await {
+                Ok(_duration) => {}
+                Err(e) => {
+                    self.metrics.messages_failed.fetch_add(1, Ordering::Relaxed);
+                    self.metrics.record_error(format!(
+                        "Session {} message {} failed: {}",
+                        session_num, msg_num, e
+                    ));
+                    // Continue with next message
+                }
+            }
+        }
+
+        self.metrics
+            .sessions_completed
+            .fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+
+    async fn run(&self) -> anyhow::Result<MetricsSummary> {
+        println!("═══════════════════════════════════════════════════════════");
+        println!("              Everruns Load Test");
+        println!("═══════════════════════════════════════════════════════════");
+        println!();
+        println!("Configuration:");
+        println!("  API URL:              {}", self.config.api_url);
+        println!("  Organization:         {}", self.config.org);
+        println!("  Sessions:             {}", self.config.sessions);
+        println!(
+            "  Messages per session: {}",
+            self.config.messages_per_session
+        );
+        println!("  Model ID:             {}", self.config.model_id);
+        println!(
+            "  Max concurrent:       {}",
+            self.config.max_concurrent_sessions
+        );
+        println!(
+            "  Total messages:       {}",
+            self.config.sessions * self.config.messages_per_session
+        );
+        println!();
+
+        // Create load test agent
+        println!("🚀 Creating load test agent...");
+        let agent_id = self.create_load_test_agent().await?;
+        println!("   Agent ID: {}", agent_id);
+        println!();
+
+        // Semaphore for concurrent session limit
+        let semaphore = Arc::new(Semaphore::new(self.config.max_concurrent_sessions));
+
+        let start_time = Instant::now();
+        let total_messages = self.config.sessions * self.config.messages_per_session;
+
+        println!(
+            "🔥 Starting load test with {} sessions ({} total messages)...",
+            self.config.sessions, total_messages
+        );
+        println!();
+
+        // Progress reporting task
+        let metrics_clone = self.metrics.clone();
+        let progress_handle = tokio::spawn(async move {
+            let mut last_completed = 0u64;
+            loop {
+                tokio::time::sleep(Duration::from_secs(5)).await;
+                let completed = metrics_clone.messages_completed.load(Ordering::Relaxed);
+                let failed = metrics_clone.messages_failed.load(Ordering::Relaxed);
+                let sessions_done = metrics_clone.sessions_completed.load(Ordering::Relaxed);
+                let rate = (completed - last_completed) as f64 / 5.0;
+                last_completed = completed;
+                println!(
+                    "   Progress: {} messages completed, {} failed, {} sessions done ({:.1} msg/sec)",
+                    completed, failed, sessions_done, rate
+                );
+            }
+        });
+
+        // Run sessions in parallel with concurrency limit
+        let session_futures: Vec<_> = (0..self.config.sessions)
+            .map(|session_num| {
+                let runner = self.clone();
+                let agent_id = agent_id.clone();
+                let semaphore = semaphore.clone();
+
+                async move {
+                    let _permit = semaphore.acquire().await.unwrap();
+                    runner.run_session(&agent_id, session_num).await
+                }
+            })
+            .collect();
+
+        // Execute all sessions
+        stream::iter(session_futures)
+            .buffer_unordered(self.config.max_concurrent_sessions)
+            .collect::<Vec<_>>()
+            .await;
+
+        let total_duration = start_time.elapsed();
+        progress_handle.abort();
+
+        // Generate summary
+        let summary = self.metrics.summary();
+
+        println!();
+        println!("═══════════════════════════════════════════════════════════");
+        println!("                    Results");
+        println!("═══════════════════════════════════════════════════════════");
+        println!();
+        println!("Duration: {:.2}s", total_duration.as_secs_f64());
+        println!();
+        println!("Sessions:");
+        println!("  Created:   {}", summary.sessions_created);
+        println!("  Completed: {}", summary.sessions_completed);
+        println!("  Failed:    {}", summary.sessions_failed);
+        println!();
+        println!("Messages:");
+        println!("  Sent:      {}", summary.messages_sent);
+        println!("  Completed: {}", summary.messages_completed);
+        println!("  Failed:    {}", summary.messages_failed);
+        println!(
+            "  Throughput: {:.1} msg/sec",
+            summary.messages_completed as f64 / total_duration.as_secs_f64()
+        );
+        println!();
+        println!("Latency (message round-trip):");
+        println!("  P50: {:.0}ms", summary.latency_p50.as_secs_f64() * 1000.0);
+        println!("  P95: {:.0}ms", summary.latency_p95.as_secs_f64() * 1000.0);
+        println!("  P99: {:.0}ms", summary.latency_p99.as_secs_f64() * 1000.0);
+        println!("  Avg: {:.0}ms", summary.latency_avg.as_secs_f64() * 1000.0);
+
+        if !summary.errors.is_empty() {
+            println!();
+            println!("Errors (first 10):");
+            for (i, error) in summary.errors.iter().take(10).enumerate() {
+                println!("  {}. {}", i + 1, error);
+            }
+            if summary.errors.len() > 10 {
+                println!("  ... and {} more", summary.errors.len() - 10);
+            }
+        }
+
+        println!();
+        println!("═══════════════════════════════════════════════════════════");
+
+        Ok(summary)
+    }
+}
+
+impl Clone for LoadTestRunner {
+    fn clone(&self) -> Self {
+        Self {
+            config: self.config.clone(),
+            client: self.client.clone(),
+            metrics: self.metrics.clone(),
+        }
+    }
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Parse CLI args
+    let args: Vec<String> = std::env::args().collect();
+
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        println!("Everruns Load Test");
+        println!();
+        println!("Usage: load_test [OPTIONS]");
+        println!();
+        println!("Environment Variables:");
+        println!("  API_URL              API endpoint (default: http://localhost:9000)");
+        println!("  ORG                  Organization (default: default)");
+        println!("  SESSIONS             Number of parallel sessions (default: 100)");
+        println!("  MESSAGES_PER_SESSION Messages per session (default: 50)");
+        println!("  MODEL_ID             Model ID (default: llmsim)");
+        println!("  MAX_CONCURRENT       Max concurrent sessions (default: 50)");
+        println!("  TIMEOUT_SECS         Request timeout in seconds (default: 300)");
+        println!();
+        println!("Model ID options for different scenarios:");
+        println!("  llmsim               - Fast responses (no latency)");
+        println!("  llmsim-ttft-100      - 100ms delay before first token");
+        println!("  llmsim-ttft-500      - 500ms delay (realistic)");
+        println!("  llmsim-ttft-2000     - 2s delay (slow model simulation)");
+        println!();
+        println!("Examples:");
+        println!("  # Basic load test (100 sessions, 50 messages each = 5000 total)");
+        println!("  just load-test");
+        println!();
+        println!("  # High volume test");
+        println!("  SESSIONS=500 MESSAGES_PER_SESSION=100 just load-test");
+        println!();
+        println!("  # With realistic LLM delays");
+        println!("  MODEL_ID=llmsim-ttft-500 just load-test");
+        println!();
+        println!("  # Stress test with many concurrent sessions");
+        println!("  SESSIONS=1000 MAX_CONCURRENT=200 just load-test");
+        println!();
+        return Ok(());
+    }
+
+    let config = LoadTestConfig::default();
+    let runner = LoadTestRunner::new(config);
+
+    runner.run().await?;
+
+    Ok(())
+}

--- a/crates/server/benches/load_test.rs
+++ b/crates/server/benches/load_test.rs
@@ -5,9 +5,10 @@
 //! - Thousands of messages per session
 //! - Realistic LLM timing simulation
 //! - Chaos scenarios (timeouts, errors, rate limits)
+//! - Result checkpointing with --save
 //!
 //! Usage:
-//!   cargo run --release -p everruns-control-plane --example load_test
+//!   cargo run --release -p everruns-server --bench load_test
 //!   # Or via just:
 //!   just load-test
 //!
@@ -17,24 +18,28 @@
 //!   MESSAGES_PER_SESSION=50         # Messages per session
 //!   MODEL_ID=llmsim                 # Model to use (llmsim, llmsim-ttft-500, etc.)
 
+use std::fs;
+use std::io::{BufReader, BufWriter};
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
+use chrono::{DateTime, Utc};
 use futures::stream::{self, StreamExt};
 use parking_lot::Mutex;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
+use sysinfo::{CpuRefreshKind, MemoryRefreshKind, RefreshKind, System};
 use tokio::sync::Semaphore;
 
 // ============================================================================
 // Configuration
 // ============================================================================
 
-#[derive(Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct LoadTestConfig {
     api_url: String,
-    org: String,
     sessions: usize,
     messages_per_session: usize,
     model_id: String,
@@ -47,7 +52,6 @@ impl Default for LoadTestConfig {
         Self {
             api_url: std::env::var("API_URL")
                 .unwrap_or_else(|_| "http://localhost:9000".to_string()),
-            org: std::env::var("ORG").unwrap_or_else(|_| "default".to_string()),
             sessions: std::env::var("SESSIONS")
                 .ok()
                 .and_then(|s| s.parse().ok())
@@ -70,8 +74,270 @@ impl Default for LoadTestConfig {
 }
 
 // ============================================================================
+// CLI Args
+// ============================================================================
+
+struct CliArgs {
+    save: bool,
+    moniker: Option<String>,
+    help: bool,
+}
+
+impl CliArgs {
+    fn parse() -> Self {
+        let args: Vec<String> = std::env::args().collect();
+
+        let help = args.iter().any(|a| a == "--help" || a == "-h");
+        let save = args.iter().any(|a| a == "--save");
+
+        let moniker = args
+            .iter()
+            .position(|a| a == "--moniker")
+            .and_then(|i| args.get(i + 1))
+            .cloned();
+
+        Self {
+            save,
+            moniker,
+            help,
+        }
+    }
+}
+
+// ============================================================================
+// Checkpoint Types
+// ============================================================================
+
+/// Environment information for a benchmark run
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct EnvironmentInfo {
+    /// Human-readable moniker (e.g., "local-M4-46GB", "ci-4cpu-8gb")
+    moniker: String,
+    /// Operating system name and version
+    os: String,
+    /// CPU model/name
+    cpu_name: String,
+    /// Number of CPU cores
+    cpu_cores: usize,
+    /// Total system memory in GB
+    memory_gb: f64,
+    /// Hostname (optional)
+    hostname: Option<String>,
+}
+
+impl EnvironmentInfo {
+    /// Detect environment information automatically
+    fn detect() -> Self {
+        let system = System::new_with_specifics(
+            RefreshKind::nothing()
+                .with_cpu(CpuRefreshKind::everything())
+                .with_memory(MemoryRefreshKind::everything()),
+        );
+
+        let cpu_name = system
+            .cpus()
+            .first()
+            .map(|cpu| cpu.brand().to_string())
+            .unwrap_or_else(|| "Unknown CPU".to_string());
+
+        let cpu_cores = system.cpus().len();
+        let memory_gb = system.total_memory() as f64 / (1024.0 * 1024.0 * 1024.0);
+
+        let os = format!(
+            "{} {}",
+            System::name().unwrap_or_default(),
+            System::os_version().unwrap_or_default()
+        );
+        let hostname = System::host_name();
+
+        // Generate default moniker from environment
+        let moniker = Self::generate_moniker(&cpu_name, cpu_cores, memory_gb);
+
+        Self {
+            moniker,
+            os,
+            cpu_name,
+            cpu_cores,
+            memory_gb,
+            hostname,
+        }
+    }
+
+    /// Detect with custom moniker
+    fn detect_with_moniker(moniker: impl Into<String>) -> Self {
+        let mut info = Self::detect();
+        info.moniker = moniker.into();
+        info
+    }
+
+    /// Generate a default moniker from CPU/memory info
+    fn generate_moniker(cpu_name: &str, cores: usize, memory_gb: f64) -> String {
+        // Extract short CPU identifier
+        let cpu_short = if cpu_name.contains("Apple") {
+            cpu_name
+                .replace("Apple ", "")
+                .split_whitespace()
+                .collect::<Vec<_>>()
+                .join("-")
+        } else if cpu_name.contains("Intel") {
+            cpu_name
+                .split_whitespace()
+                .find(|s| s.starts_with('i') && s.contains('-'))
+                .unwrap_or("Intel")
+                .to_string()
+        } else if cpu_name.contains("AMD") {
+            let parts: Vec<&str> = cpu_name.split_whitespace().collect();
+            if parts.len() >= 4 {
+                format!(
+                    "R{}-{}",
+                    parts.get(2).unwrap_or(&""),
+                    parts.get(3).unwrap_or(&"")
+                )
+            } else {
+                "AMD".to_string()
+            }
+        } else {
+            format!("{}c", cores)
+        };
+
+        format!("local-{}-{}GB", cpu_short, memory_gb.round() as u64)
+    }
+}
+
+/// Serializable metrics for checkpointing
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct MetricsSnapshot {
+    sessions_created: u64,
+    sessions_completed: u64,
+    sessions_failed: u64,
+    messages_sent: u64,
+    messages_completed: u64,
+    messages_failed: u64,
+    latency_p50_ms: f64,
+    latency_p95_ms: f64,
+    latency_p99_ms: f64,
+    latency_avg_ms: f64,
+    throughput_msg_per_sec: f64,
+    duration_secs: f64,
+    error_count: usize,
+}
+
+/// A load test checkpoint for saving results
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct LoadTestCheckpoint {
+    /// Unique ID for this checkpoint
+    id: String,
+    /// Timestamp when test was run
+    timestamp: DateTime<Utc>,
+    /// Environment information
+    environment: EnvironmentInfo,
+    /// Test configuration
+    config: LoadTestConfig,
+    /// Metrics snapshot
+    metrics: MetricsSnapshot,
+    /// Sample errors (first 10)
+    errors: Vec<String>,
+}
+
+impl LoadTestCheckpoint {
+    fn new(
+        environment: EnvironmentInfo,
+        config: LoadTestConfig,
+        metrics: MetricsSnapshot,
+        errors: Vec<String>,
+    ) -> Self {
+        Self {
+            id: uuid::Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)).to_string(),
+            timestamp: Utc::now(),
+            environment,
+            config,
+            metrics,
+            errors,
+        }
+    }
+
+    fn filename(&self) -> String {
+        format!(
+            "load_test_{}_{}_{}_{}.json",
+            self.config.sessions,
+            self.config.messages_per_session,
+            self.environment.moniker.replace(' ', "_").to_lowercase(),
+            self.timestamp.format("%Y%m%d_%H%M%S"),
+        )
+    }
+}
+
+/// Manages checkpoint storage
+struct CheckpointStore {
+    directory: PathBuf,
+}
+
+impl CheckpointStore {
+    fn new() -> Self {
+        Self {
+            directory: PathBuf::from("crates/server/benches/checkpoints"),
+        }
+    }
+
+    fn save(&self, checkpoint: &LoadTestCheckpoint) -> std::io::Result<PathBuf> {
+        fs::create_dir_all(&self.directory)?;
+
+        let path = self.directory.join(checkpoint.filename());
+        let file = fs::File::create(&path)?;
+        let writer = BufWriter::new(file);
+        serde_json::to_writer_pretty(writer, checkpoint)?;
+
+        let absolute = path.canonicalize().unwrap_or(path);
+        Ok(absolute)
+    }
+
+    fn list_recent(&self, limit: usize) -> std::io::Result<Vec<LoadTestCheckpoint>> {
+        if !self.directory.exists() {
+            return Ok(Vec::new());
+        }
+
+        let mut checkpoints = Vec::new();
+
+        for entry in fs::read_dir(&self.directory)? {
+            let entry = entry?;
+            let path = entry.path();
+
+            if path.extension().map(|e| e == "json").unwrap_or(false)
+                && let Ok(file) = fs::File::open(&path)
+            {
+                let reader = BufReader::new(file);
+                if let Ok(checkpoint) =
+                    serde_json::from_reader::<_, LoadTestCheckpoint>(reader)
+                {
+                    checkpoints.push(checkpoint);
+                }
+            }
+        }
+
+        // Sort by timestamp (newest first)
+        checkpoints.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        checkpoints.truncate(limit);
+
+        Ok(checkpoints)
+    }
+}
+
+// ============================================================================
 // API Types
 // ============================================================================
+
+#[derive(Debug, Serialize)]
+struct CreateHarnessRequest {
+    name: String,
+    system_prompt: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    default_model_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Harness {
+    id: String,
+}
 
 #[derive(Debug, Serialize)]
 struct CreateAgentRequest {
@@ -87,7 +353,12 @@ struct Agent {
 
 #[derive(Debug, Serialize)]
 struct CreateSessionRequest {
+    harness_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    agent_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     model_id: Option<String>,
 }
 
@@ -154,12 +425,11 @@ impl Metrics {
     fn record_error(&self, error: String) {
         let mut errors = self.errors.lock();
         if errors.len() < 100 {
-            // Cap error collection
             errors.push(error);
         }
     }
 
-    fn summary(&self) -> MetricsSummary {
+    fn summary(&self, duration: Duration) -> MetricsSummary {
         let mut latencies = self.latencies.lock().clone();
         latencies.sort();
 
@@ -181,17 +451,22 @@ impl Metrics {
             latencies.iter().sum::<Duration>() / latencies.len() as u32
         };
 
+        let messages_completed = self.messages_completed.load(Ordering::Relaxed);
+        let throughput = messages_completed as f64 / duration.as_secs_f64();
+
         MetricsSummary {
             sessions_created: self.sessions_created.load(Ordering::Relaxed),
             sessions_completed: self.sessions_completed.load(Ordering::Relaxed),
             sessions_failed: self.sessions_failed.load(Ordering::Relaxed),
             messages_sent: self.messages_sent.load(Ordering::Relaxed),
-            messages_completed: self.messages_completed.load(Ordering::Relaxed),
+            messages_completed,
             messages_failed: self.messages_failed.load(Ordering::Relaxed),
             latency_p50: p50,
             latency_p95: p95,
             latency_p99: p99,
             latency_avg: avg,
+            throughput,
+            duration,
             errors: self.errors.lock().clone(),
         }
     }
@@ -208,7 +483,29 @@ struct MetricsSummary {
     latency_p95: Duration,
     latency_p99: Duration,
     latency_avg: Duration,
+    throughput: f64,
+    duration: Duration,
     errors: Vec<String>,
+}
+
+impl MetricsSummary {
+    fn to_snapshot(&self) -> MetricsSnapshot {
+        MetricsSnapshot {
+            sessions_created: self.sessions_created,
+            sessions_completed: self.sessions_completed,
+            sessions_failed: self.sessions_failed,
+            messages_sent: self.messages_sent,
+            messages_completed: self.messages_completed,
+            messages_failed: self.messages_failed,
+            latency_p50_ms: self.latency_p50.as_secs_f64() * 1000.0,
+            latency_p95_ms: self.latency_p95.as_secs_f64() * 1000.0,
+            latency_p99_ms: self.latency_p99.as_secs_f64() * 1000.0,
+            latency_avg_ms: self.latency_avg.as_secs_f64() * 1000.0,
+            throughput_msg_per_sec: self.throughput,
+            duration_secs: self.duration.as_secs_f64(),
+            error_count: self.errors.len(),
+        }
+    }
 }
 
 // ============================================================================
@@ -236,8 +533,31 @@ impl LoadTestRunner {
         }
     }
 
+    async fn create_load_test_harness(&self) -> anyhow::Result<String> {
+        let url = format!("{}/v1/harnesses", self.config.api_url);
+
+        let req = CreateHarnessRequest {
+            name: format!("Load Test Harness {}", chrono::Utc::now().timestamp()),
+            system_prompt: "You are a helpful assistant for load testing. Respond concisely."
+                .to_string(),
+            default_model_id: Some(self.config.model_id.clone()),
+        };
+
+        let resp = self
+            .client
+            .post(&url)
+            .json(&req)
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<Harness>()
+            .await?;
+
+        Ok(resp.id)
+    }
+
     async fn create_load_test_agent(&self) -> anyhow::Result<String> {
-        let url = format!("{}/v1/orgs/{}/agents", self.config.api_url, self.config.org);
+        let url = format!("{}/v1/agents", self.config.api_url);
 
         let req = CreateAgentRequest {
             name: format!("Load Test Agent {}", chrono::Utc::now().timestamp()),
@@ -259,13 +579,17 @@ impl LoadTestRunner {
         Ok(resp.id)
     }
 
-    async fn create_session(&self, agent_id: &str, session_num: usize) -> anyhow::Result<String> {
-        let url = format!(
-            "{}/v1/orgs/{}/agents/{}/sessions",
-            self.config.api_url, self.config.org, agent_id
-        );
+    async fn create_session(
+        &self,
+        harness_id: &str,
+        agent_id: &str,
+        session_num: usize,
+    ) -> anyhow::Result<String> {
+        let url = format!("{}/v1/sessions", self.config.api_url);
 
         let req = CreateSessionRequest {
+            harness_id: harness_id.to_string(),
+            agent_id: Some(agent_id.to_string()),
             title: Some(format!("Load Test Session {}", session_num)),
             model_id: Some(self.config.model_id.clone()),
         };
@@ -288,13 +612,12 @@ impl LoadTestRunner {
 
     async fn send_message(
         &self,
-        agent_id: &str,
         session_id: &str,
         message_num: usize,
     ) -> anyhow::Result<Duration> {
         let url = format!(
-            "{}/v1/orgs/{}/agents/{}/sessions/{}/messages",
-            self.config.api_url, self.config.org, agent_id, session_id
+            "{}/v1/sessions/{}/messages",
+            self.config.api_url, session_id
         );
 
         let start = Instant::now();
@@ -325,7 +648,7 @@ impl LoadTestRunner {
             .await?;
 
         // Wait for turn completion by polling events
-        self.wait_for_turn_completion(agent_id, session_id).await?;
+        self.wait_for_turn_completion(session_id).await?;
 
         let duration = start.elapsed();
         self.metrics.record_latency(duration);
@@ -336,14 +659,10 @@ impl LoadTestRunner {
         Ok(duration)
     }
 
-    async fn wait_for_turn_completion(
-        &self,
-        agent_id: &str,
-        session_id: &str,
-    ) -> anyhow::Result<()> {
+    async fn wait_for_turn_completion(&self, session_id: &str) -> anyhow::Result<()> {
         let base_url = format!(
-            "{}/v1/orgs/{}/agents/{}/sessions/{}/events",
-            self.config.api_url, self.config.org, agent_id, session_id
+            "{}/v1/sessions/{}/events",
+            self.config.api_url, session_id
         );
 
         let timeout = Duration::from_secs(60);
@@ -382,9 +701,14 @@ impl LoadTestRunner {
         }
     }
 
-    async fn run_session(&self, agent_id: &str, session_num: usize) -> anyhow::Result<()> {
+    async fn run_session(
+        &self,
+        harness_id: &str,
+        agent_id: &str,
+        session_num: usize,
+    ) -> anyhow::Result<()> {
         // Create session
-        let session_id = match self.create_session(agent_id, session_num).await {
+        let session_id = match self.create_session(harness_id, agent_id, session_num).await {
             Ok(id) => id,
             Err(e) => {
                 self.metrics.sessions_failed.fetch_add(1, Ordering::Relaxed);
@@ -396,7 +720,7 @@ impl LoadTestRunner {
 
         // Send messages sequentially within session
         for msg_num in 0..self.config.messages_per_session {
-            match self.send_message(agent_id, &session_id, msg_num).await {
+            match self.send_message(&session_id, msg_num).await {
                 Ok(_duration) => {}
                 Err(e) => {
                     self.metrics.messages_failed.fetch_add(1, Ordering::Relaxed);
@@ -422,7 +746,6 @@ impl LoadTestRunner {
         println!();
         println!("Configuration:");
         println!("  API URL:              {}", self.config.api_url);
-        println!("  Organization:         {}", self.config.org);
         println!("  Sessions:             {}", self.config.sessions);
         println!(
             "  Messages per session: {}",
@@ -439,10 +762,12 @@ impl LoadTestRunner {
         );
         println!();
 
-        // Create load test agent
-        println!("🚀 Creating load test agent...");
+        // Create load test harness + agent
+        println!("🚀 Creating load test harness and agent...");
+        let harness_id = self.create_load_test_harness().await?;
+        println!("   Harness ID: {}", harness_id);
         let agent_id = self.create_load_test_agent().await?;
-        println!("   Agent ID: {}", agent_id);
+        println!("   Agent ID:   {}", agent_id);
         println!();
 
         // Semaphore for concurrent session limit
@@ -479,12 +804,15 @@ impl LoadTestRunner {
         let session_futures: Vec<_> = (0..self.config.sessions)
             .map(|session_num| {
                 let runner = self.clone();
+                let harness_id = harness_id.clone();
                 let agent_id = agent_id.clone();
                 let semaphore = semaphore.clone();
 
                 async move {
                     let _permit = semaphore.acquire().await.unwrap();
-                    runner.run_session(&agent_id, session_num).await
+                    runner
+                        .run_session(&harness_id, &agent_id, session_num)
+                        .await
                 }
             })
             .collect();
@@ -499,7 +827,7 @@ impl LoadTestRunner {
         progress_handle.abort();
 
         // Generate summary
-        let summary = self.metrics.summary();
+        let summary = self.metrics.summary(total_duration);
 
         println!();
         println!("═══════════════════════════════════════════════════════════");
@@ -517,10 +845,7 @@ impl LoadTestRunner {
         println!("  Sent:      {}", summary.messages_sent);
         println!("  Completed: {}", summary.messages_completed);
         println!("  Failed:    {}", summary.messages_failed);
-        println!(
-            "  Throughput: {:.1} msg/sec",
-            summary.messages_completed as f64 / total_duration.as_secs_f64()
-        );
+        println!("  Throughput: {:.1} msg/sec", summary.throughput);
         println!();
         println!("Latency (message round-trip):");
         println!("  P50: {:.0}ms", summary.latency_p50.as_secs_f64() * 1000.0);
@@ -560,51 +885,151 @@ impl Clone for LoadTestRunner {
 // Main
 // ============================================================================
 
+fn print_help() {
+    println!("Everruns Load Test");
+    println!();
+    println!("Usage: load_test [OPTIONS]");
+    println!();
+    println!("Options:");
+    println!("  --save              Save results to crates/server/benches/checkpoints/");
+    println!("  --moniker <NAME>    Set custom environment moniker for saved results");
+    println!("  --help, -h          Show this help message");
+    println!();
+    println!("Environment Variables:");
+    println!("  API_URL              API endpoint (default: http://localhost:9000)");
+    println!("  SESSIONS             Number of parallel sessions (default: 100)");
+    println!("  MESSAGES_PER_SESSION Messages per session (default: 50)");
+    println!("  MODEL_ID             Model ID (default: llmsim)");
+    println!("  MAX_CONCURRENT       Max concurrent sessions (default: 50)");
+    println!("  TIMEOUT_SECS         Request timeout in seconds (default: 300)");
+    println!();
+    println!("Model ID options for different scenarios:");
+    println!("  llmsim               - Fast responses (no latency)");
+    println!("  llmsim-ttft-100      - 100ms delay before first token");
+    println!("  llmsim-ttft-500      - 500ms delay (realistic)");
+    println!("  llmsim-ttft-2000     - 2s delay (slow model simulation)");
+    println!();
+    println!("Examples:");
+    println!("  # Basic load test");
+    println!("  just load-test medium");
+    println!();
+    println!("  # Save results with custom moniker");
+    println!("  just load-test medium --save --moniker ci-4cpu-8gb");
+    println!();
+    println!("  # High volume test with save");
+    println!("  SESSIONS=500 just load-test heavy --save");
+}
+
+fn print_comparison(current: &MetricsSnapshot, previous: &[LoadTestCheckpoint]) {
+    if previous.is_empty() {
+        return;
+    }
+
+    let baseline = &previous[0];
+    let baseline_metrics = &baseline.metrics;
+
+    println!();
+    println!("📊 Comparison with previous run ({}):", baseline.environment.moniker);
+    println!(
+        "   Previous: {} @ {}",
+        baseline.config.sessions * baseline.config.messages_per_session,
+        baseline.timestamp.format("%Y-%m-%d %H:%M")
+    );
+
+    let pct_change = |current: f64, baseline: f64| -> f64 {
+        if baseline == 0.0 {
+            0.0
+        } else {
+            ((current - baseline) / baseline) * 100.0
+        }
+    };
+
+    let arrow = |pct: f64, higher_is_better: bool| -> &'static str {
+        let is_better = if higher_is_better { pct > 0.0 } else { pct < 0.0 };
+        if pct.abs() < 1.0 {
+            "≈"
+        } else if is_better {
+            "✅"
+        } else {
+            "❌"
+        }
+    };
+
+    let throughput_pct = pct_change(current.throughput_msg_per_sec, baseline_metrics.throughput_msg_per_sec);
+    let p50_pct = pct_change(current.latency_p50_ms, baseline_metrics.latency_p50_ms);
+    let p99_pct = pct_change(current.latency_p99_ms, baseline_metrics.latency_p99_ms);
+
+    println!(
+        "   Throughput: {:>8.1} → {:>8.1} msg/sec ({:+.1}%) {}",
+        baseline_metrics.throughput_msg_per_sec,
+        current.throughput_msg_per_sec,
+        throughput_pct,
+        arrow(throughput_pct, true)
+    );
+    println!(
+        "   P50:        {:>8.1} → {:>8.1} ms       ({:+.1}%) {}",
+        baseline_metrics.latency_p50_ms,
+        current.latency_p50_ms,
+        p50_pct,
+        arrow(p50_pct, false)
+    );
+    println!(
+        "   P99:        {:>8.1} → {:>8.1} ms       ({:+.1}%) {}",
+        baseline_metrics.latency_p99_ms,
+        current.latency_p99_ms,
+        p99_pct,
+        arrow(p99_pct, false)
+    );
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // Parse CLI args
-    let args: Vec<String> = std::env::args().collect();
+    let cli = CliArgs::parse();
 
-    if args.iter().any(|a| a == "--help" || a == "-h") {
-        println!("Everruns Load Test");
-        println!();
-        println!("Usage: load_test [OPTIONS]");
-        println!();
-        println!("Environment Variables:");
-        println!("  API_URL              API endpoint (default: http://localhost:9000)");
-        println!("  ORG                  Organization (default: default)");
-        println!("  SESSIONS             Number of parallel sessions (default: 100)");
-        println!("  MESSAGES_PER_SESSION Messages per session (default: 50)");
-        println!("  MODEL_ID             Model ID (default: llmsim)");
-        println!("  MAX_CONCURRENT       Max concurrent sessions (default: 50)");
-        println!("  TIMEOUT_SECS         Request timeout in seconds (default: 300)");
-        println!();
-        println!("Model ID options for different scenarios:");
-        println!("  llmsim               - Fast responses (no latency)");
-        println!("  llmsim-ttft-100      - 100ms delay before first token");
-        println!("  llmsim-ttft-500      - 500ms delay (realistic)");
-        println!("  llmsim-ttft-2000     - 2s delay (slow model simulation)");
-        println!();
-        println!("Examples:");
-        println!("  # Basic load test (100 sessions, 50 messages each = 5000 total)");
-        println!("  just load-test");
-        println!();
-        println!("  # High volume test");
-        println!("  SESSIONS=500 MESSAGES_PER_SESSION=100 just load-test");
-        println!();
-        println!("  # With realistic LLM delays");
-        println!("  MODEL_ID=llmsim-ttft-500 just load-test");
-        println!();
-        println!("  # Stress test with many concurrent sessions");
-        println!("  SESSIONS=1000 MAX_CONCURRENT=200 just load-test");
-        println!();
+    if cli.help {
+        print_help();
         return Ok(());
     }
 
     let config = LoadTestConfig::default();
-    let runner = LoadTestRunner::new(config);
+    let runner = LoadTestRunner::new(config.clone());
 
-    runner.run().await?;
+    let summary = runner.run().await?;
+
+    // Save checkpoint if requested
+    if cli.save {
+        let environment = match &cli.moniker {
+            Some(m) => EnvironmentInfo::detect_with_moniker(m),
+            None => EnvironmentInfo::detect(),
+        };
+
+        let store = CheckpointStore::new();
+
+        // Load previous results for comparison
+        let previous = store.list_recent(5).unwrap_or_default();
+
+        let snapshot = summary.to_snapshot();
+
+        // Print comparison if we have previous results
+        print_comparison(&snapshot, &previous);
+
+        let checkpoint = LoadTestCheckpoint::new(
+            environment,
+            config,
+            snapshot,
+            summary.errors.into_iter().take(10).collect(),
+        );
+
+        match store.save(&checkpoint) {
+            Ok(path) => {
+                println!();
+                println!("💾 Results saved to: {}", path.display());
+            }
+            Err(e) => {
+                eprintln!("⚠️  Failed to save results: {}", e);
+            }
+        }
+    }
 
     Ok(())
 }

--- a/crates/server/benches/load_test.rs
+++ b/crates/server/benches/load_test.rs
@@ -10,7 +10,7 @@
 //!   just load-test
 //!
 //! Configuration via environment:
-//!   API_URL=http://localhost:9000   # API endpoint
+//!   API_URL=http://localhost:9300/api   # API endpoint
 //!   SESSIONS=100                    # Number of parallel sessions
 //!   MESSAGES_PER_SESSION=50         # Messages per session
 //!   MODEL_ID=llmsim                 # Model to use (llmsim, llmsim-ttft-500, etc.)
@@ -55,7 +55,7 @@ impl Default for LoadTestConfig {
     fn default() -> Self {
         Self {
             api_url: std::env::var("API_URL")
-                .unwrap_or_else(|_| "http://localhost:9000".to_string()),
+                .unwrap_or_else(|_| "http://localhost:9300/api".to_string()),
             sessions: std::env::var("SESSIONS")
                 .ok()
                 .and_then(|s| s.parse().ok())
@@ -344,18 +344,18 @@ struct CreateSessionRequest {
 #[derive(Debug, Deserialize)]
 struct Session {
     id: String,
-}
-
-/// Event polling requires offset/limit which the SDK doesn't support yet
-#[derive(Debug, Deserialize)]
-struct Event {
-    #[serde(rename = "type")]
-    event_type: String,
+    #[serde(default)]
+    status: String,
 }
 
 #[derive(Debug, Deserialize)]
-struct EventsResponse {
-    data: Vec<Event>,
+struct MessageResponse {
+    role: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct MessagesListResponse {
+    data: Vec<MessageResponse>,
 }
 
 // ============================================================================
@@ -537,8 +537,20 @@ impl LoadTestRunner {
         Ok(resp.id)
     }
 
-    /// Send message via raw reqwest and poll for completion
-    async fn send_message(&self, session_id: &str, message_num: usize) -> anyhow::Result<Duration> {
+    /// Send message and wait for the agent's response to appear.
+    /// Waits for session to be idle before sending to ensure the server
+    /// creates a new turn (it won't if the session is still active).
+    async fn send_message(
+        &self,
+        session_id: &str,
+        message_num: usize,
+        expected_agent_count: usize,
+    ) -> anyhow::Result<Duration> {
+        // Ensure session is idle before sending (server ignores messages to active sessions)
+        if message_num > 0 {
+            self.wait_for_session_idle(session_id).await?;
+        }
+
         let start = Instant::now();
 
         let text = format!(
@@ -549,8 +561,6 @@ impl LoadTestRunner {
 
         self.metrics.messages_sent.fetch_add(1, Ordering::Relaxed);
 
-        // Use raw reqwest instead of SDK — the published SDK's Message type
-        // may be out of sync with the server, and we don't need the response body.
         let url = format!("{}/v1/sessions/{}/messages", self.config.api_url, session_id);
         let body = serde_json::json!({
             "message": {
@@ -565,8 +575,9 @@ impl LoadTestRunner {
             .await?
             .error_for_status()?;
 
-        // Wait for turn completion by polling events (needs offset/limit)
-        self.wait_for_turn_completion(session_id).await?;
+        // Wait until the agent's response message appears
+        self.wait_for_agent_response(session_id, expected_agent_count)
+            .await?;
 
         let duration = start.elapsed();
         self.metrics.record_latency(duration);
@@ -577,39 +588,60 @@ impl LoadTestRunner {
         Ok(duration)
     }
 
-    /// Poll events via raw reqwest (SDK lacks offset/limit pagination)
-    async fn wait_for_turn_completion(&self, session_id: &str) -> anyhow::Result<()> {
-        let base_url = format!("{}/v1/sessions/{}/events", self.config.api_url, session_id);
-
+    /// Poll session status until idle.
+    async fn wait_for_session_idle(&self, session_id: &str) -> anyhow::Result<()> {
+        let url = format!("{}/v1/sessions/{}", self.config.api_url, session_id);
         let timeout = Duration::from_secs(60);
         let start = Instant::now();
-        let mut last_event_count = 0;
 
         loop {
             if start.elapsed() > timeout {
-                return Err(anyhow::anyhow!("Timeout waiting for turn completion"));
+                return Err(anyhow::anyhow!("Timeout waiting for session idle"));
             }
 
-            let url = format!("{}?limit=100&offset={}", base_url, last_event_count);
-            let resp = self
+            let session: Session = self
                 .http
                 .get(&url)
                 .send()
                 .await?
                 .error_for_status()?
-                .json::<EventsResponse>()
+                .json()
                 .await?;
 
-            last_event_count += resp.data.len();
+            if session.status == "idle" {
+                return Ok(());
+            }
 
-            // Check for session.idled or session.completed
-            let completed = resp.data.iter().any(|e| {
-                e.event_type == "session.idled"
-                    || e.event_type == "session.completed"
-                    || e.event_type == "session.failed"
-            });
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
 
-            if completed {
+    /// Poll messages endpoint until we see the expected number of agent messages.
+    async fn wait_for_agent_response(
+        &self,
+        session_id: &str,
+        expected_agent_count: usize,
+    ) -> anyhow::Result<()> {
+        let url = format!("{}/v1/sessions/{}/messages", self.config.api_url, session_id);
+        let timeout = Duration::from_secs(60);
+        let start = Instant::now();
+
+        loop {
+            if start.elapsed() > timeout {
+                return Err(anyhow::anyhow!("Timeout waiting for agent response"));
+            }
+
+            let resp: MessagesListResponse = self
+                .http
+                .get(&url)
+                .send()
+                .await?
+                .error_for_status()?
+                .json()
+                .await?;
+
+            let agent_count = resp.data.iter().filter(|m| m.role == "agent").count();
+            if agent_count >= expected_agent_count {
                 return Ok(());
             }
 
@@ -629,9 +661,13 @@ impl LoadTestRunner {
             }
         };
 
-        // Send messages sequentially within session
+        // Send messages sequentially — each waits for agent response before next
         for msg_num in 0..self.config.messages_per_session {
-            match self.send_message(&session_id, msg_num).await {
+            let expected_agent_count = msg_num + 1;
+            match self
+                .send_message(&session_id, msg_num, expected_agent_count)
+                .await
+            {
                 Ok(_duration) => {}
                 Err(e) => {
                     self.metrics.messages_failed.fetch_add(1, Ordering::Relaxed);
@@ -804,7 +840,7 @@ fn print_help() {
     println!("  --help, -h          Show this help message");
     println!();
     println!("Environment Variables:");
-    println!("  API_URL              API endpoint (default: http://localhost:9000)");
+    println!("  API_URL              API endpoint (default: http://localhost:9300/api)");
     println!("  SESSIONS             Number of parallel sessions (default: 100)");
     println!("  MESSAGES_PER_SESSION Messages per session (default: 50)");
     println!("  MODEL_ID             Model ID (default: seed llmsim model)");

--- a/crates/server/benches/load_test.rs
+++ b/crates/server/benches/load_test.rs
@@ -280,7 +280,7 @@ struct CheckpointStore {
 impl CheckpointStore {
     fn new() -> Self {
         Self {
-            directory: PathBuf::from("crates/server/benches/checkpoints"),
+            directory: PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/checkpoints"),
         }
     }
 

--- a/crates/server/benches/load_test.rs
+++ b/crates/server/benches/load_test.rs
@@ -266,21 +266,20 @@ impl ServerInfo {
 
         // GET /v1/durable/health -> worker topology
         let durable_url = format!("{}/v1/durable/health", base_url);
-        let (workers, active_workers, total_capacity) =
-            match http.get(&durable_url).send().await {
-                Ok(resp) => {
-                    if let Ok(body) = resp.json::<serde_json::Value>().await {
-                        (
-                            body["total_workers"].as_u64().unwrap_or(0) as usize,
-                            body["active_workers"].as_u64().unwrap_or(0) as usize,
-                            body["total_capacity"].as_u64().unwrap_or(0) as usize,
-                        )
-                    } else {
-                        (0, 0, 0)
-                    }
+        let (workers, active_workers, total_capacity) = match http.get(&durable_url).send().await {
+            Ok(resp) => {
+                if let Ok(body) = resp.json::<serde_json::Value>().await {
+                    (
+                        body["total_workers"].as_u64().unwrap_or(0) as usize,
+                        body["active_workers"].as_u64().unwrap_or(0) as usize,
+                        body["total_capacity"].as_u64().unwrap_or(0) as usize,
+                    )
+                } else {
+                    (0, 0, 0)
                 }
-                Err(_) => (0, 0, 0),
-            };
+            }
+            Err(_) => (0, 0, 0),
+        };
 
         // Target: explicit env var or auto-inferred from URL + worker count
         let target = std::env::var("TARGET").unwrap_or_else(|_| {
@@ -666,7 +665,10 @@ impl LoadTestRunner {
 
         self.metrics.messages_sent.fetch_add(1, Ordering::Relaxed);
 
-        let url = format!("{}/v1/sessions/{}/messages", self.config.api_url, session_id);
+        let url = format!(
+            "{}/v1/sessions/{}/messages",
+            self.config.api_url, session_id
+        );
         let body = serde_json::json!({
             "message": {
                 "role": "user",
@@ -727,7 +729,10 @@ impl LoadTestRunner {
         session_id: &str,
         expected_agent_count: usize,
     ) -> anyhow::Result<()> {
-        let url = format!("{}/v1/sessions/{}/messages", self.config.api_url, session_id);
+        let url = format!(
+            "{}/v1/sessions/{}/messages",
+            self.config.api_url, session_id
+        );
         let timeout = Duration::from_secs(60);
         let start = Instant::now();
 
@@ -985,7 +990,9 @@ fn print_help() {
     println!("  TARGET=docker-example just load-test quick --save");
     println!();
     println!("  # Named bench (history depth test)");
-    println!("  SESSIONS=1 MESSAGES_PER_SESSION=200 just load-test quick --save --bench-name history-depth");
+    println!(
+        "  SESSIONS=1 MESSAGES_PER_SESSION=200 just load-test quick --save --bench-name history-depth"
+    );
     println!();
     println!("  # High volume test with save");
     println!("  SESSIONS=500 just load-test heavy --save");

--- a/crates/server/benches/load_test.rs
+++ b/crates/server/benches/load_test.rs
@@ -14,6 +14,7 @@
 //!   SESSIONS=100                    # Number of parallel sessions
 //!   MESSAGES_PER_SESSION=50         # Messages per session
 //!   MODEL_ID=llmsim                 # Model to use (llmsim, llmsim-ttft-500, etc.)
+//!   TARGET=docker-example           # Target label (auto-detected if unset)
 
 use std::fs;
 use std::io::{BufReader, BufWriter};
@@ -49,6 +50,8 @@ struct LoadTestConfig {
     model_id: String,
     max_concurrent_sessions: usize,
     timeout_secs: u64,
+    #[serde(default = "default_bench_name")]
+    bench_name: String,
 }
 
 impl Default for LoadTestConfig {
@@ -74,6 +77,7 @@ impl Default for LoadTestConfig {
                 .ok()
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(300),
+            bench_name: "throughput".to_string(),
         }
     }
 }
@@ -85,6 +89,7 @@ impl Default for LoadTestConfig {
 struct CliArgs {
     save: bool,
     moniker: Option<String>,
+    bench_name: Option<String>,
     help: bool,
 }
 
@@ -101,9 +106,16 @@ impl CliArgs {
             .and_then(|i| args.get(i + 1))
             .cloned();
 
+        let bench_name = args
+            .iter()
+            .position(|a| a == "--bench-name")
+            .and_then(|i| args.get(i + 1))
+            .cloned();
+
         Self {
             save,
             moniker,
+            bench_name,
             help,
         }
     }
@@ -209,6 +221,85 @@ impl EnvironmentInfo {
     }
 }
 
+/// Server information fetched from health endpoints before the test
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ServerInfo {
+    /// Server version (from GET /health)
+    version: String,
+    /// Auth mode (from GET /health)
+    auth_mode: String,
+    /// Target label (from TARGET env var or auto-inferred)
+    target: String,
+    /// Total registered workers (from GET /v1/durable/health)
+    workers: usize,
+    /// Currently active workers
+    active_workers: usize,
+    /// Total task capacity across all workers
+    total_capacity: usize,
+}
+
+impl ServerInfo {
+    /// Fetch server info from health endpoints.
+    async fn fetch(http: &Client, api_url: &str) -> Self {
+        // Derive base URL: /api -> /health (sibling, not child)
+        let base_url = api_url.trim_end_matches('/');
+        let health_url = if let Some(prefix) = base_url.strip_suffix("/api") {
+            format!("{}/health", prefix)
+        } else {
+            format!("{}/health", base_url)
+        };
+
+        // GET /health -> version, auth_mode
+        let (version, auth_mode) = match http.get(&health_url).send().await {
+            Ok(resp) => {
+                if let Ok(body) = resp.json::<serde_json::Value>().await {
+                    (
+                        body["version"].as_str().unwrap_or("unknown").to_string(),
+                        body["auth_mode"].as_str().unwrap_or("unknown").to_string(),
+                    )
+                } else {
+                    ("unknown".to_string(), "unknown".to_string())
+                }
+            }
+            Err(_) => ("unknown".to_string(), "unknown".to_string()),
+        };
+
+        // GET /v1/durable/health -> worker topology
+        let durable_url = format!("{}/v1/durable/health", base_url);
+        let (workers, active_workers, total_capacity) =
+            match http.get(&durable_url).send().await {
+                Ok(resp) => {
+                    if let Ok(body) = resp.json::<serde_json::Value>().await {
+                        (
+                            body["total_workers"].as_u64().unwrap_or(0) as usize,
+                            body["active_workers"].as_u64().unwrap_or(0) as usize,
+                            body["total_capacity"].as_u64().unwrap_or(0) as usize,
+                        )
+                    } else {
+                        (0, 0, 0)
+                    }
+                }
+                Err(_) => (0, 0, 0),
+            };
+
+        // Target: explicit env var or auto-inferred from URL + worker count
+        let target = std::env::var("TARGET").unwrap_or_else(|_| {
+            let is_local = api_url.contains("localhost") || api_url.contains("127.0.0.1");
+            let location = if is_local { "local" } else { "remote" };
+            format!("{}-{}w", location, workers)
+        });
+
+        Self {
+            version,
+            auth_mode,
+            target,
+            workers,
+            active_workers,
+            total_capacity,
+        }
+    }
+}
+
 /// Serializable metrics for checkpointing
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct MetricsSnapshot {
@@ -232,8 +323,14 @@ struct MetricsSnapshot {
 struct LoadTestCheckpoint {
     /// Unique ID for this checkpoint
     id: String,
+    /// Bench name (e.g., "throughput", "history-depth", "horizontal-scale")
+    #[serde(default = "default_bench_name")]
+    bench_name: String,
     /// Timestamp when test was run
     timestamp: DateTime<Utc>,
+    /// Server information (version, target, workers)
+    #[serde(default)]
+    server: Option<ServerInfo>,
     /// Environment information
     environment: EnvironmentInfo,
     /// Test configuration
@@ -244,8 +341,14 @@ struct LoadTestCheckpoint {
     errors: Vec<String>,
 }
 
+fn default_bench_name() -> String {
+    "throughput".to_string()
+}
+
 impl LoadTestCheckpoint {
     fn new(
+        bench_name: String,
+        server: ServerInfo,
         environment: EnvironmentInfo,
         config: LoadTestConfig,
         metrics: MetricsSnapshot,
@@ -253,7 +356,9 @@ impl LoadTestCheckpoint {
     ) -> Self {
         Self {
             id: uuid::Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)).to_string(),
+            bench_name,
             timestamp: Utc::now(),
+            server: Some(server),
             environment,
             config,
             metrics,
@@ -263,9 +368,9 @@ impl LoadTestCheckpoint {
 
     fn filename(&self) -> String {
         format!(
-            "load_test_{}_{}_{}_{}.json",
+            "{}_{}_{}_{}.json",
+            self.bench_name,
             self.config.sessions,
-            self.config.messages_per_session,
             self.environment.moniker.replace(' ', "_").to_lowercase(),
             self.timestamp.format("%Y%m%d_%H%M%S"),
         )
@@ -686,10 +791,29 @@ impl LoadTestRunner {
         Ok(())
     }
 
-    async fn run(&self) -> anyhow::Result<MetricsSummary> {
+    /// Fetch server info from health endpoints
+    async fn fetch_server_info(&self) -> ServerInfo {
+        ServerInfo::fetch(&self.http, &self.config.api_url).await
+    }
+
+    async fn run(&self) -> anyhow::Result<(MetricsSummary, ServerInfo)> {
+        // Fetch server info before the test
+        let server_info = self.fetch_server_info().await;
+
         println!("═══════════════════════════════════════════════════════════");
-        println!("              Everruns Load Test");
+        println!(
+            "              Everruns Load Test [{}]",
+            self.config.bench_name
+        );
         println!("═══════════════════════════════════════════════════════════");
+        println!();
+        println!("Server:");
+        println!("  Version:   {}", server_info.version);
+        println!("  Target:    {}", server_info.target);
+        println!(
+            "  Workers:   {} active / {} total (capacity: {})",
+            server_info.active_workers, server_info.workers, server_info.total_capacity
+        );
         println!();
         println!("Configuration:");
         println!("  API URL:              {}", self.config.api_url);
@@ -810,7 +934,7 @@ impl LoadTestRunner {
         println!();
         println!("═══════════════════════════════════════════════════════════");
 
-        Ok(summary)
+        Ok((summary, server_info))
     }
 }
 
@@ -836,6 +960,7 @@ fn print_help() {
     println!();
     println!("Options:");
     println!("  --save              Save results to crates/server/benches/checkpoints/");
+    println!("  --bench-name <NAME> Bench name (default: throughput)");
     println!("  --moniker <NAME>    Set custom environment moniker for saved results");
     println!("  --help, -h          Show this help message");
     println!();
@@ -846,6 +971,8 @@ fn print_help() {
     println!("  MODEL_ID             Model ID (default: seed llmsim model)");
     println!("  MAX_CONCURRENT       Max concurrent sessions (default: 50)");
     println!("  TIMEOUT_SECS         Request timeout in seconds (default: 300)");
+    println!("  TARGET               Target label for saved results (default: auto-detected)");
+    println!("                       Examples: dev, docker-example, staging");
     println!();
     println!("Examples:");
     println!("  # Basic load test");
@@ -854,11 +981,21 @@ fn print_help() {
     println!("  # Save results with custom moniker");
     println!("  just load-test medium --save --moniker ci-4cpu-8gb");
     println!();
+    println!("  # Load test against docker example stack");
+    println!("  TARGET=docker-example just load-test quick --save");
+    println!();
+    println!("  # Named bench (history depth test)");
+    println!("  SESSIONS=1 MESSAGES_PER_SESSION=200 just load-test quick --save --bench-name history-depth");
+    println!();
     println!("  # High volume test with save");
     println!("  SESSIONS=500 just load-test heavy --save");
 }
 
-fn print_comparison(current: &MetricsSnapshot, previous: &[LoadTestCheckpoint]) {
+fn print_comparison(
+    current: &MetricsSnapshot,
+    current_server: &ServerInfo,
+    previous: &[LoadTestCheckpoint],
+) {
     if previous.is_empty() {
         return;
     }
@@ -876,6 +1013,22 @@ fn print_comparison(current: &MetricsSnapshot, previous: &[LoadTestCheckpoint]) 
         baseline.config.sessions * baseline.config.messages_per_session,
         baseline.timestamp.format("%Y-%m-%d %H:%M")
     );
+
+    // Warn if target differs
+    if let Some(ref prev_server) = baseline.server {
+        if prev_server.target != current_server.target {
+            println!(
+                "   WARNING: target mismatch! current={}, previous={}",
+                current_server.target, prev_server.target
+            );
+        }
+        if prev_server.version != current_server.version {
+            println!(
+                "   Version: {} -> {}",
+                prev_server.version, current_server.version
+            );
+        }
+    }
 
     let pct_change = |current: f64, baseline: f64| -> f64 {
         if baseline == 0.0 {
@@ -939,10 +1092,13 @@ async fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let config = LoadTestConfig::default();
+    let mut config = LoadTestConfig::default();
+    if let Some(name) = cli.bench_name {
+        config.bench_name = name;
+    }
     let runner = LoadTestRunner::new(config.clone());
 
-    let summary = runner.run().await?;
+    let (summary, server_info) = runner.run().await?;
 
     // Save checkpoint if requested
     if cli.save {
@@ -953,15 +1109,23 @@ async fn main() -> anyhow::Result<()> {
 
         let store = CheckpointStore::new();
 
-        // Load previous results for comparison
-        let previous = store.list_recent(5).unwrap_or_default();
+        // Load previous results for comparison (same bench name only)
+        let previous: Vec<_> = store
+            .list_recent(50)
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|c| c.bench_name == config.bench_name)
+            .take(5)
+            .collect();
 
         let snapshot = summary.to_snapshot();
 
         // Print comparison if we have previous results
-        print_comparison(&snapshot, &previous);
+        print_comparison(&snapshot, &server_info, &previous);
 
         let checkpoint = LoadTestCheckpoint::new(
+            config.bench_name.clone(),
+            server_info,
             environment,
             config,
             snapshot,

--- a/crates/server/benches/load_test.rs
+++ b/crates/server/benches/load_test.rs
@@ -34,6 +34,9 @@ use tokio::sync::Semaphore;
 /// Seed harness ID from seed.rs (DEFAULT_HARNESS = 0x01933b5a_0000_7000_8000_000000000601)
 const DEFAULT_HARNESS_ID: &str = "harness_01933b5a000070008000000000000601";
 
+/// Seed llmsim model ID from seed.rs (LLMSIM_DEFAULT = 0x01933b5a_0000_7000_8000_000000000401)
+const DEFAULT_LLMSIM_MODEL_ID: &str = "model_01933b5a000070008000000000000401";
+
 // ============================================================================
 // Configuration
 // ============================================================================
@@ -61,7 +64,8 @@ impl Default for LoadTestConfig {
                 .ok()
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(50),
-            model_id: std::env::var("MODEL_ID").unwrap_or_else(|_| "llmsim".to_string()),
+            model_id: std::env::var("MODEL_ID")
+                .unwrap_or_else(|_| DEFAULT_LLMSIM_MODEL_ID.to_string()),
             max_concurrent_sessions: std::env::var("MAX_CONCURRENT")
                 .ok()
                 .and_then(|s| s.parse().ok())
@@ -351,7 +355,7 @@ struct Event {
 
 #[derive(Debug, Deserialize)]
 struct EventsResponse {
-    items: Vec<Event>,
+    data: Vec<Event>,
 }
 
 // ============================================================================
@@ -533,7 +537,7 @@ impl LoadTestRunner {
         Ok(resp.id)
     }
 
-    /// Send message via SDK and poll for completion via raw reqwest
+    /// Send message via raw reqwest and poll for completion
     async fn send_message(&self, session_id: &str, message_num: usize) -> anyhow::Result<Duration> {
         let start = Instant::now();
 
@@ -545,7 +549,21 @@ impl LoadTestRunner {
 
         self.metrics.messages_sent.fetch_add(1, Ordering::Relaxed);
 
-        self.sdk.messages().create(session_id, &text).await?;
+        // Use raw reqwest instead of SDK — the published SDK's Message type
+        // may be out of sync with the server, and we don't need the response body.
+        let url = format!("{}/v1/sessions/{}/messages", self.config.api_url, session_id);
+        let body = serde_json::json!({
+            "message": {
+                "role": "user",
+                "content": [{ "type": "text", "text": text }]
+            }
+        });
+        self.http
+            .post(&url)
+            .json(&body)
+            .send()
+            .await?
+            .error_for_status()?;
 
         // Wait for turn completion by polling events (needs offset/limit)
         self.wait_for_turn_completion(session_id).await?;
@@ -582,10 +600,10 @@ impl LoadTestRunner {
                 .json::<EventsResponse>()
                 .await?;
 
-            last_event_count += resp.items.len();
+            last_event_count += resp.data.len();
 
             // Check for session.idled or session.completed
-            let completed = resp.items.iter().any(|e| {
+            let completed = resp.data.iter().any(|e| {
                 e.event_type == "session.idled"
                     || e.event_type == "session.completed"
                     || e.event_type == "session.failed"
@@ -789,15 +807,9 @@ fn print_help() {
     println!("  API_URL              API endpoint (default: http://localhost:9000)");
     println!("  SESSIONS             Number of parallel sessions (default: 100)");
     println!("  MESSAGES_PER_SESSION Messages per session (default: 50)");
-    println!("  MODEL_ID             Model ID (default: llmsim)");
+    println!("  MODEL_ID             Model ID (default: seed llmsim model)");
     println!("  MAX_CONCURRENT       Max concurrent sessions (default: 50)");
     println!("  TIMEOUT_SECS         Request timeout in seconds (default: 300)");
-    println!();
-    println!("Model ID options for different scenarios:");
-    println!("  llmsim               - Fast responses (no latency)");
-    println!("  llmsim-ttft-100      - 100ms delay before first token");
-    println!("  llmsim-ttft-500      - 500ms delay (realistic)");
-    println!("  llmsim-ttft-2000     - 2s delay (slow model simulation)");
     println!();
     println!("Examples:");
     println!("  # Basic load test");

--- a/crates/worker/src/durable_runner.rs
+++ b/crates/worker/src/durable_runner.rs
@@ -496,38 +496,57 @@ impl AgentRunner for DurableRunner {
         let workflow_id = session_id.uuid();
         let input_json = serde_json::to_value(&input)?;
 
-        let mut store = self.store.lock().await;
-
-        // Check if workflow already exists
-        let workflow_exists = match store.get_workflow_status(workflow_id).await {
-            Ok((status, _, _)) => {
-                if !status.is_terminal() {
-                    info!(
-                        session_id = %session_id,
-                        workflow_id = %workflow_id,
-                        status = ?status,
-                        "Workflow already running, skipping creation"
-                    );
-                    return Ok(());
+        // Check if workflow already exists and wait for it to complete if needed.
+        // Race condition: session becomes idle (in execute_reason_activity) BEFORE
+        // schedule_next_activity marks the workflow as Completed. If a new message
+        // arrives during this window, the workflow is still non-terminal. We wait
+        // briefly instead of silently dropping the new turn.
+        let workflow_exists = {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+            loop {
+                let mut store = self.store.lock().await;
+                match store.get_workflow_status(workflow_id).await {
+                    Ok((status, _, _)) => {
+                        if status.is_terminal() {
+                            info!(
+                                session_id = %session_id,
+                                workflow_id = %workflow_id,
+                                status = ?status,
+                                "Existing workflow is terminal, resetting for new turn"
+                            );
+                            break true;
+                        }
+                        // Workflow is non-terminal — release lock and wait
+                        drop(store);
+                        if std::time::Instant::now() > deadline {
+                            return Err(anyhow::anyhow!(
+                                "Timeout waiting for previous workflow to complete for session {}",
+                                session_id
+                            ));
+                        }
+                        info!(
+                            session_id = %session_id,
+                            workflow_id = %workflow_id,
+                            status = ?status,
+                            "Workflow still running, waiting for completion before starting new turn"
+                        );
+                        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    }
+                    Err(e) => {
+                        let err_str = e.to_string();
+                        if err_str.contains("not found") || err_str.contains("NOT_FOUND") {
+                            break false;
+                        }
+                        return Err(anyhow::anyhow!(
+                            "Failed to check workflow status: {}",
+                            e
+                        ));
+                    }
                 }
-                // Workflow exists but is terminal - we'll reset it for a new turn
-                info!(
-                    session_id = %session_id,
-                    workflow_id = %workflow_id,
-                    status = ?status,
-                    "Existing workflow is terminal, resetting for new turn"
-                );
-                true
-            }
-            Err(e) => {
-                // Check if it's a not found error (expected for new workflows)
-                let err_str = e.to_string();
-                if !err_str.contains("not found") && !err_str.contains("NOT_FOUND") {
-                    return Err(anyhow::anyhow!("Failed to check workflow status: {}", e));
-                }
-                false
             }
         };
+
+        let mut store = self.store.lock().await;
 
         // Enqueue the initial activity (input processing)
         let activity_id = format!("input_{}", Uuid::now_v7());

--- a/crates/worker/src/durable_runner.rs
+++ b/crates/worker/src/durable_runner.rs
@@ -537,10 +537,7 @@ impl AgentRunner for DurableRunner {
                         if err_str.contains("not found") || err_str.contains("NOT_FOUND") {
                             break false;
                         }
-                        return Err(anyhow::anyhow!(
-                            "Failed to check workflow status: {}",
-                            e
-                        ));
+                        return Err(anyhow::anyhow!("Failed to check workflow status: {}", e));
                     }
                 }
             }

--- a/justfile
+++ b/justfile
@@ -123,3 +123,29 @@ start-production *args:
 # Stop all services (API, UI, Docker)
 stop-all:
     ./scripts/lib/services.sh stop-all
+
+# === Load Testing ===
+
+# Run load test against running API (requires API + Worker running)
+load-test *args:
+    cargo run --release -p everruns-server --bench load_test -- {{args}}
+
+# Run quick load test (10 sessions, 10 messages each)
+load-test-quick:
+    SESSIONS=10 MESSAGES_PER_SESSION=10 MAX_CONCURRENT=10 cargo run --release -p everruns-server --bench load_test
+
+# Run medium load test (100 sessions, 50 messages each = 5000 total)
+load-test-medium:
+    SESSIONS=100 MESSAGES_PER_SESSION=50 MAX_CONCURRENT=50 cargo run --release -p everruns-server --bench load_test
+
+# Run heavy load test (500 sessions, 100 messages each = 50000 total)
+load-test-heavy:
+    SESSIONS=500 MESSAGES_PER_SESSION=100 MAX_CONCURRENT=100 cargo run --release -p everruns-server --bench load_test
+
+# Run load test with realistic LLM delays
+load-test-realistic:
+    MODEL_ID=llmsim-ttft-500 SESSIONS=100 MESSAGES_PER_SESSION=50 cargo run --release -p everruns-server --bench load_test
+
+# Run load test with slow LLM simulation
+load-test-slow:
+    MODEL_ID=llmsim-ttft-2000 SESSIONS=50 MESSAGES_PER_SESSION=20 cargo run --release -p everruns-server --bench load_test

--- a/justfile
+++ b/justfile
@@ -127,7 +127,7 @@ stop-all:
 # === Load Testing ===
 
 # Load test subcommand: just load-test <profile> [args]
-# Profiles: quick, medium, heavy, realistic, slow
+# Profiles: quick, medium, heavy
 # Example: just load-test medium
 #          just load-test quick --help
 #          SESSIONS=200 just load-test medium
@@ -154,23 +154,9 @@ load-test profile="medium" *args:
             MAX_CONCURRENT="${MAX_CONCURRENT:-100}" \
             cargo bench --package everruns-server --bench load_test -- {{args}}
             ;;
-        realistic)
-            MODEL_ID="${MODEL_ID:-llmsim-ttft-500}" \
-            SESSIONS="${SESSIONS:-100}" \
-            MESSAGES_PER_SESSION="${MESSAGES_PER_SESSION:-50}" \
-            MAX_CONCURRENT="${MAX_CONCURRENT:-50}" \
-            cargo bench --package everruns-server --bench load_test -- {{args}}
-            ;;
-        slow)
-            MODEL_ID="${MODEL_ID:-llmsim-ttft-2000}" \
-            SESSIONS="${SESSIONS:-50}" \
-            MESSAGES_PER_SESSION="${MESSAGES_PER_SESSION:-20}" \
-            MAX_CONCURRENT="${MAX_CONCURRENT:-25}" \
-            cargo bench --package everruns-server --bench load_test -- {{args}}
-            ;;
         *)
             echo "Unknown profile: {{profile}}"
-            echo "Available profiles: quick, medium, heavy, realistic, slow"
+            echo "Available profiles: quick, medium, heavy"
             echo ""
             echo "Usage: just load-test <profile> [args]"
             echo ""
@@ -178,14 +164,11 @@ load-test profile="medium" *args:
             echo "  quick     - 10 sessions, 10 messages (100 total)"
             echo "  medium    - 100 sessions, 50 messages (5000 total) [default]"
             echo "  heavy     - 500 sessions, 100 messages (50000 total)"
-            echo "  realistic - medium + 500ms TTFT delay"
-            echo "  slow      - 50 sessions, 20 messages + 2s TTFT delay"
             echo ""
             echo "Examples:"
             echo "  just load-test quick"
             echo "  just load-test heavy"
             echo "  SESSIONS=200 just load-test medium"
-            echo "  MODEL_ID=llmsim-ttft-1000 just load-test medium"
             exit 1
             ;;
     esac

--- a/justfile
+++ b/justfile
@@ -126,26 +126,66 @@ stop-all:
 
 # === Load Testing ===
 
-# Run load test against running API (requires API + Worker running)
-load-test *args:
-    cargo run --release -p everruns-server --bench load_test -- {{args}}
-
-# Run quick load test (10 sessions, 10 messages each)
-load-test-quick:
-    SESSIONS=10 MESSAGES_PER_SESSION=10 MAX_CONCURRENT=10 cargo run --release -p everruns-server --bench load_test
-
-# Run medium load test (100 sessions, 50 messages each = 5000 total)
-load-test-medium:
-    SESSIONS=100 MESSAGES_PER_SESSION=50 MAX_CONCURRENT=50 cargo run --release -p everruns-server --bench load_test
-
-# Run heavy load test (500 sessions, 100 messages each = 50000 total)
-load-test-heavy:
-    SESSIONS=500 MESSAGES_PER_SESSION=100 MAX_CONCURRENT=100 cargo run --release -p everruns-server --bench load_test
-
-# Run load test with realistic LLM delays
-load-test-realistic:
-    MODEL_ID=llmsim-ttft-500 SESSIONS=100 MESSAGES_PER_SESSION=50 cargo run --release -p everruns-server --bench load_test
-
-# Run load test with slow LLM simulation
-load-test-slow:
-    MODEL_ID=llmsim-ttft-2000 SESSIONS=50 MESSAGES_PER_SESSION=20 cargo run --release -p everruns-server --bench load_test
+# Load test subcommand: just load-test <profile> [args]
+# Profiles: quick, medium, heavy, realistic, slow
+# Example: just load-test medium
+#          just load-test quick --help
+#          SESSIONS=200 just load-test medium
+[no-cd]
+load-test profile="medium" *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    case "{{profile}}" in
+        quick)
+            SESSIONS="${SESSIONS:-10}" \
+            MESSAGES_PER_SESSION="${MESSAGES_PER_SESSION:-10}" \
+            MAX_CONCURRENT="${MAX_CONCURRENT:-10}" \
+            cargo run --release -p everruns-server --bench load_test -- {{args}}
+            ;;
+        medium)
+            SESSIONS="${SESSIONS:-100}" \
+            MESSAGES_PER_SESSION="${MESSAGES_PER_SESSION:-50}" \
+            MAX_CONCURRENT="${MAX_CONCURRENT:-50}" \
+            cargo run --release -p everruns-server --bench load_test -- {{args}}
+            ;;
+        heavy)
+            SESSIONS="${SESSIONS:-500}" \
+            MESSAGES_PER_SESSION="${MESSAGES_PER_SESSION:-100}" \
+            MAX_CONCURRENT="${MAX_CONCURRENT:-100}" \
+            cargo run --release -p everruns-server --bench load_test -- {{args}}
+            ;;
+        realistic)
+            MODEL_ID="${MODEL_ID:-llmsim-ttft-500}" \
+            SESSIONS="${SESSIONS:-100}" \
+            MESSAGES_PER_SESSION="${MESSAGES_PER_SESSION:-50}" \
+            MAX_CONCURRENT="${MAX_CONCURRENT:-50}" \
+            cargo run --release -p everruns-server --bench load_test -- {{args}}
+            ;;
+        slow)
+            MODEL_ID="${MODEL_ID:-llmsim-ttft-2000}" \
+            SESSIONS="${SESSIONS:-50}" \
+            MESSAGES_PER_SESSION="${MESSAGES_PER_SESSION:-20}" \
+            MAX_CONCURRENT="${MAX_CONCURRENT:-25}" \
+            cargo run --release -p everruns-server --bench load_test -- {{args}}
+            ;;
+        *)
+            echo "Unknown profile: {{profile}}"
+            echo "Available profiles: quick, medium, heavy, realistic, slow"
+            echo ""
+            echo "Usage: just load-test <profile> [args]"
+            echo ""
+            echo "Profiles:"
+            echo "  quick     - 10 sessions, 10 messages (100 total)"
+            echo "  medium    - 100 sessions, 50 messages (5000 total) [default]"
+            echo "  heavy     - 500 sessions, 100 messages (50000 total)"
+            echo "  realistic - medium + 500ms TTFT delay"
+            echo "  slow      - 50 sessions, 20 messages + 2s TTFT delay"
+            echo ""
+            echo "Examples:"
+            echo "  just load-test quick"
+            echo "  just load-test heavy"
+            echo "  SESSIONS=200 just load-test medium"
+            echo "  MODEL_ID=llmsim-ttft-1000 just load-test medium"
+            exit 1
+            ;;
+    esac

--- a/justfile
+++ b/justfile
@@ -140,33 +140,33 @@ load-test profile="medium" *args:
             SESSIONS="${SESSIONS:-10}" \
             MESSAGES_PER_SESSION="${MESSAGES_PER_SESSION:-10}" \
             MAX_CONCURRENT="${MAX_CONCURRENT:-10}" \
-            cargo run --release -p everruns-server --bench load_test -- {{args}}
+            cargo bench --package everruns-server --bench load_test -- {{args}}
             ;;
         medium)
             SESSIONS="${SESSIONS:-100}" \
             MESSAGES_PER_SESSION="${MESSAGES_PER_SESSION:-50}" \
             MAX_CONCURRENT="${MAX_CONCURRENT:-50}" \
-            cargo run --release -p everruns-server --bench load_test -- {{args}}
+            cargo bench --package everruns-server --bench load_test -- {{args}}
             ;;
         heavy)
             SESSIONS="${SESSIONS:-500}" \
             MESSAGES_PER_SESSION="${MESSAGES_PER_SESSION:-100}" \
             MAX_CONCURRENT="${MAX_CONCURRENT:-100}" \
-            cargo run --release -p everruns-server --bench load_test -- {{args}}
+            cargo bench --package everruns-server --bench load_test -- {{args}}
             ;;
         realistic)
             MODEL_ID="${MODEL_ID:-llmsim-ttft-500}" \
             SESSIONS="${SESSIONS:-100}" \
             MESSAGES_PER_SESSION="${MESSAGES_PER_SESSION:-50}" \
             MAX_CONCURRENT="${MAX_CONCURRENT:-50}" \
-            cargo run --release -p everruns-server --bench load_test -- {{args}}
+            cargo bench --package everruns-server --bench load_test -- {{args}}
             ;;
         slow)
             MODEL_ID="${MODEL_ID:-llmsim-ttft-2000}" \
             SESSIONS="${SESSIONS:-50}" \
             MESSAGES_PER_SESSION="${MESSAGES_PER_SESSION:-20}" \
             MAX_CONCURRENT="${MAX_CONCURRENT:-25}" \
-            cargo run --release -p everruns-server --bench load_test -- {{args}}
+            cargo bench --package everruns-server --bench load_test -- {{args}}
             ;;
         *)
             echo "Unknown profile: {{profile}}"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -111,8 +111,18 @@ check_postgres_ready() {
     return $?
   fi
 
-  # If no tools available, just rely on port check (less reliable)
-  return 0
+  # No pg_isready or psql available — probe the PostgreSQL wire protocol.
+  # Send a minimal SSLRequest packet and check for a valid response (S or N).
+  # This catches stale port forwards (e.g., Colima SSH mux) that accept TCP
+  # but have no PostgreSQL behind them.
+  local response
+  response=$(printf '\x00\x00\x00\x08\x04\xd2\x16\x2f' | \
+    nc -w 2 "$host" "$port" 2>/dev/null | head -c1 | od -An -tx1 | tr -d ' ')
+  # PostgreSQL responds with 'S' (0x53) or 'N' (0x4e) to SSLRequest
+  if [ "$response" = "53" ] || [ "$response" = "4e" ]; then
+    return 0
+  fi
+  return 1
 }
 
 

--- a/specs/load-testing.md
+++ b/specs/load-testing.md
@@ -1,0 +1,149 @@
+# Load Testing Specification
+
+## Abstract
+
+End-to-end load testing framework for the Everruns API. Measures throughput, latency, and reliability under concurrent session/message workloads using the llmsim provider.
+
+## Goals
+
+1. Repeatable benchmarks with saved checkpoints for regression detection
+2. Automatic server metadata capture (version, target, worker topology)
+3. Named bench types for different test scenarios
+4. Comparison against previous runs of the same bench
+
+## Non-Goals
+
+1. LLM provider benchmarking (llmsim isolates server performance)
+2. Client-side performance (SDK overhead is negligible)
+3. Infrastructure provisioning (assumes running server)
+
+## Architecture
+
+Single benchmark binary at `crates/server/benches/load_test.rs`. Uses `everruns-sdk` for agent/message operations and raw `reqwest` for session creation and event polling where the SDK lacks support.
+
+### Flow
+
+1. Fetch server info from `/health` and `/v1/durable/health`
+2. Create a load test agent with llmsim as default model
+3. Spawn N concurrent sessions (controlled by semaphore)
+4. Each session sends M messages sequentially, waiting for agent response
+5. Collect latency, throughput, and error metrics
+6. Optionally save checkpoint with full metadata
+
+## Configuration
+
+All configuration via environment variables, overridden by CLI args where applicable.
+
+| Variable | Default | Description |
+|---|---|---|
+| `API_URL` | `http://localhost:9300/api` | Server API endpoint |
+| `SESSIONS` | `100` | Number of parallel sessions |
+| `MESSAGES_PER_SESSION` | `50` | Messages per session |
+| `MODEL_ID` | seed llmsim model | Model to use |
+| `MAX_CONCURRENT` | `50` | Max concurrent sessions |
+| `TIMEOUT_SECS` | `300` | Per-request timeout |
+| `TARGET` | auto-detected | Target label (e.g., `dev`, `docker-example`) |
+
+### CLI Arguments
+
+| Argument | Description |
+|---|---|
+| `--save` | Save results to `crates/server/benches/checkpoints/` |
+| `--bench-name <NAME>` | Bench name, defaults to `throughput` |
+| `--moniker <NAME>` | Custom environment moniker |
+| `--help` | Show help |
+
+## Bench Names
+
+Named benches distinguish different test scenarios. Comparisons only match runs with the same bench name.
+
+| Name | Description | Typical Config |
+|---|---|---|
+| `throughput` | Baseline throughput (default) | 100 sessions, 50 messages |
+| `history-depth` | Message history scaling | 1 session, 200+ messages |
+| `horizontal-scale` | Worker scaling | Fixed load, vary workers |
+| `burst` | Burst capacity | High concurrency, low messages |
+
+## Justfile Profiles
+
+Profiles set session/message/concurrency defaults. CLI args pass through.
+
+```bash
+just load-test quick              # 10 sessions, 10 messages
+just load-test medium             # 100 sessions, 50 messages (default)
+just load-test heavy              # 500 sessions, 100 messages
+```
+
+## Checkpoints
+
+Saved to `crates/server/benches/checkpoints/` as JSON. Filename format: `{bench_name}_{sessions}_{moniker}_{datetime}.json`.
+
+### Checkpoint Schema
+
+```json
+{
+  "id": "uuid-v7",
+  "bench_name": "throughput",
+  "timestamp": "2026-02-22T18:00:00Z",
+  "server": {
+    "version": "0.8.0",
+    "auth_mode": "None",
+    "target": "docker-example",
+    "workers": 3,
+    "active_workers": 3,
+    "total_capacity": 30
+  },
+  "environment": {
+    "moniker": "local-M4-Pro-48GB",
+    "os": "Darwin 15.5",
+    "cpu_name": "Apple M4 Pro",
+    "cpu_cores": 14,
+    "memory_gb": 48.0,
+    "hostname": "MAC-P73L96T"
+  },
+  "config": { "..." },
+  "metrics": {
+    "sessions_created": 10,
+    "sessions_completed": 10,
+    "messages_sent": 100,
+    "messages_completed": 100,
+    "throughput_msg_per_sec": 26.6,
+    "latency_p50_ms": 338.0,
+    "latency_p95_ms": 686.0,
+    "latency_p99_ms": 794.0,
+    "..."
+  },
+  "errors": []
+}
+```
+
+### Target Auto-Detection
+
+When `TARGET` is not set, inferred from URL and worker count:
+- `localhost` / `127.0.0.1` -> `local-{N}w`
+- Remote host -> `remote-{N}w`
+
+Explicit `TARGET` overrides auto-detection.
+
+### Comparison
+
+When saving, the tool compares against previous runs with the **same bench name**. Warns on target mismatch between runs.
+
+## Usage Examples
+
+```bash
+# Quick smoke test
+just load-test quick
+
+# Save results against dev mode
+just load-test quick --save
+
+# Save against docker example stack with explicit target
+TARGET=docker-example just load-test medium --save
+
+# Named bench: history depth test
+SESSIONS=1 MESSAGES_PER_SESSION=200 just load-test quick --save --bench-name history-depth
+
+# Heavy load with custom moniker
+just load-test heavy --save --moniker ci-4cpu-8gb
+```


### PR DESCRIPTION
## What
Load testing infrastructure for end-to-end API benchmarking using the llmsim provider, plus a fix for a multi-turn race condition in the durable execution engine.

## Why
- Need repeatable benchmarks for throughput, latency, and reliability regression detection
- Multi-turn workflows had a race condition where messages sent during workflow completion could be silently dropped

## How
**Load Testing:**
- Single benchmark binary at `crates/server/benches/load_test.rs` using `everruns-sdk` + raw `reqwest`
- Justfile profiles: `quick` (10x10), `medium` (100x50), `heavy` (500x100)
- Checkpoint persistence with JSON snapshots, environment capture, and comparison against previous runs
- Named bench types (`throughput`, `history-depth`, `horizontal-scale`, `burst`) with scoped comparisons
- Server metadata capture (version, target, worker topology) from health endpoints
- New `specs/load-testing.md` spec

**Durable Race Fix:**
- `durable_runner.rs`: Wait (with 10s timeout) for workflow completion instead of silently skipping new turns
- `memory.rs` / `postgres.rs`: Clear transient fields (result, error, timestamps) when resetting to Pending
- Comprehensive tests for the race condition

**Script Fix:**
- `scripts/lib/common.sh`: Probe PostgreSQL protocol (SSLRequest packet) instead of trusting open TCP port

## Risk
- Low
- Load test is a dev-only benchmark binary (no production impact)
- Durable fix adds a bounded wait (10s timeout) for workflow completion — safe fallback on timeout
- Script fix is more robust than the previous open-port check

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered