### PR TITLE
fix(docs): resolve SEO crawling issues (308 redirects, excluded pages)

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -11,6 +11,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // https://astro.build/config
 export default defineConfig({
   site: "https://docs.everruns.com",
+  trailingSlash: "always",
   vite: {
     resolve: {
       // Enable Starlight component imports from symlinked docs/ directory
@@ -80,18 +81,17 @@ export default defineConfig({
           label: "Features",
           autogenerate: { directory: "features" },
         },
-        // SRE Guide hidden for now
-        // {
-        //   label: "SRE Guide",
-        //   items: [
-        //     { label: "Environment Variables", slug: "sre/environment-variables" },
-        //     { label: "Admin Container", slug: "sre/admin-container" },
-        //     {
-        //       label: "Runbooks",
-        //       autogenerate: { directory: "sre/runbooks" },
-        //     },
-        //   ],
-        // },
+        {
+          label: "SRE Guide",
+          items: [
+            { label: "Environment Variables", slug: "sre/environment-variables" },
+            { label: "Admin Container", slug: "sre/admin-container" },
+            {
+              label: "Runbooks",
+              autogenerate: { directory: "sre/runbooks" },
+            },
+          ],
+        },
         {
           label: "Ecosystem",
           autogenerate: { directory: "ecosystem" },

--- a/apps/docs/public/_redirects
+++ b/apps/docs/public/_redirects
@@ -1,0 +1,3 @@
+# Redirect removed pages to closest relevant page
+/sre/runbooks/production-migrations/ /sre/admin-container/ 301
+/sre/runbooks/production-migrations /sre/admin-container/ 301

--- a/docs/features/sdk.mdx
+++ b/docs/features/sdk.mdx
@@ -309,13 +309,13 @@ The SDKs support all event types from the Everruns API:
 | **LLM** | `llm.generation` |
 | **Session** | `session.started`, `session.activated`, `session.idled` |
 
-See the [Events documentation](/features/events) for detailed information about event streaming.
+See the [Events documentation](/features/events/) for detailed information about event streaming.
 
 ## Resources
 
 - [GitHub Repository](https://github.com/everruns/sdk) - Source code and examples
-- [API Reference](/api) - Full API documentation
-- [Events Documentation](/features/events) - Event streaming details
+- [API Reference](/api/) - Full API documentation
+- [Events Documentation](/features/events/) - Event streaming details
 
 ## Overview Video
 

--- a/docs/getting-started/architecture.md
+++ b/docs/getting-started/architecture.md
@@ -44,10 +44,10 @@ Administrative interface for platform operators. **Not required for production u
 - Session monitoring
 - LLM provider settings
 
-See [Management UI](/features/ui) for details.
+See [Management UI](/features/ui/) for details.
 
 ## Further Reading
 
-- [Introduction](/getting-started/introduction) - Getting started
-- [API Reference](/api) - Full API documentation
-- [Capabilities](/features/capabilities) - Extend agent functionality
+- [Introduction](/getting-started/introduction/) - Getting started
+- [API Reference](/api/) - Full API documentation
+- [Capabilities](/features/capabilities/) - Extend agent functionality

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -76,7 +76,7 @@ A Capability is a modular, reusable configuration unit that extends the behavior
 - MCP servers appear as virtual capabilities with `mcp:{uuid}` IDs
 - Capabilities can depend on other capabilities, resolved in topological order
 
-See [Capabilities](/features/capabilities) for a full list and configuration details.
+See [Capabilities](/features/capabilities/) for a full list and configuration details.
 
 ### Tool
 
@@ -132,7 +132,7 @@ An Event is an immutable, append-only record. Events are the primary data store 
 - Cannot be updated or deleted
 - Carries correlation context: turn ID, input message ID, execution ID
 
-See [Events](/features/events) for the full event reference.
+See [Events](/features/events/) for the full event reference.
 
 ### File System
 

--- a/docs/getting-started/docker-compose.md
+++ b/docs/getting-started/docker-compose.md
@@ -184,6 +184,6 @@ docker compose exec worker-1 /bin/sh -c "echo" || echo "Cannot exec (distroless 
 
 ## Next Steps
 
-- [API Reference](/api) - Full API documentation
-- [Capabilities](/features/capabilities) - Extend agent functionality
-- [Environment Variables](/sre/environment-variables) - Advanced configuration
+- [API Reference](/api/) - Full API documentation
+- [Capabilities](/features/capabilities/) - Extend agent functionality
+- [Environment Variables](/sre/environment-variables/) - Advanced configuration

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -40,7 +40,7 @@ Capabilities are modular functionality units that extend agent behavior. They ca
 - Provide tools for the agent to use
 - Modify execution behavior
 
-See [Capabilities](/features/capabilities) for more details.
+See [Capabilities](/features/capabilities/) for more details.
 
 ## Getting Started
 

--- a/specs/maintenance.md
+++ b/specs/maintenance.md
@@ -191,7 +191,21 @@ Run the [code-simplifier](https://github.com/anthropics/claude-plugins-official/
 
 
 
-Run `just pre-pr` to automate checks 1-10 where possible. Manual review needed for spec accuracy, threat model, performance review, SDK parity, and AGENTS.md content.
+### 15. Docs Site SEO & Crawlability
+
+Verify the documentation site at `docs.everruns.com` is healthy for search engines and users.
+
+1. Build docs: `npm run build` in `apps/docs/` — must succeed without warnings
+2. Verify sitemap: `sitemap.xml` includes all published pages (currently 128+); no missing entries
+3. Check for orphaned pages: all built HTML pages must be reachable via sidebar navigation or cross-links — pages hidden from sidebar (e.g., commented-out SRE section) should either be restored to navigation or excluded from build
+4. Verify `robots.txt` allows all crawlers and points to correct sitemap URL
+5. Meta descriptions: spot-check 5+ pages (homepage, introduction, API operation, feature page) for `<meta name="description">` presence
+6. Page titles: verify titles are ≤70 characters and properly formatted (no raw `METHOD /path` prefixes leaking)
+7. Trailing slash consistency: confirm Astro `trailingSlash` setting aligns with hosting platform (Cloudflare Pages enforces trailing slashes via 308 redirects for directory-style URLs — this is expected behavior, not a bug)
+8. Internal links: spot-check navigation links resolve without unexpected redirects or 404s
+9. Search index: verify Pagefind search works on the built site
+
+Run `just pre-pr` to automate checks 1-10 where possible. Manual review needed for spec accuracy, threat model, performance review, SDK parity, AGENTS.md content, and docs site SEO.
 
 ## Frequency
 


### PR DESCRIPTION
## What
Fix Google Search Console issues causing 308 redirects and excluded pages on docs.everruns.com.

## Why
Google Search Console showed:
- Introduction page returning HTTP 308 (excluded from indexing)
- SRE runbook pages never crawled (no internal links, only sitemap)
- Removed production-migrations page returning 404

## How
- Add trailingSlash: always to Astro config to prevent 308 redirects
- Fix 13 internal markdown links missing trailing slashes
- Un-comment SRE Guide sidebar section for page discoverability
- Add _redirects file for removed production-migrations page

## Risk
- Low
- Docs-only change

## Checklist
- [x] Tests added or updated (docs build verified)
- [x] Backward compatibility considered