### PR TITLE
feat(core): implement OpenAI tool_search capability for deferred tool loading

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ Fix root cause. Unsure: read more code; if stuck, ask w/ short options. Unrecogn
 - `specs/apps.md` - Apps system (agent deployment to distribution channels)
 - `specs/slack-integration.md` - Slack bot integration (app-scoped webhook, session routing)
 - `specs/feature-flags.md` - Feature flags system (env vars, deployment grade, UI gating)
+- `specs/tool-search.md` - OpenAI tool_search deferred tool loading capability
 
 ### Skills
 

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -756,6 +756,8 @@ mod tests {
                 "required": ["operation"]
             }),
             policy: Default::default(),
+            category: None,
+            deferrable: Default::default(),
         })
     }
 

--- a/crates/core/src/capabilities/mcp.rs
+++ b/crates/core/src/capabilities/mcp.rs
@@ -12,7 +12,7 @@
 
 use crate::capability_types::{CapabilityId, CapabilityStatus};
 use crate::mcp_server::{McpToolDefinition, mcp_tool_name};
-use crate::tool_types::{BuiltinTool, ToolDefinition, ToolPolicy};
+use crate::tool_types::{BuiltinTool, DeferrablePolicy, ToolDefinition, ToolPolicy};
 use crate::tools::Tool;
 
 use super::Capability;
@@ -90,6 +90,8 @@ impl McpCapability {
                 .unwrap_or_else(|| format!("Tool from MCP server: {}", self.server_name)),
             parameters: mcp_tool.input_schema.clone(),
             policy: ToolPolicy::Auto,
+            category: self.category().map(|s| s.to_string()),
+            deferrable: DeferrablePolicy::default(),
         })
     }
 }

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -960,18 +960,12 @@ pub async fn collect_capabilities_with_configs(
             // Collect tools
             tools.extend(capability.tools());
 
-            // Collect tool definitions with category from capability
-            let cap_category = capability.category().map(|s| s.to_string());
+            // Collect tool definitions, propagating capability category if not already set
+            let cap_category = capability.category();
             for def in capability.tool_definitions() {
-                // Propagate capability category to tool definition if not already set
-                let def = if def.category().is_none() {
-                    if let Some(ref cat) = cap_category {
-                        def.with_category(cat.clone())
-                    } else {
-                        def
-                    }
-                } else {
-                    def
+                let def = match (def.category(), cap_category) {
+                    (None, Some(cat)) => def.with_category(cat),
+                    _ => def,
                 };
                 tool_definitions.push(def);
             }

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -81,6 +81,7 @@ mod fake_warehouse;
 mod file_system;
 pub mod mcp;
 mod noop;
+mod openai_tool_search;
 mod platform_management;
 mod research;
 mod sample_data;
@@ -138,6 +139,9 @@ pub use mcp::{
     parse_mcp_capability_id,
 };
 pub use noop::NoopCapability;
+pub use openai_tool_search::{
+    DEFAULT_TOOL_SEARCH_THRESHOLD, OPENAI_TOOL_SEARCH_CAPABILITY_ID, OpenAiToolSearchCapability,
+};
 pub use platform_management::{
     ListCapabilitiesTool, ManageAgentsTool, ManageHarnessesTool, ManageSessionsTool,
     PlatformManagementCapability, SessionInteractTool,
@@ -477,6 +481,9 @@ impl CapabilityRegistry {
         registry.register(VirtualBashCapability);
         registry.register(SessionScheduleCapability);
 
+        // OpenAI tool_search (deferred tool loading, all environments)
+        registry.register(OpenAiToolSearchCapability::new());
+
         // Skills (filesystem-based discovery + activation, all environments)
         registry.register(SkillsCapability);
 
@@ -625,6 +632,8 @@ pub struct CollectedCapabilities {
     pub message_filter_providers: Vec<(Arc<dyn MessageFilterProvider>, serde_json::Value)>,
     /// IDs of capabilities that were collected
     pub applied_ids: Vec<String>,
+    /// Tool search configuration (set when openai_tool_search capability is present)
+    pub tool_search: Option<crate::llm_driver_registry::ToolSearchConfig>,
 }
 
 impl CollectedCapabilities {
@@ -933,6 +942,7 @@ pub async fn collect_capabilities_with_configs(
     let mut message_filter_providers: Vec<(Arc<dyn MessageFilterProvider>, serde_json::Value)> =
         Vec::new();
     let mut applied_ids: Vec<String> = Vec::new();
+    let mut tool_search: Option<crate::llm_driver_registry::ToolSearchConfig> = None;
 
     for cap_config in capability_configs {
         let cap_id = cap_config.capability_ref.as_str();
@@ -950,8 +960,36 @@ pub async fn collect_capabilities_with_configs(
             // Collect tools
             tools.extend(capability.tools());
 
-            // Collect tool definitions
-            tool_definitions.extend(capability.tool_definitions());
+            // Collect tool definitions with category from capability
+            let cap_category = capability.category().map(|s| s.to_string());
+            for def in capability.tool_definitions() {
+                // Propagate capability category to tool definition if not already set
+                let def = if def.category().is_none() {
+                    if let Some(ref cat) = cap_category {
+                        def.with_category(cat.clone())
+                    } else {
+                        def
+                    }
+                } else {
+                    def
+                };
+                tool_definitions.push(def);
+            }
+
+            // Detect OpenAI tool_search capability
+            if cap_id == OPENAI_TOOL_SEARCH_CAPABILITY_ID {
+                // Parse threshold from config, fall back to default
+                let threshold = cap_config
+                    .config
+                    .get("threshold")
+                    .and_then(|v| v.as_u64())
+                    .map(|v| v as usize)
+                    .unwrap_or(DEFAULT_TOOL_SEARCH_THRESHOLD);
+                tool_search = Some(crate::llm_driver_registry::ToolSearchConfig {
+                    enabled: true,
+                    threshold,
+                });
+            }
 
             // Collect mount points
             mounts.extend(capability.mounts());
@@ -975,6 +1013,7 @@ pub async fn collect_capabilities_with_configs(
         mounts,
         message_filter_providers,
         applied_ids,
+        tool_search,
     }
 }
 
@@ -1059,6 +1098,7 @@ pub async fn apply_capabilities(
         max_iterations: base_runtime_agent.max_iterations,
         temperature: base_runtime_agent.temperature,
         max_tokens: base_runtime_agent.max_tokens,
+        tool_search: collected.tool_search,
     };
 
     AppliedCapabilities {
@@ -1151,9 +1191,10 @@ mod tests {
         assert!(registry.has("session_schedule"));
         assert!(registry.has("platform_management"));
         assert!(registry.has("system_commands"));
+        assert!(registry.has("openai_tool_search"));
         // Experimental capabilities NOT included in prod
         assert!(!registry.has("docker_container"));
-        assert_eq!(registry.len(), 22);
+        assert_eq!(registry.len(), 23);
     }
 
     #[test]
@@ -2381,5 +2422,130 @@ mod tests {
         // Default capabilities should be Low
         let noop = registry.get("noop").unwrap();
         assert_eq!(noop.risk_level(), RiskLevel::Low);
+    }
+
+    // =========================================================================
+    // OpenAI tool_search capability collection tests
+    // =========================================================================
+
+    #[tokio::test]
+    async fn test_apply_capabilities_openai_tool_search() {
+        let registry = CapabilityRegistry::with_builtins();
+        let base_runtime_agent = RuntimeAgent::new("You are a helpful assistant.", "gpt-5.4");
+
+        let applied = apply_capabilities(
+            base_runtime_agent.clone(),
+            &["openai_tool_search".to_string()],
+            &registry,
+            &test_ctx(),
+        )
+        .await;
+
+        // OpenAiToolSearchCapability provides no tools and no system prompt
+        assert_eq!(
+            applied.runtime_agent.system_prompt,
+            base_runtime_agent.system_prompt
+        );
+        assert!(applied.tool_registry.is_empty());
+        assert_eq!(applied.applied_ids, vec!["openai_tool_search"]);
+
+        // tool_search config should be set on the runtime agent
+        let ts = applied.runtime_agent.tool_search.as_ref().unwrap();
+        assert!(ts.enabled);
+        assert_eq!(ts.threshold, DEFAULT_TOOL_SEARCH_THRESHOLD);
+    }
+
+    #[tokio::test]
+    async fn test_apply_capabilities_openai_tool_search_with_other_capabilities() {
+        let registry = CapabilityRegistry::with_builtins();
+        let base_runtime_agent = RuntimeAgent::new("You are a helpful assistant.", "gpt-5.4");
+
+        let applied = apply_capabilities(
+            base_runtime_agent,
+            &[
+                "current_time".to_string(),
+                "openai_tool_search".to_string(),
+                "test_math".to_string(),
+            ],
+            &registry,
+            &test_ctx(),
+        )
+        .await;
+
+        // Should have tools from current_time and test_math
+        assert!(applied.tool_registry.has("get_current_time"));
+        assert!(applied.tool_registry.has("add"));
+        assert!(applied.tool_registry.has("subtract"));
+        assert!(applied.tool_registry.has("multiply"));
+        assert!(applied.tool_registry.has("divide"));
+
+        // tool_search should still be configured
+        let ts = applied.runtime_agent.tool_search.as_ref().unwrap();
+        assert!(ts.enabled);
+        assert_eq!(ts.threshold, DEFAULT_TOOL_SEARCH_THRESHOLD);
+    }
+
+    #[tokio::test]
+    async fn test_collect_capabilities_tool_search_custom_threshold() {
+        let registry = CapabilityRegistry::with_builtins();
+
+        let configs = vec![AgentCapabilityConfig {
+            capability_ref: CapabilityId::new("openai_tool_search"),
+            config: serde_json::json!({"threshold": 5}),
+        }];
+
+        let collected = collect_capabilities_with_configs(&configs, &registry, &test_ctx()).await;
+
+        let ts = collected.tool_search.as_ref().unwrap();
+        assert!(ts.enabled);
+        assert_eq!(ts.threshold, 5);
+    }
+
+    #[tokio::test]
+    async fn test_collect_capabilities_no_tool_search_without_capability() {
+        let registry = CapabilityRegistry::with_builtins();
+
+        let configs = vec![AgentCapabilityConfig {
+            capability_ref: CapabilityId::new("current_time"),
+            config: serde_json::json!({}),
+        }];
+
+        let collected = collect_capabilities_with_configs(&configs, &registry, &test_ctx()).await;
+
+        assert!(collected.tool_search.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_collect_capabilities_tool_search_category_propagation() {
+        let registry = CapabilityRegistry::with_builtins();
+
+        // test_math capability has category "Testing"
+        let configs = vec![
+            AgentCapabilityConfig {
+                capability_ref: CapabilityId::new("test_math"),
+                config: serde_json::json!({}),
+            },
+            AgentCapabilityConfig {
+                capability_ref: CapabilityId::new("openai_tool_search"),
+                config: serde_json::json!({}),
+            },
+        ];
+
+        let collected = collect_capabilities_with_configs(&configs, &registry, &test_ctx()).await;
+
+        // Verify tool_search is configured
+        assert!(collected.tool_search.is_some());
+
+        // Verify tools have categories from their capability
+        for tool_def in &collected.tool_definitions {
+            // test_math tools should have the Math category
+            if ["add", "subtract", "multiply", "divide"].contains(&tool_def.name()) {
+                assert!(
+                    tool_def.category().is_some(),
+                    "Tool {} should have a category from its capability",
+                    tool_def.name()
+                );
+            }
+        }
     }
 }

--- a/crates/core/src/capabilities/openai_tool_search.rs
+++ b/crates/core/src/capabilities/openai_tool_search.rs
@@ -1,0 +1,115 @@
+// OpenAI Tool Search Capability
+//
+// When added to an agent, enables tool_search (deferred tool loading) for
+// models that support it (GPT-5.4+). Tools are grouped into namespaces
+// based on capability categories, and their full parameter schemas are
+// loaded on-demand by the model instead of sent upfront.
+//
+// This capability does not provide any tools itself — it configures the
+// LLM driver to use tool_search when constructing the API request.
+//
+// If the model does not support tool_search (tool_search=false in profile),
+// this capability is silently ignored — no error, no crash.
+
+use super::{Capability, CapabilityStatus, SystemPromptContext};
+use crate::llm_driver_registry::ToolSearchConfig;
+use async_trait::async_trait;
+
+/// Default minimum tool count to activate tool_search.
+/// Below this threshold, full schemas are sent even when capability is enabled.
+pub const DEFAULT_TOOL_SEARCH_THRESHOLD: usize = 15;
+
+/// Capability ID for OpenAI tool search
+pub const OPENAI_TOOL_SEARCH_CAPABILITY_ID: &str = "openai_tool_search";
+
+/// OpenAI Tool Search capability.
+///
+/// Adding this capability to an agent/harness enables deferred tool loading
+/// for models that support it. The `threshold` controls the minimum number
+/// of tools before tool_search activates (default: 15).
+pub struct OpenAiToolSearchCapability {
+    threshold: usize,
+}
+
+impl OpenAiToolSearchCapability {
+    pub fn new() -> Self {
+        Self {
+            threshold: DEFAULT_TOOL_SEARCH_THRESHOLD,
+        }
+    }
+
+    pub fn with_threshold(threshold: usize) -> Self {
+        Self { threshold }
+    }
+
+    /// Returns the ToolSearchConfig for this capability
+    pub fn tool_search_config(&self) -> ToolSearchConfig {
+        ToolSearchConfig {
+            enabled: true,
+            threshold: self.threshold,
+        }
+    }
+}
+
+impl Default for OpenAiToolSearchCapability {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Capability for OpenAiToolSearchCapability {
+    fn id(&self) -> &str {
+        OPENAI_TOOL_SEARCH_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "OpenAI Tool Search"
+    }
+
+    fn description(&self) -> &str {
+        "Enables deferred tool loading for models that support it (GPT-5.4+). \
+         Reduces token usage by loading tool schemas on-demand instead of upfront."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Optimization")
+    }
+
+    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
+        None // No system prompt needed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_capability_metadata() {
+        let cap = OpenAiToolSearchCapability::new();
+        assert_eq!(cap.id(), OPENAI_TOOL_SEARCH_CAPABILITY_ID);
+        assert_eq!(cap.name(), "OpenAI Tool Search");
+        assert_eq!(cap.status(), CapabilityStatus::Available);
+        assert!(cap.tools().is_empty());
+    }
+
+    #[test]
+    fn test_default_threshold() {
+        let cap = OpenAiToolSearchCapability::new();
+        let config = cap.tool_search_config();
+        assert!(config.enabled);
+        assert_eq!(config.threshold, DEFAULT_TOOL_SEARCH_THRESHOLD);
+    }
+
+    #[test]
+    fn test_custom_threshold() {
+        let cap = OpenAiToolSearchCapability::with_threshold(5);
+        let config = cap.tool_search_config();
+        assert_eq!(config.threshold, 5);
+    }
+}

--- a/crates/core/src/capabilities/skills.rs
+++ b/crates/core/src/capabilities/skills.rs
@@ -14,7 +14,7 @@
 // mounts skill files into the VFS so this capability discovers them.
 
 use super::{Capability, CapabilityStatus, SystemPromptContext};
-use crate::tool_types::{BuiltinTool, ToolDefinition, ToolPolicy};
+use crate::tool_types::{BuiltinTool, DeferrablePolicy, ToolDefinition, ToolPolicy};
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
@@ -200,6 +200,8 @@ Skills are instruction packages (SKILL.md files) that teach the agent new abilit
                     "required": []
                 }),
                 policy: ToolPolicy::Auto,
+                category: None,
+                deferrable: DeferrablePolicy::default(),
             }),
             ToolDefinition::Builtin(BuiltinTool {
                 name: "activate_skill".to_string(),
@@ -219,6 +221,8 @@ Skills are instruction packages (SKILL.md files) that teach the agent new abilit
                     "required": ["name"]
                 }),
                 policy: ToolPolicy::Auto,
+                category: None,
+                deferrable: DeferrablePolicy::default(),
             }),
         ]
     }

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -2621,7 +2621,7 @@ mod contract_tests {
 
     #[test]
     fn act_started_with_definitions_populates_display_names() {
-        use crate::tool_types::{BuiltinTool, ToolPolicy};
+        use crate::tool_types::{BuiltinTool, DeferrablePolicy, ToolPolicy};
 
         let tool_calls = vec![
             ToolCall {
@@ -2641,6 +2641,8 @@ mod contract_tests {
             description: "Gets weather".to_string(),
             parameters: serde_json::json!({}),
             policy: ToolPolicy::Auto,
+            category: None,
+            deferrable: DeferrablePolicy::default(),
         })];
 
         let data = ActStartedData::with_definitions(&tool_calls, &tool_defs);
@@ -2688,7 +2690,7 @@ mod contract_tests {
 
     #[test]
     fn tool_definition_summary_display_name() {
-        use crate::tool_types::{BuiltinTool, ToolPolicy};
+        use crate::tool_types::{BuiltinTool, DeferrablePolicy, ToolPolicy};
 
         let def = crate::tool_types::ToolDefinition::Builtin(BuiltinTool {
             name: "read_file".to_string(),
@@ -2696,6 +2698,8 @@ mod contract_tests {
             description: "Reads a file".to_string(),
             parameters: serde_json::json!({}),
             policy: ToolPolicy::Auto,
+            category: None,
+            deferrable: DeferrablePolicy::default(),
         });
 
         let summary = ToolDefinitionSummary::from(&def);

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -159,13 +159,14 @@ pub use capabilities::{
     GetCurrentTimeTool, GetForecastTool, GetSessionInfoTool, GetWeatherTool, GrepFilesTool,
     IntegrationPlugin, ListDirectoryTool, MAX_RESOLVED_CAPABILITIES, MCP_CAPABILITY_PREFIX,
     McpCapability, MountAccess, MountDirectoryBuilder, MountEntry, MountPoint, MountSource,
-    MultiplyTool, NoopCapability, PlatformManagementCapability, ReadFileTool, ResearchCapability,
-    ResolvedCapabilities, RiskLevel, SampleDataCapability, SessionCapability,
-    SessionSqlDatabaseCapability, SqlExecuteTool, SqlQueryTool, SqlSchemaTool, StatFileTool,
-    StatelessTodoListCapability, SubtractTool, TestMathCapability, TestWeatherCapability,
-    WriteFileTool, WriteSessionTitleTool, WriteTodosTool, apply_capabilities, collect_capabilities,
-    collect_capabilities_with_configs, compute_features, get_dependencies, is_mcp_capability,
-    mcp_capability_id, parse_mcp_capability_id, resolve_dependencies,
+    MultiplyTool, NoopCapability, OPENAI_TOOL_SEARCH_CAPABILITY_ID, OpenAiToolSearchCapability,
+    PlatformManagementCapability, ReadFileTool, ResearchCapability, ResolvedCapabilities,
+    RiskLevel, SampleDataCapability, SessionCapability, SessionSqlDatabaseCapability,
+    SqlExecuteTool, SqlQueryTool, SqlSchemaTool, StatFileTool, StatelessTodoListCapability,
+    SubtractTool, TestMathCapability, TestWeatherCapability, WriteFileTool, WriteSessionTitleTool,
+    WriteTodosTool, apply_capabilities, collect_capabilities, collect_capabilities_with_configs,
+    compute_features, get_dependencies, is_mcp_capability, mcp_capability_id,
+    parse_mcp_capability_id, resolve_dependencies,
 };
 pub use capabilities::{
     AttachSkillCapability, SKILL_CAPABILITY_PREFIX, SKILLS_CAPABILITY_ID, SKILLS_DISCOVERY_PATH,
@@ -181,7 +182,7 @@ pub use atoms::{
 
 // Tool types (runtime types defined in this crate)
 pub use tool_types::{
-    BuiltinTool, ClientSideTool, ToolCall, ToolDefinition, ToolPolicy, ToolResult,
+    BuiltinTool, ClientSideTool, DeferrablePolicy, ToolCall, ToolDefinition, ToolPolicy, ToolResult,
 };
 
 // Note: CapabilityId and CapabilityStatus are re-exported via capabilities module

--- a/crates/core/src/llm_driver_registry.rs
+++ b/crates/core/src/llm_driver_registry.rs
@@ -372,6 +372,20 @@ pub enum LlmMessageRole {
 // Configuration and Response Types
 // ============================================================================
 
+/// Configuration for tool_search (deferred tool loading).
+///
+/// When enabled, the driver groups tools into namespaces and marks them with
+/// `defer_loading: true` so the model only loads full schemas on-demand.
+/// This reduces token usage for agents with many tools.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct ToolSearchConfig {
+    /// Enable tool_search for this request (requires model support)
+    pub enabled: bool,
+    /// Minimum number of tools before activating tool_search.
+    /// Below this threshold, full schemas are sent even when enabled.
+    pub threshold: usize,
+}
+
 /// Configuration for an LLM call
 #[derive(Debug, Clone)]
 pub struct LlmCallConfig {
@@ -388,6 +402,8 @@ pub struct LlmCallConfig {
     /// Previous response ID for stateful continuation (OpenAI Responses API).
     /// When set, the provider can skip re-encoding cached context.
     pub previous_response_id: Option<String>,
+    /// Tool search configuration for deferred tool loading
+    pub tool_search: Option<ToolSearchConfig>,
 }
 
 impl From<&RuntimeAgent> for LlmCallConfig {
@@ -400,6 +416,7 @@ impl From<&RuntimeAgent> for LlmCallConfig {
             reasoning_effort: None, // Set by ReasonAtom from user message controls
             metadata: HashMap::new(), // Set by ReasonAtom with session/agent context
             previous_response_id: None,
+            tool_search: runtime_agent.tool_search.clone(),
         }
     }
 }
@@ -494,6 +511,12 @@ impl LlmCallConfigBuilder {
     /// Set previous response ID for stateful continuation
     pub fn previous_response_id(mut self, id: Option<String>) -> Self {
         self.config.previous_response_id = id;
+        self
+    }
+
+    /// Set tool_search configuration
+    pub fn tool_search(mut self, config: ToolSearchConfig) -> Self {
+        self.config.tool_search = Some(config);
         self
     }
 

--- a/crates/core/src/llm_model_profiles.rs
+++ b/crates/core/src/llm_model_profiles.rs
@@ -176,6 +176,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text, Modality::Audio],
             }),
             reasoning_effort: None,
+            tool_search: false,
         }),
 
         "gpt-4o-mini" => Some(LlmModelProfile {
@@ -205,6 +206,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            tool_search: false,
         }),
 
         "o1" => Some(LlmModelProfile {
@@ -234,6 +236,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_standard()),
+            tool_search: false,
         }),
 
         "o1-mini" => Some(LlmModelProfile {
@@ -263,6 +266,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_standard()),
+            tool_search: false,
         }),
 
         "o1-pro" => Some(LlmModelProfile {
@@ -292,6 +296,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_high_only()),
+            tool_search: false,
         }),
 
         "o3-mini" => Some(LlmModelProfile {
@@ -321,6 +326,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_standard()),
+            tool_search: false,
         }),
 
         "o3" => Some(LlmModelProfile {
@@ -350,6 +356,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_standard()),
+            tool_search: false,
         }),
 
         "o3-pro" => Some(LlmModelProfile {
@@ -379,6 +386,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_high_only()),
+            tool_search: false,
         }),
 
         "o4-mini" => Some(LlmModelProfile {
@@ -408,6 +416,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_standard()),
+            tool_search: false,
         }),
 
         // GPT-4.1 family models
@@ -438,6 +447,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            tool_search: false,
         }),
 
         "gpt-4.1-mini" => Some(LlmModelProfile {
@@ -467,6 +477,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            tool_search: false,
         }),
 
         "gpt-4.1-nano" => Some(LlmModelProfile {
@@ -496,6 +507,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            tool_search: false,
         }),
 
         // GPT-5 family models
@@ -527,6 +539,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt5_pre51()),
+            tool_search: false,
         }),
 
         "gpt-5-mini" => Some(LlmModelProfile {
@@ -556,6 +569,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt5_pre51()),
+            tool_search: false,
         }),
 
         "gpt-5-nano" => Some(LlmModelProfile {
@@ -585,6 +599,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt5_pre51()),
+            tool_search: false,
         }),
 
         "gpt-5-pro" => Some(LlmModelProfile {
@@ -614,6 +629,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_high_only()),
+            tool_search: false,
         }),
 
         "gpt-5-codex" => Some(LlmModelProfile {
@@ -643,6 +659,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt5_pre51()),
+            tool_search: false,
         }),
 
         // GPT-5.1 models: default none, supports none/low/medium/high
@@ -673,6 +690,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt51()),
+            tool_search: false,
         }),
 
         "gpt-5.1-codex" => Some(LlmModelProfile {
@@ -702,6 +720,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt51()),
+            tool_search: false,
         }),
 
         "gpt-5.1-codex-mini" => Some(LlmModelProfile {
@@ -731,6 +750,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt51()),
+            tool_search: false,
         }),
 
         // GPT-5.1-codex-max and after: supports xhigh
@@ -761,6 +781,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt52()),
+            tool_search: false,
         }),
 
         // GPT-5.2 models: supports xhigh, 400K context
@@ -791,6 +812,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt52()),
+            tool_search: false,
         }),
 
         "gpt-5.2-pro" => Some(LlmModelProfile {
@@ -820,6 +842,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt52_pro()),
+            tool_search: false,
         }),
 
         "gpt-5.2-codex" => Some(LlmModelProfile {
@@ -849,6 +872,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt52()),
+            tool_search: false,
         }),
 
         // GPT-5.3 Codex: same pricing as 5.2, 25% faster inference
@@ -879,6 +903,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt52()),
+            tool_search: false,
         }),
 
         // GPT-5.4 models: 1.05M context, native computer use, released 2026-03-05
@@ -909,6 +934,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt52()),
+            tool_search: true,
         }),
 
         "gpt-5.4-pro" => Some(LlmModelProfile {
@@ -938,6 +964,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt52_pro()),
+            tool_search: true,
         }),
 
         // GPT-5 chat-latest models (point to latest chat-optimized versions)
@@ -968,6 +995,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt5_pre51()),
+            tool_search: false,
         }),
 
         "gpt-5.1-chat-latest" => Some(LlmModelProfile {
@@ -997,6 +1025,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt51()),
+            tool_search: false,
         }),
 
         "gpt-5.2-chat-latest" => Some(LlmModelProfile {
@@ -1026,6 +1055,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt52()),
+            tool_search: false,
         }),
 
         // Deep research models
@@ -1056,6 +1086,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_standard()),
+            tool_search: false,
         }),
 
         "o4-mini-deep-research" => Some(LlmModelProfile {
@@ -1085,6 +1116,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_standard()),
+            tool_search: false,
         }),
 
         "o1-preview" => Some(LlmModelProfile {
@@ -1114,6 +1146,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_standard()),
+            tool_search: false,
         }),
 
         _ => None,
@@ -1153,6 +1186,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_adaptive_thinking()),
+            tool_search: false,
         }),
 
         "claude-sonnet-4-6" => Some(LlmModelProfile {
@@ -1182,6 +1216,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_adaptive_thinking()),
+            tool_search: false,
         }),
 
         // Claude 4.5 series
@@ -1212,6 +1247,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_extended_thinking()),
+            tool_search: false,
         }),
 
         "claude-sonnet-4-5" => Some(LlmModelProfile {
@@ -1241,6 +1277,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_extended_thinking()),
+            tool_search: false,
         }),
 
         "claude-haiku-4-5" => Some(LlmModelProfile {
@@ -1270,6 +1307,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_extended_thinking()),
+            tool_search: false,
         }),
 
         // Claude 4.1 series
@@ -1300,6 +1338,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_extended_thinking()),
+            tool_search: false,
         }),
 
         // Claude 4 series
@@ -1330,6 +1369,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_extended_thinking()),
+            tool_search: false,
         }),
 
         "claude-opus-4" => Some(LlmModelProfile {
@@ -1359,6 +1399,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_extended_thinking()),
+            tool_search: false,
         }),
 
         // Claude 3.7 series
@@ -1389,6 +1430,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_extended_thinking()),
+            tool_search: false,
         }),
 
         // Claude 3.5 series
@@ -1419,6 +1461,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            tool_search: false,
         }),
 
         "claude-3-5-haiku" => Some(LlmModelProfile {
@@ -1448,6 +1491,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            tool_search: false,
         }),
 
         "claude-3-opus" => Some(LlmModelProfile {
@@ -1477,6 +1521,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            tool_search: false,
         }),
 
         "claude-3-sonnet" => Some(LlmModelProfile {
@@ -1506,6 +1551,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            tool_search: false,
         }),
 
         "claude-3-haiku" => Some(LlmModelProfile {
@@ -1535,6 +1581,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            tool_search: false,
         }),
 
         _ => None,
@@ -1601,6 +1648,7 @@ fn get_gemini_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            tool_search: false,
         }),
 
         "gemini-2.5-flash" => Some(LlmModelProfile {
@@ -1635,6 +1683,7 @@ fn get_gemini_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            tool_search: false,
         }),
 
         "gemini-2.0-flash" => Some(LlmModelProfile {
@@ -1669,6 +1718,7 @@ fn get_gemini_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text, Modality::Image],
             }),
             reasoning_effort: None,
+            tool_search: false,
         }),
 
         "gemini-1.5-pro" => Some(LlmModelProfile {
@@ -1703,6 +1753,7 @@ fn get_gemini_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            tool_search: false,
         }),
 
         "gemini-1.5-flash" => Some(LlmModelProfile {
@@ -1737,6 +1788,7 @@ fn get_gemini_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            tool_search: false,
         }),
 
         _ => None,
@@ -1774,6 +1826,7 @@ fn get_llmsim_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt52()), // Same as GPT-5.2
+            tool_search: false,
         }),
         _ => None,
     }

--- a/crates/core/src/llm_models.rs
+++ b/crates/core/src/llm_models.rs
@@ -310,6 +310,11 @@ pub struct LlmModelProfile {
     /// Reasoning effort configuration (for reasoning models)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<ReasoningEffortConfig>,
+    /// Whether the model supports tool_search (deferred tool loading).
+    /// When true, the driver can use namespaces and defer_loading to reduce
+    /// token usage for large tool sets. Currently supported by GPT-5.4+.
+    #[serde(default)]
+    pub tool_search: bool,
 }
 
 #[cfg(test)]

--- a/crates/core/src/llmsim_driver.rs
+++ b/crates/core/src/llmsim_driver.rs
@@ -598,6 +598,7 @@ mod tests {
             reasoning_effort: None,
             metadata: std::collections::HashMap::new(),
             previous_response_id: None,
+            tool_search: None,
         }
     }
 

--- a/crates/core/src/memory.rs
+++ b/crates/core/src/memory.rs
@@ -895,6 +895,8 @@ mod tests {
             description: "Get weather".to_string(),
             parameters: serde_json::json!({}),
             policy: crate::tool_types::ToolPolicy::Auto,
+            category: None,
+            deferrable: crate::tool_types::DeferrablePolicy::default(),
         });
 
         let result = executor.execute(&tool_call, &tool_def).await.unwrap();

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -215,8 +215,76 @@ impl OpenResponsesProtocolLlmDriver {
                 name: tool.name().to_string(),
                 description: tool.description().to_string(),
                 parameters: tool.parameters().clone(),
+                defer_loading: None,
             })
             .collect()
+    }
+
+    /// Convert tools with tool_search support: groups tools into namespaces,
+    /// marks them as deferred, and appends a `tool_search` entry.
+    fn convert_tools_with_search(tools: &[ToolDefinition], threshold: usize) -> Vec<ResponsesTool> {
+        use crate::tool_types::DeferrablePolicy;
+        use std::collections::HashMap;
+
+        // Below threshold: fall back to standard conversion
+        if tools.len() < threshold {
+            return Self::convert_tools(tools);
+        }
+
+        let mut namespaces: HashMap<String, Vec<ResponsesTool>> = HashMap::new();
+        let mut ungrouped = vec![];
+        let mut never_defer = vec![];
+
+        for tool in tools {
+            let should_defer = match tool.deferrable() {
+                DeferrablePolicy::Never => false,
+                DeferrablePolicy::Automatic | DeferrablePolicy::Always => true,
+            };
+
+            let func = ResponsesTool::Function {
+                r#type: "function".to_string(),
+                name: tool.name().to_string(),
+                description: tool.description().to_string(),
+                parameters: tool.parameters().clone(),
+                defer_loading: if should_defer { Some(true) } else { None },
+            };
+
+            if !should_defer {
+                never_defer.push(func);
+            } else {
+                match tool.category() {
+                    Some(cat) => {
+                        namespaces.entry(cat.to_string()).or_default().push(func);
+                    }
+                    None => ungrouped.push(func),
+                }
+            }
+        }
+
+        let mut result: Vec<ResponsesTool> = Vec::new();
+
+        // Non-deferred tools first (always visible to model)
+        result.extend(never_defer);
+
+        // Namespaced tools
+        for (name, tools) in namespaces {
+            result.push(ResponsesTool::Namespace {
+                r#type: "namespace".to_string(),
+                name: name.clone(),
+                description: format!("Tools for {}", name),
+                tools,
+            });
+        }
+
+        // Ungrouped deferred tools
+        result.extend(ungrouped);
+
+        // Add tool_search activator
+        result.push(ResponsesTool::ToolSearch {
+            r#type: "tool_search".to_string(),
+        });
+
+        result
     }
 
     /// Compact a conversation to reduce context size
@@ -470,6 +538,15 @@ impl LlmDriver for OpenResponsesProtocolLlmDriver {
 
         let tools = if config.tools.is_empty() {
             None
+        } else if let Some(ref ts_config) = config.tool_search {
+            if ts_config.enabled {
+                Some(Self::convert_tools_with_search(
+                    &config.tools,
+                    ts_config.threshold,
+                ))
+            } else {
+                Some(Self::convert_tools(&config.tools))
+            }
         } else {
             Some(Self::convert_tools(&config.tools))
         };
@@ -1471,12 +1548,24 @@ struct ResponsesInputAudio {
 #[derive(Debug, Serialize)]
 #[serde(untagged)]
 enum ResponsesTool {
+    /// Standard function tool (or deferred function with defer_loading)
     Function {
         r#type: String,
         name: String,
         description: String,
         parameters: Value,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        defer_loading: Option<bool>,
     },
+    /// Namespace grouping for tool_search (groups related deferred tools)
+    Namespace {
+        r#type: String,
+        name: String,
+        description: String,
+        tools: Vec<ResponsesTool>,
+    },
+    /// Activates tool_search on the request
+    ToolSearch { r#type: String },
 }
 
 // ============================================================================
@@ -1630,6 +1719,7 @@ mod tests {
                 },
                 "required": ["location"]
             }),
+            defer_loading: None,
         };
 
         let json = serde_json::to_value(&tool).unwrap();
@@ -2266,6 +2356,7 @@ mod tests {
             reasoning_effort: Some("none".to_string()),
             metadata: std::collections::HashMap::new(),
             previous_response_id: None,
+            tool_search: None,
         };
 
         // Simulate the driver's filter logic
@@ -2295,6 +2386,7 @@ mod tests {
             reasoning_effort: Some("high".to_string()),
             metadata: std::collections::HashMap::new(),
             previous_response_id: None,
+            tool_search: None,
         };
 
         let reasoning = config
@@ -2391,5 +2483,264 @@ mod tests {
         assert_ne!(r1["id"], r2["id"], "Reasoning items should have unique IDs");
         assert_eq!(r1["encrypted_content"], "encrypted_1");
         assert_eq!(r2["encrypted_content"], "encrypted_2");
+    }
+
+    // ========================================================================
+    // tool_search / convert_tools_with_search tests
+    // ========================================================================
+
+    /// Helper: create a ToolDefinition with optional category and deferrable policy
+    fn make_tool(
+        name: &str,
+        category: Option<&str>,
+        deferrable: crate::tool_types::DeferrablePolicy,
+    ) -> ToolDefinition {
+        ToolDefinition::Builtin(crate::tool_types::BuiltinTool {
+            name: name.to_string(),
+            display_name: None,
+            description: format!("{} description", name),
+            parameters: json!({"type": "object", "properties": {}}),
+            policy: crate::tool_types::ToolPolicy::Auto,
+            category: category.map(|s| s.to_string()),
+            deferrable,
+        })
+    }
+
+    #[test]
+    fn test_convert_tools_with_search_below_threshold_falls_back() {
+        use crate::tool_types::DeferrablePolicy;
+
+        let tools: Vec<ToolDefinition> = (0..5)
+            .map(|i| {
+                make_tool(
+                    &format!("tool_{i}"),
+                    Some("cat"),
+                    DeferrablePolicy::Automatic,
+                )
+            })
+            .collect();
+
+        // threshold=15, only 5 tools → should fall back to standard convert_tools
+        let result = OpenResponsesProtocolLlmDriver::convert_tools_with_search(&tools, 15);
+        assert_eq!(result.len(), 5);
+        // No ToolSearch entry, no namespaces
+        let json = serde_json::to_value(&result).unwrap();
+        for item in json.as_array().unwrap() {
+            assert_eq!(item["type"], "function");
+            assert!(item.get("defer_loading").is_none() || item["defer_loading"].is_null());
+        }
+    }
+
+    #[test]
+    fn test_convert_tools_with_search_groups_by_category() {
+        use crate::tool_types::DeferrablePolicy;
+
+        let mut tools = vec![];
+        // 10 "FileSystem" tools + 6 "Weather" tools = 16, threshold=15
+        for i in 0..10 {
+            tools.push(make_tool(
+                &format!("fs_tool_{i}"),
+                Some("FileSystem"),
+                DeferrablePolicy::Automatic,
+            ));
+        }
+        for i in 0..6 {
+            tools.push(make_tool(
+                &format!("weather_tool_{i}"),
+                Some("Weather"),
+                DeferrablePolicy::Automatic,
+            ));
+        }
+
+        let result = OpenResponsesProtocolLlmDriver::convert_tools_with_search(&tools, 15);
+        let json = serde_json::to_value(&result).unwrap();
+        let arr = json.as_array().unwrap();
+
+        // Should have: 2 namespace entries + 1 tool_search entry = 3
+        assert_eq!(arr.len(), 3);
+
+        // Last entry should be tool_search
+        assert_eq!(arr.last().unwrap()["type"], "tool_search");
+
+        // The two namespace entries
+        let ns: Vec<&Value> = arr.iter().filter(|v| v["type"] == "namespace").collect();
+        assert_eq!(ns.len(), 2);
+
+        let ns_names: Vec<&str> = ns.iter().map(|v| v["name"].as_str().unwrap()).collect();
+        assert!(ns_names.contains(&"FileSystem"));
+        assert!(ns_names.contains(&"Weather"));
+
+        // Check tool counts inside namespaces
+        for n in &ns {
+            let inner_tools = n["tools"].as_array().unwrap();
+            match n["name"].as_str().unwrap() {
+                "FileSystem" => assert_eq!(inner_tools.len(), 10),
+                "Weather" => assert_eq!(inner_tools.len(), 6),
+                other => panic!("Unexpected namespace: {other}"),
+            }
+            // All inner tools should have defer_loading: true
+            for t in inner_tools {
+                assert_eq!(t["defer_loading"], true);
+            }
+        }
+    }
+
+    #[test]
+    fn test_convert_tools_with_search_never_defer_stays_top_level() {
+        use crate::tool_types::DeferrablePolicy;
+
+        let mut tools = vec![];
+        // 2 Never-defer tools
+        tools.push(make_tool(
+            "write_todos",
+            Some("Productivity"),
+            DeferrablePolicy::Never,
+        ));
+        tools.push(make_tool(
+            "get_session_info",
+            Some("Session"),
+            DeferrablePolicy::Never,
+        ));
+        // 14 Automatic tools in "FileSystem" category
+        for i in 0..14 {
+            tools.push(make_tool(
+                &format!("fs_tool_{i}"),
+                Some("FileSystem"),
+                DeferrablePolicy::Automatic,
+            ));
+        }
+
+        let result = OpenResponsesProtocolLlmDriver::convert_tools_with_search(&tools, 15);
+        let json = serde_json::to_value(&result).unwrap();
+        let arr = json.as_array().unwrap();
+
+        // 2 never-defer functions + 1 FileSystem namespace + 1 tool_search = 4
+        assert_eq!(arr.len(), 4);
+
+        // First two should be non-deferred functions
+        let funcs: Vec<&Value> = arr.iter().filter(|v| v["type"] == "function").collect();
+        assert_eq!(funcs.len(), 2);
+        for f in &funcs {
+            // No defer_loading on never-defer tools
+            assert!(f.get("defer_loading").is_none() || f["defer_loading"].is_null());
+        }
+
+        // Namespace
+        let ns: Vec<&Value> = arr.iter().filter(|v| v["type"] == "namespace").collect();
+        assert_eq!(ns.len(), 1);
+        assert_eq!(ns[0]["name"], "FileSystem");
+        assert_eq!(ns[0]["tools"].as_array().unwrap().len(), 14);
+    }
+
+    #[test]
+    fn test_convert_tools_with_search_ungrouped_tools() {
+        use crate::tool_types::DeferrablePolicy;
+
+        let mut tools = vec![];
+        // 10 categorized tools
+        for i in 0..10 {
+            tools.push(make_tool(
+                &format!("cat_tool_{i}"),
+                Some("Cat"),
+                DeferrablePolicy::Automatic,
+            ));
+        }
+        // 6 uncategorized tools (no category → ungrouped)
+        for i in 0..6 {
+            tools.push(make_tool(
+                &format!("misc_tool_{i}"),
+                None,
+                DeferrablePolicy::Automatic,
+            ));
+        }
+
+        let result = OpenResponsesProtocolLlmDriver::convert_tools_with_search(&tools, 15);
+        let json = serde_json::to_value(&result).unwrap();
+        let arr = json.as_array().unwrap();
+
+        // 1 namespace + 6 ungrouped functions + 1 tool_search = 8
+        assert_eq!(arr.len(), 8);
+
+        let ns: Vec<&Value> = arr.iter().filter(|v| v["type"] == "namespace").collect();
+        assert_eq!(ns.len(), 1);
+        assert_eq!(ns[0]["tools"].as_array().unwrap().len(), 10);
+
+        let funcs: Vec<&Value> = arr.iter().filter(|v| v["type"] == "function").collect();
+        assert_eq!(funcs.len(), 6);
+        // These ungrouped tools should still have defer_loading: true
+        for f in &funcs {
+            assert_eq!(f["defer_loading"], true);
+        }
+
+        assert_eq!(arr.last().unwrap()["type"], "tool_search");
+    }
+
+    #[test]
+    fn test_convert_tools_with_search_always_policy() {
+        use crate::tool_types::DeferrablePolicy;
+
+        let mut tools = vec![];
+        // 14 Automatic tools
+        for i in 0..14 {
+            tools.push(make_tool(
+                &format!("tool_{i}"),
+                Some("General"),
+                DeferrablePolicy::Automatic,
+            ));
+        }
+        // 1 Always tool (should be deferred even if only at threshold)
+        tools.push(make_tool(
+            "always_tool",
+            Some("General"),
+            DeferrablePolicy::Always,
+        ));
+
+        // Exactly at threshold (15 tools, threshold=15)
+        let result = OpenResponsesProtocolLlmDriver::convert_tools_with_search(&tools, 15);
+        let json = serde_json::to_value(&result).unwrap();
+        let arr = json.as_array().unwrap();
+
+        // 1 namespace (General) + 1 tool_search = 2
+        assert_eq!(arr.len(), 2);
+
+        let ns = &arr[0];
+        assert_eq!(ns["type"], "namespace");
+        let inner = ns["tools"].as_array().unwrap();
+        assert_eq!(inner.len(), 15);
+        // All should have defer_loading: true
+        for t in inner {
+            assert_eq!(t["defer_loading"], true);
+        }
+    }
+
+    #[test]
+    fn test_tool_search_serialization_format() {
+        // Verify the ToolSearch entry serializes correctly
+        let ts = ResponsesTool::ToolSearch {
+            r#type: "tool_search".to_string(),
+        };
+        let json = serde_json::to_value(&ts).unwrap();
+        assert_eq!(json, json!({"type": "tool_search"}));
+    }
+
+    #[test]
+    fn test_namespace_serialization_format() {
+        let ns = ResponsesTool::Namespace {
+            r#type: "namespace".to_string(),
+            name: "FileSystem".to_string(),
+            description: "Tools for FileSystem".to_string(),
+            tools: vec![ResponsesTool::Function {
+                r#type: "function".to_string(),
+                name: "read_file".to_string(),
+                description: "Read a file".to_string(),
+                parameters: json!({}),
+                defer_loading: Some(true),
+            }],
+        };
+        let json = serde_json::to_value(&ns).unwrap();
+        assert_eq!(json["type"], "namespace");
+        assert_eq!(json["name"], "FileSystem");
+        assert_eq!(json["tools"][0]["name"], "read_file");
+        assert_eq!(json["tools"][0]["defer_loading"], true);
     }
 }

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -268,10 +268,11 @@ impl OpenResponsesProtocolLlmDriver {
 
         // Namespaced tools
         for (name, tools) in namespaces {
+            let description = format!("Tools for {name}");
             result.push(ResponsesTool::Namespace {
                 r#type: "namespace".to_string(),
-                name: name.clone(),
-                description: format!("Tools for {}", name),
+                name,
+                description,
                 tools,
             });
         }

--- a/crates/core/src/runtime_agent.rs
+++ b/crates/core/src/runtime_agent.rs
@@ -15,6 +15,7 @@ use crate::capabilities::{
     CapabilityRegistry, SystemPromptContext, collect_capabilities, resolve_dependencies,
 };
 use crate::harness::Harness;
+use crate::llm_driver_registry::ToolSearchConfig;
 use crate::tool_types::ToolDefinition;
 use serde::{Deserialize, Serialize};
 
@@ -42,6 +43,10 @@ pub struct RuntimeAgent {
     /// Maximum tokens to generate per response
     #[serde(default)]
     pub max_tokens: Option<u32>,
+
+    /// Tool search config (set by openai_tool_search capability)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_search: Option<ToolSearchConfig>,
 }
 
 fn default_max_iterations() -> usize {
@@ -58,6 +63,7 @@ impl RuntimeAgent {
             max_iterations: default_max_iterations(),
             temperature: None,
             max_tokens: None,
+            tool_search: None,
         }
     }
 }
@@ -71,6 +77,7 @@ impl Default for RuntimeAgent {
             max_iterations: default_max_iterations(),
             temperature: None,
             max_tokens: None,
+            tool_search: None,
         }
     }
 }
@@ -200,6 +207,11 @@ impl RuntimeAgentBuilder {
         // Apply tool definitions
         if !collected.tool_definitions.is_empty() {
             self = self.tools(collected.tool_definitions);
+        }
+
+        // Apply tool_search config if capability provided one
+        if let Some(ts_config) = collected.tool_search {
+            self.runtime_agent.tool_search = Some(ts_config);
         }
 
         self
@@ -520,7 +532,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_builder_with_agent_client_side_tools() {
-        use crate::tool_types::{ClientSideTool, ToolDefinition};
+        use crate::tool_types::{ClientSideTool, DeferrablePolicy, ToolDefinition};
         use uuid::{NoContext, Timestamp, Uuid};
 
         let registry = CapabilityRegistry::with_builtins();
@@ -537,6 +549,8 @@ mod tests {
                     "selector": {"type": "string"}
                 }
             }),
+            category: None,
+            deferrable: DeferrablePolicy::default(),
         });
 
         let agent = Agent {
@@ -571,7 +585,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_builder_with_agent_client_side_and_capabilities() {
-        use crate::tool_types::{ClientSideTool, ToolDefinition};
+        use crate::tool_types::{ClientSideTool, DeferrablePolicy, ToolDefinition};
         use uuid::{NoContext, Timestamp, Uuid};
 
         let registry = CapabilityRegistry::with_builtins();
@@ -583,6 +597,8 @@ mod tests {
             display_name: None,
             description: "Deploy to staging".to_string(),
             parameters: serde_json::json!({"type": "object"}),
+            category: None,
+            deferrable: DeferrablePolicy::default(),
         });
 
         let agent = Agent {

--- a/crates/core/src/tool_types.rs
+++ b/crates/core/src/tool_types.rs
@@ -24,6 +24,25 @@ pub enum ToolPolicy {
     ClientSide,
 }
 
+/// Controls whether a tool's full schema can be deferred (tool_search).
+///
+/// When tool_search is active and a model supports it, tools marked as
+/// `Automatic` or `Always` will have `defer_loading: true` set, meaning
+/// only the name+description are sent upfront and full parameter schemas
+/// are loaded on-demand by the model.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum DeferrablePolicy {
+    /// Never defer — always send full schema (e.g., high-frequency tools like write_todos)
+    Never,
+    /// Let the driver decide based on tool count threshold (default)
+    #[default]
+    Automatic,
+    /// Always defer when tool_search is active, regardless of threshold
+    Always,
+}
+
 /// Tool definition in agent configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
@@ -55,6 +74,12 @@ pub struct BuiltinTool {
     /// Tool policy (auto or requires_approval)
     #[serde(default)]
     pub policy: ToolPolicy,
+    /// Category for tool_search namespace grouping (from parent capability)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,
+    /// Whether this tool's schema can be deferred via tool_search
+    #[serde(default)]
+    pub deferrable: DeferrablePolicy,
 }
 
 /// Client-side tool - executed by the client, not the server
@@ -71,6 +96,12 @@ pub struct ClientSideTool {
     pub description: String,
     /// JSON schema for tool parameters
     pub parameters: serde_json::Value,
+    /// Category for tool_search namespace grouping (from parent capability)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,
+    /// Whether this tool's schema can be deferred via tool_search
+    #[serde(default)]
+    pub deferrable: DeferrablePolicy,
 }
 
 impl ToolDefinition {
@@ -112,6 +143,31 @@ impl ToolDefinition {
             ToolDefinition::Builtin(b) => &b.policy,
             ToolDefinition::ClientSide(_) => &ToolPolicy::ClientSide,
         }
+    }
+
+    /// Get the tool category for namespace grouping
+    pub fn category(&self) -> Option<&str> {
+        match self {
+            ToolDefinition::Builtin(b) => b.category.as_deref(),
+            ToolDefinition::ClientSide(c) => c.category.as_deref(),
+        }
+    }
+
+    /// Get the deferrable policy for tool_search
+    pub fn deferrable(&self) -> &DeferrablePolicy {
+        match self {
+            ToolDefinition::Builtin(b) => &b.deferrable,
+            ToolDefinition::ClientSide(c) => &c.deferrable,
+        }
+    }
+
+    /// Set the category on this tool definition (builder pattern)
+    pub fn with_category(mut self, category: impl Into<String>) -> Self {
+        match &mut self {
+            ToolDefinition::Builtin(b) => b.category = Some(category.into()),
+            ToolDefinition::ClientSide(c) => c.category = Some(category.into()),
+        }
+        self
     }
 }
 
@@ -241,6 +297,8 @@ mod tests {
             description: "A test tool".to_string(),
             parameters: serde_json::json!({"type": "object"}),
             policy: ToolPolicy::RequiresApproval,
+            category: None,
+            deferrable: DeferrablePolicy::default(),
         });
 
         assert_eq!(tool.name(), "test_tool");
@@ -258,6 +316,8 @@ mod tests {
             description: "Gets weather".to_string(),
             parameters: serde_json::json!({}),
             policy: ToolPolicy::Auto,
+            category: None,
+            deferrable: DeferrablePolicy::default(),
         });
         assert_eq!(builtin.display_name(), Some("Get Weather"));
 
@@ -266,6 +326,8 @@ mod tests {
             display_name: Some("Deploy".to_string()),
             description: "Deploys".to_string(),
             parameters: serde_json::json!({}),
+            category: None,
+            deferrable: DeferrablePolicy::default(),
         });
         assert_eq!(client.display_name(), Some("Deploy"));
     }
@@ -278,6 +340,8 @@ mod tests {
             description: "test".to_string(),
             parameters: serde_json::json!({}),
             policy: ToolPolicy::Auto,
+            category: None,
+            deferrable: DeferrablePolicy::default(),
         };
         let json = serde_json::to_string(&tool).unwrap();
         assert!(!json.contains("display_name"));
@@ -288,6 +352,8 @@ mod tests {
             description: "test".to_string(),
             parameters: serde_json::json!({}),
             policy: ToolPolicy::Auto,
+            category: None,
+            deferrable: DeferrablePolicy::default(),
         };
         let json = serde_json::to_string(&tool_with).unwrap();
         assert!(json.contains("\"display_name\":\"Test\""));
@@ -357,6 +423,8 @@ mod tests {
             display_name: None,
             description: "Run a test suite".to_string(),
             parameters: serde_json::json!({"type": "object"}),
+            category: None,
+            deferrable: DeferrablePolicy::default(),
         });
 
         let json = serde_json::to_string(&tool).unwrap();
@@ -380,6 +448,8 @@ mod tests {
                 },
                 "required": ["env"]
             }),
+            category: None,
+            deferrable: DeferrablePolicy::default(),
         });
 
         assert_eq!(tool.name(), "deploy_app");
@@ -396,6 +466,8 @@ mod tests {
             display_name: None,
             description: "".to_string(),
             parameters: serde_json::json!({}),
+            category: None,
+            deferrable: DeferrablePolicy::default(),
         });
         assert_eq!(tool.policy(), &ToolPolicy::ClientSide);
     }
@@ -425,12 +497,16 @@ mod tests {
                 description: "A server tool".to_string(),
                 parameters: serde_json::json!({"type": "object"}),
                 policy: ToolPolicy::Auto,
+                category: None,
+                deferrable: DeferrablePolicy::default(),
             }),
             ToolDefinition::ClientSide(ClientSideTool {
                 name: "client_tool".to_string(),
                 display_name: None,
                 description: "A client tool".to_string(),
                 parameters: serde_json::json!({"type": "object"}),
+                category: None,
+                deferrable: DeferrablePolicy::default(),
             }),
         ];
 

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -17,7 +17,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::error;
 
-use crate::tool_types::{BuiltinTool, ToolCall, ToolDefinition, ToolPolicy, ToolResult};
+use crate::tool_types::{
+    BuiltinTool, DeferrablePolicy, ToolCall, ToolDefinition, ToolPolicy, ToolResult,
+};
 use crate::traits::ToolContext;
 
 use crate::error::Result;
@@ -361,6 +363,8 @@ pub trait Tool: Send + Sync {
             description: self.description().to_string(),
             parameters: self.parameters_schema(),
             policy: self.policy(),
+            category: None,
+            deferrable: DeferrablePolicy::default(),
         })
     }
 }

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -903,6 +903,7 @@ async fn test_driver_registry_integration() {
         reasoning_effort: None,
         metadata: std::collections::HashMap::new(),
         previous_response_id: None,
+        tool_search: None,
     };
 
     let response = driver

--- a/crates/core/tests/tool_calling_test.rs
+++ b/crates/core/tests/tool_calling_test.rs
@@ -4,7 +4,9 @@
 // the ToolExecutor trait work correctly together.
 
 use async_trait::async_trait;
-use everruns_core::{BuiltinTool, ToolCall, ToolDefinition, ToolPolicy, ToolResultImage};
+use everruns_core::{
+    BuiltinTool, DeferrablePolicy, ToolCall, ToolDefinition, ToolPolicy, ToolResultImage,
+};
 use everruns_core::{
     GetCurrentTimeTool, Message, MessageRetriever, MessageRole, SessionId,
     memory::InMemoryMessageRetriever,
@@ -41,6 +43,8 @@ async fn test_tool_registry_as_executor() {
         description: "Echo".to_string(),
         parameters: json!({}),
         policy: ToolPolicy::Auto,
+        category: None,
+        deferrable: DeferrablePolicy::default(),
     });
 
     // Execute via ToolExecutor trait
@@ -66,6 +70,8 @@ async fn test_get_current_time_tool() {
         description: "Get time".to_string(),
         parameters: json!({}),
         policy: ToolPolicy::Auto,
+        category: None,
+        deferrable: DeferrablePolicy::default(),
     });
 
     let result = registry.execute(&tool_call, &tool_def).await.unwrap();
@@ -95,6 +101,8 @@ async fn test_tool_error_handling() {
         description: "A tool that fails".to_string(),
         parameters: json!({}),
         policy: ToolPolicy::Auto,
+        category: None,
+        deferrable: DeferrablePolicy::default(),
     });
 
     // Execute and verify error is packaged as {"error": "..."} in result field
@@ -126,6 +134,8 @@ async fn test_internal_error_is_hidden() {
         description: "A tool that fails internally".to_string(),
         parameters: json!({}),
         policy: ToolPolicy::Auto,
+        category: None,
+        deferrable: DeferrablePolicy::default(),
     });
 
     // Execute and verify internal error is hidden (packaged as {"error": "..."} with generic message)
@@ -155,6 +165,8 @@ async fn test_tool_not_found_error() {
         description: "Does not exist".to_string(),
         parameters: json!({}),
         policy: ToolPolicy::Auto,
+        category: None,
+        deferrable: DeferrablePolicy::default(),
     });
 
     // Should return error for tool not found
@@ -220,6 +232,8 @@ async fn test_custom_tool_execution() {
         description: "Counter".to_string(),
         parameters: json!({}),
         policy: ToolPolicy::Auto,
+        category: None,
+        deferrable: DeferrablePolicy::default(),
     });
 
     // Execute multiple times
@@ -259,6 +273,8 @@ async fn test_multiple_tools_in_registry() {
         description: "Get time".to_string(),
         parameters: json!({}),
         policy: ToolPolicy::Auto,
+        category: None,
+        deferrable: DeferrablePolicy::default(),
     });
 
     let time_result = registry.execute(&time_call, &time_def).await.unwrap();
@@ -278,6 +294,8 @@ async fn test_multiple_tools_in_registry() {
         description: "Echo".to_string(),
         parameters: json!({}),
         policy: ToolPolicy::Auto,
+        category: None,
+        deferrable: DeferrablePolicy::default(),
     });
 
     let echo_result = registry.execute(&echo_call, &echo_def).await.unwrap();

--- a/crates/core/tests/tool_search_test.rs
+++ b/crates/core/tests/tool_search_test.rs
@@ -1,0 +1,130 @@
+// Integration tests for tool_search (deferred tool loading).
+//
+// Tests the full pipeline: OpenAiToolSearchCapability → RuntimeAgent → LlmCallConfig →
+// OpenResponses driver with tool_search enabled.
+//
+// Includes a real GPT-5.4 integration test that exercises tool_search end-to-end.
+//
+// Run all:
+//   cargo test -p everruns-core --test tool_search_test --features llm-tests
+//
+// Required env vars (tests skip gracefully if missing):
+//   OPENAI_API_KEY
+#![cfg(feature = "llm-tests")]
+
+mod llm_test_matrix;
+
+use llm_test_matrix::*;
+
+use everruns_core::capabilities::{
+    CurrentTimeCapability, FileSystemCapability, OpenAiToolSearchCapability, SessionCapability,
+    StatelessTodoListCapability, TestMathCapability, TestWeatherCapability,
+};
+use everruns_core::in_memory_loop::InMemoryAgenticLoop;
+
+// ============================================================================
+// Scenario: tool_search with GPT-5.4 (many tools → deferred loading)
+// ============================================================================
+
+/// Tests tool_search end-to-end with GPT-5.4:
+/// - Adds enough capabilities to exceed the threshold (16 tools > 15)
+/// - Adds OpenAiToolSearchCapability
+/// - Verifies the model can still call tools correctly with deferred schemas
+#[tokio::test]
+async fn test_gpt54_tool_search_with_many_capabilities() {
+    let Some(model) = OPENAI_GPT54.model() else {
+        eprintln!("Skipping: {} not set", OPENAI_GPT54.label());
+        return;
+    };
+
+    let runner = InMemoryAgenticLoop::builder()
+        .agent_name("Tool Search Agent")
+        .system_prompt(
+            "You are a helpful assistant. When asked about time, use the get_current_time tool.",
+        )
+        .model(model)
+        .driver_registry(all_providers_registry())
+        // Add multiple capabilities to exceed the 15-tool threshold (16 total)
+        .capability(CurrentTimeCapability) // 1 tool
+        .capability(TestMathCapability) // 4 tools
+        .capability(TestWeatherCapability) // 2 tools
+        .capability(FileSystemCapability) // 6 tools
+        .capability(SessionCapability) // 2 tools
+        .capability(StatelessTodoListCapability) // 1 tool
+        // Enable tool_search
+        .capability(OpenAiToolSearchCapability::new())
+        .max_iterations(5)
+        .build()
+        .await
+        .unwrap();
+
+    let result = runner.run_turn("What time is it right now?").await.unwrap();
+
+    assert!(result.success, "Turn should succeed: {:?}", result.error);
+    assert!(
+        result.tool_calls_count > 0,
+        "Model should call get_current_time even with deferred tool loading"
+    );
+}
+
+/// Tests tool_search with a lower custom threshold so it activates with few tools
+#[tokio::test]
+async fn test_gpt54_tool_search_low_threshold() {
+    let Some(model) = OPENAI_GPT54.model() else {
+        eprintln!("Skipping: {} not set", OPENAI_GPT54.label());
+        return;
+    };
+
+    let runner = InMemoryAgenticLoop::builder()
+        .agent_name("Low Threshold Agent")
+        .system_prompt("When asked to add numbers, use the add tool.")
+        .model(model)
+        .driver_registry(all_providers_registry())
+        .capability(TestMathCapability)
+        .capability(CurrentTimeCapability)
+        // Low threshold: tool_search activates even with few tools (5 > 3)
+        .capability(OpenAiToolSearchCapability::with_threshold(3))
+        .max_iterations(5)
+        .build()
+        .await
+        .unwrap();
+
+    let result = runner.run_turn("What is 7 + 3?").await.unwrap();
+
+    assert!(result.success, "Turn should succeed: {:?}", result.error);
+    assert!(
+        result.tool_calls_count > 0,
+        "Model should call add tool even with deferred schemas"
+    );
+}
+
+/// Tests that tool_search gracefully works when below threshold
+/// (falls back to standard tool format — no namespaces, no defer_loading)
+#[tokio::test]
+async fn test_gpt54_tool_search_below_threshold_fallback() {
+    let Some(model) = OPENAI_GPT54.model() else {
+        eprintln!("Skipping: {} not set", OPENAI_GPT54.label());
+        return;
+    };
+
+    let runner = InMemoryAgenticLoop::builder()
+        .agent_name("Below Threshold Agent")
+        .system_prompt("When asked about time, use the get_current_time tool.")
+        .model(model)
+        .driver_registry(all_providers_registry())
+        // Only 1 tool — well below default threshold of 15
+        .capability(CurrentTimeCapability)
+        .capability(OpenAiToolSearchCapability::new())
+        .max_iterations(5)
+        .build()
+        .await
+        .unwrap();
+
+    let result = runner.run_turn("What time is it?").await.unwrap();
+
+    assert!(result.success, "Turn should succeed: {:?}", result.error);
+    assert!(
+        result.tool_calls_count > 0,
+        "Should still work with standard tool format (below threshold)"
+    );
+}

--- a/crates/gemini/src/driver.rs
+++ b/crates/gemini/src/driver.rs
@@ -1066,7 +1066,7 @@ mod tests {
 
     #[test]
     fn test_convert_tools() {
-        use everruns_core::tool_types::{BuiltinTool, ToolPolicy};
+        use everruns_core::tool_types::{BuiltinTool, DeferrablePolicy, ToolPolicy};
         let tools = vec![ToolDefinition::Builtin(BuiltinTool {
             name: "get_weather".to_string(),
             display_name: None,
@@ -1079,6 +1079,8 @@ mod tests {
                 "required": ["city"]
             }),
             policy: ToolPolicy::Auto,
+            category: None,
+            deferrable: DeferrablePolicy::default(),
         })];
 
         let gemini_tools = GeminiLlmDriver::convert_tools(&tools);
@@ -1091,7 +1093,7 @@ mod tests {
 
     #[test]
     fn test_convert_tools_strips_additional_properties() {
-        use everruns_core::tool_types::{BuiltinTool, ToolPolicy};
+        use everruns_core::tool_types::{BuiltinTool, DeferrablePolicy, ToolPolicy};
         let tools = vec![ToolDefinition::Builtin(BuiltinTool {
             name: "search".to_string(),
             display_name: None,
@@ -1105,6 +1107,8 @@ mod tests {
                 "additionalProperties": false
             }),
             policy: ToolPolicy::Auto,
+            category: None,
+            deferrable: DeferrablePolicy::default(),
         })];
 
         let gemini_tools = GeminiLlmDriver::convert_tools(&tools).unwrap();

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -931,7 +931,7 @@ impl DirectWorkerAdapters {
     ) -> Result<Vec<ToolDefinition>> {
         use everruns_core::capabilities::mcp::parse_mcp_capability_id;
         use everruns_core::mcp_server::mcp_tool_name;
-        use everruns_core::tool_types::{BuiltinTool, ToolPolicy};
+        use everruns_core::tool_types::{BuiltinTool, DeferrablePolicy, ToolPolicy};
 
         let capability_rows = self
             .db
@@ -987,6 +987,8 @@ impl DirectWorkerAdapters {
                     description,
                     parameters: tool.input_schema,
                     policy: ToolPolicy::Auto,
+                    category: None,
+                    deferrable: DeferrablePolicy::default(),
                 }));
             }
         }

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -306,6 +306,7 @@ const SEED_HARNESSES: &[SeedHarness] = &[
             "session",
             "agent_instructions",
             "skills",
+            "openai_tool_search",
         ],
     },
     SeedHarness {
@@ -322,6 +323,7 @@ const SEED_HARNESSES: &[SeedHarness] = &[
             "agent_instructions",
             "skills",
             "platform_management",
+            "openai_tool_search",
         ],
     },
 ];

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -1721,13 +1721,14 @@ mod tests {
             .find(|h| h.name == "Generic")
             .expect("Generic harness should exist");
 
-        assert_eq!(generic.capabilities.len(), 6);
+        assert_eq!(generic.capabilities.len(), 7);
         assert!(generic.capabilities.contains(&"session_file_system"));
         assert!(generic.capabilities.contains(&"virtual_bash"));
         assert!(generic.capabilities.contains(&"session_storage"));
         assert!(generic.capabilities.contains(&"session"));
         assert!(generic.capabilities.contains(&"agent_instructions"));
         assert!(generic.capabilities.contains(&"skills"));
+        assert!(generic.capabilities.contains(&"openai_tool_search"));
         assert!(generic.tags.contains(&"generic"));
         assert!(generic.tags.contains(&"default"));
     }

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -891,7 +891,7 @@ async fn test_get_generic_harness() {
     assert!(harness.tags.contains(&"generic".to_string()));
     assert!(harness.tags.contains(&"default".to_string()));
 
-    // Verify Generic harness has the expected 6 capabilities
+    // Verify Generic harness has the expected 7 capabilities
     let cap_ids: Vec<&str> = harness
         .capabilities
         .iter()
@@ -899,8 +899,8 @@ async fn test_get_generic_harness() {
         .collect();
     assert_eq!(
         cap_ids.len(),
-        6,
-        "Generic harness should have 6 capabilities"
+        7,
+        "Generic harness should have 7 capabilities"
     );
     assert!(
         cap_ids.contains(&"session_file_system"),
@@ -923,6 +923,10 @@ async fn test_get_generic_harness() {
         "Should have agent instructions"
     );
     assert!(cap_ids.contains(&"skills"), "Should have skills discovery");
+    assert!(
+        cap_ids.contains(&"openai_tool_search"),
+        "Should have OpenAI tool search"
+    );
 }
 
 #[tokio::test]
@@ -1091,11 +1095,11 @@ async fn test_copy_seed_generic_harness() {
         .json();
 
     assert_eq!(copied.name, "Generic (copy)");
-    // Generic harness has 6 capabilities
+    // Generic harness has 7 capabilities
     assert_eq!(
         copied.capabilities.len(),
-        6,
-        "Copied harness should have same 6 capabilities"
+        7,
+        "Copied harness should have same 7 capabilities"
     );
 }
 
@@ -1799,8 +1803,8 @@ async fn test_chat_harness_has_platform_management() {
 
     assert_eq!(
         cap_ids.len(),
-        7,
-        "Platform Chat harness should have 7 capabilities (Generic + platform_management)"
+        8,
+        "Platform Chat harness should have 8 capabilities (Generic + platform_management)"
     );
     assert!(
         cap_ids.contains(&"platform_management"),

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -389,7 +389,7 @@ mod tests {
     use super::*;
     use everruns_core::atoms::AtomContext;
     use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId, TurnId};
-    use everruns_core::{BuiltinTool, ToolCall, ToolDefinition, ToolPolicy};
+    use everruns_core::{BuiltinTool, DeferrablePolicy, ToolCall, ToolDefinition, ToolPolicy};
     use serde_json::json;
     use uuid::Uuid;
 
@@ -456,6 +456,8 @@ mod tests {
                 description: "Get weather".to_string(),
                 parameters: json!({}),
                 policy: ToolPolicy::Auto,
+                category: None,
+                deferrable: DeferrablePolicy::default(),
             })],
         };
 

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -1051,7 +1051,7 @@ pub async fn load_turn_context(
 fn proto_mcp_tool_def_to_tool_definition(
     proto_tool: proto::McpToolDef,
 ) -> everruns_core::ToolDefinition {
-    use everruns_core::tool_types::{BuiltinTool, ToolDefinition, ToolPolicy};
+    use everruns_core::tool_types::{BuiltinTool, DeferrablePolicy, ToolDefinition, ToolPolicy};
 
     // Convert proto Struct to serde_json::Value
     let parameters = proto_tool
@@ -1065,6 +1065,8 @@ fn proto_mcp_tool_def_to_tool_definition(
         description: proto_tool.description,
         parameters,
         policy: ToolPolicy::Auto, // MCP tools are auto-executed
+        category: None,
+        deferrable: DeferrablePolicy::default(),
     })
 }
 

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -1012,7 +1012,7 @@ async fn schedule_next_activity<S: WorkflowEventStore>(
 mod tests {
     use super::*;
     use everruns_core::tool_types::{
-        BuiltinTool, ClientSideTool, ToolCall, ToolDefinition, ToolPolicy,
+        BuiltinTool, ClientSideTool, DeferrablePolicy, ToolCall, ToolDefinition, ToolPolicy,
     };
 
     #[test]
@@ -1065,6 +1065,8 @@ mod tests {
             description: "Get weather".to_string(),
             parameters: serde_json::json!({"type": "object"}),
             policy: ToolPolicy::Auto,
+            category: None,
+            deferrable: DeferrablePolicy::default(),
         })];
 
         let tool_calls = vec![ToolCall {
@@ -1086,6 +1088,8 @@ mod tests {
             display_name: None,
             description: "Click element".to_string(),
             parameters: serde_json::json!({"type": "object"}),
+            category: None,
+            deferrable: DeferrablePolicy::default(),
         })];
 
         let tool_calls = vec![ToolCall {
@@ -1109,18 +1113,24 @@ mod tests {
                 description: "Get current time".to_string(),
                 parameters: serde_json::json!({"type": "object"}),
                 policy: ToolPolicy::Auto,
+                category: None,
+                deferrable: DeferrablePolicy::default(),
             }),
             ToolDefinition::ClientSide(ClientSideTool {
                 name: "browser_click".to_string(),
                 display_name: None,
                 description: "Click element".to_string(),
                 parameters: serde_json::json!({"type": "object"}),
+                category: None,
+                deferrable: DeferrablePolicy::default(),
             }),
             ToolDefinition::ClientSide(ClientSideTool {
                 name: "browser_type".to_string(),
                 display_name: None,
                 description: "Type text".to_string(),
                 parameters: serde_json::json!({"type": "object"}),
+                category: None,
+                deferrable: DeferrablePolicy::default(),
             }),
             ToolDefinition::Builtin(BuiltinTool {
                 name: "read_file".to_string(),
@@ -1128,6 +1138,8 @@ mod tests {
                 description: "Read a file".to_string(),
                 parameters: serde_json::json!({"type": "object"}),
                 policy: ToolPolicy::Auto,
+                category: None,
+                deferrable: DeferrablePolicy::default(),
             }),
         ];
 
@@ -1176,6 +1188,8 @@ mod tests {
             display_name: None,
             description: "Known client tool".to_string(),
             parameters: serde_json::json!({"type": "object"}),
+            category: None,
+            deferrable: DeferrablePolicy::default(),
         })];
 
         let tool_calls = vec![
@@ -1206,6 +1220,8 @@ mod tests {
             display_name: None,
             description: "A tool".to_string(),
             parameters: serde_json::json!({"type": "object"}),
+            category: None,
+            deferrable: DeferrablePolicy::default(),
         })];
 
         let tool_calls: Vec<ToolCall> = vec![];
@@ -1240,12 +1256,16 @@ mod tests {
                     description: "Get current time".to_string(),
                     parameters: serde_json::json!({"type": "object"}),
                     policy: ToolPolicy::Auto,
+                    category: None,
+                    deferrable: DeferrablePolicy::default(),
                 }),
                 ToolDefinition::ClientSide(ClientSideTool {
                     name: "deploy_app".to_string(),
                     display_name: None,
                     description: "Deploy application".to_string(),
                     parameters: serde_json::json!({"type": "object"}),
+                    category: None,
+                    deferrable: DeferrablePolicy::default(),
                 }),
             ],
             max_iterations: 100,
@@ -1281,12 +1301,16 @@ mod tests {
                 description: "Delete a file".to_string(),
                 parameters: serde_json::json!({"type": "object"}),
                 policy: ToolPolicy::RequiresApproval,
+                category: None,
+                deferrable: DeferrablePolicy::default(),
             }),
             ToolDefinition::ClientSide(ClientSideTool {
                 name: "browser_click".to_string(),
                 display_name: None,
                 description: "Click element".to_string(),
                 parameters: serde_json::json!({"type": "object"}),
+                category: None,
+                deferrable: DeferrablePolicy::default(),
             }),
         ];
 

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -4260,6 +4260,17 @@
           "parameters"
         ],
         "properties": {
+          "category": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Category for tool_search namespace grouping (from parent capability)"
+          },
+          "deferrable": {
+            "$ref": "#/components/schemas/DeferrablePolicy",
+            "description": "Whether this tool's schema can be deferred via tool_search"
+          },
           "description": {
             "type": "string",
             "description": "Tool description for LLM"
@@ -4402,6 +4413,17 @@
           "parameters"
         ],
         "properties": {
+          "category": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Category for tool_search namespace grouping (from parent capability)"
+          },
+          "deferrable": {
+            "$ref": "#/components/schemas/DeferrablePolicy",
+            "description": "Whether this tool's schema can be deferred via tool_search"
+          },
           "description": {
             "type": "string",
             "description": "Tool description for LLM"
@@ -5090,6 +5112,15 @@
             "type": "string"
           }
         }
+      },
+      "DeferrablePolicy": {
+        "type": "string",
+        "description": "Controls whether a tool's full schema can be deferred (tool_search).\n\nWhen tool_search is active and a model supports it, tools marked as\n`Automatic` or `Always` will have `defer_loading: true` set, meaning\nonly the name+description are sent upfront and full parameter schemas\nare loaded on-demand by the model.",
+        "enum": [
+          "never",
+          "automatic",
+          "always"
+        ]
       },
       "DeleteQuery": {
         "type": "object",
@@ -7319,6 +7350,10 @@
           "tool_call": {
             "type": "boolean",
             "description": "Whether the model supports tool/function calling"
+          },
+          "tool_search": {
+            "type": "boolean",
+            "description": "Whether the model supports tool_search (deferred tool loading).\nWhen true, the driver can use namespaces and defer_loading to reduce\ntoken usage for large tool sets. Currently supported by GPT-5.4+."
           }
         }
       },

--- a/docs/capabilities/index.md
+++ b/docs/capabilities/index.md
@@ -47,6 +47,14 @@ Agent self-management, dynamic instructions, and skill discovery.
 | [AGENTS.md](/capabilities/agent-instructions/) | `agent_instructions` | 0 |
 | [Agent Skills](/capabilities/agent-skills/) | `skills` | 2 |
 
+### Optimization
+
+Performance and cost optimization for LLM interactions.
+
+| Capability | ID | Tools |
+|---|---|---|
+| [OpenAI Tool Search](/capabilities/openai-tool-search/) | `openai_tool_search` | 0 |
+
 ### Demo
 
 Pre-built domain simulations for testing and demonstrations.

--- a/docs/capabilities/openai-tool-search.md
+++ b/docs/capabilities/openai-tool-search.md
@@ -1,0 +1,102 @@
+---
+title: OpenAI Tool Search
+description: Deferred tool loading for agents with many tools, reducing token usage on OpenAI GPT-5.4+ models
+sidebar:
+  order: 90
+---
+
+| | |
+|---|---|
+| **ID** | `openai_tool_search` |
+| **Category** | Optimization |
+| **Features** | None |
+| **Dependencies** | None |
+
+Enables [OpenAI's tool_search](https://platform.openai.com/docs/guides/tool-search) for agents with many tools. Instead of sending full parameter schemas for every tool upfront, only tool names and descriptions are sent initially. The model loads full schemas on-demand when it decides to call a tool.
+
+This reduces prompt token usage significantly for agents with 15+ tools, without changing how tools are called or how results are returned.
+
+## Tools
+
+None — this capability configures the LLM driver, it does not provide tools.
+
+## How It Works
+
+1. **Threshold check** — tool_search only activates when the total tool count meets or exceeds the threshold (default: 15)
+2. **Namespace grouping** — tools are grouped by their capability's category into [namespace](https://platform.openai.com/docs/api-reference/responses/create#responses-create-tools) entries, giving the model semantic structure for discovery
+3. **Deferred schemas** — tools marked as deferrable have `defer_loading: true` set, meaning only name + description are sent upfront
+4. **`tool_search` entry** — a `{"type": "tool_search"}` activator is appended to the tools array, enabling the model's built-in tool search index
+5. **Transparent execution** — tool calls and results work identically; the only difference is how tools are presented to the model
+
+### DeferrablePolicy
+
+Each tool has a `deferrable` policy that controls whether its schema can be deferred:
+
+| Policy | Behavior |
+|---|---|
+| `never` | Full schema always sent (use for high-frequency tools like `write_todos`) |
+| `automatic` | Deferred when tool_search is active and above threshold (default) |
+| `always` | Always deferred when tool_search is active, regardless of threshold |
+
+### Model Support
+
+Tool search requires model-level support. Currently supported:
+
+| Model | Supported |
+|---|---|
+| `gpt-5.4` | Yes |
+| `gpt-5.4-pro` | Yes |
+| All other models | No (capability is silently ignored) |
+
+When the capability is enabled but the model doesn't support tool_search, the feature is silently skipped — no errors, no behavior change.
+
+## Configuration
+
+### Default (threshold: 15)
+
+```json
+{
+  "capabilities": ["openai_tool_search"]
+}
+```
+
+### Custom threshold
+
+```json
+{
+  "capabilities": [
+    {
+      "capability_ref": "openai_tool_search",
+      "config": { "threshold": 10 }
+    }
+  ]
+}
+```
+
+Lower thresholds activate tool_search with fewer tools. Set to `1` to always activate when the capability is present.
+
+## Use Cases
+
+- **Many-tool agents** — agents with 15+ tools (e.g., file system + bash + database + web fetch + skills) benefit from reduced prompt tokens
+- **Cost optimization** — fewer input tokens per request when most tools aren't needed for a given turn
+- **Latency reduction** — smaller request payloads can reduce time-to-first-token
+
+## Example
+
+An agent with 20 tools and `openai_tool_search` enabled:
+
+**Without tool_search:** all 20 tool schemas sent in every request (~4,000 tokens)
+
+**With tool_search:** 20 tool names + descriptions sent (~800 tokens), full schemas loaded on-demand only for tools the model decides to call
+
+## Limitations
+
+- **OpenAI-only** — tool_search is an OpenAI Responses API feature; other providers (Anthropic, Gemini) ignore this capability
+- **GPT-5.4+ only** — earlier OpenAI models don't support tool_search
+- **No client-side tools** — currently only applies to built-in (server-executed) tools
+
+## See Also
+
+- [OpenAI Tool Search documentation](https://platform.openai.com/docs/guides/tool-search) — official OpenAI guide
+- [OpenAI Responses API: tools parameter](https://platform.openai.com/docs/api-reference/responses/create#responses-create-tools) — API reference for namespace and tool_search types
+- [Capabilities Overview](/capabilities/)

--- a/specs/tool-search.md
+++ b/specs/tool-search.md
@@ -1,0 +1,328 @@
+# Tool Search Specification
+
+## Abstract
+
+Tool search enables deferred tool loading — instead of sending all tool definitions (with full JSON schemas) to the LLM on every request, only tool names and descriptions are sent upfront. Full schemas are loaded on-demand when the model decides it needs a tool. This reduces token usage, cost, and latency for agents with many capabilities.
+
+Inspired by OpenAI's GPT-5.4 `tool_search` feature, but designed as a provider-agnostic capability within the everruns architecture.
+
+## Motivation
+
+Current flow: all capability tools → `RuntimeAgent.tools` → `LlmCallConfig.tools` → full JSON schemas sent to every LLM call. With 30+ capabilities and MCP servers, tool definitions can consume 5K-15K tokens per request.
+
+GPT-5.4's `tool_search` demonstrated 47% token reduction on 250-tool workloads at same accuracy. We want similar benefits, ideally across all providers.
+
+## How GPT-5.4 tool_search Works
+
+OpenAI's implementation has two modes:
+
+### Hosted Mode
+
+```json
+{
+  "model": "gpt-5.4",
+  "tools": [
+    {
+      "type": "namespace",
+      "name": "crm",
+      "description": "CRM tools for customer lookup and order management.",
+      "tools": [
+        {
+          "type": "function",
+          "name": "list_open_orders",
+          "description": "List open orders for a customer ID.",
+          "defer_loading": true,
+          "parameters": { "type": "object", ... }
+        }
+      ]
+    },
+    { "type": "tool_search" }
+  ]
+}
+```
+
+Model sees name + description upfront, parameters loaded only when needed. For namespaces, model sees only namespace name + description until it searches within.
+
+### Client-Executed Mode
+
+Model emits `tool_search_call` → client responds with `tool_search_output` containing matched tools. Multi-turn handshake.
+
+## Design: Capability-Driven Tool Search
+
+### Decision: Model Profile Flag
+
+Add `tool_search: bool` to `LlmModelProfile`. Only models that natively support `tool_search` (currently GPT-5.4+) get the optimized path. Other models continue receiving full tool definitions.
+
+```rust
+pub struct LlmModelProfile {
+    // ... existing fields ...
+    /// Whether the model supports tool_search (deferred tool loading)
+    pub tool_search: bool,
+}
+```
+
+This is the right granularity — tool_search is a model-level capability like `tool_call`, `reasoning`, or `structured_output`. The profile already drives behavior in `ReasonAtom` (e.g., stripping reasoning_effort for non-reasoning models).
+
+### Decision: Hosted Mode Only (Initially)
+
+Use hosted tool_search (server-side, single-turn). Client-executed mode adds multi-turn complexity for marginal benefit — OpenAI's hosted search already handles the matching. Client-executed mode is a future option if we need custom tool registries or cross-provider search.
+
+### Decision: Capability Categories as Namespaces
+
+Map capability categories to tool_search namespaces. Each capability already has `category` (Data, Management, MCP Servers, etc.) and a description. This maps cleanly:
+
+```
+Capability(session_file_system, category="File System")
+  → Namespace("file_system", "File system tools for reading, writing, and managing files")
+    → Functions: read_file, write_file, list_directory, ... (all defer_loading: true)
+```
+
+For MCP servers, each server is already a natural namespace:
+
+```
+MCP Server("github", "GitHub integration")
+  → Namespace("mcp_github", "GitHub integration for repos, issues, PRs")
+    → Functions: mcp_github__search_repos, mcp_github__create_issue, ...
+```
+
+### Decision: Transparent Deferral Logic in LLM Driver
+
+The deferral decision lives in the OpenAI driver's `convert_tools()`, not in capability code. Capabilities don't need to know about tool_search — they just provide tools as today. The driver checks the model profile and restructures the tools array accordingly.
+
+```
+Capability.tools()  →  RuntimeAgent.tools  →  LlmCallConfig.tools
+                                                      ↓
+                                            LlmDriver checks profile.tool_search
+                                                      ↓
+                                    ┌─────────────────┴──────────────────┐
+                                    │ tool_search=false                   │ tool_search=true
+                                    │ (current behavior)                  │ (new behavior)
+                                    ↓                                     ↓
+                            Vec<ResponsesTool::Function>          Vec<ResponsesTool> with:
+                            (full schemas)                        - Namespace groupings
+                                                                  - defer_loading: true
+                                                                  - { "type": "tool_search" }
+```
+
+### Decision: ToolDefinition Metadata for Grouping
+
+Add optional `category` to `ToolDefinition` so the driver can group tools into namespaces:
+
+```rust
+pub struct BuiltinTool {
+    pub name: String,
+    pub display_name: Option<String>,
+    pub description: String,
+    pub parameters: serde_json::Value,
+    pub policy: ToolPolicy,
+    /// Category for tool_search namespace grouping (from parent capability)
+    pub category: Option<String>,
+}
+```
+
+Capabilities already have categories. When `collect_capabilities()` builds the tool list, propagate the capability's category to each tool definition. The driver then groups by category when building namespaces.
+
+## How to Decide What Gets Deferred
+
+### Deferral Heuristic
+
+**All tools are deferred by default** when tool_search is active. The model sees names + descriptions for individual functions, and only namespace-level info for grouped tools. This is the right default because:
+
+1. Tool descriptions are the primary signal for tool selection (not parameter schemas)
+2. Parameter schemas are only needed after the model decides to call a tool
+3. OpenAI's hosted search handles the matching well
+
+### Exceptions (Never Defer)
+
+Some tools should never be deferred because they're called on nearly every turn:
+
+- `write_todos` — used for task tracking on most turns
+- Tools in the "always-on" set configured per-agent
+
+This maps to a `defer_loading: bool` field on `ToolDefinition`, defaulting to `true` when tool_search is active. Capabilities can override via `always_loaded_tools() -> Vec<&str>`.
+
+### Tool Count Threshold
+
+Only activate tool_search when `tools.len() >= TOOL_SEARCH_THRESHOLD` (suggested: 15). Below this threshold, full schemas fit comfortably in context and the overhead of deferred loading (potential extra latency on first call) isn't worth it.
+
+```rust
+const TOOL_SEARCH_THRESHOLD: usize = 15;
+
+// In driver:
+let use_tool_search = profile.tool_search && config.tools.len() >= TOOL_SEARCH_THRESHOLD;
+```
+
+## Model Profile Updates
+
+### GPT-5.4 Family
+
+```rust
+"gpt-5.4" => Some(LlmModelProfile {
+    // ... existing fields ...
+    tool_search: true,  // NEW
+}),
+
+"gpt-5.4-pro" => Some(LlmModelProfile {
+    // ... existing fields ...
+    tool_search: true,  // NEW
+}),
+```
+
+### All Other Models
+
+```rust
+tool_search: false,  // Default for all existing models
+```
+
+When other providers adopt similar features (Anthropic, Gemini), flip the flag per model.
+
+## OpenAI Driver Changes
+
+### ResponsesTool Enum Extension
+
+```rust
+enum ResponsesTool {
+    Function {
+        r#type: String,
+        name: String,
+        description: String,
+        parameters: Value,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        defer_loading: Option<bool>,
+    },
+    Namespace {
+        r#type: String,
+        name: String,
+        description: String,
+        tools: Vec<ResponsesTool>,
+    },
+    ToolSearch {
+        r#type: String,
+    },
+}
+```
+
+### convert_tools with tool_search
+
+```rust
+fn convert_tools_with_search(
+    tools: &[ToolDefinition],
+    threshold: usize,
+) -> Vec<ResponsesTool> {
+    if tools.len() < threshold {
+        return Self::convert_tools(tools);  // existing path
+    }
+
+    let mut namespaces: HashMap<String, Vec<ResponsesTool>> = HashMap::new();
+    let mut ungrouped = vec![];
+
+    for tool in tools {
+        let func = ResponsesTool::Function {
+            r#type: "function".into(),
+            name: tool.name().into(),
+            description: tool.description().into(),
+            parameters: tool.parameters().clone(),
+            defer_loading: Some(true),
+        };
+
+        match tool.category() {
+            Some(cat) => namespaces.entry(cat.into()).or_default().push(func),
+            None => ungrouped.push(func),
+        }
+    }
+
+    let mut result: Vec<ResponsesTool> = namespaces
+        .into_iter()
+        .map(|(name, tools)| ResponsesTool::Namespace {
+            r#type: "namespace".into(),
+            name,
+            description: format!("Tools for {}", name),
+            tools,
+        })
+        .collect();
+
+    result.extend(ungrouped);
+    result.push(ResponsesTool::ToolSearch { r#type: "tool_search".into() });
+    result
+}
+```
+
+## Provider Abstraction
+
+### Non-OpenAI Providers
+
+For Anthropic and Gemini (no native tool_search):
+
+1. **Short-term**: Send full tool definitions (current behavior). `tool_search: false` in profile.
+2. **Medium-term**: Implement client-side tool search as a pre-processing step in the driver — send only names + descriptions as a summary tool, handle tool discovery in the agent loop.
+3. **Long-term**: When providers adopt similar features, use their native APIs.
+
+### Client-Side Tool Search (Future)
+
+For providers without native tool_search, we could implement it ourselves:
+
+1. Send tool names + descriptions in system prompt (not as tool definitions)
+2. Add a synthetic `_discover_tools` tool that the model calls with a query
+3. Match query against tool descriptions using simple TF-IDF or embedding similarity
+4. Inject matched tool definitions into the next turn
+
+This is a significant effort and should wait until we validate the value of tool_search with OpenAI models first.
+
+## LlmCallConfig Changes
+
+No changes needed. `LlmCallConfig.tools` continues to carry all tool definitions. The deferral decision is purely in the driver layer. The driver receives the profile via the model field and looks up `tool_search` support.
+
+However, the driver needs access to the model profile. Two options:
+
+1. **Pass profile through LlmCallConfig** — add `model_profile: Option<LlmModelProfile>` field
+2. **Look up in driver** — driver already knows its provider type, can call `get_model_profile()`
+
+Option 2 is cleaner. The driver constructor already has the provider context.
+
+## Observability
+
+Track tool_search effectiveness via existing metadata:
+
+- `tool_search_active: bool` in `LlmCompletionMetadata`
+- Compare `prompt_tokens` between tool_search and non-tool_search requests
+- Log which tools were actually loaded (from response events, if OpenAI exposes this)
+
+## Implementation Plan
+
+### Phase 1: Model Profile + Driver (Low Risk)
+
+1. Add `tool_search: bool` to `LlmModelProfile` (default false)
+2. Set `tool_search: true` for GPT-5.4 family
+3. Add `category: Option<String>` to `BuiltinTool` / `ToolDefinition`
+4. Propagate capability category to tool definitions in `collect_capabilities()`
+5. Extend `ResponsesTool` enum with `Namespace` and `ToolSearch` variants
+6. Add `convert_tools_with_search()` to OpenAI driver
+7. Gate on `profile.tool_search && tools.len() >= threshold`
+
+### Phase 2: Tuning + Observability
+
+8. Add `tool_search_active` to completion metadata
+9. Compare token usage with/without tool_search in staging
+10. Tune `TOOL_SEARCH_THRESHOLD` based on real workloads
+11. Identify tools that should never be deferred
+
+### Phase 3: Cross-Provider (Future)
+
+12. Client-side tool search for Anthropic/Gemini
+13. Namespace discovery for MCP servers
+14. Per-agent tool_search configuration override
+
+## Open Questions
+
+1. **Should tool_search be configurable per-agent?** Could add `tool_search: Option<bool>` to agent config, overriding model profile default. Useful for agents that always need all tools loaded (e.g., short deterministic workflows).
+
+2. **How does tool_search interact with infinity context?** If we're already compacting context, deferred tools add complexity to the compaction logic. The compacted state may not include tool search results.
+
+3. **MCP server tool discovery latency.** MCP tools are already lazily cached (24h TTL). With tool_search, the model might request tools from an MCP server that hasn't been polled recently. Need to handle stale cache gracefully.
+
+## References
+
+- [OpenAI Tool Search Guide](https://developers.openai.com/api/docs/guides/tools-tool-search/)
+- [GPT-5.4 Announcement](https://openai.com/index/introducing-gpt-5-4/)
+- [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses)
+- Internal: `specs/capabilities.md`, `specs/llm-drivers.md`


### PR DESCRIPTION
## What
Add OpenAI tool_search capability that enables deferred tool loading for GPT-5.4+ models. When enabled, only tool names and descriptions are sent upfront - full parameter schemas are loaded on-demand by the model.

## Why
Agents with 15+ tools send ~4,000 tokens of tool schemas per request. Tool search reduces this to ~800 tokens by deferring schema loading, reducing cost and latency.

## How
- New `OpenAiToolSearchCapability` (ID: `openai_tool_search`) in the capabilities system
- `DeferrablePolicy` enum (Never/Automatic/Always) on tool definitions controls per-tool deferral
- Capability categories map to OpenAI namespace groupings for semantic tool discovery
- `ToolSearchConfig` propagates through: capability -> CollectedCapabilities -> RuntimeAgent -> LlmCallConfig -> driver
- `convert_tools_with_search()` in the OpenAI Responses protocol driver groups tools into namespaces, marks them with `defer_loading: true`, and appends a `tool_search` activator
- Graceful degradation: silently falls back to standard tool format when model doesn't support tool_search or tool count is below threshold
- Added to Generic and Platform Chat seed harnesses by default

## Risk
- Low
- OpenAI-only feature; non-OpenAI providers ignore it entirely. Models without tool_search support silently skip the feature. Threshold-based activation means small-tool agents are unaffected.

## Checklist
- [x] Tests added or updated
  - 7 unit tests for convert_tools_with_search (threshold fallback, namespace grouping, DeferrablePolicy variants, serialization)
  - 5 capability collection tests (config propagation, custom threshold, category propagation)
  - 3 capability unit tests (metadata, default/custom threshold)
  - 3 GPT-5.4 integration tests (many tools, low threshold, below-threshold fallback)
  - Seed harness test updated for new capability count
- [x] Backward compatibility considered - new fields have serde(default), no breaking changes
