### PR TITLE
refactor: rename GRPC_* env vars to WORKER_GRPC_* prefix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,9 +17,11 @@ SECRETS_ENCRYPTION_KEY=kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=
 # Previous key for rotation (optional, same format as above)
 # SECRETS_ENCRYPTION_KEY_PREVIOUS=kek-v0:...
 
-# gRPC Configuration (worker -> server communication)
+# Worker gRPC Configuration (worker -> server communication)
 # The worker connects to the server gRPC server for all database operations
-GRPC_ADDRESS=127.0.0.1:9001
+WORKER_GRPC_ADDRESS=127.0.0.1:9001
+# Bearer token for worker gRPC authentication (required in production)
+# WORKER_GRPC_AUTH_TOKEN=your-secret-token
 
 # Authentication (Admin Mode) - Single admin user for development
 # AUTH_MODE=admin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,7 +300,7 @@ jobs:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       SECRETS_ENCRYPTION_KEY: kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=
       API_BASE_URL: http://localhost:9000
-      GRPC_AUTH_TOKEN: test-grpc-token-for-ci
+      WORKER_GRPC_AUTH_TOKEN: test-grpc-token-for-ci
 
     steps:
       - uses: actions/checkout@v4

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -573,7 +573,7 @@ impl ServerAppBuilder {
                 // Mitigation: Bearer token auth required in production (panics if missing)
                 let grpc_token = grpc_service::require_grpc_auth_token();
                 let auth_interceptor = grpc_service::GrpcAuthInterceptor::new(Some(grpc_token));
-                let addr = grpc_addr.parse().expect("Invalid GRPC_ADDR");
+                let addr = grpc_addr.parse().expect("Invalid WORKER_GRPC_ADDR");
                 tracing::info!("gRPC server listening on {}", addr);
                 if let Err(e) = tonic::transport::Server::builder()
                     .layer(tonic::service::interceptor::InterceptorLayer::new(

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -168,19 +168,19 @@ use tonic::{Request, Response, Status, Streaming};
 
 /// Read the gRPC auth token from the environment. When set, all gRPC
 /// requests must include `authorization: Bearer <token>` metadata.
-/// Returns `None` if `GRPC_AUTH_TOKEN` is unset (auth disabled — dev only).
+/// Returns `None` if `WORKER_GRPC_AUTH_TOKEN` is unset (auth disabled — dev only).
 pub fn grpc_auth_token_from_env() -> Option<String> {
-    std::env::var("GRPC_AUTH_TOKEN")
+    std::env::var("WORKER_GRPC_AUTH_TOKEN")
         .ok()
         .filter(|t| !t.is_empty())
 }
 
-/// TM-DURABLE-002: Validate that GRPC_AUTH_TOKEN is set in production.
+/// TM-DURABLE-002: Validate that WORKER_GRPC_AUTH_TOKEN is set in production.
 /// Panics if the token is missing when not in dev mode.
 pub fn require_grpc_auth_token() -> String {
     grpc_auth_token_from_env().unwrap_or_else(|| {
         panic!(
-            "GRPC_AUTH_TOKEN must be set when not in dev mode. \
+            "WORKER_GRPC_AUTH_TOKEN must be set when not in dev mode. \
              Without it, gRPC endpoints are unauthenticated."
         )
     })
@@ -3093,21 +3093,21 @@ mod tests {
         assert_eq!(err.code(), tonic::Code::Unauthenticated);
     }
 
-    // TM-DURABLE-002: require_grpc_auth_token panics when GRPC_AUTH_TOKEN is unset
+    // TM-DURABLE-002: require_grpc_auth_token panics when WORKER_GRPC_AUTH_TOKEN is unset
     #[test]
-    #[should_panic(expected = "GRPC_AUTH_TOKEN must be set")]
+    #[should_panic(expected = "WORKER_GRPC_AUTH_TOKEN must be set")]
     fn test_require_grpc_auth_token_panics_without_env() {
         // SAFETY: single-threaded test; no other thread reads this var concurrently
-        unsafe { std::env::remove_var("GRPC_AUTH_TOKEN") };
+        unsafe { std::env::remove_var("WORKER_GRPC_AUTH_TOKEN") };
         require_grpc_auth_token();
     }
 
     #[test]
     fn test_require_grpc_auth_token_returns_value() {
         // SAFETY: single-threaded test; no other thread reads this var concurrently
-        unsafe { std::env::set_var("GRPC_AUTH_TOKEN", "test-token-123") };
+        unsafe { std::env::set_var("WORKER_GRPC_AUTH_TOKEN", "test-token-123") };
         let token = require_grpc_auth_token();
         assert_eq!(token, "test-token-123");
-        unsafe { std::env::remove_var("GRPC_AUTH_TOKEN") };
+        unsafe { std::env::remove_var("WORKER_GRPC_AUTH_TOKEN") };
     }
 }

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -31,7 +31,8 @@ impl ServerConfig {
             .unwrap_or_default();
 
         let addr = std::env::var("ADDR").unwrap_or_else(|_| "0.0.0.0:9000".to_string());
-        let grpc_addr = std::env::var("GRPC_ADDR").unwrap_or_else(|_| "0.0.0.0:9001".to_string());
+        let grpc_addr =
+            std::env::var("WORKER_GRPC_ADDR").unwrap_or_else(|_| "0.0.0.0:9001".to_string());
 
         Self {
             dev_mode,

--- a/crates/worker/src/durable_runner.rs
+++ b/crates/worker/src/durable_runner.rs
@@ -453,11 +453,11 @@ impl DurableRunner {
         }
     }
 
-    /// Create from GRPC_ADDRESS environment variable (defaults to 127.0.0.1:9001)
+    /// Create from WORKER_GRPC_ADDRESS environment variable (defaults to 127.0.0.1:9001)
     /// Used by workers
     pub async fn from_env() -> Result<Self> {
         let grpc_address =
-            std::env::var("GRPC_ADDRESS").unwrap_or_else(|_| "127.0.0.1:9001".to_string());
+            std::env::var("WORKER_GRPC_ADDRESS").unwrap_or_else(|_| "127.0.0.1:9001".to_string());
 
         Self::new(&grpc_address).await
     }

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -149,14 +149,14 @@ impl DurableWorkerConfig {
             std::env::var("WORKER_ID").unwrap_or_else(|_| format!("worker-{}", Uuid::now_v7()));
 
         let grpc_address =
-            std::env::var("GRPC_ADDRESS").unwrap_or_else(|_| "127.0.0.1:9001".to_string());
+            std::env::var("WORKER_GRPC_ADDRESS").unwrap_or_else(|_| "127.0.0.1:9001".to_string());
 
         let max_concurrent = std::env::var("MAX_CONCURRENT_TASKS")
             .ok()
             .and_then(|s| s.parse().ok())
             .unwrap_or(10);
 
-        let connect_timeout_secs: u64 = std::env::var("GRPC_CONNECT_TIMEOUT")
+        let connect_timeout_secs: u64 = std::env::var("WORKER_GRPC_CONNECT_TIMEOUT")
             .ok()
             .and_then(|s| s.parse().ok())
             .unwrap_or(30);

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -60,7 +60,7 @@ impl GrpcClient {
             .map_err(|e| grpc_error(format!("gRPC connection failed: {}", e)))?;
 
         // THREAT[TM-DURABLE-002]: gRPC unauthenticated access
-        // Mitigation: Attach bearer token from GRPC_AUTH_TOKEN env
+        // Mitigation: Attach bearer token from WORKER_GRPC_AUTH_TOKEN env
         let auth = GrpcClientAuth::from_env();
         let client = WorkerServiceClient::with_interceptor(channel, auth)
             .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE)

--- a/crates/worker/src/grpc_durable_store.rs
+++ b/crates/worker/src/grpc_durable_store.rs
@@ -30,9 +30,9 @@ pub struct GrpcClientAuth {
 }
 
 impl GrpcClientAuth {
-    /// Build from env. Reads `GRPC_AUTH_TOKEN`; returns no-op when unset.
+    /// Build from env. Reads `WORKER_GRPC_AUTH_TOKEN`; returns no-op when unset.
     pub fn from_env() -> Self {
-        let token = std::env::var("GRPC_AUTH_TOKEN")
+        let token = std::env::var("WORKER_GRPC_AUTH_TOKEN")
             .ok()
             .filter(|t| !t.is_empty())
             .and_then(|t| format!("Bearer {}", t).parse().ok());
@@ -88,7 +88,7 @@ impl GrpcDurableStore {
             {
                 Ok(channel) => {
                     // THREAT[TM-DURABLE-002]: gRPC unauthenticated access
-                    // Mitigation: Attach bearer token from GRPC_AUTH_TOKEN env
+                    // Mitigation: Attach bearer token from WORKER_GRPC_AUTH_TOKEN env
                     let auth = GrpcClientAuth::from_env();
                     let client = WorkerServiceClient::with_interceptor(channel, auth);
                     if attempt > 1 {

--- a/docs/sre/environment-variables.md
+++ b/docs/sre/environment-variables.md
@@ -200,9 +200,9 @@ The UI makes all API requests (including SSE) to `/api/*` paths. Caddy reverse p
 - Connection cycling prevents stale connections through proxies and load balancers
 - When running behind HTTP/1.1 proxies, increase `SSE_REALTIME_CYCLE_SECS` to reduce reconnection frequency
 
-## Worker Configuration
+## Worker gRPC Configuration
 
-### GRPC_ADDRESS
+### WORKER_GRPC_ADDRESS
 
 Address of the control-plane gRPC server for worker communication.
 
@@ -214,13 +214,63 @@ Address of the control-plane gRPC server for worker communication.
 **Example:**
 
 ```bash
-GRPC_ADDRESS=127.0.0.1:9001
+WORKER_GRPC_ADDRESS=127.0.0.1:9001
 ```
 
 **Notes:**
 - Workers communicate with the control-plane via gRPC for all database operations
 - The control-plane exposes both HTTP (port 9000) and gRPC (port 9001) interfaces
 - Workers are stateless and do not connect directly to the database
+
+### WORKER_GRPC_AUTH_TOKEN
+
+Bearer token for authenticating worker gRPC connections to the control-plane.
+
+| Property | Value |
+|----------|-------|
+| **Required** | Yes (production); No (dev mode) |
+| **Default** | Unset (auth disabled) |
+
+**Example:**
+
+```bash
+WORKER_GRPC_AUTH_TOKEN=your-secret-token
+```
+
+**Notes:**
+- Must be set on both the server and all workers (same value)
+- When unset, gRPC auth is disabled (acceptable for local development only)
+- Server panics on startup if unset when not in dev mode
+
+### WORKER_GRPC_ADDR
+
+Bind address for the server-side gRPC listener (control-plane only).
+
+| Property | Value |
+|----------|-------|
+| **Required** | No (server only) |
+| **Default** | `0.0.0.0:9001` |
+
+**Example:**
+
+```bash
+WORKER_GRPC_ADDR=0.0.0.0:9001
+```
+
+### WORKER_GRPC_CONNECT_TIMEOUT
+
+Timeout in seconds for worker initial connection to control-plane gRPC.
+
+| Property | Value |
+|----------|-------|
+| **Required** | No (worker only) |
+| **Default** | `30` |
+
+**Example:**
+
+```bash
+WORKER_GRPC_CONNECT_TIMEOUT=60
+```
 
 ## OpenTelemetry Configuration
 

--- a/docs/sre/runbooks/durable-mode-setup.md
+++ b/docs/sre/runbooks/durable-mode-setup.md
@@ -43,7 +43,7 @@ In a separate terminal:
 
 ```bash
 # Workers only need gRPC address - NO DATABASE_URL required!
-export GRPC_ADDRESS="127.0.0.1:9001"
+export WORKER_GRPC_ADDRESS="127.0.0.1:9001"
 
 # Start the durable worker
 cargo run -p everruns-worker --bin durable-worker
@@ -72,7 +72,8 @@ async fn main() -> anyhow::Result<()> {
 |----------|-------------|---------|
 | `RUNNER_MODE` | Runner mode (durable only) | `durable` |
 | `DATABASE_URL` | PostgreSQL connection URL | Required |
-| `GRPC_ADDRESS` | Control-plane gRPC address | `127.0.0.1:9001` |
+| `WORKER_GRPC_ADDRESS` | Control-plane gRPC address | `127.0.0.1:9001` |
+| `WORKER_GRPC_AUTH_TOKEN` | Bearer token for gRPC auth | Unset (disabled) |
 | `WORKER_ID` | Unique worker identifier | Auto-generated |
 | `MAX_CONCURRENT_TASKS` | Max tasks per worker | `10` |
 
@@ -195,7 +196,7 @@ WHERE status = 'claimed'
 
 ### Worker Not Processing Tasks
 
-1. Check worker is running and connected to correct `GRPC_ADDRESS`
+1. Check worker is running and connected to correct `WORKER_GRPC_ADDRESS`
 2. Verify `activity_types` match task types in queue
 3. Check worker heartbeat in `durable_workers` table
 

--- a/example.just
+++ b/example.just
@@ -33,6 +33,12 @@ start tag="latest":
         export DEFAULT_GEMINI_API_KEY="$GEMINI_API_KEY"
     fi
 
+    # Pass through worker gRPC auth token if set
+    if [[ -n "${WORKER_GRPC_AUTH_TOKEN:-}" ]]; then
+        echo "✅ WORKER_GRPC_AUTH_TOKEN found"
+        export WORKER_GRPC_AUTH_TOKEN="$WORKER_GRPC_AUTH_TOKEN"
+    fi
+
     echo "✅ Local docker compose not running, starting example full stack..."
     cd examples
     docker compose -f docker-compose-full.yaml up --pull always -d

--- a/examples/docker-compose-full.yaml
+++ b/examples/docker-compose-full.yaml
@@ -14,6 +14,7 @@
 #
 #   2. Create .env file with:
 #      SECRETS_ENCRYPTION_KEY=kek-v1:<your-generated-key>
+#      WORKER_GRPC_AUTH_TOKEN=<your-token>  # Required: worker gRPC auth token
 #      DEFAULT_OPENAI_API_KEY=sk-...        # Optional: OpenAI API key
 #      DEFAULT_ANTHROPIC_API_KEY=sk-ant-... # Optional: Anthropic API key
 #      DEFAULT_GEMINI_API_KEY=...           # Optional: Google Gemini API key
@@ -61,6 +62,7 @@ services:
       DEFAULT_OPENAI_API_KEY: ${DEFAULT_OPENAI_API_KEY:-}
       DEFAULT_ANTHROPIC_API_KEY: ${DEFAULT_ANTHROPIC_API_KEY:-}
       DEFAULT_GEMINI_API_KEY: ${DEFAULT_GEMINI_API_KEY:-}
+      WORKER_GRPC_AUTH_TOKEN: ${WORKER_GRPC_AUTH_TOKEN:-}
       HOST: 0.0.0.0
       PORT: "9000"
       RUST_LOG: info
@@ -84,7 +86,8 @@ services:
     image: ghcr.io/everruns/everruns-worker:${EVERRUNS_TAG:-latest}
     container_name: everruns-worker-1
     environment:
-      GRPC_ADDRESS: server:9001
+      WORKER_GRPC_ADDRESS: server:9001
+      WORKER_GRPC_AUTH_TOKEN: ${WORKER_GRPC_AUTH_TOKEN:-}
       RUST_LOG: info
       OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4318
     depends_on:
@@ -96,7 +99,8 @@ services:
     image: ghcr.io/everruns/everruns-worker:${EVERRUNS_TAG:-latest}
     container_name: everruns-worker-2
     environment:
-      GRPC_ADDRESS: server:9001
+      WORKER_GRPC_ADDRESS: server:9001
+      WORKER_GRPC_AUTH_TOKEN: ${WORKER_GRPC_AUTH_TOKEN:-}
       RUST_LOG: info
       OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4318
     depends_on:
@@ -108,7 +112,8 @@ services:
     image: ghcr.io/everruns/everruns-worker:${EVERRUNS_TAG:-latest}
     container_name: everruns-worker-3
     environment:
-      GRPC_ADDRESS: server:9001
+      WORKER_GRPC_ADDRESS: server:9001
+      WORKER_GRPC_AUTH_TOKEN: ${WORKER_GRPC_AUTH_TOKEN:-}
       RUST_LOG: info
       OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4318
     depends_on:

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -434,13 +434,13 @@ Indirect prompt injection via tool results or user messages is an inherent LLM l
 | ID | Threat | Severity | Mitigation | Status |
 |----|--------|----------|------------|--------|
 | TM-DURABLE-001 | Task hijacking | High | Ownership verified on completion; late finisher gets `TaskNotOwned` error | MITIGATED |
-| TM-DURABLE-002 | gRPC unauthenticated access | High | Bearer token auth via `GRPC_AUTH_TOKEN` env var; auth disabled if env var unset; no org scoping in gRPC handlers | **OPEN** |
+| TM-DURABLE-002 | gRPC unauthenticated access | High | Bearer token auth via `WORKER_GRPC_AUTH_TOKEN` env var; auth disabled if env var unset; no org scoping in gRPC handlers | **OPEN** |
 | TM-DURABLE-003 | Event injection | Medium | Events created via gRPC only; validated for session membership | MITIGATED |
 | TM-DURABLE-004 | Queue flooding | Medium | Per-workflow pending task limit (default 100, configurable via `MAX_PENDING_TASKS_PER_WORKFLOW`) | MITIGATED |
 | TM-DURABLE-005 | Heartbeat timeout manipulation | Low | 30s timeout is reasonable for LLM operations; reclaimed tasks re-queued | MITIGATED |
 | TM-DURABLE-006 | Dead letter queue growth | Low | Failed tasks preserved in DLQ; no automatic cleanup | **ACCEPTED** |
 | TM-DURABLE-007 | Task state manipulation | Medium | Tasks immutable after creation; only status transitions allowed via state machine | MITIGATED |
-| TM-DURABLE-008 | Worker impersonation | High | Bearer token auth via `GRPC_AUTH_TOKEN` prevents unauthorized access | MITIGATED (same as TM-DURABLE-002) |
+| TM-DURABLE-008 | Worker impersonation | High | Bearer token auth via `WORKER_GRPC_AUTH_TOKEN` prevents unauthorized access | MITIGATED (same as TM-DURABLE-002) |
 | TM-DURABLE-009 | Replay attack on workflow events | Low | Event store is append-only; events processed in sequence order | MITIGATED |
 | TM-DURABLE-010 | Durable API endpoints unauthenticated | High | All `/v1/durable/*` endpoints lack `AuthUser`/`ResolvedOrg` extractors; accessible without auth | **OPEN** |
 
@@ -455,13 +455,13 @@ Worker B continues execution → task completes correctly
 Prevents duplicate activity execution when workers lose connectivity.
 
 **TM-DURABLE-002 — gRPC Security (OPEN):**
-Workers authenticate to control plane gRPC (port 9001) via bearer token (`GRPC_AUTH_TOKEN` env var).
+Workers authenticate to control plane gRPC (port 9001) via bearer token (`WORKER_GRPC_AUTH_TOKEN` env var).
 - Server: `GrpcAuthInterceptor` validates `authorization: Bearer <token>` on every request
 - Client: `GrpcClientAuth` injects the bearer token into every outgoing request
-- When `GRPC_AUTH_TOKEN` is unset, auth is disabled — **not restricted to dev mode**
+- When `WORKER_GRPC_AUTH_TOKEN` is unset, auth is disabled — **not restricted to dev mode**
 - No org_id scoping in gRPC handlers; compromised worker can access all orgs
 - Network isolation remains as defense-in-depth
-- **Recommendation:** Fail startup if `GRPC_AUTH_TOKEN` unset when `AUTH_MODE != none`. Add `org_id` to gRPC request context.
+- **Recommendation:** Fail startup if `WORKER_GRPC_AUTH_TOKEN` unset when `AUTH_MODE != none`. Add `org_id` to gRPC request context.
 
 **TM-DURABLE-010 — Durable API Endpoints Unauthenticated (OPEN):**
 All `/v1/durable/*` HTTP endpoints use `State(state): State<AppState>` only — no `AuthUser` or `ResolvedOrg` extractor. Any network-reachable client can list workflows, drain workers, cancel tasks, and view DLQ.
@@ -783,7 +783,7 @@ Search results from Brave Search are returned as tool results. Adversarial conte
 | TM-AUTH-001 | No rate limiting on login | High | Per-IP rate limiting on auth endpoints |
 | TM-AUTH-007 | OAuth state not validated | High | Store state in cookie; validate in callback |
 | TM-AUTH-015 | JWT secret insecure default | High | Fail startup if AUTH_JWT_SECRET unset in production |
-| TM-DURABLE-002 | gRPC auth optional, no org scoping | High | Require GRPC_AUTH_TOKEN in production; add org scoping |
+| TM-DURABLE-002 | gRPC auth optional, no org scoping | High | Require WORKER_GRPC_AUTH_TOKEN in production; add org scoping |
 | TM-DURABLE-010 | Durable API endpoints unauthenticated | High | Add AuthUser/ResolvedOrg to all /v1/durable/* endpoints |
 | TM-TENANT-008 | User listing cross-org | High | Add org filtering to GET /v1/users |
 | TM-DOS-008 | ReDoS via file grep endpoint | Medium | Add regex complexity limits and timeout |
@@ -826,7 +826,7 @@ Search results from Brave Search are returned as tool results. Adversarial conte
 | Database TLS | TM-API-001 | Use `sslmode=require` in `DATABASE_URL` for production; no code-level enforcement |
 | Secure env vars | TM-AUTH-002, TM-CRYPTO-001 | Never commit secrets to source control |
 | Configure CORS | TM-API-007, TM-WEB-007 | Set explicit allowed origins in production |
-| Network isolation | TM-DURABLE-002 | Keep gRPC port 9001 on private network; set `GRPC_AUTH_TOKEN` in production |
+| Network isolation | TM-DURABLE-002 | Keep gRPC port 9001 on private network; set `WORKER_GRPC_AUTH_TOKEN` in production |
 | Evaluate Braintrust | TM-OBS-001 | Assess data classification before enabling |
 | Secure OTLP endpoint | TM-OBS-003 | Use trusted internal infrastructure only |
 | OAuth provider trust | TM-AUTH-012 | Verify email ownership at OAuth providers |


### PR DESCRIPTION
## What
Rename all gRPC-related environment variables to use `WORKER_GRPC_` prefix, reflecting that gRPC is the internal worker-server protocol.

- `GRPC_AUTH_TOKEN` → `WORKER_GRPC_AUTH_TOKEN`
- `GRPC_ADDRESS` → `WORKER_GRPC_ADDRESS`
- `GRPC_ADDR` → `WORKER_GRPC_ADDR`
- `GRPC_CONNECT_TIMEOUT` → `WORKER_GRPC_CONNECT_TIMEOUT`

Also adds `WORKER_GRPC_AUTH_TOKEN` to `.env.example`, `docker-compose-full.yaml` (server + all workers), `example.just` passthrough, and CI.

## Why
The gRPC protocol is purely internal between workers and the control-plane server. The generic `GRPC_*` prefix was ambiguous — renaming to `WORKER_GRPC_*` makes the purpose clear and groups all worker gRPC config together.

## How
Pure string rename across Rust source (`std::env::var()` calls, comments, panic messages, tests), config files (`.env.example`, `docker-compose-full.yaml`, `example.just`, CI), docs (`environment-variables.md`, `durable-mode-setup.md`), and specs (`threat-model.md`).

No logic changes — the gRPC auth mechanism, connection logic, and config parsing are identical.

## Risk
- Low
- Deployments with hardcoded `GRPC_AUTH_TOKEN` / `GRPC_ADDRESS` will need to update env vars. No backward compat shim (internal code per AGENTS.md).

## Checklist
- [x] Tests added or updated (existing `test_require_grpc_auth_token_*` tests updated to new env var name)
- [x] Backward compatibility considered (not needed — internal code)