### PR TITLE
feat(server): multi-instance control plane support (EVE-40)

### DIFF
--- a/crates/server/src/api/durable.rs
+++ b/crates/server/src/api/durable.rs
@@ -589,11 +589,23 @@ pub struct MetricsPoint {
     pub workflows_started_total: u64,
 }
 
-/// Metrics time series response
+/// Metrics time series response.
+///
+/// In multi-instance deployments, each instance maintains its own metrics
+/// ring buffer. The `instance_count` field indicates how many instances
+/// are expected so consumers can aggregate or label appropriately.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct MetricsTimeSeriesResponse {
     pub points: Vec<MetricsPoint>,
     pub resolution_seconds: u64,
+    /// Number of expected control-plane instances (from EXPECTED_INSTANCES env).
+    /// When >1, these metrics represent only this instance's view.
+    #[serde(skip_serializing_if = "is_one")]
+    pub instance_count: u32,
+}
+
+fn is_one(v: &u32) -> bool {
+    *v == 1
 }
 
 /// Background metrics collector maintaining a ring buffer of timestamped health snapshots
@@ -715,9 +727,15 @@ pub async fn get_metrics_timeseries(
     State(state): State<AppState>,
 ) -> Result<Json<MetricsTimeSeriesResponse>, (StatusCode, Json<ErrorResponse>)> {
     let points = state.metrics.get_points().await;
+    let instance_count: u32 = std::env::var("EXPECTED_INSTANCES")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1)
+        .max(1);
     Ok(Json(MetricsTimeSeriesResponse {
         points,
         resolution_seconds: 10,
+        instance_count,
     }))
 }
 
@@ -2651,6 +2669,7 @@ mod tests {
                 },
             ],
             resolution_seconds: 10,
+            instance_count: 1,
         };
 
         let json = serde_json::to_string(&response).unwrap();
@@ -2658,11 +2677,24 @@ mod tests {
         assert!(json.contains("\"points\""));
         assert!(json.contains("\"tasks_completed_total\":100"));
         assert!(json.contains("\"tasks_completed_total\":105"));
+        // instance_count=1 is skipped in serialization
+        assert!(!json.contains("instance_count"));
 
         // Verify round-trip deserialization shape
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed["resolution_seconds"], 10);
         assert_eq!(parsed["points"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_metrics_timeseries_instance_count_serialization() {
+        let response = MetricsTimeSeriesResponse {
+            points: vec![],
+            resolution_seconds: 10,
+            instance_count: 3,
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(json.contains("\"instance_count\":3"));
     }
 
     // ============================================
@@ -3028,6 +3060,7 @@ mod tests {
                 },
             ],
             resolution_seconds: 10,
+            instance_count: 1,
         };
 
         // Verify monotonicity of cumulative counters

--- a/crates/server/src/api/sse.rs
+++ b/crates/server/src/api/sse.rs
@@ -204,22 +204,48 @@ impl Default for SseConnectionLimits {
 
 impl SseConnectionLimits {
     /// Load limits from environment variables with sensible defaults.
+    ///
+    /// When running multiple control-plane instances behind a load balancer,
+    /// set `EXPECTED_INSTANCES` to divide global and per-org limits across
+    /// instances. Per-session limits are NOT divided since a single session's
+    /// SSE connections typically land on the same instance (sticky sessions)
+    /// or are acceptably over-counted.
     pub fn from_env() -> Self {
         let defaults = Self::default();
-        Self {
-            global_max: std::env::var("SSE_GLOBAL_MAX")
-                .ok()
-                .and_then(|v| v.parse().ok())
-                .unwrap_or(defaults.global_max),
+        let instances: usize = std::env::var("EXPECTED_INSTANCES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(1)
+            .max(1);
+
+        let raw_global = std::env::var("SSE_GLOBAL_MAX")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(defaults.global_max);
+        let raw_per_org = std::env::var("SSE_PER_ORG_MAX")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(defaults.per_org_max);
+
+        let limits = Self {
+            global_max: (raw_global / instances).max(1),
             per_session_max: std::env::var("SSE_PER_SESSION_MAX")
                 .ok()
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(defaults.per_session_max),
-            per_org_max: std::env::var("SSE_PER_ORG_MAX")
-                .ok()
-                .and_then(|v| v.parse().ok())
-                .unwrap_or(defaults.per_org_max),
+            per_org_max: (raw_per_org / instances).max(1),
+        };
+
+        if instances > 1 {
+            tracing::info!(
+                instances,
+                global_max = limits.global_max,
+                per_org_max = limits.per_org_max,
+                "SSE connection limits adjusted for multi-instance deployment"
+            );
         }
+
+        limits
     }
 }
 
@@ -822,5 +848,67 @@ mod tests {
             config.heartbeat_interval(),
             sdk_read_timeout
         );
+    }
+
+    #[test]
+    fn test_sse_limits_default_single_instance() {
+        // SAFETY: test is run single-threaded
+        unsafe {
+            std::env::remove_var("EXPECTED_INSTANCES");
+            std::env::remove_var("SSE_GLOBAL_MAX");
+            std::env::remove_var("SSE_PER_ORG_MAX");
+            std::env::remove_var("SSE_PER_SESSION_MAX");
+        }
+        let limits = SseConnectionLimits::from_env();
+        assert_eq!(limits.global_max, 10_000);
+        assert_eq!(limits.per_org_max, 1_000);
+        assert_eq!(limits.per_session_max, 5);
+    }
+
+    #[test]
+    fn test_sse_limits_multi_instance_divides_global_and_org() {
+        // SAFETY: test is run single-threaded
+        unsafe {
+            std::env::set_var("EXPECTED_INSTANCES", "4");
+            std::env::remove_var("SSE_GLOBAL_MAX");
+            std::env::remove_var("SSE_PER_ORG_MAX");
+            std::env::remove_var("SSE_PER_SESSION_MAX");
+        }
+        let limits = SseConnectionLimits::from_env();
+        // 10_000 / 4 = 2_500
+        assert_eq!(limits.global_max, 2_500);
+        // 1_000 / 4 = 250
+        assert_eq!(limits.per_org_max, 250);
+        // Per-session NOT divided
+        assert_eq!(limits.per_session_max, 5);
+        unsafe {
+            std::env::remove_var("EXPECTED_INSTANCES");
+        }
+    }
+
+    #[test]
+    fn test_sse_connection_tracker_try_acquire_and_drop() {
+        let tracker = Arc::new(SseConnectionTracker::new(SseConnectionLimits {
+            global_max: 2,
+            per_session_max: 2,
+            per_org_max: 2,
+        }));
+
+        let session = uuid::Uuid::new_v4();
+        let guard1 = tracker.try_acquire(1, session).unwrap();
+        let guard2 = tracker.try_acquire(1, session).unwrap();
+
+        // Third should fail (global_max = 2)
+        assert_eq!(
+            tracker.try_acquire(1, session).unwrap_err(),
+            SseConnectionRejection::GlobalLimitReached
+        );
+
+        // Drop one guard, should be able to acquire again
+        drop(guard1);
+        let _guard3 = tracker.try_acquire(1, session).unwrap();
+
+        drop(guard2);
+        drop(_guard3);
     }
 }

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -68,6 +68,9 @@ impl Database {
     }
 
     /// Create database connection pool from URL with configurable pool settings.
+    ///
+    /// Multi-instance sizing: set `DATABASE_POOL_MAX = pg_max_connections / N - margin`
+    /// where N = number of control-plane instances.
     pub async fn from_url(database_url: &str) -> Result<Self> {
         let config = DatabasePoolConfig::from_env();
         let pool = PgPoolOptions::new()
@@ -84,6 +87,40 @@ impl Database {
             idle_timeout_secs = config.idle_timeout.as_secs(),
             "Database connection pool initialized"
         );
+
+        // Multi-instance pool sizing check
+        let instances: u32 = std::env::var("EXPECTED_INSTANCES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(1)
+            .max(1);
+        if instances > 1 {
+            let estimated_total = config.max_connections.saturating_mul(instances);
+            // PostgreSQL default max_connections is 100; warn if we'd exceed 80% of it
+            let pg_max: u32 = std::env::var("PG_MAX_CONNECTIONS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(100);
+            if estimated_total > pg_max * 80 / 100 {
+                tracing::warn!(
+                    pool_max = config.max_connections,
+                    instances,
+                    estimated_total,
+                    pg_max,
+                    "Pool size × instances ({estimated_total}) exceeds 80% of PG_MAX_CONNECTIONS ({pg_max}). \
+                     Reduce DATABASE_POOL_MAX or increase PostgreSQL max_connections."
+                );
+            } else {
+                tracing::info!(
+                    pool_max = config.max_connections,
+                    instances,
+                    estimated_total,
+                    pg_max,
+                    "Database pool sizing OK for multi-instance deployment"
+                );
+            }
+        }
+
         Ok(Self { pool })
     }
 

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -605,3 +605,32 @@ This ensures:
 - Users can only send allowed content types (text, images)
 - System can store all content types (including tool calls, results)
 - No conversion needed between storage and core layers
+
+## Multi-Instance Deployment
+
+Multiple control-plane instances can run behind a load balancer for HA.
+
+### What's Already Multi-Instance Safe
+
+| Component | Reason |
+|-----------|--------|
+| PostgreSQL database | Shared, connection pool per instance |
+| Migrations | Advisory lock protected |
+| Task claiming (SKIP LOCKED) | Naturally partitions work |
+| Worker registration | Database-backed, any server can serve any worker |
+| PgListener (task_available) | Each instance runs its own listener; all receive NOTIFY |
+| PgListener (event_available) | Same; SSE clients on any instance see all events |
+
+### Configuration (`EXPECTED_INSTANCES`)
+
+Set `EXPECTED_INSTANCES=N` to inform each instance about the total count:
+
+- **SSE connection limits**: Global and per-org limits divided by N. Per-session limits unchanged.
+- **Database pool sizing**: Set `DATABASE_POOL_MAX = pg_max_connections / N - margin`. A startup warning fires if pool × instances exceeds 80% of `PG_MAX_CONNECTIONS` (default 100).
+- **Metrics**: Each instance maintains its own ring buffer. The `/v1/durable/metrics/timeseries` response includes `instance_count` when >1.
+
+### Load Balancer Requirements
+
+- HTTP/1.1 or HTTP/2 for SSE (long-lived connections)
+- Health check: `GET /health`
+- No session affinity required (stateless API; SSE reconnects are idempotent)


### PR DESCRIPTION
## Summary
- Add `EXPECTED_INSTANCES` env var for multi-instance deployments behind a load balancer
- SSE connection limits: divide global/per-org by instance count, per-session unchanged
- Database pool sizing: startup warning when pool × instances exceeds 80% of PG_MAX_CONNECTIONS
- Metrics timeseries response includes `instance_count` when >1
- Architecture spec: multi-instance deployment section with configuration guide

PgListener-based task and event notifications already work across instances (each instance runs its own listener on shared PostgreSQL NOTIFY channels).

## Test plan
- [x] 340 unit tests pass (4 new: SSE limit division, connection tracker acquire/drop, metrics instance_count serialization)
- [x] `cargo clippy -- -D warnings` clean
- [x] `just pre-push` passes
- [x] OpenAPI spec unchanged (no new public API endpoints)
- [x] Architecture spec updated with multi-instance deployment section
- [ ] Integration tests (CI)

Closes EVE-40