### PR TITLE
docs: rename DuckDuckGo and reorder sidebar

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -93,6 +93,17 @@ export default defineConfig({
               ],
             },
             {
+              label: "Capabilities",
+              link: "/capabilities/",
+              icon: "puzzle",
+              items: [
+                {
+                  label: "Capabilities",
+                  autogenerate: { directory: "capabilities" },
+                },
+              ],
+            },
+            {
               label: "Integrations",
               link: "/integrations/daytona/",
               icon: "laptop",
@@ -112,14 +123,26 @@ export default defineConfig({
               ],
             },
             {
-              label: "Capabilities",
-              link: "/capabilities/",
-              icon: "puzzle",
+              label: "Tutorials",
+              link: "/tutorials/building-agents-using-sdk/",
+              icon: "rocket",
               items: [
                 {
-                  label: "Capabilities",
-                  autogenerate: { directory: "capabilities" },
+                  label: "Tutorials",
+                  items: [
+                    { label: "Building Agents Using the SDK", slug: "tutorials/building-agents-using-sdk" },
+                  ],
                 },
+              ],
+            },
+            {
+              label: "Reference",
+              link: "/api/",
+              icon: "information",
+              id: "reference",
+              items: [
+                { label: "Event Reference", slug: "event-reference" },
+                ...openAPISidebarGroups,
               ],
             },
             {
@@ -136,29 +159,6 @@ export default defineConfig({
                       label: "Runbooks",
                       autogenerate: { directory: "sre/runbooks" },
                     },
-                  ],
-                },
-              ],
-            },
-            {
-              label: "Reference",
-              link: "/api/",
-              icon: "information",
-              id: "reference",
-              items: [
-                { label: "Event Reference", slug: "event-reference" },
-                ...openAPISidebarGroups,
-              ],
-            },
-            {
-              label: "Tutorials",
-              link: "/tutorials/building-agents-using-sdk/",
-              icon: "rocket",
-              items: [
-                {
-                  label: "Tutorials",
-                  items: [
-                    { label: "Building Agents Using the SDK", slug: "tutorials/building-agents-using-sdk" },
                   ],
                 },
               ],

--- a/docs/integrations/duckduckgo.md
+++ b/docs/integrations/duckduckgo.md
@@ -1,5 +1,5 @@
 ---
-title: DuckDuckGo Integration
+title: DuckDuckGo
 description: Free instant answers, definitions, and topic summaries via DuckDuckGo
 ---
 


### PR DESCRIPTION
## What
Rename DuckDuckGo Integration doc to DuckDuckGo and reorder docs sidebar.

## Why
Clean up doc naming and enforce consistent sidebar order: Get Started, Capabilities, Integrations, Tutorials, Reference, Operations.

## How
- Changed frontmatter title in `docs/integrations/duckduckgo.md` from "DuckDuckGo Integration" to "DuckDuckGo"
- Reordered sidebar topics in `apps/docs/astro.config.mjs`

## Risk
- Low
- Docs-only change, no runtime impact

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered