### PR TITLE
fix(api): add regex pattern length limit on grep endpoint (EVE-36)

### DIFF
--- a/crates/server/src/services/session_file.rs
+++ b/crates/server/src/services/session_file.rs
@@ -439,8 +439,19 @@ impl SessionFileService {
     }
 
     /// Search files using grep-like pattern matching
+    /// Max regex pattern length to prevent resource-intensive compilation (TM-DOS-008)
+    const MAX_GREP_PATTERN_LEN: usize = 1000;
+
     pub async fn grep(&self, session_id: Uuid, req: GrepInput) -> Result<Vec<GrepResult>> {
-        // Validate regex pattern
+        // TM-DOS-008: Limit pattern length to prevent expensive regex compilation.
+        // Note: Rust's `regex` crate already prevents catastrophic backtracking
+        // (uses Thompson NFA), but compilation cost is O(n) in pattern length.
+        anyhow::ensure!(
+            req.pattern.len() <= Self::MAX_GREP_PATTERN_LEN,
+            "Regex pattern too long (max {} characters)",
+            Self::MAX_GREP_PATTERN_LEN
+        );
+
         let regex = Regex::new(&req.pattern)?;
 
         // Get matching files from database


### PR DESCRIPTION
## Summary
- Add 1000-character limit on regex patterns in session file grep endpoint
- Rust's `regex` crate already prevents catastrophic backtracking (Thompson NFA), but pattern compilation cost is O(n) so length limits are still prudent

Closes EVE-36 (TM-DOS-008)

## Test plan
- [x] Verified compilation
- [x] Pattern length check returns error for oversized patterns