### PR TITLE
chore(release): prepare v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.8.2] - 2026-03-01
+
+### Highlights
+
+- **Global Chat Page** — New global chat page and Chat harness for direct agent conversations ([#602](https://github.com/everruns/everruns/pull/602), [#608](https://github.com/everruns/everruns/pull/608))
+- **Platform Management Capability** — New capability for platform operations, wired through Chat harness and gRPC workers ([#587](https://github.com/everruns/everruns/pull/587), [#608](https://github.com/everruns/everruns/pull/608), [#615](https://github.com/everruns/everruns/pull/615), [#622](https://github.com/everruns/everruns/pull/622))
+- **SSE Reliability** — Periodic heartbeat comments, HTTP/2 flow control tuning, 1000-connection limit, reliable event ordering via sequence resolution ([#604](https://github.com/everruns/everruns/pull/604), [#584](https://github.com/everruns/everruns/pull/584), [#585](https://github.com/everruns/everruns/pull/585), [#597](https://github.com/everruns/everruns/pull/597), [#606](https://github.com/everruns/everruns/pull/606))
+- **Durable Dashboard Metrics** — Time-series graphs, accurate worker counts, throughput rates, and dev-mode support ([#578](https://github.com/everruns/everruns/pull/578), [#590](https://github.com/everruns/everruns/pull/590), [#596](https://github.com/everruns/everruns/pull/596), [#610](https://github.com/everruns/everruns/pull/610))
+- **OpenAI Context Caching** — Thread `previous_response_id` for server-side context caching across turns ([#594](https://github.com/everruns/everruns/pull/594))
+
+### What's Changed
+
+- fix(worker): wire platform_store in DurableWorker act_activity path ([#622](https://github.com/everruns/everruns/pull/622))
+- chore: add /process-issues command for Linear issue processing ([#619](https://github.com/everruns/everruns/pull/619))
+- chore(specs): security audit — 12 findings with threat model updates ([#618](https://github.com/everruns/everruns/pull/618))
+- feat(ship): add code simplification and security review phases ([#616](https://github.com/everruns/everruns/pull/616))
+- chore(ship): add impact awareness to Phase 5 quality gates ([#617](https://github.com/everruns/everruns/pull/617))
+- fix(server): downgrade missing directory log from error to debug ([#614](https://github.com/everruns/everruns/pull/614))
+- fix(worker): implement PlatformStore for gRPC workers ([#615](https://github.com/everruns/everruns/pull/615))
+- chore(deps): upgrade bashkit v0.1.7 → v0.1.8 ([#613](https://github.com/everruns/everruns/pull/613))
+- fix(example): always pull fresh images on start ([#612](https://github.com/everruns/everruns/pull/612))
+- chore(deps): upgrade everruns-sdk v0.1.2 → v0.1.3 ([#611](https://github.com/everruns/everruns/pull/611))
+- fix(durable): fix dashboard metrics for dev mode and show all statuses ([#610](https://github.com/everruns/everruns/pull/610))
+- feat(ui): add preview tabs to harness detail and edit pages ([#607](https://github.com/everruns/everruns/pull/607))
+- refactor(bench): always use llmsim-latency model in load tests ([#609](https://github.com/everruns/everruns/pull/609))
+- feat(capabilities): register platform_management in Chat harness, rename to Platform Chat ([#608](https://github.com/everruns/everruns/pull/608))
+- fix(server): resolve since_id to sequence for reliable event ordering ([#606](https://github.com/everruns/everruns/pull/606))
+- chore(deps): bump the npm_and_yarn group across 1 directory with 1 update ([#605](https://github.com/everruns/everruns/pull/605))
+- feat(sse): add periodic heartbeat comments to all SSE streams ([#604](https://github.com/everruns/everruns/pull/604))
+- feat(ui,server): add global chat page and Chat harness ([#602](https://github.com/everruns/everruns/pull/602))
+- fix(server): eliminate env var race in Http2FlowConfig tests ([#601](https://github.com/everruns/everruns/pull/601))
+- fix(load-test): remove SSE retry cap to use SDK default unlimited reconnects ([#599](https://github.com/everruns/everruns/pull/599))
+- chore(deps): upgrade bashkit v0.1.6 → v0.1.7 ([#598](https://github.com/everruns/everruns/pull/598))
+- fix(sse): bump SDK with SSE disconnect fix, configurable cycling ([#597](https://github.com/everruns/everruns/pull/597))
+- fix(durable): show workflow/task throughput rates instead of gauges ([#596](https://github.com/everruns/everruns/pull/596))
+- fix(docs): block /cdn-cgi/ in robots.txt ([#595](https://github.com/everruns/everruns/pull/595))
+- feat(core): thread previous_response_id for OpenAI server-side context caching ([#594](https://github.com/everruns/everruns/pull/594))
+- fix(ci): stop cancelling in-progress CI runs on main ([#593](https://github.com/everruns/everruns/pull/593))
+- chore: upgrade Node.js from 20 to 22 LTS ([#592](https://github.com/everruns/everruns/pull/592))
+- chore(ui): update oxfmt to 0.35.0 ([#591](https://github.com/everruns/everruns/pull/591))
+- fix(durable): fix dashboard worker count and metrics accuracy ([#590](https://github.com/everruns/everruns/pull/590))
+- fix(docs): resolve SEO crawling issues (308 redirects, excluded pages) ([#589](https://github.com/everruns/everruns/pull/589))
+- fix(bench): eagerly connect SSE stream before sending messages ([#588](https://github.com/everruns/everruns/pull/588))
+- feat(core): add platform management capability ([#587](https://github.com/everruns/everruns/pull/587))
+- fix(server): configure HTTP/2 flow control for high-concurrency SSE ([#584](https://github.com/everruns/everruns/pull/584))
+- chore(specs): remove code-derivable content, link to source files ([#586](https://github.com/everruns/everruns/pull/586))
+- fix(server): bump per-org SSE connection limit from 50 to 1000 ([#585](https://github.com/everruns/everruns/pull/585))
+- fix(bench): use SDK EventStream for SSE reconnection in load test ([#582](https://github.com/everruns/everruns/pull/582))
+- feat(server): add types positive filter to events endpoints ([#581](https://github.com/everruns/everruns/pull/581))
+- feat(durable): add metrics time-series graphs to overview dashboard ([#578](https://github.com/everruns/everruns/pull/578))
+- feat(fake_aws): autonomous Cost & Security Auditor with rich seed data ([#577](https://github.com/everruns/everruns/pull/577))
+- feat(bench): replace polling with SSE for turn completion detection ([#580](https://github.com/everruns/everruns/pull/580))
+- fix(durable): add summary to workers list response ([#579](https://github.com/everruns/everruns/pull/579))
+- fix(server): use axum_extra::extract::Query for SSE exclude param ([#575](https://github.com/everruns/everruns/pull/575))
+- chore(ship): expand /ship command to enforce full quality workflow ([#576](https://github.com/everruns/everruns/pull/576))
+- feat(llmsim): add latency and streaming simulation for benchmarks ([#574](https://github.com/everruns/everruns/pull/574))
+- fix(ui): merge orphan input.message into turn.started in trajectory view ([#573](https://github.com/everruns/everruns/pull/573))
+- refactor(server): extract ServerAppBuilder, remove server::run() ([#572](https://github.com/everruns/everruns/pull/572))
+- fix(durable): skip postgres-dependent tests without PostgreSQL ([#571](https://github.com/everruns/everruns/pull/571))
+
 ## [0.8.1] - 2026-02-22
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d67d43201f4d20c78bcda740c142ca52482d81da80681533d33bf3f0596c8e2"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -567,9 +567,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-codesandbox"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -1381,7 +1381,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -1398,7 +1398,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1495,7 +1495,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2201,7 +2201,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2547,9 +2547,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.88"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e709f3e3d22866f9c25b3aff01af289b18422cc8b4262fb19103ee80fe513d"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2618,13 +2618,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
- "redox_syscall 0.7.1",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -3409,18 +3410,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3429,9 +3430,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -3465,6 +3466,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "png"
@@ -3643,9 +3650,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
+checksum = "83c41efbf8f90ac44de7f3a868f0867851d261b56291732d0cbf7cceaaeb55a6"
 dependencies = [
  "bitflags 2.11.0",
  "memchr",
@@ -3932,9 +3939,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35985aa610addc02e24fc232012c86fd11f14111180f902b67e2d5331f8ebf2b"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -3990,9 +3997,9 @@ checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "relative-path"
@@ -4221,9 +4228,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -4997,9 +5004,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
  "getrandom 0.4.1",
@@ -5815,9 +5822,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.111"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1adf1535672f5b7824f817792b1afd731d7e843d2d04ec8f27e8cb51edd8ac"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5828,9 +5835,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.61"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe88540d1c934c4ec8e6db0afa536876c5441289d7f9f9123d4f065ac1250a6b"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -5842,9 +5849,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.111"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e638317c08b21663aed4d2b9a2091450548954695ff4efa75bff5fa546b3b1"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5852,9 +5859,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.111"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c64760850114d03d5f65457e96fc988f11f01d38fbaa51b254e4ab5809102af"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5865,9 +5872,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.111"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60eecd4fe26177cfa3339eb00b4a36445889ba3ad37080c2429879718e20ca41"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -5921,9 +5928,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.88"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6bb20ed2d9572df8584f6dc81d68a41a625cadc6f15999d649a70ce7e3597a"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6076,7 +6083,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6716,18 +6723,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns Contributors"]

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "everruns-ui",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@streamdown/code": "^1.0.3",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "exports": {
     "./providers/*": "./src/providers/*.tsx",


### PR DESCRIPTION
## What
Prepare the v0.8.2 patch release — version bumps, lock file updates, and CHANGELOG.md entries.

## Why
Ship 48 merged PRs since v0.8.1 including global chat page, platform management capability, SSE reliability improvements, durable dashboard metrics, and OpenAI context caching.

## How
- Bumped version to 0.8.2 in `Cargo.toml` and `apps/ui/package.json`
- Regenerated `Cargo.lock` and `package-lock.json`
- Added v0.8.2 section to `CHANGELOG.md` with highlights and full commit list

## Risk
- Low
- Version bump only, no code changes

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

### Post-merge
After merging, the release workflow will automatically:
- Create git tag `v0.8.2`
- Create GitHub Release with notes from CHANGELOG.md
- Trigger Docker image build with version tag