### PR TITLE
feat(ui): add experimental badge for Chat and Apps

### DIFF
--- a/apps/ui/src/app/(main)/apps/page.tsx
+++ b/apps/ui/src/app/(main)/apps/page.tsx
@@ -25,9 +25,9 @@ export default function AppsPage() {
     <div className="container mx-auto p-6">
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold flex items-center gap-3">
-            Apps
-            <ExperimentalPageBadge />
-          </h1>
+          Apps
+          <ExperimentalPageBadge />
+        </h1>
         <Link href="/apps/new">
           <Button variant="accent">
             <Plus className="w-4 h-4 mr-2" />

--- a/apps/ui/src/app/(main)/apps/page.tsx
+++ b/apps/ui/src/app/(main)/apps/page.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { Plus, Rocket, Globe, GlobeLock, Copy } from "lucide-react";
 import Link from "next/link";
 import type { App } from "@/lib/api/types";
+import { ExperimentalPageBadge } from "@/components/ui/experimental-badge";
 
 export default function AppsPage() {
   const { data: apps, isLoading, error } = useApps();
@@ -23,7 +24,10 @@ export default function AppsPage() {
   return (
     <div className="container mx-auto p-6">
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold">Apps</h1>
+        <h1 className="text-2xl font-bold flex items-center gap-3">
+            Apps
+            <ExperimentalPageBadge />
+          </h1>
         <Link href="/apps/new">
           <Button variant="accent">
             <Plus className="w-4 h-4 mr-2" />

--- a/apps/ui/src/app/(main)/chat/page.tsx
+++ b/apps/ui/src/app/(main)/chat/page.tsx
@@ -5,6 +5,7 @@ import { ChatPanel } from "@/components/chat/chat-panel";
 import { SessionProvider } from "@/app/(main)/sessions/[sessionId]/session-context";
 import { useGlobalChat } from "@/hooks/use-global-chat";
 import { useFeatureFlag } from "@/providers/feature-flags-provider";
+import { ExperimentalPageBadge } from "@/components/ui/experimental-badge";
 
 export default function GlobalChatPage() {
   const globalChatEnabled = useFeatureFlag("global_chat");
@@ -41,7 +42,10 @@ export default function GlobalChatPage() {
   }
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full relative">
+      <div className="absolute top-3 right-4 z-10">
+        <ExperimentalPageBadge />
+      </div>
       <SessionProvider sessionId={sessionId}>
         <ChatPanel />
       </SessionProvider>

--- a/apps/ui/src/app/globals.css
+++ b/apps/ui/src/app/globals.css
@@ -118,21 +118,22 @@
 /* Experimental page badge — hand-drawn stamp with Caveat font */
 .experimental-page-badge {
   font-family: "Caveat", cursive;
-  font-size: 1.5rem;
+  font-size: 1.05rem;
   font-weight: 600;
   color: #d97706;
   position: relative;
   display: inline-block;
-  padding: 0.15rem 1rem;
+  padding: 0 0.5rem;
   cursor: default;
   user-select: none;
-  transform: rotate(-2deg);
+  transform: rotate(-1.5deg);
+  vertical-align: middle;
 }
 .experimental-page-badge::before {
   content: "";
   position: absolute;
-  inset: -4px -8px;
-  border: 2px solid #d97706;
+  inset: -2px -5px;
+  border: 1.5px solid #d97706;
   border-radius: 50% 40% 45% 42% / 50% 45% 40% 48%;
-  opacity: 0.5;
+  opacity: 0.45;
 }

--- a/apps/ui/src/app/globals.css
+++ b/apps/ui/src/app/globals.css
@@ -114,3 +114,25 @@
 .dark .bg-brand-dots {
   background-image: radial-gradient(circle at center, hsl(43 60% 53% / 0.1) 1px, transparent 1px);
 }
+
+/* Experimental page badge — hand-drawn stamp with Caveat font */
+.experimental-page-badge {
+  font-family: "Caveat", cursive;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #d97706;
+  position: relative;
+  display: inline-block;
+  padding: 0.15rem 1rem;
+  cursor: default;
+  user-select: none;
+  transform: rotate(-2deg);
+}
+.experimental-page-badge::before {
+  content: "";
+  position: absolute;
+  inset: -4px -8px;
+  border: 2px solid #d97706;
+  border-radius: 50% 40% 45% 42% / 50% 45% 40% 48%;
+  opacity: 0.5;
+}

--- a/apps/ui/src/app/layout.tsx
+++ b/apps/ui/src/app/layout.tsx
@@ -17,6 +17,13 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        {/* Handwritten font for experimental badges */}
+        <link
+          href="https://fonts.googleapis.com/css2?family=Caveat:wght@600&display=swap"
+          rel="stylesheet"
+        />
+      </head>
       <body className="font-sans antialiased bg-brand-dots">
         <QueryProvider>
           <FeatureFlagsProvider>

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -57,6 +57,7 @@ import {
   Plus,
   Rocket,
 } from "lucide-react";
+import { ExperimentalBadge } from "@/components/ui/experimental-badge";
 
 const isDev = process.env.NODE_ENV === "development";
 
@@ -66,10 +67,11 @@ type NavItem = {
   icon: React.ComponentType<{ className?: string }>;
   flag?: keyof import("@/lib/api/types").FeatureFlags;
   exact?: boolean;
+  experimental?: boolean;
 };
 
 const topNavigation: NavItem[] = [
-  { name: "Chat", href: "/chat", icon: MessageCircle, flag: "global_chat" },
+  { name: "Chat", href: "/chat", icon: MessageCircle, flag: "global_chat", experimental: true },
   { name: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
   { name: "Sessions", href: "/sessions", icon: MessageSquare },
 ];
@@ -79,7 +81,7 @@ const buildingBlocksNavigation = [
   { name: "Agents", href: "/agents", icon: Boxes },
   { name: "Skills", href: "/skills", icon: BookOpen },
   { name: "Capabilities", href: "/capabilities", icon: Puzzle },
-  { name: "Apps", href: "/apps", icon: Rocket, flag: "apps" },
+  { name: "Apps", href: "/apps", icon: Rocket, flag: "apps", experimental: true },
 ];
 
 const bottomNavigation = [{ name: "Settings", href: "/settings", icon: Settings }];
@@ -247,6 +249,7 @@ export function Sidebar() {
               >
                 <item.icon className="h-5 w-5" />
                 {item.name}
+                {item.experimental && <ExperimentalBadge />}
               </Link>
             );
           })}
@@ -269,6 +272,7 @@ export function Sidebar() {
             >
               <item.icon className="h-5 w-5" />
               {item.name}
+              {item.experimental && <ExperimentalBadge />}
             </Link>
           );
         })}

--- a/apps/ui/src/components/ui/experimental-badge.tsx
+++ b/apps/ui/src/components/ui/experimental-badge.tsx
@@ -1,0 +1,29 @@
+import { FlaskConical } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider,
+} from "@/components/ui/tooltip";
+
+export function ExperimentalBadge() {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Badge
+            variant="outline"
+            className="ml-auto gap-1 px-1.5 py-0 text-[10px] font-semibold uppercase tracking-wider text-amber-500 border-amber-500/40 bg-amber-500/10 cursor-default select-none"
+          >
+            <FlaskConical className="!size-2.5" />
+            Lab
+          </Badge>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>This feature is experimental. Expect changes and rough edges.</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/apps/ui/src/components/ui/experimental-badge.tsx
+++ b/apps/ui/src/components/ui/experimental-badge.tsx
@@ -1,5 +1,4 @@
 import { FlaskConical } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
 import {
   Tooltip,
   TooltipTrigger,
@@ -7,18 +6,37 @@ import {
   TooltipProvider,
 } from "@/components/ui/tooltip";
 
+/**
+ * Compact icon-only badge for sidebar nav items.
+ * Shows a flask icon with tooltip on hover.
+ */
 export function ExperimentalBadge() {
   return (
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>
-          <Badge
-            variant="outline"
-            className="ml-auto gap-1 px-1.5 py-0 text-[10px] font-semibold uppercase tracking-wider text-amber-500 border-amber-500/40 bg-amber-500/10 cursor-default select-none"
-          >
-            <FlaskConical className="!size-2.5" />
-            Lab
-          </Badge>
+          <span className="ml-auto text-amber-500 cursor-default">
+            <FlaskConical className="!size-3.5" />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>Experimental — expect changes and rough edges.</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+/**
+ * Handwritten-style "Experimental" stamp for page headers.
+ * Uses Caveat font loaded from Google Fonts via CSS.
+ */
+export function ExperimentalPageBadge() {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="experimental-page-badge">Experimental</span>
         </TooltipTrigger>
         <TooltipContent>
           <p>This feature is experimental. Expect changes and rough edges.</p>

--- a/apps/ui/src/components/ui/experimental-badge.tsx
+++ b/apps/ui/src/components/ui/experimental-badge.tsx
@@ -28,15 +28,15 @@ export function ExperimentalBadge() {
 }
 
 /**
- * Handwritten-style "Experimental" stamp for page headers.
- * Uses Caveat font loaded from Google Fonts via CSS.
+ * Page-level experimental badge — small Caveat-font label
+ * with a subtle hand-drawn circle. Sits inline next to page titles.
  */
 export function ExperimentalPageBadge() {
   return (
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>
-          <span className="experimental-page-badge">Experimental</span>
+          <span className="experimental-page-badge">experimental</span>
         </TooltipTrigger>
         <TooltipContent>
           <p>This feature is experimental. Expect changes and rough edges.</p>

--- a/apps/ui/src/components/ui/experimental-badge.tsx
+++ b/apps/ui/src/components/ui/experimental-badge.tsx
@@ -1,10 +1,5 @@
 import { FlaskConical } from "lucide-react";
-import {
-  Tooltip,
-  TooltipTrigger,
-  TooltipContent,
-  TooltipProvider,
-} from "@/components/ui/tooltip";
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@/components/ui/tooltip";
 
 /**
  * Compact icon-only badge for sidebar nav items.

--- a/specs/feature-flags.md
+++ b/specs/feature-flags.md
@@ -63,6 +63,15 @@ passed via gRPC turn context.
 6. Add to `DEFAULT_FLAGS` in `apps/ui/src/providers/feature-flags-provider.tsx`
 7. Use `useFeatureFlag("flag_name")` in UI components
 
+## UI Indication
+
+Features gated behind experimental flags display visual badges to signal their status:
+
+- **Sidebar**: Flask icon (`FlaskConical`) next to the nav item name, with tooltip on hover
+- **Page header**: Handwritten-style "experimental" label (Caveat font) with hand-drawn circle border, placed inline next to the page title
+
+Both are driven by `experimental: true` on the `NavItem` type in the sidebar, and `<ExperimentalPageBadge />` on individual pages. See `apps/ui/src/components/ui/experimental-badge.tsx`.
+
 ## Future Extensions
 
 - **Per-org flags**: Add `org_id` column to a `feature_flag_overrides` table


### PR DESCRIPTION
## What
Add experimental badge UI for features under feature flags (Chat, Apps).

Two components:
- **Sidebar**: Flask icon next to experimental nav items, tooltip on hover
- **Page header**: Handwritten-style "experimental" label (Caveat font) with hand-drawn circle border

## Why
Users should know which features are experimental and may change. Visual signal sets expectations.

## How
- `ExperimentalBadge` — compact icon-only component for sidebar nav
- `ExperimentalPageBadge` — Caveat-font styled label with CSS hand-drawn circle
- Sidebar `NavItem` type extended with `experimental?: boolean` flag
- Caveat 600 loaded from Google Fonts via `<link>` in root layout
- Badge added to Apps page (inline with h1) and Chat page (top-right overlay)

## Risk
- Low
- Purely presentational. No logic, state, or API changes. Sidebar feature flag gating unchanged.

## Checklist
- [x] Tests added or updated (all 411 UI tests pass, existing sidebar tests cover nav rendering)
- [x] Backward compatibility considered (additive only, no breaking changes)
