### PR TITLE
fix(grpc): require GRPC_AUTH_TOKEN in production mode (EVE-37)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,6 +300,7 @@ jobs:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       SECRETS_ENCRYPTION_KEY: kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=
       API_BASE_URL: http://localhost:9000
+      GRPC_AUTH_TOKEN: test-grpc-token-for-ci
 
     steps:
       - uses: actions/checkout@v4

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -556,8 +556,7 @@ impl ServerAppBuilder {
                 // THREAT[TM-DURABLE-002]: gRPC unauthenticated access
                 // Mitigation: Bearer token auth required in production (panics if missing)
                 let grpc_token = grpc_service::require_grpc_auth_token();
-                let auth_interceptor =
-                    grpc_service::GrpcAuthInterceptor::new(Some(grpc_token));
+                let auth_interceptor = grpc_service::GrpcAuthInterceptor::new(Some(grpc_token));
                 let addr = grpc_addr.parse().expect("Invalid GRPC_ADDR");
                 tracing::info!("gRPC server listening on {}", addr);
                 if let Err(e) = tonic::transport::Server::builder()

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -554,10 +554,10 @@ impl ServerAppBuilder {
                     grpc_svc.set_task_broadcaster(broadcaster);
                 }
                 // THREAT[TM-DURABLE-002]: gRPC unauthenticated access
-                // Mitigation: Bearer token auth via GRPC_AUTH_TOKEN env var
-                let auth_interceptor = grpc_service::GrpcAuthInterceptor::new(
-                    grpc_service::grpc_auth_token_from_env(),
-                );
+                // Mitigation: Bearer token auth required in production (panics if missing)
+                let grpc_token = grpc_service::require_grpc_auth_token();
+                let auth_interceptor =
+                    grpc_service::GrpcAuthInterceptor::new(Some(grpc_token));
                 let addr = grpc_addr.parse().expect("Invalid GRPC_ADDR");
                 tracing::info!("gRPC server listening on {}", addr);
                 if let Err(e) = tonic::transport::Server::builder()

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -175,6 +175,17 @@ pub fn grpc_auth_token_from_env() -> Option<String> {
         .filter(|t| !t.is_empty())
 }
 
+/// TM-DURABLE-002: Validate that GRPC_AUTH_TOKEN is set in production.
+/// Panics if the token is missing when not in dev mode.
+pub fn require_grpc_auth_token() -> String {
+    grpc_auth_token_from_env().unwrap_or_else(|| {
+        panic!(
+            "GRPC_AUTH_TOKEN must be set when not in dev mode. \
+             Without it, gRPC endpoints are unauthenticated."
+        )
+    })
+}
+
 /// Tonic interceptor that validates bearer token on every gRPC request.
 /// If `expected_token` is `None`, all requests are allowed (dev mode).
 #[derive(Clone)]
@@ -3080,5 +3091,23 @@ mod tests {
             .insert("authorization", "Basic secret123".parse().unwrap());
         let err = interceptor.call(request).unwrap_err();
         assert_eq!(err.code(), tonic::Code::Unauthenticated);
+    }
+
+    // TM-DURABLE-002: require_grpc_auth_token panics when GRPC_AUTH_TOKEN is unset
+    #[test]
+    #[should_panic(expected = "GRPC_AUTH_TOKEN must be set")]
+    fn test_require_grpc_auth_token_panics_without_env() {
+        // SAFETY: single-threaded test; no other thread reads this var concurrently
+        unsafe { std::env::remove_var("GRPC_AUTH_TOKEN") };
+        require_grpc_auth_token();
+    }
+
+    #[test]
+    fn test_require_grpc_auth_token_returns_value() {
+        // SAFETY: single-threaded test; no other thread reads this var concurrently
+        unsafe { std::env::set_var("GRPC_AUTH_TOKEN", "test-token-123") };
+        let token = require_grpc_auth_token();
+        assert_eq!(token, "test-token-123");
+        unsafe { std::env::remove_var("GRPC_AUTH_TOKEN") };
     }
 }


### PR DESCRIPTION
## What
gRPC auth token is now mandatory in production (non-dev) mode.

## Why
EVE-37 / TM-DURABLE-002: When `GRPC_AUTH_TOKEN` was unset, all gRPC requests were allowed without authentication, enabling unauthenticated worker access and cross-org data manipulation.

## How
- Added `require_grpc_auth_token()` that panics at startup if `GRPC_AUTH_TOKEN` is missing
- Updated app_builder to use `require_grpc_auth_token()` instead of `grpc_auth_token_from_env()` (which returned `Option`)
- gRPC server only starts when `!dev_mode`, so dev mode is unaffected

## Risk
- Medium
- Existing production deployments without `GRPC_AUTH_TOKEN` will fail to start. This is intentional — those deployments were running without gRPC auth.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered