### PR TITLE
fix(ui): merge orphan input.message into turn.started in trajectory view

### DIFF
--- a/apps/ui/src/__tests__/trajectory-utils.test.ts
+++ b/apps/ui/src/__tests__/trajectory-utils.test.ts
@@ -1,4 +1,8 @@
-import { buildTurns, buildTrajectory, countStructuralEvents } from "@/components/trajectory/trajectory-utils";
+import {
+  buildTurns,
+  buildTrajectory,
+  countStructuralEvents,
+} from "@/components/trajectory/trajectory-utils";
 import type { Event, EventContext } from "@/lib/api/types";
 
 // --- Helpers ---
@@ -68,9 +72,7 @@ function actStartedEvent(turnId: string, inputMessageId: string): Event {
   return makeEvent(
     "act.started",
     {
-      tool_calls: [
-        { id: "tc-1", name: "bash", display_name: "Bash" },
-      ],
+      tool_calls: [{ id: "tc-1", name: "bash", display_name: "Bash" }],
     },
     turnContext(turnId, inputMessageId),
   );
@@ -113,11 +115,7 @@ function outputMessageCompletedEvent(turnId: string, inputMessageId: string, tex
   );
 }
 
-function turnCompletedEvent(
-  turnId: string,
-  inputMessageId: string,
-  iterations: number = 1,
-): Event {
+function turnCompletedEvent(turnId: string, inputMessageId: string, iterations: number = 1): Event {
   return makeEvent(
     "turn.completed",
     { turn_id: turnId, duration_ms: 500, iterations },
@@ -126,11 +124,7 @@ function turnCompletedEvent(
 }
 
 function turnFailedEvent(turnId: string, inputMessageId: string, error: string): Event {
-  return makeEvent(
-    "turn.failed",
-    { turn_id: turnId, error },
-    turnContext(turnId, inputMessageId),
-  );
+  return makeEvent("turn.failed", { turn_id: turnId, error }, turnContext(turnId, inputMessageId));
 }
 
 // --- Tests ---

--- a/apps/ui/src/__tests__/trajectory-utils.test.ts
+++ b/apps/ui/src/__tests__/trajectory-utils.test.ts
@@ -1,0 +1,407 @@
+import { buildTurns, buildTrajectory, countStructuralEvents } from "@/components/trajectory/trajectory-utils";
+import type { Event, EventContext } from "@/lib/api/types";
+
+// --- Helpers ---
+
+let seqCounter = 0;
+
+function resetSeq() {
+  seqCounter = 0;
+}
+
+function emptyContext(): EventContext {
+  return {};
+}
+
+function turnContext(turnId: string, inputMessageId: string): EventContext {
+  return { turn_id: turnId, input_message_id: inputMessageId };
+}
+
+function makeEvent(
+  type: string,
+  data: Record<string, unknown>,
+  context: EventContext = emptyContext(),
+): Event {
+  seqCounter++;
+  return {
+    id: `evt-${seqCounter}`,
+    type,
+    ts: `2025-01-01T00:00:${String(seqCounter).padStart(2, "0")}Z`,
+    session_id: "session-1",
+    context,
+    data,
+    sequence: seqCounter,
+  };
+}
+
+function inputMessageEvent(messageId: string, text: string, context?: EventContext): Event {
+  return makeEvent(
+    "input.message",
+    {
+      message: {
+        id: messageId,
+        role: "user",
+        content: [{ type: "text", text }],
+      },
+    },
+    context,
+  );
+}
+
+function turnStartedEvent(turnId: string, inputMessageId: string): Event {
+  return makeEvent(
+    "turn.started",
+    { turn_id: turnId, input_message_id: inputMessageId },
+    turnContext(turnId, inputMessageId),
+  );
+}
+
+function reasonCompletedEvent(turnId: string, inputMessageId: string): Event {
+  return makeEvent(
+    "reason.completed",
+    { has_tool_calls: true, tool_call_count: 1, duration_ms: 100 },
+    turnContext(turnId, inputMessageId),
+  );
+}
+
+function actStartedEvent(turnId: string, inputMessageId: string): Event {
+  return makeEvent(
+    "act.started",
+    {
+      tool_calls: [
+        { id: "tc-1", name: "bash", display_name: "Bash" },
+      ],
+    },
+    turnContext(turnId, inputMessageId),
+  );
+}
+
+function toolCompletedEvent(turnId: string, inputMessageId: string): Event {
+  return makeEvent(
+    "tool.completed",
+    {
+      tool_call_id: "tc-1",
+      name: "bash",
+      display_name: "Bash",
+      success: true,
+      status: "completed",
+      duration_ms: 50,
+    },
+    turnContext(turnId, inputMessageId),
+  );
+}
+
+function actCompletedEvent(turnId: string, inputMessageId: string): Event {
+  return makeEvent(
+    "act.completed",
+    { success_count: 1, error_count: 0, duration_ms: 50 },
+    turnContext(turnId, inputMessageId),
+  );
+}
+
+function outputMessageCompletedEvent(turnId: string, inputMessageId: string, text: string): Event {
+  return makeEvent(
+    "output.message.completed",
+    {
+      message: {
+        id: `msg-out-${seqCounter}`,
+        role: "agent",
+        content: [{ type: "text", text }],
+      },
+    },
+    turnContext(turnId, inputMessageId),
+  );
+}
+
+function turnCompletedEvent(
+  turnId: string,
+  inputMessageId: string,
+  iterations: number = 1,
+): Event {
+  return makeEvent(
+    "turn.completed",
+    { turn_id: turnId, duration_ms: 500, iterations },
+    turnContext(turnId, inputMessageId),
+  );
+}
+
+function turnFailedEvent(turnId: string, inputMessageId: string, error: string): Event {
+  return makeEvent(
+    "turn.failed",
+    { turn_id: turnId, error },
+    turnContext(turnId, inputMessageId),
+  );
+}
+
+// --- Tests ---
+
+describe("trajectory-utils", () => {
+  beforeEach(resetSeq);
+
+  describe("buildTurns", () => {
+    it("groups input.message + turn.started into single turn (orphan adoption)", () => {
+      const events = [
+        inputMessageEvent("msg-1", "Hello"),
+        turnStartedEvent("turn-1", "msg-1"),
+        reasonCompletedEvent("turn-1", "msg-1"),
+        outputMessageCompletedEvent("turn-1", "msg-1", "Hi there"),
+        turnCompletedEvent("turn-1", "msg-1"),
+      ];
+
+      const turns = buildTurns(events);
+
+      expect(turns).toHaveLength(1);
+      expect(turns[0].turnId).toBe("turn-1");
+      expect(turns[0].userMessage?.text).toBe("Hello");
+      expect(turns[0].agentMessage?.text).toBe("Hi there");
+      expect(turns[0].completed).toBe(true);
+    });
+
+    it("groups turn.started + input.message in normal order (no orphan)", () => {
+      const events = [
+        turnStartedEvent("turn-1", "msg-1"),
+        inputMessageEvent("msg-1", "Hello"),
+        reasonCompletedEvent("turn-1", "msg-1"),
+        outputMessageCompletedEvent("turn-1", "msg-1", "Hi there"),
+        turnCompletedEvent("turn-1", "msg-1"),
+      ];
+
+      const turns = buildTurns(events);
+
+      expect(turns).toHaveLength(1);
+      expect(turns[0].turnId).toBe("turn-1");
+      expect(turns[0].userMessage?.text).toBe("Hello");
+      expect(turns[0].agentMessage?.text).toBe("Hi there");
+    });
+
+    it("handles multiple turns with orphan adoption", () => {
+      const events = [
+        // Turn 1: orphan pattern
+        inputMessageEvent("msg-1", "First"),
+        turnStartedEvent("turn-1", "msg-1"),
+        reasonCompletedEvent("turn-1", "msg-1"),
+        outputMessageCompletedEvent("turn-1", "msg-1", "Response 1"),
+        turnCompletedEvent("turn-1", "msg-1"),
+        // Turn 2: orphan pattern
+        inputMessageEvent("msg-2", "Second"),
+        turnStartedEvent("turn-2", "msg-2"),
+        reasonCompletedEvent("turn-2", "msg-2"),
+        outputMessageCompletedEvent("turn-2", "msg-2", "Response 2"),
+        turnCompletedEvent("turn-2", "msg-2"),
+      ];
+
+      const turns = buildTurns(events);
+
+      expect(turns).toHaveLength(2);
+      expect(turns[0].turnId).toBe("turn-1");
+      expect(turns[0].userMessage?.text).toBe("First");
+      expect(turns[0].agentMessage?.text).toBe("Response 1");
+      expect(turns[1].turnId).toBe("turn-2");
+      expect(turns[1].userMessage?.text).toBe("Second");
+      expect(turns[1].agentMessage?.text).toBe("Response 2");
+    });
+
+    it("keeps orphan turn when input_message_id does not match", () => {
+      const events = [
+        inputMessageEvent("msg-1", "Hello"),
+        turnStartedEvent("turn-1", "msg-different"),
+        reasonCompletedEvent("turn-1", "msg-different"),
+        turnCompletedEvent("turn-1", "msg-different"),
+      ];
+
+      const turns = buildTurns(events);
+
+      // Orphan not adopted, so two turns
+      expect(turns).toHaveLength(2);
+      expect(turns[0].turnId).toMatch(/^orphan-/);
+      expect(turns[0].userMessage?.text).toBe("Hello");
+      expect(turns[1].turnId).toBe("turn-1");
+    });
+
+    it("handles turn with tool calls", () => {
+      const events = [
+        inputMessageEvent("msg-1", "Run a command"),
+        turnStartedEvent("turn-1", "msg-1"),
+        reasonCompletedEvent("turn-1", "msg-1"),
+        actStartedEvent("turn-1", "msg-1"),
+        toolCompletedEvent("turn-1", "msg-1"),
+        actCompletedEvent("turn-1", "msg-1"),
+        outputMessageCompletedEvent("turn-1", "msg-1", "Done"),
+        turnCompletedEvent("turn-1", "msg-1"),
+      ];
+
+      const turns = buildTurns(events);
+
+      expect(turns).toHaveLength(1);
+      expect(turns[0].turnId).toBe("turn-1");
+      expect(turns[0].userMessage?.text).toBe("Run a command");
+      expect(turns[0].iterations).toHaveLength(1);
+      expect(turns[0].iterations[0].toolGroup?.tools).toHaveLength(1);
+      expect(turns[0].iterations[0].toolGroup?.tools[0].name).toBe("bash");
+      expect(turns[0].agentMessage?.text).toBe("Done");
+    });
+
+    it("handles failed turn", () => {
+      const events = [
+        inputMessageEvent("msg-1", "Break"),
+        turnStartedEvent("turn-1", "msg-1"),
+        turnFailedEvent("turn-1", "msg-1", "Something went wrong"),
+      ];
+
+      const turns = buildTurns(events);
+
+      expect(turns).toHaveLength(1);
+      expect(turns[0].turnId).toBe("turn-1");
+      expect(turns[0].failed).toBe(true);
+      expect(turns[0].errorMessage).toBe("Something went wrong");
+      expect(turns[0].userMessage?.text).toBe("Break");
+    });
+
+    it("handles empty events", () => {
+      const turns = buildTurns([]);
+      expect(turns).toHaveLength(0);
+    });
+
+    it("preserves orphan messageId after adoption", () => {
+      const events = [
+        inputMessageEvent("msg-1", "Hello"),
+        turnStartedEvent("turn-1", "msg-1"),
+        turnCompletedEvent("turn-1", "msg-1"),
+      ];
+
+      const turns = buildTurns(events);
+
+      expect(turns).toHaveLength(1);
+      expect(turns[0].userMessage?.messageId).toBe("msg-1");
+      expect(turns[0].inputMessageId).toBe("msg-1");
+    });
+
+    it("handles input.message with context.turn_id (no orphan needed)", () => {
+      // When input.message already has turn context (e.g. from scheduler)
+      const ctx = turnContext("turn-1", "msg-1");
+      const events = [
+        turnStartedEvent("turn-1", "msg-1"),
+        inputMessageEvent("msg-1", "Hello", ctx),
+        reasonCompletedEvent("turn-1", "msg-1"),
+        outputMessageCompletedEvent("turn-1", "msg-1", "Hi"),
+        turnCompletedEvent("turn-1", "msg-1"),
+      ];
+
+      const turns = buildTurns(events);
+
+      expect(turns).toHaveLength(1);
+      expect(turns[0].turnId).toBe("turn-1");
+      expect(turns[0].userMessage?.text).toBe("Hello");
+      expect(turns[0].agentMessage?.text).toBe("Hi");
+    });
+
+    it("handles orphan with no message id (no match possible)", () => {
+      const events = [
+        // input.message with no message.id
+        makeEvent("input.message", {
+          message: { role: "user", content: [{ type: "text", text: "Hi" }] },
+        }),
+        turnStartedEvent("turn-1", "msg-1"),
+        turnCompletedEvent("turn-1", "msg-1"),
+      ];
+
+      const turns = buildTurns(events);
+
+      // Can't match without messageId, so orphan stays separate
+      expect(turns).toHaveLength(2);
+      expect(turns[0].turnId).toMatch(/^orphan-/);
+      expect(turns[1].turnId).toBe("turn-1");
+    });
+  });
+
+  describe("buildTrajectory", () => {
+    it("creates correct nodes for a single turn with orphan adoption", () => {
+      const events = [
+        inputMessageEvent("msg-1", "Hello"),
+        turnStartedEvent("turn-1", "msg-1"),
+        reasonCompletedEvent("turn-1", "msg-1"),
+        outputMessageCompletedEvent("turn-1", "msg-1", "Hi there"),
+        turnCompletedEvent("turn-1", "msg-1"),
+      ];
+
+      const { nodes, stats } = buildTrajectory(events);
+
+      // Should have: 1 group + 1 user + 1 reasoning + 1 agent = 4 nodes
+      const groupNodes = nodes.filter((n) => n.type === "turnGroup");
+      const userNodes = nodes.filter((n) => n.type === "userMessage");
+      const agentNodes = nodes.filter((n) => n.type === "agentMessage");
+
+      expect(groupNodes).toHaveLength(1);
+      expect(userNodes).toHaveLength(1);
+      expect(agentNodes).toHaveLength(1);
+
+      // User and agent should be in the same group
+      expect(userNodes[0].parentId).toBe(groupNodes[0].id);
+      expect(agentNodes[0].parentId).toBe(groupNodes[0].id);
+
+      expect(stats.turnCount).toBe(1);
+      expect(stats.completedTurns).toBe(1);
+    });
+
+    it("creates single group for orphan-adopted turn (not two groups)", () => {
+      const events = [
+        inputMessageEvent("msg-1", "Hello"),
+        turnStartedEvent("turn-1", "msg-1"),
+        outputMessageCompletedEvent("turn-1", "msg-1", "Hi"),
+        turnCompletedEvent("turn-1", "msg-1"),
+      ];
+
+      const { nodes, stats } = buildTrajectory(events);
+
+      const groupNodes = nodes.filter((n) => n.type === "turnGroup");
+      expect(groupNodes).toHaveLength(1);
+      expect(stats.turnCount).toBe(1);
+    });
+
+    it("stats reflect merged turns", () => {
+      const events = [
+        inputMessageEvent("msg-1", "First"),
+        turnStartedEvent("turn-1", "msg-1"),
+        reasonCompletedEvent("turn-1", "msg-1"),
+        actStartedEvent("turn-1", "msg-1"),
+        toolCompletedEvent("turn-1", "msg-1"),
+        actCompletedEvent("turn-1", "msg-1"),
+        outputMessageCompletedEvent("turn-1", "msg-1", "Done 1"),
+        turnCompletedEvent("turn-1", "msg-1", 1),
+        inputMessageEvent("msg-2", "Second"),
+        turnStartedEvent("turn-2", "msg-2"),
+        reasonCompletedEvent("turn-2", "msg-2"),
+        outputMessageCompletedEvent("turn-2", "msg-2", "Done 2"),
+        turnCompletedEvent("turn-2", "msg-2", 1),
+      ];
+
+      const { stats } = buildTrajectory(events);
+
+      expect(stats.turnCount).toBe(2);
+      expect(stats.completedTurns).toBe(2);
+      expect(stats.totalToolCalls).toBe(1);
+    });
+  });
+
+  describe("countStructuralEvents", () => {
+    it("counts only structural events", () => {
+      const events = [
+        inputMessageEvent("msg-1", "Hello"),
+        turnStartedEvent("turn-1", "msg-1"),
+        makeEvent("output.message.delta", { text: "partial" }), // not structural
+        outputMessageCompletedEvent("turn-1", "msg-1", "Hi"),
+        turnCompletedEvent("turn-1", "msg-1"),
+      ];
+
+      expect(countStructuralEvents(events)).toBe(4);
+    });
+
+    it("returns 0 for undefined", () => {
+      expect(countStructuralEvents(undefined)).toBe(0);
+    });
+
+    it("returns 0 for empty array", () => {
+      expect(countStructuralEvents([])).toBe(0);
+    });
+  });
+});

--- a/apps/ui/src/components/trajectory/trajectory-utils.ts
+++ b/apps/ui/src/components/trajectory/trajectory-utils.ts
@@ -139,11 +139,11 @@ function truncate(text: string, maxLen: number): string {
 
 // --- Build trajectory from events ---
 
-interface TurnAccumulator {
+export interface TurnAccumulator {
   turnId: string;
   startTs: string;
   inputMessageId?: string;
-  userMessage?: { eventId: string; text: string; ts: string };
+  userMessage?: { eventId: string; text: string; ts: string; messageId?: string };
   iterations: IterationAccumulator[];
   agentMessage?: { eventId: string; text: string; ts: string; hasToolCalls: boolean };
   completed: boolean;
@@ -153,7 +153,7 @@ interface TurnAccumulator {
   iterationCount?: number;
 }
 
-interface IterationAccumulator {
+export interface IterationAccumulator {
   reasoning?: {
     eventId: string;
     ts: string;
@@ -177,7 +177,7 @@ interface IterationAccumulator {
   };
 }
 
-function buildTurns(events: Event[]): TurnAccumulator[] {
+export function buildTurns(events: Event[]): TurnAccumulator[] {
   const turns: TurnAccumulator[] = [];
   let currentTurn: TurnAccumulator | null = null;
   let currentIteration: IterationAccumulator | null = null;
@@ -196,29 +196,46 @@ function buildTurns(events: Event[]): TurnAccumulator[] {
     switch (event.type) {
       case "turn.started": {
         const data = event.data as TurnStartedData;
-        currentTurn = {
-          turnId: data.turn_id,
-          startTs: event.ts,
-          inputMessageId: data.input_message_id,
-          iterations: [],
-          completed: false,
-          failed: false,
-        };
+
+        // Check if previous turn is an orphan (input.message arrived before turn.started).
+        // Adopt it by updating its turnId instead of creating a duplicate turn.
+        const lastTurn = turns.length > 0 ? turns[turns.length - 1] : null;
+        const isOrphan =
+          lastTurn &&
+          !lastTurn.completed &&
+          lastTurn.turnId.startsWith("orphan-") &&
+          lastTurn.userMessage?.messageId === data.input_message_id;
+
+        if (isOrphan && lastTurn) {
+          lastTurn.turnId = data.turn_id;
+          lastTurn.inputMessageId = data.input_message_id;
+          currentTurn = lastTurn;
+        } else {
+          currentTurn = {
+            turnId: data.turn_id,
+            startTs: event.ts,
+            inputMessageId: data.input_message_id,
+            iterations: [],
+            completed: false,
+            failed: false,
+          };
+          turns.push(currentTurn);
+        }
         currentIteration = null;
-        turns.push(currentTurn);
         break;
       }
 
       case "input.message": {
         const data = event.data as InputMessageData;
         const text = getTextFromContent(data.message?.content || []);
+        const messageId = data.message?.id;
         if (currentTurn) {
-          currentTurn.userMessage = { eventId: event.id, text, ts: event.ts };
+          currentTurn.userMessage = { eventId: event.id, text, ts: event.ts, messageId };
         } else {
           const orphanTurn: TurnAccumulator = {
             turnId: `orphan-${event.id}`,
             startTs: event.ts,
-            userMessage: { eventId: event.id, text, ts: event.ts },
+            userMessage: { eventId: event.id, text, ts: event.ts, messageId },
             iterations: [],
             completed: false,
             failed: false,


### PR DESCRIPTION
## What
Fix trajectory view splitting user and agent messages into separate turns.

## Why
The API emits `input.message` with `EventContext::empty()` (no `turn_id`) before
the worker emits `turn.started`. In `buildTurns()`, this created an orphan turn
for the user message, then a separate turn for all agent output — showing them as
two visual turns instead of one.

## How
When `turn.started` arrives, check if the previous turn is an orphan whose
`userMessage.messageId` matches `input_message_id`. If so, adopt the orphan by
updating its `turnId` rather than creating a duplicate turn.

Changes:
- `trajectory-utils.ts`: Add `messageId` to user message tracking, adopt orphan
  turns in `turn.started` handler. Export `buildTurns` and accumulator types for testing.
- New `trajectory-utils.test.ts`: 16 tests covering orphan adoption, normal ordering,
  multi-turn, mismatched IDs, failed turns, tool calls, missing message IDs, and stats.

## Risk
- Low
- Only changes frontend trajectory grouping logic. No backend changes. Existing
  behavior preserved when events arrive in normal order (turn.started before input.message).

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered