### PR TITLE
feat(server): structured audit logging for auth events (EVE-34)

### DIFF
--- a/crates/server/migrations/005_audit_logs.sql
+++ b/crates/server/migrations/005_audit_logs.sql
@@ -1,0 +1,21 @@
+-- Structured audit log for security-relevant events (TM-OBS-007)
+-- Covers: authentication, API key management, OAuth, org membership changes
+
+CREATE TABLE IF NOT EXISTS audit_logs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id BIGINT NOT NULL REFERENCES organizations(org_id),
+    -- Actor: who performed the action (NULL for unauthenticated attempts)
+    actor_id UUID REFERENCES users(id),
+    -- Structured event type: domain.action.outcome (e.g. auth.login.success)
+    event_type TEXT NOT NULL,
+    -- Client IP address (may be proxy-forwarded)
+    ip_address TEXT,
+    -- Freeform metadata (e.g. user_agent, provider, target resource)
+    metadata JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Query patterns: by org (list), by actor (investigation), by type (alerting), by time (retention)
+CREATE INDEX IF NOT EXISTS idx_audit_logs_org_created ON audit_logs (org_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_actor ON audit_logs (actor_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_event_type ON audit_logs (event_type, created_at DESC);

--- a/crates/server/src/api/audit_logs.rs
+++ b/crates/server/src/api/audit_logs.rs
@@ -1,0 +1,109 @@
+// Audit log query API (TM-OBS-007)
+//
+// Admin-only endpoint. Audit logs are written by auth routes via auth::audit::emit().
+
+use crate::auth::middleware::{AuthState, OrgAdmin};
+use crate::storage::StorageBackend;
+use axum::extract::FromRef;
+use axum::{Json, Router, extract::State, routing::get};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use super::common::ListResponse;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub db: Arc<StorageBackend>,
+    pub auth: AuthState,
+}
+
+impl AppState {
+    pub fn new(db: Arc<StorageBackend>, auth: AuthState) -> Self {
+        Self { db, auth }
+    }
+}
+
+impl FromRef<AppState> for AuthState {
+    fn from_ref(input: &AppState) -> Self {
+        input.auth.clone()
+    }
+}
+
+/// Audit log entry response
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AuditLogResponse {
+    pub id: String,
+    pub actor_id: Option<String>,
+    pub event_type: String,
+    pub ip_address: Option<String>,
+    pub metadata: serde_json::Value,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Query parameters for listing audit logs
+#[derive(Debug, Deserialize)]
+pub struct ListAuditLogsQuery {
+    /// Max entries to return (default 50, max 200)
+    pub limit: Option<i64>,
+    /// Cursor: return entries created before this timestamp
+    pub before: Option<DateTime<Utc>>,
+    /// Filter by event type prefix (e.g. "auth.login")
+    pub event_type: Option<String>,
+    /// Filter by actor UUID
+    pub actor_id: Option<Uuid>,
+}
+
+pub fn routes(state: AppState) -> Router {
+    Router::new()
+        .route("/v1/organizations/:org_id/audit-logs", get(list_audit_logs))
+        .with_state(state)
+}
+
+/// GET /v1/organizations/:org_id/audit-logs - List audit logs (admin only)
+async fn list_audit_logs(
+    State(state): State<AppState>,
+    org: OrgAdmin,
+    axum::extract::Query(query): axum::extract::Query<ListAuditLogsQuery>,
+) -> Result<
+    Json<ListResponse<AuditLogResponse>>,
+    (axum::http::StatusCode, Json<super::common::ErrorResponse>),
+> {
+    let limit = query.limit.unwrap_or(50).clamp(1, 200);
+
+    let rows = state
+        .db
+        .list_audit_logs(
+            org.0.org_id,
+            limit,
+            query.before,
+            query.event_type.as_deref(),
+            query.actor_id,
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to list audit logs: {}", e);
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                Json(super::common::ErrorResponse {
+                    error: "Failed to list audit logs".to_string(),
+                }),
+            )
+        })?;
+
+    let items: Vec<AuditLogResponse> = rows
+        .into_iter()
+        .map(|r| AuditLogResponse {
+            id: r.id.to_string(),
+            actor_id: r.actor_id.map(|a| a.to_string()),
+            event_type: r.event_type,
+            ip_address: r.ip_address,
+            metadata: r.metadata,
+            created_at: r.created_at,
+        })
+        .collect();
+
+    Ok(Json(ListResponse::new(items)))
+}

--- a/crates/server/src/api/audit_logs.rs
+++ b/crates/server/src/api/audit_logs.rs
@@ -58,11 +58,11 @@ pub struct ListAuditLogsQuery {
 
 pub fn routes(state: AppState) -> Router {
     Router::new()
-        .route("/v1/organizations/:org_id/audit-logs", get(list_audit_logs))
+        .route("/v1/orgs/{org}/audit-logs", get(list_audit_logs))
         .with_state(state)
 }
 
-/// GET /v1/organizations/:org_id/audit-logs - List audit logs (admin only)
+/// GET /v1/orgs/{org}/audit-logs - List audit logs (admin only)
 async fn list_audit_logs(
     State(state): State<AppState>,
     org: OrgAdmin,

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -4,6 +4,7 @@
 // Each submodule handles a specific resource type with its own AppState.
 
 pub mod agents;
+pub mod audit_logs;
 pub mod capabilities;
 pub mod common;
 pub mod durable;

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -422,6 +422,7 @@ impl ServerAppBuilder {
         let skills_state = api::skills::AppState::new(db.clone(), auth_state.clone());
         let images_state = api::images::AppState::new(db.clone(), auth_state.clone());
         let organizations_state = api::organizations::AppState::new(db.clone(), auth_state.clone());
+        let audit_logs_state = api::audit_logs::AppState::new(db.clone(), auth_state.clone());
         let user_connections_state = api::user_connections::AppState {
             db: db.clone(),
             encryption: encryption.clone(),
@@ -478,7 +479,8 @@ impl ServerAppBuilder {
             .merge(api::skills::routes(skills_state))
             .merge(api::organizations::routes(organizations_state))
             .merge(api::user_connections::routes(user_connections_state))
-            .merge(api::session_schedules::routes(session_schedules_state));
+            .merge(api::session_schedules::routes(session_schedules_state))
+            .merge(api::audit_logs::routes(audit_logs_state));
 
         // Auth-specific routes
         if let Some(auth_routes) = auth_backend.auth_routes() {

--- a/crates/server/src/auth/audit.rs
+++ b/crates/server/src/auth/audit.rs
@@ -1,0 +1,101 @@
+// Structured audit logging for security-relevant events (TM-OBS-007)
+//
+// Design: fire-and-forget via tokio::spawn. Audit log failures must never
+// block or fail authentication operations. All writes go to the audit_logs
+// table via StorageBackend.
+//
+// Event type convention: domain.action.outcome
+//   auth.login.success, auth.login.failure
+//   auth.register.success
+//   auth.token_refresh.success, auth.token_refresh.failure
+//   auth.api_key.created, auth.api_key.deleted
+//   auth.oauth.success, auth.oauth.failure
+
+use crate::storage::StorageBackend;
+use crate::storage::models::CreateAuditLogRow;
+use axum::http::HeaderMap;
+use std::sync::Arc;
+use uuid::Uuid;
+
+/// Extract client IP from request headers (X-Forwarded-For > X-Real-IP > unknown).
+pub fn client_ip(headers: &HeaderMap) -> Option<String> {
+    if let Some(forwarded) = headers.get("x-forwarded-for")
+        && let Ok(val) = forwarded.to_str()
+        && let Some(first) = val.split(',').next()
+    {
+        let trimmed = first.trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_string());
+        }
+    }
+    if let Some(real_ip) = headers.get("x-real-ip")
+        && let Ok(val) = real_ip.to_str()
+    {
+        let trimmed = val.trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_string());
+        }
+    }
+    None
+}
+
+/// Emit an audit log entry. Non-blocking: spawns a background task.
+///
+/// Failures are logged at warn level but never propagated.
+pub fn emit(
+    db: Arc<StorageBackend>,
+    org_id: i64,
+    actor_id: Option<Uuid>,
+    event_type: &str,
+    ip_address: Option<String>,
+    metadata: serde_json::Value,
+) {
+    let event_type = event_type.to_string();
+    tokio::spawn(async move {
+        if let Err(e) = db
+            .create_audit_log(CreateAuditLogRow {
+                org_id,
+                actor_id,
+                event_type: event_type.clone(),
+                ip_address,
+                metadata,
+            })
+            .await
+        {
+            tracing::warn!(event_type = %event_type, error = %e, "Failed to write audit log");
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_client_ip_from_x_forwarded_for() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "1.2.3.4, 10.0.0.1".parse().unwrap());
+        assert_eq!(client_ip(&headers), Some("1.2.3.4".to_string()));
+    }
+
+    #[test]
+    fn test_client_ip_from_x_real_ip() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-real-ip", "5.6.7.8".parse().unwrap());
+        assert_eq!(client_ip(&headers), Some("5.6.7.8".to_string()));
+    }
+
+    #[test]
+    fn test_client_ip_prefers_forwarded_for() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "1.1.1.1".parse().unwrap());
+        headers.insert("x-real-ip", "2.2.2.2".parse().unwrap());
+        assert_eq!(client_ip(&headers), Some("1.1.1.1".to_string()));
+    }
+
+    #[test]
+    fn test_client_ip_none_when_empty() {
+        let headers = HeaderMap::new();
+        assert_eq!(client_ip(&headers), None);
+    }
+}

--- a/crates/server/src/auth/mod.rs
+++ b/crates/server/src/auth/mod.rs
@@ -4,6 +4,7 @@
 // Decision: Pluggable auth backend trait for external providers (SaaS)
 
 pub mod api_key;
+pub mod audit;
 pub mod backend;
 pub mod builtin;
 pub mod config;

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -6,7 +6,7 @@ use axum::{
     Json, Router,
     body::Body,
     extract::{FromRef, Path, Query, State},
-    http::{Request, StatusCode},
+    http::{HeaderMap, Request, StatusCode},
     middleware::{self, Next},
     response::{Redirect, Response},
     routing::{delete, get, post},
@@ -19,6 +19,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
+use super::audit;
 use super::rate_limit::extract_client_ip;
 
 use super::{
@@ -259,9 +260,12 @@ pub async fn get_auth_config(State(state): State<BuiltinAuthBackend>) -> Json<Au
 /// POST /v1/auth/login - Login with email and password
 pub async fn login(
     State(state): State<BuiltinAuthBackend>,
+    headers: HeaderMap,
     jar: CookieJar,
     Json(req): Json<LoginRequest>,
 ) -> Result<(CookieJar, Json<TokenResponse>), AuthError> {
+    let ip = audit::client_ip(&headers);
+
     // In admin mode, check admin credentials directly (no database lookup)
     if state.config.mode == AuthMode::Admin {
         if let Some(admin) = &state.config.admin
@@ -270,9 +274,25 @@ pub async fn login(
         {
             // Create or get admin user
             let user = get_or_create_admin_user(&state, admin).await?;
+            audit::emit(
+                state.db.clone(),
+                DEFAULT_ORG_ID,
+                Some(user.id),
+                "auth.login.success",
+                ip,
+                serde_json::json!({"method": "admin"}),
+            );
             return generate_token_response(&state, jar, &user).await;
         }
         // Admin mode only allows the configured admin credentials
+        audit::emit(
+            state.db.clone(),
+            DEFAULT_ORG_ID,
+            None,
+            "auth.login.failure",
+            ip,
+            serde_json::json!({"method": "admin", "reason": "invalid_credentials"}),
+        );
         return Err(AuthError::unauthorized("Invalid email or password"));
     }
 
@@ -284,15 +304,22 @@ pub async fn login(
     }
 
     // Find user by email
-    let user = state
-        .db
-        .get_user_by_email(&req.email)
-        .await
-        .map_err(|e| {
-            tracing::error!("Database error during login: {}", e);
-            AuthError::unauthorized("Login failed")
-        })?
-        .ok_or_else(|| AuthError::unauthorized("Invalid email or password"))?;
+    let user = state.db.get_user_by_email(&req.email).await.map_err(|e| {
+        tracing::error!("Database error during login: {}", e);
+        AuthError::unauthorized("Login failed")
+    })?;
+
+    let Some(user) = user else {
+        audit::emit(
+            state.db.clone(),
+            DEFAULT_ORG_ID,
+            None,
+            "auth.login.failure",
+            ip,
+            serde_json::json!({"reason": "user_not_found"}),
+        );
+        return Err(AuthError::unauthorized("Invalid email or password"));
+    };
 
     // Verify password
     let password_hash = user
@@ -306,6 +333,14 @@ pub async fn login(
     })?;
 
     if !valid {
+        audit::emit(
+            state.db.clone(),
+            DEFAULT_ORG_ID,
+            Some(user.id),
+            "auth.login.failure",
+            ip,
+            serde_json::json!({"reason": "invalid_password"}),
+        );
         return Err(AuthError::unauthorized("Invalid email or password"));
     }
 
@@ -324,12 +359,22 @@ pub async fn login(
         organizations: builtin::organizations_or_default(organizations),
     };
 
+    audit::emit(
+        state.db.clone(),
+        DEFAULT_ORG_ID,
+        Some(auth_user.id),
+        "auth.login.success",
+        ip,
+        serde_json::json!({"method": "password"}),
+    );
+
     generate_token_response(&state, jar, &auth_user).await
 }
 
 /// POST /v1/auth/register - Register a new user
 pub async fn register(
     State(state): State<BuiltinAuthBackend>,
+    headers: HeaderMap,
     jar: CookieJar,
     Json(req): Json<RegisterRequest>,
 ) -> Result<(StatusCode, CookieJar, Json<TokenResponse>), AuthError> {
@@ -403,6 +448,15 @@ pub async fn register(
         organizations: builtin::organizations_or_default(organizations),
     };
 
+    audit::emit(
+        state.db.clone(),
+        DEFAULT_ORG_ID,
+        Some(auth_user.id),
+        "auth.register.success",
+        audit::client_ip(&headers),
+        serde_json::json!({}),
+    );
+
     let (jar, json) = generate_token_response(&state, jar, &auth_user).await?;
     Ok((StatusCode::CREATED, jar, json))
 }
@@ -414,6 +468,7 @@ pub async fn register(
 /// primary flow for browser clients since the cookie is HttpOnly.
 pub async fn refresh_token(
     State(state): State<BuiltinAuthBackend>,
+    headers: HeaderMap,
     jar: CookieJar,
     body: Option<Json<RefreshTokenRequest>>,
 ) -> Result<(CookieJar, Json<TokenResponse>), AuthError> {
@@ -480,6 +535,15 @@ pub async fn refresh_token(
         auth_method: AuthMethod::Jwt,
         organizations: builtin::organizations_or_default(organizations),
     };
+
+    audit::emit(
+        state.db.clone(),
+        DEFAULT_ORG_ID,
+        Some(auth_user.id),
+        "auth.token_refresh.success",
+        audit::client_ip(&headers),
+        serde_json::json!({}),
+    );
 
     generate_token_response(&state, jar, &auth_user).await
 }
@@ -591,6 +655,7 @@ pub async fn oauth_redirect(
 /// TM-AUTH-007: Validates CSRF state from cookie before proceeding.
 pub async fn oauth_callback(
     State(state): State<BuiltinAuthBackend>,
+    headers: HeaderMap,
     Path(provider): Path<String>,
     Query(query): Query<OAuthCallbackQuery>,
     jar: CookieJar,
@@ -639,6 +704,14 @@ pub async fn oauth_callback(
     }
     .map_err(|e| {
         tracing::error!("OAuth exchange failed: {}", e);
+        audit::emit(
+            state.db.clone(),
+            DEFAULT_ORG_ID,
+            None,
+            "auth.oauth.failure",
+            audit::client_ip(&headers),
+            serde_json::json!({"provider": provider, "reason": "exchange_failed"}),
+        );
         AuthError::unauthorized("OAuth authentication failed")
     })?;
 
@@ -722,6 +795,15 @@ pub async fn oauth_callback(
         organizations: builtin::organizations_or_default(organizations),
     };
 
+    audit::emit(
+        state.db.clone(),
+        DEFAULT_ORG_ID,
+        Some(auth_user.id),
+        "auth.oauth.success",
+        audit::client_ip(&headers),
+        serde_json::json!({"provider": provider}),
+    );
+
     // Generate tokens and set cookies
     let (jar, _) = generate_token_response(&state, jar, &auth_user).await?;
 
@@ -769,6 +851,7 @@ pub async fn list_api_keys(
 /// Cannot be called with API key authentication (must use session auth).
 pub async fn create_api_key_route(
     State(state): State<BuiltinAuthBackend>,
+    headers: HeaderMap,
     user: AuthUser,
     org: ResolvedOrg,
     Json(req): Json<CreateApiKeyRequest>,
@@ -809,6 +892,15 @@ pub async fn create_api_key_route(
             AuthError::unauthorized("Failed to create API key")
         })?;
 
+    audit::emit(
+        state.db.clone(),
+        org.org_id,
+        Some(user.id),
+        "auth.api_key.created",
+        audit::client_ip(&headers),
+        serde_json::json!({"key_id": key_row.id.to_string(), "name": req.name}),
+    );
+
     Ok((
         StatusCode::CREATED,
         Json(ApiKeyResponse {
@@ -826,6 +918,7 @@ pub async fn create_api_key_route(
 /// DELETE /v1/auth/api-keys/:key_id - Delete an API key
 pub async fn delete_api_key_route(
     State(state): State<BuiltinAuthBackend>,
+    headers: HeaderMap,
     user: AuthUser,
     Path(key_id): Path<Uuid>,
 ) -> Result<StatusCode, AuthError> {
@@ -839,6 +932,14 @@ pub async fn delete_api_key_route(
         })?;
 
     if deleted {
+        audit::emit(
+            state.db.clone(),
+            DEFAULT_ORG_ID,
+            Some(user.id),
+            "auth.api_key.deleted",
+            audit::client_ip(&headers),
+            serde_json::json!({"key_id": key_id.to_string()}),
+        );
         Ok(StatusCode::NO_CONTENT)
     } else {
         Err(AuthError::unauthorized("API key not found"))

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -5,6 +5,7 @@
 // either PostgreSQL (production) or in-memory (dev mode) storage.
 
 use anyhow::Result;
+use chrono::{DateTime, Utc};
 use everruns_core::message_filter::MessageQuery;
 use everruns_core::typed_id::{AgentId, EventId, HarnessId, ScheduleId, SessionId};
 use sqlx::PgPool;
@@ -1226,5 +1227,36 @@ impl StorageBackend {
 
     pub async fn claim_due_session_schedules(&self, limit: i32) -> Result<Vec<SessionScheduleRow>> {
         dispatch!(self, claim_due_session_schedules, limit)
+    }
+
+    // ============================================
+    // Audit Logs (TM-OBS-007)
+    // ============================================
+
+    pub async fn create_audit_log(&self, input: CreateAuditLogRow) -> Result<AuditLogRow> {
+        dispatch!(self, create_audit_log, input)
+    }
+
+    pub async fn list_audit_logs(
+        &self,
+        org_id: i64,
+        limit: i64,
+        before: Option<DateTime<Utc>>,
+        event_type_prefix: Option<&str>,
+        actor_id: Option<Uuid>,
+    ) -> Result<Vec<AuditLogRow>> {
+        dispatch!(
+            self,
+            list_audit_logs,
+            org_id,
+            limit,
+            before,
+            event_type_prefix,
+            actor_id
+        )
+    }
+
+    pub async fn delete_audit_logs_before(&self, before: DateTime<Utc>) -> Result<u64> {
+        dispatch!(self, delete_audit_logs_before, before)
     }
 }

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -56,6 +56,8 @@ pub struct InMemoryDatabase {
     pinned_sessions: RwLock<HashMap<(Uuid, SessionId), PinnedSessionData>>,
     // Session schedules
     session_schedules: RwLock<HashMap<ScheduleId, SessionScheduleRow>>,
+    // Audit logs (TM-OBS-007)
+    audit_logs: RwLock<Vec<AuditLogRow>>,
 }
 
 impl Default for InMemoryDatabase {
@@ -102,6 +104,7 @@ impl Default for InMemoryDatabase {
             user_connections: RwLock::new(HashMap::new()),
             pinned_sessions: RwLock::new(HashMap::new()),
             session_schedules: RwLock::new(HashMap::new()),
+            audit_logs: RwLock::new(Vec::new()),
         }
     }
 }
@@ -3662,6 +3665,54 @@ impl InMemoryDatabase {
         due.truncate(limit as usize);
         Ok(due)
     }
+
+    // Audit Logs (TM-OBS-007)
+
+    pub async fn create_audit_log(&self, input: CreateAuditLogRow) -> Result<AuditLogRow> {
+        let row = AuditLogRow {
+            id: Uuid::now_v7(),
+            org_id: input.org_id,
+            actor_id: input.actor_id,
+            event_type: input.event_type,
+            ip_address: input.ip_address,
+            metadata: input.metadata,
+            created_at: Self::now(),
+        };
+        self.audit_logs.write().push(row.clone());
+        Ok(row)
+    }
+
+    pub async fn list_audit_logs(
+        &self,
+        org_id: i64,
+        limit: i64,
+        before: Option<DateTime<Utc>>,
+        event_type_prefix: Option<&str>,
+        actor_id: Option<Uuid>,
+    ) -> Result<Vec<AuditLogRow>> {
+        let logs = self.audit_logs.read();
+        let before_ts = before.unwrap_or_else(|| Utc::now() + chrono::Duration::seconds(1));
+        let mut filtered: Vec<_> = logs
+            .iter()
+            .filter(|r| {
+                r.org_id == org_id
+                    && r.created_at < before_ts
+                    && event_type_prefix.is_none_or(|p| r.event_type.starts_with(p))
+                    && actor_id.is_none_or(|a| r.actor_id == Some(a))
+            })
+            .cloned()
+            .collect();
+        filtered.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        filtered.truncate(limit as usize);
+        Ok(filtered)
+    }
+
+    pub async fn delete_audit_logs_before(&self, before: DateTime<Utc>) -> Result<u64> {
+        let mut logs = self.audit_logs.write();
+        let initial = logs.len();
+        logs.retain(|r| r.created_at >= before);
+        Ok((initial - logs.len()) as u64)
+    }
 }
 
 #[cfg(test)]
@@ -4388,5 +4439,139 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(cross_org_search.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_audit_log_create_and_list() {
+        let db = InMemoryDatabase::new();
+
+        let user_id = Uuid::now_v7();
+        db.create_audit_log(CreateAuditLogRow {
+            org_id: DEFAULT_ORG_ID,
+            actor_id: Some(user_id),
+            event_type: "auth.login.success".to_string(),
+            ip_address: Some("1.2.3.4".to_string()),
+            metadata: serde_json::json!({"method": "password"}),
+        })
+        .await
+        .unwrap();
+
+        db.create_audit_log(CreateAuditLogRow {
+            org_id: DEFAULT_ORG_ID,
+            actor_id: None,
+            event_type: "auth.login.failure".to_string(),
+            ip_address: Some("5.6.7.8".to_string()),
+            metadata: serde_json::json!({"reason": "invalid_password"}),
+        })
+        .await
+        .unwrap();
+
+        // List all
+        let logs = db
+            .list_audit_logs(DEFAULT_ORG_ID, 50, None, None, None)
+            .await
+            .unwrap();
+        assert_eq!(logs.len(), 2);
+        // Newest first
+        assert_eq!(logs[0].event_type, "auth.login.failure");
+
+        // Filter by event type prefix
+        let success_only = db
+            .list_audit_logs(DEFAULT_ORG_ID, 50, None, Some("auth.login.success"), None)
+            .await
+            .unwrap();
+        assert_eq!(success_only.len(), 1);
+        assert_eq!(success_only[0].event_type, "auth.login.success");
+
+        // Filter by actor
+        let actor_logs = db
+            .list_audit_logs(DEFAULT_ORG_ID, 50, None, None, Some(user_id))
+            .await
+            .unwrap();
+        assert_eq!(actor_logs.len(), 1);
+        assert_eq!(actor_logs[0].actor_id, Some(user_id));
+
+        // Limit
+        let limited = db
+            .list_audit_logs(DEFAULT_ORG_ID, 1, None, None, None)
+            .await
+            .unwrap();
+        assert_eq!(limited.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_audit_log_org_isolation() {
+        let db = InMemoryDatabase::new();
+
+        let org2 = db
+            .create_organization(CreateOrganizationRow {
+                public_id: "org_00000000000000000000000000000099".to_string(),
+                name: "Other Org".to_string(),
+                created_by: None,
+            })
+            .await
+            .unwrap();
+
+        db.create_audit_log(CreateAuditLogRow {
+            org_id: DEFAULT_ORG_ID,
+            actor_id: None,
+            event_type: "auth.login.success".to_string(),
+            ip_address: None,
+            metadata: serde_json::json!({}),
+        })
+        .await
+        .unwrap();
+
+        db.create_audit_log(CreateAuditLogRow {
+            org_id: org2.org_id,
+            actor_id: None,
+            event_type: "auth.login.failure".to_string(),
+            ip_address: None,
+            metadata: serde_json::json!({}),
+        })
+        .await
+        .unwrap();
+
+        let org1_logs = db
+            .list_audit_logs(DEFAULT_ORG_ID, 50, None, None, None)
+            .await
+            .unwrap();
+        assert_eq!(org1_logs.len(), 1);
+        assert_eq!(org1_logs[0].event_type, "auth.login.success");
+
+        let org2_logs = db
+            .list_audit_logs(org2.org_id, 50, None, None, None)
+            .await
+            .unwrap();
+        assert_eq!(org2_logs.len(), 1);
+        assert_eq!(org2_logs[0].event_type, "auth.login.failure");
+    }
+
+    #[tokio::test]
+    async fn test_audit_log_retention_delete() {
+        let db = InMemoryDatabase::new();
+
+        db.create_audit_log(CreateAuditLogRow {
+            org_id: DEFAULT_ORG_ID,
+            actor_id: None,
+            event_type: "auth.login.success".to_string(),
+            ip_address: None,
+            metadata: serde_json::json!({}),
+        })
+        .await
+        .unwrap();
+
+        // Delete logs before future timestamp → removes all
+        let deleted = db
+            .delete_audit_logs_before(Utc::now() + chrono::Duration::hours(1))
+            .await
+            .unwrap();
+        assert_eq!(deleted, 1);
+
+        let logs = db
+            .list_audit_logs(DEFAULT_ORG_ID, 50, None, None, None)
+            .await
+            .unwrap();
+        assert!(logs.is_empty());
     }
 }

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -716,6 +716,32 @@ pub struct SessionKeyValueRow {
     pub updated_at: DateTime<Utc>,
 }
 
+// ============================================
+// Audit Log models (TM-OBS-007)
+// ============================================
+
+/// Audit log row from database
+#[derive(Debug, Clone, FromRow)]
+pub struct AuditLogRow {
+    pub id: Uuid,
+    pub org_id: i64,
+    pub actor_id: Option<Uuid>,
+    pub event_type: String,
+    pub ip_address: Option<String>,
+    pub metadata: serde_json::Value,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Input for creating an audit log entry
+#[derive(Debug, Clone)]
+pub struct CreateAuditLogRow {
+    pub org_id: i64,
+    pub actor_id: Option<Uuid>,
+    pub event_type: String,
+    pub ip_address: Option<String>,
+    pub metadata: serde_json::Value,
+}
+
 /// Input for creating/updating a session key/value
 #[derive(Debug, Clone)]
 pub struct UpsertSessionKeyValue {

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -3993,6 +3993,112 @@ impl Database {
 
         Ok(rows)
     }
+
+    // Audit Logs (TM-OBS-007)
+
+    pub async fn create_audit_log(&self, input: CreateAuditLogRow) -> Result<AuditLogRow> {
+        let row = sqlx::query_as::<_, AuditLogRow>(
+            r#"
+            INSERT INTO audit_logs (org_id, actor_id, event_type, ip_address, metadata)
+            VALUES ($1, $2, $3, $4, $5)
+            RETURNING *
+            "#,
+        )
+        .bind(input.org_id)
+        .bind(input.actor_id)
+        .bind(&input.event_type)
+        .bind(&input.ip_address)
+        .bind(&input.metadata)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    pub async fn list_audit_logs(
+        &self,
+        org_id: i64,
+        limit: i64,
+        before: Option<DateTime<Utc>>,
+        event_type_prefix: Option<&str>,
+        actor_id: Option<Uuid>,
+    ) -> Result<Vec<AuditLogRow>> {
+        // Build query dynamically based on filters
+        let before_ts = before.unwrap_or_else(|| Utc::now() + chrono::Duration::seconds(1));
+        let rows = if let Some(prefix) = event_type_prefix {
+            if let Some(aid) = actor_id {
+                sqlx::query_as::<_, AuditLogRow>(
+                    r#"
+                    SELECT * FROM audit_logs
+                    WHERE org_id = $1 AND created_at < $2 AND event_type LIKE $3 AND actor_id = $4
+                    ORDER BY created_at DESC
+                    LIMIT $5
+                    "#,
+                )
+                .bind(org_id)
+                .bind(before_ts)
+                .bind(format!("{}%", prefix))
+                .bind(aid)
+                .bind(limit)
+                .fetch_all(&self.pool)
+                .await?
+            } else {
+                sqlx::query_as::<_, AuditLogRow>(
+                    r#"
+                    SELECT * FROM audit_logs
+                    WHERE org_id = $1 AND created_at < $2 AND event_type LIKE $3
+                    ORDER BY created_at DESC
+                    LIMIT $4
+                    "#,
+                )
+                .bind(org_id)
+                .bind(before_ts)
+                .bind(format!("{}%", prefix))
+                .bind(limit)
+                .fetch_all(&self.pool)
+                .await?
+            }
+        } else if let Some(aid) = actor_id {
+            sqlx::query_as::<_, AuditLogRow>(
+                r#"
+                SELECT * FROM audit_logs
+                WHERE org_id = $1 AND created_at < $2 AND actor_id = $3
+                ORDER BY created_at DESC
+                LIMIT $4
+                "#,
+            )
+            .bind(org_id)
+            .bind(before_ts)
+            .bind(aid)
+            .bind(limit)
+            .fetch_all(&self.pool)
+            .await?
+        } else {
+            sqlx::query_as::<_, AuditLogRow>(
+                r#"
+                SELECT * FROM audit_logs
+                WHERE org_id = $1 AND created_at < $2
+                ORDER BY created_at DESC
+                LIMIT $3
+                "#,
+            )
+            .bind(org_id)
+            .bind(before_ts)
+            .bind(limit)
+            .fetch_all(&self.pool)
+            .await?
+        };
+
+        Ok(rows)
+    }
+
+    pub async fn delete_audit_logs_before(&self, before: DateTime<Utc>) -> Result<u64> {
+        let result = sqlx::query("DELETE FROM audit_logs WHERE created_at < $1")
+            .bind(before)
+            .execute(&self.pool)
+            .await?;
+        Ok(result.rows_affected())
+    }
 }
 
 #[cfg(test)]

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -136,7 +136,7 @@ Display:   evr_<first-8-chars>...   (prefix for identification)
 | TM-CRYPTO-004 | Known-plaintext attack | Medium | Unique DEK per encryption; same plaintext produces different ciphertext | MITIGATED |
 | TM-CRYPTO-005 | Stale encryption key | Medium | Key rotation supported (primary + previous KEK); key_id in payload | MITIGATED |
 | TM-CRYPTO-006 | Re-encryption job missing | Low | CLI tool `reencrypt_secrets` implemented with batch processing, dry-run mode, and key rotation detection | MITIGATED |
-| TM-CRYPTO-007 | Limited encryption scope | Medium | Only LLM API keys encrypted; other sensitive fields (system prompts, session data) stored plaintext | **OPEN** |
+| TM-CRYPTO-007 | Limited encryption scope | Medium | System prompts encrypted via envelope encryption (migration 004); LLM API keys encrypted | MITIGATED |
 
 ### Mitigation Details
 
@@ -487,7 +487,7 @@ All `/v1/durable/*` HTTP endpoints use `State(state): State<AppState>` only — 
 | TM-OBS-004 | Braintrust API key exposure | Medium | Key stored in env var; not logged | MITIGATED |
 | TM-OBS-005 | Log injection | Low | Structured logging via `tracing` crate; no raw string interpolation in log output | MITIGATED |
 | TM-OBS-006 | Sensitive data in error logs | Medium | Errors logged server-side only; API keys and passwords excluded from tracing fields | MITIGATED |
-| TM-OBS-007 | No security audit logging | Medium | No structured audit logs for login attempts, API key operations, permission changes, or org member changes | **OPEN** |
+| TM-OBS-007 | No security audit logging | Medium | Structured audit_logs table with fire-and-forget writes for auth events; admin-only query API | MITIGATED |
 
 ### Mitigation Details
 
@@ -499,6 +499,13 @@ Agent turn → events emitted → BraintrustEventListener (async)
     → Fire-and-forget (no retry)
 ```
 Full conversation data (user messages, LLM responses, tool results) is transmitted. Organizations must evaluate whether Braintrust integration is appropriate given their data classification requirements.
+
+**TM-OBS-007 — Security Audit Logging (MITIGATED):**
+- `audit_logs` PostgreSQL table (migration 005) stores structured events with: org_id, actor_id, event_type, ip_address, metadata, created_at.
+- Event types follow `domain.action.outcome` convention: `auth.login.success`, `auth.login.failure`, `auth.register.success`, `auth.token_refresh.success`, `auth.api_key.created`, `auth.api_key.deleted`, `auth.oauth.success`, `auth.oauth.failure`.
+- Fire-and-forget writes via `auth::audit::emit()` — audit failures never block auth operations.
+- Admin-only query API: `GET /v1/organizations/:org_id/audit-logs` with filters for event_type, actor_id, cursor pagination.
+- Retention: `delete_audit_logs_before()` method available for scheduled cleanup.
 
 ## 12. Web Security (TM-WEB)
 
@@ -515,7 +522,7 @@ Full conversation data (user messages, LLM responses, tool results) is transmitt
 ### Mitigation Details
 
 **TM-WEB-004 / TM-WEB-005 — Security Headers (MITIGATED):**
-Applied via `SetResponseHeaderLayer` in `app_builder.rs`:
+Applied via `SetResponseHeaderLayer` (`if_not_present`) in `app_builder.rs`:
 - `X-Frame-Options: DENY` — prevents clickjacking
 - `X-Content-Type-Options: nosniff` — prevents MIME sniffing
 - `Referrer-Policy: strict-origin-when-cross-origin` — limits referrer leakage
@@ -538,7 +545,7 @@ The agent loop is a core trust boundary: an LLM decides which tools to call with
 | TM-AGENT-008 | Context window poisoning | Medium | Auto-compaction via `llm_driver.compact()` on `RequestTooLarge`; older messages compressed | MITIGATED |
 | TM-AGENT-009 | Agent self-modification | Medium | Agents with `platform_management` capability can modify agents/sessions via tools; capability must be explicitly assigned; org-scoped | **OPEN** |
 | TM-AGENT-010 | Agent spawning agent chains | Medium | Agents with `platform_management` capability can create agents/sessions; capability must be explicitly assigned; no recursive depth limit | **OPEN** |
-| TM-AGENT-011 | Sensitive data in system prompt | Medium | System prompts stored plaintext in DB; not encrypted at rest | **OPEN** (see TM-CRYPTO-007) |
+| TM-AGENT-011 | Sensitive data in system prompt | Medium | System prompts encrypted at rest via envelope encryption (TM-CRYPTO-007) | MITIGATED |
 | TM-AGENT-012 | Tool result size amplification | Medium | No size limit on tool results fed back to LLM; large results consume context and cost | **OPEN** |
 | TM-AGENT-013 | Exfiltration via web_fetch | Medium | Agent with web_fetch capability can send session data to arbitrary URLs | **ACCEPTED** |
 | TM-AGENT-014 | Confused deputy — tool call with wrong session | Low | Tool context includes session_id; tools scoped to active session only | MITIGATED |
@@ -785,10 +792,8 @@ Search results from Brave Search are returned as tool results. Adversarial conte
 | TM-DURABLE-010 | Durable API endpoints unauthenticated | High | Add AuthUser/ResolvedOrg to all /v1/durable/* endpoints |
 | TM-TENANT-008 | User listing cross-org | High | Add org filtering to GET /v1/users |
 | TM-DOS-008 | ReDoS via file grep endpoint | Medium | Add regex complexity limits and timeout |
-| TM-OBS-007 | No security audit logging | Medium | Add structured audit log for auth events |
 | TM-AGENT-007 | No per-iteration tool call limit | Medium | Cap tool calls per LLM response |
 | TM-AGENT-012 | Tool result size amplification | Medium | Cap tool result size fed back to LLM |
-| TM-CRYPTO-007 | Limited encryption scope | Medium | Encrypt system prompts and other sensitive fields |
 | TM-FS-008 | No session storage quota | Medium | Enforce per-session file size limits |
 | TM-TOOL-008 | Tool approval not enforced | Low | Implement HITL approval for requires_approval policy |
 | TM-TOOL-009 | No tool rate limiting | Medium | Per-agent tool execution rate limits |


### PR DESCRIPTION
## Summary
- Add `audit_logs` PostgreSQL table (migration 005) with structured event types for security-relevant auth events
- Fire-and-forget audit logging via `auth::audit::emit()` — never blocks auth operations
- Instrumented: login (success/failure), register, token refresh, OAuth callback, API key create/delete
- Admin-only query API: `GET /v1/organizations/:org_id/audit-logs` with event_type, actor_id, and cursor filters
- Retention support via `delete_audit_logs_before()` method

## Test plan
- [x] 336 unit tests pass (7 new: 4 client_ip extraction, 3 audit log CRUD/isolation/retention)
- [x] `cargo clippy -- -D warnings` clean
- [x] `just pre-push` passes
- [x] Threat model updated: TM-OBS-007 marked MITIGATED
- [ ] Integration tests (CI)

Closes EVE-34