### PR TITLE
fix(ci): stop cancelling in-progress CI runs on main

### DIFF
--- a/.github/workflows/brave-search-integration.yml
+++ b/.github/workflows/brave-search-integration.yml
@@ -11,7 +11,7 @@ on:
       - 'integrations/brave-search/**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,10 @@ on:
   pull_request:
     branches: [main]
 
-# Cancel in-progress runs for the same PR/branch on new pushes
+# Cancel in-progress runs for the same PR/branch on new pushes.
+# On main, let every run finish so merged commits aren't silently skipped.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## What
Fix CI concurrency groups so that pushes to `main` no longer cancel in-progress runs from previous commits.

## Why
The concurrency key `github.head_ref || github.ref` resolves to `refs/heads/main` for all pushes to main, causing each merge to cancel the CI run of the previous merge. This means CI results for merged commits are silently skipped.

## How
Replace `github.ref` with `github.run_id` in the fallback. For PRs, `github.head_ref` still groups by branch (so new pushes cancel stale runs). On main, `github.head_ref` is empty, so each run gets a unique `github.run_id` — no cancellation.

Applied to both `ci.yml` and `brave-search-integration.yml`.

## Risk
- Low
- Worst case: slightly more concurrent CI runs on main (by design)

## Checklist
- [x] Tests added or updated (CI-config-only change; validated by CI itself)
- [x] Backward compatibility considered (no impact)