### PR TITLE
feat(core): add ExternalActor for channel-agnostic user identity

### DIFF
--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -668,9 +668,17 @@ where
             patched_messages.clone()
         };
 
-        // Add conversation messages with resolved images
+        // Add conversation messages with resolved images.
+        // For user messages with an external_actor, prefix the first text part
+        // with the actor's display label so the LLM knows who is speaking.
         for msg in &patched_messages {
-            llm_messages.push(LlmMessage::from_message_with_images(msg, &resolved_images));
+            let mut llm_msg = LlmMessage::from_message_with_images(msg, &resolved_images);
+            if msg.role == MessageRole::User
+                && let Some(ref actor) = msg.external_actor
+            {
+                llm_msg.prepend_text_prefix(&format!("[{}] ", actor.display_label()));
+            }
+            llm_messages.push(llm_msg);
         }
 
         // 12. Build LLM call config with reasoning effort and metadata

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -93,8 +93,8 @@ pub mod turn;
 // Re-exports for convenience
 pub use error::{AgentLoopError, Result};
 pub use message::{
-    ContentPart, ContentType, Controls, ImageContentPart, ImageFileContentPart, InputContentPart,
-    Message, MessageRole, ReasoningConfig, TextContentPart, ToolCallContentPart,
+    ContentPart, ContentType, Controls, ExternalActor, ImageContentPart, ImageFileContentPart,
+    InputContentPart, Message, MessageRole, ReasoningConfig, TextContentPart, ToolCallContentPart,
     ToolResultContentPart,
 };
 pub use message_filter::{

--- a/crates/core/src/llm_driver_registry.rs
+++ b/crates/core/src/llm_driver_registry.rs
@@ -281,6 +281,33 @@ impl LlmMessage {
     pub fn content_as_text(&self) -> String {
         self.content.to_text()
     }
+
+    /// Prepend a prefix to the first text content.
+    ///
+    /// Used by ReasonAtom to inject external actor identity (e.g. "[Alice] ")
+    /// into user messages from external channels.
+    pub fn prepend_text_prefix(&mut self, prefix: &str) {
+        match &mut self.content {
+            LlmMessageContent::Text(text) => {
+                *text = format!("{}{}", prefix, text);
+            }
+            LlmMessageContent::Parts(parts) => {
+                for part in parts.iter_mut() {
+                    if let LlmContentPart::Text { text } = part {
+                        *text = format!("{}{}", prefix, text);
+                        return;
+                    }
+                }
+                // No text part found — prepend one
+                parts.insert(
+                    0,
+                    LlmContentPart::Text {
+                        text: prefix.to_string(),
+                    },
+                );
+            }
+        }
+    }
 }
 
 /// Message content - either a simple string or array of content parts
@@ -1085,6 +1112,7 @@ mod tests {
             thinking_signature: None,
             controls: None,
             metadata: None,
+            external_actor: None,
             created_at: chrono::Utc::now(),
         };
 
@@ -1103,6 +1131,7 @@ mod tests {
             thinking_signature: None,
             controls: None,
             metadata: None,
+            external_actor: None,
             created_at: chrono::Utc::now(),
         };
 
@@ -1134,6 +1163,7 @@ mod tests {
             thinking_signature: None,
             controls: None,
             metadata: None,
+            external_actor: None,
             created_at: chrono::Utc::now(),
         };
 
@@ -1155,6 +1185,7 @@ mod tests {
             thinking_signature: None,
             controls: None,
             metadata: None,
+            external_actor: None,
             created_at: chrono::Utc::now(),
         };
 
@@ -1187,6 +1218,7 @@ mod tests {
             thinking_signature: None,
             controls: None,
             metadata: None,
+            external_actor: None,
             created_at: chrono::Utc::now(),
         };
 
@@ -1228,6 +1260,7 @@ mod tests {
             thinking_signature: None,
             controls: None,
             metadata: None,
+            external_actor: None,
             created_at: chrono::Utc::now(),
         };
 
@@ -1249,6 +1282,61 @@ mod tests {
                     panic!("Expected text placeholder for missing image");
                 }
             }
+        }
+    }
+
+    #[test]
+    fn test_prepend_text_prefix_simple_text() {
+        let mut msg = LlmMessage::text(LlmMessageRole::User, "Hello bot");
+        msg.prepend_text_prefix("[Alice] ");
+        assert_eq!(msg.content_as_text(), "[Alice] Hello bot");
+    }
+
+    #[test]
+    fn test_prepend_text_prefix_parts() {
+        let mut msg = LlmMessage::parts(
+            LlmMessageRole::User,
+            vec![
+                LlmContentPart::Text {
+                    text: "Hello".to_string(),
+                },
+                LlmContentPart::Image {
+                    url: "data:image/png;base64,abc".to_string(),
+                },
+            ],
+        );
+        msg.prepend_text_prefix("[Bob] ");
+        match &msg.content {
+            LlmMessageContent::Parts(parts) => {
+                if let LlmContentPart::Text { text } = &parts[0] {
+                    assert_eq!(text, "[Bob] Hello");
+                } else {
+                    panic!("Expected text part");
+                }
+            }
+            _ => panic!("Expected parts content"),
+        }
+    }
+
+    #[test]
+    fn test_prepend_text_prefix_parts_no_text() {
+        let mut msg = LlmMessage::parts(
+            LlmMessageRole::User,
+            vec![LlmContentPart::Image {
+                url: "data:image/png;base64,abc".to_string(),
+            }],
+        );
+        msg.prepend_text_prefix("[Eve] ");
+        match &msg.content {
+            LlmMessageContent::Parts(parts) => {
+                assert_eq!(parts.len(), 2);
+                if let LlmContentPart::Text { text } = &parts[0] {
+                    assert_eq!(text, "[Eve] ");
+                } else {
+                    panic!("Expected prepended text part");
+                }
+            }
+            _ => panic!("Expected parts content"),
         }
     }
 }

--- a/crates/core/src/memory.rs
+++ b/crates/core/src/memory.rs
@@ -82,6 +82,7 @@ impl InMemoryMessageRetriever {
             thinking_signature: None,
             controls: input.controls,
             metadata: input.metadata,
+            external_actor: None,
             created_at: Utc::now(),
         };
 

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -54,6 +54,38 @@ impl From<&str> for MessageRole {
 }
 
 // ============================================
+// External Actor (channel-agnostic user identity)
+// ============================================
+
+/// External actor identity for messages originating from external channels
+/// (Slack, Discord, Teams, etc.).
+///
+/// Channel adapters populate this to identify the sender without coupling
+/// core logic to any specific channel. The ReasonAtom uses this to prefix
+/// user messages so the LLM knows who is speaking.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct ExternalActor {
+    /// Opaque actor identifier from the source channel (e.g. Slack user ID "U0123456789")
+    pub actor_id: String,
+    /// Resolved display name (e.g. "Alice"). Falls back to actor_id if absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor_name: Option<String>,
+    /// Source channel identifier (e.g. "slack", "discord")
+    pub source: String,
+    /// Channel-specific metadata (e.g. team_id, channel_id)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<std::collections::HashMap<String, String>>,
+}
+
+impl ExternalActor {
+    /// Human-readable label: display name if available, otherwise actor_id.
+    pub fn display_label(&self) -> &str {
+        self.actor_name.as_deref().unwrap_or(&self.actor_id)
+    }
+}
+
+// ============================================
 // Controls (runtime options for message processing)
 // ============================================
 
@@ -114,6 +146,10 @@ pub struct Message {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "openapi", schema(value_type = Option<Object>))]
     pub metadata: Option<std::collections::HashMap<String, serde_json::Value>>,
+
+    /// External actor identity (for messages from external channels like Slack)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_actor: Option<ExternalActor>,
 
     /// Timestamp when the message was created
     pub created_at: DateTime<Utc>,
@@ -488,6 +524,7 @@ impl Message {
             thinking_signature: None,
             controls: None,
             metadata: None,
+            external_actor: None,
             created_at: Utc::now(),
         }
     }
@@ -502,6 +539,7 @@ impl Message {
             thinking_signature: None,
             controls: None,
             metadata: None,
+            external_actor: None,
             created_at: Utc::now(),
         }
     }
@@ -536,6 +574,7 @@ impl Message {
             thinking_signature: None,
             controls: None,
             metadata: None,
+            external_actor: None,
             created_at: Utc::now(),
         }
     }
@@ -550,6 +589,7 @@ impl Message {
             thinking_signature: None,
             controls: None,
             metadata: None,
+            external_actor: None,
             created_at: Utc::now(),
         }
     }
@@ -573,6 +613,7 @@ impl Message {
             thinking_signature: None,
             controls: None,
             metadata: None,
+            external_actor: None,
             created_at: Utc::now(),
         }
     }
@@ -607,6 +648,7 @@ impl Message {
             thinking_signature: None,
             controls: None,
             metadata: None,
+            external_actor: None,
             created_at: Utc::now(),
         }
     }

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -391,6 +391,8 @@ message Message {
     optional string thinking = 7;
     // Cryptographic signature for thinking content (required when sending thinking back)
     optional string thinking_signature = 8;
+    // External actor identity (for messages from external channels like Slack)
+    optional google.protobuf.Struct external_actor = 9;
 }
 
 message LoadMessagesRequest {

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -456,6 +456,13 @@ pub fn proto_message_to_schema(
         .map(|s| serde_json::from_value(proto_struct_to_json(s)))
         .transpose()?;
 
+    // Convert prost Struct to ExternalActor
+    let external_actor: Option<everruns_core::ExternalActor> = value
+        .external_actor
+        .as_ref()
+        .map(|s| serde_json::from_value(proto_struct_to_json(s)))
+        .transpose()?;
+
     let role = parse_message_role(&value.role);
 
     Ok(everruns_core::Message {
@@ -466,6 +473,7 @@ pub fn proto_message_to_schema(
         thinking_signature: value.thinking_signature,
         controls,
         metadata,
+        external_actor,
         created_at,
     })
 }
@@ -488,6 +496,12 @@ pub fn schema_message_to_proto(value: &everruns_core::Message) -> proto::Message
         json_to_proto_struct(&json)
     });
 
+    // Convert external_actor to Struct
+    let external_actor = value.external_actor.as_ref().map(|ea| {
+        let json = serde_json::to_value(ea).unwrap_or_default();
+        json_to_proto_struct(&json)
+    });
+
     proto::Message {
         id: Some(uuid_to_proto_uuid(value.id.uuid())),
         role: value.role.to_string(),
@@ -497,6 +511,7 @@ pub fn schema_message_to_proto(value: &everruns_core::Message) -> proto::Message
         created_at: Some(datetime_to_proto_timestamp(value.created_at)),
         thinking: value.thinking.clone(),
         thinking_signature: value.thinking_signature.clone(),
+        external_actor,
     }
 }
 
@@ -1134,6 +1149,7 @@ mod tests {
             thinking_signature: Some("test_signature_abc123".to_string()),
             controls: None,
             metadata: None,
+            external_actor: None,
             created_at: Utc::now(),
         };
 
@@ -1170,6 +1186,7 @@ mod tests {
             thinking_signature: None,
             controls: None,
             metadata: None,
+            external_actor: None,
             created_at: Utc::now(),
         };
 

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -1202,4 +1202,77 @@ mod tests {
         // Verify thinking field remains None
         assert_eq!(schema_message.thinking, None);
     }
+
+    #[test]
+    fn test_external_actor_proto_roundtrip() {
+        use chrono::Utc;
+        use everruns_core::{ContentPart, ExternalActor, Message, MessageRole};
+        use uuid::Uuid;
+
+        let actor = ExternalActor {
+            actor_id: "U0123456789".to_string(),
+            actor_name: Some("Alice".to_string()),
+            source: "slack".to_string(),
+            metadata: Some(
+                [("channel".to_string(), "C999".to_string())]
+                    .into_iter()
+                    .collect(),
+            ),
+        };
+
+        let message = Message {
+            id: Uuid::now_v7().into(),
+            role: MessageRole::User,
+            content: vec![ContentPart::text("Hello")],
+            thinking: None,
+            thinking_signature: None,
+            controls: None,
+            metadata: None,
+            external_actor: Some(actor.clone()),
+            created_at: Utc::now(),
+        };
+
+        let proto_message = schema_message_to_proto(&message);
+        assert!(proto_message.external_actor.is_some());
+
+        let schema_message = proto_message_to_schema(proto_message).unwrap();
+        let roundtripped = schema_message.external_actor.unwrap();
+        assert_eq!(roundtripped.actor_id, "U0123456789");
+        assert_eq!(roundtripped.actor_name, Some("Alice".to_string()));
+        assert_eq!(roundtripped.source, "slack");
+        assert_eq!(
+            roundtripped
+                .metadata
+                .as_ref()
+                .unwrap()
+                .get("channel")
+                .unwrap(),
+            "C999"
+        );
+    }
+
+    #[test]
+    fn test_external_actor_none_proto_roundtrip() {
+        use chrono::Utc;
+        use everruns_core::{ContentPart, Message, MessageRole};
+        use uuid::Uuid;
+
+        let message = Message {
+            id: Uuid::now_v7().into(),
+            role: MessageRole::User,
+            content: vec![ContentPart::text("Hello")],
+            thinking: None,
+            thinking_signature: None,
+            controls: None,
+            metadata: None,
+            external_actor: None,
+            created_at: Utc::now(),
+        };
+
+        let proto_message = schema_message_to_proto(&message);
+        assert!(proto_message.external_actor.is_none());
+
+        let schema_message = proto_message_to_schema(proto_message).unwrap();
+        assert!(schema_message.external_actor.is_none());
+    }
 }

--- a/crates/server/src/api/messages.rs
+++ b/crates/server/src/api/messages.rs
@@ -125,6 +125,9 @@ pub struct CreateMessageRequest {
     /// Tags for the message
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,
+    /// External actor identity (for messages from external channels like Slack)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_actor: Option<everruns_core::ExternalActor>,
 }
 
 #[cfg(test)]
@@ -139,6 +142,7 @@ impl CreateMessageRequest {
             controls: None,
             metadata: None,
             tags: None,
+            external_actor: None,
         }
     }
 }

--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -27,7 +27,9 @@ use everruns_worker::AgentRunner;
 use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
+use std::collections::HashMap;
 use std::sync::Arc;
+use tokio::sync::RwLock;
 
 use crate::api::messages::{CreateMessageRequest, InputContentPart, InputMessage, MessageRole};
 use crate::api::sessions::CreateSessionRequest;
@@ -98,6 +100,10 @@ struct AckResponse {
     ok: bool,
 }
 
+/// Resolved Slack user display name.
+/// `Some(name)` = resolved, `None` = resolution failed (don't retry).
+type SlackUserCache = Arc<RwLock<HashMap<String, Option<String>>>>;
+
 /// App-scoped Slack state (no auth required).
 #[derive(Clone)]
 pub struct SlackState {
@@ -105,6 +111,8 @@ pub struct SlackState {
     pub app_service: Arc<AppService>,
     pub session_service: Arc<SessionService>,
     pub message_service: Arc<MessageService>,
+    /// Cache of Slack user ID → display name. Shared across requests.
+    user_name_cache: SlackUserCache,
 }
 
 impl SlackState {
@@ -114,6 +122,7 @@ impl SlackState {
             session_service: Arc::new(SessionService::new(db.clone())),
             message_service: Arc::new(MessageService::new(db.clone(), runner)),
             db,
+            user_name_cache: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 }
@@ -255,7 +264,32 @@ async fn process_slack_message(
     event: &SlackEvent,
 ) -> anyhow::Result<()> {
     let org_id = app.org_id;
-    let text = event.text.clone().unwrap_or_default();
+    let raw_text = event.text.clone().unwrap_or_default();
+    let slack_user_id = event.user.clone().unwrap_or_default();
+
+    // Resolve Slack user display name (gracefully falls back to user ID)
+    let display_name = if !slack_user_id.is_empty() {
+        resolve_slack_user_name(
+            &state.user_name_cache,
+            &slack_config.bot_token,
+            &slack_user_id,
+        )
+        .await
+    } else {
+        None
+    };
+
+    // Build user label: "John Doe" or "U0123456789" as fallback
+    let user_label = display_name
+        .as_deref()
+        .unwrap_or(if !slack_user_id.is_empty() {
+            &slack_user_id
+        } else {
+            "unknown"
+        });
+
+    // Prefix message with user identity so the LLM knows who's speaking
+    let text = format!("[{}] {}", user_label, raw_text);
 
     // Resolve org_public_id
     let org_row = state
@@ -314,11 +348,11 @@ async fn process_slack_message(
             content: vec![InputContentPart::text(text)],
         },
         controls: None,
-        metadata: Some(
-            [
+        metadata: Some({
+            let mut meta: std::collections::HashMap<String, serde_json::Value> = [
                 (
                     "slack_user".to_string(),
-                    serde_json::Value::String(event.user.clone().unwrap_or_default()),
+                    serde_json::Value::String(slack_user_id.clone()),
                 ),
                 (
                     "slack_channel".to_string(),
@@ -330,8 +364,15 @@ async fn process_slack_message(
                 ),
             ]
             .into_iter()
-            .collect(),
-        ),
+            .collect();
+            if let Some(ref name) = display_name {
+                meta.insert(
+                    "slack_display_name".to_string(),
+                    serde_json::Value::String(name.clone()),
+                );
+            }
+            meta
+        }),
         tags: None,
     };
 
@@ -507,6 +548,101 @@ fn extract_response_text(data: &serde_json::Value) -> Option<String> {
         None
     } else {
         Some(text_parts.join("\n"))
+    }
+}
+
+/// Resolve a Slack user ID to a display name via `users.info` API.
+///
+/// Returns the display name (or real_name fallback) on success, or `None` if
+/// resolution fails (missing `users:read` scope, network error, etc.).
+/// Results are cached: successful lookups and permanent failures (missing scope)
+/// are not retried. Transient errors are retried on next call.
+async fn resolve_slack_user_name(
+    cache: &SlackUserCache,
+    bot_token: &str,
+    user_id: &str,
+) -> Option<String> {
+    // Check cache first
+    {
+        let cache_read = cache.read().await;
+        if let Some(cached) = cache_read.get(user_id) {
+            return cached.clone();
+        }
+    }
+
+    // Call Slack API (user IDs are alphanumeric, safe to interpolate)
+    let client = reqwest::Client::new();
+    let url = format!("https://slack.com/api/users.info?user={user_id}");
+    let result = client
+        .get(&url)
+        .header("Authorization", format!("Bearer {}", bot_token))
+        .send()
+        .await;
+
+    let response: reqwest::Response = match result {
+        Ok(r) => r,
+        Err(e) => {
+            // Transient network error — don't cache, allow retry
+            tracing::warn!(user_id = user_id, error = %e, "Failed to fetch Slack user info (network)");
+            return None;
+        }
+    };
+
+    let body: serde_json::Value = match response.json().await {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::warn!(user_id = user_id, error = %e, "Failed to parse Slack users.info response");
+            return None;
+        }
+    };
+
+    if body.get("ok").and_then(|v| v.as_bool()).unwrap_or(false) {
+        // Success — extract display_name, fall back to real_name, then name
+        let user_obj = body.get("user");
+        let profile = user_obj.and_then(|u| u.get("profile"));
+        let display_name = profile
+            .and_then(|p| p.get("display_name"))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .or_else(|| {
+                user_obj
+                    .and_then(|u| u.get("real_name"))
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+            })
+            .or_else(|| {
+                user_obj
+                    .and_then(|u| u.get("name"))
+                    .and_then(|v| v.as_str())
+            })
+            .map(String::from);
+
+        let mut cache_write = cache.write().await;
+        cache_write.insert(user_id.to_string(), display_name.clone());
+        display_name
+    } else {
+        let error = body
+            .get("error")
+            .and_then(|e| e.as_str())
+            .unwrap_or("unknown");
+        tracing::warn!(
+            user_id = user_id,
+            error = error,
+            "Slack users.info API error"
+        );
+
+        // Permanent errors (missing scope, invalid token) — cache as None to avoid repeated calls
+        if error == "missing_scope"
+            || error == "not_authed"
+            || error == "invalid_auth"
+            || error == "token_revoked"
+            || error == "account_inactive"
+        {
+            let mut cache_write = cache.write().await;
+            cache_write.insert(user_id.to_string(), None);
+        }
+
+        None
     }
 }
 
@@ -828,6 +964,98 @@ mod tests {
     fn test_extract_response_text_empty_content() {
         let data = serde_json::json!({"message": {"content": []}});
         assert!(extract_response_text(&data).is_none());
+    }
+
+    #[tokio::test]
+    async fn test_resolve_slack_user_name_cache_hit() {
+        let cache: SlackUserCache = Arc::new(RwLock::new(HashMap::new()));
+        cache
+            .write()
+            .await
+            .insert("U123".to_string(), Some("Alice".to_string()));
+
+        let result = resolve_slack_user_name(&cache, "xoxb-fake", "U123").await;
+        assert_eq!(result, Some("Alice".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_slack_user_name_cache_hit_none() {
+        // Cached failure (e.g., missing_scope) should return None without API call
+        let cache: SlackUserCache = Arc::new(RwLock::new(HashMap::new()));
+        cache.write().await.insert("U123".to_string(), None);
+
+        let result = resolve_slack_user_name(&cache, "xoxb-fake", "U123").await;
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_slack_user_name_api_failure_not_cached() {
+        // Network failures should not be cached (allow retry)
+        let cache: SlackUserCache = Arc::new(RwLock::new(HashMap::new()));
+
+        // Use an invalid URL-ish token that will fail network-level
+        // (the function uses hardcoded slack.com URL, so with a bad token
+        // it will get a response but not a network error — test cache emptiness)
+        let _result = resolve_slack_user_name(&cache, "xoxb-invalid", "U999").await;
+
+        // If it got a Slack API error response (not_authed/invalid_auth), it should cache None.
+        // If it was a network error, cache should be empty.
+        // Either way the function gracefully returns None — that's the key behavior.
+        // We just verify it doesn't panic.
+    }
+
+    #[test]
+    fn test_message_prefix_with_display_name() {
+        let display_name = Some("Alice".to_string());
+        let slack_user_id = "U123";
+        let raw_text = "Hello bot";
+
+        let user_label = display_name
+            .as_deref()
+            .unwrap_or(if !slack_user_id.is_empty() {
+                slack_user_id
+            } else {
+                "unknown"
+            });
+        let text = format!("[{}] {}", user_label, raw_text);
+
+        assert_eq!(text, "[Alice] Hello bot");
+    }
+
+    #[test]
+    fn test_message_prefix_fallback_to_user_id() {
+        let display_name: Option<String> = None;
+        let slack_user_id = "U0123456789";
+        let raw_text = "Hello bot";
+
+        let user_label = display_name
+            .as_deref()
+            .unwrap_or(if !slack_user_id.is_empty() {
+                slack_user_id
+            } else {
+                "unknown"
+            });
+        let text = format!("[{}] {}", user_label, raw_text);
+
+        assert_eq!(text, "[U0123456789] Hello bot");
+    }
+
+    #[test]
+    fn test_message_prefix_no_user() {
+        let display_name: Option<String> = None;
+        let slack_user_id = "";
+        let raw_text = "Hello bot";
+
+        let user_label = display_name
+            .as_deref()
+            .unwrap_or(if !slack_user_id.is_empty() {
+                slack_user_id
+            } else {
+                "unknown"
+            });
+        let text = format!("[{}] {}", user_label, raw_text);
+
+        assert_eq!(text, "[unknown] Hello bot");
     }
 
     // Test helpers

--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -264,7 +264,7 @@ async fn process_slack_message(
     event: &SlackEvent,
 ) -> anyhow::Result<()> {
     let org_id = app.org_id;
-    let raw_text = event.text.clone().unwrap_or_default();
+    let text = event.text.clone().unwrap_or_default();
     let slack_user_id = event.user.clone().unwrap_or_default();
 
     // Resolve Slack user display name (gracefully falls back to user ID)
@@ -279,17 +279,28 @@ async fn process_slack_message(
         None
     };
 
-    // Build user label: "John Doe" or "U0123456789" as fallback
-    let user_label = display_name
-        .as_deref()
-        .unwrap_or(if !slack_user_id.is_empty() {
-            &slack_user_id
-        } else {
-            "unknown"
-        });
-
-    // Prefix message with user identity so the LLM knows who's speaking
-    let text = format!("[{}] {}", user_label, raw_text);
+    // Build ExternalActor for channel-agnostic user identity
+    let external_actor = if !slack_user_id.is_empty() {
+        let mut actor_metadata = std::collections::HashMap::new();
+        if let Some(ref channel) = event.channel {
+            actor_metadata.insert("channel".to_string(), channel.clone());
+        }
+        if let Some(ref team_id) = slack_config.team_id {
+            actor_metadata.insert("team_id".to_string(), team_id.clone());
+        }
+        Some(everruns_core::ExternalActor {
+            actor_id: slack_user_id.clone(),
+            actor_name: display_name.clone(),
+            source: "slack".to_string(),
+            metadata: if actor_metadata.is_empty() {
+                None
+            } else {
+                Some(actor_metadata)
+            },
+        })
+    } else {
+        None
+    };
 
     // Resolve org_public_id
     let org_row = state
@@ -342,18 +353,16 @@ async fn process_slack_message(
     };
 
     // Create user message (triggers agent workflow)
+    // Slack-specific metadata (ts for threading) stays in metadata;
+    // user identity is carried by external_actor.
     let create_msg = CreateMessageRequest {
         message: InputMessage {
             role: MessageRole::User,
             content: vec![InputContentPart::text(text)],
         },
         controls: None,
-        metadata: Some({
-            let mut meta: std::collections::HashMap<String, serde_json::Value> = [
-                (
-                    "slack_user".to_string(),
-                    serde_json::Value::String(slack_user_id.clone()),
-                ),
+        metadata: Some(
+            [
                 (
                     "slack_channel".to_string(),
                     serde_json::Value::String(event.channel.clone().unwrap_or_default()),
@@ -364,16 +373,10 @@ async fn process_slack_message(
                 ),
             ]
             .into_iter()
-            .collect();
-            if let Some(ref name) = display_name {
-                meta.insert(
-                    "slack_display_name".to_string(),
-                    serde_json::Value::String(name.clone()),
-                );
-            }
-            meta
-        }),
+            .collect(),
+        ),
         tags: None,
+        external_actor,
     };
 
     let message = state
@@ -1005,57 +1008,62 @@ mod tests {
     }
 
     #[test]
-    fn test_message_prefix_with_display_name() {
-        let display_name = Some("Alice".to_string());
-        let slack_user_id = "U123";
-        let raw_text = "Hello bot";
-
-        let user_label = display_name
-            .as_deref()
-            .unwrap_or(if !slack_user_id.is_empty() {
-                slack_user_id
-            } else {
-                "unknown"
-            });
-        let text = format!("[{}] {}", user_label, raw_text);
-
-        assert_eq!(text, "[Alice] Hello bot");
+    fn test_external_actor_display_label_with_name() {
+        let actor = everruns_core::ExternalActor {
+            actor_id: "U123".to_string(),
+            actor_name: Some("Alice".to_string()),
+            source: "slack".to_string(),
+            metadata: None,
+        };
+        assert_eq!(actor.display_label(), "Alice");
     }
 
     #[test]
-    fn test_message_prefix_fallback_to_user_id() {
-        let display_name: Option<String> = None;
-        let slack_user_id = "U0123456789";
-        let raw_text = "Hello bot";
-
-        let user_label = display_name
-            .as_deref()
-            .unwrap_or(if !slack_user_id.is_empty() {
-                slack_user_id
-            } else {
-                "unknown"
-            });
-        let text = format!("[{}] {}", user_label, raw_text);
-
-        assert_eq!(text, "[U0123456789] Hello bot");
+    fn test_external_actor_display_label_fallback_to_id() {
+        let actor = everruns_core::ExternalActor {
+            actor_id: "U0123456789".to_string(),
+            actor_name: None,
+            source: "slack".to_string(),
+            metadata: None,
+        };
+        assert_eq!(actor.display_label(), "U0123456789");
     }
 
     #[test]
-    fn test_message_prefix_no_user() {
-        let display_name: Option<String> = None;
-        let slack_user_id = "";
-        let raw_text = "Hello bot";
+    fn test_external_actor_with_metadata() {
+        let mut metadata = std::collections::HashMap::new();
+        metadata.insert("channel".to_string(), "C123".to_string());
+        metadata.insert("team_id".to_string(), "T456".to_string());
 
-        let user_label = display_name
-            .as_deref()
-            .unwrap_or(if !slack_user_id.is_empty() {
-                slack_user_id
-            } else {
-                "unknown"
-            });
-        let text = format!("[{}] {}", user_label, raw_text);
+        let actor = everruns_core::ExternalActor {
+            actor_id: "U123".to_string(),
+            actor_name: Some("Alice".to_string()),
+            source: "slack".to_string(),
+            metadata: Some(metadata),
+        };
 
-        assert_eq!(text, "[unknown] Hello bot");
+        assert_eq!(actor.source, "slack");
+        let meta = actor.metadata.as_ref().unwrap();
+        assert_eq!(meta.get("channel").unwrap(), "C123");
+        assert_eq!(meta.get("team_id").unwrap(), "T456");
+    }
+
+    #[test]
+    fn test_external_actor_serialization_roundtrip() {
+        let actor = everruns_core::ExternalActor {
+            actor_id: "U123".to_string(),
+            actor_name: Some("Alice".to_string()),
+            source: "slack".to_string(),
+            metadata: None,
+        };
+
+        let json = serde_json::to_value(&actor).unwrap();
+        assert_eq!(json["actor_id"], "U123");
+        assert_eq!(json["actor_name"], "Alice");
+        assert_eq!(json["source"], "slack");
+
+        let deserialized: everruns_core::ExternalActor = serde_json::from_value(json).unwrap();
+        assert_eq!(deserialized, actor);
     }
 
     // Test helpers

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1036,6 +1036,7 @@ fn event_to_message(event: Event) -> Option<Message> {
                 thinking_signature: None,
                 controls: None,
                 metadata: None,
+                external_actor: None,
                 created_at: event.ts,
             })
         }
@@ -1547,6 +1548,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
             thinking_signature: None,
             controls: None,
             metadata: None,
+            external_actor: None,
             created_at: now,
         };
 

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -850,6 +850,11 @@ impl WorkerService for WorkerServiceImpl {
                 everruns_internal_protocol::json_to_proto_struct(&json)
             });
 
+            let external_actor = message.external_actor.as_ref().map(|ea| {
+                let json = serde_json::to_value(ea).unwrap_or_default();
+                everruns_internal_protocol::json_to_proto_struct(&json)
+            });
+
             proto_messages.push(proto::Message {
                 id: Some(uuid_to_proto_uuid(message.id.uuid())),
                 role: message.role.to_string(),
@@ -859,6 +864,7 @@ impl WorkerService for WorkerServiceImpl {
                 created_at: Some(datetime_to_proto_timestamp(message.created_at)),
                 thinking: message.thinking.clone(),
                 thinking_signature: message.thinking_signature.clone(),
+                external_actor,
             });
         }
 
@@ -1185,6 +1191,11 @@ impl WorkerService for WorkerServiceImpl {
                 everruns_internal_protocol::json_to_proto_struct(&json)
             });
 
+            let external_actor = message.external_actor.as_ref().map(|ea| {
+                let json = serde_json::to_value(ea).unwrap_or_default();
+                everruns_internal_protocol::json_to_proto_struct(&json)
+            });
+
             proto_messages.push(proto::Message {
                 id: Some(uuid_to_proto_uuid(message.id.uuid())),
                 role: message.role.to_string(),
@@ -1194,6 +1205,7 @@ impl WorkerService for WorkerServiceImpl {
                 created_at: Some(datetime_to_proto_timestamp(message.created_at)),
                 thinking: message.thinking.clone(),
                 thinking_signature: message.thinking_signature.clone(),
+                external_actor,
             });
         }
 
@@ -1256,6 +1268,7 @@ impl WorkerService for WorkerServiceImpl {
             thinking_signature: None,
             controls,
             metadata,
+            external_actor: None,
             created_at: Utc::now(),
         };
 
@@ -1299,6 +1312,11 @@ impl WorkerService for WorkerServiceImpl {
             json_to_proto_struct(&json)
         });
 
+        let external_actor = message.external_actor.as_ref().map(|ea| {
+            let json = serde_json::to_value(ea).unwrap_or_default();
+            json_to_proto_struct(&json)
+        });
+
         let proto_message = proto::Message {
             id: Some(uuid_to_proto_uuid(message.id.uuid())),
             role: message.role.to_string(),
@@ -1308,6 +1326,7 @@ impl WorkerService for WorkerServiceImpl {
             created_at: Some(datetime_to_proto_timestamp(message.created_at)),
             thinking: message.thinking.clone(),
             thinking_signature: message.thinking_signature.clone(),
+            external_actor,
         };
 
         Ok(Response::new(AddMessageResponse {
@@ -3380,6 +3399,7 @@ impl WorkerService for WorkerServiceImpl {
             thinking_signature: None,
             controls: None,
             metadata: None,
+            external_actor: None,
             created_at: now,
         };
 

--- a/crates/server/src/services/message.rs
+++ b/crates/server/src/services/message.rs
@@ -76,6 +76,7 @@ impl MessageService {
             thinking_signature: None,
             controls: req.controls.clone(),
             metadata: req.metadata.clone(),
+            external_actor: req.external_actor.clone(),
             created_at: now,
         };
 

--- a/crates/server/src/session_scheduler.rs
+++ b/crates/server/src/session_scheduler.rs
@@ -134,6 +134,7 @@ async fn poll_and_trigger(
             thinking_signature: None,
             controls: None,
             metadata: Some(metadata),
+            external_actor: None,
             created_at: now,
         };
 

--- a/crates/server/src/storage/message_store.rs
+++ b/crates/server/src/storage/message_store.rs
@@ -61,6 +61,7 @@ impl DbMessageRetriever {
             thinking_signature: None,
             controls: input.controls,
             metadata: input.metadata,
+            external_actor: None,
             created_at: Utc::now(),
         };
 

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -347,6 +347,15 @@ fn proto_message_to_message(proto_msg: proto::Message) -> Result<Message> {
         thinking_signature: proto_msg.thinking_signature, // Cryptographic signature for thinking
         controls,
         metadata,
+        external_actor: {
+            use everruns_internal_protocol::proto_struct_to_json;
+            proto_msg
+                .external_actor
+                .as_ref()
+                .map(|s| serde_json::from_value(proto_struct_to_json(s)))
+                .transpose()
+                .unwrap_or(None)
+        },
         created_at: proto_timestamp_or_now(proto_msg.created_at.as_ref()),
     })
 }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -4880,6 +4880,17 @@
               }
             ]
           },
+          "external_actor": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ExternalActor",
+                "description": "External actor identity (for messages from external channels like Slack)"
+              }
+            ]
+          },
           "message": {
             "$ref": "#/components/schemas/InputMessage",
             "description": "The message to create"
@@ -5315,6 +5326,44 @@
             "content": [],
             "id": "...",
             "role": "user"
+          }
+        }
+      },
+      "ExternalActor": {
+        "type": "object",
+        "description": "External actor identity for messages originating from external channels\n(Slack, Discord, Teams, etc.).\n\nChannel adapters populate this to identify the sender without coupling\ncore logic to any specific channel. The ReasonAtom uses this to prefix\nuser messages so the LLM knows who is speaking.",
+        "required": [
+          "actor_id",
+          "source"
+        ],
+        "properties": {
+          "actor_id": {
+            "type": "string",
+            "description": "Opaque actor identifier from the source channel (e.g. Slack user ID \"U0123456789\")"
+          },
+          "actor_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Resolved display name (e.g. \"Alice\"). Falls back to actor_id if absent."
+          },
+          "metadata": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "description": "Channel-specific metadata (e.g. team_id, channel_id)",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "source": {
+            "type": "string",
+            "description": "Source channel identifier (e.g. \"slack\", \"discord\")"
           }
         }
       },
@@ -7631,6 +7680,17 @@
             "type": "string",
             "format": "date-time",
             "description": "Timestamp when the message was created"
+          },
+          "external_actor": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ExternalActor",
+                "description": "External actor identity (for messages from external channels like Slack)"
+              }
+            ]
           },
           "id": {
             "type": "string",

--- a/specs/slack-integration.md
+++ b/specs/slack-integration.md
@@ -60,10 +60,26 @@ Apps page at `/apps` with:
 - Webhook URL display (for copying into Slack app config)
 - Delete confirmation
 
+## User Identity
+
+Slack user identity is carried via the channel-agnostic `ExternalActor` struct (see `crates/core/src/message.rs`). The Slack handler:
+
+1. Resolves Slack user ID → display name via `users.info` API (requires `users:read` scope)
+2. Populates `ExternalActor { actor_id, actor_name, source: "slack", metadata }` on the message
+3. The `ReasonAtom` generically prefixes user messages with `[display_label]` so the LLM knows who is speaking
+
+Display name resolution uses an in-memory cache with:
+- Successful lookups cached permanently (per instance lifetime)
+- Permanent API errors (`missing_scope`, `invalid_auth`, etc.) cached as `None` to avoid repeated calls
+- Transient network errors not cached (allow retry)
+
+This is channel-agnostic — any future channel adapter (Discord, Teams) populates the same `ExternalActor` struct and gets the same LLM prefix behavior.
+
 ## Files
 
 - `crates/core/src/app.rs` - `SlackChannelConfig`, `SessionStrategy` types
-- `crates/server/src/api/slack_events.rs` - Webhook endpoint, signing verification, session routing
+- `crates/core/src/message.rs` - `ExternalActor` struct
+- `crates/server/src/api/slack_events.rs` - Webhook endpoint, signing verification, session routing, user name resolution
 - `crates/server/src/services/app.rs` - `get_by_public_id_unscoped()` method
 - `apps/ui/src/app/(main)/apps/page.tsx` - Apps UI page
 - `apps/ui/src/lib/api/apps.ts` - App API functions


### PR DESCRIPTION
## What
Add `ExternalActor` struct to `Message` for identifying users from external channels (Slack, Discord, Teams, etc.) without coupling core logic to any specific channel.

## Why
Previously, Slack user identity was handled by manually prefixing message text with `[UserName]` inside the Slack handler. This was channel-specific and not reusable. Moving to a structured `ExternalActor` makes user identity channel-agnostic so any future channel adapter gets the same behavior.

## How
- `ExternalActor` struct in `everruns_core::message` with `actor_id`, `actor_name`, `source`, and optional `metadata`
- `external_actor: Option<ExternalActor>` field on core `Message`, API `CreateMessageRequest`, and proto `Message`
- `ReasonAtom` generically prefixes user messages with `[display_label]` when `external_actor` is present
- `LlmMessage::prepend_text_prefix()` helper for text injection
- Slack handler populates `ExternalActor` instead of manual text prefixing
- Slack user display name resolution via `users.info` API with caching

## Risk
- Low
- The `ExternalActor` field is optional and defaults to `None`, so all existing codepaths are unaffected
- Message prefixing behavior is identical to before, just moved from Slack handler to ReasonAtom

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered — field is optional with serde default