### PR TITLE
fix(worker): enforce WorkerAdapters parity at compile time (EVE-44)

### DIFF
--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -125,6 +125,18 @@ service WorkerService {
     // Get MCP server info by name prefix (for tool execution)
     rpc GetMcpServerByPrefix(GetMcpServerByPrefixRequest) returns (GetMcpServerByPrefixResponse);
 
+    // === User connection token resolution ===
+    // Resolve user connection tokens (e.g. GitHub, Daytona) lazily at tool execution time
+    // Server-side decrypts stored tokens or mints fresh GitHub App tokens
+    rpc GetConnectionToken(GetConnectionTokenRequest) returns (GetConnectionTokenResponse);
+
+    // === Session schedule operations ===
+    // CRUD for session-scoped scheduled tasks (one-shot and recurring cron)
+    rpc CreateSessionSchedule(CreateSessionScheduleRequest) returns (CreateSessionScheduleResponse);
+    rpc CancelSessionSchedule(CancelSessionScheduleRequest) returns (CancelSessionScheduleResponse);
+    rpc ListSessionSchedules(ListSessionSchedulesRequest) returns (ListSessionSchedulesResponse);
+    rpc CountActiveSessionSchedules(CountActiveSessionSchedulesRequest) returns (CountActiveSessionSchedulesResponse);
+
     // === Session storage operations ===
     // Key/value and secret storage for session-scoped data
 
@@ -1002,6 +1014,76 @@ message SessionStorageListSecretsRequest {
 
 message SessionStorageListSecretsResponse {
     repeated StorageSecretInfo secrets = 1;
+}
+
+// ============================================================================
+// User connection token types
+// ============================================================================
+
+message GetConnectionTokenRequest {
+    Uuid session_id = 1;
+    string provider = 2;  // e.g. "github", "daytona", "gitlab"
+}
+
+message GetConnectionTokenResponse {
+    optional string token = 1;  // Decrypted token, or None if not connected
+}
+
+// ============================================================================
+// Session schedule types
+// ============================================================================
+
+message SessionScheduleProto {
+    Uuid id = 1;
+    Uuid session_id = 2;
+    string description = 3;
+    optional string cron_expression = 4;
+    optional Timestamp scheduled_at = 5;
+    string timezone = 6;
+    string schedule_type = 7;  // "oneshot" or "recurring"
+    bool enabled = 8;
+    optional Timestamp next_trigger_at = 9;
+    optional Timestamp last_triggered_at = 10;
+    int32 trigger_count = 11;
+    Timestamp created_at = 12;
+    Timestamp updated_at = 13;
+}
+
+message CreateSessionScheduleRequest {
+    Uuid session_id = 1;
+    string description = 2;
+    optional string cron_expression = 3;
+    optional Timestamp scheduled_at = 4;
+    string timezone = 5;
+}
+
+message CreateSessionScheduleResponse {
+    SessionScheduleProto schedule = 1;
+}
+
+message CancelSessionScheduleRequest {
+    Uuid session_id = 1;
+    Uuid schedule_id = 2;
+}
+
+message CancelSessionScheduleResponse {
+    SessionScheduleProto schedule = 1;
+}
+
+message ListSessionSchedulesRequest {
+    Uuid session_id = 1;
+}
+
+message ListSessionSchedulesResponse {
+    repeated SessionScheduleProto schedules = 1;
+}
+
+message CountActiveSessionSchedulesRequest {
+    Uuid session_id = 1;
+}
+
+message CountActiveSessionSchedulesResponse {
+    uint32 count = 1;
 }
 
 // ============================================================================

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -820,26 +820,30 @@ impl WorkerAdapters for DirectWorkerAdapters {
         self.sqldb_store.clone()
     }
 
-    fn storage_store(&self) -> Option<Arc<dyn everruns_core::traits::SessionStorageStore>> {
-        self.storage_store.clone()
+    fn storage_store(&self) -> Arc<dyn everruns_core::traits::SessionStorageStore> {
+        self.storage_store
+            .clone()
+            .expect("DirectWorkerAdapters: storage_store not set (call with_storage_store)")
     }
 
-    fn connection_resolver(
-        &self,
-    ) -> Option<Arc<dyn everruns_core::traits::UserConnectionResolver>> {
-        self.connection_resolver.clone()
+    fn connection_resolver(&self) -> Arc<dyn everruns_core::traits::UserConnectionResolver> {
+        self.connection_resolver.clone().expect(
+            "DirectWorkerAdapters: connection_resolver not set (call with_connection_resolver)",
+        )
     }
 
-    fn schedule_store(&self) -> Option<Arc<dyn everruns_core::traits::SessionScheduleStore>> {
-        self.schedule_store.clone()
+    fn schedule_store(&self) -> Arc<dyn everruns_core::traits::SessionScheduleStore> {
+        self.schedule_store
+            .clone()
+            .expect("DirectWorkerAdapters: schedule_store not set (call with_schedule_store)")
     }
 
-    fn platform_store(&self) -> Option<Arc<dyn everruns_core::platform_store::PlatformStore>> {
-        Some(Arc::new(DirectPlatformStore::new(
+    fn platform_store(&self) -> Arc<dyn everruns_core::platform_store::PlatformStore> {
+        Arc::new(DirectPlatformStore::new(
             self.db.clone(),
             self.event_service.clone(),
             self.runner.clone(),
-        )))
+        ))
     }
 
     async fn build_tool_registry(&self, agent_id: Uuid) -> Result<ToolRegistry> {

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -25,6 +25,9 @@ use everruns_internal_protocol::proto::{
     self,
     AddMessageRequest,
     AddMessageResponse,
+    // Session schedule operations
+    CancelSessionScheduleRequest,
+    CancelSessionScheduleResponse,
     CheckCircuitBreakerRequest,
     CheckCircuitBreakerResponse,
     CircuitBreakerState as ProtoCircuitBreakerState,
@@ -36,8 +39,12 @@ use everruns_internal_protocol::proto::{
     CompleteDurableTaskResponse,
     CountActiveDurableWorkflowsRequest,
     CountActiveDurableWorkflowsResponse,
+    CountActiveSessionSchedulesRequest,
+    CountActiveSessionSchedulesResponse,
     CreateDurableWorkflowRequest,
     CreateDurableWorkflowResponse,
+    CreateSessionScheduleRequest,
+    CreateSessionScheduleResponse,
     DeregisterDurableWorkerRequest,
     DeregisterDurableWorkerResponse,
     DurableWorkflowStatus,
@@ -50,6 +57,9 @@ use everruns_internal_protocol::proto::{
     FailDurableTaskResponse,
     GetAgentRequest,
     GetAgentResponse,
+    // Connection token resolution
+    GetConnectionTokenRequest,
+    GetConnectionTokenResponse,
     GetDefaultModelRequest,
     GetDefaultModelResponse,
     GetDurableWorkflowStatusRequest,
@@ -68,6 +78,8 @@ use everruns_internal_protocol::proto::{
     HeartbeatDurableTaskResponse,
     HeartbeatDurableWorkerRequest,
     HeartbeatDurableWorkerResponse,
+    ListSessionSchedulesRequest,
+    ListSessionSchedulesResponse,
     LoadMessagesRequest,
     LoadMessagesResponse,
     McpServerInfo,
@@ -285,6 +297,10 @@ pub struct WorkerServiceImpl {
     session_storage_store: Option<Arc<dyn everruns_core::traits::SessionStorageStore>>,
     /// Agent runner for triggering turn workflows (platform management send_message)
     runner: Option<Arc<dyn everruns_worker::AgentRunner>>,
+    /// Lazy connection token resolver (decrypts stored tokens / mints GitHub App tokens)
+    connection_resolver: Option<Arc<dyn everruns_core::traits::UserConnectionResolver>>,
+    /// Session schedule store for schedule CRUD
+    schedule_store: Option<Arc<dyn everruns_core::traits::SessionScheduleStore>>,
 }
 
 impl WorkerServiceImpl {
@@ -326,6 +342,29 @@ impl WorkerServiceImpl {
                 }
             });
 
+        // Create connection resolver (requires encryption for token decryption)
+        let connection_resolver: Option<Arc<dyn everruns_core::traits::UserConnectionResolver>> =
+            encryption.as_ref().map(|enc| {
+                // GitHub App token minting requires env vars (set in production via Doppler)
+                let github_app_minter = Self::github_app_minter_from_env();
+                Arc::new(crate::storage::DbConnectionResolver::new(
+                    db.as_ref().clone(),
+                    enc.as_ref().clone(),
+                    github_app_minter,
+                )) as Arc<dyn everruns_core::traits::UserConnectionResolver>
+            });
+
+        // Create schedule store (PostgreSQL mode only)
+        let schedule_store: Option<Arc<dyn everruns_core::traits::SessionScheduleStore>> =
+            if db.pool().is_some() {
+                Some(Arc::new(crate::storage::DbSessionScheduleStore::new(
+                    db.clone(),
+                    DEFAULT_ORG_ID,
+                )))
+            } else {
+                None
+            };
+
         Self {
             event_service,
             agent_service,
@@ -340,6 +379,8 @@ impl WorkerServiceImpl {
             db,
             session_storage_store,
             runner,
+            connection_resolver,
+            schedule_store,
         }
     }
 
@@ -364,6 +405,40 @@ impl WorkerServiceImpl {
         self.session_storage_store
             .as_ref()
             .ok_or_else(|| Status::unavailable("Session storage not available"))
+    }
+
+    /// Get connection resolver or return unavailable error
+    #[allow(clippy::result_large_err)]
+    fn connection_resolver(
+        &self,
+    ) -> Result<&Arc<dyn everruns_core::traits::UserConnectionResolver>, Status> {
+        self.connection_resolver
+            .as_ref()
+            .ok_or_else(|| Status::unavailable("Connection resolver not available (no encryption)"))
+    }
+
+    /// Get schedule store or return unavailable error
+    #[allow(clippy::result_large_err)]
+    fn schedule_store(
+        &self,
+    ) -> Result<&Arc<dyn everruns_core::traits::SessionScheduleStore>, Status> {
+        self.schedule_store
+            .as_ref()
+            .ok_or_else(|| Status::unavailable("Schedule store not available"))
+    }
+
+    /// Build a GitHubAppTokenMinter from environment variables (if configured).
+    fn github_app_minter_from_env() -> Option<crate::storage::GitHubAppTokenMinter> {
+        let app_id = std::env::var("GITHUB_APP_ID")
+            .ok()
+            .filter(|s| !s.is_empty())?;
+        let private_key = std::env::var("GITHUB_APP_PRIVATE_KEY")
+            .ok()
+            .filter(|s| !s.is_empty())?;
+        Some(crate::storage::GitHubAppTokenMinter::new(
+            app_id,
+            private_key,
+        ))
     }
 
     /// Get organization public_id from org_id
@@ -487,6 +562,38 @@ fn parse_uuid(proto_uuid: Option<&proto::Uuid>) -> Result<uuid::Uuid, Status> {
         .ok_or_else(|| Status::invalid_argument("Missing UUID"))?;
     uuid::Uuid::parse_str(uuid_str)
         .map_err(|e| Status::invalid_argument(format!("Invalid UUID: {}", e)))
+}
+
+/// Convert a SessionSchedule to proto representation.
+fn session_schedule_to_proto(
+    s: &everruns_core::session_schedule::SessionSchedule,
+) -> proto::SessionScheduleProto {
+    use everruns_internal_protocol::datetime_to_proto_timestamp;
+
+    let schedule_type = match s.schedule_type {
+        everruns_core::session_schedule::ScheduleType::Recurring => "recurring".to_string(),
+        everruns_core::session_schedule::ScheduleType::OneShot => "oneshot".to_string(),
+    };
+
+    proto::SessionScheduleProto {
+        id: Some(proto::Uuid {
+            value: s.id.uuid().to_string(),
+        }),
+        session_id: Some(proto::Uuid {
+            value: s.session_id.uuid().to_string(),
+        }),
+        description: s.description.clone(),
+        cron_expression: s.cron_expression.clone(),
+        scheduled_at: s.scheduled_at.map(datetime_to_proto_timestamp),
+        timezone: s.timezone.clone(),
+        schedule_type,
+        enabled: s.enabled,
+        next_trigger_at: s.next_trigger_at.map(datetime_to_proto_timestamp),
+        last_triggered_at: s.last_triggered_at.map(datetime_to_proto_timestamp),
+        trigger_count: s.trigger_count as i32,
+        created_at: Some(datetime_to_proto_timestamp(s.created_at)),
+        updated_at: Some(datetime_to_proto_timestamp(s.updated_at)),
+    }
 }
 
 /// Extract a Message from an Event's data field
@@ -2524,6 +2631,129 @@ impl WorkerService for WorkerServiceImpl {
         Ok(Response::new(SessionStorageListSecretsResponse {
             secrets: proto_secrets,
         }))
+    }
+
+    // ========================================================================
+    // Connection token resolution
+    // ========================================================================
+
+    async fn get_connection_token(
+        &self,
+        request: Request<GetConnectionTokenRequest>,
+    ) -> Result<Response<GetConnectionTokenResponse>, Status> {
+        let req = request.into_inner();
+        let session_id = parse_uuid(req.session_id.as_ref())?;
+        let resolver = self.connection_resolver()?;
+
+        let token = resolver
+            .get_connection_token(session_id.into(), &req.provider)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to resolve connection token: {}", e);
+                Status::internal("Failed to resolve connection token")
+            })?;
+
+        Ok(Response::new(GetConnectionTokenResponse { token }))
+    }
+
+    // ========================================================================
+    // Session schedule operations
+    // ========================================================================
+
+    async fn create_session_schedule(
+        &self,
+        request: Request<CreateSessionScheduleRequest>,
+    ) -> Result<Response<CreateSessionScheduleResponse>, Status> {
+        let req = request.into_inner();
+        let session_id = parse_uuid(req.session_id.as_ref())?;
+        let store = self.schedule_store()?;
+
+        let scheduled_at = req
+            .scheduled_at
+            .as_ref()
+            .map(everruns_internal_protocol::proto_timestamp_to_datetime);
+
+        let schedule = store
+            .create_schedule(
+                session_id.into(),
+                req.description,
+                req.cron_expression,
+                scheduled_at,
+                req.timezone,
+            )
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to create schedule: {}", e);
+                Status::internal(format!("Failed to create schedule: {}", e))
+            })?;
+
+        Ok(Response::new(CreateSessionScheduleResponse {
+            schedule: Some(session_schedule_to_proto(&schedule)),
+        }))
+    }
+
+    async fn cancel_session_schedule(
+        &self,
+        request: Request<CancelSessionScheduleRequest>,
+    ) -> Result<Response<CancelSessionScheduleResponse>, Status> {
+        let req = request.into_inner();
+        let session_id = parse_uuid(req.session_id.as_ref())?;
+        let schedule_id = parse_uuid(req.schedule_id.as_ref())?;
+        let store = self.schedule_store()?;
+
+        let schedule = store
+            .cancel_schedule(
+                session_id.into(),
+                everruns_core::typed_id::ScheduleId::from_uuid(schedule_id),
+            )
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to cancel schedule: {}", e);
+                Status::internal(format!("Failed to cancel schedule: {}", e))
+            })?;
+
+        Ok(Response::new(CancelSessionScheduleResponse {
+            schedule: Some(session_schedule_to_proto(&schedule)),
+        }))
+    }
+
+    async fn list_session_schedules(
+        &self,
+        request: Request<ListSessionSchedulesRequest>,
+    ) -> Result<Response<ListSessionSchedulesResponse>, Status> {
+        let req = request.into_inner();
+        let session_id = parse_uuid(req.session_id.as_ref())?;
+        let store = self.schedule_store()?;
+
+        let schedules = store.list_schedules(session_id.into()).await.map_err(|e| {
+            tracing::error!("Failed to list schedules: {}", e);
+            Status::internal(format!("Failed to list schedules: {}", e))
+        })?;
+
+        let proto_schedules = schedules.iter().map(session_schedule_to_proto).collect();
+
+        Ok(Response::new(ListSessionSchedulesResponse {
+            schedules: proto_schedules,
+        }))
+    }
+
+    async fn count_active_session_schedules(
+        &self,
+        request: Request<CountActiveSessionSchedulesRequest>,
+    ) -> Result<Response<CountActiveSessionSchedulesResponse>, Status> {
+        let req = request.into_inner();
+        let session_id = parse_uuid(req.session_id.as_ref())?;
+        let store = self.schedule_store()?;
+
+        let count = store
+            .count_active_schedules(session_id.into())
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to count active schedules: {}", e);
+                Status::internal(format!("Failed to count active schedules: {}", e))
+            })?;
+
+        Ok(Response::new(CountActiveSessionSchedulesResponse { count }))
     }
 
     // ========================================================================

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -1315,6 +1315,180 @@ impl SessionStorageStore for GrpcSessionStorageStore {
 }
 
 // ============================================================================
+// GrpcConnectionResolver - UserConnectionResolver over gRPC
+// ============================================================================
+
+/// gRPC-backed user connection resolver.
+///
+/// Proxies `get_connection_token` calls to the control-plane which has access
+/// to encrypted tokens and GitHub App credentials.
+pub struct GrpcConnectionResolver {
+    client: GrpcClient,
+}
+
+impl GrpcConnectionResolver {
+    pub fn new(client: GrpcClient) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl everruns_core::traits::UserConnectionResolver for GrpcConnectionResolver {
+    async fn get_connection_token(
+        &self,
+        session_id: everruns_core::SessionId,
+        provider: &str,
+    ) -> Result<Option<String>> {
+        let mut client = self.client.inner.lock().await;
+        let request = proto::GetConnectionTokenRequest {
+            session_id: Some(uuid_to_proto(session_id.uuid())),
+            provider: provider.to_string(),
+        };
+        let response = client
+            .get_connection_token(request)
+            .await
+            .map_err(|e| grpc_error(format!("gRPC get_connection_token failed: {}", e)))?;
+        Ok(response.into_inner().token)
+    }
+}
+
+// ============================================================================
+// GrpcScheduleStore - SessionScheduleStore over gRPC
+// ============================================================================
+
+/// gRPC-backed session schedule store.
+///
+/// Proxies schedule CRUD to the control-plane via gRPC RPCs.
+pub struct GrpcScheduleStore {
+    client: GrpcClient,
+}
+
+impl GrpcScheduleStore {
+    pub fn new(client: GrpcClient) -> Self {
+        Self { client }
+    }
+}
+
+fn proto_schedule_to_schema(
+    s: proto::SessionScheduleProto,
+) -> Result<everruns_core::session_schedule::SessionSchedule> {
+    use everruns_core::session_schedule::{ScheduleType, SessionSchedule};
+    use everruns_core::typed_id::{ScheduleId, SessionId};
+
+    let id_uuid = proto_uuid_to_uuid(s.id.as_ref())?;
+    let session_uuid = proto_uuid_to_uuid(s.session_id.as_ref())?;
+
+    let schedule_type = match s.schedule_type.as_str() {
+        "recurring" => ScheduleType::Recurring,
+        _ => ScheduleType::OneShot,
+    };
+
+    Ok(SessionSchedule {
+        id: ScheduleId::from_uuid(id_uuid),
+        session_id: SessionId::from_uuid(session_uuid),
+        description: s.description,
+        cron_expression: s.cron_expression,
+        scheduled_at: s.scheduled_at.as_ref().map(proto_timestamp_to_datetime),
+        timezone: s.timezone,
+        enabled: s.enabled,
+        schedule_type,
+        next_trigger_at: s.next_trigger_at.as_ref().map(proto_timestamp_to_datetime),
+        last_triggered_at: s
+            .last_triggered_at
+            .as_ref()
+            .map(proto_timestamp_to_datetime),
+        trigger_count: s.trigger_count as u32,
+        created_at: proto_timestamp_or_now(s.created_at.as_ref()),
+        updated_at: proto_timestamp_or_now(s.updated_at.as_ref()),
+    })
+}
+
+#[async_trait]
+impl everruns_core::traits::SessionScheduleStore for GrpcScheduleStore {
+    async fn create_schedule(
+        &self,
+        session_id: everruns_core::SessionId,
+        description: String,
+        cron_expression: Option<String>,
+        scheduled_at: Option<chrono::DateTime<chrono::Utc>>,
+        timezone: String,
+    ) -> Result<everruns_core::session_schedule::SessionSchedule> {
+        let mut client = self.client.inner.lock().await;
+        let request = proto::CreateSessionScheduleRequest {
+            session_id: Some(uuid_to_proto(session_id.uuid())),
+            description,
+            cron_expression,
+            scheduled_at: scheduled_at.map(everruns_internal_protocol::datetime_to_proto_timestamp),
+            timezone,
+        };
+        let response = client
+            .create_session_schedule(request)
+            .await
+            .map_err(|e| grpc_error(format!("gRPC create_session_schedule failed: {}", e)))?;
+        let proto_schedule = response
+            .into_inner()
+            .schedule
+            .ok_or_else(|| grpc_error("No schedule in response"))?;
+        proto_schedule_to_schema(proto_schedule)
+    }
+
+    async fn cancel_schedule(
+        &self,
+        session_id: everruns_core::SessionId,
+        schedule_id: everruns_core::typed_id::ScheduleId,
+    ) -> Result<everruns_core::session_schedule::SessionSchedule> {
+        let mut client = self.client.inner.lock().await;
+        let request = proto::CancelSessionScheduleRequest {
+            session_id: Some(uuid_to_proto(session_id.uuid())),
+            schedule_id: Some(uuid_to_proto(schedule_id.uuid())),
+        };
+        let response = client
+            .cancel_session_schedule(request)
+            .await
+            .map_err(|e| grpc_error(format!("gRPC cancel_session_schedule failed: {}", e)))?;
+        let proto_schedule = response
+            .into_inner()
+            .schedule
+            .ok_or_else(|| grpc_error("No schedule in response"))?;
+        proto_schedule_to_schema(proto_schedule)
+    }
+
+    async fn list_schedules(
+        &self,
+        session_id: everruns_core::SessionId,
+    ) -> Result<Vec<everruns_core::session_schedule::SessionSchedule>> {
+        let mut client = self.client.inner.lock().await;
+        let request = proto::ListSessionSchedulesRequest {
+            session_id: Some(uuid_to_proto(session_id.uuid())),
+        };
+        let response = client
+            .list_session_schedules(request)
+            .await
+            .map_err(|e| grpc_error(format!("gRPC list_session_schedules failed: {}", e)))?;
+        response
+            .into_inner()
+            .schedules
+            .into_iter()
+            .map(proto_schedule_to_schema)
+            .collect()
+    }
+
+    async fn count_active_schedules(&self, session_id: everruns_core::SessionId) -> Result<u32> {
+        let mut client = self.client.inner.lock().await;
+        let request = proto::CountActiveSessionSchedulesRequest {
+            session_id: Some(uuid_to_proto(session_id.uuid())),
+        };
+        let response = client
+            .count_active_session_schedules(request)
+            .await
+            .map_err(|e| {
+                grpc_error(format!("gRPC count_active_session_schedules failed: {}", e))
+            })?;
+        Ok(response.into_inner().count)
+    }
+}
+
+// ============================================================================
 // GrpcPlatformStore - PlatformStore implementation over gRPC
 // ============================================================================
 

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -329,6 +329,20 @@ impl WorkerAdapters for GrpcWorkerAdapters {
         Some(Arc::new(GrpcSessionStorageStore::new(self.client.clone())))
     }
 
+    fn connection_resolver(
+        &self,
+    ) -> Option<Arc<dyn everruns_core::traits::UserConnectionResolver>> {
+        Some(Arc::new(crate::grpc_adapters::GrpcConnectionResolver::new(
+            self.client.clone(),
+        )))
+    }
+
+    fn schedule_store(&self) -> Option<Arc<dyn everruns_core::traits::SessionScheduleStore>> {
+        Some(Arc::new(crate::grpc_adapters::GrpcScheduleStore::new(
+            self.client.clone(),
+        )))
+    }
+
     fn platform_store(&self) -> Option<Arc<dyn everruns_core::platform_store::PlatformStore>> {
         Some(Arc::new(crate::grpc_adapters::GrpcPlatformStore::new(
             self.client.clone(),

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -325,29 +325,27 @@ impl WorkerAdapters for GrpcWorkerAdapters {
         create_driver_registry()
     }
 
-    fn storage_store(&self) -> Option<Arc<dyn everruns_core::traits::SessionStorageStore>> {
-        Some(Arc::new(GrpcSessionStorageStore::new(self.client.clone())))
+    fn storage_store(&self) -> Arc<dyn everruns_core::traits::SessionStorageStore> {
+        Arc::new(GrpcSessionStorageStore::new(self.client.clone()))
     }
 
-    fn connection_resolver(
-        &self,
-    ) -> Option<Arc<dyn everruns_core::traits::UserConnectionResolver>> {
-        Some(Arc::new(crate::grpc_adapters::GrpcConnectionResolver::new(
-            self.client.clone(),
-        )))
-    }
-
-    fn schedule_store(&self) -> Option<Arc<dyn everruns_core::traits::SessionScheduleStore>> {
-        Some(Arc::new(crate::grpc_adapters::GrpcScheduleStore::new(
-            self.client.clone(),
-        )))
-    }
-
-    fn platform_store(&self) -> Option<Arc<dyn everruns_core::platform_store::PlatformStore>> {
-        Some(Arc::new(crate::grpc_adapters::GrpcPlatformStore::new(
+    fn platform_store(&self) -> Arc<dyn everruns_core::platform_store::PlatformStore> {
+        Arc::new(crate::grpc_adapters::GrpcPlatformStore::new(
             self.client.clone(),
             everruns_core::DEFAULT_ORG_ID,
-        )))
+        ))
+    }
+
+    fn connection_resolver(&self) -> Arc<dyn everruns_core::traits::UserConnectionResolver> {
+        Arc::new(crate::grpc_adapters::GrpcConnectionResolver::new(
+            self.client.clone(),
+        ))
+    }
+
+    fn schedule_store(&self) -> Arc<dyn everruns_core::traits::SessionScheduleStore> {
+        Arc::new(crate::grpc_adapters::GrpcScheduleStore::new(
+            self.client.clone(),
+        ))
     }
 
     async fn build_tool_registry(&self, agent_id: Uuid) -> Result<ToolRegistry> {

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -795,18 +795,11 @@ async fn execute_act_activity<A: WorkerAdapters>(
     if let Some(sqldb_store) = adapters.sqldb_store() {
         atom = atom.with_sqldb_store(sqldb_store);
     }
-    if let Some(storage_store) = adapters.storage_store() {
-        atom = atom.with_storage_store(storage_store);
-    }
-    if let Some(connection_resolver) = adapters.connection_resolver() {
-        atom = atom.with_connection_resolver(connection_resolver);
-    }
-    if let Some(schedule_store) = adapters.schedule_store() {
-        atom = atom.with_schedule_store(schedule_store);
-    }
-    if let Some(platform_store) = adapters.platform_store() {
-        atom = atom.with_platform_store(platform_store);
-    }
+    atom = atom
+        .with_storage_store(adapters.storage_store())
+        .with_connection_resolver(adapters.connection_resolver())
+        .with_schedule_store(adapters.schedule_store())
+        .with_platform_store(adapters.platform_store());
 
     let result = atom.execute(input.clone()).await?;
 

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -214,9 +214,9 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
 
     /// Get the session SQL database store (if available).
     ///
-    /// Returns None when the backend can't support session SQL databases
-    /// (e.g. gRPC workers — SQLite is inherently local/in-memory).
-    // TODO(EVE-44): Add gRPC proxy for session SQL databases
+    /// Returns None when the backend doesn't yet expose session SQL databases
+    /// via gRPC. The store is PostgreSQL-backed and should be available in all
+    /// deployment modes once gRPC support is added (EVE-44).
     fn sqldb_store(&self) -> Option<everruns_core::traits::SessionSqlDbStoreRef> {
         None
     }

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -63,14 +63,10 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
     /// Set a session title.
     async fn set_session_title(
         &self,
-        _org_id: i64,
-        _session_id: Uuid,
-        _title: String,
-    ) -> Result<Session> {
-        Err(everruns_core::AgentLoopError::store(
-            "set_session_title not supported by this adapter",
-        ))
-    }
+        org_id: i64,
+        session_id: Uuid,
+        title: String,
+    ) -> Result<Session>;
 
     // =========================================================================
     // Message Operations
@@ -217,36 +213,39 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
     }
 
     /// Get the session SQL database store (if available).
-    /// Default returns None (not all backends support session SQL databases).
+    ///
+    /// Returns None when the backend can't support session SQL databases
+    /// (e.g. gRPC workers — SQLite is inherently local/in-memory).
+    // TODO(EVE-44): Add gRPC proxy for session SQL databases
     fn sqldb_store(&self) -> Option<everruns_core::traits::SessionSqlDbStoreRef> {
         None
     }
 
-    /// Get the session storage store for kv_store/secret_store tools (if available).
-    /// Default returns None (not all backends support session storage).
-    fn storage_store(&self) -> Option<Arc<dyn everruns_core::traits::SessionStorageStore>> {
-        None
-    }
+    // =========================================================================
+    // Required Store Accessors
+    //
+    // NO default implementations. Every WorkerAdapters impl MUST provide these.
+    // This is enforced at compile time to prevent the class of bug where a new
+    // adapter silently returns None and tools fail at runtime with misleading
+    // errors (e.g. "API key not configured" when the real issue is a missing
+    // gRPC endpoint).
+    //
+    // For stores with full gRPC support, the return type is non-optional.
+    // For stores still missing gRPC RPCs, the return type is Option but there
+    // is no default — implementors must explicitly return None or Some.
+    // =========================================================================
 
-    /// Get the user connection resolver for lazy token lookup (if available).
-    /// Default returns None (not all backends support user connections).
-    fn connection_resolver(
-        &self,
-    ) -> Option<Arc<dyn everruns_core::traits::UserConnectionResolver>> {
-        None
-    }
+    /// Get the session storage store for kv_store/secret_store tools.
+    fn storage_store(&self) -> Arc<dyn everruns_core::traits::SessionStorageStore>;
 
-    /// Get the session schedule store for scheduling tools (if available).
-    /// Default returns None (not all backends support session schedules).
-    fn schedule_store(&self) -> Option<Arc<dyn everruns_core::traits::SessionScheduleStore>> {
-        None
-    }
+    /// Get the platform store for org-level management tools.
+    fn platform_store(&self) -> Arc<dyn everruns_core::platform_store::PlatformStore>;
 
-    /// Get the platform store for org-level management tools (if available).
-    /// Default returns None (not all backends support platform management).
-    fn platform_store(&self) -> Option<Arc<dyn everruns_core::platform_store::PlatformStore>> {
-        None
-    }
+    /// Get the user connection resolver for lazy token lookup.
+    fn connection_resolver(&self) -> Arc<dyn everruns_core::traits::UserConnectionResolver>;
+
+    /// Get the session schedule store for scheduling tools.
+    fn schedule_store(&self) -> Arc<dyn everruns_core::traits::SessionScheduleStore>;
 }
 
 // =============================================================================

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -277,7 +277,7 @@ The `TaskWorker` provides a unified worker implementation that works with both i
    - `read_file()`, `write_file()` (session filesystem)
    - `load_turn_context()` - Batched context loading
    - `storage_store()`, `platform_store()`, `connection_resolver()`, `schedule_store()` — **required**, non-optional
-   - `sqldb_store()` — optional with default `None` (inherently local, EVE-44)
+   - `sqldb_store()` — optional with default `None` until gRPC support added (EVE-44)
 
 2. **Implementations**:
    - `DirectWorkerAdapters` - Direct storage access (in-process workers)
@@ -290,7 +290,7 @@ The `TaskWorker` provides a unified worker implementation that works with both i
 | DEV_MODE | `InMemoryWorkflowEventStore` | `DirectWorkerAdapters` | Local development |
 | Production | `PostgresWorkflowEventStore` | `GrpcWorkerAdapters` | External workers |
 
-**Adapter Parity Principle**: Both `DirectWorkerAdapters` and `GrpcWorkerAdapters` must implement every `WorkerAdapters` method. The trait enforces this at compile time: store accessors have no default implementations, so adding a new store requires updating both adapters or the build fails. Methods return `Arc<dyn T>` (non-optional) to guarantee the store is available in both backends. The only exception is `sqldb_store()` which returns `Option` with a default `None` because SQLite is inherently local (tracked in EVE-44).
+**Adapter Parity Principle**: Both `DirectWorkerAdapters` and `GrpcWorkerAdapters` must implement every `WorkerAdapters` method. The trait enforces this at compile time: store accessors have no default implementations, so adding a new store requires updating both adapters or the build fails. Methods return `Arc<dyn T>` (non-optional) to guarantee the store is available in both backends. The only exception is `sqldb_store()` which returns `Option` with a default `None` until gRPC support is added (tracked in EVE-44).
 
 **Benefits of Unified Architecture**:
 - Single codebase for activity implementations (input, reason, act)

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -276,6 +276,8 @@ The `TaskWorker` provides a unified worker implementation that works with both i
    - `emit_event()`, `get_model_with_provider()`
    - `read_file()`, `write_file()` (session filesystem)
    - `load_turn_context()` - Batched context loading
+   - `storage_store()`, `platform_store()`, `connection_resolver()`, `schedule_store()` — **required**, non-optional
+   - `sqldb_store()` — optional with default `None` (inherently local, EVE-44)
 
 2. **Implementations**:
    - `DirectWorkerAdapters` - Direct storage access (in-process workers)
@@ -288,11 +290,14 @@ The `TaskWorker` provides a unified worker implementation that works with both i
 | DEV_MODE | `InMemoryWorkflowEventStore` | `DirectWorkerAdapters` | Local development |
 | Production | `PostgresWorkflowEventStore` | `GrpcWorkerAdapters` | External workers |
 
+**Adapter Parity Principle**: Both `DirectWorkerAdapters` and `GrpcWorkerAdapters` must implement every `WorkerAdapters` method. The trait enforces this at compile time: store accessors have no default implementations, so adding a new store requires updating both adapters or the build fails. Methods return `Arc<dyn T>` (non-optional) to guarantee the store is available in both backends. The only exception is `sqldb_store()` which returns `Option` with a default `None` because SQLite is inherently local (tracked in EVE-44).
+
 **Benefits of Unified Architecture**:
 - Single codebase for activity implementations (input, reason, act)
 - Shared task scheduling logic
 - Easy to test with mock adapters
 - Consistent behavior across deployment modes
+- Compile-time enforcement of adapter parity
 
 ### Core Abstractions (`everruns-core`)
 


### PR DESCRIPTION
## What
Enforce compile-time parity across all WorkerAdapters implementations and add missing gRPC support for connection_resolver and schedule_store.

## Why
The previous design had default `fn foo() -> Option<...> { None }` implementations on the trait. When gRPC adapters were missing implementations, the defaults silently returned `None`, causing tools (kv_store, secret_store, schedules, user connections) to fail at runtime with misleading errors instead of surfacing the real issue: missing gRPC endpoints.

## How
**Trait enforcement (compile-time)**:
- Removed all default `None` implementations from store accessors
- Changed `storage_store()`, `platform_store()`, `connection_resolver()`, `schedule_store()` to return non-optional `Arc<dyn T>`
- Removed `set_session_title()` default (both impls already override)
- Only `sqldb_store()` retains `Option` with default `None` — PostgreSQL-backed but gRPC support not yet added (EVE-44)

**New gRPC endpoints**:
- `GetConnectionToken` RPC — proxies encrypted token resolution to control-plane
- `CreateSessionSchedule`, `CancelSessionSchedule`, `ListSessionSchedules`, `CountActiveSessionSchedules` RPCs
- `GrpcConnectionResolver` and `GrpcScheduleStore` client adapters
- Server-side handlers in `grpc_service.rs`

**Spec updates**:
- `specs/architecture.md` — documented Adapter Parity Principle

## Risk
- Low
- DirectWorkerAdapters uses `.expect()` for stores set via builder pattern — panics at startup if not configured (caught immediately, not at runtime tool call)
- gRPC endpoints follow existing patterns (mTLS-protected internal service)

## Checklist
- [x] Tests added or updated (1742 passing, 2 pre-existing TLS failures)
- [x] Backward compatibility considered (internal-only trait, no external API changes)
