### PR TITLE
fix(server): warn when DATABASE_URL lacks TLS in production (EVE-39)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
 # Database
+# Local development (no TLS):
 DATABASE_URL=postgres://everruns:everruns@localhost:5432/everruns
+# Production (TLS required):
+# DATABASE_URL=postgres://user:pass@host:5432/db?sslmode=require
 
 # LLM Provider API Keys
 # NOTE: LLM provider API keys (OpenAI, Anthropic) are stored in the database

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -224,6 +224,21 @@ impl ServerAppBuilder {
         } else {
             let database_url = std::env::var("DATABASE_URL")
                 .context("DATABASE_URL environment variable required")?;
+
+            // TM-NEW: Warn when DATABASE_URL lacks TLS in production
+            if !database_url.contains("sslmode=") {
+                tracing::warn!(
+                    "DATABASE_URL does not specify sslmode. \
+                     For production, use sslmode=require or sslmode=verify-full \
+                     to encrypt database connections."
+                );
+            } else if database_url.contains("sslmode=disable") {
+                tracing::warn!(
+                    "DATABASE_URL has sslmode=disable — database connections are unencrypted. \
+                     For production, use sslmode=require or sslmode=verify-full."
+                );
+            }
+
             let backend = StorageBackend::postgres(&database_url)
                 .await
                 .context("Failed to connect to database")?;


### PR DESCRIPTION
## Summary
- Add startup warnings when DATABASE_URL doesn't include sslmode= or uses sslmode=disable
- Update .env.example with production TLS connection string example

Closes EVE-39

## Test plan
- [x] Verified startup warning triggers for URLs without sslmode
- [x] Verified warning triggers for sslmode=disable
- [x] No warning for URLs with sslmode=require