### PR TITLE
docs(capabilities): add Capabilities navigation tab with top 15 capability reference pages

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -112,6 +112,17 @@ export default defineConfig({
               ],
             },
             {
+              label: "Capabilities",
+              link: "/capabilities/",
+              icon: "puzzle",
+              items: [
+                {
+                  label: "Capabilities",
+                  autogenerate: { directory: "capabilities" },
+                },
+              ],
+            },
+            {
               label: "Operations",
               link: "/sre/environment-variables/",
               icon: "setting",

--- a/docs/capabilities/agent-instructions.md
+++ b/docs/capabilities/agent-instructions.md
@@ -1,0 +1,70 @@
+---
+title: Agent Instructions
+description: Dynamic project instructions from AGENTS.md in the session workspace
+---
+
+| | |
+|---|---|
+| **ID** | `agent_instructions` |
+| **Category** | Configuration |
+| **Risk** | Low |
+| **Features** | None |
+| **Dependencies** | None |
+
+Reads `AGENTS.md` from the session workspace and injects its content into the system prompt. The file is re-read on every conversation turn, so changes are picked up automatically without restarting the session.
+
+## Tools
+
+None — this capability only contributes to the system prompt.
+
+## How It Works
+
+1. Agent sends a message
+2. Before processing, the system reads `/workspace/AGENTS.md` from the session filesystem
+3. Content is wrapped in `<agent-instructions source="AGENTS.md">` XML tags
+4. Injected at the beginning of the system prompt (before other capability prompts)
+
+## Use Cases
+
+- **Project conventions** — coding style, naming rules, architectural constraints
+- **Build instructions** — how to compile, test, and deploy the project
+- **Context injection** — repository structure, key files, domain-specific terminology
+- **Dynamic guidance** — update instructions mid-session by modifying the file
+
+## Example
+
+Upload an `AGENTS.md` to the session workspace:
+
+```markdown
+# Project: acme-api
+
+## Stack
+- Python 3.12, FastAPI, SQLAlchemy
+- PostgreSQL 16, Redis 7
+
+## Conventions
+- Use snake_case for all Python identifiers
+- All endpoints return JSON with `{ data, error }` envelope
+- Tests go in `tests/` mirroring `src/` structure
+
+## Build
+- `pip install -e ".[dev]"` to install
+- `pytest` to run tests
+- `ruff check .` to lint
+```
+
+The agent will follow these instructions for every turn in the session.
+
+## Notes
+
+- File path: `/workspace/AGENTS.md` (plain Markdown, max 32 KiB)
+- Re-read every turn — edits take effect immediately
+- If the file doesn't exist, no instructions are added (no error)
+- Works with [File System](/capabilities/file-system/) tools to update instructions dynamically
+
+## See Also
+
+- [Agent Instructions feature guide](/features/agent-instructions/) — detailed documentation
+- [File System](/capabilities/file-system/) — manage the AGENTS.md file
+- [Agent Skills](/capabilities/agent-skills/) — another way to inject specialized instructions
+- [Capabilities Overview](/capabilities/)

--- a/docs/capabilities/agent-skills.md
+++ b/docs/capabilities/agent-skills.md
@@ -1,0 +1,85 @@
+---
+title: Agent Skills
+description: Discover and activate portable instruction packages from the session workspace
+---
+
+| | |
+|---|---|
+| **ID** | `skills` |
+| **Category** | Skills |
+| **Risk** | Low |
+| **Features** | None |
+| **Dependencies** | [`session_file_system`](/capabilities/file-system/) |
+
+Discover and activate skills from `/.agents/skills/` in the session filesystem. Skills are portable instruction packages following the [Agent Skills](https://agentskills.io/) open specification.
+
+## Tools
+
+### `list_skills`
+
+Scan `/.agents/skills/` for available skills. Returns names and descriptions only (~100 tokens per skill).
+
+### `activate_skill`
+
+Load a skill's full instructions by name.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Skill name (directory name under `/.agents/skills/`) |
+
+Returns: full SKILL.md content and list of bundled files.
+
+## How It Works
+
+Skills use progressive disclosure to keep context efficient:
+
+1. **Discovery** (~100 tokens) — `list_skills` returns only names and descriptions
+2. **Activation** (<5000 tokens) — `activate_skill` loads the full SKILL.md instructions
+3. **Resources** (on-demand) — bundled files accessible via [File System](/capabilities/file-system/) tools
+
+## Use Cases
+
+- **Project-specific workflows** — upload skills for your project's deployment, testing, or review processes
+- **Specialized knowledge** — domain-specific instructions (e.g., security review checklists)
+- **Reusable templates** — code generation patterns, documentation templates
+
+## Example
+
+Skills are uploaded to the session workspace:
+
+```
+/.agents/skills/
+  deploy/
+    SKILL.md          # Deployment instructions
+    templates/
+      k8s-deploy.yaml # Kubernetes template
+  code-review/
+    SKILL.md          # Review checklist and process
+```
+
+Agent discovers and uses them:
+
+```
+Agent:
+  → list_skills()
+  ← [{ name: "deploy", description: "Production deployment workflow" },
+     { name: "code-review", description: "Code review checklist" }]
+
+  → activate_skill({ name: "deploy" })
+  ← { instructions: "## Deployment Process\n1. Run tests...", files: ["templates/k8s-deploy.yaml"] }
+```
+
+## Notes
+
+- Skills are per-session (uploaded to session filesystem)
+- Path traversal protection on skill names
+- Invalid SKILL.md files are reported but don't block discovery of other skills
+- For organization-wide skills, see the [Skills Registry](/features/skills-registry/)
+
+## See Also
+
+- [Agent Skills feature guide](/features/skills/) — detailed skills documentation
+- [Skills Registry](/features/skills-registry/) — API-managed skills
+- [Agent Instructions](/capabilities/agent-instructions/) — simpler alternative for project context
+- [File System](/capabilities/file-system/) — upload skill files
+- [Capabilities Overview](/capabilities/)

--- a/docs/capabilities/current-time.md
+++ b/docs/capabilities/current-time.md
@@ -1,0 +1,47 @@
+---
+title: Current Time
+description: Get the current date and time in various formats and timezones
+---
+
+| | |
+|---|---|
+| **ID** | `current_time` |
+| **Category** | Utilities |
+| **Risk** | Low |
+| **Features** | None |
+| **Dependencies** | None |
+
+Provides a tool to get the current date and time. Supports multiple formats and timezones.
+
+## Tools
+
+### `get_current_time`
+
+Get the current date and time.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `timezone` | string | no | IANA timezone (e.g., `America/New_York`, `Europe/London`) |
+| `format` | string | no | Output format: `iso8601`, `unix`, `human` |
+
+## Use Cases
+
+- **Time-aware agents** — agents that need to reference "today" or "right now"
+- **Scheduling context** — determine current time before creating [schedules](/capabilities/session-schedules/)
+- **Logging** — timestamp entries in reports or logs
+- **Timezone conversion** — answer questions about current time in different regions
+
+## Example
+
+```
+User: What time is it in Tokyo?
+
+Agent:
+  → get_current_time({ timezone: "Asia/Tokyo", format: "human" })
+  ← "Wednesday, March 6, 2026, 2:30 PM JST"
+```
+
+## See Also
+
+- [Session Schedules](/capabilities/session-schedules/) — schedule future tasks
+- [Capabilities Overview](/capabilities/)

--- a/docs/capabilities/fake-aws.md
+++ b/docs/capabilities/fake-aws.md
@@ -1,0 +1,56 @@
+---
+title: Fake AWS
+description: Demo capability with simulated AWS infrastructure management tools
+---
+
+| | |
+|---|---|
+| **ID** | `fake_aws` |
+| **Category** | Demo |
+| **Risk** | Low |
+| **Features** | None |
+| **Dependencies** | None |
+
+Simulated AWS infrastructure management tools for testing and demonstrations. Covers EC2, RDS, S3, IAM, security groups, and CloudWatch. State is persisted in the session filesystem under `/aws/`. Simulates realistic API latency (configurable via `FAKE_AWS_LATENCY_MS`).
+
+## Tools
+
+| Tool | Description |
+|---|---|
+| `aws_list_ec2_instances` | List EC2 instances |
+| `aws_create_ec2_instance` | Launch a new EC2 instance |
+| `aws_stop_ec2_instance` | Stop an EC2 instance |
+| `aws_list_rds_databases` | List RDS databases |
+| `aws_create_rds_database` | Create an RDS database |
+| `aws_list_s3_buckets` | List S3 buckets |
+| `aws_create_s3_bucket` | Create an S3 bucket |
+| `aws_list_iam_users` | List IAM users |
+| `aws_create_iam_user` | Create an IAM user |
+| `aws_list_security_groups` | List security groups |
+| `aws_get_cloudwatch_metrics` | Get CloudWatch metrics |
+
+## Use Cases
+
+- **DevOps agent demos** — showcase agents managing cloud infrastructure
+- **Testing multi-service workflows** — validate agents coordinating across AWS services
+- **Training** — practice AWS operations without real cloud access or cost
+
+## Example
+
+```
+User: Set up a web server with a database
+
+Agent:
+  → aws_create_ec2_instance({ instance_type: "t3.medium", ami: "ami-web-server" })
+  ← { instance_id: "i-abc123", status: "running" }
+  → aws_create_rds_database({ engine: "postgres", instance_class: "db.t3.micro" })
+  ← { db_identifier: "db-xyz789", status: "available", endpoint: "db-xyz789.rds.amazonaws.com" }
+  → aws_create_s3_bucket({ bucket_name: "app-assets-prod" })
+  ← { bucket: "app-assets-prod", status: "created" }
+```
+
+## See Also
+
+- [Fake Warehouse](/capabilities/fake-warehouse/) — simulated warehouse operations
+- [Fake CRM](/capabilities/fake-crm/) — simulated customer management
+- [Capabilities Overview](/capabilities/)

--- a/docs/capabilities/fake-crm.md
+++ b/docs/capabilities/fake-crm.md
@@ -1,0 +1,69 @@
+---
+title: Fake CRM
+description: Demo capability with simulated CRM and customer support tools
+---
+
+| | |
+|---|---|
+| **ID** | `fake_crm` |
+| **Category** | Demo |
+| **Risk** | Low |
+| **Features** | None |
+| **Dependencies** | None |
+
+Simulated CRM and customer support tools for testing and demonstrations. Manage customers, support tickets, and interaction history. State is persisted in the session filesystem.
+
+## Tools
+
+| Tool | Description |
+|---|---|
+| `crm_list_customers` | List customers with pagination |
+| `crm_get_customer` | Get customer details by ID |
+| `crm_create_customer` | Create a new customer |
+| `crm_list_tickets` | List support tickets |
+| `crm_create_ticket` | Create a support ticket |
+| `crm_update_ticket` | Update ticket status |
+| `crm_add_interaction` | Add a customer interaction note |
+| `crm_search_customers` | Search customers by criteria |
+
+## Use Cases
+
+- **Support agent demos** — showcase agents handling customer inquiries and ticket management
+- **Testing conversational workflows** — validate agents managing customer interactions
+- **Prompt development** — develop customer service agent prompts with realistic data
+
+## Example
+
+```
+User: A customer called about a billing issue, create a ticket
+
+Agent:
+  → crm_search_customers({ query: "billing issue" })
+  ← []
+  → crm_list_customers({ limit: 5 })
+  ← [{ id: "cust-001", name: "Jane Smith", email: "jane@example.com" }, ...]
+
+  "Which customer reported the billing issue?"
+
+User: Jane Smith
+
+Agent:
+  → crm_create_ticket({
+      customer_id: "cust-001",
+      subject: "Billing discrepancy",
+      priority: "high",
+      description: "Customer reports incorrect charge on latest invoice"
+    })
+  ← { ticket_id: "TKT-042", status: "open" }
+  → crm_add_interaction({
+      customer_id: "cust-001",
+      type: "phone",
+      notes: "Customer called about billing discrepancy. Ticket TKT-042 created."
+    })
+```
+
+## See Also
+
+- [Fake Warehouse](/capabilities/fake-warehouse/) — simulated warehouse operations
+- [Fake AWS](/capabilities/fake-aws/) — simulated cloud infrastructure
+- [Capabilities Overview](/capabilities/)

--- a/docs/capabilities/fake-warehouse.md
+++ b/docs/capabilities/fake-warehouse.md
@@ -1,0 +1,55 @@
+---
+title: Fake Warehouse
+description: Demo capability with simulated warehouse management tools
+---
+
+| | |
+|---|---|
+| **ID** | `fake_warehouse` |
+| **Category** | Demo |
+| **Risk** | Low |
+| **Features** | None |
+| **Dependencies** | None |
+
+Simulated warehouse management tools for testing and demonstrations. Provides inventory tracking, shipment management, order processing, invoicing, and returns. State is persisted in the session filesystem.
+
+## Tools
+
+| Tool | Description |
+|---|---|
+| `warehouse_get_inventory` | Get current inventory levels |
+| `warehouse_update_inventory` | Update item quantities |
+| `warehouse_create_shipment` | Create a new shipment |
+| `warehouse_list_shipments` | List all shipments |
+| `warehouse_update_shipment_status` | Update shipment status |
+| `warehouse_create_order` | Create a new order |
+| `warehouse_list_orders` | List all orders |
+| `warehouse_create_invoice` | Generate an invoice |
+| `warehouse_process_return` | Process a return |
+| `warehouse_inventory_report` | Generate inventory report |
+
+## Use Cases
+
+- **Agent demos** — showcase multi-tool agent workflows with realistic domain operations
+- **Testing tool calling** — validate agent behavior with complex, stateful tool chains
+- **Prompt engineering** — develop and test system prompts for warehouse management agents
+
+## Example
+
+```
+User: Create an order for 50 widgets and ship it
+
+Agent:
+  → warehouse_create_order({ items: [{ sku: "WIDGET-001", quantity: 50 }], customer: "Acme Corp" })
+  ← { order_id: "ORD-001", status: "created" }
+  → warehouse_create_shipment({ order_id: "ORD-001", carrier: "FedEx" })
+  ← { shipment_id: "SHP-001", status: "pending" }
+  → warehouse_update_shipment_status({ shipment_id: "SHP-001", status: "shipped" })
+  → warehouse_create_invoice({ order_id: "ORD-001" })
+```
+
+## See Also
+
+- [Fake AWS](/capabilities/fake-aws/) — simulated cloud infrastructure
+- [Fake CRM](/capabilities/fake-crm/) — simulated customer management
+- [Capabilities Overview](/capabilities/)

--- a/docs/capabilities/file-system.md
+++ b/docs/capabilities/file-system.md
@@ -1,0 +1,98 @@
+---
+title: File System
+description: Read, write, search, and manage files in an isolated per-session workspace
+---
+
+| | |
+|---|---|
+| **ID** | `session_file_system` |
+| **Category** | File Operations |
+| **Risk** | Low |
+| **Features** | `file_system` (unlocks Workspace tab) |
+| **Dependencies** | None |
+
+Provides tools to access and manipulate files in the session workspace. Each session has an isolated filesystem rooted at `/workspace`. Files persist for the session duration.
+
+## Tools
+
+### `read_file`
+
+Read the contents of a file.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `path` | string | yes | Absolute path (e.g., `/workspace/src/main.py`) |
+
+### `write_file`
+
+Create or overwrite a file. Parent directories are created automatically.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `path` | string | yes | Absolute path |
+| `content` | string | yes | File content |
+
+### `list_directory`
+
+List files and directories at a given path.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `path` | string | yes | Directory path |
+
+### `grep_files`
+
+Search file contents with regex patterns.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `pattern` | string | yes | Regex pattern |
+| `path` | string | no | Directory to search (default: `/workspace`) |
+
+### `delete_file`
+
+Delete a file or directory.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `path` | string | yes | Path to delete |
+
+### `stat_file`
+
+Get file metadata (size, type, timestamps).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `path` | string | yes | Path to stat |
+
+## Use Cases
+
+- **Code generation** — agent writes source files, configs, and scripts to the workspace
+- **Document processing** — read uploaded files, transform content, write results
+- **Project scaffolding** — create directory structures with boilerplate files
+- **Log analysis** — grep through log files for patterns and errors
+
+## Example
+
+Agent creates a Python project:
+
+```
+User: Create a Flask hello world app
+
+Agent:
+  → write_file("/workspace/app.py", "from flask import Flask\napp = Flask(__name__)\n\n@app.route('/')\ndef hello():\n    return 'Hello, World!'\n")
+  → write_file("/workspace/requirements.txt", "flask>=3.0\n")
+```
+
+## Notes
+
+- All paths must be under `/workspace`
+- Files are session-scoped — no cross-session access
+- Parent directories are auto-created on write
+- Shared filesystem with [Virtual Bash](/capabilities/virtual-bash/) (same `/workspace`)
+
+## See Also
+
+- [Virtual Bash](/capabilities/virtual-bash/) — execute commands against these files
+- [Session Storage](/capabilities/session-storage/) — key/value and secret storage
+- [Capabilities Overview](/capabilities/)

--- a/docs/capabilities/index.md
+++ b/docs/capabilities/index.md
@@ -1,0 +1,125 @@
+---
+title: Capabilities Overview
+description: Modular functionality units that extend agent behavior with tools, system prompts, and execution features
+---
+
+Capabilities are modular units that extend what an agent can do. Each capability can contribute:
+
+- **Tools** — callable functions the agent can invoke during conversations
+- **System prompt additions** — context and instructions prepended to the agent's prompt
+- **Features** — UI elements unlocked when the capability is active (e.g., Workspace tab)
+
+Agents compose capabilities — enable only what you need.
+
+## Capability Reference
+
+### Core
+
+Fundamental capabilities for file operations, command execution, web access, and session management.
+
+| Capability | ID | Tools | Risk |
+|---|---|---|---|
+| [File System](/capabilities/file-system/) | `session_file_system` | 6 | Low |
+| [Virtual Bash](/capabilities/virtual-bash/) | `virtual_bash` | 1 | High |
+| [Session](/capabilities/session/) | `session` | 2 | Low |
+| [Session Storage](/capabilities/session-storage/) | `session_storage` | 2 | Low |
+| [Web Fetch](/capabilities/web-fetch/) | `web_fetch` | 1 | High |
+
+### Data & Productivity
+
+Structured data, time awareness, task tracking, and scheduling.
+
+| Capability | ID | Tools | Risk |
+|---|---|---|---|
+| [SQL Database](/capabilities/sql-database/) | `session_sql_database` | 3 | Low |
+| [Current Time](/capabilities/current-time/) | `current_time` | 1 | Low |
+| [Task Management](/capabilities/task-management/) | `stateless_todo_list` | 1 | Low |
+| [Session Schedules](/capabilities/session-schedules/) | `session_schedule` | 3 | Low |
+
+### Platform & Configuration
+
+Agent self-management, dynamic instructions, and skill discovery.
+
+| Capability | ID | Tools | Risk |
+|---|---|---|---|
+| [Platform Management](/capabilities/platform-management/) | `platform_management` | 5 | Low |
+| [Agent Instructions](/capabilities/agent-instructions/) | `agent_instructions` | 0 | Low |
+| [Agent Skills](/capabilities/agent-skills/) | `skills` | 2 | Low |
+
+### Demo
+
+Pre-built domain simulations for testing and demonstrations.
+
+| Capability | ID | Tools | Risk |
+|---|---|---|---|
+| [Fake Warehouse](/capabilities/fake-warehouse/) | `fake_warehouse` | 10 | Low |
+| [Fake AWS](/capabilities/fake-aws/) | `fake_aws` | 11 | Low |
+| [Fake CRM](/capabilities/fake-crm/) | `fake_crm` | 8 | Low |
+
+## Quick Start
+
+### Enable via API
+
+```bash
+curl -X POST http://localhost:9300/api/v1/agents \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "My Agent",
+    "system_prompt": "You are a helpful assistant.",
+    "capabilities": ["session_file_system", "virtual_bash", "web_fetch"]
+  }'
+```
+
+### Enable via UI
+
+1. Navigate to the Agent detail page
+2. Open the **Capabilities** section
+3. Toggle capabilities on/off
+4. Reorder with drag handles (order affects system prompt priority)
+5. Save
+
+### List available capabilities
+
+```bash
+curl http://localhost:9300/api/v1/capabilities
+```
+
+## Key Concepts
+
+### Dependencies
+
+Some capabilities depend on others. Dependencies are resolved automatically at runtime — you don't need to manually add them.
+
+| Capability | Depends On |
+|---|---|
+| [Virtual Bash](/capabilities/virtual-bash/) | [File System](/capabilities/file-system/) |
+| [Agent Skills](/capabilities/agent-skills/) | [File System](/capabilities/file-system/) |
+
+### Features
+
+Capabilities declare UI features they contribute. The session aggregates features from all active capabilities to decide which UI tabs to render.
+
+| Feature | UI Element | Contributed By |
+|---|---|---|
+| `file_system` | Workspace tab | [File System](/capabilities/file-system/), [Virtual Bash](/capabilities/virtual-bash/) |
+| `secrets` | Storage tab | [Session Storage](/capabilities/session-storage/) |
+| `key_value` | Storage tab | [Session Storage](/capabilities/session-storage/) |
+| `schedules` | Schedules tab | [Session Schedules](/capabilities/session-schedules/) |
+| `sql_database` | Database tab | [SQL Database](/capabilities/sql-database/) |
+
+### Risk Levels
+
+| Level | Who Can Assign | Examples |
+|---|---|---|
+| Low | Any org member | File System, Current Time |
+| High | Admin only | Virtual Bash, Web Fetch |
+
+### Ordering
+
+Capabilities are applied in the order configured on the agent. Earlier capabilities' system prompt additions appear first. Place the most important context-setting capabilities first.
+
+## See Also
+
+- [Concepts](/getting-started/concepts/) — how capabilities fit into the Harness → Agent → Session model
+- [API Reference](/api/) — full API documentation
+- [MCP Servers](/features/capabilities/#mcp-virtual-capabilities) — external tool servers as virtual capabilities

--- a/docs/capabilities/platform-management.md
+++ b/docs/capabilities/platform-management.md
@@ -1,0 +1,126 @@
+---
+title: Platform Management
+description: Programmatic management of harnesses, agents, and sessions
+---
+
+| | |
+|---|---|
+| **ID** | `platform_management` |
+| **Category** | Platform |
+| **Risk** | Low |
+| **Features** | None |
+| **Dependencies** | None |
+
+Tools to manage Everruns entities programmatically. Create, list, update, and delete harnesses, agents, and sessions — and interact with sessions by sending messages.
+
+## Tools
+
+### `list_capabilities`
+
+Discover available capabilities (built-in, MCP servers, skills).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `search` | string | no | Case-insensitive filter by name, description, category, or ID |
+
+### `manage_harnesses`
+
+CRUD operations on [harnesses](/getting-started/concepts/).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `operation` | enum | yes | `list`, `get`, `create`, `update`, `delete`, `copy` |
+| `harness_id` | string | conditional | Required for `get`, `update`, `delete`, `copy` |
+| `name` | string | conditional | Required for `create` |
+| `system_prompt` | string | conditional | Required for `create` |
+| `description` | string | no | Optional description |
+| `capabilities` | string[] | no | Capabilities to enable |
+
+### `manage_agents`
+
+CRUD operations on [agents](/getting-started/concepts/).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `operation` | enum | yes | `list`, `get`, `create`, `update`, `delete` |
+| `agent_id` | string | conditional | Required for `get`, `update`, `delete` |
+| `name` | string | conditional | Required for `create` |
+| `system_prompt` | string | conditional | Required for `create` |
+| `description` | string | no | Optional description |
+| `capabilities` | string[] | no | Capabilities to enable |
+
+### `manage_sessions`
+
+CRUD operations on [sessions](/getting-started/concepts/).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `operation` | enum | yes | `list`, `get`, `create`, `delete` |
+| `session_id` | string | conditional | Required for `get`, `delete` |
+| `harness_id` | string | conditional | Required for `create` |
+| `agent_id` | string | no | Optional for `create` and `list` |
+| `title` | string | no | Optional for `create` |
+| `limit` | integer | no | Optional for `list` |
+
+### `session_interact`
+
+Send messages to sessions and manage turn lifecycle.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `operation` | enum | yes | `send_message`, `get_messages`, `wait_for_idle` |
+| `session_id` | string | yes | Target session ID |
+| `content` | string | conditional | Required for `send_message` |
+| `limit` | integer | no | Message count for `get_messages` (default: 10) |
+| `timeout_secs` | integer | no | Timeout for `wait_for_idle` (default: 300) |
+
+## Use Cases
+
+- **Meta-agents** — an agent that creates and configures other agents
+- **Orchestration** — spawn sessions across multiple agents and collect results
+- **Self-configuration** — agent inspects available capabilities before setting up new agents
+- **Automated testing** — programmatically create sessions and verify agent responses
+
+## Example
+
+Agent creates a specialized sub-agent and interacts with it:
+
+```
+Agent:
+  → list_capabilities({ search: "file" })
+  ← [{ id: "session_file_system", name: "File System", ... }]
+
+  → manage_agents({
+      operation: "create",
+      name: "Code Reviewer",
+      system_prompt: "You review code for bugs and style issues.",
+      capabilities: ["session_file_system", "virtual_bash"]
+    })
+  ← { "agent_id": "agt_01xyz...", "ui_link": "/agents/agt_01xyz..." }
+
+  → manage_sessions({
+      operation: "create",
+      harness_id: "hrs_01abc...",
+      agent_id: "agt_01xyz..."
+    })
+  ← { "session_id": "ses_01def...", "ui_link": "/chat?session=ses_01def..." }
+
+  → session_interact({
+      operation: "send_message",
+      session_id: "ses_01def...",
+      content: "Review this Python function: def add(a, b): return a + b"
+    })
+```
+
+## Notes
+
+- All tool results include `ui_link` fields for navigating to the web interface
+- `list_capabilities` searches across built-in, MCP server, and skill capabilities
+- Session interaction follows the same turn lifecycle as the UI
+
+## See Also
+
+- [Concepts](/getting-started/concepts/) — Harness, Agent, Session model
+- [Agent Skills](/capabilities/agent-skills/) — skill discovery
+- [API Reference](/api/) — full REST API
+- [Capabilities Overview](/capabilities/)

--- a/docs/capabilities/session-schedules.md
+++ b/docs/capabilities/session-schedules.md
@@ -1,0 +1,73 @@
+---
+title: Session Schedules
+description: Schedule one-shot and recurring tasks within a session
+---
+
+| | |
+|---|---|
+| **ID** | `session_schedule` |
+| **Category** | Session |
+| **Risk** | Low |
+| **Features** | `schedules` (unlocks Schedules tab) |
+| **Dependencies** | None |
+
+Schedule future tasks within the current session. Supports one-shot (run once at a specific time) and recurring (cron expression) schedules.
+
+## Tools
+
+### `create_schedule`
+
+Create a new scheduled task.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `message` | string | yes | The message/task to execute |
+| `scheduled_at` | string | conditional | ISO 8601 datetime for one-shot schedules |
+| `cron_expression` | string | conditional | Cron expression for recurring schedules |
+
+Provide either `scheduled_at` or `cron_expression`, not both.
+
+### `cancel_schedule`
+
+Cancel an active schedule.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `schedule_id` | string | yes | ID of the schedule to cancel |
+
+### `list_schedules`
+
+List all schedules for the current session.
+
+## Use Cases
+
+- **Periodic monitoring** — check system status every hour
+- **Reminders** — schedule a follow-up at a specific time
+- **Recurring reports** — generate daily summaries
+- **Delayed actions** — schedule a task for later execution
+
+## Example
+
+```
+User: Check the deployment status every 30 minutes
+
+Agent:
+  → create_schedule({
+      message: "Check deployment status and report any issues",
+      cron_expression: "*/30 * * * *"
+    })
+  ← { "schedule_id": "sch_01abc...", "cron_expression": "*/30 * * * *", "status": "active" }
+```
+
+## Notes
+
+- Maximum 5 active schedules per session
+- Cron uses standard 5-field format (minute, hour, day, month, weekday)
+- Scheduled messages are sent to the session as if the user sent them
+- Use [Current Time](/capabilities/current-time/) to determine "now" before scheduling
+
+## See Also
+
+- [Current Time](/capabilities/current-time/) — get current time for scheduling context
+- [Session](/capabilities/session/) — session metadata
+- [Capabilities Overview](/capabilities/)

--- a/docs/capabilities/session-storage.md
+++ b/docs/capabilities/session-storage.md
@@ -1,0 +1,73 @@
+---
+title: Session Storage
+description: Key/value storage and encrypted secret storage within a session
+---
+
+| | |
+|---|---|
+| **ID** | `session_storage` |
+| **Category** | Storage |
+| **Risk** | Low |
+| **Features** | `secrets`, `key_value` (unlocks Storage tab) |
+| **Dependencies** | None |
+
+Two storage mechanisms scoped to the current session:
+
+- **Key/Value store** — plain-text storage for general data
+- **Secret store** — AES-256-GCM encrypted storage for sensitive data
+
+## Tools
+
+### `kv_store`
+
+Manage plain-text key/value pairs.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `operation` | enum | yes | `set`, `get`, `delete`, or `list` |
+| `key` | string | conditional | Required for `set`, `get`, `delete` |
+| `value` | string | conditional | Required for `set` |
+
+### `secret_store`
+
+Manage encrypted secrets. Same interface as `kv_store` but values are encrypted at rest.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `operation` | enum | yes | `set`, `get`, `delete`, or `list` |
+| `name` | string | conditional | Required for `set`, `get`, `delete` |
+| `value` | string | conditional | Required for `set` |
+
+## Use Cases
+
+- **API key management** — store third-party API keys securely during a session
+- **State persistence** — save intermediate results between conversation turns
+- **Configuration** — store user preferences or settings for the session
+- **Credential handling** — securely store tokens needed for multi-step workflows
+
+## Example
+
+```
+User: Store my GitHub token so you can use it later
+
+Agent:
+  → secret_store({ operation: "set", name: "github_token", value: "ghp_abc123..." })
+  ← "Secret 'github_token' stored successfully"
+
+  (later in conversation)
+  → secret_store({ operation: "get", name: "github_token" })
+  ← { "name": "github_token", "value": "ghp_abc123..." }
+```
+
+## Notes
+
+- Data is session-scoped — no cross-session access
+- `set` uses upsert semantics (overwrites existing keys)
+- Secret operations require `SECRETS_ENCRYPTION_KEY` to be configured
+- `list` returns keys/names only (not values) for secrets
+
+## See Also
+
+- [Session](/capabilities/session/) — session metadata
+- [File System](/capabilities/file-system/) — file-based storage alternative
+- [Capabilities Overview](/capabilities/)

--- a/docs/capabilities/session.md
+++ b/docs/capabilities/session.md
@@ -1,0 +1,52 @@
+---
+title: Session
+description: Read and update current session metadata
+---
+
+| | |
+|---|---|
+| **ID** | `session` |
+| **Category** | Session |
+| **Risk** | Low |
+| **Features** | None |
+| **Dependencies** | None |
+
+Tools to read and update session metadata like title and agent information.
+
+## Tools
+
+### `get_session_info`
+
+Get current session metadata.
+
+Returns: session ID, title, agent name.
+
+### `write_session_title`
+
+Update the session title.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `title` | string | yes | New session title |
+
+## Use Cases
+
+- **Auto-titling** — agent sets a descriptive title based on the conversation topic
+- **Context awareness** — agent reads its own session ID for logging or references
+
+## Example
+
+```
+User: Help me debug the login issue
+
+Agent:
+  → write_session_title("Debug: Login authentication failure")
+  → get_session_info()
+  ← { "session_id": "ses_01abc...", "title": "Debug: Login authentication failure", "agent_name": "DevOps Agent" }
+```
+
+## See Also
+
+- [Session Storage](/capabilities/session-storage/) — persist data within the session
+- [Session Schedules](/capabilities/session-schedules/) — schedule future tasks
+- [Capabilities Overview](/capabilities/)

--- a/docs/capabilities/sql-database.md
+++ b/docs/capabilities/sql-database.md
@@ -1,0 +1,68 @@
+---
+title: SQL Database
+description: Session-scoped SQLite databases for structured data storage and querying
+---
+
+| | |
+|---|---|
+| **ID** | `session_sql_database` |
+| **Category** | Data |
+| **Risk** | Low |
+| **Features** | `sql_database` |
+| **Dependencies** | None |
+
+Session-scoped SQLite databases for structured data storage. Create tables, insert data, and run queries — all isolated to the current session.
+
+## Tools
+
+### `sql_execute`
+
+Run DDL/DML statements (CREATE TABLE, INSERT, UPDATE, DELETE).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `sql` | string | yes | SQL statement to execute |
+
+### `sql_query`
+
+Run SELECT queries. Results limited to 1000 rows.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `sql` | string | yes | SELECT query |
+
+### `sql_schema`
+
+Introspect the database schema — list tables, columns, and types.
+
+## Use Cases
+
+- **Data analysis** — import CSV/JSON data into tables and run analytical queries
+- **Structured storage** — store relational data that doesn't fit key/value patterns
+- **Reporting** — aggregate and summarize data with SQL
+- **Prototyping** — test database schemas and queries before implementing
+
+## Example
+
+```
+User: Track my reading list
+
+Agent:
+  → sql_execute("CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT, author TEXT, status TEXT DEFAULT 'unread')")
+  → sql_execute("INSERT INTO books (title, author) VALUES ('Designing Data-Intensive Applications', 'Martin Kleppmann')")
+  → sql_execute("INSERT INTO books (title, author, status) VALUES ('The Pragmatic Programmer', 'Hunt & Thomas', 'read')")
+  → sql_query("SELECT title, author, status FROM books ORDER BY title")
+  ← [{ "title": "Designing Data-Intensive Applications", "author": "Martin Kleppmann", "status": "unread" }, ...]
+```
+
+## Notes
+
+- Database is session-scoped — destroyed when the session ends
+- SELECT queries return at most 1000 rows
+- Standard SQLite SQL syntax
+
+## See Also
+
+- [Session Storage](/capabilities/session-storage/) — simpler key/value alternative
+- [File System](/capabilities/file-system/) — file-based data storage
+- [Capabilities Overview](/capabilities/)

--- a/docs/capabilities/task-management.md
+++ b/docs/capabilities/task-management.md
@@ -1,0 +1,60 @@
+---
+title: Task Management
+description: Structured task lists for tracking multi-step work progress
+---
+
+| | |
+|---|---|
+| **ID** | `stateless_todo_list` |
+| **Category** | Productivity |
+| **Risk** | Low |
+| **Features** | None |
+| **Dependencies** | None |
+
+Enables agents to create and manage structured task lists. State is maintained in conversation history — each tool call sends the complete list.
+
+## Tools
+
+### `write_todos`
+
+Create or update the complete task list. Each call replaces the entire list.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `todos` | array | yes | Array of `{ content, status, activeForm }` objects |
+
+Task statuses: `pending`, `in_progress`, `completed`.
+
+## Use Cases
+
+- **Multi-step implementations** — track progress across a complex coding task
+- **User-requested lists** — manage a checklist of items the user provides
+- **Workflow tracking** — show progress on multi-file refactoring or migration tasks
+
+## Example
+
+```
+User: Refactor the auth module to use JWT
+
+Agent:
+  → write_todos([
+      { content: "Analyze current auth implementation", status: "in_progress", activeForm: "Analyzing current auth" },
+      { content: "Add JWT dependency", status: "pending", activeForm: "Adding JWT dependency" },
+      { content: "Implement token generation", status: "pending", activeForm: "Implementing token generation" },
+      { content: "Update middleware", status: "pending", activeForm: "Updating middleware" },
+      { content: "Run tests", status: "pending", activeForm: "Running tests" }
+    ])
+```
+
+## Notes
+
+- **Stateless** — no database table; state lives in conversation history
+- Each `write_todos` call must include the **complete** list (not incremental updates)
+- Best practice: exactly one task `in_progress` at a time
+- Only mark a task `completed` when fully done (tests pass, no errors)
+- `activeForm` is the present-continuous label shown during execution (e.g., "Running tests")
+
+## See Also
+
+- [Session](/capabilities/session/) — session metadata management
+- [Capabilities Overview](/capabilities/)

--- a/docs/capabilities/virtual-bash.md
+++ b/docs/capabilities/virtual-bash.md
@@ -1,0 +1,61 @@
+---
+title: Virtual Bash
+description: Sandboxed bash command execution in an isolated environment
+---
+
+| | |
+|---|---|
+| **ID** | `virtual_bash` |
+| **Category** | Execution |
+| **Risk** | High (admin required) |
+| **Features** | `file_system` (unlocks Workspace tab) |
+| **Dependencies** | [`session_file_system`](/capabilities/file-system/) |
+
+Execute bash commands in a sandboxed environment with no access to the host system. Powered by [bashkit](https://github.com/everruns/bashkit), a WASM-like execution sandbox. The session filesystem is mounted at `/workspace`.
+
+## Tools
+
+### `bash`
+
+Execute a shell command.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `command` | string | yes | Shell command to execute |
+| `working_dir` | string | no | Working directory (default: `/workspace`) |
+| `timeout` | integer | no | Timeout in seconds |
+
+Returns stdout, stderr, and exit code.
+
+## Use Cases
+
+- **Code execution** — run scripts, compile code, execute tests
+- **Data processing** — pipe commands, transform files with standard Unix tools
+- **Environment setup** — install packages, configure environments
+- **Build automation** — run build tools, linters, formatters
+
+## Example
+
+Agent runs a Python script and inspects the output:
+
+```
+User: Run the test suite
+
+Agent:
+  → bash("cd /workspace && python -m pytest tests/ -v")
+  ← stdout: "tests/test_api.py::test_health PASSED\ntests/test_api.py::test_create PASSED\n2 passed in 0.34s"
+  ← exit_code: 0
+```
+
+## Notes
+
+- **Sandboxed** — no network access, no host filesystem access
+- Commands operate on the same `/workspace` as [File System](/capabilities/file-system/) tools
+- Files written by bash are immediately visible to file system tools and vice versa
+- Built-in shell commands: `cd`, `ls`, `cat`, `echo`, `grep`, `head`, `tail`, etc.
+- Resource limits prevent infinite loops
+
+## See Also
+
+- [File System](/capabilities/file-system/) — file operations on the same workspace
+- [Capabilities Overview](/capabilities/)

--- a/docs/capabilities/web-fetch.md
+++ b/docs/capabilities/web-fetch.md
@@ -1,0 +1,60 @@
+---
+title: Web Fetch
+description: Fetch web content from URLs with HTML-to-markdown conversion
+---
+
+| | |
+|---|---|
+| **ID** | `web_fetch` |
+| **Category** | Network |
+| **Risk** | High (admin required) |
+| **Features** | None |
+| **Dependencies** | None |
+
+Fetch content from URLs and convert HTML to markdown or plain text. Powered by [fetchkit](https://github.com/everruns/fetchkit) with built-in SSRF protection.
+
+## Tools
+
+### `web_fetch`
+
+Fetch a URL and return its content.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `url` | string | yes | URL to fetch |
+| `method` | string | no | HTTP method (default: `GET`) |
+| `as_markdown` | boolean | no | Convert HTML to markdown |
+| `as_text` | boolean | no | Convert HTML to plain text |
+
+Returns: content body, status code, metadata (size, content type, filename, last modified).
+
+## Use Cases
+
+- **Research** — fetch documentation, API references, or web articles
+- **Data collection** — retrieve JSON/CSV data from public APIs
+- **Content extraction** — convert web pages to clean markdown for processing
+- **Link verification** — check if URLs are reachable and inspect response metadata
+
+## Example
+
+```
+User: Summarize the Python 3.12 changelog
+
+Agent:
+  → web_fetch({ url: "https://docs.python.org/3/whatsnew/3.12.html", as_markdown: true })
+  ← (markdown content of the changelog page)
+
+  "Python 3.12 introduces several key changes: ..."
+```
+
+## Notes
+
+- **Timeouts**: 1s for first byte, 30s for body. Partial content returned on body timeout.
+- **Binary content**: Images, PDFs, etc. return metadata only (content type, size) — not the binary data.
+- **SSRF protection**: Private IPs (loopback, RFC1918, link-local, CGNAT) are blocked by default with DNS pinning to prevent rebinding attacks.
+- **Excessive newlines**: Automatically filtered from converted content.
+
+## See Also
+
+- [File System](/capabilities/file-system/) — save fetched content to workspace
+- [Capabilities Overview](/capabilities/)

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -586,6 +586,7 @@ See `crates/server/migrations/001_base_schema.sql` for the `agent_capabilities` 
 2. Register in `CapabilityRegistry::with_builtins()` (same file)
 3. Add tool implementations if needed (implement `Tool` trait from `crates/core/src/tools.rs`)
 4. No database migration required — capability ID validated at runtime
+5. Update documentation at `docs/capabilities/` — add a page for the new capability and update the overview table in `docs/capabilities/index.md`
 
 ### Capability Mount Points
 

--- a/specs/documentation.md
+++ b/specs/documentation.md
@@ -23,6 +23,9 @@ docs/
 ├── index.mdx             # Landing page (template: splash)
 ├── getting-started/
 │   └── introduction.md
+├── capabilities/
+│   ├── index.md          # Capabilities overview + reference table
+│   └── *.md              # Per-capability pages (file-system, virtual-bash, etc.)
 ├── features/
 │   └── capabilities.md
 ├── integrations/
@@ -48,6 +51,7 @@ rendered as horizontal tabs below the header on desktop:
 |-----|---------|
 | Get Started | Getting Started guides + Features |
 | Integrations | Integrations + Observability + Ecosystem |
+| Capabilities | Per-capability reference pages (tools, examples, use cases) |
 | Operations | SRE Guide + Runbooks |
 | Reference | Event Reference + API Reference (OpenAPI) |
 


### PR DESCRIPTION
## What

Add a new top-level "Capabilities" navigation tab to the documentation site with 16 pages: an overview index plus individual reference pages for 15 capabilities.

## Why

Capabilities are a core concept in Everruns but had no dedicated documentation section. Users had no structured reference for capability IDs, available tools, parameters, dependencies, or usage examples.

## How

- Added `Capabilities` topic to `starlight-sidebar-topics` in `astro.config.mjs`
- Created `docs/capabilities/index.md` with a reference table of all 15 capabilities, quick start, and key concepts (dependencies, features, risk levels)
- Created individual pages organized by category:
  - **Core**: File System, Virtual Bash, Session, Session Storage, Web Fetch
  - **Data & Productivity**: SQL Database, Current Time, Task Management, Session Schedules
  - **Platform & Configuration**: Platform Management, Agent Instructions, Agent Skills
  - **Demo**: Fake Warehouse, Fake AWS, Fake CRM
- Each page includes: metadata table (ID, risk, features, dependencies), tool reference, use cases, realistic examples, and cross-links
- Updated `specs/capabilities.md` to include docs update step when adding new capabilities
- Updated `specs/documentation.md` to reflect the new Capabilities tab

## Risk
- Low
- Documentation-only change. No code changes. Docs build verified green (146 pages).

## Checklist
- [x] Tests added or updated (N/A — docs only, build verified)
- [x] Backward compatibility considered (additive change only)