### PR TITLE
feat(capabilities): add list_capabilities tool to platform management

### DIFF
--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -137,8 +137,8 @@ pub use mcp::{
 };
 pub use noop::NoopCapability;
 pub use platform_management::{
-    ManageAgentsTool, ManageHarnessesTool, ManageSessionsTool, PlatformManagementCapability,
-    SessionInteractTool,
+    ListCapabilitiesTool, ManageAgentsTool, ManageHarnessesTool, ManageSessionsTool,
+    PlatformManagementCapability, SessionInteractTool,
 };
 pub use research::ResearchCapability;
 pub use sample_data::SampleDataCapability;

--- a/crates/core/src/capabilities/platform_management.rs
+++ b/crates/core/src/capabilities/platform_management.rs
@@ -47,6 +47,19 @@ impl Capability for PlatformManagementCapability {
         Some(
             r#"You have platform management tools to manage Everruns entities:
 
+## Capabilities
+
+Capabilities are the primary way to extend agent and harness functionality. Each capability provides tools, system prompt additions, or both. There are three types:
+- **Built-in**: Core capabilities like file system, bash, web fetch, research, etc.
+- **MCP Servers**: External tool providers connected via the Model Context Protocol.
+- **Skills**: Reusable instruction sets that teach agents domain-specific workflows.
+
+When creating or updating agents/harnesses, use `list_capabilities` to discover available capability IDs, then pass them in the `capabilities` parameter.
+
+`list_capabilities` - Discover available capabilities:
+- search: Optional filter by name, description, category, or ID
+- Returns: capability ID, name, description, type, tools, dependencies
+
 `manage_harnesses` - Harness CRUD operations:
 - operation: "list" - List all harnesses
 - operation: "get" - Get a harness by ID (requires: harness_id)
@@ -79,6 +92,7 @@ All results include UI links to view entities in the web interface."#,
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
         vec![
+            Box::new(ListCapabilitiesTool),
             Box::new(ManageHarnessesTool),
             Box::new(ManageAgentsTool),
             Box::new(ManageSessionsTool),
@@ -998,6 +1012,109 @@ impl Tool for SessionInteractTool {
     }
 }
 
+// =============================================================================
+// Tool: list_capabilities
+// =============================================================================
+
+pub struct ListCapabilitiesTool;
+
+#[async_trait]
+impl Tool for ListCapabilitiesTool {
+    fn name(&self) -> &str {
+        "list_capabilities"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("List Capabilities")
+    }
+
+    fn description(&self) -> &str {
+        "List and search available capabilities (built-in, MCP servers, and skills). Use this to discover what capabilities exist before creating or updating agents and harnesses."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "search": {
+                    "type": "string",
+                    "description": "Optional search query to filter capabilities by name, description, category, or ID (case-insensitive)"
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "list_capabilities requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let store = match get_platform_store(context) {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let search = get_str(&arguments, "search");
+
+        match store.list_capabilities(search).await {
+            Ok(capabilities) => {
+                let items: Vec<Value> = capabilities
+                    .iter()
+                    .map(|c| {
+                        let mut item = json!({
+                            "id": c.id.as_str(),
+                            "name": c.name,
+                            "description": c.description,
+                            "status": c.status.to_string(),
+                        });
+                        if let Some(cat) = &c.category {
+                            item["category"] = json!(cat);
+                        }
+                        if c.is_mcp {
+                            item["type"] = json!("mcp_server");
+                        } else if c.is_skill {
+                            item["type"] = json!("skill");
+                        } else {
+                            item["type"] = json!("builtin");
+                        }
+                        if !c.tool_definitions.is_empty() {
+                            item["tool_count"] = json!(c.tool_definitions.len());
+                            item["tools"] = json!(
+                                c.tool_definitions
+                                    .iter()
+                                    .map(|t| t.name())
+                                    .collect::<Vec<_>>()
+                            );
+                        }
+                        if !c.dependencies.is_empty() {
+                            item["dependencies"] = json!(c.dependencies);
+                        }
+                        item
+                    })
+                    .collect();
+                let count = items.len();
+                ToolExecutionResult::success(json!({
+                    "capabilities": items,
+                    "count": count,
+                    "hint": "Use capability IDs when creating or updating agents and harnesses via manage_agents or manage_harnesses (capabilities parameter)."
+                }))
+            }
+            Err(e) => ToolExecutionResult::tool_error(format!("Failed to list capabilities: {e}")),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1021,11 +1138,12 @@ mod tests {
     }
 
     #[test]
-    fn capability_provides_four_tools() {
+    fn capability_provides_five_tools() {
         let cap = PlatformManagementCapability;
         let tools = cap.tools();
-        assert_eq!(tools.len(), 4);
+        assert_eq!(tools.len(), 5);
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(names.contains(&"list_capabilities"));
         assert!(names.contains(&"manage_harnesses"));
         assert!(names.contains(&"manage_agents"));
         assert!(names.contains(&"manage_sessions"));
@@ -1594,7 +1712,8 @@ mod tests {
 
     #[tokio::test]
     async fn all_tools_require_context() {
-        // All four tools should have requires_context = true
+        // All five tools should have requires_context = true
+        assert!(ListCapabilitiesTool.requires_context());
         assert!(ManageHarnessesTool.requires_context());
         assert!(ManageAgentsTool.requires_context());
         assert!(ManageSessionsTool.requires_context());
@@ -1605,12 +1724,14 @@ mod tests {
     async fn all_tools_without_context_return_error() {
         // execute() (no context) should fail for all tools
         for tool_name in [
+            "list_capabilities",
             "manage_harnesses",
             "manage_agents",
             "manage_sessions",
             "session_interact",
         ] {
             let result = match tool_name {
+                "list_capabilities" => ListCapabilitiesTool.execute(json!({})).await,
                 "manage_harnesses" => {
                     ManageHarnessesTool
                         .execute(json!({"operation": "list"}))
@@ -1638,13 +1759,76 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn list_capabilities_returns_all() {
+        let ctx = mock_context();
+        let tool = ListCapabilitiesTool;
+        let result = tool.execute_with_context(json!({}), &ctx).await;
+        match result {
+            ToolExecutionResult::Success(v) => {
+                let count = v["count"].as_u64().unwrap();
+                assert!(count > 0, "should return at least one capability");
+                let caps = v["capabilities"].as_array().unwrap();
+                // Verify each capability has required fields
+                for cap in caps {
+                    assert!(cap["id"].is_string());
+                    assert!(cap["name"].is_string());
+                    assert!(cap["type"].is_string());
+                }
+                assert!(v["hint"].as_str().unwrap().contains("capability IDs"));
+            }
+            other => panic!("expected success, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn list_capabilities_search_filters_results() {
+        let ctx = mock_context();
+        let tool = ListCapabilitiesTool;
+        let result = tool
+            .execute_with_context(json!({"search": "current_time"}), &ctx)
+            .await;
+        match result {
+            ToolExecutionResult::Success(v) => {
+                let count = v["count"].as_u64().unwrap();
+                assert!(count >= 1, "should find at least current_time");
+                let caps = v["capabilities"].as_array().unwrap();
+                assert!(
+                    caps.iter()
+                        .any(|c| c["id"].as_str().unwrap() == "current_time"),
+                    "should contain current_time"
+                );
+            }
+            other => panic!("expected success, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn list_capabilities_search_no_match() {
+        let ctx = mock_context();
+        let tool = ListCapabilitiesTool;
+        let result = tool
+            .execute_with_context(json!({"search": "zzz_nonexistent_zzz"}), &ctx)
+            .await;
+        match result {
+            ToolExecutionResult::Success(v) => {
+                assert_eq!(v["count"], 0);
+            }
+            other => panic!("expected success, got: {other:?}"),
+        }
+    }
+
     #[test]
     fn capability_has_system_prompt_addition() {
         let cap = PlatformManagementCapability;
         let prompt = cap.system_prompt_addition().expect("should have prompt");
+        assert!(prompt.contains("list_capabilities"));
         assert!(prompt.contains("manage_harnesses"));
         assert!(prompt.contains("manage_agents"));
         assert!(prompt.contains("manage_sessions"));
         assert!(prompt.contains("session_interact"));
+        // Capabilities section should be mentioned
+        assert!(prompt.contains("Capabilities"));
+        assert!(prompt.contains("primary way to extend"));
     }
 }

--- a/crates/core/src/capability_dto.rs
+++ b/crates/core/src/capability_dto.rs
@@ -68,6 +68,18 @@ fn default_risk_level() -> RiskLevel {
 }
 
 impl CapabilityInfo {
+    /// Case-insensitive search across name, description, category, and ID.
+    pub fn matches_search(&self, query: &str) -> bool {
+        let q = query.to_lowercase();
+        self.name.to_lowercase().contains(&q)
+            || self.description.to_lowercase().contains(&q)
+            || self.id.as_str().to_lowercase().contains(&q)
+            || self
+                .category
+                .as_deref()
+                .is_some_and(|cat| cat.to_lowercase().contains(&q))
+    }
+
     /// Create a CapabilityInfo DTO from a core Capability trait object
     pub fn from_core(cap: &dyn crate::capabilities::Capability) -> Self {
         // Check if this is an MCP or skill capability by checking the ID prefix
@@ -309,5 +321,36 @@ mod tests {
         let noop_cap = registry.get("noop").unwrap();
         let info = CapabilityInfo::from_core(noop_cap.as_ref());
         assert_eq!(info.risk_level, RiskLevel::Low);
+    }
+
+    #[test]
+    fn test_matches_search() {
+        let cap = CapabilityInfo {
+            id: CapabilityId::new("web_fetch"),
+            name: "Web Fetch".to_string(),
+            description: "Fetch content from URLs".to_string(),
+            status: CapabilityStatus::Available,
+            icon: None,
+            category: Some("Network".to_string()),
+            system_prompt: None,
+            tool_definitions: vec![],
+            is_mcp: false,
+            is_skill: false,
+            dependencies: vec![],
+            features: vec![],
+            risk_level: RiskLevel::Low,
+        };
+
+        // Matches by name (case-insensitive)
+        assert!(cap.matches_search("web"));
+        assert!(cap.matches_search("WEB FETCH"));
+        // Matches by description
+        assert!(cap.matches_search("urls"));
+        // Matches by ID
+        assert!(cap.matches_search("web_fetch"));
+        // Matches by category
+        assert!(cap.matches_search("network"));
+        // No match
+        assert!(!cap.matches_search("zzz_nonexistent"));
     }
 }

--- a/crates/core/src/platform_store.rs
+++ b/crates/core/src/platform_store.rs
@@ -6,6 +6,7 @@
 // Decision: PlatformMessage is a simplified view (role + text + timestamp)
 
 use crate::agent::Agent;
+use crate::capability_dto::CapabilityInfo;
 use crate::error::Result;
 use crate::harness::Harness;
 use crate::session::Session;
@@ -146,6 +147,16 @@ pub trait PlatformStore: Send + Sync {
         session_id: SessionId,
         timeout_secs: Option<u64>,
     ) -> Result<String>;
+
+    // =========================================================================
+    // Capabilities
+    // =========================================================================
+
+    /// List all available capabilities (built-in + MCP servers + skills).
+    ///
+    /// Optionally filter by a search query (case-insensitive match against
+    /// name, description, category, and capability ID).
+    async fn list_capabilities(&self, search: Option<&str>) -> Result<Vec<CapabilityInfo>>;
 
     // =========================================================================
     // UI Links
@@ -357,6 +368,27 @@ pub mod tests {
         }
         async fn wait_for_idle(&self, _id: SessionId, _t: Option<u64>) -> Result<String> {
             Ok("idle".to_string())
+        }
+        async fn list_capabilities(&self, search: Option<&str>) -> Result<Vec<CapabilityInfo>> {
+            let registry = crate::capabilities::CapabilityRegistry::with_builtins();
+            let mut caps: Vec<CapabilityInfo> = registry
+                .list()
+                .iter()
+                .map(|c| CapabilityInfo::from_core(c.as_ref()))
+                .collect();
+            if let Some(q) = search {
+                let q = q.to_lowercase();
+                caps.retain(|c| {
+                    c.name.to_lowercase().contains(&q)
+                        || c.description.to_lowercase().contains(&q)
+                        || c.id.as_str().to_lowercase().contains(&q)
+                        || c.category
+                            .as_deref()
+                            .is_some_and(|cat| cat.to_lowercase().contains(&q))
+                });
+            }
+            caps.sort_by(|a, b| a.name.cmp(&b.name));
+            Ok(caps)
         }
         fn base_url(&self) -> &str {
             "http://localhost:3000"

--- a/crates/core/src/platform_store.rs
+++ b/crates/core/src/platform_store.rs
@@ -377,15 +377,7 @@ pub mod tests {
                 .map(|c| CapabilityInfo::from_core(c.as_ref()))
                 .collect();
             if let Some(q) = search {
-                let q = q.to_lowercase();
-                caps.retain(|c| {
-                    c.name.to_lowercase().contains(&q)
-                        || c.description.to_lowercase().contains(&q)
-                        || c.id.as_str().to_lowercase().contains(&q)
-                        || c.category
-                            .as_deref()
-                            .is_some_and(|cat| cat.to_lowercase().contains(&q))
-                });
+                caps.retain(|c| c.matches_search(q));
             }
             caps.sort_by(|a, b| a.name.cmp(&b.name));
             Ok(caps)

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -181,6 +181,9 @@ service WorkerService {
     // Turn management
     rpc PlatformWaitForIdle(PlatformWaitForIdleRequest) returns (PlatformWaitForIdleResponse);
 
+    // Capability discovery
+    rpc PlatformListCapabilities(PlatformListCapabilitiesRequest) returns (PlatformListCapabilitiesResponse);
+
     // Base URL for UI links
     rpc PlatformGetBaseUrl(PlatformGetBaseUrlRequest) returns (PlatformGetBaseUrlResponse);
 }
@@ -1164,6 +1167,31 @@ message PlatformWaitForIdleRequest {
 
 message PlatformWaitForIdleResponse {
     string status = 1;
+}
+
+// === Capability discovery ===
+
+message PlatformListCapabilitiesRequest {
+    int64 org_id = 1;
+    optional string search = 2;
+}
+
+message PlatformCapabilityInfo {
+    string id = 1;
+    string name = 2;
+    string description = 3;
+    string status = 4;
+    optional string category = 5;
+    optional string icon = 6;
+    bool is_mcp = 7;
+    bool is_skill = 8;
+    uint32 tool_count = 9;
+    repeated string tool_names = 10;
+    repeated string dependencies = 11;
+}
+
+message PlatformListCapabilitiesResponse {
+    repeated PlatformCapabilityInfo capabilities = 1;
 }
 
 // === Base URL ===

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1691,15 +1691,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
             .map_err(|e| store_error(format!("Failed to list capabilities: {e}")))?;
 
         if let Some(q) = search {
-            let q = q.to_lowercase();
-            caps.retain(|c| {
-                c.name.to_lowercase().contains(&q)
-                    || c.description.to_lowercase().contains(&q)
-                    || c.id.as_str().to_lowercase().contains(&q)
-                    || c.category
-                        .as_deref()
-                        .is_some_and(|cat| cat.to_lowercase().contains(&q))
-            });
+            caps.retain(|c| c.matches_search(q));
         }
 
         caps.sort_by(|a, b| a.name.cmp(&b.name));

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1051,6 +1051,7 @@ pub struct DirectPlatformStore {
     db: Arc<StorageBackend>,
     event_service: Arc<EventService>,
     runner: Option<Arc<dyn everruns_worker::AgentRunner>>,
+    capability_service: crate::services::CapabilityService,
 }
 
 impl DirectPlatformStore {
@@ -1059,10 +1060,12 @@ impl DirectPlatformStore {
         event_service: Arc<EventService>,
         runner: Option<Arc<dyn everruns_worker::AgentRunner>>,
     ) -> Self {
+        let capability_service = crate::services::CapabilityService::new(db.clone(), None);
         Self {
             db,
             event_service,
             runner,
+            capability_service,
         }
     }
 
@@ -1671,6 +1674,36 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
 
             tokio::time::sleep(poll_interval).await;
         }
+    }
+
+    // =========================================================================
+    // Capabilities
+    // =========================================================================
+
+    async fn list_capabilities(
+        &self,
+        search: Option<&str>,
+    ) -> everruns_core::error::Result<Vec<everruns_core::CapabilityInfo>> {
+        let mut caps = self
+            .capability_service
+            .list_all(DEFAULT_ORG_ID)
+            .await
+            .map_err(|e| store_error(format!("Failed to list capabilities: {e}")))?;
+
+        if let Some(q) = search {
+            let q = q.to_lowercase();
+            caps.retain(|c| {
+                c.name.to_lowercase().contains(&q)
+                    || c.description.to_lowercase().contains(&q)
+                    || c.id.as_str().to_lowercase().contains(&q)
+                    || c.category
+                        .as_deref()
+                        .is_some_and(|cat| cat.to_lowercase().contains(&q))
+            });
+        }
+
+        caps.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(caps)
     }
 
     // =========================================================================

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -3056,17 +3056,9 @@ impl WorkerService for WorkerServiceImpl {
 
         // Apply search filter if provided
         let filtered: Vec<_> = if let Some(ref q) = req.search {
-            let q = q.to_lowercase();
             capabilities
                 .into_iter()
-                .filter(|c| {
-                    c.name.to_lowercase().contains(&q)
-                        || c.description.to_lowercase().contains(&q)
-                        || c.id.as_str().to_lowercase().contains(&q)
-                        || c.category
-                            .as_deref()
-                            .is_some_and(|cat| cat.to_lowercase().contains(&q))
-                })
+                .filter(|c| c.matches_search(q))
                 .collect()
         } else {
             capabilities

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -6,8 +6,8 @@
 // Decision: No direct database access - all operations go through services layer
 
 use crate::services::{
-    AgentService, EventService, HarnessService, LlmResolverService, McpServerService,
-    SessionFileService, SessionService,
+    AgentService, CapabilityService, EventService, HarnessService, LlmResolverService,
+    McpServerService, SessionFileService, SessionService,
     session_file::{CreateDirectoryInput, CreateFileInput, GrepInput, UpdateFileInput},
 };
 use crate::storage::{EncryptionService, StorageBackend};
@@ -72,6 +72,7 @@ use everruns_internal_protocol::proto::{
     LoadMessagesResponse,
     McpServerInfo,
     McpToolDef,
+    PlatformCapabilityInfo,
     // Platform management types
     PlatformCopyHarnessRequest,
     PlatformCopyHarnessResponse,
@@ -93,6 +94,8 @@ use everruns_internal_protocol::proto::{
     PlatformGetMessagesResponse,
     PlatformListAgentsRequest,
     PlatformListAgentsResponse,
+    PlatformListCapabilitiesRequest,
+    PlatformListCapabilitiesResponse,
     PlatformListHarnessesRequest,
     PlatformListHarnessesResponse,
     PlatformListSessionsRequest,
@@ -272,6 +275,7 @@ pub struct WorkerServiceImpl {
     session_file_service: SessionFileService,
     llm_resolver_service: LlmResolverService,
     mcp_server_service: McpServerService,
+    capability_service: CapabilityService,
     durable_store: Option<Arc<PostgresWorkflowEventStore>>,
     /// Task notification broadcaster for push-based notifications
     task_broadcaster: Option<Arc<TaskNotificationBroadcaster>>,
@@ -296,6 +300,7 @@ impl WorkerServiceImpl {
         let session_file_service = SessionFileService::new(db.clone());
         let llm_resolver_service = LlmResolverService::new(db.clone(), encryption.clone());
         let mcp_server_service = McpServerService::new(db.clone(), encryption.clone());
+        let capability_service = CapabilityService::new(db.clone(), encryption.clone());
 
         // Create durable store using the pool if available (PostgreSQL mode only)
         // In dev mode (in-memory), durable execution is handled differently
@@ -329,6 +334,7 @@ impl WorkerServiceImpl {
             session_file_service,
             llm_resolver_service,
             mcp_server_service,
+            capability_service,
             durable_store,
             task_broadcaster: None, // Set via set_task_broadcaster() after async initialization
             db,
@@ -3035,6 +3041,61 @@ impl WorkerService for WorkerServiceImpl {
 
             tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
         }
+    }
+
+    async fn platform_list_capabilities(
+        &self,
+        request: Request<PlatformListCapabilitiesRequest>,
+    ) -> Result<Response<PlatformListCapabilitiesResponse>, Status> {
+        let req = request.into_inner();
+        let capabilities = self
+            .capability_service
+            .list_all(req.org_id)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to list capabilities: {}", e)))?;
+
+        // Apply search filter if provided
+        let filtered: Vec<_> = if let Some(ref q) = req.search {
+            let q = q.to_lowercase();
+            capabilities
+                .into_iter()
+                .filter(|c| {
+                    c.name.to_lowercase().contains(&q)
+                        || c.description.to_lowercase().contains(&q)
+                        || c.id.as_str().to_lowercase().contains(&q)
+                        || c.category
+                            .as_deref()
+                            .is_some_and(|cat| cat.to_lowercase().contains(&q))
+                })
+                .collect()
+        } else {
+            capabilities
+        };
+
+        let proto_caps = filtered
+            .iter()
+            .map(|c| PlatformCapabilityInfo {
+                id: c.id.as_str().to_string(),
+                name: c.name.clone(),
+                description: c.description.clone(),
+                status: c.status.to_string(),
+                category: c.category.clone(),
+                icon: c.icon.clone(),
+                is_mcp: c.is_mcp,
+                is_skill: c.is_skill,
+                tool_count: c.tool_definitions.len() as u32,
+                tool_names: c
+                    .tool_definitions
+                    .iter()
+                    .map(|t| t.name().to_string())
+                    .collect(),
+                dependencies: c.dependencies.clone(),
+            })
+            .collect();
+
+        Ok(Response::new(PlatformListCapabilitiesResponse {
+            capabilities: proto_caps,
+        }))
     }
 
     async fn platform_get_base_url(

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -312,7 +312,7 @@ const SEED_HARNESSES: &[SeedHarness] = &[
         id: seed_ids::CHAT_HARNESS,
         name: "Platform Chat",
         description: "Conversational harness for the global chat interface with platform management capabilities.",
-        system_prompt: "You are a helpful assistant.",
+        system_prompt: "You are a helpful assistant on the Everruns platform.\n\nCapabilities are the primary way to extend agent functionality. Use `list_capabilities` to discover available capabilities (built-in, MCP servers, and skills), then assign them when creating agents or harnesses.\n\nWhen creating agents, always use `list_capabilities` first to find relevant capability IDs to include.",
         tags: &["chat", "seed"],
         capabilities: &[
             "session_file_system",

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -1735,6 +1735,53 @@ impl everruns_core::platform_store::PlatformStore for GrpcPlatformStore {
     }
 
     // =========================================================================
+    // Capabilities
+    // =========================================================================
+
+    async fn list_capabilities(
+        &self,
+        search: Option<&str>,
+    ) -> Result<Vec<everruns_core::CapabilityInfo>> {
+        let mut client = self.client.inner.lock().await;
+        let response = client
+            .platform_list_capabilities(proto::PlatformListCapabilitiesRequest {
+                org_id: self.org_id,
+                search: search.map(|s| s.to_string()),
+            })
+            .await
+            .map_err(|e| grpc_error(format!("gRPC platform_list_capabilities failed: {}", e)))?;
+
+        let caps = response
+            .into_inner()
+            .capabilities
+            .into_iter()
+            .map(|c| everruns_core::CapabilityInfo {
+                id: everruns_core::CapabilityId::new(&c.id),
+                name: c.name,
+                description: c.description,
+                status: if c.status == "available" {
+                    everruns_core::CapabilityStatus::Available
+                } else if c.status == "coming_soon" {
+                    everruns_core::CapabilityStatus::ComingSoon
+                } else {
+                    everruns_core::CapabilityStatus::Deprecated
+                },
+                icon: c.icon,
+                category: c.category,
+                system_prompt: None,
+                tool_definitions: vec![], // Tool definitions not sent over gRPC (tool names suffice for listing)
+                is_mcp: c.is_mcp,
+                is_skill: c.is_skill,
+                dependencies: c.dependencies,
+                features: vec![],
+                risk_level: everruns_core::RiskLevel::Low,
+            })
+            .collect();
+
+        Ok(caps)
+    }
+
+    // =========================================================================
     // UI Links
     // =========================================================================
 

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -631,6 +631,11 @@ See `crates/core/src/capabilities/sample_data.rs` for a concrete example of `mou
 - **Purpose**: Programmatic management of Everruns entities (harnesses, agents, sessions) via tool calls
 - **System Prompt**: Describes available management tools and common workflows
 - **Tools**:
+  - `list_capabilities` - Discover available capabilities (built-in, MCP servers, skills)
+    - Parameters:
+      - `search`: string - Optional case-insensitive filter by name, description, category, or ID
+    - Returns: Array of capabilities with id, name, description, type (builtin/mcp_server/skill), tools, dependencies
+    - Policy: Auto
   - `manage_harnesses` - Harness CRUD operations
     - Parameters:
       - `operation`: enum (list, get, create, update, delete, copy) - The operation to perform
@@ -680,6 +685,10 @@ All platform management tools require session context to access the `PlatformSto
 ##### Design Decision: UI Links
 
 All tool results include `ui_link` fields pointing to the relevant UI page (e.g., `/harnesses/{id}`, `/agents/{id}`, `/chat?session={id}`). This lets agents direct users to the web interface for visual management.
+
+##### Design Decision: Capability Discovery via list_capabilities
+
+The `list_capabilities` tool enables agents (particularly the Platform Chat) to discover available capabilities before creating or updating agents/harnesses. It queries the `PlatformStore.list_capabilities()` method which returns built-in capabilities, MCP server capabilities, and skill capabilities. The search parameter supports case-insensitive filtering across name, description, category, and ID. The Platform Chat harness system prompt instructs the agent to use `list_capabilities` before creating agents.
 
 ##### Design Decision: PlatformStore Trait
 


### PR DESCRIPTION
## What
Add `list_capabilities` tool to the platform_management capability, enabling agents to discover available capabilities (built-in, MCP servers, and skills) before creating or updating agents/harnesses.

## Why
The Platform Chat agent (and any agent with platform_management) needs to know which capabilities exist to configure agents properly. Previously, there was no way for an agent to programmatically discover available capabilities — they had to rely on hardcoded knowledge or user input.

## How
- Added `ListCapabilitiesTool` to `PlatformManagementCapability` with optional search parameter (case-insensitive match on name, description, category, ID)
- Extended `PlatformStore` trait with `list_capabilities()` method
- Implemented in `DirectPlatformStore` (via `CapabilityService`), `GrpcPlatformStore` (via new proto messages), and `MockPlatformStore`
- Added `CapabilityInfo::matches_search()` to DRY up search filter logic across 3 implementations
- Updated Platform Chat harness system prompt to reference capabilities
- Updated `specs/capabilities.md` with tool documentation

## Risk
- Low
- Read-only operation; no state mutation. Search is in-memory string matching (no injection surface).

## Checklist
- [x] Tests added or updated (6 new/updated tests: tool count, context requirement, list all, search filter, no match, system prompt content)
- [x] Backward compatibility considered (additive change only — new tool, new trait method)