### PR TITLE
fix(server): use axum_extra::extract::Query for SSE exclude param

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,7 @@ dependencies = [
  "bytes",
  "cookie",
  "fastrand",
+ "form_urlencoded",
  "futures-core",
  "futures-util",
  "http",
@@ -351,6 +352,9 @@ dependencies = [
  "mime",
  "multer",
  "pin-project-lite",
+ "serde_core",
+ "serde_html_form",
+ "serde_path_to_error",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1464,6 +1468,7 @@ dependencies = [
  "regex",
  "reqwest 0.13.1",
  "serde",
+ "serde_html_form",
  "serde_json",
  "serde_yaml",
  "sha2",
@@ -4424,6 +4429,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_html_form"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2f2d7ff8a2140333718bb329f5c40fc5f0865b84c426183ce14c97d2ab8154f"
+dependencies = [
+ "form_urlencoded",
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ futures = "0.3"
 
 # HTTP framework
 axum = { version = "0.8", features = ["macros"] }
-axum-extra = { version = "0.12", features = ["cookie", "multipart"] }
+axum-extra = { version = "0.12", features = ["cookie", "multipart", "query"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -73,6 +73,7 @@ prost.workspace = true
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-native-certs", "blocking"] }
 http-body-util = "0.1"
 sysinfo = "0.33"
+serde_html_form = "0.2"  # Same deserializer axum-extra::extract::Query uses
 everruns-sdk.workspace = true
 
 [[bench]]

--- a/crates/server/src/api/events.rs
+++ b/crates/server/src/api/events.rs
@@ -7,11 +7,15 @@ use crate::storage::StorageBackend;
 use axum::extract::FromRef;
 use axum::{
     Json, Router,
-    extract::{Path, Query, State},
+    extract::{Path, State},
     http::StatusCode,
     response::sse::{Event as SseEvent, KeepAlive, Sse},
     routing::get,
 };
+// Use axum_extra::extract::Query (backed by serde_html_form) instead of axum's
+// built-in Query (backed by serde_urlencoded) because serde_urlencoded does not
+// support deserializing repeated query keys (?exclude=a&exclude=b) into Vec<String>.
+use axum_extra::extract::Query;
 use everruns_core::typed_id::{EventId, SessionId};
 use everruns_core::{Event, EventListener};
 use serde::Deserialize;
@@ -567,11 +571,8 @@ mod tests {
     }
 
     /// Test that EventsQuery JSON deserialization works with prefixed event IDs.
-    /// This simulates what axum Query extractor does when parsing query params.
     #[test]
     fn test_events_query_deserializes_prefixed_event_id() {
-        // axum internally uses serde to deserialize query params
-        // Test JSON deserialization to verify EventId's Deserialize impl works
         let json = r#"{"since_id": "event_019c263feac17809a9d442e25317890b", "exclude": []}"#;
         let query: EventsQuery = serde_json::from_str(json)
             .expect("Should deserialize EventsQuery with prefixed event ID");
@@ -585,7 +586,7 @@ mod tests {
     }
 
     #[test]
-    fn test_events_query_with_exclude() {
+    fn test_events_query_json_with_exclude() {
         let json = r#"{"since_id": "event_019c263feac17809a9d442e25317890b", "exclude": ["output.message.delta", "reason.thinking.delta"]}"#;
         let query: EventsQuery =
             serde_json::from_str(json).expect("Should deserialize EventsQuery");
@@ -604,5 +605,64 @@ mod tests {
 
         assert!(query.since_id.is_none());
         assert!(query.exclude.is_empty());
+    }
+
+    // Tests below use serde_html_form (the actual deserializer backing
+    // axum_extra::extract::Query) to verify real URL query string parsing.
+
+    /// Repeated keys (?exclude=a&exclude=b) must deserialize into Vec<String>.
+    /// This was broken with axum's built-in Query (serde_urlencoded) and is
+    /// the primary bug this fix addresses.
+    #[test]
+    fn test_query_string_exclude_repeated_keys() {
+        let qs = "exclude=output.message.delta&exclude=reason.thinking.delta";
+        let query: EventsQuery = serde_html_form::from_str(qs).expect("repeated keys should parse");
+
+        assert_eq!(query.exclude.len(), 2);
+        assert_eq!(query.exclude[0], "output.message.delta");
+        assert_eq!(query.exclude[1], "reason.thinking.delta");
+        assert!(query.since_id.is_none());
+    }
+
+    /// Single exclude value should work.
+    #[test]
+    fn test_query_string_exclude_single() {
+        let qs = "exclude=output.message.delta";
+        let query: EventsQuery =
+            serde_html_form::from_str(qs).expect("single exclude should parse");
+
+        assert_eq!(query.exclude.len(), 1);
+        assert_eq!(query.exclude[0], "output.message.delta");
+    }
+
+    /// No exclude param at all should default to empty vec.
+    #[test]
+    fn test_query_string_no_exclude() {
+        let qs = "since_id=event_019c263feac17809a9d442e25317890b";
+        let query: EventsQuery = serde_html_form::from_str(qs).expect("no exclude should parse");
+
+        assert!(query.exclude.is_empty());
+        assert!(query.since_id.is_some());
+    }
+
+    /// Empty query string should work (all fields optional/defaulted).
+    #[test]
+    fn test_query_string_empty() {
+        let qs = "";
+        let query: EventsQuery = serde_html_form::from_str(qs).expect("empty query should parse");
+
+        assert!(query.since_id.is_none());
+        assert!(query.exclude.is_empty());
+    }
+
+    /// Combined since_id and exclude params.
+    #[test]
+    fn test_query_string_since_id_with_exclude() {
+        let qs = "since_id=event_019c263feac17809a9d442e25317890b&exclude=output.message.delta&exclude=reason.thinking.delta";
+        let query: EventsQuery =
+            serde_html_form::from_str(qs).expect("combined params should parse");
+
+        assert!(query.since_id.is_some());
+        assert_eq!(query.exclude.len(), 2);
     }
 }


### PR DESCRIPTION
## What
Switch the SSE and events list endpoints from `axum::extract::Query` to `axum_extra::extract::Query` for `EventsQuery` deserialization.

## Why
`axum::extract::Query` delegates to `serde_urlencoded`, which cannot deserialize repeated query keys (`?exclude=a&exclude=b`) into `Vec<String>` — it sees a single string instead of a sequence. The UI sends exclude params as repeated keys via `URLSearchParams.append()`, causing 400 errors on both the SSE (`/v1/sessions/{id}/sse`) and events list (`/v1/sessions/{id}/events`) endpoints.

The existing `#[param(style = Form, explode = true)]` utoipa annotation only affects OpenAPI doc generation, not actual deserialization.

## How
- Enable the `query` feature on `axum-extra` (workspace `Cargo.toml`)
- Import `axum_extra::extract::Query` (backed by `serde_html_form`) instead of `axum::extract::Query` in the events module
- Add `serde_html_form` as a dev-dependency for testing
- Add 5 new tests that exercise actual URL query string deserialization (repeated keys, single key, no exclude, empty query, combined params)

No other endpoints are affected — `EventsQuery` is the only `Query`-extracted struct with a `Vec` field.

## Risk
- Low
- The `axum_extra::extract::Query` extractor is a drop-in replacement. `serde_html_form` is a superset of `serde_urlencoded` behavior, so all existing valid query strings continue to work.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered