### PR TITLE
perf(auth): cache API key auth validation with 5-min TTL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,6 +865,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,6 +1232,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "eventsource-stream"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1517,6 +1547,7 @@ dependencies = [
  "image",
  "inventory",
  "jsonwebtoken",
+ "moka",
  "parking_lot",
  "prost",
  "prost-types",
@@ -3013,6 +3044,26 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85f8024e1c8e71c778968af91d43700ce1d11b219d127d79fb2934153b82b42b"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
 ]
 
 [[package]]
@@ -5199,6 +5250,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,9 @@ rstest = "0.25"
 # Plugin system for external integrations
 inventory = "0.3"
 
+# In-process caching (async-aware)
+moka = { version = "0.12", features = ["future"] }
+
 [profile.dev]
 opt-level = 0
 # line-tables-only: file:line in backtraces, drops full DWARF type/variable info

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -58,6 +58,7 @@ parking_lot.workspace = true
 cron = "0.15"
 inventory.workspace = true
 zip = { version = "2", default-features = false, features = ["deflate"] }
+moka.workspace = true
 
 everruns-core = { path = "../core", features = ["openapi", "sqlx"] }
 everruns-integrations-codesandbox = { path = "../../integrations/codesandbox" }

--- a/crates/server/src/auth/builtin.rs
+++ b/crates/server/src/auth/builtin.rs
@@ -1,10 +1,14 @@
 // Built-in authentication backend (JWT + password + OAuth + API keys)
 // Decision: Default for OSS. All existing behavior preserved.
+// Decision: API key auth results cached in-process (moka, 5-min TTL) to avoid
+// 4 sequential DB queries per request. Invalidated on key deletion.
 
 use async_trait::async_trait;
 use axum::Router;
 use everruns_core::{DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, OrgMembership, OrgRole};
+use moka::future::Cache;
 use std::sync::Arc;
+use std::time::Duration;
 use uuid::Uuid;
 
 use super::api_key::{ValidatedApiKey, hash_api_key, is_valid_api_key_format};
@@ -17,6 +21,12 @@ use super::routes::{self, AuthConfigResponse};
 use crate::storage::StorageBackend;
 use crate::valkey::ValkeyClient;
 
+/// TTL for cached API key auth results.
+const API_KEY_CACHE_TTL: Duration = Duration::from_secs(300); // 5 minutes
+
+/// Max entries in the API key auth cache.
+const API_KEY_CACHE_MAX_CAPACITY: u64 = 10_000;
+
 /// Built-in authentication backend (JWT + password + OAuth + API keys).
 /// This is the default for OSS deployments.
 #[derive(Clone)]
@@ -25,6 +35,15 @@ pub struct BuiltinAuthBackend {
     pub jwt_service: Arc<JwtService>,
     pub db: Arc<StorageBackend>,
     pub rate_limiter: AuthRateLimiter,
+    /// In-process cache: key_hash -> AuthUser. Avoids 4 sequential DB queries per API-key request.
+    api_key_cache: Cache<String, AuthUser>,
+}
+
+fn build_api_key_cache() -> Cache<String, AuthUser> {
+    Cache::builder()
+        .max_capacity(API_KEY_CACHE_MAX_CAPACITY)
+        .time_to_live(API_KEY_CACHE_TTL)
+        .build()
 }
 
 impl BuiltinAuthBackend {
@@ -36,6 +55,7 @@ impl BuiltinAuthBackend {
             jwt_service,
             db,
             rate_limiter: AuthRateLimiter::new(),
+            api_key_cache: build_api_key_cache(),
         }
     }
 
@@ -47,53 +67,31 @@ impl BuiltinAuthBackend {
             jwt_service,
             db,
             rate_limiter: AuthRateLimiter::with_valkey(valkey),
+            api_key_cache: build_api_key_cache(),
         }
     }
-}
 
-#[async_trait]
-impl AuthBackend for BuiltinAuthBackend {
-    async fn validate_token(&self, token: &str) -> Result<AuthUser, AuthError> {
-        let claims = self.jwt_service.validate_access_token(token).map_err(|e| {
-            tracing::debug!("JWT validation failed: {}", e);
-            AuthError::unauthorized("Invalid or expired token")
-        })?;
-
-        let user_id = Uuid::parse_str(&claims.sub)
-            .map_err(|_| AuthError::unauthorized("Invalid user ID in token"))?;
-
-        // Fetch organization memberships for the user
-        let organizations = fetch_user_organizations(&self.db, user_id).await?;
-
-        // If user has no organizations, fall back to default organization
-        if organizations.is_empty() {
-            tracing::warn!(
-                user_id = %user_id,
-                "User has no organizations, falling back to default org"
-            );
-        }
-        let organizations = organizations_or_default(organizations);
-
-        Ok(AuthUser {
-            id: user_id,
-            email: claims.email,
-            name: claims.name,
-            roles: claims.roles,
-            auth_method: AuthMethod::Jwt,
-            organizations,
-        })
+    /// Invalidate a cached API key entry by its hash.
+    pub async fn invalidate_api_key_cache(&self, key_hash: &str) {
+        self.api_key_cache.invalidate(key_hash).await;
     }
 
-    async fn validate_api_key(&self, key: &str) -> Result<AuthUser, AuthError> {
-        if !is_valid_api_key_format(key) {
-            return Err(AuthError::unauthorized("Invalid API key format"));
-        }
+    /// Invalidate all cached API key entries (e.g. after user/org updates).
+    pub fn invalidate_all_api_key_cache(&self) {
+        self.api_key_cache.invalidate_all();
+    }
 
-        let key_hash = hash_api_key(key);
+    /// Entry count in the cache (for testing/metrics).
+    #[cfg(test)]
+    pub fn api_key_cache_entry_count(&self) -> u64 {
+        self.api_key_cache.entry_count()
+    }
 
+    /// Validate API key against DB (4 sequential queries). Called on cache miss.
+    async fn validate_api_key_from_db(&self, key_hash: &str) -> Result<AuthUser, AuthError> {
         let api_key_row = self
             .db
-            .get_api_key_by_hash(&key_hash)
+            .get_api_key_by_hash(key_hash)
             .await
             .map_err(|e| {
                 tracing::error!("Failed to fetch API key: {}", e);
@@ -171,6 +169,61 @@ impl AuthBackend for BuiltinAuthBackend {
             }],
         })
     }
+}
+
+#[async_trait]
+impl AuthBackend for BuiltinAuthBackend {
+    async fn validate_token(&self, token: &str) -> Result<AuthUser, AuthError> {
+        let claims = self.jwt_service.validate_access_token(token).map_err(|e| {
+            tracing::debug!("JWT validation failed: {}", e);
+            AuthError::unauthorized("Invalid or expired token")
+        })?;
+
+        let user_id = Uuid::parse_str(&claims.sub)
+            .map_err(|_| AuthError::unauthorized("Invalid user ID in token"))?;
+
+        // Fetch organization memberships for the user
+        let organizations = fetch_user_organizations(&self.db, user_id).await?;
+
+        // If user has no organizations, fall back to default organization
+        if organizations.is_empty() {
+            tracing::warn!(
+                user_id = %user_id,
+                "User has no organizations, falling back to default org"
+            );
+        }
+        let organizations = organizations_or_default(organizations);
+
+        Ok(AuthUser {
+            id: user_id,
+            email: claims.email,
+            name: claims.name,
+            roles: claims.roles,
+            auth_method: AuthMethod::Jwt,
+            organizations,
+        })
+    }
+
+    async fn validate_api_key(&self, key: &str) -> Result<AuthUser, AuthError> {
+        if !is_valid_api_key_format(key) {
+            return Err(AuthError::unauthorized("Invalid API key format"));
+        }
+
+        let key_hash = hash_api_key(key);
+
+        // Check cache first — avoids 4 sequential DB queries on hit
+        if let Some(cached) = self.api_key_cache.get(&key_hash).await {
+            tracing::trace!("API key auth cache hit");
+            return Ok(cached);
+        }
+
+        let auth_user = self.validate_api_key_from_db(&key_hash).await?;
+
+        // Populate cache
+        self.api_key_cache.insert(key_hash, auth_user.clone()).await;
+
+        Ok(auth_user)
+    }
 
     fn auth_routes(&self) -> Option<Router> {
         Some(routes::routes(self.clone()))
@@ -227,5 +280,129 @@ pub(super) fn organizations_or_default(organizations: Vec<OrgMembership>) -> Vec
         }]
     } else {
         organizations
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a cache with custom TTL for testing.
+    fn build_test_cache(ttl: Duration) -> Cache<String, AuthUser> {
+        Cache::builder().max_capacity(100).time_to_live(ttl).build()
+    }
+
+    fn test_auth_user() -> AuthUser {
+        AuthUser {
+            id: Uuid::nil(),
+            email: "test@example.com".to_string(),
+            name: "Test User".to_string(),
+            roles: vec!["user".to_string()],
+            auth_method: AuthMethod::ApiKey,
+            organizations: vec![OrgMembership {
+                org_id: 1,
+                public_id: "org_test".to_string(),
+                name: "Test Org".to_string(),
+                role: OrgRole::Member,
+            }],
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cache_hit_returns_cached_user() {
+        let cache = build_api_key_cache();
+        let user = test_auth_user();
+        let key_hash = "abc123hash".to_string();
+
+        // Insert into cache
+        cache.insert(key_hash.clone(), user.clone()).await;
+
+        // Should hit
+        let cached = cache.get(&key_hash).await;
+        assert!(cached.is_some());
+        let cached = cached.unwrap();
+        assert_eq!(cached.id, user.id);
+        assert_eq!(cached.email, user.email);
+        assert_eq!(cached.organizations.len(), 1);
+        assert_eq!(cached.organizations[0].org_id, 1);
+    }
+
+    #[tokio::test]
+    async fn test_cache_miss_returns_none() {
+        let cache = build_api_key_cache();
+        let result = cache.get(&"nonexistent".to_string()).await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_cache_invalidate_single_key() {
+        let cache = build_api_key_cache();
+        let user = test_auth_user();
+        let key_hash = "abc123hash".to_string();
+
+        cache.insert(key_hash.clone(), user).await;
+        assert!(cache.get(&key_hash).await.is_some());
+
+        // Invalidate
+        cache.invalidate(&key_hash).await;
+        assert!(cache.get(&key_hash).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_cache_invalidate_all() {
+        let cache = build_api_key_cache();
+        let user = test_auth_user();
+
+        cache.insert("key1".to_string(), user.clone()).await;
+        cache.insert("key2".to_string(), user).await;
+        assert!(cache.get(&"key1".to_string()).await.is_some());
+        assert!(cache.get(&"key2".to_string()).await.is_some());
+
+        // Invalidate all
+        cache.invalidate_all();
+        // run_pending_tasks needed for invalidate_all to take effect
+        cache.run_pending_tasks().await;
+        assert!(cache.get(&"key1".to_string()).await.is_none());
+        assert!(cache.get(&"key2".to_string()).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_cache_ttl_expiry() {
+        // Use a very short TTL
+        let cache = build_test_cache(Duration::from_millis(50));
+        let user = test_auth_user();
+        let key_hash = "ttl_test".to_string();
+
+        cache.insert(key_hash.clone(), user).await;
+        assert!(cache.get(&key_hash).await.is_some());
+
+        // Wait for TTL to expire
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(cache.get(&key_hash).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_cache_different_keys_independent() {
+        let cache = build_api_key_cache();
+        let user1 = test_auth_user();
+        let mut user2 = test_auth_user();
+        user2.email = "other@example.com".to_string();
+
+        cache.insert("key_a".to_string(), user1).await;
+        cache.insert("key_b".to_string(), user2).await;
+
+        // Invalidate only key_a
+        cache.invalidate(&"key_a".to_string()).await;
+
+        assert!(cache.get(&"key_a".to_string()).await.is_none());
+        let remaining = cache.get(&"key_b".to_string()).await;
+        assert!(remaining.is_some());
+        assert_eq!(remaining.unwrap().email, "other@example.com");
+    }
+
+    #[test]
+    fn test_cache_constants() {
+        assert_eq!(API_KEY_CACHE_TTL, Duration::from_secs(300));
+        assert_eq!(API_KEY_CACHE_MAX_CAPACITY, 10_000);
     }
 }

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -932,6 +932,10 @@ pub async fn delete_api_key_route(
         })?;
 
     if deleted {
+        // Invalidate entire API key auth cache — we don't have the key_hash here,
+        // only the key_id (UUID). Deletion is rare so full invalidation is fine.
+        state.invalidate_all_api_key_cache();
+
         audit::emit(
             state.db.clone(),
             DEFAULT_ORG_ID,


### PR DESCRIPTION
## What

Add in-process moka cache (key_hash -> AuthUser, 5-min TTL, 10k max entries) to avoid 4 sequential DB queries on every API-key authenticated request. Invalidate cache on key deletion.

## Why

Fixes EVE-48. Every API-key request ran get_api_key_by_hash, get_user, get_organization, get_organization_member sequentially. These rarely change but were fetched on every single request.

## How

- Added moka crate (async future feature) as workspace dependency
- BuiltinAuthBackend now holds a Cache<String, AuthUser> field
- validate_api_key() checks cache before falling back to validate_api_key_from_db()
- On cache miss, result is inserted into cache
- delete_api_key_route calls invalidate_all_api_key_cache() after successful deletion
- Exposed invalidate_api_key_cache(key_hash) and invalidate_all_api_key_cache() for targeted/bulk invalidation

## Risk

- Low
- Cache staleness window of up to 5 minutes if user/org data changes without explicit invalidation. Acceptable for auth metadata that rarely changes. Key deletion triggers immediate full cache invalidation.

## Checklist

- [x] Tests added or updated (7 cache unit tests: hit, miss, single invalidation, bulk invalidation, TTL expiry, key independence, constants)
- [x] Backward compatibility considered (additive change, no API changes)