### PR TITLE
feat(fake_aws): autonomous Cost & Security Auditor with rich seed data

### DIFF
--- a/crates/core/src/capabilities/fake_aws.rs
+++ b/crates/core/src/capabilities/fake_aws.rs
@@ -212,14 +212,15 @@ const SG_PATH: &str = "/aws/security_groups.json";
 
 fn seed_ec2() -> Vec<Ec2Instance> {
     vec![
+        // --- Healthy production instances ---
         Ec2Instance {
-            instance_id: "i-0123456789abcdef0".into(),
+            instance_id: "i-0a1b2c3d4e5f60001".into(),
             instance_type: "t3.medium".into(),
             state: "running".into(),
             availability_zone: "us-east-1a".into(),
-            private_ip: "10.0.1.100".into(),
-            public_ip: Some("54.123.45.67".into()),
-            launch_time: "2025-01-01T10:00:00Z".into(),
+            private_ip: "10.0.1.10".into(),
+            public_ip: Some("54.200.10.1".into()),
+            launch_time: "2025-06-15T08:00:00Z".into(),
             tags: vec![
                 Tag {
                     key: "Name".into(),
@@ -229,39 +230,194 @@ fn seed_ec2() -> Vec<Ec2Instance> {
                     key: "Environment".into(),
                     value: "production".into(),
                 },
+                Tag {
+                    key: "Team".into(),
+                    value: "platform".into(),
+                },
             ],
         },
         Ec2Instance {
-            instance_id: "i-0987654321fedcba0".into(),
+            instance_id: "i-0a1b2c3d4e5f60002".into(),
+            instance_type: "t3.medium".into(),
+            state: "running".into(),
+            availability_zone: "us-east-1b".into(),
+            private_ip: "10.0.2.10".into(),
+            public_ip: Some("54.200.10.2".into()),
+            launch_time: "2025-06-15T08:05:00Z".into(),
+            tags: vec![
+                Tag {
+                    key: "Name".into(),
+                    value: "web-server-02".into(),
+                },
+                Tag {
+                    key: "Environment".into(),
+                    value: "production".into(),
+                },
+                Tag {
+                    key: "Team".into(),
+                    value: "platform".into(),
+                },
+            ],
+        },
+        Ec2Instance {
+            instance_id: "i-0a1b2c3d4e5f60003".into(),
+            instance_type: "t3.large".into(),
+            state: "running".into(),
+            availability_zone: "us-east-1a".into(),
+            private_ip: "10.0.1.20".into(),
+            public_ip: Some("54.200.10.3".into()),
+            launch_time: "2025-07-01T10:00:00Z".into(),
+            tags: vec![
+                Tag {
+                    key: "Name".into(),
+                    value: "api-server-01".into(),
+                },
+                Tag {
+                    key: "Environment".into(),
+                    value: "production".into(),
+                },
+                Tag {
+                    key: "Team".into(),
+                    value: "backend".into(),
+                },
+            ],
+        },
+        Ec2Instance {
+            instance_id: "i-0a1b2c3d4e5f60004".into(),
             instance_type: "t3.large".into(),
             state: "running".into(),
             availability_zone: "us-east-1b".into(),
-            private_ip: "10.0.2.100".into(),
-            public_ip: Some("54.123.45.68".into()),
-            launch_time: "2025-01-01T11:00:00Z".into(),
+            private_ip: "10.0.2.20".into(),
+            public_ip: Some("54.200.10.4".into()),
+            launch_time: "2025-07-01T10:05:00Z".into(),
+            tags: vec![
+                Tag {
+                    key: "Name".into(),
+                    value: "api-server-02".into(),
+                },
+                Tag {
+                    key: "Environment".into(),
+                    value: "production".into(),
+                },
+                Tag {
+                    key: "Team".into(),
+                    value: "backend".into(),
+                },
+            ],
+        },
+        // --- ISSUE: Idle expensive instance (m5.xlarge barely doing anything) ---
+        Ec2Instance {
+            instance_id: "i-0a1b2c3d4e5f60005".into(),
+            instance_type: "m5.xlarge".into(),
+            state: "running".into(),
+            availability_zone: "us-east-1a".into(),
+            private_ip: "10.0.1.30".into(),
+            public_ip: Some("54.200.10.5".into()),
+            launch_time: "2025-03-10T09:00:00Z".into(),
+            tags: vec![
+                Tag {
+                    key: "Name".into(),
+                    value: "batch-processor-01".into(),
+                },
+                Tag {
+                    key: "Environment".into(),
+                    value: "production".into(),
+                },
+            ],
+        },
+        // --- ISSUE: Old-gen instance type (m4), missing Environment tag ---
+        Ec2Instance {
+            instance_id: "i-0a1b2c3d4e5f60006".into(),
+            instance_type: "m4.large".into(),
+            state: "running".into(),
+            availability_zone: "us-east-1a".into(),
+            private_ip: "10.0.1.40".into(),
+            public_ip: Some("54.200.10.6".into()),
+            launch_time: "2024-11-01T12:00:00Z".into(),
             tags: vec![Tag {
                 key: "Name".into(),
-                value: "api-server-01".into(),
+                value: "legacy-app-01".into(),
             }],
+        },
+        // --- ISSUE: Dev instance running for months, wasting money ---
+        Ec2Instance {
+            instance_id: "i-0a1b2c3d4e5f60007".into(),
+            instance_type: "t3.small".into(),
+            state: "running".into(),
+            availability_zone: "us-east-1a".into(),
+            private_ip: "10.0.1.50".into(),
+            public_ip: Some("54.200.10.7".into()),
+            launch_time: "2025-01-15T14:00:00Z".into(),
+            tags: vec![
+                Tag {
+                    key: "Name".into(),
+                    value: "test-server-01".into(),
+                },
+                Tag {
+                    key: "Environment".into(),
+                    value: "development".into(),
+                },
+                Tag {
+                    key: "Owner".into(),
+                    value: "intern-temp".into(),
+                },
+            ],
+        },
+        // --- ISSUE: Stopped expensive instance, NO tags at all ---
+        Ec2Instance {
+            instance_id: "i-0a1b2c3d4e5f60008".into(),
+            instance_type: "c5.2xlarge".into(),
+            state: "stopped".into(),
+            availability_zone: "us-east-1b".into(),
+            private_ip: "10.0.2.60".into(),
+            public_ip: None,
+            launch_time: "2025-02-01T08:00:00Z".into(),
+            tags: vec![],
         },
     ]
 }
 
 fn seed_rds() -> Vec<RdsDatabase> {
-    vec![RdsDatabase {
-        db_instance_id: "prod-postgres-01".into(),
-        engine: "postgres".into(),
-        engine_version: "15.4".into(),
-        instance_class: "db.t3.medium".into(),
-        status: "available".into(),
-        endpoint: "prod-postgres-01.abc123.us-east-1.rds.amazonaws.com".into(),
-        port: 5432,
-        storage_gb: 100,
-    }]
+    vec![
+        // Healthy production database
+        RdsDatabase {
+            db_instance_id: "prod-postgres-01".into(),
+            engine: "postgres".into(),
+            engine_version: "15.4".into(),
+            instance_class: "db.t3.medium".into(),
+            status: "available".into(),
+            endpoint: "prod-postgres-01.abc123.us-east-1.rds.amazonaws.com".into(),
+            port: 5432,
+            storage_gb: 100,
+        },
+        // ISSUE: Oversized instance for what is actually a staging workload
+        RdsDatabase {
+            db_instance_id: "staging-mysql-01".into(),
+            engine: "mysql".into(),
+            engine_version: "8.0".into(),
+            instance_class: "db.r5.large".into(),
+            status: "available".into(),
+            endpoint: "staging-mysql-01.abc123.us-east-1.rds.amazonaws.com".into(),
+            port: 3306,
+            storage_gb: 500,
+        },
+        // ISSUE: End-of-life Postgres 11 (EOL Nov 2023)
+        RdsDatabase {
+            db_instance_id: "legacy-pg-11".into(),
+            engine: "postgres".into(),
+            engine_version: "11.22".into(),
+            instance_class: "db.t3.small".into(),
+            status: "available".into(),
+            endpoint: "legacy-pg-11.abc123.us-east-1.rds.amazonaws.com".into(),
+            port: 5432,
+            storage_gb: 20,
+        },
+    ]
 }
 
 fn seed_s3() -> Vec<S3Bucket> {
     vec![
+        // Healthy: properly configured backup bucket
         S3Bucket {
             name: "company-data-backup".into(),
             region: "us-east-1".into(),
@@ -269,11 +425,44 @@ fn seed_s3() -> Vec<S3Bucket> {
             versioning_enabled: true,
             encryption_enabled: true,
         },
+        // ISSUE: Production assets without versioning
         S3Bucket {
             name: "static-assets-prod".into(),
-            region: "us-west-2".into(),
+            region: "us-east-1".into(),
             creation_date: "2024-08-15T00:00:00Z".into(),
             versioning_enabled: false,
+            encryption_enabled: true,
+        },
+        // ISSUE: No encryption AND no versioning — dump bucket
+        S3Bucket {
+            name: "temp-data-dump".into(),
+            region: "us-east-1".into(),
+            creation_date: "2025-04-01T00:00:00Z".into(),
+            versioning_enabled: false,
+            encryption_enabled: false,
+        },
+        // CRITICAL: PII bucket without encryption!
+        S3Bucket {
+            name: "customer-pii-records".into(),
+            region: "us-east-1".into(),
+            creation_date: "2024-09-10T00:00:00Z".into(),
+            versioning_enabled: true,
+            encryption_enabled: false,
+        },
+        // ISSUE: Stale dev bucket, no encryption, no versioning
+        S3Bucket {
+            name: "dev-test-artifacts".into(),
+            region: "us-west-2".into(),
+            creation_date: "2025-01-20T00:00:00Z".into(),
+            versioning_enabled: false,
+            encryption_enabled: false,
+        },
+        // Healthy: well-configured archive
+        S3Bucket {
+            name: "log-archive-2024".into(),
+            region: "us-east-1".into(),
+            creation_date: "2024-01-01T00:00:00Z".into(),
+            versioning_enabled: true,
             encryption_enabled: true,
         },
     ]
@@ -281,6 +470,7 @@ fn seed_s3() -> Vec<S3Bucket> {
 
 fn seed_iam() -> Vec<IamUser> {
     vec![
+        // ISSUE: Human user with full admin — should use roles instead
         IamUser {
             username: "admin-user".into(),
             user_id: "AIDAI23XYZABC123DEF".into(),
@@ -288,6 +478,7 @@ fn seed_iam() -> Vec<IamUser> {
             created_at: "2024-01-15T10:00:00Z".into(),
             permissions: vec!["AdministratorAccess".into()],
         },
+        // ISSUE: Overly broad PowerUserAccess
         IamUser {
             username: "developer-user".into(),
             user_id: "AIDAI23XYZABC456GHI".into(),
@@ -295,33 +486,182 @@ fn seed_iam() -> Vec<IamUser> {
             created_at: "2024-02-20T14:30:00Z".into(),
             permissions: vec!["PowerUserAccess".into()],
         },
+        // CRITICAL: CI bot with AdministratorAccess — massive risk
+        IamUser {
+            username: "ci-deploy-bot".into(),
+            user_id: "AIDAI23XYZABC789JKL".into(),
+            arn: "arn:aws:iam::123456789012:user/ci-deploy-bot".into(),
+            created_at: "2024-06-01T09:00:00Z".into(),
+            permissions: vec!["AdministratorAccess".into(), "IAMFullAccess".into()],
+        },
+        // ISSUE: Temp intern account with excessive permissions
+        IamUser {
+            username: "intern-temp".into(),
+            user_id: "AIDAI23XYZABCMNOPQR".into(),
+            arn: "arn:aws:iam::123456789012:user/intern-temp".into(),
+            created_at: "2025-06-01T10:00:00Z".into(),
+            permissions: vec![
+                "AmazonS3FullAccess".into(),
+                "AmazonEC2FullAccess".into(),
+                "AmazonRDSFullAccess".into(),
+            ],
+        },
+        // Healthy: monitoring service with read-only access
+        IamUser {
+            username: "monitoring-svc".into(),
+            user_id: "AIDAI23XYZABCSTUVWX".into(),
+            arn: "arn:aws:iam::123456789012:user/monitoring-svc".into(),
+            created_at: "2024-03-01T08:00:00Z".into(),
+            permissions: vec!["CloudWatchReadOnlyAccess".into()],
+        },
+        // Mostly OK: analyst with appropriately scoped access
+        IamUser {
+            username: "data-analyst".into(),
+            user_id: "AIDAI23XYZABCYZABCD".into(),
+            arn: "arn:aws:iam::123456789012:user/data-analyst".into(),
+            created_at: "2024-08-15T11:00:00Z".into(),
+            permissions: vec![
+                "AmazonS3ReadOnlyAccess".into(),
+                "AmazonAthenaFullAccess".into(),
+            ],
+        },
     ]
 }
 
 fn seed_security_groups() -> Vec<SecurityGroup> {
-    vec![SecurityGroup {
-        group_id: "sg-0123456789abcdef0".into(),
-        group_name: "web-server-sg".into(),
-        description: "Security group for web servers".into(),
-        vpc_id: "vpc-abc123".into(),
-        inbound_rules: vec![
-            SecurityRule {
-                protocol: "tcp".into(),
-                port_range: "80".into(),
+    vec![
+        // Mostly OK: standard web-facing security group
+        SecurityGroup {
+            group_id: "sg-0a1b2c3d4e5f60001".into(),
+            group_name: "web-server-sg".into(),
+            description: "Security group for web servers".into(),
+            vpc_id: "vpc-abc123".into(),
+            inbound_rules: vec![
+                SecurityRule {
+                    protocol: "tcp".into(),
+                    port_range: "80".into(),
+                    source: "0.0.0.0/0".into(),
+                },
+                SecurityRule {
+                    protocol: "tcp".into(),
+                    port_range: "443".into(),
+                    source: "0.0.0.0/0".into(),
+                },
+            ],
+            outbound_rules: vec![SecurityRule {
+                protocol: "-1".into(),
+                port_range: "all".into(),
                 source: "0.0.0.0/0".into(),
-            },
-            SecurityRule {
-                protocol: "tcp".into(),
-                port_range: "443".into(),
+            }],
+        },
+        // CRITICAL: Database ports open to the entire internet!
+        SecurityGroup {
+            group_id: "sg-0a1b2c3d4e5f60002".into(),
+            group_name: "database-sg".into(),
+            description: "Security group for databases".into(),
+            vpc_id: "vpc-abc123".into(),
+            inbound_rules: vec![
+                SecurityRule {
+                    protocol: "tcp".into(),
+                    port_range: "5432".into(),
+                    source: "0.0.0.0/0".into(),
+                },
+                SecurityRule {
+                    protocol: "tcp".into(),
+                    port_range: "3306".into(),
+                    source: "0.0.0.0/0".into(),
+                },
+            ],
+            outbound_rules: vec![SecurityRule {
+                protocol: "-1".into(),
+                port_range: "all".into(),
                 source: "0.0.0.0/0".into(),
-            },
-        ],
-        outbound_rules: vec![SecurityRule {
-            protocol: "-1".into(),
-            port_range: "all".into(),
-            source: "0.0.0.0/0".into(),
-        }],
-    }]
+            }],
+        },
+        // CRITICAL: SSH and RDP open to the world
+        SecurityGroup {
+            group_id: "sg-0a1b2c3d4e5f60003".into(),
+            group_name: "admin-access-sg".into(),
+            description: "Security group for admin access".into(),
+            vpc_id: "vpc-abc123".into(),
+            inbound_rules: vec![
+                SecurityRule {
+                    protocol: "tcp".into(),
+                    port_range: "22".into(),
+                    source: "0.0.0.0/0".into(),
+                },
+                SecurityRule {
+                    protocol: "tcp".into(),
+                    port_range: "3389".into(),
+                    source: "0.0.0.0/0".into(),
+                },
+            ],
+            outbound_rules: vec![SecurityRule {
+                protocol: "-1".into(),
+                port_range: "all".into(),
+                source: "0.0.0.0/0".into(),
+            }],
+        },
+    ]
+}
+
+// ============================================================================
+// CloudWatch metric profiles for seed resources
+// ============================================================================
+
+/// Per-resource metric base values. Overrides the generic default so seed
+/// instances tell a realistic story the auditor can discover.
+fn metric_profile_base(resource_id: &str, metric: &str) -> Option<f64> {
+    match (resource_id, metric) {
+        // web-server-01: healthy, moderate-high load
+        ("i-0a1b2c3d4e5f60001", "CPUUtilization") => Some(62.0),
+        ("i-0a1b2c3d4e5f60001", "MemoryUtilization") => Some(71.0),
+        ("i-0a1b2c3d4e5f60001", "NetworkIn") => Some(85_000.0),
+
+        // web-server-02: healthy, moderate load
+        ("i-0a1b2c3d4e5f60002", "CPUUtilization") => Some(48.0),
+        ("i-0a1b2c3d4e5f60002", "MemoryUtilization") => Some(55.0),
+        ("i-0a1b2c3d4e5f60002", "NetworkIn") => Some(72_000.0),
+
+        // api-server-01: healthy, moderate load
+        ("i-0a1b2c3d4e5f60003", "CPUUtilization") => Some(45.0),
+        ("i-0a1b2c3d4e5f60003", "MemoryUtilization") => Some(60.0),
+        ("i-0a1b2c3d4e5f60003", "NetworkIn") => Some(95_000.0),
+
+        // api-server-02: healthy, moderate load
+        ("i-0a1b2c3d4e5f60004", "CPUUtilization") => Some(42.0),
+        ("i-0a1b2c3d4e5f60004", "MemoryUtilization") => Some(58.0),
+        ("i-0a1b2c3d4e5f60004", "NetworkIn") => Some(88_000.0),
+
+        // batch-processor-01: IDLE — nearly zero utilization on expensive m5.xlarge
+        ("i-0a1b2c3d4e5f60005", "CPUUtilization") => Some(2.1),
+        ("i-0a1b2c3d4e5f60005", "MemoryUtilization") => Some(5.3),
+        ("i-0a1b2c3d4e5f60005", "NetworkIn") => Some(320.0),
+
+        // legacy-app-01: very low utilization on old-gen m4
+        ("i-0a1b2c3d4e5f60006", "CPUUtilization") => Some(4.8),
+        ("i-0a1b2c3d4e5f60006", "MemoryUtilization") => Some(12.0),
+        ("i-0a1b2c3d4e5f60006", "NetworkIn") => Some(1_200.0),
+
+        // test-server-01: minimal dev traffic
+        ("i-0a1b2c3d4e5f60007", "CPUUtilization") => Some(3.2),
+        ("i-0a1b2c3d4e5f60007", "MemoryUtilization") => Some(9.0),
+        ("i-0a1b2c3d4e5f60007", "NetworkIn") => Some(800.0),
+
+        // prod-postgres-01: healthy RDS
+        ("prod-postgres-01", "CPUUtilization") => Some(38.0),
+        ("prod-postgres-01", "MemoryUtilization") => Some(65.0),
+
+        // staging-mysql-01: underutilized oversized RDS
+        ("staging-mysql-01", "CPUUtilization") => Some(8.5),
+        ("staging-mysql-01", "MemoryUtilization") => Some(15.0),
+
+        // legacy-pg-11: EOL database, low load
+        ("legacy-pg-11", "CPUUtilization") => Some(6.0),
+        ("legacy-pg-11", "MemoryUtilization") => Some(22.0),
+
+        _ => None,
+    }
 }
 
 // ============================================================================
@@ -1234,27 +1574,28 @@ impl Tool for AwsGetCloudWatchMetricsTool {
             }
         }
 
-        // Generate metric datapoints — deterministic from resource_id hash for
-        // reproducible benchmark results
+        // Generate metric datapoints — use per-resource profiles for seed instances
+        // so auditor sees realistic data (idle instances have low CPU, etc.),
+        // with deterministic variation from resource_id hash.
         let hash: u32 = resource_id
             .bytes()
             .fold(0u32, |acc, b| acc.wrapping_mul(31).wrapping_add(b as u32));
+        let base = metric_profile_base(resource_id, metric_name).unwrap_or(match metric_name {
+            "CPUUtilization" => 30.0,
+            "MemoryUtilization" => 55.0,
+            "DiskReadOps" => 150.0,
+            "NetworkIn" => 1024.0 * 50.0,
+            _ => 30.0,
+        });
         let datapoints: Vec<Value> = (0..12)
             .map(|i| {
-                let base = match metric_name {
-                    "CPUUtilization" => 30.0,
-                    "MemoryUtilization" => 55.0,
-                    "DiskReadOps" => 150.0,
-                    "NetworkIn" => 1024.0 * 50.0,
-                    _ => 30.0,
-                };
                 let variation = ((hash.wrapping_add(i * 7)) % 200) as f64 / 10.0 - 10.0;
-                let avg = (base + variation + i as f64 * 1.5).max(0.0);
+                let avg = (base + variation * (base / 30.0)).max(0.0);
                 json!({
                     "timestamp": chrono::Utc::now() - chrono::Duration::minutes(i as i64 * 5),
-                    "average": avg,
-                    "minimum": (avg * 0.7).max(0.0),
-                    "maximum": avg * 1.3
+                    "average": (avg * 100.0).round() / 100.0,
+                    "minimum": ((avg * 0.7).max(0.0) * 100.0).round() / 100.0,
+                    "maximum": (avg * 1.3 * 100.0).round() / 100.0
                 })
             })
             .collect();

--- a/crates/core/src/capabilities/fake_aws.rs
+++ b/crates/core/src/capabilities/fake_aws.rs
@@ -1,7 +1,9 @@
-//! Fake AWS Tools Capability - demo tools for AWS infrastructure management
+//! Fake AWS Tools Capability - mock AWS infrastructure management
 //!
-//! This capability provides mock AWS management tools that store state
-//! in the session file system. Perfect for demos and testing.
+//! All state is persisted in the session file system under `/aws/`.
+//! Every tool call simulates realistic AWS API latency (configurable via
+//! `FAKE_AWS_LATENCY_MS` env var; default 0 = no delay, set e.g. 200 for
+//! benchmarking long-running agents).
 //!
 //! Tools provided:
 //! - `aws_list_ec2_instances`: List EC2 instances
@@ -17,90 +19,127 @@
 //! - `aws_get_cloudwatch_metrics`: Get CloudWatch metrics
 
 use super::{Capability, CapabilityStatus};
+use crate::SessionId;
 use crate::tools::{Tool, ToolExecutionResult};
-use crate::traits::ToolContext;
+use crate::traits::{SessionFileStore, ToolContext};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+use std::sync::OnceLock;
+use std::time::Duration;
 
-/// Fake AWS Tools capability - mock AWS infrastructure management for demos
-pub struct FakeAwsCapability;
+// ============================================================================
+// Latency simulation
+// ============================================================================
 
-impl Capability for FakeAwsCapability {
-    fn id(&self) -> &str {
-        "fake_aws"
-    }
+/// Base latency loaded once from `FAKE_AWS_LATENCY_MS` (default: 0).
+fn base_latency_ms() -> u64 {
+    static BASE: OnceLock<u64> = OnceLock::new();
+    *BASE.get_or_init(|| {
+        std::env::var("FAKE_AWS_LATENCY_MS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0)
+    })
+}
 
-    fn name(&self) -> &str {
-        "Fake AWS Tools"
-    }
+/// Operation-type multipliers applied to the base latency.
+#[derive(Clone, Copy)]
+enum OpKind {
+    /// List / describe operations (~1x base)
+    List,
+    /// Create / launch operations (~3x base)
+    Create,
+    /// Modify / stop operations (~2x base)
+    Modify,
+    /// Metrics / query operations (~1.5x base)
+    Query,
+}
 
-    fn description(&self) -> &str {
-        "Demo capability: AWS infrastructure management tools (EC2, RDS, S3, IAM, CloudWatch). State stored in session filesystem."
-    }
-
-    fn status(&self) -> CapabilityStatus {
-        CapabilityStatus::Available
-    }
-
-    fn icon(&self) -> Option<&str> {
-        Some("cloud")
-    }
-
-    fn category(&self) -> Option<&str> {
-        Some("Demo Tools")
-    }
-
-    fn system_prompt_addition(&self) -> Option<&str> {
-        Some(
-            r#"You have access to AWS infrastructure management tools. All AWS data is stored in /aws/ directory.
-
-Available tools:
-- `aws_list_ec2_instances`: List all EC2 instances with their status
-- `aws_create_ec2_instance`: Launch a new EC2 instance
-- `aws_stop_ec2_instance`: Stop a running EC2 instance
-- `aws_list_rds_databases`: List RDS database instances
-- `aws_create_rds_database`: Create a new RDS database
-- `aws_list_s3_buckets`: List all S3 buckets
-- `aws_create_s3_bucket`: Create a new S3 bucket
-- `aws_list_iam_users`: List IAM users and their permissions
-- `aws_create_iam_user`: Create a new IAM user
-- `aws_list_security_groups`: List security groups and rules
-- `aws_get_cloudwatch_metrics`: Get CloudWatch metrics for resources
-
-Data structure:
-- /aws/ec2_instances.json - EC2 instance records
-- /aws/rds_databases.json - RDS database records
-- /aws/s3_buckets.json - S3 bucket records
-- /aws/iam_users.json - IAM user records
-- /aws/security_groups.json - Security group records
-- /aws/cloudwatch_metrics.json - CloudWatch metrics data"#,
-        )
-    }
-
-    fn tools(&self) -> Vec<Box<dyn Tool>> {
-        vec![
-            Box::new(AwsListEc2InstancesTool),
-            Box::new(AwsCreateEc2InstanceTool),
-            Box::new(AwsStopEc2InstanceTool),
-            Box::new(AwsListRdsDatabasesTool),
-            Box::new(AwsCreateRdsDatabaseTool),
-            Box::new(AwsListS3BucketsTool),
-            Box::new(AwsCreateS3BucketTool),
-            Box::new(AwsListIamUsersTool),
-            Box::new(AwsCreateIamUserTool),
-            Box::new(AwsListSecurityGroupsTool),
-            Box::new(AwsGetCloudWatchMetricsTool),
-        ]
+impl OpKind {
+    fn multiplier(self) -> f64 {
+        match self {
+            OpKind::List => 1.0,
+            OpKind::Create => 3.0,
+            OpKind::Modify => 2.0,
+            OpKind::Query => 1.5,
+        }
     }
 }
 
-// Helper structs for AWS data
+/// Deterministic jitter derived from current timestamp sub-micros (no rand dep).
+fn jitter_factor() -> f64 {
+    let nanos = chrono::Utc::now().timestamp_subsec_nanos();
+    // Produces a value in [0.8, 1.2)
+    0.8 + (nanos % 400) as f64 / 1000.0
+}
+
+/// Sleep to simulate AWS API latency. No-op when base is 0.
+async fn simulate_latency(op: OpKind) {
+    let base = base_latency_ms();
+    if base == 0 {
+        return;
+    }
+    let ms = (base as f64 * op.multiplier() * jitter_factor()) as u64;
+    tokio::time::sleep(Duration::from_millis(ms)).await;
+}
+
+// ============================================================================
+// Persistence helpers
+// ============================================================================
+
+/// Read a JSON collection from the session file store, returning seed data on
+/// first access and persisting it.
+async fn read_or_seed<T: Serialize + for<'de> Deserialize<'de>>(
+    store: &dyn SessionFileStore,
+    session_id: SessionId,
+    path: &str,
+    seed: impl FnOnce() -> Vec<T>,
+) -> Vec<T> {
+    if let Ok(Some(file)) = store.read_file(session_id, path).await
+        && let Ok(items) = serde_json::from_str::<Vec<T>>(file.content.as_deref().unwrap_or(""))
+    {
+        return items;
+    }
+    // First access — persist seed data
+    let items = seed();
+    if let Ok(json) = serde_json::to_string_pretty(&items) {
+        let _ = store.write_file(session_id, path, &json, "text").await;
+    }
+    items
+}
+
+/// Persist a collection back to the session file store.
+async fn persist<T: Serialize>(
+    store: &dyn SessionFileStore,
+    session_id: SessionId,
+    path: &str,
+    items: &[T],
+) -> Result<(), anyhow::Error> {
+    let json = serde_json::to_string_pretty(items)?;
+    store.write_file(session_id, path, &json, "text").await?;
+    Ok(())
+}
+
+/// Extract the file store from context or return a tool error.
+macro_rules! require_file_store {
+    ($ctx:expr) => {
+        match &$ctx.file_store {
+            Some(s) => s.as_ref(),
+            None => return ToolExecutionResult::tool_error("File system not available"),
+        }
+    };
+}
+
+// ============================================================================
+// Data model structs
+// ============================================================================
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct Ec2Instance {
     instance_id: String,
     instance_type: String,
-    state: String, // running, stopped, terminated
+    state: String,
     availability_zone: String,
     private_ip: String,
     public_ip: Option<String>,
@@ -162,6 +201,207 @@ struct SecurityRule {
 }
 
 // ============================================================================
+// Seed data factories
+// ============================================================================
+
+const EC2_PATH: &str = "/aws/ec2_instances.json";
+const RDS_PATH: &str = "/aws/rds_databases.json";
+const S3_PATH: &str = "/aws/s3_buckets.json";
+const IAM_PATH: &str = "/aws/iam_users.json";
+const SG_PATH: &str = "/aws/security_groups.json";
+
+fn seed_ec2() -> Vec<Ec2Instance> {
+    vec![
+        Ec2Instance {
+            instance_id: "i-0123456789abcdef0".into(),
+            instance_type: "t3.medium".into(),
+            state: "running".into(),
+            availability_zone: "us-east-1a".into(),
+            private_ip: "10.0.1.100".into(),
+            public_ip: Some("54.123.45.67".into()),
+            launch_time: "2025-01-01T10:00:00Z".into(),
+            tags: vec![
+                Tag {
+                    key: "Name".into(),
+                    value: "web-server-01".into(),
+                },
+                Tag {
+                    key: "Environment".into(),
+                    value: "production".into(),
+                },
+            ],
+        },
+        Ec2Instance {
+            instance_id: "i-0987654321fedcba0".into(),
+            instance_type: "t3.large".into(),
+            state: "running".into(),
+            availability_zone: "us-east-1b".into(),
+            private_ip: "10.0.2.100".into(),
+            public_ip: Some("54.123.45.68".into()),
+            launch_time: "2025-01-01T11:00:00Z".into(),
+            tags: vec![Tag {
+                key: "Name".into(),
+                value: "api-server-01".into(),
+            }],
+        },
+    ]
+}
+
+fn seed_rds() -> Vec<RdsDatabase> {
+    vec![RdsDatabase {
+        db_instance_id: "prod-postgres-01".into(),
+        engine: "postgres".into(),
+        engine_version: "15.4".into(),
+        instance_class: "db.t3.medium".into(),
+        status: "available".into(),
+        endpoint: "prod-postgres-01.abc123.us-east-1.rds.amazonaws.com".into(),
+        port: 5432,
+        storage_gb: 100,
+    }]
+}
+
+fn seed_s3() -> Vec<S3Bucket> {
+    vec![
+        S3Bucket {
+            name: "company-data-backup".into(),
+            region: "us-east-1".into(),
+            creation_date: "2024-06-01T00:00:00Z".into(),
+            versioning_enabled: true,
+            encryption_enabled: true,
+        },
+        S3Bucket {
+            name: "static-assets-prod".into(),
+            region: "us-west-2".into(),
+            creation_date: "2024-08-15T00:00:00Z".into(),
+            versioning_enabled: false,
+            encryption_enabled: true,
+        },
+    ]
+}
+
+fn seed_iam() -> Vec<IamUser> {
+    vec![
+        IamUser {
+            username: "admin-user".into(),
+            user_id: "AIDAI23XYZABC123DEF".into(),
+            arn: "arn:aws:iam::123456789012:user/admin-user".into(),
+            created_at: "2024-01-15T10:00:00Z".into(),
+            permissions: vec!["AdministratorAccess".into()],
+        },
+        IamUser {
+            username: "developer-user".into(),
+            user_id: "AIDAI23XYZABC456GHI".into(),
+            arn: "arn:aws:iam::123456789012:user/developer-user".into(),
+            created_at: "2024-02-20T14:30:00Z".into(),
+            permissions: vec!["PowerUserAccess".into()],
+        },
+    ]
+}
+
+fn seed_security_groups() -> Vec<SecurityGroup> {
+    vec![SecurityGroup {
+        group_id: "sg-0123456789abcdef0".into(),
+        group_name: "web-server-sg".into(),
+        description: "Security group for web servers".into(),
+        vpc_id: "vpc-abc123".into(),
+        inbound_rules: vec![
+            SecurityRule {
+                protocol: "tcp".into(),
+                port_range: "80".into(),
+                source: "0.0.0.0/0".into(),
+            },
+            SecurityRule {
+                protocol: "tcp".into(),
+                port_range: "443".into(),
+                source: "0.0.0.0/0".into(),
+            },
+        ],
+        outbound_rules: vec![SecurityRule {
+            protocol: "-1".into(),
+            port_range: "all".into(),
+            source: "0.0.0.0/0".into(),
+        }],
+    }]
+}
+
+// ============================================================================
+// Capability
+// ============================================================================
+
+pub struct FakeAwsCapability;
+
+impl Capability for FakeAwsCapability {
+    fn id(&self) -> &str {
+        "fake_aws"
+    }
+
+    fn name(&self) -> &str {
+        "Fake AWS Tools"
+    }
+
+    fn description(&self) -> &str {
+        "Mock AWS infrastructure tools (EC2, RDS, S3, IAM, CloudWatch). \
+         All state persisted in session filesystem. Latency emulation via FAKE_AWS_LATENCY_MS."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("cloud")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Demo Tools")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(
+            r#"You have access to AWS infrastructure management tools. All AWS data is stored in /aws/ directory.
+
+Available tools:
+- `aws_list_ec2_instances`: List all EC2 instances with their status
+- `aws_create_ec2_instance`: Launch a new EC2 instance
+- `aws_stop_ec2_instance`: Stop a running EC2 instance
+- `aws_list_rds_databases`: List RDS database instances
+- `aws_create_rds_database`: Create a new RDS database
+- `aws_list_s3_buckets`: List all S3 buckets
+- `aws_create_s3_bucket`: Create a new S3 bucket
+- `aws_list_iam_users`: List IAM users and their permissions
+- `aws_create_iam_user`: Create a new IAM user
+- `aws_list_security_groups`: List security groups and rules
+- `aws_get_cloudwatch_metrics`: Get CloudWatch metrics for resources
+
+Data structure:
+- /aws/ec2_instances.json - EC2 instance records
+- /aws/rds_databases.json - RDS database records
+- /aws/s3_buckets.json - S3 bucket records
+- /aws/iam_users.json - IAM user records
+- /aws/security_groups.json - Security group records
+
+API calls have realistic latency. All mutations are persisted."#,
+        )
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(AwsListEc2InstancesTool),
+            Box::new(AwsCreateEc2InstanceTool),
+            Box::new(AwsStopEc2InstanceTool),
+            Box::new(AwsListRdsDatabasesTool),
+            Box::new(AwsCreateRdsDatabaseTool),
+            Box::new(AwsListS3BucketsTool),
+            Box::new(AwsCreateS3BucketTool),
+            Box::new(AwsListIamUsersTool),
+            Box::new(AwsCreateIamUserTool),
+            Box::new(AwsListSecurityGroupsTool),
+            Box::new(AwsGetCloudWatchMetricsTool),
+        ]
+    }
+}
+
+// ============================================================================
 // Tool: aws_list_ec2_instances
 // ============================================================================
 
@@ -204,87 +444,12 @@ impl Tool for AwsListEc2InstancesTool {
         arguments: Value,
         context: &ToolContext,
     ) -> ToolExecutionResult {
-        let file_store = match &context.file_store {
-            Some(store) => store,
-            None => return ToolExecutionResult::tool_error("File system not available"),
-        };
+        let store = require_file_store!(context);
+        simulate_latency(OpKind::List).await;
 
         let state_filter = arguments.get("state").and_then(|v| v.as_str());
+        let instances = read_or_seed(store, context.session_id, EC2_PATH, seed_ec2).await;
 
-        // Read EC2 instances
-        let instances: Vec<Ec2Instance> = match file_store
-            .read_file(context.session_id, "/aws/ec2_instances.json")
-            .await
-        {
-            Ok(Some(file)) => serde_json::from_str(file.content.as_deref().unwrap_or(""))
-                .unwrap_or_else(|_| {
-                    // Initialize with sample data
-                    vec![
-                        Ec2Instance {
-                            instance_id: "i-0123456789abcdef0".to_string(),
-                            instance_type: "t3.medium".to_string(),
-                            state: "running".to_string(),
-                            availability_zone: "us-east-1a".to_string(),
-                            private_ip: "10.0.1.100".to_string(),
-                            public_ip: Some("54.123.45.67".to_string()),
-                            launch_time: "2025-01-01T10:00:00Z".to_string(),
-                            tags: vec![
-                                Tag {
-                                    key: "Name".to_string(),
-                                    value: "web-server-01".to_string(),
-                                },
-                                Tag {
-                                    key: "Environment".to_string(),
-                                    value: "production".to_string(),
-                                },
-                            ],
-                        },
-                        Ec2Instance {
-                            instance_id: "i-0987654321fedcba0".to_string(),
-                            instance_type: "t3.large".to_string(),
-                            state: "running".to_string(),
-                            availability_zone: "us-east-1b".to_string(),
-                            private_ip: "10.0.2.100".to_string(),
-                            public_ip: Some("54.123.45.68".to_string()),
-                            launch_time: "2025-01-01T11:00:00Z".to_string(),
-                            tags: vec![Tag {
-                                key: "Name".to_string(),
-                                value: "api-server-01".to_string(),
-                            }],
-                        },
-                    ]
-                }),
-            _ => {
-                // Create initial data
-                let initial = vec![Ec2Instance {
-                    instance_id: "i-0123456789abcdef0".to_string(),
-                    instance_type: "t3.medium".to_string(),
-                    state: "running".to_string(),
-                    availability_zone: "us-east-1a".to_string(),
-                    private_ip: "10.0.1.100".to_string(),
-                    public_ip: Some("54.123.45.67".to_string()),
-                    launch_time: chrono::Utc::now().to_rfc3339(),
-                    tags: vec![Tag {
-                        key: "Name".to_string(),
-                        value: "web-server-01".to_string(),
-                    }],
-                }];
-
-                let content = serde_json::to_string_pretty(&initial).unwrap();
-                let _ = file_store
-                    .write_file(
-                        context.session_id,
-                        "/aws/ec2_instances.json",
-                        &content,
-                        "text",
-                    )
-                    .await;
-
-                initial
-            }
-        };
-
-        // Apply filter
         let filtered: Vec<_> = if let Some(state) = state_filter {
             instances.into_iter().filter(|i| i.state == state).collect()
         } else {
@@ -353,10 +518,8 @@ impl Tool for AwsCreateEc2InstanceTool {
         arguments: Value,
         context: &ToolContext,
     ) -> ToolExecutionResult {
-        let file_store = match &context.file_store {
-            Some(store) => store,
-            None => return ToolExecutionResult::tool_error("File system not available"),
-        };
+        let store = require_file_store!(context);
+        simulate_latency(OpKind::Create).await;
 
         let instance_type = match arguments.get("instance_type").and_then(|v| v.as_str()) {
             Some(t) => t,
@@ -366,30 +529,21 @@ impl Tool for AwsCreateEc2InstanceTool {
                 );
             }
         };
-
         let name = match arguments.get("name").and_then(|v| v.as_str()) {
             Some(n) => n,
             None => return ToolExecutionResult::tool_error("Missing required parameter: name"),
         };
-
-        let availability_zone = arguments
+        let az = arguments
             .get("availability_zone")
             .and_then(|v| v.as_str())
             .unwrap_or("us-east-1a");
 
-        // Read current instances
-        let mut instances: Vec<Ec2Instance> = match file_store
-            .read_file(context.session_id, "/aws/ec2_instances.json")
-            .await
-        {
-            Ok(Some(file)) => {
-                serde_json::from_str(file.content.as_deref().unwrap_or("")).unwrap_or_default()
-            }
-            _ => vec![],
-        };
+        let mut instances = read_or_seed(store, context.session_id, EC2_PATH, seed_ec2).await;
 
-        // Create new instance
-        let instance_id = format!("i-{:016x}", chrono::Utc::now().timestamp() as u64);
+        let instance_id = format!(
+            "i-{:016x}",
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0) as u64
+        );
         let private_ip = format!("10.0.{}.{}", (instances.len() % 254) + 1, 100);
         let public_ip = format!(
             "54.{}.{}.{}",
@@ -401,38 +555,27 @@ impl Tool for AwsCreateEc2InstanceTool {
         let instance = Ec2Instance {
             instance_id: instance_id.clone(),
             instance_type: instance_type.to_string(),
-            state: "running".to_string(),
-            availability_zone: availability_zone.to_string(),
-            private_ip,
+            state: "running".into(),
+            availability_zone: az.to_string(),
+            private_ip: private_ip.clone(),
             public_ip: Some(public_ip.clone()),
             launch_time: chrono::Utc::now().to_rfc3339(),
             tags: vec![Tag {
-                key: "Name".to_string(),
+                key: "Name".into(),
                 value: name.to_string(),
             }],
         };
+        instances.push(instance);
 
-        instances.push(instance.clone());
-
-        // Save instances
-        let content = serde_json::to_string_pretty(&instances).unwrap();
-        match file_store
-            .write_file(
-                context.session_id,
-                "/aws/ec2_instances.json",
-                &content,
-                "text",
-            )
-            .await
-        {
+        match persist(store, context.session_id, EC2_PATH, &instances).await {
             Ok(_) => ToolExecutionResult::success(json!({
                 "instance_id": instance_id,
                 "state": "running",
-                "private_ip": instance.private_ip,
+                "private_ip": private_ip,
                 "public_ip": public_ip,
                 "message": "EC2 instance launched successfully"
             })),
-            Err(e) => ToolExecutionResult::internal_error(e),
+            Err(e) => ToolExecutionResult::tool_error(format!("Failed to persist: {e}")),
         }
     }
 
@@ -484,10 +627,8 @@ impl Tool for AwsStopEc2InstanceTool {
         arguments: Value,
         context: &ToolContext,
     ) -> ToolExecutionResult {
-        let file_store = match &context.file_store {
-            Some(store) => store,
-            None => return ToolExecutionResult::tool_error("File system not available"),
-        };
+        let store = require_file_store!(context);
+        simulate_latency(OpKind::Modify).await;
 
         let instance_id = match arguments.get("instance_id").and_then(|v| v.as_str()) {
             Some(id) => id,
@@ -496,18 +637,8 @@ impl Tool for AwsStopEc2InstanceTool {
             }
         };
 
-        // Read instances
-        let mut instances: Vec<Ec2Instance> = match file_store
-            .read_file(context.session_id, "/aws/ec2_instances.json")
-            .await
-        {
-            Ok(Some(file)) => {
-                serde_json::from_str(file.content.as_deref().unwrap_or("")).unwrap_or_default()
-            }
-            _ => vec![],
-        };
+        let mut instances = read_or_seed(store, context.session_id, EC2_PATH, seed_ec2).await;
 
-        // Find and stop instance
         let instance = match instances.iter_mut().find(|i| i.instance_id == instance_id) {
             Some(i) => i,
             None => {
@@ -519,25 +650,15 @@ impl Tool for AwsStopEc2InstanceTool {
         };
 
         let old_state = instance.state.clone();
-        instance.state = "stopped".to_string();
+        instance.state = "stopped".into();
 
-        // Save updated instances
-        let content = serde_json::to_string_pretty(&instances).unwrap();
-        match file_store
-            .write_file(
-                context.session_id,
-                "/aws/ec2_instances.json",
-                &content,
-                "text",
-            )
-            .await
-        {
+        match persist(store, context.session_id, EC2_PATH, &instances).await {
             Ok(_) => ToolExecutionResult::success(json!({
                 "instance_id": instance_id,
                 "old_state": old_state,
                 "new_state": "stopped"
             })),
-            Err(e) => ToolExecutionResult::internal_error(e),
+            Err(e) => ToolExecutionResult::tool_error(format!("Failed to persist: {e}")),
         }
     }
 
@@ -547,7 +668,7 @@ impl Tool for AwsStopEc2InstanceTool {
 }
 
 // ============================================================================
-// Remaining tools (simplified implementations)
+// Tool: aws_list_rds_databases
 // ============================================================================
 
 pub struct AwsListRdsDatabasesTool;
@@ -579,30 +700,10 @@ impl Tool for AwsListRdsDatabasesTool {
         _arguments: Value,
         context: &ToolContext,
     ) -> ToolExecutionResult {
-        let file_store = match &context.file_store {
-            Some(store) => store,
-            None => return ToolExecutionResult::tool_error("File system not available"),
-        };
+        let store = require_file_store!(context);
+        simulate_latency(OpKind::List).await;
 
-        let databases: Vec<RdsDatabase> = match file_store
-            .read_file(context.session_id, "/aws/rds_databases.json")
-            .await
-        {
-            Ok(Some(file)) => serde_json::from_str(file.content.as_deref().unwrap_or(""))
-                .unwrap_or_else(|_| {
-                    vec![RdsDatabase {
-                        db_instance_id: "prod-postgres-01".to_string(),
-                        engine: "postgres".to_string(),
-                        engine_version: "15.4".to_string(),
-                        instance_class: "db.t3.medium".to_string(),
-                        status: "available".to_string(),
-                        endpoint: "prod-postgres-01.abc123.us-east-1.rds.amazonaws.com".to_string(),
-                        port: 5432,
-                        storage_gb: 100,
-                    }]
-                }),
-            _ => vec![],
-        };
+        let databases = read_or_seed(store, context.session_id, RDS_PATH, seed_rds).await;
 
         ToolExecutionResult::success(
             json!({"databases": databases, "total_count": databases.len()}),
@@ -613,6 +714,10 @@ impl Tool for AwsListRdsDatabasesTool {
         true
     }
 }
+
+// ============================================================================
+// Tool: aws_create_rds_database
+// ============================================================================
 
 pub struct AwsCreateRdsDatabaseTool;
 
@@ -651,24 +756,81 @@ impl Tool for AwsCreateRdsDatabaseTool {
     async fn execute_with_context(
         &self,
         arguments: Value,
-        _context: &ToolContext,
+        context: &ToolContext,
     ) -> ToolExecutionResult {
-        let db_id = arguments
-            .get("db_instance_id")
-            .and_then(|v| v.as_str())
-            .unwrap_or("unknown");
+        let store = require_file_store!(context);
+        simulate_latency(OpKind::Create).await;
 
-        ToolExecutionResult::success(json!({
-            "db_instance_id": db_id,
-            "status": "creating",
-            "message": "RDS database creation initiated"
-        }))
+        let db_id = match arguments.get("db_instance_id").and_then(|v| v.as_str()) {
+            Some(id) => id,
+            None => {
+                return ToolExecutionResult::tool_error(
+                    "Missing required parameter: db_instance_id",
+                );
+            }
+        };
+        let engine = match arguments.get("engine").and_then(|v| v.as_str()) {
+            Some(e) => e,
+            None => return ToolExecutionResult::tool_error("Missing required parameter: engine"),
+        };
+        let instance_class = match arguments.get("instance_class").and_then(|v| v.as_str()) {
+            Some(c) => c,
+            None => {
+                return ToolExecutionResult::tool_error(
+                    "Missing required parameter: instance_class",
+                );
+            }
+        };
+        let storage_gb = arguments
+            .get("storage_gb")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(20) as i32;
+
+        let engine_version = match engine {
+            "postgres" => "15.4",
+            "mysql" => "8.0",
+            "mariadb" => "10.11",
+            _ => "unknown",
+        };
+        let port = match engine {
+            "postgres" => 5432,
+            "mysql" | "mariadb" => 3306,
+            _ => 5432,
+        };
+
+        let mut databases = read_or_seed(store, context.session_id, RDS_PATH, seed_rds).await;
+
+        let db = RdsDatabase {
+            db_instance_id: db_id.to_string(),
+            engine: engine.to_string(),
+            engine_version: engine_version.to_string(),
+            instance_class: instance_class.to_string(),
+            status: "creating".into(),
+            endpoint: format!("{}.abc123.us-east-1.rds.amazonaws.com", db_id),
+            port,
+            storage_gb,
+        };
+        databases.push(db);
+
+        match persist(store, context.session_id, RDS_PATH, &databases).await {
+            Ok(_) => ToolExecutionResult::success(json!({
+                "db_instance_id": db_id,
+                "status": "creating",
+                "endpoint": format!("{}.abc123.us-east-1.rds.amazonaws.com", db_id),
+                "message": "RDS database creation initiated"
+            })),
+            Err(e) => ToolExecutionResult::tool_error(format!("Failed to persist: {e}")),
+        }
     }
 
     fn requires_context(&self) -> bool {
         true
     }
 }
+
+// ============================================================================
+// Tool: aws_list_s3_buckets
+// ============================================================================
 
 pub struct AwsListS3BucketsTool;
 
@@ -697,24 +859,12 @@ impl Tool for AwsListS3BucketsTool {
     async fn execute_with_context(
         &self,
         _arguments: Value,
-        _context: &ToolContext,
+        context: &ToolContext,
     ) -> ToolExecutionResult {
-        let buckets = vec![
-            S3Bucket {
-                name: "company-data-backup".to_string(),
-                region: "us-east-1".to_string(),
-                creation_date: "2024-06-01T00:00:00Z".to_string(),
-                versioning_enabled: true,
-                encryption_enabled: true,
-            },
-            S3Bucket {
-                name: "static-assets-prod".to_string(),
-                region: "us-west-2".to_string(),
-                creation_date: "2024-08-15T00:00:00Z".to_string(),
-                versioning_enabled: false,
-                encryption_enabled: true,
-            },
-        ];
+        let store = require_file_store!(context);
+        simulate_latency(OpKind::List).await;
+
+        let buckets = read_or_seed(store, context.session_id, S3_PATH, seed_s3).await;
 
         ToolExecutionResult::success(json!({"buckets": buckets, "total_count": buckets.len()}))
     }
@@ -723,6 +873,10 @@ impl Tool for AwsListS3BucketsTool {
         true
     }
 }
+
+// ============================================================================
+// Tool: aws_create_s3_bucket
+// ============================================================================
 
 pub struct AwsCreateS3BucketTool;
 
@@ -761,24 +915,59 @@ impl Tool for AwsCreateS3BucketTool {
     async fn execute_with_context(
         &self,
         arguments: Value,
-        _context: &ToolContext,
+        context: &ToolContext,
     ) -> ToolExecutionResult {
-        let bucket_name = arguments
-            .get("bucket_name")
-            .and_then(|v| v.as_str())
-            .unwrap_or("unknown");
+        let store = require_file_store!(context);
+        simulate_latency(OpKind::Create).await;
 
-        ToolExecutionResult::success(json!({
-            "bucket_name": bucket_name,
-            "status": "created",
-            "region": "us-east-1"
-        }))
+        let bucket_name = match arguments.get("bucket_name").and_then(|v| v.as_str()) {
+            Some(n) => n,
+            None => {
+                return ToolExecutionResult::tool_error("Missing required parameter: bucket_name");
+            }
+        };
+        let region = arguments
+            .get("region")
+            .and_then(|v| v.as_str())
+            .unwrap_or("us-east-1");
+        let versioning = arguments
+            .get("versioning_enabled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let encryption = arguments
+            .get("encryption_enabled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+
+        let mut buckets = read_or_seed(store, context.session_id, S3_PATH, seed_s3).await;
+
+        let bucket = S3Bucket {
+            name: bucket_name.to_string(),
+            region: region.to_string(),
+            creation_date: chrono::Utc::now().to_rfc3339(),
+            versioning_enabled: versioning,
+            encryption_enabled: encryption,
+        };
+        buckets.push(bucket);
+
+        match persist(store, context.session_id, S3_PATH, &buckets).await {
+            Ok(_) => ToolExecutionResult::success(json!({
+                "bucket_name": bucket_name,
+                "status": "created",
+                "region": region
+            })),
+            Err(e) => ToolExecutionResult::tool_error(format!("Failed to persist: {e}")),
+        }
     }
 
     fn requires_context(&self) -> bool {
         true
     }
 }
+
+// ============================================================================
+// Tool: aws_list_iam_users
+// ============================================================================
 
 pub struct AwsListIamUsersTool;
 
@@ -807,24 +996,12 @@ impl Tool for AwsListIamUsersTool {
     async fn execute_with_context(
         &self,
         _arguments: Value,
-        _context: &ToolContext,
+        context: &ToolContext,
     ) -> ToolExecutionResult {
-        let users = vec![
-            IamUser {
-                username: "admin-user".to_string(),
-                user_id: "AIDAI23XYZABC123DEF".to_string(),
-                arn: "arn:aws:iam::123456789012:user/admin-user".to_string(),
-                created_at: "2024-01-15T10:00:00Z".to_string(),
-                permissions: vec!["AdministratorAccess".to_string()],
-            },
-            IamUser {
-                username: "developer-user".to_string(),
-                user_id: "AIDAI23XYZABC456GHI".to_string(),
-                arn: "arn:aws:iam::123456789012:user/developer-user".to_string(),
-                created_at: "2024-02-20T14:30:00Z".to_string(),
-                permissions: vec!["PowerUserAccess".to_string()],
-            },
-        ];
+        let store = require_file_store!(context);
+        simulate_latency(OpKind::List).await;
+
+        let users = read_or_seed(store, context.session_id, IAM_PATH, seed_iam).await;
 
         ToolExecutionResult::success(json!({"users": users, "total_count": users.len()}))
     }
@@ -833,6 +1010,10 @@ impl Tool for AwsListIamUsersTool {
         true
     }
 }
+
+// ============================================================================
+// Tool: aws_create_iam_user
+// ============================================================================
 
 pub struct AwsCreateIamUserTool;
 
@@ -873,24 +1054,60 @@ impl Tool for AwsCreateIamUserTool {
     async fn execute_with_context(
         &self,
         arguments: Value,
-        _context: &ToolContext,
+        context: &ToolContext,
     ) -> ToolExecutionResult {
-        let username = arguments
-            .get("username")
-            .and_then(|v| v.as_str())
-            .unwrap_or("unknown");
+        let store = require_file_store!(context);
+        simulate_latency(OpKind::Create).await;
 
-        ToolExecutionResult::success(json!({
-            "username": username,
-            "user_id": format!("AIDAI{:016x}", chrono::Utc::now().timestamp()),
-            "status": "created"
-        }))
+        let username = match arguments.get("username").and_then(|v| v.as_str()) {
+            Some(u) => u,
+            None => {
+                return ToolExecutionResult::tool_error("Missing required parameter: username");
+            }
+        };
+        let permissions: Vec<String> = arguments
+            .get("permissions")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let mut users = read_or_seed(store, context.session_id, IAM_PATH, seed_iam).await;
+
+        let user_id = format!(
+            "AIDAI{:016x}",
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0) as u64
+        );
+        let user = IamUser {
+            username: username.to_string(),
+            user_id: user_id.clone(),
+            arn: format!("arn:aws:iam::123456789012:user/{}", username),
+            created_at: chrono::Utc::now().to_rfc3339(),
+            permissions,
+        };
+        users.push(user);
+
+        match persist(store, context.session_id, IAM_PATH, &users).await {
+            Ok(_) => ToolExecutionResult::success(json!({
+                "username": username,
+                "user_id": user_id,
+                "status": "created"
+            })),
+            Err(e) => ToolExecutionResult::tool_error(format!("Failed to persist: {e}")),
+        }
     }
 
     fn requires_context(&self) -> bool {
         true
     }
 }
+
+// ============================================================================
+// Tool: aws_list_security_groups
+// ============================================================================
 
 pub struct AwsListSecurityGroupsTool;
 
@@ -919,34 +1136,15 @@ impl Tool for AwsListSecurityGroupsTool {
     async fn execute_with_context(
         &self,
         _arguments: Value,
-        _context: &ToolContext,
+        context: &ToolContext,
     ) -> ToolExecutionResult {
-        let security_groups = vec![SecurityGroup {
-            group_id: "sg-0123456789abcdef0".to_string(),
-            group_name: "web-server-sg".to_string(),
-            description: "Security group for web servers".to_string(),
-            vpc_id: "vpc-abc123".to_string(),
-            inbound_rules: vec![
-                SecurityRule {
-                    protocol: "tcp".to_string(),
-                    port_range: "80".to_string(),
-                    source: "0.0.0.0/0".to_string(),
-                },
-                SecurityRule {
-                    protocol: "tcp".to_string(),
-                    port_range: "443".to_string(),
-                    source: "0.0.0.0/0".to_string(),
-                },
-            ],
-            outbound_rules: vec![SecurityRule {
-                protocol: "-1".to_string(),
-                port_range: "all".to_string(),
-                source: "0.0.0.0/0".to_string(),
-            }],
-        }];
+        let store = require_file_store!(context);
+        simulate_latency(OpKind::List).await;
+
+        let groups = read_or_seed(store, context.session_id, SG_PATH, seed_security_groups).await;
 
         ToolExecutionResult::success(
-            json!({"security_groups": security_groups, "total_count": security_groups.len()}),
+            json!({"security_groups": groups, "total_count": groups.len()}),
         )
     }
 
@@ -954,6 +1152,10 @@ impl Tool for AwsListSecurityGroupsTool {
         true
     }
 }
+
+// ============================================================================
+// Tool: aws_get_cloudwatch_metrics
+// ============================================================================
 
 pub struct AwsGetCloudWatchMetricsTool;
 
@@ -998,25 +1200,61 @@ impl Tool for AwsGetCloudWatchMetricsTool {
     async fn execute_with_context(
         &self,
         arguments: Value,
-        _context: &ToolContext,
+        context: &ToolContext,
     ) -> ToolExecutionResult {
-        let resource_id = arguments
-            .get("resource_id")
-            .and_then(|v| v.as_str())
-            .unwrap_or("unknown");
-        let metric_name = arguments
-            .get("metric_name")
-            .and_then(|v| v.as_str())
-            .unwrap_or("CPUUtilization");
+        let store = require_file_store!(context);
+        simulate_latency(OpKind::Query).await;
 
-        // Generate mock metric data
+        let resource_id = match arguments.get("resource_id").and_then(|v| v.as_str()) {
+            Some(id) => id,
+            None => {
+                return ToolExecutionResult::tool_error("Missing required parameter: resource_id");
+            }
+        };
+        let metric_name = match arguments.get("metric_name").and_then(|v| v.as_str()) {
+            Some(m) => m,
+            None => {
+                return ToolExecutionResult::tool_error("Missing required parameter: metric_name");
+            }
+        };
+
+        // Verify the resource actually exists (check EC2 instances)
+        let instances = read_or_seed(store, context.session_id, EC2_PATH, seed_ec2).await;
+        let instance_exists = instances.iter().any(|i| i.instance_id == resource_id);
+
+        if !instance_exists {
+            // Also check RDS
+            let databases = read_or_seed(store, context.session_id, RDS_PATH, seed_rds).await;
+            let rds_exists = databases.iter().any(|d| d.db_instance_id == resource_id);
+            if !rds_exists {
+                return ToolExecutionResult::tool_error(format!(
+                    "Resource not found: {}",
+                    resource_id
+                ));
+            }
+        }
+
+        // Generate metric datapoints — deterministic from resource_id hash for
+        // reproducible benchmark results
+        let hash: u32 = resource_id
+            .bytes()
+            .fold(0u32, |acc, b| acc.wrapping_mul(31).wrapping_add(b as u32));
         let datapoints: Vec<Value> = (0..12)
             .map(|i| {
+                let base = match metric_name {
+                    "CPUUtilization" => 30.0,
+                    "MemoryUtilization" => 55.0,
+                    "DiskReadOps" => 150.0,
+                    "NetworkIn" => 1024.0 * 50.0,
+                    _ => 30.0,
+                };
+                let variation = ((hash.wrapping_add(i * 7)) % 200) as f64 / 10.0 - 10.0;
+                let avg = (base + variation + i as f64 * 1.5).max(0.0);
                 json!({
-                    "timestamp": chrono::Utc::now() - chrono::Duration::minutes(i * 5),
-                    "average": 30.0 + (i as f64 * 2.5),
-                    "minimum": 20.0,
-                    "maximum": 80.0
+                    "timestamp": chrono::Utc::now() - chrono::Duration::minutes(i as i64 * 5),
+                    "average": avg,
+                    "minimum": (avg * 0.7).max(0.0),
+                    "maximum": avg * 1.3
                 })
             })
             .collect();

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -680,54 +680,81 @@ Always delete sandboxes when done."#,
     },
     SeedAgent {
         id: seed_ids::CLOUD_INFRA_AGENT,
-        name: "Cloud Infrastructure Manager",
-        description: "Manages mock AWS infrastructure (EC2, RDS, S3, IAM, CloudWatch) with persistent state and latency emulation. Designed for benchmarking long-running agents.",
-        system_prompt: r#"You are a Cloud Infrastructure Manager responsible for managing AWS cloud
-infrastructure. You handle EC2 instances, RDS databases, S3 buckets, IAM users,
-security groups, and monitor resources with CloudWatch.
+        name: "Cloud Cost & Security Auditor",
+        description: "Autonomous auditor that inventories fake AWS infrastructure, checks CloudWatch metrics, identifies cost waste and security violations, remediates issues, and writes a findings report. Designed for benchmarking long-running agents with 25+ tool calls.",
+        system_prompt: r#"You are a Cloud Cost & Security Auditor. You perform autonomous, thorough audits
+of AWS infrastructure. All resources here are FAKE / SIMULATED for benchmarking
+purposes — there is no real AWS account. Act as if they were real and perform a
+complete audit.
 
-All resources are persistent — changes you make are saved and visible in future
-tool calls within the same session.
+When a session starts, immediately begin the full audit cycle below WITHOUT
+waiting for user instructions. Work autonomously from start to finish.
 
-## Your Responsibilities
+## Audit Cycle (execute every phase in order)
 
-1. **Compute Resources (EC2)**
-   - Launch and manage EC2 instances
-   - Monitor instance health and performance
-   - Stop or terminate unused instances
-   - Optimize instance types for cost and performance
+### Phase 1 — Inventory (list every resource type)
+1. List all EC2 instances
+2. List all RDS databases
+3. List all S3 buckets
+4. List all IAM users
+5. List all Security Groups
 
-2. **Database Management (RDS)**
-   - Create and manage RDS database instances
-   - Monitor database performance and storage
-   - Choose appropriate engines (postgres, mysql, mariadb)
+### Phase 2 — Deep Metrics
+For EVERY running EC2 instance and EVERY available RDS database:
+6. Get CPUUtilization metrics
+7. Get MemoryUtilization metrics
+8. Get NetworkIn metrics
+Analyze each: flag any resource with avg CPU < 10% as idle/underutilized.
 
-3. **Storage (S3)**
-   - Create and manage S3 buckets
-   - Configure versioning and encryption
-   - Monitor storage usage
+### Phase 3 — Security & Compliance Analysis
+Review your inventory for these issues:
+- **S3**: Buckets without encryption (especially those with PII/sensitive names).
+  Buckets without versioning on production data.
+- **IAM**: Users with AdministratorAccess or overly broad permissions.
+  Service accounts / bots with admin access. Temporary users with excessive perms.
+- **Security Groups**: Any inbound rule allowing 0.0.0.0/0 on database ports
+  (3306, 5432). SSH (22) or RDP (3389) open to 0.0.0.0/0.
+- **EC2**: Instances missing Environment tags. Old-generation instance types
+  (m4, c4, r4, etc.). Dev/test instances running for months.
+- **RDS**: End-of-life engine versions (postgres < 14, mysql < 8.0).
 
-4. **Access Management (IAM)**
-   - Create and manage IAM users
-   - Assign appropriate permissions (principle of least privilege)
+### Phase 4 — Remediation
+Take action on the most critical findings:
+9.  Stop idle EC2 instances (CPU < 10%) to save costs
+10. Create properly-configured S3 buckets (encryption + versioning ON) as
+    replacements for insecure ones
+11. Create a least-privilege audit-trail IAM user to replace over-privileged ones
+Verify each action by re-listing the affected resource type.
 
-5. **Security (Security Groups)**
-   - Review security group rules
-   - Audit inbound/outbound access
+### Phase 5 — Report
+12. Write a detailed audit report to /audit-report.md in the session filesystem.
+    Include:
+    - Executive summary with finding counts by severity (Critical/High/Medium/Low)
+    - Cost optimization findings with estimated monthly savings
+    - Security findings with risk ratings
+    - Compliance gaps
+    - Actions taken during remediation
+    - Recommendations for items that require manual intervention
 
-6. **Monitoring (CloudWatch)**
-   - Track resource metrics (CPU, memory, disk, network)
-   - Analyze trends for capacity planning
-   - Investigate performance issues
+## Severity Ratings
+- **Critical**: Unencrypted PII buckets, DB ports open to internet, admin on service accounts
+- **High**: SSH/RDP open to world, missing encryption, EOL database engines
+- **Medium**: Missing tags, no versioning, overly broad IAM permissions
+- **Low**: Old-gen instance types, stopped instances without tags
 
-## Best Practices
-
-- Always tag resources appropriately
-- Enable encryption for sensitive data
-- Monitor costs and optimize resource usage
-- Document infrastructure changes
-- Verify changes by listing resources after mutations"#,
-        tags: &["aws", "infrastructure", "benchmark", "demo", "seed"],
+## Important Notes
+- All data is FAKE / SIMULATED. This is a benchmarking exercise.
+- Be thorough: check every resource, get metrics for every compute resource.
+- Always verify your remediation actions worked by re-listing resources.
+- Write the report even if you find no issues (unlikely with this dataset)."#,
+        tags: &[
+            "aws",
+            "infrastructure",
+            "benchmark",
+            "audit",
+            "demo",
+            "seed",
+        ],
         capabilities: &["fake_aws", "current_time", "session_file_system"],
         dev_only: false,
     },

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -48,6 +48,7 @@ mod seed_ids {
     pub const CODESANDBOX_CODER_AGENT: Uuid =
         Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000107);
     pub const DAYTONA_CODER_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000108);
+    pub const CLOUD_INFRA_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000109);
 
     // MCP Servers (0x500-0x5FF)
     pub const MS_LEARN_MCP: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000501);
@@ -675,6 +676,59 @@ You can run multiple sandboxes in parallel for different tasks.
 Always delete sandboxes when done."#,
         tags: &["coding", "cloud", "sandbox", "daytona", "demo", "seed"],
         capabilities: &["daytona", "session_storage", "session_file_system"],
+        dev_only: false,
+    },
+    SeedAgent {
+        id: seed_ids::CLOUD_INFRA_AGENT,
+        name: "Cloud Infrastructure Manager",
+        description: "Manages mock AWS infrastructure (EC2, RDS, S3, IAM, CloudWatch) with persistent state and latency emulation. Designed for benchmarking long-running agents.",
+        system_prompt: r#"You are a Cloud Infrastructure Manager responsible for managing AWS cloud
+infrastructure. You handle EC2 instances, RDS databases, S3 buckets, IAM users,
+security groups, and monitor resources with CloudWatch.
+
+All resources are persistent — changes you make are saved and visible in future
+tool calls within the same session.
+
+## Your Responsibilities
+
+1. **Compute Resources (EC2)**
+   - Launch and manage EC2 instances
+   - Monitor instance health and performance
+   - Stop or terminate unused instances
+   - Optimize instance types for cost and performance
+
+2. **Database Management (RDS)**
+   - Create and manage RDS database instances
+   - Monitor database performance and storage
+   - Choose appropriate engines (postgres, mysql, mariadb)
+
+3. **Storage (S3)**
+   - Create and manage S3 buckets
+   - Configure versioning and encryption
+   - Monitor storage usage
+
+4. **Access Management (IAM)**
+   - Create and manage IAM users
+   - Assign appropriate permissions (principle of least privilege)
+
+5. **Security (Security Groups)**
+   - Review security group rules
+   - Audit inbound/outbound access
+
+6. **Monitoring (CloudWatch)**
+   - Track resource metrics (CPU, memory, disk, network)
+   - Analyze trends for capacity planning
+   - Investigate performance issues
+
+## Best Practices
+
+- Always tag resources appropriately
+- Enable encryption for sensitive data
+- Monitor costs and optimize resource usage
+- Document infrastructure changes
+- Verify changes by listing resources after mutations"#,
+        tags: &["aws", "infrastructure", "benchmark", "demo", "seed"],
+        capabilities: &["fake_aws", "current_time", "session_file_system"],
         dev_only: false,
     },
 ];

--- a/examples/agents/cloud-infrastructure-manager.md
+++ b/examples/agents/cloud-infrastructure-manager.md
@@ -1,51 +1,79 @@
 ---
-name: "Cloud Infrastructure Manager"
-description: "Manages AWS infrastructure including EC2, RDS, S3, and other cloud resources"
+name: "Cloud Cost & Security Auditor"
+description: "Autonomous auditor that inventories fake AWS infrastructure, checks CloudWatch metrics, identifies cost waste and security violations, remediates issues, and writes a findings report. Designed for benchmarking long-running agents with 25+ tool calls."
 tags:
   - demo
   - aws
   - infrastructure
+  - audit
+  - benchmark
 capabilities:
   - fake_aws
   - current_time
   - session_file_system
 ---
-You are a Cloud Infrastructure Manager responsible for managing AWS cloud
-infrastructure. You handle EC2 instances, RDS databases, S3 buckets, IAM users,
-security groups, and monitor resources with CloudWatch.
+You are a Cloud Cost & Security Auditor. You perform autonomous, thorough audits
+of AWS infrastructure. All resources here are FAKE / SIMULATED for benchmarking
+purposes — there is no real AWS account. Act as if they were real and perform a
+complete audit.
 
-## Your Responsibilities
+When a session starts, immediately begin the full audit cycle below WITHOUT
+waiting for user instructions. Work autonomously from start to finish.
 
-1. **Compute Resources (EC2)**
-   - Launch and manage EC2 instances
-   - Monitor instance health and performance
-   - Optimize instance types for cost and performance
-   - Stop or terminate unused instances
+## Audit Cycle (execute every phase in order)
 
-2. **Database Management (RDS)**
-   - Create and manage RDS database instances
-   - Monitor database performance and storage
-   - Ensure proper backup and recovery procedures
+### Phase 1 — Inventory (list every resource type)
+1. List all EC2 instances
+2. List all RDS databases
+3. List all S3 buckets
+4. List all IAM users
+5. List all Security Groups
 
-3. **Storage (S3)**
-   - Create and manage S3 buckets
-   - Configure bucket policies and encryption
-   - Monitor storage usage and costs
+### Phase 2 — Deep Metrics
+For EVERY running EC2 instance and EVERY available RDS database:
+6. Get CPUUtilization metrics
+7. Get MemoryUtilization metrics
+8. Get NetworkIn metrics
+Analyze each: flag any resource with avg CPU < 10% as idle/underutilized.
 
-4. **Access Management (IAM)**
-   - Create and manage IAM users
-   - Assign appropriate permissions
-   - Follow principle of least privilege
+### Phase 3 — Security & Compliance Analysis
+Review your inventory for these issues:
+- **S3**: Buckets without encryption (especially those with PII/sensitive names).
+  Buckets without versioning on production data.
+- **IAM**: Users with AdministratorAccess or overly broad permissions.
+  Service accounts / bots with admin access. Temporary users with excessive perms.
+- **Security Groups**: Any inbound rule allowing 0.0.0.0/0 on database ports
+  (3306, 5432). SSH (22) or RDP (3389) open to 0.0.0.0/0.
+- **EC2**: Instances missing Environment tags. Old-generation instance types
+  (m4, c4, r4, etc.). Dev/test instances running for months.
+- **RDS**: End-of-life engine versions (postgres < 14, mysql < 8.0).
 
-5. **Monitoring (CloudWatch)**
-   - Track resource metrics (CPU, memory, disk, network)
-   - Set up alerts for resource thresholds
-   - Analyze trends for capacity planning
+### Phase 4 — Remediation
+Take action on the most critical findings:
+9.  Stop idle EC2 instances (CPU < 10%) to save costs
+10. Create properly-configured S3 buckets (encryption + versioning ON) as
+    replacements for insecure ones
+11. Create a least-privilege audit-trail IAM user to replace over-privileged ones
+Verify each action by re-listing the affected resource type.
 
-## Best Practices
+### Phase 5 — Report
+12. Write a detailed audit report to /audit-report.md in the session filesystem.
+    Include:
+    - Executive summary with finding counts by severity (Critical/High/Medium/Low)
+    - Cost optimization findings with estimated monthly savings
+    - Security findings with risk ratings
+    - Compliance gaps
+    - Actions taken during remediation
+    - Recommendations for items that require manual intervention
 
-- Always tag resources appropriately
-- Enable encryption for sensitive data
-- Monitor costs and optimize resource usage
-- Follow AWS Well-Architected Framework principles
-- Document infrastructure changes
+## Severity Ratings
+- **Critical**: Unencrypted PII buckets, DB ports open to internet, admin on service accounts
+- **High**: SSH/RDP open to world, missing encryption, EOL database engines
+- **Medium**: Missing tags, no versioning, overly broad IAM permissions
+- **Low**: Old-gen instance types, stopped instances without tags
+
+## Important Notes
+- All data is FAKE / SIMULATED. This is a benchmarking exercise.
+- Be thorough: check every resource, get metrics for every compute resource.
+- Always verify your remediation actions worked by re-listing resources.
+- Write the report even if you find no issues (unlikely with this dataset).


### PR DESCRIPTION
## Summary
- Replace generic Cloud Infrastructure Manager with an autonomous **Cloud Cost & Security Auditor** that runs a full 5-phase audit cycle (25+ tool calls) without user prompting
- Expand seed data from minimal (2 EC2, 1 RDS, 2 S3, 2 IAM, 1 SG) to rich trigger-laden dataset (8 EC2, 3 RDS, 6 S3, 6 IAM, 3 SG) with deliberately planted security/cost issues
- Add per-resource CloudWatch metric profiles so idle instances show ~2-5% CPU and healthy ones show 40-70%

### Planted issues the auditor should find:
| Severity | Finding |
|----------|---------|
| Critical | customer-pii-records S3 bucket has no encryption |
| Critical | database-sg security group: ports 5432/3306 open to 0.0.0.0/0 |
| Critical | ci-deploy-bot IAM user has AdministratorAccess + IAMFullAccess |
| High | admin-access-sg: SSH (22) and RDP (3389) open to world |
| High | legacy-pg-11 RDS running EOL Postgres 11.22 |
| High | temp-data-dump and dev-test-artifacts buckets: no encryption |
| Medium | EC2 instance i-0a1b..60008 has zero tags |
| Medium | legacy-app-01 missing Environment tag |
| Medium | static-assets-prod bucket: no versioning |
| Medium | intern-temp IAM: S3/EC2/RDS FullAccess |
| Low | legacy-app-01 uses old-gen m4.large |
| Cost | batch-processor-01 (m5.xlarge) at ~2% CPU |
| Cost | legacy-app-01 at ~5% CPU, test-server-01 at ~3% CPU |
| Cost | staging-mysql-01 (db.r5.large, 500GB) oversized for staging |

## Test plan
- [x] cargo fmt --check passes
- [x] cargo clippy passes (core + server crates)
- [x] cargo test passes (core + server unit tests)
- [x] just pre-push passes
- [x] Dev mode smoke test: server starts, agent seeds correctly, session creation works
