### PR TITLE
feat(capabilities): add risk level classification and admin approval (EVE-17)

### DIFF
--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -362,6 +362,34 @@ pub trait Capability: Send + Sync {
     fn message_filter_provider(&self) -> Option<Arc<dyn MessageFilterProvider>> {
         None
     }
+
+    /// Returns the risk level of this capability.
+    ///
+    /// TM-AGENT-005: High-risk capabilities (code execution, network access)
+    /// require admin approval when assigned to agents/harnesses. Capabilities
+    /// that combine execution + network access enable data exfiltration.
+    ///
+    /// By default, returns `RiskLevel::Low`.
+    fn risk_level(&self) -> RiskLevel {
+        RiskLevel::Low
+    }
+}
+
+/// Risk classification for capabilities (TM-AGENT-005).
+///
+/// Used to enforce approval requirements when assigning capabilities.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum RiskLevel {
+    /// No special approval needed
+    Low,
+    /// Logged but allowed for org members
+    Medium,
+    /// Requires org admin role to assign
+    High,
 }
 
 // ============================================================================
@@ -2302,5 +2330,36 @@ mod tests {
             &registry,
         );
         assert_eq!(features, vec!["schedules"]);
+    }
+
+    #[test]
+    fn test_risk_level_ordering() {
+        assert!(RiskLevel::Low < RiskLevel::Medium);
+        assert!(RiskLevel::Medium < RiskLevel::High);
+    }
+
+    #[test]
+    fn test_risk_level_serde_roundtrip() {
+        let high = RiskLevel::High;
+        let json = serde_json::to_string(&high).unwrap();
+        assert_eq!(json, "\"high\"");
+        let back: RiskLevel = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, RiskLevel::High);
+    }
+
+    #[test]
+    fn test_high_risk_capabilities() {
+        let registry = CapabilityRegistry::with_builtins();
+
+        // virtual_bash and web_fetch should be High
+        let bash = registry.get("virtual_bash").unwrap();
+        assert_eq!(bash.risk_level(), RiskLevel::High);
+
+        let fetch = registry.get("web_fetch").unwrap();
+        assert_eq!(fetch.risk_level(), RiskLevel::High);
+
+        // Default capabilities should be Low
+        let noop = registry.get("noop").unwrap();
+        assert_eq!(noop.risk_level(), RiskLevel::Low);
     }
 }

--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -11,7 +11,7 @@
 //! - Resource limits prevent runaway scripts (max commands, loop iterations)
 //! - Context-aware tool that requires session filesystem access
 
-use super::{Capability, CapabilityStatus};
+use super::{Capability, CapabilityStatus, RiskLevel};
 use crate::session_file::SessionFile;
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::{SessionFileStore, ToolContext};
@@ -86,6 +86,10 @@ impl Capability for VirtualBashCapability {
 
     fn status(&self) -> CapabilityStatus {
         CapabilityStatus::Available
+    }
+
+    fn risk_level(&self) -> RiskLevel {
+        RiskLevel::High
     }
 
     fn icon(&self) -> Option<&str> {

--- a/crates/core/src/capabilities/web_fetch.rs
+++ b/crates/core/src/capabilities/web_fetch.rs
@@ -9,7 +9,7 @@
 //! - Timeout for first byte: 1 second (connect + time to first response byte)
 //! - Timeout for body: 30 seconds total, partial content returned if exceeded
 
-use super::{Capability, CapabilityStatus};
+use super::{Capability, CapabilityStatus, RiskLevel};
 use crate::tools::{Tool, ToolExecutionResult};
 use async_trait::async_trait;
 use fetchkit::{
@@ -36,6 +36,10 @@ impl Capability for WebFetchCapability {
 
     fn status(&self) -> CapabilityStatus {
         CapabilityStatus::Available
+    }
+
+    fn risk_level(&self) -> RiskLevel {
+        RiskLevel::High
     }
 
     fn icon(&self) -> Option<&str> {

--- a/crates/core/src/capability_dto.rs
+++ b/crates/core/src/capability_dto.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
 
+use crate::capabilities::RiskLevel;
 use crate::capability_types::{CapabilityId, CapabilityStatus};
 use crate::tool_types::ToolDefinition;
 
@@ -54,6 +55,16 @@ pub struct CapabilityInfo {
     /// Multiple capabilities can contribute the same feature.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub features: Vec<String>,
+    /// TM-AGENT-005: Risk level. High-risk capabilities require admin approval.
+    #[serde(skip_serializing_if = "is_low_risk", default = "default_risk_level")]
+    pub risk_level: RiskLevel,
+}
+
+fn is_low_risk(r: &RiskLevel) -> bool {
+    *r == RiskLevel::Low
+}
+fn default_risk_level() -> RiskLevel {
+    RiskLevel::Low
 }
 
 impl CapabilityInfo {
@@ -78,6 +89,7 @@ impl CapabilityInfo {
             is_skill,
             dependencies: cap.dependencies().iter().map(|s| s.to_string()).collect(),
             features: cap.features().iter().map(|s| s.to_string()).collect(),
+            risk_level: cap.risk_level(),
         }
     }
 }
@@ -112,6 +124,7 @@ mod tests {
             is_skill: false,
             dependencies: vec![],
             features: vec![],
+            risk_level: RiskLevel::Low,
         };
 
         let json = serde_json::to_string(&cap).unwrap();
@@ -143,6 +156,7 @@ mod tests {
             is_skill: false,
             dependencies: vec![],
             features: vec![],
+            risk_level: RiskLevel::Low,
         };
 
         let json = serde_json::to_string(&cap).unwrap();
@@ -164,6 +178,7 @@ mod tests {
             is_skill: false,
             dependencies: vec!["session_file_system".to_string()],
             features: vec![],
+            risk_level: RiskLevel::Low,
         };
 
         let json = serde_json::to_string(&cap).unwrap();
@@ -217,6 +232,7 @@ mod tests {
             is_skill: false,
             dependencies: vec![],
             features: vec!["secrets".to_string(), "key_value".to_string()],
+            risk_level: RiskLevel::Low,
         };
 
         let json = serde_json::to_string(&cap).unwrap();
@@ -240,5 +256,58 @@ mod tests {
         let noop_cap = registry.get("noop").unwrap();
         let info = CapabilityInfo::from_core(noop_cap.as_ref());
         assert!(info.features.is_empty());
+    }
+
+    #[test]
+    fn test_risk_level_serialization() {
+        // Low risk should be skipped in serialization
+        let cap = CapabilityInfo {
+            id: CapabilityId::new("safe"),
+            name: "Safe".to_string(),
+            description: "Low risk".to_string(),
+            status: CapabilityStatus::Available,
+            icon: None,
+            category: None,
+            system_prompt: None,
+            tool_definitions: vec![],
+            is_mcp: false,
+            is_skill: false,
+            dependencies: vec![],
+            features: vec![],
+            risk_level: RiskLevel::Low,
+        };
+        let json = serde_json::to_string(&cap).unwrap();
+        assert!(
+            !json.contains("\"risk_level\""),
+            "Low risk should be omitted"
+        );
+
+        // High risk should be present
+        let cap_high = CapabilityInfo {
+            risk_level: RiskLevel::High,
+            ..cap
+        };
+        let json = serde_json::to_string(&cap_high).unwrap();
+        assert!(json.contains("\"risk_level\":\"high\""));
+    }
+
+    #[test]
+    fn test_from_core_populates_risk_level() {
+        let registry = crate::capabilities::CapabilityRegistry::with_builtins();
+
+        // virtual_bash is High risk
+        let bash_cap = registry.get("virtual_bash").unwrap();
+        let info = CapabilityInfo::from_core(bash_cap.as_ref());
+        assert_eq!(info.risk_level, RiskLevel::High);
+
+        // web_fetch is High risk
+        let fetch_cap = registry.get("web_fetch").unwrap();
+        let info = CapabilityInfo::from_core(fetch_cap.as_ref());
+        assert_eq!(info.risk_level, RiskLevel::High);
+
+        // noop is Low risk (default)
+        let noop_cap = registry.get("noop").unwrap();
+        let info = CapabilityInfo::from_core(noop_cap.as_ref());
+        assert_eq!(info.risk_level, RiskLevel::Low);
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -155,12 +155,12 @@ pub use capabilities::{
     IntegrationPlugin, ListDirectoryTool, MAX_RESOLVED_CAPABILITIES, MCP_CAPABILITY_PREFIX,
     McpCapability, MountAccess, MountDirectoryBuilder, MountEntry, MountPoint, MountSource,
     MultiplyTool, NoopCapability, PlatformManagementCapability, ReadFileTool, ResearchCapability,
-    ResolvedCapabilities, SampleDataCapability, SessionCapability, SessionSqlDatabaseCapability,
-    SqlExecuteTool, SqlQueryTool, SqlSchemaTool, StatFileTool, StatelessTodoListCapability,
-    SubtractTool, TestMathCapability, TestWeatherCapability, WriteFileTool, WriteSessionTitleTool,
-    WriteTodosTool, apply_capabilities, collect_capabilities, collect_capabilities_with_configs,
-    compute_features, get_dependencies, is_mcp_capability, mcp_capability_id,
-    parse_mcp_capability_id, resolve_dependencies,
+    ResolvedCapabilities, RiskLevel, SampleDataCapability, SessionCapability,
+    SessionSqlDatabaseCapability, SqlExecuteTool, SqlQueryTool, SqlSchemaTool, StatFileTool,
+    StatelessTodoListCapability, SubtractTool, TestMathCapability, TestWeatherCapability,
+    WriteFileTool, WriteSessionTitleTool, WriteTodosTool, apply_capabilities, collect_capabilities,
+    collect_capabilities_with_configs, compute_features, get_dependencies, is_mcp_capability,
+    mcp_capability_id, parse_mcp_capability_id, resolve_dependencies,
 };
 pub use capabilities::{
     AttachSkillCapability, SKILL_CAPABILITY_PREFIX, SKILLS_CAPABILITY_ID, SKILLS_DISCOVERY_PATH,

--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -14,7 +14,7 @@ use axum::{
 };
 use chrono::Utc;
 use everruns_core::typed_id::{AgentId, ModelId};
-use everruns_core::{Agent, AgentCapabilityConfig, AgentStatus, ToolDefinition};
+use everruns_core::{Agent, AgentCapabilityConfig, AgentStatus, OrgRole, ToolDefinition};
 
 use super::common::{ApiOptionExt, ApiResultExt, ErrorResponse, ListResponse};
 use super::validation::{
@@ -216,6 +216,32 @@ pub fn routes(state: AppState) -> Router {
         .with_state(state)
 }
 
+/// TM-AGENT-005: Reject if any requested capabilities are high-risk and the
+/// caller does not have at least Admin role.
+fn require_admin_for_high_risk(
+    org: &ResolvedOrg,
+    caps: &[AgentCapabilityConfig],
+    capability_service: &CapabilityService,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    if caps.is_empty() || org.role.has_permission(OrgRole::Admin) {
+        return Ok(());
+    }
+    let refs: Vec<&str> = caps.iter().map(|c| c.capability_ref.as_str()).collect();
+    let high = capability_service.high_risk_ids(&refs);
+    if !high.is_empty() {
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse {
+                error: format!(
+                    "Admin role required to assign high-risk capabilities: {}",
+                    high.join(", ")
+                ),
+            }),
+        ));
+    }
+    Ok(())
+}
+
 /// POST /v1/agents - Create a new agent
 #[utoipa::path(
     post,
@@ -240,6 +266,9 @@ pub async fn create_agent(
         &req.system_prompt,
         req.capabilities.len(),
     )?;
+
+    // TM-AGENT-005: High-risk capabilities require admin role
+    require_admin_for_high_risk(&org, &req.capabilities, &state.capability_service)?;
 
     let client_id = req.id;
     let agent = match state.service.create(org.org_id, client_id, req).await {
@@ -357,6 +386,11 @@ pub async fn update_agent(
         req.system_prompt.as_deref(),
         req.capabilities.as_ref().map(|c| c.len()),
     )?;
+
+    // TM-AGENT-005: High-risk capabilities require admin role
+    if let Some(caps) = &req.capabilities {
+        require_admin_for_high_risk(&org, caps, &state.capability_service)?;
+    }
 
     let agent = state
         .service
@@ -499,6 +533,9 @@ pub async fn upsert_agent(
         req.capabilities.len(),
     )?;
 
+    // TM-AGENT-005: High-risk capabilities require admin role
+    require_admin_for_high_risk(&org, &req.capabilities, &state.capability_service)?;
+
     let (agent, was_created) = state
         .service
         .upsert(org.org_id, &agent_id.to_string(), req)
@@ -631,6 +668,9 @@ pub async fn import_agent(
             .collect(),
         tools: vec![],
     };
+
+    // TM-AGENT-005: High-risk capabilities require admin role
+    require_admin_for_high_risk(&org, &request.capabilities, &state.capability_service)?;
 
     let agent = state
         .service

--- a/crates/server/src/services/capability.rs
+++ b/crates/server/src/services/capability.rs
@@ -18,7 +18,7 @@ use crate::storage::{EncryptionService, StorageBackend};
 use anyhow::Result;
 use everruns_core::capabilities::{Capability, CapabilityRegistry};
 use everruns_core::{
-    CapabilityId, CapabilityInfo, CapabilityStatus, McpCapability, McpToolDefinition,
+    CapabilityId, CapabilityInfo, CapabilityStatus, McpCapability, McpToolDefinition, RiskLevel,
     mcp_capability_id, skill_capability_id,
 };
 use std::sync::Arc;
@@ -81,6 +81,7 @@ impl CapabilityService {
                 is_skill: false,
                 dependencies: vec![], // MCP capabilities have no dependencies
                 features: vec![],
+                risk_level: RiskLevel::Low,
             });
         }
 
@@ -104,6 +105,7 @@ impl CapabilityService {
                 is_skill: true,
                 dependencies: vec!["session_file_system".to_string()],
                 features: vec![],
+                risk_level: RiskLevel::Low,
             });
         }
 
@@ -149,6 +151,7 @@ impl CapabilityService {
                     is_skill: false,
                     dependencies: vec![], // MCP capabilities have no dependencies
                     features: vec![],
+                    risk_level: RiskLevel::Low,
                 }));
             }
             return Ok(None);
@@ -171,6 +174,7 @@ impl CapabilityService {
                     is_skill: true,
                     dependencies: vec!["session_file_system".to_string()],
                     features: vec![],
+                    risk_level: RiskLevel::Low,
                 }));
             }
             return Ok(None);
@@ -210,6 +214,23 @@ impl CapabilityService {
     #[allow(dead_code)]
     pub fn registry(&self) -> &CapabilityRegistry {
         &self.registry
+    }
+
+    /// Return the IDs of any high-risk capabilities in the given list.
+    ///
+    /// Looks up each capability in the built-in registry.  MCP and skill
+    /// capabilities are always Low risk (user-configured), so only built-in
+    /// capabilities can be High.
+    pub fn high_risk_ids(&self, cap_refs: &[&str]) -> Vec<String> {
+        cap_refs
+            .iter()
+            .filter(|id| {
+                self.registry
+                    .get(id)
+                    .is_some_and(|c| c.risk_level() == RiskLevel::High)
+            })
+            .map(|id| id.to_string())
+            .collect()
     }
 
     /// Get the database storage backend

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -4366,6 +4366,10 @@
             "type": "string",
             "description": "Display name"
           },
+          "risk_level": {
+            "$ref": "#/components/schemas/RiskLevel",
+            "description": "TM-AGENT-005: Risk level. High-risk capabilities require admin approval."
+          },
           "status": {
             "type": "string",
             "description": "Current status"
@@ -5921,6 +5925,10 @@
                 "name": {
                   "type": "string",
                   "description": "Display name"
+                },
+                "risk_level": {
+                  "$ref": "#/components/schemas/RiskLevel",
+                  "description": "TM-AGENT-005: Risk level. High-risk capabilities require admin approval."
                 },
                 "status": {
                   "type": "string",
@@ -8255,6 +8263,15 @@
             "description": "The API value (e.g., \"low\", \"medium\")"
           }
         }
+      },
+      "RiskLevel": {
+        "type": "string",
+        "description": "Risk classification for capabilities (TM-AGENT-005).\n\nUsed to enforce approval requirements when assigning capabilities.",
+        "enum": [
+          "low",
+          "medium",
+          "high"
+        ]
       },
       "ScheduleExecutionResponse": {
         "type": "object",

--- a/integrations/codesandbox/src/lib.rs
+++ b/integrations/codesandbox/src/lib.rs
@@ -14,7 +14,7 @@ pub mod state;
 pub mod tools;
 pub mod types;
 
-use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin};
+use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin, RiskLevel};
 use everruns_core::tools::Tool;
 
 use tools::*;
@@ -53,6 +53,10 @@ impl Capability for CodeSandboxCapability {
 
     fn status(&self) -> CapabilityStatus {
         CapabilityStatus::Available
+    }
+
+    fn risk_level(&self) -> RiskLevel {
+        RiskLevel::High
     }
 
     fn icon(&self) -> Option<&str> {

--- a/integrations/daytona/src/lib.rs
+++ b/integrations/daytona/src/lib.rs
@@ -14,7 +14,7 @@ pub mod connection;
 pub mod state;
 mod tools;
 
-use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin};
+use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin, RiskLevel};
 use everruns_core::connection_provider::ConnectionProviderPlugin;
 use everruns_core::tools::Tool;
 
@@ -82,6 +82,10 @@ impl Capability for DaytonaCapability {
 
     fn status(&self) -> CapabilityStatus {
         CapabilityStatus::Available
+    }
+
+    fn risk_level(&self) -> RiskLevel {
+        RiskLevel::High
     }
 
     fn icon(&self) -> Option<&str> {

--- a/integrations/docker/src/lib.rs
+++ b/integrations/docker/src/lib.rs
@@ -17,7 +17,7 @@
 //! }
 //! ```
 
-use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin};
+use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin, RiskLevel};
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
 
@@ -108,6 +108,10 @@ impl Capability for DockerContainerCapability {
 
     fn status(&self) -> CapabilityStatus {
         CapabilityStatus::Available
+    }
+
+    fn risk_level(&self) -> RiskLevel {
+        RiskLevel::High
     }
 
     fn icon(&self) -> Option<&str> {

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -61,6 +61,7 @@ Capabilities are defined in **everruns-core** and resolved at the **API layer**:
 | `is_mcp` | boolean | True if this is an MCP virtual capability |
 | `dependencies` | string[] | IDs of capabilities this capability depends on |
 | `features` | string[] | UI feature strings this capability contributes to |
+| `risk_level` | RiskLevel | Risk classification: `low` (default, omitted in JSON), `medium`, `high` |
 
 ##### Description Markdown Support
 
@@ -216,6 +217,20 @@ MCP and Skill virtual capabilities currently declare no features.
 #### compute_features()
 
 See `crates/core/src/capabilities/mod.rs` for `compute_features()` — resolves dependencies, collects features, deduplicates.
+
+### Risk Levels (TM-AGENT-005)
+
+Each capability declares a `RiskLevel` via the `Capability` trait. The API enforces that assigning high-risk capabilities to an agent requires `OrgRole::Admin`.
+
+| Level | Description | Enforcement |
+|-------|-------------|-------------|
+| `low` | Default. No special requirements. | Any org member |
+| `medium` | Logged but allowed for org members. | Any org member |
+| `high` | Can execute arbitrary code or access external resources. | Requires Admin role |
+
+High-risk built-in capabilities: `virtual_bash`, `web_fetch`, `docker_container`, `daytona`, `codesandbox`.
+
+See `crates/core/src/capabilities/mod.rs` for the `RiskLevel` enum and `crates/server/src/api/agents.rs` for `require_admin_for_high_risk()`.
 
 ### Built-in Capabilities
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -534,7 +534,7 @@ The agent loop is a core trust boundary: an LLM decides which tools to call with
 | TM-AGENT-002 | Indirect prompt injection via tool results | High | Tool results use `tool_result` role, not `system`; LLM may still follow adversarial instructions in results | **ACCEPTED** |
 | TM-AGENT-003 | Indirect prompt injection via MCP tool descriptions | Medium | MCP tool names/descriptions fed to LLM as tool schema; adversarial descriptions could influence behavior | **ACCEPTED** |
 | TM-AGENT-004 | Agent jailbreak via system prompt | Medium | System prompt set by org member at agent creation; no sanitization of prompt content | **BY DESIGN** |
-| TM-AGENT-005 | Capability escalation via agent creation | High | Agent creator chooses capabilities; no approval workflow for dangerous capabilities (virtual_bash, docker) | **OPEN** |
+| TM-AGENT-005 | Capability escalation via agent creation | High | RiskLevel enum on Capability trait; high-risk capabilities (virtual_bash, web_fetch, docker, daytona, codesandbox) require Admin role to assign via API | MITIGATED |
 | TM-AGENT-006 | Cost runaway — unbounded LLM calls | High | Max iterations per turn (default 100); configurable per agent | MITIGATED |
 | TM-AGENT-007 | Cost runaway — many tools per iteration | Medium | No per-iteration tool call limit; agent can invoke many tools in a single LLM response | **OPEN** |
 | TM-AGENT-008 | Context window poisoning | Medium | Auto-compaction via `llm_driver.compact()` on `RequestTooLarge`; older messages compressed | MITIGATED |
@@ -572,11 +572,8 @@ Combined prompt sent to LLM as system message
 ```
 The agent creator is trusted within their org. A malicious system prompt can instruct the agent to misuse its capabilities, but only within the sandbox (session files, SQLite, bash sandbox). The blast radius is limited to the session.
 
-**TM-AGENT-005 — Capability Escalation (OPEN):**
-Capabilities are all-or-nothing. An org member can create an agent with `virtual_bash` + `web_fetch`, giving it the ability to execute bash commands and exfiltrate results via HTTP. No approval workflow exists for dangerous capability combinations.
-
-- **Recommendation:** Implement HITL approval for high-risk capabilities (`virtual_bash`, `docker_container`). Consider capability scoping (e.g., read-only filesystem).
-- **Priority:** Medium
+**TM-AGENT-005 — Capability Escalation (MITIGATED):**
+Each capability declares a `RiskLevel` (Low, Medium, High) via the `Capability` trait. High-risk capabilities (`virtual_bash`, `web_fetch`, `docker_container`, `daytona`, `codesandbox`) require `OrgRole::Admin` to assign. The check runs in create/update/upsert/import agent API handlers, returning 403 if a non-admin user attempts to assign a high-risk capability. The `risk_level` field is exposed in the capabilities list API for UI display.
 
 **TM-AGENT-006 — Iteration Limit:**
 ```rust
@@ -792,7 +789,6 @@ Search results from Brave Search are returned as tool results. Adversarial conte
 | TM-TENANT-008 | User listing cross-org | High | Add org filtering to GET /v1/users |
 | TM-DOS-008 | ReDoS via file grep endpoint | Medium | Add regex complexity limits and timeout |
 | TM-OBS-007 | No security audit logging | Medium | Add structured audit log for auth events |
-| TM-AGENT-005 | No approval for dangerous capabilities | High | HITL approval for virtual_bash, docker |
 | TM-AGENT-007 | No per-iteration tool call limit | Medium | Cap tool calls per LLM response |
 | TM-AGENT-012 | Tool result size amplification | Medium | Cap tool result size fed back to LLM |
 | TM-CRYPTO-007 | Limited encryption scope | Medium | Encrypt system prompts and other sensitive fields |
@@ -835,7 +831,7 @@ Search results from Brave Search are returned as tool results. Adversarial conte
 | Evaluate Braintrust | TM-OBS-001 | Assess data classification before enabling |
 | Secure OTLP endpoint | TM-OBS-003 | Use trusted internal infrastructure only |
 | OAuth provider trust | TM-AUTH-012 | Verify email ownership at OAuth providers |
-| Review agent capabilities | TM-AGENT-005, TM-AGENT-013 | Audit capability assignments; avoid virtual_bash + web_fetch on untrusted agents |
+| Review agent capabilities | TM-AGENT-005, TM-AGENT-013 | High-risk capabilities require Admin role; audit capability assignments for org admin accounts |
 | System prompt review | TM-AGENT-004 | Review agent system prompts for jailbreak patterns before deployment |
 | Block cloud metadata | TM-API-009 | Defense-in-depth: enable IMDSv2 (AWS), metadata concealment (GCP), or equivalent; fetchkit v0.1.2 blocks 169.254.0.0/16 at application level |
 | Worker network isolation | TM-API-008, TM-API-010, TM-API-011 | Defense-in-depth: restrict worker container egress; fetchkit v0.1.2 blocks private IPs at application level |


### PR DESCRIPTION
## Summary
- Add `RiskLevel` enum (Low/Medium/High) to the `Capability` trait with `#[serde(rename_all = "lowercase")]` serialization
- High-risk capabilities (`virtual_bash`, `web_fetch`, `docker_container`, `daytona`, `codesandbox`) require `OrgRole::Admin` to assign
- Validation enforced in create/update/upsert/import agent API handlers, returning 403 for non-admin users
- `risk_level` field exposed in capabilities list API for UI display (omitted when Low)
- Updated threat model: TM-AGENT-005 marked as MITIGATED

## Test plan
- [x] Unit tests for RiskLevel ordering and serde roundtrip
- [x] Unit tests for CapabilityInfo risk_level serialization (Low omitted, High present)
- [x] Unit tests for from_core() populating risk_level from registry
- [x] Clippy clean, fmt clean, pre-push passes
- [x] 329 server unit tests pass
- [ ] CI green

Closes EVE-17