### PR TITLE
feat(server): add types positive filter to events endpoints

### DIFF
--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -70,6 +70,35 @@ pub const SESSION_IDLED: &str = "session.idled";
 // Schedule events
 pub const SCHEDULE_TRIGGERED: &str = "schedule.triggered";
 
+/// All valid event types for API filtering validation.
+/// Used by `types` and `exclude` query parameter validation to reject unknown types
+/// and prevent unbounded arrays from reaching the database.
+pub const VALID_EVENT_TYPES: &[&str] = &[
+    INPUT_MESSAGE,
+    OUTPUT_MESSAGE_STARTED,
+    OUTPUT_MESSAGE_DELTA,
+    OUTPUT_MESSAGE_COMPLETED,
+    TURN_STARTED,
+    TURN_COMPLETED,
+    TURN_FAILED,
+    TURN_CANCELLED,
+    REASON_STARTED,
+    REASON_COMPLETED,
+    ACT_STARTED,
+    ACT_COMPLETED,
+    TOOL_STARTED,
+    TOOL_COMPLETED,
+    TOOL_CALL_REQUESTED,
+    LLM_GENERATION,
+    REASON_THINKING_STARTED,
+    REASON_THINKING_DELTA,
+    REASON_THINKING_COMPLETED,
+    SESSION_STARTED,
+    SESSION_ACTIVATED,
+    SESSION_IDLED,
+    SCHEDULE_TRIGGERED,
+];
+
 // ============================================================================
 // Event Context
 // ============================================================================

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -193,7 +193,7 @@ pub use events::{
     SessionActivatedData, SessionIdledData, SessionStartedData, TOOL_CALL_REQUESTED,
     TOOL_COMPLETED, TOOL_STARTED, TURN_CANCELLED, TURN_COMPLETED, TURN_FAILED, TURN_STARTED,
     TokenUsage, ToolCallRequestedData, ToolCallSummary, ToolCompletedData, ToolStartedData,
-    TurnCancelledData, TurnCompletedData, TurnFailedData, TurnStartedData,
+    TurnCancelledData, TurnCompletedData, TurnFailedData, TurnStartedData, VALID_EVENT_TYPES,
 };
 pub use harness::{Harness, HarnessStatus};
 pub use llm_model_profiles::get_model_profile;

--- a/crates/server/src/api/events.rs
+++ b/crates/server/src/api/events.rs
@@ -17,7 +17,7 @@ use axum::{
 // support deserializing repeated query keys (?exclude=a&exclude=b) into Vec<String>.
 use axum_extra::extract::Query;
 use everruns_core::typed_id::{EventId, SessionId};
-use everruns_core::{Event, EventListener};
+use everruns_core::{Event, EventListener, VALID_EVENT_TYPES};
 use serde::Deserialize;
 
 use super::common::{ErrorResponse, ListResponse};
@@ -41,11 +41,58 @@ use utoipa::{IntoParams, ToSchema};
 pub struct EventsQuery {
     /// Filter events with ID greater than this event ID (prefixed format: event_{32-hex})
     pub since_id: Option<EventId>,
+    /// Positive type filter: only return events matching these types (can be specified multiple times).
+    /// When empty, all types are returned. Example: ?types=turn.started&types=turn.completed
+    #[serde(default)]
+    #[param(style = Form, explode = true)]
+    pub types: Vec<String>,
     /// Event types to exclude from the response (can be specified multiple times).
-    /// Common delta events to exclude: output.message.delta, reason.thinking.delta
+    /// Applied after `types` filter. Common delta events to exclude: output.message.delta, reason.thinking.delta
     #[serde(default)]
     #[param(style = Form, explode = true)]
     pub exclude: Vec<String>,
+}
+
+impl EventsQuery {
+    /// Validate types and exclude parameters.
+    /// Rejects unknown event types and limits array size to prevent abuse.
+    fn validate(&self) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+        validate_event_type_list(&self.types, "types")?;
+        validate_event_type_list(&self.exclude, "exclude")?;
+        Ok(())
+    }
+}
+
+/// Max event types per filter parameter. There are ~23 known types; 25 is generous.
+const MAX_EVENT_TYPE_FILTER_SIZE: usize = 25;
+
+/// Validate a list of event type strings: checks size limit and known types.
+fn validate_event_type_list(
+    types: &[String],
+    param_name: &str,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    if types.len() > MAX_EVENT_TYPE_FILTER_SIZE {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!(
+                    "{param_name}: too many values ({}, max {MAX_EVENT_TYPE_FILTER_SIZE})",
+                    types.len()
+                ),
+            }),
+        ));
+    }
+    for t in types {
+        if !VALID_EVENT_TYPES.contains(&t.as_str()) {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!("{param_name}: unknown event type '{t}'"),
+                }),
+            ));
+        }
+    }
+    Ok(())
 }
 
 // ============================================
@@ -147,6 +194,13 @@ pub fn routes(state: AppState) -> Router {
 /// Use the `since_id` query parameter to resume from a specific event. The server
 /// will only send events with IDs greater than the specified value. Event IDs are
 /// UUID v7 (monotonically increasing), ensuring reliable ordering.
+///
+/// ## Event Type Filtering
+///
+/// Use `types` for positive filtering (only return these types) and `exclude` for
+/// negative filtering (remove these types). When both are provided, `types` narrows
+/// first, then `exclude` removes from that set. Both accept only known event types
+/// (max 25 per parameter). Unknown types return 400.
 #[utoipa::path(
     get,
     path = "/v1/sessions/{session_id}/sse",
@@ -169,6 +223,8 @@ pub async fn stream_sse(
     Query(query): Query<EventsQuery>,
 ) -> Result<Sse<impl Stream<Item = Result<SseEvent, Infallible>>>, (StatusCode, Json<ErrorResponse>)>
 {
+    query.validate()?;
+
     let session_id: SessionId = session_id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -222,10 +278,11 @@ pub async fn stream_sse(
             )
         })?;
 
-    tracing::info!(session_id = %session_id, since_id = ?query.since_id, exclude = ?query.exclude, "Starting event stream");
+    tracing::info!(session_id = %session_id, since_id = ?query.since_id, types = ?query.types, exclude = ?query.exclude, "Starting event stream");
 
     let event_service = state.event_service.clone();
     let initial_since_id = query.since_id.map(|id| id.uuid());
+    let filter_types = query.types;
     let exclude_types = query.exclude;
 
     // Use realtime config for session events (fast updates for interactive UX)
@@ -276,6 +333,7 @@ pub async fn stream_sse(
         last_id: Option<Uuid>,
         backoff_ms: u64,
         config: SseStreamConfig,
+        filter_types: Vec<String>,
         exclude_types: Vec<String>,
         connection_start: Instant,
         /// Waker triggered by pg_notify when events arrive for this session
@@ -287,6 +345,7 @@ pub async fn stream_sse(
         last_id: initial_since_id,
         backoff_ms: config.min_backoff_ms,
         config,
+        filter_types,
         exclude_types,
         connection_start,
         event_waker,
@@ -360,7 +419,7 @@ pub async fn stream_sse(
 
                     // Fetch events since last ID
                     tracing::debug!(session_id = %session_id, last_id = ?state.last_id, "SSE: fetching events");
-                    match event_service.list(session_id, None, state.last_id, &state.exclude_types).await {
+                    match event_service.list(session_id, None, state.last_id, &state.filter_types, &state.exclude_types).await {
                         Ok(events) if !events.is_empty() => {
                             // Get the last event ID for next iteration
                             let new_last_id = Some(events.last().unwrap().id.uuid());
@@ -397,6 +456,7 @@ pub async fn stream_sse(
                                 last_id: new_last_id,
                                 backoff_ms: new_backoff,
                                 config: state.config,
+                                filter_types: state.filter_types,
                                 exclude_types: state.exclude_types,
                                 connection_start: state.connection_start,
                                 event_waker: state.event_waker,
@@ -468,6 +528,11 @@ impl<S: Stream> Stream for GuardedStream<S> {
 // ============================================
 
 /// GET /v1/sessions/{session_id}/events - List events (JSON)
+///
+/// Returns events for a session as a JSON array. Supports filtering by event type
+/// via `types` (positive: only these types) and `exclude` (negative: remove these types).
+/// When both are provided, `types` narrows first, then `exclude` removes from that set.
+/// Both accept only known event types (max 25 per parameter). Unknown types return 400.
 #[utoipa::path(
     get,
     path = "/v1/sessions/{session_id}/events",
@@ -477,7 +542,7 @@ impl<S: Stream> Stream for GuardedStream<S> {
     ),
     responses(
         (status = 200, description = "Events list", body = ListResponse<Event>),
-        (status = 400, description = "Invalid session ID"),
+        (status = 400, description = "Invalid session ID or invalid event type filter"),
         (status = 404, description = "Session not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -489,6 +554,8 @@ pub async fn list_events(
     Path(session_id): Path<String>,
     Query(query): Query<EventsQuery>,
 ) -> Result<Json<ListResponse<Event>>, (StatusCode, Json<ErrorResponse>)> {
+    query.validate()?;
+
     let session_id: SessionId = session_id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -523,6 +590,7 @@ pub async fn list_events(
 
     // Fetch events using EventService (converts rows to core::Event)
     // Optional since_id filter for incremental fetching
+    // Optional types filter for positive event type selection
     // Optional exclude filter for filtering out event types (e.g., delta events)
     let events = state
         .event_service
@@ -530,6 +598,7 @@ pub async fn list_events(
             session_id.uuid(),
             None,
             query.since_id.map(|id| id.uuid()),
+            &query.types,
             &query.exclude,
         )
         .await
@@ -664,5 +733,185 @@ mod tests {
 
         assert!(query.since_id.is_some());
         assert_eq!(query.exclude.len(), 2);
+    }
+
+    // ============================================
+    // types (positive filter) query string tests
+    // ============================================
+
+    /// Repeated types keys (?types=a&types=b) parse into Vec<String>.
+    #[test]
+    fn test_query_string_types_repeated_keys() {
+        let qs = "types=turn.started&types=turn.completed";
+        let query: EventsQuery =
+            serde_html_form::from_str(qs).expect("repeated types should parse");
+
+        assert_eq!(query.types.len(), 2);
+        assert_eq!(query.types[0], "turn.started");
+        assert_eq!(query.types[1], "turn.completed");
+        assert!(query.exclude.is_empty());
+    }
+
+    /// Single types value.
+    #[test]
+    fn test_query_string_types_single() {
+        let qs = "types=input.message";
+        let query: EventsQuery = serde_html_form::from_str(qs).expect("single types should parse");
+
+        assert_eq!(query.types.len(), 1);
+        assert_eq!(query.types[0], "input.message");
+    }
+
+    /// No types param defaults to empty vec (all types returned).
+    #[test]
+    fn test_query_string_no_types() {
+        let qs = "";
+        let query: EventsQuery = serde_html_form::from_str(qs).expect("no types should parse");
+
+        assert!(query.types.is_empty());
+    }
+
+    /// Combined types and exclude params.
+    #[test]
+    fn test_query_string_types_with_exclude() {
+        let qs = "types=turn.started&types=turn.completed&types=turn.failed&exclude=turn.failed";
+        let query: EventsQuery = serde_html_form::from_str(qs).expect("types+exclude should parse");
+
+        assert_eq!(query.types.len(), 3);
+        assert_eq!(query.exclude.len(), 1);
+        assert_eq!(query.exclude[0], "turn.failed");
+    }
+
+    /// All three params combined: since_id, types, exclude.
+    #[test]
+    fn test_query_string_all_params() {
+        let qs = "since_id=event_019c263feac17809a9d442e25317890b&types=turn.started&types=turn.completed&exclude=turn.completed";
+        let query: EventsQuery = serde_html_form::from_str(qs).expect("all params should parse");
+
+        assert!(query.since_id.is_some());
+        assert_eq!(query.types.len(), 2);
+        assert_eq!(query.exclude.len(), 1);
+    }
+
+    /// JSON deserialization with types field.
+    #[test]
+    fn test_events_query_json_with_types() {
+        let json = r#"{"types": ["turn.started", "turn.completed"], "exclude": []}"#;
+        let query: EventsQuery = serde_json::from_str(json).expect("Should deserialize with types");
+
+        assert_eq!(query.types.len(), 2);
+        assert!(query.types.contains(&"turn.started".to_string()));
+        assert!(query.types.contains(&"turn.completed".to_string()));
+        assert!(query.exclude.is_empty());
+    }
+
+    /// JSON deserialization with both types and exclude.
+    #[test]
+    fn test_events_query_json_types_and_exclude() {
+        let json = r#"{"types": ["turn.started", "turn.completed", "session.idled"], "exclude": ["session.idled"]}"#;
+        let query: EventsQuery =
+            serde_json::from_str(json).expect("Should deserialize types+exclude");
+
+        assert_eq!(query.types.len(), 3);
+        assert_eq!(query.exclude.len(), 1);
+    }
+
+    // ============================================
+    // Validation tests
+    // ============================================
+
+    #[test]
+    fn test_validate_valid_types() {
+        let query = EventsQuery {
+            since_id: None,
+            types: vec!["turn.started".to_string(), "turn.completed".to_string()],
+            exclude: vec![],
+        };
+        assert!(query.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_valid_exclude() {
+        let query = EventsQuery {
+            since_id: None,
+            types: vec![],
+            exclude: vec![
+                "output.message.delta".to_string(),
+                "reason.thinking.delta".to_string(),
+            ],
+        };
+        assert!(query.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_empty_is_ok() {
+        let query = EventsQuery {
+            since_id: None,
+            types: vec![],
+            exclude: vec![],
+        };
+        assert!(query.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_unknown_type_rejected() {
+        let query = EventsQuery {
+            since_id: None,
+            types: vec!["turn.started".to_string(), "bogus.type".to_string()],
+            exclude: vec![],
+        };
+        let err = query.validate().unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert!(err.1.error.contains("bogus.type"));
+        assert!(err.1.error.contains("types"));
+    }
+
+    #[test]
+    fn test_validate_unknown_exclude_rejected() {
+        let query = EventsQuery {
+            since_id: None,
+            types: vec![],
+            exclude: vec!["not.a.real.type".to_string()],
+        };
+        let err = query.validate().unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert!(err.1.error.contains("not.a.real.type"));
+        assert!(err.1.error.contains("exclude"));
+    }
+
+    #[test]
+    fn test_validate_too_many_types_rejected() {
+        let types: Vec<String> = (0..30).map(|i| format!("type.{i}")).collect();
+        let query = EventsQuery {
+            since_id: None,
+            types,
+            exclude: vec![],
+        };
+        let err = query.validate().unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert!(err.1.error.contains("too many"));
+    }
+
+    #[test]
+    fn test_validate_too_many_exclude_rejected() {
+        let exclude: Vec<String> = (0..30).map(|i| format!("type.{i}")).collect();
+        let query = EventsQuery {
+            since_id: None,
+            types: vec![],
+            exclude,
+        };
+        let err = query.validate().unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert!(err.1.error.contains("too many"));
+    }
+
+    #[test]
+    fn test_validate_all_known_types_accepted() {
+        let query = EventsQuery {
+            since_id: None,
+            types: VALID_EVENT_TYPES.iter().map(|s| s.to_string()).collect(),
+            exclude: vec![],
+        };
+        assert!(query.validate().is_ok());
     }
 }

--- a/crates/server/src/services/event.rs
+++ b/crates/server/src/services/event.rs
@@ -199,11 +199,15 @@ impl EventService {
 
     /// List events for a session, filtering out unsupported events.
     /// Unsupported events are internal and never exposed via API.
+    /// `filter_types`: positive filter — when non-empty, only return matching types.
+    /// `exclude_types`: negative filter — remove matching types from the result.
+    /// When both are provided, `filter_types` narrows first, then `exclude_types` removes.
     pub async fn list(
         &self,
         session_id: Uuid,
         since_sequence: Option<i32>,
         since_id: Option<Uuid>,
+        filter_types: &[String],
         exclude_types: &[String],
     ) -> Result<Vec<Event>> {
         let rows = self
@@ -212,6 +216,7 @@ impl EventService {
                 SessionId::from_uuid(session_id),
                 since_sequence,
                 since_id.map(EventId::from_uuid),
+                filter_types,
                 exclude_types,
             )
             .await?;

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -345,6 +345,7 @@ impl StorageBackend {
         session_id: SessionId,
         since_sequence: Option<i32>,
         since_id: Option<EventId>,
+        filter_types: &[String],
         exclude_types: &[String],
     ) -> Result<Vec<EventRow>> {
         dispatch!(
@@ -353,6 +354,7 @@ impl StorageBackend {
             session_id,
             since_sequence,
             since_id,
+            filter_types,
             exclude_types
         )
     }

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -966,6 +966,7 @@ impl InMemoryDatabase {
         session_id: SessionId,
         since_sequence: Option<i32>,
         since_id: Option<EventId>,
+        filter_types: &[String],
         exclude_types: &[String],
     ) -> Result<Vec<EventRow>> {
         let events = self.events.read();
@@ -975,7 +976,11 @@ impl InMemoryDatabase {
                 if e.session_id != session_id {
                     return false;
                 }
-                // Filter out excluded event types
+                // Positive type filter: only include matching types (when non-empty)
+                if !filter_types.is_empty() && !filter_types.contains(&e.event_type) {
+                    return false;
+                }
+                // Negative type filter: exclude matching types
                 if !exclude_types.is_empty() && exclude_types.contains(&e.event_type) {
                     return false;
                 }
@@ -3764,11 +3769,214 @@ mod tests {
             .unwrap();
         }
 
-        let events = db.list_events(session.id, None, None, &[]).await.unwrap();
+        let events = db
+            .list_events(session.id, None, None, &[], &[])
+            .await
+            .unwrap();
         assert_eq!(events.len(), 3);
         assert_eq!(events[0].sequence, 1);
         assert_eq!(events[1].sequence, 2);
         assert_eq!(events[2].sequence, 3);
+    }
+
+    /// Helper: create an agent + session for event filter tests.
+    async fn create_session_with_events(db: &InMemoryDatabase) -> SessionId {
+        let agent = db
+            .create_agent(
+                DEFAULT_ORG_ID,
+                CreateAgentRow {
+                    public_id: AgentId::new().to_string(),
+                    name: "Filter Test Agent".to_string(),
+                    description: None,
+                    system_prompt: String::new(),
+                    default_model_id: None,
+                    tags: vec![],
+                    tools: serde_json::json!([]),
+                },
+            )
+            .await
+            .unwrap();
+
+        let session = db
+            .create_session(CreateSessionRow {
+                org_id: DEFAULT_ORG_ID,
+                harness_id: None,
+                agent_id: Some(agent.id),
+                title: None,
+                tags: vec![],
+                model_id: None,
+                capabilities: serde_json::json!([]),
+                tools: serde_json::json!([]),
+            })
+            .await
+            .unwrap();
+
+        // Create events of different types
+        for event_type in [
+            "input.message",
+            "output.message.delta",
+            "output.message.completed",
+            "turn.started",
+            "turn.completed",
+            "reason.thinking.delta",
+        ] {
+            db.create_event(CreateEventRow {
+                session_id: session.id,
+                event_type: event_type.to_string(),
+                ts: Utc::now(),
+                context: serde_json::json!({}),
+                data: serde_json::json!({}),
+                metadata: None,
+                tags: None,
+            })
+            .await
+            .unwrap();
+        }
+
+        session.id
+    }
+
+    #[tokio::test]
+    async fn test_list_events_filter_types_positive() {
+        let db = InMemoryDatabase::new();
+        let session_id = create_session_with_events(&db).await;
+
+        // Positive filter: only turn events
+        let events = db
+            .list_events(
+                session_id,
+                None,
+                None,
+                &["turn.started".to_string(), "turn.completed".to_string()],
+                &[],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(events.len(), 2);
+        assert!(events.iter().all(|e| e.event_type.starts_with("turn.")));
+    }
+
+    #[tokio::test]
+    async fn test_list_events_filter_types_single() {
+        let db = InMemoryDatabase::new();
+        let session_id = create_session_with_events(&db).await;
+
+        // Positive filter: single type
+        let events = db
+            .list_events(session_id, None, None, &["input.message".to_string()], &[])
+            .await
+            .unwrap();
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type, "input.message");
+    }
+
+    #[tokio::test]
+    async fn test_list_events_filter_types_empty_returns_all() {
+        let db = InMemoryDatabase::new();
+        let session_id = create_session_with_events(&db).await;
+
+        // Empty types = return all (6 events created)
+        let events = db
+            .list_events(session_id, None, None, &[], &[])
+            .await
+            .unwrap();
+
+        assert_eq!(events.len(), 6);
+    }
+
+    #[tokio::test]
+    async fn test_list_events_filter_types_no_match() {
+        let db = InMemoryDatabase::new();
+        let session_id = create_session_with_events(&db).await;
+
+        // Types that don't exist — empty result
+        let events = db
+            .list_events(
+                session_id,
+                None,
+                None,
+                &["nonexistent.type".to_string()],
+                &[],
+            )
+            .await
+            .unwrap();
+
+        assert!(events.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_list_events_exclude_only() {
+        let db = InMemoryDatabase::new();
+        let session_id = create_session_with_events(&db).await;
+
+        // Exclude delta events (2 of 6)
+        let events = db
+            .list_events(
+                session_id,
+                None,
+                None,
+                &[],
+                &[
+                    "output.message.delta".to_string(),
+                    "reason.thinking.delta".to_string(),
+                ],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(events.len(), 4);
+        assert!(events.iter().all(|e| !e.event_type.contains("delta")));
+    }
+
+    #[tokio::test]
+    async fn test_list_events_types_and_exclude_combined() {
+        let db = InMemoryDatabase::new();
+        let session_id = create_session_with_events(&db).await;
+
+        // types narrows to turn.* + input.message (3 events),
+        // then exclude removes turn.completed (1 event) → 2 events remain
+        let events = db
+            .list_events(
+                session_id,
+                None,
+                None,
+                &[
+                    "turn.started".to_string(),
+                    "turn.completed".to_string(),
+                    "input.message".to_string(),
+                ],
+                &["turn.completed".to_string()],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(events.len(), 2);
+        let types: Vec<&str> = events.iter().map(|e| e.event_type.as_str()).collect();
+        assert!(types.contains(&"turn.started"));
+        assert!(types.contains(&"input.message"));
+        assert!(!types.contains(&"turn.completed"));
+    }
+
+    #[tokio::test]
+    async fn test_list_events_types_fully_excluded() {
+        let db = InMemoryDatabase::new();
+        let session_id = create_session_with_events(&db).await;
+
+        // types selects one event, exclude removes that same type → empty
+        let events = db
+            .list_events(
+                session_id,
+                None,
+                None,
+                &["input.message".to_string()],
+                &["input.message".to_string()],
+            )
+            .await
+            .unwrap();
+
+        assert!(events.is_empty());
     }
 
     #[tokio::test]

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -1101,10 +1101,13 @@ impl Database {
         session_id: SessionId,
         since_sequence: Option<i32>,
         since_id: Option<EventId>,
+        filter_types: &[String],
         exclude_types: &[String],
     ) -> Result<Vec<EventRow>> {
-        // Prefer since_id (UUID v7 monotonically increasing) over sequence for filtering
-        // exclude_types filters out unwanted event types (e.g., delta events)
+        // Prefer since_id (UUID v7 monotonically increasing) over sequence for filtering.
+        // filter_types: positive filter — when non-empty, only return matching event types.
+        // exclude_types: negative filter — remove matching event types from results.
+        // When both are provided, filter_types narrows first, then exclude_types removes.
         let rows = match (since_id, since_sequence) {
             (Some(id), _) => {
                 sqlx::query_as::<_, EventRow>(
@@ -1112,12 +1115,14 @@ impl Database {
                     SELECT id, session_id, sequence, event_type, ts, context, data, metadata, tags, created_at
                     FROM events
                     WHERE session_id = $1 AND id > $2
-                      AND (cardinality($3::text[]) = 0 OR event_type <> ALL($3))
+                      AND (cardinality($3::text[]) = 0 OR event_type = ANY($3))
+                      AND (cardinality($4::text[]) = 0 OR event_type <> ALL($4))
                     ORDER BY id ASC
                     "#,
                 )
                 .bind(session_id.uuid())
                 .bind(id.uuid())
+                .bind(filter_types)
                 .bind(exclude_types)
                 .fetch_all(&self.pool)
                 .await?
@@ -1128,12 +1133,14 @@ impl Database {
                     SELECT id, session_id, sequence, event_type, ts, context, data, metadata, tags, created_at
                     FROM events
                     WHERE session_id = $1 AND sequence > $2
-                      AND (cardinality($3::text[]) = 0 OR event_type <> ALL($3))
+                      AND (cardinality($3::text[]) = 0 OR event_type = ANY($3))
+                      AND (cardinality($4::text[]) = 0 OR event_type <> ALL($4))
                     ORDER BY sequence ASC
                     "#,
                 )
                 .bind(session_id.uuid())
                 .bind(seq)
+                .bind(filter_types)
                 .bind(exclude_types)
                 .fetch_all(&self.pool)
                 .await?
@@ -1144,11 +1151,13 @@ impl Database {
                     SELECT id, session_id, sequence, event_type, ts, context, data, metadata, tags, created_at
                     FROM events
                     WHERE session_id = $1
-                      AND (cardinality($2::text[]) = 0 OR event_type <> ALL($2))
+                      AND (cardinality($2::text[]) = 0 OR event_type = ANY($2))
+                      AND (cardinality($3::text[]) = 0 OR event_type <> ALL($3))
                     ORDER BY sequence ASC
                     "#,
                 )
                 .bind(session_id.uuid())
+                .bind(filter_types)
                 .bind(exclude_types)
                 .fetch_all(&self.pool)
                 .await?

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -299,7 +299,7 @@ async fn test_event_crud() {
 
     // List events
     let events = backend
-        .list_events(session.id, None, None, &[])
+        .list_events(session.id, None, None, &[], &[])
         .await
         .expect("Failed to list events");
     assert_eq!(events.len(), 1);
@@ -307,7 +307,7 @@ async fn test_event_crud() {
 
     // List with since_id filter
     let events_since = backend
-        .list_events(session.id, None, Some(event.id), &[])
+        .list_events(session.id, None, Some(event.id), &[], &[])
         .await
         .expect("Failed to list events with since_id");
     assert!(
@@ -386,6 +386,7 @@ async fn test_event_exclude_types() {
             session.id,
             None,
             None,
+            &[],
             &["output.message.delta".to_string()],
         )
         .await
@@ -394,6 +395,118 @@ async fn test_event_exclude_types() {
     assert_eq!(events[0].event_type, "input.message");
 
     // Note: No cleanup - events are append-only so sessions with events cannot be deleted
+}
+
+#[tokio::test]
+async fn test_event_filter_types() {
+    let backend = create_test_backend().await;
+
+    let agent = backend
+        .create_agent(
+            TEST_ORG_ID,
+            CreateAgentRow {
+                public_id: everruns_core::AgentId::new().to_string(),
+                name: "Event Filter Types Agent".to_string(),
+                description: None,
+                system_prompt: "Test".to_string(),
+                default_model_id: None,
+                tags: vec![],
+                tools: serde_json::json!([]),
+            },
+        )
+        .await
+        .expect("Failed to create agent");
+
+    let session = backend
+        .create_session(CreateSessionRow {
+            org_id: TEST_ORG_ID,
+            harness_id: None,
+            agent_id: Some(agent.id),
+            title: None,
+            tags: vec![],
+            model_id: None,
+            capabilities: serde_json::json!([]),
+            tools: serde_json::json!([]),
+        })
+        .await
+        .expect("Failed to create session");
+
+    // Create events of different types
+    for event_type in [
+        "input.message",
+        "output.message.delta",
+        "output.message.completed",
+        "turn.started",
+        "turn.completed",
+    ] {
+        backend
+            .create_event(CreateEventRow {
+                session_id: session.id,
+                event_type: event_type.to_string(),
+                ts: Utc::now(),
+                context: json!({}),
+                data: json!({}),
+                metadata: None,
+                tags: None,
+            })
+            .await
+            .expect("Failed to create event");
+    }
+
+    // Positive filter: only turn events
+    let events = backend
+        .list_events(
+            session.id,
+            None,
+            None,
+            &["turn.started".to_string(), "turn.completed".to_string()],
+            &[],
+        )
+        .await
+        .expect("Failed to list events with types filter");
+    assert_eq!(events.len(), 2);
+    assert!(events.iter().all(|e| e.event_type.starts_with("turn.")));
+
+    // Empty types = all events
+    let events = backend
+        .list_events(session.id, None, None, &[], &[])
+        .await
+        .expect("Failed to list all events");
+    assert_eq!(events.len(), 5);
+
+    // types + exclude combined: types selects 3, exclude removes 1
+    let events = backend
+        .list_events(
+            session.id,
+            None,
+            None,
+            &[
+                "input.message".to_string(),
+                "turn.started".to_string(),
+                "turn.completed".to_string(),
+            ],
+            &["turn.completed".to_string()],
+        )
+        .await
+        .expect("Failed to list events with types+exclude");
+    assert_eq!(events.len(), 2);
+    let types: Vec<&str> = events.iter().map(|e| e.event_type.as_str()).collect();
+    assert!(types.contains(&"input.message"));
+    assert!(types.contains(&"turn.started"));
+    assert!(!types.contains(&"turn.completed"));
+
+    // types with no match → empty
+    let events = backend
+        .list_events(
+            session.id,
+            None,
+            None,
+            &["nonexistent.type".to_string()],
+            &[],
+        )
+        .await
+        .expect("Failed to list events with unmatched types");
+    assert!(events.is_empty());
 }
 
 // ============================================

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2746,6 +2746,7 @@
           "events"
         ],
         "summary": "GET /v1/sessions/{session_id}/events - List events (JSON)",
+        "description": "Returns events for a session as a JSON array. Supports filtering by event type\nvia `types` (positive: only these types) and `exclude` (negative: remove these types).\nWhen both are provided, `types` narrows first, then `exclude` removes from that set.\nBoth accept only known event types (max 25 per parameter). Unknown types return 400.",
         "operationId": "list_events",
         "parameters": [
           {
@@ -2774,9 +2775,23 @@
             }
           },
           {
+            "name": "types",
+            "in": "query",
+            "description": "Positive type filter: only return events matching these types (can be specified multiple times).\nWhen empty, all types are returned. Example: ?types=turn.started&types=turn.completed",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "style": "form",
+            "explode": true
+          },
+          {
             "name": "exclude",
             "in": "query",
-            "description": "Event types to exclude from the response (can be specified multiple times).\nCommon delta events to exclude: output.message.delta, reason.thinking.delta",
+            "description": "Event types to exclude from the response (can be specified multiple times).\nApplied after `types` filter. Common delta events to exclude: output.message.delta, reason.thinking.delta",
             "required": false,
             "schema": {
               "type": "array",
@@ -2800,7 +2815,7 @@
             }
           },
           "400": {
-            "description": "Invalid session ID"
+            "description": "Invalid session ID or invalid event type filter"
           },
           "404": {
             "description": "Session not found"
@@ -3448,7 +3463,7 @@
           "events"
         ],
         "summary": "GET /v1/sessions/{session_id}/sse - Stream events (SSE notifications)",
-        "description": "Establishes a Server-Sent Events (SSE) connection for real-time event streaming.\n\n## Connection Lifecycle Events\n\n- **connected**: Sent immediately when the stream is established.\n  Data: `{\"status\":\"connected\"}`\n\n- **disconnecting**: Sent before the server closes the connection for graceful cycling.\n  Data: `{\"reason\":\"connection_cycle\",\"retry_ms\":100}`\n  Clients should reconnect immediately using the `since_id` of the last received event.\n\n## Connection Cycling\n\nConnections are automatically cycled every 5 minutes to prevent stale connections\nthrough proxies and load balancers. Before closing, the server sends a `disconnecting`\nevent so clients can reconnect seamlessly without missing events.\n\n## Retry Hints\n\nEach SSE event includes a `retry:` field (in milliseconds) that hints how long\nclients should wait before reconnecting if the connection is lost:\n- During active streaming: 100ms (fast reconnect)\n- During idle periods: increases with backoff up to 500ms\n- After `disconnecting` event: 100ms (immediate reconnect)\n\n## Resuming Streams\n\nUse the `since_id` query parameter to resume from a specific event. The server\nwill only send events with IDs greater than the specified value. Event IDs are\nUUID v7 (monotonically increasing), ensuring reliable ordering.",
+        "description": "Establishes a Server-Sent Events (SSE) connection for real-time event streaming.\n\n## Connection Lifecycle Events\n\n- **connected**: Sent immediately when the stream is established.\n  Data: `{\"status\":\"connected\"}`\n\n- **disconnecting**: Sent before the server closes the connection for graceful cycling.\n  Data: `{\"reason\":\"connection_cycle\",\"retry_ms\":100}`\n  Clients should reconnect immediately using the `since_id` of the last received event.\n\n## Connection Cycling\n\nConnections are automatically cycled every 5 minutes to prevent stale connections\nthrough proxies and load balancers. Before closing, the server sends a `disconnecting`\nevent so clients can reconnect seamlessly without missing events.\n\n## Retry Hints\n\nEach SSE event includes a `retry:` field (in milliseconds) that hints how long\nclients should wait before reconnecting if the connection is lost:\n- During active streaming: 100ms (fast reconnect)\n- During idle periods: increases with backoff up to 500ms\n- After `disconnecting` event: 100ms (immediate reconnect)\n\n## Resuming Streams\n\nUse the `since_id` query parameter to resume from a specific event. The server\nwill only send events with IDs greater than the specified value. Event IDs are\nUUID v7 (monotonically increasing), ensuring reliable ordering.\n\n## Event Type Filtering\n\nUse `types` for positive filtering (only return these types) and `exclude` for\nnegative filtering (remove these types). When both are provided, `types` narrows\nfirst, then `exclude` removes from that set. Both accept only known event types\n(max 25 per parameter). Unknown types return 400.",
         "operationId": "stream_sse",
         "parameters": [
           {
@@ -3477,9 +3492,23 @@
             }
           },
           {
+            "name": "types",
+            "in": "query",
+            "description": "Positive type filter: only return events matching these types (can be specified multiple times).\nWhen empty, all types are returned. Example: ?types=turn.started&types=turn.completed",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "style": "form",
+            "explode": true
+          },
+          {
             "name": "exclude",
             "in": "query",
-            "description": "Event types to exclude from the response (can be specified multiple times).\nCommon delta events to exclude: output.message.delta, reason.thinking.delta",
+            "description": "Event types to exclude from the response (can be specified multiple times).\nApplied after `types` filter. Common delta events to exclude: output.message.delta, reason.thinking.delta",
             "required": false,
             "schema": {
               "type": "array",

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -259,6 +259,16 @@ Server-Sent Events (SSE) for real-time UI updates and event listing.
 | GET | `/v1/sessions/{session_id}/sse` | Stream events (SSE) |
 | GET | `/v1/sessions/{session_id}/events` | List events (JSON) |
 
+**Query Parameters** (both endpoints):
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `since_id` | EventId | Resume after this event ID |
+| `types` | string[] | Positive filter: only return matching event types. Empty = all. Repeated key format: `?types=a&types=b` |
+| `exclude` | string[] | Negative filter: remove matching event types. Applied after `types`. Repeated key format: `?exclude=a&exclude=b` |
+
+When both `types` and `exclude` are provided, `types` narrows first, then `exclude` removes from that set. Both accept only known event types (max 25 per parameter). See [events.md](events.md) for full filtering semantics.
+
 ### LLM Provider Configuration
 
 | Method | Path | Description |

--- a/specs/events.md
+++ b/specs/events.md
@@ -1041,6 +1041,27 @@ Events can be filtered by:
 - `sequence`: For pagination and replay (after sequence N)
 - `turn_id`: Filter events for a specific turn
 
+### Query Parameter Filters
+
+Both the SSE (`/v1/sessions/{id}/sse`) and JSON (`/v1/sessions/{id}/events`) endpoints accept:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `since_id` | EventId | Resume after this event ID (UUID v7 monotonic) |
+| `types` | string[] | **Positive filter**: only return events matching these types. Empty = all types. |
+| `exclude` | string[] | **Negative filter**: remove matching types from the result. |
+
+**Semantics when both are provided:** `types` narrows first, then `exclude` removes from that set.
+
+**Examples:**
+- Only turn lifecycle: `?types=turn.started&types=turn.completed`
+- Everything except deltas: `?exclude=output.message.delta&exclude=reason.thinking.delta`
+- Turn events but not failures: `?types=turn.started&types=turn.completed&types=turn.failed&exclude=turn.failed`
+
+**Validation:**
+- Both parameters accept only known event types (see Event Type Registry). Unknown types return 400.
+- Maximum 25 values per parameter to prevent abuse.
+
 ### Message Events Filter
 
 A partial index exists for efficient message queries:


### PR DESCRIPTION
## Summary
- Add `types` query parameter to SSE and JSON events endpoints for positive event type filtering
- When `types` is non-empty, only matching event types are returned; when empty, all types returned
- `types` narrows first, then `exclude` removes from that set when both are provided
- Filter applied in-database (PostgreSQL `= ANY()`) and in-memory (dev mode) for efficiency
- Validate against known event types (`VALID_EVENT_TYPES`), reject unknown types with 400
- Limit to 25 values per parameter to prevent DB abuse

## Test plan
- [x] 24 API unit tests: query string parsing, JSON deserialization, validation (known types, unknown types, size limits)
- [x] 8 in-memory storage tests: positive filter, single type, empty returns all, no match, exclude-only, combined types+exclude, fully excluded
- [x] Integration tests: `test_event_filter_types` against real PostgreSQL (positive filter, empty, combined, no match)
- [x] `just pre-push` passes (fmt, clippy, lockfile)
- [x] All 277 server unit tests pass
- [ ] CI green

https://claude.ai/code/session_01VAMv69TgpUzZ3agRexzGNd