### PR TITLE
feat(commands): add custom commands system with UI autocomplete

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ Fix root cause. Unsure: read more code; if stuck, ask w/ short options. Unrecogn
 - `specs/maintenance.md` - Pre-release maintenance checklist
 - `specs/xml-prompt-formatting.md` - XML tags for system prompt structure
 - `specs/skills-registry.md` - Agent Skills registry (agentskills.io format)
+- `specs/commands.md` - Slash commands system (system + skill commands)
 - `specs/linear-issues.md` - Linear issue processing workflow
 - `specs/daytona.md` - Daytona cloud sandbox integration
 - `specs/brave-search.md` - Brave Search web search integration

--- a/apps/ui/src/components/chat/chat-panel.tsx
+++ b/apps/ui/src/components/chat/chat-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useMemo } from "react";
+import { useState, useRef, useEffect, useMemo, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
@@ -18,16 +18,21 @@ import type {
   OutputMessageCompletedData,
   ToolCallRequestedData,
   ContentPart,
+  CommandDescriptor,
 } from "@/lib/api/types";
 import { isImageFilePart } from "@/lib/api/types";
 import { ToolCallCardFromEvent } from "@/components/chat/tool-call-card-from-event";
 import { MessageInfoIcon } from "@/components/chat/message-info-icon";
 import { ImageAttachments, MessageImage } from "@/components/chat/image-attachments";
+import {
+  CommandAutocomplete,
+  shouldShowCommandAutocomplete,
+} from "@/components/chat/command-autocomplete";
 import { ThinkingIndicator } from "@/components/thinking-indicator";
 import { StreamingMessage } from "@/components/streaming-message";
 import { StreamdownMessage } from "@/components/chat/streamdown-message";
 import { useSessionContext } from "@/app/(main)/sessions/[sessionId]/session-context";
-import { useLlmModels, useImageAttachments } from "@/hooks";
+import { useLlmModels, useImageAttachments, useSessionCommands } from "@/hooks";
 import { sendUserMessageWithImages } from "@/lib/api/messages";
 import { useMutation } from "@tanstack/react-query";
 import { ALLOWED_IMAGE_TYPES } from "@/lib/api/types";
@@ -77,6 +82,38 @@ export function ChatPanel() {
     hasImages,
     isUploading,
   } = useImageAttachments({ sessionId });
+
+  // Commands autocomplete
+  const { data: commandsData } = useSessionCommands(sessionId);
+  const commands = commandsData?.commands ?? [];
+  const [showCommands, setShowCommands] = useState(false);
+
+  const handleCommandSelect = useCallback(
+    (cmd: CommandDescriptor) => {
+      setShowCommands(false);
+      if (cmd.source === "system") {
+        // System commands: send as slash message directly
+        setInputValue(`/${cmd.name}`);
+        // Submit immediately
+        const controls: Controls | undefined = selectedModelId
+          ? { model_id: selectedModelId }
+          : undefined;
+        sendMessage.mutateAsync({
+          sessionId,
+          content: `/${cmd.name}`,
+          controls,
+        });
+        setInputValue("");
+        setIsWaitingForResponse(true);
+        textareaRef.current?.focus();
+      } else {
+        // Skill commands: inject as message to trigger prompt expansion
+        setInputValue(`/${cmd.name} `);
+        textareaRef.current?.focus();
+      }
+    },
+    [sessionId, selectedModelId, sendMessage, setIsWaitingForResponse],
+  );
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -201,6 +238,8 @@ export function ChatPanel() {
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // Let command autocomplete handle keyboard when visible
+    if (showCommands) return;
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       handleSubmit(e);
@@ -444,10 +483,21 @@ export function ChatPanel() {
               }
             }}
           >
+            <CommandAutocomplete
+              commands={commands}
+              inputValue={inputValue}
+              visible={showCommands}
+              onSelect={handleCommandSelect}
+              onDismiss={() => setShowCommands(false)}
+            />
             <Textarea
               ref={textareaRef}
               value={inputValue}
-              onChange={(e) => setInputValue(e.target.value)}
+              onChange={(e) => {
+                const val = e.target.value;
+                setInputValue(val);
+                setShowCommands(shouldShowCommandAutocomplete(val));
+              }}
               onKeyDown={handleKeyDown}
               onPaste={(e) => {
                 const items = e.clipboardData?.items;
@@ -464,7 +514,7 @@ export function ChatPanel() {
                   addFiles(imageFiles);
                 }
               }}
-              placeholder="Type a message... (Paste or drop images, Enter to send)"
+              placeholder="Type a message or / for commands... (Enter to send)"
               className="w-full min-h-[60px] max-h-[200px] resize-none"
             />
           </div>

--- a/apps/ui/src/components/chat/command-autocomplete.tsx
+++ b/apps/ui/src/components/chat/command-autocomplete.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { Terminal, Sparkles } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { CommandDescriptor } from "@/lib/api/types";
+
+interface CommandAutocompleteProps {
+  commands: CommandDescriptor[];
+  inputValue: string;
+  onSelect: (command: CommandDescriptor) => void;
+  onDismiss: () => void;
+  visible: boolean;
+}
+
+export function CommandAutocomplete({
+  commands,
+  inputValue,
+  onSelect,
+  onDismiss,
+  visible,
+}: CommandAutocompleteProps) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // Filter commands based on input after "/"
+  const query = inputValue.startsWith("/") ? inputValue.slice(1).toLowerCase() : "";
+  const filtered = commands.filter(
+    (cmd) =>
+      cmd.name.toLowerCase().includes(query) || cmd.description.toLowerCase().includes(query),
+  );
+
+  // Reset selection when filter changes
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [query]);
+
+  // Scroll selected item into view
+  useEffect(() => {
+    if (!listRef.current) return;
+    const items = listRef.current.querySelectorAll("[data-command-item]");
+    items[selectedIndex]?.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (!visible || filtered.length === 0) return;
+
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSelectedIndex((i) => (i + 1) % filtered.length);
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSelectedIndex((i) => (i - 1 + filtered.length) % filtered.length);
+      } else if (e.key === "Enter" || e.key === "Tab") {
+        e.preventDefault();
+        onSelect(filtered[selectedIndex]);
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        onDismiss();
+      }
+    },
+    [visible, filtered, selectedIndex, onSelect, onDismiss],
+  );
+
+  useEffect(() => {
+    if (visible) {
+      document.addEventListener("keydown", handleKeyDown, true);
+      return () => document.removeEventListener("keydown", handleKeyDown, true);
+    }
+  }, [visible, handleKeyDown]);
+
+  if (!visible || filtered.length === 0) return null;
+
+  return (
+    <div
+      ref={listRef}
+      className="absolute bottom-full left-0 right-0 mb-1 z-50 max-h-[240px] overflow-y-auto rounded-md border bg-popover p-1 shadow-md"
+    >
+      {filtered.map((cmd, i) => (
+        <button
+          key={cmd.name}
+          data-command-item
+          type="button"
+          className={cn(
+            "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none select-none",
+            i === selectedIndex ? "bg-muted text-foreground" : "text-popover-foreground",
+          )}
+          onMouseEnter={() => setSelectedIndex(i)}
+          onMouseDown={(e) => {
+            e.preventDefault(); // Keep textarea focus
+            onSelect(cmd);
+          }}
+        >
+          {cmd.source === "system" ? (
+            <Terminal className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
+          ) : (
+            <Sparkles className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
+          )}
+          <span className="font-mono text-xs text-foreground">/{cmd.name}</span>
+          <span className="text-xs text-muted-foreground truncate">{cmd.description}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Returns whether the command autocomplete should be visible based on input.
+ * Visible when: input starts with "/" and cursor is still in the command token
+ * (no space after the slash-word).
+ */
+export function shouldShowCommandAutocomplete(input: string): boolean {
+  return /^\/\S*$/.test(input);
+}

--- a/apps/ui/src/hooks/index.ts
+++ b/apps/ui/src/hooks/index.ts
@@ -10,3 +10,4 @@ export * from "./use-durable";
 export * from "./use-image-attachments";
 export * from "./use-session-schedules";
 export * from "./use-global-chat";
+export * from "./use-commands";

--- a/apps/ui/src/hooks/use-commands.ts
+++ b/apps/ui/src/hooks/use-commands.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { getSessionCommands } from "@/lib/api/commands";
+import { queryKeys } from "@/lib/query-keys";
+
+export function useSessionCommands(sessionId: string) {
+  return useQuery({
+    queryKey: queryKeys.commands.list(sessionId),
+    queryFn: () => getSessionCommands(sessionId),
+    enabled: !!sessionId,
+    staleTime: 60000,
+  });
+}

--- a/apps/ui/src/lib/api/commands.ts
+++ b/apps/ui/src/lib/api/commands.ts
@@ -1,0 +1,9 @@
+// Commands API functions
+
+import { api } from "./client";
+import type { CommandsResponse } from "./types";
+
+export async function getSessionCommands(sessionId: string): Promise<CommandsResponse> {
+  const response = await api.get<CommandsResponse>(`/v1/sessions/${sessionId}/commands`);
+  return response.data;
+}

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -1654,3 +1654,26 @@ export interface ConnectionFormField {
   placeholder?: string;
   help_text?: string;
 }
+
+// ============================================
+// Command types
+// ============================================
+
+export type CommandSource = "system" | "skill";
+
+export interface CommandArg {
+  name: string;
+  description: string;
+  required: boolean;
+}
+
+export interface CommandDescriptor {
+  name: string;
+  description: string;
+  source: CommandSource;
+  args?: CommandArg[];
+}
+
+export interface CommandsResponse {
+  commands: CommandDescriptor[];
+}

--- a/apps/ui/src/lib/query-keys.ts
+++ b/apps/ui/src/lib/query-keys.ts
@@ -131,6 +131,12 @@ export const queryKeys = {
       ["session-schedule", sessionId, scheduleId] as const,
   },
 
+  // Command queries
+  commands: {
+    all: ["commands"] as const,
+    list: (sessionId: string) => ["commands", sessionId] as const,
+  },
+
   // Skill queries
   skills: {
     all: ["skills"] as const,

--- a/crates/core/src/capabilities/attach_skill.rs
+++ b/crates/core/src/capabilities/attach_skill.rs
@@ -56,6 +56,13 @@ pub struct SkillMeta {
     pub description: String,
     /// Source location (filesystem path or "registry")
     pub source: SkillSource,
+    /// Whether this skill appears as a /slash command for users
+    #[serde(default = "default_true")]
+    pub user_invocable: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 /// Where a skill was discovered from
@@ -95,6 +102,8 @@ pub struct AttachSkillCapability {
     skill_md_content: String,
     /// Bundled files (path -> content)
     files: Vec<(String, String)>,
+    /// Whether this skill is user-invocable as a /slash command
+    user_invocable: bool,
 }
 
 impl AttachSkillCapability {
@@ -109,7 +118,19 @@ impl AttachSkillCapability {
         instructions: String,
         files: Vec<(String, String)>,
     ) -> Self {
-        let skill_md_content = reconstruct_skill_md(&name, &description, &instructions);
+        Self::from_registry_with_invocable(skill_id, name, description, instructions, files, true)
+    }
+
+    pub fn from_registry_with_invocable(
+        skill_id: Uuid,
+        name: String,
+        description: String,
+        instructions: String,
+        files: Vec<(String, String)>,
+        user_invocable: bool,
+    ) -> Self {
+        let skill_md_content =
+            reconstruct_skill_md(&name, &description, &instructions, user_invocable);
 
         Self {
             capability_id: skill_capability_id(skill_id),
@@ -117,12 +138,18 @@ impl AttachSkillCapability {
             skill_description: description,
             skill_md_content,
             files,
+            user_invocable,
         }
     }
 
     /// Get the skill name
     pub fn skill_name(&self) -> &str {
         &self.skill_name
+    }
+
+    /// Whether this skill is user-invocable as a /slash command
+    pub fn user_invocable(&self) -> bool {
+        self.user_invocable
     }
 
     /// Build mount points for the skill directory.
@@ -185,10 +212,22 @@ impl Capability for AttachSkillCapability {
 ///
 /// <instructions body>
 /// ```
-fn reconstruct_skill_md(name: &str, description: &str, instructions: &str) -> String {
+fn reconstruct_skill_md(
+    name: &str,
+    description: &str,
+    instructions: &str,
+    user_invocable: bool,
+) -> String {
     // Quote description to handle YAML-special characters (:, #, etc.)
     let safe_description = format!("\"{}\"", description.replace('"', "\\\""));
-    format!("---\nname: {name}\ndescription: {safe_description}\n---\n\n{instructions}")
+    let invocable_line = if user_invocable {
+        String::new()
+    } else {
+        "user-invocable: false\n".to_string()
+    };
+    format!(
+        "---\nname: {name}\ndescription: {safe_description}\n{invocable_line}---\n\n{instructions}"
+    )
 }
 
 /// Parse SKILL.md files from a list of (path, content) entries discovered in the session VFS.
@@ -207,6 +246,7 @@ pub fn discover_skills_from_entries(
                     name: parsed.name.clone(),
                     description: parsed.description.clone(),
                     source: SkillSource::Filesystem { path: path.clone() },
+                    user_invocable: parsed.user_invocable,
                 };
                 let instructions = SkillInstructions {
                     instructions: parsed.instructions,
@@ -396,6 +436,7 @@ mod tests {
             "test-skill",
             "A test skill",
             "# Instructions\nDo the thing.",
+            true,
         );
 
         // Should be parseable by parse_skill_md
@@ -403,6 +444,7 @@ mod tests {
         assert_eq!(parsed.name, "test-skill");
         assert_eq!(parsed.description, "A test skill");
         assert!(parsed.instructions.contains("# Instructions"));
+        assert!(parsed.user_invocable);
     }
 
     #[test]
@@ -411,6 +453,7 @@ mod tests {
             "test-skill",
             "Description with: colons and \"quotes\"",
             "# Body",
+            true,
         );
 
         let parsed = crate::skill::parse_skill_md(&content).unwrap();
@@ -419,6 +462,15 @@ mod tests {
             parsed.description,
             "Description with: colons and \"quotes\""
         );
+    }
+
+    #[test]
+    fn test_reconstruct_skill_md_not_invocable() {
+        let content = reconstruct_skill_md("bg-skill", "Background context", "# Body", false);
+
+        let parsed = crate::skill::parse_skill_md(&content).unwrap();
+        assert_eq!(parsed.name, "bg-skill");
+        assert!(!parsed.user_invocable);
     }
 
     #[test]
@@ -441,6 +493,7 @@ mod tests {
             source: SkillSource::Registry {
                 skill_id: "abc".to_string(),
             },
+            user_invocable: true,
         };
 
         let json = serde_json::to_string(&meta).unwrap();

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -18,6 +18,7 @@
 //!
 //! Each capability is in its own file with collocated tools.
 
+use crate::command::CommandDescriptor;
 use crate::deployment::DeploymentGrade;
 use crate::message_filter::MessageFilterProvider;
 use crate::runtime_agent::RuntimeAgent;
@@ -89,6 +90,7 @@ mod session_sql_database;
 mod session_storage;
 mod skills;
 mod stateless_todo_list;
+mod system_commands;
 mod test_math;
 mod test_weather;
 mod virtual_bash;
@@ -153,6 +155,7 @@ pub use session_sql_database::{
 pub use session_storage::{KvStoreTool, SecretStoreTool, SessionStorageCapability};
 pub use skills::{SKILLS_CAPABILITY_ID, SkillsCapability};
 pub use stateless_todo_list::{StatelessTodoListCapability, WriteTodosTool};
+pub use system_commands::{SYSTEM_COMMANDS_CAPABILITY_ID, SystemCommandsCapability};
 pub use test_math::{AddTool, DivideTool, MultiplyTool, SubtractTool, TestMathCapability};
 pub use test_weather::{GetForecastTool, GetWeatherTool, TestWeatherCapability};
 pub use virtual_bash::{BashTool, VirtualBashCapability};
@@ -373,6 +376,17 @@ pub trait Capability: Send + Sync {
     fn risk_level(&self) -> RiskLevel {
         RiskLevel::Low
     }
+
+    /// Returns system commands this capability provides.
+    ///
+    /// System commands are user-invocable /slash commands that execute directly
+    /// without involving the LLM. They are surfaced in the UI command palette
+    /// alongside invocable skills.
+    ///
+    /// By default, returns an empty vector (no commands).
+    fn commands(&self) -> Vec<CommandDescriptor> {
+        vec![]
+    }
 }
 
 /// Risk classification for capabilities (TM-AGENT-005).
@@ -465,6 +479,9 @@ impl CapabilityRegistry {
 
         // Skills (filesystem-based discovery + activation, all environments)
         registry.register(SkillsCapability);
+
+        // System commands (/clear, /status, /compact, /model)
+        registry.register(SystemCommandsCapability);
 
         // Demo capability with mount points (all environments)
         registry.register(SampleDataCapability);
@@ -1101,9 +1118,10 @@ mod tests {
         assert!(registry.has("skills"));
         assert!(registry.has("session_schedule"));
         assert!(registry.has("platform_management"));
-        // 21 core built-in capabilities
+        assert!(registry.has("system_commands"));
+        // 22 core built-in capabilities
         // (integration plugins like docker_container, codesandbox add more when linked)
-        assert!(registry.len() >= 21);
+        assert!(registry.len() >= 22);
     }
 
     #[test]
@@ -1132,9 +1150,10 @@ mod tests {
         assert!(registry.has("skills"));
         assert!(registry.has("session_schedule"));
         assert!(registry.has("platform_management"));
+        assert!(registry.has("system_commands"));
         // Experimental capabilities NOT included in prod
         assert!(!registry.has("docker_container"));
-        assert_eq!(registry.len(), 21);
+        assert_eq!(registry.len(), 22);
     }
 
     #[test]

--- a/crates/core/src/capabilities/skills.rs
+++ b/crates/core/src/capabilities/skills.rs
@@ -145,7 +145,11 @@ Skills are instruction packages (SKILL.md files) that teach the agent new abilit
             if let Ok(Some(file)) = file_store.read_file(ctx.session_id, &skill_md_path).await {
                 let content = file.content.as_deref().unwrap_or("");
                 if let Ok(parsed) = crate::skill::parse_skill_md(content) {
-                    discovered_skills.push((parsed.name, parsed.description));
+                    discovered_skills.push((
+                        parsed.name,
+                        parsed.description,
+                        parsed.user_invocable,
+                    ));
                 }
             }
         }
@@ -155,9 +159,12 @@ Skills are instruction packages (SKILL.md files) that teach the agent new abilit
         if !discovered_skills.is_empty() {
             let total = discovered_skills.len();
             prompt.push_str("\n\nAvailable skills:\n");
-            for (name, description) in discovered_skills.iter().take(MAX_SKILLS_IN_PROMPT) {
+            for (name, description, user_invocable) in
+                discovered_skills.iter().take(MAX_SKILLS_IN_PROMPT)
+            {
                 let desc = truncate_description(description, MAX_DESCRIPTION_CHARS);
-                prompt.push_str(&format!("- **{}**: {}\n", name, desc));
+                let invocable_hint = if *user_invocable { " (/{name})" } else { "" };
+                prompt.push_str(&format!("- **{name}**: {desc}{invocable_hint}\n"));
             }
             if total > MAX_SKILLS_IN_PROMPT {
                 prompt.push_str(&format!(
@@ -310,6 +317,7 @@ impl Tool for ListSkillsTool {
                             "description": parsed.description,
                             "path": workspace_path(&skill_md_path),
                             "version": parsed.version,
+                            "user_invocable": parsed.user_invocable,
                         }));
                     }
                     Err(errors) => {

--- a/crates/core/src/capabilities/system_commands.rs
+++ b/crates/core/src/capabilities/system_commands.rs
@@ -1,13 +1,13 @@
 // System Commands Capability
 //
-// Provides built-in /slash commands that execute directly without the LLM.
-// These are session-control commands like /clear, /status, /compact.
+// Extension point for built-in /slash commands that execute directly
+// without the LLM. Commands will be added here as they are implemented
+// (e.g., /clear, /status, /compact).
 //
 // System commands are surfaced to the UI via the commands() trait method
 // and executed via the commands API endpoint.
 
 use super::{Capability, CapabilityStatus};
-use crate::command::{CommandArg, CommandDescriptor, CommandSource};
 
 /// System commands capability ID
 pub const SYSTEM_COMMANDS_CAPABILITY_ID: &str = "system_commands";
@@ -16,6 +16,7 @@ pub const SYSTEM_COMMANDS_CAPABILITY_ID: &str = "system_commands";
 ///
 /// Provides session-control commands that execute directly without
 /// involving the LLM. These appear in the UI command palette.
+/// Commands are added as their handlers are implemented.
 pub struct SystemCommandsCapability;
 
 impl Capability for SystemCommandsCapability {
@@ -28,7 +29,7 @@ impl Capability for SystemCommandsCapability {
     }
 
     fn description(&self) -> &str {
-        "Built-in session control commands like /clear and /status."
+        "Built-in session control commands."
     }
 
     fn status(&self) -> CapabilityStatus {
@@ -41,39 +42,6 @@ impl Capability for SystemCommandsCapability {
 
     fn category(&self) -> Option<&str> {
         Some("System")
-    }
-
-    fn commands(&self) -> Vec<CommandDescriptor> {
-        vec![
-            CommandDescriptor {
-                name: "clear".to_string(),
-                description: "Clear conversation history and start fresh".to_string(),
-                source: CommandSource::System,
-                args: vec![],
-            },
-            CommandDescriptor {
-                name: "status".to_string(),
-                description: "Show session status, active model, and token usage".to_string(),
-                source: CommandSource::System,
-                args: vec![],
-            },
-            CommandDescriptor {
-                name: "compact".to_string(),
-                description: "Summarize conversation to free context space".to_string(),
-                source: CommandSource::System,
-                args: vec![],
-            },
-            CommandDescriptor {
-                name: "model".to_string(),
-                description: "Switch the active LLM model for this session".to_string(),
-                source: CommandSource::System,
-                args: vec![CommandArg {
-                    name: "model_id".to_string(),
-                    description: "Model identifier to switch to".to_string(),
-                    required: false,
-                }],
-            },
-        ]
     }
 }
 
@@ -105,30 +73,9 @@ mod tests {
     }
 
     #[test]
-    fn test_system_commands_provides_commands() {
+    fn test_system_commands_empty_until_implemented() {
         let cap = SystemCommandsCapability;
         let commands = cap.commands();
-        assert!(!commands.is_empty());
-
-        let names: Vec<&str> = commands.iter().map(|c| c.name.as_str()).collect();
-        assert!(names.contains(&"clear"));
-        assert!(names.contains(&"status"));
-        assert!(names.contains(&"compact"));
-        assert!(names.contains(&"model"));
-
-        // All system commands
-        for cmd in &commands {
-            assert_eq!(cmd.source, CommandSource::System);
-        }
-    }
-
-    #[test]
-    fn test_model_command_has_args() {
-        let cap = SystemCommandsCapability;
-        let commands = cap.commands();
-        let model_cmd = commands.iter().find(|c| c.name == "model").unwrap();
-        assert_eq!(model_cmd.args.len(), 1);
-        assert_eq!(model_cmd.args[0].name, "model_id");
-        assert!(!model_cmd.args[0].required);
+        assert!(commands.is_empty());
     }
 }

--- a/crates/core/src/capabilities/system_commands.rs
+++ b/crates/core/src/capabilities/system_commands.rs
@@ -1,0 +1,134 @@
+// System Commands Capability
+//
+// Provides built-in /slash commands that execute directly without the LLM.
+// These are session-control commands like /clear, /status, /compact.
+//
+// System commands are surfaced to the UI via the commands() trait method
+// and executed via the commands API endpoint.
+
+use super::{Capability, CapabilityStatus};
+use crate::command::{CommandArg, CommandDescriptor, CommandSource};
+
+/// System commands capability ID
+pub const SYSTEM_COMMANDS_CAPABILITY_ID: &str = "system_commands";
+
+/// Built-in system commands capability.
+///
+/// Provides session-control commands that execute directly without
+/// involving the LLM. These appear in the UI command palette.
+pub struct SystemCommandsCapability;
+
+impl Capability for SystemCommandsCapability {
+    fn id(&self) -> &str {
+        SYSTEM_COMMANDS_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "System Commands"
+    }
+
+    fn description(&self) -> &str {
+        "Built-in session control commands like /clear and /status."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("terminal")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("System")
+    }
+
+    fn commands(&self) -> Vec<CommandDescriptor> {
+        vec![
+            CommandDescriptor {
+                name: "clear".to_string(),
+                description: "Clear conversation history and start fresh".to_string(),
+                source: CommandSource::System,
+                args: vec![],
+            },
+            CommandDescriptor {
+                name: "status".to_string(),
+                description: "Show session status, active model, and token usage".to_string(),
+                source: CommandSource::System,
+                args: vec![],
+            },
+            CommandDescriptor {
+                name: "compact".to_string(),
+                description: "Summarize conversation to free context space".to_string(),
+                source: CommandSource::System,
+                args: vec![],
+            },
+            CommandDescriptor {
+                name: "model".to_string(),
+                description: "Switch the active LLM model for this session".to_string(),
+                source: CommandSource::System,
+                args: vec![CommandArg {
+                    name: "model_id".to_string(),
+                    description: "Model identifier to switch to".to_string(),
+                    required: false,
+                }],
+            },
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_system_commands_capability_metadata() {
+        let cap = SystemCommandsCapability;
+        assert_eq!(cap.id(), SYSTEM_COMMANDS_CAPABILITY_ID);
+        assert_eq!(cap.name(), "System Commands");
+        assert_eq!(cap.status(), CapabilityStatus::Available);
+        assert_eq!(cap.icon(), Some("terminal"));
+        assert_eq!(cap.category(), Some("System"));
+    }
+
+    #[test]
+    fn test_system_commands_no_tools() {
+        let cap = SystemCommandsCapability;
+        assert!(cap.tools().is_empty());
+        assert!(cap.tool_definitions().is_empty());
+    }
+
+    #[test]
+    fn test_system_commands_no_system_prompt() {
+        let cap = SystemCommandsCapability;
+        assert!(cap.system_prompt_addition().is_none());
+    }
+
+    #[test]
+    fn test_system_commands_provides_commands() {
+        let cap = SystemCommandsCapability;
+        let commands = cap.commands();
+        assert!(!commands.is_empty());
+
+        let names: Vec<&str> = commands.iter().map(|c| c.name.as_str()).collect();
+        assert!(names.contains(&"clear"));
+        assert!(names.contains(&"status"));
+        assert!(names.contains(&"compact"));
+        assert!(names.contains(&"model"));
+
+        // All system commands
+        for cmd in &commands {
+            assert_eq!(cmd.source, CommandSource::System);
+        }
+    }
+
+    #[test]
+    fn test_model_command_has_args() {
+        let cap = SystemCommandsCapability;
+        let commands = cap.commands();
+        let model_cmd = commands.iter().find(|c| c.name == "model").unwrap();
+        assert_eq!(model_cmd.args.len(), 1);
+        assert_eq!(model_cmd.args[0].name, "model_id");
+        assert!(!model_cmd.args[0].required);
+    }
+}

--- a/crates/core/src/command.rs
+++ b/crates/core/src/command.rs
@@ -1,0 +1,63 @@
+// Custom Commands System
+//
+// Commands are user-invocable actions triggered via /slash syntax.
+// Two sources:
+// 1. System commands — from capabilities, execute directly (no LLM)
+// 2. Skill commands — from skills with user-invocable: true, expand to prompt
+//
+// Skills marked user-invocable appear in the command palette alongside
+// system commands. The UI fetches available commands and renders autocomplete.
+
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "openapi")]
+use utoipa::ToSchema;
+
+/// Descriptor for a command available in a session
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct CommandDescriptor {
+    /// Command name (used as /name)
+    pub name: String,
+    /// Human-readable description shown in autocomplete
+    pub description: String,
+    /// Where this command comes from
+    pub source: CommandSource,
+    /// Arguments this command accepts
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<CommandArg>,
+}
+
+/// Where a command originates from
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum CommandSource {
+    /// Built-in system command from a capability (no LLM, direct action)
+    System,
+    /// From a skill with user-invocable: true (expands to prompt, triggers LLM)
+    Skill,
+}
+
+/// Argument descriptor for a command
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct CommandArg {
+    /// Argument name
+    pub name: String,
+    /// Description of the argument
+    pub description: String,
+    /// Whether the argument is required
+    #[serde(default)]
+    pub required: bool,
+}
+
+/// Result of executing a system command
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct CommandResult {
+    /// Whether the command succeeded
+    pub success: bool,
+    /// Human-readable message describing the result
+    pub message: String,
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -55,6 +55,7 @@ pub mod skill;
 
 pub mod atoms;
 pub mod capabilities;
+pub mod command;
 pub mod error;
 pub mod llm_driver_registry;
 pub mod llm_retry;

--- a/crates/core/src/skill.rs
+++ b/crates/core/src/skill.rs
@@ -93,6 +93,9 @@ pub struct Skill {
     pub source_type: SkillSourceType,
     pub status: SkillStatus,
     pub version: String,
+    /// Whether this skill appears as a /slash command for users
+    #[serde(default = "default_true")]
+    pub user_invocable: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -116,6 +119,8 @@ pub struct ParsedSkillMd {
     pub version: String,
     /// Markdown body (after frontmatter)
     pub instructions: String,
+    /// Whether this skill appears as a /slash command for users (default: true)
+    pub user_invocable: bool,
 }
 
 /// YAML frontmatter structure
@@ -129,6 +134,13 @@ struct SkillFrontmatter {
     metadata: HashMap<String, serde_json::Value>,
     #[serde(rename = "allowed-tools")]
     allowed_tools: Option<String>,
+    /// Whether this skill appears as a /slash command (default: true)
+    #[serde(rename = "user-invocable", default = "default_true")]
+    user_invocable: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 /// Skill content response (for /content endpoint)
@@ -239,6 +251,7 @@ pub fn parse_skill_md(content: &str) -> Result<ParsedSkillMd, Vec<String>> {
         allowed_tools: fm.allowed_tools,
         version,
         instructions: body,
+        user_invocable: fm.user_invocable,
     })
 }
 
@@ -450,6 +463,50 @@ Body.
         let result = validate_skill_md(content);
         assert!(!result.valid);
         assert!(!result.errors.is_empty());
+    }
+
+    #[test]
+    fn test_parse_user_invocable_default_true() {
+        let content = r#"---
+name: my-skill
+description: A skill without explicit invocable field.
+---
+
+Instructions.
+"#;
+        let parsed = parse_skill_md(content).unwrap();
+        assert!(
+            parsed.user_invocable,
+            "user_invocable should default to true"
+        );
+    }
+
+    #[test]
+    fn test_parse_user_invocable_explicit_true() {
+        let content = r#"---
+name: my-skill
+description: An invocable skill.
+user-invocable: true
+---
+
+Instructions.
+"#;
+        let parsed = parse_skill_md(content).unwrap();
+        assert!(parsed.user_invocable);
+    }
+
+    #[test]
+    fn test_parse_user_invocable_false() {
+        let content = r#"---
+name: background-context
+description: Context the agent should know but not a user command.
+user-invocable: false
+---
+
+Instructions.
+"#;
+        let parsed = parse_skill_md(content).unwrap();
+        assert!(!parsed.user_invocable);
     }
 
     #[test]

--- a/crates/server/src/api/commands.rs
+++ b/crates/server/src/api/commands.rs
@@ -1,6 +1,6 @@
 // Commands API
 //
-// Provides endpoints for discovering and executing slash commands.
+// Provides endpoint for discovering slash commands.
 // Commands come from two sources:
 // 1. System commands — from capabilities (no LLM, direct action)
 // 2. Skill commands — from skills with user-invocable: true (prompt expansion)
@@ -14,7 +14,7 @@ use axum::{
     http::StatusCode,
     routing::get,
 };
-use everruns_core::command::{CommandDescriptor, CommandResult};
+use everruns_core::command::CommandDescriptor;
 use everruns_core::typed_id::SessionId;
 use serde::Serialize;
 use std::sync::Arc;
@@ -62,15 +62,13 @@ pub fn routes(state: AppState) -> Router {
 /// GET /v1/sessions/{session_id}/commands
 ///
 /// List all available commands for a session. Returns system commands from
-/// capabilities and invocable skills from the session's VFS.
+/// capabilities and invocable skills from the session's org.
 async fn list_session_commands(
     State(state): State<AppState>,
     org: ResolvedOrg,
     Path(session_id): Path<SessionId>,
-    // session_id is used to scope the response; skills discovery
-    // will be added when VFS scanning is integrated
 ) -> Result<Json<CommandsResponse>, (StatusCode, Json<super::ErrorResponse>)> {
-    let _ = (org.org_id, session_id); // Will be used for skill discovery
+    let _ = session_id; // Reserved for session-scoped command filtering
 
     // Collect system commands from all capabilities
     let mut commands = Vec::new();
@@ -93,23 +91,4 @@ async fn list_session_commands(
     commands.extend(skill_commands);
 
     Ok(Json(CommandsResponse { commands }))
-}
-
-/// POST /v1/sessions/{session_id}/commands/{command_name}
-///
-/// Execute a system command. Skill commands should be invoked by sending
-/// a message with the expanded skill instructions instead.
-async fn _execute_command(
-    State(_state): State<AppState>,
-    _org: ResolvedOrg,
-    Path((_session_id, _command_name)): Path<(SessionId, String)>,
-) -> Result<Json<CommandResult>, (StatusCode, Json<super::ErrorResponse>)> {
-    // System command execution will be implemented when specific
-    // commands (clear, status, compact) have their handlers
-    Err((
-        StatusCode::NOT_IMPLEMENTED,
-        Json(super::ErrorResponse {
-            error: "Command execution not yet implemented".to_string(),
-        }),
-    ))
 }

--- a/crates/server/src/api/commands.rs
+++ b/crates/server/src/api/commands.rs
@@ -1,0 +1,115 @@
+// Commands API
+//
+// Provides endpoints for discovering and executing slash commands.
+// Commands come from two sources:
+// 1. System commands — from capabilities (no LLM, direct action)
+// 2. Skill commands — from skills with user-invocable: true (prompt expansion)
+
+use crate::auth::{AuthState, ResolvedOrg};
+use crate::services::CapabilityService;
+use axum::extract::FromRef;
+use axum::{
+    Json, Router,
+    extract::{Path, State},
+    http::StatusCode,
+    routing::get,
+};
+use everruns_core::command::{CommandDescriptor, CommandResult};
+use everruns_core::typed_id::SessionId;
+use serde::Serialize;
+use std::sync::Arc;
+use utoipa::ToSchema;
+
+/// App state for commands routes
+#[derive(Clone)]
+pub struct AppState {
+    pub capability_service: Arc<CapabilityService>,
+    pub auth: AuthState,
+}
+
+impl AppState {
+    pub fn new(capability_service: Arc<CapabilityService>, auth: AuthState) -> Self {
+        Self {
+            capability_service,
+            auth,
+        }
+    }
+}
+
+impl FromRef<AppState> for AuthState {
+    fn from_ref(input: &AppState) -> Self {
+        input.auth.clone()
+    }
+}
+
+/// Response for listing available commands
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct CommandsResponse {
+    /// Available commands
+    pub commands: Vec<CommandDescriptor>,
+}
+
+/// Create command routes
+pub fn routes(state: AppState) -> Router {
+    Router::new()
+        .route(
+            "/v1/sessions/{session_id}/commands",
+            get(list_session_commands),
+        )
+        .with_state(state)
+}
+
+/// GET /v1/sessions/{session_id}/commands
+///
+/// List all available commands for a session. Returns system commands from
+/// capabilities and invocable skills from the session's VFS.
+async fn list_session_commands(
+    State(state): State<AppState>,
+    org: ResolvedOrg,
+    Path(session_id): Path<SessionId>,
+    // session_id is used to scope the response; skills discovery
+    // will be added when VFS scanning is integrated
+) -> Result<Json<CommandsResponse>, (StatusCode, Json<super::ErrorResponse>)> {
+    let _ = (org.org_id, session_id); // Will be used for skill discovery
+
+    // Collect system commands from all capabilities
+    let mut commands = Vec::new();
+    let system_commands = state.capability_service.list_system_commands();
+    commands.extend(system_commands);
+
+    // Collect invocable skill commands from the org's skills
+    let skill_commands = state
+        .capability_service
+        .list_skill_commands(org.org_id)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(super::ErrorResponse {
+                    error: format!("Failed to list skill commands: {e}"),
+                }),
+            )
+        })?;
+    commands.extend(skill_commands);
+
+    Ok(Json(CommandsResponse { commands }))
+}
+
+/// POST /v1/sessions/{session_id}/commands/{command_name}
+///
+/// Execute a system command. Skill commands should be invoked by sending
+/// a message with the expanded skill instructions instead.
+async fn _execute_command(
+    State(_state): State<AppState>,
+    _org: ResolvedOrg,
+    Path((_session_id, _command_name)): Path<(SessionId, String)>,
+) -> Result<Json<CommandResult>, (StatusCode, Json<super::ErrorResponse>)> {
+    // System command execution will be implemented when specific
+    // commands (clear, status, compact) have their handlers
+    Err((
+        StatusCode::NOT_IMPLEMENTED,
+        Json(super::ErrorResponse {
+            error: "Command execution not yet implemented".to_string(),
+        }),
+    ))
+}

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -6,6 +6,7 @@
 pub mod agents;
 pub mod audit_logs;
 pub mod capabilities;
+pub mod commands;
 pub mod common;
 pub mod durable;
 pub mod events;

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -392,6 +392,8 @@ impl ServerAppBuilder {
             capability_service.clone(),
             auth_state.clone(),
         );
+        let commands_state =
+            api::commands::AppState::new(capability_service.clone(), auth_state.clone());
         let agents_state =
             api::agents::AppState::new(db.clone(), capability_service, auth_state.clone());
         let session_files_state = api::session_files::AppState::new(db.clone(), auth_state.clone());
@@ -480,7 +482,8 @@ impl ServerAppBuilder {
             .merge(api::organizations::routes(organizations_state))
             .merge(api::user_connections::routes(user_connections_state))
             .merge(api::session_schedules::routes(session_schedules_state))
-            .merge(api::audit_logs::routes(audit_logs_state));
+            .merge(api::audit_logs::routes(audit_logs_state))
+            .merge(api::commands::routes(commands_state));
 
         // Auth-specific routes
         if let Some(auth_routes) = auth_backend.auth_routes() {

--- a/crates/server/src/services/capability.rs
+++ b/crates/server/src/services/capability.rs
@@ -239,6 +239,38 @@ impl CapabilityService {
         &self.db
     }
 
+    /// List system commands from all registered capabilities.
+    ///
+    /// System commands execute directly without the LLM (e.g., /clear, /status).
+    pub fn list_system_commands(&self) -> Vec<everruns_core::command::CommandDescriptor> {
+        self.registry
+            .list()
+            .iter()
+            .flat_map(|cap| cap.commands())
+            .collect()
+    }
+
+    /// List invocable skill commands from the org's skills registry.
+    ///
+    /// Returns skills where user_invocable is true, formatted as commands.
+    pub async fn list_skill_commands(
+        &self,
+        org_id: i64,
+    ) -> Result<Vec<everruns_core::command::CommandDescriptor>> {
+        let skills = self.skill_service.list(org_id).await?;
+        let commands = skills
+            .into_iter()
+            .filter(|s| s.status == everruns_core::SkillStatus::Active && s.user_invocable)
+            .map(|s| everruns_core::command::CommandDescriptor {
+                name: s.name,
+                description: s.description,
+                source: everruns_core::command::CommandSource::Skill,
+                args: vec![],
+            })
+            .collect();
+        Ok(commands)
+    }
+
     /// Preview the final agent shape by computing the merged system prompt and tools.
     ///
     /// This collects contributions from all specified capabilities and their dependencies:

--- a/crates/server/src/services/skill.rs
+++ b/crates/server/src/services/skill.rs
@@ -50,7 +50,11 @@ impl SkillService {
         }
 
         let public_id = SkillId::new().to_string();
-        let metadata = serde_json::to_value(&parsed.metadata)?;
+        let mut metadata_map = parsed.metadata.clone();
+        if !parsed.user_invocable {
+            metadata_map.insert("user_invocable".to_string(), serde_json::Value::Bool(false));
+        }
+        let metadata = serde_json::to_value(&metadata_map)?;
 
         let input = CreateSkillRow {
             public_id,
@@ -103,7 +107,11 @@ impl SkillService {
         }
 
         let public_id = SkillId::new().to_string();
-        let metadata = serde_json::to_value(&parsed.metadata)?;
+        let mut metadata_map = parsed.metadata.clone();
+        if !parsed.user_invocable {
+            metadata_map.insert("user_invocable".to_string(), serde_json::Value::Bool(false));
+        }
+        let metadata = serde_json::to_value(&metadata_map)?;
 
         let input = CreateSkillRow {
             public_id,
@@ -262,6 +270,12 @@ impl SkillService {
         let metadata: HashMap<String, serde_json::Value> =
             serde_json::from_value(row.metadata.clone()).unwrap_or_default();
 
+        // user_invocable defaults to true; only false if explicitly set in metadata
+        let user_invocable = metadata
+            .get("user_invocable")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+
         Skill {
             id: row.id,
             name: row.name.clone(),
@@ -273,6 +287,7 @@ impl SkillService {
             source_type: SkillSourceType::from(row.source_type.as_str()),
             status: SkillStatus::from(row.status.as_str()),
             version: row.version.clone(),
+            user_invocable,
             created_at: row.created_at,
             updated_at: row.updated_at,
         }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -6753,6 +6753,10 @@
                   "type": "string",
                   "format": "date-time"
                 },
+                "user_invocable": {
+                  "type": "boolean",
+                  "description": "Whether this skill appears as a /slash command for users"
+                },
                 "version": {
                   "type": "string"
                 }
@@ -8971,6 +8975,10 @@
           "updated_at": {
             "type": "string",
             "format": "date-time"
+          },
+          "user_invocable": {
+            "type": "boolean",
+            "description": "Whether this skill appears as a /slash command for users"
           },
           "version": {
             "type": "string"

--- a/specs/commands.md
+++ b/specs/commands.md
@@ -1,0 +1,39 @@
+# Commands System
+
+Slash commands for session interaction, following patterns from Claude Code, Codex CLI, and GitHub Copilot.
+
+## Design
+
+Two command sources, unified under `CommandDescriptor`:
+
+1. **System Commands** — from capabilities via `Capability::commands()`. Execute directly without LLM (session control).
+2. **Skill Commands** — from skills marked `user-invocable: true` in SKILL.md frontmatter. Expand to prompt injection (LLM processes the skill instructions).
+
+Commands are NOT tools. They either execute directly (system) or inject instructions into the conversation (skills).
+
+## Types
+
+See `crates/core/src/command.rs` for `CommandDescriptor`, `CommandSource`, `CommandArg`, `CommandResult`.
+
+## Capability Trait Extension
+
+`Capability::commands()` returns `Vec<CommandDescriptor>` (default: empty). Capabilities that provide commands override this method.
+
+See `crates/core/src/capabilities/system_commands.rs` for the built-in system commands capability (`/clear`, `/status`, `/compact`, `/model`).
+
+## Skill Invocability
+
+SKILL.md frontmatter supports `user-invocable` (default: `true`). Skills with `user-invocable: false` provide context/tools but don't appear as slash commands.
+
+For DB-backed skills, `user_invocable` is stored in the metadata JSON field (no schema migration needed). See `crates/server/src/services/skill.rs`.
+
+## API
+
+- `GET /v1/sessions/{session_id}/commands` — returns all available commands (system + invocable skills)
+- `POST /v1/sessions/{session_id}/commands/{command_name}` — execute a command (placeholder)
+
+See `crates/server/src/api/commands.rs` for route handlers.
+
+## UI Integration
+
+The UI fetches commands via the GET endpoint to populate command palette / autocomplete when the user types `/`. System commands execute immediately; skill commands expand the skill's instructions into the conversation.

--- a/specs/commands.md
+++ b/specs/commands.md
@@ -6,7 +6,7 @@ Slash commands for session interaction, following patterns from Claude Code, Cod
 
 Two command sources, unified under `CommandDescriptor`:
 
-1. **System Commands** — from capabilities via `Capability::commands()`. Execute directly without LLM (session control).
+1. **System Commands** — from capabilities via `Capability::commands()`. Execute directly without LLM (session control). No system commands are registered yet; the `SystemCommandsCapability` is the extension point.
 2. **Skill Commands** — from skills marked `user-invocable: true` in SKILL.md frontmatter. Expand to prompt injection (LLM processes the skill instructions).
 
 Commands are NOT tools. They either execute directly (system) or inject instructions into the conversation (skills).
@@ -19,7 +19,7 @@ See `crates/core/src/command.rs` for `CommandDescriptor`, `CommandSource`, `Comm
 
 `Capability::commands()` returns `Vec<CommandDescriptor>` (default: empty). Capabilities that provide commands override this method.
 
-See `crates/core/src/capabilities/system_commands.rs` for the built-in system commands capability (`/clear`, `/status`, `/compact`, `/model`).
+See `crates/core/src/capabilities/system_commands.rs` for the system commands capability (currently empty; add commands as handlers are implemented).
 
 ## Skill Invocability
 
@@ -30,10 +30,13 @@ For DB-backed skills, `user_invocable` is stored in the metadata JSON field (no 
 ## API
 
 - `GET /v1/sessions/{session_id}/commands` — returns all available commands (system + invocable skills)
-- `POST /v1/sessions/{session_id}/commands/{command_name}` — execute a command (placeholder)
 
-See `crates/server/src/api/commands.rs` for route handlers.
+See `crates/server/src/api/commands.rs` for route handler.
 
 ## UI Integration
 
-The UI fetches commands via the GET endpoint to populate command palette / autocomplete when the user types `/`. System commands execute immediately; skill commands expand the skill's instructions into the conversation.
+- `apps/ui/src/components/chat/command-autocomplete.tsx` — autocomplete popup component
+- `apps/ui/src/hooks/use-commands.ts` — `useSessionCommands` React Query hook
+- `apps/ui/src/lib/api/commands.ts` — API client
+
+The UI fetches commands via the GET endpoint to populate autocomplete when the user types `/` in the chat input. Keyboard navigation (arrows, Enter/Tab, Escape) is supported. System commands would execute immediately; skill commands fill the input with `/{name}` for the user to send.


### PR DESCRIPTION
## What
Add a custom slash commands system with UI command autocomplete. Commands come from two sources:
- **System commands** — from capabilities via `Capability::commands()` trait method (extension point, no commands registered yet)
- **Skill commands** — from skills marked `user-invocable: true` in SKILL.md frontmatter

## Why
Users need a discoverable way to invoke skills and session controls via `/slash` syntax, following industry patterns (Claude Code, Codex CLI, GitHub Copilot).

## How
**Backend:**
- New `command.rs` types: `CommandDescriptor`, `CommandSource`, `CommandArg`
- `Capability` trait extended with `commands()` method
- `SystemCommandsCapability` registered (empty, extension point for future commands)
- `user-invocable` frontmatter field for SKILL.md (default: true), stored in metadata JSON for DB skills
- `GET /v1/sessions/{session_id}/commands` endpoint returns system + skill commands
- `CapabilityService` methods: `list_system_commands()`, `list_skill_commands()`

**UI:**
- `CommandAutocomplete` component with keyboard navigation (arrows, Enter/Tab, Escape)
- `useSessionCommands` React Query hook
- Integrated into `ChatPanel`: shows on `/` input, filters as user types
- System commands submit directly; skill commands fill input for editing

## Risk
- Low
- Read-only discovery endpoint, no state mutations. Auth-gated same as all other endpoints.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered