### PR TITLE
fix(bench): eagerly connect SSE stream before sending messages

### DIFF
--- a/crates/server/benches/load_test.rs
+++ b/crates/server/benches/load_test.rs
@@ -7,6 +7,8 @@
 //!   Uses SDK's `EventStream` which handles automatic reconnection on
 //!   server-initiated `disconnecting` events (5-min connection cycling),
 //!   exponential backoff on errors, and resume via `since_id`.
+//!   The SSE stream is eagerly connected before the first message send
+//!   to avoid missing fast `session.idled` events from the worker.
 //!
 //! Usage:
 //!   cargo bench --package everruns-server --bench load_test
@@ -694,6 +696,9 @@ impl LoadTestRunner {
 
     /// Open an SSE stream for a session using the SDK's EventStream.
     ///
+    /// Returns a lazily-connected stream. Callers must poll it once (eager connect)
+    /// before sending messages to ensure the HTTP connection is live.
+    ///
     /// The SDK handles automatic reconnection on `disconnecting` events,
     /// exponential backoff on errors, and resume via `since_id`.
     fn open_sse_stream(&self, session_id: &str) -> everruns_sdk::sse::EventStream {
@@ -759,8 +764,40 @@ impl LoadTestRunner {
             }
         };
 
-        // Open SSE stream — SDK EventStream handles reconnection transparently
+        // Open SSE stream and eagerly connect before sending any messages.
+        //
+        // EventStream connects lazily: the HTTP connection is only established on
+        // first poll_next(). If we defer that to wait_for_idle_via_sse(), a fast
+        // worker may emit session.idled before the stream is live, missing the event.
+        // Polling here triggers connect() → HTTP GET → server sends `connected`
+        // (consumed internally by SDK) → Pending (no business events yet).
         let mut sse_stream = self.open_sse_stream(&session_id);
+        match tokio::time::timeout(Duration::from_secs(5), sse_stream.next()).await {
+            Err(_) => {
+                // Timeout — expected: connection is live, no business events yet.
+            }
+            Ok(Some(Ok(event))) => {
+                // Unexpected business event on a fresh session — not harmful,
+                // but log for visibility.
+                tracing::debug!(
+                    session_id,
+                    event_type = %event.event_type,
+                    "Received event during eager SSE connect"
+                );
+            }
+            Ok(Some(Err(e))) => {
+                self.metrics.record_error(format!(
+                    "Session {} SSE eager connect error: {}",
+                    session_num, e
+                ));
+            }
+            Ok(None) => {
+                self.metrics.record_error(format!(
+                    "Session {} SSE stream closed during eager connect",
+                    session_num
+                ));
+            }
+        }
 
         // Send messages sequentially — each waits for session.idled via SSE.
         // SDK's EventStream handles reconnection on `disconnecting` events transparently.

--- a/specs/load-testing.md
+++ b/specs/load-testing.md
@@ -32,7 +32,7 @@ Each session opens a single SSE connection (`GET /v1/sessions/{id}/sse`) after c
 3. Spawn N concurrent sessions (controlled by semaphore)
 4. Each session:
    a. Creates session via API
-   b. Opens SSE stream (`GET /v1/sessions/{id}/sse`)
+   b. Opens SSE stream (`GET /v1/sessions/{id}/sse`) and eagerly connects (polls once to establish HTTP connection before any messages are sent — prevents missing fast `session.idled` events)
    c. Sends M messages sequentially
    d. After each message: waits for `session.idled` SSE event (turn complete)
    e. Measures latency from POST /messages to `session.idled` received


### PR DESCRIPTION
## What

Eagerly connect the SSE stream in the load test before sending any messages. Previously, `EventStream` connected lazily on the first `poll_next()` call inside `wait_for_idle_via_sse()`.

## Why

The SDK's `EventStream::new()` sets `inner: None` — the actual HTTP connection is only established on the first `poll_next()`. When the first poll is deferred to `wait_for_idle_via_sse()`, a fast worker may emit `session.idled` before the SSE connection is live, causing the event to be missed and the load test to time out.

## How

After creating the SSE stream in `run_session()`, immediately poll it with a 5-second timeout. The SDK receives and consumes the server's `connected` event internally, then returns `Pending` (no business events on a fresh session). This ensures the HTTP connection is established before any message is sent.

- `crates/server/benches/load_test.rs`: Added eager connect via `tokio::time::timeout(5s, sse_stream.next())` before the message loop, with error handling for all outcomes.
- `specs/load-testing.md`: Updated flow documentation to reflect eager connection step.

## Risk

- Low
- Bench-only change. Adds a 5s timeout per session during eager connect. Could slow down session creation by up to 5s if the server is unreachable, but this is bounded and the session would fail later anyway.

## Checklist

- [x] Tests added or updated (bench-only change, verified clippy/compile)
- [x] Backward compatibility considered (N/A — internal bench tooling)