### PR TITLE
feat(auth): add per-IP rate limiting on auth endpoints (EVE-31)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1460,6 +1460,7 @@ dependencies = [
  "everruns-session-sqldb",
  "everruns-worker",
  "futures",
+ "governor",
  "hex",
  "http-body-util",
  "hyper",
@@ -1919,6 +1920,29 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "governor"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be93b4ec2e4710b04d9264c0c7350cdd62a8c20e5e4ac732552ebb8f0debe8eb"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.9.2",
+ "smallvec",
+ "spinning_top",
+ "web-time",
 ]
 
 [[package]]
@@ -2954,6 +2978,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2962,6 +2992,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "ntapi"
@@ -3678,6 +3714,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3906,6 +3957,15 @@ dependencies = [
  "time",
  "unicode-segmentation",
  "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -4643,6 +4703,15 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
 dependencies = [
  "lock_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,9 @@ aes-gcm = "0.10"
 rand = "0.9"
 base64 = "0.22"
 
+# Rate limiting
+governor = "0.8"
+
 # Authentication
 argon2 = "0.5"
 jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -51,6 +51,7 @@ regex.workspace = true
 async-trait.workspace = true
 aes-gcm.workspace = true
 argon2.workspace = true
+governor.workspace = true
 parking_lot.workspace = true
 cron = "0.15"
 inventory.workspace = true

--- a/crates/server/src/auth/builtin.rs
+++ b/crates/server/src/auth/builtin.rs
@@ -12,6 +12,7 @@ use super::backend::AuthBackend;
 use super::config::AuthConfig;
 use super::jwt::JwtService;
 use super::middleware::{AuthError, AuthMethod, AuthUser};
+use super::rate_limit::AuthRateLimiter;
 use super::routes::{self, AuthConfigResponse};
 use crate::storage::StorageBackend;
 
@@ -22,6 +23,7 @@ pub struct BuiltinAuthBackend {
     pub config: AuthConfig,
     pub jwt_service: Arc<JwtService>,
     pub db: Arc<StorageBackend>,
+    pub rate_limiter: AuthRateLimiter,
 }
 
 impl BuiltinAuthBackend {
@@ -31,6 +33,7 @@ impl BuiltinAuthBackend {
             config,
             jwt_service,
             db,
+            rate_limiter: AuthRateLimiter::new(),
         }
     }
 }

--- a/crates/server/src/auth/mod.rs
+++ b/crates/server/src/auth/mod.rs
@@ -10,6 +10,7 @@ pub mod config;
 pub mod jwt;
 pub mod middleware;
 pub mod oauth;
+pub mod rate_limit;
 pub mod routes;
 
 pub use backend::AuthBackend;

--- a/crates/server/src/auth/rate_limit.rs
+++ b/crates/server/src/auth/rate_limit.rs
@@ -1,0 +1,193 @@
+// TM-AUTH-001: Per-IP rate limiting for authentication endpoints.
+// Decision: Use governor crate with in-memory state (per-instance).
+// Decision: Different limits for login (strict), register (strict), refresh (relaxed).
+// Decision: Keyed by client IP extracted from X-Forwarded-For or socket addr.
+
+use axum::{
+    body::Body,
+    extract::ConnectInfo,
+    http::{Request, StatusCode},
+    response::{IntoResponse, Response},
+};
+use governor::{Quota, RateLimiter, clock::DefaultClock, state::keyed::DashMapStateStore};
+use std::{net::IpAddr, num::NonZeroU32, sync::Arc};
+
+type KeyedLimiter = RateLimiter<IpAddr, DashMapStateStore<IpAddr>, DefaultClock>;
+
+/// Rate limiter for auth endpoints, shared via Arc.
+#[derive(Clone)]
+pub struct AuthRateLimiter {
+    /// Login: 10 requests per minute per IP
+    login: Arc<KeyedLimiter>,
+    /// Register: 5 requests per minute per IP
+    register: Arc<KeyedLimiter>,
+    /// Refresh: 30 requests per minute per IP
+    refresh: Arc<KeyedLimiter>,
+}
+
+impl Default for AuthRateLimiter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AuthRateLimiter {
+    pub fn new() -> Self {
+        Self {
+            login: Arc::new(RateLimiter::keyed(Quota::per_minute(
+                NonZeroU32::new(10).unwrap(),
+            ))),
+            register: Arc::new(RateLimiter::keyed(Quota::per_minute(
+                NonZeroU32::new(5).unwrap(),
+            ))),
+            refresh: Arc::new(RateLimiter::keyed(Quota::per_minute(
+                NonZeroU32::new(30).unwrap(),
+            ))),
+        }
+    }
+
+    /// Check login rate limit. Returns Err(429) if exceeded.
+    pub fn check_login(&self, ip: IpAddr) -> Result<(), RateLimitError> {
+        self.check(&self.login, ip)
+    }
+
+    /// Check register rate limit. Returns Err(429) if exceeded.
+    pub fn check_register(&self, ip: IpAddr) -> Result<(), RateLimitError> {
+        self.check(&self.register, ip)
+    }
+
+    /// Check refresh rate limit. Returns Err(429) if exceeded.
+    pub fn check_refresh(&self, ip: IpAddr) -> Result<(), RateLimitError> {
+        self.check(&self.refresh, ip)
+    }
+
+    fn check(&self, limiter: &KeyedLimiter, ip: IpAddr) -> Result<(), RateLimitError> {
+        match limiter.check_key(&ip) {
+            Ok(_) => Ok(()),
+            Err(_) => {
+                tracing::warn!(ip = %ip, "Rate limit exceeded on auth endpoint");
+                Err(RateLimitError)
+            }
+        }
+    }
+}
+
+/// Small error type to avoid large Result<(), Response> on the stack.
+pub struct RateLimitError;
+
+impl From<RateLimitError> for Response {
+    fn from(_: RateLimitError) -> Self {
+        (
+            StatusCode::TOO_MANY_REQUESTS,
+            [("retry-after", "60")],
+            axum::Json(serde_json::json!({
+                "error": "Too many requests. Please try again later."
+            })),
+        )
+            .into_response()
+    }
+}
+
+/// Extract client IP from request. Checks X-Forwarded-For first, falls back to
+/// X-Real-IP, then ConnectInfo peer addr, then loopback.
+pub fn extract_client_ip(req: &Request<Body>) -> IpAddr {
+    // X-Forwarded-For: client, proxy1, proxy2 — take the first (leftmost)
+    if let Some(forwarded) = req.headers().get("x-forwarded-for")
+        && let Ok(val) = forwarded.to_str()
+        && let Some(first) = val.split(',').next()
+        && let Ok(ip) = first.trim().parse::<IpAddr>()
+    {
+        return ip;
+    }
+
+    // X-Real-IP (single IP, set by reverse proxy)
+    if let Some(real_ip) = req.headers().get("x-real-ip")
+        && let Ok(val) = real_ip.to_str()
+        && let Ok(ip) = val.trim().parse::<IpAddr>()
+    {
+        return ip;
+    }
+
+    // ConnectInfo from axum (socket peer address)
+    if let Some(connect_info) = req.extensions().get::<ConnectInfo<std::net::SocketAddr>>() {
+        return connect_info.0.ip();
+    }
+
+    // Fallback: loopback (shouldn't happen in production)
+    IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn test_login_rate_limit_allows_initial_requests() {
+        let limiter = AuthRateLimiter::new();
+        let ip = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
+        assert!(limiter.check_login(ip).is_ok());
+    }
+
+    #[test]
+    fn test_login_rate_limit_blocks_after_burst() {
+        let limiter = AuthRateLimiter::new();
+        let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        for _ in 0..10 {
+            let _ = limiter.check_login(ip);
+        }
+        assert!(limiter.check_login(ip).is_err());
+    }
+
+    #[test]
+    fn test_register_rate_limit_stricter_than_login() {
+        let limiter = AuthRateLimiter::new();
+        let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+        for _ in 0..5 {
+            let _ = limiter.check_register(ip);
+        }
+        assert!(
+            limiter.check_register(ip).is_err(),
+            "Register should be blocked after 5 requests"
+        );
+    }
+
+    #[test]
+    fn test_different_ips_have_separate_limits() {
+        let limiter = AuthRateLimiter::new();
+        let ip1 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+        let ip2 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 4));
+        for _ in 0..5 {
+            let _ = limiter.check_register(ip1);
+        }
+        assert!(limiter.check_register(ip1).is_err());
+        assert!(limiter.check_register(ip2).is_ok());
+    }
+
+    #[test]
+    fn test_extract_ip_from_x_forwarded_for() {
+        let req = Request::builder()
+            .header("x-forwarded-for", "203.0.113.50, 70.41.3.18")
+            .body(Body::empty())
+            .unwrap();
+        let ip = extract_client_ip(&req);
+        assert_eq!(ip, IpAddr::V4(Ipv4Addr::new(203, 0, 113, 50)));
+    }
+
+    #[test]
+    fn test_extract_ip_from_x_real_ip() {
+        let req = Request::builder()
+            .header("x-real-ip", "198.51.100.25")
+            .body(Body::empty())
+            .unwrap();
+        let ip = extract_client_ip(&req);
+        assert_eq!(ip, IpAddr::V4(Ipv4Addr::new(198, 51, 100, 25)));
+    }
+
+    #[test]
+    fn test_extract_ip_fallback_to_loopback() {
+        let req = Request::builder().body(Body::empty()).unwrap();
+        let ip = extract_client_ip(&req);
+        assert_eq!(ip, IpAddr::V4(Ipv4Addr::LOCALHOST));
+    }
+}

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -4,9 +4,11 @@
 
 use axum::{
     Json, Router,
+    body::Body,
     extract::{FromRef, Path, Query, State},
-    http::StatusCode,
-    response::Redirect,
+    http::{Request, StatusCode},
+    middleware::{self, Next},
+    response::{Redirect, Response},
     routing::{delete, get, post},
 };
 use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
@@ -16,6 +18,8 @@ use rand::Rng;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
+
+use super::rate_limit::extract_client_ip;
 
 use super::{
     api_key::generate_api_key,
@@ -151,14 +155,70 @@ pub struct AuthConfigResponse {
     pub signup_enabled: bool,
 }
 
+/// Rate limit middleware for login endpoint
+async fn rate_limit_login(
+    State(state): State<BuiltinAuthBackend>,
+    req: Request<Body>,
+    next: Next,
+) -> Response {
+    let ip = extract_client_ip(&req);
+    if let Err(e) = state.rate_limiter.check_login(ip) {
+        return e.into();
+    }
+    next.run(req).await
+}
+
+/// Rate limit middleware for register endpoint
+async fn rate_limit_register(
+    State(state): State<BuiltinAuthBackend>,
+    req: Request<Body>,
+    next: Next,
+) -> Response {
+    let ip = extract_client_ip(&req);
+    if let Err(e) = state.rate_limiter.check_register(ip) {
+        return e.into();
+    }
+    next.run(req).await
+}
+
+/// Rate limit middleware for refresh endpoint
+async fn rate_limit_refresh(
+    State(state): State<BuiltinAuthBackend>,
+    req: Request<Body>,
+    next: Next,
+) -> Response {
+    let ip = extract_client_ip(&req);
+    if let Err(e) = state.rate_limiter.check_refresh(ip) {
+        return e.into();
+    }
+    next.run(req).await
+}
+
 /// Create auth routes
 pub fn routes(state: BuiltinAuthBackend) -> Router {
-    Router::new()
-        // Public routes
-        .route("/v1/auth/config", get(get_auth_config))
+    // Rate-limited routes (sensitive auth endpoints)
+    let login_route = Router::new()
         .route("/v1/auth/login", post(login))
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            rate_limit_login,
+        ));
+    let register_route = Router::new()
         .route("/v1/auth/register", post(register))
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            rate_limit_register,
+        ));
+    let refresh_route = Router::new()
         .route("/v1/auth/refresh", post(refresh_token))
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            rate_limit_refresh,
+        ));
+
+    Router::new()
+        // Public routes (no rate limit needed)
+        .route("/v1/auth/config", get(get_auth_config))
         .route("/v1/auth/logout", post(logout))
         // OAuth routes
         .route("/v1/auth/oauth/{provider}", get(oauth_redirect))
@@ -170,6 +230,10 @@ pub fn routes(state: BuiltinAuthBackend) -> Router {
             get(list_api_keys).post(create_api_key_route),
         )
         .route("/v1/auth/api-keys/{key_id}", delete(delete_api_key_route))
+        // Merge rate-limited routes
+        .merge(login_route)
+        .merge(register_route)
+        .merge(refresh_route)
         .with_state(state)
 }
 


### PR DESCRIPTION
## Summary
- Add per-IP rate limiting to login (10/min), register (5/min), and refresh (30/min) auth endpoints using `governor` crate
- Extract client IP from X-Forwarded-For, X-Real-IP, or socket addr
- Return 429 Too Many Requests with Retry-After header when limit exceeded

Closes EVE-31 (TM-AUTH-001)

## Test plan
- [x] Unit tests for rate limit enforcement (burst exhaustion, per-IP isolation)
- [x] Unit tests for IP extraction from proxy headers
- [x] Clippy clean, formatted