### PR TITLE
fix(api): enforce org isolation on user listing endpoint (EVE-30)

### DIFF
--- a/crates/server/src/api/users.rs
+++ b/crates/server/src/api/users.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
 
-use crate::auth::middleware::{AuthState, AuthUser};
+use crate::auth::middleware::{AuthState, AuthUser, ResolvedOrg};
 use axum::extract::FromRef;
 
 /// Cookie name for storing selected organization
@@ -84,10 +84,10 @@ pub fn routes(state: UsersState) -> Router {
         .with_state(state)
 }
 
-/// GET /v1/users - List all users
+/// GET /v1/users - List users in current organization
 ///
-/// Lists all users in the system with optional search filtering.
-/// Requires authentication (admin access recommended).
+/// Lists users that belong to the current organization with optional search filtering.
+/// TM-TENANT-008: Enforces org isolation to prevent cross-tenant user enumeration.
 #[utoipa::path(
     get,
     path = "/v1/users",
@@ -95,7 +95,7 @@ pub fn routes(state: UsersState) -> Router {
         ("search" = Option<String>, Query, description = "Search by name or email")
     ),
     responses(
-        (status = 200, description = "List of users", body = ListResponse<User>),
+        (status = 200, description = "List of users in organization", body = ListResponse<User>),
         (status = 401, description = "Unauthorized"),
         (status = 500, description = "Internal server error")
     ),
@@ -103,12 +103,13 @@ pub fn routes(state: UsersState) -> Router {
 )]
 pub async fn list_users(
     State(state): State<UsersState>,
-    _auth: AuthUser, // Require authentication
+    org: ResolvedOrg,
     Query(query): Query<ListUsersQuery>,
 ) -> Result<Json<ListResponse<User>>, StatusCode> {
+    // TM-TENANT-008: Filter users by org membership to enforce tenant isolation
     let rows = state
         .db
-        .list_users(query.search.as_deref())
+        .list_users_by_org(org.org_id, query.search.as_deref())
         .await
         .map_err(|e| {
             tracing::error!("Failed to list users: {}", e);

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -112,6 +112,14 @@ impl StorageBackend {
         dispatch!(self, list_users, search)
     }
 
+    pub async fn list_users_by_org(
+        &self,
+        org_id: i64,
+        search: Option<&str>,
+    ) -> Result<Vec<UserRow>> {
+        dispatch!(self, list_users_by_org, org_id, search)
+    }
+
     // ============================================
     // API Keys
     // ============================================

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -243,6 +243,39 @@ impl InMemoryDatabase {
         Ok(result)
     }
 
+    /// List users within an organization (TM-TENANT-008: org-scoped user listing)
+    pub async fn list_users_by_org(
+        &self,
+        org_id: i64,
+        search: Option<&str>,
+    ) -> Result<Vec<UserRow>> {
+        let members = self.organization_members.read();
+        let users = self.users.read();
+
+        // Get user IDs that belong to this org
+        let org_user_ids: std::collections::HashSet<_> = members
+            .keys()
+            .filter(|(oid, _)| *oid == org_id)
+            .map(|(_, uid)| *uid)
+            .collect();
+
+        let mut result: Vec<_> = users
+            .values()
+            .filter(|u| org_user_ids.contains(&u.id))
+            .filter(|u| match search {
+                Some(query) if !query.trim().is_empty() => {
+                    let pattern = query.trim().to_lowercase();
+                    u.name.to_lowercase().contains(&pattern)
+                        || u.email.to_lowercase().contains(&pattern)
+                }
+                _ => true,
+            })
+            .cloned()
+            .collect();
+        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(result)
+    }
+
     // ============================================
     // API Keys
     // ============================================
@@ -4218,5 +4251,115 @@ mod tests {
         // Most recent session should be first
         assert_eq!(sessions[0].title, Some("Session 5".to_string()));
         assert_eq!(sessions[4].title, Some("Session 1".to_string()));
+    }
+
+    // TM-TENANT-008: Verify org-scoped user listing prevents cross-tenant enumeration
+    #[tokio::test]
+    async fn test_list_users_by_org_isolation() {
+        let db = InMemoryDatabase::new();
+
+        // Create two orgs
+        let org1 = db
+            .create_organization(CreateOrganizationRow {
+                public_id: "org_00000000000000000000000000000010".to_string(),
+                name: "Org 1".to_string(),
+                created_by: None,
+            })
+            .await
+            .unwrap();
+        let org2 = db
+            .create_organization(CreateOrganizationRow {
+                public_id: "org_00000000000000000000000000000020".to_string(),
+                name: "Org 2".to_string(),
+                created_by: None,
+            })
+            .await
+            .unwrap();
+
+        // Create three users
+        let user1 = db
+            .create_user(CreateUserRow {
+                email: "alice@example.com".to_string(),
+                name: "Alice".to_string(),
+                avatar_url: None,
+                roles: vec!["user".to_string()],
+                password_hash: None,
+                email_verified: true,
+                auth_provider: None,
+                auth_provider_id: None,
+                external_id: None,
+            })
+            .await
+            .unwrap();
+        let user2 = db
+            .create_user(CreateUserRow {
+                email: "bob@example.com".to_string(),
+                name: "Bob".to_string(),
+                avatar_url: None,
+                roles: vec!["user".to_string()],
+                password_hash: None,
+                email_verified: true,
+                auth_provider: None,
+                auth_provider_id: None,
+                external_id: None,
+            })
+            .await
+            .unwrap();
+        let _user3 = db
+            .create_user(CreateUserRow {
+                email: "charlie@example.com".to_string(),
+                name: "Charlie".to_string(),
+                avatar_url: None,
+                roles: vec!["user".to_string()],
+                password_hash: None,
+                email_verified: true,
+                auth_provider: None,
+                auth_provider_id: None,
+                external_id: None,
+            })
+            .await
+            .unwrap();
+
+        // Add users to different orgs
+        db.add_organization_member(org1.org_id, user1.id, "member")
+            .await
+            .unwrap();
+        db.add_organization_member(org1.org_id, user2.id, "member")
+            .await
+            .unwrap();
+        db.add_organization_member(org2.org_id, user2.id, "member")
+            .await
+            .unwrap();
+        // user3 not in any of these orgs
+
+        // Org1 should see alice + bob
+        let org1_users = db.list_users_by_org(org1.org_id, None).await.unwrap();
+        assert_eq!(org1_users.len(), 2);
+        let org1_emails: Vec<_> = org1_users.iter().map(|u| u.email.as_str()).collect();
+        assert!(org1_emails.contains(&"alice@example.com"));
+        assert!(org1_emails.contains(&"bob@example.com"));
+
+        // Org2 should see only bob
+        let org2_users = db.list_users_by_org(org2.org_id, None).await.unwrap();
+        assert_eq!(org2_users.len(), 1);
+        assert_eq!(org2_users[0].email, "bob@example.com");
+
+        // Charlie should not appear in either org
+        assert!(!org1_emails.contains(&"charlie@example.com"));
+
+        // Search within org should filter
+        let search_results = db
+            .list_users_by_org(org1.org_id, Some("alice"))
+            .await
+            .unwrap();
+        assert_eq!(search_results.len(), 1);
+        assert_eq!(search_results[0].email, "alice@example.com");
+
+        // Search in org2 for alice should return nothing (alice not in org2)
+        let cross_org_search = db
+            .list_users_by_org(org2.org_id, Some("alice"))
+            .await
+            .unwrap();
+        assert_eq!(cross_org_search.len(), 0);
     }
 }

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -266,6 +266,49 @@ impl Database {
         Ok(rows)
     }
 
+    /// List users within an organization (TM-TENANT-008: org-scoped user listing)
+    /// Filters via organization_members join to enforce tenant isolation.
+    pub async fn list_users_by_org(
+        &self,
+        org_id: i64,
+        search: Option<&str>,
+    ) -> Result<Vec<UserRow>> {
+        let rows = match search {
+            Some(query) if !query.trim().is_empty() => {
+                let search_pattern = format!("%{}%", query.trim().to_lowercase());
+                sqlx::query_as::<_, UserRow>(
+                    r#"
+                    SELECT u.id, u.email, u.name, u.avatar_url, u.roles, u.password_hash, u.email_verified, u.auth_provider, u.auth_provider_id, u.created_at, u.updated_at, u.external_id
+                    FROM users u
+                    JOIN organization_members om ON u.id = om.user_id
+                    WHERE om.org_id = $1 AND (LOWER(u.name) LIKE $2 OR LOWER(u.email) LIKE $2)
+                    ORDER BY u.created_at DESC
+                    "#,
+                )
+                .bind(org_id)
+                .bind(&search_pattern)
+                .fetch_all(&self.pool)
+                .await?
+            }
+            _ => {
+                sqlx::query_as::<_, UserRow>(
+                    r#"
+                    SELECT u.id, u.email, u.name, u.avatar_url, u.roles, u.password_hash, u.email_verified, u.auth_provider, u.auth_provider_id, u.created_at, u.updated_at, u.external_id
+                    FROM users u
+                    JOIN organization_members om ON u.id = om.user_id
+                    WHERE om.org_id = $1
+                    ORDER BY u.created_at DESC
+                    "#,
+                )
+                .bind(org_id)
+                .fetch_all(&self.pool)
+                .await?
+            }
+        };
+
+        Ok(rows)
+    }
+
     // ============================================
     // API Keys
     // ============================================

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3985,8 +3985,8 @@
         "tags": [
           "users"
         ],
-        "summary": "GET /v1/users - List all users",
-        "description": "Lists all users in the system with optional search filtering.\nRequires authentication (admin access recommended).",
+        "summary": "GET /v1/users - List users in current organization",
+        "description": "Lists users that belong to the current organization with optional search filtering.\nTM-TENANT-008: Enforces org isolation to prevent cross-tenant user enumeration.",
         "operationId": "list_users",
         "parameters": [
           {
@@ -4001,7 +4001,7 @@
         ],
         "responses": {
           "200": {
-            "description": "List of users",
+            "description": "List of users in organization",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
## What
The `GET /v1/users` endpoint now filters users by organization membership instead of returning all users system-wide.

## Why
EVE-30 / TM-TENANT-008: The endpoint lacked org isolation, allowing any authenticated user to enumerate all users across all organizations.

## How
- Added `ResolvedOrg` extractor to `list_users` handler
- Added `list_users_by_org(org_id, search)` to both PostgreSQL and InMemory storage backends
- PostgreSQL implementation joins `users` with `organization_members` on `org_id`
- InMemory implementation filters by org membership set

## Risk
- Low
- Existing callers that relied on seeing all users will now only see org members. This is the correct behavior per multitenancy spec.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered