### PR TITLE
chore(release): prepare v0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.8.3] - 2026-03-06
+
+### Highlights
+
+- **GPT-5.4 Support** — Full model profiles for GPT-5.4 and GPT-5.4 Pro with input token limits ([#653](https://github.com/everruns/everruns/pull/653), [#654](https://github.com/everruns/everruns/pull/654), [#657](https://github.com/everruns/everruns/pull/657))
+- **Custom Commands** — Slash command system with UI autocomplete ([#667](https://github.com/everruns/everruns/pull/667))
+- **Security Hardening** — Per-IP rate limiting, structured audit logging, mTLS, security headers, account enumeration prevention ([#627](https://github.com/everruns/everruns/pull/627), [#633](https://github.com/everruns/everruns/pull/633), [#634](https://github.com/everruns/everruns/pull/634), [#636](https://github.com/everruns/everruns/pull/636), [#641](https://github.com/everruns/everruns/pull/641))
+- **Durable Engine Scaling** — Multi-instance control plane, capacity-aware fair-share claiming, worker backpressure ([#637](https://github.com/everruns/everruns/pull/637), [#638](https://github.com/everruns/everruns/pull/638), [#639](https://github.com/everruns/everruns/pull/639), [#640](https://github.com/everruns/everruns/pull/640))
+- **DuckDuckGo Search** — DuckDuckGo Instant Answer search integration ([#663](https://github.com/everruns/everruns/pull/663))
+
+### What's Changed
+
+- feat(core): add GPT-5.4 and GPT-5.4 Pro model profiles ([#653](https://github.com/everruns/everruns/pull/653)) by [@chaliy](https://github.com/chaliy)
+- feat(core): add GPT-5.4 model profiles and integration tests ([#654](https://github.com/everruns/everruns/pull/654)) by [@chaliy](https://github.com/chaliy)
+- feat(core): add optional input token limit to LlmModelLimits ([#657](https://github.com/everruns/everruns/pull/657)) by [@chaliy](https://github.com/chaliy)
+- feat(commands): add custom commands system with UI autocomplete ([#667](https://github.com/everruns/everruns/pull/667)) by [@chaliy](https://github.com/chaliy)
+- feat(duckduckgo): add DuckDuckGo Instant Answer search integration ([#663](https://github.com/everruns/everruns/pull/663)) by [@chaliy](https://github.com/chaliy)
+- feat(users): add profile page with full name editing ([#649](https://github.com/everruns/everruns/pull/649)) by [@chaliy](https://github.com/chaliy)
+- feat(ui): Claude Code-style bash tool rendering ([#644](https://github.com/everruns/everruns/pull/644)) by [@chaliy](https://github.com/chaliy)
+- feat(capabilities): add list_capabilities tool to platform management ([#642](https://github.com/everruns/everruns/pull/642)) by [@chaliy](https://github.com/chaliy)
+- feat(capabilities): add risk level classification and admin approval ([#631](https://github.com/everruns/everruns/pull/631)) by [@chaliy](https://github.com/chaliy)
+- feat(grpc): add mutual TLS (mTLS) support for worker-server communication ([#641](https://github.com/everruns/everruns/pull/641)) by [@chaliy](https://github.com/chaliy)
+- feat(grpc): add gRPC support for sqldb_store in WorkerAdapters ([#645](https://github.com/everruns/everruns/pull/645)) by [@chaliy](https://github.com/chaliy)
+- feat(durable): resource-based worker backpressure ([#638](https://github.com/everruns/everruns/pull/638)) by [@chaliy](https://github.com/chaliy)
+- feat(durable): capacity-aware fair-share task claiming ([#639](https://github.com/everruns/everruns/pull/639)) by [@chaliy](https://github.com/chaliy)
+- feat(durable): load-proportional claim jitter ([#640](https://github.com/everruns/everruns/pull/640)) by [@chaliy](https://github.com/chaliy)
+- feat(server): multi-instance control plane support ([#637](https://github.com/everruns/everruns/pull/637)) by [@chaliy](https://github.com/chaliy)
+- feat(server): structured audit logging for auth events ([#636](https://github.com/everruns/everruns/pull/636)) by [@chaliy](https://github.com/chaliy)
+- feat(server): add security response headers ([#634](https://github.com/everruns/everruns/pull/634)) by [@chaliy](https://github.com/chaliy)
+- feat(auth): add per-IP rate limiting on auth endpoints ([#627](https://github.com/everruns/everruns/pull/627)) by [@chaliy](https://github.com/chaliy)
+- feat(storage): add encrypted system_prompt columns ([#630](https://github.com/everruns/everruns/pull/630)) by [@chaliy](https://github.com/chaliy)
+- feat(chat): add run-agent, harness-avoidance, and confirmation guidelines to chat system prompt ([#648](https://github.com/everruns/everruns/pull/648)) by [@chaliy](https://github.com/chaliy)
+- feat(docs): add horizontal navigation tabs ([#662](https://github.com/everruns/everruns/pull/662)) by [@chaliy](https://github.com/chaliy)
+- feat: Slack bot integration with Apps abstraction ([#671](https://github.com/everruns/everruns/pull/671)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): provider icons invisible on light theme ([#670](https://github.com/everruns/everruns/pull/670)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): render plain URLs as links in chat markdown ([#646](https://github.com/everruns/everruns/pull/646)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): default to Generic harness in New Session dialog ([#632](https://github.com/everruns/everruns/pull/632)) by [@chaliy](https://github.com/chaliy)
+- fix(vfs): block deletion of readonly files ([#669](https://github.com/everruns/everruns/pull/669)) by [@chaliy](https://github.com/chaliy)
+- fix(capabilities): scope platform store to session org and fix public URL default ([#647](https://github.com/everruns/everruns/pull/647)) by [@chaliy](https://github.com/chaliy)
+- fix(auth): prevent account enumeration via registration endpoint ([#633](https://github.com/everruns/everruns/pull/633)) by [@chaliy](https://github.com/chaliy)
+- fix(api): add regex pattern length limit on grep endpoint ([#629](https://github.com/everruns/everruns/pull/629)) by [@chaliy](https://github.com/chaliy)
+- fix(server): warn when DATABASE_URL lacks TLS in production ([#628](https://github.com/everruns/everruns/pull/628)) by [@chaliy](https://github.com/chaliy)
+- fix(worker): enforce WorkerAdapters parity at compile time ([#643](https://github.com/everruns/everruns/pull/643)) by [@chaliy](https://github.com/chaliy)
+- fix(docker): pin UI builder stage to amd64 to avoid QEMU SIGILL ([#652](https://github.com/everruns/everruns/pull/652)) by [@chaliy](https://github.com/chaliy)
+- fix(ci): merge env-var SSE tests to prevent flaky race condition ([#656](https://github.com/everruns/everruns/pull/656)) by [@chaliy](https://github.com/chaliy)
+- fix(ci): skip arm64 QEMU build for UI Docker image ([#651](https://github.com/everruns/everruns/pull/651)) by [@chaliy](https://github.com/chaliy)
+- refactor(capabilities): adjust risk levels, rename capabilities, add Daytona docs ([#675](https://github.com/everruns/everruns/pull/675)) by [@chaliy](https://github.com/chaliy)
+- refactor: rename GRPC_* env vars to WORKER_GRPC_* prefix ([#635](https://github.com/everruns/everruns/pull/635)) by [@chaliy](https://github.com/chaliy)
+- revert(server): remove system_prompt_encrypted ([#659](https://github.com/everruns/everruns/pull/659)) by [@chaliy](https://github.com/chaliy)
+- docs(capabilities): add Capabilities navigation tab with top 15 capability reference pages ([#672](https://github.com/everruns/everruns/pull/672)) by [@chaliy](https://github.com/chaliy)
+- docs: add tutorial for building agents using the Everruns SDK ([#661](https://github.com/everruns/everruns/pull/661)) by [@chaliy](https://github.com/chaliy)
+- docs: reduce duplication in building-agents-using-sdk tutorial ([#674](https://github.com/everruns/everruns/pull/674)) by [@chaliy](https://github.com/chaliy)
+- docs: improve meta descriptions for SEO ([#660](https://github.com/everruns/everruns/pull/660)) by [@chaliy](https://github.com/chaliy)
+- chore: pre-release maintenance — update dependencies ([#668](https://github.com/everruns/everruns/pull/668)) by [@chaliy](https://github.com/chaliy)
+- chore(migrations): squash 005_apps into 004_v0.8.3 ([#678](https://github.com/everruns/everruns/pull/678)) by [@chaliy](https://github.com/chaliy)
+- chore(db): squash migrations 004-006 into 004_v0.8.3 ([#673](https://github.com/everruns/everruns/pull/673)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump dompurify from 3.3.1 to 3.3.2 in /apps/docs ([#655](https://github.com/everruns/everruns/pull/655)) by [@dependabot](https://github.com/dependabot)
+- chore(deps): bump svgo from 4.0.0 to 4.0.1 in /apps/docs ([#650](https://github.com/everruns/everruns/pull/650)) by [@dependabot](https://github.com/dependabot)
+- chore(docs): add IndexNow verification key file ([#658](https://github.com/everruns/everruns/pull/658)) by [@chaliy](https://github.com/chaliy)
+
+### Migration Notes
+
+**0.8.2 → 0.8.3:** Requires fresh database (new migration squash). The `GRPC_*` environment variables have been renamed to `WORKER_GRPC_*` — update your configuration accordingly.
+
 ## [0.8.2] - 2026-03-01
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-codesandbox"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -1381,7 +1381,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1451,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4714,12 +4714,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.2"
+version = "0.8.3"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns Contributors"]

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "everruns-ui",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@streamdown/code": "^1.0.3",
@@ -4511,6 +4511,70 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.1",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": true,
   "exports": {
     "./providers/*": "./src/providers/*.tsx",


### PR DESCRIPTION
## Release v0.8.3

This PR prepares the v0.8.3 release. Key highlight: **GPT-5.4 support**.

### Highlights

- **GPT-5.4 Support** — Full model profiles for GPT-5.4 and GPT-5.4 Pro with input token limits
- **Custom Commands** — Slash command system with UI autocomplete
- **Security Hardening** — Per-IP rate limiting, audit logging, mTLS, security headers
- **Durable Engine Scaling** — Multi-instance control plane, capacity-aware claiming, backpressure
- **DuckDuckGo Search** — DuckDuckGo Instant Answer search integration

### Checklist
- [ ] Review CHANGELOG.md entries
- [ ] Verify version numbers updated
- [ ] CI passes

### Post-merge
After merging, the release workflow will automatically:
- Create git tag `v0.8.3`
- Create GitHub Release with notes from CHANGELOG.md
- Trigger Docker image build with version tag