### PR TITLE
fix(server): bump per-org SSE connection limit from 50 to 1000

### DIFF
--- a/crates/server/src/api/sse.rs
+++ b/crates/server/src/api/sse.rs
@@ -136,7 +136,7 @@ impl Default for SseConnectionLimits {
         Self {
             global_max: 10_000,
             per_session_max: 5,
-            per_org_max: 50,
+            per_org_max: 1_000,
         }
     }
 }
@@ -594,7 +594,7 @@ mod tests {
         let limits = SseConnectionLimits::default();
         assert_eq!(limits.global_max, 10_000);
         assert_eq!(limits.per_session_max, 5);
-        assert_eq!(limits.per_org_max, 50);
+        assert_eq!(limits.per_org_max, 1_000);
     }
 
     #[test]

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -678,7 +678,7 @@ When a bash script calls `bash` or `sh` or uses `eval`, bashkit re-invokes its o
 |----|--------|----------|------------|--------|
 | TM-DOS-001 | Large API request body | High | Input size limits on all fields; multipart upload capped at 101 MB | MITIGATED |
 | TM-DOS-002 | Agent loop infinite iteration | High | Max 10 iterations per turn; configurable | MITIGATED |
-| TM-DOS-003 | SSE connection exhaustion | Medium | SSE connections tied to session; no global connection limit | **OPEN** |
+| TM-DOS-003 | SSE connection exhaustion | Medium | Global (10k), per-org (1k), per-session (5) SSE connection limits via SseConnectionTracker | MITIGATED |
 | TM-DOS-004 | Database connection pool exhaustion | Medium | sqlx connection pool with max_connections; timeouts on acquisition | MITIGATED |
 | TM-DOS-005 | Session file storage abuse | Medium | No per-session storage quota; large files stored as PostgreSQL BYTEA | **OPEN** (see TM-FS-008) |
 | TM-DOS-006 | Durable task queue flooding | Medium | Per-workflow pending task limit (see TM-DURABLE-004) | MITIGATED |
@@ -771,7 +771,7 @@ Search results from Brave Search are returned as tool results. Adversarial conte
 | TM-FS-008 | No session storage quota | Medium | Enforce per-session file size limits |
 | TM-TOOL-008 | Tool approval not enforced | Low | Implement HITL approval for requires_approval policy |
 | TM-TOOL-009 | No tool rate limiting | Medium | Per-agent tool execution rate limits |
-| TM-DOS-003 | SSE connection exhaustion | Medium | Global SSE connection limit with per-user cap |
+| TM-DOS-003 | SSE connection exhaustion | Medium | Global (10k), per-org (1k), per-session (5) limits enforced |
 | TM-AGENT-016 | Plaintext secrets in chat history | Medium | Prefer Settings UI; phase out in-chat secret collection |
 | TM-CSB-002 | Unbounded sandbox creation | Medium | Add per-session sandbox count limit |
 


### PR DESCRIPTION
## What
Bump the per-org SSE connection limit from 50 to 1,000. Update TM-DOS-003 from OPEN to MITIGATED.

## Why
per_org_max=50 is too low. A real user with 50 open sessions (each with 1 SSE connection) hits the cap while using only 0.5% of global capacity (10k). Raising to 1k gives orgs room to grow while still preventing a single org from exhausting server resources.

## How
- Changed `per_org_max` default from `50` to `1_000` in `SseConnectionLimits::default()`
- Updated the default-assertion unit test
- Marked TM-DOS-003 as MITIGATED in `specs/threat-model.md` (global/per-org/per-session limits are all enforced)

## Risk
- Low
- Orgs can now hold up to 1k SSE connections (10% of global capacity) instead of 50 (0.5%). Still bounded by the global 10k limit. The `SSE_PER_ORG_MAX` env var override remains available for operators.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered