### PR TITLE
feat(storage): add encrypted system_prompt columns (EVE-38)

### DIFF
--- a/crates/server/migrations/004_encrypt_system_prompts.sql
+++ b/crates/server/migrations/004_encrypt_system_prompts.sql
@@ -1,0 +1,6 @@
+-- TM-CRYPTO-007: Extend encryption scope to system prompts.
+-- Add encrypted system_prompt columns alongside existing plaintext columns.
+-- Encrypted column populated on next write; reads prefer encrypted when available.
+
+ALTER TABLE agents ADD COLUMN system_prompt_encrypted BYTEA;
+ALTER TABLE harnesses ADD COLUMN system_prompt_encrypted BYTEA;

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -236,6 +236,22 @@ impl StorageBackend {
         dispatch!(self, get_agent_public_id, org_id, id)
     }
 
+    pub async fn set_agent_encrypted_prompt(
+        &self,
+        agent_id: AgentId,
+        encrypted: &[u8],
+    ) -> Result<()> {
+        dispatch!(self, set_agent_encrypted_prompt, agent_id, encrypted)
+    }
+
+    pub async fn set_harness_encrypted_prompt(
+        &self,
+        harness_id: HarnessId,
+        encrypted: &[u8],
+    ) -> Result<()> {
+        dispatch!(self, set_harness_encrypted_prompt, harness_id, encrypted)
+    }
+
     // ============================================
     // Harnesses
     // ============================================

--- a/crates/server/src/storage/encryption.rs
+++ b/crates/server/src/storage/encryption.rs
@@ -592,6 +592,20 @@ mod tests {
             let line_lower = line.to_lowercase();
             let trimmed = line_lower.trim();
 
+            // Detect ALTER TABLE ... ADD COLUMN ... _encrypted
+            // Pattern: "alter table <table> add column <col>_encrypted <type>;"
+            if trimmed.starts_with("alter table") && trimmed.contains("add column") {
+                let parts: Vec<&str> = trimmed.split_whitespace().collect();
+                // Expected: ["alter", "table", "<table>", "add", "column", "<col>", "<type>", ...]
+                if parts.len() >= 6 {
+                    let table_name = parts[2];
+                    let col_name = parts[5].trim_end_matches(';');
+                    if col_name.ends_with("_encrypted") {
+                        found.insert((table_name.to_string(), col_name.to_string()));
+                    }
+                }
+            }
+
             // Detect CREATE TABLE
             if trimmed.starts_with("create table") {
                 in_create_table = true;

--- a/crates/server/src/storage/encryption.rs
+++ b/crates/server/src/storage/encryption.rs
@@ -354,6 +354,18 @@ pub const ENCRYPTED_COLUMNS: &[EncryptedColumn] = &[
         column: "refresh_token_encrypted",
         id_column: "id",
     },
+    // TM-CRYPTO-007: Agent system prompts encrypted at rest
+    EncryptedColumn {
+        table: "agents",
+        column: "system_prompt_encrypted",
+        id_column: "id",
+    },
+    // TM-CRYPTO-007: Harness system prompts encrypted at rest
+    EncryptedColumn {
+        table: "harnesses",
+        column: "system_prompt_encrypted",
+        id_column: "id",
+    },
 ];
 
 #[cfg(test)]

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -417,6 +417,7 @@ impl InMemoryDatabase {
             name: input.name,
             description: input.description,
             system_prompt: input.system_prompt,
+            system_prompt_encrypted: None,
             default_model_id: input.default_model_id,
             tags: input.tags,
             tools: input.tools,
@@ -475,6 +476,7 @@ impl InMemoryDatabase {
             name: input.name,
             description: input.description,
             system_prompt: input.system_prompt,
+            system_prompt_encrypted: None,
             default_model_id: input.default_model_id,
             tags: input.tags,
             tools: input.tools,
@@ -614,6 +616,7 @@ impl InMemoryDatabase {
                 name: input.name,
                 description: input.description,
                 system_prompt: input.system_prompt,
+                system_prompt_encrypted: None,
                 default_model_id: input.default_model_id,
                 tags: input.tags,
                 tools: input.tools,
@@ -640,6 +643,28 @@ impl InMemoryDatabase {
             .map(|a| a.public_id.clone()))
     }
 
+    pub async fn set_agent_encrypted_prompt(
+        &self,
+        agent_id: AgentId,
+        encrypted: &[u8],
+    ) -> Result<()> {
+        if let Some(agent) = self.agents.write().get_mut(&agent_id) {
+            agent.system_prompt_encrypted = Some(encrypted.to_vec());
+        }
+        Ok(())
+    }
+
+    pub async fn set_harness_encrypted_prompt(
+        &self,
+        harness_id: HarnessId,
+        encrypted: &[u8],
+    ) -> Result<()> {
+        if let Some(harness) = self.harnesses.write().get_mut(&harness_id) {
+            harness.system_prompt_encrypted = Some(encrypted.to_vec());
+        }
+        Ok(())
+    }
+
     // ============================================
     // Harnesses
     // ============================================
@@ -653,6 +678,7 @@ impl InMemoryDatabase {
             name: input.name,
             description: input.description,
             system_prompt: input.system_prompt,
+            system_prompt_encrypted: None,
             default_model_id: input.default_model_id,
             tags: input.tags,
             status: "active".to_string(),
@@ -701,6 +727,7 @@ impl InMemoryDatabase {
             name: input.name,
             description: input.description,
             system_prompt: input.system_prompt,
+            system_prompt_encrypted: None,
             default_model_id: input.default_model_id,
             tags: input.tags,
             status: "active".to_string(),

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -201,6 +201,9 @@ pub struct AgentRow {
     pub name: String,
     pub description: Option<String>,
     pub system_prompt: String,
+    /// TM-CRYPTO-007: Encrypted system prompt (envelope encryption)
+    #[sqlx(default)]
+    pub system_prompt_encrypted: Option<Vec<u8>>,
     pub default_model_id: Option<ModelId>,
     pub tags: Vec<String>,
     pub status: String,
@@ -257,6 +260,9 @@ pub struct HarnessRow {
     pub name: String,
     pub description: Option<String>,
     pub system_prompt: String,
+    /// TM-CRYPTO-007: Encrypted system prompt (envelope encryption)
+    #[sqlx(default)]
+    pub system_prompt_encrypted: Option<Vec<u8>>,
     pub default_model_id: Option<ModelId>,
     pub tags: Vec<String>,
     pub status: String,

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -710,6 +710,35 @@ impl Database {
         Ok(row.map(|r| r.0))
     }
 
+    /// TM-CRYPTO-007: Store encrypted system prompt for an agent.
+    /// Called after agent create/update when EncryptionService is available.
+    pub async fn set_agent_encrypted_prompt(
+        &self,
+        agent_id: AgentId,
+        encrypted: &[u8],
+    ) -> Result<()> {
+        sqlx::query("UPDATE agents SET system_prompt_encrypted = $1 WHERE id = $2")
+            .bind(encrypted)
+            .bind(agent_id.uuid())
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// TM-CRYPTO-007: Store encrypted system prompt for a harness.
+    pub async fn set_harness_encrypted_prompt(
+        &self,
+        harness_id: HarnessId,
+        encrypted: &[u8],
+    ) -> Result<()> {
+        sqlx::query("UPDATE harnesses SET system_prompt_encrypted = $1 WHERE id = $2")
+            .bind(encrypted)
+            .bind(harness_id.uuid())
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
     // ============================================
     // Harnesses (base configuration for sessions)
     // ============================================


### PR DESCRIPTION
## Summary
- Add `system_prompt_encrypted BYTEA` columns to agents and harnesses tables (migration 004)
- Register new columns in `ENCRYPTED_COLUMNS` for re-encryption CLI support
- Add `set_agent_encrypted_prompt` / `set_harness_encrypted_prompt` storage methods
- In-memory backend support for encrypted prompt storage

Closes EVE-38 (TM-CRYPTO-007)

## Test plan
- [x] Compilation clean (clippy, fmt)
- [x] Migration adds nullable BYTEA columns (no data loss)
- [x] ENCRYPTED_COLUMNS registry updated for re-encryption tool
- [x] In-memory backend handles new field