### PR TITLE
feat(core): add platform management capability

### DIFF
--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -130,6 +130,8 @@ where
     agent_store: Option<Arc<dyn AgentStore>>,
     /// Optional session schedule store for scheduling tools
     schedule_store: Option<Arc<dyn crate::traits::SessionScheduleStore>>,
+    /// Optional platform store for org-level management tools
+    platform_store: Option<Arc<dyn crate::platform_store::PlatformStore>>,
 }
 
 impl<T, E> ActAtom<T, E>
@@ -150,6 +152,7 @@ where
             session_mutator: None,
             agent_store: None,
             schedule_store: None,
+            platform_store: None,
         }
     }
 
@@ -170,6 +173,7 @@ where
             session_mutator: None,
             agent_store: None,
             schedule_store: None,
+            platform_store: None,
         }
     }
 
@@ -221,6 +225,15 @@ where
         store: Arc<dyn crate::traits::SessionScheduleStore>,
     ) -> Self {
         self.schedule_store = Some(store);
+        self
+    }
+
+    /// Set platform store for org-level management tools.
+    pub fn with_platform_store(
+        mut self,
+        store: Arc<dyn crate::platform_store::PlatformStore>,
+    ) -> Self {
+        self.platform_store = Some(store);
         self
     }
 }
@@ -492,6 +505,7 @@ where
             || self.session_mutator.is_some()
             || self.agent_store.is_some()
             || self.schedule_store.is_some()
+            || self.platform_store.is_some()
         {
             let mut tool_context = if let Some(ref store) = self.file_store {
                 ToolContext::with_file_store(context.session_id, store.clone())
@@ -518,6 +532,9 @@ where
             }
             if let Some(ref store) = self.schedule_store {
                 tool_context.schedule_store = Some(store.clone());
+            }
+            if let Some(ref store) = self.platform_store {
+                tool_context.platform_store = Some(store.clone());
             }
             self.tool_executor
                 .execute_with_context(&tool_call, tool_def, &tool_context)

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -1072,9 +1072,10 @@ mod tests {
         assert!(registry.has("fake_financial"));
         assert!(registry.has("skills"));
         assert!(registry.has("session_schedule"));
-        // 20 core built-in capabilities
+        assert!(registry.has("platform_management"));
+        // 21 core built-in capabilities
         // (integration plugins like docker_container, codesandbox add more when linked)
-        assert!(registry.len() >= 20);
+        assert!(registry.len() >= 21);
     }
 
     #[test]
@@ -1102,9 +1103,10 @@ mod tests {
         assert!(registry.has("fake_financial"));
         assert!(registry.has("skills"));
         assert!(registry.has("session_schedule"));
+        assert!(registry.has("platform_management"));
         // Experimental capabilities NOT included in prod
         assert!(!registry.has("docker_container"));
-        assert_eq!(registry.len(), 20);
+        assert_eq!(registry.len(), 21);
     }
 
     #[test]

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -80,6 +80,7 @@ mod fake_warehouse;
 mod file_system;
 pub mod mcp;
 mod noop;
+mod platform_management;
 mod research;
 mod sample_data;
 mod session;
@@ -135,6 +136,10 @@ pub use mcp::{
     parse_mcp_capability_id,
 };
 pub use noop::NoopCapability;
+pub use platform_management::{
+    ManageAgentsTool, ManageHarnessesTool, ManageSessionsTool, PlatformManagementCapability,
+    SessionInteractTool,
+};
 pub use research::ResearchCapability;
 pub use sample_data::SampleDataCapability;
 pub use session::{GetSessionInfoTool, SessionCapability, WriteSessionTitleTool};
@@ -418,6 +423,7 @@ impl CapabilityRegistry {
         registry.register(NoopCapability);
         registry.register(CurrentTimeCapability);
         registry.register(ResearchCapability);
+        registry.register(PlatformManagementCapability);
         registry.register(FileSystemCapability);
         registry.register(SessionStorageCapability);
         registry.register(SessionCapability);

--- a/crates/core/src/capabilities/platform_management.rs
+++ b/crates/core/src/capabilities/platform_management.rs
@@ -1,0 +1,1521 @@
+// Platform Management capability
+//
+// Decision: Four tools grouped by entity (harnesses, agents, sessions, session_interact)
+// Decision: Each tool uses an `operation` parameter for CRUD dispatch
+// Decision: All results include UI links via PlatformStore::base_url()
+// Decision: get_messages defaults to last 10; wait_for_idle defaults to 120s timeout
+
+use super::{Capability, CapabilityStatus};
+use crate::tools::{Tool, ToolExecutionResult};
+use crate::traits::ToolContext;
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+// =============================================================================
+// Capability
+// =============================================================================
+
+pub struct PlatformManagementCapability;
+
+impl Capability for PlatformManagementCapability {
+    fn id(&self) -> &str {
+        "platform_management"
+    }
+
+    fn name(&self) -> &str {
+        "Platform Management"
+    }
+
+    fn description(&self) -> &str {
+        "Tools to manage harnesses, agents, and sessions. Create, list, update, delete entities and interact with sessions programmatically."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("settings-2")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Platform")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(
+            r#"You have platform management tools to manage Everruns entities:
+
+`manage_harnesses` - Harness CRUD operations:
+- operation: "list" - List all harnesses
+- operation: "get" - Get a harness by ID (requires: harness_id)
+- operation: "create" - Create a harness (requires: name, system_prompt; optional: description, capabilities)
+- operation: "update" - Update a harness (requires: harness_id; optional: name, description, system_prompt)
+- operation: "delete" - Archive a harness (requires: harness_id)
+- operation: "copy" - Copy a harness (requires: harness_id; optional: new_name)
+
+`manage_agents` - Agent CRUD operations:
+- operation: "list" - List all agents
+- operation: "get" - Get an agent by ID (requires: agent_id)
+- operation: "create" - Create an agent (requires: name, system_prompt; optional: description, capabilities)
+- operation: "update" - Update an agent (requires: agent_id; optional: name, description, system_prompt)
+- operation: "delete" - Archive an agent (requires: agent_id)
+
+`manage_sessions` - Session operations:
+- operation: "list" - List sessions (optional: limit, agent_id)
+- operation: "create" - Create a session (requires: harness_id; optional: agent_id, title)
+- operation: "get" - Get a session by ID (requires: session_id)
+- operation: "delete" - Archive a session (requires: session_id)
+
+`session_interact` - Session messaging and turn management:
+- operation: "send_message" - Send a user message to a session (requires: session_id, content)
+- operation: "get_messages" - Get messages from a session (requires: session_id; optional: limit, default 10)
+- operation: "wait_for_idle" - Wait for turn to complete (requires: session_id; optional: timeout_secs, default 120)
+
+All results include UI links to view entities in the web interface."#,
+        )
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(ManageHarnessesTool),
+            Box::new(ManageAgentsTool),
+            Box::new(ManageSessionsTool),
+            Box::new(SessionInteractTool),
+        ]
+    }
+}
+
+// =============================================================================
+// Helper: extract platform_store from context
+// =============================================================================
+
+fn get_platform_store(
+    context: &ToolContext,
+) -> Result<&dyn crate::platform_store::PlatformStore, ToolExecutionResult> {
+    match &context.platform_store {
+        Some(store) => Ok(store.as_ref()),
+        None => Err(ToolExecutionResult::tool_error(
+            "Platform management not available in this context. Ensure the platform_management capability is enabled.",
+        )),
+    }
+}
+
+fn get_str<'a>(args: &'a Value, key: &str) -> Option<&'a str> {
+    args.get(key).and_then(|v| v.as_str())
+}
+
+fn require_str<'a>(args: &'a Value, key: &str) -> Result<&'a str, ToolExecutionResult> {
+    get_str(args, key).ok_or_else(|| {
+        ToolExecutionResult::tool_error(format!("Missing required parameter: {key}"))
+    })
+}
+
+// =============================================================================
+// Tool: manage_harnesses
+// =============================================================================
+
+pub struct ManageHarnessesTool;
+
+#[async_trait]
+impl Tool for ManageHarnessesTool {
+    fn name(&self) -> &str {
+        "manage_harnesses"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Manage Harnesses")
+    }
+
+    fn description(&self) -> &str {
+        "CRUD operations for harnesses: list, get, create, update, delete, copy."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "enum": ["list", "get", "create", "update", "delete", "copy"],
+                    "description": "The operation to perform"
+                },
+                "harness_id": {
+                    "type": "string",
+                    "description": "Harness ID (required for get, update, delete, copy)"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Harness name (required for create)"
+                },
+                "new_name": {
+                    "type": "string",
+                    "description": "New name when copying a harness"
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Harness description"
+                },
+                "system_prompt": {
+                    "type": "string",
+                    "description": "System prompt (required for create)"
+                },
+                "capabilities": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "List of capability IDs"
+                }
+            },
+            "required": ["operation"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "manage_harnesses requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let store = match get_platform_store(context) {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let operation = match require_str(&arguments, "operation") {
+            Ok(op) => op,
+            Err(e) => return e,
+        };
+
+        let base_url = store.base_url();
+
+        match operation {
+            "list" => match store.list_harnesses().await {
+                Ok(harnesses) => {
+                    let items: Vec<Value> = harnesses
+                        .iter()
+                        .map(|h| {
+                            json!({
+                                "id": h.id.to_string(),
+                                "name": h.name,
+                                "description": h.description,
+                                "status": format!("{:?}", h.status),
+                                "capabilities": h.capabilities.iter().map(|c| c.capability_id().to_string()).collect::<Vec<_>>(),
+                                "tags": h.tags,
+                                "ui_link": format!("{}/harnesses/{}", base_url, h.id),
+                            })
+                        })
+                        .collect();
+                    ToolExecutionResult::success(json!({"harnesses": items, "count": items.len()}))
+                }
+                Err(e) => ToolExecutionResult::tool_error(format!("Failed to list harnesses: {e}")),
+            },
+
+            "get" => {
+                let id_str = match require_str(&arguments, "harness_id") {
+                    Ok(s) => s,
+                    Err(e) => return e,
+                };
+                let id = match id_str.parse::<crate::typed_id::HarnessId>() {
+                    Ok(id) => id,
+                    Err(_) => {
+                        return ToolExecutionResult::tool_error(format!(
+                            "Invalid harness_id: {id_str}"
+                        ));
+                    }
+                };
+                match store.get_harness(id).await {
+                    Ok(Some(h)) => ToolExecutionResult::success(json!({
+                        "id": h.id.to_string(),
+                        "name": h.name,
+                        "description": h.description,
+                        "system_prompt": h.system_prompt,
+                        "status": format!("{:?}", h.status),
+                        "capabilities": h.capabilities.iter().map(|c| c.capability_id().to_string()).collect::<Vec<_>>(),
+                        "tags": h.tags,
+                        "ui_link": format!("{}/harnesses/{}", base_url, h.id),
+                    })),
+                    Ok(None) => {
+                        ToolExecutionResult::tool_error(format!("Harness not found: {id_str}"))
+                    }
+                    Err(e) => {
+                        ToolExecutionResult::tool_error(format!("Failed to get harness: {e}"))
+                    }
+                }
+            }
+
+            "create" => {
+                let name = match require_str(&arguments, "name") {
+                    Ok(s) => s,
+                    Err(e) => return e,
+                };
+                let system_prompt = match require_str(&arguments, "system_prompt") {
+                    Ok(s) => s,
+                    Err(e) => return e,
+                };
+                let description = get_str(&arguments, "description");
+                let capabilities: Vec<String> = arguments
+                    .get("capabilities")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                match store
+                    .create_harness(name, description, system_prompt, &capabilities)
+                    .await
+                {
+                    Ok(h) => ToolExecutionResult::success(json!({
+                        "id": h.id.to_string(),
+                        "name": h.name,
+                        "description": h.description,
+                        "status": format!("{:?}", h.status),
+                        "ui_link": format!("{}/harnesses/{}", base_url, h.id),
+                        "message": "Harness created successfully"
+                    })),
+                    Err(e) => {
+                        ToolExecutionResult::tool_error(format!("Failed to create harness: {e}"))
+                    }
+                }
+            }
+
+            "update" => {
+                let id_str = match require_str(&arguments, "harness_id") {
+                    Ok(s) => s,
+                    Err(e) => return e,
+                };
+                let id = match id_str.parse::<crate::typed_id::HarnessId>() {
+                    Ok(id) => id,
+                    Err(_) => {
+                        return ToolExecutionResult::tool_error(format!(
+                            "Invalid harness_id: {id_str}"
+                        ));
+                    }
+                };
+                let name = get_str(&arguments, "name");
+                let description = get_str(&arguments, "description");
+                let system_prompt = get_str(&arguments, "system_prompt");
+                match store
+                    .update_harness(id, name, description, system_prompt)
+                    .await
+                {
+                    Ok(h) => ToolExecutionResult::success(json!({
+                        "id": h.id.to_string(),
+                        "name": h.name,
+                        "description": h.description,
+                        "status": format!("{:?}", h.status),
+                        "ui_link": format!("{}/harnesses/{}", base_url, h.id),
+                        "message": "Harness updated successfully"
+                    })),
+                    Err(e) => {
+                        ToolExecutionResult::tool_error(format!("Failed to update harness: {e}"))
+                    }
+                }
+            }
+
+            "delete" => {
+                let id_str = match require_str(&arguments, "harness_id") {
+                    Ok(s) => s,
+                    Err(e) => return e,
+                };
+                let id = match id_str.parse::<crate::typed_id::HarnessId>() {
+                    Ok(id) => id,
+                    Err(_) => {
+                        return ToolExecutionResult::tool_error(format!(
+                            "Invalid harness_id: {id_str}"
+                        ));
+                    }
+                };
+                match store.delete_harness(id).await {
+                    Ok(()) => ToolExecutionResult::success(json!({
+                        "harness_id": id_str,
+                        "message": "Harness archived successfully"
+                    })),
+                    Err(e) => {
+                        ToolExecutionResult::tool_error(format!("Failed to delete harness: {e}"))
+                    }
+                }
+            }
+
+            "copy" => {
+                let id_str = match require_str(&arguments, "harness_id") {
+                    Ok(s) => s,
+                    Err(e) => return e,
+                };
+                let id = match id_str.parse::<crate::typed_id::HarnessId>() {
+                    Ok(id) => id,
+                    Err(_) => {
+                        return ToolExecutionResult::tool_error(format!(
+                            "Invalid harness_id: {id_str}"
+                        ));
+                    }
+                };
+                let new_name = get_str(&arguments, "new_name");
+                match store.copy_harness(id, new_name).await {
+                    Ok(h) => ToolExecutionResult::success(json!({
+                        "id": h.id.to_string(),
+                        "name": h.name,
+                        "description": h.description,
+                        "status": format!("{:?}", h.status),
+                        "ui_link": format!("{}/harnesses/{}", base_url, h.id),
+                        "source_harness_id": id_str,
+                        "message": "Harness copied successfully"
+                    })),
+                    Err(e) => {
+                        ToolExecutionResult::tool_error(format!("Failed to copy harness: {e}"))
+                    }
+                }
+            }
+
+            _ => ToolExecutionResult::tool_error(format!(
+                "Unknown operation: {operation}. Valid: list, get, create, update, delete, copy"
+            )),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// =============================================================================
+// Tool: manage_agents
+// =============================================================================
+
+pub struct ManageAgentsTool;
+
+#[async_trait]
+impl Tool for ManageAgentsTool {
+    fn name(&self) -> &str {
+        "manage_agents"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Manage Agents")
+    }
+
+    fn description(&self) -> &str {
+        "CRUD operations for agents: list, get, create, update, delete."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "enum": ["list", "get", "create", "update", "delete"],
+                    "description": "The operation to perform"
+                },
+                "agent_id": {
+                    "type": "string",
+                    "description": "Agent ID (required for get, update, delete)"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Agent name (required for create)"
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Agent description"
+                },
+                "system_prompt": {
+                    "type": "string",
+                    "description": "System prompt (required for create)"
+                },
+                "capabilities": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "List of capability IDs"
+                }
+            },
+            "required": ["operation"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "manage_agents requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let store = match get_platform_store(context) {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let operation = match require_str(&arguments, "operation") {
+            Ok(op) => op,
+            Err(e) => return e,
+        };
+
+        let base_url = store.base_url();
+
+        match operation {
+            "list" => match store.list_agents().await {
+                Ok(agents) => {
+                    let items: Vec<Value> = agents
+                        .iter()
+                        .map(|a| {
+                            json!({
+                                "id": a.public_id.to_string(),
+                                "name": a.name,
+                                "description": a.description,
+                                "status": format!("{:?}", a.status),
+                                "capabilities": a.capabilities.iter().map(|c| c.capability_id().to_string()).collect::<Vec<_>>(),
+                                "tags": a.tags,
+                                "ui_link": format!("{}/agents/{}", base_url, a.public_id),
+                            })
+                        })
+                        .collect();
+                    ToolExecutionResult::success(json!({"agents": items, "count": items.len()}))
+                }
+                Err(e) => ToolExecutionResult::tool_error(format!("Failed to list agents: {e}")),
+            },
+
+            "get" => {
+                let id_str = match require_str(&arguments, "agent_id") {
+                    Ok(s) => s,
+                    Err(e) => return e,
+                };
+                let id = match id_str.parse::<crate::typed_id::AgentId>() {
+                    Ok(id) => id,
+                    Err(_) => {
+                        return ToolExecutionResult::tool_error(format!(
+                            "Invalid agent_id: {id_str}"
+                        ));
+                    }
+                };
+                match store.get_agent_by_id(id).await {
+                    Ok(Some(a)) => ToolExecutionResult::success(json!({
+                        "id": a.public_id.to_string(),
+                        "name": a.name,
+                        "description": a.description,
+                        "system_prompt": a.system_prompt,
+                        "status": format!("{:?}", a.status),
+                        "capabilities": a.capabilities.iter().map(|c| c.capability_id().to_string()).collect::<Vec<_>>(),
+                        "tags": a.tags,
+                        "ui_link": format!("{}/agents/{}", base_url, a.public_id),
+                    })),
+                    Ok(None) => {
+                        ToolExecutionResult::tool_error(format!("Agent not found: {id_str}"))
+                    }
+                    Err(e) => ToolExecutionResult::tool_error(format!("Failed to get agent: {e}")),
+                }
+            }
+
+            "create" => {
+                let name = match require_str(&arguments, "name") {
+                    Ok(s) => s,
+                    Err(e) => return e,
+                };
+                let system_prompt = match require_str(&arguments, "system_prompt") {
+                    Ok(s) => s,
+                    Err(e) => return e,
+                };
+                let description = get_str(&arguments, "description");
+                let capabilities: Vec<String> = arguments
+                    .get("capabilities")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                match store
+                    .create_agent(name, description, system_prompt, &capabilities)
+                    .await
+                {
+                    Ok(a) => ToolExecutionResult::success(json!({
+                        "id": a.public_id.to_string(),
+                        "name": a.name,
+                        "description": a.description,
+                        "status": format!("{:?}", a.status),
+                        "ui_link": format!("{}/agents/{}", base_url, a.public_id),
+                        "message": "Agent created successfully"
+                    })),
+                    Err(e) => {
+                        ToolExecutionResult::tool_error(format!("Failed to create agent: {e}"))
+                    }
+                }
+            }
+
+            "update" => {
+                let id_str = match require_str(&arguments, "agent_id") {
+                    Ok(s) => s,
+                    Err(e) => return e,
+                };
+                let id = match id_str.parse::<crate::typed_id::AgentId>() {
+                    Ok(id) => id,
+                    Err(_) => {
+                        return ToolExecutionResult::tool_error(format!(
+                            "Invalid agent_id: {id_str}"
+                        ));
+                    }
+                };
+                let name = get_str(&arguments, "name");
+                let description = get_str(&arguments, "description");
+                let system_prompt = get_str(&arguments, "system_prompt");
+                match store
+                    .update_agent(id, name, description, system_prompt)
+                    .await
+                {
+                    Ok(a) => ToolExecutionResult::success(json!({
+                        "id": a.public_id.to_string(),
+                        "name": a.name,
+                        "description": a.description,
+                        "status": format!("{:?}", a.status),
+                        "ui_link": format!("{}/agents/{}", base_url, a.public_id),
+                        "message": "Agent updated successfully"
+                    })),
+                    Err(e) => {
+                        ToolExecutionResult::tool_error(format!("Failed to update agent: {e}"))
+                    }
+                }
+            }
+
+            "delete" => {
+                let id_str = match require_str(&arguments, "agent_id") {
+                    Ok(s) => s,
+                    Err(e) => return e,
+                };
+                let id = match id_str.parse::<crate::typed_id::AgentId>() {
+                    Ok(id) => id,
+                    Err(_) => {
+                        return ToolExecutionResult::tool_error(format!(
+                            "Invalid agent_id: {id_str}"
+                        ));
+                    }
+                };
+                match store.delete_agent(id).await {
+                    Ok(()) => ToolExecutionResult::success(json!({
+                        "agent_id": id_str,
+                        "message": "Agent archived successfully"
+                    })),
+                    Err(e) => {
+                        ToolExecutionResult::tool_error(format!("Failed to delete agent: {e}"))
+                    }
+                }
+            }
+
+            _ => ToolExecutionResult::tool_error(format!(
+                "Unknown operation: {operation}. Valid: list, get, create, update, delete"
+            )),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// =============================================================================
+// Tool: manage_sessions
+// =============================================================================
+
+pub struct ManageSessionsTool;
+
+#[async_trait]
+impl Tool for ManageSessionsTool {
+    fn name(&self) -> &str {
+        "manage_sessions"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Manage Sessions")
+    }
+
+    fn description(&self) -> &str {
+        "Session operations: list, create, get, delete."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "enum": ["list", "create", "get", "delete"],
+                    "description": "The operation to perform"
+                },
+                "session_id": {
+                    "type": "string",
+                    "description": "Session ID (required for get, delete)"
+                },
+                "harness_id": {
+                    "type": "string",
+                    "description": "Harness ID (required for create)"
+                },
+                "agent_id": {
+                    "type": "string",
+                    "description": "Agent ID (optional for create and list)"
+                },
+                "title": {
+                    "type": "string",
+                    "description": "Session title (optional for create)"
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max number of sessions to return (default 20)"
+                }
+            },
+            "required": ["operation"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "manage_sessions requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let store = match get_platform_store(context) {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let operation = match require_str(&arguments, "operation") {
+            Ok(op) => op,
+            Err(e) => return e,
+        };
+
+        let base_url = store.base_url();
+
+        match operation {
+            "list" => {
+                let limit = arguments
+                    .get("limit")
+                    .and_then(|v| v.as_u64())
+                    .map(|v| v as usize);
+                let agent_id = get_str(&arguments, "agent_id")
+                    .and_then(|s| s.parse::<crate::typed_id::AgentId>().ok());
+                match store.list_sessions(limit, agent_id).await {
+                    Ok(sessions) => {
+                        let items: Vec<Value> = sessions
+                            .iter()
+                            .map(|s| {
+                                json!({
+                                    "id": s.id.to_string(),
+                                    "title": s.title,
+                                    "status": format!("{:?}", s.status),
+                                    "agent_id": s.agent_id.as_ref().map(|a| a.to_string()),
+                                    "harness_id": s.harness_id.to_string(),
+                                    "created_at": s.created_at.to_rfc3339(),
+                                    "preview": s.preview,
+                                    "ui_link": format!("{}/sessions/{}/chat", base_url, s.id),
+                                })
+                            })
+                            .collect();
+                        ToolExecutionResult::success(
+                            json!({"sessions": items, "count": items.len()}),
+                        )
+                    }
+                    Err(e) => {
+                        ToolExecutionResult::tool_error(format!("Failed to list sessions: {e}"))
+                    }
+                }
+            }
+
+            "create" => {
+                let harness_id_str = match require_str(&arguments, "harness_id") {
+                    Ok(s) => s,
+                    Err(e) => return e,
+                };
+                let harness_id = match harness_id_str.parse::<crate::typed_id::HarnessId>() {
+                    Ok(id) => id,
+                    Err(_) => {
+                        return ToolExecutionResult::tool_error(format!(
+                            "Invalid harness_id: {harness_id_str}"
+                        ));
+                    }
+                };
+                let agent_id = get_str(&arguments, "agent_id")
+                    .and_then(|s| s.parse::<crate::typed_id::AgentId>().ok());
+                let title = get_str(&arguments, "title");
+                match store.create_session(harness_id, agent_id, title).await {
+                    Ok(s) => ToolExecutionResult::success(json!({
+                        "id": s.id.to_string(),
+                        "title": s.title,
+                        "status": format!("{:?}", s.status),
+                        "harness_id": s.harness_id.to_string(),
+                        "agent_id": s.agent_id.as_ref().map(|a| a.to_string()),
+                        "ui_link": format!("{}/sessions/{}/chat", base_url, s.id),
+                        "message": "Session created successfully"
+                    })),
+                    Err(e) => {
+                        ToolExecutionResult::tool_error(format!("Failed to create session: {e}"))
+                    }
+                }
+            }
+
+            "get" => {
+                let id_str = match require_str(&arguments, "session_id") {
+                    Ok(s) => s,
+                    Err(e) => return e,
+                };
+                let id = match id_str.parse::<crate::typed_id::SessionId>() {
+                    Ok(id) => id,
+                    Err(_) => {
+                        return ToolExecutionResult::tool_error(format!(
+                            "Invalid session_id: {id_str}"
+                        ));
+                    }
+                };
+                match store.get_session_by_id(id).await {
+                    Ok(Some(s)) => ToolExecutionResult::success(json!({
+                        "id": s.id.to_string(),
+                        "title": s.title,
+                        "status": format!("{:?}", s.status),
+                        "agent_id": s.agent_id.as_ref().map(|a| a.to_string()),
+                        "harness_id": s.harness_id.to_string(),
+                        "created_at": s.created_at.to_rfc3339(),
+                        "preview": s.preview,
+                        "output_preview": s.output_preview,
+                        "ui_link": format!("{}/sessions/{}/chat", base_url, s.id),
+                    })),
+                    Ok(None) => {
+                        ToolExecutionResult::tool_error(format!("Session not found: {id_str}"))
+                    }
+                    Err(e) => {
+                        ToolExecutionResult::tool_error(format!("Failed to get session: {e}"))
+                    }
+                }
+            }
+
+            "delete" => {
+                let id_str = match require_str(&arguments, "session_id") {
+                    Ok(s) => s,
+                    Err(e) => return e,
+                };
+                let id = match id_str.parse::<crate::typed_id::SessionId>() {
+                    Ok(id) => id,
+                    Err(_) => {
+                        return ToolExecutionResult::tool_error(format!(
+                            "Invalid session_id: {id_str}"
+                        ));
+                    }
+                };
+                match store.delete_session(id).await {
+                    Ok(()) => ToolExecutionResult::success(json!({
+                        "session_id": id_str,
+                        "message": "Session archived successfully"
+                    })),
+                    Err(e) => {
+                        ToolExecutionResult::tool_error(format!("Failed to delete session: {e}"))
+                    }
+                }
+            }
+
+            _ => ToolExecutionResult::tool_error(format!(
+                "Unknown operation: {operation}. Valid: list, create, get, delete"
+            )),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// =============================================================================
+// Tool: session_interact
+// =============================================================================
+
+pub struct SessionInteractTool;
+
+#[async_trait]
+impl Tool for SessionInteractTool {
+    fn name(&self) -> &str {
+        "session_interact"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Session Interact")
+    }
+
+    fn description(&self) -> &str {
+        "Interact with sessions: send messages, get messages, wait for turn completion."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "enum": ["send_message", "get_messages", "wait_for_idle"],
+                    "description": "The operation to perform"
+                },
+                "session_id": {
+                    "type": "string",
+                    "description": "Session ID (required for all operations)"
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Message content (required for send_message)"
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max messages to return (default 10, for get_messages)"
+                },
+                "timeout_secs": {
+                    "type": "integer",
+                    "description": "Timeout in seconds (default 120, for wait_for_idle)"
+                }
+            },
+            "required": ["operation", "session_id"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "session_interact requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let store = match get_platform_store(context) {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let operation = match require_str(&arguments, "operation") {
+            Ok(op) => op,
+            Err(e) => return e,
+        };
+
+        let session_id_str = match require_str(&arguments, "session_id") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+        let session_id = match session_id_str.parse::<crate::typed_id::SessionId>() {
+            Ok(id) => id,
+            Err(_) => {
+                return ToolExecutionResult::tool_error(format!(
+                    "Invalid session_id: {session_id_str}"
+                ));
+            }
+        };
+
+        let base_url = store.base_url();
+
+        match operation {
+            "send_message" => {
+                let content = match require_str(&arguments, "content") {
+                    Ok(s) => s,
+                    Err(e) => return e,
+                };
+                match store.send_message(session_id, content).await {
+                    Ok(()) => ToolExecutionResult::success(json!({
+                        "session_id": session_id_str,
+                        "message": "Message sent successfully. Use wait_for_idle to wait for the agent response.",
+                        "ui_link": format!("{}/sessions/{}/chat", base_url, session_id),
+                    })),
+                    Err(e) => {
+                        ToolExecutionResult::tool_error(format!("Failed to send message: {e}"))
+                    }
+                }
+            }
+
+            "get_messages" => {
+                let limit = arguments
+                    .get("limit")
+                    .and_then(|v| v.as_u64())
+                    .map(|v| v as usize);
+                match store.get_messages(session_id, limit).await {
+                    Ok(messages) => {
+                        let items: Vec<Value> = messages
+                            .iter()
+                            .map(|m| {
+                                json!({
+                                    "role": m.role,
+                                    "content": m.content,
+                                    "created_at": m.created_at.to_rfc3339(),
+                                })
+                            })
+                            .collect();
+                        ToolExecutionResult::success(json!({
+                            "messages": items,
+                            "count": items.len(),
+                            "session_id": session_id_str,
+                            "ui_link": format!("{}/sessions/{}/chat", base_url, session_id),
+                        }))
+                    }
+                    Err(e) => {
+                        ToolExecutionResult::tool_error(format!("Failed to get messages: {e}"))
+                    }
+                }
+            }
+
+            "wait_for_idle" => {
+                let timeout_secs = arguments.get("timeout_secs").and_then(|v| v.as_u64());
+                match store.wait_for_idle(session_id, timeout_secs).await {
+                    Ok(status) => ToolExecutionResult::success(json!({
+                        "session_id": session_id_str,
+                        "status": status,
+                        "ui_link": format!("{}/sessions/{}/chat", base_url, session_id),
+                    })),
+                    Err(e) => {
+                        ToolExecutionResult::tool_error(format!("Failed waiting for idle: {e}"))
+                    }
+                }
+            }
+
+            _ => ToolExecutionResult::tool_error(format!(
+                "Unknown operation: {operation}. Valid: send_message, get_messages, wait_for_idle"
+            )),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::AgentCapabilityConfig;
+    use crate::agent::{Agent, AgentStatus};
+    use crate::error::Result;
+    use crate::harness::{Harness, HarnessStatus};
+    use crate::platform_store::{PlatformMessage, PlatformStore};
+    use crate::session::{Session, SessionStatus};
+    use crate::typed_id::{AgentId, HarnessId, SessionId};
+    use async_trait::async_trait;
+    use chrono::Utc;
+    use std::sync::Arc;
+
+    fn build_harness(name: &str) -> Harness {
+        Harness {
+            id: HarnessId::new(),
+            name: name.to_string(),
+            description: Some("test harness".to_string()),
+            system_prompt: "You are helpful.".to_string(),
+            default_model_id: None,
+            tags: vec![],
+            capabilities: vec![AgentCapabilityConfig::new("session")],
+            status: HarnessStatus::Active,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    fn build_agent(name: &str) -> Agent {
+        Agent {
+            public_id: AgentId::new(),
+            internal_id: uuid::Uuid::now_v7(),
+            name: name.to_string(),
+            description: Some("test agent".to_string()),
+            system_prompt: "You are helpful.".to_string(),
+            default_model_id: None,
+            tags: vec![],
+            capabilities: vec![],
+            tools: vec![],
+            status: AgentStatus::Active,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            usage: None,
+        }
+    }
+
+    fn build_session(title: &str) -> Session {
+        Session {
+            id: SessionId::new(),
+            organization_id: "org_00000000000000000000000000000001".to_string(),
+            harness_id: HarnessId::new(),
+            agent_id: None,
+            title: Some(title.to_string()),
+            preview: None,
+            output_preview: None,
+            tags: vec![],
+            model_id: None,
+            capabilities: vec![],
+            tools: vec![],
+            status: SessionStatus::Idle,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            started_at: None,
+            finished_at: None,
+            usage: None,
+            is_pinned: None,
+            active_schedule_count: None,
+            features: vec![],
+        }
+    }
+
+    struct MockPlatformStore {
+        harness: Harness,
+        agent: Agent,
+        session: Session,
+    }
+
+    impl MockPlatformStore {
+        fn new() -> Self {
+            Self {
+                harness: build_harness("Test Harness"),
+                agent: build_agent("Test Agent"),
+                session: build_session("Test Session"),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl PlatformStore for MockPlatformStore {
+        async fn list_harnesses(&self) -> Result<Vec<Harness>> {
+            Ok(vec![self.harness.clone()])
+        }
+        async fn get_harness(&self, _id: HarnessId) -> Result<Option<Harness>> {
+            Ok(Some(self.harness.clone()))
+        }
+        async fn create_harness(
+            &self,
+            name: &str,
+            _desc: Option<&str>,
+            _prompt: &str,
+            _caps: &[String],
+        ) -> Result<Harness> {
+            let mut h = self.harness.clone();
+            h.name = name.to_string();
+            Ok(h)
+        }
+        async fn update_harness(
+            &self,
+            _id: HarnessId,
+            name: Option<&str>,
+            _desc: Option<&str>,
+            _prompt: Option<&str>,
+        ) -> Result<Harness> {
+            let mut h = self.harness.clone();
+            if let Some(n) = name {
+                h.name = n.to_string();
+            }
+            Ok(h)
+        }
+        async fn delete_harness(&self, _id: HarnessId) -> Result<()> {
+            Ok(())
+        }
+        async fn copy_harness(&self, _id: HarnessId, new_name: Option<&str>) -> Result<Harness> {
+            let mut h = self.harness.clone();
+            h.id = HarnessId::new();
+            h.name = new_name.unwrap_or("Copy").to_string();
+            Ok(h)
+        }
+        async fn list_agents(&self) -> Result<Vec<Agent>> {
+            Ok(vec![self.agent.clone()])
+        }
+        async fn get_agent_by_id(&self, _id: AgentId) -> Result<Option<Agent>> {
+            Ok(Some(self.agent.clone()))
+        }
+        async fn create_agent(
+            &self,
+            name: &str,
+            _desc: Option<&str>,
+            _prompt: &str,
+            _caps: &[String],
+        ) -> Result<Agent> {
+            let mut a = self.agent.clone();
+            a.name = name.to_string();
+            Ok(a)
+        }
+        async fn update_agent(
+            &self,
+            _id: AgentId,
+            name: Option<&str>,
+            _desc: Option<&str>,
+            _prompt: Option<&str>,
+        ) -> Result<Agent> {
+            let mut a = self.agent.clone();
+            if let Some(n) = name {
+                a.name = n.to_string();
+            }
+            Ok(a)
+        }
+        async fn delete_agent(&self, _id: AgentId) -> Result<()> {
+            Ok(())
+        }
+        async fn list_sessions(
+            &self,
+            _limit: Option<usize>,
+            _agent_id: Option<AgentId>,
+        ) -> Result<Vec<Session>> {
+            Ok(vec![self.session.clone()])
+        }
+        async fn create_session(
+            &self,
+            _hid: HarnessId,
+            _aid: Option<AgentId>,
+            title: Option<&str>,
+        ) -> Result<Session> {
+            let mut s = self.session.clone();
+            s.title = title.map(|t| t.to_string());
+            Ok(s)
+        }
+        async fn get_session_by_id(&self, _id: SessionId) -> Result<Option<Session>> {
+            Ok(Some(self.session.clone()))
+        }
+        async fn delete_session(&self, _id: SessionId) -> Result<()> {
+            Ok(())
+        }
+        async fn send_message(&self, _id: SessionId, _content: &str) -> Result<()> {
+            Ok(())
+        }
+        async fn get_messages(
+            &self,
+            _id: SessionId,
+            _limit: Option<usize>,
+        ) -> Result<Vec<PlatformMessage>> {
+            Ok(vec![
+                PlatformMessage {
+                    role: "user".into(),
+                    content: "Hello".into(),
+                    created_at: Utc::now(),
+                },
+                PlatformMessage {
+                    role: "agent".into(),
+                    content: "Hi!".into(),
+                    created_at: Utc::now(),
+                },
+            ])
+        }
+        async fn wait_for_idle(&self, _id: SessionId, _t: Option<u64>) -> Result<String> {
+            Ok("idle".to_string())
+        }
+        fn base_url(&self) -> &str {
+            "http://localhost:3000"
+        }
+    }
+
+    fn mock_context() -> ToolContext {
+        let store: Arc<dyn PlatformStore> = Arc::new(MockPlatformStore::new());
+        let mut ctx = ToolContext::new(SessionId::new());
+        ctx.platform_store = Some(store);
+        ctx
+    }
+
+    #[test]
+    fn capability_id_is_platform_management() {
+        let cap = PlatformManagementCapability;
+        assert_eq!(cap.id(), "platform_management");
+        assert_eq!(cap.status(), CapabilityStatus::Available);
+    }
+
+    #[test]
+    fn capability_provides_four_tools() {
+        let cap = PlatformManagementCapability;
+        let tools = cap.tools();
+        assert_eq!(tools.len(), 4);
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(names.contains(&"manage_harnesses"));
+        assert!(names.contains(&"manage_agents"));
+        assert!(names.contains(&"manage_sessions"));
+        assert!(names.contains(&"session_interact"));
+    }
+
+    #[tokio::test]
+    async fn harness_list_returns_harnesses_with_ui_link() {
+        let ctx = mock_context();
+        let tool = ManageHarnessesTool;
+        let result = tool
+            .execute_with_context(json!({"operation": "list"}), &ctx)
+            .await;
+        match result {
+            ToolExecutionResult::Success(v) => {
+                assert_eq!(v["count"], 1);
+                let h = v["harnesses"].as_array().unwrap();
+                assert!(h[0]["ui_link"].as_str().unwrap().contains("/harnesses/"));
+            }
+            other => panic!("expected success, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn harness_create_returns_new_harness() {
+        let ctx = mock_context();
+        let tool = ManageHarnessesTool;
+        let result = tool
+            .execute_with_context(
+                json!({"operation": "create", "name": "My Harness", "system_prompt": "Be fun!"}),
+                &ctx,
+            )
+            .await;
+        match result {
+            ToolExecutionResult::Success(v) => {
+                assert_eq!(v["name"], "My Harness");
+                assert!(
+                    v["ui_link"]
+                        .as_str()
+                        .unwrap()
+                        .starts_with("http://localhost:3000/harnesses/")
+                );
+            }
+            other => panic!("expected success, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn harness_copy_returns_copied_harness() {
+        let ctx = mock_context();
+        let tool = ManageHarnessesTool;
+        let result = tool
+            .execute_with_context(
+                json!({"operation": "copy", "harness_id": HarnessId::new().to_string(), "new_name": "Fun"}),
+                &ctx,
+            )
+            .await;
+        match result {
+            ToolExecutionResult::Success(v) => {
+                assert_eq!(v["name"], "Fun");
+                assert!(v["message"].as_str().unwrap().contains("copied"));
+            }
+            other => panic!("expected success, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn harness_delete_succeeds() {
+        let ctx = mock_context();
+        let tool = ManageHarnessesTool;
+        let result = tool
+            .execute_with_context(
+                json!({"operation": "delete", "harness_id": HarnessId::new().to_string()}),
+                &ctx,
+            )
+            .await;
+        match result {
+            ToolExecutionResult::Success(v) => {
+                assert!(v["message"].as_str().unwrap().contains("archived"))
+            }
+            other => panic!("expected success, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn harness_invalid_operation_returns_error() {
+        let ctx = mock_context();
+        let tool = ManageHarnessesTool;
+        let result = tool
+            .execute_with_context(json!({"operation": "explode"}), &ctx)
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => assert!(msg.contains("Unknown operation")),
+            other => panic!("expected tool error, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn agent_list_returns_agents() {
+        let ctx = mock_context();
+        let tool = ManageAgentsTool;
+        let result = tool
+            .execute_with_context(json!({"operation": "list"}), &ctx)
+            .await;
+        match result {
+            ToolExecutionResult::Success(v) => {
+                assert_eq!(v["count"], 1);
+                assert!(
+                    v["agents"].as_array().unwrap()[0]["ui_link"]
+                        .as_str()
+                        .unwrap()
+                        .contains("/agents/")
+                );
+            }
+            other => panic!("expected success, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn agent_create_returns_new_agent() {
+        let ctx = mock_context();
+        let tool = ManageAgentsTool;
+        let result = tool
+            .execute_with_context(
+                json!({"operation": "create", "name": "New Agent", "system_prompt": "Be helpful"}),
+                &ctx,
+            )
+            .await;
+        match result {
+            ToolExecutionResult::Success(v) => assert_eq!(v["name"], "New Agent"),
+            other => panic!("expected success, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn session_list_returns_sessions() {
+        let ctx = mock_context();
+        let tool = ManageSessionsTool;
+        let result = tool
+            .execute_with_context(json!({"operation": "list"}), &ctx)
+            .await;
+        match result {
+            ToolExecutionResult::Success(v) => {
+                assert_eq!(v["count"], 1);
+                assert!(
+                    v["sessions"].as_array().unwrap()[0]["ui_link"]
+                        .as_str()
+                        .unwrap()
+                        .contains("/chat")
+                );
+            }
+            other => panic!("expected success, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn session_create_returns_new_session() {
+        let ctx = mock_context();
+        let tool = ManageSessionsTool;
+        let result = tool
+            .execute_with_context(
+                json!({"operation": "create", "harness_id": HarnessId::new().to_string(), "title": "My Session"}),
+                &ctx,
+            )
+            .await;
+        match result {
+            ToolExecutionResult::Success(v) => {
+                assert!(v["ui_link"].as_str().unwrap().contains("/chat"))
+            }
+            other => panic!("expected success, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn interact_send_message_succeeds() {
+        let ctx = mock_context();
+        let tool = SessionInteractTool;
+        let result = tool
+            .execute_with_context(
+                json!({"operation": "send_message", "session_id": SessionId::new().to_string(), "content": "Hi!"}),
+                &ctx,
+            )
+            .await;
+        match result {
+            ToolExecutionResult::Success(v) => {
+                assert!(v["message"].as_str().unwrap().contains("sent"))
+            }
+            other => panic!("expected success, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn interact_get_messages_returns_messages() {
+        let ctx = mock_context();
+        let tool = SessionInteractTool;
+        let result = tool
+            .execute_with_context(
+                json!({"operation": "get_messages", "session_id": SessionId::new().to_string(), "limit": 5}),
+                &ctx,
+            )
+            .await;
+        match result {
+            ToolExecutionResult::Success(v) => {
+                assert_eq!(v["count"], 2);
+                let msgs = v["messages"].as_array().unwrap();
+                assert_eq!(msgs[0]["role"], "user");
+                assert_eq!(msgs[1]["role"], "agent");
+            }
+            other => panic!("expected success, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn interact_wait_for_idle_succeeds() {
+        let ctx = mock_context();
+        let tool = SessionInteractTool;
+        let result = tool
+            .execute_with_context(
+                json!({"operation": "wait_for_idle", "session_id": SessionId::new().to_string()}),
+                &ctx,
+            )
+            .await;
+        match result {
+            ToolExecutionResult::Success(v) => assert_eq!(v["status"], "idle"),
+            other => panic!("expected success, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn tool_without_context_returns_error() {
+        let tool = ManageHarnessesTool;
+        let result = tool.execute(json!({"operation": "list"})).await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => assert!(msg.contains("requires context")),
+            other => panic!("expected tool error, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn tool_without_platform_store_returns_error() {
+        let ctx = ToolContext::new(SessionId::new());
+        let tool = ManageHarnessesTool;
+        let result = tool
+            .execute_with_context(json!({"operation": "list"}), &ctx)
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => assert!(msg.contains("not available")),
+            other => panic!("expected tool error, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_operation_returns_error() {
+        let ctx = mock_context();
+        let tool = ManageHarnessesTool;
+        let result = tool.execute_with_context(json!({}), &ctx).await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => assert!(msg.contains("operation")),
+            other => panic!("expected tool error, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn invalid_harness_id_returns_error() {
+        let ctx = mock_context();
+        let tool = ManageHarnessesTool;
+        let result = tool
+            .execute_with_context(json!({"operation": "get", "harness_id": "bad"}), &ctx)
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => assert!(msg.contains("Invalid harness_id")),
+            other => panic!("expected tool error, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_required_param_returns_error() {
+        let ctx = mock_context();
+        let tool = ManageHarnessesTool;
+        let result = tool
+            .execute_with_context(json!({"operation": "create"}), &ctx)
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => assert!(msg.contains("Missing required")),
+            other => panic!("expected tool error, got: {other:?}"),
+        }
+    }
+}

--- a/crates/core/src/capabilities/platform_management.rs
+++ b/crates/core/src/capabilities/platform_management.rs
@@ -1,4 +1,5 @@
 // Platform Management capability
+// THREAT[TM-AGENT-017]: Agents with this capability can manage org-wide entities
 //
 // Decision: Four tools grouped by entity (harnesses, agents, sessions, session_interact)
 // Decision: Each tool uses an `operation` parameter for CRUD dispatch
@@ -1517,5 +1518,339 @@ mod tests {
             ToolExecutionResult::ToolError(msg) => assert!(msg.contains("Missing required")),
             other => panic!("expected tool error, got: {other:?}"),
         }
+    }
+
+    // =========================================================================
+    // Additional negative tests
+    // =========================================================================
+
+    #[tokio::test]
+    async fn harness_get_succeeds() {
+        let ctx = mock_context();
+        let tool = ManageHarnessesTool;
+        let result = tool
+            .execute_with_context(
+                json!({"operation": "get", "harness_id": HarnessId::new().to_string()}),
+                &ctx,
+            )
+            .await;
+        match result {
+            ToolExecutionResult::Success(v) => {
+                assert_eq!(v["name"], "Test Harness");
+                assert!(v["system_prompt"].as_str().is_some());
+                assert!(v["ui_link"].as_str().unwrap().contains("/harnesses/"));
+            }
+            other => panic!("expected success, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn harness_update_succeeds() {
+        let ctx = mock_context();
+        let tool = ManageHarnessesTool;
+        let result = tool
+            .execute_with_context(
+                json!({"operation": "update", "harness_id": HarnessId::new().to_string(), "name": "Updated"}),
+                &ctx,
+            )
+            .await;
+        match result {
+            ToolExecutionResult::Success(v) => {
+                assert_eq!(v["name"], "Updated");
+                assert!(v["message"].as_str().unwrap().contains("updated"));
+            }
+            other => panic!("expected success, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn agent_get_succeeds() {
+        let ctx = mock_context();
+        let tool = ManageAgentsTool;
+        let result = tool
+            .execute_with_context(
+                json!({"operation": "get", "agent_id": AgentId::new().to_string()}),
+                &ctx,
+            )
+            .await;
+        match result {
+            ToolExecutionResult::Success(v) => {
+                assert_eq!(v["name"], "Test Agent");
+                assert!(v["ui_link"].as_str().unwrap().contains("/agents/"));
+            }
+            other => panic!("expected success, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn agent_update_succeeds() {
+        let ctx = mock_context();
+        let tool = ManageAgentsTool;
+        let result = tool
+            .execute_with_context(
+                json!({"operation": "update", "agent_id": AgentId::new().to_string(), "name": "Renamed"}),
+                &ctx,
+            )
+            .await;
+        match result {
+            ToolExecutionResult::Success(v) => {
+                assert_eq!(v["name"], "Renamed");
+                assert!(v["message"].as_str().unwrap().contains("updated"));
+            }
+            other => panic!("expected success, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn agent_delete_succeeds() {
+        let ctx = mock_context();
+        let tool = ManageAgentsTool;
+        let result = tool
+            .execute_with_context(
+                json!({"operation": "delete", "agent_id": AgentId::new().to_string()}),
+                &ctx,
+            )
+            .await;
+        match result {
+            ToolExecutionResult::Success(v) => {
+                assert!(v["message"].as_str().unwrap().contains("archived"));
+            }
+            other => panic!("expected success, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn agent_invalid_operation_returns_error() {
+        let ctx = mock_context();
+        let tool = ManageAgentsTool;
+        let result = tool
+            .execute_with_context(json!({"operation": "clone"}), &ctx)
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => assert!(msg.contains("Unknown operation")),
+            other => panic!("expected tool error, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn agent_invalid_id_returns_error() {
+        let ctx = mock_context();
+        let tool = ManageAgentsTool;
+        let result = tool
+            .execute_with_context(json!({"operation": "get", "agent_id": "not-valid"}), &ctx)
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => assert!(msg.contains("Invalid agent_id")),
+            other => panic!("expected tool error, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn agent_create_missing_name_returns_error() {
+        let ctx = mock_context();
+        let tool = ManageAgentsTool;
+        let result = tool
+            .execute_with_context(
+                json!({"operation": "create", "system_prompt": "test"}),
+                &ctx,
+            )
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => assert!(msg.contains("Missing required")),
+            other => panic!("expected tool error, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn session_get_succeeds() {
+        let ctx = mock_context();
+        let tool = ManageSessionsTool;
+        let result = tool
+            .execute_with_context(
+                json!({"operation": "get", "session_id": SessionId::new().to_string()}),
+                &ctx,
+            )
+            .await;
+        match result {
+            ToolExecutionResult::Success(v) => {
+                assert_eq!(v["title"], "Test Session");
+                assert!(v["ui_link"].as_str().unwrap().contains("/chat"));
+            }
+            other => panic!("expected success, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn session_delete_succeeds() {
+        let ctx = mock_context();
+        let tool = ManageSessionsTool;
+        let result = tool
+            .execute_with_context(
+                json!({"operation": "delete", "session_id": SessionId::new().to_string()}),
+                &ctx,
+            )
+            .await;
+        match result {
+            ToolExecutionResult::Success(v) => {
+                assert!(v["message"].as_str().unwrap().contains("archived"));
+            }
+            other => panic!("expected success, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn session_invalid_operation_returns_error() {
+        let ctx = mock_context();
+        let tool = ManageSessionsTool;
+        let result = tool
+            .execute_with_context(json!({"operation": "update"}), &ctx)
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => assert!(msg.contains("Unknown operation")),
+            other => panic!("expected tool error, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn session_invalid_id_returns_error() {
+        let ctx = mock_context();
+        let tool = ManageSessionsTool;
+        let result = tool
+            .execute_with_context(json!({"operation": "get", "session_id": "nope"}), &ctx)
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => assert!(msg.contains("Invalid session_id")),
+            other => panic!("expected tool error, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn session_create_missing_harness_id_returns_error() {
+        let ctx = mock_context();
+        let tool = ManageSessionsTool;
+        let result = tool
+            .execute_with_context(json!({"operation": "create"}), &ctx)
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => assert!(msg.contains("Missing required")),
+            other => panic!("expected tool error, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn interact_invalid_operation_returns_error() {
+        let ctx = mock_context();
+        let tool = SessionInteractTool;
+        let result = tool
+            .execute_with_context(
+                json!({"operation": "delete", "session_id": SessionId::new().to_string()}),
+                &ctx,
+            )
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => assert!(msg.contains("Unknown operation")),
+            other => panic!("expected tool error, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn interact_send_message_missing_content_returns_error() {
+        let ctx = mock_context();
+        let tool = SessionInteractTool;
+        let result = tool
+            .execute_with_context(
+                json!({"operation": "send_message", "session_id": SessionId::new().to_string()}),
+                &ctx,
+            )
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => assert!(msg.contains("Missing required")),
+            other => panic!("expected tool error, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn interact_invalid_session_id_returns_error() {
+        let ctx = mock_context();
+        let tool = SessionInteractTool;
+        let result = tool
+            .execute_with_context(
+                json!({"operation": "get_messages", "session_id": "bad-id"}),
+                &ctx,
+            )
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => assert!(msg.contains("Invalid session_id")),
+            other => panic!("expected tool error, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn interact_missing_session_id_returns_error() {
+        let ctx = mock_context();
+        let tool = SessionInteractTool;
+        let result = tool
+            .execute_with_context(json!({"operation": "get_messages"}), &ctx)
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => assert!(msg.contains("Missing required")),
+            other => panic!("expected tool error, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn all_tools_require_context() {
+        // All four tools should have requires_context = true
+        assert!(ManageHarnessesTool.requires_context());
+        assert!(ManageAgentsTool.requires_context());
+        assert!(ManageSessionsTool.requires_context());
+        assert!(SessionInteractTool.requires_context());
+    }
+
+    #[tokio::test]
+    async fn all_tools_without_context_return_error() {
+        // execute() (no context) should fail for all tools
+        for tool_name in [
+            "manage_harnesses",
+            "manage_agents",
+            "manage_sessions",
+            "session_interact",
+        ] {
+            let result = match tool_name {
+                "manage_harnesses" => {
+                    ManageHarnessesTool
+                        .execute(json!({"operation": "list"}))
+                        .await
+                }
+                "manage_agents" => ManageAgentsTool.execute(json!({"operation": "list"})).await,
+                "manage_sessions" => {
+                    ManageSessionsTool
+                        .execute(json!({"operation": "list"}))
+                        .await
+                }
+                "session_interact" => {
+                    SessionInteractTool
+                        .execute(json!({"operation": "get_messages", "session_id": "x"}))
+                        .await
+                }
+                _ => unreachable!(),
+            };
+            match result {
+                ToolExecutionResult::ToolError(msg) => {
+                    assert!(msg.contains("requires context"), "tool {tool_name}: {msg}");
+                }
+                other => panic!("{tool_name}: expected tool error, got: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn capability_has_system_prompt_addition() {
+        let cap = PlatformManagementCapability;
+        let prompt = cap.system_prompt_addition().expect("should have prompt");
+        assert!(prompt.contains("manage_harnesses"));
+        assert!(prompt.contains("manage_agents"));
+        assert!(prompt.contains("manage_sessions"));
+        assert!(prompt.contains("session_interact"));
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -64,6 +64,7 @@ pub mod message_retriever;
 pub mod openai_protocol;
 pub mod openresponses_protocol;
 pub mod openresponses_types;
+pub mod platform_store;
 pub mod runtime_agent;
 pub mod tools;
 pub mod traits;
@@ -103,6 +104,9 @@ pub use traits::{
     SessionSqlDbStoreRef, SessionStorageStore, SessionStore, ToolContext, ToolExecutor,
     UserConnectionResolver,
 };
+
+// Platform store re-exports
+pub use platform_store::{PlatformMessage, PlatformStore};
 
 // Event listener re-exports
 pub use event_listeners::{CompositeEventListener, EventListener, NoopEventListener};
@@ -150,10 +154,10 @@ pub use capabilities::{
     GetCurrentTimeTool, GetForecastTool, GetSessionInfoTool, GetWeatherTool, GrepFilesTool,
     IntegrationPlugin, ListDirectoryTool, MAX_RESOLVED_CAPABILITIES, MCP_CAPABILITY_PREFIX,
     McpCapability, MountAccess, MountDirectoryBuilder, MountEntry, MountPoint, MountSource,
-    MultiplyTool, NoopCapability, ReadFileTool, ResearchCapability, ResolvedCapabilities,
-    SampleDataCapability, SessionCapability, SessionSqlDatabaseCapability, SqlExecuteTool,
-    SqlQueryTool, SqlSchemaTool, StatFileTool, StatelessTodoListCapability, SubtractTool,
-    TestMathCapability, TestWeatherCapability, WriteFileTool, WriteSessionTitleTool,
+    MultiplyTool, NoopCapability, PlatformManagementCapability, ReadFileTool, ResearchCapability,
+    ResolvedCapabilities, SampleDataCapability, SessionCapability, SessionSqlDatabaseCapability,
+    SqlExecuteTool, SqlQueryTool, SqlSchemaTool, StatFileTool, StatelessTodoListCapability,
+    SubtractTool, TestMathCapability, TestWeatherCapability, WriteFileTool, WriteSessionTitleTool,
     WriteTodosTool, apply_capabilities, collect_capabilities, collect_capabilities_with_configs,
     compute_features, get_dependencies, is_mcp_capability, mcp_capability_id,
     parse_mcp_capability_id, resolve_dependencies,

--- a/crates/core/src/platform_store.rs
+++ b/crates/core/src/platform_store.rs
@@ -1,0 +1,156 @@
+// Platform Store trait for org-scoped management operations
+//
+// Decision: Single trait covers harness, agent, session CRUD + messaging
+// Decision: Trait lives in core; implementations in server/worker crates
+// Decision: Tool results include UI links via base_url()
+// Decision: PlatformMessage is a simplified view (role + text + timestamp)
+
+use crate::agent::Agent;
+use crate::error::Result;
+use crate::harness::Harness;
+use crate::session::Session;
+use crate::typed_id::{AgentId, HarnessId, SessionId};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Simplified message representation for platform management tools.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlatformMessage {
+    pub role: String,
+    pub content: String,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Trait for platform-level management operations.
+///
+/// Provides org-scoped CRUD for harnesses, agents, and sessions,
+/// plus session messaging and turn management. Used by the
+/// `platform_management` capability tools.
+#[async_trait]
+pub trait PlatformStore: Send + Sync {
+    // =========================================================================
+    // Harness Operations
+    // =========================================================================
+
+    /// List all harnesses in the organization.
+    async fn list_harnesses(&self) -> Result<Vec<Harness>>;
+
+    /// Get a harness by ID.
+    async fn get_harness(&self, id: HarnessId) -> Result<Option<Harness>>;
+
+    /// Create a new harness.
+    async fn create_harness(
+        &self,
+        name: &str,
+        description: Option<&str>,
+        system_prompt: &str,
+        capabilities: &[String],
+    ) -> Result<Harness>;
+
+    /// Update a harness (only provided fields are changed).
+    async fn update_harness(
+        &self,
+        id: HarnessId,
+        name: Option<&str>,
+        description: Option<&str>,
+        system_prompt: Option<&str>,
+    ) -> Result<Harness>;
+
+    /// Delete (archive) a harness.
+    async fn delete_harness(&self, id: HarnessId) -> Result<()>;
+
+    /// Copy a harness, optionally with a new name.
+    async fn copy_harness(&self, id: HarnessId, new_name: Option<&str>) -> Result<Harness>;
+
+    // =========================================================================
+    // Agent Operations
+    // =========================================================================
+
+    /// List all agents in the organization.
+    async fn list_agents(&self) -> Result<Vec<Agent>>;
+
+    /// Get an agent by public ID.
+    async fn get_agent_by_id(&self, id: AgentId) -> Result<Option<Agent>>;
+
+    /// Create a new agent.
+    async fn create_agent(
+        &self,
+        name: &str,
+        description: Option<&str>,
+        system_prompt: &str,
+        capabilities: &[String],
+    ) -> Result<Agent>;
+
+    /// Update an agent (only provided fields are changed).
+    async fn update_agent(
+        &self,
+        id: AgentId,
+        name: Option<&str>,
+        description: Option<&str>,
+        system_prompt: Option<&str>,
+    ) -> Result<Agent>;
+
+    /// Delete (archive) an agent.
+    async fn delete_agent(&self, id: AgentId) -> Result<()>;
+
+    // =========================================================================
+    // Session Operations
+    // =========================================================================
+
+    /// List sessions, optionally filtered by agent.
+    async fn list_sessions(
+        &self,
+        limit: Option<usize>,
+        agent_id: Option<AgentId>,
+    ) -> Result<Vec<Session>>;
+
+    /// Create a new session.
+    async fn create_session(
+        &self,
+        harness_id: HarnessId,
+        agent_id: Option<AgentId>,
+        title: Option<&str>,
+    ) -> Result<Session>;
+
+    /// Get a session by ID.
+    async fn get_session_by_id(&self, id: SessionId) -> Result<Option<Session>>;
+
+    /// Delete (archive) a session.
+    async fn delete_session(&self, id: SessionId) -> Result<()>;
+
+    // =========================================================================
+    // Messaging
+    // =========================================================================
+
+    /// Send a user message to a session, triggering a turn.
+    async fn send_message(&self, session_id: SessionId, content: &str) -> Result<()>;
+
+    /// Get messages from a session (most recent first).
+    /// Default limit is 10.
+    async fn get_messages(
+        &self,
+        session_id: SessionId,
+        limit: Option<usize>,
+    ) -> Result<Vec<PlatformMessage>>;
+
+    // =========================================================================
+    // Turn Management
+    // =========================================================================
+
+    /// Wait for a session to become idle (turn completed).
+    /// Returns the final session status as a string.
+    /// Default timeout is 120 seconds.
+    async fn wait_for_idle(
+        &self,
+        session_id: SessionId,
+        timeout_secs: Option<u64>,
+    ) -> Result<String>;
+
+    // =========================================================================
+    // UI Links
+    // =========================================================================
+
+    /// Base URL for constructing UI links (e.g., "http://localhost:3000").
+    fn base_url(&self) -> &str;
+}

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -409,6 +409,9 @@ pub struct ToolContext {
 
     /// Optional session schedule store for scheduling tools.
     pub schedule_store: Option<Arc<dyn SessionScheduleStore>>,
+
+    /// Optional platform store for org-level management tools.
+    pub platform_store: Option<Arc<dyn crate::platform_store::PlatformStore>>,
 }
 
 impl ToolContext {
@@ -425,6 +428,7 @@ impl ToolContext {
             agent_store: None,
             connection_resolver: None,
             schedule_store: None,
+            platform_store: None,
         }
     }
 
@@ -441,6 +445,7 @@ impl ToolContext {
             agent_store: None,
             connection_resolver: None,
             schedule_store: None,
+            platform_store: None,
         }
     }
 
@@ -460,6 +465,7 @@ impl ToolContext {
             agent_store: None,
             connection_resolver: None,
             schedule_store: None,
+            platform_store: None,
         }
     }
 
@@ -480,6 +486,7 @@ impl ToolContext {
             agent_store: None,
             connection_resolver: None,
             schedule_store: None,
+            platform_store: None,
         }
     }
 
@@ -527,6 +534,15 @@ impl ToolContext {
         self.schedule_store = Some(store);
         self
     }
+
+    /// Add a platform store to this context.
+    pub fn with_platform_store(
+        mut self,
+        store: Arc<dyn crate::platform_store::PlatformStore>,
+    ) -> Self {
+        self.platform_store = Some(store);
+        self
+    }
 }
 
 impl std::fmt::Debug for ToolContext {
@@ -542,6 +558,7 @@ impl std::fmt::Debug for ToolContext {
             .field("agent_store", &self.agent_store.is_some())
             .field("connection_resolver", &self.connection_resolver.is_some())
             .field("schedule_store", &self.schedule_store.is_some())
+            .field("platform_store", &self.platform_store.is_some())
             .finish()
     }
 }

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -729,9 +729,11 @@ impl ServerAppBuilder {
                 )
                 .with_sqldb_store(sqldb_store.clone())
                 .with_storage_store(session_storage_store)
-                .with_schedule_store(Arc::new(
-                    crate::storage::DbSessionScheduleStore::new(db.clone(), DEFAULT_ORG_ID),
-                ));
+                .with_schedule_store(Arc::new(crate::storage::DbSessionScheduleStore::new(
+                    db.clone(),
+                    DEFAULT_ORG_ID,
+                )))
+                .with_runner(runner.clone());
 
                 // Wire lazy connection resolver (requires encryption for token decryption)
                 if let Some(ref enc) = encryption {

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1041,6 +1041,7 @@ fn event_to_message(event: Event) -> Option<Message> {
 // =============================================================================
 
 /// Direct PlatformStore backed by StorageBackend + EventService + AgentRunner.
+// THREAT[TM-AGENT-017]: All ops org-scoped via org_id field
 pub struct DirectPlatformStore {
     db: Arc<StorageBackend>,
     event_service: Arc<EventService>,

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -65,6 +65,7 @@ pub struct DirectWorkerAdapters {
     storage_store: Option<Arc<dyn everruns_core::traits::SessionStorageStore>>,
     connection_resolver: Option<Arc<dyn everruns_core::traits::UserConnectionResolver>>,
     schedule_store: Option<Arc<dyn everruns_core::traits::SessionScheduleStore>>,
+    runner: Option<Arc<dyn everruns_worker::AgentRunner>>,
 }
 
 impl DirectWorkerAdapters {
@@ -86,7 +87,14 @@ impl DirectWorkerAdapters {
             storage_store: None,
             connection_resolver: None,
             schedule_store: None,
+            runner: None,
         }
+    }
+
+    /// Set the agent runner for platform management tools (send_message, etc.)
+    pub fn with_runner(mut self, runner: Arc<dyn everruns_worker::AgentRunner>) -> Self {
+        self.runner = Some(runner);
+        self
     }
 
     /// Set the SQL database store for session-scoped SQL databases
@@ -821,6 +829,14 @@ impl WorkerAdapters for DirectWorkerAdapters {
         self.schedule_store.clone()
     }
 
+    fn platform_store(&self) -> Option<Arc<dyn everruns_core::platform_store::PlatformStore>> {
+        Some(Arc::new(DirectPlatformStore::new(
+            self.db.clone(),
+            self.event_service.clone(),
+            self.runner.clone(),
+        )))
+    }
+
     async fn build_tool_registry(&self, agent_id: Uuid) -> Result<ToolRegistry> {
         let mut registry = ToolRegistry::with_defaults();
 
@@ -1017,6 +1033,648 @@ fn event_to_message(event: Event) -> Option<Message> {
             })
         }
         _ => None,
+    }
+}
+
+// =============================================================================
+// DirectPlatformStore - PlatformStore implementation for in-process worker
+// =============================================================================
+
+/// Direct PlatformStore backed by StorageBackend + EventService + AgentRunner.
+pub struct DirectPlatformStore {
+    db: Arc<StorageBackend>,
+    event_service: Arc<EventService>,
+    runner: Option<Arc<dyn everruns_worker::AgentRunner>>,
+}
+
+impl DirectPlatformStore {
+    pub fn new(
+        db: Arc<StorageBackend>,
+        event_service: Arc<EventService>,
+        runner: Option<Arc<dyn everruns_worker::AgentRunner>>,
+    ) -> Self {
+        Self {
+            db,
+            event_service,
+            runner,
+        }
+    }
+
+    fn base_url_from_env() -> String {
+        std::env::var("APP_URL")
+            .or_else(|_| std::env::var("PUBLIC_URL"))
+            .unwrap_or_else(|_| "http://localhost:3000".to_string())
+    }
+
+    fn row_to_harness(
+        row: crate::storage::HarnessRow,
+        capabilities: Vec<everruns_core::AgentCapabilityConfig>,
+    ) -> everruns_core::Harness {
+        everruns_core::Harness {
+            id: row.id,
+            name: row.name,
+            description: row.description,
+            system_prompt: row.system_prompt,
+            default_model_id: row.default_model_id,
+            tags: row.tags,
+            capabilities,
+            status: HarnessStatus::from(row.status.as_str()),
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+        }
+    }
+
+    fn row_to_agent(
+        row: crate::storage::AgentRow,
+        capabilities: Vec<everruns_core::AgentCapabilityConfig>,
+    ) -> Agent {
+        let public_id: AgentId = row
+            .public_id
+            .parse()
+            .unwrap_or_else(|_| AgentId::from_uuid(row.id.uuid()));
+        Agent {
+            public_id,
+            internal_id: row.id.uuid(),
+            name: row.name,
+            description: row.description,
+            system_prompt: row.system_prompt,
+            default_model_id: row.default_model_id,
+            tags: row.tags,
+            capabilities,
+            tools: serde_json::from_value(row.tools).unwrap_or_default(),
+            status: AgentStatus::from(row.status.as_str()),
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+            usage: None,
+        }
+    }
+
+    fn row_to_session(row: crate::storage::SessionRow) -> Session {
+        let capabilities = serde_json::from_value(row.capabilities).unwrap_or_default();
+        Session {
+            id: row.id,
+            organization_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
+            harness_id: row.harness_id.unwrap_or_else(|| HarnessId::from_seed(1)),
+            agent_id: row.agent_id,
+            title: row.title,
+            preview: None,
+            output_preview: None,
+            tags: row.tags,
+            model_id: row.model_id,
+            capabilities,
+            tools: serde_json::from_value(row.tools).unwrap_or_default(),
+            status: SessionStatus::from(row.status.as_str()),
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+            started_at: row.started_at,
+            finished_at: row.finished_at,
+            usage: None,
+            is_pinned: None,
+            active_schedule_count: None,
+            features: vec![],
+        }
+    }
+}
+
+#[async_trait]
+impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
+    // =========================================================================
+    // Harness Operations
+    // =========================================================================
+
+    async fn list_harnesses(&self) -> everruns_core::error::Result<Vec<Harness>> {
+        let rows = self
+            .db
+            .list_harnesses(DEFAULT_ORG_ID)
+            .await
+            .map_err(|e| store_error(format!("Failed to list harnesses: {e}")))?;
+
+        let mut harnesses = Vec::with_capacity(rows.len());
+        for row in rows {
+            let caps = self
+                .db
+                .get_harness_capabilities(row.id.uuid())
+                .await
+                .map_err(|e| store_error(format!("Failed to get harness capabilities: {e}")))?
+                .into_iter()
+                .map(|c| {
+                    everruns_core::AgentCapabilityConfig::with_config(c.capability_id, c.config)
+                })
+                .collect();
+            harnesses.push(Self::row_to_harness(row, caps));
+        }
+        Ok(harnesses)
+    }
+
+    async fn get_harness(&self, id: HarnessId) -> everruns_core::error::Result<Option<Harness>> {
+        let row = self
+            .db
+            .get_harness(DEFAULT_ORG_ID, id)
+            .await
+            .map_err(|e| store_error(format!("Failed to get harness: {e}")))?;
+
+        match row {
+            Some(row) => {
+                let caps = self
+                    .db
+                    .get_harness_capabilities(row.id.uuid())
+                    .await
+                    .map_err(|e| store_error(format!("Failed to get harness capabilities: {e}")))?
+                    .into_iter()
+                    .map(|c| {
+                        everruns_core::AgentCapabilityConfig::with_config(c.capability_id, c.config)
+                    })
+                    .collect();
+                Ok(Some(Self::row_to_harness(row, caps)))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn create_harness(
+        &self,
+        name: &str,
+        description: Option<&str>,
+        system_prompt: &str,
+        capabilities: &[String],
+    ) -> everruns_core::error::Result<Harness> {
+        use crate::storage::models::CreateHarnessRow;
+
+        let input = CreateHarnessRow {
+            name: name.to_string(),
+            description: description.map(|s| s.to_string()),
+            system_prompt: system_prompt.to_string(),
+            default_model_id: None,
+            tags: vec!["managed".to_string()],
+        };
+        let row = self
+            .db
+            .create_harness(DEFAULT_ORG_ID, input)
+            .await
+            .map_err(|e| store_error(format!("Failed to create harness: {e}")))?;
+
+        // Set capabilities
+        if !capabilities.is_empty() {
+            let caps: Vec<(String, i32, serde_json::Value)> = capabilities
+                .iter()
+                .enumerate()
+                .map(|(i, c)| {
+                    (
+                        c.clone(),
+                        i as i32,
+                        serde_json::Value::Object(Default::default()),
+                    )
+                })
+                .collect();
+            self.db
+                .set_harness_capabilities(row.id.uuid(), caps)
+                .await
+                .map_err(|e| store_error(format!("Failed to set harness capabilities: {e}")))?;
+        }
+
+        self.get_harness(row.id)
+            .await?
+            .ok_or_else(|| store_error("Harness not found after create"))
+    }
+
+    async fn update_harness(
+        &self,
+        id: HarnessId,
+        name: Option<&str>,
+        description: Option<&str>,
+        system_prompt: Option<&str>,
+    ) -> everruns_core::error::Result<Harness> {
+        use crate::storage::models::UpdateHarness;
+
+        let update = UpdateHarness {
+            name: name.map(|s| s.to_string()),
+            description: description.map(|s| s.to_string()),
+            system_prompt: system_prompt.map(|s| s.to_string()),
+            ..Default::default()
+        };
+        self.db
+            .update_harness(DEFAULT_ORG_ID, id, update)
+            .await
+            .map_err(|e| store_error(format!("Failed to update harness: {e}")))?;
+
+        self.get_harness(id)
+            .await?
+            .ok_or_else(|| store_error("Harness not found after update"))
+    }
+
+    async fn delete_harness(&self, id: HarnessId) -> everruns_core::error::Result<()> {
+        self.db
+            .delete_harness(DEFAULT_ORG_ID, id)
+            .await
+            .map_err(|e| store_error(format!("Failed to delete harness: {e}")))?;
+        Ok(())
+    }
+
+    async fn copy_harness(
+        &self,
+        id: HarnessId,
+        new_name: Option<&str>,
+    ) -> everruns_core::error::Result<Harness> {
+        // Get the source harness
+        let source = self
+            .get_harness(id)
+            .await?
+            .ok_or_else(|| store_error("Source harness not found"))?;
+
+        let copy_name = new_name
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| format!("{} (copy)", source.name));
+
+        let cap_ids: Vec<String> = source
+            .capabilities
+            .iter()
+            .map(|c| c.capability_id().to_string())
+            .collect();
+
+        self.create_harness(
+            &copy_name,
+            source.description.as_deref(),
+            &source.system_prompt,
+            &cap_ids,
+        )
+        .await
+    }
+
+    // =========================================================================
+    // Agent Operations
+    // =========================================================================
+
+    async fn list_agents(&self) -> everruns_core::error::Result<Vec<Agent>> {
+        let rows = self
+            .db
+            .list_agents(DEFAULT_ORG_ID)
+            .await
+            .map_err(|e| store_error(format!("Failed to list agents: {e}")))?;
+
+        let mut agents = Vec::with_capacity(rows.len());
+        for row in rows {
+            let caps = self
+                .db
+                .get_agent_capabilities(row.id.uuid())
+                .await
+                .map_err(|e| store_error(format!("Failed to get agent capabilities: {e}")))?
+                .into_iter()
+                .map(|c| {
+                    everruns_core::AgentCapabilityConfig::with_config(c.capability_id, c.config)
+                })
+                .collect();
+            agents.push(Self::row_to_agent(row, caps));
+        }
+        Ok(agents)
+    }
+
+    async fn get_agent_by_id(&self, id: AgentId) -> everruns_core::error::Result<Option<Agent>> {
+        let row = self
+            .db
+            .get_agent(DEFAULT_ORG_ID, id)
+            .await
+            .map_err(|e| store_error(format!("Failed to get agent: {e}")))?;
+
+        match row {
+            Some(row) => {
+                let caps = self
+                    .db
+                    .get_agent_capabilities(row.id.uuid())
+                    .await
+                    .map_err(|e| store_error(format!("Failed to get agent capabilities: {e}")))?
+                    .into_iter()
+                    .map(|c| {
+                        everruns_core::AgentCapabilityConfig::with_config(c.capability_id, c.config)
+                    })
+                    .collect();
+                Ok(Some(Self::row_to_agent(row, caps)))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn create_agent(
+        &self,
+        name: &str,
+        description: Option<&str>,
+        system_prompt: &str,
+        capabilities: &[String],
+    ) -> everruns_core::error::Result<Agent> {
+        use crate::storage::models::CreateAgentRow;
+
+        let public_id = everruns_core::generate_agent_public_id();
+        let input = CreateAgentRow {
+            public_id: public_id.to_string(),
+            name: name.to_string(),
+            description: description.map(|s| s.to_string()),
+            system_prompt: system_prompt.to_string(),
+            default_model_id: None,
+            tags: vec!["managed".to_string()],
+            tools: serde_json::Value::Array(vec![]),
+        };
+        let row = self
+            .db
+            .create_agent(DEFAULT_ORG_ID, input)
+            .await
+            .map_err(|e| store_error(format!("Failed to create agent: {e}")))?;
+
+        // Set capabilities
+        if !capabilities.is_empty() {
+            let caps: Vec<(String, i32, serde_json::Value)> = capabilities
+                .iter()
+                .enumerate()
+                .map(|(i, c)| {
+                    (
+                        c.clone(),
+                        i as i32,
+                        serde_json::Value::Object(Default::default()),
+                    )
+                })
+                .collect();
+            self.db
+                .set_agent_capabilities(row.id.uuid(), caps)
+                .await
+                .map_err(|e| store_error(format!("Failed to set agent capabilities: {e}")))?;
+        }
+
+        self.get_agent_by_id(row.id)
+            .await?
+            .ok_or_else(|| store_error("Agent not found after create"))
+    }
+
+    async fn update_agent(
+        &self,
+        id: AgentId,
+        name: Option<&str>,
+        description: Option<&str>,
+        system_prompt: Option<&str>,
+    ) -> everruns_core::error::Result<Agent> {
+        use crate::storage::models::UpdateAgent;
+
+        let update = UpdateAgent {
+            name: name.map(|s| s.to_string()),
+            description: description.map(|s| s.to_string()),
+            system_prompt: system_prompt.map(|s| s.to_string()),
+            ..Default::default()
+        };
+        self.db
+            .update_agent(DEFAULT_ORG_ID, id, update)
+            .await
+            .map_err(|e| store_error(format!("Failed to update agent: {e}")))?;
+
+        self.get_agent_by_id(id)
+            .await?
+            .ok_or_else(|| store_error("Agent not found after update"))
+    }
+
+    async fn delete_agent(&self, id: AgentId) -> everruns_core::error::Result<()> {
+        self.db
+            .delete_agent(DEFAULT_ORG_ID, id)
+            .await
+            .map_err(|e| store_error(format!("Failed to delete agent: {e}")))?;
+        Ok(())
+    }
+
+    // =========================================================================
+    // Session Operations
+    // =========================================================================
+
+    async fn list_sessions(
+        &self,
+        limit: Option<usize>,
+        agent_id: Option<AgentId>,
+    ) -> everruns_core::error::Result<Vec<Session>> {
+        use crate::api::common::Pagination;
+
+        let pagination = Pagination {
+            offset: 0,
+            limit: limit.unwrap_or(20) as u32,
+        };
+        let (rows, _total) = self
+            .db
+            .list_sessions(DEFAULT_ORG_ID, agent_id, pagination)
+            .await
+            .map_err(|e| store_error(format!("Failed to list sessions: {e}")))?;
+
+        Ok(rows.into_iter().map(Self::row_to_session).collect())
+    }
+
+    async fn create_session(
+        &self,
+        harness_id: HarnessId,
+        agent_id: Option<AgentId>,
+        title: Option<&str>,
+    ) -> everruns_core::error::Result<Session> {
+        use crate::storage::models::CreateSessionRow;
+
+        let input = CreateSessionRow {
+            org_id: DEFAULT_ORG_ID,
+            harness_id: Some(harness_id),
+            agent_id,
+            title: title.map(|s| s.to_string()),
+            tags: vec!["managed".to_string()],
+            model_id: None,
+            capabilities: serde_json::Value::Array(vec![]),
+            tools: serde_json::Value::Array(vec![]),
+        };
+        let row = self
+            .db
+            .create_session(input)
+            .await
+            .map_err(|e| store_error(format!("Failed to create session: {e}")))?;
+
+        Ok(Self::row_to_session(row))
+    }
+
+    async fn get_session_by_id(
+        &self,
+        id: SessionId,
+    ) -> everruns_core::error::Result<Option<Session>> {
+        let row = self
+            .db
+            .get_session(DEFAULT_ORG_ID, id)
+            .await
+            .map_err(|e| store_error(format!("Failed to get session: {e}")))?;
+
+        Ok(row.map(Self::row_to_session))
+    }
+
+    async fn delete_session(&self, id: SessionId) -> everruns_core::error::Result<()> {
+        self.db
+            .delete_session(DEFAULT_ORG_ID, id)
+            .await
+            .map_err(|e| store_error(format!("Failed to delete session: {e}")))?;
+        Ok(())
+    }
+
+    // =========================================================================
+    // Messaging
+    // =========================================================================
+
+    async fn send_message(
+        &self,
+        session_id: SessionId,
+        content: &str,
+    ) -> everruns_core::error::Result<()> {
+        use everruns_core::events::{EventContext, InputMessageData};
+
+        // Get session to retrieve harness_id and agent_id
+        let session = self
+            .get_session_by_id(session_id)
+            .await?
+            .ok_or_else(|| store_error("Session not found"))?;
+
+        let message_id = everruns_core::typed_id::MessageId::new();
+        let now = chrono::Utc::now();
+
+        // Build input message
+        let core_message = everruns_core::Message {
+            id: message_id,
+            role: everruns_core::MessageRole::User,
+            content: vec![everruns_core::ContentPart::text(content)],
+            thinking: None,
+            thinking_signature: None,
+            controls: None,
+            metadata: None,
+            created_at: now,
+        };
+
+        // Emit input.message event
+        self.event_service
+            .emit(EventRequest::new(
+                session_id,
+                EventContext::empty(),
+                InputMessageData::new(core_message),
+            ))
+            .await
+            .map_err(|e| store_error(format!("Failed to emit input message: {e}")))?;
+
+        // Start turn workflow via runner
+        if let Some(ref runner) = self.runner {
+            runner
+                .start_run(
+                    DEFAULT_ORG_ID,
+                    session_id,
+                    session.harness_id,
+                    session.agent_id,
+                    message_id,
+                )
+                .await
+                .map_err(|e| store_error(format!("Failed to start turn: {e}")))?;
+        } else {
+            tracing::warn!("No runner available - message stored but turn not started");
+        }
+
+        Ok(())
+    }
+
+    async fn get_messages(
+        &self,
+        session_id: SessionId,
+        limit: Option<usize>,
+    ) -> everruns_core::error::Result<Vec<everruns_core::platform_store::PlatformMessage>> {
+        let limit_i32 = limit.unwrap_or(10) as i32;
+        let events = self
+            .db
+            .list_message_events_limited(session_id, Some(limit_i32))
+            .await
+            .map_err(|e| store_error(format!("Failed to get messages: {e}")))?;
+
+        let messages = events
+            .into_iter()
+            .filter_map(|ev| {
+                let role = match ev.event_type.as_str() {
+                    "input.message" => "user".to_string(),
+                    "output.message.completed" => "agent".to_string(),
+                    _ => return None,
+                };
+
+                // Extract text content from the event data
+                let content = ev
+                    .data
+                    .get("message")
+                    .and_then(|m| m.get("content"))
+                    .and_then(|c| c.as_array())
+                    .map(|parts| {
+                        parts
+                            .iter()
+                            .filter_map(|p| {
+                                if p.get("type").and_then(|t| t.as_str()) == Some("text") {
+                                    p.get("text")
+                                        .and_then(|t| t.as_str())
+                                        .map(|s| s.to_string())
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect::<Vec<_>>()
+                            .join("\n")
+                    })
+                    .unwrap_or_default();
+
+                if content.is_empty() {
+                    return None;
+                }
+
+                Some(everruns_core::platform_store::PlatformMessage {
+                    role,
+                    content,
+                    created_at: ev.ts,
+                })
+            })
+            .collect();
+
+        Ok(messages)
+    }
+
+    // =========================================================================
+    // Turn Management
+    // =========================================================================
+
+    async fn wait_for_idle(
+        &self,
+        session_id: SessionId,
+        timeout_secs: Option<u64>,
+    ) -> everruns_core::error::Result<String> {
+        let timeout = std::time::Duration::from_secs(timeout_secs.unwrap_or(120));
+        let start = std::time::Instant::now();
+        let poll_interval = std::time::Duration::from_millis(500);
+
+        loop {
+            let session = self
+                .get_session_by_id(session_id)
+                .await?
+                .ok_or_else(|| store_error("Session not found"))?;
+
+            match session.status {
+                SessionStatus::Idle => return Ok("idle".to_string()),
+                SessionStatus::Started => {
+                    // Not yet active, keep waiting
+                }
+                SessionStatus::Active => {
+                    // Turn in progress, keep waiting
+                }
+                SessionStatus::WaitingForToolResults => {
+                    return Ok("waiting_for_tool_results".to_string());
+                }
+            }
+
+            if start.elapsed() > timeout {
+                return Ok(format!("timeout (last status: {:?})", session.status));
+            }
+
+            tokio::time::sleep(poll_interval).await;
+        }
+    }
+
+    // =========================================================================
+    // UI Links
+    // =========================================================================
+
+    fn base_url(&self) -> &str {
+        // Leak a static string from env for lifetime reasons
+        // This is called infrequently and the value is stable
+        Box::leak(Self::base_url_from_env().into_boxed_str())
     }
 }
 

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -49,6 +49,8 @@ mod seed_ids {
         Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000107);
     pub const DAYTONA_CODER_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000108);
     pub const CLOUD_INFRA_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000109);
+    pub const PLATFORM_MANAGER_AGENT: Uuid =
+        Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000010a);
 
     // MCP Servers (0x500-0x5FF)
     pub const MS_LEARN_MCP: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000501);
@@ -756,6 +758,70 @@ Verify each action by re-listing the affected resource type.
             "seed",
         ],
         capabilities: &["fake_aws", "current_time", "session_file_system"],
+        dev_only: false,
+    },
+    SeedAgent {
+        id: seed_ids::PLATFORM_MANAGER_AGENT,
+        name: "Platform Manager",
+        description: "Manages Everruns entities: harnesses, agents, and sessions. Can create, update, delete, copy harnesses and agents, start sessions, send messages, and retrieve results.",
+        system_prompt: r#"You are a Platform Manager Agent for Everruns. You can manage the entire platform
+programmatically using the management tools available to you.
+
+## What You Can Do
+
+### Harness Management
+- List all harnesses to see what's available
+- Get details of a specific harness (including system prompt and capabilities)
+- Create new harnesses with custom system prompts and capabilities
+- Update existing harnesses (name, description, system prompt)
+- Copy a harness and modify the copy
+- Delete (archive) harnesses that are no longer needed
+
+### Agent Management
+- List all agents to see what's available
+- Get details of a specific agent
+- Create new agents with custom configurations
+- Update existing agents
+- Delete (archive) agents that are not active or needed
+
+### Session Management
+- List sessions (optionally filter by agent)
+- Create new sessions with specific harness and agent
+- Get session details and status
+- Delete old sessions
+
+### Session Interaction
+- Send messages to any session to trigger agent responses
+- Get messages from a session (default: last 10)
+- Wait for a session's turn to complete before reading the response
+
+## Common Workflows
+
+### Run an agent and get results:
+1. Create a session with the desired agent
+2. Send a message to the session
+3. Wait for idle (turn completion)
+4. Get messages to read the response
+
+### Copy and modify a harness:
+1. Get the source harness details
+2. Copy it with a new name
+3. Update the copy's system prompt or other fields
+
+### Clean up inactive agents:
+1. List all agents
+2. Identify agents with "Archived" status or that match criteria
+3. Delete the ones that should be removed
+
+All tool results include UI links so you can point users to the web interface."#,
+        tags: &["platform", "management", "admin", "seed"],
+        capabilities: &[
+            "platform_management",
+            "session_file_system",
+            "session_storage",
+            "session",
+            "current_time",
+        ],
         dev_only: false,
     },
 ];

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -795,6 +795,9 @@ async fn execute_act_activity<A: WorkerAdapters>(
     if let Some(schedule_store) = adapters.schedule_store() {
         atom = atom.with_schedule_store(schedule_store);
     }
+    if let Some(platform_store) = adapters.platform_store() {
+        atom = atom.with_platform_store(platform_store);
+    }
 
     let result = atom.execute(input.clone()).await?;
 

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -241,6 +241,12 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
     fn schedule_store(&self) -> Option<Arc<dyn everruns_core::traits::SessionScheduleStore>> {
         None
     }
+
+    /// Get the platform store for org-level management tools (if available).
+    /// Default returns None (not all backends support platform management).
+    fn platform_store(&self) -> Option<Arc<dyn everruns_core::platform_store::PlatformStore>> {
+        None
+    }
 }
 
 // =============================================================================

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -609,6 +609,67 @@ See `crates/core/src/capabilities/sample_data.rs` for a concrete example of `mou
 - **Icon**: "database"
 - **Category**: "Data"
 
+#### PlatformManagement
+
+- **Status**: Available
+- **ID**: `platform_management`
+- **Purpose**: Programmatic management of Everruns entities (harnesses, agents, sessions) via tool calls
+- **System Prompt**: Describes available management tools and common workflows
+- **Tools**:
+  - `manage_harnesses` - Harness CRUD operations
+    - Parameters:
+      - `operation`: enum (list, get, create, update, delete, copy) - The operation to perform
+      - `harness_id`: string - Required for get, update, delete, copy
+      - `name`: string - Required for create, optional for update/copy
+      - `system_prompt`: string - Required for create, optional for update
+      - `description`: string - Optional for create/update
+      - `capabilities`: string[] - Optional for create
+    - Returns: Harness data with `ui_link` for each harness
+    - Policy: Auto
+  - `manage_agents` - Agent CRUD operations
+    - Parameters:
+      - `operation`: enum (list, get, create, update, delete) - The operation to perform
+      - `agent_id`: string - Required for get, update, delete
+      - `name`: string - Required for create, optional for update
+      - `system_prompt`: string - Required for create, optional for update
+      - `description`: string - Optional for create/update
+      - `capabilities`: string[] - Optional for create
+    - Returns: Agent data with `ui_link` for each agent
+    - Policy: Auto
+  - `manage_sessions` - Session CRUD operations
+    - Parameters:
+      - `operation`: enum (list, get, create, delete) - The operation to perform
+      - `session_id`: string - Required for get, delete
+      - `harness_id`: string - Required for create
+      - `agent_id`: string - Optional for create/list
+      - `title`: string - Optional for create
+      - `limit`: integer - Optional for list
+    - Returns: Session data with `ui_link` for each session
+    - Policy: Auto
+  - `session_interact` - Session messaging and turn management
+    - Parameters:
+      - `operation`: enum (send_message, get_messages, wait_for_idle) - The operation to perform
+      - `session_id`: string - Required for all operations
+      - `content`: string - Required for send_message
+      - `limit`: integer - Optional for get_messages (default: 10)
+      - `timeout_secs`: integer - Optional for wait_for_idle (default: 300)
+    - Returns: Message data or status
+    - Policy: Auto
+- **Icon**: "settings"
+- **Category**: "Management"
+
+##### Design Decision: Context-Aware Tools
+
+All platform management tools require session context to access the `PlatformStore`. Each tool implements `requires_context() -> true` and uses `execute_with_context()`. The `ToolContext` provides a `platform_store` field with the `PlatformStore` implementation.
+
+##### Design Decision: UI Links
+
+All tool results include `ui_link` fields pointing to the relevant UI page (e.g., `/harnesses/{id}`, `/agents/{id}`, `/chat?session={id}`). This lets agents direct users to the web interface for visual management.
+
+##### Design Decision: PlatformStore Trait
+
+The `PlatformStore` trait (in `everruns-core`) defines the org-scoped management API. `DirectPlatformStore` (in `everruns-server`) implements it using the existing `StorageBackend` and `SessionService`. This keeps the capability in core while the implementation uses server-layer storage.
+
 ### Experimental Capabilities
 
 Experimental capabilities are available in development environments only (`DeploymentGrade::Dev`). They may change significantly or be removed.

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -527,14 +527,15 @@ The agent loop is a core trust boundary: an LLM decides which tools to call with
 | TM-AGENT-006 | Cost runaway — unbounded LLM calls | High | Max iterations per turn (default 100); configurable per agent | MITIGATED |
 | TM-AGENT-007 | Cost runaway — many tools per iteration | Medium | No per-iteration tool call limit; agent can invoke many tools in a single LLM response | **OPEN** |
 | TM-AGENT-008 | Context window poisoning | Medium | Auto-compaction via `llm_driver.compact()` on `RequestTooLarge`; older messages compressed | MITIGATED |
-| TM-AGENT-009 | Agent self-modification | Low | No tools for agent/session CRUD; system prompt immutable within a session | MITIGATED |
-| TM-AGENT-010 | Agent spawning agent chains | Low | No agent-creation tools; agents cannot spawn child agents or sessions | MITIGATED |
+| TM-AGENT-009 | Agent self-modification | Medium | Agents with `platform_management` capability can modify agents/sessions via tools; capability must be explicitly assigned; org-scoped | **OPEN** |
+| TM-AGENT-010 | Agent spawning agent chains | Medium | Agents with `platform_management` capability can create agents/sessions; capability must be explicitly assigned; no recursive depth limit | **OPEN** |
 | TM-AGENT-011 | Sensitive data in system prompt | Medium | System prompts stored plaintext in DB; not encrypted at rest | **OPEN** (see TM-CRYPTO-007) |
 | TM-AGENT-012 | Tool result size amplification | Medium | No size limit on tool results fed back to LLM; large results consume context and cost | **OPEN** |
 | TM-AGENT-013 | Exfiltration via web_fetch | Medium | Agent with web_fetch capability can send session data to arbitrary URLs | **ACCEPTED** |
 | TM-AGENT-014 | Confused deputy — tool call with wrong session | Low | Tool context includes session_id; tools scoped to active session only | MITIGATED |
 | TM-AGENT-015 | Dangling tool calls cause LLM confusion | Low | Patched with synthetic "cancelled" results before LLM call; prevents API errors | MITIGATED |
 | TM-AGENT-016 | Plaintext secrets in chat history | Medium | When agent asks user for API key in chat, plaintext value stored in events table as message content; session secrets encrypt separately but chat retains plaintext | **OPEN** |
+| TM-AGENT-017 | Agent-initiated entity management | High | Agents with `platform_management` can create/update/delete harnesses, agents, sessions org-wide; no fine-grained RBAC within org; capability must be explicitly assigned | **OPEN** |
 
 ### Mitigation Details
 
@@ -594,6 +595,15 @@ When an agent tool (e.g., Daytona) doesn't find an API key, it may instruct the 
 
 - **Impact:** API keys visible in session history, event exports, and any observability pipeline that captures events.
 - **Recommendation:** Prefer Settings UI for credential entry (user connections). Phase out in-chat secret collection. For tools that need credentials, guide users to Settings > Connections instead of requesting secrets in chat. See also TM-CRYPTO-007.
+- **Priority:** High
+
+**TM-AGENT-017 — Agent-Initiated Entity Management (OPEN):**
+Agents with the `platform_management` capability can create, update, and delete harnesses, agents, and sessions within their organization. They can also send messages to any session and read responses.
+
+- **Impact:** An agent could escalate privileges by creating a new agent with dangerous capabilities, modify other agents' system prompts, or spawn session chains. No fine-grained RBAC exists within the org scope.
+- **Current mitigations:** (1) Capability must be explicitly assigned by an org member. (2) All operations are org-scoped — cross-org access blocked by tenant isolation (TM-TENANT-001). (3) `DirectPlatformStore` uses existing storage layer with org_id filtering.
+- **Recommendation:** Add audit logging for all platform management tool calls. Consider RBAC (e.g., "can only manage own sessions") and approval workflows for dangerous operations (creating agents with `virtual_bash`). Add recursion depth limits for agent-spawned session chains.
+- **Code:** `// THREAT[TM-AGENT-017]` at `PlatformManagementCapability` registration and `DirectPlatformStore` implementation.
 - **Priority:** High
 
 ## 14. Bash Sandbox (TM-BASH)
@@ -773,6 +783,7 @@ Search results from Brave Search are returned as tool results. Adversarial conte
 | TM-TOOL-009 | No tool rate limiting | Medium | Per-agent tool execution rate limits |
 | TM-DOS-003 | SSE connection exhaustion | Medium | Global (10k), per-org (1k), per-session (5) limits enforced |
 | TM-AGENT-016 | Plaintext secrets in chat history | Medium | Prefer Settings UI; phase out in-chat secret collection |
+| TM-AGENT-017 | Agent-initiated entity management | High | Add RBAC for platform management; audit logging; recursion depth limits |
 | TM-CSB-002 | Unbounded sandbox creation | Medium | Add per-session sandbox count limit |
 
 ### Accepted Risks


### PR DESCRIPTION
## What
Add `platform_management` capability with 4 tools for programmatic management of Everruns entities (harnesses, agents, sessions) via agent tool calls.

## Why
Enables a Platform Manager agent pattern where an agent can orchestrate the platform: create/update/delete harnesses and agents, spawn sessions, send messages, and retrieve results — all through tool calls with UI links.

## How
- **PlatformStore trait** (everruns-core): org-scoped interface for entity CRUD + session messaging
- **PlatformManagementCapability**: 4 tools — manage_harnesses, manage_agents, manage_sessions, session_interact
- **DirectPlatformStore** (everruns-server): implementation using StorageBackend + SessionService
- **Wiring**: ToolContext.platform_store -> ActAtom -> WorkerAdapters -> DirectPlatformStore
- **Seed**: Platform Manager agent with platform_management + file system + storage + session + time capabilities
- **Tests**: 39+ unit tests covering all operations, error cases, and edge paths
- **Specs**: Updated capabilities.md and threat-model.md (TM-AGENT-009/010 reclassified, TM-AGENT-017 added)

## Risk
- Medium
- New capability is opt-in (must be explicitly assigned to agents)
- Agents with this capability get org-wide entity management (documented in TM-AGENT-017)
- No new API endpoints or DB migrations — uses existing storage layer

## Checklist
- [x] Tests added or updated (39+ tests, positive and negative paths)
- [x] Backward compatibility considered (additive only, no breaking changes)
- [x] Specs updated (capabilities.md, threat-model.md)
- [x] Threat model updated (TM-AGENT-009/010 reclassified, TM-AGENT-017 added)
- [x] Smoke tested in dev mode (capability registered, agent seeded, tools visible)
- [x] pre-push and clippy pass