### PR TITLE
feat(ui): add Playwright smoke tests for deployed environments

### DIFF
--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -66,6 +66,20 @@ curl -s -X POST "http://localhost:9300/api/v1/agents" \
   -d '{"name": "Test", "system_prompt": "You are helpful."}' | jq '.id'
 ```
 
+### 6. Deployed Environment Smoke Tests
+
+```bash
+# Against dev.everruns.com (cloud agent with Doppler)
+PLAYWRIGHT_CHROMIUM_PATH=/root/.cache/ms-playwright/chromium-1194/chrome-linux/chrome \
+  doppler run -- npx playwright test --project smoke
+
+# Against custom URL
+SMOKE_BASE_URL=https://staging.everruns.com \
+  npx playwright test --project smoke
+```
+
+Tests health, auth config, login page. Password-auth tests auto-skip on external auth deployments. See `specs/smoke-test-spec.md`.
+
 ## Full API Reference
 
 See https://docs.everruns.com for complete API documentation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,7 @@ Fix root cause. Unsure: read more code; if stuck, ask w/ short options. Unrecogn
 - `specs/codesandbox.md` - CodeSandbox cloud sandbox integration
 - `specs/infinity-context.md` - Unlimited conversation length via context management
 - `specs/load-testing.md` - End-to-end load testing framework and benchmarking process
+- `specs/smoke-test-spec.md` - Playwright smoke tests for deployed environments
 
 ### Skills
 

--- a/apps/ui/e2e/smoke.spec.ts
+++ b/apps/ui/e2e/smoke.spec.ts
@@ -1,0 +1,123 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Smoke tests for deployed environments (e.g., dev.everruns.com).
+ *
+ * Run:
+ *   doppler run -- npx playwright test --project smoke
+ *
+ * Required env:
+ *   SMOKE_BASE_URL (or defaults to https://dev.everruns.com)
+ *   TEST_USER_1_PASSWORD (for admin/full auth modes with password login)
+ *
+ * Works with auth modes: none, admin, full, external
+ */
+
+const TEST_EMAIL = process.env.TEST_USER_1_EMAIL || "aliceeverruns@gmail.com";
+
+// Fetch auth config once and cache
+let authConfig: { mode: string; password_auth_enabled: boolean } | null = null;
+
+async function getAuthConfig(
+  request: import("@playwright/test").APIRequestContext,
+): Promise<typeof authConfig> {
+  if (authConfig) return authConfig;
+  const resp = await request.get("/api/v1/auth/config");
+  expect(resp.ok()).toBeTruthy();
+  authConfig = await resp.json();
+  return authConfig;
+}
+
+test.describe("Smoke: health", () => {
+  test("health endpoint returns ok", async ({ request }) => {
+    const resp = await request.get("/health");
+    expect(resp.ok()).toBeTruthy();
+    const body = await resp.json();
+    expect(body.status).toBe("ok");
+  });
+
+  test("auth config endpoint returns valid config", async ({ request }) => {
+    const resp = await request.get("/api/v1/auth/config");
+    expect(resp.ok()).toBeTruthy();
+    const body = await resp.json();
+    expect(body.mode).toBeTruthy();
+    expect(["none", "admin", "full", "external"]).toContain(body.mode);
+  });
+});
+
+test.describe("Smoke: login flow", () => {
+  test("login page loads", async ({ page }) => {
+    await page.goto("/login");
+    // Login page should show the Everruns branding regardless of auth mode
+    // In "none" mode it may redirect to dashboard
+    await page.waitForLoadState("networkidle");
+    const url = page.url();
+    expect(url).toMatch(/\/(login|dashboard)/);
+  });
+
+  test("password login and dashboard", async ({ page, request }) => {
+    const config = await getAuthConfig(request);
+
+    // Skip if password auth is not enabled
+    test.skip(
+      !config!.password_auth_enabled,
+      "Password auth not enabled (auth mode: " + config!.mode + ")",
+    );
+
+    await page.goto("/login");
+    await expect(page.getByText("Welcome back")).toBeVisible({ timeout: 15000 });
+
+    await page.getByLabel("Email").fill(TEST_EMAIL);
+    await page.getByLabel("Password").fill(process.env.TEST_USER_1_PASSWORD!);
+    await page.getByRole("button", { name: "Sign in" }).click();
+
+    await expect(page).toHaveURL(/\/dashboard/, { timeout: 15000 });
+    await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible({ timeout: 10000 });
+  });
+
+  test("navigate to agents page after login", async ({ page, request }) => {
+    const config = await getAuthConfig(request);
+    test.skip(!config!.password_auth_enabled, "Password auth not enabled");
+
+    await loginWithPassword(page);
+
+    await page.getByRole("link", { name: "Agents" }).first().click();
+    await expect(page).toHaveURL(/\/agents/, { timeout: 10000 });
+    await expect(page.getByRole("heading", { name: "Agents" })).toBeVisible({ timeout: 10000 });
+  });
+
+  test("navigate to sessions page after login", async ({ page, request }) => {
+    const config = await getAuthConfig(request);
+    test.skip(!config!.password_auth_enabled, "Password auth not enabled");
+
+    await loginWithPassword(page);
+
+    await page.getByRole("link", { name: "Sessions" }).first().click();
+    await expect(page).toHaveURL(/\/sessions/, { timeout: 10000 });
+    await expect(page.getByRole("heading", { name: "Sessions" })).toBeVisible({ timeout: 10000 });
+  });
+
+  test("logout after login", async ({ page, request }) => {
+    const config = await getAuthConfig(request);
+    test.skip(!config!.password_auth_enabled, "Password auth not enabled");
+
+    await loginWithPassword(page);
+
+    const userName = process.env.TEST_USER_1_NAME || "Alice Everruns";
+    await page.getByText(userName).click();
+    await page.getByRole("menuitem", { name: /sign out/i }).click();
+
+    await expect(page).toHaveURL(/\/login/, { timeout: 10000 });
+  });
+});
+
+/** Helper: password login and wait for dashboard */
+async function loginWithPassword(page: import("@playwright/test").Page) {
+  await page.goto("/login");
+  await expect(page.getByText("Welcome back")).toBeVisible({ timeout: 15000 });
+  await page.getByLabel("Email").fill(TEST_EMAIL);
+  await page.getByLabel("Password").fill(process.env.TEST_USER_1_PASSWORD!);
+  await page.getByRole("button", { name: "Sign in" }).click();
+  await expect(page).toHaveURL(/\/dashboard/, { timeout: 15000 });
+  await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible({ timeout: 10000 });
+}

--- a/apps/ui/playwright.config.ts
+++ b/apps/ui/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig, devices } from "@playwright/test";
 
 /**
  * Playwright configuration for UI e2e tests.
@@ -7,10 +7,37 @@ import { defineConfig, devices } from '@playwright/test';
  *   npm run e2e          # Run tests
  *   npm run e2e:ui       # Run with UI mode
  *   npm run e2e:headed   # Run in headed mode
+ *   doppler run -- npx playwright test --project smoke  # Smoke tests
  */
+
+const chromiumArgs = [
+  "--no-sandbox",
+  "--disable-setuid-sandbox",
+  "--disable-gpu",
+  "--disable-software-rasterizer",
+  "--disable-dev-shm-usage",
+  "--single-process",
+];
+
+// Parse proxy from environment (used by smoke tests in cloud agents).
+// Proxy URL format: http://user:pass@host:port
+function parseProxy(envUrl?: string) {
+  if (!envUrl) return undefined;
+  try {
+    const url = new URL(envUrl);
+    const server = `${url.protocol}//${url.hostname}:${url.port}`;
+    const username = decodeURIComponent(url.username) || undefined;
+    const password = decodeURIComponent(url.password) || undefined;
+    return { server, username, password };
+  } catch {
+    return { server: envUrl };
+  }
+}
+const proxy = parseProxy(process.env.HTTPS_PROXY || process.env.https_proxy);
+
 export default defineConfig({
-  testDir: './e2e',
-  outputDir: './e2e/test-results',
+  testDir: "./e2e",
+  outputDir: "./e2e/test-results",
 
   // Run tests in parallel
   fullyParallel: true,
@@ -25,49 +52,57 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
 
   // Reporter to use
-  reporter: [
-    ['html', { outputFolder: './e2e/playwright-report' }],
-    ['list'],
-  ],
+  reporter: [["html", { outputFolder: "./e2e/playwright-report" }], ["list"]],
 
   // Shared settings for all projects
   use: {
     // Base URL to use in actions like `await page.goto('/')`
-    baseURL: 'http://localhost:9100',
+    baseURL: "http://localhost:9100",
 
     // Collect trace when retrying the failed test
-    trace: 'on-first-retry',
+    trace: "on-first-retry",
 
     // Take screenshot on failure
-    screenshot: 'only-on-failure',
+    screenshot: "only-on-failure",
   },
 
   // Configure projects for browsers
   projects: [
     {
-      name: 'chromium',
+      name: "chromium",
+      testIgnore: "smoke.spec.ts",
       use: {
-        ...devices['Desktop Chrome'],
-        // Use older chromium that works in restricted environments
+        ...devices["Desktop Chrome"],
         launchOptions: {
           executablePath: process.env.PLAYWRIGHT_CHROMIUM_PATH,
-          args: [
-            '--no-sandbox',
-            '--disable-setuid-sandbox',
-            '--disable-gpu',
-            '--disable-software-rasterizer',
-            '--disable-dev-shm-usage',
-            '--single-process',
-          ],
+          args: chromiumArgs,
+        },
+      },
+    },
+    // Smoke tests against deployed environments (e.g., dev.everruns.com)
+    // Run: doppler run -- npx playwright test --project smoke
+    {
+      name: "smoke",
+      testMatch: "smoke.spec.ts",
+      use: {
+        ...devices["Desktop Chrome"],
+        baseURL: process.env.SMOKE_BASE_URL || "https://dev.everruns.com",
+        // Forward proxy from environment so tests work in cloud agents
+        ...(proxy ? { proxy } : {}),
+        // Accept TLS certs from proxy/CDN in non-local environments
+        ignoreHTTPSErrors: true,
+        launchOptions: {
+          executablePath: process.env.PLAYWRIGHT_CHROMIUM_PATH,
+          args: chromiumArgs,
         },
       },
     },
   ],
 
-  // Run local dev server before starting tests
+  // Run local dev server before starting tests (only for non-smoke projects)
   webServer: {
-    command: 'npm run dev',
-    url: 'http://localhost:9100',
+    command: "npm run dev",
+    url: "http://localhost:9100",
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,
   },

--- a/specs/smoke-test-spec.md
+++ b/specs/smoke-test-spec.md
@@ -1,0 +1,64 @@
+# Smoke Test Specification
+
+## Abstract
+
+Playwright-based smoke tests verifying core UI and API health against deployed environments (e.g., `dev.everruns.com`). Complements existing localhost-only tests.
+
+## Motivation
+
+Existing tests run against localhost. Smoke tests against deployed environments catch deployment-specific issues: proxy, DNS, TLS, auth provider config, CDN.
+
+## Design
+
+### Architecture
+
+Separate Playwright project (`smoke`) in `apps/ui/playwright.config.ts`. No webServer needed — tests hit a live deployment. Adapts to the target's auth mode (none, admin, full, external) at runtime.
+
+### Environment Variables
+
+| Variable | Source | Description |
+|----------|--------|-------------|
+| `SMOKE_BASE_URL` | CLI / env | Target URL (default: `https://dev.everruns.com`) |
+| `TEST_USER_1_EMAIL` | Doppler | Test user email |
+| `TEST_USER_1_NAME` | Doppler | Test user display name |
+| `TEST_USER_1_PASSWORD` | Doppler | Test user password (admin/full modes) |
+| `PLAYWRIGHT_CHROMIUM_PATH` | env | Custom Chromium path (cloud agents) |
+
+### Proxy Support
+
+Cloud agent environments use an HTTPS egress proxy. The config parses `HTTPS_PROXY` to extract server/username/password and passes them to Playwright's browser context. TLS errors from proxy interception are accepted (`ignoreHTTPSErrors`).
+
+### Test Scope
+
+**Always run (any auth mode):**
+1. `GET /health` returns `{"status":"ok"}`
+2. `GET /api/v1/auth/config` returns valid config with recognized mode
+3. Login page loads (or redirects to dashboard in `none` mode)
+
+**Password-auth modes only (admin/full):**
+4. Email/password login redirects to dashboard
+5. Dashboard renders heading
+6. Sidebar navigation to Agents page
+7. Sidebar navigation to Sessions page
+8. Logout returns to login page
+
+Tests auto-skip when password auth is disabled (e.g., `external` mode on dev.everruns.com).
+
+### Running
+
+```bash
+# Against dev.everruns.com (secrets from Doppler, cloud agent)
+PLAYWRIGHT_CHROMIUM_PATH=/root/.cache/ms-playwright/chromium-1194/chrome-linux/chrome \
+  doppler run -- npx playwright test --project smoke
+
+# Against a custom environment
+SMOKE_BASE_URL=https://staging.everruns.com \
+TEST_USER_1_PASSWORD=secret \
+  npx playwright test --project smoke
+```
+
+### Files
+
+- `apps/ui/playwright.config.ts` — `smoke` project config (proxy, baseURL, ignoreHTTPSErrors)
+- `apps/ui/e2e/smoke.spec.ts` — Smoke test suite
+- `specs/smoke-test-spec.md` — This spec


### PR DESCRIPTION
## Summary
- Add Playwright `smoke` project to test deployed environments (e.g., dev.everruns.com)
- Tests health endpoint, auth config, and login page loading
- Password-auth tests (login, navigation, logout) auto-skip when auth mode is external
- Proxy support with credential parsing for cloud agent environments
- New spec at `specs/smoke-test-spec.md`

## Test plan
- [x] Smoke tests pass against dev.everruns.com (3 passed, 4 skipped — external auth)
- [x] `just pre-push` passes
- [x] Existing chromium project unaffected (smoke.spec.ts excluded via testIgnore)

https://claude.ai/code/session_015t7CWi41jxnwbRjTGBoDpo