### PR TITLE
chore(deps): upgrade everruns-sdk v0.1.2 → v0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1142,7 +1142,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1413,8 +1413,8 @@ dependencies = [
 
 [[package]]
 name = "everruns-sdk"
-version = "0.1.2"
-source = "git+https://github.com/everruns/sdk?branch=main#9c829fc264053154ed212eaf54e5c0184559ed1e"
+version = "0.1.3"
+source = "git+https://github.com/everruns/sdk?tag=v0.1.3#0e367c56bf7c8a70987235a2b040d4775240832a"
 dependencies = [
  "async-stream",
  "futures",
@@ -2973,7 +2973,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3725,7 +3725,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4212,7 +4212,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4270,7 +4270,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5001,7 +5001,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,8 +94,8 @@ regex = "1.11"
 time = "0.3"
 parking_lot = "0.12"
 
-# Everruns SDK (git main: SSE disconnect retry fix, backoff reset, client reuse)
-everruns-sdk = { git = "https://github.com/everruns/sdk", branch = "main" }
+# Everruns SDK
+everruns-sdk = { git = "https://github.com/everruns/sdk", tag = "v0.1.3" }
 
 # gRPC (tonic)
 tonic = "0.14"


### PR DESCRIPTION
## What
Upgrade `everruns-sdk` from v0.1.2 (git main) to v0.1.3 (tagged release).

## Why
Pin to latest released SDK version for reproducible builds and to pick up new features/fixes:
- Poll-level idle timeout for half-open SSE connections
- Harness support with optional agent parameter
- SSE read timeout and disconnect retry improvements
- Structured enum for graceful disconnect signaling

## How
Changed `Cargo.toml` workspace dependency from `branch = "main"` to `tag = "v0.1.3"` and updated `Cargo.lock`.

## Risk
- Low
- Dependency-only change; SDK API is backward compatible (0.1.2 → 0.1.3)

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered