### PR TITLE
feat(core): add feature flags system with global_chat flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,7 @@ Fix root cause. Unsure: read more code; if stuck, ask w/ short options. Unrecogn
 - `specs/load-testing.md` - End-to-end load testing framework and benchmarking process
 - `specs/apps.md` - Apps system (agent deployment to distribution channels)
 - `specs/slack-integration.md` - Slack bot integration (app-scoped webhook, session routing)
+- `specs/feature-flags.md` - Feature flags system (env vars, deployment grade, UI gating)
 
 ### Skills
 

--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -61,6 +61,13 @@ jest.mock("@/hooks/use-organizations", () => ({
   }),
 }));
 
+// Mock feature flags provider
+jest.mock("@/providers/feature-flags-provider", () => ({
+  useFeatureFlags: () => ({
+    global_chat: true,
+  }),
+}));
+
 describe("Sidebar", () => {
   beforeEach(() => {
     mockPathname.mockReturnValue("/dashboard");

--- a/apps/ui/src/app/(main)/chat/page.tsx
+++ b/apps/ui/src/app/(main)/chat/page.tsx
@@ -4,9 +4,22 @@ import { Loader2 } from "lucide-react";
 import { ChatPanel } from "@/components/chat/chat-panel";
 import { SessionProvider } from "@/app/(main)/sessions/[sessionId]/session-context";
 import { useGlobalChat } from "@/hooks/use-global-chat";
+import { useFeatureFlag } from "@/providers/feature-flags-provider";
 
 export default function GlobalChatPage() {
+  const globalChatEnabled = useFeatureFlag("global_chat");
   const { sessionId, isLoading, error } = useGlobalChat();
+
+  if (!globalChatEnabled) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="text-center text-muted-foreground">
+          <p className="text-lg font-medium">Global Chat is not enabled</p>
+          <p className="text-sm">This feature is currently disabled.</p>
+        </div>
+      </div>
+    );
+  }
 
   if (isLoading || !sessionId) {
     return (

--- a/apps/ui/src/app/layout.tsx
+++ b/apps/ui/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { QueryProvider } from "@/providers/query-provider";
+import { FeatureFlagsProvider } from "@/providers/feature-flags-provider";
 import { AuthProvider } from "@/providers/auth-provider";
 import { OrgProvider } from "@/providers/org-provider";
 
@@ -18,9 +19,11 @@ export default function RootLayout({
     <html lang="en">
       <body className="font-sans antialiased bg-brand-dots">
         <QueryProvider>
-          <AuthProvider>
-            <OrgProvider>{children}</OrgProvider>
-          </AuthProvider>
+          <FeatureFlagsProvider>
+            <AuthProvider>
+              <OrgProvider>{children}</OrgProvider>
+            </AuthProvider>
+          </FeatureFlagsProvider>
         </QueryProvider>
       </body>
     </html>

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -7,6 +7,7 @@ import Image from "next/image";
 import { usePathname, useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/providers/auth-provider";
+import { useFeatureFlags } from "@/providers/feature-flags-provider";
 import { useOrg } from "@/providers/org-provider";
 import { useLogout } from "@/hooks/use-auth";
 import { useCreateOrganization } from "@/hooks/use-organizations";
@@ -59,8 +60,16 @@ import {
 
 const isDev = process.env.NODE_ENV === "development";
 
-const topNavigation = [
-  { name: "Chat", href: "/chat", icon: MessageCircle },
+type NavItem = {
+  name: string;
+  href: string;
+  icon: React.ComponentType<{ className?: string }>;
+  flag?: keyof import("@/lib/api/types").FeatureFlags;
+  exact?: boolean;
+};
+
+const topNavigation: NavItem[] = [
+  { name: "Chat", href: "/chat", icon: MessageCircle, flag: "global_chat" },
   { name: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
   { name: "Sessions", href: "/sessions", icon: MessageSquare },
 ];
@@ -160,6 +169,7 @@ export function Sidebar() {
   const pathname = usePathname();
   const router = useRouter();
   const { user, requiresAuth } = useAuth();
+  const featureFlags = useFeatureFlags();
   const { currentOrg, organizations, setCurrentOrg } = useOrg();
   const logoutMutation = useLogout();
   const [createOrgOpen, setCreateOrgOpen] = useState(false);
@@ -220,24 +230,26 @@ export function Sidebar() {
 
       {/* Navigation */}
       <nav className="flex-1 min-h-0 overflow-y-auto space-y-1 py-4">
-        {topNavigation.map((item) => {
-          const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
-          return (
-            <Link
-              key={item.name}
-              href={item.href}
-              className={cn(
-                "flex items-center gap-3 px-3 py-2 text-sm font-medium transition-colors",
-                isActive
-                  ? "bg-accent/10 text-accent-foreground border-l-2 border-accent"
-                  : "text-muted-foreground hover:bg-muted hover:text-foreground border-l-2 border-transparent",
-              )}
-            >
-              <item.icon className="h-5 w-5" />
-              {item.name}
-            </Link>
-          );
-        })}
+        {topNavigation
+          .filter((item) => !item.flag || featureFlags[item.flag])
+          .map((item) => {
+            const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
+            return (
+              <Link
+                key={item.name}
+                href={item.href}
+                className={cn(
+                  "flex items-center gap-3 px-3 py-2 text-sm font-medium transition-colors",
+                  isActive
+                    ? "bg-accent/10 text-accent-foreground border-l-2 border-accent"
+                    : "text-muted-foreground hover:bg-muted hover:text-foreground border-l-2 border-transparent",
+                )}
+              >
+                <item.icon className="h-5 w-5" />
+                {item.name}
+              </Link>
+            );
+          })}
 
         {/* Building Blocks section */}
         <div className="my-3 border-t" />

--- a/apps/ui/src/lib/api/feature-flags.ts
+++ b/apps/ui/src/lib/api/feature-flags.ts
@@ -1,0 +1,8 @@
+// Feature flags API client
+import { api } from "./client";
+import type { FeatureFlags } from "./types";
+
+export async function getFeatureFlags(): Promise<FeatureFlags> {
+  const { data } = await api.get<FeatureFlags>("/v1/feature-flags");
+  return data;
+}

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -710,6 +710,10 @@ export interface HealthResponse {
 
 export type AuthMode = "none" | "admin" | "full" | "external";
 
+export interface FeatureFlags {
+  global_chat: boolean;
+}
+
 export interface AuthConfigResponse {
   mode: AuthMode;
   password_auth_enabled: boolean;

--- a/apps/ui/src/providers/feature-flags-provider.tsx
+++ b/apps/ui/src/providers/feature-flags-provider.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+// Feature flags provider
+//
+// Decision: Fetch flags once on mount via React Query (cached, no repeated queries).
+// Decision: Default all flags to false while loading to avoid flash of gated content.
+// Decision: Provider sits above OrgProvider so flags are available everywhere.
+
+import { createContext, useContext, type ReactNode } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { getFeatureFlags } from "@/lib/api/feature-flags";
+import type { FeatureFlags } from "@/lib/api/types";
+
+const DEFAULT_FLAGS: FeatureFlags = {
+  global_chat: false,
+};
+
+export interface FeatureFlagsContextValue {
+  flags: FeatureFlags;
+  isLoading: boolean;
+}
+
+const FeatureFlagsContext = createContext<FeatureFlagsContextValue | undefined>(undefined);
+
+export function FeatureFlagsProvider({ children }: { children: ReactNode }) {
+  const { data, isLoading } = useQuery({
+    queryKey: ["feature-flags"],
+    queryFn: getFeatureFlags,
+    staleTime: 5 * 60 * 1000, // 5 min
+    refetchOnWindowFocus: false,
+  });
+
+  const value: FeatureFlagsContextValue = {
+    flags: data ?? DEFAULT_FLAGS,
+    isLoading,
+  };
+
+  return <FeatureFlagsContext.Provider value={value}>{children}</FeatureFlagsContext.Provider>;
+}
+
+export function useFeatureFlags(): FeatureFlags {
+  const context = useContext(FeatureFlagsContext);
+  if (context === undefined) {
+    throw new Error("useFeatureFlags must be used within a FeatureFlagsProvider");
+  }
+  return context.flags;
+}
+
+export function useFeatureFlag(flag: keyof FeatureFlags): boolean {
+  const flags = useFeatureFlags();
+  return flags[flag];
+}

--- a/crates/core/src/feature_flags.rs
+++ b/crates/core/src/feature_flags.rs
@@ -1,0 +1,137 @@
+// Feature flags system
+//
+// Decision: Feature flags are system-level, computed from env vars + deployment grade.
+// Decision: Flags marked "experimental" auto-enable in dev (DeploymentGrade::Dev).
+// Decision: Explicit env var (FEATURE_<NAME>=true/false) always takes priority.
+// Decision: Struct-based for type safety; `is_enabled(&str)` for dynamic lookup.
+// Decision: Future extensibility: per-org/per-user flags, external providers (LaunchDarkly).
+// Decision: No database storage needed yet — env vars + deployment grade suffice.
+
+use serde::{Deserialize, Serialize};
+
+use crate::deployment::DeploymentGrade;
+
+/// System-level feature flags.
+///
+/// Currently backed by environment variables and deployment grade.
+/// Future: per-org flags, per-user flags, external providers.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FeatureFlags {
+    /// Global chat (per-user singleton chat session). Experimental.
+    pub global_chat: bool,
+}
+
+impl FeatureFlags {
+    /// Compute feature flags from environment variables and deployment grade.
+    pub fn from_env(grade: &DeploymentGrade) -> Self {
+        Self {
+            global_chat: experimental_flag("FEATURE_GLOBAL_CHAT", grade),
+        }
+    }
+
+    /// Look up a flag by name (for dynamic/string-based access).
+    pub fn is_enabled(&self, flag: &str) -> bool {
+        match flag {
+            "global_chat" => self.global_chat,
+            _ => false,
+        }
+    }
+
+    /// All flags enabled (for testing).
+    #[cfg(test)]
+    pub fn all_enabled() -> Self {
+        Self { global_chat: true }
+    }
+}
+
+/// Resolve an experimental flag.
+///
+/// Priority: explicit env var > experimental default (enabled in dev) > false.
+fn experimental_flag(env_var: &str, grade: &DeploymentGrade) -> bool {
+    if let Ok(val) = std::env::var(env_var) {
+        return val == "true" || val == "1";
+    }
+    grade.experimental_features_enabled()
+}
+
+/// Resolve a standard (non-experimental) flag.
+///
+/// Priority: explicit env var > default.
+#[allow(dead_code)]
+fn standard_flag(env_var: &str, default: bool) -> bool {
+    std::env::var(env_var)
+        .map(|v| v == "true" || v == "1")
+        .unwrap_or(default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_flags() {
+        let flags = FeatureFlags::default();
+        assert!(!flags.global_chat);
+    }
+
+    // SAFETY: env var tests must run single-threaded (--test-threads=1).
+    // set_var/remove_var are unsafe in edition 2024 due to thread-safety.
+
+    #[test]
+    fn test_experimental_enabled_in_dev() {
+        unsafe { std::env::remove_var("FEATURE_GLOBAL_CHAT") };
+        let flags = FeatureFlags::from_env(&DeploymentGrade::Dev);
+        assert!(flags.global_chat);
+    }
+
+    #[test]
+    fn test_experimental_disabled_in_prod() {
+        unsafe { std::env::remove_var("FEATURE_GLOBAL_CHAT") };
+        let flags = FeatureFlags::from_env(&DeploymentGrade::Prod);
+        assert!(!flags.global_chat);
+    }
+
+    #[test]
+    fn test_env_override_enables_in_prod() {
+        unsafe { std::env::set_var("FEATURE_GLOBAL_CHAT", "true") };
+        let flags = FeatureFlags::from_env(&DeploymentGrade::Prod);
+        assert!(flags.global_chat);
+        unsafe { std::env::remove_var("FEATURE_GLOBAL_CHAT") };
+    }
+
+    #[test]
+    fn test_env_override_disables_in_dev() {
+        unsafe { std::env::set_var("FEATURE_GLOBAL_CHAT", "false") };
+        let flags = FeatureFlags::from_env(&DeploymentGrade::Dev);
+        assert!(!flags.global_chat);
+        unsafe { std::env::remove_var("FEATURE_GLOBAL_CHAT") };
+    }
+
+    #[test]
+    fn test_is_enabled_dynamic() {
+        let flags = FeatureFlags { global_chat: true };
+        assert!(flags.is_enabled("global_chat"));
+        assert!(!flags.is_enabled("nonexistent"));
+    }
+
+    #[test]
+    fn test_serialization() {
+        let flags = FeatureFlags { global_chat: true };
+        let json = serde_json::to_string(&flags).unwrap();
+        assert!(json.contains("\"global_chat\":true"));
+
+        let parsed: FeatureFlags = serde_json::from_str(&json).unwrap();
+        assert_eq!(flags, parsed);
+    }
+
+    #[test]
+    fn test_standard_flag() {
+        unsafe { std::env::remove_var("FEATURE_TEST_STD") };
+        assert!(!standard_flag("FEATURE_TEST_STD", false));
+        assert!(standard_flag("FEATURE_TEST_STD", true));
+
+        unsafe { std::env::set_var("FEATURE_TEST_STD", "1") };
+        assert!(standard_flag("FEATURE_TEST_STD", false));
+        unsafe { std::env::remove_var("FEATURE_TEST_STD") };
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -23,6 +23,9 @@ pub mod tool_types;
 // Deployment configuration
 pub mod deployment;
 
+// Feature flags
+pub mod feature_flags;
+
 // Telemetry (OpenTelemetry with gen-ai semantic conventions)
 pub mod telemetry;
 
@@ -237,6 +240,9 @@ pub use typed_id::{
 
 // Deployment configuration
 pub use deployment::DeploymentGrade;
+
+// Feature flags
+pub use feature_flags::FeatureFlags;
 
 // Observation backends
 pub use observation::{BraintrustConfig, BraintrustListener, OtelEventListener};

--- a/crates/server/src/api/feature_flags.rs
+++ b/crates/server/src/api/feature_flags.rs
@@ -1,0 +1,24 @@
+// Feature flags API endpoint
+//
+// Decision: GET /v1/feature-flags is public (no auth required).
+//   Feature flags are non-sensitive system config needed before auth completes.
+// Decision: Flags computed once at startup and served from memory (no DB query).
+
+use axum::{Json, Router, extract::State, routing::get};
+use everruns_core::FeatureFlags;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub flags: FeatureFlags,
+}
+
+pub fn routes(state: AppState) -> Router {
+    Router::new().route(
+        "/v1/feature-flags",
+        get(get_feature_flags).with_state(state),
+    )
+}
+
+async fn get_feature_flags(State(state): State<AppState>) -> Json<FeatureFlags> {
+    Json(state.flags.clone())
+}

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -11,6 +11,7 @@ pub mod commands;
 pub mod common;
 pub mod durable;
 pub mod events;
+pub mod feature_flags;
 pub mod harnesses;
 pub mod images;
 pub mod llm_models;

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -444,6 +444,14 @@ impl ServerAppBuilder {
             auth_mode: format!("{:?}", auth_config.mode),
         };
 
+        // Feature flags (computed from env vars + deployment grade)
+        let feature_flags =
+            everruns_core::FeatureFlags::from_env(&everruns_core::DeploymentGrade::from_env());
+        tracing::info!(?feature_flags, "Feature flags computed");
+        let feature_flags_state = api::feature_flags::AppState {
+            flags: feature_flags,
+        };
+
         if !self.config.api_prefix.is_empty() {
             tracing::info!(
                 prefix = %self.config.api_prefix,
@@ -487,7 +495,8 @@ impl ServerAppBuilder {
             .merge(api::session_schedules::routes(session_schedules_state))
             .merge(api::audit_logs::routes(audit_logs_state))
             .merge(api::commands::routes(commands_state))
-            .merge(api::slack_events::routes(slack_state));
+            .merge(api::slack_events::routes(slack_state))
+            .merge(api::feature_flags::routes(feature_flags_state));
 
         // Auth-specific routes
         if let Some(auth_routes) = auth_backend.auth_routes() {

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -43,6 +43,27 @@ async fn test_health_endpoint() {
 }
 
 // ============================================
+// Feature Flags Endpoint Tests
+// ============================================
+
+#[tokio::test]
+async fn test_feature_flags_endpoint() {
+    let server = TestServer::new().await;
+
+    let body: Value = server
+        .get("/v1/feature-flags")
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+
+    // Should return a JSON object with boolean flags
+    assert!(body.is_object());
+    assert!(body.get("global_chat").is_some());
+    // In test env (DEV_MODE=true), experimental flags are enabled
+    assert!(body["global_chat"].is_boolean());
+}
+
+// ============================================
 // Agent CRUD Tests
 // ============================================
 

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -190,6 +190,10 @@ impl TestServer {
         let skills_state = api::skills::AppState::new(db.clone(), auth_state.clone());
         let images_state = api::images::AppState::new(db.clone(), auth_state.clone());
         let organizations_state = api::organizations::AppState::new(db.clone(), auth_state.clone());
+        let feature_flags = everruns_core::FeatureFlags::from_env(&grade);
+        let feature_flags_state = api::feature_flags::AppState {
+            flags: feature_flags,
+        };
 
         // Build API routes
         let api_routes = Router::new()
@@ -211,6 +215,7 @@ impl TestServer {
             .merge(api::skills::routes(skills_state))
             .merge(api::images::routes(images_state))
             .merge(api::organizations::routes(organizations_state))
+            .merge(api::feature_flags::routes(feature_flags_state))
             .merge(auth::routes(auth_backend));
 
         // Build main router with health endpoint

--- a/specs/feature-flags.md
+++ b/specs/feature-flags.md
@@ -1,0 +1,71 @@
+# Feature Flags
+
+System-level feature flags that control feature availability across the platform.
+
+## Design
+
+### Principles
+
+- **Env-first**: Flags are controlled via `FEATURE_<NAME>` environment variables
+- **Experimental auto-enable**: Flags marked "experimental" are auto-enabled in dev (`DeploymentGrade::Dev`)
+- **Explicit override wins**: `FEATURE_<NAME>=true/false` always takes priority over defaults
+- **Type-safe**: `FeatureFlags` struct with named boolean fields
+- **Fetch once**: UI fetches flags once on mount (React Query with 5min stale time)
+- **No DB needed (yet)**: Backed by env vars + deployment grade, no database table
+
+### Flag Resolution Order
+
+1. Explicit env var `FEATURE_<NAME>=true|1` or `=false|0`
+2. For experimental flags: `DeploymentGrade::Dev` -> `true`
+3. Default: `false`
+
+### Flag Types
+
+- **Experimental**: Auto-enabled in dev, disabled in prod. Use for features under active development.
+- **Standard**: Off by default everywhere. Enabled explicitly via env var.
+
+## Current Flags
+
+| Flag | Env Var | Type | Description |
+|------|---------|------|-------------|
+| `global_chat` | `FEATURE_GLOBAL_CHAT` | Experimental | Per-user singleton chat session |
+
+## Architecture
+
+### Backend
+
+- **Core**: `crates/core/src/feature_flags.rs` — `FeatureFlags` struct, `from_env()`, resolution helpers
+- **API**: `GET /v1/feature-flags` — public endpoint, returns `FeatureFlags` as JSON
+- **Server**: `crates/server/src/api/feature_flags.rs` — route handler
+
+Flags are computed once at server startup and served from memory.
+
+### Frontend
+
+- **API client**: `apps/ui/src/lib/api/feature-flags.ts`
+- **Provider**: `apps/ui/src/providers/feature-flags-provider.tsx` — React context, fetches once
+- **Hooks**: `useFeatureFlags()` (all flags), `useFeatureFlag("flag_name")` (single flag)
+- **Types**: `FeatureFlags` in `apps/ui/src/lib/api/types.ts`
+
+### Workers
+
+Workers currently do not need direct flag access. If needed in future, flags can be
+passed via gRPC turn context.
+
+## Adding a New Flag
+
+1. Add field to `FeatureFlags` struct in `crates/core/src/feature_flags.rs`
+2. Add resolution in `from_env()` using `experimental_flag()` or `standard_flag()`
+3. Add to `is_enabled()` match arm
+4. Update `default()` and `all_enabled()`
+5. Add to `FeatureFlags` interface in `apps/ui/src/lib/api/types.ts`
+6. Add to `DEFAULT_FLAGS` in `apps/ui/src/providers/feature-flags-provider.tsx`
+7. Use `useFeatureFlag("flag_name")` in UI components
+
+## Future Extensions
+
+- **Per-org flags**: Add `org_id` column to a `feature_flag_overrides` table
+- **Per-user flags**: Add `user_id` column
+- **External providers**: Implement a `FeatureFlagProvider` trait; plug in LaunchDarkly, Unleash, etc.
+- **Runtime toggle**: Admin API to update flag overrides without restart
+- **Worker propagation**: Include flags in gRPC `GetTurnContext` response


### PR DESCRIPTION
## What
Add a feature flags system that gates UI features based on environment variables and deployment grade. First flag: `global_chat` (experimental).

## Why
Need a lightweight mechanism to enable/disable features per environment without code deploys. Experimental features should auto-enable in dev mode but stay off in production unless explicitly opted in.

## How
- **Backend**: `FeatureFlags` struct in `everruns-core` with `from_env()` resolution (env var > deployment grade > default). Public `GET /v1/feature-flags` endpoint serves flags from memory (computed once at startup).
- **Frontend**: `FeatureFlagsProvider` fetches flags once via React Query. `useFeatureFlag("name")` hook gates components. Sidebar filters nav items by flag. Chat page shows disabled message when flag is off.
- **Flag types**: "experimental" (auto-enabled in dev) and "standard" (off by default everywhere).

## Risk
- Low
- No existing behavior changes — global_chat was already visible in dev (still is via experimental auto-enable), hidden in prod (still is)

## Checklist
- [x] Tests added or updated (8 unit tests for flag resolution, integration test for API endpoint)
- [x] Backward compatibility considered (no breaking changes, additive only)