### PR TITLE
feat(ui): add preview tabs to harness detail and edit pages

### DIFF
--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -10283,6 +10283,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
@@ -11,9 +11,11 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { PromptEditor } from "@/components/ui/prompt-editor";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { CapabilitySelector } from "@/components/agents/capability-selector";
+import { HarnessPreview } from "@/components/harnesses/harness-preview";
 import { ModelPicker } from "@/components/models/model-picker";
-import { ArrowLeft, Save, Trash2 } from "lucide-react";
+import { ArrowLeft, Save, Trash2, Eye, Edit2 } from "lucide-react";
 import type { AgentCapabilityConfig } from "@/lib/api/types";
 
 interface FormData {
@@ -34,6 +36,7 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
 
   const { data: allCapabilities, isLoading: capabilitiesLoading } = useCapabilities();
 
+  const [activeTab, setActiveTab] = useState<string>("edit");
   const [formChanges, setFormChanges] = useState<Partial<FormData>>({});
 
   const initialFormData = useMemo((): FormData => {
@@ -161,139 +164,206 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
 
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold">Edit Harness</h1>
+        <Tabs value={activeTab} onValueChange={setActiveTab}>
+          <TabsList>
+            <TabsTrigger value="edit">
+              <Edit2 className="w-4 h-4 mr-2" />
+              Edit
+            </TabsTrigger>
+            <TabsTrigger value="preview">
+              <Eye className="w-4 h-4 mr-2" />
+              Preview
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
       </div>
 
-      <form onSubmit={handleSubmit}>
-        <div className="grid gap-6 lg:grid-cols-3">
-          {/* Main form */}
-          <div className="lg:col-span-2 space-y-6">
-            <Card>
-              <CardHeader>
-                <CardTitle>Harness Details</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-6">
-                <div className="space-y-2">
-                  <Label htmlFor="name">Name</Label>
-                  <Input
-                    id="name"
-                    placeholder="My Harness"
-                    value={formData.name}
-                    onChange={(e) => handleFormChange("name", e.target.value)}
-                    required
-                  />
-                </div>
+      <Tabs value={activeTab} onValueChange={setActiveTab}>
+        {/* Edit Tab Content */}
+        <TabsContent value="edit">
+          <form onSubmit={handleSubmit}>
+            <div className="grid gap-6 lg:grid-cols-3">
+              {/* Main form */}
+              <div className="lg:col-span-2 space-y-6">
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Harness Details</CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-6">
+                    <div className="space-y-2">
+                      <Label htmlFor="name">Name</Label>
+                      <Input
+                        id="name"
+                        placeholder="My Harness"
+                        value={formData.name}
+                        onChange={(e) => handleFormChange("name", e.target.value)}
+                        required
+                      />
+                    </div>
 
-                <div className="space-y-2">
-                  <Label htmlFor="description">Description</Label>
-                  <Textarea
-                    id="description"
-                    placeholder="Describe what this harness does..."
-                    value={formData.description}
-                    onChange={(e) => handleFormChange("description", e.target.value)}
-                    rows={2}
-                  />
-                </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="description">Description</Label>
+                      <Textarea
+                        id="description"
+                        placeholder="Describe what this harness does..."
+                        value={formData.description}
+                        onChange={(e) => handleFormChange("description", e.target.value)}
+                        rows={2}
+                      />
+                    </div>
 
-                <div className="space-y-2">
-                  <Label htmlFor="tags">Tags</Label>
-                  <Input
-                    id="tags"
-                    placeholder="tag1, tag2, tag3"
-                    value={formData.tags}
-                    onChange={(e) => handleFormChange("tags", e.target.value)}
-                  />
-                  <p className="text-xs text-muted-foreground">Comma-separated list of tags</p>
-                </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="tags">Tags</Label>
+                      <Input
+                        id="tags"
+                        placeholder="tag1, tag2, tag3"
+                        value={formData.tags}
+                        onChange={(e) => handleFormChange("tags", e.target.value)}
+                      />
+                      <p className="text-xs text-muted-foreground">Comma-separated list of tags</p>
+                    </div>
 
-                <div className="space-y-2">
-                  <Label htmlFor="model">Model (optional)</Label>
-                  <ModelPicker
-                    value={formData.default_model_id || ""}
-                    onChange={(value) => handleFormChange("default_model_id", value)}
-                    placeholder="Use default model"
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    Select a specific model or leave empty to use the default
-                  </p>
-                </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="model">Model (optional)</Label>
+                      <ModelPicker
+                        value={formData.default_model_id || ""}
+                        onChange={(value) => handleFormChange("default_model_id", value)}
+                        placeholder="Use default model"
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Select a specific model or leave empty to use the default
+                      </p>
+                    </div>
 
-                <div className="space-y-2">
-                  <Label htmlFor="system_prompt">System Prompt</Label>
-                  <PromptEditor
-                    id="system_prompt"
-                    placeholder="You are a helpful assistant..."
-                    value={formData.system_prompt}
-                    onChange={(value) => handleFormChange("system_prompt", value)}
-                    required
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    Instructions for the AI model (supports Markdown)
-                  </p>
-                </div>
-              </CardContent>
-            </Card>
+                    <div className="space-y-2">
+                      <Label htmlFor="system_prompt">System Prompt</Label>
+                      <PromptEditor
+                        id="system_prompt"
+                        placeholder="You are a helpful assistant..."
+                        value={formData.system_prompt}
+                        onChange={(value) => handleFormChange("system_prompt", value)}
+                        required
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Instructions for the AI model (supports Markdown)
+                      </p>
+                    </div>
+                  </CardContent>
+                </Card>
 
-            {/* Danger Zone */}
-            <Card className="border-destructive/50">
-              <CardHeader>
-                <CardTitle className="text-destructive">Danger Zone</CardTitle>
-                <CardDescription>Irreversible actions that affect this harness</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="font-medium">Delete this harness</p>
-                    <p className="text-sm text-muted-foreground">
-                      Once deleted, this harness will be permanently removed.
-                    </p>
-                  </div>
-                  <Button
-                    type="button"
-                    variant="destructive"
-                    onClick={handleDelete}
-                    disabled={deleteHarness.isPending}
-                  >
-                    <Trash2 className="w-4 h-4 mr-2" />
-                    {deleteHarness.isPending ? "Deleting..." : "Delete Harness"}
+                {/* Danger Zone */}
+                <Card className="border-destructive/50">
+                  <CardHeader>
+                    <CardTitle className="text-destructive">Danger Zone</CardTitle>
+                    <CardDescription>Irreversible actions that affect this harness</CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="font-medium">Delete this harness</p>
+                        <p className="text-sm text-muted-foreground">
+                          Once deleted, this harness will be permanently removed.
+                        </p>
+                      </div>
+                      <Button
+                        type="button"
+                        variant="destructive"
+                        onClick={handleDelete}
+                        disabled={deleteHarness.isPending}
+                      >
+                        <Trash2 className="w-4 h-4 mr-2" />
+                        {deleteHarness.isPending ? "Deleting..." : "Delete Harness"}
+                      </Button>
+                    </div>
+                  </CardContent>
+                </Card>
+              </div>
+
+              {/* Capabilities sidebar */}
+              <div className="space-y-6">
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Capabilities</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <CapabilitySelector
+                      capabilities={allCapabilities || []}
+                      selected={selectedCapabilities}
+                      onChange={handleCapabilitiesChange}
+                      disabled={isSaving}
+                    />
+                  </CardContent>
+                </Card>
+
+                {/* Save button */}
+                <div className="flex gap-4">
+                  <Button type="submit" disabled={isSaving} className="flex-1">
+                    <Save className="w-4 h-4 mr-2" />
+                    {isSaving ? "Saving..." : "Save Changes"}
+                  </Button>
+                  <Button type="button" variant="outline" onClick={() => router.back()}>
+                    Cancel
                   </Button>
                 </div>
-              </CardContent>
-            </Card>
-          </div>
 
-          {/* Capabilities sidebar */}
-          <div className="space-y-6">
-            <Card>
-              <CardHeader>
-                <CardTitle>Capabilities</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <CapabilitySelector
-                  capabilities={allCapabilities || []}
-                  selected={selectedCapabilities}
-                  onChange={handleCapabilitiesChange}
-                  disabled={isSaving}
-                />
-              </CardContent>
-            </Card>
+                {updateHarness.error && (
+                  <p className="text-sm text-destructive">Error: {updateHarness.error.message}</p>
+                )}
+              </div>
+            </div>
+          </form>
+        </TabsContent>
 
-            {/* Save button */}
-            <div className="flex gap-4">
-              <Button type="submit" disabled={isSaving} className="flex-1">
-                <Save className="w-4 h-4 mr-2" />
-                {isSaving ? "Saving..." : "Save Changes"}
-              </Button>
-              <Button type="button" variant="outline" onClick={() => router.back()}>
-                Cancel
-              </Button>
+        {/* Preview Tab Content */}
+        <TabsContent value="preview">
+          <div className="grid gap-6 lg:grid-cols-3">
+            <div className="lg:col-span-2">
+              <HarnessPreview
+                systemPrompt={formData.system_prompt}
+                capabilities={selectedCapabilities}
+              />
             </div>
 
-            {updateHarness.error && (
-              <p className="text-sm text-destructive">Error: {updateHarness.error.message}</p>
-            )}
+            {/* Summary sidebar */}
+            <div className="space-y-6">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Harness Summary</CardTitle>
+                  <CardDescription>Current configuration</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div>
+                    <p className="text-sm font-medium">Name</p>
+                    <p className="text-sm text-muted-foreground">{formData.name || "(not set)"}</p>
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium">Description</p>
+                    <p className="text-sm text-muted-foreground">
+                      {formData.description || "(not set)"}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium">Capabilities</p>
+                    <p className="text-sm text-muted-foreground">
+                      {selectedCapabilities.length} capabilit
+                      {selectedCapabilities.length !== 1 ? "ies" : "y"} enabled
+                    </p>
+                  </div>
+                </CardContent>
+              </Card>
+
+              <Card className="border-dashed">
+                <CardContent className="pt-6">
+                  <p className="text-sm text-muted-foreground text-center">
+                    This preview shows what the final harness will look like after applying all
+                    capabilities. Switch to the Edit tab to make changes.
+                  </p>
+                </CardContent>
+              </Card>
+            </div>
           </div>
-        </div>
-      </form>
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useMemo, useCallback } from "react";
+import { use, useMemo, useCallback, useState } from "react";
 import {
   useHarness,
   useCapabilities,
@@ -17,7 +17,9 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { MarkdownDisplay } from "@/components/ui/prompt-editor";
 import { InlineStreamdownMessage } from "@/components/chat/streamdown-message";
 import { ProviderIcon } from "@/components/providers/provider-icon";
-import { ArrowLeft, Pencil, Copy, Trash2 } from "lucide-react";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { HarnessPreview } from "@/components/harnesses/harness-preview";
+import { ArrowLeft, Pencil, Copy, Trash2, Eye, LayoutDashboard } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import type { Capability, LlmModelWithProvider } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
@@ -25,6 +27,7 @@ import { getCapabilityIcon } from "@/lib/capability-icons";
 export default function HarnessDetailPage({ params }: { params: Promise<{ harnessId: string }> }) {
   const { harnessId } = use(params);
   const router = useRouter();
+  const [activeTab, setActiveTab] = useState("overview");
   const { data: harness, isLoading: harnessLoading } = useHarness(harnessId);
   const { data: allCapabilities } = useCapabilities();
   const { data: llmModels } = useLlmModels();
@@ -125,113 +128,138 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
         </div>
       </div>
 
-      <div className="grid gap-6 lg:grid-cols-3">
-        <div className="lg:col-span-2 space-y-6">
-          <Card>
-            <CardHeader>
-              <CardTitle>System Prompt</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <MarkdownDisplay content={harness.system_prompt} />
-            </CardContent>
-          </Card>
-        </div>
+      <Tabs value={activeTab} onValueChange={setActiveTab}>
+        <TabsList className="mb-6">
+          <TabsTrigger value="overview">
+            <LayoutDashboard className="w-4 h-4 mr-2" />
+            Overview
+          </TabsTrigger>
+          <TabsTrigger value="preview">
+            <Eye className="w-4 h-4 mr-2" />
+            Preview
+          </TabsTrigger>
+        </TabsList>
 
-        <div className="space-y-6">
-          <Card>
-            <CardHeader>
-              <CardTitle>Capabilities</CardTitle>
-            </CardHeader>
-            <CardContent>
-              {harnessCapabilities.length === 0 ? (
-                <p className="text-sm text-muted-foreground">
-                  No capabilities enabled.{" "}
-                  <Link
-                    href={`/harnesses/${harnessId}/edit`}
-                    className="text-primary hover:underline"
-                  >
-                    Add some
-                  </Link>
-                </p>
-              ) : (
-                <div className="space-y-2">
-                  {harnessCapabilities.map((capConfig) => {
-                    const cap = getCapabilityInfo(capConfig.ref);
-                    if (!cap) return null;
-                    const IconComponent = getCapabilityIcon(cap.icon);
+        <TabsContent value="overview">
+          <div className="grid gap-6 lg:grid-cols-3">
+            <div className="lg:col-span-2 space-y-6">
+              <Card>
+                <CardHeader>
+                  <CardTitle>System Prompt</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <MarkdownDisplay content={harness.system_prompt} />
+                </CardContent>
+              </Card>
+            </div>
 
-                    return (
-                      <div
-                        key={capConfig.ref}
-                        className="flex items-center gap-2 p-2 rounded-md border bg-muted/50"
+            <div className="space-y-6">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Capabilities</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  {harnessCapabilities.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                      No capabilities enabled.{" "}
+                      <Link
+                        href={`/harnesses/${harnessId}/edit`}
+                        className="text-primary hover:underline"
                       >
-                        <IconComponent className="w-4 h-4" />
-                        <div className="flex-1">
-                          <p className="text-sm font-medium">{cap.name}</p>
-                          <p className="text-xs text-muted-foreground">{cap.description}</p>
-                        </div>
+                        Add some
+                      </Link>
+                    </p>
+                  ) : (
+                    <div className="space-y-2">
+                      {harnessCapabilities.map((capConfig) => {
+                        const cap = getCapabilityInfo(capConfig.ref);
+                        if (!cap) return null;
+                        const IconComponent = getCapabilityIcon(cap.icon);
+
+                        return (
+                          <div
+                            key={capConfig.ref}
+                            className="flex items-center gap-2 p-2 rounded-md border bg-muted/50"
+                          >
+                            <IconComponent className="w-4 h-4" />
+                            <div className="flex-1">
+                              <p className="text-sm font-medium">{cap.name}</p>
+                              <p className="text-xs text-muted-foreground">{cap.description}</p>
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle>Configuration</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  {defaultModel && (
+                    <div>
+                      <p className="text-sm font-medium mb-2">Default Model</p>
+                      <div className="flex items-center gap-2">
+                        <ProviderIcon providerType={defaultModel.provider_type} size="sm" />
+                        <span className="text-sm">{defaultModel.display_name}</span>
                       </div>
-                    );
-                  })}
-                </div>
-              )}
-            </CardContent>
-          </Card>
+                    </div>
+                  )}
 
-          <Card>
-            <CardHeader>
-              <CardTitle>Configuration</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              {defaultModel && (
-                <div>
-                  <p className="text-sm font-medium mb-2">Default Model</p>
-                  <div className="flex items-center gap-2">
-                    <ProviderIcon providerType={defaultModel.provider_type} size="sm" />
-                    <span className="text-sm">{defaultModel.display_name}</span>
+                  {harness.description && (
+                    <div>
+                      <p className="text-sm font-medium">Description</p>
+                      <div className="text-sm text-muted-foreground">
+                        <InlineStreamdownMessage>{harness.description}</InlineStreamdownMessage>
+                      </div>
+                    </div>
+                  )}
+
+                  {harness.tags.length > 0 && (
+                    <div>
+                      <p className="text-sm font-medium mb-2">Tags</p>
+                      <div className="flex flex-wrap gap-1">
+                        {harness.tags.map((tag) => (
+                          <Badge key={tag} variant="outline">
+                            {tag}
+                          </Badge>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  <div>
+                    <p className="text-sm font-medium">Created</p>
+                    <p className="text-sm text-muted-foreground">
+                      {new Date(harness.created_at).toLocaleString()}
+                    </p>
                   </div>
-                </div>
-              )}
 
-              {harness.description && (
-                <div>
-                  <p className="text-sm font-medium">Description</p>
-                  <div className="text-sm text-muted-foreground">
-                    <InlineStreamdownMessage>{harness.description}</InlineStreamdownMessage>
+                  <div>
+                    <p className="text-sm font-medium">Updated</p>
+                    <p className="text-sm text-muted-foreground">
+                      {new Date(harness.updated_at).toLocaleString()}
+                    </p>
                   </div>
-                </div>
-              )}
+                </CardContent>
+              </Card>
+            </div>
+          </div>
+        </TabsContent>
 
-              {harness.tags.length > 0 && (
-                <div>
-                  <p className="text-sm font-medium mb-2">Tags</p>
-                  <div className="flex flex-wrap gap-1">
-                    {harness.tags.map((tag) => (
-                      <Badge key={tag} variant="outline">
-                        {tag}
-                      </Badge>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              <div>
-                <p className="text-sm font-medium">Created</p>
-                <p className="text-sm text-muted-foreground">
-                  {new Date(harness.created_at).toLocaleString()}
-                </p>
-              </div>
-
-              <div>
-                <p className="text-sm font-medium">Updated</p>
-                <p className="text-sm text-muted-foreground">
-                  {new Date(harness.updated_at).toLocaleString()}
-                </p>
-              </div>
-            </CardContent>
-          </Card>
-        </div>
-      </div>
+        <TabsContent value="preview">
+          <HarnessPreview
+            systemPrompt={harness.system_prompt}
+            capabilities={harnessCapabilities.map((cap) => ({
+              ref: cap.ref,
+              config: cap.config,
+            }))}
+          />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/apps/ui/src/components/harnesses/harness-preview.tsx
+++ b/apps/ui/src/components/harnesses/harness-preview.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePreviewHarness } from "@/hooks/use-harnesses";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import type { AgentCapabilityConfig, AgentPreviewResponse, ToolDefinition } from "@/lib/api/types";
+import { Wrench, FileText, AlertCircle } from "lucide-react";
+
+interface HarnessPreviewProps {
+  systemPrompt: string;
+  capabilities: AgentCapabilityConfig[];
+}
+
+export function HarnessPreview({ systemPrompt, capabilities }: HarnessPreviewProps) {
+  const previewMutation = usePreviewHarness();
+  const [preview, setPreview] = useState<AgentPreviewResponse | null>(null);
+
+  useEffect(() => {
+    previewMutation.mutate(
+      {
+        system_prompt: systemPrompt,
+        capabilities,
+      },
+      {
+        onSuccess: (data) => {
+          setPreview(data);
+        },
+      },
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [systemPrompt, JSON.stringify(capabilities)]);
+
+  if (previewMutation.isPending && !preview) {
+    return (
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-6 w-32" />
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-40 w-full" />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-6 w-32" />
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-24 w-full" />
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (previewMutation.error) {
+    return (
+      <Card className="border-destructive">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-destructive">
+            <AlertCircle className="w-5 h-5" />
+            Preview Error
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            Failed to generate preview: {previewMutation.error.message}
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!preview) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <FileText className="w-5 h-5" />
+            Full System Prompt
+          </CardTitle>
+          <CardDescription>
+            The complete system prompt including capability additions
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ScrollArea className="h-[400px] rounded-md border p-4 bg-muted/50">
+            <pre className="text-sm whitespace-pre-wrap font-mono">{preview.system_prompt}</pre>
+          </ScrollArea>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Wrench className="w-5 h-5" />
+            Available Tools
+            <Badge variant="secondary" className="ml-2">
+              {preview.tools.length}
+            </Badge>
+          </CardTitle>
+          <CardDescription>
+            Tools available from the enabled capabilities
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {preview.tools.length === 0 ? (
+            <p className="text-sm text-muted-foreground italic">
+              No tools available. Add capabilities to enable tools.
+            </p>
+          ) : (
+            <div className="space-y-4">
+              {preview.tools.map((tool, index) => (
+                <ToolCard key={index} tool={tool} />
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function ToolCard({ tool }: { tool: ToolDefinition }) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    <div className="border rounded-lg p-4 bg-card">
+      <div className="flex items-start justify-between">
+        <div className="space-y-1">
+          <h4 className="font-semibold text-sm font-mono">{tool.name}</h4>
+          <p className="text-sm text-muted-foreground">{tool.description}</p>
+        </div>
+        {"policy" in tool && tool.policy === "requires_approval" && (
+          <Badge variant="outline" className="text-xs">
+            Requires approval
+          </Badge>
+        )}
+      </div>
+
+      <div className="mt-3">
+        <button
+          type="button"
+          className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+          onClick={() => setIsExpanded(!isExpanded)}
+        >
+          {isExpanded ? "Hide parameters" : "Show parameters"}
+        </button>
+        {isExpanded && (
+          <ScrollArea className="mt-2 max-h-[200px]">
+            <pre className="text-xs p-2 bg-muted rounded-md overflow-x-auto font-mono">
+              {JSON.stringify(tool.parameters, null, 2)}
+            </pre>
+          </ScrollArea>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/harnesses/harness-preview.tsx
+++ b/apps/ui/src/components/harnesses/harness-preview.tsx
@@ -106,9 +106,7 @@ export function HarnessPreview({ systemPrompt, capabilities }: HarnessPreviewPro
               {preview.tools.length}
             </Badge>
           </CardTitle>
-          <CardDescription>
-            Tools available from the enabled capabilities
-          </CardDescription>
+          <CardDescription>Tools available from the enabled capabilities</CardDescription>
         </CardHeader>
         <CardContent>
           {preview.tools.length === 0 ? (

--- a/apps/ui/src/components/harnesses/index.ts
+++ b/apps/ui/src/components/harnesses/index.ts
@@ -1,1 +1,2 @@
 export { HarnessCard } from "./harness-card";
+export { HarnessPreview } from "./harness-preview";

--- a/apps/ui/src/hooks/use-harnesses.ts
+++ b/apps/ui/src/hooks/use-harnesses.ts
@@ -8,10 +8,15 @@ import {
   deleteHarness,
   getHarness,
   listHarnesses,
+  previewHarness,
   updateHarness,
 } from "@/lib/api/harnesses";
 import { queryKeys } from "@/lib/query-keys";
-import type { CreateHarnessRequest, UpdateHarnessRequest } from "@/lib/api/types";
+import type {
+  CreateHarnessRequest,
+  PreviewHarnessRequest,
+  UpdateHarnessRequest,
+} from "@/lib/api/types";
 import { useOrg } from "@/providers/org-provider";
 
 export function useHarnesses() {
@@ -91,5 +96,11 @@ export function useDeleteHarness() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.harnesses.all });
     },
+  });
+}
+
+export function usePreviewHarness() {
+  return useMutation({
+    mutationFn: (request: PreviewHarnessRequest) => previewHarness(request),
   });
 }

--- a/apps/ui/src/lib/api/harnesses.ts
+++ b/apps/ui/src/lib/api/harnesses.ts
@@ -2,7 +2,14 @@
 // Org is sent via everruns_org cookie (set by OrgProvider via /v1/users/me/switch-org)
 
 import { api } from "./client";
-import type { Harness, CreateHarnessRequest, UpdateHarnessRequest, ListResponse } from "./types";
+import type {
+  Harness,
+  CreateHarnessRequest,
+  UpdateHarnessRequest,
+  ListResponse,
+  PreviewHarnessRequest,
+  AgentPreviewResponse,
+} from "./types";
 
 export async function createHarness(request: CreateHarnessRequest): Promise<Harness> {
   const response = await api.post<Harness>("/v1/harnesses", request);
@@ -33,5 +40,12 @@ export async function deleteHarness(harnessId: string): Promise<void> {
 
 export async function copyHarness(harnessId: string): Promise<Harness> {
   const response = await api.post<Harness>(`/v1/harnesses/${harnessId}/copy`, {});
+  return response.data;
+}
+
+export async function previewHarness(
+  request: PreviewHarnessRequest,
+): Promise<AgentPreviewResponse> {
+  const response = await api.post<AgentPreviewResponse>("/v1/harnesses/preview", request);
   return response.data;
 }

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -99,6 +99,7 @@ Harnesses define the base environment and capabilities for sessions. See [harnes
 | PATCH | `/v1/harnesses/{id}` | Update harness |
 | DELETE | `/v1/harnesses/{id}` | Delete harness |
 | POST | `/v1/harnesses/{id}/copy` | Copy harness (new ID, "{name} (copy)") |
+| POST | `/v1/harnesses/preview` | Preview merged system prompt + tools |
 
 ### Sessions
 


### PR DESCRIPTION
## What
Add Preview tabs to harness detail and edit pages, matching the existing agent preview pattern.

## Why
The backend already supports `POST /v1/harnesses/preview` but the UI had no way to invoke it. Agents have Preview tabs on their detail and edit pages; harnesses should have the same capability.

## How
- Added `previewHarness()` API function and `usePreviewHarness()` React Query hook
- Created `HarnessPreview` component (mirrors `AgentPreview`) that calls the harness preview endpoint and displays the full merged system prompt and available tools
- Harness detail page now has Overview/Preview tabs (like agent detail)
- Harness edit page now has Edit/Preview tabs with a summary sidebar (like agent edit)

## Risk
- Low
- UI-only change; no backend modifications. The preview endpoint was already implemented and tested.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered