### PR TITLE
fix(ui): default to Generic harness in New Session dialog

### DIFF
--- a/apps/ui/src/app/(main)/sessions/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/page.tsx
@@ -77,8 +77,9 @@ export default function SessionsPage() {
   }, [agents]);
 
   const handleOpenNewSessionDialog = () => {
-    // Pre-select the first harness
-    setNewSessionHarnessId(harnesses?.[0]?.id || "");
+    // Pre-select the Generic harness, falling back to the first harness
+    const genericHarness = harnesses?.find((h) => h.name === "Generic");
+    setNewSessionHarnessId(genericHarness?.id || harnesses?.[0]?.id || "");
     // Pre-select the filtered agent if one is selected, otherwise leave empty (optional)
     setNewSessionAgentId(selectedAgentId || "");
     setNewSessionDialogOpen(true);


### PR DESCRIPTION
## Summary
- Pre-selects the **Generic** harness (instead of first in list) when opening New Session dialog
- Falls back to the first harness if Generic is unavailable

## Test plan
- [ ] Open New Session dialog - verify Generic is pre-selected
- [ ] Delete Generic harness - open dialog - verify first available harness is selected