### PR TITLE
chore: add /process-issues command for Linear issue processing

### DIFF
--- a/.claude/commands/process-issues.md
+++ b/.claude/commands/process-issues.md
@@ -1,0 +1,96 @@
+# Process Issues
+
+Process open Linear issues: pick up, fix, ship, close. One PR per issue, max 5 issues in parallel.
+
+Full workflow design and rationale: `specs/linear-issues.md`.
+
+## Arguments
+
+- `$ARGUMENTS` - Optional: Linear team/project filter, specific issue IDs, or priority filter
+
+## Instructions
+
+### Phase 1: Prerequisites
+
+Verify environment:
+
+```bash
+doppler run -- env | rg 'LINEAR_API_KEY|GITHUB_TOKEN'
+doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" gh auth status'
+```
+
+Linear MCP server must be configured in `.mcp.json`.
+
+### Phase 2: Query and Prioritize
+
+1. Query open issues from Linear via MCP (apply `$ARGUMENTS` filters if provided)
+2. Read each issue's title, description, labels, priority, and linked PRs
+3. Sort by priority (Urgent > Critical > High > Medium > Low), then oldest first within same priority
+4. Select up to **5 issues** to process in parallel
+
+### Phase 3: Process Each Issue
+
+For each selected issue, run these steps. Process up to 5 issues concurrently using subagents.
+
+#### 3a. Pick Up
+
+1. Mark issue as **In Progress** in Linear
+2. Assign to current agent/user if unassigned
+
+#### 3b. Analyze
+
+1. Parse issue for reproduction steps, expected behavior, acceptance criteria
+2. Search codebase for relevant files
+3. Identify root cause (bugs) or implementation scope (features)
+4. If requirements are ambiguous: add a Linear comment requesting clarification, skip this issue
+
+#### 3c. Branch
+
+```bash
+git fetch origin main && git checkout -b {issue-id}-{short-description} origin/main
+```
+
+- `{issue-id}`: Linear issue identifier (e.g., `ENG-123`)
+- `{short-description}`: kebab-case summary (e.g., `fix-session-timeout`)
+
+#### 3d. Implement and Ship
+
+Run `/ship` to implement, test, validate, create PR, and merge. Pass the Linear issue context:
+
+- **What to implement**: the issue description and acceptance criteria
+- **PR "Why" section**: link to Linear issue (e.g., `Fixes ENG-123`)
+- **Write failing test first** for bugs; validate acceptance criteria for features
+
+`/ship` handles: test coverage, code simplification, security review, artifact updates, smoke testing, quality gates (including rebase on main), PR creation, CI wait, and merge.
+
+#### 3e. Close Issue
+
+After PR is merged:
+
+1. Mark issue as **Done** in Linear
+2. Add a comment on the Linear issue linking to the merged PR
+
+### Phase 4: Report
+
+After all issues are processed, report:
+
+- Issues completed (with PR links)
+- Issues skipped (with reasons)
+- Issues that failed (with error details)
+
+## Skipping Rules
+
+Skip an issue and move to the next if:
+
+- Blocked by external dependency (add comment, leave as In Progress)
+- Requirements ambiguous and clarification pending
+- Requires access/permissions not available
+
+Always add a Linear comment explaining why.
+
+## Notes
+
+- One PR per issue, always. No batch PRs.
+- No partial fixes — fully resolve or skip.
+- Max 5 issues in parallel to avoid resource contention.
+- See `specs/linear-issues.md` for design rationale, prioritization details, and non-requirements.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ All cloud secrets are in Doppler (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GITHUB
 
 ### Linear
 
-We use [Linear](https://linear.app) for issue tracking. MCP server configured in `.mcp.json`. Token (`LINEAR_API_KEY`) is in Doppler.
+We use [Linear](https://linear.app) for issue tracking. MCP server configured in `.mcp.json`. Token (`LINEAR_API_KEY`) is in Doppler. Use [`/process-issues`](.claude/commands/process-issues.md) to batch-process open issues (up to 5 in parallel).
 
 For GitHub CLI, map token explicitly:
 

--- a/specs/linear-issues.md
+++ b/specs/linear-issues.md
@@ -4,6 +4,8 @@
 
 This specification defines the workflow for processing Linear issues using coding agents. Each open issue is picked up, fixed with extensive test coverage, documented, and shipped as an individual PR that is merged when CI is green.
 
+Executable workflow: `/process-issues` command (`.claude/commands/process-issues.md`).
+
 ## Requirements
 
 ### Prerequisites
@@ -12,107 +14,13 @@ This specification defines the workflow for processing Linear issues using codin
 - `LINEAR_API_KEY` available via Doppler
 - GitHub CLI authenticated: `doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" gh auth status'`
 
-### Workflow per Issue
+### Workflow Summary
 
-For each open Linear issue, execute the following steps in order:
+Each issue follows: pick up → analyze → branch → implement → ship → close. The `/process-issues` command orchestrates this, delegating implementation and shipping to `/ship`.
 
-#### 1. Pick Up Issue
+**Concurrency:** process up to 5 issues in parallel.
 
-1. Query open issues from Linear via MCP (filter by team/project as appropriate)
-2. Read issue title, description, labels, priority, and any linked PRs
-3. Mark issue as **In Progress** in Linear
-4. Assign to current agent/user if unassigned
-
-#### 2. Analyze and Plan
-
-1. Parse issue description for reproduction steps, expected behavior, and acceptance criteria
-2. Search codebase for relevant files using issue keywords
-3. Identify root cause (for bugs) or implementation scope (for features)
-4. Create a todo list with actionable steps
-5. If requirements are ambiguous, add a comment on the Linear issue requesting clarification and move to the next issue
-
-#### 3. Create Branch
-
-1. Branch from `main`: `git checkout -b claude/{issue-id}-{short-description}`
-2. Branch name must use lowercase kebab-case
-
-#### 4. Implement Fix
-
-1. **Write failing test first** (for bugs: reproduces the issue; for features: validates acceptance criteria)
-2. Implement the minimal fix or feature
-3. Avoid over-engineering: only change what the issue requires
-4. Follow project style (see `specs/code-organization.md`)
-
-#### 5. Test Coverage
-
-Every fix must include extensive test coverage:
-
-**Unit Tests:**
-- Test the changed function/module directly
-- Cover happy path, error cases, and edge cases
-- For bug fixes: test must fail without the fix applied
-- For features: test must cover all acceptance criteria
-- Aim for coverage of all touched code paths
-
-**Integration Tests:**
-- Test the change through the service layer or API boundary
-- Verify side effects (database state, events emitted, etc.)
-- Test interaction with adjacent components
-- For API changes: test request validation, response shape, error codes
-
-**Test Naming:**
-- `test_{function}_{scenario}_{expected}` (e.g., `test_create_agent_duplicate_name_returns_conflict`)
-- Tests must be deterministic and independent
-
-#### 6. Update Specs and Docs
-
-If the change affects documented behavior:
-
-1. Update relevant specs in `specs/` to reflect new behavior
-2. Update OpenAPI spec: `./scripts/export-openapi.sh`
-3. Update docs in `apps/docs/` if user-facing behavior changes
-4. Update `AGENTS.md` if development workflow or tooling changes
-5. Update test cases in `test_cases/` if manual test steps change
-
-#### 7. Pre-PR Validation
-
-Run the full pre-PR checklist:
-
-1. `cargo fmt --check`
-2. `cargo clippy --all-targets --all-features -- -D warnings`
-3. `cargo test --all-features`
-4. `npm run lint` + `npm run build` in `apps/ui/` (if UI touched)
-5. `./scripts/export-openapi.sh` (if API touched)
-6. `npm run build` in `apps/docs/` (if docs touched)
-7. Rebase on main: `git fetch origin main && git rebase origin/main`
-
-Or use shorthand: `just pre-pr`
-
-#### 8. Create PR
-
-1. Push branch: `git push -u origin <branch-name>`
-2. Create PR using `.github/pull_request_template.md`:
-   - **What**: Description of the change
-   - **Why**: Link to Linear issue (e.g., `Fixes LIN-123`)
-   - **How**: High-level approach
-   - **Risk**: Low / Medium / High with what can break
-   - **Checklist**: Tests added, specs updated
-3. Commit format: `fix(scope): description` or `feat(scope): description`
-4. Use `chore` type for spec-only or doc-only changes
-5. Never add Claude session links to PR body or commits
-
-#### 9. Merge When Green
-
-1. Wait for CI to pass (all GitHub Actions checks green)
-2. **Never merge when CI is red** — no exceptions
-3. If CI fails: fix the issue, push again, wait for green
-4. Merge strategy: **Squash and Merge**
-
-#### 10. Close Issue
-
-1. Mark issue as **Done** in Linear
-2. Add a comment on the Linear issue linking to the merged PR
-3. Move to next open issue
+**Branch naming:** `{issue-id}-{short-description}` from `main` (lowercase kebab-case).
 
 ### Issue Prioritization
 
@@ -123,6 +31,14 @@ Process issues in this order:
 3. **Medium** priority
 4. **Low** priority
 5. Within same priority: oldest first (FIFO)
+
+### Test Coverage Requirements
+
+Every fix must include extensive test coverage:
+
+- **Unit tests:** test changed function/module directly; cover happy path, error cases, edge cases; for bug fixes, test must fail without fix; for features, cover all acceptance criteria
+- **Integration tests:** test through service layer or API boundary; verify side effects (database state, events emitted); test adjacent component interaction; for API changes, test request validation, response shape, error codes
+- **Test naming:** `test_{function}_{scenario}_{expected}` (e.g., `test_create_agent_duplicate_name_returns_conflict`); tests must be deterministic and independent
 
 ### Skipping Issues
 


### PR DESCRIPTION
## What
Add `/process-issues` slash command and refactor `specs/linear-issues.md` to eliminate duplication.

## Why
No executable command existed for batch-processing Linear issues. The spec contained detailed step-by-step instructions that duplicated `/ship` and belonged in an actionable command instead.

## How
- New `.claude/commands/process-issues.md`: orchestrates querying Linear, picking up issues (up to 5 in parallel), branching, delegating to `/ship`, and closing issues
- Refactored `specs/linear-issues.md`: trimmed to design intent (prioritization, test coverage requirements, skipping rules, non-requirements) with cross-reference to the command
- Updated `AGENTS.md` Linear section to mention the new command
- Branch naming: `{issue-id}-{short-description}` (no `claude/` prefix)

## Risk
- Low
- Documentation-only change, no runtime behavior affected

## Checklist
- [x] No code changes (docs/config only)
- [x] Specs updated
- [x] AGENTS.md updated
- [x] No duplication between spec and command