### PR TITLE
fix(durable): add summary to workers list response

### DIFF
--- a/apps/ui/src/__tests__/workers-page.test.tsx
+++ b/apps/ui/src/__tests__/workers-page.test.tsx
@@ -1,0 +1,521 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import WorkersPage from "@/app/(main)/durable/workers/page";
+import type { DurableWorker, WorkersResponse, WorkersSummary } from "@/lib/api/types";
+
+// Mock worker data
+function makeWorker(overrides: Partial<DurableWorker> = {}): DurableWorker {
+  return {
+    id: "worker-abc-123",
+    worker_group: "default",
+    activity_types: ["run_session"],
+    max_concurrency: 10,
+    current_load: 3,
+    status: "active",
+    accepting_tasks: true,
+    started_at: "2024-01-01T00:00:00Z",
+    last_heartbeat_at: new Date().toISOString(),
+    hostname: "host-1",
+    version: "0.8.1",
+    tasks_completed: 100,
+    tasks_failed: 2,
+    avg_task_duration_ms: 500,
+    ...overrides,
+  };
+}
+
+const mockActiveWorker = makeWorker({
+  id: "w-active-1",
+  status: "active",
+  max_concurrency: 10,
+  current_load: 3,
+});
+const mockDrainingWorker = makeWorker({
+  id: "w-draining-1",
+  status: "draining",
+  max_concurrency: 8,
+  current_load: 2,
+  accepting_tasks: false,
+});
+const mockStoppedWorker = makeWorker({
+  id: "w-stopped-1",
+  status: "stopped",
+  max_concurrency: 10,
+  current_load: 0,
+  accepting_tasks: false,
+});
+
+const mockSummary: WorkersSummary = {
+  active: 1,
+  draining: 1,
+  stopped: 1,
+  total_capacity: 10,
+  total_load: 3,
+};
+
+const mockWorkersResponse: WorkersResponse = {
+  data: [mockActiveWorker, mockDrainingWorker, mockStoppedWorker],
+  total: 3,
+  summary: mockSummary,
+};
+
+// Mock hooks
+const mockUseWorkers = jest.fn();
+const mockUseDrainWorker = jest.fn();
+const mockUseResumeWorker = jest.fn();
+
+jest.mock("@/hooks", () => ({
+  useWorkers: () => mockUseWorkers(),
+  useDrainWorker: () => mockUseDrainWorker(),
+  useResumeWorker: () => mockUseResumeWorker(),
+}));
+
+// Mock Next.js navigation
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  usePathname: () => "/durable/workers",
+}));
+
+// Mock window.confirm
+const mockConfirm = jest.fn();
+window.confirm = mockConfirm;
+
+describe("WorkersPage", () => {
+  let queryClient: QueryClient;
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    jest.clearAllMocks();
+
+    // Default mock return values
+    mockUseWorkers.mockReturnValue({
+      data: mockWorkersResponse,
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    mockUseDrainWorker.mockReturnValue({
+      mutate: jest.fn(),
+      isPending: false,
+    });
+
+    mockUseResumeWorker.mockReturnValue({
+      mutate: jest.fn(),
+      isPending: false,
+    });
+
+    mockConfirm.mockReturnValue(true);
+  });
+
+  // ============================================
+  // Loading State Tests
+  // ============================================
+
+  describe("Loading State", () => {
+    it("shows skeleton loading state", () => {
+      mockUseWorkers.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      render(<WorkersPage />, { wrapper });
+
+      const skeletons = document.querySelectorAll('[class*="animate-pulse"]');
+      expect(skeletons.length).toBeGreaterThan(0);
+    });
+
+    it("renders header during loading", () => {
+      mockUseWorkers.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      render(<WorkersPage />, { wrapper });
+
+      expect(screen.getByText("Workers")).toBeInTheDocument();
+    });
+  });
+
+  // ============================================
+  // Error State Tests
+  // ============================================
+
+  describe("Error State", () => {
+    it("shows error message when workers fail to load", () => {
+      mockUseWorkers.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new Error("Network error"),
+        refetch: jest.fn(),
+      });
+
+      render(<WorkersPage />, { wrapper });
+
+      expect(screen.getByText(/Unable to Load Workers/i)).toBeInTheDocument();
+    });
+
+    it("shows retry button on error", () => {
+      mockUseWorkers.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new Error("Network error"),
+        refetch: jest.fn(),
+      });
+
+      render(<WorkersPage />, { wrapper });
+
+      expect(screen.getByRole("button", { name: /Retry/i })).toBeInTheDocument();
+    });
+
+    it("calls refetch when retry button is clicked", () => {
+      const mockRefetch = jest.fn();
+      mockUseWorkers.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new Error("Network error"),
+        refetch: mockRefetch,
+      });
+
+      render(<WorkersPage />, { wrapper });
+
+      fireEvent.click(screen.getByRole("button", { name: /Retry/i }));
+      expect(mockRefetch).toHaveBeenCalled();
+    });
+  });
+
+  // ============================================
+  // Empty State Tests
+  // ============================================
+
+  describe("Empty State", () => {
+    it("shows empty state when no workers exist", () => {
+      mockUseWorkers.mockReturnValue({
+        data: {
+          data: [],
+          total: 0,
+          summary: { active: 0, draining: 0, stopped: 0, total_capacity: 0, total_load: 0 },
+        },
+        isLoading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      render(<WorkersPage />, { wrapper });
+
+      expect(screen.getByText(/No Workers Connected/i)).toBeInTheDocument();
+    });
+  });
+
+  // ============================================
+  // Summary Stats Card Tests
+  // ============================================
+
+  describe("Summary Stats Cards", () => {
+    it("displays total workers count", () => {
+      render(<WorkersPage />, { wrapper });
+
+      expect(screen.getByText("Total Workers")).toBeInTheDocument();
+      // total = 3 (from mockWorkersResponse.total)
+      expect(screen.getByText("3")).toBeInTheDocument();
+    });
+
+    it("displays active workers count in description", () => {
+      render(<WorkersPage />, { wrapper });
+
+      expect(screen.getByText("1 active")).toBeInTheDocument();
+    });
+
+    it("displays total capacity from summary", () => {
+      render(<WorkersPage />, { wrapper });
+
+      expect(screen.getByText("Total Capacity")).toBeInTheDocument();
+      expect(screen.getByText("10")).toBeInTheDocument();
+    });
+
+    it("displays total load in capacity description", () => {
+      render(<WorkersPage />, { wrapper });
+
+      expect(screen.getByText("3 in use")).toBeInTheDocument();
+    });
+
+    it("displays load percentage", () => {
+      render(<WorkersPage />, { wrapper });
+
+      // "Load" appears as both a card title and table header; verify via card title selector
+      const loadCards = screen.getAllByText("Load");
+      expect(loadCards.length).toBeGreaterThanOrEqual(1);
+      // 3/10 * 100 = 30.0%
+      expect(screen.getByText("30.0%")).toBeInTheDocument();
+    });
+
+    it("displays load slots description", () => {
+      render(<WorkersPage />, { wrapper });
+
+      expect(screen.getByText("3/10 slots")).toBeInTheDocument();
+    });
+
+    it("displays draining count", () => {
+      render(<WorkersPage />, { wrapper });
+
+      expect(screen.getByText("Draining")).toBeInTheDocument();
+    });
+
+    it("displays stopped count in draining description", () => {
+      render(<WorkersPage />, { wrapper });
+
+      expect(screen.getByText("1 stopped")).toBeInTheDocument();
+    });
+
+    it("shows 0% load when no capacity", () => {
+      mockUseWorkers.mockReturnValue({
+        data: {
+          data: [],
+          total: 0,
+          summary: { active: 0, draining: 0, stopped: 0, total_capacity: 0, total_load: 0 },
+        },
+        isLoading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      render(<WorkersPage />, { wrapper });
+
+      expect(screen.getByText("0%")).toBeInTheDocument();
+    });
+
+    it("handles missing summary gracefully", () => {
+      mockUseWorkers.mockReturnValue({
+        data: { data: [], total: 0 },
+        isLoading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      render(<WorkersPage />, { wrapper });
+
+      // Should still render without crashing, using fallback values
+      expect(screen.getByText("Total Workers")).toBeInTheDocument();
+      expect(screen.getByText("0 active")).toBeInTheDocument();
+    });
+  });
+
+  // ============================================
+  // Worker Table Rendering Tests
+  // ============================================
+
+  describe("Worker Table Rendering", () => {
+    it("renders worker table with correct headers", () => {
+      render(<WorkersPage />, { wrapper });
+
+      // Some header names overlap with card titles (e.g. "Load"), so use getAllByText
+      expect(screen.getByText("Worker")).toBeInTheDocument();
+      expect(screen.getByText("Status")).toBeInTheDocument();
+      expect(screen.getByText("Group")).toBeInTheDocument();
+      expect(screen.getAllByText("Load").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText("Accepting")).toBeInTheDocument();
+      expect(screen.getByText("Activities")).toBeInTheDocument();
+      expect(screen.getByText("Completed")).toBeInTheDocument();
+      expect(screen.getByText("Avg Duration")).toBeInTheDocument();
+      expect(screen.getByText("Last Heartbeat")).toBeInTheDocument();
+      expect(screen.getByText("Actions")).toBeInTheDocument();
+    });
+
+    it("renders worker hostnames", () => {
+      render(<WorkersPage />, { wrapper });
+
+      // All 3 workers share hostname "host-1"
+      const hostnames = screen.getAllByText("host-1");
+      expect(hostnames.length).toBe(3);
+    });
+
+    it("renders status badges for each worker", () => {
+      render(<WorkersPage />, { wrapper });
+
+      expect(screen.getByText("active")).toBeInTheDocument();
+      expect(screen.getByText("draining")).toBeInTheDocument();
+      expect(screen.getByText("stopped")).toBeInTheDocument();
+    });
+
+    it("renders worker group badges", () => {
+      render(<WorkersPage />, { wrapper });
+
+      // All workers have "default" group
+      const defaultBadges = screen.getAllByText("default");
+      expect(defaultBadges.length).toBe(3);
+    });
+
+    it("renders activity type badges", () => {
+      render(<WorkersPage />, { wrapper });
+
+      const activityBadges = screen.getAllByText("run_session");
+      expect(activityBadges.length).toBe(3);
+    });
+
+    it("renders task completed counts", () => {
+      render(<WorkersPage />, { wrapper });
+
+      // All workers have 100 tasks_completed
+      const completedCounts = screen.getAllByText("100");
+      expect(completedCounts.length).toBe(3);
+    });
+  });
+
+  // ============================================
+  // Worker Action Tests
+  // ============================================
+
+  describe("Worker Actions", () => {
+    it("shows Drain button for active workers", () => {
+      render(<WorkersPage />, { wrapper });
+
+      const drainButton = screen.getByRole("button", { name: /Drain/i });
+      expect(drainButton).toBeInTheDocument();
+    });
+
+    it("shows Resume button for draining workers", () => {
+      render(<WorkersPage />, { wrapper });
+
+      const resumeButton = screen.getByRole("button", { name: /Resume/i });
+      expect(resumeButton).toBeInTheDocument();
+    });
+
+    it("calls drain mutation after confirmation", () => {
+      const mockDrainMutate = jest.fn();
+      mockUseDrainWorker.mockReturnValue({
+        mutate: mockDrainMutate,
+        isPending: false,
+      });
+      mockConfirm.mockReturnValue(true);
+
+      render(<WorkersPage />, { wrapper });
+
+      fireEvent.click(screen.getByRole("button", { name: /Drain/i }));
+      expect(mockConfirm).toHaveBeenCalled();
+      expect(mockDrainMutate).toHaveBeenCalledWith("w-active-1");
+    });
+
+    it("does not drain when confirmation is cancelled", () => {
+      const mockDrainMutate = jest.fn();
+      mockUseDrainWorker.mockReturnValue({
+        mutate: mockDrainMutate,
+        isPending: false,
+      });
+      mockConfirm.mockReturnValue(false);
+
+      render(<WorkersPage />, { wrapper });
+
+      fireEvent.click(screen.getByRole("button", { name: /Drain/i }));
+      expect(mockConfirm).toHaveBeenCalled();
+      expect(mockDrainMutate).not.toHaveBeenCalled();
+    });
+
+    it("calls resume mutation without confirmation", () => {
+      const mockResumeMutate = jest.fn();
+      mockUseResumeWorker.mockReturnValue({
+        mutate: mockResumeMutate,
+        isPending: false,
+      });
+
+      render(<WorkersPage />, { wrapper });
+
+      fireEvent.click(screen.getByRole("button", { name: /Resume/i }));
+      expect(mockResumeMutate).toHaveBeenCalledWith("w-draining-1");
+    });
+
+    it("does not show action buttons for stopped workers", () => {
+      mockUseWorkers.mockReturnValue({
+        data: {
+          data: [mockStoppedWorker],
+          total: 1,
+          summary: { active: 0, draining: 0, stopped: 1, total_capacity: 0, total_load: 0 },
+        },
+        isLoading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      render(<WorkersPage />, { wrapper });
+
+      expect(screen.queryByRole("button", { name: /Drain/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /Resume/i })).not.toBeInTheDocument();
+    });
+  });
+
+  // ============================================
+  // Summary with various worker configurations
+  // ============================================
+
+  describe("Summary with different worker configurations", () => {
+    it("handles all draining workers", () => {
+      const allDraining: WorkersResponse = {
+        data: [
+          makeWorker({
+            id: "w1",
+            status: "draining",
+            max_concurrency: 10,
+            current_load: 5,
+            accepting_tasks: false,
+          }),
+          makeWorker({
+            id: "w2",
+            status: "draining",
+            max_concurrency: 10,
+            current_load: 3,
+            accepting_tasks: false,
+          }),
+        ],
+        total: 2,
+        summary: { active: 0, draining: 2, stopped: 0, total_capacity: 0, total_load: 0 },
+      };
+
+      mockUseWorkers.mockReturnValue({
+        data: allDraining,
+        isLoading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      render(<WorkersPage />, { wrapper });
+
+      expect(screen.getByText("0 active")).toBeInTheDocument();
+      expect(screen.getByText("0%")).toBeInTheDocument();
+    });
+
+    it("handles high load scenario", () => {
+      const highLoad: WorkersResponse = {
+        data: [makeWorker({ id: "w1", status: "active", max_concurrency: 10, current_load: 9 })],
+        total: 1,
+        summary: { active: 1, draining: 0, stopped: 0, total_capacity: 10, total_load: 9 },
+      };
+
+      mockUseWorkers.mockReturnValue({
+        data: highLoad,
+        isLoading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      render(<WorkersPage />, { wrapper });
+
+      // 9/10 * 100 = 90.0%
+      expect(screen.getByText("90.0%")).toBeInTheDocument();
+      expect(screen.getByText("9/10 slots")).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/ui/src/hooks/use-durable.ts
+++ b/apps/ui/src/hooks/use-durable.ts
@@ -124,9 +124,21 @@ export function useDurableSSE(options?: { enabled?: boolean }) {
 
           // Update all durable query caches
           queryClient.setQueryData(["durable", "health"], snapshot.health);
+
+          // Compute worker summary from the workers array
+          const activeWorkers = snapshot.workers.filter((w) => w.status === "active");
+          const workersSummary = {
+            active: activeWorkers.length,
+            draining: snapshot.workers.filter((w) => w.status === "draining").length,
+            stopped: snapshot.workers.filter((w) => w.status === "stopped").length,
+            total_capacity: activeWorkers.reduce((sum, w) => sum + w.max_concurrency, 0),
+            total_load: activeWorkers.reduce((sum, w) => sum + w.current_load, 0),
+          };
+
           queryClient.setQueryData(["durable", "workers"], {
             data: snapshot.workers,
             total: snapshot.workers.length,
+            summary: workersSummary,
           });
           queryClient.setQueryData(["durable", "workflows", undefined], snapshot.workflows);
           queryClient.setQueryData(["durable", "tasks", undefined], snapshot.tasks);

--- a/crates/server/src/api/durable.rs
+++ b/crates/server/src/api/durable.rs
@@ -228,11 +228,22 @@ impl From<WorkerInfo> for WorkerResponse {
     }
 }
 
+/// Workers summary stats
+#[derive(Debug, Serialize, ToSchema)]
+pub struct WorkersSummaryResponse {
+    pub active: usize,
+    pub draining: usize,
+    pub stopped: usize,
+    pub total_capacity: usize,
+    pub total_load: usize,
+}
+
 /// Workers list response
 #[derive(Debug, Serialize, ToSchema)]
 pub struct WorkersListResponse {
     pub data: Vec<WorkerResponse>,
     pub total: usize,
+    pub summary: WorkersSummaryResponse,
 }
 
 /// Workflow response
@@ -556,7 +567,27 @@ pub async fn list_workers(
     let total = workers.len();
     let data: Vec<WorkerResponse> = workers.into_iter().map(WorkerResponse::from).collect();
 
-    Ok(Json(WorkersListResponse { data, total }))
+    let summary = WorkersSummaryResponse {
+        active: data.iter().filter(|w| w.status == "active").count(),
+        draining: data.iter().filter(|w| w.status == "draining").count(),
+        stopped: data.iter().filter(|w| w.status == "stopped").count(),
+        total_capacity: data
+            .iter()
+            .filter(|w| w.status == "active")
+            .map(|w| w.max_concurrency as usize)
+            .sum(),
+        total_load: data
+            .iter()
+            .filter(|w| w.status == "active")
+            .map(|w| w.current_load as usize)
+            .sum(),
+    };
+
+    Ok(Json(WorkersListResponse {
+        data,
+        total,
+        summary,
+    }))
 }
 
 /// POST /v1/durable/workers/:worker_id/drain - Drain a worker

--- a/crates/server/src/api/durable.rs
+++ b/crates/server/src/api/durable.rs
@@ -2009,4 +2009,196 @@ mod tests {
         let reason = parsed["reason"].as_str().unwrap_or("unknown");
         assert_eq!(reason, "error");
     }
+
+    // ============================================
+    // WorkersSummaryResponse tests
+    // ============================================
+
+    /// Helper to create a WorkerResponse for testing
+    fn make_worker(
+        id: &str,
+        status: &str,
+        max_concurrency: u32,
+        current_load: u32,
+    ) -> WorkerResponse {
+        WorkerResponse {
+            id: id.to_string(),
+            worker_group: Some("default".to_string()),
+            activity_types: vec!["run_session".to_string()],
+            max_concurrency,
+            current_load,
+            status: status.to_string(),
+            accepting_tasks: status == "active",
+            backpressure_reason: None,
+            started_at: Utc::now(),
+            last_heartbeat_at: Utc::now(),
+            hostname: Some("host1".to_string()),
+            version: Some("0.8.1".to_string()),
+            metadata: None,
+            tasks_completed: 100,
+            tasks_failed: 2,
+            avg_task_duration_ms: Some(500),
+        }
+    }
+
+    /// Build a WorkersListResponse the same way list_workers() does
+    fn build_workers_list(workers: Vec<WorkerResponse>) -> WorkersListResponse {
+        let total = workers.len();
+        let summary = WorkersSummaryResponse {
+            active: workers.iter().filter(|w| w.status == "active").count(),
+            draining: workers.iter().filter(|w| w.status == "draining").count(),
+            stopped: workers.iter().filter(|w| w.status == "stopped").count(),
+            total_capacity: workers
+                .iter()
+                .filter(|w| w.status == "active")
+                .map(|w| w.max_concurrency as usize)
+                .sum(),
+            total_load: workers
+                .iter()
+                .filter(|w| w.status == "active")
+                .map(|w| w.current_load as usize)
+                .sum(),
+        };
+        WorkersListResponse {
+            data: workers,
+            total,
+            summary,
+        }
+    }
+
+    #[test]
+    fn test_workers_summary_mixed_statuses() {
+        let workers = vec![
+            make_worker("w1", "active", 10, 3),
+            make_worker("w2", "active", 8, 5),
+            make_worker("w3", "draining", 10, 2),
+            make_worker("w4", "stopped", 10, 0),
+        ];
+
+        let resp = build_workers_list(workers);
+
+        assert_eq!(resp.total, 4);
+        assert_eq!(resp.summary.active, 2);
+        assert_eq!(resp.summary.draining, 1);
+        assert_eq!(resp.summary.stopped, 1);
+        // Only active workers count toward capacity/load
+        assert_eq!(resp.summary.total_capacity, 18); // 10 + 8
+        assert_eq!(resp.summary.total_load, 8); // 3 + 5
+    }
+
+    #[test]
+    fn test_workers_summary_all_active() {
+        let workers = vec![
+            make_worker("w1", "active", 10, 5),
+            make_worker("w2", "active", 10, 3),
+            make_worker("w3", "active", 10, 7),
+        ];
+
+        let resp = build_workers_list(workers);
+
+        assert_eq!(resp.summary.active, 3);
+        assert_eq!(resp.summary.draining, 0);
+        assert_eq!(resp.summary.stopped, 0);
+        assert_eq!(resp.summary.total_capacity, 30);
+        assert_eq!(resp.summary.total_load, 15);
+    }
+
+    #[test]
+    fn test_workers_summary_no_active_workers() {
+        let workers = vec![
+            make_worker("w1", "draining", 10, 2),
+            make_worker("w2", "stopped", 10, 0),
+        ];
+
+        let resp = build_workers_list(workers);
+
+        assert_eq!(resp.summary.active, 0);
+        assert_eq!(resp.summary.draining, 1);
+        assert_eq!(resp.summary.stopped, 1);
+        // Draining/stopped workers don't count toward capacity/load
+        assert_eq!(resp.summary.total_capacity, 0);
+        assert_eq!(resp.summary.total_load, 0);
+    }
+
+    #[test]
+    fn test_workers_summary_empty_list() {
+        let resp = build_workers_list(vec![]);
+
+        assert_eq!(resp.total, 0);
+        assert_eq!(resp.summary.active, 0);
+        assert_eq!(resp.summary.draining, 0);
+        assert_eq!(resp.summary.stopped, 0);
+        assert_eq!(resp.summary.total_capacity, 0);
+        assert_eq!(resp.summary.total_load, 0);
+    }
+
+    #[test]
+    fn test_workers_summary_serialization_includes_summary() {
+        let workers = vec![
+            make_worker("w1", "active", 10, 3),
+            make_worker("w2", "draining", 8, 1),
+        ];
+
+        let resp = build_workers_list(workers);
+        let json = serde_json::to_string(&resp).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        // Verify summary field exists and has correct values
+        assert!(
+            parsed["summary"].is_object(),
+            "summary must be present in JSON"
+        );
+        assert_eq!(parsed["summary"]["active"], 1);
+        assert_eq!(parsed["summary"]["draining"], 1);
+        assert_eq!(parsed["summary"]["stopped"], 0);
+        assert_eq!(parsed["summary"]["total_capacity"], 10);
+        assert_eq!(parsed["summary"]["total_load"], 3);
+
+        // Verify top-level fields
+        assert_eq!(parsed["total"], 2);
+        assert!(parsed["data"].is_array());
+        assert_eq!(parsed["data"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_workers_summary_only_active_contribute_to_capacity() {
+        // Edge case: a draining worker with high load should NOT inflate totals
+        let workers = vec![
+            make_worker("w1", "active", 5, 2),
+            make_worker("w2", "draining", 100, 80),
+            make_worker("w3", "stopped", 50, 0),
+        ];
+
+        let resp = build_workers_list(workers);
+
+        assert_eq!(resp.summary.total_capacity, 5); // Only w1
+        assert_eq!(resp.summary.total_load, 2); // Only w1
+    }
+
+    #[test]
+    fn test_workers_summary_single_active_worker() {
+        let workers = vec![make_worker("w1", "active", 20, 15)];
+
+        let resp = build_workers_list(workers);
+
+        assert_eq!(resp.summary.active, 1);
+        assert_eq!(resp.summary.draining, 0);
+        assert_eq!(resp.summary.stopped, 0);
+        assert_eq!(resp.summary.total_capacity, 20);
+        assert_eq!(resp.summary.total_load, 15);
+    }
+
+    #[test]
+    fn test_workers_summary_zero_load_active_workers() {
+        let workers = vec![
+            make_worker("w1", "active", 10, 0),
+            make_worker("w2", "active", 10, 0),
+        ];
+
+        let resp = build_workers_list(workers);
+
+        assert_eq!(resp.summary.active, 2);
+        assert_eq!(resp.summary.total_capacity, 20);
+        assert_eq!(resp.summary.total_load, 0);
+    }
 }


### PR DESCRIPTION
## What
Add `WorkersSummaryResponse` to the workers list API response, providing pre-computed summary stats (active/draining/stopped counts, total capacity, total load). UI SSE handler also computes matching summary from snapshot data.

## Why
Workers page needs summary stats for the dashboard cards (Total Workers, Total Capacity, Load %, Draining). Previously these had to be computed client-side from the raw workers array on every render; now the API provides them directly.

## How
- Backend: New `WorkersSummaryResponse` struct with `active`, `draining`, `stopped`, `total_capacity`, `total_load` fields. Computed in `list_workers()` handler — only active workers contribute to capacity/load.
- UI: `useDurableSSE` computes matching summary from SSE snapshot workers array and includes it in the React Query cache update.
- Tests: 8 backend unit tests (mixed statuses, empty list, serialization, capacity isolation). 30 UI tests (loading/error/empty states, summary cards, table rendering, drain/resume actions).

## Risk
- Low
- Additive-only API change. `summary` field is new; existing consumers unaffected. UI already uses `data?.summary` with optional chaining.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered