### PR TITLE
fix(docs): correct Slack OAuth scope from app_mentions:events to app_mentions:read

### DIFF
--- a/docs/integrations/slack.md
+++ b/docs/integrations/slack.md
@@ -20,7 +20,7 @@ Everruns integrates with [Slack](https://slack.com) to deploy agents as bots tha
 2. Name your app and select the workspace
 3. Navigate to **OAuth & Permissions** and add these **Bot Token Scopes**:
    - `chat:write` — Send messages
-   - `app_mentions:events` — React to @mentions (optional)
+   - `app_mentions:read` — React to @mentions (optional)
 4. Click **Install to Workspace** and authorize
 5. Copy the **Bot User OAuth Token** (`xoxb-...`) from the OAuth page
 


### PR DESCRIPTION
## What
Fix incorrect Slack OAuth scope in the Slack integration docs. Changed `app_mentions:events` to `app_mentions:read`.

## Why
`app_mentions:events` is not a valid Slack Bot Token OAuth scope. The correct scope is `app_mentions:read`. Users following the docs would not find this scope in the Slack permissions UI.

## How
Single-word change in `docs/integrations/slack.md` line 23.

## Risk
- Low
- Documentation only — no code changes

## Checklist
- [x] Tests added or updated (N/A — docs only)
- [x] Backward compatibility considered (N/A — docs only)