### PR TITLE
fix(load-test): remove SSE retry cap to use SDK default unlimited reconnects

### DIFF
--- a/crates/server/benches/load_test.rs
+++ b/crates/server/benches/load_test.rs
@@ -702,10 +702,9 @@ impl LoadTestRunner {
     /// The SDK handles automatic reconnection on `disconnecting` events,
     /// exponential backoff on errors, and resume via `since_id`.
     fn open_sse_stream(&self, session_id: &str) -> everruns_sdk::sse::EventStream {
-        self.sdk.events().stream_with_options(
-            session_id,
-            StreamOptions::exclude_deltas().with_max_retries(5),
-        )
+        self.sdk
+            .events()
+            .stream_with_options(session_id, StreamOptions::exclude_deltas())
     }
 
     /// Wait for a `session.idled` event on the SSE stream.


### PR DESCRIPTION
## What
Remove explicit `.with_max_retries(5)` from load test SSE stream setup, using the SDK's default unlimited reconnects instead.

## Why
Load test SSE streams die mid-session during the server's 5-minute connection cycling. With 50 concurrent sessions reconnecting simultaneously, transient network errors exhaust the 5-retry budget quickly. The SDK already defaults to unlimited retries with exponential backoff and counter reset on successful connect — the load test was unnecessarily overriding this.

## How
Single-line change: remove `.with_max_retries(5)` from `open_sse_stream()` in `load_test.rs`. The SDK's `StreamOptions::exclude_deltas()` already returns options with `max_retries: None` (unlimited).

## Risk
- Low
- Load test only; no production code changed. Worst case: load test retries forever on a truly dead server (which is the desired behavior — test should wait for server, not silently fail).

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered