### PR TITLE
perf(llm): cache model/provider resolution with 1-hour TTL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,6 +865,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,6 +1232,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "eventsource-stream"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1517,6 +1547,7 @@ dependencies = [
  "image",
  "inventory",
  "jsonwebtoken",
+ "moka",
  "parking_lot",
  "prost",
  "prost-types",
@@ -3013,6 +3044,26 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85f8024e1c8e71c778968af91d43700ce1d11b219d127d79fb2934153b82b42b"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
 ]
 
 [[package]]
@@ -5199,6 +5250,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,9 @@ prost-types = "0.14"
 # Image processing (for thumbnail generation)
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "gif", "webp"] }
 
+# In-process caching
+moka = { version = "0.12", features = ["future"] }
+
 # Fault injection testing
 fail = "0.5"
 rstest = "0.25"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -57,6 +57,7 @@ fred.workspace = true
 parking_lot.workspace = true
 cron = "0.15"
 inventory.workspace = true
+moka.workspace = true
 zip = { version = "2", default-features = false, features = ["deflate"] }
 
 everruns-core = { path = "../core", features = ["openapi", "sqlx"] }

--- a/crates/server/src/api/llm_models.rs
+++ b/crates/server/src/api/llm_models.rs
@@ -17,7 +17,7 @@ use serde::Deserialize;
 use std::sync::Arc;
 use utoipa::{IntoParams, ToSchema};
 
