### PR TITLE
feat(sse): add periodic heartbeat comments to all SSE streams

### DIFF
--- a/crates/server/src/api/durable.rs
+++ b/crates/server/src/api/durable.rs
@@ -1753,7 +1753,10 @@ pub async fn stream_durable_sse(
     })
     .flatten();
 
-    Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
+    let keep_alive = KeepAlive::new()
+        .interval(config.heartbeat_interval())
+        .text("heartbeat");
+    Ok(Sse::new(stream).keep_alive(keep_alive))
 }
 
 /// GET /v1/durable/workflows/:workflow_id/sse - Stream workflow state (SSE)
@@ -2009,7 +2012,10 @@ pub async fn stream_workflow_sse(
     })
     .flatten();
 
-    Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
+    let keep_alive = KeepAlive::new()
+        .interval(config.heartbeat_interval())
+        .text("heartbeat");
+    Ok(Sse::new(stream).keep_alive(keep_alive))
 }
 
 #[cfg(test)]

--- a/crates/server/src/api/events.rs
+++ b/crates/server/src/api/events.rs
@@ -503,7 +503,10 @@ pub async fn stream_sse(
         _guard: sse_guard,
     };
 
-    Ok(Sse::new(guarded_stream).keep_alive(KeepAlive::default()))
+    let keep_alive = KeepAlive::new()
+        .interval(config.heartbeat_interval())
+        .text("heartbeat");
+    Ok(Sse::new(guarded_stream).keep_alive(keep_alive))
 }
 
 /// Stream wrapper that holds an SSE connection guard until the stream is dropped.

--- a/crates/server/src/api/sse.rs
+++ b/crates/server/src/api/sse.rs
@@ -25,12 +25,18 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-/// SSE stream configuration with backoff and connection cycling parameters.
+/// SSE stream configuration with backoff, connection cycling, and heartbeat parameters.
 ///
 /// Connection cycling duration is configurable via environment variables to
 /// accommodate different proxy configurations:
 /// - `SSE_REALTIME_CYCLE_SECS` (default: 300) — session event streams
 /// - `SSE_MONITORING_CYCLE_SECS` (default: 600) — durable monitoring streams
+/// - `SSE_HEARTBEAT_INTERVAL_SECS` (default: 30) — heartbeat comment interval
+///
+/// Heartbeat comments (`: heartbeat\n\n`) are sent periodically on all SSE streams
+/// to allow clients to detect stale/half-open connections. The interval MUST be
+/// less than the client read timeout (SDK default: 60s) with safety margin.
+/// At 30s, this gives a 2x safety factor.
 ///
 /// When running behind proxies with HTTP/1.1 backends (no h2c), increase the
 /// cycling interval to reduce reconnection frequency and avoid exhausting
@@ -46,6 +52,10 @@ pub struct SseStreamConfig {
     pub max_connection_secs: u64,
     /// Retry hint for immediate reconnect after disconnecting event (ms)
     pub disconnect_retry_ms: u64,
+    /// Interval between heartbeat SSE comments (seconds).
+    /// Heartbeats are SSE comments (`: heartbeat\n\n`) invisible to event parsers
+    /// but reset the client's TCP read timer to detect stale connections.
+    pub heartbeat_interval_secs: u64,
 }
 
 impl SseStreamConfig {
@@ -61,6 +71,7 @@ impl SseStreamConfig {
             max_backoff_ms: 500,
             max_connection_secs: cycle_secs,
             disconnect_retry_ms: 100, // Fast reconnect
+            heartbeat_interval_secs: heartbeat_interval_from_env(),
         }
     }
 
@@ -76,6 +87,7 @@ impl SseStreamConfig {
             max_backoff_ms: 20000,
             max_connection_secs: cycle_secs,
             disconnect_retry_ms: 1000, // 1 second reconnect
+            heartbeat_interval_secs: heartbeat_interval_from_env(),
         }
     }
 
@@ -117,6 +129,25 @@ impl SseStreamConfig {
     pub fn disconnect_retry(&self) -> Duration {
         Duration::from_millis(self.disconnect_retry_ms)
     }
+
+    /// Get heartbeat interval for SSE keepalive comments.
+    /// Used to configure axum's `KeepAlive::interval()`.
+    pub fn heartbeat_interval(&self) -> Duration {
+        Duration::from_secs(self.heartbeat_interval_secs)
+    }
+}
+
+/// Default heartbeat interval (30 seconds).
+/// Must be less than SDK read timeout (60s) with safety margin.
+/// 30s gives a 2x safety factor.
+const DEFAULT_HEARTBEAT_INTERVAL_SECS: u64 = 30;
+
+/// Read heartbeat interval from `SSE_HEARTBEAT_INTERVAL_SECS` env var, falling back to default.
+fn heartbeat_interval_from_env() -> u64 {
+    std::env::var("SSE_HEARTBEAT_INTERVAL_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_HEARTBEAT_INTERVAL_SECS)
 }
 
 impl Default for SseStreamConfig {
@@ -357,24 +388,28 @@ mod tests {
     fn test_realtime_config() {
         unsafe {
             std::env::remove_var("SSE_REALTIME_CYCLE_SECS");
+            std::env::remove_var("SSE_HEARTBEAT_INTERVAL_SECS");
         }
         let config = SseStreamConfig::realtime();
         assert_eq!(config.min_backoff_ms, 100);
         assert_eq!(config.max_backoff_ms, 500);
         assert_eq!(config.max_connection_secs, 300);
         assert_eq!(config.disconnect_retry_ms, 100);
+        assert_eq!(config.heartbeat_interval_secs, 30);
     }
 
     #[test]
     fn test_monitoring_config() {
         unsafe {
             std::env::remove_var("SSE_MONITORING_CYCLE_SECS");
+            std::env::remove_var("SSE_HEARTBEAT_INTERVAL_SECS");
         }
         let config = SseStreamConfig::monitoring();
         assert_eq!(config.min_backoff_ms, 1000);
         assert_eq!(config.max_backoff_ms, 20000);
         assert_eq!(config.max_connection_secs, 600);
         assert_eq!(config.disconnect_retry_ms, 1000);
+        assert_eq!(config.heartbeat_interval_secs, 30);
     }
 
     #[test]
@@ -728,5 +763,64 @@ mod tests {
             std::env::remove_var("SSE_REALTIME_CYCLE_SECS");
         }
         assert_eq!(config.max_connection_secs, 300); // falls back to default
+    }
+
+    // ============================================
+    // Heartbeat Tests
+    // ============================================
+
+    #[test]
+    fn test_heartbeat_interval_default() {
+        unsafe {
+            std::env::remove_var("SSE_HEARTBEAT_INTERVAL_SECS");
+        }
+        let config = SseStreamConfig::realtime();
+        assert_eq!(config.heartbeat_interval_secs, 30);
+        assert_eq!(config.heartbeat_interval(), Duration::from_secs(30));
+
+        let config = SseStreamConfig::monitoring();
+        assert_eq!(config.heartbeat_interval_secs, 30);
+        assert_eq!(config.heartbeat_interval(), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn test_heartbeat_interval_env_override() {
+        unsafe {
+            std::env::set_var("SSE_HEARTBEAT_INTERVAL_SECS", "15");
+        }
+        let config = SseStreamConfig::realtime();
+        unsafe {
+            std::env::remove_var("SSE_HEARTBEAT_INTERVAL_SECS");
+        }
+        assert_eq!(config.heartbeat_interval_secs, 15);
+        assert_eq!(config.heartbeat_interval(), Duration::from_secs(15));
+    }
+
+    #[test]
+    fn test_heartbeat_interval_env_invalid_fallback() {
+        unsafe {
+            std::env::set_var("SSE_HEARTBEAT_INTERVAL_SECS", "not_a_number");
+        }
+        let config = SseStreamConfig::realtime();
+        unsafe {
+            std::env::remove_var("SSE_HEARTBEAT_INTERVAL_SECS");
+        }
+        assert_eq!(config.heartbeat_interval_secs, 30); // falls back to default
+    }
+
+    #[test]
+    fn test_heartbeat_interval_less_than_sdk_read_timeout() {
+        // SDK read timeout is 60s. Heartbeat must be less than that.
+        unsafe {
+            std::env::remove_var("SSE_HEARTBEAT_INTERVAL_SECS");
+        }
+        let config = SseStreamConfig::realtime();
+        let sdk_read_timeout = Duration::from_secs(60);
+        assert!(
+            config.heartbeat_interval() < sdk_read_timeout,
+            "heartbeat interval {:?} must be < SDK read timeout {:?}",
+            config.heartbeat_interval(),
+            sdk_read_timeout
+        );
     }
 }

--- a/docs/features/events.md
+++ b/docs/features/events.md
@@ -45,6 +45,18 @@ SSE streams include special lifecycle events for connection management:
 | `connected` | Sent immediately when the stream is established |
 | `disconnecting` | Sent before the server gracefully closes the connection |
 
+### Heartbeat Comments
+
+All SSE streams send periodic heartbeat comments every 30 seconds to allow clients to detect stale connections:
+
+```
+: heartbeat
+```
+
+Heartbeat comments are standard SSE comments (lines starting with `:`) — they are **invisible to event parsers** and do not appear as events. They simply reset the TCP read timer so clients can distinguish between "connection alive but idle" and "connection dead."
+
+**For SDK/client developers:** Set a read timeout of 45 seconds (1.5x the 30s heartbeat interval). If no data (events or heartbeats) arrives within 45s, treat the connection as stale and reconnect with `since_id`. The server sends heartbeats during all phases: idle, model thinking, tool execution, and active streaming.
+
 ### Connection Cycling
 
 To prevent stale connections through proxies and load balancers, SSE connections are automatically cycled:

--- a/docs/features/sdk.mdx
+++ b/docs/features/sdk.mdx
@@ -11,7 +11,7 @@ The Everruns SDK provides official client libraries for building AI agent applic
 
 - **Consistent API** across Rust, Python, and TypeScript
 - **Async/await patterns** throughout all SDKs
-- **SSE streaming** with automatic reconnection
+- **SSE streaming** with automatic reconnection and heartbeat-based stale connection detection
 - **Typed models** generated from OpenAPI specifications
 - **Sub-client organization** (agents, sessions, messages, events)
 

--- a/docs/sre/environment-variables.md
+++ b/docs/sre/environment-variables.md
@@ -183,6 +183,23 @@ The UI makes all API requests (including SSE) to `/api/*` paths. Caddy reverse p
 - Disable response buffering for SSE endpoints
 - Example Caddy config: see `local/Caddyfile`
 
+## SSE Streaming Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SSE_REALTIME_CYCLE_SECS` | `300` | Connection cycle interval for session event streams (seconds) |
+| `SSE_MONITORING_CYCLE_SECS` | `600` | Connection cycle interval for durable monitoring streams (seconds) |
+| `SSE_HEARTBEAT_INTERVAL_SECS` | `30` | Interval between heartbeat comments on all SSE streams (seconds) |
+| `SSE_GLOBAL_MAX` | `10000` | Maximum total SSE connections across all users |
+| `SSE_PER_SESSION_MAX` | `5` | Maximum SSE connections per session |
+| `SSE_PER_ORG_MAX` | `1000` | Maximum SSE connections per organization |
+
+**Notes:**
+- Heartbeat comments (`: heartbeat\n\n`) are sent on all SSE streams to detect stale connections
+- The heartbeat interval must be less than the SDK read timeout (default: 60s) with safety margin
+- Connection cycling prevents stale connections through proxies and load balancers
+- When running behind HTTP/1.1 proxies, increase `SSE_REALTIME_CYCLE_SECS` to reduce reconnection frequency
+
 ## Worker Configuration
 
 ### GRPC_ADDRESS

--- a/specs/events-contract.md
+++ b/specs/events-contract.md
@@ -77,6 +77,18 @@ The context object fields are stable:
 
 New optional fields may be added to EventContext.
 
+## Heartbeat Comments
+
+All SSE streams send periodic heartbeat comments (`: heartbeat\n\n`) every 30 seconds. These are **not events** — they are SSE comments invisible to event parsers. They serve as a liveness signal for clients to detect stale connections.
+
+**Contract guarantees:**
+- Heartbeats are sent on all SSE streams regardless of activity (idle, active, thinking)
+- Heartbeat interval is configurable via `SSE_HEARTBEAT_INTERVAL_SECS` (default: 30)
+- Heartbeat comments do not affect event ordering, IDs, or schema
+- SDKs should set a read timeout of 1.5x the heartbeat interval (45s) to detect stale connections
+
+**Non-breaking:** Changing heartbeat text or interval is non-breaking since comments are ignored by parsers.
+
 ## Versioning
 
 Events follow semantic versioning aligned with the API version:

--- a/specs/events.md
+++ b/specs/events.md
@@ -937,6 +937,30 @@ SSE streams include special lifecycle events for connection management:
 | `connected` | Sent immediately when the stream is established. Data: `{"status":"connected"}` |
 | `disconnecting` | Sent before graceful close. Data: `{"reason":"connection_cycle","retry_ms":100}` |
 
+### Heartbeat Comments
+
+All SSE streams send periodic heartbeat comments to allow clients to detect stale/half-open connections:
+
+```
+: heartbeat
+
+```
+
+Heartbeat comments are standard SSE comments (lines starting with `:`) and are **invisible to all spec-compliant event parsers** — they do not appear as events. They serve solely to reset the client's TCP read timer.
+
+| Property | Value |
+|----------|-------|
+| Format | `: heartbeat\n\n` (SSE comment) |
+| Interval | 30 seconds (configurable via `SSE_HEARTBEAT_INTERVAL_SECS`) |
+| Scope | All SSE streams (session events, durable monitoring, workflow monitoring) |
+| Activity-independent | Fires during idle, model-thinking, tool-execution, and active streaming |
+| Schema impact | None — SSE comments are not events |
+| Backward-compatible | Yes — all spec-compliant SSE parsers ignore comments |
+
+**Why 30 seconds?** The SDK default read timeout is 60s. At 30s heartbeat interval, clients have a 2x safety factor: if no heartbeat arrives within 45s (1.5x interval), the connection is almost certainly dead.
+
+**Bandwidth impact:** Each heartbeat is 14 bytes (`": heartbeat\r\n\r\n"`). At 30s intervals, this adds ~0.47 bytes/second per connection — negligible even at 10,000 concurrent connections (~4.7 KB/s total).
+
 ### Connection Cycling
 
 To prevent stale connections through proxies and load balancers, SSE connections are automatically cycled:
@@ -973,6 +997,11 @@ SDKs MUST:
 2. Handle `disconnecting` event by reconnecting with `since_id` parameter
 3. Handle `onerror` with exponential backoff (EventSource default behavior)
 4. Use `retry:` hint for reconnection timing
+5. Set a read timeout of 45s (1.5x the 30s heartbeat interval) to detect stale connections
+
+**Heartbeat handling:** SDKs do NOT need to explicitly handle heartbeat comments — SSE parsers ignore them automatically. The heartbeats simply prevent the read timeout from firing on healthy connections. If no data (events or heartbeats) arrives within the read timeout, the SDK should treat the connection as stale and reconnect with `since_id`.
+
+**Read timeout rationale:** 45s = 1.5x heartbeat interval (30s). This gives a 0.5x margin for network jitter and server scheduling delays. The previous 60s timeout (2x) also works but is slower to detect stale connections.
 
 Example client implementation:
 


### PR DESCRIPTION
## What

Add periodic SSE comment heartbeats (`: heartbeat\n\n`) every 30 seconds on all SSE streams to enable clients to reliably detect stale/half-open TCP connections.

## Why

~6% of SSE connections under load lose the `disconnecting` event during connection cycling, leaving clients blocked on `read()` forever. The SDK workaround (60s read timeout) cannot distinguish "stale connection" from "legitimately idle" (model thinking, waiting for user input). Server-side heartbeats eliminate this ambiguity: if no data (events or heartbeats) arrives within 45s, the connection is dead.

## How

- Add `heartbeat_interval_secs` field to `SseStreamConfig` (default: 30s, configurable via `SSE_HEARTBEAT_INTERVAL_SECS` env var)
- Replace `KeepAlive::default()` with explicit `KeepAlive::new().interval(30s).text("heartbeat")` on all 3 SSE endpoints:
  - `/v1/sessions/{session_id}/sse` (session events)
  - `/v1/durable/sse` (global durable monitoring)
  - `/v1/durable/workflows/{workflow_id}/sse` (workflow monitoring)
- Heartbeats are SSE comments (`: heartbeat\n\n`), invisible to all spec-compliant event parsers — no schema change, fully backward-compatible

## Risk

- **Low**
- SSE comments are part of the SSE spec and ignored by all parsers
- No schema changes, no breaking changes
- Bandwidth impact: ~0.47 bytes/second per connection (14 bytes every 30s)
- Existing `connected`/`disconnecting` lifecycle events unchanged

## Checklist

- [x] Tests added or updated (4 new heartbeat tests, all 33 SSE tests passing)
- [x] Backward compatibility considered (SSE comments are invisible to parsers)
- [x] Specs updated (`specs/events.md`, `specs/events-contract.md`)
- [x] Docs updated (`docs/features/events.md`, `docs/features/sdk.mdx`, `docs/sre/environment-variables.md`)
- [x] Smoke tested in dev mode (heartbeats verified on session + durable SSE streams)
- [x] `just pre-push` passing
- [x] SDK team follow-up documented: reduce read timeout from 60s to 45s (1.5x heartbeat interval)

Closes #603