### PR TITLE
fix(docker): pin UI builder stage to amd64 to avoid QEMU SIGILL

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -48,9 +48,6 @@ jobs:
             dockerfile: apps/ui/Dockerfile
             image_name: everruns-ui
             context: apps/ui
-            # Next.js static generation crashes under QEMU arm64 emulation
-            # (signal 4 / Illegal instruction), so build amd64 only
-            amd64_only: true
 
     steps:
       - uses: actions/checkout@v4
@@ -98,11 +95,10 @@ jobs:
 
       # Build ARM64 only on main push, version tags, and release dispatches
       # PRs only build amd64 for faster CI
-      # Targets with amd64_only skip arm64 (e.g. Next.js crashes under QEMU)
       - name: Determine platforms
         id: platforms
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ] || [ "${{ matrix.amd64_only }}" = "true" ]; then
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
           else
             echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT

--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -1,5 +1,11 @@
 # Multi-stage build for Next.js standalone output
-FROM node:22-alpine AS builder
+#
+# The builder stage is pinned to linux/amd64 because Next.js static page
+# generation runs V8 JIT-compiled code that crashes under QEMU arm64
+# user-mode emulation (SIGILL — V8 emits ARM64 instructions QEMU doesn't
+# support). The standalone output is platform-independent JS, so building
+# on amd64 and copying into the target-platform runtime image is safe.
+FROM --platform=linux/amd64 node:22-alpine AS builder
 WORKDIR /app
 
 # Install dependencies
@@ -10,7 +16,7 @@ RUN npm ci
 COPY . .
 RUN npm run build
 
-# Production image
+# Production image — uses the target platform (amd64 or arm64)
 FROM node:22-alpine AS ui
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Next.js static page generation crashes under QEMU arm64 emulation (V8 JIT emits ARM64 instructions QEMU cannot handle → SIGILL). Previous builds passed only because the Docker layer cache was hit; any UI source change invalidating the cache triggers the crash.
- Pins the Dockerfile builder stage to `linux/amd64` via `FROM --platform=linux/amd64`. Next.js standalone output is platform-independent JS, so cross-building is safe. The production stage still runs on the target platform.
- Reverts the prior workaround (#651) that dropped arm64 entirely from the UI image.

## Test plan
- [ ] Docker Publish CI passes for all targets including UI with both amd64 and arm64 platforms
- [ ] Verify the arm64 UI image runs correctly (`docker run --platform linux/arm64`)