### PR TITLE
chore: reorganize Linear tickets to OSS project

### DIFF
--- a/.claude/commands/process-issues.md
+++ b/.claude/commands/process-issues.md
@@ -1,12 +1,12 @@
 # Process Issues
 
-Process open Linear issues: pick up, fix, ship, close. One PR per issue, max 5 issues in parallel.
+Process open Linear issues in the **OSS** project: pick up, fix, ship, close. One PR per issue, max 5 issues in parallel.
 
 Full workflow design and rationale: `specs/linear-issues.md`.
 
 ## Arguments
 
-- `$ARGUMENTS` - Optional: Linear team/project filter, specific issue IDs, or priority filter
+- `$ARGUMENTS` - Optional: specific issue IDs, priority filter, or project override (defaults to OSS project)
 
 ## Instructions
 
@@ -23,7 +23,7 @@ Linear MCP server must be configured in `.mcp.json`.
 
 ### Phase 2: Query and Prioritize
 
-1. Query open issues from Linear via MCP (apply `$ARGUMENTS` filters if provided)
+1. Query open issues from the **OSS** project in Linear via MCP (apply `$ARGUMENTS` filters if provided)
 2. Read each issue's title, description, labels, priority, and linked PRs
 3. Sort by priority (Urgent > Critical > High > Medium > Low), then oldest first within same priority
 4. Select up to **5 issues** to process in parallel

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ All cloud secrets are in Doppler (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GITHUB
 
 ### Linear
 
-We use [Linear](https://linear.app) for issue tracking. MCP server configured in `.mcp.json`. Token (`LINEAR_API_KEY`) is in Doppler. Use [`/process-issues`](.claude/commands/process-issues.md) to batch-process open issues (up to 5 in parallel).
+We use [Linear](https://linear.app) for issue tracking (project: **OSS**, team: **EVE**). MCP server configured in `.mcp.json`. Token (`LINEAR_API_KEY`) is in Doppler. Use [`/process-issues`](.claude/commands/process-issues.md) to batch-process open issues (up to 5 in parallel). All issues for this repo belong to the OSS project.
 
 For GitHub CLI, map token explicitly:
 

--- a/specs/linear-issues.md
+++ b/specs/linear-issues.md
@@ -6,6 +6,14 @@ This specification defines the workflow for processing Linear issues using codin
 
 Executable workflow: `/process-issues` command (`.claude/commands/process-issues.md`).
 
+## Project Scope
+
+This repository manages issues in the **OSS** project within the Everruns Linear workspace. All new issues for this repo should be created in the OSS project. The `/process-issues` command queries the OSS project by default.
+
+- **Linear workspace:** Everruns
+- **Team:** EVE
+- **Project:** OSS
+
 ## Requirements
 
 ### Prerequisites


### PR DESCRIPTION
## Summary
- Moved all 46 root-level EVE tickets to the OSS project in Linear
- Updated `specs/linear-issues.md` with Project Scope section (OSS project, EVE team)
- Updated `.claude/commands/process-issues.md` to default queries to OSS project
- Updated `AGENTS.md` Linear section with project/team reference

SaaS tickets (EVE-45, EVE-46) left in their SaaS project unchanged.

## Test plan
- [x] Verified all 46 root tickets moved successfully via Linear API
- [x] Confirmed SaaS tickets untouched
- [x] `just pre-push` passes