### PR TITLE
feat(duckduckgo): add DuckDuckGo Instant Answer search integration

### DIFF
--- a/.github/workflows/duckduckgo-integration.yml
+++ b/.github/workflows/duckduckgo-integration.yml
@@ -1,0 +1,46 @@
+name: DuckDuckGo Integration
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'integrations/duckduckgo/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'integrations/duckduckgo/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  integration-test:
+    name: DuckDuckGo API Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install protobuf compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "duckduckgo-integration"
+
+      - name: Run integration tests
+        run: cargo test -p everruns-integrations-duckduckgo --features integration

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,7 @@ Fix root cause. Unsure: read more code; if stuck, ask w/ short options. Unrecogn
 - `specs/linear-issues.md` - Linear issue processing workflow
 - `specs/daytona.md` - Daytona cloud sandbox integration
 - `specs/brave-search.md` - Brave Search web search integration
+- `specs/duckduckgo.md` - DuckDuckGo instant answer search integration
 - `specs/harness-types.md` - Built-in harness types (Base, Generic)
 - `specs/client-side-tools.md` - Client-side tools for API/SDK consumers
 - `specs/codesandbox.md` - CodeSandbox cloud sandbox integration

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1380,6 +1380,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "everruns-integrations-duckduckgo"
+version = "0.7.0"
+dependencies = [
+ "async-trait",
+ "everruns-core",
+ "inventory",
+ "reqwest 0.13.1",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "wiremock",
+]
+
+[[package]]
 name = "everruns-internal-protocol"
 version = "0.8.2"
 dependencies = [
@@ -1455,6 +1470,7 @@ dependencies = [
  "everruns-integrations-codesandbox",
  "everruns-integrations-daytona",
  "everruns-integrations-docker",
+ "everruns-integrations-duckduckgo",
  "everruns-internal-protocol",
  "everruns-sdk",
  "everruns-session-sqldb",
@@ -1529,6 +1545,7 @@ dependencies = [
  "everruns-integrations-codesandbox",
  "everruns-integrations-daytona",
  "everruns-integrations-docker",
+ "everruns-integrations-duckduckgo",
  "everruns-internal-protocol",
  "everruns-openai",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.7.0"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "everruns-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "integrations/docker",
     "integrations/daytona",
     "integrations/brave-search",
+    "integrations/duckduckgo",
 ]
 
 exclude = [

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -61,6 +61,7 @@ everruns-core = { path = "../core", features = ["openapi", "sqlx"] }
 everruns-integrations-codesandbox = { path = "../../integrations/codesandbox" }
 everruns-integrations-docker = { path = "../../integrations/docker" }
 everruns-integrations-brave-search = { path = "../../integrations/brave-search" }
+everruns-integrations-duckduckgo = { path = "../../integrations/duckduckgo" }
 everruns-integrations-daytona = { path = "../../integrations/daytona" }
 everruns-session-sqldb = { path = "../session-sqldb" }
 everruns-worker = { path = "../worker" }  # For AgentRunner trait

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -8,6 +8,7 @@ extern crate everruns_integrations_brave_search;
 extern crate everruns_integrations_codesandbox;
 extern crate everruns_integrations_daytona;
 extern crate everruns_integrations_docker;
+extern crate everruns_integrations_duckduckgo;
 
 // API routes and types (shared for OpenAPI generation)
 pub mod api;

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -18,6 +18,7 @@ everruns-core = { path = "../core" }
 everruns-integrations-codesandbox = { path = "../../integrations/codesandbox" }
 everruns-integrations-docker = { path = "../../integrations/docker" }
 everruns-integrations-brave-search = { path = "../../integrations/brave-search" }
+everruns-integrations-duckduckgo = { path = "../../integrations/duckduckgo" }
 everruns-integrations-daytona = { path = "../../integrations/daytona" }
 everruns-openai = { path = "../openai" }
 everruns-anthropic = { path = "../anthropic" }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -3,6 +3,7 @@ extern crate everruns_integrations_brave_search;
 extern crate everruns_integrations_codesandbox;
 extern crate everruns_integrations_daytona;
 extern crate everruns_integrations_docker;
+extern crate everruns_integrations_duckduckgo;
 
 pub mod activities;
 pub mod adapters;

--- a/docs/integrations/duckduckgo.md
+++ b/docs/integrations/duckduckgo.md
@@ -1,0 +1,84 @@
+---
+title: DuckDuckGo Integration
+description: Free instant answers, definitions, and topic summaries via DuckDuckGo
+---
+
+Everruns integrates with [DuckDuckGo](https://duckduckgo.com/) to provide instant answers via the [DuckDuckGo Instant Answer API](https://api.duckduckgo.com/api). Agents can look up facts, definitions, topic summaries (from Wikipedia and other sources), and related topics — all without an API key.
+
+## What You Get
+
+- **Instant Answers**: Direct answers for calculations, IP lookups, conversions, and more
+- **Topic Abstracts**: Wikipedia-style summaries for well-known topics
+- **Definitions**: Dictionary definitions from Wiktionary and other sources
+- **Related Topics**: Links to related topics for deeper exploration
+- **No API Key Required**: The DuckDuckGo Instant Answer API is completely free
+
+## Quick Start
+
+### 1. No Setup Needed
+
+Unlike other integrations, DuckDuckGo requires no API key or configuration. The DuckDuckGo Instant Answer API is free and public.
+
+### 2. Enable the Capability
+
+Add the `duckduckgo` capability to your agent or harness configuration. In dev mode, it's available as an experimental capability.
+
+### 3. Use in Sessions
+
+Agents with the DuckDuckGo capability can use this tool:
+
+| Tool | Description |
+|------|-------------|
+| `duckduckgo_search` | Get instant answers, abstracts, definitions, and related topics |
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | string | Yes | Search query |
+| `no_html` | boolean | No | Strip HTML from result text (default: `true`) |
+
+### Response Fields
+
+The tool returns a JSON object with available fields:
+
+| Field | Description |
+|-------|-------------|
+| `query` | The original query |
+| `type` | Response type: `article`, `disambiguation`, `category`, `name`, `exclusive`, or `nothing` |
+| `heading` | Topic heading |
+| `abstract` | `{ text, source, url }` — topic summary |
+| `answer` | `{ text, type }` — direct answer (calculations, etc.) |
+| `definition` | `{ text, source, url }` — dictionary definition |
+| `related_topics` | Array of `{ text, url }` — related topics (max 10) |
+| `results` | Array of `{ text, url }` — official/direct results |
+
+Only non-empty fields are included in the response.
+
+## When to Use DuckDuckGo vs Brave Search
+
+| Use Case | DuckDuckGo | Brave Search |
+|----------|------------|--------------|
+| Quick facts and definitions | ✅ Best choice | Works but slower |
+| Wikipedia-style summaries | ✅ Best choice | Not available |
+| Calculations and conversions | ✅ Direct answers | Not available |
+| Full web search results | ❌ Not available | ✅ Best choice |
+| Current news and articles | ❌ Limited | ✅ Best choice |
+| API key required | No | Yes |
+
+Both capabilities can be enabled simultaneously — the agent will choose the right tool based on the task.
+
+## Security
+
+- **No secrets**: No API key or credentials to manage
+- **Read-only**: The API only returns information, no write operations
+- **Privacy**: DuckDuckGo does not track searches
+
+## Status
+
+**Experimental** — available in dev mode only. This capability may change in future releases.
+
+## Links
+
+- [DuckDuckGo](https://duckduckgo.com/)
+- [DuckDuckGo Instant Answer API](https://api.duckduckgo.com/api)

--- a/integrations/duckduckgo/Cargo.toml
+++ b/integrations/duckduckgo/Cargo.toml
@@ -1,0 +1,35 @@
+# DuckDuckGo Integration
+# Decision: External integration crate, auto-registered via inventory plugin system
+# Decision: Experimental-only (gated behind DeploymentGrade::Dev)
+# Decision: No API key required (DuckDuckGo Instant Answer API is free)
+
+[package]
+name = "everruns-integrations-duckduckgo"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "DuckDuckGo Instant Answer search integration for Everruns"
+
+[dependencies]
+everruns-core = { path = "../../crates/core" }
+inventory.workspace = true
+
+# HTTP client for DuckDuckGo API
+reqwest.workspace = true
+
+# Serialization
+serde.workspace = true
+serde_json.workspace = true
+
+# Async
+async-trait.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+
+[features]
+integration = [] # Gate real-API tests; CI passes --features integration
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full", "test-util"] }
+wiremock = "0.6"

--- a/integrations/duckduckgo/src/client.rs
+++ b/integrations/duckduckgo/src/client.rs
@@ -1,0 +1,384 @@
+//! DuckDuckGo Instant Answer API client.
+
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+// ============================================================================
+// API Response Types
+// ============================================================================
+
+/// Top-level response from DuckDuckGo Instant Answer API.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstantAnswerResponse {
+    /// Topic summary (typically from Wikipedia).
+    #[serde(rename = "Abstract", default)]
+    pub r#abstract: String,
+
+    /// Source of the abstract (e.g. "Wikipedia").
+    #[serde(rename = "AbstractSource", default)]
+    pub abstract_source: String,
+
+    /// URL of the abstract source.
+    #[serde(rename = "AbstractURL", default)]
+    pub abstract_url: String,
+
+    /// Instant answer text.
+    #[serde(rename = "Answer", default)]
+    pub answer: String,
+
+    /// Type of answer (e.g. "calc", "color", "ip", etc.).
+    #[serde(rename = "AnswerType", default)]
+    pub answer_type: String,
+
+    /// Definition text.
+    #[serde(rename = "Definition", default)]
+    pub definition: String,
+
+    /// Source of the definition.
+    #[serde(rename = "DefinitionSource", default)]
+    pub definition_source: String,
+
+    /// URL for the definition source.
+    #[serde(rename = "DefinitionURL", default)]
+    pub definition_url: String,
+
+    /// Topic heading.
+    #[serde(rename = "Heading", default)]
+    pub heading: String,
+
+    /// Response type: A (article), D (disambiguation), C (category),
+    /// N (name), E (exclusive), or empty.
+    #[serde(rename = "Type", default)]
+    pub response_type: String,
+
+    /// Related topics.
+    #[serde(rename = "RelatedTopics", default)]
+    pub related_topics: Vec<TopicResult>,
+
+    /// Official results (e.g. official website).
+    #[serde(rename = "Results", default)]
+    pub results: Vec<TopicResult>,
+}
+
+/// A topic result entry — can be either a direct result or a group.
+///
+/// DuckDuckGo API returns two shapes: direct results with `Text`/`FirstURL`,
+/// and topic groups with `Name`/`Topics`. We deserialize both into this struct
+/// and distinguish by checking which fields are populated.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TopicResult {
+    /// Display text (may contain HTML).
+    #[serde(rename = "Text", default)]
+    pub text: String,
+
+    /// URL for this topic.
+    #[serde(rename = "FirstURL", default)]
+    pub first_url: String,
+
+    /// Group name (for grouped/categorized topics).
+    #[serde(rename = "Name", default)]
+    pub name: String,
+
+    /// Nested topics (for grouped results).
+    #[serde(rename = "Topics", default)]
+    pub topics: Vec<TopicResult>,
+}
+
+impl TopicResult {
+    /// Whether this is a direct result (has text and URL).
+    pub fn is_direct(&self) -> bool {
+        !self.first_url.is_empty()
+    }
+
+    /// Whether this is a topic group (has nested topics).
+    pub fn is_group(&self) -> bool {
+        !self.topics.is_empty()
+    }
+}
+
+// ============================================================================
+// DuckDuckGoClient
+// ============================================================================
+
+pub struct DuckDuckGoClient {
+    http: reqwest::Client,
+    api_base: String,
+}
+
+impl Default for DuckDuckGoClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DuckDuckGoClient {
+    pub fn new() -> Self {
+        Self::with_base_url(crate::DUCKDUCKGO_API_BASE.to_string())
+    }
+
+    pub fn with_base_url(api_base: String) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            api_base,
+        }
+    }
+
+    /// Query the DuckDuckGo Instant Answer API.
+    pub async fn instant_answer(
+        &self,
+        query: &str,
+        no_html: bool,
+    ) -> Result<InstantAnswerResponse, String> {
+        let mut url = format!(
+            "{}/?q={}&format=json&no_redirect=1",
+            self.api_base,
+            urlencoding::encode(query)
+        );
+        if no_html {
+            url.push_str("&no_html=1");
+        }
+
+        debug!("DuckDuckGo query: {query}");
+
+        let resp = self
+            .http
+            .get(&url)
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .map_err(|e| format!("Failed to connect to DuckDuckGo API: {e}"))?;
+
+        let status = resp.status();
+        let body_text = resp
+            .text()
+            .await
+            .map_err(|e| format!("Failed to read response: {e}"))?;
+
+        if !status.is_success() {
+            return Err(format!("DuckDuckGo API error ({status}): {body_text}"));
+        }
+
+        serde_json::from_str(&body_text).map_err(|e| format!("Invalid JSON from DuckDuckGo: {e}"))
+    }
+}
+
+pub(crate) mod urlencoding {
+    /// Percent-encode a string for use in query parameters.
+    pub fn encode(input: &str) -> String {
+        let mut result = String::with_capacity(input.len() * 2);
+        for byte in input.bytes() {
+            match byte {
+                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                    result.push(byte as char);
+                }
+                _ => {
+                    result.push('%');
+                    result.push_str(&format!("{byte:02X}"));
+                }
+            }
+        }
+        result
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn sample_response() -> serde_json::Value {
+        serde_json::json!({
+            "Abstract": "Rust is a multi-paradigm programming language.",
+            "AbstractSource": "Wikipedia",
+            "AbstractURL": "https://en.wikipedia.org/wiki/Rust_(programming_language)",
+            "Answer": "",
+            "AnswerType": "",
+            "Definition": "",
+            "DefinitionSource": "",
+            "DefinitionURL": "",
+            "Heading": "Rust (programming language)",
+            "Type": "A",
+            "RelatedTopics": [
+                {
+                    "Text": "Cargo is the Rust package manager.",
+                    "FirstURL": "https://doc.rust-lang.org/cargo/",
+                    "Name": "",
+                    "Topics": []
+                }
+            ],
+            "Results": [
+                {
+                    "Text": "Official Rust website",
+                    "FirstURL": "https://www.rust-lang.org/",
+                    "Name": "",
+                    "Topics": []
+                }
+            ]
+        })
+    }
+
+    #[tokio::test]
+    async fn test_instant_answer_success() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(sample_response()))
+            .mount(&mock_server)
+            .await;
+
+        let client = DuckDuckGoClient::with_base_url(mock_server.uri());
+        let result = client.instant_answer("rust programming", false).await;
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.heading, "Rust (programming language)");
+        assert_eq!(response.response_type, "A");
+        assert!(response.r#abstract.contains("Rust"));
+        assert_eq!(response.abstract_source, "Wikipedia");
+        assert_eq!(response.related_topics.len(), 1);
+        assert_eq!(response.results.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_instant_answer_empty_response() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "Abstract": "",
+                "AbstractSource": "",
+                "AbstractURL": "",
+                "Answer": "",
+                "AnswerType": "",
+                "Definition": "",
+                "DefinitionSource": "",
+                "DefinitionURL": "",
+                "Heading": "",
+                "Type": "",
+                "RelatedTopics": [],
+                "Results": []
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = DuckDuckGoClient::with_base_url(mock_server.uri());
+        let result = client.instant_answer("asdfghjkl", false).await;
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert!(response.r#abstract.is_empty());
+        assert!(response.heading.is_empty());
+        assert!(response.related_topics.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_instant_answer_with_no_html() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(sample_response()))
+            .mount(&mock_server)
+            .await;
+
+        let client = DuckDuckGoClient::with_base_url(mock_server.uri());
+        let result = client.instant_answer("rust", true).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_instant_answer_server_error() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("Internal Server Error"))
+            .mount(&mock_server)
+            .await;
+
+        let client = DuckDuckGoClient::with_base_url(mock_server.uri());
+        let result = client.instant_answer("test", false).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("500"));
+    }
+
+    #[tokio::test]
+    async fn test_instant_answer_malformed_json() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not json"))
+            .mount(&mock_server)
+            .await;
+
+        let client = DuckDuckGoClient::with_base_url(mock_server.uri());
+        let result = client.instant_answer("test", false).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid JSON"));
+    }
+
+    #[test]
+    fn test_topic_result_is_direct() {
+        let direct = TopicResult {
+            text: "Some text".to_string(),
+            first_url: "https://example.com".to_string(),
+            name: String::new(),
+            topics: vec![],
+        };
+        assert!(direct.is_direct());
+        assert!(!direct.is_group());
+    }
+
+    #[test]
+    fn test_topic_result_is_group() {
+        let group = TopicResult {
+            text: String::new(),
+            first_url: String::new(),
+            name: "Category".to_string(),
+            topics: vec![TopicResult {
+                text: "Nested".to_string(),
+                first_url: "https://example.com".to_string(),
+                name: String::new(),
+                topics: vec![],
+            }],
+        };
+        assert!(group.is_group());
+        assert!(!group.is_direct());
+    }
+
+    #[test]
+    fn test_response_deserialization() {
+        let json = r#"{
+            "Abstract": "Test abstract",
+            "AbstractSource": "Wikipedia",
+            "AbstractURL": "https://en.wikipedia.org/wiki/Test",
+            "Answer": "42",
+            "AnswerType": "calc",
+            "Definition": "A test",
+            "DefinitionSource": "Wiktionary",
+            "DefinitionURL": "https://en.wiktionary.org/wiki/test",
+            "Heading": "Test",
+            "Type": "A",
+            "RelatedTopics": [],
+            "Results": []
+        }"#;
+        let response: InstantAnswerResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(response.r#abstract, "Test abstract");
+        assert_eq!(response.answer, "42");
+        assert_eq!(response.answer_type, "calc");
+        assert_eq!(response.heading, "Test");
+        assert_eq!(response.response_type, "A");
+    }
+
+    #[test]
+    fn test_response_deserialization_minimal() {
+        // DuckDuckGo API always returns all fields, but with defaults
+        let json = r#"{}"#;
+        let response: InstantAnswerResponse = serde_json::from_str(json).unwrap();
+        assert!(response.r#abstract.is_empty());
+        assert!(response.heading.is_empty());
+        assert!(response.related_topics.is_empty());
+        assert!(response.results.is_empty());
+    }
+}

--- a/integrations/duckduckgo/src/client.rs
+++ b/integrations/duckduckgo/src/client.rs
@@ -1,5 +1,6 @@
 //! DuckDuckGo Instant Answer API client.
 
+use serde::de::{self, Deserializer};
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 
@@ -23,7 +24,8 @@ pub struct InstantAnswerResponse {
     pub abstract_url: String,
 
     /// Instant answer text.
-    #[serde(rename = "Answer", default)]
+    /// DuckDuckGo returns this as a string or an object depending on query type.
+    #[serde(rename = "Answer", default, deserialize_with = "string_or_stringify")]
     pub answer: String,
 
     /// Type of answer (e.g. "calc", "color", "ip", etc.).
@@ -93,6 +95,21 @@ impl TopicResult {
     /// Whether this is a topic group (has nested topics).
     pub fn is_group(&self) -> bool {
         !self.topics.is_empty()
+    }
+}
+
+/// Deserialize a value that may be a string or an object (stringify objects).
+/// DuckDuckGo API returns `Answer` as a string for some queries and as an
+/// object for others (e.g. calculations).
+fn string_or_stringify<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer).map_err(de::Error::custom)?;
+    match value {
+        serde_json::Value::String(s) => Ok(s),
+        serde_json::Value::Null => Ok(String::new()),
+        other => Ok(other.to_string()),
     }
 }
 
@@ -380,5 +397,25 @@ mod tests {
         assert!(response.heading.is_empty());
         assert!(response.related_topics.is_empty());
         assert!(response.results.is_empty());
+    }
+
+    #[test]
+    fn test_response_answer_as_object() {
+        // DuckDuckGo returns Answer as an object for some queries (e.g. calculations)
+        let json = r#"{
+            "Answer": {"data": "2+2=4", "type": "calc"},
+            "Heading": "2+2",
+            "Type": ""
+        }"#;
+        let response: InstantAnswerResponse = serde_json::from_str(json).unwrap();
+        assert!(!response.answer.is_empty());
+        assert!(response.answer.contains("2+2=4"));
+    }
+
+    #[test]
+    fn test_response_answer_as_null() {
+        let json = r#"{"Answer": null}"#;
+        let response: InstantAnswerResponse = serde_json::from_str(json).unwrap();
+        assert!(response.answer.is_empty());
     }
 }

--- a/integrations/duckduckgo/src/lib.rs
+++ b/integrations/duckduckgo/src/lib.rs
@@ -1,0 +1,136 @@
+//! DuckDuckGo Integration (Experimental)
+//!
+//! Instant answers via DuckDuckGo Instant Answer API.
+//! Provides `duckduckgo_search` tool for agents to get instant answers,
+//! abstracts, related topics, and definitions.
+//!
+//! Decision: External integration crate, auto-registered via inventory plugin system
+//! Decision: No API key required — DuckDuckGo Instant Answer API is free
+//! Decision: Stateless — no per-resource state management needed
+
+pub mod client;
+mod tools;
+
+use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin};
+use everruns_core::tools::Tool;
+
+use tools::DuckDuckGoSearchTool;
+
+// ============================================================================
+// Integration Plugin Registration
+// ============================================================================
+
+inventory::submit! {
+    IntegrationPlugin {
+        experimental_only: true,
+        factory: || Box::new(DuckDuckGoCapability),
+    }
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const DUCKDUCKGO_API_BASE: &str = "https://api.duckduckgo.com";
+
+// ============================================================================
+// DuckDuckGoCapability
+// ============================================================================
+
+pub struct DuckDuckGoCapability;
+
+impl Capability for DuckDuckGoCapability {
+    fn id(&self) -> &str {
+        "duckduckgo"
+    }
+
+    fn name(&self) -> &str {
+        "[Experimental] DuckDuckGo"
+    }
+
+    fn description(&self) -> &str {
+        "Search for instant answers using DuckDuckGo Instant Answer API. \
+         Agents can get abstracts, definitions, related topics, and direct answers. \
+         EXPERIMENTAL: This capability may change."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("search")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Network")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(
+            r#"## DuckDuckGo (Experimental)
+
+Instant answers via DuckDuckGo Instant Answer API. Use this to get quick facts, definitions, abstracts (from Wikipedia and other sources), and related topics.
+
+No API key required — the DuckDuckGo Instant Answer API is free.
+
+Tools:
+- `duckduckgo_search` - Get instant answers, abstracts, and related topics for a query
+
+Note: This returns curated instant answers, not full web search results. For comprehensive web search, use Brave Search if available."#,
+        )
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![Box::new(DuckDuckGoSearchTool)]
+    }
+
+    fn dependencies(&self) -> Vec<&'static str> {
+        vec![]
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::capabilities::CapabilityStatus;
+
+    #[test]
+    fn test_capability_metadata() {
+        let cap = DuckDuckGoCapability;
+        assert_eq!(cap.id(), "duckduckgo");
+        assert_eq!(cap.name(), "[Experimental] DuckDuckGo");
+        assert_eq!(cap.status(), CapabilityStatus::Available);
+        assert_eq!(cap.icon(), Some("search"));
+        assert_eq!(cap.category(), Some("Network"));
+    }
+
+    #[test]
+    fn test_capability_has_all_tools() {
+        let cap = DuckDuckGoCapability;
+        let tools = cap.tools();
+        assert_eq!(tools.len(), 1);
+
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(names.contains(&"duckduckgo_search"));
+    }
+
+    #[test]
+    fn test_capability_has_system_prompt() {
+        let cap = DuckDuckGoCapability;
+        let prompt = cap.system_prompt_addition().unwrap();
+        assert!(prompt.contains("duckduckgo_search"));
+        assert!(prompt.contains("DuckDuckGo"));
+        assert!(prompt.contains("Experimental"));
+    }
+
+    #[test]
+    fn test_capability_no_dependencies() {
+        let cap = DuckDuckGoCapability;
+        assert!(cap.dependencies().is_empty());
+    }
+}

--- a/integrations/duckduckgo/src/tools.rs
+++ b/integrations/duckduckgo/src/tools.rs
@@ -1,0 +1,433 @@
+//! Tool implementations for DuckDuckGo operations.
+
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::traits::ToolContext;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use crate::client::DuckDuckGoClient;
+
+// ============================================================================
+// DuckDuckGoSearchTool
+// ============================================================================
+
+pub struct DuckDuckGoSearchTool;
+
+#[async_trait]
+impl Tool for DuckDuckGoSearchTool {
+    fn name(&self) -> &str {
+        "duckduckgo_search"
+    }
+
+    fn description(&self) -> &str {
+        "Get instant answers from DuckDuckGo. Returns abstracts (from Wikipedia and other sources), \
+         definitions, direct answers, and related topics. \
+         No API key required."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Search query string"
+                },
+                "no_html": {
+                    "type": "boolean",
+                    "description": "Strip HTML from result text (default: true)",
+                    "default": true
+                }
+            },
+            "required": ["query"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let query = match arguments.get("query").and_then(|v| v.as_str()) {
+            Some(q) if !q.is_empty() => q,
+            _ => {
+                return ToolExecutionResult::tool_error("Missing required parameter: query");
+            }
+        };
+
+        let no_html = arguments
+            .get("no_html")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+
+        let client = DuckDuckGoClient::new();
+
+        match client.instant_answer(query, no_html).await {
+            Ok(response) => format_response(query, &response),
+            Err(e) => ToolExecutionResult::tool_error(e),
+        }
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        _context: &ToolContext,
+    ) -> ToolExecutionResult {
+        // No context needed — DuckDuckGo API is free, no API key required.
+        self.execute(arguments).await
+    }
+
+    fn requires_context(&self) -> bool {
+        false
+    }
+}
+
+/// Format the DuckDuckGo API response into the tool result.
+fn format_response(
+    query: &str,
+    response: &crate::client::InstantAnswerResponse,
+) -> ToolExecutionResult {
+    let mut result = json!({
+        "query": query,
+        "type": match response.response_type.as_str() {
+            "A" => "article",
+            "D" => "disambiguation",
+            "C" => "category",
+            "N" => "name",
+            "E" => "exclusive",
+            "" => "nothing",
+            other => other,
+        },
+    });
+
+    // Abstract (Wikipedia-style summary)
+    if !response.r#abstract.is_empty() {
+        result["abstract"] = json!({
+            "text": response.r#abstract,
+            "source": response.abstract_source,
+            "url": response.abstract_url,
+        });
+    }
+
+    // Heading
+    if !response.heading.is_empty() {
+        result["heading"] = json!(response.heading);
+    }
+
+    // Direct answer (calculations, IP, etc.)
+    if !response.answer.is_empty() {
+        result["answer"] = json!({
+            "text": response.answer,
+            "type": response.answer_type,
+        });
+    }
+
+    // Definition
+    if !response.definition.is_empty() {
+        result["definition"] = json!({
+            "text": response.definition,
+            "source": response.definition_source,
+            "url": response.definition_url,
+        });
+    }
+
+    // Related topics (flatten groups into a single list, limit to keep output reasonable)
+    let mut topics: Vec<Value> = Vec::new();
+    for topic in &response.related_topics {
+        if topic.is_direct() {
+            topics.push(json!({
+                "text": topic.text,
+                "url": topic.first_url,
+            }));
+        } else if topic.is_group() {
+            for nested in &topic.topics {
+                if nested.is_direct() {
+                    topics.push(json!({
+                        "text": nested.text,
+                        "url": nested.first_url,
+                    }));
+                }
+            }
+        }
+        if topics.len() >= 10 {
+            break;
+        }
+    }
+    if !topics.is_empty() {
+        result["related_topics"] = json!(topics);
+    }
+
+    // Official results
+    let results: Vec<Value> = response
+        .results
+        .iter()
+        .filter(|r| r.is_direct())
+        .map(|r| {
+            json!({
+                "text": r.text,
+                "url": r.first_url,
+            })
+        })
+        .collect();
+    if !results.is_empty() {
+        result["results"] = json!(results);
+    }
+
+    ToolExecutionResult::success(result)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_tool_name() {
+        let tool = DuckDuckGoSearchTool;
+        assert_eq!(tool.name(), "duckduckgo_search");
+    }
+
+    #[test]
+    fn test_tool_has_description() {
+        let tool = DuckDuckGoSearchTool;
+        assert!(!tool.description().is_empty());
+        assert!(tool.description().contains("DuckDuckGo"));
+    }
+
+    #[test]
+    fn test_tool_does_not_require_context() {
+        let tool = DuckDuckGoSearchTool;
+        assert!(!tool.requires_context());
+    }
+
+    #[test]
+    fn test_search_schema_has_required_query() {
+        let tool = DuckDuckGoSearchTool;
+        let schema = tool.parameters_schema();
+        let required = schema["required"].as_array().unwrap();
+        let required_strs: Vec<&str> = required.iter().map(|v| v.as_str().unwrap()).collect();
+        assert!(required_strs.contains(&"query"));
+        assert_eq!(required_strs.len(), 1);
+    }
+
+    #[test]
+    fn test_search_schema_has_no_html_field() {
+        let tool = DuckDuckGoSearchTool;
+        let schema = tool.parameters_schema();
+        assert!(schema["properties"]["no_html"].is_object());
+    }
+
+    #[test]
+    fn test_search_schema_disallows_additional_properties() {
+        let tool = DuckDuckGoSearchTool;
+        let schema = tool.parameters_schema();
+        assert_eq!(schema["additionalProperties"], json!(false));
+    }
+
+    #[tokio::test]
+    async fn test_missing_query() {
+        let tool = DuckDuckGoSearchTool;
+        let result = tool.execute(json!({})).await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(
+                    msg.contains("Missing required parameter"),
+                    "Expected missing param error, got: {msg}"
+                );
+            }
+            _ => panic!("Expected ToolError for missing query"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_empty_query() {
+        let tool = DuckDuckGoSearchTool;
+        let result = tool.execute(json!({"query": ""})).await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(
+                    msg.contains("Missing required parameter"),
+                    "Expected missing param error, got: {msg}"
+                );
+            }
+            _ => panic!("Expected ToolError for empty query"),
+        }
+    }
+
+    #[test]
+    fn test_format_response_article() {
+        let response = crate::client::InstantAnswerResponse {
+            r#abstract: "Rust is a programming language.".to_string(),
+            abstract_source: "Wikipedia".to_string(),
+            abstract_url: "https://en.wikipedia.org/wiki/Rust".to_string(),
+            answer: String::new(),
+            answer_type: String::new(),
+            definition: String::new(),
+            definition_source: String::new(),
+            definition_url: String::new(),
+            heading: "Rust (programming language)".to_string(),
+            response_type: "A".to_string(),
+            related_topics: vec![crate::client::TopicResult {
+                text: "Cargo".to_string(),
+                first_url: "https://doc.rust-lang.org/cargo/".to_string(),
+                name: String::new(),
+                topics: vec![],
+            }],
+            results: vec![crate::client::TopicResult {
+                text: "Official site".to_string(),
+                first_url: "https://www.rust-lang.org/".to_string(),
+                name: String::new(),
+                topics: vec![],
+            }],
+        };
+
+        let result = format_response("rust", &response);
+        match result {
+            ToolExecutionResult::Success(val) => {
+                assert_eq!(val["query"], "rust");
+                assert_eq!(val["type"], "article");
+                assert_eq!(val["heading"], "Rust (programming language)");
+                assert_eq!(val["abstract"]["text"], "Rust is a programming language.");
+                assert_eq!(val["abstract"]["source"], "Wikipedia");
+                assert_eq!(val["related_topics"].as_array().unwrap().len(), 1);
+                assert_eq!(val["results"].as_array().unwrap().len(), 1);
+            }
+            _ => panic!("Expected Success result"),
+        }
+    }
+
+    #[test]
+    fn test_format_response_empty() {
+        let response = crate::client::InstantAnswerResponse {
+            r#abstract: String::new(),
+            abstract_source: String::new(),
+            abstract_url: String::new(),
+            answer: String::new(),
+            answer_type: String::new(),
+            definition: String::new(),
+            definition_source: String::new(),
+            definition_url: String::new(),
+            heading: String::new(),
+            response_type: String::new(),
+            related_topics: vec![],
+            results: vec![],
+        };
+
+        let result = format_response("nonexistent", &response);
+        match result {
+            ToolExecutionResult::Success(val) => {
+                assert_eq!(val["query"], "nonexistent");
+                assert_eq!(val["type"], "nothing");
+                assert!(val.get("abstract").is_none());
+                assert!(val.get("heading").is_none());
+                assert!(val.get("answer").is_none());
+                assert!(val.get("related_topics").is_none());
+                assert!(val.get("results").is_none());
+            }
+            _ => panic!("Expected Success result"),
+        }
+    }
+
+    #[test]
+    fn test_format_response_with_answer() {
+        let response = crate::client::InstantAnswerResponse {
+            r#abstract: String::new(),
+            abstract_source: String::new(),
+            abstract_url: String::new(),
+            answer: "42".to_string(),
+            answer_type: "calc".to_string(),
+            definition: String::new(),
+            definition_source: String::new(),
+            definition_url: String::new(),
+            heading: String::new(),
+            response_type: String::new(),
+            related_topics: vec![],
+            results: vec![],
+        };
+
+        let result = format_response("6*7", &response);
+        match result {
+            ToolExecutionResult::Success(val) => {
+                assert_eq!(val["answer"]["text"], "42");
+                assert_eq!(val["answer"]["type"], "calc");
+            }
+            _ => panic!("Expected Success result"),
+        }
+    }
+
+    #[test]
+    fn test_format_response_with_definition() {
+        let response = crate::client::InstantAnswerResponse {
+            r#abstract: String::new(),
+            abstract_source: String::new(),
+            abstract_url: String::new(),
+            answer: String::new(),
+            answer_type: String::new(),
+            definition: "A test is an assessment.".to_string(),
+            definition_source: "Wiktionary".to_string(),
+            definition_url: "https://en.wiktionary.org/wiki/test".to_string(),
+            heading: "Test".to_string(),
+            response_type: String::new(),
+            related_topics: vec![],
+            results: vec![],
+        };
+
+        let result = format_response("test", &response);
+        match result {
+            ToolExecutionResult::Success(val) => {
+                assert_eq!(val["definition"]["text"], "A test is an assessment.");
+                assert_eq!(val["definition"]["source"], "Wiktionary");
+            }
+            _ => panic!("Expected Success result"),
+        }
+    }
+
+    #[test]
+    fn test_format_response_flattens_topic_groups() {
+        let response = crate::client::InstantAnswerResponse {
+            r#abstract: String::new(),
+            abstract_source: String::new(),
+            abstract_url: String::new(),
+            answer: String::new(),
+            answer_type: String::new(),
+            definition: String::new(),
+            definition_source: String::new(),
+            definition_url: String::new(),
+            heading: String::new(),
+            response_type: "D".to_string(),
+            related_topics: vec![
+                crate::client::TopicResult {
+                    text: "Direct topic".to_string(),
+                    first_url: "https://example.com/1".to_string(),
+                    name: String::new(),
+                    topics: vec![],
+                },
+                crate::client::TopicResult {
+                    text: String::new(),
+                    first_url: String::new(),
+                    name: "Category".to_string(),
+                    topics: vec![crate::client::TopicResult {
+                        text: "Nested topic".to_string(),
+                        first_url: "https://example.com/2".to_string(),
+                        name: String::new(),
+                        topics: vec![],
+                    }],
+                },
+            ],
+            results: vec![],
+        };
+
+        let result = format_response("test", &response);
+        match result {
+            ToolExecutionResult::Success(val) => {
+                let topics = val["related_topics"].as_array().unwrap();
+                assert_eq!(topics.len(), 2);
+                assert_eq!(topics[0]["text"], "Direct topic");
+                assert_eq!(topics[1]["text"], "Nested topic");
+            }
+            _ => panic!("Expected Success result"),
+        }
+    }
+}

--- a/integrations/duckduckgo/tests/plugin_registration.rs
+++ b/integrations/duckduckgo/tests/plugin_registration.rs
@@ -1,0 +1,69 @@
+//! Integration test: verify DuckDuckGo plugin registers via inventory.
+
+use everruns_core::capabilities::{CapabilityRegistry, IntegrationPlugin};
+use everruns_core::deployment::DeploymentGrade;
+
+// Force linker to include the integration crate's inventory submissions.
+use everruns_integrations_duckduckgo as _;
+
+#[test]
+fn test_duckduckgo_plugin_is_submitted() {
+    let plugins: Vec<&IntegrationPlugin> = inventory::iter::<IntegrationPlugin>().collect();
+    assert!(
+        plugins.iter().any(|p| {
+            let cap = (p.factory)();
+            cap.id() == "duckduckgo"
+        }),
+        "DuckDuckGo IntegrationPlugin should be submitted via inventory"
+    );
+}
+
+#[test]
+fn test_duckduckgo_plugin_is_experimental() {
+    let plugins: Vec<&IntegrationPlugin> = inventory::iter::<IntegrationPlugin>().collect();
+    let duckduckgo = plugins
+        .iter()
+        .find(|p| {
+            let cap = (p.factory)();
+            cap.id() == "duckduckgo"
+        })
+        .expect("DuckDuckGo plugin not found");
+
+    assert!(
+        duckduckgo.experimental_only,
+        "DuckDuckGo should be marked experimental_only"
+    );
+}
+
+#[test]
+fn test_duckduckgo_registered_in_dev_registry() {
+    let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
+    assert!(
+        registry.has("duckduckgo"),
+        "DuckDuckGo should be in dev registry"
+    );
+}
+
+#[test]
+fn test_duckduckgo_not_registered_in_prod_registry() {
+    let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Prod);
+    assert!(
+        !registry.has("duckduckgo"),
+        "DuckDuckGo should NOT be in prod registry"
+    );
+}
+
+#[test]
+fn test_duckduckgo_capability_metadata() {
+    let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
+    let cap = registry
+        .get("duckduckgo")
+        .expect("DuckDuckGo capability not found");
+
+    assert_eq!(cap.id(), "duckduckgo");
+    assert_eq!(cap.name(), "[Experimental] DuckDuckGo");
+    assert_eq!(cap.icon(), Some("search"));
+    assert_eq!(cap.category(), Some("Network"));
+    assert!(cap.dependencies().is_empty());
+    assert_eq!(cap.tools().len(), 1);
+}

--- a/integrations/duckduckgo/tests/smoke_real_api.rs
+++ b/integrations/duckduckgo/tests/smoke_real_api.rs
@@ -1,0 +1,78 @@
+//! Real API smoke tests for DuckDuckGo.
+//!
+//! Gated behind `integration` feature — only compiled when run with:
+//!   cargo test -p everruns-integrations-duckduckgo --features integration
+//!
+//! DuckDuckGo Instant Answer API is free and requires no API key,
+//! but we gate these tests to avoid hitting the API in every CI run.
+
+#![cfg(feature = "integration")]
+
+use everruns_integrations_duckduckgo::client::DuckDuckGoClient;
+
+#[tokio::test]
+async fn smoke_basic_search() {
+    let client = DuckDuckGoClient::new();
+
+    let resp = client
+        .instant_answer("Rust programming language", false)
+        .await
+        .expect("search should succeed");
+
+    // Should return an article-type response for a well-known topic
+    assert!(
+        !resp.heading.is_empty() || !resp.r#abstract.is_empty(),
+        "should return some content for a well-known query"
+    );
+}
+
+#[tokio::test]
+async fn smoke_calculation_answer() {
+    let client = DuckDuckGoClient::new();
+
+    let resp = client
+        .instant_answer("2+2", false)
+        .await
+        .expect("calculation query should succeed");
+
+    // DuckDuckGo may or may not return an answer for simple calculations,
+    // but the API call should succeed without error.
+    let _ = resp;
+}
+
+#[tokio::test]
+async fn smoke_no_html_mode() {
+    let client = DuckDuckGoClient::new();
+
+    let resp = client
+        .instant_answer("HTML", true)
+        .await
+        .expect("no_html search should succeed");
+
+    // With no_html=true, abstract text should not contain HTML tags
+    if !resp.r#abstract.is_empty() {
+        assert!(
+            !resp.r#abstract.contains("<a href="),
+            "no_html mode should strip HTML tags"
+        );
+    }
+}
+
+#[tokio::test]
+async fn smoke_disambiguation() {
+    let client = DuckDuckGoClient::new();
+
+    let resp = client
+        .instant_answer("Mercury", false)
+        .await
+        .expect("disambiguation query should succeed");
+
+    // Mercury is ambiguous (planet, element, god) — should return related topics
+    // or a disambiguation type response
+    let has_content =
+        !resp.heading.is_empty() || !resp.related_topics.is_empty() || !resp.r#abstract.is_empty();
+    assert!(
+        has_content,
+        "should return some content for ambiguous query"
+    );
+}

--- a/specs/duckduckgo.md
+++ b/specs/duckduckgo.md
@@ -1,0 +1,147 @@
+# DuckDuckGo Capability Specification
+
+## Abstract
+
+The DuckDuckGo capability integrates [DuckDuckGo Instant Answer API](https://api.duckduckgo.com/api) as an agent tool. Agents can get instant answers, abstracts (from Wikipedia and other sources), definitions, and related topics. Stateless — no per-resource state management needed.
+
+**Status**: Experimental (Dev only)
+
+## Architecture
+
+### Single API
+
+DuckDuckGo exposes one API layer:
+
+1. **Instant Answer API** (`https://api.duckduckgo.com/`) — get instant answers. Auth: none (free, no API key required).
+
+```
+┌────────────────────────────────────────────┐
+│              Agent Session                  │
+│                                             │
+│  Tool Call (duckduckgo_search)             │
+│         ↓                                   │
+│  No API key needed                         │
+│         ↓                                   │
+│  ┌─────────────────────────────────────┐   │
+│  │ DuckDuckGoClient                    │   │
+│  │  - Instant Answer API               │   │
+│  └─────────────────────────────────────┘   │
+│         ↓                                   │
+│  Return results to agent                   │
+└────────────────────────────────────────────┘
+```
+
+### No API Key Required
+
+The DuckDuckGo Instant Answer API is free and requires no authentication. This makes it simpler than Brave Search — no connection resolver or session secrets needed. The tool does not require context (`requires_context() = false`).
+
+## Tools
+
+### duckduckgo_search
+
+Get instant answers from DuckDuckGo.
+
+- **Parameters**:
+  - `query`: string (required) — search query
+  - `no_html`: boolean (optional, default: true) — strip HTML from result text
+- **Returns**: Object with available fields:
+  - `query`: the original query
+  - `type`: response type — `article`, `disambiguation`, `category`, `name`, `exclusive`, or `nothing`
+  - `heading`: topic heading (if available)
+  - `abstract`: `{ text, source, url }` — topic summary from Wikipedia or other sources
+  - `answer`: `{ text, type }` — direct answer (calculations, IP lookups, etc.)
+  - `definition`: `{ text, source, url }` — dictionary definition
+  - `related_topics`: array of `{ text, url }` — related topics (flattened from groups, max 10)
+  - `results`: array of `{ text, url }` — official/direct results
+
+## Security
+
+- **No API key**: The DuckDuckGo Instant Answer API is free and public. No secrets to manage.
+- **Rate limiting**: Deferred to DuckDuckGo API. No formal rate limit documented, but excessive use may be throttled.
+
+## Error Handling
+
+| Scenario | Result Type | Message |
+|----------|-------------|---------|
+| Missing query param | `ToolError` | "Missing required parameter: query" |
+| HTTP error | `ToolError` | "DuckDuckGo API error ({status}): ..." |
+| Network error | `ToolError` | "Failed to connect to DuckDuckGo API: ..." |
+
+## Design Decisions
+
+### No API key (unlike Brave Search)
+
+DuckDuckGo Instant Answer API is free and public. No connection resolver or session secrets needed. This simplifies the integration significantly and means `requires_context() = false`.
+
+### Instant answers (not web search results)
+
+DuckDuckGo does not offer an official API for full organic web search results. The Instant Answer API returns curated content: abstracts, definitions, calculations, and related topics. For comprehensive web search, agents should use Brave Search. DuckDuckGo complements Brave Search for quick facts and definitions.
+
+### Stateless (no per-resource state)
+
+Like Brave Search, DuckDuckGo is stateless. Each query is independent.
+
+### no_html defaults to true
+
+HTML in results is stripped by default since agents process plain text. The parameter is exposed in case HTML content is desired.
+
+### Related topics limited to 10
+
+The API can return many related topics, especially for disambiguation queries. We cap at 10 to keep tool output reasonable for LLM context windows.
+
+## Testing
+
+### Unit & mock tests
+
+Run without flags — no API key needed:
+
+```bash
+cargo test -p everruns-integrations-duckduckgo
+```
+
+Uses `wiremock` for HTTP-level assertions.
+
+### Integration tests (real API)
+
+Gated behind the `integration` Cargo feature so they never compile in normal `cargo test` runs:
+
+```bash
+cargo test -p everruns-integrations-duckduckgo --features integration
+```
+
+Tests: `smoke_basic_search`, `smoke_calculation_answer`, `smoke_no_html_mode`, `smoke_disambiguation` in `tests/smoke_real_api.rs`.
+
+No API key is needed even for integration tests (the DuckDuckGo API is free), but we gate them to avoid hitting the API in every CI run.
+
+### CI
+
+Dedicated workflow `.github/workflows/duckduckgo-integration.yml`:
+
+- **Path-filtered**: only triggers when `integrations/duckduckgo/**` changes.
+- No secrets needed (free API).
+- Passes `--features integration` to compile and run the real-API tests.
+
+## Crate Structure
+
+`integrations/duckduckgo/` → `everruns-integrations-duckduckgo`
+
+External integration crate, auto-registered via `inventory::submit!` plugin system.
+
+**Force-link required**: Both `crates/server/src/lib.rs` and `crates/worker/src/lib.rs` must contain `extern crate everruns_integrations_duckduckgo;`.
+
+| File | Purpose |
+|------|---------|
+| `src/lib.rs` | Plugin registration, constants, `DuckDuckGoCapability` impl |
+| `src/client.rs` | `DuckDuckGoClient` HTTP client, API response types |
+| `src/tools.rs` | `DuckDuckGoSearchTool` implementation, response formatting |
+| `tests/plugin_registration.rs` | Integration tests for inventory registration and dev/prod gating |
+| `tests/smoke_real_api.rs` | Real-API smoke tests (behind `integration` feature) |
+
+## Capability Registration
+
+- **ID**: `duckduckgo`
+- **Name**: `[Experimental] DuckDuckGo`
+- **Status**: Available (Dev only)
+- **Icon**: `search`
+- **Category**: `Network`
+- **Dependencies**: none


### PR DESCRIPTION
## What
Add DuckDuckGo Instant Answer API integration as an experimental capability. Agents can search for instant answers, definitions, abstracts (from Wikipedia and other sources), and related topics.

## Why
Provides a free, no-API-key-required web search capability for agents. Complements Brave Search (which requires an API key) with a zero-config alternative suitable for quick facts and definitions.

## How
- New `integrations/duckduckgo/` crate with client, tool, and capability registration
- Uses the DuckDuckGo Instant Answer API (free, no key required)
- Registered via `inventory` plugin system, auto-discovered at startup
- Gated behind `DeploymentGrade::Dev` (experimental only)
- `duckduckgo_search` tool with `query` and `no_html` parameters
- Formats responses with heading, abstract, answer, definition, and related topics
- 26 unit tests + 5 integration tests (plugin registration)
- Docs page at `docs/integrations/duckduckgo.md`
- Spec at `specs/duckduckgo.md`

## Risk
- Low
- No impact on existing capabilities; experimental-only, gated behind dev mode
- No API key required, so no secret management concerns
- DuckDuckGo API is free and rate-limit-friendly

## Checklist
- [x] Tests added or updated (31 tests: 26 unit + 5 integration)
- [x] Backward compatibility considered (new feature, no breaking changes)
- [x] Smoke tested in dev mode (E2E: agent creation, session, tool call, response)
- [x] Spec added (`specs/duckduckgo.md`)
- [x] Docs added (`docs/integrations/duckduckgo.md`)
- [x] pre-push checks pass