### PR TITLE
fix(worker): implement PlatformStore for gRPC workers

### DIFF
--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -151,6 +151,38 @@ service WorkerService {
 
     // List all secret names in a session (without values)
     rpc SessionStorageListSecrets(SessionStorageListSecretsRequest) returns (SessionStorageListSecretsResponse);
+
+    // === Platform management operations ===
+    // Used by the platform_management capability tools to manage org-wide entities
+    // via gRPC workers (mirrors PlatformStore trait in core)
+
+    // Harness operations
+    rpc PlatformListHarnesses(PlatformListHarnessesRequest) returns (PlatformListHarnessesResponse);
+    rpc PlatformCreateHarness(PlatformCreateHarnessRequest) returns (PlatformCreateHarnessResponse);
+    rpc PlatformUpdateHarness(PlatformUpdateHarnessRequest) returns (PlatformUpdateHarnessResponse);
+    rpc PlatformDeleteHarness(PlatformDeleteHarnessRequest) returns (PlatformDeleteHarnessResponse);
+    rpc PlatformCopyHarness(PlatformCopyHarnessRequest) returns (PlatformCopyHarnessResponse);
+
+    // Agent operations
+    rpc PlatformListAgents(PlatformListAgentsRequest) returns (PlatformListAgentsResponse);
+    rpc PlatformCreateAgent(PlatformCreateAgentRequest) returns (PlatformCreateAgentResponse);
+    rpc PlatformUpdateAgent(PlatformUpdateAgentRequest) returns (PlatformUpdateAgentResponse);
+    rpc PlatformDeleteAgent(PlatformDeleteAgentRequest) returns (PlatformDeleteAgentResponse);
+
+    // Session operations
+    rpc PlatformListSessions(PlatformListSessionsRequest) returns (PlatformListSessionsResponse);
+    rpc PlatformCreateSession(PlatformCreateSessionRequest) returns (PlatformCreateSessionResponse);
+    rpc PlatformDeleteSession(PlatformDeleteSessionRequest) returns (PlatformDeleteSessionResponse);
+
+    // Messaging operations
+    rpc PlatformSendMessage(PlatformSendMessageRequest) returns (PlatformSendMessageResponse);
+    rpc PlatformGetMessages(PlatformGetMessagesRequest) returns (PlatformGetMessagesResponse);
+
+    // Turn management
+    rpc PlatformWaitForIdle(PlatformWaitForIdleRequest) returns (PlatformWaitForIdleResponse);
+
+    // Base URL for UI links
+    rpc PlatformGetBaseUrl(PlatformGetBaseUrlRequest) returns (PlatformGetBaseUrlResponse);
 }
 
 // ============================================================================
@@ -967,4 +999,177 @@ message SessionStorageListSecretsRequest {
 
 message SessionStorageListSecretsResponse {
     repeated StorageSecretInfo secrets = 1;
+}
+
+// ============================================================================
+// Platform management types
+// ============================================================================
+
+// Simplified message for platform management (role + text + timestamp)
+message PlatformMessage {
+    string role = 1;
+    string content = 2;
+    Timestamp created_at = 3;
+}
+
+// === Harness operations ===
+
+message PlatformListHarnessesRequest {
+    int64 org_id = 1;
+}
+
+message PlatformListHarnessesResponse {
+    repeated Harness harnesses = 1;
+}
+
+message PlatformCreateHarnessRequest {
+    int64 org_id = 1;
+    string name = 2;
+    optional string description = 3;
+    string system_prompt = 4;
+    repeated string capabilities = 5;
+}
+
+message PlatformCreateHarnessResponse {
+    Harness harness = 1;
+}
+
+message PlatformUpdateHarnessRequest {
+    int64 org_id = 1;
+    Uuid harness_id = 2;
+    optional string name = 3;
+    optional string description = 4;
+    optional string system_prompt = 5;
+}
+
+message PlatformUpdateHarnessResponse {
+    Harness harness = 1;
+}
+
+message PlatformDeleteHarnessRequest {
+    int64 org_id = 1;
+    Uuid harness_id = 2;
+}
+
+message PlatformDeleteHarnessResponse {}
+
+message PlatformCopyHarnessRequest {
+    int64 org_id = 1;
+    Uuid harness_id = 2;
+    optional string new_name = 3;
+}
+
+message PlatformCopyHarnessResponse {
+    Harness harness = 1;
+}
+
+// === Agent operations ===
+
+message PlatformListAgentsRequest {
+    int64 org_id = 1;
+}
+
+message PlatformListAgentsResponse {
+    repeated Agent agents = 1;
+}
+
+message PlatformCreateAgentRequest {
+    int64 org_id = 1;
+    string name = 2;
+    optional string description = 3;
+    string system_prompt = 4;
+    repeated string capabilities = 5;
+}
+
+message PlatformCreateAgentResponse {
+    Agent agent = 1;
+}
+
+message PlatformUpdateAgentRequest {
+    int64 org_id = 1;
+    Uuid agent_id = 2;
+    optional string name = 3;
+    optional string description = 4;
+    optional string system_prompt = 5;
+}
+
+message PlatformUpdateAgentResponse {
+    Agent agent = 1;
+}
+
+message PlatformDeleteAgentRequest {
+    int64 org_id = 1;
+    Uuid agent_id = 2;
+}
+
+message PlatformDeleteAgentResponse {}
+
+// === Session operations ===
+
+message PlatformListSessionsRequest {
+    int64 org_id = 1;
+    optional uint32 limit = 2;
+    optional Uuid agent_id = 3;
+}
+
+message PlatformListSessionsResponse {
+    repeated Session sessions = 1;
+}
+
+message PlatformCreateSessionRequest {
+    int64 org_id = 1;
+    Uuid harness_id = 2;
+    optional Uuid agent_id = 3;
+    optional string title = 4;
+}
+
+message PlatformCreateSessionResponse {
+    Session session = 1;
+}
+
+message PlatformDeleteSessionRequest {
+    int64 org_id = 1;
+    Uuid session_id = 2;
+}
+
+message PlatformDeleteSessionResponse {}
+
+// === Messaging operations ===
+
+message PlatformSendMessageRequest {
+    int64 org_id = 1;
+    Uuid session_id = 2;
+    string content = 3;
+}
+
+message PlatformSendMessageResponse {}
+
+message PlatformGetMessagesRequest {
+    int64 org_id = 1;
+    Uuid session_id = 2;
+    optional uint32 limit = 3;
+}
+
+message PlatformGetMessagesResponse {
+    repeated PlatformMessage messages = 1;
+}
+
+// === Turn management ===
+
+message PlatformWaitForIdleRequest {
+    int64 org_id = 1;
+    Uuid session_id = 2;
+    optional uint64 timeout_secs = 3;
+}
+
+message PlatformWaitForIdleResponse {
+    string status = 1;
+}
+
+// === Base URL ===
+
+message PlatformGetBaseUrlRequest {}
+
+message PlatformGetBaseUrlResponse {
+    string base_url = 1;
 }

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -529,6 +529,7 @@ impl ServerAppBuilder {
             let grpc_db = db.clone();
             let grpc_encryption = encryption.clone();
             let grpc_event_service = event_service.clone();
+            let grpc_runner = runner.clone();
             let grpc_addr = self.config.grpc_addr.clone();
 
             let task_broadcaster = if let Some(pool) = db.pool() {
@@ -547,6 +548,7 @@ impl ServerAppBuilder {
                     (*grpc_event_service).clone(),
                     grpc_db,
                     grpc_encryption,
+                    Some(grpc_runner),
                 );
                 if let Some(broadcaster) = task_broadcaster {
                     grpc_svc.set_task_broadcaster(broadcaster);

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -22,43 +22,144 @@ use everruns_durable::{
     record_workflow_cancelled, record_workflow_completed, record_workflow_failed,
 };
 use everruns_internal_protocol::proto::{
-    self, AddMessageRequest, AddMessageResponse, CheckCircuitBreakerRequest,
-    CheckCircuitBreakerResponse, CircuitBreakerState as ProtoCircuitBreakerState,
-    ClaimDurableTasksRequest, ClaimDurableTasksResponse, CommitExecRequest, CommitExecResponse,
-    CompleteDurableTaskRequest, CompleteDurableTaskResponse, CountActiveDurableWorkflowsRequest,
-    CountActiveDurableWorkflowsResponse, CreateDurableWorkflowRequest,
-    CreateDurableWorkflowResponse, DeregisterDurableWorkerRequest, DeregisterDurableWorkerResponse,
-    DurableWorkflowStatus, EmitEventRequest, EmitEventResponse, EmitEventStreamResponse,
-    EnqueueDurableTaskRequest, EnqueueDurableTaskResponse, FailDurableTaskRequest,
-    FailDurableTaskResponse, GetAgentRequest, GetAgentResponse, GetDefaultModelRequest,
-    GetDefaultModelResponse, GetDurableWorkflowStatusRequest, GetDurableWorkflowStatusResponse,
-    GetHarnessRequest, GetHarnessResponse, GetMcpServerByPrefixRequest,
-    GetMcpServerByPrefixResponse, GetModelWithProviderRequest, GetModelWithProviderResponse,
-    GetSessionRequest, GetSessionResponse, GetTurnContextRequest, GetTurnContextResponse,
-    HeartbeatDurableTaskRequest, HeartbeatDurableTaskResponse, HeartbeatDurableWorkerRequest,
-    HeartbeatDurableWorkerResponse, LoadMessagesRequest, LoadMessagesResponse, McpServerInfo,
-    McpToolDef, RecordCircuitBreakerFailureRequest, RecordCircuitBreakerFailureResponse,
-    RecordCircuitBreakerSuccessRequest, RecordCircuitBreakerSuccessResponse,
-    RegisterDurableWorkerRequest, RegisterDurableWorkerResponse, ResolveImageRequest,
-    ResolveImageResponse, ResolveImagesRequest, ResolveImagesResponse, ResolvedImageData,
-    SessionCreateDirectoryRequest, SessionCreateDirectoryResponse, SessionDeleteFileRequest,
-    SessionDeleteFileResponse, SessionGrepFilesRequest, SessionGrepFilesResponse,
-    SessionListDirectoryRequest, SessionListDirectoryResponse, SessionReadFileRequest,
-    SessionReadFileResponse, SessionStatFileRequest, SessionStatFileResponse,
-    SessionStorageDeleteSecretRequest, SessionStorageDeleteSecretResponse,
-    SessionStorageDeleteValueRequest, SessionStorageDeleteValueResponse,
-    SessionStorageGetSecretRequest, SessionStorageGetSecretResponse, SessionStorageGetValueRequest,
-    SessionStorageGetValueResponse, SessionStorageListKeysRequest, SessionStorageListKeysResponse,
-    SessionStorageListSecretsRequest, SessionStorageListSecretsResponse,
-    SessionStorageSetSecretRequest, SessionStorageSetSecretResponse, SessionStorageSetValueRequest,
-    SessionStorageSetValueResponse, SessionWriteFileRequest, SessionWriteFileResponse,
-    SetSessionStatusRequest, SetSessionStatusResponse, SetSessionTitleRequest,
-    SetSessionTitleResponse, SubscribeTaskNotificationsRequest, TaskNotification,
-    TaskNotificationType, UpdateDurableWorkflowStatusRequest, UpdateDurableWorkflowStatusResponse,
+    self,
+    AddMessageRequest,
+    AddMessageResponse,
+    CheckCircuitBreakerRequest,
+    CheckCircuitBreakerResponse,
+    CircuitBreakerState as ProtoCircuitBreakerState,
+    ClaimDurableTasksRequest,
+    ClaimDurableTasksResponse,
+    CommitExecRequest,
+    CommitExecResponse,
+    CompleteDurableTaskRequest,
+    CompleteDurableTaskResponse,
+    CountActiveDurableWorkflowsRequest,
+    CountActiveDurableWorkflowsResponse,
+    CreateDurableWorkflowRequest,
+    CreateDurableWorkflowResponse,
+    DeregisterDurableWorkerRequest,
+    DeregisterDurableWorkerResponse,
+    DurableWorkflowStatus,
+    EmitEventRequest,
+    EmitEventResponse,
+    EmitEventStreamResponse,
+    EnqueueDurableTaskRequest,
+    EnqueueDurableTaskResponse,
+    FailDurableTaskRequest,
+    FailDurableTaskResponse,
+    GetAgentRequest,
+    GetAgentResponse,
+    GetDefaultModelRequest,
+    GetDefaultModelResponse,
+    GetDurableWorkflowStatusRequest,
+    GetDurableWorkflowStatusResponse,
+    GetHarnessRequest,
+    GetHarnessResponse,
+    GetMcpServerByPrefixRequest,
+    GetMcpServerByPrefixResponse,
+    GetModelWithProviderRequest,
+    GetModelWithProviderResponse,
+    GetSessionRequest,
+    GetSessionResponse,
+    GetTurnContextRequest,
+    GetTurnContextResponse,
+    HeartbeatDurableTaskRequest,
+    HeartbeatDurableTaskResponse,
+    HeartbeatDurableWorkerRequest,
+    HeartbeatDurableWorkerResponse,
+    LoadMessagesRequest,
+    LoadMessagesResponse,
+    McpServerInfo,
+    McpToolDef,
+    // Platform management types
+    PlatformCopyHarnessRequest,
+    PlatformCopyHarnessResponse,
+    PlatformCreateAgentRequest,
+    PlatformCreateAgentResponse,
+    PlatformCreateHarnessRequest,
+    PlatformCreateHarnessResponse,
+    PlatformCreateSessionRequest,
+    PlatformCreateSessionResponse,
+    PlatformDeleteAgentRequest,
+    PlatformDeleteAgentResponse,
+    PlatformDeleteHarnessRequest,
+    PlatformDeleteHarnessResponse,
+    PlatformDeleteSessionRequest,
+    PlatformDeleteSessionResponse,
+    PlatformGetBaseUrlRequest,
+    PlatformGetBaseUrlResponse,
+    PlatformGetMessagesRequest,
+    PlatformGetMessagesResponse,
+    PlatformListAgentsRequest,
+    PlatformListAgentsResponse,
+    PlatformListHarnessesRequest,
+    PlatformListHarnessesResponse,
+    PlatformListSessionsRequest,
+    PlatformListSessionsResponse,
+    PlatformSendMessageRequest,
+    PlatformSendMessageResponse,
+    PlatformUpdateAgentRequest,
+    PlatformUpdateAgentResponse,
+    PlatformUpdateHarnessRequest,
+    PlatformUpdateHarnessResponse,
+    PlatformWaitForIdleRequest,
+    PlatformWaitForIdleResponse,
+    RecordCircuitBreakerFailureRequest,
+    RecordCircuitBreakerFailureResponse,
+    RecordCircuitBreakerSuccessRequest,
+    RecordCircuitBreakerSuccessResponse,
+    RegisterDurableWorkerRequest,
+    RegisterDurableWorkerResponse,
+    ResolveImageRequest,
+    ResolveImageResponse,
+    ResolveImagesRequest,
+    ResolveImagesResponse,
+    ResolvedImageData,
+    SessionCreateDirectoryRequest,
+    SessionCreateDirectoryResponse,
+    SessionDeleteFileRequest,
+    SessionDeleteFileResponse,
+    SessionGrepFilesRequest,
+    SessionGrepFilesResponse,
+    SessionListDirectoryRequest,
+    SessionListDirectoryResponse,
+    SessionReadFileRequest,
+    SessionReadFileResponse,
+    SessionStatFileRequest,
+    SessionStatFileResponse,
+    SessionStorageDeleteSecretRequest,
+    SessionStorageDeleteSecretResponse,
+    SessionStorageDeleteValueRequest,
+    SessionStorageDeleteValueResponse,
+    SessionStorageGetSecretRequest,
+    SessionStorageGetSecretResponse,
+    SessionStorageGetValueRequest,
+    SessionStorageGetValueResponse,
+    SessionStorageListKeysRequest,
+    SessionStorageListKeysResponse,
+    SessionStorageListSecretsRequest,
+    SessionStorageListSecretsResponse,
+    SessionStorageSetSecretRequest,
+    SessionStorageSetSecretResponse,
+    SessionStorageSetValueRequest,
+    SessionStorageSetValueResponse,
+    SessionWriteFileRequest,
+    SessionWriteFileResponse,
+    SetSessionStatusRequest,
+    SetSessionStatusResponse,
+    SetSessionTitleRequest,
+    SetSessionTitleResponse,
+    SubscribeTaskNotificationsRequest,
+    TaskNotification,
+    TaskNotificationType,
+    UpdateDurableWorkflowStatusRequest,
+    UpdateDurableWorkflowStatusResponse,
 };
 use everruns_internal_protocol::{
-    WorkerService, WorkerServiceServer, proto_event_request_to_schema, schema_agent_to_proto,
-    schema_event_to_proto, schema_harness_to_proto,
+    WorkerService, WorkerServiceServer,
+    datetime_to_proto_timestamp as ip_datetime_to_proto_timestamp, proto_event_request_to_schema,
+    schema_agent_to_proto, schema_event_to_proto, schema_harness_to_proto, schema_session_to_proto,
 };
 use std::pin::Pin;
 use std::sync::Arc;
@@ -126,6 +227,8 @@ pub struct WorkerServiceImpl {
     db: Arc<StorageBackend>,
     /// Session storage store for key/value and secret operations
     session_storage_store: Option<Arc<dyn everruns_core::traits::SessionStorageStore>>,
+    /// Agent runner for triggering turn workflows (platform management send_message)
+    runner: Option<Arc<dyn everruns_worker::AgentRunner>>,
 }
 
 impl WorkerServiceImpl {
@@ -133,6 +236,7 @@ impl WorkerServiceImpl {
         event_service: EventService,
         db: Arc<StorageBackend>,
         encryption: Option<Arc<EncryptionService>>,
+        runner: Option<Arc<dyn everruns_worker::AgentRunner>>,
     ) -> Self {
         let agent_service = AgentService::new(db.clone());
         let harness_service = HarnessService::new(db.clone());
@@ -177,6 +281,7 @@ impl WorkerServiceImpl {
             task_broadcaster: None, // Set via set_task_broadcaster() after async initialization
             db,
             session_storage_store,
+            runner,
         }
     }
 
@@ -2355,6 +2460,534 @@ impl WorkerService for WorkerServiceImpl {
         Ok(Response::new(SessionStorageListSecretsResponse {
             secrets: proto_secrets,
         }))
+    }
+
+    // ========================================================================
+    // Platform management operations
+    // ========================================================================
+
+    async fn platform_list_harnesses(
+        &self,
+        request: Request<PlatformListHarnessesRequest>,
+    ) -> Result<Response<PlatformListHarnessesResponse>, Status> {
+        let req = request.into_inner();
+        let harnesses = self
+            .harness_service
+            .list(req.org_id)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to list harnesses: {}", e)))?;
+
+        let proto_harnesses = harnesses.iter().map(schema_harness_to_proto).collect();
+        Ok(Response::new(PlatformListHarnessesResponse {
+            harnesses: proto_harnesses,
+        }))
+    }
+
+    async fn platform_create_harness(
+        &self,
+        request: Request<PlatformCreateHarnessRequest>,
+    ) -> Result<Response<PlatformCreateHarnessResponse>, Status> {
+        let req = request.into_inner();
+        let capabilities: Vec<everruns_core::AgentCapabilityConfig> = req
+            .capabilities
+            .iter()
+            .map(|id| everruns_core::AgentCapabilityConfig::new(id.as_str()))
+            .collect();
+
+        let create_req = crate::api::harnesses::CreateHarnessRequest {
+            name: req.name,
+            description: req.description,
+            system_prompt: req.system_prompt,
+            default_model_id: None,
+            tags: vec![],
+            capabilities,
+        };
+
+        let harness = self
+            .harness_service
+            .create(req.org_id, create_req)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to create harness: {}", e)))?;
+
+        Ok(Response::new(PlatformCreateHarnessResponse {
+            harness: Some(schema_harness_to_proto(&harness)),
+        }))
+    }
+
+    async fn platform_update_harness(
+        &self,
+        request: Request<PlatformUpdateHarnessRequest>,
+    ) -> Result<Response<PlatformUpdateHarnessResponse>, Status> {
+        let req = request.into_inner();
+        let harness_id = parse_uuid(req.harness_id.as_ref())?;
+
+        let update_req = crate::api::harnesses::UpdateHarnessRequest {
+            name: req.name,
+            description: req.description,
+            system_prompt: req.system_prompt,
+            default_model_id: None,
+            tags: None,
+            capabilities: None,
+            status: None,
+        };
+
+        let harness = self
+            .harness_service
+            .update(req.org_id, harness_id, update_req)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to update harness: {}", e)))?
+            .ok_or_else(|| Status::not_found("Harness not found"))?;
+
+        Ok(Response::new(PlatformUpdateHarnessResponse {
+            harness: Some(schema_harness_to_proto(&harness)),
+        }))
+    }
+
+    async fn platform_delete_harness(
+        &self,
+        request: Request<PlatformDeleteHarnessRequest>,
+    ) -> Result<Response<PlatformDeleteHarnessResponse>, Status> {
+        let req = request.into_inner();
+        let harness_id = parse_uuid(req.harness_id.as_ref())?;
+
+        self.harness_service
+            .delete(req.org_id, harness_id)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to delete harness: {}", e)))?;
+
+        Ok(Response::new(PlatformDeleteHarnessResponse {}))
+    }
+
+    async fn platform_copy_harness(
+        &self,
+        request: Request<PlatformCopyHarnessRequest>,
+    ) -> Result<Response<PlatformCopyHarnessResponse>, Status> {
+        let req = request.into_inner();
+        let harness_id = parse_uuid(req.harness_id.as_ref())?;
+
+        let harness = self
+            .harness_service
+            .copy(req.org_id, harness_id)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to copy harness: {}", e)))?
+            .ok_or_else(|| Status::not_found("Harness not found"))?;
+
+        // If a new_name was provided, update the copy with the new name
+        let harness = if let Some(new_name) = req.new_name {
+            let update_req = crate::api::harnesses::UpdateHarnessRequest {
+                name: Some(new_name),
+                description: None,
+                system_prompt: None,
+                default_model_id: None,
+                tags: None,
+                capabilities: None,
+                status: None,
+            };
+            self.harness_service
+                .update(req.org_id, harness.id.uuid(), update_req)
+                .await
+                .map_err(|e| Status::internal(format!("Failed to rename copied harness: {}", e)))?
+                .unwrap_or(harness)
+        } else {
+            harness
+        };
+
+        Ok(Response::new(PlatformCopyHarnessResponse {
+            harness: Some(schema_harness_to_proto(&harness)),
+        }))
+    }
+
+    async fn platform_list_agents(
+        &self,
+        request: Request<PlatformListAgentsRequest>,
+    ) -> Result<Response<PlatformListAgentsResponse>, Status> {
+        let req = request.into_inner();
+        let agents = self
+            .agent_service
+            .list(req.org_id)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to list agents: {}", e)))?;
+
+        let proto_agents = agents.iter().map(schema_agent_to_proto).collect();
+        Ok(Response::new(PlatformListAgentsResponse {
+            agents: proto_agents,
+        }))
+    }
+
+    async fn platform_create_agent(
+        &self,
+        request: Request<PlatformCreateAgentRequest>,
+    ) -> Result<Response<PlatformCreateAgentResponse>, Status> {
+        let req = request.into_inner();
+        let capabilities: Vec<everruns_core::AgentCapabilityConfig> = req
+            .capabilities
+            .iter()
+            .map(|id| everruns_core::AgentCapabilityConfig::new(id.as_str()))
+            .collect();
+
+        let create_req = crate::api::agents::CreateAgentRequest {
+            id: None,
+            name: req.name,
+            description: req.description,
+            system_prompt: req.system_prompt,
+            default_model_id: None,
+            tags: vec![],
+            capabilities,
+            tools: vec![],
+        };
+
+        let agent = self
+            .agent_service
+            .create(req.org_id, None, create_req)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to create agent: {}", e)))?;
+
+        Ok(Response::new(PlatformCreateAgentResponse {
+            agent: Some(schema_agent_to_proto(&agent)),
+        }))
+    }
+
+    async fn platform_update_agent(
+        &self,
+        request: Request<PlatformUpdateAgentRequest>,
+    ) -> Result<Response<PlatformUpdateAgentResponse>, Status> {
+        let req = request.into_inner();
+        let agent_id = parse_uuid(req.agent_id.as_ref())?;
+
+        // Resolve UUID to public_id for the service
+        let agent = self
+            .agent_service
+            .get(req.org_id, agent_id)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to get agent: {}", e)))?
+            .ok_or_else(|| Status::not_found("Agent not found"))?;
+
+        let update_req = crate::api::agents::UpdateAgentRequest {
+            name: req.name,
+            description: req.description,
+            system_prompt: req.system_prompt,
+            default_model_id: None,
+            tags: None,
+            capabilities: None,
+            tools: None,
+            status: None,
+        };
+
+        let updated = self
+            .agent_service
+            .update(req.org_id, &agent.public_id.to_string(), update_req)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to update agent: {}", e)))?
+            .ok_or_else(|| Status::not_found("Agent not found"))?;
+
+        Ok(Response::new(PlatformUpdateAgentResponse {
+            agent: Some(schema_agent_to_proto(&updated)),
+        }))
+    }
+
+    async fn platform_delete_agent(
+        &self,
+        request: Request<PlatformDeleteAgentRequest>,
+    ) -> Result<Response<PlatformDeleteAgentResponse>, Status> {
+        let req = request.into_inner();
+        let agent_id = parse_uuid(req.agent_id.as_ref())?;
+
+        // Resolve UUID to public_id for the service
+        let agent = self
+            .agent_service
+            .get(req.org_id, agent_id)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to get agent: {}", e)))?
+            .ok_or_else(|| Status::not_found("Agent not found"))?;
+
+        self.agent_service
+            .delete(req.org_id, &agent.public_id.to_string())
+            .await
+            .map_err(|e| Status::internal(format!("Failed to delete agent: {}", e)))?;
+
+        Ok(Response::new(PlatformDeleteAgentResponse {}))
+    }
+
+    async fn platform_list_sessions(
+        &self,
+        request: Request<PlatformListSessionsRequest>,
+    ) -> Result<Response<PlatformListSessionsResponse>, Status> {
+        let req = request.into_inner();
+        let org_public_id = self.get_org_public_id(req.org_id).await?;
+
+        let limit = req.limit.unwrap_or(20);
+        let agent_id = match req.agent_id {
+            Some(ref uuid_proto) => Some(parse_uuid(Some(uuid_proto))?),
+            None => None,
+        };
+
+        let pagination = crate::api::common::Pagination { offset: 0, limit };
+
+        let (sessions, _total) = self
+            .session_service
+            .list(req.org_id, &org_public_id, agent_id, None, pagination)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to list sessions: {}", e)))?;
+
+        let proto_sessions = sessions.iter().map(schema_session_to_proto).collect();
+        Ok(Response::new(PlatformListSessionsResponse {
+            sessions: proto_sessions,
+        }))
+    }
+
+    async fn platform_create_session(
+        &self,
+        request: Request<PlatformCreateSessionRequest>,
+    ) -> Result<Response<PlatformCreateSessionResponse>, Status> {
+        let req = request.into_inner();
+        let org_public_id = self.get_org_public_id(req.org_id).await?;
+        let harness_id = parse_uuid(req.harness_id.as_ref())?;
+
+        let agent_uuid = match req.agent_id {
+            Some(ref uuid_proto) => Some(parse_uuid(Some(uuid_proto))?),
+            None => None,
+        };
+
+        // Look up agent public_id if agent_uuid is provided
+        let agent_public_id = if let Some(aid) = agent_uuid {
+            let agent = self
+                .agent_service
+                .get(req.org_id, aid)
+                .await
+                .map_err(|e| Status::internal(format!("Failed to get agent: {}", e)))?
+                .ok_or_else(|| Status::not_found("Agent not found"))?;
+            Some(agent.public_id)
+        } else {
+            None
+        };
+
+        let create_req = crate::api::sessions::CreateSessionRequest {
+            harness_id: everruns_core::HarnessId::from_uuid(harness_id),
+            agent_id: agent_public_id,
+            title: req.title,
+            tags: vec![],
+            model_id: None,
+            capabilities: vec![],
+            tools: vec![],
+        };
+
+        let session = self
+            .session_service
+            .create(
+                req.org_id,
+                &org_public_id,
+                harness_id,
+                agent_uuid,
+                create_req.agent_id,
+                create_req,
+            )
+            .await
+            .map_err(|e| Status::internal(format!("Failed to create session: {}", e)))?;
+
+        Ok(Response::new(PlatformCreateSessionResponse {
+            session: Some(schema_session_to_proto(&session)),
+        }))
+    }
+
+    async fn platform_delete_session(
+        &self,
+        request: Request<PlatformDeleteSessionRequest>,
+    ) -> Result<Response<PlatformDeleteSessionResponse>, Status> {
+        let req = request.into_inner();
+        let session_id = parse_uuid(req.session_id.as_ref())?;
+
+        self.session_service
+            .delete(req.org_id, session_id)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to delete session: {}", e)))?;
+
+        Ok(Response::new(PlatformDeleteSessionResponse {}))
+    }
+
+    async fn platform_send_message(
+        &self,
+        request: Request<PlatformSendMessageRequest>,
+    ) -> Result<Response<PlatformSendMessageResponse>, Status> {
+        let req = request.into_inner();
+        let session_id = parse_uuid(req.session_id.as_ref())?;
+        let org_public_id = self.get_org_public_id(req.org_id).await?;
+
+        // Get session to find harness_id and agent_id
+        let session = self
+            .session_service
+            .get(req.org_id, &org_public_id, session_id, None)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to get session: {}", e)))?
+            .ok_or_else(|| Status::not_found("Session not found"))?;
+
+        // Create message event
+        let message_id = uuid::Uuid::now_v7();
+        let now = chrono::Utc::now();
+
+        let core_message = everruns_core::Message {
+            id: everruns_core::MessageId::from_uuid(message_id),
+            role: everruns_core::MessageRole::User,
+            content: vec![everruns_core::ContentPart::text(&req.content)],
+            thinking: None,
+            thinking_signature: None,
+            controls: None,
+            metadata: None,
+            created_at: now,
+        };
+
+        let session_id_typed = everruns_core::SessionId::from_uuid(session_id);
+        let message_id_typed = everruns_core::MessageId::from_uuid(message_id);
+
+        // Emit input message event
+        self.event_service
+            .emit(everruns_core::EventRequest::new(
+                session_id_typed,
+                everruns_core::events::EventContext::empty(),
+                everruns_core::events::InputMessageData::new(core_message),
+            ))
+            .await
+            .map_err(|e| Status::internal(format!("Failed to emit message event: {}", e)))?;
+
+        // Start turn workflow if runner is available
+        if let Some(ref runner) = self.runner {
+            let runner = runner.clone();
+            let harness_id = session.harness_id;
+            let agent_id = session.agent_id;
+            tokio::spawn(async move {
+                if let Err(e) = runner
+                    .start_run(
+                        req.org_id,
+                        session_id_typed,
+                        harness_id,
+                        agent_id,
+                        message_id_typed,
+                    )
+                    .await
+                {
+                    tracing::error!(
+                        session_id = %session_id,
+                        error = %e,
+                        "Platform send_message: failed to start turn workflow"
+                    );
+                }
+            });
+        }
+
+        Ok(Response::new(PlatformSendMessageResponse {}))
+    }
+
+    async fn platform_get_messages(
+        &self,
+        request: Request<PlatformGetMessagesRequest>,
+    ) -> Result<Response<PlatformGetMessagesResponse>, Status> {
+        let req = request.into_inner();
+        let session_id = parse_uuid(req.session_id.as_ref())?;
+        let limit = req.limit.unwrap_or(10) as i32;
+
+        let events = self
+            .event_service
+            .list_message_events_limited(session_id, Some(limit))
+            .await
+            .map_err(|e| Status::internal(format!("Failed to list messages: {}", e)))?;
+
+        let proto_messages: Vec<proto::PlatformMessage> = events
+            .iter()
+            .filter_map(|ev| {
+                let (role, content) = match &ev.data {
+                    everruns_core::EventData::InputMessage(d) => {
+                        let text: String = d
+                            .message
+                            .content
+                            .iter()
+                            .filter_map(|p| match p {
+                                everruns_core::ContentPart::Text(t) => Some(t.text.as_str()),
+                                _ => None,
+                            })
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        ("user".to_string(), text)
+                    }
+                    everruns_core::EventData::OutputMessageCompleted(d) => {
+                        let text: String = d
+                            .message
+                            .content
+                            .iter()
+                            .filter_map(|p| match p {
+                                everruns_core::ContentPart::Text(t) => Some(t.text.as_str()),
+                                _ => None,
+                            })
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        ("assistant".to_string(), text)
+                    }
+                    _ => return None,
+                };
+
+                if content.is_empty() {
+                    return None;
+                }
+
+                Some(proto::PlatformMessage {
+                    role,
+                    content,
+                    created_at: Some(ip_datetime_to_proto_timestamp(ev.ts)),
+                })
+            })
+            .collect();
+
+        Ok(Response::new(PlatformGetMessagesResponse {
+            messages: proto_messages,
+        }))
+    }
+
+    async fn platform_wait_for_idle(
+        &self,
+        request: Request<PlatformWaitForIdleRequest>,
+    ) -> Result<Response<PlatformWaitForIdleResponse>, Status> {
+        let req = request.into_inner();
+        let session_id = parse_uuid(req.session_id.as_ref())?;
+        let org_public_id = self.get_org_public_id(req.org_id).await?;
+        let timeout_secs = req.timeout_secs.unwrap_or(120);
+
+        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(timeout_secs);
+
+        loop {
+            let session = self
+                .session_service
+                .get(req.org_id, &org_public_id, session_id, None)
+                .await
+                .map_err(|e| Status::internal(format!("Failed to get session: {}", e)))?
+                .ok_or_else(|| Status::not_found("Session not found"))?;
+
+            let status_str = session.status.to_string();
+            if status_str == "idle"
+                || status_str == "waiting_for_tool_results"
+                || status_str == "error"
+            {
+                return Ok(Response::new(PlatformWaitForIdleResponse {
+                    status: status_str,
+                }));
+            }
+
+            if tokio::time::Instant::now() >= deadline {
+                return Ok(Response::new(PlatformWaitForIdleResponse {
+                    status: "timeout".to_string(),
+                }));
+            }
+
+            tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+        }
+    }
+
+    async fn platform_get_base_url(
+        &self,
+        _request: Request<PlatformGetBaseUrlRequest>,
+    ) -> Result<Response<PlatformGetBaseUrlResponse>, Status> {
+        let base_url = std::env::var("APP_URL")
+            .or_else(|_| std::env::var("PUBLIC_URL"))
+            .unwrap_or_else(|_| "http://localhost:3000".to_string());
+
+        Ok(Response::new(PlatformGetBaseUrlResponse { base_url }))
     }
 }
 

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -1313,3 +1313,439 @@ impl SessionStorageStore for GrpcSessionStorageStore {
             .collect())
     }
 }
+
+// ============================================================================
+// GrpcPlatformStore - PlatformStore implementation over gRPC
+// ============================================================================
+
+/// gRPC-backed platform store for org-scoped management operations.
+///
+/// Proxies all PlatformStore trait methods to the control-plane via gRPC RPCs.
+/// Used by gRPC workers to support the platform_management capability.
+pub struct GrpcPlatformStore {
+    client: GrpcClient,
+    org_id: i64,
+}
+
+impl GrpcPlatformStore {
+    pub fn new(client: GrpcClient, org_id: i64) -> Self {
+        Self { client, org_id }
+    }
+}
+
+#[async_trait]
+impl everruns_core::platform_store::PlatformStore for GrpcPlatformStore {
+    // =========================================================================
+    // Harness Operations
+    // =========================================================================
+
+    async fn list_harnesses(&self) -> Result<Vec<Harness>> {
+        let mut client = self.client.inner.lock().await;
+        let response = client
+            .platform_list_harnesses(proto::PlatformListHarnessesRequest {
+                org_id: self.org_id,
+            })
+            .await
+            .map_err(|e| grpc_error(format!("gRPC platform_list_harnesses failed: {}", e)))?;
+
+        response
+            .into_inner()
+            .harnesses
+            .into_iter()
+            .map(|h| {
+                everruns_internal_protocol::proto_harness_to_schema(h)
+                    .map_err(|e| grpc_error(format!("Harness conversion failed: {}", e)))
+            })
+            .collect()
+    }
+
+    async fn get_harness(&self, id: everruns_core::HarnessId) -> Result<Option<Harness>> {
+        let mut client = self.client.inner.lock().await;
+        let response = client
+            .get_harness(proto::GetHarnessRequest {
+                harness_id: Some(uuid_to_proto(id.uuid())),
+                org_id: self.org_id,
+            })
+            .await
+            .map_err(|e| grpc_error(format!("gRPC get_harness failed: {}", e)))?;
+
+        match response.into_inner().harness {
+            Some(h) => Ok(Some(
+                everruns_internal_protocol::proto_harness_to_schema(h)
+                    .map_err(|e| grpc_error(format!("Harness conversion failed: {}", e)))?,
+            )),
+            None => Ok(None),
+        }
+    }
+
+    async fn create_harness(
+        &self,
+        name: &str,
+        description: Option<&str>,
+        system_prompt: &str,
+        capabilities: &[String],
+    ) -> Result<Harness> {
+        let mut client = self.client.inner.lock().await;
+        let response = client
+            .platform_create_harness(proto::PlatformCreateHarnessRequest {
+                org_id: self.org_id,
+                name: name.to_string(),
+                description: description.map(|s| s.to_string()),
+                system_prompt: system_prompt.to_string(),
+                capabilities: capabilities.to_vec(),
+            })
+            .await
+            .map_err(|e| grpc_error(format!("gRPC platform_create_harness failed: {}", e)))?;
+
+        let harness = response
+            .into_inner()
+            .harness
+            .ok_or_else(|| grpc_error("No harness in create response"))?;
+
+        everruns_internal_protocol::proto_harness_to_schema(harness)
+            .map_err(|e| grpc_error(format!("Harness conversion failed: {}", e)))
+    }
+
+    async fn update_harness(
+        &self,
+        id: everruns_core::HarnessId,
+        name: Option<&str>,
+        description: Option<&str>,
+        system_prompt: Option<&str>,
+    ) -> Result<Harness> {
+        let mut client = self.client.inner.lock().await;
+        let response = client
+            .platform_update_harness(proto::PlatformUpdateHarnessRequest {
+                org_id: self.org_id,
+                harness_id: Some(uuid_to_proto(id.uuid())),
+                name: name.map(|s| s.to_string()),
+                description: description.map(|s| s.to_string()),
+                system_prompt: system_prompt.map(|s| s.to_string()),
+            })
+            .await
+            .map_err(|e| grpc_error(format!("gRPC platform_update_harness failed: {}", e)))?;
+
+        let harness = response
+            .into_inner()
+            .harness
+            .ok_or_else(|| grpc_error("No harness in update response"))?;
+
+        everruns_internal_protocol::proto_harness_to_schema(harness)
+            .map_err(|e| grpc_error(format!("Harness conversion failed: {}", e)))
+    }
+
+    async fn delete_harness(&self, id: everruns_core::HarnessId) -> Result<()> {
+        let mut client = self.client.inner.lock().await;
+        client
+            .platform_delete_harness(proto::PlatformDeleteHarnessRequest {
+                org_id: self.org_id,
+                harness_id: Some(uuid_to_proto(id.uuid())),
+            })
+            .await
+            .map_err(|e| grpc_error(format!("gRPC platform_delete_harness failed: {}", e)))?;
+        Ok(())
+    }
+
+    async fn copy_harness(
+        &self,
+        id: everruns_core::HarnessId,
+        new_name: Option<&str>,
+    ) -> Result<Harness> {
+        let mut client = self.client.inner.lock().await;
+        let response = client
+            .platform_copy_harness(proto::PlatformCopyHarnessRequest {
+                org_id: self.org_id,
+                harness_id: Some(uuid_to_proto(id.uuid())),
+                new_name: new_name.map(|s| s.to_string()),
+            })
+            .await
+            .map_err(|e| grpc_error(format!("gRPC platform_copy_harness failed: {}", e)))?;
+
+        let harness = response
+            .into_inner()
+            .harness
+            .ok_or_else(|| grpc_error("No harness in copy response"))?;
+
+        everruns_internal_protocol::proto_harness_to_schema(harness)
+            .map_err(|e| grpc_error(format!("Harness conversion failed: {}", e)))
+    }
+
+    // =========================================================================
+    // Agent Operations
+    // =========================================================================
+
+    async fn list_agents(&self) -> Result<Vec<Agent>> {
+        let mut client = self.client.inner.lock().await;
+        let response = client
+            .platform_list_agents(proto::PlatformListAgentsRequest {
+                org_id: self.org_id,
+            })
+            .await
+            .map_err(|e| grpc_error(format!("gRPC platform_list_agents failed: {}", e)))?;
+
+        response
+            .into_inner()
+            .agents
+            .into_iter()
+            .map(|a| {
+                everruns_internal_protocol::proto_agent_to_schema(a)
+                    .map_err(|e| grpc_error(format!("Agent conversion failed: {}", e)))
+            })
+            .collect()
+    }
+
+    async fn get_agent_by_id(&self, id: AgentId) -> Result<Option<Agent>> {
+        let mut client = self.client.inner.lock().await;
+        let response = client
+            .get_agent(proto::GetAgentRequest {
+                agent_id: Some(uuid_to_proto(id.uuid())),
+                org_id: self.org_id,
+            })
+            .await
+            .map_err(|e| grpc_error(format!("gRPC get_agent failed: {}", e)))?;
+
+        match response.into_inner().agent {
+            Some(a) => Ok(Some(
+                everruns_internal_protocol::proto_agent_to_schema(a)
+                    .map_err(|e| grpc_error(format!("Agent conversion failed: {}", e)))?,
+            )),
+            None => Ok(None),
+        }
+    }
+
+    async fn create_agent(
+        &self,
+        name: &str,
+        description: Option<&str>,
+        system_prompt: &str,
+        capabilities: &[String],
+    ) -> Result<Agent> {
+        let mut client = self.client.inner.lock().await;
+        let response = client
+            .platform_create_agent(proto::PlatformCreateAgentRequest {
+                org_id: self.org_id,
+                name: name.to_string(),
+                description: description.map(|s| s.to_string()),
+                system_prompt: system_prompt.to_string(),
+                capabilities: capabilities.to_vec(),
+            })
+            .await
+            .map_err(|e| grpc_error(format!("gRPC platform_create_agent failed: {}", e)))?;
+
+        let agent = response
+            .into_inner()
+            .agent
+            .ok_or_else(|| grpc_error("No agent in create response"))?;
+
+        everruns_internal_protocol::proto_agent_to_schema(agent)
+            .map_err(|e| grpc_error(format!("Agent conversion failed: {}", e)))
+    }
+
+    async fn update_agent(
+        &self,
+        id: AgentId,
+        name: Option<&str>,
+        description: Option<&str>,
+        system_prompt: Option<&str>,
+    ) -> Result<Agent> {
+        let mut client = self.client.inner.lock().await;
+        let response = client
+            .platform_update_agent(proto::PlatformUpdateAgentRequest {
+                org_id: self.org_id,
+                agent_id: Some(uuid_to_proto(id.uuid())),
+                name: name.map(|s| s.to_string()),
+                description: description.map(|s| s.to_string()),
+                system_prompt: system_prompt.map(|s| s.to_string()),
+            })
+            .await
+            .map_err(|e| grpc_error(format!("gRPC platform_update_agent failed: {}", e)))?;
+
+        let agent = response
+            .into_inner()
+            .agent
+            .ok_or_else(|| grpc_error("No agent in update response"))?;
+
+        everruns_internal_protocol::proto_agent_to_schema(agent)
+            .map_err(|e| grpc_error(format!("Agent conversion failed: {}", e)))
+    }
+
+    async fn delete_agent(&self, id: AgentId) -> Result<()> {
+        let mut client = self.client.inner.lock().await;
+        client
+            .platform_delete_agent(proto::PlatformDeleteAgentRequest {
+                org_id: self.org_id,
+                agent_id: Some(uuid_to_proto(id.uuid())),
+            })
+            .await
+            .map_err(|e| grpc_error(format!("gRPC platform_delete_agent failed: {}", e)))?;
+        Ok(())
+    }
+
+    // =========================================================================
+    // Session Operations
+    // =========================================================================
+
+    async fn list_sessions(
+        &self,
+        limit: Option<usize>,
+        agent_id: Option<AgentId>,
+    ) -> Result<Vec<Session>> {
+        let mut client = self.client.inner.lock().await;
+        let response = client
+            .platform_list_sessions(proto::PlatformListSessionsRequest {
+                org_id: self.org_id,
+                limit: limit.map(|l| l as u32),
+                agent_id: agent_id.map(|id| uuid_to_proto(id.uuid())),
+            })
+            .await
+            .map_err(|e| grpc_error(format!("gRPC platform_list_sessions failed: {}", e)))?;
+
+        response
+            .into_inner()
+            .sessions
+            .into_iter()
+            .map(|s| {
+                everruns_internal_protocol::proto_session_to_schema(s)
+                    .map_err(|e| grpc_error(format!("Session conversion failed: {}", e)))
+            })
+            .collect()
+    }
+
+    async fn create_session(
+        &self,
+        harness_id: everruns_core::HarnessId,
+        agent_id: Option<AgentId>,
+        title: Option<&str>,
+    ) -> Result<Session> {
+        let mut client = self.client.inner.lock().await;
+        let response = client
+            .platform_create_session(proto::PlatformCreateSessionRequest {
+                org_id: self.org_id,
+                harness_id: Some(uuid_to_proto(harness_id.uuid())),
+                agent_id: agent_id.map(|id| uuid_to_proto(id.uuid())),
+                title: title.map(|s| s.to_string()),
+            })
+            .await
+            .map_err(|e| grpc_error(format!("gRPC platform_create_session failed: {}", e)))?;
+
+        let session = response
+            .into_inner()
+            .session
+            .ok_or_else(|| grpc_error("No session in create response"))?;
+
+        everruns_internal_protocol::proto_session_to_schema(session)
+            .map_err(|e| grpc_error(format!("Session conversion failed: {}", e)))
+    }
+
+    async fn get_session_by_id(&self, id: SessionId) -> Result<Option<Session>> {
+        let mut client = self.client.inner.lock().await;
+        let response = client
+            .get_session(proto::GetSessionRequest {
+                session_id: Some(uuid_to_proto(id.uuid())),
+                org_id: self.org_id,
+            })
+            .await
+            .map_err(|e| grpc_error(format!("gRPC get_session failed: {}", e)))?;
+
+        match response.into_inner().session {
+            Some(s) => Ok(Some(
+                everruns_internal_protocol::proto_session_to_schema(s)
+                    .map_err(|e| grpc_error(format!("Session conversion failed: {}", e)))?,
+            )),
+            None => Ok(None),
+        }
+    }
+
+    async fn delete_session(&self, id: SessionId) -> Result<()> {
+        let mut client = self.client.inner.lock().await;
+        client
+            .platform_delete_session(proto::PlatformDeleteSessionRequest {
+                org_id: self.org_id,
+                session_id: Some(uuid_to_proto(id.uuid())),
+            })
+            .await
+            .map_err(|e| grpc_error(format!("gRPC platform_delete_session failed: {}", e)))?;
+        Ok(())
+    }
+
+    // =========================================================================
+    // Messaging
+    // =========================================================================
+
+    async fn send_message(&self, session_id: SessionId, content: &str) -> Result<()> {
+        let mut client = self.client.inner.lock().await;
+        client
+            .platform_send_message(proto::PlatformSendMessageRequest {
+                org_id: self.org_id,
+                session_id: Some(uuid_to_proto(session_id.uuid())),
+                content: content.to_string(),
+            })
+            .await
+            .map_err(|e| grpc_error(format!("gRPC platform_send_message failed: {}", e)))?;
+        Ok(())
+    }
+
+    async fn get_messages(
+        &self,
+        session_id: SessionId,
+        limit: Option<usize>,
+    ) -> Result<Vec<everruns_core::platform_store::PlatformMessage>> {
+        let mut client = self.client.inner.lock().await;
+        let response = client
+            .platform_get_messages(proto::PlatformGetMessagesRequest {
+                org_id: self.org_id,
+                session_id: Some(uuid_to_proto(session_id.uuid())),
+                limit: limit.map(|l| l as u32),
+            })
+            .await
+            .map_err(|e| grpc_error(format!("gRPC platform_get_messages failed: {}", e)))?;
+
+        Ok(response
+            .into_inner()
+            .messages
+            .into_iter()
+            .map(|m| everruns_core::platform_store::PlatformMessage {
+                role: m.role,
+                content: m.content,
+                created_at: proto_timestamp_or_now(m.created_at.as_ref()),
+            })
+            .collect())
+    }
+
+    // =========================================================================
+    // Turn Management
+    // =========================================================================
+
+    async fn wait_for_idle(
+        &self,
+        session_id: SessionId,
+        timeout_secs: Option<u64>,
+    ) -> Result<String> {
+        let mut client = self.client.inner.lock().await;
+        let response = client
+            .platform_wait_for_idle(proto::PlatformWaitForIdleRequest {
+                org_id: self.org_id,
+                session_id: Some(uuid_to_proto(session_id.uuid())),
+                timeout_secs,
+            })
+            .await
+            .map_err(|e| grpc_error(format!("gRPC platform_wait_for_idle failed: {}", e)))?;
+
+        Ok(response.into_inner().status)
+    }
+
+    // =========================================================================
+    // UI Links
+    // =========================================================================
+
+    fn base_url(&self) -> &str {
+        // Cache the base_url as a leaked static to satisfy the &str lifetime
+        // Called infrequently, value stable across runtime
+        static BASE_URL: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+        BASE_URL.get_or_init(|| {
+            std::env::var("APP_URL")
+                .or_else(|_| std::env::var("PUBLIC_URL"))
+                .unwrap_or_else(|_| "http://localhost:3000".to_string())
+        })
+    }
+}

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -329,6 +329,13 @@ impl WorkerAdapters for GrpcWorkerAdapters {
         Some(Arc::new(GrpcSessionStorageStore::new(self.client.clone())))
     }
 
+    fn platform_store(&self) -> Option<Arc<dyn everruns_core::platform_store::PlatformStore>> {
+        Some(Arc::new(crate::grpc_adapters::GrpcPlatformStore::new(
+            self.client.clone(),
+            everruns_core::DEFAULT_ORG_ID,
+        )))
+    }
+
     async fn build_tool_registry(&self, agent_id: Uuid) -> Result<ToolRegistry> {
         let mut registry = ToolRegistry::with_defaults();
 

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -184,6 +184,7 @@ Workers communicate with the control-plane via gRPC instead of direct database a
    - `GrpcSessionFileStore` - Implements `SessionFileStore` trait via gRPC
    - `GrpcEventEmitter` - Implements `EventEmitter` trait via gRPC
    - `GrpcDurableStore` - Implements durable workflow operations via gRPC
+   - `GrpcPlatformStore` - Implements `PlatformStore` trait via gRPC (platform management capability)
 
 3. **Durable Execution gRPC Operations**:
    - `ClaimDurableTasks` - Workers poll for pending tasks


### PR DESCRIPTION
## Summary
- **Root cause**: `GrpcWorkerAdapters::platform_store()` returned `None` (default trait impl), causing "Platform management not available in this context" for all gRPC-connected workers
- Add 16 typed gRPC RPCs to `worker.proto` for platform management operations (harness/agent/session CRUD, messaging, turn management, base URL)
- Implement `GrpcPlatformStore` in the worker crate that proxies all `PlatformStore` trait methods via typed RPCs to the control-plane service layer
- Wire `platform_store()` in `GrpcWorkerAdapters` to return the new `GrpcPlatformStore`
- Pass `AgentRunner` to `WorkerServiceImpl` so `send_message` can trigger turn workflows

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] Unit tests pass (316 tests in affected crates)
- [x] Smoke tested in dev mode: `manage_harnesses` tool called successfully, returned harness list, session completed normally
- [ ] Smoke test in full mode (PostgreSQL + gRPC worker) to verify end-to-end gRPC path
- [ ] CI green