-use crate::services::LlmModelService;
+use crate::services::{LlmModelService, LlmResolverService};
 
 #[derive(Clone)]
 pub struct AppState {
@@ -26,9 +26,18 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn new(db: Arc<StorageBackend>, auth: AuthState) -> Self {
+    pub fn new(
+        db: Arc<StorageBackend>,
+        auth: AuthState,
+        llm_resolver: Option<Arc<LlmResolverService>>,
+    ) -> Self {
+        let service = if let Some(resolver) = llm_resolver {
+            LlmModelService::with_resolver(db, resolver)
+        } else {
+            LlmModelService::new(db)
+        };
         Self {
-            service: Arc::new(LlmModelService::new(db)),
+            service: Arc::new(service),
             auth,
         }
     }

--- a/crates/server/src/api/llm_providers.rs
+++ b/crates/server/src/api/llm_providers.rs
@@ -2,7 +2,7 @@
 // Routes: /v1/llm-providers/...
 
 use crate::auth::{AuthState, ResolvedOrg};
-use crate::services::{LlmProviderService, ModelSyncService, SyncResult};
+use crate::services::{LlmProviderService, LlmResolverService, ModelSyncService, SyncResult};
 use crate::storage::{EncryptionService, StorageBackend};
 use axum::extract::FromRef;
 use axum::{
@@ -33,9 +33,15 @@ impl AppState {
         encryption: Option<Arc<EncryptionService>>,
         driver_registry: Arc<DriverRegistry>,
         auth: AuthState,
+        llm_resolver: Option<Arc<LlmResolverService>>,
     ) -> Self {
+        let service = if let Some(resolver) = llm_resolver {
+            LlmProviderService::with_resolver(db.clone(), encryption, resolver)
+        } else {
+            LlmProviderService::new(db.clone(), encryption)
+        };
         Self {
-            service: Arc::new(LlmProviderService::new(db.clone(), encryption)),
+            service: Arc::new(service),
             sync_service: Arc::new(ModelSyncService::new(db, driver_registry)),
             auth,
         }

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -385,13 +385,22 @@ impl ServerAppBuilder {
             auth: auth_state.clone(),
         };
         let driver_registry = Arc::new(create_driver_registry());
+        let llm_resolver = Arc::new(services::LlmResolverService::new(
+            db.clone(),
+            encryption.clone(),
+        ));
         let llm_providers_state = api::llm_providers::AppState::new(
             db.clone(),
             encryption.clone(),
             driver_registry.clone(),
             auth_state.clone(),
+            Some(llm_resolver.clone()),
         );
-        let llm_models_state = api::llm_models::AppState::new(db.clone(), auth_state.clone());
+        let llm_models_state = api::llm_models::AppState::new(
+            db.clone(),
+            auth_state.clone(),
+            Some(llm_resolver.clone()),
+        );
         let mcp_servers_state =
             api::mcp_servers::AppState::new(db.clone(), encryption.clone(), auth_state.clone());
         let capability_service = Arc::new(services::CapabilityService::new(
@@ -779,10 +788,7 @@ impl ServerAppBuilder {
             if let Some(shared_store) = shared_durable_store {
                 tracing::info!("DEV MODE: Starting task worker for in-process execution");
 
-                let llm_resolver = Arc::new(services::LlmResolverService::new(
-                    db.clone(),
-                    encryption.clone(),
-                ));
+                // Reuse the shared llm_resolver from Phase 5
                 let mcp_server_service = Arc::new(services::McpServerService::new(
                     db.clone(),
                     encryption.clone(),

--- a/crates/server/src/services/llm_model.rs
+++ b/crates/server/src/services/llm_model.rs
@@ -1,5 +1,9 @@
 // LLM Model service for business logic
+//
+// On create/update/delete, the LLM resolver cache is invalidated so that
+// subsequent model resolutions pick up the new model config.
 
+use crate::services::LlmResolverService;
 use crate::storage::{
     StorageBackend,
     models::{CreateLlmModelRow, LlmModelRow, LlmModelWithProviderRow, UpdateLlmModel},
@@ -16,11 +20,29 @@ use crate::api::llm_models::{CreateLlmModelRequest, UpdateLlmModelRequest};
 
 pub struct LlmModelService {
     db: Arc<StorageBackend>,
+    llm_resolver: Option<Arc<LlmResolverService>>,
 }
 
 impl LlmModelService {
     pub fn new(db: Arc<StorageBackend>) -> Self {
-        Self { db }
+        Self {
+            db,
+            llm_resolver: None,
+        }
+    }
+
+    pub fn with_resolver(db: Arc<StorageBackend>, resolver: Arc<LlmResolverService>) -> Self {
+        Self {
+            db,
+            llm_resolver: Some(resolver),
+        }
+    }
+
+    /// Invalidate resolver cache after model mutation.
+    async fn invalidate_resolver_cache(&self, org_id: i64) {
+        if let Some(ref resolver) = self.llm_resolver {
+            resolver.invalidate_cache(org_id).await;
+        }
     }
 
     pub async fn create(
@@ -46,6 +68,7 @@ impl LlmModelService {
         };
 
         let row = self.db.create_llm_model(org_id, input).await?;
+        self.invalidate_resolver_cache(org_id).await;
         Ok(Self::row_to_model(&row))
     }
 
@@ -160,11 +183,18 @@ impl LlmModelService {
         };
 
         let row = self.db.update_llm_model(org_id, id, input).await?;
+        if row.is_some() {
+            self.invalidate_resolver_cache(org_id).await;
+        }
         Ok(row.as_ref().map(Self::row_to_model))
     }
 
     pub async fn delete(&self, org_id: i64, id: Uuid) -> Result<bool> {
-        self.db.delete_llm_model(org_id, id).await
+        let deleted = self.db.delete_llm_model(org_id, id).await?;
+        if deleted {
+            self.invalidate_resolver_cache(org_id).await;
+        }
+        Ok(deleted)
     }
 
     /// Get the default model

--- a/crates/server/src/services/llm_provider.rs
+++ b/crates/server/src/services/llm_provider.rs
@@ -1,5 +1,9 @@
 // LLM Provider service for business logic
+//
+// On create/update/delete, the LLM resolver cache is invalidated so that
+// subsequent model resolutions pick up the new provider config.
 
+use crate::services::LlmResolverService;
 use crate::storage::{
     EncryptionService, StorageBackend,
     models::{CreateLlmProviderRow, LlmProviderRow, UpdateLlmProvider},
@@ -15,11 +19,35 @@ use crate::api::llm_providers::{CreateLlmProviderRequest, UpdateLlmProviderReque
 pub struct LlmProviderService {
     db: Arc<StorageBackend>,
     encryption: Option<Arc<EncryptionService>>,
+    llm_resolver: Option<Arc<LlmResolverService>>,
 }
 
 impl LlmProviderService {
     pub fn new(db: Arc<StorageBackend>, encryption: Option<Arc<EncryptionService>>) -> Self {
-        Self { db, encryption }
+        Self {
+            db,
+            encryption,
+            llm_resolver: None,
+        }
+    }
+
+    pub fn with_resolver(
+        db: Arc<StorageBackend>,
+        encryption: Option<Arc<EncryptionService>>,
+        resolver: Arc<LlmResolverService>,
+    ) -> Self {
+        Self {
+            db,
+            encryption,
+            llm_resolver: Some(resolver),
+        }
+    }
+
+    /// Invalidate resolver cache after provider mutation.
+    async fn invalidate_resolver_cache(&self, org_id: i64) {
+        if let Some(ref resolver) = self.llm_resolver {
+            resolver.invalidate_cache(org_id).await;
+        }
     }
 
     pub async fn create(&self, org_id: i64, req: CreateLlmProviderRequest) -> Result<LlmProvider> {
@@ -43,6 +71,7 @@ impl LlmProviderService {
         };
 
         let row = self.db.create_llm_provider(org_id, input).await?;
+        self.invalidate_resolver_cache(org_id).await;
         Ok(Self::row_to_provider(&row))
     }
 
@@ -86,11 +115,18 @@ impl LlmProviderService {
         };
 
         let row = self.db.update_llm_provider(org_id, id, input).await?;
+        if row.is_some() {
+            self.invalidate_resolver_cache(org_id).await;
+        }
         Ok(row.as_ref().map(Self::row_to_provider))
     }
 
     pub async fn delete(&self, org_id: i64, id: Uuid) -> Result<bool> {
-        self.db.delete_llm_provider(org_id, id).await
+        let deleted = self.db.delete_llm_provider(org_id, id).await?;
+        if deleted {
+            self.invalidate_resolver_cache(org_id).await;
+        }
+        Ok(deleted)
     }
 
     fn row_to_provider(row: &LlmProviderRow) -> LlmProvider {

--- a/crates/server/src/services/llm_resolver.rs
+++ b/crates/server/src/services/llm_resolver.rs
@@ -3,6 +3,10 @@
 // This service handles the resolution of LLM models with their provider credentials,
 // including API key decryption. Used by gRPC service for worker communication.
 //
+// Decision: In-process moka cache keyed on (org_id, model_id) with 1-hour TTL.
+// Providers/models change rarely but resolution is called per LLM request.
+// Cache is invalidated explicitly via invalidate_cache() on provider/model CRUD.
+//
 // API key resolution order (handled at service layer):
 // 1. Decrypted key from database (if set)
 // 2. Environment variable fallback (for development convenience):
@@ -12,8 +16,19 @@
 use crate::storage::{EncryptionService, StorageBackend, models::LlmProviderRow};
 use anyhow::Result;
 use everruns_core::DEFAULT_ORG_ID;
+use moka::future::Cache;
 use std::sync::Arc;
+use std::time::Duration;
 use uuid::Uuid;
+
+/// Cache TTL for resolved models (1 hour).
+const CACHE_TTL: Duration = Duration::from_secs(3600);
+
+/// Max cache entries. Each org+model combo is one entry.
+const CACHE_MAX_ENTRIES: u64 = 1_000;
+
+/// Sentinel UUID for default-model cache key (all zeros is unused by uuidv7).
+const DEFAULT_MODEL_SENTINEL: Uuid = Uuid::nil();
 
 /// Get default API key from environment variable based on provider type.
 ///
@@ -57,31 +72,83 @@ pub struct ResolvedModel {
     pub base_url: Option<String>,
 }
 
+/// Cache key: (org_id, model_uuid). Default-model lookups use DEFAULT_MODEL_SENTINEL.
+type CacheKey = (i64, Uuid);
+
 pub struct LlmResolverService {
     db: Arc<StorageBackend>,
     encryption: Option<Arc<EncryptionService>>,
+    cache: Cache<CacheKey, Option<ResolvedModel>>,
 }
 
 impl LlmResolverService {
     pub fn new(db: Arc<StorageBackend>, encryption: Option<Arc<EncryptionService>>) -> Self {
-        Self { db, encryption }
+        let cache = Cache::builder()
+            .max_capacity(CACHE_MAX_ENTRIES)
+            .time_to_live(CACHE_TTL)
+            .build();
+        Self {
+            db,
+            encryption,
+            cache,
+        }
     }
 
-    /// Resolve a model by ID with decrypted provider credentials
+    /// Resolve a model by ID with decrypted provider credentials.
+    /// Results are cached per (org_id, model_id) with 1-hour TTL.
     pub async fn resolve_model(&self, model_id: Uuid) -> Result<Option<ResolvedModel>> {
-        // Look up the model
-        // TODO: Get org_id from context after Phase 3
-        let model_row = self.db.get_llm_model(DEFAULT_ORG_ID, model_id).await?;
+        let org_id = DEFAULT_ORG_ID;
+        let key = (org_id, model_id);
+
+        if let Some(cached) = self.cache.get(&key).await {
+            return Ok(cached);
+        }
+
+        let result = self.resolve_model_uncached(org_id, model_id).await?;
+        self.cache.insert(key, result.clone()).await;
+        Ok(result)
+    }
+
+    /// Resolve the default model with decrypted provider credentials.
+    /// Cached under sentinel key (org_id, nil UUID).
+    pub async fn resolve_default_model(&self) -> Result<Option<ResolvedModel>> {
+        let org_id = DEFAULT_ORG_ID;
+        let key = (org_id, DEFAULT_MODEL_SENTINEL);
+
+        if let Some(cached) = self.cache.get(&key).await {
+            return Ok(cached);
+        }
+
+        let result = self.resolve_default_model_uncached(org_id).await?;
+        self.cache.insert(key, result.clone()).await;
+        Ok(result)
+    }
+
+    /// Invalidate all cached resolutions for an org.
+    /// Call on provider/model create, update, or delete.
+    pub async fn invalidate_cache(&self, _org_id: i64) {
+        // moka doesn't support prefix invalidation; full invalidation is fine
+        // given the small cache size and 1-hour TTL.
+        self.cache.invalidate_all();
+        tracing::debug!("LLM resolver cache invalidated");
+    }
+
+    /// Uncached model resolution by UUID.
+    async fn resolve_model_uncached(
+        &self,
+        org_id: i64,
+        model_id: Uuid,
+    ) -> Result<Option<ResolvedModel>> {
+        let model_row = self.db.get_llm_model(org_id, model_id).await?;
 
         let model_row = match model_row {
             Some(row) => row,
             None => return Ok(None),
         };
 
-        // Look up the provider
         let provider_row = self
             .db
-            .get_llm_provider(DEFAULT_ORG_ID, model_row.provider_id.uuid())
+            .get_llm_provider(org_id, model_row.provider_id.uuid())
             .await?;
 
         let provider_row = match provider_row {
@@ -89,7 +156,6 @@ impl LlmResolverService {
             None => return Ok(None),
         };
 
-        // Try to decrypt API key if encryption is available and provider has encrypted key
         let api_key = self.resolve_api_key(&provider_row)?;
 
         Ok(Some(ResolvedModel {
@@ -100,21 +166,18 @@ impl LlmResolverService {
         }))
     }
 
-    /// Resolve the default model with decrypted provider credentials
-    pub async fn resolve_default_model(&self) -> Result<Option<ResolvedModel>> {
-        // Look up the default model
-        // TODO: Get org_id from context after Phase 3
-        let model_row = self.db.get_default_llm_model(DEFAULT_ORG_ID).await?;
+    /// Uncached default model resolution.
+    async fn resolve_default_model_uncached(&self, org_id: i64) -> Result<Option<ResolvedModel>> {
+        let model_row = self.db.get_default_llm_model(org_id).await?;
 
         let model_row = match model_row {
             Some(row) => row,
             None => return Ok(None),
         };
 
-        // Look up the provider
         let provider_row = self
             .db
-            .get_llm_provider(DEFAULT_ORG_ID, model_row.provider_id.uuid())
+            .get_llm_provider(org_id, model_row.provider_id.uuid())
             .await?;
 
         let provider_row = match provider_row {
@@ -122,7 +185,6 @@ impl LlmResolverService {
             None => return Ok(None),
         };
 
-        // Try to decrypt API key if encryption is available and provider has encrypted key
         let api_key = self.resolve_api_key(&provider_row)?;
 
         Ok(Some(ResolvedModel {
@@ -167,6 +229,11 @@ impl LlmResolverService {
     /// Check if encryption service is available
     pub fn has_encryption(&self) -> bool {
         self.encryption.is_some()
+    }
+
+    /// Return current cache entry count (for testing/metrics).
+    pub fn cache_entry_count(&self) -> u64 {
+        self.cache.entry_count()
     }
 }
 
@@ -244,5 +311,274 @@ mod tests {
     fn test_get_default_api_key_empty_value() {
         let env = mock_env(&[("DEFAULT_OPENAI_API_KEY", "")]);
         assert_eq!(get_default_api_key_with_lookup("openai", &env), None);
+    }
+
+    #[test]
+    fn test_default_model_sentinel_is_nil() {
+        assert!(DEFAULT_MODEL_SENTINEL.is_nil());
+    }
+
+    #[test]
+    fn test_cache_key_different_org_ids() {
+        let key_a: CacheKey = (1, Uuid::new_v4());
+        let key_b: CacheKey = (2, key_a.1);
+        assert_ne!(key_a, key_b);
+    }
+
+    #[test]
+    fn test_cache_key_different_model_ids() {
+        let key_a: CacheKey = (1, Uuid::new_v4());
+        let key_b: CacheKey = (1, Uuid::new_v4());
+        assert_ne!(key_a, key_b);
+    }
+
+    // --- Integration tests with in-memory storage ---
+
+    use crate::storage::StorageBackend;
+    use crate::storage::models::{CreateLlmModelRow, CreateLlmProviderRow};
+
+    /// Helper: create resolver with in-memory storage and seed a provider + model.
+    /// Returns (resolver, model_uuid).
+    async fn setup_resolver_with_model() -> (LlmResolverService, Uuid) {
+        let db = Arc::new(StorageBackend::in_memory());
+        let resolver = LlmResolverService::new(db.clone(), None);
+        let org_id = DEFAULT_ORG_ID;
+
+        let provider_row = db
+            .create_llm_provider(
+                org_id,
+                CreateLlmProviderRow {
+                    name: "Test OpenAI".to_string(),
+                    provider_type: "openai".to_string(),
+                    base_url: None,
+                    api_key_encrypted: None,
+                    settings: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let model_row = db
+            .create_llm_model(
+                org_id,
+                CreateLlmModelRow {
+                    provider_id: provider_row.id,
+                    model_id: "gpt-4o".to_string(),
+                    display_name: "GPT-4o".to_string(),
+                    capabilities: vec!["chat".to_string()],
+                    is_default: false,
+                    is_favorite: false,
+                    source: "manual".to_string(),
+                    provider_metadata: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        (resolver, model_row.id.uuid())
+    }
+
+    #[tokio::test]
+    async fn test_resolve_model_cache_miss_then_hit() {
+        let (resolver, model_id) = setup_resolver_with_model().await;
+
+        // Cache starts empty
+        assert_eq!(resolver.cache_entry_count(), 0);
+
+        // First call: cache miss -> populates cache
+        let result = resolver.resolve_model(model_id).await.unwrap();
+        assert!(result.is_some());
+        let resolved = result.unwrap();
+        assert_eq!(resolved.model_id, "gpt-4o");
+        assert_eq!(resolved.provider_type, "openai");
+
+        // Run pending moka tasks so entry_count updates
+        resolver.cache.run_pending_tasks().await;
+        assert_eq!(resolver.cache_entry_count(), 1);
+
+        // Second call: cache hit (same result)
+        let result2 = resolver.resolve_model(model_id).await.unwrap();
+        assert!(result2.is_some());
+        assert_eq!(result2.unwrap().model_id, "gpt-4o");
+
+        // Still one entry
+        assert_eq!(resolver.cache_entry_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_model_not_found_is_cached() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let resolver = LlmResolverService::new(db, None);
+
+        let missing_id = Uuid::new_v4();
+
+        // First call: miss, returns None, caches it
+        let result = resolver.resolve_model(missing_id).await.unwrap();
+        assert!(result.is_none());
+
+        resolver.cache.run_pending_tasks().await;
+        assert_eq!(resolver.cache_entry_count(), 1);
+
+        // Second call: cache hit (still None)
+        let result2 = resolver.resolve_model(missing_id).await.unwrap();
+        assert!(result2.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_invalidate_cache_clears_entries() {
+        let (resolver, model_id) = setup_resolver_with_model().await;
+
+        // Populate cache
+        resolver.resolve_model(model_id).await.unwrap();
+        resolver.cache.run_pending_tasks().await;
+        assert_eq!(resolver.cache_entry_count(), 1);
+
+        // Invalidate
+        resolver.invalidate_cache(DEFAULT_ORG_ID).await;
+        resolver.cache.run_pending_tasks().await;
+        assert_eq!(resolver.cache_entry_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_different_models_cached_independently() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let resolver = LlmResolverService::new(db.clone(), None);
+        let org_id = DEFAULT_ORG_ID;
+
+        let provider_row = db
+            .create_llm_provider(
+                org_id,
+                CreateLlmProviderRow {
+                    name: "Anthropic".to_string(),
+                    provider_type: "anthropic".to_string(),
+                    base_url: None,
+                    api_key_encrypted: None,
+                    settings: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let model_a = db
+            .create_llm_model(
+                org_id,
+                CreateLlmModelRow {
+                    provider_id: provider_row.id,
+                    model_id: "claude-3-opus".to_string(),
+                    display_name: "Claude 3 Opus".to_string(),
+                    capabilities: vec![],
+                    is_default: false,
+                    is_favorite: false,
+                    source: "manual".to_string(),
+                    provider_metadata: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let model_b = db
+            .create_llm_model(
+                org_id,
+                CreateLlmModelRow {
+                    provider_id: provider_row.id,
+                    model_id: "claude-3-sonnet".to_string(),
+                    display_name: "Claude 3 Sonnet".to_string(),
+                    capabilities: vec![],
+                    is_default: true,
+                    is_favorite: false,
+                    source: "manual".to_string(),
+                    provider_metadata: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Resolve both models
+        let ra = resolver.resolve_model(model_a.id.uuid()).await.unwrap();
+        let rb = resolver.resolve_model(model_b.id.uuid()).await.unwrap();
+
+        assert_eq!(ra.unwrap().model_id, "claude-3-opus");
+        assert_eq!(rb.unwrap().model_id, "claude-3-sonnet");
+
+        resolver.cache.run_pending_tasks().await;
+        assert_eq!(resolver.cache_entry_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_default_model_cached() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let resolver = LlmResolverService::new(db.clone(), None);
+        let org_id = DEFAULT_ORG_ID;
+
+        let provider_row = db
+            .create_llm_provider(
+                org_id,
+                CreateLlmProviderRow {
+                    name: "OpenAI".to_string(),
+                    provider_type: "openai".to_string(),
+                    base_url: None,
+                    api_key_encrypted: None,
+                    settings: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        db.create_llm_model(
+            org_id,
+            CreateLlmModelRow {
+                provider_id: provider_row.id,
+                model_id: "gpt-4o".to_string(),
+                display_name: "GPT-4o".to_string(),
+                capabilities: vec![],
+                is_default: true,
+                is_favorite: false,
+                source: "manual".to_string(),
+                provider_metadata: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        // First call: populates cache
+        let result = resolver.resolve_default_model().await.unwrap();
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().model_id, "gpt-4o");
+
+        resolver.cache.run_pending_tasks().await;
+        assert_eq!(resolver.cache_entry_count(), 1);
+
+        // Second call: cache hit
+        let result2 = resolver.resolve_default_model().await.unwrap();
+        assert!(result2.is_some());
+        assert_eq!(result2.unwrap().model_id, "gpt-4o");
+    }
+
+    #[tokio::test]
+    async fn test_invalidation_forces_fresh_resolution() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let resolver = LlmResolverService::new(db.clone(), None);
+        let org_id = DEFAULT_ORG_ID;
+
+        // Resolve a missing model -> cached as None
+        let missing_id = Uuid::new_v4();
+        let result = resolver.resolve_model(missing_id).await.unwrap();
+        assert!(result.is_none());
+
+        resolver.cache.run_pending_tasks().await;
+        assert_eq!(resolver.cache_entry_count(), 1);
+
+        // Invalidate cache
+        resolver.invalidate_cache(org_id).await;
+        resolver.cache.run_pending_tasks().await;
+        assert_eq!(resolver.cache_entry_count(), 0);
+
+        // Next resolve goes to DB again (still None since model doesn't exist)
+        let result2 = resolver.resolve_model(missing_id).await.unwrap();
+        assert!(result2.is_none());
+
+        // But entry is re-cached
+        resolver.cache.run_pending_tasks().await;
+        assert_eq!(resolver.cache_entry_count(), 1);
     }
 }

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -153,8 +153,9 @@ impl TestServer {
             encryption.clone(),
             driver_registry.clone(),
             auth_state.clone(),
+            None,
         );
-        let llm_models_state = api::llm_models::AppState::new(db.clone(), auth_state.clone());
+        let llm_models_state = api::llm_models::AppState::new(db.clone(), auth_state.clone(), None);
         let mcp_servers_state =
             api::mcp_servers::AppState::new(db.clone(), encryption.clone(), auth_state.clone());
         let capability_service = Arc::new(services::CapabilityService::new(


### PR DESCRIPTION
## What
Add moka in-process cache to LlmResolverService with 1-hour TTL and wire invalidation from provider/model CRUD operations.

## Why
Fixes EVE-49. LLM model/provider resolution queries the DB on every LLM request despite providers and models changing rarely. Caching eliminates redundant DB queries.

## How
- Added moka crate (async cache) as workspace dependency
- LlmResolverService now wraps a Cache with 1-hour TTL and 1000 max entries
- resolve_model() and resolve_default_model() check cache before DB queries
- invalidate_cache() clears all entries on provider/model CRUD
- LlmProviderService and LlmModelService call invalidate_cache() after create/update/delete
- Shared LlmResolverService instance created in app builder Phase 5

## Risk
- Low
- Cache staleness bounded by 1-hour TTL; explicit invalidation on CRUD covers normal path

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered