### PR TITLE
fix(capabilities): scope platform store to session org and fix public URL default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,11 @@ WORKER_GRPC_ADDRESS=127.0.0.1:9001
 # WORKER_GRPC_TLS_CA_CERT=/path/to/ca.pem
 # WORKER_GRPC_TLS_DOMAIN=control-plane.internal
 
+# Public App URL (used to construct UI links in capability tool results)
+# For local dev, defaults to http://localhost:9300 (Caddy proxy)
+# For production, set to your public domain (e.g., https://app.everruns.com)
+# PUBLIC_APP_URL=https://app.everruns.com
+
 # Authentication (Admin Mode) - Single admin user for development
 # AUTH_MODE=admin
 # AUTH_JWT_SECRET=MJ5SiIlm9mTmiVJV8O2NLrxnuEZDFuO/iXkjVXGqWD0=

--- a/crates/core/src/capabilities/platform_management.rs
+++ b/crates/core/src/capabilities/platform_management.rs
@@ -1184,7 +1184,7 @@ mod tests {
                     v["ui_link"]
                         .as_str()
                         .unwrap()
-                        .starts_with("http://localhost:3000/harnesses/")
+                        .starts_with("http://localhost:9300/harnesses/")
                 );
             }
             other => panic!("expected success, got: {other:?}"),

--- a/crates/core/src/platform_store.rs
+++ b/crates/core/src/platform_store.rs
@@ -162,7 +162,7 @@ pub trait PlatformStore: Send + Sync {
     // UI Links
     // =========================================================================
 
-    /// Base URL for constructing UI links (e.g., "http://localhost:3000").
+    /// Base URL for constructing UI links (e.g., "http://localhost:9300").
     fn base_url(&self) -> &str;
 }
 
@@ -383,7 +383,7 @@ pub mod tests {
             Ok(caps)
         }
         fn base_url(&self) -> &str {
-            "http://localhost:3000"
+            "http://localhost:9300"
         }
     }
 }

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -833,7 +833,10 @@ impl WorkerAdapters for DirectWorkerAdapters {
             .expect("DirectWorkerAdapters: schedule_store not set (call with_schedule_store)")
     }
 
-    fn platform_store(&self) -> Arc<dyn everruns_core::platform_store::PlatformStore> {
+    fn platform_store(
+        &self,
+        _org_id: i64,
+    ) -> Arc<dyn everruns_core::platform_store::PlatformStore> {
         Arc::new(DirectPlatformStore::new(
             self.db.clone(),
             self.event_service.clone(),
@@ -1069,9 +1072,9 @@ impl DirectPlatformStore {
     }
 
     fn base_url_from_env() -> String {
-        std::env::var("APP_URL")
-            .or_else(|_| std::env::var("PUBLIC_URL"))
-            .unwrap_or_else(|_| "http://localhost:3000".to_string())
+        std::env::var("PUBLIC_APP_URL")
+            .or_else(|_| std::env::var("APP_URL"))
+            .unwrap_or_else(|_| "http://localhost:9300".to_string())
     }
 
     fn row_to_harness(

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -3578,9 +3578,9 @@ impl WorkerService for WorkerServiceImpl {
         &self,
         _request: Request<PlatformGetBaseUrlRequest>,
     ) -> Result<Response<PlatformGetBaseUrlResponse>, Status> {
-        let base_url = std::env::var("APP_URL")
-            .or_else(|_| std::env::var("PUBLIC_URL"))
-            .unwrap_or_else(|_| "http://localhost:3000".to_string());
+        let base_url = std::env::var("PUBLIC_APP_URL")
+            .or_else(|_| std::env::var("APP_URL"))
+            .unwrap_or_else(|_| "http://localhost:9300".to_string());
 
         Ok(Response::new(PlatformGetBaseUrlResponse { base_url }))
     }

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -1964,9 +1964,9 @@ impl everruns_core::platform_store::PlatformStore for GrpcPlatformStore {
         // Called infrequently, value stable across runtime
         static BASE_URL: std::sync::OnceLock<String> = std::sync::OnceLock::new();
         BASE_URL.get_or_init(|| {
-            std::env::var("APP_URL")
-                .or_else(|_| std::env::var("PUBLIC_URL"))
-                .unwrap_or_else(|_| "http://localhost:3000".to_string())
+            std::env::var("PUBLIC_APP_URL")
+                .or_else(|_| std::env::var("APP_URL"))
+                .unwrap_or_else(|_| "http://localhost:9300".to_string())
         })
     }
 }

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -333,10 +333,10 @@ impl WorkerAdapters for GrpcWorkerAdapters {
         Arc::new(GrpcSessionStorageStore::new(self.client.clone()))
     }
 
-    fn platform_store(&self) -> Arc<dyn everruns_core::platform_store::PlatformStore> {
+    fn platform_store(&self, org_id: i64) -> Arc<dyn everruns_core::platform_store::PlatformStore> {
         Arc::new(crate::grpc_adapters::GrpcPlatformStore::new(
             self.client.clone(),
-            everruns_core::DEFAULT_ORG_ID,
+            org_id,
         ))
     }
 

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -797,7 +797,7 @@ async fn execute_act_activity<A: WorkerAdapters>(
         .with_storage_store(adapters.storage_store())
         .with_connection_resolver(adapters.connection_resolver())
         .with_schedule_store(adapters.schedule_store())
-        .with_platform_store(adapters.platform_store());
+        .with_platform_store(adapters.platform_store(org_id));
 
     let result = atom.execute(input.clone()).await?;
 

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -233,7 +233,8 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
     fn storage_store(&self) -> Arc<dyn everruns_core::traits::SessionStorageStore>;
 
     /// Get the platform store for org-level management tools.
-    fn platform_store(&self) -> Arc<dyn everruns_core::platform_store::PlatformStore>;
+    /// Takes org_id so the store is scoped to the current session's organization.
+    fn platform_store(&self, org_id: i64) -> Arc<dyn everruns_core::platform_store::PlatformStore>;
 
     /// Get the user connection resolver for lazy token lookup.
     fn connection_resolver(&self) -> Arc<dyn everruns_core::traits::UserConnectionResolver>;

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -618,7 +618,7 @@ When an agent tool (e.g., Daytona) doesn't find an API key, it may instruct the 
 Agents with the `platform_management` capability can create, update, and delete harnesses, agents, and sessions within their organization. They can also send messages to any session and read responses.
 
 - **Impact:** An agent could escalate privileges by creating a new agent with dangerous capabilities, modify other agents' system prompts, or spawn session chains. No fine-grained RBAC exists within the org scope.
-- **Current mitigations:** (1) Capability must be explicitly assigned by an org member. (2) All operations are org-scoped — cross-org access blocked by tenant isolation (TM-TENANT-001). (3) `DirectPlatformStore` uses existing storage layer with org_id filtering.
+- **Current mitigations:** (1) Capability must be explicitly assigned by an org member. (2) All operations are org-scoped — cross-org access blocked by tenant isolation (TM-TENANT-001). (3) `DirectPlatformStore` uses existing storage layer with org_id filtering. (4) `WorkerAdapters::platform_store(org_id)` receives the session's actual org_id from activity context, preventing cross-org access via hardcoded defaults.
 - **Recommendation:** Add audit logging for all platform management tool calls. Consider RBAC (e.g., "can only manage own sessions") and approval workflows for dangerous operations (creating agents with `virtual_bash`). Add recursion depth limits for agent-spawned session chains.
 - **Code:** `// THREAT[TM-AGENT-017]` at `PlatformManagementCapability` registration and `DirectPlatformStore` implementation.
 - **Priority:** High


### PR DESCRIPTION
## What
Two fixes to the platform management capability:
1. `WorkerAdapters::platform_store()` now takes `org_id` parameter so the platform store is scoped to the current session's organization
2. Standardized public URL env var to `PUBLIC_APP_URL` (with `APP_URL` fallback) and changed default from `http://localhost:3000` to `http://localhost:9300`

## Why
1. `GrpcWorkerAdapters::platform_store()` was hardcoded to `DEFAULT_ORG_ID`, meaning platform management tools in worker mode always operated on the default org regardless of session context — potential cross-org data leakage in multi-tenant deployments
2. The default base URL `localhost:3000` was wrong — port 9300 is the unified Caddy proxy entry point that users actually access

## How
- Added `org_id: i64` parameter to `WorkerAdapters::platform_store()` trait method
- Updated all implementations (`GrpcWorkerAdapters`, `DirectWorkerAdapters`) and the call site in `unified_worker.rs` where `org_id` is already available from the activity input
- Changed env var priority to `PUBLIC_APP_URL` > `APP_URL` > `http://localhost:9300` in all 3 locations (DirectPlatformStore, GrpcPlatformStore, grpc_service)
- Updated mock test store, test assertions, and `.env.example`
- Updated TM-AGENT-017 mitigation in threat model

## Risk
- Low
- Trait signature change is internal-only; no API or UI changes. The `org_id` was already flowing through the activity system — this just threads it through to the platform store.

## Checklist
- [x] Tests added or updated (42 platform management tests pass, test assertion updated for new URL)
- [x] Backward compatibility considered (APP_URL still works as fallback)