### PR TITLE
fix(docs): block /cdn-cgi/ in robots.txt

### DIFF
--- a/apps/docs/public/robots.txt
+++ b/apps/docs/public/robots.txt
@@ -35,5 +35,6 @@ Allow: /
 # Default
 User-agent: *
 Allow: /
+Disallow: /cdn-cgi/
 
 Sitemap: https://docs.everruns.com/sitemap.xml


### PR DESCRIPTION
## What
Add `Disallow: /cdn-cgi/` to docs robots.txt.

## Why
Cloudflare email obfuscation generates `/cdn-cgi/l/email-protection` URLs that return 4xx when crawled, showing up as errors in SEO site scans.

## How
Single-line addition to the default `User-agent: *` block in `apps/docs/public/robots.txt`.

## Risk
- Low
- No functional impact; only affects crawler behavior on Cloudflare infrastructure paths

## Checklist
- [x] Tests added or updated (N/A — static file)
- [x] Backward compatibility considered (additive change)