### PR TITLE
fix(api): require authentication on all durable API endpoints (EVE-29)

### DIFF
--- a/crates/server/src/api/durable.rs
+++ b/crates/server/src/api/durable.rs
@@ -57,10 +57,7 @@ impl AppState {
     /// Create new state with an optional workflow event store
     ///
     /// Collector holds 360 points = 1 hour at 10s intervals.
-    pub fn new(
-        store: Option<Arc<dyn WorkflowEventStore + Send + Sync>>,
-        auth: AuthState,
-    ) -> Self {
+    pub fn new(store: Option<Arc<dyn WorkflowEventStore + Send + Sync>>, auth: AuthState) -> Self {
         Self {
             store,
             metrics: MetricsCollector::new(360),
@@ -2060,7 +2057,10 @@ mod tests {
     fn test_auth_state() -> AuthState {
         use crate::auth::config::AuthConfig;
         let config = AuthConfig::default();
-        AuthState::builtin(config, std::sync::Arc::new(crate::storage::StorageBackend::in_memory()))
+        AuthState::builtin(
+            config,
+            std::sync::Arc::new(crate::storage::StorageBackend::in_memory()),
+        )
     }
 
     #[test]

--- a/crates/server/src/api/durable.rs
+++ b/crates/server/src/api/durable.rs
@@ -35,22 +35,36 @@ use uuid::Uuid;
 
 use super::common::ErrorResponse;
 use super::sse::{DisconnectReason, SseStreamConfig};
+use crate::auth::middleware::{AuthState, AuthUser};
+use axum::extract::FromRef;
 
 /// App state for durable routes
+/// TM-DURABLE-010: All durable endpoints require authentication.
 #[derive(Clone)]
 pub struct AppState {
     store: Option<Arc<dyn WorkflowEventStore + Send + Sync>>,
     metrics: MetricsCollector,
+    auth: AuthState,
+}
+
+impl FromRef<AppState> for AuthState {
+    fn from_ref(state: &AppState) -> Self {
+        state.auth.clone()
+    }
 }
 
 impl AppState {
     /// Create new state with an optional workflow event store
     ///
     /// Collector holds 360 points = 1 hour at 10s intervals.
-    pub fn new(store: Option<Arc<dyn WorkflowEventStore + Send + Sync>>) -> Self {
+    pub fn new(
+        store: Option<Arc<dyn WorkflowEventStore + Send + Sync>>,
+        auth: AuthState,
+    ) -> Self {
         Self {
             store,
             metrics: MetricsCollector::new(360),
+            auth,
         }
     }
 
@@ -673,6 +687,7 @@ pub struct SendSignalRequest {
     tag = "durable"
 )]
 pub async fn get_health(
+    _auth: AuthUser,
     State(state): State<AppState>,
 ) -> Result<Json<HealthResponse>, (StatusCode, Json<ErrorResponse>)> {
     let store = state.get_store()?;
@@ -699,6 +714,7 @@ pub async fn get_health(
     tag = "durable"
 )]
 pub async fn get_metrics_timeseries(
+    _auth: AuthUser,
     State(state): State<AppState>,
 ) -> Result<Json<MetricsTimeSeriesResponse>, (StatusCode, Json<ErrorResponse>)> {
     let points = state.metrics.get_points().await;
@@ -723,6 +739,7 @@ pub async fn get_metrics_timeseries(
     tag = "durable"
 )]
 pub async fn list_workers(
+    _auth: AuthUser,
     State(state): State<AppState>,
     Query(query): Query<ListWorkersQuery>,
 ) -> Result<Json<WorkersListResponse>, (StatusCode, Json<ErrorResponse>)> {
@@ -782,6 +799,7 @@ pub async fn list_workers(
     tag = "durable"
 )]
 pub async fn drain_worker(
+    _auth: AuthUser,
     State(state): State<AppState>,
     Path(worker_id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
@@ -813,6 +831,7 @@ pub async fn drain_worker(
     tag = "durable"
 )]
 pub async fn resume_worker(
+    _auth: AuthUser,
     State(state): State<AppState>,
     Path(worker_id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
@@ -847,6 +866,7 @@ pub async fn resume_worker(
     tag = "durable"
 )]
 pub async fn list_workflows(
+    _auth: AuthUser,
     State(state): State<AppState>,
     Query(query): Query<ListWorkflowsQuery>,
 ) -> Result<Json<WorkflowsListResponse>, (StatusCode, Json<ErrorResponse>)> {
@@ -904,6 +924,7 @@ pub async fn list_workflows(
     tag = "durable"
 )]
 pub async fn get_workflow(
+    _auth: AuthUser,
     State(state): State<AppState>,
     Path(workflow_id): Path<Uuid>,
 ) -> Result<Json<WorkflowResponse>, (StatusCode, Json<ErrorResponse>)> {
@@ -953,6 +974,7 @@ pub async fn get_workflow(
     tag = "durable"
 )]
 pub async fn get_workflow_events(
+    _auth: AuthUser,
     State(state): State<AppState>,
     Path(workflow_id): Path<Uuid>,
 ) -> Result<Json<WorkflowEventsListResponse>, (StatusCode, Json<ErrorResponse>)> {
@@ -991,6 +1013,7 @@ pub async fn get_workflow_events(
     tag = "durable"
 )]
 pub async fn cancel_workflow(
+    _auth: AuthUser,
     State(state): State<AppState>,
     Path(workflow_id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
@@ -1035,6 +1058,7 @@ pub async fn cancel_workflow(
     tag = "durable"
 )]
 pub async fn send_signal(
+    _auth: AuthUser,
     State(state): State<AppState>,
     Path(workflow_id): Path<Uuid>,
     Json(req): Json<SendSignalRequest>,
@@ -1077,6 +1101,7 @@ pub async fn send_signal(
     tag = "durable"
 )]
 pub async fn list_tasks(
+    _auth: AuthUser,
     State(state): State<AppState>,
     Query(query): Query<ListTasksQuery>,
 ) -> Result<Json<TasksListResponse>, (StatusCode, Json<ErrorResponse>)> {
@@ -1135,6 +1160,7 @@ pub async fn list_tasks(
     tag = "durable"
 )]
 pub async fn list_dlq(
+    _auth: AuthUser,
     State(state): State<AppState>,
     Query(query): Query<ListDlqQuery>,
 ) -> Result<Json<DlqListResponse>, (StatusCode, Json<ErrorResponse>)> {
@@ -1180,6 +1206,7 @@ pub async fn list_dlq(
     tag = "durable"
 )]
 pub async fn retry_dlq(
+    _auth: AuthUser,
     State(state): State<AppState>,
     Path(dlq_id): Path<Uuid>,
 ) -> Result<Json<Uuid>, (StatusCode, Json<ErrorResponse>)> {
@@ -1216,6 +1243,7 @@ pub async fn retry_dlq(
     tag = "durable"
 )]
 pub async fn list_circuit_breakers(
+    _auth: AuthUser,
     State(state): State<AppState>,
 ) -> Result<Json<CircuitBreakersListResponse>, (StatusCode, Json<ErrorResponse>)> {
     let store = state.get_store()?;
@@ -1253,6 +1281,7 @@ pub async fn list_circuit_breakers(
     tag = "durable"
 )]
 pub async fn get_circuit_breaker(
+    _auth: AuthUser,
     State(state): State<AppState>,
     Path(key): Path<String>,
 ) -> Result<Json<CircuitBreakerResponse>, (StatusCode, Json<ErrorResponse>)> {
@@ -1294,6 +1323,7 @@ pub async fn get_circuit_breaker(
     tag = "durable"
 )]
 pub async fn force_open_circuit_breaker(
+    _auth: AuthUser,
     State(state): State<AppState>,
     Path(key): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
@@ -1327,6 +1357,7 @@ pub async fn force_open_circuit_breaker(
     tag = "durable"
 )]
 pub async fn force_close_circuit_breaker(
+    _auth: AuthUser,
     State(state): State<AppState>,
     Path(key): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
@@ -1371,6 +1402,7 @@ pub async fn force_close_circuit_breaker(
     tag = "durable"
 )]
 pub async fn delete_circuit_breaker(
+    _auth: AuthUser,
     State(state): State<AppState>,
     Path(key): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
@@ -1455,6 +1487,7 @@ struct WorkflowSnapshot {
     tag = "durable"
 )]
 pub async fn stream_durable_sse(
+    _auth: AuthUser,
     State(state): State<AppState>,
 ) -> Result<Sse<impl Stream<Item = Result<SseEvent, Infallible>>>, StatusCode> {
     // Verify store is available
@@ -1792,6 +1825,7 @@ pub async fn stream_durable_sse(
     tag = "durable"
 )]
 pub async fn stream_workflow_sse(
+    _auth: AuthUser,
     State(state): State<AppState>,
     Path(workflow_id): Path<Uuid>,
 ) -> Result<Sse<impl Stream<Item = Result<SseEvent, Infallible>>>, StatusCode> {
@@ -2022,6 +2056,13 @@ pub async fn stream_workflow_sse(
 mod tests {
     use super::*;
 
+    /// Create a test AuthState with AuthMode::None (no auth required in tests)
+    fn test_auth_state() -> AuthState {
+        use crate::auth::config::AuthConfig;
+        let config = AuthConfig::default();
+        AuthState::builtin(config, std::sync::Arc::new(crate::storage::StorageBackend::in_memory()))
+    }
+
     #[test]
     fn test_durable_snapshot_serialization() {
         let snapshot = DurableSnapshot {
@@ -2217,7 +2258,7 @@ mod tests {
 
     #[test]
     fn test_app_state_get_store_none() {
-        let state = AppState::new(None);
+        let state = AppState::new(None, test_auth_state());
         let result = state.get_store();
         assert!(result.is_err());
     }

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -397,7 +397,9 @@ impl ServerAppBuilder {
                         as Arc<dyn WorkflowEventStore + Send + Sync>
                 })
             };
-        let durable_state = api::durable::AppState::new(durable_store.clone());
+        // TM-DURABLE-010: All durable endpoints require authentication
+        let durable_state =
+            api::durable::AppState::new(durable_store.clone(), auth_state.clone());
         durable_state.spawn_metrics_sampler();
         let scheduler_store = durable_store.clone();
         let schedules_state =

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -398,8 +398,7 @@ impl ServerAppBuilder {
                 })
             };
         // TM-DURABLE-010: All durable endpoints require authentication
-        let durable_state =
-            api::durable::AppState::new(durable_store.clone(), auth_state.clone());
+        let durable_state = api::durable::AppState::new(durable_store.clone(), auth_state.clone());
         durable_state.spawn_metrics_sampler();
         let scheduler_store = durable_store.clone();
         let schedules_state =

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -184,7 +184,8 @@ impl TestServer {
             db: db.clone(),
             auth: auth_state.clone(),
         };
-        let durable_state = api::durable::AppState::new(Some(durable_store.clone()));
+        let durable_state =
+            api::durable::AppState::new(Some(durable_store.clone()), auth_state.clone());
         let schedules_state = api::schedules::ScheduleAppState::new(Some(durable_store));
         let skills_state = api::skills::AppState::new(db.clone(), auth_state.clone());
         let images_state = api::images::AppState::new(db.clone(), auth_state.clone());

--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -5160,16 +5160,26 @@ mod durable_sse_tests {
     use tokio::net::TcpListener;
     use tower::ServiceExt;
 
+    fn test_auth_state() -> everruns_server::auth::middleware::AuthState {
+        use everruns_server::auth::config::AuthConfig;
+        use everruns_server::storage::StorageBackend;
+        let config = AuthConfig::default();
+        everruns_server::auth::middleware::AuthState::builtin(
+            config,
+            std::sync::Arc::new(StorageBackend::in_memory()),
+        )
+    }
+
     /// Create a test router with in-memory durable store
     fn create_test_app() -> Router {
         let store = Arc::new(InMemoryWorkflowEventStore::new());
-        let state = durable::AppState::new(Some(store));
+        let state = durable::AppState::new(Some(store), test_auth_state());
         durable::routes(state)
     }
 
     /// Create a test router with no durable store (simulates 503)
     fn create_test_app_no_store() -> Router {
-        let state = durable::AppState::new(None);
+        let state = durable::AppState::new(None, test_auth_state());
         durable::routes(state)
     }
 


### PR DESCRIPTION
## What
All `/v1/durable/*` endpoints now require authentication via `AuthUser` extractor.

## Why
EVE-29 / TM-DURABLE-010: All durable workflow endpoints (health, workers, workflows, tasks, DLQ, circuit breakers, SSE) were accessible without authentication, allowing unauthenticated users to view, cancel, and manipulate durable workflows.

## How
- Added `AuthState` to durable `AppState` with `FromRef` impl
- Added `_auth: AuthUser` parameter to all 20 handler functions
- Updated `AppState::new` to accept `AuthState`
- Updated test harness and integration tests

## Risk
- Low
- Callers without valid auth will now get 401. This is the correct behavior.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered