### PR TITLE
fix(auth): require AUTH_JWT_SECRET when authentication is enabled (EVE-35)

### DIFF
--- a/crates/server/src/auth/config.rs
+++ b/crates/server/src/auth/config.rs
@@ -166,15 +166,20 @@ impl AuthConfig {
         let api_prefix = std::env::var("API_PREFIX").unwrap_or_default();
 
         // JWT configuration
+        // TM-AUTH-002: Require AUTH_JWT_SECRET when authentication is enabled.
+        // In AuthMode::None, generate a random secret (tokens are not validated).
+        // In AuthMode::Admin or AuthMode::Full, refuse to start without a secret.
         let jwt_secret = std::env::var("AUTH_JWT_SECRET").unwrap_or_else(|_| {
             if mode == AuthMode::None {
-                // Generate a random secret for dev mode
                 use rand::Rng;
                 let bytes: [u8; 32] = rand::rng().random();
                 hex::encode(bytes)
             } else {
-                tracing::warn!("AUTH_JWT_SECRET not set, using insecure default");
-                "insecure-dev-secret-change-me".to_string()
+                panic!(
+                    "AUTH_JWT_SECRET must be set when AUTH_MODE is '{}'. \
+                     Without it, JWTs can be forged by anyone.",
+                    mode.as_str()
+                )
             }
         });
 
@@ -513,6 +518,17 @@ mod tests {
         assert!(
             !config.signup_enabled(),
             "Admin mode should never allow signup"
+        );
+    }
+
+    // TM-AUTH-002: Verify the insecure hardcoded fallback is removed
+    #[test]
+    fn test_default_jwt_config_has_no_insecure_secret() {
+        // AuthConfig::default() should not contain the old hardcoded fallback
+        let config = AuthConfig::default();
+        assert_ne!(
+            config.jwt.secret, "insecure-dev-secret-change-me",
+            "Default config must not use the insecure hardcoded secret"
         );
     }
 }


### PR DESCRIPTION
## What
`AUTH_JWT_SECRET` is now mandatory when `AUTH_MODE` is `admin` or `full`.

## Why
EVE-35 / TM-AUTH-002: When `AUTH_JWT_SECRET` was not set with `AUTH_MODE=admin` or `AUTH_MODE=full`, the server fell back to a hardcoded string `insecure-dev-secret-change-me`, enabling anyone to forge JWT tokens.

## How
- Replaced hardcoded fallback with `panic!` when `AUTH_MODE != none` and `AUTH_JWT_SECRET` is missing
- `AuthMode::None` still generates a random secret (tokens not validated in that mode)
- Clear error message explains why startup failed

## Risk
- Medium
- Existing deployments using `AUTH_MODE=admin` or `AUTH_MODE=full` without `AUTH_JWT_SECRET` will fail to start. This is intentional — those deployments were using a known secret.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered