### PR TITLE
feat(core): add apps feature flag

### DIFF
--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -65,6 +65,7 @@ jest.mock("@/hooks/use-organizations", () => ({
 jest.mock("@/providers/feature-flags-provider", () => ({
   useFeatureFlags: () => ({
     global_chat: true,
+    apps: true,
   }),
 }));
 

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -79,7 +79,7 @@ const buildingBlocksNavigation = [
   { name: "Agents", href: "/agents", icon: Boxes },
   { name: "Skills", href: "/skills", icon: BookOpen },
   { name: "Capabilities", href: "/capabilities", icon: Puzzle },
-  { name: "Apps", href: "/apps", icon: Rocket },
+  { name: "Apps", href: "/apps", icon: Rocket, flag: "apps" },
 ];
 
 const bottomNavigation = [{ name: "Settings", href: "/settings", icon: Settings }];

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -712,6 +712,7 @@ export type AuthMode = "none" | "admin" | "full" | "external";
 
 export interface FeatureFlags {
   global_chat: boolean;
+  apps: boolean;
 }
 
 export interface AuthConfigResponse {

--- a/apps/ui/src/providers/feature-flags-provider.tsx
+++ b/apps/ui/src/providers/feature-flags-provider.tsx
@@ -13,6 +13,7 @@ import type { FeatureFlags } from "@/lib/api/types";
 
 const DEFAULT_FLAGS: FeatureFlags = {
   global_chat: false,
+  apps: false,
 };
 
 export interface FeatureFlagsContextValue {

--- a/crates/core/src/feature_flags.rs
+++ b/crates/core/src/feature_flags.rs
@@ -19,6 +19,8 @@ use crate::deployment::DeploymentGrade;
 pub struct FeatureFlags {
     /// Global chat (per-user singleton chat session). Experimental.
     pub global_chat: bool,
+    /// Apps (agent deployment to distribution channels). Experimental.
+    pub apps: bool,
 }
 
 impl FeatureFlags {
@@ -26,6 +28,7 @@ impl FeatureFlags {
     pub fn from_env(grade: &DeploymentGrade) -> Self {
         Self {
             global_chat: experimental_flag("FEATURE_GLOBAL_CHAT", grade),
+            apps: experimental_flag("FEATURE_APPS", grade),
         }
     }
 
@@ -33,6 +36,7 @@ impl FeatureFlags {
     pub fn is_enabled(&self, flag: &str) -> bool {
         match flag {
             "global_chat" => self.global_chat,
+            "apps" => self.apps,
             _ => false,
         }
     }
@@ -40,7 +44,10 @@ impl FeatureFlags {
     /// All flags enabled (for testing).
     #[cfg(test)]
     pub fn all_enabled() -> Self {
-        Self { global_chat: true }
+        Self {
+            global_chat: true,
+            apps: true,
+        }
     }
 }
 
@@ -72,6 +79,7 @@ mod tests {
     fn test_default_flags() {
         let flags = FeatureFlags::default();
         assert!(!flags.global_chat);
+        assert!(!flags.apps);
     }
 
     // SAFETY: env var tests must run single-threaded (--test-threads=1).
@@ -80,15 +88,19 @@ mod tests {
     #[test]
     fn test_experimental_enabled_in_dev() {
         unsafe { std::env::remove_var("FEATURE_GLOBAL_CHAT") };
+        unsafe { std::env::remove_var("FEATURE_APPS") };
         let flags = FeatureFlags::from_env(&DeploymentGrade::Dev);
         assert!(flags.global_chat);
+        assert!(flags.apps);
     }
 
     #[test]
     fn test_experimental_disabled_in_prod() {
         unsafe { std::env::remove_var("FEATURE_GLOBAL_CHAT") };
+        unsafe { std::env::remove_var("FEATURE_APPS") };
         let flags = FeatureFlags::from_env(&DeploymentGrade::Prod);
         assert!(!flags.global_chat);
+        assert!(!flags.apps);
     }
 
     #[test]
@@ -109,14 +121,21 @@ mod tests {
 
     #[test]
     fn test_is_enabled_dynamic() {
-        let flags = FeatureFlags { global_chat: true };
+        let flags = FeatureFlags {
+            global_chat: true,
+            apps: true,
+        };
         assert!(flags.is_enabled("global_chat"));
+        assert!(flags.is_enabled("apps"));
         assert!(!flags.is_enabled("nonexistent"));
     }
 
     #[test]
     fn test_serialization() {
-        let flags = FeatureFlags { global_chat: true };
+        let flags = FeatureFlags {
+            global_chat: true,
+            apps: true,
+        };
         let json = serde_json::to_string(&flags).unwrap();
         assert!(json.contains("\"global_chat\":true"));
 

--- a/specs/feature-flags.md
+++ b/specs/feature-flags.md
@@ -29,6 +29,7 @@ System-level feature flags that control feature availability across the platform
 | Flag | Env Var | Type | Description |
 |------|---------|------|-------------|
 | `global_chat` | `FEATURE_GLOBAL_CHAT` | Experimental | Per-user singleton chat session |
+| `apps` | `FEATURE_APPS` | Experimental | Apps (agent deployment to distribution channels) |
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

- Add `apps` experimental feature flag (`FEATURE_APPS` env var) to gate Apps UI
- Auto-enabled in dev mode, disabled in prod — requires explicit `FEATURE_APPS=true` to enable
- Gates the Apps sidebar nav item behind the flag
- Updates spec, tests, and UI types/provider

## Test plan

- [x] `just pre-push` passes (fmt, clippy, lint)
- [x] `cargo test -p everruns-core feature_flags` — all 8 tests pass
- [ ] Smoke test: dev mode shows Apps in sidebar
- [ ] Smoke test: prod mode hides Apps from sidebar
- [ ] Smoke test: `FEATURE_APPS=true` in prod enables Apps nav