### PR TITLE
feat(durable): capacity-aware fair-share task claiming (EVE-42)

### DIFF
--- a/crates/durable/src/persistence/memory.rs
+++ b/crates/durable/src/persistence/memory.rs
@@ -763,6 +763,28 @@ impl WorkflowEventStore for InMemoryWorkflowEventStore {
         Ok(0)
     }
 
+    async fn get_capacity_snapshot(&self) -> Result<CapacitySnapshot, StoreError> {
+        let workers = self.workers.read();
+        let heartbeat_threshold =
+            Utc::now() - chrono::Duration::seconds(WORKER_HEARTBEAT_TIMEOUT_SECS);
+
+        let mut total_available: u32 = 0;
+        let mut active_workers: u32 = 0;
+        for w in workers.values() {
+            if w.status == "active"
+                && w.accepting_tasks
+                && w.last_heartbeat_at > heartbeat_threshold
+            {
+                total_available += w.max_concurrency.saturating_sub(w.current_load);
+                active_workers += 1;
+            }
+        }
+        Ok(CapacitySnapshot {
+            total_available,
+            active_workers,
+        })
+    }
+
     async fn list_workers(&self, filter: WorkerFilter) -> Result<Vec<WorkerInfo>, StoreError> {
         let workers = self.workers.read();
         let mut result: Vec<_> = workers

--- a/crates/durable/src/persistence/mod.rs
+++ b/crates/durable/src/persistence/mod.rs
@@ -12,11 +12,12 @@ mod store;
 pub use memory::InMemoryWorkflowEventStore;
 pub use postgres::PostgresWorkflowEventStore;
 pub use store::{
-    CircuitBreakerState, ClaimedTask, CreateScheduleRow, DEFAULT_MAX_PENDING_TASKS_PER_WORKFLOW,
-    DlqEntry, DlqFilter, HeartbeatResponse, Pagination, ScheduleExecutionFilter,
-    ScheduleExecutionRow, ScheduleExecutionStatus, ScheduleFilter, ScheduleRow, ScheduleStats,
-    ScheduleTargetType, SchedulerInstanceInfo, StoreError, SystemHealth, TaskDefinition,
-    TaskFailureOutcome, TaskFilter, TaskInfo, TaskStatus, TraceContext, UpdateSchedule,
-    WORKER_HEARTBEAT_TIMEOUT_SECS, WorkerFilter, WorkerInfo, WorkflowEventInfo, WorkflowEventStore,
-    WorkflowFilter, WorkflowInfo, WorkflowInfoExtended, WorkflowStatus, event_type_name,
+    CapacitySnapshot, CircuitBreakerState, ClaimedTask, CreateScheduleRow,
+    DEFAULT_MAX_PENDING_TASKS_PER_WORKFLOW, DlqEntry, DlqFilter, HeartbeatResponse, Pagination,
+    ScheduleExecutionFilter, ScheduleExecutionRow, ScheduleExecutionStatus, ScheduleFilter,
+    ScheduleRow, ScheduleStats, ScheduleTargetType, SchedulerInstanceInfo, StoreError,
+    SystemHealth, TaskDefinition, TaskFailureOutcome, TaskFilter, TaskInfo, TaskStatus,
+    TraceContext, UpdateSchedule, WORKER_HEARTBEAT_TIMEOUT_SECS, WorkerFilter, WorkerInfo,
+    WorkflowEventInfo, WorkflowEventStore, WorkflowFilter, WorkflowInfo, WorkflowInfoExtended,
+    WorkflowStatus, event_type_name,
 };

--- a/crates/durable/src/persistence/postgres.rs
+++ b/crates/durable/src/persistence/postgres.rs
@@ -14,13 +14,13 @@ use tracing::{debug, error, info, instrument};
 use uuid::Uuid;
 
 use super::store::{
-    CircuitBreakerState, ClaimedTask, CreateScheduleRow, DlqEntry, DlqFilter, HeartbeatResponse,
-    Pagination, ScheduleExecutionFilter, ScheduleExecutionRow, ScheduleExecutionStatus,
-    ScheduleFilter, ScheduleRow, ScheduleStats, ScheduleTargetType, SchedulerInstanceInfo,
-    StoreError, SystemHealth, TaskDefinition, TaskFailureOutcome, TaskFilter, TaskInfo, TaskStatus,
-    TraceContext, UpdateSchedule, WORKER_HEARTBEAT_TIMEOUT_SECS, WorkerFilter, WorkerInfo,
-    WorkflowEventInfo, WorkflowEventStore, WorkflowFilter, WorkflowInfo, WorkflowInfoExtended,
-    WorkflowStatus,
+    CapacitySnapshot, CircuitBreakerState, ClaimedTask, CreateScheduleRow, DlqEntry, DlqFilter,
+    HeartbeatResponse, Pagination, ScheduleExecutionFilter, ScheduleExecutionRow,
+    ScheduleExecutionStatus, ScheduleFilter, ScheduleRow, ScheduleStats, ScheduleTargetType,
+    SchedulerInstanceInfo, StoreError, SystemHealth, TaskDefinition, TaskFailureOutcome,
+    TaskFilter, TaskInfo, TaskStatus, TraceContext, UpdateSchedule, WORKER_HEARTBEAT_TIMEOUT_SECS,
+    WorkerFilter, WorkerInfo, WorkflowEventInfo, WorkflowEventStore, WorkflowFilter, WorkflowInfo,
+    WorkflowInfoExtended, WorkflowStatus,
 };
 use crate::reliability::{CircuitBreakerConfig, CircuitState};
 use crate::workflow::{ActivityOptions, WorkflowError, WorkflowEvent, WorkflowSignal};
@@ -1096,6 +1096,32 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
         }
 
         Ok(reclaimed)
+    }
+
+    #[instrument(skip(self))]
+    async fn get_capacity_snapshot(&self) -> Result<CapacitySnapshot, StoreError> {
+        let row = sqlx::query(
+            r#"
+            SELECT
+                COALESCE(SUM(max_concurrency - current_load), 0)::INT AS total_available,
+                COUNT(*)::INT AS active_workers
+            FROM durable_workers
+            WHERE status = 'active'
+              AND accepting_tasks = true
+              AND last_heartbeat_at > NOW() - INTERVAL '30 seconds'
+            "#,
+        )
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| {
+            error!("Failed to get capacity snapshot: {}", e);
+            StoreError::Database(e.to_string())
+        })?;
+
+        Ok(CapacitySnapshot {
+            total_available: row.get::<i32, _>("total_available") as u32,
+            active_workers: row.get::<i32, _>("active_workers") as u32,
+        })
     }
 
     #[instrument(skip(self, error_history))]

--- a/crates/durable/src/persistence/store.rs
+++ b/crates/durable/src/persistence/store.rs
@@ -327,6 +327,15 @@ pub struct WorkerInfo {
     pub avg_task_duration_ms: Option<u64>,
 }
 
+/// Snapshot of total system worker capacity for fair-share claiming.
+#[derive(Debug, Clone, Default)]
+pub struct CapacitySnapshot {
+    /// Total available slots across all active, accepting workers
+    pub total_available: u32,
+    /// Number of active workers that are accepting tasks
+    pub active_workers: u32,
+}
+
 /// Filter for listing DLQ entries
 #[derive(Debug, Clone, Default)]
 pub struct DlqFilter {
@@ -533,6 +542,12 @@ pub trait WorkflowEventStore: Send + Sync + 'static {
     /// Returns the number of tasks that were reclaimed
     async fn deregister_worker(&self, _worker_id: &str) -> Result<usize, StoreError> {
         Ok(0)
+    }
+
+    /// Get a snapshot of total system worker capacity.
+    /// Used by workers to compute fair-share claim limits.
+    async fn get_capacity_snapshot(&self) -> Result<CapacitySnapshot, StoreError> {
+        Ok(CapacitySnapshot::default())
     }
 
     // =========================================================================

--- a/crates/durable/src/worker/pool.rs
+++ b/crates/durable/src/worker/pool.rs
@@ -420,17 +420,27 @@ impl WorkerPool {
                     continue;
                 }
 
-                // Calculate how many tasks to claim
-                let available_slots = backpressure.available_slots();
-                if available_slots == 0 {
+                // Calculate how many tasks to claim (fair-share)
+                let my_available = backpressure.available_slots();
+                if my_available == 0 {
                     if poller.wait().await {
                         break;
                     }
                     continue;
                 }
 
+                // Cap claim batch to fair share of total system capacity
+                let claim_limit = match store.get_capacity_snapshot().await {
+                    Ok(snap) => fair_share_claim_limit(
+                        my_available,
+                        snap.total_available,
+                        snap.active_workers,
+                    ),
+                    Err(_) => my_available, // error: no cap
+                };
+
                 // Poll for tasks
-                match poller.poll(available_slots).await {
+                match poller.poll(claim_limit).await {
                     Ok(tasks) => {
                         for task in tasks {
                             // Get handler
@@ -578,6 +588,24 @@ impl WorkerPool {
     }
 }
 
+/// Compute fair-share claim limit for a worker given its available slots
+/// and the total system capacity. Returns the capped number of tasks to claim.
+///
+/// When there's only one worker (or capacity is unknown), returns my_available.
+/// With multiple workers, each gets a proportional share:
+///   ceil(my_available² / total_available), minimum 1.
+pub(crate) fn fair_share_claim_limit(
+    my_available: usize,
+    total_available: u32,
+    active_workers: u32,
+) -> usize {
+    if active_workers <= 1 || total_available == 0 {
+        return my_available;
+    }
+    let share = (my_available as f64 / total_available as f64) * my_available as f64;
+    (share.ceil() as usize).max(1)
+}
+
 /// Serde support for Duration as milliseconds
 mod duration_millis {
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -632,5 +660,40 @@ mod tests {
     fn test_worker_pool_status() {
         assert_ne!(WorkerPoolStatus::Running, WorkerPoolStatus::Stopped);
         assert_ne!(WorkerPoolStatus::Draining, WorkerPoolStatus::Running);
+    }
+
+    #[test]
+    fn test_fair_share_single_worker() {
+        // Single worker gets full allocation
+        assert_eq!(fair_share_claim_limit(10, 10, 1), 10);
+        assert_eq!(fair_share_claim_limit(5, 5, 0), 5);
+    }
+
+    #[test]
+    fn test_fair_share_equal_workers() {
+        // 3 workers, each with 10 available (total 30)
+        // Each should get ceil(10 * 10/30) = ceil(3.33) = 4
+        assert_eq!(fair_share_claim_limit(10, 30, 3), 4);
+    }
+
+    #[test]
+    fn test_fair_share_unequal_workers() {
+        // Worker A: 8 available, Worker B: 2 available, total: 10
+        // A gets ceil(8 * 8/10) = ceil(6.4) = 7
+        assert_eq!(fair_share_claim_limit(8, 10, 2), 7);
+        // B gets ceil(2 * 2/10) = ceil(0.4) = 1 (minimum 1)
+        assert_eq!(fair_share_claim_limit(2, 10, 2), 1);
+    }
+
+    #[test]
+    fn test_fair_share_minimum_one() {
+        // Even with tiny share, always claim at least 1
+        assert_eq!(fair_share_claim_limit(1, 100, 10), 1);
+    }
+
+    #[test]
+    fn test_fair_share_zero_total() {
+        // Edge case: total_available = 0
+        assert_eq!(fair_share_claim_limit(5, 0, 3), 5);
     }
 }


### PR DESCRIPTION
## Summary

- Add fair-share task claiming: workers cap their claim batch size proportional to their share of total system capacity
- Prevents any single worker from grabbing all pending tasks in multi-worker deployments
- Add `CapacitySnapshot` struct and `get_capacity_snapshot()` method to `WorkflowEventStore` trait
- Implemented in both PostgreSQL (SQL aggregate) and InMemory stores
- Extract `fair_share_claim_limit()` as a pure, testable function
- Formula: `ceil(my_available² / total_available)`, minimum 1
- Single-worker deployments unaffected (no cap applied)

## Test plan

- [x] 5 new unit tests: equal workers, unequal workers, single worker, minimum claim, zero total edge case
- [x] All 130 durable crate tests pass
- [x] Server crate compiles cleanly
- [x] `just pre-push` clean (fmt, clippy, lockfile)
- [ ] CI green

## Linear

Closes EVE-42