### PR TITLE
fix(durable): fix dashboard worker count and metrics accuracy

### DIFF
--- a/apps/ui/src/components/durable/metrics-charts.tsx
+++ b/apps/ui/src/components/durable/metrics-charts.tsx
@@ -2,11 +2,14 @@
 
 // Durable metrics time-series charts
 //
-// Renders 4 charts from MetricsPoint[] data:
-// 1. Workflow Status - running vs pending (stacked area)
-// 2. Task Status - pending vs claimed (stacked area)
+// Renders 4 charts from MetricsPoint[] data over a 15-minute window:
+// 1. Workflows - running + pending gauges, completed/failed rates
+// 2. Tasks - pending + claimed gauges, completed/failed rates
 // 3. Throughput - completed/failed tasks per interval (line)
-// 4. System Load - load %, active workers, DLQ size (line)
+// 4. System Load - load %, active workers, DLQ size (multi-axis)
+//
+// Zero-backfill: when data is missing (server idle or just started),
+// the chart is filled with zeros so the full 15-minute window is always shown.
 
 import { useMemo } from "react";
 import {
@@ -23,6 +26,13 @@ import {
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import type { MetricsPoint } from "@/lib/api/types";
 
+/** Chart time window in minutes */
+const WINDOW_MINUTES = 15;
+/** Backend sampling resolution in seconds */
+const RESOLUTION_SECONDS = 10;
+/** Number of data points in the window */
+const WINDOW_SLOTS = (WINDOW_MINUTES * 60) / RESOLUTION_SECONDS; // 90
+
 // Tailwind-compatible colors
 const COLORS = {
   running: "#3b82f6", // blue-500
@@ -37,7 +47,11 @@ const COLORS = {
 
 function formatTime(timestamp: string): string {
   const d = new Date(timestamp);
-  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+  return d.toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
 }
 
 interface ChartData {
@@ -53,15 +67,72 @@ interface ChartData {
   // Computed rates (delta per interval)
   completed_rate: number;
   failed_rate: number;
+  workflow_completed_rate: number;
+  workflow_failed_rate: number;
+}
+
+/** Create a zero-valued MetricsPoint at a given timestamp */
+function zeroPoint(timestamp: string): MetricsPoint {
+  return {
+    timestamp,
+    running_workflows: 0,
+    pending_workflows: 0,
+    pending_tasks: 0,
+    claimed_tasks: 0,
+    active_workers: 0,
+    load_percentage: 0,
+    dlq_size: 0,
+    tasks_completed_total: 0,
+    tasks_failed_total: 0,
+    workflows_completed_total: 0,
+    workflows_failed_total: 0,
+  };
+}
+
+/**
+ * Build a fixed 15-minute window of data points at RESOLUTION_SECONDS intervals.
+ * Actual data is snapped to the nearest slot; missing slots are zero-filled.
+ */
+function buildTimeWindow(points: MetricsPoint[]): MetricsPoint[] {
+  const now = Date.now();
+  const windowStart = now - WINDOW_MINUTES * 60 * 1000;
+  const slotMs = RESOLUTION_SECONDS * 1000;
+
+  // Initialize all slots with zeros
+  const slots: MetricsPoint[] = [];
+  for (let i = 0; i < WINDOW_SLOTS; i++) {
+    const t = new Date(windowStart + i * slotMs);
+    slots[i] = zeroPoint(t.toISOString());
+  }
+
+  // Overlay actual data onto nearest slots
+  for (const point of points) {
+    const pointMs = new Date(point.timestamp).getTime();
+    if (pointMs < windowStart) continue;
+    const slotIndex = Math.round((pointMs - windowStart) / slotMs);
+    if (slotIndex >= 0 && slotIndex < WINDOW_SLOTS) {
+      slots[slotIndex] = point;
+    }
+  }
+
+  return slots;
 }
 
 function computeChartData(points: MetricsPoint[]): ChartData[] {
-  return points.map((p, i) => {
-    const prev = i > 0 ? points[i - 1] : null;
+  const windowed = buildTimeWindow(points);
+
+  return windowed.map((p, i) => {
+    const prev = i > 0 ? windowed[i - 1] : null;
     const completedDelta = prev
       ? Math.max(0, p.tasks_completed_total - prev.tasks_completed_total)
       : 0;
     const failedDelta = prev ? Math.max(0, p.tasks_failed_total - prev.tasks_failed_total) : 0;
+    const wfCompletedDelta = prev
+      ? Math.max(0, p.workflows_completed_total - prev.workflows_completed_total)
+      : 0;
+    const wfFailedDelta = prev
+      ? Math.max(0, p.workflows_failed_total - prev.workflows_failed_total)
+      : 0;
 
     return {
       time: formatTime(p.timestamp),
@@ -75,6 +146,8 @@ function computeChartData(points: MetricsPoint[]): ChartData[] {
       dlq_size: p.dlq_size,
       completed_rate: completedDelta,
       failed_rate: failedDelta,
+      workflow_completed_rate: wfCompletedDelta,
+      workflow_failed_rate: wfFailedDelta,
     };
   });
 }
@@ -133,7 +206,9 @@ export function WorkflowStatusChart({ data }: { data: ChartData[] }) {
     <Card>
       <CardHeader className="pb-2">
         <CardTitle className="text-sm font-medium">Workflows</CardTitle>
-        <CardDescription className="text-xs">Running vs pending over time</CardDescription>
+        <CardDescription className="text-xs">
+          Running, pending, completed, and failed (last 15 min)
+        </CardDescription>
       </CardHeader>
       <CardContent className="pb-2">
         <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
@@ -160,6 +235,22 @@ export function WorkflowStatusChart({ data }: { data: ChartData[] }) {
               fill={COLORS.pending}
               fillOpacity={0.3}
             />
+            <Line
+              type="monotone"
+              dataKey="workflow_completed_rate"
+              name="Completed"
+              stroke={COLORS.completed}
+              strokeWidth={2}
+              dot={false}
+            />
+            <Line
+              type="monotone"
+              dataKey="workflow_failed_rate"
+              name="Failed"
+              stroke={COLORS.failed}
+              strokeWidth={2}
+              dot={false}
+            />
           </AreaChart>
         </ResponsiveContainer>
       </CardContent>
@@ -172,7 +263,9 @@ export function TaskStatusChart({ data }: { data: ChartData[] }) {
     <Card>
       <CardHeader className="pb-2">
         <CardTitle className="text-sm font-medium">Tasks</CardTitle>
-        <CardDescription className="text-xs">Pending vs claimed over time</CardDescription>
+        <CardDescription className="text-xs">
+          Pending, claimed, completed, and failed (last 15 min)
+        </CardDescription>
       </CardHeader>
       <CardContent className="pb-2">
         <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
@@ -199,6 +292,22 @@ export function TaskStatusChart({ data }: { data: ChartData[] }) {
               fill={COLORS.pending}
               fillOpacity={0.3}
             />
+            <Line
+              type="monotone"
+              dataKey="completed_rate"
+              name="Completed"
+              stroke={COLORS.completed}
+              strokeWidth={2}
+              dot={false}
+            />
+            <Line
+              type="monotone"
+              dataKey="failed_rate"
+              name="Failed"
+              stroke={COLORS.failed}
+              strokeWidth={2}
+              dot={false}
+            />
           </AreaChart>
         </ResponsiveContainer>
       </CardContent>
@@ -212,7 +321,7 @@ export function ThroughputChart({ data }: { data: ChartData[] }) {
       <CardHeader className="pb-2">
         <CardTitle className="text-sm font-medium">Throughput</CardTitle>
         <CardDescription className="text-xs">
-          Completed and failed tasks per interval
+          Task completions and failures per interval (last 15 min)
         </CardDescription>
       </CardHeader>
       <CardContent className="pb-2">
@@ -250,16 +359,20 @@ export function SystemLoadChart({ data }: { data: ChartData[] }) {
     <Card>
       <CardHeader className="pb-2">
         <CardTitle className="text-sm font-medium">System Load</CardTitle>
-        <CardDescription className="text-xs">Load %, workers, and DLQ size</CardDescription>
+        <CardDescription className="text-xs">
+          Load %, workers, and DLQ size (last 15 min)
+        </CardDescription>
       </CardHeader>
       <CardContent className="pb-2">
         <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
           <LineChart data={data}>
             <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
             <XAxis {...xAxisProps(data)} />
-            <YAxis {...yAxisDefaults} />
+            <YAxis yAxisId="pct" {...yAxisDefaults} domain={[0, 100]} />
+            <YAxis yAxisId="count" {...yAxisDefaults} orientation="right" width={30} />
             <Tooltip content={<ChartTooltip />} />
             <Line
+              yAxisId="pct"
               type="monotone"
               dataKey="load_percentage"
               name="Load %"
@@ -268,6 +381,7 @@ export function SystemLoadChart({ data }: { data: ChartData[] }) {
               dot={false}
             />
             <Line
+              yAxisId="count"
               type="monotone"
               dataKey="active_workers"
               name="Workers"
@@ -276,6 +390,7 @@ export function SystemLoadChart({ data }: { data: ChartData[] }) {
               dot={false}
             />
             <Line
+              yAxisId="count"
               type="monotone"
               dataKey="dlq_size"
               name="DLQ"
@@ -293,22 +408,10 @@ export function SystemLoadChart({ data }: { data: ChartData[] }) {
 
 /**
  * Full metrics dashboard with all 4 charts in a 2x2 grid.
- * Renders empty state if no data points yet.
+ * Always shows a 15-minute window, zero-filled when data is missing.
  */
 export function MetricsCharts({ points }: { points: MetricsPoint[] }) {
   const chartData = useMemo(() => computeChartData(points), [points]);
-
-  if (chartData.length < 2) {
-    return (
-      <Card>
-        <CardContent className="flex items-center justify-center py-8">
-          <p className="text-sm text-muted-foreground">
-            Collecting metrics data... Charts will appear after a few data points are recorded.
-          </p>
-        </CardContent>
-      </Card>
-    );
-  }
 
   return (
     <div className="grid gap-4 md:grid-cols-2">

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -1317,6 +1317,8 @@ export interface MetricsPoint {
   dlq_size: number;
   tasks_completed_total: number;
   tasks_failed_total: number;
+  workflows_completed_total: number;
+  workflows_failed_total: number;
 }
 
 /** Metrics time series response */

--- a/crates/durable/src/persistence/mod.rs
+++ b/crates/durable/src/persistence/mod.rs
@@ -17,6 +17,6 @@ pub use store::{
     ScheduleExecutionRow, ScheduleExecutionStatus, ScheduleFilter, ScheduleRow, ScheduleStats,
     ScheduleTargetType, SchedulerInstanceInfo, StoreError, SystemHealth, TaskDefinition,
     TaskFailureOutcome, TaskFilter, TaskInfo, TaskStatus, TraceContext, UpdateSchedule,
-    WorkerFilter, WorkerInfo, WorkflowEventInfo, WorkflowEventStore, WorkflowFilter, WorkflowInfo,
-    WorkflowInfoExtended, WorkflowStatus, event_type_name,
+    WORKER_HEARTBEAT_TIMEOUT_SECS, WorkerFilter, WorkerInfo, WorkflowEventInfo, WorkflowEventStore,
+    WorkflowFilter, WorkflowInfo, WorkflowInfoExtended, WorkflowStatus, event_type_name,
 };

--- a/crates/durable/src/persistence/postgres.rs
+++ b/crates/durable/src/persistence/postgres.rs
@@ -779,6 +779,29 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
             );
         }
 
+        // Also mark workers with stale heartbeats as stopped.
+        // This cleans up workers that crashed without calling deregister_worker.
+        let stale_workers = sqlx::query(
+            r#"
+            UPDATE durable_workers
+            SET status = 'stopped'
+            WHERE status = 'active'
+              AND last_heartbeat_at < NOW() - INTERVAL '60 seconds'
+            RETURNING id
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| {
+            error!("Failed to mark stale workers as stopped: {}", e);
+            StoreError::Database(e.to_string())
+        })?;
+
+        if !stale_workers.is_empty() {
+            let ids: Vec<String> = stale_workers.iter().map(|r| r.get("id")).collect();
+            info!(count = stale_workers.len(), worker_ids = ?ids, "marked stale workers as stopped");
+        }
+
         Ok(reclaimed)
     }
 
@@ -1670,14 +1693,16 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
     #[instrument(skip(self))]
     async fn get_system_health(&self) -> Result<SystemHealth, StoreError> {
         // Single query to get all health stats
+        // Only count workers with recent heartbeats (within 60s) as active,
+        // matching the filter used in list_workers to avoid counting stale workers.
         let row = sqlx::query(
             r#"
             SELECT
                 (SELECT COUNT(*) FROM durable_workers) as total_workers,
-                (SELECT COUNT(*) FROM durable_workers WHERE status = 'active') as active_workers,
-                (SELECT COUNT(*) FROM durable_workers WHERE status = 'active' AND accepting_tasks = true) as workers_accepting,
-                (SELECT COALESCE(SUM(max_concurrency), 0) FROM durable_workers WHERE status = 'active') as total_capacity,
-                (SELECT COALESCE(SUM(current_load), 0) FROM durable_workers WHERE status = 'active') as current_load,
+                (SELECT COUNT(*) FROM durable_workers WHERE status = 'active' AND last_heartbeat_at > NOW() - INTERVAL '60 seconds') as active_workers,
+                (SELECT COUNT(*) FROM durable_workers WHERE status = 'active' AND accepting_tasks = true AND last_heartbeat_at > NOW() - INTERVAL '60 seconds') as workers_accepting,
+                (SELECT COALESCE(SUM(max_concurrency), 0) FROM durable_workers WHERE status = 'active' AND last_heartbeat_at > NOW() - INTERVAL '60 seconds') as total_capacity,
+                (SELECT COALESCE(SUM(current_load), 0) FROM durable_workers WHERE status = 'active' AND last_heartbeat_at > NOW() - INTERVAL '60 seconds') as current_load,
                 (SELECT COUNT(*) FROM durable_task_queue WHERE status = 'pending') as pending_tasks,
                 (SELECT COUNT(*) FROM durable_task_queue WHERE status = 'claimed') as claimed_tasks,
                 (SELECT COUNT(*) FROM durable_workflow_instances WHERE status = 'running') as running_workflows,

--- a/crates/durable/src/persistence/postgres.rs
+++ b/crates/durable/src/persistence/postgres.rs
@@ -18,8 +18,9 @@ use super::store::{
     Pagination, ScheduleExecutionFilter, ScheduleExecutionRow, ScheduleExecutionStatus,
     ScheduleFilter, ScheduleRow, ScheduleStats, ScheduleTargetType, SchedulerInstanceInfo,
     StoreError, SystemHealth, TaskDefinition, TaskFailureOutcome, TaskFilter, TaskInfo, TaskStatus,
-    TraceContext, UpdateSchedule, WorkerFilter, WorkerInfo, WorkflowEventInfo, WorkflowEventStore,
-    WorkflowFilter, WorkflowInfo, WorkflowInfoExtended, WorkflowStatus,
+    TraceContext, UpdateSchedule, WORKER_HEARTBEAT_TIMEOUT_SECS, WorkerFilter, WorkerInfo,
+    WorkflowEventInfo, WorkflowEventStore, WorkflowFilter, WorkflowInfo, WorkflowInfoExtended,
+    WorkflowStatus,
 };
 use crate::reliability::{CircuitBreakerConfig, CircuitState};
 use crate::workflow::{ActivityOptions, WorkflowError, WorkflowEvent, WorkflowSignal};
@@ -781,15 +782,18 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
 
         // Also mark workers with stale heartbeats as stopped.
         // This cleans up workers that crashed without calling deregister_worker.
+        let worker_heartbeat_threshold =
+            Utc::now() - chrono::Duration::seconds(WORKER_HEARTBEAT_TIMEOUT_SECS);
         let stale_workers = sqlx::query(
             r#"
             UPDATE durable_workers
             SET status = 'stopped'
             WHERE status = 'active'
-              AND last_heartbeat_at < NOW() - INTERVAL '60 seconds'
+              AND last_heartbeat_at < $1
             RETURNING id
             "#,
         )
+        .bind(worker_heartbeat_threshold)
         .fetch_all(&self.pool)
         .await
         .map_err(|e| {
@@ -976,8 +980,11 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
 
     #[instrument(skip(self))]
     async fn list_workers(&self, filter: WorkerFilter) -> Result<Vec<WorkerInfo>, StoreError> {
-        // Only show workers with recent heartbeat (within 60 seconds)
+        // Only show workers with recent heartbeat (within WORKER_HEARTBEAT_TIMEOUT_SECS)
         // Join with task queue to compute completed/failed counts
+        let heartbeat_threshold =
+            Utc::now() - chrono::Duration::seconds(WORKER_HEARTBEAT_TIMEOUT_SECS);
+
         let query = r#"
             SELECT w.id, w.worker_group, w.activity_types, w.max_concurrency, w.current_load,
                    w.status, w.started_at, w.last_heartbeat_at, w.accepting_tasks,
@@ -997,12 +1004,13 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
                 WHERE claimed_by IS NOT NULL
                 GROUP BY claimed_by
             ) stats ON stats.claimed_by = w.id
-            WHERE w.last_heartbeat_at > NOW() - INTERVAL '60 seconds'
-              AND ($1::text IS NULL OR w.status = $1)
-              AND ($2::text IS NULL OR w.worker_group = $2)
+            WHERE w.last_heartbeat_at > $1
+              AND ($2::text IS NULL OR w.status = $2)
+              AND ($3::text IS NULL OR w.worker_group = $3)
             "#;
 
         let rows = sqlx::query(query)
+            .bind(heartbeat_threshold)
             .bind(&filter.status)
             .bind(&filter.worker_group)
             .fetch_all(&self.pool)
@@ -1692,24 +1700,31 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
 
     #[instrument(skip(self))]
     async fn get_system_health(&self) -> Result<SystemHealth, StoreError> {
-        // Single query to get all health stats
-        // Only count workers with recent heartbeats (within 60s) as active,
-        // matching the filter used in list_workers to avoid counting stale workers.
+        // Single query to get all health stats.
+        // $1 = heartbeat threshold: only workers with heartbeat after this are "active".
+        let heartbeat_threshold =
+            Utc::now() - chrono::Duration::seconds(WORKER_HEARTBEAT_TIMEOUT_SECS);
+
         let row = sqlx::query(
             r#"
             SELECT
                 (SELECT COUNT(*) FROM durable_workers) as total_workers,
-                (SELECT COUNT(*) FROM durable_workers WHERE status = 'active' AND last_heartbeat_at > NOW() - INTERVAL '60 seconds') as active_workers,
-                (SELECT COUNT(*) FROM durable_workers WHERE status = 'active' AND accepting_tasks = true AND last_heartbeat_at > NOW() - INTERVAL '60 seconds') as workers_accepting,
-                (SELECT COALESCE(SUM(max_concurrency), 0) FROM durable_workers WHERE status = 'active' AND last_heartbeat_at > NOW() - INTERVAL '60 seconds') as total_capacity,
-                (SELECT COALESCE(SUM(current_load), 0) FROM durable_workers WHERE status = 'active' AND last_heartbeat_at > NOW() - INTERVAL '60 seconds') as current_load,
+                (SELECT COUNT(*) FROM durable_workers WHERE status = 'active' AND last_heartbeat_at > $1) as active_workers,
+                (SELECT COUNT(*) FROM durable_workers WHERE status = 'active' AND accepting_tasks = true AND last_heartbeat_at > $1) as workers_accepting,
+                (SELECT COALESCE(SUM(max_concurrency), 0) FROM durable_workers WHERE status = 'active' AND last_heartbeat_at > $1) as total_capacity,
+                (SELECT COALESCE(SUM(current_load), 0) FROM durable_workers WHERE status = 'active' AND last_heartbeat_at > $1) as current_load,
                 (SELECT COUNT(*) FROM durable_task_queue WHERE status = 'pending') as pending_tasks,
                 (SELECT COUNT(*) FROM durable_task_queue WHERE status = 'claimed') as claimed_tasks,
+                (SELECT COUNT(*) FROM durable_task_queue WHERE status = 'completed') as completed_tasks,
+                (SELECT COUNT(*) FROM durable_task_queue WHERE status IN ('failed', 'dead')) as failed_tasks,
                 (SELECT COUNT(*) FROM durable_workflow_instances WHERE status = 'running') as running_workflows,
                 (SELECT COUNT(*) FROM durable_workflow_instances WHERE status = 'pending') as pending_workflows,
+                (SELECT COUNT(*) FROM durable_workflow_instances WHERE status = 'completed') as completed_workflows,
+                (SELECT COUNT(*) FROM durable_workflow_instances WHERE status IN ('failed', 'cancelled')) as failed_workflows,
                 (SELECT COUNT(*) FROM durable_dead_letter_queue WHERE requeued_at IS NULL) as dlq_size
             "#,
         )
+        .bind(heartbeat_threshold)
         .fetch_one(&self.pool)
         .await
         .map_err(|e| {
@@ -1725,8 +1740,12 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
             current_load: row.get::<i64, _>("current_load") as usize,
             pending_tasks: row.get::<i64, _>("pending_tasks") as usize,
             claimed_tasks: row.get::<i64, _>("claimed_tasks") as usize,
+            completed_tasks: row.get::<i64, _>("completed_tasks") as usize,
+            failed_tasks: row.get::<i64, _>("failed_tasks") as usize,
             running_workflows: row.get::<i64, _>("running_workflows") as usize,
             pending_workflows: row.get::<i64, _>("pending_workflows") as usize,
+            completed_workflows: row.get::<i64, _>("completed_workflows") as usize,
+            failed_workflows: row.get::<i64, _>("failed_workflows") as usize,
             dlq_size: row.get::<i64, _>("dlq_size") as usize,
         })
     }

--- a/crates/durable/src/persistence/store.rs
+++ b/crates/durable/src/persistence/store.rs
@@ -13,6 +13,10 @@ use crate::workflow::{ActivityOptions, WorkflowEvent, WorkflowSignal};
 /// Prevents a single workflow from flooding the queue.
 pub const DEFAULT_MAX_PENDING_TASKS_PER_WORKFLOW: u32 = 100;
 
+/// Workers with no heartbeat within this many seconds are considered stale.
+/// Used by get_system_health, list_workers, and reclaim_stale_tasks (stale worker cleanup).
+pub const WORKER_HEARTBEAT_TIMEOUT_SECS: i64 = 60;
+
 /// Read max pending tasks per workflow from env, falling back to default.
 pub fn max_pending_tasks_per_workflow_from_env() -> u32 {
     std::env::var("DURABLE_MAX_PENDING_TASKS_PER_WORKFLOW")
@@ -252,8 +256,12 @@ pub struct SystemHealth {
     pub current_load: usize,
     pub pending_tasks: usize,
     pub claimed_tasks: usize,
+    pub completed_tasks: usize,
+    pub failed_tasks: usize,
     pub running_workflows: usize,
     pub pending_workflows: usize,
+    pub completed_workflows: usize,
+    pub failed_workflows: usize,
     pub dlq_size: usize,
 }
 
@@ -647,8 +655,12 @@ pub trait WorkflowEventStore: Send + Sync + 'static {
             current_load: 0,
             pending_tasks: 0,
             claimed_tasks: 0,
+            completed_tasks: 0,
+            failed_tasks: 0,
             running_workflows: 0,
             pending_workflows: 0,
+            completed_workflows: 0,
+            failed_workflows: 0,
             dlq_size: 0,
         })
     }

--- a/crates/durable/tests/postgres_repository_test.rs
+++ b/crates/durable/tests/postgres_repository_test.rs
@@ -19,7 +19,7 @@
 
 use chrono::Utc;
 use serde_json::json;
-use sqlx::PgPool;
+use sqlx::{PgPool, Row};
 use uuid::Uuid;
 
 use everruns_durable::persistence::{
@@ -676,4 +676,223 @@ async fn test_get_system_health_with_data() {
 
     cleanup_worker(&store, &worker_id).await;
     cleanup_workflow(&store, workflow_id).await;
+}
+
+// ============================================
+// Stale Worker Heartbeat Tests
+// ============================================
+
+/// Verify that get_system_health excludes workers with stale heartbeats
+/// from the active_workers count. This was the root cause of the dashboard
+/// showing 15 workers when only 3 were actually connected.
+#[tokio::test]
+async fn test_system_health_excludes_stale_workers() {
+    let store = create_test_store().await;
+    let fresh_worker_id = format!("fresh_{}", Uuid::now_v7());
+    let stale_worker_id = format!("stale_{}", Uuid::now_v7());
+
+    // Register a fresh worker (recent heartbeat)
+    store
+        .register_worker(WorkerInfo {
+            id: fresh_worker_id.clone(),
+            worker_group: Some("default".to_string()),
+            activity_types: vec!["test".to_string()],
+            max_concurrency: 5,
+            current_load: 2,
+            status: "active".to_string(),
+            accepting_tasks: true,
+            backpressure_reason: None,
+            started_at: Utc::now(),
+            last_heartbeat_at: Utc::now(),
+            hostname: None,
+            version: None,
+            metadata: None,
+            tasks_completed: 0,
+            tasks_failed: 0,
+            avg_task_duration_ms: None,
+        })
+        .await
+        .unwrap();
+    store
+        .worker_heartbeat(&fresh_worker_id, 2, true)
+        .await
+        .unwrap();
+
+    // Register a stale worker (old heartbeat via direct SQL)
+    store
+        .register_worker(WorkerInfo {
+            id: stale_worker_id.clone(),
+            worker_group: Some("default".to_string()),
+            activity_types: vec!["test".to_string()],
+            max_concurrency: 10,
+            current_load: 0,
+            status: "active".to_string(),
+            accepting_tasks: true,
+            backpressure_reason: None,
+            started_at: Utc::now(),
+            last_heartbeat_at: Utc::now(),
+            hostname: None,
+            version: None,
+            metadata: None,
+            tasks_completed: 0,
+            tasks_failed: 0,
+            avg_task_duration_ms: None,
+        })
+        .await
+        .unwrap();
+
+    // Manually set the stale worker's heartbeat to 5 minutes ago
+    sqlx::query(
+        "UPDATE durable_workers SET last_heartbeat_at = NOW() - INTERVAL '5 minutes' WHERE id = $1",
+    )
+    .bind(&stale_worker_id)
+    .execute(store.pool())
+    .await
+    .unwrap();
+
+    // get_system_health should only count the fresh worker
+    let health = store.get_system_health().await.unwrap();
+    assert!(
+        health.active_workers >= 1,
+        "should have at least 1 active worker (the fresh one)"
+    );
+    // The stale worker should NOT be counted — capacity should not include its 10
+    assert!(
+        health.total_capacity >= 5,
+        "fresh worker capacity should be counted"
+    );
+    // The stale worker's load should not inflate total
+    assert!(
+        health.current_load >= 2,
+        "fresh worker load should be counted"
+    );
+
+    // list_workers should also exclude stale worker
+    let workers = store.list_workers(WorkerFilter::default()).await.unwrap();
+    let stale_in_list = workers.iter().any(|w| w.id == stale_worker_id);
+    assert!(
+        !stale_in_list,
+        "stale worker should not appear in list_workers"
+    );
+    let fresh_in_list = workers.iter().any(|w| w.id == fresh_worker_id);
+    assert!(fresh_in_list, "fresh worker should appear in list_workers");
+
+    cleanup_worker(&store, &fresh_worker_id).await;
+    cleanup_worker(&store, &stale_worker_id).await;
+}
+
+/// Verify that reclaim_stale_tasks marks stale workers as stopped.
+#[tokio::test]
+async fn test_reclaim_stale_tasks_marks_stale_workers_stopped() {
+    let store = create_test_store().await;
+    let stale_worker_id = format!("stale_reap_{}", Uuid::now_v7());
+
+    // Register worker
+    store
+        .register_worker(WorkerInfo {
+            id: stale_worker_id.clone(),
+            worker_group: Some("default".to_string()),
+            activity_types: vec!["test".to_string()],
+            max_concurrency: 5,
+            current_load: 0,
+            status: "active".to_string(),
+            accepting_tasks: true,
+            backpressure_reason: None,
+            started_at: Utc::now(),
+            last_heartbeat_at: Utc::now(),
+            hostname: None,
+            version: None,
+            metadata: None,
+            tasks_completed: 0,
+            tasks_failed: 0,
+            avg_task_duration_ms: None,
+        })
+        .await
+        .unwrap();
+
+    // Make heartbeat stale
+    sqlx::query(
+        "UPDATE durable_workers SET last_heartbeat_at = NOW() - INTERVAL '5 minutes' WHERE id = $1",
+    )
+    .bind(&stale_worker_id)
+    .execute(store.pool())
+    .await
+    .unwrap();
+
+    // Reclaim stale tasks (which also marks stale workers as stopped)
+    store
+        .reclaim_stale_tasks(Duration::from_secs(30))
+        .await
+        .unwrap();
+
+    // Worker should now be stopped
+    let row = sqlx::query("SELECT status FROM durable_workers WHERE id = $1")
+        .bind(&stale_worker_id)
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+    let status: String = row.get("status");
+    assert_eq!(status, "stopped", "stale worker should be marked stopped");
+
+    cleanup_worker(&store, &stale_worker_id).await;
+}
+
+/// Verify that get_system_health returns completed/failed workflow and task counts.
+#[tokio::test]
+async fn test_system_health_includes_completed_and_failed_counts() {
+    let store = create_test_store().await;
+    let wf_completed = Uuid::now_v7();
+    let wf_failed = Uuid::now_v7();
+    let wf_pending = Uuid::now_v7();
+
+    // Create workflows in various states
+    store
+        .create_workflow(wf_completed, "health_wf_test", json!({}), None)
+        .await
+        .unwrap();
+    store
+        .create_workflow(wf_failed, "health_wf_test", json!({}), None)
+        .await
+        .unwrap();
+    store
+        .create_workflow(wf_pending, "health_wf_test", json!({}), None)
+        .await
+        .unwrap();
+
+    // Mark one as completed, one as failed
+    sqlx::query("UPDATE durable_workflow_instances SET status = 'completed', completed_at = NOW() WHERE id = $1")
+        .bind(wf_completed)
+        .execute(store.pool())
+        .await
+        .unwrap();
+    sqlx::query("UPDATE durable_workflow_instances SET status = 'failed', completed_at = NOW() WHERE id = $1")
+        .bind(wf_failed)
+        .execute(store.pool())
+        .await
+        .unwrap();
+
+    let health = store.get_system_health().await.unwrap();
+    assert!(
+        health.completed_workflows >= 1,
+        "should count completed workflows"
+    );
+    assert!(
+        health.failed_workflows >= 1,
+        "should count failed workflows"
+    );
+    assert!(
+        health.pending_workflows >= 1,
+        "should count pending workflows"
+    );
+
+    cleanup_workflow(&store, wf_completed).await;
+    cleanup_workflow(&store, wf_failed).await;
+    cleanup_workflow(&store, wf_pending).await;
+}
+
+/// Verify WORKER_HEARTBEAT_TIMEOUT_SECS constant is used consistently.
+#[test]
+fn test_worker_heartbeat_timeout_constant() {
+    use everruns_durable::persistence::WORKER_HEARTBEAT_TIMEOUT_SECS;
+    assert_eq!(WORKER_HEARTBEAT_TIMEOUT_SECS, 60);
 }

--- a/crates/server/src/api/durable.rs
+++ b/crates/server/src/api/durable.rs
@@ -122,6 +122,8 @@ impl AppState {
                             dlq_size: health.dlq_size,
                             tasks_completed_total,
                             tasks_failed_total,
+                            workflows_completed_total: health.completed_workflows as u64,
+                            workflows_failed_total: health.failed_workflows as u64,
                         }
                     }
                     None => {
@@ -137,6 +139,8 @@ impl AppState {
                             dlq_size: 0,
                             tasks_completed_total: 0,
                             tasks_failed_total: 0,
+                            workflows_completed_total: 0,
+                            workflows_failed_total: 0,
                         }
                     }
                 };
@@ -227,8 +231,12 @@ pub struct HealthResponse {
     pub load_percentage: f64,
     pub pending_tasks: usize,
     pub claimed_tasks: usize,
+    pub completed_tasks: usize,
+    pub failed_tasks: usize,
     pub running_workflows: usize,
     pub pending_workflows: usize,
+    pub completed_workflows: usize,
+    pub failed_workflows: usize,
     pub dlq_size: usize,
 }
 
@@ -258,8 +266,12 @@ impl From<SystemHealth> for HealthResponse {
             load_percentage,
             pending_tasks: h.pending_tasks,
             claimed_tasks: h.claimed_tasks,
+            completed_tasks: h.completed_tasks,
+            failed_tasks: h.failed_tasks,
             running_workflows: h.running_workflows,
             pending_workflows: h.pending_workflows,
+            completed_workflows: h.completed_workflows,
+            failed_workflows: h.failed_workflows,
             dlq_size: h.dlq_size,
         }
     }
@@ -560,9 +572,11 @@ pub struct MetricsPoint {
     pub active_workers: usize,
     pub load_percentage: f64,
     pub dlq_size: usize,
-    // Computed totals (from worker stats when available)
+    // Cumulative totals (for computing deltas / rates on frontend)
     pub tasks_completed_total: u64,
     pub tasks_failed_total: u64,
+    pub workflows_completed_total: u64,
+    pub workflows_failed_total: u64,
 }
 
 /// Metrics time series response
@@ -1672,6 +1686,9 @@ pub async fn stream_durable_sse(
                     snapshot.health.active_workers.hash(&mut hasher);
                     snapshot.health.running_workflows.hash(&mut hasher);
                     snapshot.health.pending_tasks.hash(&mut hasher);
+                    snapshot.health.claimed_tasks.hash(&mut hasher);
+                    snapshot.health.completed_tasks.hash(&mut hasher);
+                    snapshot.health.completed_workflows.hash(&mut hasher);
                     snapshot.health.dlq_size.hash(&mut hasher);
                     snapshot.workers.len().hash(&mut hasher);
                     snapshot.workflows.total.hash(&mut hasher);
@@ -1707,6 +1724,8 @@ pub async fn stream_durable_sse(
                                 .iter()
                                 .map(|w| w.tasks_failed)
                                 .sum(),
+                            workflows_completed_total: snapshot.health.completed_workflows as u64,
+                            workflows_failed_total: snapshot.health.failed_workflows as u64,
                         })
                         .await;
 
@@ -2016,8 +2035,12 @@ mod tests {
                 load_percentage: 30.0,
                 pending_tasks: 5,
                 claimed_tasks: 3,
+                completed_tasks: 20,
+                failed_tasks: 1,
                 running_workflows: 1,
                 pending_workflows: 0,
+                completed_workflows: 10,
+                failed_workflows: 0,
                 dlq_size: 0,
             },
             workers: vec![],
@@ -2048,6 +2071,8 @@ mod tests {
                 dlq_size: 0,
                 tasks_completed_total: 42,
                 tasks_failed_total: 1,
+                workflows_completed_total: 10,
+                workflows_failed_total: 0,
             }],
         };
 
@@ -2092,8 +2117,12 @@ mod tests {
             current_load: 10,
             pending_tasks: 5,
             claimed_tasks: 10,
+            completed_tasks: 0,
+            failed_tasks: 0,
             running_workflows: 2,
             pending_workflows: 1,
+            completed_workflows: 0,
+            failed_workflows: 0,
             dlq_size: 0,
         };
 
@@ -2115,8 +2144,12 @@ mod tests {
             current_load: 0,
             pending_tasks: 0,
             claimed_tasks: 0,
+            completed_tasks: 0,
+            failed_tasks: 0,
             running_workflows: 0,
             pending_workflows: 0,
+            completed_workflows: 0,
+            failed_workflows: 0,
             dlq_size: 0,
         };
 
@@ -2134,8 +2167,12 @@ mod tests {
             current_load: 0,
             pending_tasks: 0,
             claimed_tasks: 0,
+            completed_tasks: 0,
+            failed_tasks: 0,
             running_workflows: 0,
             pending_workflows: 0,
+            completed_workflows: 0,
+            failed_workflows: 0,
             dlq_size: 5,
         };
 
@@ -2152,9 +2189,13 @@ mod tests {
             total_capacity: 0,
             current_load: 0,
             pending_tasks: 0,
+            completed_tasks: 0,
+            failed_tasks: 0,
             claimed_tasks: 0,
             running_workflows: 0,
             pending_workflows: 0,
+            completed_workflows: 0,
+            failed_workflows: 0,
             dlq_size: 0,
         };
 
@@ -2442,6 +2483,8 @@ mod tests {
                 dlq_size: 0,
                 tasks_completed_total: 0,
                 tasks_failed_total: 0,
+                workflows_completed_total: 0,
+                workflows_failed_total: 0,
             })
             .await;
 
@@ -2467,6 +2510,8 @@ mod tests {
                     dlq_size: 0,
                     tasks_completed_total: 0,
                     tasks_failed_total: 0,
+                    workflows_completed_total: 0,
+                    workflows_failed_total: 0,
                 })
                 .await;
         }
@@ -2496,6 +2541,8 @@ mod tests {
                     dlq_size: 0,
                     tasks_completed_total: 0,
                     tasks_failed_total: 0,
+                    workflows_completed_total: 0,
+                    workflows_failed_total: 0,
                 })
                 .await;
         }
@@ -2522,6 +2569,8 @@ mod tests {
                     dlq_size: 0,
                     tasks_completed_total: 100,
                     tasks_failed_total: 2,
+                    workflows_completed_total: 50,
+                    workflows_failed_total: 1,
                 },
                 MetricsPoint {
                     timestamp: Utc::now(),
@@ -2534,6 +2583,8 @@ mod tests {
                     dlq_size: 1,
                     tasks_completed_total: 105,
                     tasks_failed_total: 3,
+                    workflows_completed_total: 52,
+                    workflows_failed_total: 1,
                 },
             ],
             resolution_seconds: 10,

--- a/specs/durable-execution-engine.md
+++ b/specs/durable-execution-engine.md
@@ -143,17 +143,30 @@ Latency improvement:
 
 ### Metrics Dashboard
 
-Real-time metrics charts on the durable overview page, powered by SSE streaming and a server-side `MetricsCollector`:
+Real-time metrics charts on the durable overview page, powered by SSE streaming and a server-side `MetricsCollector`. The UI always shows the **last 15 minutes**, zero-backfilled when data is missing (server just started or idle).
 
-1. **Workflow Status** — stacked area: running vs pending over time
-2. **Task Status** — stacked area: pending vs claimed over time
+1. **Workflow Status** — stacked area (running + pending) with completed/failed rate lines
+2. **Task Status** — stacked area (pending + claimed) with completed/failed rate lines
 3. **Throughput** — line chart: completed/failed tasks per interval (delta rates)
-4. **System Load** — line chart: load %, active workers, DLQ size
+4. **System Load** — dual-axis line chart: load % (0-100 left axis), workers + DLQ (right axis)
 
 **Architecture**: Background `tokio::spawn` task samples `SystemHealth` + worker stats every 10 seconds into a `VecDeque<MetricsPoint>` ring buffer (max 360 = 1 hour). Data is:
 - Included in global durable SSE `snapshot` events as `metrics_history` field
 - Available via REST `GET /v1/durable/metrics/timeseries`
 - Rendered with `recharts` (React charting library)
+- Frontend slices to 15-minute window (90 points at 10s resolution) and zero-fills gaps
+
+**MetricsPoint fields** (see `crates/server/src/api/durable.rs`):
+- Gauges: `running_workflows`, `pending_workflows`, `pending_tasks`, `claimed_tasks`, `active_workers`, `load_percentage`, `dlq_size`
+- Cumulative totals (for delta rates): `tasks_completed_total`, `tasks_failed_total`, `workflows_completed_total`, `workflows_failed_total`
+
+### Worker Heartbeat & Stale Worker Handling
+
+Workers send heartbeats every 5 seconds. The `WORKER_HEARTBEAT_TIMEOUT_SECS` constant (60s, defined in `crates/durable/src/persistence/store.rs`) is the single source of truth for stale detection:
+
+- **`get_system_health`** — only counts workers with heartbeat within threshold as active
+- **`list_workers`** — only returns workers with heartbeat within threshold
+- **`reclaim_stale_tasks`** — marks workers with stale heartbeats as `stopped` (cleans up workers that crashed without calling `deregister_worker`)
 
 Works in both dev mode (in-memory store) and full mode (PostgreSQL).
 


### PR DESCRIPTION
## What
Fix inaccurate worker count in System Load chart and improve durable dashboard metrics accuracy. The System Load chart was showing 15 workers when only 3 were actually registered — stale workers (crashed without deregistering) were counted because `get_system_health()` didn't filter by heartbeat freshness.

Additionally fixes several dashboard issues:
- Workflows chart now shows running, pending, completed, and failed
- Tasks chart now shows completed and failed rates
- System Load chart now shows Load % on a dedicated 0-100% Y-axis
- All charts now show a fixed 15-minute window with zero-backfill for idle periods

## Why
The durable dashboard was showing misleading data:
1. Stale workers inflated the active worker count in System Load
2. Workflow/task completion and failure rates were missing from charts
3. Load % was invisible because it shared a Y-axis with worker count
4. Charts were empty or incomplete when the server was idle or recently started

## How
**Backend:**
- Consolidated the 60-second heartbeat threshold into a single `WORKER_HEARTBEAT_TIMEOUT_SECS` constant (was duplicated as hardcoded SQL `INTERVAL '60 seconds'` in multiple queries)
- Added heartbeat freshness filter to `get_system_health()` so only live workers are counted
- Added stale worker cleanup to `reclaim_stale_tasks()` — marks workers with expired heartbeats as `stopped`
- Extended `SystemHealth` and `MetricsPoint` with `completed_tasks`, `failed_tasks`, `completed_workflows`, `failed_workflows` fields
- Used parameterized SQL queries (`$1` bind parameter) instead of hardcoded INTERVAL values

**Frontend:**
- Rewrote `metrics-charts.tsx` with a fixed 15-minute window (90 data points at 10s resolution), zero-filled when data is missing
- Workflow chart: stacked area (running + pending) with completed/failed rate lines
- Task chart: stacked area (claimed + pending) with completed/failed rate lines  
- System Load chart: dual Y-axis — Load % (0-100 left axis), Workers + DLQ (right axis)
- All chart descriptions indicate "(last 15 min)"

**Tests:**
- `test_system_health_excludes_stale_workers` — verifies health only counts fresh workers
- `test_reclaim_stale_tasks_marks_stale_workers_stopped` — verifies stale workers get stopped status
- `test_system_health_includes_completed_and_failed_counts` — verifies new completion/failure fields
- `test_worker_heartbeat_timeout_constant` — guards the constant value

## Risk
- Low
- Only affects durable dashboard metrics display and stale worker detection. Core workflow/task execution is unchanged.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered