### PR TITLE
refactor(capabilities): adjust risk levels, rename capabilities, add Daytona docs

### DIFF
--- a/crates/core/src/capabilities/agent_instructions.rs
+++ b/crates/core/src/capabilities/agent_instructions.rs
@@ -35,7 +35,7 @@ impl Capability for AgentInstructionsCapability {
     }
 
     fn name(&self) -> &str {
-        "Agent Instructions"
+        "AGENTS.md"
     }
 
     fn description(&self) -> &str {
@@ -215,7 +215,7 @@ mod tests {
         let cap = AgentInstructionsCapability;
 
         assert_eq!(cap.id(), "agent_instructions");
-        assert_eq!(cap.name(), "Agent Instructions");
+        assert_eq!(cap.name(), "AGENTS.md");
         assert_eq!(cap.status(), CapabilityStatus::Available);
         assert_eq!(cap.icon(), Some("file-text"));
         assert_eq!(cap.category(), Some("Configuration"));
@@ -303,7 +303,7 @@ mod tests {
         let cap = registry.get("agent_instructions").unwrap();
 
         assert_eq!(cap.id(), "agent_instructions");
-        assert_eq!(cap.name(), "Agent Instructions");
+        assert_eq!(cap.name(), "AGENTS.md");
     }
 
     #[test]

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -2367,15 +2367,16 @@ mod tests {
     }
 
     #[test]
-    fn test_high_risk_capabilities() {
+    fn test_capability_risk_levels() {
         let registry = CapabilityRegistry::with_builtins();
 
-        // virtual_bash and web_fetch should be High
+        // virtual_bash is Low (in-memory sandboxed execution)
         let bash = registry.get("virtual_bash").unwrap();
-        assert_eq!(bash.risk_level(), RiskLevel::High);
+        assert_eq!(bash.risk_level(), RiskLevel::Low);
 
+        // web_fetch is Medium (network access)
         let fetch = registry.get("web_fetch").unwrap();
-        assert_eq!(fetch.risk_level(), RiskLevel::High);
+        assert_eq!(fetch.risk_level(), RiskLevel::Medium);
 
         // Default capabilities should be Low
         let noop = registry.get("noop").unwrap();

--- a/crates/core/src/capabilities/session_schedule.rs
+++ b/crates/core/src/capabilities/session_schedule.rs
@@ -23,7 +23,7 @@ impl Capability for SessionScheduleCapability {
     }
 
     fn name(&self) -> &str {
-        "Session Schedules"
+        "Schedules"
     }
 
     fn description(&self) -> &str {

--- a/crates/core/src/capabilities/session_storage.rs
+++ b/crates/core/src/capabilities/session_storage.rs
@@ -22,7 +22,7 @@ impl Capability for SessionStorageCapability {
     }
 
     fn name(&self) -> &str {
-        "Session Storage"
+        "Storage"
     }
 
     fn description(&self) -> &str {
@@ -471,7 +471,7 @@ mod tests {
     fn test_capability_metadata() {
         let cap = SessionStorageCapability;
         assert_eq!(cap.id(), "session_storage");
-        assert_eq!(cap.name(), "Session Storage");
+        assert_eq!(cap.name(), "Storage");
         assert_eq!(cap.status(), CapabilityStatus::Available);
         assert_eq!(cap.icon(), Some("database"));
         assert_eq!(cap.category(), Some("Storage"));

--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -11,7 +11,7 @@
 //! - Resource limits prevent runaway scripts (max commands, loop iterations)
 //! - Context-aware tool that requires session filesystem access
 
-use super::{Capability, CapabilityStatus, RiskLevel};
+use super::{Capability, CapabilityStatus};
 use crate::session_file::SessionFile;
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::{SessionFileStore, ToolContext};
@@ -86,10 +86,6 @@ impl Capability for VirtualBashCapability {
 
     fn status(&self) -> CapabilityStatus {
         CapabilityStatus::Available
-    }
-
-    fn risk_level(&self) -> RiskLevel {
-        RiskLevel::High
     }
 
     fn icon(&self) -> Option<&str> {

--- a/crates/core/src/capabilities/web_fetch.rs
+++ b/crates/core/src/capabilities/web_fetch.rs
@@ -39,7 +39,7 @@ impl Capability for WebFetchCapability {
     }
 
     fn risk_level(&self) -> RiskLevel {
-        RiskLevel::High
+        RiskLevel::Medium
     }
 
     fn icon(&self) -> Option<&str> {

--- a/crates/core/src/capability_dto.rs
+++ b/crates/core/src/capability_dto.rs
@@ -233,7 +233,7 @@ mod tests {
     fn test_capability_with_features_serialization() {
         let cap = CapabilityInfo {
             id: CapabilityId::new("session_storage"),
-            name: "Session Storage".to_string(),
+            name: "Storage".to_string(),
             description: "Storage capability".to_string(),
             status: CapabilityStatus::Available,
             icon: None,
@@ -307,15 +307,15 @@ mod tests {
     fn test_from_core_populates_risk_level() {
         let registry = crate::capabilities::CapabilityRegistry::with_builtins();
 
-        // virtual_bash is High risk
+        // virtual_bash is Low risk (in-memory sandboxed execution)
         let bash_cap = registry.get("virtual_bash").unwrap();
         let info = CapabilityInfo::from_core(bash_cap.as_ref());
-        assert_eq!(info.risk_level, RiskLevel::High);
+        assert_eq!(info.risk_level, RiskLevel::Low);
 
-        // web_fetch is High risk
+        // web_fetch is Medium risk (network access)
         let fetch_cap = registry.get("web_fetch").unwrap();
         let info = CapabilityInfo::from_core(fetch_cap.as_ref());
-        assert_eq!(info.risk_level, RiskLevel::High);
+        assert_eq!(info.risk_level, RiskLevel::Medium);
 
         // noop is Low risk (default)
         let noop_cap = registry.get("noop").unwrap();

--- a/docs/capabilities/agent-instructions.md
+++ b/docs/capabilities/agent-instructions.md
@@ -1,5 +1,5 @@
 ---
-title: Agent Instructions
+title: AGENTS.md
 description: Dynamic project instructions from AGENTS.md in the session workspace
 ---
 
@@ -7,7 +7,6 @@ description: Dynamic project instructions from AGENTS.md in the session workspac
 |---|---|
 | **ID** | `agent_instructions` |
 | **Category** | Configuration |
-| **Risk** | Low |
 | **Features** | None |
 | **Dependencies** | None |
 
@@ -64,7 +63,7 @@ The agent will follow these instructions for every turn in the session.
 
 ## See Also
 
-- [Agent Instructions feature guide](/features/agent-instructions/) — detailed documentation
+- [AGENTS.md feature guide](/features/agent-instructions/) — detailed documentation
 - [File System](/capabilities/file-system/) — manage the AGENTS.md file
 - [Agent Skills](/capabilities/agent-skills/) — another way to inject specialized instructions
 - [Capabilities Overview](/capabilities/)

--- a/docs/capabilities/agent-skills.md
+++ b/docs/capabilities/agent-skills.md
@@ -7,7 +7,6 @@ description: Discover and activate portable instruction packages from the sessio
 |---|---|
 | **ID** | `skills` |
 | **Category** | Skills |
-| **Risk** | Low |
 | **Features** | None |
 | **Dependencies** | [`session_file_system`](/capabilities/file-system/) |
 
@@ -80,6 +79,6 @@ Agent:
 
 - [Agent Skills feature guide](/features/skills/) — detailed skills documentation
 - [Skills Registry](/features/skills-registry/) — API-managed skills
-- [Agent Instructions](/capabilities/agent-instructions/) — simpler alternative for project context
+- [AGENTS.md](/capabilities/agent-instructions/) — simpler alternative for project context
 - [File System](/capabilities/file-system/) — upload skill files
 - [Capabilities Overview](/capabilities/)

--- a/docs/capabilities/current-time.md
+++ b/docs/capabilities/current-time.md
@@ -7,7 +7,6 @@ description: Get the current date and time in various formats and timezones
 |---|---|
 | **ID** | `current_time` |
 | **Category** | Utilities |
-| **Risk** | Low |
 | **Features** | None |
 | **Dependencies** | None |
 
@@ -43,5 +42,5 @@ Agent:
 
 ## See Also
 
-- [Session Schedules](/capabilities/session-schedules/) — schedule future tasks
+- [Schedules](/capabilities/session-schedules/) — schedule future tasks
 - [Capabilities Overview](/capabilities/)

--- a/docs/capabilities/daytona.md
+++ b/docs/capabilities/daytona.md
@@ -1,0 +1,121 @@
+---
+title: Daytona
+description: Cloud-based sandboxed code execution via Daytona
+---
+
+| | |
+|---|---|
+| **ID** | `daytona` |
+| **Category** | Execution |
+| **Features** | None |
+| **Dependencies** | [`session_storage`](/capabilities/session-storage/) |
+
+Run code in cloud-based sandboxes powered by Daytona. Create multiple isolated Linux environments per session, execute commands, manage files, and download results.
+
+## Tools
+
+### `daytona_create_sandbox`
+
+Create and start a new sandbox.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `title` | string | no | Sandbox name |
+| `image` | string | no | Container image |
+| `upload_files` | array | no | Files to upload after creation |
+
+### `daytona_exec`
+
+Run a shell command in a sandbox (synchronous).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `sandbox_id` | string | yes | Target sandbox |
+| `command` | string | yes | Shell command to execute |
+| `cwd` | string | no | Working directory |
+| `timeout_ms` | integer | no | Timeout in milliseconds |
+
+### `daytona_read_file`
+
+Read a file from a sandbox.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `sandbox_id` | string | yes | Target sandbox |
+| `path` | string | yes | File path |
+
+### `daytona_write_file`
+
+Write a file to a sandbox.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `sandbox_id` | string | yes | Target sandbox |
+| `path` | string | yes | File path |
+| `content` | string | yes | File content |
+
+### `daytona_download_workspace`
+
+Download sandbox workspace to session storage.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `sandbox_id` | string | yes | Target sandbox |
+
+### `daytona_list_sandboxes`
+
+List all sandboxes for the current session.
+
+### `daytona_manage_sandbox`
+
+Stop or delete a sandbox.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `sandbox_id` | string | yes | Target sandbox |
+| `action` | string | yes | `stop` or `delete` |
+
+### `daytona_git_clone`
+
+Clone a git repository into a sandbox. Automatically uses connected GitHub credentials for private repos.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `sandbox_id` | string | yes | Target sandbox |
+| `url` | string | yes | Repository URL or `user/repo` shorthand |
+| `branch` | string | no | Branch to clone |
+
+### `daytona_git_credentials`
+
+Configure git credentials for push/pull/fetch.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `sandbox_id` | string | yes | Target sandbox |
+
+## Authentication
+
+Daytona API key is resolved automatically:
+
+1. Session secret `DAYTONA_API_KEY` (highest priority)
+2. User connection (Settings > Connections > Daytona)
+
+## Use Cases
+
+- **Code execution** — run and test code in isolated Linux environments
+- **Multi-language projects** — use custom container images for any stack
+- **Repository analysis** — clone and explore repos in a sandbox
+- **Build and test** — compile, test, and package in clean environments
+
+## Notes
+
+- Each sandbox is a full isolated Linux environment with network access
+- Sandboxes auto-stop after 5 minutes of inactivity
+- Always delete sandboxes when done to free resources
+- All tools except `daytona_create_sandbox` and `daytona_list_sandboxes` require a `sandbox_id`
+
+## See Also
+
+- [Storage](/capabilities/session-storage/) — API key and state persistence
+- [Daytona integration guide](/integrations/daytona/) — setup and configuration
+- [Capabilities Overview](/capabilities/)

--- a/docs/capabilities/fake-aws.md
+++ b/docs/capabilities/fake-aws.md
@@ -7,7 +7,6 @@ description: Demo capability with simulated AWS infrastructure management tools
 |---|---|
 | **ID** | `fake_aws` |
 | **Category** | Demo |
-| **Risk** | Low |
 | **Features** | None |
 | **Dependencies** | None |
 

--- a/docs/capabilities/fake-crm.md
+++ b/docs/capabilities/fake-crm.md
@@ -7,7 +7,6 @@ description: Demo capability with simulated CRM and customer support tools
 |---|---|
 | **ID** | `fake_crm` |
 | **Category** | Demo |
-| **Risk** | Low |
 | **Features** | None |
 | **Dependencies** | None |
 

--- a/docs/capabilities/fake-warehouse.md
+++ b/docs/capabilities/fake-warehouse.md
@@ -7,7 +7,6 @@ description: Demo capability with simulated warehouse management tools
 |---|---|
 | **ID** | `fake_warehouse` |
 | **Category** | Demo |
-| **Risk** | Low |
 | **Features** | None |
 | **Dependencies** | None |
 

--- a/docs/capabilities/file-system.md
+++ b/docs/capabilities/file-system.md
@@ -7,7 +7,6 @@ description: Read, write, search, and manage files in an isolated per-session wo
 |---|---|
 | **ID** | `session_file_system` |
 | **Category** | File Operations |
-| **Risk** | Low |
 | **Features** | `file_system` (unlocks Workspace tab) |
 | **Dependencies** | None |
 
@@ -94,5 +93,5 @@ Agent:
 ## See Also
 
 - [Virtual Bash](/capabilities/virtual-bash/) — execute commands against these files
-- [Session Storage](/capabilities/session-storage/) — key/value and secret storage
+- [Storage](/capabilities/session-storage/) — key/value and secret storage
 - [Capabilities Overview](/capabilities/)

--- a/docs/capabilities/index.md
+++ b/docs/capabilities/index.md
@@ -17,44 +17,45 @@ Agents compose capabilities — enable only what you need.
 
 Fundamental capabilities for file operations, command execution, web access, and session management.
 
-| Capability | ID | Tools | Risk |
-|---|---|---|---|
-| [File System](/capabilities/file-system/) | `session_file_system` | 6 | Low |
-| [Virtual Bash](/capabilities/virtual-bash/) | `virtual_bash` | 1 | High |
-| [Session](/capabilities/session/) | `session` | 2 | Low |
-| [Session Storage](/capabilities/session-storage/) | `session_storage` | 2 | Low |
-| [Web Fetch](/capabilities/web-fetch/) | `web_fetch` | 1 | High |
+| Capability | ID | Tools |
+|---|---|---|
+| [File System](/capabilities/file-system/) | `session_file_system` | 6 |
+| [Virtual Bash](/capabilities/virtual-bash/) | `virtual_bash` | 1 |
+| [Session](/capabilities/session/) | `session` | 2 |
+| [Storage](/capabilities/session-storage/) | `session_storage` | 2 |
+| [Web Fetch](/capabilities/web-fetch/) | `web_fetch` | 1 |
+| [Daytona](/capabilities/daytona/) | `daytona` | 9 |
 
 ### Data & Productivity
 
 Structured data, time awareness, task tracking, and scheduling.
 
-| Capability | ID | Tools | Risk |
-|---|---|---|---|
-| [SQL Database](/capabilities/sql-database/) | `session_sql_database` | 3 | Low |
-| [Current Time](/capabilities/current-time/) | `current_time` | 1 | Low |
-| [Task Management](/capabilities/task-management/) | `stateless_todo_list` | 1 | Low |
-| [Session Schedules](/capabilities/session-schedules/) | `session_schedule` | 3 | Low |
+| Capability | ID | Tools |
+|---|---|---|
+| [SQL Database](/capabilities/sql-database/) | `session_sql_database` | 3 |
+| [Current Time](/capabilities/current-time/) | `current_time` | 1 |
+| [Task Management](/capabilities/task-management/) | `stateless_todo_list` | 1 |
+| [Schedules](/capabilities/session-schedules/) | `session_schedule` | 3 |
 
 ### Platform & Configuration
 
 Agent self-management, dynamic instructions, and skill discovery.
 
-| Capability | ID | Tools | Risk |
-|---|---|---|---|
-| [Platform Management](/capabilities/platform-management/) | `platform_management` | 5 | Low |
-| [Agent Instructions](/capabilities/agent-instructions/) | `agent_instructions` | 0 | Low |
-| [Agent Skills](/capabilities/agent-skills/) | `skills` | 2 | Low |
+| Capability | ID | Tools |
+|---|---|---|
+| [Platform Management](/capabilities/platform-management/) | `platform_management` | 5 |
+| [AGENTS.md](/capabilities/agent-instructions/) | `agent_instructions` | 0 |
+| [Agent Skills](/capabilities/agent-skills/) | `skills` | 2 |
 
 ### Demo
 
 Pre-built domain simulations for testing and demonstrations.
 
-| Capability | ID | Tools | Risk |
-|---|---|---|---|
-| [Fake Warehouse](/capabilities/fake-warehouse/) | `fake_warehouse` | 10 | Low |
-| [Fake AWS](/capabilities/fake-aws/) | `fake_aws` | 11 | Low |
-| [Fake CRM](/capabilities/fake-crm/) | `fake_crm` | 8 | Low |
+| Capability | ID | Tools |
+|---|---|---|
+| [Fake Warehouse](/capabilities/fake-warehouse/) | `fake_warehouse` | 10 |
+| [Fake AWS](/capabilities/fake-aws/) | `fake_aws` | 11 |
+| [Fake CRM](/capabilities/fake-crm/) | `fake_crm` | 8 |
 
 ## Quick Start
 
@@ -102,17 +103,10 @@ Capabilities declare UI features they contribute. The session aggregates feature
 | Feature | UI Element | Contributed By |
 |---|---|---|
 | `file_system` | Workspace tab | [File System](/capabilities/file-system/), [Virtual Bash](/capabilities/virtual-bash/) |
-| `secrets` | Storage tab | [Session Storage](/capabilities/session-storage/) |
-| `key_value` | Storage tab | [Session Storage](/capabilities/session-storage/) |
-| `schedules` | Schedules tab | [Session Schedules](/capabilities/session-schedules/) |
+| `secrets` | Storage tab | [Storage](/capabilities/session-storage/) |
+| `key_value` | Storage tab | [Storage](/capabilities/session-storage/) |
+| `schedules` | Schedules tab | [Schedules](/capabilities/session-schedules/) |
 | `sql_database` | Database tab | [SQL Database](/capabilities/sql-database/) |
-
-### Risk Levels
-
-| Level | Who Can Assign | Examples |
-|---|---|---|
-| Low | Any org member | File System, Current Time |
-| High | Admin only | Virtual Bash, Web Fetch |
 
 ### Ordering
 

--- a/docs/capabilities/platform-management.md
+++ b/docs/capabilities/platform-management.md
@@ -7,7 +7,6 @@ description: Programmatic management of harnesses, agents, and sessions
 |---|---|
 | **ID** | `platform_management` |
 | **Category** | Platform |
-| **Risk** | Low |
 | **Features** | None |
 | **Dependencies** | None |
 

--- a/docs/capabilities/session-schedules.md
+++ b/docs/capabilities/session-schedules.md
@@ -1,5 +1,5 @@
 ---
-title: Session Schedules
+title: Schedules
 description: Schedule one-shot and recurring tasks within a session
 ---
 
@@ -7,7 +7,6 @@ description: Schedule one-shot and recurring tasks within a session
 |---|---|
 | **ID** | `session_schedule` |
 | **Category** | Session |
-| **Risk** | Low |
 | **Features** | `schedules` (unlocks Schedules tab) |
 | **Dependencies** | None |
 

--- a/docs/capabilities/session-storage.md
+++ b/docs/capabilities/session-storage.md
@@ -1,5 +1,5 @@
 ---
-title: Session Storage
+title: Storage
 description: Key/value storage and encrypted secret storage within a session
 ---
 
@@ -7,7 +7,6 @@ description: Key/value storage and encrypted secret storage within a session
 |---|---|
 | **ID** | `session_storage` |
 | **Category** | Storage |
-| **Risk** | Low |
 | **Features** | `secrets`, `key_value` (unlocks Storage tab) |
 | **Dependencies** | None |
 

--- a/docs/capabilities/session.md
+++ b/docs/capabilities/session.md
@@ -7,7 +7,6 @@ description: Read and update current session metadata
 |---|---|
 | **ID** | `session` |
 | **Category** | Session |
-| **Risk** | Low |
 | **Features** | None |
 | **Dependencies** | None |
 
@@ -47,6 +46,6 @@ Agent:
 
 ## See Also
 
-- [Session Storage](/capabilities/session-storage/) — persist data within the session
-- [Session Schedules](/capabilities/session-schedules/) — schedule future tasks
+- [Storage](/capabilities/session-storage/) — persist data within the session
+- [Schedules](/capabilities/session-schedules/) — schedule future tasks
 - [Capabilities Overview](/capabilities/)

--- a/docs/capabilities/sql-database.md
+++ b/docs/capabilities/sql-database.md
@@ -7,7 +7,6 @@ description: Session-scoped SQLite databases for structured data storage and que
 |---|---|
 | **ID** | `session_sql_database` |
 | **Category** | Data |
-| **Risk** | Low |
 | **Features** | `sql_database` |
 | **Dependencies** | None |
 
@@ -63,6 +62,6 @@ Agent:
 
 ## See Also
 
-- [Session Storage](/capabilities/session-storage/) — simpler key/value alternative
+- [Storage](/capabilities/session-storage/) — simpler key/value alternative
 - [File System](/capabilities/file-system/) — file-based data storage
 - [Capabilities Overview](/capabilities/)

--- a/docs/capabilities/task-management.md
+++ b/docs/capabilities/task-management.md
@@ -7,7 +7,6 @@ description: Structured task lists for tracking multi-step work progress
 |---|---|
 | **ID** | `stateless_todo_list` |
 | **Category** | Productivity |
-| **Risk** | Low |
 | **Features** | None |
 | **Dependencies** | None |
 

--- a/docs/capabilities/virtual-bash.md
+++ b/docs/capabilities/virtual-bash.md
@@ -7,7 +7,6 @@ description: Sandboxed bash command execution in an isolated environment
 |---|---|
 | **ID** | `virtual_bash` |
 | **Category** | Execution |
-| **Risk** | High (admin required) |
 | **Features** | `file_system` (unlocks Workspace tab) |
 | **Dependencies** | [`session_file_system`](/capabilities/file-system/) |
 

--- a/docs/capabilities/web-fetch.md
+++ b/docs/capabilities/web-fetch.md
@@ -7,7 +7,6 @@ description: Fetch web content from URLs with HTML-to-markdown conversion
 |---|---|
 | **ID** | `web_fetch` |
 | **Category** | Network |
-| **Risk** | High (admin required) |
 | **Features** | None |
 | **Dependencies** | None |
 

--- a/docs/features/agent-instructions.md
+++ b/docs/features/agent-instructions.md
@@ -3,7 +3,7 @@ title: AGENTS.md
 description: Provide project-level instructions to agents via AGENTS.md
 ---
 
-The **Agent Instructions** capability reads an `AGENTS.md` file from the session workspace and automatically includes it in the agent's system prompt on every turn. This gives you a simple, standard way to provide project-level context — coding conventions, style guides, build instructions, or any other guidance — to your agents.
+The **AGENTS.md** capability reads an `AGENTS.md` file from the session workspace and automatically includes it in the agent's system prompt on every turn. This gives you a simple, standard way to provide project-level context — coding conventions, style guides, build instructions, or any other guidance — to your agents.
 
 ## Overview
 
@@ -102,7 +102,7 @@ The file is re-read on every LLM turn. You can edit `AGENTS.md` at any point dur
 
 1. Navigate to the Agent detail page
 2. Find **Capabilities** in the sidebar
-3. Enable **Agent Instructions**
+3. Enable **AGENTS.md**
 4. Save changes
 
 Then write an `AGENTS.md` file to the session workspace using the file tools or bash.

--- a/docs/features/capabilities.md
+++ b/docs/features/capabilities.md
@@ -15,7 +15,7 @@ When you assign capabilities to an agent, those capabilities enhance what the ag
 
 ## Available Capabilities
 
-### Agent Instructions
+### AGENTS.md
 
 **Status**: Available
 
@@ -24,7 +24,7 @@ Reads `AGENTS.md` from the session workspace and includes it in the system promp
 - **No tools** — this capability only injects context into the system prompt
 - **File**: `/workspace/AGENTS.md` (plain Markdown, max 32 KiB)
 - **Use cases**: Project conventions, coding style, build instructions, architecture notes
-- See [Agent Instructions](/features/agent-instructions/) for full documentation
+- See [AGENTS.md](/features/agent-instructions/) for full documentation
 
 ### Current Time
 

--- a/docs/features/harnesses.md
+++ b/docs/features/harnesses.md
@@ -40,7 +40,7 @@ A general-purpose harness bundling the core capabilities most agents need. This 
 |------------|-----------------|
 | **File System** | Read, write, list, grep, and delete files in the session workspace (`/workspace`) |
 | **Virtual Bash** | Sandboxed bash shell for running commands, scripts, and text processing |
-| **Session Storage** | Key/value store for general data and encrypted secret storage for API keys and credentials |
+| **Storage** | Key/value store for general data and encrypted secret storage for API keys and credentials |
 | **Session** | Access session metadata and manage session title |
 
 ## Choosing a Harness

--- a/specs/agent-instructions.md
+++ b/specs/agent-instructions.md
@@ -1,8 +1,8 @@
-# Agent Instructions (AGENTS.md) Specification
+# AGENTS.md Specification
 
 ## Abstract
 
-The Agent Instructions capability reads an `AGENTS.md` file from the session workspace and dynamically injects its content into the system prompt on every LLM turn. This provides project-level context and coding conventions to agents without modifying the agent's system prompt directly.
+The AGENTS.md capability reads an `AGENTS.md` file from the session workspace and dynamically injects its content into the system prompt on every LLM turn. This provides project-level context and coding conventions to agents without modifying the agent's system prompt directly.
 
 ## Background
 
@@ -36,7 +36,7 @@ pub struct AgentInstructionsCapability;
 #[async_trait]
 impl Capability for AgentInstructionsCapability {
     fn id(&self) -> &str { "agent_instructions" }
-    fn name(&self) -> &str { "Agent Instructions" }
+    fn name(&self) -> &str { "AGENTS.md" }
     fn status(&self) -> CapabilityStatus { CapabilityStatus::Available }
     fn icon(&self) -> Option<&str> { Some("file-text") }
     fn category(&self) -> Option<&str> { Some("Configuration") }
@@ -136,7 +136,7 @@ GET /v1/capabilities
 Response includes:
 {
   "id": "agent_instructions",
-  "name": "Agent Instructions",
+  "name": "AGENTS.md",
   "description": "Reads AGENTS.md from the session workspace...",
   "status": "available",
   "icon": "file-text",

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -226,9 +226,9 @@ Each capability declares a `RiskLevel` via the `Capability` trait. The API enfor
 |-------|-------------|-------------|
 | `low` | Default. No special requirements. | Any org member |
 | `medium` | Logged but allowed for org members. | Any org member |
-| `high` | Can execute arbitrary code or access external resources. | Requires Admin role |
+| `high` | Can access external compute or resources. | Requires Admin role |
 
-High-risk built-in capabilities: `virtual_bash`, `web_fetch`, `docker_container`, `daytona`, `codesandbox`.
+High-risk built-in capabilities: `docker_container`, `daytona`, `codesandbox`.
 
 See `crates/core/src/capabilities/mod.rs` for the `RiskLevel` enum and `crates/server/src/api/agents.rs` for `require_admin_for_high_risk()`.
 

--- a/specs/harness-types.md
+++ b/specs/harness-types.md
@@ -40,9 +40,9 @@ The recommended default harness. Bundles the core capabilities needed for genera
 |---------------|------|---------|
 | `session_file_system` | File System | Read, write, list, grep, delete files in `/workspace` |
 | `virtual_bash` | Virtual Bash | Sandboxed bash shell for code execution and scripting |
-| `session_storage` | Session Storage | Key/value store and encrypted secret storage |
+| `session_storage` | Storage | Key/value store and encrypted secret storage |
 | `session` | Session | Session info access and title management |
-| `agent_instructions` | Agent Instructions | Reads AGENTS.md from workspace and injects into system prompt |
+| `agent_instructions` | AGENTS.md | Reads AGENTS.md from workspace and injects into system prompt |
 | `skills` | Agent Skills | Discover and activate skills from `/.agents/skills/` in session filesystem |
 
 **Use cases:**
@@ -68,9 +68,9 @@ Conversational harness for the global chat interface. Extends Generic capabiliti
 |---------------|------|---------|
 | `session_file_system` | File System | Read, write, list, grep, delete files in `/workspace` |
 | `virtual_bash` | Virtual Bash | Sandboxed bash shell for code execution and scripting |
-| `session_storage` | Session Storage | Key/value store and encrypted secret storage |
+| `session_storage` | Storage | Key/value store and encrypted secret storage |
 | `session` | Session | Session info access and title management |
-| `agent_instructions` | Agent Instructions | Reads AGENTS.md from workspace and injects into system prompt |
+| `agent_instructions` | AGENTS.md | Reads AGENTS.md from workspace and injects into system prompt |
 | `skills` | Agent Skills | Discover and activate skills from `/.agents/skills/` in session filesystem |
 | `platform_management` | Platform Management | Manage harnesses, agents, and sessions via tools |
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -543,7 +543,7 @@ The agent loop is a core trust boundary: an LLM decides which tools to call with
 | TM-AGENT-002 | Indirect prompt injection via tool results | High | Tool results use `tool_result` role, not `system`; LLM may still follow adversarial instructions in results | **ACCEPTED** |
 | TM-AGENT-003 | Indirect prompt injection via MCP tool descriptions | Medium | MCP tool names/descriptions fed to LLM as tool schema; adversarial descriptions could influence behavior | **ACCEPTED** |
 | TM-AGENT-004 | Agent jailbreak via system prompt | Medium | System prompt set by org member at agent creation; no sanitization of prompt content | **BY DESIGN** |
-| TM-AGENT-005 | Capability escalation via agent creation | High | RiskLevel enum on Capability trait; high-risk capabilities (virtual_bash, web_fetch, docker, daytona, codesandbox) require Admin role to assign via API | MITIGATED |
+| TM-AGENT-005 | Capability escalation via agent creation | High | RiskLevel enum on Capability trait; high-risk capabilities (docker, daytona, codesandbox) require Admin role to assign via API | MITIGATED |
 | TM-AGENT-006 | Cost runaway — unbounded LLM calls | High | Max iterations per turn (default 100); configurable per agent | MITIGATED |
 | TM-AGENT-007 | Cost runaway — many tools per iteration | Medium | No per-iteration tool call limit; agent can invoke many tools in a single LLM response | **OPEN** |
 | TM-AGENT-008 | Context window poisoning | Medium | Auto-compaction via `llm_driver.compact()` on `RequestTooLarge`; older messages compressed | MITIGATED |
@@ -582,7 +582,7 @@ Combined prompt sent to LLM as system message
 The agent creator is trusted within their org. A malicious system prompt can instruct the agent to misuse its capabilities, but only within the sandbox (session files, SQLite, bash sandbox). The blast radius is limited to the session.
 
 **TM-AGENT-005 — Capability Escalation (MITIGATED):**
-Each capability declares a `RiskLevel` (Low, Medium, High) via the `Capability` trait. High-risk capabilities (`virtual_bash`, `web_fetch`, `docker_container`, `daytona`, `codesandbox`) require `OrgRole::Admin` to assign. The check runs in create/update/upsert/import agent API handlers, returning 403 if a non-admin user attempts to assign a high-risk capability. The `risk_level` field is exposed in the capabilities list API for UI display.
+Each capability declares a `RiskLevel` (Low, Medium, High) via the `Capability` trait. High-risk capabilities (`docker_container`, `daytona`, `codesandbox`) require `OrgRole::Admin` to assign. The check runs in create/update/upsert/import agent API handlers, returning 403 if a non-admin user attempts to assign a high-risk capability. The `risk_level` field is exposed in the capabilities list API for UI display.
 
 **TM-AGENT-006 — Iteration Limit:**
 ```rust


### PR DESCRIPTION
## What

- Change `virtual_bash` risk level from High to Low (in-memory sandboxed execution)
- Change `web_fetch` risk level from High to Medium (network access but SSRF-protected)
- Rename capability display names: Session Schedules → Schedules, Session Storage → Storage, Agent Instructions → AGENTS.md
- Remove Risk column/row from all capability documentation pages
- Add `docs/capabilities/daytona.md` capability reference page

## Why

`virtual_bash` runs in-memory with no host/network access — High risk was overly restrictive. `web_fetch` has SSRF protection so Medium is more appropriate. Display name renames make the UI cleaner. Risk columns in docs added noise without value. Daytona was missing from capability docs.

## How

- Removed `risk_level()` override from `VirtualBashCapability` (defaults to Low)
- Changed `web_fetch` risk level enum to `Medium`
- Updated `name()` return values in 3 capability structs
- Removed `| **Risk** |` rows from 15 doc pages via sed
- Updated specs/threat-model to reflect new high-risk list (docker, daytona, codesandbox)
- Created Daytona capability reference doc page

## Risk
- Low
- Admin enforcement still applies to docker/daytona/codesandbox (High). Non-admin users can now assign virtual_bash and web_fetch without admin role.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered