### PR TITLE
feat(slack): per-app manifest generation and setup guide

### DIFF
--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -416,7 +416,6 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
               )}
             </CardContent>
           </Card>
-
         </div>
 
         {/* Sidebar */}
@@ -575,8 +574,8 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
               </button>
             </div>
             <p className="text-xs text-muted-foreground">
-              After saving, invite the bot to a channel (<code>/invite @{app?.name}</code>) and
-              send a message to test.
+              After saving, invite the bot to a channel (<code>/invite @{app?.name}</code>) and send
+              a message to test.
             </p>
           </CardContent>
         </Card>
@@ -652,7 +651,9 @@ function SetupSteps({
       <div className="flex gap-3">
         <StepIcon done={hasSlackConfig} />
         <div className="flex-1 space-y-1">
-          <p className={`text-sm font-medium ${hasSlackConfig ? "text-muted-foreground line-through" : ""}`}>
+          <p
+            className={`text-sm font-medium ${hasSlackConfig ? "text-muted-foreground line-through" : ""}`}
+          >
             1. Create a Slack App
           </p>
           {currentStep === 1 && (
@@ -662,11 +663,7 @@ function SetupSteps({
                 configured). Review and click <strong>Create</strong>, then install to your
                 workspace.
               </p>
-              <Button
-                size="sm"
-                onClick={onCreateSlackApp}
-                disabled={creatingSlackApp}
-              >
+              <Button size="sm" onClick={onCreateSlackApp} disabled={creatingSlackApp}>
                 <ExternalLink className="w-3 h-3 mr-1" />
                 {creatingSlackApp ? "Opening..." : "Create Slack App"}
               </Button>
@@ -679,7 +676,9 @@ function SetupSteps({
       <div className="flex gap-3">
         <StepIcon done={hasSlackConfig} />
         <div className="flex-1 space-y-1">
-          <p className={`text-sm font-medium ${hasSlackConfig ? "text-muted-foreground line-through" : ""}`}>
+          <p
+            className={`text-sm font-medium ${hasSlackConfig ? "text-muted-foreground line-through" : ""}`}
+          >
             2. Copy credentials back
           </p>
           {currentStep === 1 && (
@@ -689,10 +688,12 @@ function SetupSteps({
               </p>
               <ul className="text-xs text-muted-foreground list-disc pl-4 space-y-1">
                 <li>
-                  <strong>Signing Secret</strong> — Slack app &rarr; Basic Information &rarr; App Credentials
+                  <strong>Signing Secret</strong> — Slack app &rarr; Basic Information &rarr; App
+                  Credentials
                 </li>
                 <li>
-                  <strong>Bot Token</strong> (<code>xoxb-...</code>) — Slack app &rarr; OAuth &amp; Permissions
+                  <strong>Bot Token</strong> (<code>xoxb-...</code>) — Slack app &rarr; OAuth &amp;
+                  Permissions
                 </li>
               </ul>
               <Button size="sm" variant="outline" onClick={onConfigure}>
@@ -708,7 +709,9 @@ function SetupSteps({
       <div className="flex gap-3">
         <StepIcon done={isPublished} />
         <div className="flex-1 space-y-1">
-          <p className={`text-sm font-medium ${isPublished ? "text-muted-foreground line-through" : ""}`}>
+          <p
+            className={`text-sm font-medium ${isPublished ? "text-muted-foreground line-through" : ""}`}
+          >
             3. Publish the app
           </p>
           {currentStep === 3 && (
@@ -723,9 +726,7 @@ function SetupSteps({
       <div className="flex gap-3">
         <Circle className="w-5 h-5 text-muted-foreground shrink-0" />
         <div className="flex-1 space-y-1">
-          <p className="text-sm font-medium">
-            4. Configure Event Subscriptions
-          </p>
+          <p className="text-sm font-medium">4. Configure Event Subscriptions</p>
           {currentStep === 4 ? (
             <div className="space-y-2">
               <p className="text-xs text-muted-foreground">
@@ -758,9 +759,7 @@ function SetupSteps({
       <div className="flex gap-3">
         <Circle className="w-5 h-5 text-muted-foreground shrink-0" />
         <div className="flex-1 space-y-1">
-          <p className="text-sm font-medium">
-            5. Invite the bot and test
-          </p>
+          <p className="text-sm font-medium">5. Invite the bot and test</p>
           <p className="text-xs text-muted-foreground">
             In Slack, use <code>/invite @botname</code> in a channel, then send a message.
           </p>

--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useState } from "react";
+import { use, useState, useCallback } from "react";
 import {
   useApp,
   useUpdateApp,
@@ -10,6 +10,7 @@ import {
 } from "@/hooks/use-apps";
 import { useAgents } from "@/hooks";
 import { useHarnesses } from "@/hooks/use-harnesses";
+import { getSlackManifest } from "@/lib/api/apps";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
@@ -34,7 +35,20 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { ArrowLeft, Globe, GlobeLock, Copy, Trash2, Pencil, Check, X, Rocket } from "lucide-react";
+import {
+  ArrowLeft,
+  Globe,
+  GlobeLock,
+  Copy,
+  Trash2,
+  Pencil,
+  Check,
+  X,
+  Rocket,
+  ExternalLink,
+  CircleCheck,
+  Circle,
+} from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import type { SessionStrategy, SlackChannelConfig, UpdateAppRequest } from "@/lib/api/types";
 
@@ -66,6 +80,8 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
   const [editTeamId, setEditTeamId] = useState("");
   const [editSessionStrategy, setEditSessionStrategy] = useState<SessionStrategy>("per_thread");
 
+  const [creatingSlackApp, setCreatingSlackApp] = useState(false);
+
   const isPublished = app?.status === "published";
   const slackConfig = app?.channel_config as SlackChannelConfig | undefined;
   const hasSlackConfig = slackConfig?.signing_secret && slackConfig?.bot_token;
@@ -74,6 +90,18 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
     typeof window !== "undefined"
       ? `${window.location.origin}/api/v1/apps/${appId}/slack/events`
       : `/api/v1/apps/${appId}/slack/events`;
+
+  const handleCreateSlackApp = useCallback(async () => {
+    setCreatingSlackApp(true);
+    try {
+      const manifest = await getSlackManifest(appId);
+      if (manifest?.create_url) {
+        window.open(manifest.create_url, "_blank");
+      }
+    } finally {
+      setCreatingSlackApp(false);
+    }
+  }, [appId]);
 
   const startEditBasic = () => {
     if (!app) return;
@@ -321,11 +349,11 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                   <div className="grid grid-cols-2 gap-4">
                     <div>
                       <p className="text-sm font-medium">Signing Secret</p>
-                      <p className="text-sm text-muted-foreground font-mono">{"•".repeat(12)}</p>
+                      <p className="text-sm text-muted-foreground font-mono">{"*".repeat(12)}</p>
                     </div>
                     <div>
                       <p className="text-sm font-medium">Bot User OAuth Token</p>
-                      <p className="text-sm text-muted-foreground font-mono">{"•".repeat(12)}</p>
+                      <p className="text-sm text-muted-foreground font-mono">{"*".repeat(12)}</p>
                     </div>
                   </div>
 
@@ -360,42 +388,35 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                           : "Per User"}
                     </p>
                   </div>
+
+                  {/* Remaining setup steps after credentials are saved */}
+                  {!isPublished && (
+                    <>
+                      <Separator />
+                      <SetupSteps
+                        hasSlackConfig={true}
+                        isPublished={false}
+                        webhookUrl={webhookUrl}
+                        onCreateSlackApp={handleCreateSlackApp}
+                        creatingSlackApp={creatingSlackApp}
+                        onConfigure={startEditSlack}
+                      />
+                    </>
+                  )}
                 </div>
               ) : (
-                <div className="text-center py-6 text-muted-foreground">
-                  <p className="mb-2">Slack integration not configured yet.</p>
-                  <p className="text-xs">
-                    Click &quot;Configure&quot; to add your Slack app credentials.
-                  </p>
-                </div>
+                <SetupSteps
+                  hasSlackConfig={false}
+                  isPublished={isPublished}
+                  webhookUrl={webhookUrl}
+                  onCreateSlackApp={handleCreateSlackApp}
+                  creatingSlackApp={creatingSlackApp}
+                  onConfigure={startEditSlack}
+                />
               )}
             </CardContent>
           </Card>
 
-          {/* Request URL Card - shown when published */}
-          {isPublished && (
-            <Card>
-              <CardHeader>
-                <CardTitle>Request URL</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm text-muted-foreground mb-3">
-                  Use this URL in your Slack app&apos;s Event Subscriptions &rarr; Request URL
-                  field.
-                </p>
-                <div className="flex items-center gap-2 bg-muted p-3 rounded-md">
-                  <Globe className="w-4 h-4 shrink-0 text-muted-foreground" />
-                  <code className="text-sm flex-1 truncate">{webhookUrl}</code>
-                  <button
-                    className="shrink-0 hover:text-foreground text-muted-foreground"
-                    onClick={() => navigator.clipboard.writeText(webhookUrl)}
-                  >
-                    <Copy className="w-4 h-4" />
-                  </button>
-                </div>
-              </CardContent>
-            </Card>
-          )}
         </div>
 
         {/* Sidebar */}
@@ -525,6 +546,42 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
         </div>
       </div>
 
+      {/* Webhook URL Card - shown when published and configured */}
+      {isPublished && hasSlackConfig && (
+        <Card className="lg:col-span-2">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Globe className="w-5 h-5" />
+              Event Subscriptions
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <p className="text-sm text-muted-foreground">
+              Paste this URL in your Slack app &rarr; <strong>Event Subscriptions</strong> &rarr;{" "}
+              <strong>Request URL</strong>. Then subscribe to bot events:{" "}
+              <code className="text-xs">message.channels</code>,{" "}
+              <code className="text-xs">message.groups</code>,{" "}
+              <code className="text-xs">message.im</code>,{" "}
+              <code className="text-xs">app_mention</code>.
+            </p>
+            <div className="flex items-center gap-2 bg-muted p-3 rounded-md">
+              <Globe className="w-4 h-4 shrink-0 text-muted-foreground" />
+              <code className="text-sm flex-1 truncate">{webhookUrl}</code>
+              <button
+                className="shrink-0 hover:text-foreground text-muted-foreground"
+                onClick={() => navigator.clipboard.writeText(webhookUrl)}
+              >
+                <Copy className="w-4 h-4" />
+              </button>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              After saving, invite the bot to a channel (<code>/invite @{app?.name}</code>) and
+              send a message to test.
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
       {/* Delete confirmation dialog */}
       <Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
         <DialogContent>
@@ -549,6 +606,166 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
           </DialogFooter>
         </DialogContent>
       </Dialog>
+    </div>
+  );
+}
+
+// =========================================================================
+// Setup Steps — inline guide for Slack integration setup
+// =========================================================================
+
+function StepIcon({ done }: { done: boolean }) {
+  return done ? (
+    <CircleCheck className="w-5 h-5 text-green-600 shrink-0" />
+  ) : (
+    <Circle className="w-5 h-5 text-muted-foreground shrink-0" />
+  );
+}
+
+function SetupSteps({
+  hasSlackConfig,
+  isPublished,
+  webhookUrl,
+  onCreateSlackApp,
+  creatingSlackApp,
+  onConfigure,
+}: {
+  hasSlackConfig: boolean;
+  isPublished: boolean;
+  webhookUrl: string;
+  onCreateSlackApp: () => void;
+  creatingSlackApp: boolean;
+  onConfigure: () => void;
+}) {
+  // Determine the current active step
+  const currentStep = !hasSlackConfig ? 1 : !isPublished ? 3 : 4;
+
+  return (
+    <div className="space-y-4">
+      {!hasSlackConfig && (
+        <p className="text-sm text-muted-foreground">
+          Follow these steps to connect a Slack bot to this app.
+        </p>
+      )}
+
+      {/* Step 1: Create Slack App */}
+      <div className="flex gap-3">
+        <StepIcon done={hasSlackConfig} />
+        <div className="flex-1 space-y-1">
+          <p className={`text-sm font-medium ${hasSlackConfig ? "text-muted-foreground line-through" : ""}`}>
+            1. Create a Slack App
+          </p>
+          {currentStep === 1 && (
+            <div className="space-y-2">
+              <p className="text-xs text-muted-foreground">
+                Opens Slack with a pre-filled manifest (bot scopes and settings are already
+                configured). Review and click <strong>Create</strong>, then install to your
+                workspace.
+              </p>
+              <Button
+                size="sm"
+                onClick={onCreateSlackApp}
+                disabled={creatingSlackApp}
+              >
+                <ExternalLink className="w-3 h-3 mr-1" />
+                {creatingSlackApp ? "Opening..." : "Create Slack App"}
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Step 2: Copy credentials */}
+      <div className="flex gap-3">
+        <StepIcon done={hasSlackConfig} />
+        <div className="flex-1 space-y-1">
+          <p className={`text-sm font-medium ${hasSlackConfig ? "text-muted-foreground line-through" : ""}`}>
+            2. Copy credentials back
+          </p>
+          {currentStep === 1 && (
+            <div className="space-y-2">
+              <p className="text-xs text-muted-foreground">
+                After creating the Slack app, copy two values back here:
+              </p>
+              <ul className="text-xs text-muted-foreground list-disc pl-4 space-y-1">
+                <li>
+                  <strong>Signing Secret</strong> — Slack app &rarr; Basic Information &rarr; App Credentials
+                </li>
+                <li>
+                  <strong>Bot Token</strong> (<code>xoxb-...</code>) — Slack app &rarr; OAuth &amp; Permissions
+                </li>
+              </ul>
+              <Button size="sm" variant="outline" onClick={onConfigure}>
+                <Pencil className="w-3 h-3 mr-1" />
+                Configure
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Step 3: Publish */}
+      <div className="flex gap-3">
+        <StepIcon done={isPublished} />
+        <div className="flex-1 space-y-1">
+          <p className={`text-sm font-medium ${isPublished ? "text-muted-foreground line-through" : ""}`}>
+            3. Publish the app
+          </p>
+          {currentStep === 3 && (
+            <p className="text-xs text-muted-foreground">
+              Click the <strong>Publish</strong> button above to activate the webhook endpoint.
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Step 4: Event Subscriptions */}
+      <div className="flex gap-3">
+        <Circle className="w-5 h-5 text-muted-foreground shrink-0" />
+        <div className="flex-1 space-y-1">
+          <p className="text-sm font-medium">
+            4. Configure Event Subscriptions
+          </p>
+          {currentStep === 4 ? (
+            <div className="space-y-2">
+              <p className="text-xs text-muted-foreground">
+                In your Slack app settings, go to <strong>Event Subscriptions</strong>, enable
+                events, and paste this Request URL:
+              </p>
+              <div className="flex items-center gap-2 bg-muted p-2 rounded-md">
+                <code className="text-xs flex-1 truncate">{webhookUrl}</code>
+                <button
+                  className="shrink-0 hover:text-foreground text-muted-foreground"
+                  onClick={() => navigator.clipboard.writeText(webhookUrl)}
+                >
+                  <Copy className="w-3 h-3" />
+                </button>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Then subscribe to bot events: <code>message.channels</code>,{" "}
+                <code>message.groups</code>, <code>message.im</code>, <code>app_mention</code>
+              </p>
+            </div>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              Add the webhook URL to your Slack app&apos;s Event Subscriptions.
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Step 5: Invite bot */}
+      <div className="flex gap-3">
+        <Circle className="w-5 h-5 text-muted-foreground shrink-0" />
+        <div className="flex-1 space-y-1">
+          <p className="text-sm font-medium">
+            5. Invite the bot and test
+          </p>
+          <p className="text-xs text-muted-foreground">
+            In Slack, use <code>/invite @botname</code> in a channel, then send a message.
+          </p>
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/ui/src/app/(main)/apps/new/page.tsx
+++ b/apps/ui/src/app/(main)/apps/new/page.tsx
@@ -42,6 +42,7 @@ export default function NewAppPage() {
         channel_type: "slack",
       });
 
+      // Redirect to detail page where user can create the Slack app
       router.push(`/apps/${app.id}`);
     } catch (error) {
       console.error("Failed to create app:", error);
@@ -120,8 +121,8 @@ export default function NewAppPage() {
             </div>
 
             <p className="text-sm text-muted-foreground">
-              After creating the app, you can configure the Slack integration on the app detail
-              page.
+              After creating the app, you&apos;ll be able to generate a Slack App manifest
+              and create the Slack bot on the detail page.
             </p>
 
             <div className="flex gap-4">

--- a/apps/ui/src/app/(main)/apps/new/page.tsx
+++ b/apps/ui/src/app/(main)/apps/new/page.tsx
@@ -121,8 +121,8 @@ export default function NewAppPage() {
             </div>
 
             <p className="text-sm text-muted-foreground">
-              After creating the app, you&apos;ll be able to generate a Slack App manifest
-              and create the Slack bot on the detail page.
+              After creating the app, you&apos;ll be able to generate a Slack App manifest and
+              create the Slack bot on the detail page.
             </p>
 
             <div className="flex gap-4">

--- a/apps/ui/src/lib/api/apps.ts
+++ b/apps/ui/src/lib/api/apps.ts
@@ -37,3 +37,17 @@ export async function unpublishApp(appId: string): Promise<App> {
   const response = await api.post<App>(`/v1/apps/${appId}/unpublish`);
   return response.data;
 }
+
+/** Get the Slack App manifest for an app. Returns manifest YAML and create URL. */
+export async function getSlackManifest(
+  appId: string,
+): Promise<{ manifest_yaml: string; create_url: string } | null> {
+  try {
+    const response = await api.get<{ manifest_yaml: string; create_url: string }>(
+      `/v1/apps/${appId}/slack/manifest`,
+    );
+    return response.data;
+  } catch {
+    return null;
+  }
+}

--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -20,7 +20,7 @@ use axum::{
     body::Bytes,
     extract::{Path, State},
     http::{HeaderMap, StatusCode},
-    routing::post,
+    routing::{get, post},
 };
 use everruns_core::{App, AppStatus, ChannelType, SessionStrategy, SlackChannelConfig};
 use everruns_worker::AgentRunner;
@@ -131,6 +131,10 @@ impl SlackState {
 pub fn routes(state: SlackState) -> Router {
     Router::new()
         .route("/v1/apps/{app_id}/slack/events", post(handle_slack_event))
+        .route(
+            "/v1/apps/{app_id}/slack/manifest",
+            get(handle_slack_manifest),
+        )
         .with_state(state)
 }
 
@@ -787,6 +791,117 @@ fn verify_slack_signature(
     Ok(())
 }
 
+// =========================================================================
+// Slack App Manifest generation — per-app "Create in Slack" helper
+// =========================================================================
+
+/// Response for the manifest endpoint.
+#[derive(Serialize)]
+struct ManifestResponse {
+    /// YAML manifest string for creating a Slack app
+    manifest_yaml: String,
+    /// Pre-filled URL to create a Slack app from the manifest
+    create_url: String,
+}
+
+/// GET /v1/apps/{app_id}/slack/manifest — Generate a Slack App manifest.
+///
+/// Returns a pre-filled YAML manifest and a URL that opens Slack's "Create app
+/// from manifest" flow. The manifest includes the correct webhook URL and bot
+/// scopes but omits `event_subscriptions` (requires a live URL, so must be
+/// configured manually after the app is created and published).
+async fn handle_slack_manifest(
+    State(state): State<SlackState>,
+    Path(app_id): Path<String>,
+) -> Result<Json<ManifestResponse>, (StatusCode, Json<ErrorResponse>)> {
+    // Look up app (unscoped — no auth for this endpoint)
+    let app = state
+        .app_service
+        .get_by_public_id_unscoped(&app_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(app_id = %app_id, error = %e, "Failed to lookup app for manifest");
+            ErrorResponse::internal_error()
+        })?
+        .ok_or_else(|| ErrorResponse::new("App not found").into_response(StatusCode::NOT_FOUND))?;
+
+    let display_name = truncate_display_name(&app.name);
+
+    // Build the YAML manifest (no event_subscriptions — requires live URL)
+    let manifest_yaml = format!(
+        "display_information:\n\
+         \x20 name: \"{name}\"\n\
+         \x20 description: \"AI agent powered by Everruns\"\n\
+         \x20 background_color: \"#1a1a2e\"\n\
+         features:\n\
+         \x20 bot_user:\n\
+         \x20   display_name: \"{display_name}\"\n\
+         \x20   always_online: true\n\
+         oauth_config:\n\
+         \x20 scopes:\n\
+         \x20   bot:\n\
+         \x20     - chat:write\n\
+         \x20     - channels:history\n\
+         \x20     - groups:history\n\
+         \x20     - im:history\n\
+         \x20     - mpim:history\n\
+         \x20     - app_mentions:read\n\
+         settings:\n\
+         \x20 org_deploy_enabled: false\n\
+         \x20 socket_mode_enabled: false\n\
+         \x20 token_rotation_enabled: false\n",
+        name = yaml_escape(&app.name),
+        display_name = yaml_escape(&display_name),
+    );
+
+    // URL-encode the manifest for the Slack "create from manifest" URL
+    let encoded = urlencoding_encode(&manifest_yaml);
+    let create_url = format!(
+        "https://api.slack.com/apps?new_app=1&manifest_yaml={}",
+        encoded
+    );
+
+    Ok(Json(ManifestResponse {
+        manifest_yaml,
+        create_url,
+    }))
+}
+
+/// Truncate display name to 80 chars (Slack limit for bot_user display_name).
+/// Uses char boundary to avoid panicking on multi-byte UTF-8.
+fn truncate_display_name(name: &str) -> String {
+    if name.len() <= 80 {
+        return name.to_string();
+    }
+    // Find the last char boundary at or before 80 bytes
+    let mut end = 80;
+    while !name.is_char_boundary(end) {
+        end -= 1;
+    }
+    name[..end].to_string()
+}
+
+/// Simple YAML string escaping: escape backslashes and double quotes.
+fn yaml_escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+/// Percent-encode a string for URL query parameters.
+fn urlencoding_encode(s: &str) -> String {
+    let mut result = String::new();
+    for byte in s.as_bytes() {
+        match *byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                result.push(*byte as char);
+            }
+            _ => {
+                result.push_str(&format!("%{:02X}", byte));
+            }
+        }
+    }
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1351,5 +1466,73 @@ mod tests {
         };
         let session = db.create_session(row).await.unwrap();
         session.id
+    }
+
+    // ==========================================
+    // Manifest helper tests
+    // ==========================================
+
+    #[test]
+    fn test_truncate_display_name_short() {
+        assert_eq!(truncate_display_name("My Bot"), "My Bot");
+    }
+
+    #[test]
+    fn test_truncate_display_name_exact_80() {
+        let exact = "a".repeat(80);
+        assert_eq!(truncate_display_name(&exact), exact);
+    }
+
+    #[test]
+    fn test_truncate_display_name_long() {
+        let long = "a".repeat(100);
+        assert_eq!(truncate_display_name(&long).len(), 80);
+    }
+
+    #[test]
+    fn test_truncate_display_name_empty() {
+        assert_eq!(truncate_display_name(""), "");
+    }
+
+    #[test]
+    fn test_truncate_display_name_multibyte() {
+        // 27 emoji × 4 bytes = 108 bytes, should truncate to 80 bytes (20 emoji)
+        let name = "🤖".repeat(27);
+        let truncated = truncate_display_name(&name);
+        assert!(truncated.len() <= 80);
+        assert!(truncated.is_char_boundary(truncated.len()));
+    }
+
+    #[test]
+    fn test_yaml_escape() {
+        assert_eq!(yaml_escape(r#"hello "world""#), r#"hello \"world\""#);
+        assert_eq!(yaml_escape(r#"back\slash"#), r#"back\\slash"#);
+    }
+
+    #[test]
+    fn test_yaml_escape_no_special_chars() {
+        assert_eq!(yaml_escape("plain text"), "plain text");
+    }
+
+    #[test]
+    fn test_yaml_escape_empty() {
+        assert_eq!(yaml_escape(""), "");
+    }
+
+    #[test]
+    fn test_urlencoding_encode() {
+        assert_eq!(urlencoding_encode("hello world"), "hello%20world");
+        assert_eq!(urlencoding_encode("a=b&c=d"), "a%3Db%26c%3Dd");
+        assert_eq!(urlencoding_encode("safe-_.~"), "safe-_.~");
+    }
+
+    #[test]
+    fn test_urlencoding_encode_empty() {
+        assert_eq!(urlencoding_encode(""), "");
+    }
+
+    #[test]
+    fn test_urlencoding_encode_newlines() {
+        assert_eq!(urlencoding_encode("a\nb"), "a%0Ab");
     }
 }

--- a/docs/integrations/slack.md
+++ b/docs/integrations/slack.md
@@ -11,8 +11,50 @@ Everruns integrates with [Slack](https://slack.com) to deploy agents as bots tha
 - **Session routing**: Conversations are mapped to sessions by thread, channel, or user
 - **Secure webhooks**: Requests are verified using Slack's signing secret (HMAC-SHA256)
 - **Async responses**: Slack is acknowledged immediately; the agent response is posted when ready
+- **Per-app Slack bots**: Each Everruns App gets its own Slack App with its own identity, name, and avatar
 
-## Quick Start
+## Quick Start (Manifest)
+
+Everruns generates a pre-filled Slack App manifest for each app, making setup faster.
+
+### 1. Create an App in Everruns
+
+1. Go to **Apps** and click **New App**
+2. Enter a name, select a Harness and Agent
+3. Click **Create App** — you'll be redirected to the detail page
+
+### 2. Create the Slack App
+
+1. On the App detail page, click **Create Slack App**
+2. This opens Slack's "Create app from manifest" page with pre-filled scopes and bot settings
+3. Review the manifest and click **Create**
+4. Install the app to your workspace when prompted
+
+### 3. Copy Credentials Back
+
+1. In your new Slack app, go to **Basic Information** and copy the **Signing Secret**
+2. Go to **OAuth & Permissions** and copy the **Bot User OAuth Token** (`xoxb-...`)
+3. Back in Everruns, click **Configure** on the Slack Integration card
+4. Paste both values and click **Save**
+
+### 4. Configure Event Subscriptions
+
+1. **Publish** the app in Everruns first (so the webhook URL is live)
+2. Copy the **Request URL** shown on the app detail page
+3. In your Slack app settings, go to **Event Subscriptions** → Enable Events
+4. Paste the Request URL — Slack will verify it automatically
+5. Subscribe to bot events: `message.channels`, `message.groups`, `message.im`, `message.mpim`, `app_mention`
+6. Click **Save Changes**
+
+> **Note:** Event subscriptions require a live webhook URL, so the Everruns app must be published before configuring this step.
+
+### 5. Start Using
+
+Invite the bot to a channel (`/invite @botname`) and send a message. The bot will respond using the configured agent.
+
+## Quick Start (Manual)
+
+If you prefer to set up everything manually without the manifest:
 
 ### 1. Create a Slack App
 
@@ -20,6 +62,10 @@ Everruns integrates with [Slack](https://slack.com) to deploy agents as bots tha
 2. Name your app and select the workspace
 3. Navigate to **OAuth & Permissions** and add these **Bot Token Scopes**:
    - `chat:write` — Send messages
+   - `channels:history` — Read messages in public channels
+   - `groups:history` — Read messages in private channels (optional)
+   - `im:history` — Read direct messages (optional)
+   - `mpim:history` — Read group direct messages (optional)
    - `app_mentions:read` — React to @mentions (optional)
 4. Click **Install to Workspace** and authorize
 5. Copy the **Bot User OAuth Token** (`xoxb-...`) from the OAuth page
@@ -35,13 +81,14 @@ You need a Harness and Agent already configured. Then create an App via the UI o
 
 **Via UI:**
 
-1. Go to **Apps** and click **Create App**
+1. Go to **Apps** and click **New App**
 2. Enter a name (e.g., "Support Bot")
 3. Select your Harness and Agent
-4. Set channel type to **Slack**
-5. Paste the **Signing Secret** and **Bot Token**
-6. Choose a session strategy (default: `per_thread`)
-7. Click **Create**
+4. Click **Create App**
+5. On the detail page, click **Configure** under Slack Integration
+6. Paste the **Signing Secret** and **Bot Token**
+7. Choose a session strategy (default: `per_thread`)
+8. Click **Save**
 
 **Via API:**
 

--- a/specs/slack-integration.md
+++ b/specs/slack-integration.md
@@ -2,27 +2,38 @@
 
 ## Abstract
 
-Slack integration allows deploying agents as Slack bots. An App binds an agent and harness to a Slack workspace with per-app signing secret verification and configurable session strategies.
+Slack integration allows deploying agents as Slack bots. Each Everruns App gets its own Slack App (own identity, name, avatar). An App binds an agent and harness to a Slack workspace with signing secret verification and configurable session strategies. Setup is streamlined via per-app manifest generation.
 
 ## Architecture
 
 ```
-Slack Events API  -->  POST /v1/apps/{app_id}/slack/events  (unauthenticated)
-                       |
-                       +-- Verify HMAC-SHA256 signing secret
-                       +-- Find/create session (by tags, per session_strategy)
-                       +-- Create user message (triggers agent workflow)
-                       +-- Dedup: skip if slack_ts already processed (DB check)
-                       +-- Background: poll events, stream each output.message.completed
-                       +-- Post each response to Slack via chat.postMessage
-                       +-- Stop on turn.completed / turn.failed
+Per-app manifest (recommended):
+  UI "Create Slack App"  -->  GET /v1/apps/{app_id}/slack/manifest  (returns YAML + create URL)
+                              |
+  Opens Slack "Create from manifest" with pre-filled scopes + bot user
+                              |
+  User copies signing_secret + bot_token back to Everruns
+
+Slack Events API         -->  POST /v1/apps/{app_id}/slack/events   (per-app, uses per-app secret)
+                              |
+                              +-- Verify HMAC-SHA256 signing secret
+                              +-- Find/create session (by tags, per session_strategy)
+                              +-- Create user message (triggers agent workflow)
+                              +-- Dedup: skip if slack_ts already processed (DB check)
+                              +-- Background: poll events, stream each output.message.completed
+                              +-- Post each response to Slack via chat.postMessage
+                              +-- Stop on turn.completed / turn.failed
 ```
+
+The events endpoint verifies HMAC-SHA256 signing secret, finds/creates session by tags, creates user message (triggers agent workflow), polls for `output.message.completed`, and posts response to Slack via `chat.postMessage`.
 
 ## Design Decisions
 
+- **One Slack App per Everruns App**: Each app has its own identity (name, avatar, scopes). This is unlike GitHub (global app) because Slack bots are user-facing with distinct identities per use case.
+- **Per-app manifest generation**: The manifest endpoint generates a YAML with correct scopes and bot user. `event_subscriptions` is omitted (requires live webhook URL — must be configured after publishing).
 - **App-scoped endpoint**: Slack is bound to an App, so the webhook is `POST /v1/apps/{app_id}/slack/events`. The App defines the agent, harness, signing secret, and session strategy.
-- **Unauthenticated**: Webhook requests come from Slack, not our users. Security is via Slack signing secret verification (HMAC-SHA256), not API key auth.
-- **Unscoped app lookup**: `get_app_by_public_id_unscoped()` looks up apps by public_id across all orgs since there's no auth context on webhook requests.
+- **Unauthenticated**: Webhook and manifest requests come from Slack or the browser. Security is via Slack signing secret verification (HMAC-SHA256), not API key auth.
+- **Unscoped app lookup**: `get_app_by_public_id_unscoped()` looks up apps across all orgs since webhooks have no auth context.
 - **Session routing via tags**: Sessions are found/created using tags like `slack:thread:{ts}`, `slack:channel:{id}`, or `slack:user:{id}` depending on the session strategy.
 - **Streaming response delivery**: The webhook acks Slack immediately (<3s), then a background task polls for agent output events. Each `output.message.completed` with text is posted to Slack as it arrives, giving users real-time progress during multi-step turns. The poller stops on `turn.completed` or `turn.failed`. Events are filtered by `input_message_id` to avoid cross-turn interference.
 - **Slack event dedup**: Slack sends both `app_mention` and `message` events for @mentions. DB-level dedup via `has_event_with_slack_ts()` prevents duplicate processing (uses JSONB `@>` containment on input.message events).
@@ -35,7 +46,7 @@ Key fields:
 - `signing_secret`: Slack app signing secret for HMAC-SHA256 verification
 - `bot_token`: Slack Bot OAuth token (`xoxb-...`) for sending responses
 - `channel_id`: Optional channel to listen on
-- `team_id`: Optional Slack workspace ID
+- `team_id`: Slack workspace ID
 - `session_strategy`: `per_thread` (default), `per_channel`, `per_user`
 
 ## Session Strategies
@@ -50,7 +61,8 @@ Key fields:
 
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
-| POST | `/v1/apps/{app_id}/slack/events` | Slack signing secret | Slack Events API webhook |
+| POST | `/v1/apps/{app_id}/slack/events` | Slack signing secret | Per-app Slack Events API webhook |
+| GET | `/v1/apps/{app_id}/slack/manifest` | None | Returns Slack App manifest YAML + create URL |
 
 All other App CRUD endpoints remain under standard API key auth at `/v1/apps`.
 
@@ -58,9 +70,12 @@ All other App CRUD endpoints remain under standard API key auth at `/v1/apps`.
 
 Apps page at `/apps` with:
 - List of apps with status badges
-- Create/Edit dialog with Slack configuration fields
+- Create page at `/apps/new` with name, harness, agent selection
+- Detail page at `/apps/{id}` with:
+  - "Create Slack App" button (opens Slack with pre-filled manifest)
+  - Manual configuration fields (signing secret, bot token)
+  - Webhook URL display for Event Subscriptions
 - Publish/Unpublish actions
-- Webhook URL display (for copying into Slack app config)
 - Delete confirmation
 
 ## User Identity
@@ -82,8 +97,11 @@ This is channel-agnostic — any future channel adapter (Discord, Teams) populat
 
 - `crates/core/src/app.rs` - `SlackChannelConfig`, `SessionStrategy` types
 - `crates/core/src/message.rs` - `ExternalActor` struct
-- `crates/server/src/api/slack_events.rs` - Webhook endpoint, signing verification, session routing, user name resolution
+- `crates/server/src/api/slack_events.rs` - Webhook endpoint, manifest generation, signing verification, session routing, user name resolution
 - `crates/server/src/services/app.rs` - `get_by_public_id_unscoped()` method
-- `apps/ui/src/app/(main)/apps/page.tsx` - Apps UI page
-- `apps/ui/src/lib/api/apps.ts` - App API functions
+- `apps/ui/src/app/(main)/apps/page.tsx` - Apps list UI page
+- `apps/ui/src/app/(main)/apps/new/page.tsx` - App creation page
+- `apps/ui/src/app/(main)/apps/[appId]/page.tsx` - App detail page with manifest + config
+- `apps/ui/src/lib/api/apps.ts` - App API functions including `getSlackManifest()`
 - `apps/ui/src/hooks/use-apps.ts` - React Query hooks
+- `docs/integrations/slack.md` - User-facing setup guide


### PR DESCRIPTION
## What
Replace manual 5-step Slack setup with streamlined manifest-based flow:
- New `GET /v1/apps/{app_id}/slack/manifest` endpoint generates pre-filled Slack App manifest (YAML) with correct bot scopes and display name
- Step-by-step setup guide on the App detail page tracks progress through create, configure, publish, subscribe events, and test
- Updated docs and specs for the manifest-based approach

## Why
Setting up a Slack bot previously required 5 manual steps with no in-app guidance. New users had to read external docs to configure scopes, events, and tokens correctly.

## How
- Backend: New unauthenticated manifest endpoint returns YAML manifest + Slack create URL (percent-encoded). Includes helpers for UTF-8-safe display name truncation, YAML escaping, and RFC 3986 URL encoding.
- Frontend: App detail page now shows a numbered setup guide with state-based progress tracking (checkmarks for completed steps). Includes Create Slack App button that opens Slack with pre-filled manifest, credential copy instructions, publish action, event subscription config with webhook URL, and bot invite/test guidance.
- Removed all global OAuth code from prior approach (per-app manifests are architecturally correct since each Everruns App needs its own Slack identity).

## Risk
- Low
- Manifest endpoint is unauthenticated (by design, same as webhook endpoint) but only returns non-sensitive data (app name + standard scopes)

## Checklist
- [x] Tests added or updated (10 new manifest helper tests + upstream dedup/streaming tests preserved)
- [x] Backward compatibility considered (no breaking changes, existing manual setup still works)