### PR TITLE
feat(llmsim): add latency and streaming simulation for benchmarks

### DIFF
--- a/crates/core/src/llmsim_driver.rs
+++ b/crates/core/src/llmsim_driver.rs
@@ -24,6 +24,7 @@ use crate::tool_types::ToolCall;
 use llmsim::generator::{LoremGenerator, ResponseGenerator};
 use llmsim::latency::LatencyProfile;
 use llmsim::openai::{ChatCompletionRequest, Message, Role};
+use tokio_stream::wrappers::ReceiverStream;
 
 // ============================================================================
 // Configuration Types
@@ -387,6 +388,22 @@ impl LlmSimDriver {
         }
     }
 
+    /// Get latency profile for a specific model name from the request.
+    /// Model names containing "-latency" enable streaming simulation with
+    /// inter-token delays using LatencyProfile::fast().
+    fn get_request_latency_profile(model_name: &str) -> Option<LatencyProfile> {
+        if model_name.contains("-latency") {
+            Some(LatencyProfile::fast())
+        } else {
+            None
+        }
+    }
+
+    /// Whether a request should use latency simulation based on config or model name.
+    fn should_simulate_latency(&self, model_name: &str) -> bool {
+        self.config.simulate_latency || model_name.contains("-latency")
+    }
+
     /// Estimate token count for text
     fn estimate_tokens(text: &str) -> u32 {
         // Simple estimation: ~4 chars per token
@@ -423,8 +440,16 @@ impl LlmDriver for LlmSimDriver {
 
         let response_text = self.generate_response(&messages);
         let tool_calls = self.get_tool_calls(&messages);
-        let latency_profile = self.get_latency_profile();
         let model_name = config.model.clone();
+        let simulate_latency = self.should_simulate_latency(&model_name);
+
+        // Select latency profile: request model name takes priority, then config
+        let latency_profile = if simulate_latency {
+            Self::get_request_latency_profile(&model_name)
+                .unwrap_or_else(|| self.get_latency_profile())
+        } else {
+            self.get_latency_profile()
+        };
 
         // Calculate token estimates
         let prompt_tokens: u32 = messages
@@ -436,12 +461,6 @@ impl LlmDriver for LlmSimDriver {
         // Build stream events
         let mut events = Vec::new();
 
-        // Simulate time-to-first-token if latency enabled
-        if self.config.simulate_latency {
-            let ttft = latency_profile.sample_ttft();
-            tokio::time::sleep(ttft).await;
-        }
-
         // Stream text in chunks (word by word for realistic streaming)
         if !response_text.is_empty() {
             let words: Vec<&str> = response_text.split_whitespace().collect();
@@ -451,17 +470,17 @@ impl LlmDriver for LlmSimDriver {
                 } else {
                     format!(" {}", word)
                 };
-                events.push(Ok(LlmStreamEvent::TextDelta(delta)));
+                events.push(LlmStreamEvent::TextDelta(delta));
             }
         }
 
         // Emit tool calls if present
         if let Some(calls) = tool_calls {
-            events.push(Ok(LlmStreamEvent::ToolCalls(calls)));
+            events.push(LlmStreamEvent::ToolCalls(calls));
         }
 
         // Final done event with metadata
-        events.push(Ok(LlmStreamEvent::Done(LlmCompletionMetadata {
+        events.push(LlmStreamEvent::Done(LlmCompletionMetadata {
             total_tokens: Some(prompt_tokens + completion_tokens),
             prompt_tokens: Some(prompt_tokens),
             completion_tokens: Some(completion_tokens),
@@ -470,9 +489,38 @@ impl LlmDriver for LlmSimDriver {
             model: Some(model_name),
             finish_reason: Some("stop".to_string()),
             retry_metadata: None, // LlmSim doesn't implement retry
-        })));
+        }));
 
-        Ok(Box::pin(stream::iter(events)))
+        // When latency simulation is enabled (via config or model name like "llmsim-latency"),
+        // stream events through a channel with realistic TTFT and inter-token delays.
+        // This simulates actual LLM streaming behavior for benchmarking.
+        if simulate_latency {
+            let (tx, rx) = tokio::sync::mpsc::channel(32);
+
+            tokio::spawn(async move {
+                // Simulate time-to-first-token delay
+                let ttft = latency_profile.sample_ttft();
+                tokio::time::sleep(ttft).await;
+
+                for event in events {
+                    let is_text_delta = matches!(&event, LlmStreamEvent::TextDelta(_));
+                    if tx.send(Ok(event)).await.is_err() {
+                        break;
+                    }
+                    // Simulate inter-token delay after each text delta
+                    if is_text_delta {
+                        let tbt = latency_profile.sample_tbt();
+                        tokio::time::sleep(tbt).await;
+                    }
+                }
+            });
+
+            Ok(Box::pin(ReceiverStream::new(rx)))
+        } else {
+            // No latency: emit all events instantly
+            let wrapped: Vec<Result<LlmStreamEvent>> = events.into_iter().map(Ok).collect();
+            Ok(Box::pin(stream::iter(wrapped)))
+        }
     }
 }
 
@@ -929,5 +977,86 @@ mod tests {
         assert_eq!(parse_ttft_from_model_name("llmsim-model"), None);
         assert_eq!(parse_ttft_from_model_name("llmsim-ttft-0"), None);
         assert_eq!(parse_ttft_from_model_name("llmsim-ttft-abc"), None);
+    }
+
+    #[test]
+    fn test_should_simulate_latency_from_model_name() {
+        // Config flag off, model name triggers latency
+        let driver = LlmSimDriver::new(LlmSimConfig::fixed("test"));
+        assert!(driver.should_simulate_latency("llmsim-latency"));
+        assert!(!driver.should_simulate_latency("llmsim-default"));
+
+        // Config flag on, any model name
+        let driver = LlmSimDriver::new(LlmSimConfig::fixed("test").with_latency());
+        assert!(driver.should_simulate_latency("llmsim-default"));
+        assert!(driver.should_simulate_latency("llmsim-latency"));
+    }
+
+    #[test]
+    fn test_get_request_latency_profile() {
+        // Model with "-latency" returns a profile
+        assert!(LlmSimDriver::get_request_latency_profile("llmsim-latency").is_some());
+        // Model without "-latency" returns None
+        assert!(LlmSimDriver::get_request_latency_profile("llmsim-default").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_latency_streaming_from_model_name() {
+        // Default driver (simulate_latency=false) but model name triggers latency
+        let driver = LlmSimDriver::new(LlmSimConfig::fixed("Hello world"));
+        let messages = vec![user_message("test")];
+
+        let mut config = make_config();
+        config.model = "llmsim-latency".to_string();
+
+        let start = std::time::Instant::now();
+        let mut stream = driver
+            .chat_completion_stream(messages, &config)
+            .await
+            .unwrap();
+
+        let mut text_parts = Vec::new();
+        let mut got_done = false;
+
+        while let Some(event) = stream.next().await {
+            match event.unwrap() {
+                LlmStreamEvent::TextDelta(text) => text_parts.push(text),
+                LlmStreamEvent::Done(meta) => {
+                    got_done = true;
+                    assert_eq!(meta.model, Some("llmsim-latency".to_string()));
+                }
+                _ => {}
+            }
+        }
+
+        assert!(got_done);
+        assert_eq!(text_parts.join(""), "Hello world");
+        // With latency simulation, streaming should take non-zero time
+        // (TTFT + inter-token delays)
+        assert!(
+            start.elapsed().as_millis() > 0,
+            "latency simulation should introduce delays"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_no_latency_streaming_is_instant() {
+        let driver = LlmSimDriver::new(LlmSimConfig::fixed("Hello world"));
+        let messages = vec![user_message("test")];
+
+        let mut config = make_config();
+        config.model = "llmsim-default".to_string();
+
+        let start = std::time::Instant::now();
+        let response = driver.chat_completion(messages, &config).await.unwrap();
+        let elapsed = start.elapsed();
+
+        assert_eq!(response.text, "Hello world");
+        // Without latency, should complete nearly instantly (under 50ms)
+        assert!(
+            elapsed.as_millis() < 50,
+            "instant mode should have no delays, took {}ms",
+            elapsed.as_millis()
+        );
     }
 }

--- a/crates/core/src/llmsim_driver.rs
+++ b/crates/core/src/llmsim_driver.rs
@@ -11,6 +11,7 @@
 // It can be configured per-test to return specific responses or tool calls.
 
 use async_trait::async_trait;
+use futures::StreamExt;
 use futures::stream;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -23,8 +24,8 @@ use crate::llm_driver_registry::{
 use crate::tool_types::ToolCall;
 use llmsim::generator::{LoremGenerator, ResponseGenerator};
 use llmsim::latency::LatencyProfile;
-use llmsim::openai::{ChatCompletionRequest, Message, Role};
-use tokio_stream::wrappers::ReceiverStream;
+use llmsim::openai::{ChatCompletionRequest, Message, Role, Usage};
+use llmsim::stream::TokenStreamBuilder;
 
 // ============================================================================
 // Configuration Types
@@ -378,30 +379,16 @@ impl LlmSimDriver {
         }
     }
 
-    /// Get latency profile if enabled
-    fn get_latency_profile(&self) -> LatencyProfile {
-        if self.config.simulate_latency {
-            // Use fast profile for tests - just enough to simulate streaming
+    /// Resolve latency profile for a request.
+    /// Model names containing "-latency" enable realistic streaming simulation
+    /// via LatencyProfile::fast(). The config flag `simulate_latency` also enables it.
+    /// Returns LatencyProfile::instant() when neither is set.
+    fn resolve_latency_profile(&self, model_name: &str) -> LatencyProfile {
+        if self.config.simulate_latency || model_name.contains("-latency") {
             LatencyProfile::fast()
         } else {
             LatencyProfile::instant()
         }
-    }
-
-    /// Get latency profile for a specific model name from the request.
-    /// Model names containing "-latency" enable streaming simulation with
-    /// inter-token delays using LatencyProfile::fast().
-    fn get_request_latency_profile(model_name: &str) -> Option<LatencyProfile> {
-        if model_name.contains("-latency") {
-            Some(LatencyProfile::fast())
-        } else {
-            None
-        }
-    }
-
-    /// Whether a request should use latency simulation based on config or model name.
-    fn should_simulate_latency(&self, model_name: &str) -> bool {
-        self.config.simulate_latency || model_name.contains("-latency")
     }
 
     /// Estimate token count for text
@@ -441,15 +428,7 @@ impl LlmDriver for LlmSimDriver {
         let response_text = self.generate_response(&messages);
         let tool_calls = self.get_tool_calls(&messages);
         let model_name = config.model.clone();
-        let simulate_latency = self.should_simulate_latency(&model_name);
-
-        // Select latency profile: request model name takes priority, then config
-        let latency_profile = if simulate_latency {
-            Self::get_request_latency_profile(&model_name)
-                .unwrap_or_else(|| self.get_latency_profile())
-        } else {
-            self.get_latency_profile()
-        };
+        let latency_profile = self.resolve_latency_profile(&model_name);
 
         // Calculate token estimates
         let prompt_tokens: u32 = messages
@@ -458,69 +437,59 @@ impl LlmDriver for LlmSimDriver {
             .sum();
         let completion_tokens = Self::estimate_tokens(&response_text);
 
-        // Build stream events
-        let mut events = Vec::new();
+        // Use llmsim's TokenStreamBuilder for streaming with latency simulation.
+        // It handles TTFT and inter-token delays natively via LatencyProfile.
+        let usage = Usage {
+            prompt_tokens,
+            completion_tokens,
+            total_tokens: prompt_tokens + completion_tokens,
+        };
 
-        // Stream text in chunks (word by word for realistic streaming)
-        if !response_text.is_empty() {
-            let words: Vec<&str> = response_text.split_whitespace().collect();
-            for (i, word) in words.iter().enumerate() {
-                let delta = if i == 0 {
-                    word.to_string()
-                } else {
-                    format!(" {}", word)
-                };
-                events.push(LlmStreamEvent::TextDelta(delta));
-            }
-        }
+        let chunk_stream = TokenStreamBuilder::new(&model_name, &response_text)
+            .latency(latency_profile)
+            .usage(usage)
+            .build()
+            .into_chunk_stream();
 
-        // Emit tool calls if present
-        if let Some(calls) = tool_calls {
-            events.push(LlmStreamEvent::ToolCalls(calls));
-        }
+        // Map llmsim ChatCompletionChunk -> our LlmStreamEvent, then append
+        // tool calls and metadata after the text stream completes.
+        let tool_calls_tail = tool_calls;
+        let model_name_done = model_name.clone();
+        let event_stream = chunk_stream.flat_map(move |chunk| {
+            let mut events: Vec<Result<LlmStreamEvent>> = Vec::new();
 
-        // Final done event with metadata
-        events.push(LlmStreamEvent::Done(LlmCompletionMetadata {
-            total_tokens: Some(prompt_tokens + completion_tokens),
-            prompt_tokens: Some(prompt_tokens),
-            completion_tokens: Some(completion_tokens),
-            cache_read_tokens: None,
-            cache_creation_tokens: None,
-            model: Some(model_name),
-            finish_reason: Some("stop".to_string()),
-            retry_metadata: None, // LlmSim doesn't implement retry
-        }));
-
-        // When latency simulation is enabled (via config or model name like "llmsim-latency"),
-        // stream events through a channel with realistic TTFT and inter-token delays.
-        // This simulates actual LLM streaming behavior for benchmarking.
-        if simulate_latency {
-            let (tx, rx) = tokio::sync::mpsc::channel(32);
-
-            tokio::spawn(async move {
-                // Simulate time-to-first-token delay
-                let ttft = latency_profile.sample_ttft();
-                tokio::time::sleep(ttft).await;
-
-                for event in events {
-                    let is_text_delta = matches!(&event, LlmStreamEvent::TextDelta(_));
-                    if tx.send(Ok(event)).await.is_err() {
-                        break;
-                    }
-                    // Simulate inter-token delay after each text delta
-                    if is_text_delta {
-                        let tbt = latency_profile.sample_tbt();
-                        tokio::time::sleep(tbt).await;
-                    }
+            for choice in &chunk.choices {
+                if let Some(content) = &choice.delta.content
+                    && !content.is_empty()
+                {
+                    events.push(Ok(LlmStreamEvent::TextDelta(content.clone())));
                 }
-            });
+            }
 
-            Ok(Box::pin(ReceiverStream::new(rx)))
-        } else {
-            // No latency: emit all events instantly
-            let wrapped: Vec<Result<LlmStreamEvent>> = events.into_iter().map(Ok).collect();
-            Ok(Box::pin(stream::iter(wrapped)))
-        }
+            stream::iter(events)
+        });
+
+        // Append tool calls + done after the text stream
+        let done_events: Vec<Result<LlmStreamEvent>> = {
+            let mut tail = Vec::new();
+            if let Some(calls) = tool_calls_tail {
+                tail.push(Ok(LlmStreamEvent::ToolCalls(calls)));
+            }
+            tail.push(Ok(LlmStreamEvent::Done(LlmCompletionMetadata {
+                total_tokens: Some(prompt_tokens + completion_tokens),
+                prompt_tokens: Some(prompt_tokens),
+                completion_tokens: Some(completion_tokens),
+                cache_read_tokens: None,
+                cache_creation_tokens: None,
+                model: Some(model_name_done),
+                finish_reason: Some("stop".to_string()),
+                retry_metadata: None,
+            })));
+            tail
+        };
+
+        let full_stream = event_stream.chain(stream::iter(done_events));
+        Ok(Box::pin(full_stream))
     }
 }
 
@@ -863,8 +832,8 @@ mod tests {
         }
 
         assert!(got_done);
-        // Should stream word by word
-        assert_eq!(text_parts.len(), 3); // "Hello", " world", " test"
+        // llmsim's TokenStream handles chunking; verify full text is correct
+        assert!(!text_parts.is_empty());
         assert_eq!(text_parts.join(""), "Hello world test");
     }
 
@@ -980,24 +949,21 @@ mod tests {
     }
 
     #[test]
-    fn test_should_simulate_latency_from_model_name() {
-        // Config flag off, model name triggers latency
+    fn test_resolve_latency_profile_from_model_name() {
         let driver = LlmSimDriver::new(LlmSimConfig::fixed("test"));
-        assert!(driver.should_simulate_latency("llmsim-latency"));
-        assert!(!driver.should_simulate_latency("llmsim-default"));
 
-        // Config flag on, any model name
+        // "-latency" in model name -> fast profile (non-instant)
+        let profile = driver.resolve_latency_profile("llmsim-latency");
+        assert!(profile.sample_ttft().as_nanos() > 0);
+
+        // default model name -> instant profile
+        let profile = driver.resolve_latency_profile("llmsim-default");
+        assert_eq!(profile.sample_ttft().as_nanos(), 0);
+
+        // config flag also enables fast profile
         let driver = LlmSimDriver::new(LlmSimConfig::fixed("test").with_latency());
-        assert!(driver.should_simulate_latency("llmsim-default"));
-        assert!(driver.should_simulate_latency("llmsim-latency"));
-    }
-
-    #[test]
-    fn test_get_request_latency_profile() {
-        // Model with "-latency" returns a profile
-        assert!(LlmSimDriver::get_request_latency_profile("llmsim-latency").is_some());
-        // Model without "-latency" returns None
-        assert!(LlmSimDriver::get_request_latency_profile("llmsim-default").is_none());
+        let profile = driver.resolve_latency_profile("llmsim-default");
+        assert!(profile.sample_ttft().as_nanos() > 0);
     }
 
     #[tokio::test]

--- a/crates/server/benches/load_test.rs
+++ b/crates/server/benches/load_test.rs
@@ -13,7 +13,7 @@
 //!   API_URL=http://localhost:9300/api   # API endpoint
 //!   SESSIONS=100                    # Number of parallel sessions
 //!   MESSAGES_PER_SESSION=50         # Messages per session
-//!   MODEL_ID=llmsim                 # Model to use (llmsim, llmsim-ttft-500, etc.)
+//!   MODEL_ID=<model_id>             # Model to use (default: llmsim-latency seed model)
 //!   TARGET=docker-example           # Target label (auto-detected if unset)
 
 use std::fs;
@@ -35,8 +35,9 @@ use tokio::sync::Semaphore;
 /// Seed harness ID from seed.rs (DEFAULT_HARNESS = 0x01933b5a_0000_7000_8000_000000000601)
 const DEFAULT_HARNESS_ID: &str = "harness_01933b5a000070008000000000000601";
 
-/// Seed llmsim model ID from seed.rs (LLMSIM_DEFAULT = 0x01933b5a_0000_7000_8000_000000000401)
-const DEFAULT_LLMSIM_MODEL_ID: &str = "model_01933b5a000070008000000000000401";
+/// Seed llmsim-latency model ID from seed.rs (LLMSIM_LATENCY = 0x01933b5a_0000_7000_8000_000000000402)
+/// Uses LatencyProfile::fast() with TTFT and inter-token delays for realistic streaming simulation.
+const DEFAULT_LLMSIM_MODEL_ID: &str = "model_01933b5a000070008000000000000402";
 
 // ============================================================================
 // Configuration

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -102,6 +102,7 @@ mod seed_ids {
 
     // LlmSim Models (0x400-0x4FF)
     pub const LLMSIM_DEFAULT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000401);
+    pub const LLMSIM_LATENCY: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000402);
 
     // Gemini Models (0x600-0x6FF)
     pub const GEMINI_25_PRO: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000601);
@@ -1187,6 +1188,14 @@ const SEED_MODELS: &[SeedModel] = &[
         provider_id: seed_ids::LLMSIM_PROVIDER,
         model_id: "llmsim-default",
         display_name: "LlmSim Default",
+        is_default: false,
+        is_favorite: false,
+    },
+    SeedModel {
+        id: seed_ids::LLMSIM_LATENCY,
+        provider_id: seed_ids::LLMSIM_PROVIDER,
+        model_id: "llmsim-latency",
+        display_name: "LlmSim Latency",
         is_default: false,
         is_favorite: false,
     },

--- a/specs/load-testing.md
+++ b/specs/load-testing.md
@@ -39,7 +39,7 @@ All configuration via environment variables, overridden by CLI args where applic
 | `API_URL` | `http://localhost:9300/api` | Server API endpoint |
 | `SESSIONS` | `100` | Number of parallel sessions |
 | `MESSAGES_PER_SESSION` | `50` | Messages per session |
-| `MODEL_ID` | seed llmsim model | Model to use |
+| `MODEL_ID` | seed llmsim-latency model | Model to use (default includes TTFT + streaming delays) |
 | `MAX_CONCURRENT` | `50` | Max concurrent sessions |
 | `TIMEOUT_SECS` | `300` | Per-request timeout |
 | `TARGET` | auto-detected | Target label (e.g., `dev`, `docker-example`) |
@@ -147,3 +147,14 @@ SESSIONS=1 MESSAGES_PER_SESSION=200 just load-test quick --save --bench-name his
 # Heavy load with custom moniker
 just load-test heavy --save --moniker ci-4cpu-8gb
 ```
+
+## Latency Simulation
+
+Load tests default to the `llmsim-latency` seed model, which simulates realistic LLM streaming behavior:
+
+- **TTFT (Time To First Token)**: Sampled from `LatencyProfile::fast()` before the first token
+- **TBT (Time Between Tokens)**: Sampled from `LatencyProfile::fast()` between each streamed word
+
+This measures end-to-end server performance under conditions closer to real LLM usage, where streaming responses arrive over time rather than instantly. The llmsim driver detects the `-latency` suffix in the model name and enables latency simulation automatically.
+
+To bypass latency simulation (e.g., for pure server overhead measurement), override the model: `MODEL_ID=model_01933b5a000070008000000000000401` (the `llmsim-default` instant model).


### PR DESCRIPTION
## What
Use llmsim's native `TokenStreamBuilder` for realistic latency and streaming simulation in the llmsim driver. Add `llmsim-latency` seed model and make it the default for load test benchmarks.

## Why
Benchmarks should exercise the streaming pipeline under realistic timing (TTFT + inter-token delays) rather than instant responses. Using llmsim's built-in `LatencyProfile` gives accurate simulation without reimplementing delay logic.

## How
- **llmsim driver**: Replace manual word-by-word streaming with `TokenStreamBuilder::new(model, text).latency(profile).usage(usage).build().into_chunk_stream()`. Model names containing `-latency` resolve to `LatencyProfile::fast()`; otherwise `LatencyProfile::instant()`.
- **Seed model**: Add `llmsim-latency` (ID `0x402`) alongside existing `llmsim-default` (`0x401`).
- **Load test**: Default model switched from `llmsim-default` to `llmsim-latency`. All benchmarks now include TTFT and TBT delays by default. Override with `MODEL_ID=model_01933b5a000070008000000000000401` for instant mode.
- **Spec**: Updated `specs/load-testing.md` with latency simulation docs.

## Risk
- Low
- Existing unit tests using `llmsim-default` model are unaffected (instant profile). Only code paths that use the `-latency` model name or `with_latency()` config get delays.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered