### PR TITLE
fix(ui): stop experimental badge overlapping chat content

### DIFF
--- a/apps/ui/src/app/(main)/chat/page.tsx
+++ b/apps/ui/src/app/(main)/chat/page.tsx
@@ -42,8 +42,8 @@ export default function GlobalChatPage() {
   }
 
   return (
-    <div className="flex flex-col h-full relative">
-      <div className="absolute top-3 right-4 z-10">
+    <div className="flex flex-col h-full">
+      <div className="flex justify-end px-4 pt-2 pb-0">
         <ExperimentalPageBadge />
       </div>
       <SessionProvider sessionId={sessionId}>


### PR DESCRIPTION
## What
Fix the experimental badge on the Chat page from overlapping chat content by switching from absolute positioning to flex layout.

## Why
The `absolute top-3 right-4 z-10` positioning caused the badge to float over the chat panel, obscuring content underneath.

## How
Replace `relative` + `absolute` positioning with a simple flex container (`flex justify-end`) so the badge takes up normal document flow space above the chat panel.

## Risk
- Low
- Only affects the Chat page layout; badge now sits in flow instead of overlapping

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered