### PR TITLE
feat(slack): event-driven delivery dispatcher replaces 120s polling

### DIFF
--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -597,25 +597,9 @@ async fn wait_and_post_response(
 }
 
 /// Extract text content from an output.message.completed event's data.
+/// Delegates to the shared implementation in `slack_delivery`.
 fn extract_response_text(data: &serde_json::Value) -> Option<String> {
-    // The event data contains a message with content parts
-    let message = data.get("message")?;
-    let content = message.get("content")?.as_array()?;
-
-    let mut text_parts = Vec::new();
-    for part in content {
-        if part.get("type")?.as_str()? == "text"
-            && let Some(text) = part.get("text").and_then(|t| t.as_str())
-        {
-            text_parts.push(text.to_string());
-        }
-    }
-
-    if text_parts.is_empty() {
-        None
-    } else {
-        Some(text_parts.join("\n"))
-    }
+    crate::slack_delivery::extract_response_text(data)
 }
 
 /// Resolve a Slack user ID to a display name via `users.info` API.
@@ -714,51 +698,14 @@ async fn resolve_slack_user_name(
 }
 
 /// Post a message to Slack using the Bot API.
+/// Delegates to the shared implementation in `slack_delivery`.
 async fn post_to_slack(
     bot_token: &str,
     channel: &str,
     thread_ts: &str,
     text: &str,
 ) -> anyhow::Result<()> {
-    let client = reqwest::Client::new();
-
-    let mut payload = serde_json::json!({
-        "channel": channel,
-        "text": text,
-    });
-
-    // Reply in thread if we have a thread_ts
-    if !thread_ts.is_empty() {
-        payload["thread_ts"] = serde_json::Value::String(thread_ts.to_string());
-    }
-
-    let response = client
-        .post("https://slack.com/api/chat.postMessage")
-        .header("Authorization", format!("Bearer {}", bot_token))
-        .header("Content-Type", "application/json")
-        .json(&payload)
-        .send()
-        .await?;
-
-    let status = response.status();
-    let body: serde_json::Value = response.json().await?;
-
-    if !body.get("ok").and_then(|v| v.as_bool()).unwrap_or(false) {
-        let error = body
-            .get("error")
-            .and_then(|e| e.as_str())
-            .unwrap_or("unknown");
-        tracing::error!(
-            channel = channel,
-            error = error,
-            status = %status,
-            "Failed to post message to Slack"
-        );
-        return Err(anyhow::anyhow!("Slack API error: {}", error));
-    }
-
-    tracing::info!(channel = channel, "Posted response to Slack");
-    Ok(())
+    crate::slack_delivery::post_to_slack(bot_token, channel, thread_ts, text).await
 }
 
 /// Verify Slack request signature using HMAC-SHA256.

--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -12,8 +12,10 @@
 // "slack:thread:{thread_ts}" or "slack:channel:{channel}" let us find or create
 // sessions based on the configured session strategy.
 //
-// Design Decision: Agent responses are posted back to Slack via a background task
-// that polls for output.message.completed events on the session.
+// Design Decision: Agent responses are posted back to Slack via an event-driven
+// dispatcher (SlackDeliveryDispatcher) that subscribes to EventNotificationBroadcaster.
+// No fixed deadline — handles arbitrarily long agent turns. Falls back to 120s
+// polling in DEV_MODE where EventNotificationBroadcaster is unavailable.
 
 use axum::{
     Json, Router,
@@ -34,6 +36,7 @@ use tokio::sync::RwLock;
 use crate::api::messages::{CreateMessageRequest, InputContentPart, InputMessage, MessageRole};
 use crate::api::sessions::CreateSessionRequest;
 use crate::services::{AppService, MessageService, SessionService};
+use crate::slack_delivery::SlackDeliveryDispatcher;
 use crate::storage::StorageBackend;
 
 use super::common::ErrorResponse;
@@ -113,16 +116,23 @@ pub struct SlackState {
     pub message_service: Arc<MessageService>,
     /// Cache of Slack user ID → display name. Shared across requests.
     user_name_cache: SlackUserCache,
+    /// Event-driven Slack delivery dispatcher (None in DEV_MODE without PostgreSQL).
+    pub delivery_dispatcher: Option<Arc<SlackDeliveryDispatcher>>,
 }
 
 impl SlackState {
-    pub fn new(db: Arc<StorageBackend>, runner: Arc<dyn AgentRunner>) -> Self {
+    pub fn new(
+        db: Arc<StorageBackend>,
+        runner: Arc<dyn AgentRunner>,
+        delivery_dispatcher: Option<Arc<SlackDeliveryDispatcher>>,
+    ) -> Self {
         Self {
             app_service: Arc::new(AppService::new(db.clone())),
             session_service: Arc::new(SessionService::new(db.clone())),
             message_service: Arc::new(MessageService::new(db.clone(), runner)),
             db,
             user_name_cache: Arc::new(RwLock::new(HashMap::new())),
+            delivery_dispatcher,
         }
     }
 }
@@ -419,7 +429,7 @@ async fn process_slack_message(
         "Slack message routed to session"
     );
 
-    // Wait for agent response and post back to Slack
+    // Register delivery for agent response posting
     let bot_token = slack_config.bot_token.clone();
     let channel = event.channel.clone().unwrap_or_default();
     // Reply in thread: use thread_ts if available, otherwise the message ts
@@ -430,21 +440,36 @@ async fn process_slack_message(
         .unwrap_or_default();
     let session_id = session.id.uuid();
     let message_id = message.id;
-    let db = state.db.clone();
 
-    tokio::spawn(async move {
-        if let Err(e) = wait_and_post_response(
-            &db, session_id, message_id, &bot_token, &channel, &thread_ts,
-        )
-        .await
-        {
-            tracing::error!(
-                session_id = %session_id,
-                error = %e,
-                "Failed to post Slack response"
-            );
-        }
-    });
+    if let Some(ref dispatcher) = state.delivery_dispatcher {
+        // Event-driven delivery: no deadline, handles arbitrarily long turns
+        dispatcher
+            .register(
+                session_id,
+                message_id.to_string(),
+                bot_token,
+                channel,
+                thread_ts,
+            )
+            .await;
+    } else {
+        // Fallback for DEV_MODE without EventNotificationBroadcaster:
+        // use the legacy polling approach
+        let db = state.db.clone();
+        tokio::spawn(async move {
+            if let Err(e) = wait_and_post_response(
+                &db, session_id, message_id, &bot_token, &channel, &thread_ts,
+            )
+            .await
+            {
+                tracing::error!(
+                    session_id = %session_id,
+                    error = %e,
+                    "Failed to post Slack response"
+                );
+            }
+        });
+    }
 
     Ok(())
 }

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -377,6 +377,20 @@ impl ServerAppBuilder {
             api::messages::AppState::new(db.clone(), runner.clone(), auth_state.clone());
         let tool_results_state =
             api::tool_results::AppState::new(db.clone(), runner.clone(), auth_state.clone());
+        // Slack delivery dispatcher: event-driven message posting (replaces 120s polling).
+        // Must be created before events_state takes ownership of event_broadcaster.
+        let slack_dispatcher = if let Some(ref broadcaster) = event_broadcaster {
+            let rx = broadcaster.subscribe();
+            let dispatcher = crate::slack_delivery::SlackDeliveryDispatcher::start(db.clone(), rx);
+            tracing::info!("Slack delivery dispatcher started (event-driven)");
+            Some(dispatcher)
+        } else {
+            tracing::info!(
+                "Slack delivery dispatcher not available (DEV_MODE), using polling fallback"
+            );
+            None
+        };
+
         let events_state = api::events::AppState {
             session_service: Arc::new(services::SessionService::new(db.clone())),
             event_service: event_service.clone(),
@@ -410,7 +424,11 @@ impl ServerAppBuilder {
         let agents_state =
             api::agents::AppState::new(db.clone(), capability_service, auth_state.clone());
         let apps_state = api::apps::AppState::new(db.clone(), auth_state.clone());
-        let slack_state = api::slack_events::SlackState::new(db.clone(), runner.clone());
+        let slack_state = api::slack_events::SlackState::new(
+            db.clone(),
+            runner.clone(),
+            slack_dispatcher.clone(),
+        );
         let session_files_state = api::session_files::AppState::new(db.clone(), auth_state.clone());
         let session_storage_state =
             api::session_storage::AppState::new(db.clone(), auth_state.clone());
@@ -851,6 +869,16 @@ impl ServerAppBuilder {
             } else {
                 tracing::info!("DEV MODE: gRPC server disabled, no task worker available");
             }
+        }
+
+        // -- Slack delivery recovery (re-register active Slack sessions after restart) --
+        if let Some(ref dispatcher) = slack_dispatcher {
+            let dispatcher = dispatcher.clone();
+            let recovery_db = db.clone();
+            tokio::spawn(async move {
+                let app_service = crate::services::AppService::new(recovery_db);
+                dispatcher.recover(&app_service).await;
+            });
         }
 
         // -- Durable task scheduler (both prod and dev) --

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -59,6 +59,9 @@ pub use server::ServerConfig;
 // Valkey (Redis-compatible) client for distributed rate limiting
 pub mod valkey;
 
+// Slack delivery dispatcher for event-driven message posting
+pub mod slack_delivery;
+
 // App builder for composable server configurations
 pub mod app_builder;
 pub use app_builder::{ServerAppBuilder, ServerContext};

--- a/crates/server/src/slack_delivery.rs
+++ b/crates/server/src/slack_delivery.rs
@@ -448,7 +448,7 @@ impl SlackDeliveryDispatcher {
 }
 
 /// Extract text content from an output.message.completed event's data.
-fn extract_response_text(data: &serde_json::Value) -> Option<String> {
+pub(crate) fn extract_response_text(data: &serde_json::Value) -> Option<String> {
     let message = data.get("message")?;
     let content = message.get("content")?.as_array()?;
 
@@ -518,7 +518,7 @@ async fn post_to_slack_with_retry(
 }
 
 /// Post a message to Slack using the Bot API.
-async fn post_to_slack(
+pub(crate) async fn post_to_slack(
     bot_token: &str,
     channel: &str,
     thread_ts: &str,
@@ -592,6 +592,21 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_response_text_single_part() {
+        let data = serde_json::json!({
+            "message": {
+                "content": [
+                    {"type": "text", "text": "Only one part."}
+                ]
+            }
+        });
+        assert_eq!(
+            extract_response_text(&data),
+            Some("Only one part.".to_string())
+        );
+    }
+
+    #[test]
     fn test_extract_response_text_no_text() {
         let data = serde_json::json!({
             "message": {
@@ -604,9 +619,49 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_response_text_empty_content() {
+        let data = serde_json::json!({
+            "message": {
+                "content": []
+            }
+        });
+        assert_eq!(extract_response_text(&data), None);
+    }
+
+    #[test]
     fn test_extract_response_text_missing_message() {
         let data = serde_json::json!({});
         assert_eq!(extract_response_text(&data), None);
+    }
+
+    #[test]
+    fn test_extract_response_text_missing_content() {
+        let data = serde_json::json!({
+            "message": {}
+        });
+        assert_eq!(extract_response_text(&data), None);
+    }
+
+    #[test]
+    fn test_extract_response_text_mixed_content() {
+        let data = serde_json::json!({
+            "message": {
+                "content": [
+                    {"type": "text", "text": "Part 1"},
+                    {"type": "tool_use", "name": "search"},
+                    {"type": "text", "text": "Part 2"}
+                ]
+            }
+        });
+        // tool_use part causes early return via `?` operator on type check
+        // Only "Part 1" is extracted before the tool_use part returns None from the iterator
+        let result = extract_response_text(&data);
+        // The `?` in part.get("type")?.as_str()? causes the for loop to
+        // short-circuit the entire function when a non-text part doesn't have
+        // the expected structure. But tool_use does have "type", so it just
+        // doesn't match "text" and the `&&` short-circuits. Both text parts
+        // should be captured.
+        assert_eq!(result, Some("Part 1\nPart 2".to_string()));
     }
 
     #[test]
@@ -620,5 +675,43 @@ mod tests {
             input_message_id: "msg_123".to_string(),
         };
         assert_eq!(k1, k2);
+    }
+
+    #[test]
+    fn test_delivery_key_different_session() {
+        let k1 = DeliveryKey {
+            session_id: Uuid::nil(),
+            input_message_id: "msg_123".to_string(),
+        };
+        let k2 = DeliveryKey {
+            session_id: Uuid::from_u128(1),
+            input_message_id: "msg_123".to_string(),
+        };
+        assert_ne!(k1, k2);
+    }
+
+    #[test]
+    fn test_delivery_key_different_message() {
+        let k1 = DeliveryKey {
+            session_id: Uuid::nil(),
+            input_message_id: "msg_123".to_string(),
+        };
+        let k2 = DeliveryKey {
+            session_id: Uuid::nil(),
+            input_message_id: "msg_456".to_string(),
+        };
+        assert_ne!(k1, k2);
+    }
+
+    #[test]
+    fn test_delivery_key_hash_consistency() {
+        use std::collections::HashMap;
+        let key = DeliveryKey {
+            session_id: Uuid::nil(),
+            input_message_id: "msg_123".to_string(),
+        };
+        let mut map = HashMap::new();
+        map.insert(key.clone(), "value");
+        assert_eq!(map.get(&key), Some(&"value"));
     }
 }

--- a/crates/server/src/slack_delivery.rs
+++ b/crates/server/src/slack_delivery.rs
@@ -1,0 +1,624 @@
+// Slack delivery dispatcher — event-driven Slack message posting
+//
+// Design Decision: Replaces the 120s polling deadline in wait_and_post_response()
+// with an event-driven approach. Subscribes to EventNotificationBroadcaster and
+// dispatches Slack messages as output.message.completed events arrive.
+//
+// Design Decision: No durable queue for the Slack HTTP call. Events are already
+// durably stored — if the server restarts, startup recovery re-registers active
+// Slack sessions and replays from the last known event. Retry on transient Slack
+// API failures uses simple exponential backoff in-process.
+//
+// Design Decision: Delivery context is keyed by (session_id, input_message_id)
+// to support concurrent turns in the same session.
+
+use everruns_core::typed_id::{EventId, SessionId};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::{RwLock, broadcast};
+use tracing::{debug, error, info, warn};
+use uuid::Uuid;
+
+use crate::event_notifications::EventNotificationPayload;
+use crate::storage::StorageBackend;
+
+/// Context needed to deliver Slack messages for a turn.
+#[derive(Debug, Clone)]
+struct DeliveryContext {
+    bot_token: String,
+    channel: String,
+    thread_ts: String,
+    input_message_id: String,
+    /// Last event ID we've processed (for cursor-based pagination).
+    since_event_id: Option<EventId>,
+}
+
+/// Key for delivery context — a turn within a session.
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+struct DeliveryKey {
+    session_id: Uuid,
+    input_message_id: String,
+}
+
+/// Event-driven Slack delivery dispatcher.
+///
+/// Subscribes to the event notification broadcaster and delivers agent output
+/// messages to Slack as they arrive, with no fixed deadline.
+pub struct SlackDeliveryDispatcher {
+    /// Active deliveries: (session_id, input_message_id) → context
+    deliveries: Arc<RwLock<HashMap<DeliveryKey, DeliveryContext>>>,
+    /// Set of session_ids that have at least one active delivery (for fast filtering)
+    active_sessions: Arc<RwLock<std::collections::HashSet<Uuid>>>,
+    db: Arc<StorageBackend>,
+    shutdown_tx: tokio::sync::watch::Sender<bool>,
+}
+
+impl SlackDeliveryDispatcher {
+    /// Create and start the dispatcher.
+    ///
+    /// `event_rx` is a broadcast receiver from EventNotificationBroadcaster.
+    /// The dispatcher runs a background task that listens for event notifications.
+    pub fn start(
+        db: Arc<StorageBackend>,
+        event_rx: broadcast::Receiver<EventNotificationPayload>,
+    ) -> Arc<Self> {
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
+        let dispatcher = Arc::new(Self {
+            deliveries: Arc::new(RwLock::new(HashMap::new())),
+            active_sessions: Arc::new(RwLock::new(std::collections::HashSet::new())),
+            db,
+            shutdown_tx,
+        });
+
+        // Spawn the event processing loop
+        let dispatcher_clone = dispatcher.clone();
+        tokio::spawn(async move {
+            dispatcher_clone.event_loop(event_rx, shutdown_rx).await;
+        });
+
+        dispatcher
+    }
+
+    /// Register a new delivery for a session turn.
+    ///
+    /// Called when a Slack message creates a new agent turn. The dispatcher will
+    /// watch for output events and post them to Slack.
+    pub async fn register(
+        &self,
+        session_id: Uuid,
+        input_message_id: String,
+        bot_token: String,
+        channel: String,
+        thread_ts: String,
+    ) {
+        let key = DeliveryKey {
+            session_id,
+            input_message_id: input_message_id.clone(),
+        };
+
+        let ctx = DeliveryContext {
+            bot_token,
+            channel,
+            thread_ts,
+            input_message_id,
+            since_event_id: None,
+        };
+
+        info!(
+            %session_id,
+            input_message_id = %ctx.input_message_id,
+            "Registered Slack delivery"
+        );
+
+        self.active_sessions.write().await.insert(session_id);
+        self.deliveries.write().await.insert(key, ctx);
+    }
+
+    /// Shutdown the dispatcher.
+    pub fn shutdown(&self) {
+        let _ = self.shutdown_tx.send(true);
+    }
+
+    /// Main event loop: listens for event notifications and processes them.
+    async fn event_loop(
+        &self,
+        mut event_rx: broadcast::Receiver<EventNotificationPayload>,
+        mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
+    ) {
+        info!("Slack delivery dispatcher started");
+
+        loop {
+            tokio::select! {
+                result = event_rx.recv() => {
+                    match result {
+                        Ok(payload) => {
+                            // Fast path: skip if no deliveries for this session
+                            if !self.active_sessions.read().await.contains(&payload.session_id) {
+                                continue;
+                            }
+                            self.process_session_events(payload.session_id).await;
+                        }
+                        Err(broadcast::error::RecvError::Lagged(n)) => {
+                            warn!(
+                                skipped = n,
+                                "Slack delivery dispatcher lagged, processing all active sessions"
+                            );
+                            // On lag, process all active sessions to catch up
+                            let sessions: Vec<Uuid> =
+                                self.active_sessions.read().await.iter().copied().collect();
+                            for session_id in sessions {
+                                self.process_session_events(session_id).await;
+                            }
+                        }
+                        Err(broadcast::error::RecvError::Closed) => {
+                            info!("Event broadcaster closed, stopping Slack delivery dispatcher");
+                            break;
+                        }
+                    }
+                }
+                _ = shutdown_rx.changed() => {
+                    info!("Slack delivery dispatcher shutting down");
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Process new events for a session, delivering messages to Slack.
+    async fn process_session_events(&self, session_id: Uuid) {
+        let session_id_typed = SessionId::from_uuid(session_id);
+        let empty: Vec<String> = vec![];
+
+        // Collect keys for this session
+        let keys: Vec<DeliveryKey> = {
+            let deliveries = self.deliveries.read().await;
+            deliveries
+                .keys()
+                .filter(|k| k.session_id == session_id)
+                .cloned()
+                .collect()
+        };
+
+        for key in keys {
+            // Get current context (clone to release lock)
+            let ctx = {
+                let deliveries = self.deliveries.read().await;
+                match deliveries.get(&key) {
+                    Some(ctx) => ctx.clone(),
+                    None => continue,
+                }
+            };
+
+            // Fetch events since last processed
+            let events = match self
+                .db
+                .list_events(session_id_typed, None, ctx.since_event_id, &empty, &empty)
+                .await
+            {
+                Ok(events) => events,
+                Err(e) => {
+                    error!(%session_id, error = %e, "Failed to list events for Slack delivery");
+                    continue;
+                }
+            };
+
+            let mut new_since_id = ctx.since_event_id;
+            let mut should_unregister = false;
+
+            for event in &events {
+                new_since_id = Some(event.id);
+
+                // Only consider events for our turn
+                let event_input_msg = event
+                    .context
+                    .get("input_message_id")
+                    .and_then(|v| v.as_str());
+                let is_our_turn = event_input_msg == Some(&ctx.input_message_id);
+
+                if !is_our_turn {
+                    continue;
+                }
+
+                // Post output messages to Slack
+                if event.event_type == "output.message.completed"
+                    && let Some(text) = extract_response_text(&event.data)
+                    && let Err(e) = post_to_slack_with_retry(
+                        &ctx.bot_token,
+                        &ctx.channel,
+                        &ctx.thread_ts,
+                        &text,
+                    )
+                    .await
+                {
+                    error!(
+                        %session_id,
+                        error = %e,
+                        "Failed to post message to Slack after retries"
+                    );
+                }
+
+                // Stop watching when turn ends
+                if event.event_type == "turn.completed" || event.event_type == "turn.failed" {
+                    debug!(
+                        %session_id,
+                        event_type = %event.event_type,
+                        "Turn ended, unregistering Slack delivery"
+                    );
+                    should_unregister = true;
+                    break;
+                }
+            }
+
+            // Update cursor or unregister
+            if should_unregister {
+                self.unregister(&key).await;
+            } else if new_since_id != ctx.since_event_id {
+                // Update the cursor
+                let mut deliveries = self.deliveries.write().await;
+                if let Some(ctx) = deliveries.get_mut(&key) {
+                    ctx.since_event_id = new_since_id;
+                }
+            }
+        }
+    }
+
+    /// Remove a delivery registration.
+    async fn unregister(&self, key: &DeliveryKey) {
+        let session_id = key.session_id;
+        self.deliveries.write().await.remove(key);
+
+        // Check if any other deliveries exist for this session
+        let has_others = self
+            .deliveries
+            .read()
+            .await
+            .keys()
+            .any(|k| k.session_id == session_id);
+
+        if !has_others {
+            self.active_sessions.write().await.remove(&session_id);
+        }
+
+        info!(
+            %session_id,
+            input_message_id = %key.input_message_id,
+            "Unregistered Slack delivery"
+        );
+    }
+
+    /// Get the number of active deliveries (for monitoring).
+    pub async fn active_delivery_count(&self) -> usize {
+        self.deliveries.read().await.len()
+    }
+
+    /// Recover active Slack deliveries after server restart.
+    ///
+    /// Finds sessions in 'active' status with slack:* tags, looks up the
+    /// corresponding app for bot_token, and re-registers deliveries for
+    /// any turns that haven't completed yet.
+    pub async fn recover(&self, app_service: &crate::services::AppService) {
+        let sessions = match self.db.find_active_slack_sessions().await {
+            Ok(sessions) => sessions,
+            Err(e) => {
+                error!(error = %e, "Failed to query active Slack sessions for recovery");
+                return;
+            }
+        };
+
+        if sessions.is_empty() {
+            debug!("No active Slack sessions to recover");
+            return;
+        }
+
+        info!(count = sessions.len(), "Recovering active Slack sessions");
+
+        for session in &sessions {
+            // Extract app_id from tags (slack:app:{app_id})
+            let app_id = match session
+                .tags
+                .iter()
+                .find_map(|t| t.strip_prefix("slack:app:"))
+            {
+                Some(id) => id.to_string(),
+                None => continue,
+            };
+
+            // Look up the app to get bot_token
+            let app = match app_service.get_by_public_id_unscoped(&app_id).await {
+                Ok(Some(app)) => app,
+                Ok(None) => {
+                    warn!(app_id = %app_id, "App not found during Slack recovery");
+                    continue;
+                }
+                Err(e) => {
+                    warn!(app_id = %app_id, error = %e, "Failed to load app for Slack recovery");
+                    continue;
+                }
+            };
+
+            let slack_config = match app.slack_config() {
+                Some(cfg) => cfg,
+                None => continue,
+            };
+
+            // Find the last input.message event to determine delivery context
+            let empty: Vec<String> = vec![];
+            let filter_types = vec!["input.message".to_string()];
+            let events = match self
+                .db
+                .list_events(session.id, None, None, &filter_types, &empty)
+                .await
+            {
+                Ok(events) => events,
+                Err(e) => {
+                    warn!(
+                        session_id = %session.id,
+                        error = %e,
+                        "Failed to list events for Slack recovery"
+                    );
+                    continue;
+                }
+            };
+
+            // Get the last input message
+            let last_input = match events.last() {
+                Some(e) => e,
+                None => continue,
+            };
+
+            let input_message_id = last_input
+                .data
+                .get("message")
+                .and_then(|m| m.get("id"))
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+
+            if input_message_id.is_empty() {
+                continue;
+            }
+
+            // Extract channel and thread_ts from message metadata
+            let metadata = last_input
+                .data
+                .get("message")
+                .and_then(|m| m.get("metadata"));
+
+            let channel = metadata
+                .and_then(|m| m.get("slack_channel"))
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+
+            let thread_ts = metadata
+                .and_then(|m| m.get("slack_ts"))
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+
+            // Check if this turn already completed
+            let turn_events = vec!["turn.completed".to_string(), "turn.failed".to_string()];
+            let completion_events = self
+                .db
+                .list_events(session.id, None, Some(last_input.id), &turn_events, &empty)
+                .await
+                .unwrap_or_default();
+
+            let turn_done = completion_events.iter().any(|e| {
+                e.context.get("input_message_id").and_then(|v| v.as_str())
+                    == Some(&input_message_id)
+            });
+
+            if turn_done {
+                debug!(
+                    session_id = %session.id,
+                    "Slack session turn already completed, skipping recovery"
+                );
+                continue;
+            }
+
+            if channel.is_empty() {
+                warn!(
+                    session_id = %session.id,
+                    "Missing channel in Slack session recovery metadata"
+                );
+                continue;
+            }
+
+            info!(
+                session_id = %session.id,
+                input_message_id = %input_message_id,
+                "Recovering Slack delivery"
+            );
+
+            self.register(
+                session.id.uuid(),
+                input_message_id,
+                slack_config.bot_token.clone(),
+                channel,
+                thread_ts,
+            )
+            .await;
+        }
+
+        let count = self.deliveries.read().await.len();
+        info!(recovered = count, "Slack delivery recovery complete");
+    }
+}
+
+/// Extract text content from an output.message.completed event's data.
+fn extract_response_text(data: &serde_json::Value) -> Option<String> {
+    let message = data.get("message")?;
+    let content = message.get("content")?.as_array()?;
+
+    let mut text_parts = Vec::new();
+    for part in content {
+        if part.get("type")?.as_str()? == "text"
+            && let Some(text) = part.get("text").and_then(|t| t.as_str())
+        {
+            text_parts.push(text.to_string());
+        }
+    }
+
+    if text_parts.is_empty() {
+        None
+    } else {
+        Some(text_parts.join("\n"))
+    }
+}
+
+/// Post a message to Slack with exponential backoff retry.
+///
+/// Retries up to 3 times on transient failures (network errors, rate limits).
+/// Non-retryable errors (invalid token, channel not found) fail immediately.
+async fn post_to_slack_with_retry(
+    bot_token: &str,
+    channel: &str,
+    thread_ts: &str,
+    text: &str,
+) -> anyhow::Result<()> {
+    let max_attempts = 3;
+    let mut delay = std::time::Duration::from_secs(1);
+
+    for attempt in 1..=max_attempts {
+        match post_to_slack(bot_token, channel, thread_ts, text).await {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                let error_str = e.to_string();
+
+                // Non-retryable Slack API errors
+                if error_str.contains("channel_not_found")
+                    || error_str.contains("not_authed")
+                    || error_str.contains("invalid_auth")
+                    || error_str.contains("token_revoked")
+                    || error_str.contains("account_inactive")
+                    || error_str.contains("no_text")
+                {
+                    return Err(e);
+                }
+
+                if attempt == max_attempts {
+                    return Err(e);
+                }
+
+                warn!(
+                    attempt,
+                    max_attempts,
+                    error = %e,
+                    "Slack post failed, retrying"
+                );
+                tokio::time::sleep(delay).await;
+                delay *= 2;
+            }
+        }
+    }
+
+    unreachable!()
+}
+
+/// Post a message to Slack using the Bot API.
+async fn post_to_slack(
+    bot_token: &str,
+    channel: &str,
+    thread_ts: &str,
+    text: &str,
+) -> anyhow::Result<()> {
+    let client = reqwest::Client::new();
+
+    let mut payload = serde_json::json!({
+        "channel": channel,
+        "text": text,
+    });
+
+    if !thread_ts.is_empty() {
+        payload["thread_ts"] = serde_json::Value::String(thread_ts.to_string());
+    }
+
+    let response = client
+        .post("https://slack.com/api/chat.postMessage")
+        .header("Authorization", format!("Bearer {}", bot_token))
+        .header("Content-Type", "application/json")
+        .json(&payload)
+        .send()
+        .await?;
+
+    let status = response.status();
+    let body: serde_json::Value = response.json().await?;
+
+    if !body.get("ok").and_then(|v| v.as_bool()).unwrap_or(false) {
+        let error = body
+            .get("error")
+            .and_then(|e| e.as_str())
+            .unwrap_or("unknown");
+
+        // Rate limited — treat as retryable
+        if error == "ratelimited" {
+            return Err(anyhow::anyhow!("Slack API rate limited"));
+        }
+
+        error!(
+            channel = channel,
+            error = error,
+            status = %status,
+            "Failed to post message to Slack"
+        );
+        return Err(anyhow::anyhow!("Slack API error: {}", error));
+    }
+
+    info!(channel = channel, "Posted response to Slack");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_response_text_valid() {
+        let data = serde_json::json!({
+            "message": {
+                "content": [
+                    {"type": "text", "text": "Hello from the agent!"},
+                    {"type": "text", "text": "Second part."}
+                ]
+            }
+        });
+        let result = extract_response_text(&data);
+        assert_eq!(
+            result,
+            Some("Hello from the agent!\nSecond part.".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_response_text_no_text() {
+        let data = serde_json::json!({
+            "message": {
+                "content": [
+                    {"type": "tool_use", "name": "search"}
+                ]
+            }
+        });
+        assert_eq!(extract_response_text(&data), None);
+    }
+
+    #[test]
+    fn test_extract_response_text_missing_message() {
+        let data = serde_json::json!({});
+        assert_eq!(extract_response_text(&data), None);
+    }
+
+    #[test]
+    fn test_delivery_key_eq() {
+        let k1 = DeliveryKey {
+            session_id: Uuid::nil(),
+            input_message_id: "msg_123".to_string(),
+        };
+        let k2 = DeliveryKey {
+            session_id: Uuid::nil(),
+            input_message_id: "msg_123".to_string(),
+        };
+        assert_eq!(k1, k2);
+    }
+}

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -303,6 +303,11 @@ impl StorageBackend {
         dispatch!(self, count_sessions_by_status, org_id)
     }
 
+    /// Find active sessions with Slack tags (for startup recovery).
+    pub async fn find_active_slack_sessions(&self) -> Result<Vec<SessionRow>> {
+        dispatch!(self, find_active_slack_sessions)
+    }
+
     /// Find a single session matching ALL given tags within an org.
     pub async fn find_session_by_tags(
         &self,

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -884,6 +884,17 @@ impl InMemoryDatabase {
         Ok(counts.into_iter().collect())
     }
 
+    /// Find active sessions with Slack tags (for startup recovery).
+    pub async fn find_active_slack_sessions(&self) -> Result<Vec<SessionRow>> {
+        let sessions = self.sessions.read();
+        let result: Vec<_> = sessions
+            .values()
+            .filter(|s| s.status == "active" && s.tags.iter().any(|t| t.starts_with("slack:app:")))
+            .cloned()
+            .collect();
+        Ok(result)
+    }
+
     /// Find a single session matching ALL given tags within an org.
     pub async fn find_session_by_tags(
         &self,

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -1056,6 +1056,27 @@ impl Database {
         Ok(row)
     }
 
+    /// Find all active sessions with Slack tags (for startup recovery).
+    /// Returns sessions where status = 'active' and any tag starts with 'slack:app:'.
+    pub async fn find_active_slack_sessions(&self) -> Result<Vec<SessionRow>> {
+        let rows = sqlx::query_as::<_, SessionRow>(
+            r#"
+            SELECT id, org_id, harness_id, agent_id, title, tags, model_id, capabilities, tools, status, created_at, updated_at, started_at, finished_at,
+                   total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens
+            FROM sessions
+            WHERE status = 'active'
+              AND EXISTS (
+                  SELECT 1 FROM unnest(tags) AS t
+                  WHERE t LIKE 'slack:app:%'
+              )
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+
     /// Update session by org and session id
     pub async fn update_session(
         &self,

--- a/specs/slack-integration.md
+++ b/specs/slack-integration.md
@@ -20,12 +20,13 @@ Slack Events API         -->  POST /v1/apps/{app_id}/slack/events   (per-app, us
                               +-- Find/create session (by tags, per session_strategy)
                               +-- Create user message (triggers agent workflow)
                               +-- Dedup: skip if slack_ts already processed (DB check)
-                              +-- Background: poll events, stream each output.message.completed
-                              +-- Post each response to Slack via chat.postMessage
-                              +-- Stop on turn.completed / turn.failed
+                              +-- Register with SlackDeliveryDispatcher (event-driven)
+                              +-- Dispatcher: subscribe to EventNotificationBroadcaster
+                              +-- On output.message.completed → post to Slack (with retry)
+                              +-- On turn.completed / turn.failed → unregister
 ```
 
-The events endpoint verifies HMAC-SHA256 signing secret, finds/creates session by tags, creates user message (triggers agent workflow), polls for `output.message.completed`, and posts response to Slack via `chat.postMessage`.
+The events endpoint verifies HMAC-SHA256 signing secret, finds/creates session by tags, creates user message (triggers agent workflow), and registers with the `SlackDeliveryDispatcher` for event-driven response delivery.
 
 ## Design Decisions
 
@@ -35,7 +36,8 @@ The events endpoint verifies HMAC-SHA256 signing secret, finds/creates session b
 - **Unauthenticated**: Webhook and manifest requests come from Slack or the browser. Security is via Slack signing secret verification (HMAC-SHA256), not API key auth.
 - **Unscoped app lookup**: `get_app_by_public_id_unscoped()` looks up apps across all orgs since webhooks have no auth context.
 - **Session routing via tags**: Sessions are found/created using tags like `slack:thread:{ts}`, `slack:channel:{id}`, or `slack:user:{id}` depending on the session strategy.
-- **Streaming response delivery**: The webhook acks Slack immediately (<3s), then a background task polls for agent output events. Each `output.message.completed` with text is posted to Slack as it arrives, giving users real-time progress during multi-step turns. The poller stops on `turn.completed` or `turn.failed`. Events are filtered by `input_message_id` to avoid cross-turn interference.
+- **Event-driven response delivery**: The webhook acks Slack immediately (<3s), then registers with `SlackDeliveryDispatcher`. The dispatcher subscribes to `EventNotificationBroadcaster` (PostgreSQL NOTIFY) and delivers `output.message.completed` text to Slack as events arrive, with no fixed deadline. Handles arbitrarily long agent turns. Posts are retried with exponential backoff (3 attempts) on transient failures. Non-retryable errors (invalid token, channel not found) fail immediately. The dispatcher unregisters on `turn.completed` or `turn.failed`. Events are filtered by `input_message_id` to avoid cross-turn interference. Falls back to legacy 120s polling in DEV_MODE (no PostgreSQL).
+- **Startup recovery**: On server restart, `SlackDeliveryDispatcher::recover()` queries sessions with `status = 'active'` and `slack:*` tags, looks up the corresponding app for the bot_token, finds the last unfinished turn, and re-registers deliveries.
 - **Slack event dedup**: Slack sends both `app_mention` and `message` events for @mentions. DB-level dedup via `has_event_with_slack_ts()` prevents duplicate processing (uses JSONB `@>` containment on input.message events).
 
 ## Channel Config
@@ -98,6 +100,7 @@ This is channel-agnostic — any future channel adapter (Discord, Teams) populat
 - `crates/core/src/app.rs` - `SlackChannelConfig`, `SessionStrategy` types
 - `crates/core/src/message.rs` - `ExternalActor` struct
 - `crates/server/src/api/slack_events.rs` - Webhook endpoint, manifest generation, signing verification, session routing, user name resolution
+- `crates/server/src/slack_delivery.rs` - Event-driven Slack delivery dispatcher with retry and startup recovery
 - `crates/server/src/services/app.rs` - `get_by_public_id_unscoped()` method
 - `apps/ui/src/app/(main)/apps/page.tsx` - Apps list UI page
 - `apps/ui/src/app/(main)/apps/new/page.tsx` - App creation page


### PR DESCRIPTION
## What
Replace the 120s polling deadline in `wait_and_post_response()` with an event-driven `SlackDeliveryDispatcher` that delivers agent output messages to Slack as they arrive, with no fixed deadline.

## Why
Agent turns longer than 120 seconds had their Slack responses silently lost. Users only saw the first ~2 minutes of output.

## How
- **SlackDeliveryDispatcher** (`slack_delivery.rs`) subscribes to `EventNotificationBroadcaster` (PostgreSQL NOTIFY)
- Maintains a map of `(session_id, input_message_id)` → delivery context (bot_token, channel, thread_ts)
- On `output.message.completed` → posts to Slack with exponential backoff retry (3 attempts)
- On `turn.completed`/`turn.failed` → unregisters the delivery
- **Startup recovery**: queries active sessions with `slack:*` tags, re-registers deliveries for incomplete turns
- **DEV_MODE fallback**: falls back to legacy 120s polling when `EventNotificationBroadcaster` is unavailable
- **Code dedup**: `extract_response_text` and `post_to_slack` consolidated into `slack_delivery.rs` (pub(crate)), delegated from `slack_events.rs`

## Risk
- Low
- Slack delivery behavior changes from polling to event-driven. Legacy fallback preserved in DEV_MODE.

## Checklist
- [x] Tests added or updated (11 unit tests for text extraction, delivery key handling)
- [x] Backward compatibility considered (DEV_MODE fallback preserved)
- [x] Spec updated (specs/slack-integration.md)
- [x] Security reviewed (no new attack surfaces, same auth/data flow)