### PR TITLE
fix(server): serialize env-var tests to prevent CI flakes

### DIFF
--- a/crates/server/src/api/sse.rs
+++ b/crates/server/src/api/sse.rs
@@ -410,8 +410,12 @@ impl Drop for SseConnectionGuard {
 mod tests {
     use super::*;
 
+    // Env-var-mutating tests must not run in parallel.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn test_realtime_config() {
+        let _lock = ENV_LOCK.lock().unwrap();
         unsafe {
             std::env::remove_var("SSE_REALTIME_CYCLE_SECS");
             std::env::remove_var("SSE_HEARTBEAT_INTERVAL_SECS");
@@ -426,6 +430,7 @@ mod tests {
 
     #[test]
     fn test_monitoring_config() {
+        let _lock = ENV_LOCK.lock().unwrap();
         unsafe {
             std::env::remove_var("SSE_MONITORING_CYCLE_SECS");
             std::env::remove_var("SSE_HEARTBEAT_INTERVAL_SECS");
@@ -749,12 +754,9 @@ mod tests {
         );
     }
 
-    // NOTE: Env var tests are inherently racy with parallel tests.
-    // These test the override mechanism; we accept that parallel test
-    // interference may cause occasional failures in isolation.
-    // Run with --test-threads=1 if needed for determinism.
     #[test]
     fn test_realtime_cycle_secs_env_override() {
+        let _lock = ENV_LOCK.lock().unwrap();
         unsafe {
             std::env::set_var("SSE_REALTIME_CYCLE_SECS", "900");
         }
@@ -768,6 +770,7 @@ mod tests {
 
     #[test]
     fn test_monitoring_cycle_secs_env_override() {
+        let _lock = ENV_LOCK.lock().unwrap();
         unsafe {
             std::env::set_var("SSE_MONITORING_CYCLE_SECS", "1800");
         }
@@ -781,6 +784,7 @@ mod tests {
 
     #[test]
     fn test_cycle_secs_env_invalid_fallback() {
+        let _lock = ENV_LOCK.lock().unwrap();
         unsafe {
             std::env::set_var("SSE_REALTIME_CYCLE_SECS", "not_a_number");
         }
@@ -797,6 +801,7 @@ mod tests {
 
     #[test]
     fn test_heartbeat_interval_default() {
+        let _lock = ENV_LOCK.lock().unwrap();
         unsafe {
             std::env::remove_var("SSE_HEARTBEAT_INTERVAL_SECS");
         }
@@ -811,6 +816,7 @@ mod tests {
 
     #[test]
     fn test_heartbeat_interval_env_override() {
+        let _lock = ENV_LOCK.lock().unwrap();
         unsafe {
             std::env::set_var("SSE_HEARTBEAT_INTERVAL_SECS", "15");
         }
@@ -824,6 +830,7 @@ mod tests {
 
     #[test]
     fn test_heartbeat_interval_env_invalid_fallback() {
+        let _lock = ENV_LOCK.lock().unwrap();
         unsafe {
             std::env::set_var("SSE_HEARTBEAT_INTERVAL_SECS", "not_a_number");
         }
@@ -836,6 +843,7 @@ mod tests {
 
     #[test]
     fn test_heartbeat_interval_less_than_sdk_read_timeout() {
+        let _lock = ENV_LOCK.lock().unwrap();
         // SDK read timeout is 60s. Heartbeat must be less than that.
         unsafe {
             std::env::remove_var("SSE_HEARTBEAT_INTERVAL_SECS");
@@ -850,14 +858,9 @@ mod tests {
         );
     }
 
-    // These tests share env vars and MUST run sequentially within a single
-    // test to avoid races with parallel test threads.
     #[test]
     fn test_sse_limits_from_env() {
-        // Serialize env-var access via a process-wide mutex to prevent races.
-        use std::sync::Mutex;
-        static ENV_MUTEX: Mutex<()> = Mutex::new(());
-        let _lock = ENV_MUTEX.lock().unwrap();
+        let _lock = ENV_LOCK.lock().unwrap();
 
         // --- default / single instance ---
         unsafe {

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -3622,6 +3622,9 @@ mod tests {
     use super::*;
     use tonic::service::Interceptor;
 
+    // Env-var-mutating tests must not run in parallel.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn test_interceptor_allows_when_no_token_configured() {
         let mut interceptor = GrpcAuthInterceptor::new(None);
@@ -3671,18 +3674,23 @@ mod tests {
         assert_eq!(err.code(), tonic::Code::Unauthenticated);
     }
 
+    /// Acquire env lock, tolerating poison from #[should_panic] tests.
+    fn lock_env() -> std::sync::MutexGuard<'static, ()> {
+        ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     // TM-DURABLE-002: require_grpc_auth_token panics when WORKER_GRPC_AUTH_TOKEN is unset
     #[test]
     #[should_panic(expected = "WORKER_GRPC_AUTH_TOKEN must be set")]
     fn test_require_grpc_auth_token_panics_without_env() {
-        // SAFETY: single-threaded test; no other thread reads this var concurrently
+        let _lock = lock_env();
         unsafe { std::env::remove_var("WORKER_GRPC_AUTH_TOKEN") };
         require_grpc_auth_token();
     }
 
     #[test]
     fn test_require_grpc_auth_token_returns_value() {
-        // SAFETY: single-threaded test; no other thread reads this var concurrently
+        let _lock = lock_env();
         unsafe { std::env::set_var("WORKER_GRPC_AUTH_TOKEN", "test-token-123") };
         let token = require_grpc_auth_token();
         assert_eq!(token, "test-token-123");
@@ -3691,7 +3699,7 @@ mod tests {
 
     #[test]
     fn test_grpc_server_tls_returns_none_when_no_env_vars() {
-        // SAFETY: single-threaded test
+        let _lock = lock_env();
         unsafe {
             std::env::remove_var("WORKER_GRPC_TLS_CERT");
             std::env::remove_var("WORKER_GRPC_TLS_KEY");
@@ -3706,6 +3714,7 @@ mod tests {
 
     #[test]
     fn test_grpc_server_tls_returns_none_when_cert_empty() {
+        let _lock = lock_env();
         unsafe {
             std::env::set_var("WORKER_GRPC_TLS_CERT", "");
             std::env::set_var("WORKER_GRPC_TLS_KEY", "");
@@ -3720,6 +3729,7 @@ mod tests {
 
     #[test]
     fn test_grpc_server_tls_returns_config_with_valid_certs() {
+        let _lock = lock_env();
         let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
         let cert_path = format!("{}/tests/fixtures/test-server-cert.pem", manifest);
         let key_path = format!("{}/tests/fixtures/test-server-key.pem", manifest);
@@ -3744,6 +3754,7 @@ mod tests {
 
     #[test]
     fn test_grpc_server_tls_with_client_ca() {
+        let _lock = lock_env();
         let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
         let cert_path = format!("{}/tests/fixtures/test-server-cert.pem", manifest);
         let key_path = format!("{}/tests/fixtures/test-server-key.pem", manifest);
@@ -3771,6 +3782,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Failed to read WORKER_GRPC_TLS_CERT")]
     fn test_grpc_server_tls_panics_on_missing_cert_file() {
+        let _lock = lock_env();
         unsafe {
             std::env::set_var("WORKER_GRPC_TLS_CERT", "/nonexistent/cert.pem");
             std::env::set_var("WORKER_GRPC_TLS_KEY", "/nonexistent/key.pem");


### PR DESCRIPTION
## Summary
- Two tests were flaky in CI due to env-var races when run in parallel:
  - `test_heartbeat_interval_default` — `SSE_HEARTBEAT_INTERVAL_SECS` leaked from `test_heartbeat_interval_env_override`
  - `test_grpc_server_tls_returns_none_when_cert_empty` — `WORKER_GRPC_TLS_CERT` leaked from `test_grpc_server_tls_returns_config_with_valid_certs`
- Added a shared `static ENV_LOCK: Mutex<()>` in both test modules so all env-var-mutating tests serialize access
- Consolidated the existing separate `ENV_MUTEX` in `test_sse_limits_from_env` into the shared lock

## Test plan
- [x] Verified both failing tests now pass with `cargo test -p everruns-server --lib --all-features`
- [x] `just pre-push` passes
- [ ] CI green