### PR TITLE
revert(server): remove system_prompt_encrypted (TM-CRYPTO-007)

### DIFF
--- a/crates/server/migrations/004_encrypt_system_prompts.sql
+++ b/crates/server/migrations/004_encrypt_system_prompts.sql
@@ -1,6 +1,6 @@
--- TM-CRYPTO-007: Extend encryption scope to system prompts.
--- Add encrypted system_prompt columns alongside existing plaintext columns.
--- Encrypted column populated on next write; reads prefer encrypted when available.
+-- Revert TM-CRYPTO-007: System prompt encryption removed.
+-- Encrypting system prompts doesn't address the root concern; PII should not
+-- be in system prompts at all. Drop the unused encrypted columns.
 
-ALTER TABLE agents ADD COLUMN system_prompt_encrypted BYTEA;
-ALTER TABLE harnesses ADD COLUMN system_prompt_encrypted BYTEA;
+ALTER TABLE agents DROP COLUMN IF EXISTS system_prompt_encrypted;
+ALTER TABLE harnesses DROP COLUMN IF EXISTS system_prompt_encrypted;

--- a/crates/server/migrations/004_encrypt_system_prompts.sql
+++ b/crates/server/migrations/004_encrypt_system_prompts.sql
@@ -1,6 +1,6 @@
--- Revert TM-CRYPTO-007: System prompt encryption removed.
--- Encrypting system prompts doesn't address the root concern; PII should not
--- be in system prompts at all. Drop the unused encrypted columns.
+-- TM-CRYPTO-007: Extend encryption scope to system prompts.
+-- Add encrypted system_prompt columns alongside existing plaintext columns.
+-- Encrypted column populated on next write; reads prefer encrypted when available.
 
-ALTER TABLE agents DROP COLUMN IF EXISTS system_prompt_encrypted;
-ALTER TABLE harnesses DROP COLUMN IF EXISTS system_prompt_encrypted;
+ALTER TABLE agents ADD COLUMN system_prompt_encrypted BYTEA;
+ALTER TABLE harnesses ADD COLUMN system_prompt_encrypted BYTEA;

--- a/crates/server/migrations/006_drop_system_prompt_encrypted.sql
+++ b/crates/server/migrations/006_drop_system_prompt_encrypted.sql
@@ -1,0 +1,6 @@
+-- Revert TM-CRYPTO-007: System prompt encryption removed.
+-- Encrypting system prompts doesn't address the root concern; PII should not
+-- be in system prompts at all. Drop the unused encrypted columns.
+
+ALTER TABLE agents DROP COLUMN IF EXISTS system_prompt_encrypted;
+ALTER TABLE harnesses DROP COLUMN IF EXISTS system_prompt_encrypted;

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -237,22 +237,6 @@ impl StorageBackend {
         dispatch!(self, get_agent_public_id, org_id, id)
     }
 
-    pub async fn set_agent_encrypted_prompt(
-        &self,
-        agent_id: AgentId,
-        encrypted: &[u8],
-    ) -> Result<()> {
-        dispatch!(self, set_agent_encrypted_prompt, agent_id, encrypted)
-    }
-
-    pub async fn set_harness_encrypted_prompt(
-        &self,
-        harness_id: HarnessId,
-        encrypted: &[u8],
-    ) -> Result<()> {
-        dispatch!(self, set_harness_encrypted_prompt, harness_id, encrypted)
-    }
-
     // ============================================
     // Harnesses
     // ============================================

--- a/crates/server/src/storage/encryption.rs
+++ b/crates/server/src/storage/encryption.rs
@@ -354,18 +354,6 @@ pub const ENCRYPTED_COLUMNS: &[EncryptedColumn] = &[
         column: "refresh_token_encrypted",
         id_column: "id",
     },
-    // TM-CRYPTO-007: Agent system prompts encrypted at rest
-    EncryptedColumn {
-        table: "agents",
-        column: "system_prompt_encrypted",
-        id_column: "id",
-    },
-    // TM-CRYPTO-007: Harness system prompts encrypted at rest
-    EncryptedColumn {
-        table: "harnesses",
-        column: "system_prompt_encrypted",
-        id_column: "id",
-    },
 ];
 
 #[cfg(test)]

--- a/crates/server/src/storage/encryption.rs
+++ b/crates/server/src/storage/encryption.rs
@@ -594,6 +594,24 @@ mod tests {
                 }
             }
 
+            // Detect ALTER TABLE ... DROP COLUMN [IF EXISTS] ... _encrypted
+            if trimmed.starts_with("alter table") && trimmed.contains("drop column") {
+                let parts: Vec<&str> = trimmed.split_whitespace().collect();
+                // Without IF EXISTS: ["alter", "table", "<table>", "drop", "column", "<col>", ...]
+                // With IF EXISTS: ["alter", "table", "<table>", "drop", "column", "if", "exists", "<col>", ...]
+                let col_idx = if parts.len() >= 8 && parts[5] == "if" && parts[6] == "exists" {
+                    7
+                } else {
+                    5
+                };
+                if parts.len() > col_idx {
+                    let col_name = parts[col_idx].trim_end_matches(';');
+                    if col_name.ends_with("_encrypted") {
+                        found.remove(&(parts[2].to_string(), col_name.to_string()));
+                    }
+                }
+            }
+
             // Detect CREATE TABLE
             if trimmed.starts_with("create table") {
                 in_create_table = true;

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -420,7 +420,6 @@ impl InMemoryDatabase {
             name: input.name,
             description: input.description,
             system_prompt: input.system_prompt,
-            system_prompt_encrypted: None,
             default_model_id: input.default_model_id,
             tags: input.tags,
             tools: input.tools,
@@ -479,7 +478,6 @@ impl InMemoryDatabase {
             name: input.name,
             description: input.description,
             system_prompt: input.system_prompt,
-            system_prompt_encrypted: None,
             default_model_id: input.default_model_id,
             tags: input.tags,
             tools: input.tools,
@@ -619,7 +617,6 @@ impl InMemoryDatabase {
                 name: input.name,
                 description: input.description,
                 system_prompt: input.system_prompt,
-                system_prompt_encrypted: None,
                 default_model_id: input.default_model_id,
                 tags: input.tags,
                 tools: input.tools,
@@ -646,28 +643,6 @@ impl InMemoryDatabase {
             .map(|a| a.public_id.clone()))
     }
 
-    pub async fn set_agent_encrypted_prompt(
-        &self,
-        agent_id: AgentId,
-        encrypted: &[u8],
-    ) -> Result<()> {
-        if let Some(agent) = self.agents.write().get_mut(&agent_id) {
-            agent.system_prompt_encrypted = Some(encrypted.to_vec());
-        }
-        Ok(())
-    }
-
-    pub async fn set_harness_encrypted_prompt(
-        &self,
-        harness_id: HarnessId,
-        encrypted: &[u8],
-    ) -> Result<()> {
-        if let Some(harness) = self.harnesses.write().get_mut(&harness_id) {
-            harness.system_prompt_encrypted = Some(encrypted.to_vec());
-        }
-        Ok(())
-    }
-
     // ============================================
     // Harnesses
     // ============================================
@@ -681,7 +656,6 @@ impl InMemoryDatabase {
             name: input.name,
             description: input.description,
             system_prompt: input.system_prompt,
-            system_prompt_encrypted: None,
             default_model_id: input.default_model_id,
             tags: input.tags,
             status: "active".to_string(),
@@ -730,7 +704,6 @@ impl InMemoryDatabase {
             name: input.name,
             description: input.description,
             system_prompt: input.system_prompt,
-            system_prompt_encrypted: None,
             default_model_id: input.default_model_id,
             tags: input.tags,
             status: "active".to_string(),

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -201,9 +201,6 @@ pub struct AgentRow {
     pub name: String,
     pub description: Option<String>,
     pub system_prompt: String,
-    /// TM-CRYPTO-007: Encrypted system prompt (envelope encryption)
-    #[sqlx(default)]
-    pub system_prompt_encrypted: Option<Vec<u8>>,
     pub default_model_id: Option<ModelId>,
     pub tags: Vec<String>,
     pub status: String,
@@ -260,9 +257,6 @@ pub struct HarnessRow {
     pub name: String,
     pub description: Option<String>,
     pub system_prompt: String,
-    /// TM-CRYPTO-007: Encrypted system prompt (envelope encryption)
-    #[sqlx(default)]
-    pub system_prompt_encrypted: Option<Vec<u8>>,
     pub default_model_id: Option<ModelId>,
     pub tags: Vec<String>,
     pub status: String,

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -747,35 +747,6 @@ impl Database {
         Ok(row.map(|r| r.0))
     }
 
-    /// TM-CRYPTO-007: Store encrypted system prompt for an agent.
-    /// Called after agent create/update when EncryptionService is available.
-    pub async fn set_agent_encrypted_prompt(
-        &self,
-        agent_id: AgentId,
-        encrypted: &[u8],
-    ) -> Result<()> {
-        sqlx::query("UPDATE agents SET system_prompt_encrypted = $1 WHERE id = $2")
-            .bind(encrypted)
-            .bind(agent_id.uuid())
-            .execute(&self.pool)
-            .await?;
-        Ok(())
-    }
-
-    /// TM-CRYPTO-007: Store encrypted system prompt for a harness.
-    pub async fn set_harness_encrypted_prompt(
-        &self,
-        harness_id: HarnessId,
-        encrypted: &[u8],
-    ) -> Result<()> {
-        sqlx::query("UPDATE harnesses SET system_prompt_encrypted = $1 WHERE id = $2")
-            .bind(encrypted)
-            .bind(harness_id.uuid())
-            .execute(&self.pool)
-            .await?;
-        Ok(())
-    }
-
     // ============================================
     // Harnesses (base configuration for sessions)
     // ============================================

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -136,7 +136,7 @@ Display:   evr_<first-8-chars>...   (prefix for identification)
 | TM-CRYPTO-004 | Known-plaintext attack | Medium | Unique DEK per encryption; same plaintext produces different ciphertext | MITIGATED |
 | TM-CRYPTO-005 | Stale encryption key | Medium | Key rotation supported (primary + previous KEK); key_id in payload | MITIGATED |
 | TM-CRYPTO-006 | Re-encryption job missing | Low | CLI tool `reencrypt_secrets` implemented with batch processing, dry-run mode, and key rotation detection | MITIGATED |
-| TM-CRYPTO-007 | Limited encryption scope | Medium | System prompts encrypted via envelope encryption (migration 004); LLM API keys encrypted | MITIGATED |
+| TM-CRYPTO-007 | Limited encryption scope | Medium | LLM API keys encrypted; system prompt encryption reverted (PII should not be in prompts) | **OPEN** |
 
 ### Mitigation Details
 
@@ -549,7 +549,7 @@ The agent loop is a core trust boundary: an LLM decides which tools to call with
 | TM-AGENT-008 | Context window poisoning | Medium | Auto-compaction via `llm_driver.compact()` on `RequestTooLarge`; older messages compressed | MITIGATED |
 | TM-AGENT-009 | Agent self-modification | Medium | Agents with `platform_management` capability can modify agents/sessions via tools; capability must be explicitly assigned; org-scoped | **OPEN** |
 | TM-AGENT-010 | Agent spawning agent chains | Medium | Agents with `platform_management` capability can create agents/sessions; capability must be explicitly assigned; no recursive depth limit | **OPEN** |
-| TM-AGENT-011 | Sensitive data in system prompt | Medium | System prompts encrypted at rest via envelope encryption (TM-CRYPTO-007) | MITIGATED |
+| TM-AGENT-011 | Sensitive data in system prompt | Medium | PII must not be placed in system prompts; no encryption at rest for prompts | **OPEN** |
 | TM-AGENT-012 | Tool result size amplification | Medium | No size limit on tool results fed back to LLM; large results consume context and cost | **OPEN** |
 | TM-AGENT-013 | Exfiltration via web_fetch | Medium | Agent with web_fetch capability can send session data to arbitrary URLs | **ACCEPTED** |
 | TM-AGENT-014 | Confused deputy — tool call with wrong session | Low | Tool context includes session_id; tools scoped to active session only | MITIGATED |
@@ -611,7 +611,7 @@ This is accepted because:
 When an agent tool (e.g., Daytona) doesn't find an API key, it may instruct the user to provide one in chat. The user types the key as a chat message, which is stored as plaintext in the `events` table (message content). The `session_secrets` table encrypts the value separately, but the original chat message retains plaintext indefinitely.
 
 - **Impact:** API keys visible in session history, event exports, and any observability pipeline that captures events.
-- **Recommendation:** Prefer Settings UI for credential entry (user connections). Phase out in-chat secret collection. For tools that need credentials, guide users to Settings > Connections instead of requesting secrets in chat. See also TM-CRYPTO-007.
+- **Recommendation:** Prefer Settings UI for credential entry (user connections). Phase out in-chat secret collection. For tools that need credentials, guide users to Settings > Connections instead of requesting secrets in chat.
 - **Priority:** High
 
 **TM-AGENT-017 — Agent-Initiated Entity Management (OPEN):**


### PR DESCRIPTION
## What
Remove `system_prompt_encrypted` columns, methods, and encryption registry entries from agents and harnesses tables. Add migration 006 to drop the columns.

## Why
Encrypting system prompts at rest doesn't address the root concern. PII should not be placed in system prompts at all. A different approach is needed.

## How
- Removed `system_prompt_encrypted` field from `AgentRow` and `HarnessRow`
- Removed `set_agent_encrypted_prompt` / `set_harness_encrypted_prompt` from repositories, memory storage, and backend
- Removed `EncryptedColumn` entries for system prompts
- Added migration 006 to `DROP COLUMN IF EXISTS system_prompt_encrypted` on both tables
- Updated encrypted columns migration parser to handle `DROP COLUMN` statements
- Reopened TM-CRYPTO-007 and TM-AGENT-011 in threat model

## Risk
- Low
- The encrypted prompt methods were never called from application code (dead code). No runtime behavior changes.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered