### PR TITLE
feat(ui): Claude Code-style bash tool rendering

### DIFF
--- a/apps/ui/src/app/dev/chat-components/page.tsx
+++ b/apps/ui/src/app/dev/chat-components/page.tsx
@@ -6,10 +6,12 @@ import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Bot, ArrowLeft } from "lucide-react";
 import { ToolCallCard } from "@/components/chat/tool-call-card";
+import { ToolCallCardFromEvent } from "@/components/chat/tool-call-card-from-event";
 import { TodoListRenderer } from "@/components/chat/todo-list-renderer";
 import { MessageInfoIcon } from "@/components/chat/message-info-icon";
 import { ImageAttachments, MessageImage } from "@/components/chat/image-attachments";
-import type { Message, Event } from "@/lib/api/types";
+import type { Message, Event, ToolCompletedData } from "@/lib/api/types";
+import type { ToolCallContent } from "@/components/chat/tool-call-utils";
 import type { PendingImage } from "@/lib/api/images";
 
 // Check if we're in development mode
@@ -396,6 +398,109 @@ const samplePendingImages: PendingImage[] = [
   },
 ];
 
+// Sample data for BashToolCallCard (event-based)
+const sampleBashEventData: Record<
+  string,
+  { toolCall: ToolCallContent; toolResult?: ToolCompletedData }
+> = {
+  // Successful command with stdout only
+  success: {
+    toolCall: {
+      id: "tc-bash-1",
+      name: "bash",
+      arguments: {
+        command: "cargo test --workspace",
+        description: "Run all workspace tests",
+      },
+    },
+    toolResult: {
+      tool_call_id: "tc-bash-1",
+      tool_name: "bash",
+      success: true,
+      status: "success",
+      result: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({
+            stdout:
+              "running 24 tests\ntest storage::tests::test_create_agent ... ok\ntest storage::tests::test_list_agents ... ok\ntest api::tests::test_health_endpoint ... ok\ntest api::tests::test_create_session ... ok\n\ntest result: ok. 24 passed; 0 failed; 0 ignored",
+            stderr: "",
+            exit_code: 0,
+            success: true,
+          }),
+        },
+      ],
+      duration_ms: 4523,
+    },
+  },
+  // Failed command with stderr
+  withStderr: {
+    toolCall: {
+      id: "tc-bash-2",
+      name: "bash",
+      arguments: {
+        command: "cargo clippy -- -D warnings",
+        description: "Run clippy linter",
+      },
+    },
+    toolResult: {
+      tool_call_id: "tc-bash-2",
+      tool_name: "bash",
+      success: true,
+      status: "success",
+      result: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({
+            stdout: "    Checking everruns-core v0.1.0\n",
+            stderr:
+              "error[E0308]: mismatched types\n  --> src/lib.rs:42:5\n   |\n42 |     let x: u32 = \"hello\";\n   |                  ^^^^^^^ expected `u32`, found `&str`\n\nerror: aborting due to 1 previous error",
+            exit_code: 1,
+            success: false,
+          }),
+        },
+      ],
+      duration_ms: 12340,
+    },
+  },
+  // Currently executing
+  executing: {
+    toolCall: {
+      id: "tc-bash-3",
+      name: "bash",
+      arguments: {
+        command: "npm run build",
+      },
+    },
+  },
+  // Simple short command
+  shortOutput: {
+    toolCall: {
+      id: "tc-bash-4",
+      name: "bash",
+      arguments: { command: "echo hello" },
+    },
+    toolResult: {
+      tool_call_id: "tc-bash-4",
+      tool_name: "bash",
+      success: true,
+      status: "success",
+      result: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({
+            stdout: "hello\n",
+            stderr: "",
+            exit_code: 0,
+            success: true,
+          }),
+        },
+      ],
+      duration_ms: 45,
+    },
+  },
+};
+
 // Sample event data for MessageInfoIcon
 const sampleEvents = {
   userMessage: {
@@ -585,6 +690,48 @@ export default function DevChatComponentsPage() {
                   <ToolCallCard
                     toolCall={sampleToolCallMessages.writeTodos.toolCall}
                     toolResult={sampleToolCallMessages.writeTodos.toolResult}
+                  />
+                </div>
+              </ShowcaseItem>
+            </ShowcaseSection>
+
+            {/* BashToolCallCard Section */}
+            <ShowcaseSection
+              title="BashToolCallCard Component"
+              description="Claude Code-style bash rendering: $ command, structured stdout/stderr"
+            >
+              <ShowcaseItem label="Successful Command (Collapsed)">
+                <div className="ml-6">
+                  <ToolCallCardFromEvent
+                    toolCall={sampleBashEventData.success.toolCall}
+                    toolResult={sampleBashEventData.success.toolResult}
+                  />
+                </div>
+              </ShowcaseItem>
+
+              <ShowcaseItem label="Failed Command with stderr">
+                <div className="ml-6">
+                  <ToolCallCardFromEvent
+                    toolCall={sampleBashEventData.withStderr.toolCall}
+                    toolResult={sampleBashEventData.withStderr.toolResult}
+                  />
+                </div>
+              </ShowcaseItem>
+
+              <ShowcaseItem label="Executing">
+                <div className="ml-6">
+                  <ToolCallCardFromEvent
+                    toolCall={sampleBashEventData.executing.toolCall}
+                    toolResult={sampleBashEventData.executing.toolResult}
+                  />
+                </div>
+              </ShowcaseItem>
+
+              <ShowcaseItem label="Short Output">
+                <div className="ml-6">
+                  <ToolCallCardFromEvent
+                    toolCall={sampleBashEventData.shortOutput.toolCall}
+                    toolResult={sampleBashEventData.shortOutput.toolResult}
                   />
                 </div>
               </ShowcaseItem>

--- a/apps/ui/src/app/dev/chat-components/page.tsx
+++ b/apps/ui/src/app/dev/chat-components/page.tsx
@@ -454,7 +454,7 @@ const sampleBashEventData: Record<
           text: JSON.stringify({
             stdout: "    Checking everruns-core v0.1.0\n",
             stderr:
-              "error[E0308]: mismatched types\n  --> src/lib.rs:42:5\n   |\n42 |     let x: u32 = \"hello\";\n   |                  ^^^^^^^ expected `u32`, found `&str`\n\nerror: aborting due to 1 previous error",
+              'error[E0308]: mismatched types\n  --> src/lib.rs:42:5\n   |\n42 |     let x: u32 = "hello";\n   |                  ^^^^^^^ expected `u32`, found `&str`\n\nerror: aborting due to 1 previous error',
             exit_code: 1,
             success: false,
           }),

--- a/apps/ui/src/components/chat/bash-tool-call-card.tsx
+++ b/apps/ui/src/components/chat/bash-tool-call-card.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Loader2, ChevronDown, ChevronRight, Terminal } from "lucide-react";
+import type { ToolCompletedData } from "@/lib/api/types";
+import { getFullText, type ToolCallContent } from "./tool-call-utils";
+
+interface BashToolCallCardProps {
+  toolCall: ToolCallContent;
+  toolResult?: ToolCompletedData;
+}
+
+interface BashOutput {
+  stdout: string;
+  stderr: string;
+  exit_code: number;
+  success: boolean;
+}
+
+/**
+ * Try to parse bash JSON output: {"stdout":"...","stderr":"...","exit_code":0,"success":true}
+ */
+function parseBashOutput(text: string): BashOutput | null {
+  try {
+    const parsed = JSON.parse(text);
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "stdout" in parsed &&
+      "exit_code" in parsed
+    ) {
+      return {
+        stdout: String(parsed.stdout ?? ""),
+        stderr: String(parsed.stderr ?? ""),
+        exit_code: Number(parsed.exit_code ?? 0),
+        success: Boolean(parsed.success ?? parsed.exit_code === 0),
+      };
+    }
+  } catch {
+    // Not JSON — fall through
+  }
+  return null;
+}
+
+/**
+ * Render a bash tool call in Claude Code style.
+ *
+ * Shows: `$ command` with status icon, collapsed output toggle.
+ * Output separates stdout/stderr with visual distinction.
+ */
+export function BashToolCallCard({ toolCall, toolResult }: BashToolCallCardProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const command = toolCall.arguments.command as string | undefined;
+  const description = toolCall.arguments.description as string | undefined;
+  const isComplete = !!toolResult;
+  const hasError = toolResult?.error !== undefined && toolResult?.error !== null;
+
+  // Parse structured bash output
+  const fullText = toolResult?.result ? getFullText(toolResult.result) : "";
+  const bashOutput = fullText ? parseBashOutput(fullText) : null;
+
+  // Determine if there's meaningful output to show
+  const hasStdout = !!bashOutput?.stdout;
+  const hasStderr = !!bashOutput?.stderr;
+  const hasOutput = bashOutput ? hasStdout || hasStderr : fullText.length > 0;
+  const exitedWithError = bashOutput ? !bashOutput.success : hasError;
+
+  // Status icon
+  const statusIcon = isComplete ? (
+    exitedWithError ? (
+      <span className="text-red-500 text-xs font-bold">!</span>
+    ) : (
+      <Check className="h-3 w-3 text-green-600/80" />
+    )
+  ) : (
+    <Loader2 className="h-3 w-3 animate-spin text-muted-foreground/60" />
+  );
+
+  // Duration display
+  const durationLabel = toolResult?.duration_ms
+    ? toolResult.duration_ms < 1000
+      ? `${toolResult.duration_ms}ms`
+      : `${(toolResult.duration_ms / 1000).toFixed(1)}s`
+    : null;
+
+  return (
+    <div className="text-xs text-muted-foreground/70">
+      {/* Command line: status + $ command */}
+      <div className="flex items-center gap-1.5">
+        {statusIcon}
+        <Terminal className="h-3 w-3 opacity-50" />
+        <button
+          onClick={() => hasOutput && setIsExpanded(!isExpanded)}
+          className={`flex items-center gap-1 min-w-0 ${hasOutput ? "cursor-pointer hover:text-muted-foreground" : "cursor-default"}`}
+        >
+          <span className="font-mono truncate">
+            <span className="opacity-50">$ </span>
+            {command ?? "bash"}
+          </span>
+        </button>
+        {durationLabel && (
+          <span className="text-[10px] opacity-40 flex-shrink-0">{durationLabel}</span>
+        )}
+        {hasOutput && (
+          <button
+            onClick={() => setIsExpanded(!isExpanded)}
+            className="opacity-40 hover:opacity-70 flex-shrink-0"
+          >
+            {isExpanded ? (
+              <ChevronDown className="h-3 w-3" />
+            ) : (
+              <ChevronRight className="h-3 w-3" />
+            )}
+          </button>
+        )}
+      </div>
+
+      {/* Description (if present, shown as subtitle) */}
+      {description && (
+        <div className="ml-[22px] text-[10px] opacity-40 truncate">{description}</div>
+      )}
+
+      {/* Tool-level error (not bash stderr) */}
+      {hasError && !bashOutput && (
+        <div className="text-red-600 ml-[22px] mt-0.5 text-[10px]">
+          Error: {toolResult?.error}
+        </div>
+      )}
+
+      {/* Expanded output */}
+      {isExpanded && (
+        <div className="mt-1 ml-[22px] space-y-0">
+          {bashOutput ? (
+            <>
+              {/* stdout */}
+              {hasStdout && (
+                <pre className="p-1.5 bg-muted/20 rounded text-[10px] leading-tight overflow-x-auto max-h-60 whitespace-pre-wrap break-all">
+                  {bashOutput.stdout}
+                </pre>
+              )}
+              {/* stderr */}
+              {hasStderr && (
+                <pre className="p-1.5 bg-red-500/5 border-l-2 border-red-400/30 rounded-r text-[10px] leading-tight overflow-x-auto max-h-40 whitespace-pre-wrap break-all text-red-600/80 dark:text-red-400/80">
+                  {bashOutput.stderr}
+                </pre>
+              )}
+              {/* Non-zero exit code */}
+              {bashOutput.exit_code !== 0 && (
+                <div className="text-[10px] text-red-500/70 mt-0.5">
+                  exit code {bashOutput.exit_code}
+                </div>
+              )}
+            </>
+          ) : (
+            /* Fallback: raw text output */
+            <pre className="p-1.5 bg-muted/20 rounded text-[10px] leading-tight overflow-x-auto max-h-60 whitespace-pre-wrap break-all">
+              {fullText}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Check if a tool name is the bash/shell tool.
+ */
+export function isBashTool(toolName: string): boolean {
+  return toolName === "bash" || toolName === "shell" || toolName === "execute_bash";
+}

--- a/apps/ui/src/components/chat/bash-tool-call-card.tsx
+++ b/apps/ui/src/components/chat/bash-tool-call-card.tsx
@@ -123,9 +123,7 @@ export function BashToolCallCard({ toolCall, toolResult }: BashToolCallCardProps
 
       {/* Tool-level error (not bash stderr) */}
       {hasError && !bashOutput && (
-        <div className="text-red-600 ml-[22px] mt-0.5 text-[10px]">
-          Error: {toolResult?.error}
-        </div>
+        <div className="text-red-600 ml-[22px] mt-0.5 text-[10px]">Error: {toolResult?.error}</div>
       )}
 
       {/* Expanded output */}

--- a/apps/ui/src/components/chat/tool-call-card-from-event.tsx
+++ b/apps/ui/src/components/chat/tool-call-card-from-event.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Check, Loader2, ChevronDown, ChevronRight } from "lucide-react";
 import type { ToolCompletedData } from "@/lib/api/types";
 import { TodoListRenderer, isWriteTodosTool } from "./todo-list-renderer";
+import { BashToolCallCard, isBashTool } from "./bash-tool-call-card";
 import { formatArguments, getFullText, type ToolCallContent } from "./tool-call-utils";
 import { ClientToolCallCard } from "./client-tool-call-card";
 
@@ -48,6 +49,11 @@ export function ToolCallCardFromEvent({
         />
       </div>
     );
+  }
+
+  // Special rendering for bash/shell tool
+  if (isBashTool(toolCall.name)) {
+    return <BashToolCallCard toolCall={toolCall} toolResult={toolResult} />;
   }
 
   const statusIcon = isComplete ? (


### PR DESCRIPTION
## What
Add a dedicated `BashToolCallCard` component that renders bash/shell tool calls in a Claude Code-style format: `$ command` with status icon, collapsible stdout/stderr output, exit code display, and duration label.

## Why
Bash tool calls are the most frequent tool type in agent sessions. The generic tool call card doesn't surface the command being run or distinguish stdout from stderr, making it hard to follow agent execution. This gives bash calls first-class rendering similar to Claude Code's terminal output.

## How
- New `BashToolCallCard` component (`bash-tool-call-card.tsx`) that:
  - Shows `$ command` with terminal icon and status indicator (spinner/check/error)
  - Parses structured JSON output (`{stdout, stderr, exit_code}`) from bash results
  - Renders stdout in neutral styling and stderr with red border-left accent
  - Shows exit code for non-zero exits
  - Displays execution duration
  - Collapsed by default with chevron toggle
- `isBashTool()` helper to detect bash/shell/execute_bash tool names
- Integrated into `ToolCallCardFromEvent` — all bash tools in session chat now use this renderer
- Dev showcase page updated with visual test cases (success, error, executing, short output)

## Risk
- Low
- Display-only change — no API, data, or backend modifications
- Falls back to raw text if JSON parsing fails

## Checklist
- [x] Tests added or updated (dev showcase visual test cases)
- [x] Backward compatibility considered (graceful fallback for non-JSON output)