### PR TITLE
feat(ui): redesign app creation flow with non-modal Slack config

### DIFF
--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -34,17 +34,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import {
-  ArrowLeft,
-  Globe,
-  GlobeLock,
-  Copy,
-  Trash2,
-  Pencil,
-  Check,
-  X,
-  Rocket,
-} from "lucide-react";
+import { ArrowLeft, Globe, GlobeLock, Copy, Trash2, Pencil, Check, X, Rocket } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import type { SessionStrategy, SlackChannelConfig, UpdateAppRequest } from "@/lib/api/types";
 
@@ -181,9 +171,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
             <CopyButton value={app.id} />
             <Badge variant={isPublished ? "default" : "secondary"}>{app.status}</Badge>
           </h1>
-          {app.description && (
-            <p className="text-muted-foreground mt-1">{app.description}</p>
-          )}
+          {app.description && <p className="text-muted-foreground mt-1">{app.description}</p>}
         </div>
         <div className="flex gap-2">
           {isPublished ? (
@@ -322,11 +310,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                       <Check className="w-3 h-3 mr-1" />
                       {updateApp.isPending ? "Saving..." : "Save"}
                     </Button>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      onClick={() => setEditingSlack(false)}
-                    >
+                    <Button size="sm" variant="outline" onClick={() => setEditingSlack(false)}>
                       <X className="w-3 h-3 mr-1" />
                       Cancel
                     </Button>
@@ -337,15 +321,11 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                   <div className="grid grid-cols-2 gap-4">
                     <div>
                       <p className="text-sm font-medium">Signing Secret</p>
-                      <p className="text-sm text-muted-foreground font-mono">
-                        {"•".repeat(12)}
-                      </p>
+                      <p className="text-sm text-muted-foreground font-mono">{"•".repeat(12)}</p>
                     </div>
                     <div>
                       <p className="text-sm font-medium">Bot User OAuth Token</p>
-                      <p className="text-sm text-muted-foreground font-mono">
-                        {"•".repeat(12)}
-                      </p>
+                      <p className="text-sm text-muted-foreground font-mono">{"•".repeat(12)}</p>
                     </div>
                   </div>
 

--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -1,0 +1,574 @@
+"use client";
+
+import { use, useState } from "react";
+import {
+  useApp,
+  useUpdateApp,
+  useDeleteApp,
+  usePublishApp,
+  useUnpublishApp,
+} from "@/hooks/use-apps";
+import { useAgents } from "@/hooks";
+import { useHarnesses } from "@/hooks/use-harnesses";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Separator } from "@/components/ui/separator";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  ArrowLeft,
+  Globe,
+  GlobeLock,
+  Copy,
+  Trash2,
+  Pencil,
+  Check,
+  X,
+  Rocket,
+} from "lucide-react";
+import { CopyButton } from "@/components/ui/copy-button";
+import type { SessionStrategy, SlackChannelConfig, UpdateAppRequest } from "@/lib/api/types";
+
+export default function AppDetailPage({ params }: { params: Promise<{ appId: string }> }) {
+  const { appId } = use(params);
+  const router = useRouter();
+  const { data: app, isLoading } = useApp(appId);
+  const { data: agents } = useAgents();
+  const { data: harnesses } = useHarnesses();
+  const updateApp = useUpdateApp();
+  const deleteAppMutation = useDeleteApp();
+  const publishApp = usePublishApp();
+  const unpublishApp = useUnpublishApp();
+
+  const [editingBasic, setEditingBasic] = useState(false);
+  const [editingSlack, setEditingSlack] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+
+  // Basic info edit state
+  const [editName, setEditName] = useState("");
+  const [editDescription, setEditDescription] = useState("");
+  const [editAgentId, setEditAgentId] = useState("");
+  const [editHarnessId, setEditHarnessId] = useState("");
+
+  // Slack config edit state
+  const [editSigningSecret, setEditSigningSecret] = useState("");
+  const [editBotToken, setEditBotToken] = useState("");
+  const [editChannelId, setEditChannelId] = useState("");
+  const [editTeamId, setEditTeamId] = useState("");
+  const [editSessionStrategy, setEditSessionStrategy] = useState<SessionStrategy>("per_thread");
+
+  const isPublished = app?.status === "published";
+  const slackConfig = app?.channel_config as SlackChannelConfig | undefined;
+  const hasSlackConfig = slackConfig?.signing_secret && slackConfig?.bot_token;
+
+  const webhookUrl =
+    typeof window !== "undefined"
+      ? `${window.location.origin}/api/v1/apps/${appId}/slack/events`
+      : `/api/v1/apps/${appId}/slack/events`;
+
+  const startEditBasic = () => {
+    if (!app) return;
+    setEditName(app.name);
+    setEditDescription(app.description ?? "");
+    setEditAgentId(app.agent_id);
+    setEditHarnessId(app.harness_id);
+    setEditingBasic(true);
+  };
+
+  const saveBasic = async () => {
+    if (!app) return;
+    await updateApp.mutateAsync({
+      appId: app.id,
+      data: {
+        name: editName,
+        description: editDescription || undefined,
+        agent_id: editAgentId,
+        harness_id: editHarnessId,
+      },
+    });
+    setEditingBasic(false);
+  };
+
+  const startEditSlack = () => {
+    setEditSigningSecret(slackConfig?.signing_secret ?? "");
+    setEditBotToken(slackConfig?.bot_token ?? "");
+    setEditChannelId(slackConfig?.channel_id ?? "");
+    setEditTeamId(slackConfig?.team_id ?? "");
+    setEditSessionStrategy(slackConfig?.session_strategy ?? "per_thread");
+    setEditingSlack(true);
+  };
+
+  const saveSlack = async () => {
+    if (!app) return;
+    const channelConfig: SlackChannelConfig = {
+      signing_secret: editSigningSecret,
+      bot_token: editBotToken,
+      session_strategy: editSessionStrategy,
+      ...(editChannelId ? { channel_id: editChannelId } : {}),
+      ...(editTeamId ? { team_id: editTeamId } : {}),
+    };
+    await updateApp.mutateAsync({
+      appId: app.id,
+      data: { channel_config: channelConfig } as UpdateAppRequest,
+    });
+    setEditingSlack(false);
+  };
+
+  const handleDelete = async () => {
+    if (!app) return;
+    await deleteAppMutation.mutateAsync(app.id);
+    router.push("/apps");
+  };
+
+  const agentName = agents?.find((a) => a.id === app?.agent_id)?.name;
+  const harnessName = harnesses?.find((h) => h.id === app?.harness_id)?.name;
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto p-6">
+        <Skeleton className="h-8 w-1/3 mb-4" />
+        <Skeleton className="h-4 w-2/3 mb-8" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (!app) {
+    return (
+      <div className="container mx-auto p-6">
+        <div className="text-red-500">App not found</div>
+        <Link href="/apps" className="text-blue-500 hover:underline">
+          Back to Apps
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto p-6">
+      <Link
+        href="/apps"
+        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-6"
+      >
+        <ArrowLeft className="w-4 h-4 mr-2" />
+        Back to Apps
+      </Link>
+
+      <div className="flex items-start justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold flex items-center gap-2">
+            <Rocket className="w-6 h-6" />
+            {app.name}
+            <CopyButton value={app.id} />
+            <Badge variant={isPublished ? "default" : "secondary"}>{app.status}</Badge>
+          </h1>
+          {app.description && (
+            <p className="text-muted-foreground mt-1">{app.description}</p>
+          )}
+        </div>
+        <div className="flex gap-2">
+          {isPublished ? (
+            <Button
+              variant="outline"
+              onClick={() => unpublishApp.mutate(app.id)}
+              disabled={unpublishApp.isPending}
+            >
+              <GlobeLock className="w-4 h-4 mr-2" />
+              Unpublish
+            </Button>
+          ) : (
+            <Button
+              variant="default"
+              onClick={() => publishApp.mutate(app.id)}
+              disabled={publishApp.isPending || !hasSlackConfig}
+            >
+              <Globe className="w-4 h-4 mr-2" />
+              Publish
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            className="text-destructive hover:text-destructive"
+            onClick={() => setShowDeleteDialog(true)}
+          >
+            <Trash2 className="w-4 h-4" />
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <div className="lg:col-span-2 space-y-6">
+          {/* Slack Integration Card */}
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between">
+              <CardTitle>Slack Integration</CardTitle>
+              {!editingSlack && (
+                <Button variant="outline" size="sm" onClick={startEditSlack}>
+                  <Pencil className="w-3 h-3 mr-1" />
+                  {hasSlackConfig ? "Edit" : "Configure"}
+                </Button>
+              )}
+            </CardHeader>
+            <CardContent>
+              {editingSlack ? (
+                <div className="space-y-4">
+                  <div>
+                    <Label htmlFor="signing_secret">Signing Secret</Label>
+                    <Input
+                      id="signing_secret"
+                      type="password"
+                      value={editSigningSecret}
+                      onChange={(e) => setEditSigningSecret(e.target.value)}
+                      placeholder="Your Slack app's signing secret"
+                      required
+                    />
+                    <p className="text-xs text-muted-foreground mt-1">
+                      Found in your Slack app &rarr; Settings &rarr; Basic Information &rarr; App
+                      Credentials
+                    </p>
+                  </div>
+
+                  <div>
+                    <Label htmlFor="bot_token">Bot User OAuth Token</Label>
+                    <Input
+                      id="bot_token"
+                      type="password"
+                      value={editBotToken}
+                      onChange={(e) => setEditBotToken(e.target.value)}
+                      placeholder="xoxb-..."
+                      required
+                    />
+                    <p className="text-xs text-muted-foreground mt-1">
+                      Found in your Slack app &rarr; OAuth &amp; Permissions &rarr; Bot User OAuth
+                      Token
+                    </p>
+                  </div>
+
+                  <Separator />
+
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <Label htmlFor="team_id">Workspace ID (optional)</Label>
+                      <Input
+                        id="team_id"
+                        value={editTeamId}
+                        onChange={(e) => setEditTeamId(e.target.value)}
+                        placeholder="T0123456789"
+                      />
+                      <p className="text-xs text-muted-foreground mt-1">
+                        Your Slack workspace (team) ID
+                      </p>
+                    </div>
+
+                    <div>
+                      <Label htmlFor="channel_id">Channel ID (optional)</Label>
+                      <Input
+                        id="channel_id"
+                        value={editChannelId}
+                        onChange={(e) => setEditChannelId(e.target.value)}
+                        placeholder="C0123456789"
+                      />
+                      <p className="text-xs text-muted-foreground mt-1">
+                        Restrict to a specific channel
+                      </p>
+                    </div>
+                  </div>
+
+                  <div>
+                    <Label htmlFor="session_strategy">Session Strategy</Label>
+                    <Select
+                      value={editSessionStrategy}
+                      onValueChange={(v) => setEditSessionStrategy(v as SessionStrategy)}
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="per_thread">Per Thread (default)</SelectItem>
+                        <SelectItem value="per_channel">Per Channel</SelectItem>
+                        <SelectItem value="per_user">Per User</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      Controls how Slack messages are grouped into sessions
+                    </p>
+                  </div>
+
+                  <div className="flex gap-2 pt-2">
+                    <Button
+                      size="sm"
+                      onClick={saveSlack}
+                      disabled={updateApp.isPending || !editSigningSecret || !editBotToken}
+                    >
+                      <Check className="w-3 h-3 mr-1" />
+                      {updateApp.isPending ? "Saving..." : "Save"}
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => setEditingSlack(false)}
+                    >
+                      <X className="w-3 h-3 mr-1" />
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              ) : hasSlackConfig ? (
+                <div className="space-y-4">
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <p className="text-sm font-medium">Signing Secret</p>
+                      <p className="text-sm text-muted-foreground font-mono">
+                        {"•".repeat(12)}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-sm font-medium">Bot User OAuth Token</p>
+                      <p className="text-sm text-muted-foreground font-mono">
+                        {"•".repeat(12)}
+                      </p>
+                    </div>
+                  </div>
+
+                  {(slackConfig?.team_id || slackConfig?.channel_id) && (
+                    <div className="grid grid-cols-2 gap-4">
+                      {slackConfig?.team_id && (
+                        <div>
+                          <p className="text-sm font-medium">Workspace ID</p>
+                          <p className="text-sm text-muted-foreground font-mono">
+                            {slackConfig.team_id}
+                          </p>
+                        </div>
+                      )}
+                      {slackConfig?.channel_id && (
+                        <div>
+                          <p className="text-sm font-medium">Channel ID</p>
+                          <p className="text-sm text-muted-foreground font-mono">
+                            {slackConfig.channel_id}
+                          </p>
+                        </div>
+                      )}
+                    </div>
+                  )}
+
+                  <div>
+                    <p className="text-sm font-medium">Session Strategy</p>
+                    <p className="text-sm text-muted-foreground">
+                      {slackConfig?.session_strategy === "per_thread"
+                        ? "Per Thread"
+                        : slackConfig?.session_strategy === "per_channel"
+                          ? "Per Channel"
+                          : "Per User"}
+                    </p>
+                  </div>
+                </div>
+              ) : (
+                <div className="text-center py-6 text-muted-foreground">
+                  <p className="mb-2">Slack integration not configured yet.</p>
+                  <p className="text-xs">
+                    Click &quot;Configure&quot; to add your Slack app credentials.
+                  </p>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Request URL Card - shown when published */}
+          {isPublished && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Request URL</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground mb-3">
+                  Use this URL in your Slack app&apos;s Event Subscriptions &rarr; Request URL
+                  field.
+                </p>
+                <div className="flex items-center gap-2 bg-muted p-3 rounded-md">
+                  <Globe className="w-4 h-4 shrink-0 text-muted-foreground" />
+                  <code className="text-sm flex-1 truncate">{webhookUrl}</code>
+                  <button
+                    className="shrink-0 hover:text-foreground text-muted-foreground"
+                    onClick={() => navigator.clipboard.writeText(webhookUrl)}
+                  >
+                    <Copy className="w-4 h-4" />
+                  </button>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+
+        {/* Sidebar */}
+        <div className="space-y-6">
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between">
+              <CardTitle>Configuration</CardTitle>
+              {!editingBasic && (
+                <Button variant="outline" size="sm" onClick={startEditBasic}>
+                  <Pencil className="w-3 h-3 mr-1" />
+                  Edit
+                </Button>
+              )}
+            </CardHeader>
+            <CardContent>
+              {editingBasic ? (
+                <div className="space-y-4">
+                  <div>
+                    <Label htmlFor="edit_name">Name</Label>
+                    <Input
+                      id="edit_name"
+                      value={editName}
+                      onChange={(e) => setEditName(e.target.value)}
+                      required
+                    />
+                  </div>
+
+                  <div>
+                    <Label htmlFor="edit_description">Description</Label>
+                    <Input
+                      id="edit_description"
+                      value={editDescription}
+                      onChange={(e) => setEditDescription(e.target.value)}
+                    />
+                  </div>
+
+                  <div>
+                    <Label>Harness</Label>
+                    <Select value={editHarnessId} onValueChange={setEditHarnessId}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select harness" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {harnesses?.map((h) => (
+                          <SelectItem key={h.id} value={h.id}>
+                            {h.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  <div>
+                    <Label>Agent</Label>
+                    <Select value={editAgentId} onValueChange={setEditAgentId}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select agent" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {agents?.map((a) => (
+                          <SelectItem key={a.id} value={a.id}>
+                            {a.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  <div className="flex gap-2">
+                    <Button
+                      size="sm"
+                      onClick={saveBasic}
+                      disabled={updateApp.isPending || !editName || !editAgentId || !editHarnessId}
+                    >
+                      <Check className="w-3 h-3 mr-1" />
+                      {updateApp.isPending ? "Saving..." : "Save"}
+                    </Button>
+                    <Button size="sm" variant="outline" onClick={() => setEditingBasic(false)}>
+                      <X className="w-3 h-3 mr-1" />
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <div className="space-y-4">
+                  <div>
+                    <p className="text-sm font-medium">Harness</p>
+                    <p className="text-sm text-muted-foreground">{harnessName ?? app.harness_id}</p>
+                  </div>
+
+                  <div>
+                    <p className="text-sm font-medium">Agent</p>
+                    <p className="text-sm text-muted-foreground">{agentName ?? app.agent_id}</p>
+                  </div>
+
+                  <div>
+                    <p className="text-sm font-medium">Channel</p>
+                    <Badge variant="outline">Slack</Badge>
+                  </div>
+
+                  <div>
+                    <p className="text-sm font-medium">Created</p>
+                    <p className="text-sm text-muted-foreground">
+                      {new Date(app.created_at).toLocaleString()}
+                    </p>
+                  </div>
+
+                  <div>
+                    <p className="text-sm font-medium">Updated</p>
+                    <p className="text-sm text-muted-foreground">
+                      {new Date(app.updated_at).toLocaleString()}
+                    </p>
+                  </div>
+
+                  {app.published_at && (
+                    <div>
+                      <p className="text-sm font-medium">Published</p>
+                      <p className="text-sm text-muted-foreground">
+                        {new Date(app.published_at).toLocaleString()}
+                      </p>
+                    </div>
+                  )}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      {/* Delete confirmation dialog */}
+      <Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete App</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete &quot;{app.name}&quot;? This will stop all incoming
+              Slack messages from being processed.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowDeleteDialog(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={deleteAppMutation.isPending}
+            >
+              {deleteAppMutation.isPending ? "Deleting..." : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/ui/src/app/(main)/apps/new/page.tsx
+++ b/apps/ui/src/app/(main)/apps/new/page.tsx
@@ -125,7 +125,10 @@ export default function NewAppPage() {
             </p>
 
             <div className="flex gap-4">
-              <Button type="submit" disabled={createApp.isPending || !name || !agentId || !harnessId}>
+              <Button
+                type="submit"
+                disabled={createApp.isPending || !name || !agentId || !harnessId}
+              >
                 {createApp.isPending ? "Creating..." : "Create App"}
               </Button>
               <Button type="button" variant="outline" onClick={() => router.back()}>

--- a/apps/ui/src/app/(main)/apps/new/page.tsx
+++ b/apps/ui/src/app/(main)/apps/new/page.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useCreateApp } from "@/hooks/use-apps";
+import { useAgents } from "@/hooks";
+import { useHarnesses } from "@/hooks/use-harnesses";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+
+export default function NewAppPage() {
+  const router = useRouter();
+  const createApp = useCreateApp();
+  const { data: agents } = useAgents();
+  const { data: harnesses } = useHarnesses();
+
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [agentId, setAgentId] = useState("");
+  const [harnessId, setHarnessId] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    try {
+      const app = await createApp.mutateAsync({
+        name,
+        description: description || undefined,
+        agent_id: agentId,
+        harness_id: harnessId,
+        channel_type: "slack",
+      });
+
+      router.push(`/apps/${app.id}`);
+    } catch (error) {
+      console.error("Failed to create app:", error);
+    }
+  };
+
+  return (
+    <div className="container mx-auto p-6">
+      <Link
+        href="/apps"
+        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-6"
+      >
+        <ArrowLeft className="w-4 h-4 mr-2" />
+        Back to Apps
+      </Link>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Create New App</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div className="space-y-2">
+              <Label htmlFor="name">Name</Label>
+              <Input
+                id="name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Support Bot"
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="description">Description</Label>
+              <Input
+                id="description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Customer support bot for #help channel"
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="harness">Harness</Label>
+                <Select value={harnessId} onValueChange={setHarnessId} required>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select harness" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {harnesses?.map((h) => (
+                      <SelectItem key={h.id} value={h.id}>
+                        {h.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="agent">Agent</Label>
+                <Select value={agentId} onValueChange={setAgentId} required>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select agent" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {agents?.map((a) => (
+                      <SelectItem key={a.id} value={a.id}>
+                        {a.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <p className="text-sm text-muted-foreground">
+              After creating the app, you can configure the Slack integration on the app detail
+              page.
+            </p>
+
+            <div className="flex gap-4">
+              <Button type="submit" disabled={createApp.isPending || !name || !agentId || !harnessId}>
+                {createApp.isPending ? "Creating..." : "Create App"}
+              </Button>
+              <Button type="button" variant="outline" onClick={() => router.back()}>
+                Cancel
+              </Button>
+            </div>
+
+            {createApp.error && (
+              <p className="text-sm text-destructive">Error: {createApp.error.message}</p>
+            )}
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/ui/src/app/(main)/apps/page.tsx
+++ b/apps/ui/src/app/(main)/apps/page.tsx
@@ -1,45 +1,16 @@
 "use client";
 
-import { useState } from "react";
-import {
-  useApps,
-  useCreateApp,
-  useDeleteApp,
-  usePublishApp,
-  useUnpublishApp,
-  useUpdateApp,
-} from "@/hooks/use-apps";
-import { useAgents } from "@/hooks";
-import { useHarnesses } from "@/hooks/use-harnesses";
+import { useApps, usePublishApp, useUnpublishApp } from "@/hooks/use-apps";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Plus, Rocket, Trash2, Globe, GlobeLock, Copy } from "lucide-react";
-import type { App, CreateAppRequest, SessionStrategy, SlackChannelConfig } from "@/lib/api/types";
+import { Plus, Rocket, Globe, GlobeLock, Copy } from "lucide-react";
+import Link from "next/link";
+import type { App } from "@/lib/api/types";
 
 export default function AppsPage() {
   const { data: apps, isLoading, error } = useApps();
-  const [showCreateDialog, setShowCreateDialog] = useState(false);
-  const [editingApp, setEditingApp] = useState<App | null>(null);
-  const [deletingApp, setDeletingApp] = useState<App | null>(null);
 
   if (error) {
     return (
@@ -53,10 +24,12 @@ export default function AppsPage() {
     <div className="container mx-auto p-6">
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold">Apps</h1>
-        <Button variant="accent" onClick={() => setShowCreateDialog(true)}>
-          <Plus className="w-4 h-4 mr-2" />
-          New App
-        </Button>
+        <Link href="/apps/new">
+          <Button variant="accent">
+            <Plus className="w-4 h-4 mr-2" />
+            New App
+          </Button>
+        </Link>
       </div>
 
       {isLoading ? (
@@ -76,49 +49,17 @@ export default function AppsPage() {
       ) : apps && apps.length > 0 ? (
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           {apps.map((app) => (
-            <AppCard
-              key={app.id}
-              app={app}
-              onEdit={() => setEditingApp(app)}
-              onDelete={() => setDeletingApp(app)}
-            />
+            <AppCard key={app.id} app={app} />
           ))}
         </div>
       ) : (
-        <EmptyState onCreateClick={() => setShowCreateDialog(true)} />
-      )}
-
-      <AppFormDialog open={showCreateDialog} onOpenChange={setShowCreateDialog} mode="create" />
-
-      {editingApp && (
-        <AppFormDialog
-          open={true}
-          onOpenChange={(open) => !open && setEditingApp(null)}
-          mode="edit"
-          app={editingApp}
-        />
-      )}
-
-      {deletingApp && (
-        <DeleteConfirmDialog
-          app={deletingApp}
-          open={true}
-          onOpenChange={(open) => !open && setDeletingApp(null)}
-        />
+        <EmptyState />
       )}
     </div>
   );
 }
 
-function AppCard({
-  app,
-  onEdit,
-  onDelete,
-}: {
-  app: App;
-  onEdit: () => void;
-  onDelete: () => void;
-}) {
+function AppCard({ app }: { app: App }) {
   const publishApp = usePublishApp();
   const unpublishApp = useUnpublishApp();
   const isPublished = app.status === "published";
@@ -128,79 +69,81 @@ function AppCard({
       : `/api/v1/apps/${app.id}/slack/events`;
 
   return (
-    <Card className="cursor-pointer hover:border-accent/50 transition-colors" onClick={onEdit}>
-      <CardHeader className="pb-2">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <Rocket className="w-5 h-5 text-muted-foreground" />
-            <h3 className="font-semibold text-lg">{app.name}</h3>
+    <Link href={`/apps/${app.id}`}>
+      <Card className="cursor-pointer hover:border-accent/50 transition-colors">
+        <CardHeader className="pb-2">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Rocket className="w-5 h-5 text-muted-foreground" />
+              <h3 className="font-semibold text-lg">{app.name}</h3>
+            </div>
+            <Badge variant={isPublished ? "default" : "secondary"}>{app.status}</Badge>
           </div>
-          <Badge variant={isPublished ? "default" : "secondary"}>{app.status}</Badge>
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-3">
-        {app.description && <p className="text-sm text-muted-foreground">{app.description}</p>}
-        <div className="flex items-center gap-2 text-xs text-muted-foreground">
-          <Badge variant="outline" className="text-xs">
-            {app.channel_type}
-          </Badge>
-          <span>Agent: {app.agent_id}</span>
-        </div>
-
-        {isPublished && (
-          <div className="flex items-center gap-1 text-xs text-muted-foreground bg-muted p-2 rounded">
-            <Globe className="w-3 h-3 shrink-0" />
-            <span className="truncate font-mono">{webhookUrl}</span>
-            <button
-              className="shrink-0 ml-1 hover:text-foreground"
-              onClick={(e) => {
-                e.stopPropagation();
-                navigator.clipboard.writeText(webhookUrl);
-              }}
-            >
-              <Copy className="w-3 h-3" />
-            </button>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {app.description && <p className="text-sm text-muted-foreground">{app.description}</p>}
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Badge variant="outline" className="text-xs">
+              Slack
+            </Badge>
+            <span>Agent: {app.agent_id}</span>
           </div>
-        )}
 
-        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-        <div className="flex gap-2 pt-2" role="group" onClick={(e) => e.stopPropagation()}>
-          {isPublished ? (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => unpublishApp.mutate(app.id)}
-              disabled={unpublishApp.isPending}
-            >
-              <GlobeLock className="w-3 h-3 mr-1" />
-              Unpublish
-            </Button>
-          ) : (
-            <Button
-              variant="default"
-              size="sm"
-              onClick={() => publishApp.mutate(app.id)}
-              disabled={publishApp.isPending}
-            >
-              <Globe className="w-3 h-3 mr-1" />
-              Publish
-            </Button>
+          {isPublished && (
+            <div className="flex items-center gap-1 text-xs text-muted-foreground bg-muted p-2 rounded">
+              <Globe className="w-3 h-3 shrink-0" />
+              <span className="truncate font-mono">{webhookUrl}</span>
+              <button
+                className="shrink-0 ml-1 hover:text-foreground"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  navigator.clipboard.writeText(webhookUrl);
+                }}
+              >
+                <Copy className="w-3 h-3" />
+              </button>
+            </div>
           )}
-          <Button
-            variant="ghost"
-            size="sm"
-            className="text-destructive hover:text-destructive"
-            onClick={onDelete}
+
+          {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+          <div
+            className="flex gap-2 pt-2"
+            role="group"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+            }}
           >
-            <Trash2 className="w-3 h-3" />
-          </Button>
-        </div>
-      </CardContent>
-    </Card>
+            {isPublished ? (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => unpublishApp.mutate(app.id)}
+                disabled={unpublishApp.isPending}
+              >
+                <GlobeLock className="w-3 h-3 mr-1" />
+                Unpublish
+              </Button>
+            ) : (
+              <Button
+                variant="default"
+                size="sm"
+                onClick={() => publishApp.mutate(app.id)}
+                disabled={publishApp.isPending}
+              >
+                <Globe className="w-3 h-3 mr-1" />
+                Publish
+              </Button>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
   );
 }
 
-function EmptyState({ onCreateClick }: { onCreateClick: () => void }) {
+function EmptyState() {
   return (
     <div className="flex flex-col items-center justify-center py-12 text-center">
       <Rocket className="w-12 h-12 text-muted-foreground mb-4" />
@@ -209,280 +152,12 @@ function EmptyState({ onCreateClick }: { onCreateClick: () => void }) {
         Apps deploy your agents to channels like Slack. Create an app to connect an agent to a Slack
         workspace.
       </p>
-      <Button variant="accent" onClick={onCreateClick}>
-        <Plus className="w-4 h-4 mr-2" />
-        Create Your First App
-      </Button>
+      <Link href="/apps/new">
+        <Button variant="accent">
+          <Plus className="w-4 h-4 mr-2" />
+          Create Your First App
+        </Button>
+      </Link>
     </div>
-  );
-}
-
-function AppFormDialog({
-  open,
-  onOpenChange,
-  mode,
-  app,
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  mode: "create" | "edit";
-  app?: App;
-}) {
-  const { data: agents } = useAgents();
-  const { data: harnesses } = useHarnesses();
-  const createApp = useCreateApp();
-  const updateAppMutation = useUpdateApp();
-
-  const existingConfig = app?.channel_config as SlackChannelConfig | undefined;
-
-  const [name, setName] = useState(app?.name ?? "");
-  const [description, setDescription] = useState(app?.description ?? "");
-  const [agentId, setAgentId] = useState(app?.agent_id ?? "");
-  const [harnessId, setHarnessId] = useState(app?.harness_id ?? "");
-  const [signingSecret, setSigningSecret] = useState(existingConfig?.signing_secret ?? "");
-  const [botToken, setBotToken] = useState(existingConfig?.bot_token ?? "");
-  const [channelId, setChannelId] = useState(existingConfig?.channel_id ?? "");
-  const [teamId, setTeamId] = useState(existingConfig?.team_id ?? "");
-  const [sessionStrategy, setSessionStrategy] = useState<SessionStrategy>(
-    existingConfig?.session_strategy ?? "per_thread",
-  );
-
-  const isPending = createApp.isPending || updateAppMutation.isPending;
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-
-    const channelConfig: SlackChannelConfig = {
-      signing_secret: signingSecret,
-      bot_token: botToken,
-      session_strategy: sessionStrategy,
-      ...(channelId ? { channel_id: channelId } : {}),
-      ...(teamId ? { team_id: teamId } : {}),
-    };
-
-    if (mode === "create") {
-      const req: CreateAppRequest = {
-        name,
-        description: description || undefined,
-        agent_id: agentId,
-        harness_id: harnessId,
-        channel_type: "slack",
-        channel_config: channelConfig,
-      };
-      await createApp.mutateAsync(req);
-    } else if (app) {
-      await updateAppMutation.mutateAsync({
-        appId: app.id,
-        data: {
-          name,
-          description: description || undefined,
-          agent_id: agentId,
-          harness_id: harnessId,
-          channel_config: channelConfig,
-        },
-      });
-    }
-
-    onOpenChange(false);
-  };
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg">
-        <form onSubmit={handleSubmit}>
-          <DialogHeader>
-            <DialogTitle>{mode === "create" ? "Create Slack App" : "Edit Slack App"}</DialogTitle>
-            <DialogDescription>
-              Connect an agent to a Slack workspace. You&apos;ll need a Slack Bot Token and Signing
-              Secret from your Slack app configuration.
-            </DialogDescription>
-          </DialogHeader>
-
-          <div className="space-y-4 py-4">
-            <div>
-              <Label htmlFor="name">Name</Label>
-              <Input
-                id="name"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder="Support Bot"
-                required
-              />
-            </div>
-
-            <div>
-              <Label htmlFor="description">Description</Label>
-              <Input
-                id="description"
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                placeholder="Customer support bot for #help channel"
-              />
-            </div>
-
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <Label htmlFor="harness">Harness</Label>
-                <Select value={harnessId} onValueChange={setHarnessId} required>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select harness" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {harnesses?.map((h) => (
-                      <SelectItem key={h.id} value={h.id}>
-                        {h.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div>
-                <Label htmlFor="agent">Agent</Label>
-                <Select value={agentId} onValueChange={setAgentId} required>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select agent" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {agents?.map((a) => (
-                      <SelectItem key={a.id} value={a.id}>
-                        {a.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-
-            <hr className="my-2" />
-            <h4 className="font-medium text-sm">Slack Configuration</h4>
-
-            <div>
-              <Label htmlFor="signing_secret">Signing Secret</Label>
-              <Input
-                id="signing_secret"
-                type="password"
-                value={signingSecret}
-                onChange={(e) => setSigningSecret(e.target.value)}
-                placeholder="Your Slack app signing secret"
-                required
-              />
-              <p className="text-xs text-muted-foreground mt-1">
-                Found in Slack App &rarr; Basic Information &rarr; App Credentials
-              </p>
-            </div>
-
-            <div>
-              <Label htmlFor="bot_token">Bot Token</Label>
-              <Input
-                id="bot_token"
-                type="password"
-                value={botToken}
-                onChange={(e) => setBotToken(e.target.value)}
-                placeholder="xoxb-..."
-                required
-              />
-              <p className="text-xs text-muted-foreground mt-1">
-                Found in Slack App &rarr; OAuth &amp; Permissions
-              </p>
-            </div>
-
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <Label htmlFor="channel_id">Channel ID (optional)</Label>
-                <Input
-                  id="channel_id"
-                  value={channelId}
-                  onChange={(e) => setChannelId(e.target.value)}
-                  placeholder="C0123456789"
-                />
-              </div>
-
-              <div>
-                <Label htmlFor="team_id">Team ID (optional)</Label>
-                <Input
-                  id="team_id"
-                  value={teamId}
-                  onChange={(e) => setTeamId(e.target.value)}
-                  placeholder="T0123456789"
-                />
-              </div>
-            </div>
-
-            <div>
-              <Label htmlFor="session_strategy">Session Strategy</Label>
-              <Select
-                value={sessionStrategy}
-                onValueChange={(v) => setSessionStrategy(v as SessionStrategy)}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="per_thread">Per Thread (default)</SelectItem>
-                  <SelectItem value="per_channel">Per Channel</SelectItem>
-                  <SelectItem value="per_user">Per User</SelectItem>
-                </SelectContent>
-              </Select>
-              <p className="text-xs text-muted-foreground mt-1">
-                Controls how Slack messages map to sessions
-              </p>
-            </div>
-          </div>
-
-          <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-              Cancel
-            </Button>
-            <Button type="submit" disabled={isPending || !name || !agentId || !harnessId}>
-              {isPending ? "Saving..." : mode === "create" ? "Create App" : "Save Changes"}
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-function DeleteConfirmDialog({
-  app,
-  open,
-  onOpenChange,
-}: {
-  app: App;
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-}) {
-  const deleteAppMutation = useDeleteApp();
-
-  const handleDelete = async () => {
-    await deleteAppMutation.mutateAsync(app.id);
-    onOpenChange(false);
-  };
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Delete App</DialogTitle>
-          <DialogDescription>
-            Are you sure you want to delete &quot;{app.name}&quot;? This will stop all incoming
-            Slack messages from being processed.
-          </DialogDescription>
-        </DialogHeader>
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button
-            variant="destructive"
-            onClick={handleDelete}
-            disabled={deleteAppMutation.isPending}
-          >
-            {deleteAppMutation.isPending ? "Deleting..." : "Delete"}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
   );
 }


### PR DESCRIPTION
## What
Redesign the App creation and management UI to separate app creation from Slack configuration. Split the monolithic modal-based page into three separate pages with a non-modal Slack setup experience.

## Why
The previous flow crammed app creation and Slack configuration into a single modal dialog, making it complex. Users should be able to create an app quickly with basic info, then configure Slack integration separately on the detail page.

## How
Split `apps/page.tsx` into three pages:
- **`/apps`** (list page) — app cards linking to detail pages, no modals
- **`/apps/new`** (creation page) — simple form: name, description, harness, agent
- **`/apps/[appId]`** (detail page) — inline Slack configuration with edit-in-place

Slack configuration uses Slack naming conventions:
- Signing Secret (Settings > Basic Information > App Credentials)
- Bot User OAuth Token (OAuth & Permissions > Bot User OAuth Token)
- Workspace ID (instead of Team ID)
- Request URL card shown when published (Event Subscriptions > Request URL)

## Risk
- Low
- UI-only changes, no backend/API modifications

## Checklist
- [x] Tests added or updated (UI lint + build verified)
- [x] Backward compatibility considered (no API changes)
