### PR TITLE
feat(core): add optional input token limit to LlmModelLimits

### DIFF
--- a/apps/ui/src/app/(main)/settings/providers/page.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/page.tsx
@@ -295,6 +295,7 @@ function ModelRow({
                   Token Limits
                 </div>
                 <div>Context: {formatTokens(profile.limits.context)}</div>
+                {profile.limits.input && <div>Input: {formatTokens(profile.limits.input)}</div>}
                 <div>Output: {formatTokens(profile.limits.output)}</div>
               </div>
             )}

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -862,6 +862,8 @@ export interface LlmModelCost {
 export interface LlmModelLimits {
   /** Maximum context window size in tokens */
   context: number;
+  /** Maximum input tokens (if different from context - output) */
+  input?: number;
   /** Maximum output tokens */
   output: number;
 }

--- a/crates/core/src/llm_model_profiles.rs
+++ b/crates/core/src/llm_model_profiles.rs
@@ -168,6 +168,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 128_000,
+                input: None,
                 output: 16_384,
             }),
             modalities: Some(LlmModelModalities {
@@ -196,6 +197,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 128_000,
+                input: None,
                 output: 16_384,
             }),
             modalities: Some(LlmModelModalities {
@@ -224,6 +226,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 200_000,
+                input: None,
                 output: 100_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -252,6 +255,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 128_000,
+                input: None,
                 output: 65_536,
             }),
             modalities: Some(LlmModelModalities {
@@ -280,6 +284,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 200_000,
+                input: None,
                 output: 100_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -308,6 +313,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 200_000,
+                input: None,
                 output: 100_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -336,6 +342,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 200_000,
+                input: None,
                 output: 100_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -364,6 +371,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 200_000,
+                input: None,
                 output: 100_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -392,6 +400,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 200_000,
+                input: None,
                 output: 100_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -421,6 +430,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 128_000,
+                input: None,
                 output: 16_384,
             }),
             modalities: Some(LlmModelModalities {
@@ -449,6 +459,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 128_000,
+                input: None,
                 output: 16_384,
             }),
             modalities: Some(LlmModelModalities {
@@ -477,6 +488,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 128_000,
+                input: None,
                 output: 16_384,
             }),
             modalities: Some(LlmModelModalities {
@@ -507,6 +519,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 128_000,
+                input: None,
                 output: 128_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -535,6 +548,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 128_000,
+                input: None,
                 output: 64_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -563,6 +577,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 128_000,
+                input: None,
                 output: 64_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -591,6 +606,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 128_000,
+                input: None,
                 output: 128_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -619,6 +635,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 128_000,
+                input: None,
                 output: 128_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -648,6 +665,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 128_000,
+                input: None,
                 output: 128_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -676,6 +694,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 128_000,
+                input: None,
                 output: 128_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -704,6 +723,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 128_000,
+                input: None,
                 output: 100_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -733,6 +753,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 128_000,
+                input: None,
                 output: 128_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -762,6 +783,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 400_000,
+                input: None,
                 output: 128_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -790,6 +812,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 400_000,
+                input: None,
                 output: 128_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -818,6 +841,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 400_000,
+                input: None,
                 output: 128_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -847,6 +871,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 400_000,
+                input: None,
                 output: 128_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -876,6 +901,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 1_050_000,
+                input: None,
                 output: 128_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -904,6 +930,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 1_050_000,
+                input: None,
                 output: 128_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -933,6 +960,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 128_000,
+                input: None,
                 output: 128_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -961,6 +989,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 128_000,
+                input: None,
                 output: 128_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -989,6 +1018,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 128_000,
+                input: None,
                 output: 16_384,
             }),
             modalities: Some(LlmModelModalities {
@@ -1018,6 +1048,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 200_000,
+                input: None,
                 output: 100_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -1046,6 +1077,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 200_000,
+                input: None,
                 output: 100_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -1074,6 +1106,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 128_000,
+                input: None,
                 output: 32_768,
             }),
             modalities: Some(LlmModelModalities {
@@ -1112,6 +1145,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 200_000,
+                input: None,
                 output: 128_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -1140,6 +1174,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 200_000,
+                input: None,
                 output: 64_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -1169,6 +1204,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 200_000,
+                input: None,
                 output: 64_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -1197,6 +1233,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 200_000,
+                input: None,
                 output: 64_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -1225,6 +1262,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 200_000,
+                input: None,
                 output: 16_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -1254,6 +1292,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 200_000,
+                input: None,
                 output: 32_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -1283,6 +1322,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 200_000,
+                input: None,
                 output: 64_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -1311,6 +1351,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 200_000,
+                input: None,
                 output: 32_000,
             }),
             modalities: Some(LlmModelModalities {
@@ -1340,6 +1381,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 200_000,
+                input: None,
                 output: 64_000, // Extended output with thinking
             }),
             modalities: Some(LlmModelModalities {
@@ -1369,6 +1411,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 200_000,
+                input: None,
                 output: 8_192,
             }),
             modalities: Some(LlmModelModalities {
@@ -1397,6 +1440,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 200_000,
+                input: None,
                 output: 8_192,
             }),
             modalities: Some(LlmModelModalities {
@@ -1425,6 +1469,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 200_000,
+                input: None,
                 output: 4_096,
             }),
             modalities: Some(LlmModelModalities {
@@ -1453,6 +1498,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 200_000,
+                input: None,
                 output: 4_096,
             }),
             modalities: Some(LlmModelModalities {
@@ -1481,6 +1527,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 200_000,
+                input: None,
                 output: 4_096,
             }),
             modalities: Some(LlmModelModalities {
@@ -1541,6 +1588,7 @@ fn get_gemini_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 1_048_576,
+                input: None,
                 output: 65_536,
             }),
             modalities: Some(LlmModelModalities {
@@ -1574,6 +1622,7 @@ fn get_gemini_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 1_048_576,
+                input: None,
                 output: 65_536,
             }),
             modalities: Some(LlmModelModalities {
@@ -1607,6 +1656,7 @@ fn get_gemini_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 1_048_576,
+                input: None,
                 output: 8_192,
             }),
             modalities: Some(LlmModelModalities {
@@ -1640,6 +1690,7 @@ fn get_gemini_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 2_097_152,
+                input: None,
                 output: 8_192,
             }),
             modalities: Some(LlmModelModalities {
@@ -1673,6 +1724,7 @@ fn get_gemini_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 1_048_576,
+                input: None,
                 output: 8_192,
             }),
             modalities: Some(LlmModelModalities {
@@ -1714,6 +1766,7 @@ fn get_llmsim_profile(model_id: &str) -> Option<LlmModelProfile> {
             }),
             limits: Some(LlmModelLimits {
                 context: 128_000,
+                input: None,
                 output: 64_000,
             }),
             modalities: Some(LlmModelModalities {

--- a/crates/core/src/llm_model_profiles.rs
+++ b/crates/core/src/llm_model_profiles.rs
@@ -2491,6 +2491,7 @@ mod tests {
 
         let limits = profile.limits.unwrap();
         assert_eq!(limits.context, 1_048_576);
+        assert!(limits.input.is_none());
     }
 
     #[test]

--- a/crates/core/src/llm_models.rs
+++ b/crates/core/src/llm_models.rs
@@ -392,6 +392,37 @@ mod tests {
     }
 
     #[test]
+    fn test_llm_model_limits_input_omitted_when_none() {
+        let limits = LlmModelLimits {
+            context: 200_000,
+            input: None,
+            output: 64_000,
+        };
+        let json = serde_json::to_value(&limits).unwrap();
+        assert!(!json.as_object().unwrap().contains_key("input"));
+    }
+
+    #[test]
+    fn test_llm_model_limits_input_included_when_some() {
+        let limits = LlmModelLimits {
+            context: 200_000,
+            input: Some(150_000),
+            output: 64_000,
+        };
+        let json = serde_json::to_value(&limits).unwrap();
+        assert_eq!(json["input"], 150_000);
+    }
+
+    #[test]
+    fn test_llm_model_limits_deserialize_without_input() {
+        let json = r#"{"context": 200000, "output": 64000}"#;
+        let limits: LlmModelLimits = serde_json::from_str(json).unwrap();
+        assert_eq!(limits.context, 200_000);
+        assert!(limits.input.is_none());
+        assert_eq!(limits.output, 64_000);
+    }
+
+    #[test]
     fn test_llm_provider_type_display() {
         // Verify Display works correctly
         assert_eq!(LlmProviderType::Openai.to_string(), "openai");

--- a/crates/core/src/llm_models.rs
+++ b/crates/core/src/llm_models.rs
@@ -201,6 +201,9 @@ pub struct LlmModelCost {
 pub struct LlmModelLimits {
     /// Maximum context window size in tokens
     pub context: i32,
+    /// Maximum input tokens (if different from context - output)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input: Option<i32>,
     /// Maximum output tokens
     pub output: i32,
 }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -7163,6 +7163,12 @@
             "format": "int32",
             "description": "Maximum context window size in tokens"
           },
+          "input": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Maximum input tokens (if different from context - output)",
+            "nullable": true
+          },
           "output": {
             "type": "integer",
             "format": "int32",

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -7164,10 +7164,12 @@
             "description": "Maximum context window size in tokens"
           },
           "input": {
-            "type": "integer",
+            "type": [
+              "integer",
+              "null"
+            ],
             "format": "int32",
-            "description": "Maximum input tokens (if different from context - output)",
-            "nullable": true
+            "description": "Maximum input tokens (if different from context - output)"
           },
           "output": {
             "type": "integer",


### PR DESCRIPTION
## What
Add optional `input: Option<i32>` field to `LlmModelLimits` struct for tracking maximum input tokens separately from the context window.

## Why
Some models have input token limits that differ from `context - output`. This field allows explicit tracking when providers document a separate input cap.

## How
- Added `input: Option<i32>` with `skip_serializing_if` to `LlmModelLimits` in Rust
- Set `input: None` on all 53 model profiles (models.dev doesn't have an explicit input field)
- Updated TypeScript types, OpenAPI spec, and UI display
- Added serialization/deserialization tests for the new field

## Risk
- Low
- Purely additive optional field, backward compatible (omitted from JSON when None, deserialization works without it)

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered