### PR TITLE
fix(durable): skip postgres-dependent tests without PostgreSQL

### DIFF
--- a/crates/durable/tests/failure_injection_test.rs
+++ b/crates/durable/tests/failure_injection_test.rs
@@ -1,11 +1,11 @@
 //! Failure injection tests using fail-rs
 //!
 //! These tests verify system behavior under various failure conditions.
-//! Run with: cargo test -p everruns-durable --test failure_injection_test --features failpoints -- --test-threads=1
+//! Run with: cargo test -p everruns-durable --test failure_injection_test --features "failpoints,postgres-tests" -- --test-threads=1
 //!
 //! Requires PostgreSQL running with DATABASE_URL set.
 
-#![cfg(feature = "failpoints")]
+#![cfg(all(feature = "failpoints", feature = "postgres-tests"))]
 
 use fail::FailScenario;
 use serde_json::json;

--- a/justfile
+++ b/justfile
@@ -42,8 +42,10 @@ build:
     cargo build
 
 # Run all tests (Rust + UI e2e)
+# Note: uses default features only. PostgreSQL-gated tests (postgres-tests, failpoints)
+# are run via `just test-integration` which sets up Docker and enables those features.
 test:
-    cargo test --all-features
+    cargo test
     cd apps/ui && npm run e2e 2>/dev/null || echo "(e2e skipped)"
 
 # Run pure unit tests (no PostgreSQL required) - fast feedback


### PR DESCRIPTION
## What
Gate `failure_injection_test.rs` behind both `failpoints` AND `postgres-tests` features, and remove `--all-features` from `just test`.

## Why
`just test` ran `cargo test --all-features`, enabling `postgres-tests` and `failpoints` feature gates. This compiled all PostgreSQL-dependent integration tests, which panic on connection in environments without PostgreSQL (CI unit-test jobs, dev mode, cloud agents).

## How
1. **`failure_injection_test.rs`** — Changed `#![cfg(feature = "failpoints")]` to `#![cfg(all(feature = "failpoints", feature = "postgres-tests"))]`. Matches the pattern used by `postgres_integration_test.rs` and `postgres_repository_test.rs`.
2. **`justfile`** — `just test` now runs `cargo test` (default features only). The `postgres-tests` and `failpoints` features are opt-in gates. The dedicated `just test-integration` recipe already enables them with Docker-backed PostgreSQL.

## Risk
- Low
- `just test` no longer runs postgres integration tests — but it never could without PostgreSQL anyway. `just test-integration` remains the correct way to run those.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered