### PR TITLE
fix(ui): provider icons invisible on light theme

### DIFF
--- a/apps/ui/src/__tests__/provider-icon.test.tsx
+++ b/apps/ui/src/__tests__/provider-icon.test.tsx
@@ -28,9 +28,7 @@ describe("ProviderIcon", () => {
 
   it("renders fallback Server icon for unknown provider type", () => {
     // Cast to simulate an unknown provider type
-    const { container } = render(
-      <ProviderIcon providerType={"unknown" as LlmProviderType} />,
-    );
+    const { container } = render(<ProviderIcon providerType={"unknown" as LlmProviderType} />);
     // Should not render an SVG from our icon set
     const svg = container.querySelector("svg");
     // lucide-react Server icon renders as SVG too, so just confirm no <img>
@@ -40,17 +38,13 @@ describe("ProviderIcon", () => {
   });
 
   it("applies showBackground styles when true", () => {
-    const { container } = render(
-      <ProviderIcon providerType="openai" showBackground={true} />,
-    );
+    const { container } = render(<ProviderIcon providerType="openai" showBackground={true} />);
     const wrapper = container.firstElementChild;
     expect(wrapper?.className).toContain("bg-primary/10");
   });
 
   it("omits background styles when showBackground is false", () => {
-    const { container } = render(
-      <ProviderIcon providerType="openai" showBackground={false} />,
-    );
+    const { container } = render(<ProviderIcon providerType="openai" showBackground={false} />);
     const wrapper = container.firstElementChild;
     expect(wrapper?.className).not.toContain("bg-primary/10");
   });

--- a/apps/ui/src/__tests__/provider-icon.test.tsx
+++ b/apps/ui/src/__tests__/provider-icon.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from "@testing-library/react";
+import { ProviderIcon, getProviderLabel } from "@/components/providers/provider-icon";
+import type { LlmProviderType } from "@/lib/api/types";
+
+describe("ProviderIcon", () => {
+  const providerTypes: LlmProviderType[] = ["openai", "openai_completions", "anthropic", "gemini"];
+
+  it.each(providerTypes)("renders inline SVG for %s provider", (providerType) => {
+    const { container } = render(<ProviderIcon providerType={providerType} />);
+    const svg = container.querySelector("svg");
+    expect(svg).toBeInTheDocument();
+    // Verify it uses currentColor for theme-adaptive rendering
+    const path = container.querySelector("path");
+    expect(path).toBeInTheDocument();
+  });
+
+  it.each(providerTypes)("does not use <img> tags (no Next.js Image) for %s", (providerType) => {
+    const { container } = render(<ProviderIcon providerType={providerType} />);
+    const img = container.querySelector("img");
+    expect(img).not.toBeInTheDocument();
+  });
+
+  it.each(providerTypes)("uses currentColor fill for %s", (providerType) => {
+    const { container } = render(<ProviderIcon providerType={providerType} />);
+    const pathsAndSvgs = container.querySelectorAll("[fill='currentColor']");
+    expect(pathsAndSvgs.length).toBeGreaterThan(0);
+  });
+
+  it("renders fallback Server icon for unknown provider type", () => {
+    // Cast to simulate an unknown provider type
+    const { container } = render(
+      <ProviderIcon providerType={"unknown" as LlmProviderType} />,
+    );
+    // Should not render an SVG from our icon set
+    const svg = container.querySelector("svg");
+    // lucide-react Server icon renders as SVG too, so just confirm no <img>
+    const img = container.querySelector("img");
+    expect(img).not.toBeInTheDocument();
+    expect(svg).toBeInTheDocument(); // Server icon from lucide
+  });
+
+  it("applies showBackground styles when true", () => {
+    const { container } = render(
+      <ProviderIcon providerType="openai" showBackground={true} />,
+    );
+    const wrapper = container.firstElementChild;
+    expect(wrapper?.className).toContain("bg-primary/10");
+  });
+
+  it("omits background styles when showBackground is false", () => {
+    const { container } = render(
+      <ProviderIcon providerType="openai" showBackground={false} />,
+    );
+    const wrapper = container.firstElementChild;
+    expect(wrapper?.className).not.toContain("bg-primary/10");
+  });
+
+  it("renders correct size for sm", () => {
+    const { container } = render(<ProviderIcon providerType="openai" size="sm" />);
+    const svg = container.querySelector("svg");
+    expect(svg?.getAttribute("width")).toBe("16");
+    expect(svg?.getAttribute("height")).toBe("16");
+  });
+
+  it("renders correct size for md (default)", () => {
+    const { container } = render(<ProviderIcon providerType="anthropic" />);
+    const svg = container.querySelector("svg");
+    expect(svg?.getAttribute("width")).toBe("20");
+    expect(svg?.getAttribute("height")).toBe("20");
+  });
+
+  it("renders correct size for lg", () => {
+    const { container } = render(<ProviderIcon providerType="gemini" size="lg" />);
+    const svg = container.querySelector("svg");
+    expect(svg?.getAttribute("width")).toBe("24");
+    expect(svg?.getAttribute("height")).toBe("24");
+  });
+
+  it("sets title attribute with provider label", () => {
+    render(<ProviderIcon providerType="openai" />);
+    expect(screen.getByTitle("OpenAI (Responses)")).toBeInTheDocument();
+  });
+});
+
+describe("getProviderLabel", () => {
+  it("returns correct label for openai", () => {
+    expect(getProviderLabel("openai")).toBe("OpenAI (Responses)");
+  });
+
+  it("returns correct label for anthropic", () => {
+    expect(getProviderLabel("anthropic")).toBe("Anthropic");
+  });
+
+  it("returns correct label for gemini", () => {
+    expect(getProviderLabel("gemini")).toBe("Google Gemini");
+  });
+
+  it("returns type string for unknown provider", () => {
+    expect(getProviderLabel("unknown" as LlmProviderType)).toBe("unknown");
+  });
+});

--- a/apps/ui/src/components/providers/provider-icon.tsx
+++ b/apps/ui/src/components/providers/provider-icon.tsx
@@ -1,13 +1,63 @@
-import Image from "next/image";
 import { Server } from "lucide-react";
 import type { LlmProviderType } from "@/lib/api/types";
 import { cn } from "@/lib/utils";
 
-const PROVIDER_ICONS: Record<LlmProviderType, string> = {
-  openai: "/providers/openai.svg",
-  openai_completions: "/providers/openai.svg",
-  anthropic: "/providers/anthropic.svg",
-  gemini: "/providers/gemini.svg",
+function OpenAiIcon({ size }: { size: number }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+    >
+      <path
+        d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364l2.0201-1.1638a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.4043-.6813zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+function AnthropicIcon({ size }: { size: number }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+    >
+      <path
+        d="M17.304 3h-3.437l5.73 18h3.437L17.304 3zM6.696 3l-5.73 18H4.43l1.307-4.26h5.905L12.95 21h3.466L10.696 3H6.696zm.64 10.74L9.2 7.895l1.864 5.845H7.336z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+function GeminiIcon({ size }: { size: number }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      width={size}
+      height={size}
+    >
+      <path d="M12 0C12 6.627 6.627 12 0 12c6.627 0 12 5.373 12 12 0-6.627 5.373-12 12-12-6.627 0-12-5.373-12-12z" />
+    </svg>
+  );
+}
+
+const PROVIDER_ICON_COMPONENTS: Record<
+  LlmProviderType,
+  React.ComponentType<{ size: number }>
+> = {
+  openai: OpenAiIcon,
+  openai_completions: OpenAiIcon,
+  anthropic: AnthropicIcon,
+  gemini: GeminiIcon,
 };
 
 const PROVIDER_LABELS: Record<LlmProviderType, string> = {
@@ -36,11 +86,11 @@ export function ProviderIcon({
   className,
   showBackground = true,
 }: ProviderIconProps) {
-  const iconPath = PROVIDER_ICONS[providerType];
+  const IconComponent = PROVIDER_ICON_COMPONENTS[providerType];
   const label = PROVIDER_LABELS[providerType];
   const { icon: iconSize, container } = sizeMap[size];
 
-  if (!iconPath) {
+  if (!IconComponent) {
     return (
       <div className={cn(showBackground && "bg-primary/10 rounded-lg", container, className)}>
         <Server className="text-primary" style={{ width: iconSize, height: iconSize }} />
@@ -53,13 +103,7 @@ export function ProviderIcon({
       className={cn(showBackground && "bg-primary/10 rounded-lg", container, className)}
       title={label}
     >
-      <Image
-        src={iconPath}
-        alt={label}
-        width={iconSize}
-        height={iconSize}
-        className="dark:invert"
-      />
+      <IconComponent size={iconSize} />
     </div>
   );
 }

--- a/apps/ui/src/components/providers/provider-icon.tsx
+++ b/apps/ui/src/components/providers/provider-icon.tsx
@@ -50,10 +50,7 @@ function GeminiIcon({ size }: { size: number }) {
   );
 }
 
-const PROVIDER_ICON_COMPONENTS: Record<
-  LlmProviderType,
-  React.ComponentType<{ size: number }>
-> = {
+const PROVIDER_ICON_COMPONENTS: Record<LlmProviderType, React.ComponentType<{ size: number }>> = {
   openai: OpenAiIcon,
   openai_completions: OpenAiIcon,
   anthropic: AnthropicIcon,


### PR DESCRIPTION
## What
Replace Next.js `<Image>` with inline SVG React components for LLM provider icons (OpenAI, Anthropic, Gemini).

## Why
Provider icons use `fill="currentColor"` in SVG. When loaded via `<Image>` (`<img>` tag), the SVGs are rendered as external resources and cannot reliably inherit the CSS `color` property from parent elements. This made icons invisible on light theme backgrounds. The `dark:invert` filter was an unreliable workaround.

## How
- Created inline SVG React components (`OpenAiIcon`, `AnthropicIcon`, `GeminiIcon`) that render SVGs directly in the DOM
- Inline SVGs properly inherit `currentColor` from the parent text color, working correctly in both light and dark themes
- Removed the `next/image` import and `dark:invert` CSS filter hack
- Added 23 unit tests covering all provider types, sizes, backgrounds, currentColor usage, and fallback behavior

## Risk
- Low
- Pure rendering change to a single UI component. No API, auth, or data changes.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered