### PR TITLE
fix(example): always pull fresh images on start

### DIFF
--- a/example.just
+++ b/example.just
@@ -35,7 +35,7 @@ start tag="latest":
 
     echo "✅ Local docker compose not running, starting example full stack..."
     cd examples
-    docker compose -f docker-compose-full.yaml up -d
+    docker compose -f docker-compose-full.yaml up --pull always -d
     echo "✅ Example full stack started!"
     echo "   - UI: http://localhost:9300"
     echo "   - Jaeger UI: http://localhost:16686"


### PR DESCRIPTION
## What
Add `--pull always` to `docker compose up` in `just example start`.

## Why
`docker compose up -d` defaults to `pull_policy=missing` — it skips pulling when a local image with the same tag exists. For mutable tags like `latest` or development builds, this silently uses stale images. Users expect `just example start` to run the newest image for the given tag.

`just example pull` was already correct — `docker compose pull` always contacts the registry regardless of local cache.

## How
Single flag addition: `--pull always` on the `docker compose up` call in `example.just`.

## Risk
- Low
- Slightly slower startup (registry digest check). No functional risk — if registry is unreachable, compose falls back to local image.

## Checklist
- [x] Tests added or updated (n/a — justfile recipe, no unit tests)
- [x] Backward compatibility considered (no breaking change)