### PR TITLE
chore(specs): remove code-derivable content, link to source files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,8 @@ Fix root cause. Unsure: read more code; if stuck, ask w/ short options. Unrecogn
 
 `specs/` contains feature specifications. New code should comply with these or propose changes.
 
+**Spec content principle:** Specs capture *design intent, rationale, and constraints* — the "why" and "what", not exhaustive "how". Don't duplicate what's readable from code (struct fields, enum variants, exact API shapes, SQL DDL). Instead, link to the source file. Example: "See `crates/core/src/models/agent.rs` for full field list." This keeps specs maintainable and prevents drift.
+
 - `specs/concepts.md` - Core entities, relationships, and concept diagram
 - `specs/architecture.md` - System architecture, crate structure, infrastructure
 - `specs/code-organization.md` - Naming conventions, type flow, testing, error handling

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -115,13 +115,7 @@ graph TD
 
 Integration crates (`codesandbox`, `docker`, `daytona`) register capabilities at startup via `inventory::submit!`. The `inventory` crate uses linker sections — if the crate is not explicitly referenced, Rust's linker will optimize it out and the `submit!` registrations silently disappear.
 
-**Both `crates/server/src/lib.rs` and `crates/worker/src/lib.rs` must have `extern crate` statements for every integration crate:**
-
-```rust
-extern crate everruns_integrations_codesandbox;
-extern crate everruns_integrations_daytona;
-extern crate everruns_integrations_docker;
-```
+**Both `crates/server/src/lib.rs` and `crates/worker/src/lib.rs` must have `extern crate` statements for every integration crate** (see those files for the current list).
 
 Adding a new integration crate requires:
 1. Create the crate under `integrations/`
@@ -134,31 +128,7 @@ Without step 3, the crate compiles but its capabilities are never registered. Th
 
 The server binary (`main.rs`) uses `ServerAppBuilder` from the library crate. The builder pattern enables SaaS wrappers to compose their own binary with custom auth, routes, event listeners, and background tasks.
 
-**`ServerAppBuilder` usage:**
-```rust
-ServerAppBuilder::new(config)
-    .auth(move |db| Arc::new(BuiltinAuthBackend::new(auth_config, db)))
-    .routes(extra_routes)       // optional: billing, admin, etc.
-    .run()
-    .await
-```
-
-- `auth()` — Sets the auth factory. Receives `StorageBackend`, returns `Arc<dyn AuthBackend>`.
-- `routes()` — Merges additional routes into the API router.
-- `ServerConfig` — Contains CLI args, API prefix, CORS origins, and addresses.
-
-**Key modules in lib crate:**
-- `app_builder` — `ServerAppBuilder` for composable server bootstrap
-- `server` — `ServerConfig` and router helpers
-- `seed` — Database seeding (moved from binary to lib for reuse)
-- `grpc_service` — gRPC WorkerService (moved from binary to lib for reuse)
-
-**Public exports from `everruns-server` lib:**
-```rust
-pub use auth::{AuthBackend, BuiltinAuthBackend};
-pub use server::ServerConfig;
-pub use app_builder::{ServerAppBuilder, ServerContext};
-```
+See `crates/server/src/app_builder.rs` for `ServerAppBuilder` — composable builder with `auth()`, `routes()`, `run()` methods. Key modules in lib crate: `app_builder`, `server` (config + router), `seed` (database seeding), `grpc_service` (WorkerService).
 
 ### Data Layer
 
@@ -368,22 +338,7 @@ a vendor-neutral, open-source API standard for multi-provider LLM interfaces.
 - **Better caching**: 40-80% better cache utilization vs Chat Completions API
 - **Provider-agnostic**: Events and responses follow a standardized format
 
-**Driver Selection**:
-```rust
-use everruns_openai::{OpenAILlmDriver, OpenAICompletionsLlmDriver};
-
-// Open Responses API (recommended for new projects)
-let driver = OpenAILlmDriver::new("api-key");
-
-// Chat Completions API (for backward compatibility)
-let driver = OpenAICompletionsLlmDriver::new("api-key");
-```
-
-**Implementation**:
-- `OpenResponsesProtocolLlmDriver` in `everruns-core` - Open Responses protocol
-- `OpenAIProtocolLlmDriver` in `everruns-core` - Chat Completions protocol
-- `OpenAILlmDriver` - Wraps Open Responses for `ProviderType::OpenAI`
-- `OpenAICompletionsLlmDriver` - Wraps Chat Completions for `ProviderType::OpenAICompletions`
+**Driver Selection**: `OpenAILlmDriver` (Responses API, recommended) or `OpenAICompletionsLlmDriver` (Chat Completions). See `crates/openai/src/driver.rs` and the protocol implementations in `crates/core/src/`.
 
 ### LlmSim Driver (Testing)
 
@@ -395,15 +350,7 @@ For integration testing without real API keys, Everruns uses [llmsim](https://gi
 4. **Latency Simulation**: Optional latency profiles for realistic timing
 5. **Usage**: Create an `llmsim` provider and model in tests, then use it as the agent's default model
 
-Example test setup:
-```rust
-// Create LlmSim provider (no API key needed)
-let provider = create_provider("llmsim", "Test Provider");
-let model = create_model(provider.id, "llmsim-test", "LlmSim Test Model");
-
-// Create agent with LlmSim model
-let agent = create_agent("Test Agent", model.id);
-```
+See integration tests in `crates/core/tests/` for usage examples.
 
 ### Capabilities System
 
@@ -478,21 +425,12 @@ See [docs/sre/environment-variables.md](../docs/sre/environment-variables.md) fo
 
 #### Event-Listener Architecture
 
-Observability is decoupled from business logic through the `EventListener` trait:
-
-```rust
-#[async_trait]
-pub trait EventListener: Send + Sync {
-    async fn on_event(&self, event: &Event);
-    fn event_types(&self) -> Option<Vec<&'static str>> { None }
-    fn name(&self) -> &'static str { "EventListener" }
-}
-```
+Observability is decoupled from business logic through the `EventListener` trait (see `crates/core/src/event_listeners.rs`).
 
 **Key components**:
-- `EventListener` trait (`core/src/traits.rs`) - Interface for observability backends
-- `OtelEventListener` (`core/src/otel_listener.rs`) - Generates OTel spans from events
-- `EventService` (`server/src/services/event.rs`) - Notifies listeners after event persistence
+- `EventListener` trait — Interface for observability backends
+- `OtelEventListener` (`core/src/otel_listener.rs`) — Generates OTel spans from events
+- `EventService` (`server/src/services/event.rs`) — Notifies listeners after event persistence
 
 **Event-to-span mapping** (following gen-ai semantic conventions):
 - `llm.generation` → `chat {model}` span with tokens, finish_reasons, response_id

--- a/specs/authentication.md
+++ b/specs/authentication.md
@@ -91,56 +91,11 @@ Account linking by email is supported (same email = same account).
 
 ### Database Schema
 
-#### users table additions
-
-```sql
-ALTER TABLE users ADD COLUMN password_hash TEXT;
-ALTER TABLE users ADD COLUMN email_verified BOOLEAN NOT NULL DEFAULT FALSE;
-ALTER TABLE users ADD COLUMN auth_provider TEXT;  -- 'google', 'github', or NULL for password
-ALTER TABLE users ADD COLUMN auth_provider_id TEXT;
-```
-
-#### api_keys table
-
-```sql
-CREATE TABLE api_keys (
-    id UUID PRIMARY KEY DEFAULT uuidv7(),
-    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    name TEXT NOT NULL,
-    key_hash TEXT NOT NULL,
-    key_prefix TEXT NOT NULL,
-    scopes JSONB NOT NULL DEFAULT '["*"]'::jsonb,
-    expires_at TIMESTAMPTZ,
-    last_used_at TIMESTAMPTZ,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-```
-
-#### refresh_tokens table
-
-```sql
-CREATE TABLE refresh_tokens (
-    id UUID PRIMARY KEY DEFAULT uuidv7(),
-    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    token_hash TEXT NOT NULL UNIQUE,
-    expires_at TIMESTAMPTZ NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-```
+See `crates/server/migrations/001_base_schema.sql` for `users`, `api_keys`, and `refresh_tokens` table DDL.
 
 #### Anonymous User (seeded at startup)
 
-For `auth=none` mode, a well-known anonymous user is seeded programmatically via `seed.rs` (not SQL migration):
-
-| Field | Value |
-|-------|-------|
-| `id` | `00000000-0000-0000-0000-000000000001` (`ANONYMOUS_USER_ID`) |
-| `email` | `anonymous@local` |
-| `name` | `Anonymous` |
-| `roles` | `["admin"]` |
-| `auth_provider` | `none` |
-
-The anonymous user is added to the default organization (`org_id = 1`) via `ensure_membership`. Constants defined in `crates/core/src/organization.rs`: `ANONYMOUS_USER_ID`, `ANONYMOUS_USER_EMAIL`, `ANONYMOUS_USER_NAME`.
+For `auth=none` mode, a well-known anonymous user is seeded via `crates/server/src/seed.rs`. Constants in `crates/core/src/organization.rs`: `ANONYMOUS_USER_ID`, `ANONYMOUS_USER_EMAIL`, `ANONYMOUS_USER_NAME`. The anonymous user has admin role and belongs to the default organization.
 
 ### Security Considerations
 
@@ -166,16 +121,7 @@ The anonymous user is added to the default organization (`org_id = 1`) via `ensu
 
 ### Configuration Discovery
 
-The UI fetches authentication configuration from `GET /v1/auth/config` on startup:
-
-```typescript
-interface AuthConfigResponse {
-  mode: "none" | "admin" | "full" | "external";
-  password_auth_enabled: boolean;
-  oauth_providers: string[];  // ["google", "github"]
-  signup_enabled: boolean;
-}
-```
+The UI fetches authentication configuration from `GET /v1/auth/config` on startup (returns mode, password/OAuth/signup status).
 
 ### Conditional Rendering
 
@@ -244,15 +190,7 @@ Authentication state is managed via:
 
 ### API Client Configuration
 
-```typescript
-// All requests go through /api prefix and include credentials for cookie-based auth
-fetch('/api/v1/agents', {
-  credentials: "include",
-  headers: { "Content-Type": "application/json" }
-});
-```
-
-The `/api` prefix is stripped by the proxy (Next.js in dev, reverse proxy in prod) before reaching the backend.
+All requests go through `/api` prefix with `credentials: "include"` for cookie-based auth. The `/api` prefix is stripped by the proxy (Next.js in dev, reverse proxy in prod) before reaching the backend.
 
 ## Pluggable Authentication Backend
 
@@ -260,79 +198,21 @@ The auth system uses a trait-based pluggable backend so external auth providers 
 
 ### AuthBackend Trait
 
-```rust
-#[async_trait]
-pub trait AuthBackend: Send + Sync + 'static {
-    /// Validate a Bearer token (JWT or opaque) and return the authenticated user.
-    async fn validate_token(&self, token: &str) -> Result<AuthUser, AuthError>;
-
-    /// Validate an API key and return the authenticated user.
-    async fn validate_api_key(&self, key: &str) -> Result<AuthUser, AuthError>;
-
-    /// Return auth-specific HTTP routes (login, register, OAuth callbacks, API key CRUD).
-    /// Returns `None` if auth is handled externally (e.g., PropelAuth hosted UI).
-    fn auth_routes(&self) -> Option<Router>;
-
-    /// Return the auth configuration for the `/v1/auth/config` endpoint.
-    fn auth_config_response(&self) -> AuthConfigResponse;
-}
-```
-
-**Location:** `crates/server/src/auth/backend.rs`
+See `crates/server/src/auth/backend.rs` for the `AuthBackend` trait. Key methods: `validate_token()`, `validate_api_key()`, `auth_routes()`, `auth_config_response()`.
 
 ### BuiltinAuthBackend (OSS Default)
 
-The default implementation wrapping existing JWT + password + API key logic:
-
-```rust
-#[derive(Clone)]
-pub struct BuiltinAuthBackend {
-    pub config: AuthConfig,
-    pub jwt_service: Arc<JwtService>,
-    pub db: Arc<StorageBackend>,
-}
-```
-
-**Location:** `crates/server/src/auth/builtin.rs`
-
-- `validate_token()` — Decodes JWT, fetches user + org memberships from DB
-- `validate_api_key()` — Validates `evr_` prefix, hashes key, looks up in DB
-- `auth_routes()` — Returns login, register, OAuth, refresh, API key CRUD routes
-- `auth_config_response()` — Returns mode, password/signup/OAuth status from `AuthConfig`
-
-Auth route handlers use `BuiltinAuthBackend` as axum state directly (not `AuthState`), with a `FromRef<BuiltinAuthBackend> for AuthState` implementation so the `AuthUser` extractor continues to work.
+See `crates/server/src/auth/builtin.rs`. Wraps JWT + password + API key logic. Auth route handlers use `BuiltinAuthBackend` as axum state directly with `FromRef<BuiltinAuthBackend> for AuthState`.
 
 ### AuthState
 
-`AuthState` holds an `Arc<dyn AuthBackend>` instead of concrete fields:
-
-```rust
-pub struct AuthState {
-    pub config: AuthConfig,
-    pub backend: Arc<dyn AuthBackend>,
-}
-```
-
-The `extract_auth_user()` middleware delegates to `backend.validate_token()` and `backend.validate_api_key()`.
-
-Convenience constructor for OSS: `AuthState::builtin(config, db)` creates a `BuiltinAuthBackend` internally.
+`AuthState` holds `Arc<dyn AuthBackend>`. The `extract_auth_user()` middleware delegates to `backend.validate_token()` and `backend.validate_api_key()`. OSS convenience: `AuthState::builtin(config, db)`.
 
 ### External Identity Support
 
-Migration `004_external_identity.sql` adds nullable `external_id` columns to `users` and `organizations` tables:
+Migration `004_external_identity.sql` adds nullable `external_id` columns to `users` and `organizations` tables, mapping external provider IDs to internal IDs. OSS: unused (NULL). SaaS: populated by auth backend sync.
 
-```sql
-ALTER TABLE users ADD COLUMN external_id TEXT UNIQUE;
-ALTER TABLE organizations ADD COLUMN external_id TEXT UNIQUE;
-```
-
-These map external provider user/org IDs to internal IDs. OSS users: unused (NULL). SaaS: populated by auth backend sync.
-
-**New storage methods:**
-- `get_user_by_external_id(external_id)` — Look up user by external provider ID
-- `get_organization_by_external_id(external_id)` — Look up org by external provider ID
-- `upsert_org_by_external_id(external_id, name)` — Create or update org by external ID
-- `ensure_membership(org_id, user_id)` — Idempotent org membership creation
+See `crates/server/src/storage/` for lookup/upsert methods: `get_user_by_external_id()`, `get_organization_by_external_id()`, `upsert_org_by_external_id()`, `ensure_membership()`.
 
 ### UI Context Exports
 

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -103,7 +103,7 @@ Fetch content from URLs and convert HTML to markdown.
 
 #### CapabilityId (String wrapper)
 
-Capability IDs are string-based for extensibility. New capabilities can be added without database migrations.
+Capability IDs are string-based for extensibility. New capabilities can be added without database migrations. See `crates/core/src/capability_types.rs` for `CapabilityId`, `CapabilityStatus`, and `AgentCapabilityConfig` types.
 
 ##### ID Format
 
@@ -112,137 +112,32 @@ Capability IDs are string-based for extensibility. New capabilities can be added
 | Built-in | `snake_case` identifier | `current_time`, `web_fetch` |
 | MCP | `mcp:{server_uuid}` | `mcp:01933b5a-0000-7000-8000-000000000501` |
 
-**Built-in IDs** use `snake_case` naming and are validated against the `CapabilityRegistry`. Each capability defines its own ID via the `Capability` trait's `id()` method.
+**Built-in IDs** use `snake_case` naming and are validated against the `CapabilityRegistry`. **MCP IDs** use the `mcp:` prefix followed by the MCP server's UUID. See `specs/mcp-servers.md` for details.
 
-**MCP IDs** use the `mcp:` prefix followed by the MCP server's UUID. These are dynamic—they exist only when the corresponding MCP server exists. See `specs/mcp-servers.md` for details.
-
-##### Quick Reference: Built-in Capabilities
-
-| ID | Name | Category | Status |
-|----|------|----------|--------|
-| `agent_instructions` | Agent Instructions | Configuration | Available |
-| `noop` | No-Op | Testing | Available |
-| `current_time` | Current Time | Utilities | Available |
-| `test_math` | Test Math | Testing | Available |
-| `test_weather` | Test Weather | Testing | Available |
-| `session_file_system` | File System | File Operations | Available |
-| `virtual_bash` | Virtual Bash | Execution | Available |
-| `session_storage` | Session Storage | Storage | Available |
-| `session` | Session | Session | Available |
-| `web_fetch` | Web Fetch | Network | Available |
-| `stateless_todo_list` | Task Management | Productivity | Available |
-| `sample_data` | Sample Data | Data | Available |
-| `docker_container` | Docker Container | Development | Available (Dev only, integration plugin) |
-| `session_sql_database` | SQL Database | Data | Available |
-| `skills` | Agent Skills | Skills | Available |
-| `research` | Research | AI | Coming Soon |
-
-```rust
-/// Simple string wrapper - capabilities define their own IDs via id() method
-pub struct CapabilityId(String);
-
-impl CapabilityId {
-    /// Create a new capability ID from a string
-    pub fn new(id: impl Into<String>) -> Self;
-
-    /// Get the ID as a string slice
-    pub fn as_str(&self) -> &str;
-}
-```
-
-#### CapabilityStatus (Enum)
-
-```rust
-pub enum CapabilityStatus {
-    Available,   // Ready for use
-    ComingSoon,  // Not yet implemented
-    Deprecated,  // No longer recommended
-}
-```
+For the full list of built-in capability IDs, see `crates/core/src/capabilities/mod.rs` (registry initialization).
 
 #### AgentCapabilityConfig (Per-agent configuration)
 
-Associates a capability with an agent, including optional per-agent configuration.
+Associates a capability with an agent via `ref` (CapabilityId) + optional `config` (JSON). The `config` field is capability-specific and passed during execution, allowing per-agent behavior.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `ref` | CapabilityId | Reference to the capability |
-| `config` | object | Per-agent configuration (capability-specific) |
-
-```rust
-/// Per-agent capability configuration
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AgentCapabilityConfig {
-    /// Reference to the capability ID
-    #[serde(rename = "ref")]
-    pub capability_ref: CapabilityId,
-    /// Per-agent configuration for this capability
-    #[serde(default)]
-    pub config: serde_json::Value,
-}
-```
-
-The `config` field is capability-specific and passed to the capability during execution.
-This allows the same capability to behave differently per-agent.
-
-**Example usage:**
-```json
-{
-  "capabilities": [
-    { "ref": "current_time", "config": {} },
-    { "ref": "web_fetch", "config": { "timeout_ms": 30000 } }
-  ]
-}
-```
-
-**Import compatibility:** For backward compatibility, import accepts both formats:
-- New format: `{ "ref": "capability_id", "config": {} }`
-- Legacy format: `"capability_id"` (converted to new format with empty config)
+**Import compatibility:** For backward compatibility, import accepts both `{ "ref": "id", "config": {} }` and plain `"id"` formats.
 
 #### Capability Trait (everruns-core)
 
-Capabilities are defined as trait implementations in the core crate:
-
-```rust
-#[async_trait]
-pub trait Capability: Send + Sync {
-    fn id(&self) -> &str;
-    fn name(&self) -> &str;
-    fn description(&self) -> &str;
-    fn status(&self) -> CapabilityStatus;
-    fn system_prompt_addition(&self) -> Option<&str> { None }
-    async fn system_prompt_contribution(&self, ctx: &SystemPromptContext) -> Option<String> { ... }
-    fn tools(&self) -> Vec<Box<dyn Tool>> { vec![] }
-    fn icon(&self) -> Option<&str> { None }
-    fn category(&self) -> Option<&str> { None }
-    fn mounts(&self) -> Vec<MountPoint> { vec![] }
-    fn dependencies(&self) -> Vec<&'static str> { vec![] }
-    fn features(&self) -> Vec<&'static str> { vec![] }
-    fn message_filter_provider(&self) -> Option<Arc<dyn MessageFilterProvider>> { None }
-}
-```
-
-The `CapabilityRegistry` in core holds all registered capability implementations. The API layer converts trait objects to DTOs using `Capability::from_core()`.
+See `crates/core/src/capabilities/mod.rs` for the `Capability` trait and `CapabilityRegistry`. Key trait methods: `id()`, `name()`, `description()`, `status()`, `system_prompt_contribution()`, `tools()`, `mounts()`, `dependencies()`, `features()`, `message_filter_provider()`.
 
 ##### System Prompt Methods
 
-- **`system_prompt_addition()`** — Sync method returning static `&str`. Used by the sync collection path (tools/mounts only callers).
-- **`system_prompt_contribution(ctx)`** — Async method receiving `SystemPromptContext` with session filesystem access. The default wraps `system_prompt_addition()` in `<capability id="...">` XML tags. Capabilities needing dynamic content (e.g., `agent_instructions`, `skills`) override this to read from the session filesystem.
-
-```rust
-pub struct SystemPromptContext {
-    pub session_id: SessionId,
-    pub file_store: Option<Arc<dyn SessionFileStore>>,
-}
-```
+- **`system_prompt_addition()`** — Sync, returns static `&str`. Used by sync collection path.
+- **`system_prompt_contribution(ctx)`** — Async, receives `SystemPromptContext` with session filesystem access. Default wraps `system_prompt_addition()` in XML tags. Capabilities needing dynamic content (e.g., `agent_instructions`, `skills`) override to read from session filesystem.
 
 ##### Collection Functions
 
-- **`collect_capabilities()`** — Sync. Collects tools, mounts, and static prompts. Used by worker adapters.
-- **`collect_capabilities_async(ctx)`** — Async. Calls `system_prompt_contribution()` for dynamic prompts. Used by the agent loop.
-- **`RuntimeAgentBuilder::with_capabilities_async(ctx)`** — Async builder method using `collect_capabilities_async`.
+- **`collect_capabilities()`** — Sync. Collects tools, mounts, static prompts.
+- **`collect_capabilities_async(ctx)`** — Async. Calls `system_prompt_contribution()` for dynamic prompts.
+- **`RuntimeAgentBuilder::with_capabilities_async(ctx)`** — Async builder method.
 
-**Note**: The `message_filter_provider()` method returns an optional filter provider that can modify how messages are retrieved for sessions using this capability. See the [Message Filters](#message-filters) section for details.
+**Note**: `message_filter_provider()` returns an optional filter that modifies message retrieval. See [Message Filters](#message-filters).
 
 ### Capability Dependencies
 
@@ -265,18 +160,7 @@ Capabilities can declare dependencies on other capabilities. When a capability i
 
 #### Example
 
-```rust
-impl Capability for SampleDataCapability {
-    fn id(&self) -> &str { "sample_data" }
-
-    fn dependencies(&self) -> Vec<&'static str> {
-        // Sample Data needs file system tools to be useful
-        vec!["session_file_system"]
-    }
-}
-```
-
-When `sample_data` is selected:
+When `sample_data` is selected (it depends on `session_file_system`):
 1. `session_file_system` is added as a dependency (if not already selected)
 2. `session_file_system` tools and system prompt are applied first
 3. `sample_data` mounts and system prompt are applied second
@@ -284,23 +168,7 @@ When `sample_data` is selected:
 
 #### Dependency Resolution API
 
-```rust
-/// Result of resolving capability dependencies
-pub struct ResolvedCapabilities {
-    /// All capability IDs after resolving dependencies (in topological order)
-    pub resolved_ids: Vec<String>,
-    /// IDs that were added as dependencies (not in the original selection)
-    pub added_as_dependencies: Vec<String>,
-    /// Original user-selected capability IDs
-    pub user_selected: Vec<String>,
-}
-
-/// Resolve capability dependencies
-pub fn resolve_dependencies(
-    selected_ids: &[String],
-    registry: &CapabilityRegistry,
-) -> Result<ResolvedCapabilities, DependencyError>;
-```
+See `crates/core/src/capabilities/mod.rs` for `resolve_dependencies()` and `ResolvedCapabilities`.
 
 #### Built-in Capabilities with Dependencies
 
@@ -345,129 +213,20 @@ MCP and Skill virtual capabilities currently declare no features.
 | `schedules` | Schedules tab | Session can create/manage schedules |
 | `sql_database` | *(reserved)* | Session has SQL database access |
 
-#### Example
-
-```rust
-impl Capability for SessionScheduleCapability {
-    fn id(&self) -> &str { "session_schedule" }
-
-    fn features(&self) -> Vec<&'static str> {
-        vec!["schedules"]
-    }
-}
-```
-
-When `session_schedule` is selected, the session's `features` will include `"schedules"`, and the UI will render the Schedules tab.
-
 #### compute_features()
 
-```rust
-/// Compute aggregated features from capability IDs.
-/// Resolves dependencies, collects features, deduplicates.
-pub fn compute_features(
-    capability_ids: &[String],
-    registry: &CapabilityRegistry,
-) -> Vec<String>;
-```
+See `crates/core/src/capabilities/mod.rs` for `compute_features()` — resolves dependencies, collects features, deduplicates.
 
 ### Built-in Capabilities
 
-#### Noop
-
-- **Status**: Available
-- **Purpose**: Testing and demonstration
-- **System Prompt**: None
-- **Tools**: None
-
-#### CurrentTime
-
-- **Status**: Available
-- **Purpose**: Get current date and time in various formats
-- **System Prompt**: None
-- **Tools**:
-  - `get_current_time` - Returns current timestamp
-    - Parameters:
-      - `timezone`: string (e.g., "UTC", "America/New_York")
-      - `format`: enum (iso8601, unix, human)
-    - Policy: Auto
-
-#### TestMath
-
-- **Status**: Available
-- **Purpose**: Testing tool calling with calculator operations
-- **System Prompt**: "You have access to math tools. Use them for calculations: add, subtract, multiply, divide."
-- **Tools**:
-  - `add` - Add two numbers
-  - `subtract` - Subtract second number from first
-  - `multiply` - Multiply two numbers
-  - `divide` - Divide first number by second
-- **Icon**: "calculator"
-- **Category**: "Testing"
-
-#### TestWeather
-
-- **Status**: Available
-- **Purpose**: Testing tool calling with mock weather data
-- **System Prompt**: "You have access to weather tools. Use get_weather for current conditions and get_forecast for multi-day forecasts."
-- **Tools**:
-  - `get_weather` - Get current weather for a city
-  - `get_forecast` - Get multi-day forecast
-- **Icon**: "cloud-sun"
-- **Category**: "Testing"
-
-#### Research (Coming Soon)
-
-- **Status**: ComingSoon
-- **Purpose**: Deep research with organized findings
-- **System Prompt**: "You have access to a research scratchpad. Use it to organize your thoughts and findings."
-- **Tools**: To be added (scratchpad, web search, etc.)
-- **Icon**: "search"
-- **Category**: "AI"
+For the full list of built-in capabilities with their tools, parameters, and system prompts, see `crates/core/src/capabilities/` (each capability has its own module).
 
 #### FileSystem
 
-- **Status**: Available
 - **ID**: `session_file_system`
 - **Purpose**: Tools to access and manipulate files in the session workspace (`/workspace`)
-- **System Prompt**: Guidance on using file system tools, best practices for exploration and file operations. Explains the `/workspace` mount point.
-- **Workspace Mount**: All paths are relative to `/workspace` (e.g., `/workspace/src/main.rs`). Paths are normalized internally to enable seamless integration with virtual_bash.
-- **Tools**:
-  - `read_file` - Read file content by path. For image files (PNG, JPEG, GIF, WebP), the image is returned as a native image content block so the LLM can see it visually.
-    - Parameters:
-      - `path`: string (required) - Absolute path to the file (e.g., '/workspace/docs/readme.txt')
-    - Returns: Object containing path, content, encoding, size_bytes. For base64-encoded image files, returns `SuccessWithImages` with the image as a native `ToolResultImage`.
-    - Policy: Auto
-  - `write_file` - Create or update a file
-    - Parameters:
-      - `path`: string (required) - Absolute path for the file
-      - `content`: string (required) - Content to write
-      - `encoding`: enum (text, base64) - Content encoding, defaults to text
-    - Returns: Object containing path, size_bytes, created status
-    - Policy: Auto
-  - `list_directory` - List files and directories at a path
-    - Parameters:
-      - `path`: string - Directory path to list, defaults to root '/'
-    - Returns: Object containing path, entries array, count
-    - Policy: Auto
-  - `grep_files` - Search file contents using regex
-    - Parameters:
-      - `pattern`: string (required) - Regex pattern to search for
-      - `path_pattern`: string - Optional path pattern filter (e.g., '*.txt')
-    - Returns: Object containing pattern, matches array, match_count
-    - Policy: Auto
-  - `delete_file` - Delete a file or directory
-    - Parameters:
-      - `path`: string (required) - Path to file or directory
-      - `recursive`: boolean - If true, delete directories recursively, defaults to false
-    - Returns: Object containing path, deleted status
-    - Policy: Auto
-  - `stat_file` - Get file or directory metadata
-    - Parameters:
-      - `path`: string (required) - Path to the file or directory
-    - Returns: Object containing path, name, exists, is_directory, is_readonly, size_bytes, timestamps
-    - Policy: Auto
-- **Icon**: "folder"
-- **Category**: "File Operations"
+- **Tools**: `read_file`, `write_file`, `list_directory`, `grep_files`, `delete_file`, `stat_file`
+- **Workspace Mount**: All paths relative to `/workspace`, normalized internally for virtual_bash integration
 
 ##### Design Decision: Context-Aware Tools
 
@@ -485,32 +244,11 @@ When writing a file like `/a/b/c.txt`, parent directories `/a` and `/a/b` are au
 
 #### VirtualBash
 
-- **Status**: Available
 - **ID**: `virtual_bash`
 - **Purpose**: Sandboxed bash shell execution for safe code execution and file manipulation
-- **System Prompt**: Guidance on bash capabilities, limitations, and best practices. Explains the `/workspace` mount point and environment.
-- **Dependencies**: `session_file_system` (bash commands operate on the same workspace)
-- **Environment**:
-  - `HOME=/home/agent`
-  - `SHELL=/bin/bash`
-  - `PATH=/usr/local/bin:/usr/bin:/bin`
-  - `WORKSPACE=/workspace`
-  - `USER=everruns`
-- **Workspace Mount**: Session files mounted at `/workspace`. Files created by bash are accessible via FileSystem tools and vice versa.
-- **Tools**:
-  - `bash` - Execute a bash command
-    - Parameters:
-      - `command`: string (required) - The bash command to execute
-      - `working_dir`: string (optional) - Working directory, defaults to `/workspace`
-      - `timeout_ms`: integer (optional) - Command timeout in milliseconds, defaults to 30000
-    - Returns: Object containing exit_code, stdout, stderr, success
-    - Policy: Auto
-- **Limits**:
-  - Max iterations: 1,000,000
-  - Max call depth: 256
-  - Max array size: 10,000
-- **Icon**: "terminal"
-- **Category**: "Execution"
+- **Dependencies**: `session_file_system` (operates on same workspace)
+- **Tools**: `bash` (execute command with optional working_dir and timeout)
+- **Workspace Mount**: Session files at `/workspace`, shared with FileSystem tools
 
 ##### Design Decision: bashkit Library
 
@@ -538,27 +276,9 @@ This ensures bash and FileSystem capability share the same file namespace.
 
 #### SessionStorage
 
-- **Status**: Available
 - **ID**: `session_storage`
 - **Purpose**: Session-scoped key/value storage and encrypted secret storage
-- **System Prompt**: Guidance on using storage tools for persisting data and secrets
-- **Tools**:
-  - `kv_store` - Key/value storage operations (plain text)
-    - Parameters:
-      - `operation`: enum (set, get, delete, list) - The operation to perform
-      - `key`: string (max 255 chars) - Required for set, get, delete
-      - `value`: string - Required for set (can be JSON-encoded)
-    - Returns: Object containing operation, key, and result (success/value/deleted/keys)
-    - Policy: Auto
-  - `secret_store` - Encrypted secret storage operations
-    - Parameters:
-      - `operation`: enum (set, get, delete, list) - The operation to perform
-      - `name`: string (max 255 chars) - Required for set, get, delete
-      - `value`: string - Required for set (will be encrypted)
-    - Returns: Object containing operation, name, and result (success/value/deleted/secrets)
-    - Policy: Auto
-- **Icon**: "database"
-- **Category**: "Storage"
+- **Tools**: `kv_store` (set/get/delete/list), `secret_store` (encrypted, same ops)
 
 ##### Design Decision: Consolidated Tools
 
@@ -586,39 +306,10 @@ Secret operations require the `SECRETS_ENCRYPTION_KEY` environment variable to b
 
 #### WebFetch
 
-- **Status**: Available
 - **ID**: `web_fetch`
 - **Purpose**: Fetch content from URLs and convert HTML to markdown or plain text
-- **System Prompt**: None (this capability does not add to the system prompt)
-- **Timeouts**:
-  - **First byte timeout**: 1 second - If server doesn't respond within 1 second, request fails
-  - **Body timeout**: 30 seconds - If body isn't fully read within 30 seconds, partial content is returned with `[..more content timed out...]` suffix
-- **Tools**:
-  - `web_fetch` - Fetch content from a URL
-    - Parameters:
-      - `url`: string (required) - The URL to fetch, must start with http:// or https://
-      - `method`: enum (GET, HEAD) - HTTP method, defaults to GET
-      - `as_markdown`: boolean - Convert HTML response to markdown format
-      - `as_text`: boolean - Convert HTML response to plain text (ignored if as_markdown is true)
-    - Returns: Object containing:
-      - `url`: The requested URL
-      - `status_code`: HTTP status code
-      - `content_type`: Response content type
-      - `size`: Number of bytes received
-      - `last_modified`: Last-Modified header value (when available)
-      - `filename`: Extracted filename from Content-Disposition header or URL (when available)
-      - `format`: "markdown", "text", or "raw" depending on conversion
-      - `content`: The fetched content (not present for HEAD requests or binary content)
-      - `truncated`: boolean - True if body was truncated due to timeout
-      - `error`: (for binary content) Error message explaining binary content is not supported
-    - Error handling:
-      - Binary content (images, PDFs, etc.) returns success with metadata and error message (not a tool error)
-      - Invalid URLs return validation errors
-      - Network errors return appropriate error messages
-      - First byte timeout returns "server did not respond within 1 second"
-    - Policy: Auto
-- **Icon**: "globe"
-- **Category**: "Network"
+- **Tools**: `web_fetch` (url, method, as_markdown, as_text)
+- **Timeouts**: First byte 1s, body 30s (partial content on timeout)
 
 ##### Design Decision: System Prompt from fetchkit
 
@@ -645,22 +336,9 @@ The capability uses the [fetchkit](https://github.com/everruns/fetchkit) library
 
 #### StatelessTodoList
 
-- **Status**: Available
 - **ID**: `stateless_todo_list`
-- **Purpose**: Enable agents to create and manage structured task lists for tracking multi-step work progress
-- **System Prompt**: Comprehensive guidance on when and how to use task management, including best practices for multi-step workflows
-- **Tools**:
-  - `write_todos` - Create or update a task list
-    - Parameters:
-      - `todos`: array of task objects, each with:
-        - `content`: string (imperative form, e.g., "Run tests", "Fix the bug")
-        - `activeForm`: string (present continuous, e.g., "Running tests", "Fixing the bug")
-        - `status`: enum (pending, in_progress, completed)
-    - Returns: success status with task counts and validated todos
-    - Validation: Warns if no task is in_progress (when pending tasks exist) or if multiple tasks are in_progress
-    - Policy: Auto
-- **Icon**: "list-checks"
-- **Category**: "Productivity"
+- **Purpose**: Structured task lists for tracking multi-step work progress
+- **Tools**: `write_todos` (replaces entire todo list each call; state in conversation history)
 
 ##### Design Decision: Stateless Implementation
 
@@ -718,24 +396,10 @@ The system prompt instructs agents to use task management when:
 
 #### SkillsDiscovery
 
-- **Status**: Available
 - **ID**: `skills`
-- **Purpose**: Discover and activate skills from the session filesystem (VFS-based skill discovery)
+- **Purpose**: Discover and activate skills from `/.agents/skills/` in session VFS
 - **Dependencies**: `session_file_system`
-- **System Prompt**: Explains the skills system, `/.agents/skills/` path, and how to use `list_skills`/`activate_skill`
-- **Tools**:
-  - `list_skills` - Scan `/.agents/skills/` in the session VFS for SKILL.md files
-    - Parameters: none
-    - Returns: Array of discovered skills with name, description, path, version
-    - Policy: Auto
-  - `activate_skill` - Load a skill's full instructions by name
-    - Parameters:
-      - `name`: string (required) - Skill directory name (e.g., `pdf-processing`)
-    - Returns: Skill instructions wrapped in `<skill name="...">` XML tags, plus bundled file paths
-    - Validation: Path traversal blocked (`..`, `/`, `\` in name rejected)
-    - Policy: Auto
-- **Icon**: "wand"
-- **Category**: "Skills"
+- **Tools**: `list_skills` (scan for SKILL.md files), `activate_skill` (load instructions by name)
 
 ##### Design Decision: VFS-Based Discovery
 
@@ -882,129 +546,13 @@ Agent capabilities are managed through the agents API:
 - `PATCH /v1/agents/{id}` - Update agent capabilities
 - `GET /v1/agents/{id}` - Get agent (includes capabilities)
 
-#### List Capabilities
-
-```http
-GET /v1/capabilities
-
-Response:
-{
-  "items": [
-    {
-      "id": "current_time",
-      "name": "Current Time",
-      "description": "Tool to get current date and time in various formats and timezones.",
-      "status": "available",
-      "icon": "clock",
-      "category": "Utilities"
-    },
-    {
-      "id": "web_fetch",
-      "name": "Web Fetch",
-      "description": "Fetch content from URLs and convert HTML responses to markdown or plain text.",
-      "status": "available",
-      "icon": "globe",
-      "category": "Network"
-    },
-    {
-      "id": "stateless_todo_list",
-      "name": "Task Management",
-      "description": "Enables agents to create and manage structured task lists for tracking multi-step work progress. State is maintained in conversation history.",
-      "status": "available",
-      "icon": "list-checks",
-      "category": "Productivity"
-    },
-    {
-      "id": "research",
-      "name": "Research",
-      "description": "Deep research capability with organized scratchpad.",
-      "status": "coming_soon",
-      "icon": "search",
-      "category": "AI"
-    }
-  ],
-  "total": 9
-}
-```
-
-#### Create Agent with Capabilities
-
-```http
-POST /v1/agents
-Content-Type: application/json
-
-{
-  "name": "Research Assistant",
-  "system_prompt": "You are a helpful research assistant.",
-  "capabilities": [
-    { "ref": "current_time", "config": {} },
-    { "ref": "test_math", "config": {} }
-  ]
-}
-
-Response:
-{
-  "id": "...",
-  "name": "Research Assistant",
-  "system_prompt": "You are a helpful research assistant.",
-  "capabilities": [
-    { "ref": "current_time", "config": {} },
-    { "ref": "test_math", "config": {} }
-  ],
-  "status": "active",
-  ...
-}
-```
-
-#### Update Agent Capabilities
-
-```http
-PATCH /v1/agents/{agent_id}
-Content-Type: application/json
-
-{
-  "capabilities": [
-    { "ref": "current_time", "config": {} },
-    { "ref": "web_fetch", "config": { "timeout_ms": 30000 } },
-    { "ref": "session_file_system", "config": {} }
-  ]
-}
-
-Response:
-{
-  "id": "...",
-  "name": "Research Assistant",
-  "capabilities": [
-    { "ref": "current_time", "config": {} },
-    { "ref": "web_fetch", "config": { "timeout_ms": 30000 } },
-    { "ref": "session_file_system", "config": {} }
-  ],
-  ...
-}
-```
-
-The array order determines the priority (earlier capabilities' system prompt additions appear first).
+Capabilities are managed via the agents API (`POST /v1/agents`, `PATCH /v1/agents/{id}`). The capabilities array order determines priority (earlier = first in system prompt). See `specs/apis.md` and the OpenAPI spec for request/response formats.
 
 ### Database Schema
 
-```sql
-CREATE TABLE agent_capabilities (
-    id UUID PRIMARY KEY DEFAULT uuidv7(),
-    agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
-    -- Capability ID is a string; validation happens at application layer
-    capability_id VARCHAR(50) NOT NULL,
-    position INTEGER NOT NULL DEFAULT 0,
-    -- Per-agent capability configuration (JSON)
-    config JSONB NOT NULL DEFAULT '{}',
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    UNIQUE(agent_id, capability_id)
-);
+See `crates/server/migrations/001_base_schema.sql` for the `agent_capabilities` table DDL.
 
-CREATE INDEX idx_agent_capabilities_agent_id ON agent_capabilities(agent_id);
-CREATE INDEX idx_agent_capabilities_position ON agent_capabilities(agent_id, position);
-```
-
-**Note**: The `capability_id` column no longer has a CHECK constraint. Validation is performed at the application layer via `CapabilityRegistry`. This allows adding new capabilities without database migrations. The `config` column stores per-agent configuration as JSON, allowing capability-specific settings per agent.
+**Note**: The `capability_id` column has no CHECK constraint — validation is at the application layer via `CapabilityRegistry`. This allows adding capabilities without database migrations.
 
 ### Design Decisions
 
@@ -1019,36 +567,10 @@ CREATE INDEX idx_agent_capabilities_position ON agent_capabilities(agent_id, pos
 
 ### Adding New Capabilities
 
-To add a new capability:
-
-1. **Implement the Capability trait**:
-   ```rust
-   pub struct MyNewCapability;
-
-   impl Capability for MyNewCapability {
-       fn id(&self) -> &str { "my_new_capability" }
-       fn name(&self) -> &str { "My New Capability" }
-       fn description(&self) -> &str { "Description here" }
-       fn status(&self) -> CapabilityStatus { CapabilityStatus::Available }
-       fn tools(&self) -> Vec<Box<dyn Tool>> { vec![] }
-   }
-   ```
-
-2. **Register in CapabilityRegistry**:
-   ```rust
-   impl CapabilityRegistry {
-       pub fn with_builtins() -> Self {
-           let mut registry = Self::new();
-           // ... existing capabilities
-           registry.register(MyNewCapability);
-           registry
-       }
-   }
-   ```
-
-3. **Add tool implementations** if needed (implement `Tool` trait)
-
-4. **No database migration required** - the capability ID is validated at runtime
+1. Implement the `Capability` trait (see `crates/core/src/capabilities/mod.rs` for trait definition)
+2. Register in `CapabilityRegistry::with_builtins()` (same file)
+3. Add tool implementations if needed (implement `Tool` trait from `crates/core/src/tools.rs`)
+4. No database migration required — capability ID validated at runtime
 
 ### Capability Mount Points
 
@@ -1056,47 +578,12 @@ Capabilities can declare mount points to populate files and directories in the s
 
 #### Mount Point Data Model
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `path` | string | Target path in session filesystem (e.g., "/samples") |
-| `access` | MountAccess | Read/write permissions: `ReadOnly` or `ReadWrite` |
-| `source` | MountSource | Content to mount (file or directory) |
-| `capability_id` | string | ID of the capability providing this mount |
+See `crates/core/src/capability_types.rs` for `MountPoint`, `MountAccess`, `MountSource`, and `MountEntry` types.
 
-#### MountAccess
-
-```rust
-pub enum MountAccess {
-    ReadOnly,   // Files cannot be modified or deleted
-    ReadWrite,  // Files can be read and written
-}
-```
-
-#### MountSource
-
-```rust
-pub enum MountSource {
-    InlineFile {
-        content: String,   // File content
-        encoding: String,  // "text" or "base64"
-    },
-    InlineDirectory {
-        entries: HashMap<String, MountEntry>,
-    },
-}
-```
-
-#### Capability Trait Addition
-
-```rust
-pub trait Capability: Send + Sync {
-    // ... existing methods ...
-
-    /// Returns mount points to populate in the session filesystem.
-    /// Default: empty vector (no mounts).
-    fn mounts(&self) -> Vec<MountPoint> { vec![] }
-}
-```
+Key concepts:
+- `MountAccess`: `ReadOnly` or `ReadWrite`
+- `MountSource`: `InlineFile` (content + encoding) or `InlineDirectory` (HashMap of entries)
+- Capabilities declare mounts via the `mounts()` trait method
 
 #### Mount Application Flow
 
@@ -1106,25 +593,9 @@ pub trait Capability: Send + Sync {
 4. Files and directories are created in session filesystem
 5. Files from readonly mounts are marked `is_readonly = true`
 
-#### Example Capability with Mounts
-
-```rust
-impl Capability for SampleDataCapability {
-    fn id(&self) -> &str { "sample_data" }
-    fn name(&self) -> &str { "Sample Data" }
-
-    fn mounts(&self) -> Vec<MountPoint> {
-        let samples_dir = MountDirectoryBuilder::new()
-            .file("users.json", USERS_JSON)
-            .file("config.yaml", CONFIG_YAML)
-            .build();
-
-        vec![MountPoint::readonly("/samples", samples_dir, self.id())]
-    }
-}
-```
-
 #### Built-in Capabilities with Mounts
+
+See `crates/core/src/capabilities/sample_data.rs` for a concrete example of `mounts()` implementation.
 
 ##### SampleData
 
@@ -1144,54 +615,11 @@ Experimental capabilities are available in development environments only (`Deplo
 
 #### DockerContainer
 
-- **Status**: Available (Dev only, integration plugin)
-- **ID**: `docker_container`
-- **Crate**: `integrations/docker/` → `everruns-integrations-docker` (auto-registered via `inventory` plugin system, force-linked via `extern crate` in server and worker — see [architecture.md](architecture.md#integration-plugin-force-linking))
-- **Purpose**: Run commands and manage files in a Docker container tied to the session
-- **System Prompt**: Guidance on using container tools, best practices for command execution
-- **Container Lifecycle**:
-  - Lazily started on first tool use
-  - Persists for session duration
-  - Uses host networking
-  - Container name: `everruns-{session_id}`
-- **Configuration** (via `AgentCapabilityConfig.config`):
-  - `image`: Docker image to use (default: `mcr.microsoft.com/devcontainers/python:3.11`)
-  - `working_dir`: Working directory inside container (default: `/workspace`)
-- **Tools**:
-  - `docker_exec` - Execute shell command in container
-    - Parameters:
-      - `command`: string (required) - Command to execute
-      - `working_dir`: string - Override working directory
-      - `config`: object - Container configuration
-    - Returns: stdout, stderr, exit_code, success
-    - Policy: Auto
-  - `docker_read_file` - Read file from container filesystem
-    - Parameters:
-      - `path`: string (required) - Absolute path to file
-      - `config`: object - Container configuration
-    - Returns: path, content, size_bytes
-    - Policy: Auto
-  - `docker_write_file` - Write file to container filesystem
-    - Parameters:
-      - `path`: string (required) - Absolute path for file
-      - `content`: string (required) - Content to write
-      - `config`: object - Container configuration
-    - Returns: path, size_bytes, success
-    - Policy: Auto
-  - `docker_logs` - Get logs from container
-    - Parameters:
-      - `tail`: integer - Number of lines from end (default: 100)
-      - `since`: string - Timestamp or relative time (e.g., '10m', '1h')
-      - `timestamps`: boolean - Include timestamps (default: false)
-    - Returns: logs, stdout, stderr, container_name, lines_requested
-    - Policy: Auto
-  - `docker_stop` - Stop and remove container
-    - Parameters:
-      - `force`: boolean - Force kill (default: false)
-    - Returns: stopped, removed, container_name, message
-    - Policy: Auto
-- **Icon**: "container"
-- **Category**: "Development"
+- **ID**: `docker_container` (Dev only, integration plugin)
+- **Crate**: `integrations/docker/` (auto-registered via `inventory`, force-linked — see [architecture.md](architecture.md#integration-plugin-force-linking))
+- **Purpose**: Run commands and manage files in a session-scoped Docker container
+- **Tools**: `docker_exec`, `docker_read_file`, `docker_write_file`, `docker_logs`, `docker_stop`
+- **Container Lifecycle**: Lazily started on first use, persists for session, named `everruns-{session_id}`
 
 ##### Design Decision: Session-Scoped Containers
 
@@ -1213,67 +641,11 @@ This capability is experimental and only available in development environments d
 
 #### CodeSandbox
 
-- **Status**: Available (Dev only)
-- **ID**: `codesandbox`
-- **Purpose**: Create and manage cloud-based sandbox VMs via CodeSandbox API for isolated code execution
-- **System Prompt**: Guidance on API key setup, sandbox lifecycle, tool usage, best practices
+- **ID**: `codesandbox` (Dev only)
+- **Purpose**: Cloud-based sandbox VMs via CodeSandbox API for isolated code execution
+- **Dependencies**: `session_storage` (API key stored as session secret `CSB_API_KEY`)
+- **Tools**: `csb_create_sandbox`, `csb_exec`, `csb_exec_status`, `csb_read_file`, `csb_write_file`, `csb_download_workspace`, `csb_list_sandboxes`, `csb_manage_sandbox`
 - **Architecture**: Two-tier API — Management API for lifecycle, Pint API for in-sandbox operations
-- **State Management**: Sandbox connection info stored in session secrets (encrypted at rest)
-- **Configuration**: API key stored as session secret `CSB_API_KEY`
-- **Dependencies**: `session_storage`
-- **Tools**:
-  - `csb_create_sandbox` - Create a new sandbox VM, optionally upload files
-    - Parameters:
-      - `title`: string - Sandbox title
-      - `template`: string - Template ID to fork from
-      - `upload_files`: array - Files to upload from session storage `[{session_path, sandbox_path}]`
-    - Returns: sandbox_id, status, workspace_path
-    - Policy: Auto
-  - `csb_exec` - Execute shell command in a sandbox (sync or async)
-    - Parameters:
-      - `sandbox_id`: string (required) - Target sandbox
-      - `command`: string (required) - Shell command
-      - `wait`: boolean (default: true) - Wait for completion
-    - Returns: exec_id, status, exit_code, output
-    - Policy: Auto
-  - `csb_exec_status` - Check execution status and get output
-    - Parameters:
-      - `sandbox_id`: string (required) - Target sandbox
-      - `exec_id`: string (required) - Execution ID
-    - Returns: exec_id, status, exit_code, output
-    - Policy: Auto
-  - `csb_read_file` - Read file from sandbox filesystem
-    - Parameters:
-      - `sandbox_id`: string (required) - Target sandbox
-      - `path`: string (required) - File path
-    - Returns: path, content
-    - Policy: Auto
-  - `csb_write_file` - Write content to file in sandbox
-    - Parameters:
-      - `sandbox_id`: string (required) - Target sandbox
-      - `path`: string (required) - File path
-      - `content`: string (required) - File content
-    - Returns: path, success
-    - Policy: Auto
-  - `csb_download_workspace` - Download entire workspace to session storage
-    - Parameters:
-      - `sandbox_id`: string (required) - Target sandbox
-      - `sandbox_path`: string - Root path in sandbox (default: workspace_path)
-      - `session_path`: string - Destination in session storage (default: /workspace)
-    - Returns: files_downloaded, files_skipped, errors
-    - Policy: Auto
-  - `csb_list_sandboxes` - List all sandboxes in this session
-    - Parameters: none
-    - Returns: sandboxes array with sandbox_id, started_at
-    - Policy: Auto
-  - `csb_manage_sandbox` - Lifecycle management (shutdown, hibernate, delete)
-    - Parameters:
-      - `sandbox_id`: string (required) - Target sandbox
-      - `action`: string (required) - "shutdown", "hibernate", or "delete"
-    - Returns: sandbox_id, action, success
-    - Policy: Auto
-- **Icon**: "cloud"
-- **Category**: "Execution"
 
 ##### Design Decision: Multiple Sandboxes Per Session
 
@@ -1319,86 +691,11 @@ Capabilities can contribute message filters that modify how messages are retriev
 
 #### MessageFilterProvider Trait
 
-```rust
-pub trait MessageFilterProvider: Send + Sync {
-    /// Modify the message query by adding filters and/or injections.
-    fn apply_filters(&self, query: &mut MessageQuery, config: &serde_json::Value);
-
-    /// Priority for filter application (lower = earlier). Default is 0.
-    fn priority(&self) -> i32 { 0 }
-}
-```
+See `crates/core/src/message_filter.rs` for `MessageFilterProvider`, `MessageFilter`, `MessageQuery`, `InjectedMessage`, and `InjectionPosition` types.
 
 #### Message Injection
 
-Ephemeral messages can be injected into the result set without persistence:
-
-```rust
-pub enum InjectionPosition {
-    Start,           // Before all messages
-    End,             // After all messages
-    BeforeIndex(usize),
-    AfterIndex(usize),
-}
-
-pub struct InjectedMessage {
-    pub position: InjectionPosition,
-    pub message: Message,
-}
-```
-
-Injections are applied after filtering and are useful for:
-- Adding conversation summaries at the start
-- Inserting system reminders before recent context
-- Appending instructions or context
-
-#### MessageQuery Builder
-
-```rust
-let query = MessageQuery::new(session_id)
-    .with_filter(MessageFilter::TimeRange {
-        from: Some(Utc::now() - Duration::hours(24)),
-        to: None,
-    })
-    .with_filter(MessageFilter::EventTypes(vec!["input.message".to_string()]))
-    .with_injection(InjectedMessage::at_start(Message::system("Summary: ...")))
-    .with_limit(100);
-```
-
-#### Example Capability with Message Filter
-
-```rust
-impl Capability for RecentMessagesCapability {
-    fn id(&self) -> &str { "recent_messages" }
-    fn name(&self) -> &str { "Recent Messages" }
-    fn description(&self) -> &str { "Only load messages from the last 24 hours" }
-
-    fn message_filter_provider(&self) -> Option<Arc<dyn MessageFilterProvider>> {
-        Some(Arc::new(RecentMessagesProvider))
-    }
-}
-
-struct RecentMessagesProvider;
-
-impl MessageFilterProvider for RecentMessagesProvider {
-    fn apply_filters(&self, query: &mut MessageQuery, config: &serde_json::Value) {
-        // Check config for custom hours setting
-        let hours = config.get("hours")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(24);
-
-        let cutoff = Utc::now() - Duration::hours(hours as i64);
-        query.filters.push(MessageFilter::TimeRange {
-            from: Some(cutoff),
-            to: None,
-        });
-    }
-
-    fn priority(&self) -> i32 {
-        -10  // Run early to reduce data loaded
-    }
-}
-```
+Ephemeral messages can be injected into the result set without persistence (summaries, reminders, context). Injections applied after filtering at positions: `Start`, `End`, `BeforeIndex(n)`, `AfterIndex(n)`.
 
 #### Filter Application Flow
 

--- a/specs/events.md
+++ b/specs/events.md
@@ -857,25 +857,7 @@ This approach provides real-time feedback as tokens are consumed during LLM call
 
 ## Database Storage
 
-Events are stored in the `events` table:
-
-```sql
-CREATE TABLE events (
-    id UUID PRIMARY KEY DEFAULT uuidv7(),
-    session_id UUID NOT NULL REFERENCES sessions(id),
-    sequence INTEGER NOT NULL,
-    event_type VARCHAR(100) NOT NULL,
-    ts TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    context JSONB NOT NULL DEFAULT '{}',
-    data JSONB NOT NULL DEFAULT '{}',
-    metadata JSONB,
-    tags TEXT[],
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    UNIQUE(session_id, sequence)
-);
-```
-
-The `data` column contains the event-specific payload. The `event_type` column is denormalized for efficient filtering. The `context` column holds correlation data (turn_id, input_message_id, exec_id). The `metadata` and `tags` columns provide additional filtering and categorization capabilities.
+See `crates/server/migrations/001_base_schema.sql` for the `events` table DDL. Key columns: `data` (JSONB, event-specific payload), `event_type` (denormalized for filtering), `context` (JSONB, correlation data).
 
 ## Storage Guarantees
 
@@ -883,22 +865,7 @@ The event store provides three key guarantees:
 
 ### 1. Append-Only Immutability
 
-Events are **immutable** once written. The database enforces this via triggers:
-
-```sql
-CREATE TRIGGER events_append_only_update
-    BEFORE UPDATE ON events
-    FOR EACH ROW EXECUTE FUNCTION prevent_event_mutation();
-
-CREATE TRIGGER events_append_only_delete
-    BEFORE DELETE ON events
-    FOR EACH ROW EXECUTE FUNCTION prevent_event_mutation();
-```
-
-**Behavior:**
-- `UPDATE` on `events` → Error: "events are append-only: UPDATE operations are not allowed"
-- `DELETE` on `events` → Error: "events are append-only: DELETE operations are not allowed"
-- `INSERT` → Allowed (append-only)
+Events are **immutable** once written. Database triggers block UPDATE and DELETE operations (see migrations for trigger DDL).
 
 **Rationale:** Event sourcing requires immutable history. Allowing mutations would break replay, audit trails, and data integrity guarantees.
 
@@ -906,28 +873,7 @@ CREATE TRIGGER events_append_only_delete
 
 Each event within a session is assigned a monotonically increasing sequence number. Sequences are allocated atomically to prevent race conditions under concurrent writes.
 
-**Implementation:**
-
-A dedicated `event_sequences` table tracks the next sequence per session:
-
-```sql
-CREATE TABLE event_sequences (
-    session_id UUID PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
-    next_sequence INTEGER NOT NULL DEFAULT 1,
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-```
-
-The `allocate_event_sequence(session_id)` function atomically allocates the next sequence:
-
-```sql
-INSERT INTO event_sequences (session_id, next_sequence, updated_at)
-VALUES (p_session_id, 2, NOW())
-ON CONFLICT (session_id) DO UPDATE
-SET next_sequence = event_sequences.next_sequence + 1,
-    updated_at = NOW()
-RETURNING next_sequence - 1;
-```
+**Implementation:** A dedicated `event_sequences` table with an atomic upsert function (`allocate_event_sequence`). See `crates/server/migrations/001_base_schema.sql` for DDL.
 
 **Guarantees:**
 - No sequence gaps within a session (barring transaction rollbacks)
@@ -1062,28 +1008,9 @@ Both the SSE (`/v1/sessions/{id}/sse`) and JSON (`/v1/sessions/{id}/events`) end
 - Both parameters accept only known event types (see Event Type Registry). Unknown types return 400.
 - Maximum 25 values per parameter to prevent abuse.
 
-### Message Events Filter
+### Partial Indexes
 
-A partial index exists for efficient message queries:
-
-```sql
-CREATE INDEX idx_events_messages ON events(session_id, sequence)
-WHERE event_type IN ('input.message', 'output.message.completed');
-```
-
-### Turn Events Filter
-
-```sql
-CREATE INDEX idx_events_turns ON events(session_id, sequence)
-WHERE event_type IN ('turn.started', 'turn.completed', 'turn.failed');
-```
-
-### Tool Events Filter
-
-```sql
-CREATE INDEX idx_events_tool_calls ON events(session_id, sequence)
-WHERE event_type IN ('tool.started', 'tool.completed');
-```
+Partial indexes exist for efficient queries on message events, turn events, and tool events. See `crates/server/migrations/001_base_schema.sql` for index DDL.
 
 ## Event Listeners
 
@@ -1091,28 +1018,7 @@ Event listeners provide a pluggable mechanism for observability backends to reac
 
 ### EventListener Trait
 
-```rust
-#[async_trait]
-pub trait EventListener: Send + Sync {
-    /// Called after an event is persisted
-    async fn on_event(&self, event: &Event);
-
-    /// Optional: filter which event types to receive
-    fn event_types(&self) -> Option<Vec<&'static str>> { None }
-
-    /// Human-readable name for logging
-    fn name(&self) -> &'static str { "EventListener" }
-}
-```
-
-### Listener Registration
-
-Listeners are registered with `EventService` at startup:
-
-```rust
-let otel_listener = Arc::new(OtelEventListener::new());
-let event_service = EventService::with_listeners(db, vec![otel_listener]);
-```
+See `crates/core/src/event_listeners.rs` for the `EventListener` trait definition. Listeners are registered with `EventService` at startup (see `crates/server/src/services/event.rs`).
 
 ### Built-in Listeners
 
@@ -1137,19 +1043,6 @@ Listeners are executed in isolation to ensure misbehaving listeners cannot disru
 - **Sequential execution**: Despite isolation, listeners are awaited sequentially to preserve ordering semantics.
 
 **Rationale:** Event listeners are pluggable integrations (OTel, metrics, audit logs) that should not affect core event processing. A bug in an observability integration should never break the application.
-
-**Implementation:**
-```rust
-// Each listener is spawned in isolation
-let handle = tokio::spawn(async move {
-    listener.on_event(&event).await;
-});
-
-// Panics are caught and logged, not propagated
-if let Err(e) = handle.await {
-    tracing::error!(listener = name, error = %e, "EventListener panicked");
-}
-```
 
 ### Custom Listeners
 

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -38,30 +38,11 @@ graph TD
 
 ### LlmDriver Trait
 
-1. **Trait Definition** (`everruns-core::llm_driver_registry`):
-   ```rust
-   #[async_trait]
-   pub trait LlmDriver: Send + Sync {
-       async fn chat_completion_stream(
-           &self,
-           messages: Vec<LlmMessage>,
-           config: &LlmCallConfig,
-       ) -> Result<LlmResponseStream>;
-   }
-   ```
+1. **Trait Definition**: See `crates/core/src/llm_driver_registry.rs` for `LlmDriver` trait, `LlmStreamEvent`, `ProviderType`, and `LlmCallConfig`.
 
-2. **Streaming Response**: Drivers MUST return a stream of `LlmStreamEvent`:
-   - `TextDelta(String)` - Incremental text content
-   - `ToolCalls(Vec<ToolCall>)` - Tool calls from the LLM
-   - `Done(LlmCompletionMetadata)` - Stream completed with metadata
-   - `Error(String)` - Error during streaming
+2. **Streaming Response**: Drivers return a stream of `LlmStreamEvent` (TextDelta, ToolCalls, ThinkingDelta, ThinkingSignature, Done, Error).
 
-3. **Provider Types**: Supported provider types are defined in `ProviderType` enum:
-   - `OpenAI` - OpenAI API using Open Responses API (recommended)
-   - `OpenAICompletions` - OpenAI API using Chat Completions API (legacy)
-   - `Anthropic` - Anthropic Claude API
-   - `Gemini` - Google Gemini API
-   - `LlmSim` - Testing simulator (llmsim crate)
+3. **Provider Types**: `OpenAI` (Responses API), `OpenAICompletions` (Chat Completions), `Anthropic`, `Gemini`, `LlmSim` (testing).
 
 ### Error Types (Contract)
 
@@ -109,21 +90,7 @@ Detect `RequestTooLarge` for:
 
 ### Driver Registry
 
-1. **Registration**: Provider crates register factories at startup:
-   ```rust
-   pub fn register_driver(registry: &mut DriverRegistry) {
-       registry.register(ProviderType::OpenAI, |api_key, base_url| {
-           Box::new(OpenAILlmDriver::new(api_key, base_url))
-       });
-   }
-   ```
-
-2. **Creation**: Drivers are created on-demand from `ProviderConfig`:
-   ```rust
-   let driver = registry.create_driver(&config)?;
-   ```
-
-3. **API Key Requirement**: All real providers require API keys. `LlmSim` is exempted for testing.
+Provider crates register factories at startup. Drivers created on-demand from `ProviderConfig`. All real providers require API keys; `LlmSim` exempted for testing. See `crates/core/src/llm_driver_registry.rs` for `DriverRegistry`.
 
 ### Message Types
 
@@ -361,22 +328,7 @@ Drivers parse provider-specific headers to determine retry timing:
 
 ### Retry Metadata
 
-On successful completion after retries, `LlmCompletionMetadata` includes:
-```rust
-pub struct RetryMetadata {
-    pub attempts: u32,              // Total attempts (1 = no retries)
-    pub total_retry_wait: Duration, // Total time spent waiting
-    pub last_rate_limit_info: Option<RateLimitInfo>,
-}
-```
-
-The `llm.generation` event includes retry info when retries occurred:
-```rust
-pub struct LlmRetryInfo {
-    pub attempts: u32,
-    pub total_wait_ms: u64,
-}
-```
+On successful completion after retries, `LlmCompletionMetadata` includes retry info (attempts, total wait time, rate limit info). The `llm.generation` event also includes retry info. See `crates/core/src/llm_driver_registry.rs` for `RetryMetadata`.
 
 ### Implementation Details
 
@@ -396,84 +348,9 @@ The `/v1/responses/compact` endpoint is a context-compression feature for the Op
    - Prior assistant messages, tool calls/results, and encrypted reasoning are replaced by one encrypted **compaction item**
 3. Use the returned `output` array as the `input` for the next `/v1/responses` call
 
-### LlmDriver Trait Methods
+### LlmDriver Compact Methods
 
-```rust
-#[async_trait]
-pub trait LlmDriver: Send + Sync {
-    // ... existing methods ...
-
-    /// Check if this driver supports the compact endpoint
-    fn supports_compact(&self) -> bool {
-        false // Default: not supported
-    }
-
-    /// Compact a conversation to reduce context size
-    async fn compact(&self, request: CompactRequest) -> Result<Option<CompactResponse>> {
-        Ok(None) // Default: not supported
-    }
-}
-```
-
-### Request Types
-
-```rust
-pub struct CompactRequest {
-    pub model: String,                     // Required
-    pub input: Vec<CompactInputItem>,      // Conversation items
-    pub previous_response_id: Option<String>, // Alternative to input
-    pub instructions: Option<String>,      // Optional system prompt
-}
-
-pub enum CompactInputItem {
-    Message { role: String, content: CompactContent },
-    FunctionCall { call_id: String, name: String, arguments: String },
-    FunctionCallOutput { call_id: String, output: String },
-    Compaction { encrypted_content: String }, // From previous compact
-}
-```
-
-### Response Types
-
-```rust
-pub struct CompactResponse {
-    pub output: Vec<CompactOutputItem>,
-    pub usage: Option<CompactUsage>,
-}
-
-pub enum CompactOutputItem {
-    Message { role: String, content: CompactContent }, // User messages kept
-    Compaction { encrypted_content: String },          // Encrypted context
-}
-```
-
-### Usage Example
-
-```rust
-use everruns_core::{CompactRequest, CompactInputItem, CompactContent};
-
-// Build compact request from conversation history
-let request = CompactRequest {
-    model: "gpt-4o".to_string(),
-    input: vec![
-        CompactInputItem::Message {
-            role: "user".to_string(),
-            content: CompactContent::Text("Hello!".to_string()),
-        },
-        // ... more conversation items
-    ],
-    previous_response_id: None,
-    instructions: None,
-};
-
-// Check if driver supports compact
-if driver.supports_compact() {
-    let response = driver.compact(request).await?;
-    if let Some(compact_response) = response {
-        // Use compact_response.output as input for next /v1/responses call
-    }
-}
-```
+The `LlmDriver` trait includes `supports_compact()` and `compact()` methods. See `crates/core/src/llm_driver_registry.rs` for `CompactRequest`, `CompactInputItem`, `CompactResponse`, and `CompactOutputItem` types.
 
 ### Provider Support
 

--- a/specs/maintenance.md
+++ b/specs/maintenance.md
@@ -148,7 +148,34 @@ Verify [everruns/sdk](https://github.com/everruns/sdk) public documentation (`do
 5. No TODO/FIXME items that should be resolved before release
 6. CHANGELOG.md has entries for all changes since last release
 
-### 13. Code Simplification
+### 13. Spec Hygiene — Avoid Code Duplication
+
+Specs should capture design intent, rationale, and constraints — not duplicate what's readable from code. Code-derivable details drift out of sync and create maintenance burden.
+
+**What to remove or replace with links:**
+- Exhaustive struct field listings → link to the Rust source file
+- Exact enum variant lists → link to the enum definition
+- Full API request/response JSON shapes → reference OpenAPI spec or handler code
+- SQL DDL / migration contents → link to migration files
+- Config file formats reproduced verbatim → link to the config file or example
+- Function signatures or trait method listings → link to the trait definition
+
+**What to keep in specs:**
+- Design rationale ("why this approach over alternatives")
+- Architectural constraints and invariants
+- Relationships between concepts (how pieces fit together)
+- Security considerations and threat boundaries
+- Behavioral contracts not obvious from types alone
+- Diagrams showing data/control flow
+
+**Link format:** Use relative paths from repo root, e.g., "See `crates/core/src/models/agent.rs` for full field list."
+
+**Review process:**
+1. For each spec, check whether sections could be replaced by "see `path/to/file.rs`"
+2. Keep the *purpose* and *constraints* of each field/endpoint; remove the exhaustive listing
+3. Ensure any remaining examples are illustrative (showing pattern), not exhaustive (listing all cases)
+
+### 14. Code Simplification
 
 Run the [code-simplifier](https://github.com/anthropics/claude-plugins-official/blob/main/plugins/code-simplifier/agents/code-simplifier.md) agent against recently modified code to clean up clarity, consistency, and maintainability issues while preserving exact functionality.
 

--- a/specs/models.md
+++ b/specs/models.md
@@ -2,7 +2,7 @@
 
 ## Abstract
 
-This document defines the core data models for Everruns - a durable agentic harness engine.
+This document defines the core data models for Everruns - a durable agentic harness engine. For full field definitions, see the Rust source types linked below.
 
 ## Requirements
 
@@ -10,21 +10,12 @@ This document defines the core data models for Everruns - a durable agentic harn
 
 Configuration for an agentic loop. An agent can have many concurrent sessions.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` (public_id) | AgentId | Typed ID with `agent_` prefix. Client-supplied or auto-generated. API-facing. |
-| `internal_id` | UUID | Internal PK. Used for FK references. Never exposed in API. |
-| `name` | string | Display name |
-| `description` | string? | Optional description (supports markdown) |
-| `system_prompt` | string | System prompt for the LLM |
-| `default_model_id` | ModelId? | Reference to llm_models table |
-| `tags` | string[] | Tags for organization/filtering |
-| `capabilities` | CapabilityId[] | Enabled capabilities |
-| `status` | enum | `active` or `archived` |
-| `created_at` | timestamp | Creation time |
-| `updated_at` | timestamp | Last modification time |
+See `crates/core/src/agent.rs` for full field definitions.
 
-**Note:** All entity IDs use the dual-ID pattern (internal UUID PK + external public_id). See `specs/id-schema.md` for details.
+Key design points:
+- All entity IDs use the dual-ID pattern (internal UUID PK + external public_id). See `specs/id-schema.md`.
+- `capabilities` field stores enabled capability references (resolved at runtime from registry)
+- `status`: `active` or `archived` (soft delete)
 
 **Input Validation Limits:**
 
@@ -42,597 +33,169 @@ Last-resort validation limits to guard against abuse. API returns generic `400 B
 
 An instance of agentic loop execution. Sessions are top-level entities under organizations, with an agent assigned to work in each session.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | SessionId | Typed ID with `session_` prefix (UUIDv7) |
-| `organization_id` | OrgId | Parent organization |
-| `agent_id` | AgentId | Agent working in this session |
-| `title` | string? | Session title (user-provided or auto-generated) |
-| `tags` | string[] | Tags for organization/filtering |
-| `model_id` | ModelId? | Override model (null = use agent default) |
-| `capabilities` | CapabilityConfig[] | Session-level capabilities (additive to agent) |
-| `status` | enum | `started`, `active`, `idle` |
-| `created_at` | timestamp | Creation time |
-| `updated_at` | timestamp | Last modification time (auto-updated on any change) |
-| `started_at` | timestamp? | Execution start time |
-| `finished_at` | timestamp? | Completion time |
-| `features` | string[] | Aggregated UI features (computed at read time, not stored) |
+See `crates/core/src/session.rs` for full field definitions.
 
-**Session Features:** The `features` field is computed at read time by aggregating `features()` from all active capabilities (harness + agent + session-level), after resolving dependencies. It is not stored in the database. See `specs/capabilities.md#capability-features`.
-
-**Session Capabilities:** The `capabilities` field allows setting session-level capabilities that are additive to the agent's capabilities. When building the RuntimeAgent, agent capabilities are applied first, then session capabilities are applied after. This enables temporarily extending an agent's capabilities for specific sessions.
-
-**Note:** Sessions are direct children of organizations (not agents). The `agent_id` specifies which agent is assigned to work in the session. This allows for organization-wide session management and future flexibility to reassign agents.
-
-Status transitions: `started` → `active` (processing) → `idle` (waiting for input)
-
-Sessions work indefinitely - after processing a message, status returns to `idle` (ready for more messages).
+Key design points:
+- Sessions are direct children of organizations (not agents). The `agent_id` specifies which agent is assigned.
+- `features` field is computed at read time by aggregating `features()` from all active capabilities (not stored). See `specs/capabilities.md#capability-features`.
+- `capabilities` allows session-level capabilities additive to the agent's. Agent capabilities applied first, then session capabilities.
+- Status transitions: `started` → `active` (processing) → `idle` (waiting for input)
+- Sessions work indefinitely — after processing, status returns to `idle`.
 
 ### Message
 
-Conversation data stored as events in the `events` table with `event_type` prefixed by `message.`. Messages are reconstructed from events when loaded.
+Conversation data stored as events in the `events` table. Messages are reconstructed from events when loaded.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | MessageId | Typed ID with `message_` prefix (stored in event.data.message_id) |
-| `session_id` | SessionId | Parent session reference (from event.session_id) |
-| `sequence` | integer | Order within session (from event.sequence) |
-| `role` | enum | `user`, `agent`, `tool_result` |
-| `content` | ContentPart[] | Array of content parts (see below) |
-| `thinking` | string? | Extended thinking content from reasoning models (Anthropic Claude) |
-| `thinking_signature` | string? | Cryptographic signature for thinking (required for multi-turn with Anthropic) |
-| `controls` | Controls? | Runtime controls for message processing |
-| `metadata` | object? | Message-level metadata (e.g., locale) |
-| `tags` | string[] | Tags for organization/filtering |
-| `created_at` | timestamp | Creation time (from event.created_at) |
+See `crates/core/src/message.rs` for `Message`, `ContentPart`, `Controls`, and `InputContentPart` types.
 
-**Note:** Messages are stored as events with types `input.message`, `output.message.completed`. Tool calls are embedded in `output.message.completed` events via `ContentPart::ToolCall`. Tool results are stored as `tool.completed` events. System messages are handled internally and not persisted to events.
+Key design points:
+- Messages stored as events with types `input.message`, `output.message.completed`. Tool calls embedded in `output.message.completed` via `ContentPart::ToolCall`. Tool results from `tool.completed` events.
+- System messages handled internally, not persisted.
+- `ContentPart` variants: `text`, `image`, `image_file`, `tool_call`, `tool_result`. Users can only send `text`, `image`, `image_file` via API.
 
-**ContentPart types (discriminated by `type` field):**
+**Controls:**
 
-```json
-// type=text
-{ "type": "text", "text": "Hello, how are you?" }
-
-// type=image (inline image data)
-{ "type": "image", "url": "https://..." }
-// or
-{ "type": "image", "base64": "...", "media_type": "image/png" }
-
-// type=image_file (reference to uploaded image)
-{ "type": "image_file", "image_id": "01933b5a-...", "filename": "photo.png" }
-
-// type=tool_call (agent requesting tool execution)
-{
-  "type": "tool_call",
-  "id": "call_abc123",
-  "name": "search",
-  "arguments": { "query": "test" }
-}
-
-// type=tool_result (result of tool execution)
-{
-  "type": "tool_result",
-  "tool_call_id": "call_abc123",
-  "result": { "matches": [...] },
-  "error": null
-}
-```
-
-**Note:** `image_file` content parts reference uploaded images (see Images API). During LLM calls, these references are resolved to actual image data using the `ImageResolver` trait. See [Image Resolution](#image-resolution) for details.
-
-**Controls structure:**
-
-```json
-{
-  "model_id": "550e8400-e29b-41d4-a716-446655440000",
-  "reasoning": {
-    "effort": "medium"
-  }
-}
-```
-
-Controls are optional and allow per-message overrides for model selection and reasoning configuration.
+Optional per-message overrides for model selection and reasoning configuration.
 
 **Extended Thinking:**
 
-When `controls.reasoning.effort` is set, models that support extended thinking (e.g., Anthropic Claude) will generate internal reasoning before producing a response. This thinking content is stored in the `thinking` field of agent messages.
-
-- `thinking`: The model's chain-of-thought reasoning (can be lengthy)
-- `thinking_signature`: Cryptographic signature required by Anthropic for multi-turn conversations
-
-Both fields must be preserved and sent back to the Anthropic API in subsequent turns when thinking is enabled. See [LLM Drivers spec](llm-drivers.md) for provider-specific requirements.
+When `controls.reasoning.effort` is set, reasoning models generate chain-of-thought before responding. The `thinking` and `thinking_signature` fields must be preserved for multi-turn conversations. See [LLM Drivers spec](llm-drivers.md) for provider-specific requirements.
 
 **Model resolution priority:**
 
-The model used for processing is determined using this priority chain:
 1. `controls.model_id` (from the last user message) - highest priority
 2. `session.model_id` - session-level override
 3. `agent.default_model_id` - agent's default model
 4. System default model - fallback if no model is configured above
 
-Each level references a UUID that points to a configured model in the `llm_models` table.
-
-**CreateMessageRequest structure:**
-
-```json
-{
-  "message": {
-    "role": "user",
-    "content": [
-      { "type": "text", "text": "Compare these two images." },
-      { "type": "image", "url": "https://example.com/image1.png" }
-    ]
-  },
-  "controls": {
-    "model_id": "550e8400-e29b-41d4-a716-446655440000",
-    "reasoning": { "effort": "medium" }
-  },
-  "metadata": {
-    "locale": "en-US",
-    "request_id": "req_123"
-  },
-  "tags": ["important", "review"]
-}
-```
-
-**Note:** The `message.role` field defaults to `"user"` and can be omitted. Only `user` messages can be created via the API; `agent`, `tool_result`, and `system` messages are created internally by the system.
-
-**InputContentPart types (allowed in user messages):**
-
-Only text, image, and image_file content can be sent by users:
-- `{ "type": "text", "text": "..." }`
-- `{ "type": "image", "url": "..." }` or `{ "type": "image", "base64": "...", "media_type": "image/png" }`
-- `{ "type": "image_file", "image_id": "...", "filename": "..." }` (reference to uploaded image)
-
-Tool calls and tool results are system-generated and cannot be created via the API.
-
-**Database storage:**
-
-Messages are stored in the `events` table with the full content in the `data` JSONB field:
-
-```json
-// Event for a user message (event_type: "input.message")
-{
-  "message_id": "01234567-89ab-cdef-0123-456789abcdef",
-  "role": "user",
-  "content": [{"type": "text", "text": "Hello, how are you?"}],
-  "controls": null,
-  "metadata": null,
-  "tags": []
-}
-
-// Event for an agent message with tool calls (event_type: "output.message.completed")
-{
-  "message_id": "...",
-  "role": "agent",
-  "content": [
-    {"type": "text", "text": "Let me search for that."},
-    {"type": "tool_call", "id": "call_abc123", "name": "search", "arguments": {"query": "test"}}
-  ],
-  "controls": null,
-  "metadata": null,
-  "tags": []
-}
-```
-
 ### Image
 
 Global storage for uploaded images. Images can be attached to messages via the `image_file` content part type.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | UUID v7 | Unique identifier |
-| `filename` | string | Original filename |
-| `content_type` | string | MIME type (image/png, image/jpeg, image/gif, image/webp) |
-| `size_bytes` | integer | File size in bytes |
-| `data` | bytes | Full image data |
-| `thumbnail_data` | bytes? | Thumbnail image data (max 200x200) |
-| `thumbnail_content_type` | string? | Thumbnail MIME type |
-| `metadata` | object | Arbitrary metadata (e.g., session_id) |
-| `created_at` | timestamp | Upload time |
+See `crates/server/src/storage/models.rs` for the `ImageRow` type.
 
 **Constraints:**
-- Maximum file size: 100MB
-- Request body limit: 101MB (100MB file + 1MB multipart overhead)
+- Maximum file size: 100MB (body limit: 101MB including multipart overhead)
 - Allowed content types: image/png, image/jpeg, image/gif, image/webp
-- Thumbnails generated automatically using Lanczos3 scaling
+- Thumbnails generated automatically (max 200x200, Lanczos3 scaling)
 
 **Storage:**
-- PostgreSQL: Full images stored in BYTEA columns
-- In-memory (DEV_MODE): Images lost on restart
+- PostgreSQL: Full images in BYTEA columns
+- In-memory (DEV_MODE): Lost on restart
 - Future: S3 storage planned
 
 ### Image Resolution
 
-When messages containing `image_file` content parts are sent to an LLM, the system resolves these references to actual image data. This is handled by the `ImageResolver` trait, implemented by `GrpcImageResolver` in the worker.
+When messages containing `image_file` content parts are sent to an LLM, the system resolves references to actual image data via the `ImageResolver` trait (`GrpcImageResolver` in worker).
 
 **Resolution Process:**
-
-1. **Extract IDs**: All unique `image_id` values are extracted from message content parts
-2. **Batch Resolve**: Images are resolved via gRPC (worker → control-plane)
-3. **Convert to Data URLs**: Resolved images are converted to `data:` URLs
-4. **Provider Formatting**: Each LLM provider converts data URLs to their native format
-
-**Provider-Specific Formats:**
-
-OpenAI Vision:
-```json
-{
-  "type": "image_url",
-  "image_url": { "url": "data:image/png;base64,..." }
-}
-```
-
-Anthropic Vision:
-```json
-{
-  "type": "image",
-  "source": {
-    "type": "base64",
-    "media_type": "image/png",
-    "data": "..."
-  }
-}
-```
+1. Extract unique `image_id` values from content parts
+2. Batch resolve via gRPC (worker → control-plane)
+3. Convert to `data:` URLs
+4. Each LLM provider formats for its vision API
 
 **gRPC Transfer:**
 
-Image data is transferred from control-plane to worker via gRPC. The gRPC message size limit is increased from 4MB (default) to 150MB to accommodate base64-encoded images (100MB raw + ~33% encoding overhead + metadata).
+Image data transferred via gRPC with 150MB message limit (100MB raw + ~33% encoding overhead).
 
-> **Warning:** The 150MB gRPC limit is a temporary workaround and should be removed in favor of a proper solution. Transferring large images inline via gRPC is inefficient and increases memory pressure on both control-plane and worker.
->
-> **Recommended future approach:**
-> - Presigned URLs: Worker fetches images directly from S3/blob storage
-> - Streaming: Transfer images in chunks rather than single large messages
-> - Direct storage access: Worker has read access to image storage
->
-> When implementing one of these solutions, revert gRPC limit to default 4MB.
+> **Warning:** The 150MB gRPC limit is a temporary workaround. Future: presigned URLs, streaming, or direct storage access. Revert to default 4MB when implemented.
 
 **Error Handling:**
-
-- Missing images: Replaced with placeholder text `[Image not found: {id}]`
-- Resolution failures: Logged as warnings, image treated as missing
-- The LLM call proceeds even if some images cannot be resolved
+- Missing images: Replaced with `[Image not found: {id}]`
+- Resolution failures: Logged as warnings, LLM call proceeds
 
 ### Event
 
-The primary data store for conversation messages and SSE notifications.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | UUID v7 | Unique identifier |
-| `session_id` | UUID v7 | Parent session reference |
-| `sequence` | integer | Order within session (atomically allocated) |
-| `event_type` | string | Type of notification (see below) |
-| `data` | JSON | Event-specific payload |
-| `context` | JSON | Correlation context (turn_id, input_message_id, exec_id) |
-| `metadata` | JSON | Arbitrary metadata |
-| `tags` | string[] | Tags for filtering |
-| `ts` | timestamp | Event timestamp |
-| `created_at` | timestamp | Storage time |
+The primary data store for conversation messages and SSE notifications. See `crates/core/src/events.rs` for `Event` and `EventData` types.
 
 **Storage Guarantees:**
 
-1. **Append-Only** - Events are immutable. UPDATE and DELETE operations are blocked at the database level via triggers. Any attempt to modify existing events will fail with error "events are append-only".
+1. **Append-Only** — Events are immutable. UPDATE and DELETE blocked via database triggers.
+2. **Atomic Per-Session Sequence** — Sequence numbers allocated atomically per session via `event_sequences` table (prevents race conditions).
+3. **Event Type Consistency** — `event_type` field must match `data` payload type. Validated at service layer.
 
-2. **Atomic Per-Session Sequence** - Sequence numbers are allocated atomically per session using a dedicated `event_sequences` table. This prevents race conditions during concurrent writes that could occur with `MAX(sequence)+1` approach.
-
-3. **Event Type Consistency** - The `event_type` field must match the type indicated by the `data` payload. This is validated at the service layer before storage. Raw/legacy events are exempt from this check.
-
-**Event Type Naming Convention:**
-
-Event types follow the pattern `{entity}.{action}` where:
-- `entity` - The domain entity (e.g., `message`, `step`, `tool`, `session`)
-- `action` - The action or state (e.g., `user`, `agent`, `started`, `completed`)
-
-This convention ensures consistent, predictable event type names across the system.
-
-**Event Types:**
-
-1. **Input Events** - User input data
-   - `input.message` - User message
-
-2. **Output Events** - Agent output lifecycle
-   - `output.message.started` - LLM started generating (UI can show "thinking" indicator)
-   - `output.message.delta` - Streaming text delta (batched ~100ms)
-   - `output.message.completed` - Agent response complete (may contain tool calls in content)
-
-3. **Turn Events** - Turn lifecycle notifications
-   - `turn.started` - Turn execution started
-   - `turn.completed` - Turn completed successfully
-   - `turn.failed` - Turn failed
-
-4. **Atom Events** - Atom lifecycle notifications
-   - `reason.started` - ReasonAtom started (LLM inference began)
-   - `reason.completed` - ReasonAtom completed (LLM response received)
-   - `act.started` - ActAtom started (tool batch execution)
-   - `act.completed` - ActAtom completed
-
-5. **Tool Events** - Individual tool execution
-   - `tool.started` - Tool execution began
-   - `tool.completed` - Tool execution finished (includes result, used for message reconstruction)
-
-5. **LLM Events** - LLM API visibility
-   - `llm.generation` - Full LLM API call with messages and response
-
-6. **Session Events** - Session lifecycle
-   - `session.started` - Session began processing
-   - `session.activated` - Session activated for processing
-   - `session.idled` - Session returned to idle state
+**Event Type Naming Convention:** `{entity}.{action}` pattern (e.g., `input.message`, `turn.completed`). See `specs/events.md` for the full event type registry and lifecycle details.
 
 **Message Reconstruction:**
 
-Messages are reconstructed from events with types: `input.message`, `output.message.completed`, `tool.completed`. Tool calls are embedded in `output.message.completed` events via `ContentPart::ToolCall`. Tool results come from `tool.completed` events.
+Messages reconstructed from events: `input.message`, `output.message.completed`, `tool.completed`. Tool calls embedded in output messages via `ContentPart::ToolCall`.
 
 ## Flow Example
 
 ```
 User sends: "How much is 2+2?"
 
-1. POST /v1/agents/{id}/sessions/{id}/messages
-   → Creates Message(role=user, content: { text: "How much is 2+2?" })
-   → Emits Event(input.message)
-   → Triggers session workflow
+1. POST /v1/sessions/{id}/messages
+   → Creates Message(role=user) → Emits input.message → Triggers workflow
 
-2. Workflow starts
-   → Updates Session(status=running)
-   → Emits Event(session.started)
+2. Workflow starts → Session(status=active) → session.started
 
-3. Turn starts
-   → Emits Event(turn.started)
+3. Turn starts → turn.started
 
 4. LLM call (ReasonAtom)
-   → Emits Event(reason.started)
-   → Emits Event(output.message.started)
-   → LLM streams response
-   → Emits Event(output.message.delta) (batched)
-   → Creates Message(role=agent, content: { text: "The answer is 4" })
-   → Emits Event(reason.completed)
-   → Emits Event(llm.generation)
-   → Emits Event(output.message.completed)
+   → reason.started → output.message.started
+   → Streams output.message.delta (batched)
+   → Creates Message(role=agent, "The answer is 4")
+   → reason.completed → llm.generation → output.message.completed
 
-5. Turn complete
-   → Emits Event(turn.completed)
-   → Updates Session(status=pending)
+5. Turn complete → turn.completed → Session(status=idle)
 
 User can send another message to continue the conversation.
 ```
 
 ### Capability
 
-Modular functionality that can be enabled on Agents. Capabilities contribute to system prompts, provide tools, and modify agent behavior.
+Modular functionality that can be enabled on Agents. See `crates/core/src/capability_types.rs` for `CapabilityStatus`, `AgentCapabilityConfig`, and `MountPoint` types. See `crates/core/src/capabilities/mod.rs` for the `Capability` trait and `CapabilityRegistry`.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | CapabilityId | Unique identifier (enum) |
-| `name` | string | Display name |
-| `description` | string | Description of functionality |
-| `status` | enum | `available`, `coming_soon`, `deprecated` |
-| `icon` | string? | Icon name for UI rendering |
-| `category` | string? | Category for grouping in UI |
-
-**Built-in Capability IDs:**
-
-| ID | Status | Description |
-|----|--------|-------------|
-| `noop` | available | No-op capability for testing |
-| `current_time` | available | Tool to get current date/time |
-| `research` | coming_soon | Deep research with scratchpad |
-| `file_system` | coming_soon | File system access tools |
-
-### AgentCapability
-
-Junction table linking Agents to Capabilities with ordering.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | UUID v7 | Unique identifier |
-| `agent_id` | UUID v7 | Parent agent reference |
-| `capability_id` | CapabilityId | Capability identifier |
-| `position` | integer | Order in capability chain (lower = earlier) |
-| `created_at` | timestamp | Creation time |
-
-**Constraints:**
-- Each agent can have each capability at most once (`UNIQUE(agent_id, capability_id)`)
-- Capabilities are applied in `position` order when building agent configuration
+See `specs/capabilities.md` for the full capabilities specification.
 
 ### LLM Provider
 
-Configuration for LLM API providers. Stores encrypted API keys and provider-specific settings.
+Configuration for LLM API providers. See `crates/core/src/llm_models.rs` for full type definitions.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | UUID v7 | Unique identifier |
-| `name` | string | Display name |
-| `provider_type` | string | `openai`, `openai_completions`, `anthropic`, `gemini`, `llmsim` |
-| `base_url` | string? | Custom API endpoint (for proxies) |
-| `api_key_encrypted` | bytes? | AES-256-GCM encrypted API key |
-| `api_key_set` | boolean | Whether API key is configured (database or DEFAULT_ env var) |
-| `is_default` | boolean | Default provider for new agents |
-| `status` | enum | `active` or `disabled` |
-| `settings` | JSON | Provider-specific settings |
-| `last_synced_at` | timestamp? | Last time models were synced from provider API |
-| `created_at` | timestamp | Creation time |
-| `updated_at` | timestamp | Last modification time |
-
-**Supported Provider Types:**
-- `openai` - OpenAI API using Open Responses API (recommended)
-- `openai_completions` - OpenAI API using Chat Completions API (legacy)
-- `anthropic` - Anthropic API (Claude models)
-- `gemini` - Google Gemini API
-- `llmsim` - Built-in simulator provider for development/testing
-
-**Note:** Ollama and Custom provider types are no longer supported.
-
-**Validation Note:** `provider_type` is intentionally stored as a plain string without a database CHECK constraint. Provider validation and graceful unknown-provider handling are implemented in the application layer for forward compatibility. LLM provider API keys are primarily configured in the database (via Settings > Providers UI), but environment variables can be used as fallbacks for development convenience.
-
-**Default Providers:**
-
-Default providers (OpenAI, Anthropic, Gemini, LlmSim) and their models are seeded on startup via the service seeding system (`server/src/seed.rs`). Seeding is idempotent (uses `ON CONFLICT DO NOTHING`) and runs in a background task. These providers have well-known UUIDs:
-
-- OpenAI: `01933b5a-0000-7000-8000-000000000001`
-- Anthropic: `01933b5a-0000-7000-8000-000000000002`
-- LlmSim: `01933b5a-0000-7000-8000-000000000003`
-- Gemini: `01933b5a-0000-7000-8000-000000000004`
-
-Model UUIDs follow a range allocation scheme:
-- `0x001-0x0FF`: LLM Providers
-- `0x100-0x1FF`: Agents (seed agents like Dad Jokes Agent, Research Agent)
-- `0x200-0x2FF`: OpenAI Models
-- `0x300-0x3FF`: Anthropic Models
-- `0x400-0x4FF`: LlmSim Models
-- `0x600-0x6FF`: Gemini Models
+Key design points:
+- `provider_type` stored as plain string without CHECK constraint (forward compatibility)
+- Supported types: `openai`, `openai_completions`, `anthropic`, `gemini`, `llmsim`
+- API keys encrypted with AES-256-GCM envelope encryption (see `specs/encryption.md`)
 
 **API Key Resolution Order:**
-1. **Database** (priority): Encrypted API key stored in `llm_providers.api_key_encrypted`
+1. **Database** (priority): Encrypted in `llm_providers.api_key_encrypted`
 2. **Environment Variable** (fallback): `DEFAULT_OPENAI_API_KEY` or `DEFAULT_ANTHROPIC_API_KEY`
 
-API keys can be configured via:
-1. The Settings > Providers UI (stores in database)
-2. The `scripts/patch-provider-keys.sh` script (patches database from `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`)
-3. Environment variables for development: `DEFAULT_OPENAI_API_KEY`, `DEFAULT_ANTHROPIC_API_KEY` (used only when database key is not set)
+Default providers and models seeded on startup via `crates/server/src/seed.rs` (idempotent, well-known UUIDs).
 
 ### LLM Model
 
-Configuration for a specific model within a provider.
+Configuration for a specific model within a provider. See `crates/core/src/llm_models.rs`.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | UUID v7 | Unique identifier |
-| `provider_id` | UUID v7 | Parent provider reference |
-| `model_id` | string | Model identifier (e.g., "gpt-4o") |
-| `display_name` | string | Display name |
-| `features` | string[] | Model features (e.g., vision, function_calling, streaming) |
-| `context_window` | integer? | Context window size |
-| `is_default` | boolean | Default model for this provider |
-| `is_favorite` | boolean | User-marked favorite for quick access |
-| `status` | enum | `active` or `disabled` |
-| `source` | enum | How model was added: `manual`, `discovered`, `predefined` |
-| `last_seen_at` | timestamp? | Last time model was seen in provider API (discovered models only) |
-| `provider_metadata` | JSON? | Raw metadata from provider API response |
-| `created_at` | timestamp | Creation time |
-| `updated_at` | timestamp | Last modification time |
-
-**Model Sources:**
-
-- `manual` - Added by user via API/UI
-- `discovered` - Automatically discovered from provider's models API
-- `predefined` - Seeded on startup (default models for providers)
-
-**Stale Model Detection:**
-
-Discovered models become "stale" when they are no longer returned by the provider's models API. A model is considered stale when `last_seen_at < provider.last_synced_at`. Stale models are kept in the database (not deleted) to preserve any user customizations.
+Key design points:
+- `source` enum: `manual` (user-added), `discovered` (from provider API), `predefined` (seeded)
+- Stale model detection: `last_seen_at < provider.last_synced_at` means model no longer returned by provider API. Stale models kept (not deleted) to preserve customizations.
 
 ### LLM Model Profile
 
-Read-only metadata describing model capabilities, costs, and limits. Profiles are computed at runtime (not stored in database) and attached to model responses.
+Read-only metadata describing model capabilities, costs, and limits. Computed at runtime (not stored in database).
 
 **Data Source:** https://models.dev/api.json
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `name` | string | Display name (e.g., "GPT-4o") |
-| `family` | string | Model family (e.g., "gpt-4o") |
-| `release_date` | string? | Release date (YYYY-MM-DD) |
-| `last_updated` | string? | Last update date (YYYY-MM-DD) |
-| `attachment` | boolean | Supports file attachments |
-| `reasoning` | boolean | Is a reasoning model |
-| `temperature` | boolean | Supports temperature parameter |
-| `knowledge` | string? | Knowledge cutoff date |
-| `tool_call` | boolean | Supports tool/function calling |
-| `structured_output` | boolean | Supports structured output |
-| `open_weights` | boolean | Has open weights |
-| `cost` | LlmModelCost? | Pricing per million tokens |
-| `limits` | LlmModelLimits? | Context and output limits |
-| `modalities` | LlmModelModalities? | Input/output modalities |
-| `reasoning_effort` | ReasoningEffortConfig? | Reasoning effort options |
+See `crates/core/src/llm_models.rs` for `LlmModelProfile`, `LlmModelCost`, `LlmModelLimits`, and `ReasoningEffortConfig` types.
 
-**LlmModelCost:**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `input` | float | Input cost per million tokens (USD) |
-| `output` | float | Output cost per million tokens (USD) |
-| `cache_read` | float? | Cached input cost per million tokens |
-
-**LlmModelLimits:**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `context` | integer | Maximum context window tokens |
-| `output` | integer | Maximum output tokens |
-
-**LlmModelModalities:**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `input` | Modality[] | Supported input types (text, image, audio, video) |
-| `output` | Modality[] | Supported output types |
-
-**ReasoningEffortConfig:**
-
-Configuration for reasoning models (OpenAI o1, o1-mini, o3-mini, o1-pro).
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `values` | ReasoningEffortValue[] | Available effort levels |
-| `default` | ReasoningEffort | Default effort level |
-
-**ReasoningEffort enum:** `none`, `minimal`, `low`, `medium`, `high`, `xhigh`
-
-**Supported Models:**
-
-- **OpenAI:** gpt-4o, gpt-4o-mini, o1, o1-mini, o1-pro, o3-mini
-- **Anthropic:** claude-sonnet-4, claude-opus-4, claude-3-5-sonnet, claude-3-5-haiku, claude-3-opus, claude-3-sonnet, claude-3-haiku
-
-Profiles are matched by provider_type + model_id with version normalization (e.g., "gpt-4o-2024-11-20" → "gpt-4o").
+Profiles matched by provider_type + model_id with version normalization (e.g., "gpt-4o-2024-11-20" → "gpt-4o").
 
 ### Model Discovery
 
-Automatic discovery of available models from provider APIs.
+Automatic discovery of available models from provider APIs (OpenAI, Anthropic).
 
-**Supported Providers:**
-- OpenAI - via `GET /v1/models`
-- Anthropic - via `GET /v1/models`
-
-**Discovery Flow:**
-
-1. **Background Sync** - Every 24 hours (configurable via `MODEL_SYNC_INTERVAL_HOURS`, set to 0 to disable)
-2. **Manual Sync** - `POST /v1/llm-providers/:id/sync-models`
-
-**Sync Behavior:**
-
-- Only providers with standard base URLs are synced (custom URLs are skipped)
-- OpenAI models are filtered to chat/completion models only (excludes embeddings, TTS, image models)
-- New models are automatically added with `source: "discovered"`
-- Existing discovered models have `last_seen_at` updated
-- Models not seen in sync become stale (detected via `last_seen_at < last_synced_at`)
-
-**Listing Models:**
-
-`GET /v1/llm-models` supports query parameters:
-- `source` - Filter by source (`manual`, `discovered`, `predefined`)
-- `include_stale` - Include stale models (default: true)
-- `favorites_only` - Only return favorites (default: false)
+- **Background Sync** — Every 24 hours (configurable via `MODEL_SYNC_INTERVAL_HOURS`, 0 to disable)
+- **Manual Sync** — `POST /v1/llm-providers/:id/sync-models`
+- Only providers with standard base URLs synced (custom URLs skipped)
+- New models added as `discovered`; existing models have `last_seen_at` updated
 
 ### UserConnection
 
 A linked external service account. User-scoped (not org-scoped). See [user-connections.md](user-connections.md) for full specification.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | UUID v7 | Internal primary key |
-| `user_id` | UUID | FK to users.id |
-| `provider` | string | `github`, `gitlab`, `bitbucket` |
-| `provider_user_id` | string? | Provider's user ID |
-| `provider_username` | string? | Display name (e.g., `octocat`) |
-| `access_token_encrypted` | bytes | Encrypted with envelope encryption |
-| `refresh_token_encrypted` | bytes? | For providers that support refresh |
-| `scopes` | string? | Granted scopes (e.g., `repo,read:user`) |
-| `expires_at` | timestamp? | NULL = no expiry (GitHub OAuth App tokens) |
-| `created_at` | timestamp | |
-| `updated_at` | timestamp | |
+See `crates/server/src/storage/models.rs` for the `UserConnectionRow` type.
 
 ## Design Decisions
 
@@ -642,8 +205,8 @@ A linked external service account. User-scoped (not org-scoped). See [user-conne
 | What are Events for? | Primary data store for messages AND SSE notifications |
 | Where are tool calls stored? | In `output.message.completed` events as `ContentPart::ToolCall` |
 | Where are tool results stored? | Events with `event_type` = `tool.completed` |
-| Session status? | Explicit status field (pending, running, failed) |
+| Session status? | Explicit status field (started, active, idle) |
 | Where are capabilities defined? | In-memory registry in API layer |
 | How are capabilities applied? | Resolved at API/service layer, merged into RuntimeAgent |
-| Where are API keys stored? | Encrypted in database (llm_providers.api_key_encrypted), decrypted at runtime |
-| Environment variables for API keys? | Yes - `DEFAULT_OPENAI_API_KEY` and `DEFAULT_ANTHROPIC_API_KEY` serve as fallbacks when database key is not set |
+| Where are API keys stored? | Encrypted in database, decrypted at runtime |
+| Environment variables for API keys? | `DEFAULT_OPENAI_API_KEY` and `DEFAULT_ANTHROPIC_API_KEY` as fallbacks |

--- a/specs/session-filesystem.md
+++ b/specs/session-filesystem.md
@@ -106,85 +106,12 @@ All endpoints under `/v1/sessions/{session_id}/fs`
 
 **Note:** Paths starting with `_` are reserved for system actions and cannot be used for file creation or updates.
 
-### Request/Response Examples
+### Request/Response
 
-**Create File:**
-```json
-POST /v1/sessions/{id}/fs/src/main.rs
-{
-  "content": "fn main() {}",
-  "encoding": "text"
-}
-```
-
-Response:
-```json
-{
-  "id": "...",
-  "session_id": "...",
-  "path": "/src/main.rs",
-  "name": "main.rs",
-  "content": "fn main() {}",
-  "encoding": "text",
-  "is_directory": false,
-  "is_readonly": false,
-  "size_bytes": 12,
-  "created_at": "...",
-  "updated_at": "..."
-}
-```
-
-**Create Directory:**
-```json
-POST /v1/agents/{id}/sessions/{id}/fs/docs
-{
-  "is_directory": true
-}
-```
-
-**List Directory:**
-```json
-GET /v1/agents/{id}/sessions/{id}/fs/src
-{
-  "data": [
-    {
-      "id": "...",
-      "path": "/src/main.rs",
-      "name": "main.rs",
-      "is_directory": false,
-      "size_bytes": 12,
-      ...
-    }
-  ]
-}
-```
-
-**Grep Search:**
-```json
-POST /v1/agents/{id}/sessions/{id}/fs/_/grep
-{
-  "pattern": "fn\\s+\\w+",
-  "path_pattern": "*.rs"
-}
-```
-
-Response:
-```json
-{
-  "data": [
-    {
-      "path": "/src/main.rs",
-      "matches": [
-        {
-          "path": "/src/main.rs",
-          "line_number": 1,
-          "line": "fn main() {}"
-        }
-      ]
-    }
-  ]
-}
-```
+See the OpenAPI spec (`./scripts/export-openapi.sh`) for detailed request/response schemas. Key patterns:
+- Create: `POST /fs/{path}` with `{ "content": "...", "encoding": "text" }`
+- Directory: `POST /fs/{path}` with `{ "is_directory": true }`
+- Grep: `POST /fs/_/grep` with `{ "pattern": "...", "path_pattern": "*.rs" }`
 
 ### Behavior
 
@@ -196,25 +123,7 @@ Response:
 
 ### Database Schema
 
-```sql
-CREATE TABLE session_files (
-    id UUID PRIMARY KEY DEFAULT uuidv7(),
-    session_id UUID NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
-    path TEXT NOT NULL,
-    content BYTEA,
-    is_directory BOOLEAN NOT NULL DEFAULT FALSE,
-    is_readonly BOOLEAN NOT NULL DEFAULT FALSE,
-    size_bytes BIGINT NOT NULL DEFAULT 0,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    CONSTRAINT session_files_unique_path UNIQUE (session_id, path),
-    CONSTRAINT session_files_path_check CHECK (path ~ '^/([^/\0]+(/[^/\0]+)*)?$'),
-    CONSTRAINT session_files_directory_no_content CHECK (NOT is_directory OR content IS NULL)
-);
-
-CREATE INDEX session_files_session_idx ON session_files(session_id);
-CREATE INDEX session_files_path_prefix_idx ON session_files(session_id, path text_pattern_ops);
-```
+See `crates/server/migrations/001_base_schema.sql` for the `session_files` table DDL (includes path validation, unique constraints, and indexes).
 
 ### UI Integration
 

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -11,33 +11,18 @@ Everruns agents can invoke tools during execution. This specification defines to
 #### Built-in Tools
 System-provided tools implemented via the `Tool` trait in `everruns-core`.
 
-**Tool Trait Interface:**
-```rust
-#[async_trait]
-pub trait Tool: Send + Sync {
-    fn name(&self) -> &str;
-    fn display_name(&self) -> Option<&str> { None }
-    fn description(&self) -> &str;
-    fn parameters_schema(&self) -> Value;
-    async fn execute(&self, arguments: Value) -> ToolExecutionResult;
-    fn policy(&self) -> ToolPolicy { ToolPolicy::Auto }
-}
-```
+See `crates/core/src/tools.rs` for the `Tool` trait, `ToolExecutionResult`, and `ToolPolicy` types.
 
 **Display Names:**
-All tools should provide a human-readable `display_name` for UI rendering (e.g., "Get Current Time" for `get_current_time`). The display name is:
-- Returned by `fn display_name(&self) -> Option<&str>` on the `Tool` trait
-- Included in `BuiltinTool` and `ClientSideTool` as `display_name: Option<String>`
-- Propagated through events (`act.started`, `tool.started`, `tool.completed`) so the UI can render it
-- The UI falls back to the technical `name` if `display_name` is absent
+Tools should provide a human-readable `display_name` for UI rendering. Propagated through events; UI falls back to technical `name` if absent.
 
 **Error Handling Contract:**
-- `ToolExecutionResult::Success(Value)` - Successful result returned to LLM as `result` field
-- `ToolExecutionResult::SuccessWithImages { result, images }` - Successful result with images. Images are sent as native image content blocks to the LLM, enabling visual understanding (not stringified JSON).
-- `ToolExecutionResult::ToolError(String)` - User-visible error packaged as `{"error": "..."}` in `result` field (e.g., `{"error": "City not found"}`)
-- `ToolExecutionResult::InternalError` - System error logged, generic message packaged as `{"error": "..."}` in `result` field (security)
+- `Success(Value)` — Result returned to LLM
+- `SuccessWithImages { result, images }` — Result with native image content blocks
+- `ToolError(String)` — User-visible error as `{"error": "..."}`
+- `InternalError` — System error logged, generic message (security)
 
-All error types continue the agent loop the same way as success - they are all packaged in the `result` field with no `error` field set. The LLM can interpret the `{"error": "..."}` payload and decide how to proceed.
+All error types continue the agent loop — packaged in `result` field, LLM decides how to proceed.
 
 **Image Support in Tool Results:**
 
@@ -67,42 +52,7 @@ Tools can also be provided by Capabilities (see [capabilities.md](capabilities.m
 - `Sandbox` capability will provide `execute_code` tool
 - `FileSystem` capability will provide read/write/search files tools
 
-**ToolRegistry:**
-Manages multiple tools and implements `ToolExecutor` trait for integration with `AgentLoop`:
-```rust
-// Create with default built-in tools (includes get_current_time, echo, math tools, etc.)
-let registry = ToolRegistry::with_defaults();
-
-// Or build a custom registry
-let registry = ToolRegistry::builder()
-    .tool(GetCurrentTime)
-    .tool(MyCustomTool)
-    .build();
-
-let agent_loop = AgentLoop::new(config, emitter, store, llm, registry);
-```
-
-### Tool Definition Schema
-
-```json
-{
-  "type": "builtin",
-  "name": "tool_name",
-  "display_name": "Tool Name",
-  "description": "What the tool does",
-  "parameters": {
-    "type": "object",
-    "properties": {
-      "param1": {
-        "type": "string",
-        "description": "Parameter description"
-      }
-    },
-    "required": ["param1"]
-  },
-  "policy": "auto"
-}
-```
+**ToolRegistry:** Manages multiple tools and implements `ToolExecutor` trait. See `crates/core/src/tools.rs` for `ToolRegistry` and its builder pattern.
 
 ### Tool Policies
 


### PR DESCRIPTION
## What
Remove ~1,870 lines of code-derivable content from 8 spec files and replace with links to source files. Add spec hygiene guidelines to AGENTS.md and maintenance.md.

## Why
Specs were duplicating information readable from code (SQL DDL, Rust struct/trait definitions, exhaustive field tables, verbose JSON examples). This duplication drifts out of sync and creates maintenance burden. Specs should capture design intent, rationale, and constraints — not repeat what's in the code.

## How
- Added spec content principle to AGENTS.md: "Don't duplicate what's readable from code. Link to the source file."
- Added Section 13 "Spec Hygiene" to specs/maintenance.md with what to remove, what to keep, link format, and review process.
- Cleaned 8 spec files: models.md, capabilities.md, authentication.md, llm-drivers.md, events.md, architecture.md, session-filesystem.md, tool-execution.md
- Replaced code blocks and field tables with links like `See crates/core/src/tools.rs for the Tool trait`
- Kept: design decisions, architectural rationale, diagrams, behavioral contracts, security considerations, flow examples

## Risk
- Low
- Docs-only change, no code modified. Risk is only that a removed section contained unique design rationale not captured elsewhere — mitigated by careful review during removal.

## Checklist
- [x] Tests added or updated (N/A — docs only)
- [x] Backward compatibility considered (N/A — docs only)