### PR TITLE
fix(slack): correct answer mapping, dedup events, and stream progress

### DIFF
--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -27,7 +27,9 @@ use everruns_worker::AgentRunner;
 use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Instant;
 
 use crate::api::messages::{CreateMessageRequest, InputContentPart, InputMessage, MessageRole};
 use crate::api::sessions::CreateSessionRequest;
@@ -37,6 +39,12 @@ use crate::storage::StorageBackend;
 use super::common::ErrorResponse;
 
 type HmacSha256 = Hmac<Sha256>;
+
+/// Dedup cache for Slack events. Keyed by message `ts`, entries expire after 60s.
+/// Prevents double-processing when Slack sends both `app_mention` and `message`
+/// events for the same @mention.
+static SLACK_EVENT_DEDUP: std::sync::LazyLock<StdMutex<HashMap<String, Instant>>> =
+    std::sync::LazyLock::new(|| StdMutex::new(HashMap::new()));
 
 /// Slack event wrapper (Events API envelope).
 #[derive(Debug, Deserialize)]
@@ -209,6 +217,27 @@ async fn handle_slack_event(
                     return Ok((StatusCode::OK, Json(ack_json())));
                 }
 
+                // Dedup: Slack sends both app_mention and message events for @mentions.
+                // Use the message ts as a dedup key with a 60s expiry window.
+                let event_ts = event.ts.clone().unwrap_or_default();
+                if !event_ts.is_empty() {
+                    let mut dedup = SLACK_EVENT_DEDUP.lock().unwrap();
+                    let now = Instant::now();
+                    // Purge stale entries
+                    dedup
+                        .retain(|_, t| now.duration_since(*t) < std::time::Duration::from_secs(60));
+                    if dedup.contains_key(&event_ts) {
+                        tracing::debug!(
+                            app_id = %app_id,
+                            ts = %event_ts,
+                            event_type = %event.event_type,
+                            "Skipping duplicate Slack event (already processed this ts)"
+                        );
+                        return Ok((StatusCode::OK, Json(ack_json())));
+                    }
+                    dedup.insert(event_ts, now);
+                }
+
                 tracing::info!(
                     app_id = %app_id,
                     event_type = %event.event_type,
@@ -362,11 +391,14 @@ async fn process_slack_message(
         .or_else(|| event.ts.clone())
         .unwrap_or_default();
     let session_id = session.id.uuid();
+    let message_id = message.id;
     let db = state.db.clone();
 
     tokio::spawn(async move {
-        if let Err(e) =
-            wait_and_post_response(&db, session_id, &bot_token, &channel, &thread_ts).await
+        if let Err(e) = wait_and_post_response(
+            &db, session_id, message_id, &bot_token, &channel, &thread_ts,
+        )
+        .await
         {
             tracing::error!(
                 session_id = %session_id,
@@ -432,11 +464,14 @@ fn build_session_title(slack_config: &SlackChannelConfig, event: &SlackEvent) ->
 
 /// Wait for agent response events and post the result back to Slack.
 ///
-/// Polls for output.message.completed events on the session, then sends
-/// the agent's response text to the Slack channel/thread.
+/// Polls for output.message.completed events on the session that match the
+/// given `input_message_id`, then sends the agent's response text to Slack.
+/// Filtering by `input_message_id` ensures each Slack message gets the correct
+/// response, not the first response in the session.
 async fn wait_and_post_response(
     db: &StorageBackend,
     session_id: uuid::Uuid,
+    input_message_id: everruns_core::typed_id::MessageId,
     bot_token: &str,
     channel: &str,
     thread_ts: &str,
@@ -444,6 +479,7 @@ async fn wait_and_post_response(
     use everruns_core::typed_id::{EventId, SessionId};
 
     let session_id_typed = SessionId::from_uuid(session_id);
+    let input_msg_str = input_message_id.to_string();
 
     // Poll for output.message.completed events (max 120 seconds)
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(120);
@@ -463,7 +499,14 @@ async fn wait_and_post_response(
         for event_row in &events {
             since_id = Some(event_row.id);
 
-            if event_row.event_type == "output.message.completed" {
+            // Only consider events triggered by our input message
+            let event_input_msg = event_row
+                .context
+                .get("input_message_id")
+                .and_then(|v| v.as_str());
+            let is_our_turn = event_input_msg == Some(&input_msg_str);
+
+            if event_row.event_type == "output.message.completed" && is_our_turn {
                 // Extract the text from the event data
                 if let Some(text) = extract_response_text(&event_row.data) {
                     post_to_slack(bot_token, channel, thread_ts, &text).await?;
@@ -472,7 +515,9 @@ async fn wait_and_post_response(
             }
 
             // Also check for turn.completed or turn.failed as terminal states
-            if event_row.event_type == "turn.completed" || event_row.event_type == "turn.failed" {
+            if (event_row.event_type == "turn.completed" || event_row.event_type == "turn.failed")
+                && is_our_turn
+            {
                 tracing::debug!(
                     session_id = %session_id,
                     event_type = %event_row.event_type,
@@ -872,5 +917,68 @@ mod tests {
             bot_id: None,
             subtype: None,
         }
+    }
+
+    #[test]
+    fn test_dedup_cache_blocks_duplicate_ts() {
+        let ts = format!("dedup_test_{}", uuid::Uuid::new_v4());
+        {
+            let mut dedup = SLACK_EVENT_DEDUP.lock().unwrap();
+            assert!(!dedup.contains_key(&ts));
+            dedup.insert(ts.clone(), Instant::now());
+        }
+        {
+            let dedup = SLACK_EVENT_DEDUP.lock().unwrap();
+            assert!(dedup.contains_key(&ts));
+        }
+    }
+
+    #[test]
+    fn test_dedup_cache_allows_different_ts() {
+        let ts1 = format!("dedup_a_{}", uuid::Uuid::new_v4());
+        let ts2 = format!("dedup_b_{}", uuid::Uuid::new_v4());
+        {
+            let mut dedup = SLACK_EVENT_DEDUP.lock().unwrap();
+            dedup.insert(ts1.clone(), Instant::now());
+        }
+        {
+            let dedup = SLACK_EVENT_DEDUP.lock().unwrap();
+            assert!(dedup.contains_key(&ts1));
+            assert!(!dedup.contains_key(&ts2));
+        }
+    }
+
+    #[test]
+    fn test_event_context_input_message_id_matching() {
+        // Simulate the filtering logic from wait_and_post_response
+        let input_msg_str = "message_01933b5a00007000800000000000001";
+
+        // Event with matching input_message_id
+        let context_match = serde_json::json!({
+            "input_message_id": "message_01933b5a00007000800000000000001",
+            "turn_id": "turn_01933b5a00007000800000000000001"
+        });
+        let event_input_msg = context_match
+            .get("input_message_id")
+            .and_then(|v| v.as_str());
+        assert_eq!(event_input_msg, Some(input_msg_str));
+
+        // Event with different input_message_id (should NOT match)
+        let context_other = serde_json::json!({
+            "input_message_id": "message_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2",
+            "turn_id": "turn_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2"
+        });
+        let other_msg = context_other
+            .get("input_message_id")
+            .and_then(|v| v.as_str());
+        assert_ne!(other_msg, Some(input_msg_str));
+
+        // Event with no context (session-level event, should NOT match)
+        let context_empty = serde_json::json!({});
+        let empty_msg = context_empty
+            .get("input_message_id")
+            .and_then(|v| v.as_str());
+        assert_eq!(empty_msg, None);
+        assert_ne!(empty_msg, Some(input_msg_str));
     }
 }

--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -27,9 +27,7 @@ use everruns_worker::AgentRunner;
 use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex as StdMutex};
-use std::time::Instant;
+use std::sync::Arc;
 
 use crate::api::messages::{CreateMessageRequest, InputContentPart, InputMessage, MessageRole};
 use crate::api::sessions::CreateSessionRequest;
@@ -39,12 +37,6 @@ use crate::storage::StorageBackend;
 use super::common::ErrorResponse;
 
 type HmacSha256 = Hmac<Sha256>;
-
-/// Dedup cache for Slack events. Keyed by message `ts`, entries expire after 60s.
-/// Prevents double-processing when Slack sends both `app_mention` and `message`
-/// events for the same @mention.
-static SLACK_EVENT_DEDUP: std::sync::LazyLock<StdMutex<HashMap<String, Instant>>> =
-    std::sync::LazyLock::new(|| StdMutex::new(HashMap::new()));
 
 /// Slack event wrapper (Events API envelope).
 #[derive(Debug, Deserialize)]
@@ -217,27 +209,6 @@ async fn handle_slack_event(
                     return Ok((StatusCode::OK, Json(ack_json())));
                 }
 
-                // Dedup: Slack sends both app_mention and message events for @mentions.
-                // Use the message ts as a dedup key with a 60s expiry window.
-                let event_ts = event.ts.clone().unwrap_or_default();
-                if !event_ts.is_empty() {
-                    let mut dedup = SLACK_EVENT_DEDUP.lock().unwrap();
-                    let now = Instant::now();
-                    // Purge stale entries
-                    dedup
-                        .retain(|_, t| now.duration_since(*t) < std::time::Duration::from_secs(60));
-                    if dedup.contains_key(&event_ts) {
-                        tracing::debug!(
-                            app_id = %app_id,
-                            ts = %event_ts,
-                            event_type = %event.event_type,
-                            "Skipping duplicate Slack event (already processed this ts)"
-                        );
-                        return Ok((StatusCode::OK, Json(ack_json())));
-                    }
-                    dedup.insert(event_ts, now);
-                }
-
                 tracing::info!(
                     app_id = %app_id,
                     event_type = %event.event_type,
@@ -335,6 +306,25 @@ async fn process_slack_message(
                 .await?
         }
     };
+
+    // Dedup: Slack sends both app_mention and message events for @mentions.
+    // Check if we already have an input.message with this slack_ts in the session.
+    // This works across server instances because the check is DB-level.
+    let slack_ts = event.ts.clone().unwrap_or_default();
+    if !slack_ts.is_empty() {
+        let already_exists = state
+            .db
+            .has_event_with_slack_ts(session.id, &slack_ts)
+            .await?;
+        if already_exists {
+            tracing::debug!(
+                session_id = %session.id,
+                slack_ts = %slack_ts,
+                "Skipping duplicate Slack event (already processed this ts)"
+            );
+            return Ok(());
+        }
+    }
 
     // Create user message (triggers agent workflow)
     let create_msg = CreateMessageRequest {
@@ -462,12 +452,12 @@ fn build_session_title(slack_config: &SlackChannelConfig, event: &SlackEvent) ->
     }
 }
 
-/// Wait for agent response events and post the result back to Slack.
+/// Wait for the agent turn to complete and post the final response to Slack.
 ///
-/// Polls for output.message.completed events on the session that match the
-/// given `input_message_id`, then sends the agent's response text to Slack.
-/// Filtering by `input_message_id` ensures each Slack message gets the correct
-/// response, not the first response in the session.
+/// Collects `output.message.completed` events for this turn (there may be several
+/// if the agent uses tools), and only posts the *last* response text once
+/// `turn.completed` fires. Filtering by `input_message_id` ensures each Slack
+/// message gets the correct response, not a response from a different turn.
 async fn wait_and_post_response(
     db: &StorageBackend,
     session_id: uuid::Uuid,
@@ -481,10 +471,15 @@ async fn wait_and_post_response(
     let session_id_typed = SessionId::from_uuid(session_id);
     let input_msg_str = input_message_id.to_string();
 
-    // Poll for output.message.completed events (max 120 seconds)
+    // Poll for events (max 120 seconds)
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(120);
     let mut since_id: Option<EventId> = None;
     let empty: Vec<String> = vec![];
+
+    // Track the latest response text for our turn. Each Reason→Act cycle emits
+    // an output.message.completed; we want the final one (the terminal response
+    // with no tool calls, right before turn.completed).
+    let mut last_response_text: Option<String> = None;
 
     loop {
         if tokio::time::Instant::now() > deadline {
@@ -506,28 +501,33 @@ async fn wait_and_post_response(
                 .and_then(|v| v.as_str());
             let is_our_turn = event_input_msg == Some(&input_msg_str);
 
-            if event_row.event_type == "output.message.completed" && is_our_turn {
-                // Extract the text from the event data
-                if let Some(text) = extract_response_text(&event_row.data) {
-                    post_to_slack(bot_token, channel, thread_ts, &text).await?;
-                    return Ok(());
-                }
+            if event_row.event_type == "output.message.completed"
+                && is_our_turn
+                && let Some(text) = extract_response_text(&event_row.data)
+            {
+                last_response_text = Some(text);
             }
 
-            // Also check for turn.completed or turn.failed as terminal states
-            if (event_row.event_type == "turn.completed" || event_row.event_type == "turn.failed")
-                && is_our_turn
-            {
-                tracing::debug!(
-                    session_id = %session_id,
-                    event_type = %event_row.event_type,
-                    "Turn ended"
-                );
+            // Post the last collected response when the turn ends
+            if event_row.event_type == "turn.completed" && is_our_turn {
+                if let Some(ref text) = last_response_text {
+                    post_to_slack(bot_token, channel, thread_ts, text).await?;
+                }
+                return Ok(());
+            }
+
+            if event_row.event_type == "turn.failed" && is_our_turn {
+                tracing::warn!(session_id = %session_id, "Turn failed, not posting to Slack");
                 return Ok(());
             }
         }
 
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+
+    // Timeout: post whatever we collected so far (if any)
+    if let Some(ref text) = last_response_text {
+        post_to_slack(bot_token, channel, thread_ts, text).await?;
     }
 
     Ok(())
@@ -919,66 +919,211 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_dedup_cache_blocks_duplicate_ts() {
-        let ts = format!("dedup_test_{}", uuid::Uuid::new_v4());
-        {
-            let mut dedup = SLACK_EVENT_DEDUP.lock().unwrap();
-            assert!(!dedup.contains_key(&ts));
-            dedup.insert(ts.clone(), Instant::now());
-        }
-        {
-            let dedup = SLACK_EVENT_DEDUP.lock().unwrap();
-            assert!(dedup.contains_key(&ts));
-        }
-    }
+    // ==========================================
+    // Event context input_message_id filtering
+    // ==========================================
 
     #[test]
-    fn test_dedup_cache_allows_different_ts() {
-        let ts1 = format!("dedup_a_{}", uuid::Uuid::new_v4());
-        let ts2 = format!("dedup_b_{}", uuid::Uuid::new_v4());
-        {
-            let mut dedup = SLACK_EVENT_DEDUP.lock().unwrap();
-            dedup.insert(ts1.clone(), Instant::now());
-        }
-        {
-            let dedup = SLACK_EVENT_DEDUP.lock().unwrap();
-            assert!(dedup.contains_key(&ts1));
-            assert!(!dedup.contains_key(&ts2));
-        }
-    }
-
-    #[test]
-    fn test_event_context_input_message_id_matching() {
-        // Simulate the filtering logic from wait_and_post_response
+    fn test_event_context_matches_correct_input_message() {
         let input_msg_str = "message_01933b5a00007000800000000000001";
 
-        // Event with matching input_message_id
-        let context_match = serde_json::json!({
+        let context = serde_json::json!({
             "input_message_id": "message_01933b5a00007000800000000000001",
             "turn_id": "turn_01933b5a00007000800000000000001"
         });
-        let event_input_msg = context_match
-            .get("input_message_id")
-            .and_then(|v| v.as_str());
+        let event_input_msg = context.get("input_message_id").and_then(|v| v.as_str());
         assert_eq!(event_input_msg, Some(input_msg_str));
+    }
 
-        // Event with different input_message_id (should NOT match)
-        let context_other = serde_json::json!({
+    #[test]
+    fn test_event_context_rejects_different_input_message() {
+        let input_msg_str = "message_01933b5a00007000800000000000001";
+
+        let context = serde_json::json!({
             "input_message_id": "message_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2",
             "turn_id": "turn_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2"
         });
-        let other_msg = context_other
-            .get("input_message_id")
-            .and_then(|v| v.as_str());
-        assert_ne!(other_msg, Some(input_msg_str));
+        let event_input_msg = context.get("input_message_id").and_then(|v| v.as_str());
+        assert_ne!(event_input_msg, Some(input_msg_str));
+    }
 
-        // Event with no context (session-level event, should NOT match)
-        let context_empty = serde_json::json!({});
-        let empty_msg = context_empty
-            .get("input_message_id")
-            .and_then(|v| v.as_str());
-        assert_eq!(empty_msg, None);
-        assert_ne!(empty_msg, Some(input_msg_str));
+    #[test]
+    fn test_event_context_rejects_empty_context() {
+        let input_msg_str = "message_01933b5a00007000800000000000001";
+        let context = serde_json::json!({});
+        let event_input_msg = context.get("input_message_id").and_then(|v| v.as_str());
+        assert_eq!(event_input_msg, None);
+        assert_ne!(event_input_msg, Some(input_msg_str));
+    }
+
+    // ==========================================
+    // DB-level dedup via has_event_with_slack_ts
+    // ==========================================
+
+    #[tokio::test]
+    async fn test_has_event_with_slack_ts_no_match() {
+        let db = StorageBackend::in_memory();
+        let session_id = setup_test_session(&db).await;
+        let result = db
+            .has_event_with_slack_ts(session_id, "1234567890.123456")
+            .await
+            .unwrap();
+        assert!(!result);
+    }
+
+    #[tokio::test]
+    async fn test_has_event_with_slack_ts_match() {
+        use crate::storage::models::CreateEventRow;
+
+        let db = StorageBackend::in_memory();
+        let session_id = setup_test_session(&db).await;
+
+        // Insert an input.message event with slack_ts in metadata
+        let event = CreateEventRow {
+            session_id,
+            event_type: "input.message".to_string(),
+            ts: chrono::Utc::now(),
+            context: serde_json::json!({}),
+            data: serde_json::json!({
+                "message": {
+                    "id": "message_00000000000000000000000000000001",
+                    "role": "user",
+                    "content": [{"type": "text", "text": "hello"}],
+                    "metadata": {
+                        "slack_ts": "1234567890.123456",
+                        "slack_user": "U123",
+                        "slack_channel": "C456"
+                    },
+                    "created_at": "2024-01-01T00:00:00Z"
+                }
+            }),
+            metadata: None,
+            tags: None,
+        };
+        db.create_event(event).await.unwrap();
+
+        // Same slack_ts should be found
+        assert!(
+            db.has_event_with_slack_ts(session_id, "1234567890.123456")
+                .await
+                .unwrap()
+        );
+
+        // Different slack_ts should NOT be found
+        assert!(
+            !db.has_event_with_slack_ts(session_id, "9999999999.999999")
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_has_event_with_slack_ts_wrong_session() {
+        use crate::storage::models::CreateEventRow;
+
+        let db = StorageBackend::in_memory();
+        let session_id = setup_test_session(&db).await;
+        let other_session_id = everruns_core::typed_id::SessionId::from_uuid(uuid::Uuid::now_v7());
+
+        // Insert event in session_id
+        let event = CreateEventRow {
+            session_id,
+            event_type: "input.message".to_string(),
+            ts: chrono::Utc::now(),
+            context: serde_json::json!({}),
+            data: serde_json::json!({
+                "message": {
+                    "id": "message_00000000000000000000000000000001",
+                    "role": "user",
+                    "content": [{"type": "text", "text": "hello"}],
+                    "metadata": { "slack_ts": "1234567890.123456" },
+                    "created_at": "2024-01-01T00:00:00Z"
+                }
+            }),
+            metadata: None,
+            tags: None,
+        };
+        db.create_event(event).await.unwrap();
+
+        // Different session should NOT find it
+        assert!(
+            !db.has_event_with_slack_ts(other_session_id, "1234567890.123456")
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_has_event_with_slack_ts_ignores_non_input_events() {
+        use crate::storage::models::CreateEventRow;
+
+        let db = StorageBackend::in_memory();
+        let session_id = setup_test_session(&db).await;
+
+        // Insert an output.message.completed event (not input.message)
+        let event = CreateEventRow {
+            session_id,
+            event_type: "output.message.completed".to_string(),
+            ts: chrono::Utc::now(),
+            context: serde_json::json!({}),
+            data: serde_json::json!({
+                "message": {
+                    "id": "message_00000000000000000000000000000001",
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "hi"}],
+                    "metadata": { "slack_ts": "1234567890.123456" },
+                    "created_at": "2024-01-01T00:00:00Z"
+                }
+            }),
+            metadata: None,
+            tags: None,
+        };
+        db.create_event(event).await.unwrap();
+
+        // Should NOT match — only input.message events count
+        assert!(
+            !db.has_event_with_slack_ts(session_id, "1234567890.123456")
+                .await
+                .unwrap()
+        );
+    }
+
+    // ==========================================
+    // Response text extraction — last vs first
+    // ==========================================
+
+    #[test]
+    fn test_extract_response_text_ignores_non_text_parts() {
+        let data = serde_json::json!({
+            "message": {
+                "content": [
+                    {"type": "image", "url": "https://example.com/img.png"},
+                    {"type": "text", "text": "Only this."}
+                ]
+            }
+        });
+        assert_eq!(extract_response_text(&data).unwrap(), "Only this.");
+    }
+
+    /// Helper: create an in-memory session for dedup tests
+    async fn setup_test_session(db: &StorageBackend) -> everruns_core::typed_id::SessionId {
+        use crate::storage::models::CreateSessionRow;
+
+        let row = CreateSessionRow {
+            org_id: 1,
+            harness_id: Some(everruns_core::typed_id::HarnessId::from_uuid(
+                uuid::Uuid::nil(),
+            )),
+            agent_id: Some(everruns_core::typed_id::AgentId::from_uuid(
+                uuid::Uuid::nil(),
+            )),
+            title: Some("test".to_string()),
+            tags: vec![],
+            model_id: None,
+            capabilities: serde_json::json!([]),
+            tools: serde_json::json!([]),
+        };
+        let session = db.create_session(row).await.unwrap();
+        session.id
     }
 }

--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -452,12 +452,12 @@ fn build_session_title(slack_config: &SlackChannelConfig, event: &SlackEvent) ->
     }
 }
 
-/// Wait for the agent turn to complete and post the final response to Slack.
+/// Wait for the agent turn to complete and stream responses to Slack.
 ///
-/// Collects `output.message.completed` events for this turn (there may be several
-/// if the agent uses tools), and only posts the *last* response text once
-/// `turn.completed` fires. Filtering by `input_message_id` ensures each Slack
-/// message gets the correct response, not a response from a different turn.
+/// Posts each `output.message.completed` text to Slack as it arrives, giving
+/// users real-time progress during multi-step turns (Reason→Act cycles).
+/// Filtering by `input_message_id` ensures we only see events from our turn.
+/// Stops polling when `turn.completed` or `turn.failed` fires.
 async fn wait_and_post_response(
     db: &StorageBackend,
     session_id: uuid::Uuid,
@@ -475,11 +475,6 @@ async fn wait_and_post_response(
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(120);
     let mut since_id: Option<EventId> = None;
     let empty: Vec<String> = vec![];
-
-    // Track the latest response text for our turn. Each Reason→Act cycle emits
-    // an output.message.completed; we want the final one (the terminal response
-    // with no tool calls, right before turn.completed).
-    let mut last_response_text: Option<String> = None;
 
     loop {
         if tokio::time::Instant::now() > deadline {
@@ -501,33 +496,28 @@ async fn wait_and_post_response(
                 .and_then(|v| v.as_str());
             let is_our_turn = event_input_msg == Some(&input_msg_str);
 
+            // Post each assistant message to Slack as it arrives. This gives
+            // users progress visibility during multi-step agent turns (e.g.
+            // "Let me search for that..." before tool execution).
             if event_row.event_type == "output.message.completed"
                 && is_our_turn
                 && let Some(text) = extract_response_text(&event_row.data)
             {
-                last_response_text = Some(text);
+                post_to_slack(bot_token, channel, thread_ts, &text).await?;
             }
 
-            // Post the last collected response when the turn ends
+            // Stop polling once the turn ends
             if event_row.event_type == "turn.completed" && is_our_turn {
-                if let Some(ref text) = last_response_text {
-                    post_to_slack(bot_token, channel, thread_ts, text).await?;
-                }
                 return Ok(());
             }
 
             if event_row.event_type == "turn.failed" && is_our_turn {
-                tracing::warn!(session_id = %session_id, "Turn failed, not posting to Slack");
+                tracing::warn!(session_id = %session_id, "Turn failed");
                 return Ok(());
             }
         }
 
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-    }
-
-    // Timeout: post whatever we collected so far (if any)
-    if let Some(ref text) = last_response_text {
-        post_to_slack(bot_token, channel, thread_ts, text).await?;
     }
 
     Ok(())

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -358,6 +358,16 @@ impl StorageBackend {
         dispatch!(self, create_event, input)
     }
 
+    /// Check if an input.message event with a given slack_ts already exists in a session.
+    /// Used for Slack event dedup across server instances.
+    pub async fn has_event_with_slack_ts(
+        &self,
+        session_id: SessionId,
+        slack_ts: &str,
+    ) -> Result<bool> {
+        dispatch!(self, has_event_with_slack_ts, session_id, slack_ts)
+    }
+
     pub async fn list_events(
         &self,
         session_id: SessionId,

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -1064,6 +1064,24 @@ impl InMemoryDatabase {
         Ok(result)
     }
 
+    /// Check if an input.message event with a given slack_ts already exists in a session.
+    pub async fn has_event_with_slack_ts(
+        &self,
+        session_id: SessionId,
+        slack_ts: &str,
+    ) -> Result<bool> {
+        let events = self.events.read();
+        let found = events.values().any(|e| {
+            e.session_id == session_id
+                && e.event_type == "input.message"
+                && e.data
+                    .pointer("/message/metadata/slack_ts")
+                    .and_then(|v| v.as_str())
+                    == Some(slack_ts)
+        });
+        Ok(found)
+    }
+
     pub async fn list_message_events(&self, session_id: SessionId) -> Result<Vec<EventRow>> {
         self.list_message_events_limited(session_id, None).await
     }

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -1201,6 +1201,33 @@ impl Database {
         Ok(row)
     }
 
+    /// Check if an input.message event with a given slack_ts already exists in a session.
+    /// Used for dedup when Slack sends duplicate events (app_mention + message).
+    pub async fn has_event_with_slack_ts(
+        &self,
+        session_id: SessionId,
+        slack_ts: &str,
+    ) -> Result<bool> {
+        let pattern = serde_json::json!({
+            "message": { "metadata": { "slack_ts": slack_ts } }
+        });
+        let row: (bool,) = sqlx::query_as(
+            r#"
+            SELECT EXISTS(
+                SELECT 1 FROM events
+                WHERE session_id = $1
+                  AND event_type = 'input.message'
+                  AND data @> $2
+            )
+            "#,
+        )
+        .bind(session_id)
+        .bind(&pattern)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(row.0)
+    }
+
     pub async fn list_events(
         &self,
         session_id: SessionId,

--- a/specs/slack-integration.md
+++ b/specs/slack-integration.md
@@ -12,8 +12,10 @@ Slack Events API  -->  POST /v1/apps/{app_id}/slack/events  (unauthenticated)
                        +-- Verify HMAC-SHA256 signing secret
                        +-- Find/create session (by tags, per session_strategy)
                        +-- Create user message (triggers agent workflow)
-                       +-- Background: poll for output.message.completed
-                       +-- Post response to Slack via chat.postMessage
+                       +-- Dedup: skip if slack_ts already processed (DB check)
+                       +-- Background: poll events, stream each output.message.completed
+                       +-- Post each response to Slack via chat.postMessage
+                       +-- Stop on turn.completed / turn.failed
 ```
 
 ## Design Decisions
@@ -22,7 +24,8 @@ Slack Events API  -->  POST /v1/apps/{app_id}/slack/events  (unauthenticated)
 - **Unauthenticated**: Webhook requests come from Slack, not our users. Security is via Slack signing secret verification (HMAC-SHA256), not API key auth.
 - **Unscoped app lookup**: `get_app_by_public_id_unscoped()` looks up apps by public_id across all orgs since there's no auth context on webhook requests.
 - **Session routing via tags**: Sessions are found/created using tags like `slack:thread:{ts}`, `slack:channel:{id}`, or `slack:user:{id}` depending on the session strategy.
-- **Async response delivery**: The webhook acks Slack immediately (<3s), then a background task polls for agent output events and posts the response via Slack's `chat.postMessage` API.
+- **Streaming response delivery**: The webhook acks Slack immediately (<3s), then a background task polls for agent output events. Each `output.message.completed` with text is posted to Slack as it arrives, giving users real-time progress during multi-step turns. The poller stops on `turn.completed` or `turn.failed`. Events are filtered by `input_message_id` to avoid cross-turn interference.
+- **Slack event dedup**: Slack sends both `app_mention` and `message` events for @mentions. DB-level dedup via `has_event_with_slack_ts()` prevents duplicate processing (uses JSONB `@>` containment on input.message events).
 
 ## Channel Config
 


### PR DESCRIPTION
## What
Three fixes for Slack bot integration:
1. **Correct answer mapping**: Filter events by `input_message_id` so each Slack message gets its own turn's response, not a response from a different concurrent turn
2. **DB-level event dedup**: Prevent duplicate processing when Slack sends both `app_mention` and `message` events for @mentions (uses `has_event_with_slack_ts()` with JSONB containment query)
3. **Stream intermediate messages**: Post each `output.message.completed` to Slack as it arrives instead of waiting for `turn.completed`, giving users real-time progress during multi-step agent turns

## Why
- Users in multi-user Slack channels could receive responses from wrong turns
- @mentions triggered duplicate agent runs (Slack sends both event types)
- Long-running agents (many Reason→Act cycles) left users with no visibility until the turn completed

## How
- `wait_and_post_response` now takes `input_message_id` and filters events by it
- Added `has_event_with_slack_ts()` to storage backends (PostgreSQL JSONB `@>`, in-memory linear scan)
- Changed from collecting-last-response-then-posting to streaming-each-response pattern
- Updated slack-integration spec to reflect new behavior

## Risk
- Low
- Intermediate messages may generate more Slack messages per turn (intentional trade-off for progress visibility)

## Checklist
- [x] Tests added or updated (event context filtering, dedup, text extraction)
- [x] Backward compatibility considered (no API changes, internal behavior only)