### PR TITLE
fix(auth): prevent account enumeration via registration endpoint (EVE-32)

### DIFF
--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -343,21 +343,22 @@ pub async fn register(
         return Err(AuthError::forbidden("Password registration is disabled"));
     }
 
-    // Check if user already exists
+    // Hash password first to make timing consistent whether or not the email exists.
+    // This prevents account enumeration via response-time differences (TM-AUTH-014).
+    let password_hash = hash_password(&req.password).map_err(|e| {
+        tracing::error!("Password hashing error: {}", e);
+        AuthError::unauthorized("Registration failed")
+    })?;
+
+    // Check if user already exists — generic error to prevent account enumeration
     let existing = state.db.get_user_by_email(&req.email).await.map_err(|e| {
         tracing::error!("Database error during registration: {}", e);
         AuthError::unauthorized("Registration failed")
     })?;
 
     if existing.is_some() {
-        return Err(AuthError::unauthorized("Email already registered"));
+        return Err(AuthError::unauthorized("Registration failed"));
     }
-
-    // Hash password
-    let password_hash = hash_password(&req.password).map_err(|e| {
-        tracing::error!("Password hashing error: {}", e);
-        AuthError::unauthorized("Registration failed")
-    })?;
 
     // Create user
     let user = state

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -101,7 +101,7 @@ Format: `TM-<CATEGORY>-<NNN>`
 | TM-AUTH-011 | Auth bypass in `none` mode | Info | By design for local development; anonymous user gets admin role | **BY DESIGN** |
 | TM-AUTH-012 | OAuth account linking collision | Medium | Accounts linked by email; if attacker controls email at provider, they gain access | **CALLER RISK** |
 | TM-AUTH-013 | Expired API key still in use | Medium | Expiration checked on every request via DB lookup; `last_used_at` tracked | MITIGATED |
-| TM-AUTH-014 | Account enumeration via registration | Medium | Returns distinct "Email already registered" error; enables email harvesting | **OPEN** |
+| TM-AUTH-014 | Account enumeration via registration | Medium | Returns generic "Registration failed" for existing emails; password hash computed first for timing consistency | MITIGATED |
 | TM-AUTH-015 | JWT secret insecure default | High | Falls back to hardcoded `insecure-dev-secret-change-me` if `AUTH_JWT_SECRET` unset; no startup check in production | **OPEN** |
 
 ### Mitigation Details
@@ -782,7 +782,6 @@ Search results from Brave Search are returned as tool results. Adversarial conte
 | ~~TM-API-012~~ | ~~WebFetch DNS rebinding~~ | ~~Medium~~ | Mitigated: fetchkit v0.1.2 DNS pinning prevents rebinding |
 | TM-AUTH-001 | No rate limiting on login | High | Per-IP rate limiting on auth endpoints |
 | TM-AUTH-007 | OAuth state not validated | High | Store state in cookie; validate in callback |
-| TM-AUTH-014 | Account enumeration via registration | Medium | Return generic error for existing emails |
 | TM-AUTH-015 | JWT secret insecure default | High | Fail startup if AUTH_JWT_SECRET unset in production |
 | TM-DURABLE-002 | gRPC auth optional, no org scoping | High | Require GRPC_AUTH_TOKEN in production; add org scoping |
 | TM-DURABLE-010 | Durable API endpoints unauthenticated | High | Add AuthUser/ResolvedOrg to all /v1/durable/* endpoints |


### PR DESCRIPTION
## Summary
- Return generic "Registration failed" instead of "Email already registered" to prevent email harvesting
- Hash password before checking email existence to eliminate timing side-channel
- Updated threat model: TM-AUTH-014 marked as MITIGATED

## Test plan
- [x] Compile clean, clippy clean, fmt clean
- [ ] CI green

Closes EVE-32