### PR TITLE
feat(capabilities): register platform_management in Chat harness, rename to Platform Chat

### DIFF
--- a/apps/ui/src/hooks/use-global-chat.ts
+++ b/apps/ui/src/hooks/use-global-chat.ts
@@ -2,7 +2,7 @@
 
 // Global chat session management.
 // Uses POST /v1/sessions/chat for per-user singleton get-or-create.
-// The backend manages the Chat harness and user-scoped tags.
+// The backend manages the Platform Chat harness and user-scoped tags.
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useOrg } from "@/providers/org-provider";

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -231,7 +231,7 @@ pub async fn create_session(
 /// POST /v1/sessions/chat - Get or create global chat session
 ///
 /// Returns the user's singleton global chat session. Creates one if it doesn't exist.
-/// Uses the Chat harness and tags for per-user singleton management.
+/// Uses the Platform Chat harness and tags for per-user singleton management.
 #[utoipa::path(
     post,
     path = "/v1/sessions/chat",

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -310,8 +310,8 @@ const SEED_HARNESSES: &[SeedHarness] = &[
     },
     SeedHarness {
         id: seed_ids::CHAT_HARNESS,
-        name: "Chat",
-        description: "Conversational harness for the global chat interface. Same capabilities as Generic.",
+        name: "Platform Chat",
+        description: "Conversational harness for the global chat interface with platform management capabilities.",
         system_prompt: "You are a helpful assistant.",
         tags: &["chat", "seed"],
         capabilities: &[
@@ -321,6 +321,7 @@ const SEED_HARNESSES: &[SeedHarness] = &[
             "session",
             "agent_instructions",
             "skills",
+            "platform_management",
         ],
     },
 ];

--- a/crates/server/src/services/session.rs
+++ b/crates/server/src/services/session.rs
@@ -337,7 +337,7 @@ impl SessionService {
 
     /// Get or create the global chat session for a user.
     /// Uses tags for per-user singleton: `["global-chat", "user:{user_id}"]`.
-    /// Creates with the Chat harness if no existing session is found.
+    /// Creates with the Platform Chat harness if no existing session is found.
     pub async fn get_or_create_chat_session(
         &self,
         org_id: i64,
@@ -362,7 +362,7 @@ impl SessionService {
             org_id,
             harness_id: Some(harness_id_typed),
             agent_id: None,
-            title: Some("Chat".to_string()),
+            title: Some("Platform Chat".to_string()),
             tags: vec!["global-chat".to_string(), user_tag],
             model_id: None,
             capabilities: serde_json::json!([]),

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -1721,3 +1721,32 @@ async fn test_chat_harness_exists_in_seed() {
     assert_eq!(chat_harness.id.to_string(), SEED_CHAT_HARNESS_ID);
     assert!(chat_harness.tags.contains(&"chat".to_string()));
 }
+
+#[tokio::test]
+async fn test_chat_harness_has_platform_management() {
+    let server = TestServer::new().await;
+
+    let harness: Harness = server
+        .get(&format!("/v1/harnesses/{}", SEED_CHAT_HARNESS_ID))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+
+    assert_eq!(harness.name, "Platform Chat");
+
+    let cap_ids: Vec<&str> = harness
+        .capabilities
+        .iter()
+        .map(|c| c.capability_id())
+        .collect();
+
+    assert_eq!(
+        cap_ids.len(),
+        7,
+        "Platform Chat harness should have 7 capabilities (Generic + platform_management)"
+    );
+    assert!(
+        cap_ids.contains(&"platform_management"),
+        "Platform Chat harness should include platform_management capability"
+    );
+}

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -1655,7 +1655,7 @@ async fn test_global_chat_creates_session() {
         .assert_success()
         .json();
 
-    assert_eq!(session.title.as_deref(), Some("Chat"));
+    assert_eq!(session.title.as_deref(), Some("Platform Chat"));
     assert!(session.tags.contains(&"global-chat".to_string()));
 }
 
@@ -1696,7 +1696,7 @@ async fn test_global_chat_has_chat_harness() {
     assert_eq!(
         session.harness_id.to_string(),
         SEED_CHAT_HARNESS_ID,
-        "Chat session should use the Chat harness"
+        "Chat session should use the Platform Chat harness"
     );
 }
 
@@ -1704,7 +1704,7 @@ async fn test_global_chat_has_chat_harness() {
 async fn test_chat_harness_exists_in_seed() {
     let server = TestServer::new().await;
 
-    // Verify the Chat harness was seeded (response is {"data": [...]})
+    // Verify the Platform Chat harness was seeded (response is {"data": [...]})
     let body = server
         .get("/v1/harnesses")
         .await
@@ -1715,8 +1715,8 @@ async fn test_chat_harness_exists_in_seed() {
 
     let chat_harness = harnesses
         .iter()
-        .find(|h| h.name == "Chat")
-        .expect("Chat harness should exist in seed data");
+        .find(|h| h.name == "Platform Chat")
+        .expect("Platform Chat harness should exist in seed data");
 
     assert_eq!(chat_harness.id.to_string(), SEED_CHAT_HARNESS_ID);
     assert!(chat_harness.tags.contains(&"chat".to_string()));

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -143,7 +143,7 @@ This enables temporarily extending an agent's capabilities for specific sessions
 
 #### Get or Create Chat Session
 
-Returns the calling user's singleton global chat session. Creates one with the Chat harness if none exists. Uses tag-based lookup (`global-chat` + `user:{user_id}`) for per-user singleton management.
+Returns the calling user's singleton global chat session. Creates one with the Platform Chat harness if none exists. Uses tag-based lookup (`global-chat` + `user:{user_id}`) for per-user singleton management.
 
 **Request:** `POST /v1/sessions/chat` (no body required)
 

--- a/specs/harness-types.md
+++ b/specs/harness-types.md
@@ -51,22 +51,33 @@ The recommended default harness. Bundles the core capabilities needed for genera
 - Agents that store API keys or credentials in session secrets
 - General-purpose assistant workflows
 
-### Chat
+### Platform Chat
 
-Conversational harness for the global chat interface. Identical capabilities to Generic, but tagged separately to support the per-user singleton session pattern.
+Conversational harness for the global chat interface. Extends Generic capabilities with platform management tools, tagged separately to support the per-user singleton session pattern.
 
 | Property | Value |
 |----------|-------|
-| Name | Chat |
+| Name | Platform Chat |
 | Seed ID | `harness_01933b5a000070008000000000000603` |
 | System Prompt | "You are a helpful assistant." |
 | Tags | `chat`, `seed` |
 
-**Capabilities:** Same as Generic (`session_file_system`, `virtual_bash`, `session_storage`, `session`, `agent_instructions`, `skills`).
+**Capabilities:** Generic capabilities plus `platform_management`:
+
+| Capability ID | Name | Purpose |
+|---------------|------|---------|
+| `session_file_system` | File System | Read, write, list, grep, delete files in `/workspace` |
+| `virtual_bash` | Virtual Bash | Sandboxed bash shell for code execution and scripting |
+| `session_storage` | Session Storage | Key/value store and encrypted secret storage |
+| `session` | Session | Session info access and title management |
+| `agent_instructions` | Agent Instructions | Reads AGENTS.md from workspace and injects into system prompt |
+| `skills` | Agent Skills | Discover and activate skills from `/.agents/skills/` in session filesystem |
+| `platform_management` | Platform Management | Manage harnesses, agents, and sessions via tools |
 
 **Use cases:**
 - Global chat interface (web UI at `/chat`)
 - Per-user singleton sessions via tag-based lookup
+- Managing Everruns entities (harnesses, agents, sessions) directly from chat
 
 ## Design Decisions
 


### PR DESCRIPTION
## What
- Add `platform_management` capability to the Chat harness seed data
- Rename the harness from "Chat" to "Platform Chat"
- Add integration test verifying the capability is present

## Why
The `platform_management` capability (which provides tools like `manage_harnesses`, `manage_agents`, `manage_sessions`, `session_interact`) was registered in the capability registry but never added to the Chat harness. Users in the global chat could not access Everruns functionality like listing harnesses or managing agents.

## How
- Added `"platform_management"` to the Chat harness capability list in `seed.rs`
- Renamed harness from "Chat" to "Platform Chat" to reflect its expanded role
- Updated all references: session title, doc comments, test assertions, specs
- Added `test_chat_harness_has_platform_management` integration test

## Risk
- Low
- Seed data change — existing Chat sessions keep their harness ID (unchanged), the harness just gets an additional capability and new name on next seed sync

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered