### PR TITLE
chore(release): prepare v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.8.1] - 2026-02-22
+
+### Highlights
+
+- **Load Testing Infrastructure** — New load testing framework with llmsim mock LLM server and durable execution race condition fix ([#568](https://github.com/everruns/everruns/pull/568))
+- **Dashboard Stats** — Total sessions count and improved session stats accuracy ([#564](https://github.com/everruns/everruns/pull/564))
+- **CI & Docs Improvements** — Docker publish fix for release tags, SEO fixes, and bashkit docs ([#563](https://github.com/everruns/everruns/pull/563), [#566](https://github.com/everruns/everruns/pull/566), [#567](https://github.com/everruns/everruns/pull/567))
+
+### What's Changed
+
+- feat(load-test): add load testing infrastructure with llmsim and durable race fix ([#568](https://github.com/everruns/everruns/pull/568))
+- docs: fix SEO issues across docs site ([#567](https://github.com/everruns/everruns/pull/567))
+- docs(ecosystem): add bashkit overview and hide SRE sidebar ([#566](https://github.com/everruns/everruns/pull/566))
+- chore(specs): add performance impact guidelines to pre-PR and maintenance checklists ([#565](https://github.com/everruns/everruns/pull/565))
+- feat(dashboard): add total sessions count and fix session stats accuracy ([#564](https://github.com/everruns/everruns/pull/564))
+- fix(ci): trigger Docker Publish for release tags via workflow_dispatch ([#563](https://github.com/everruns/everruns/pull/563))
+
 ## [0.8.0] - 2026-02-21
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,9 +990,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1204,7 +1204,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1257,7 +1257,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1326,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-codesandbox"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1358,7 +1358,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1429,7 +1429,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1504,7 +1504,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2537,9 +2537,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.87"
+version = "0.3.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f0862381daaec758576dcc22eb7bbf4d7efd67328553f3b45a412a51a3fb21"
+checksum = "c7e709f3e3d22866f9c25b3aff01af289b18422cc8b4262fb19103ee80fe513d"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2639,9 +2639,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -4198,9 +4198,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.11.0",
  "errno",
@@ -5792,9 +5792,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.110"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de241cdc66a9d91bd84f097039eb140cdc6eec47e0cdbaf9d932a1dd6c35866"
+checksum = "ec1adf1535672f5b7824f817792b1afd731d7e843d2d04ec8f27e8cb51edd8ac"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5805,9 +5805,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.60"
+version = "0.4.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42e96ea38f49b191e08a1bab66c7ffdba24b06f9995b39a9dd60222e5b6f1da"
+checksum = "fe88540d1c934c4ec8e6db0afa536876c5441289d7f9f9123d4f065ac1250a6b"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -5819,9 +5819,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.110"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12fdf6649048f2e3de6d7d5ff3ced779cdedee0e0baffd7dff5cdfa3abc8a52"
+checksum = "19e638317c08b21663aed4d2b9a2091450548954695ff4efa75bff5fa546b3b1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5829,9 +5829,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.110"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e63d1795c565ac3462334c1e396fd46dbf481c40f51f5072c310717bc4fb309"
+checksum = "2c64760850114d03d5f65457e96fc988f11f01d38fbaa51b254e4ab5809102af"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5842,9 +5842,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.110"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f9cdac23a5ce71f6bf9f8824898a501e511892791ea2a0c6b8568c68b9cb53"
+checksum = "60eecd4fe26177cfa3339eb00b4a36445889ba3ad37080c2429879718e20ca41"
 dependencies = [
  "unicode-ident",
 ]
@@ -5898,9 +5898,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.87"
+version = "0.3.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c7c5718134e770ee62af3b6b4a84518ec10101aad610c024b64d6ff29bb1ff"
+checksum = "9d6bb20ed2d9572df8584f6dc81d68a41a625cadc6f15999d649a70ce7e3597a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns Contributors"]

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "everruns-ui",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@streamdown/code": "^1.0.3",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "exports": {
     "./providers/*": "./src/providers/*.tsx",


### PR DESCRIPTION
## Release v0.8.1

This PR prepares the v0.8.1 patch release.

### Highlights

- **Load Testing Infrastructure** — New load testing framework with llmsim mock LLM server and durable execution race condition fix (#568)
- **Dashboard Stats** — Total sessions count and improved session stats accuracy (#564)
- **CI & Docs Improvements** — Docker publish fix for release tags, SEO fixes, and bashkit docs (#563, #566, #567)

### What's Changed

- feat(load-test): add load testing infrastructure with llmsim and durable race fix (#568)
- docs: fix SEO issues across docs site (#567)
- docs(ecosystem): add bashkit overview and hide SRE sidebar (#566)
- chore(specs): add performance impact guidelines to pre-PR and maintenance checklists (#565)
- feat(dashboard): add total sessions count and fix session stats accuracy (#564)
- fix(ci): trigger Docker Publish for release tags via workflow_dispatch (#563)

### Checklist
- [ ] Review CHANGELOG.md entries
- [ ] Verify version numbers updated
- [ ] CI passes

### Post-merge
After merging, the release workflow will automatically:
- Create git tag v0.8.1
- Create GitHub Release with notes from CHANGELOG.md
- Trigger Docker image build with version tag
