### PR TITLE
fix(core): move tool_search guard to RuntimeAgentBuilder

### DIFF
--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -32,6 +32,8 @@ use crate::llm_driver_registry::{
     LlmCallConfig, LlmCompletionMetadata, LlmContentPart, LlmDriver, LlmMessage, LlmMessageContent,
     LlmMessageRole, LlmResponseStream, LlmStreamEvent,
 };
+use crate::llm_model_profiles::get_model_profile;
+use crate::llm_models::LlmProviderType;
 use crate::llm_retry::{
     LlmRetryConfig, RateLimitInfo, RetryMetadata, is_rate_limit_status, is_transient_error,
 };
@@ -537,14 +539,30 @@ impl LlmDriver for OpenResponsesProtocolLlmDriver {
     ) -> Result<LlmResponseStream> {
         let (instructions, input_items) = Self::build_input(&messages);
 
+        // Only use tool_search when the model actually supports it (currently GPT-5.4+).
+        // Sending tool_search to unsupported models causes 400 errors.
+        let model_supports_tool_search = get_model_profile(&LlmProviderType::Openai, &config.model)
+            .is_some_and(|p| p.tool_search);
+
+        if config.tool_search.as_ref().is_some_and(|ts| ts.enabled) && !model_supports_tool_search {
+            tracing::debug!(
+                model = %config.model,
+                "tool_search capability enabled but model does not support it; falling back to standard tools"
+            );
+        }
+
         let tools = if config.tools.is_empty() {
             None
-        } else if let Some(ref ts_config) = config.tool_search {
-            if ts_config.enabled {
-                Some(Self::convert_tools_with_search(
-                    &config.tools,
-                    ts_config.threshold,
-                ))
+        } else if model_supports_tool_search {
+            if let Some(ref ts_config) = config.tool_search {
+                if ts_config.enabled {
+                    Some(Self::convert_tools_with_search(
+                        &config.tools,
+                        ts_config.threshold,
+                    ))
+                } else {
+                    Some(Self::convert_tools(&config.tools))
+                }
             } else {
                 Some(Self::convert_tools(&config.tools))
             }

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -32,8 +32,6 @@ use crate::llm_driver_registry::{
     LlmCallConfig, LlmCompletionMetadata, LlmContentPart, LlmDriver, LlmMessage, LlmMessageContent,
     LlmMessageRole, LlmResponseStream, LlmStreamEvent,
 };
-use crate::llm_model_profiles::get_model_profile;
-use crate::llm_models::LlmProviderType;
 use crate::llm_retry::{
     LlmRetryConfig, RateLimitInfo, RetryMetadata, is_rate_limit_status, is_transient_error,
 };
@@ -539,30 +537,14 @@ impl LlmDriver for OpenResponsesProtocolLlmDriver {
     ) -> Result<LlmResponseStream> {
         let (instructions, input_items) = Self::build_input(&messages);
 
-        // Only use tool_search when the model actually supports it (currently GPT-5.4+).
-        // Sending tool_search to unsupported models causes 400 errors.
-        let model_supports_tool_search = get_model_profile(&LlmProviderType::Openai, &config.model)
-            .is_some_and(|p| p.tool_search);
-
-        if config.tool_search.as_ref().is_some_and(|ts| ts.enabled) && !model_supports_tool_search {
-            tracing::debug!(
-                model = %config.model,
-                "tool_search capability enabled but model does not support it; falling back to standard tools"
-            );
-        }
-
         let tools = if config.tools.is_empty() {
             None
-        } else if model_supports_tool_search {
-            if let Some(ref ts_config) = config.tool_search {
-                if ts_config.enabled {
-                    Some(Self::convert_tools_with_search(
-                        &config.tools,
-                        ts_config.threshold,
-                    ))
-                } else {
-                    Some(Self::convert_tools(&config.tools))
-                }
+        } else if let Some(ref ts_config) = config.tool_search {
+            if ts_config.enabled {
+                Some(Self::convert_tools_with_search(
+                    &config.tools,
+                    ts_config.threshold,
+                ))
             } else {
                 Some(Self::convert_tools(&config.tools))
             }

--- a/crates/core/src/runtime_agent.rs
+++ b/crates/core/src/runtime_agent.rs
@@ -16,6 +16,8 @@ use crate::capabilities::{
 };
 use crate::harness::Harness;
 use crate::llm_driver_registry::ToolSearchConfig;
+use crate::llm_model_profiles::get_model_profile;
+use crate::llm_models::LlmProviderType;
 use crate::tool_types::ToolDefinition;
 use serde::{Deserialize, Serialize};
 
@@ -269,8 +271,30 @@ impl RuntimeAgentBuilder {
         self
     }
 
-    /// Build the runtime agent
-    pub fn build(self) -> RuntimeAgent {
+    /// Set tool_search configuration
+    pub fn tool_search(mut self, config: ToolSearchConfig) -> Self {
+        self.runtime_agent.tool_search = Some(config);
+        self
+    }
+
+    /// Build the runtime agent.
+    ///
+    /// Validates that tool_search is only enabled for models that support it
+    /// (currently GPT-5.4+). Clears tool_search for unsupported models to
+    /// prevent 400 errors from the OpenAI API.
+    pub fn build(mut self) -> RuntimeAgent {
+        if self.runtime_agent.tool_search.is_some() {
+            let model_supports =
+                get_model_profile(&LlmProviderType::Openai, &self.runtime_agent.model)
+                    .is_some_and(|p| p.tool_search);
+            if !model_supports {
+                tracing::debug!(
+                    model = %self.runtime_agent.model,
+                    "tool_search capability configured but model does not support it; disabling"
+                );
+                self.runtime_agent.tool_search = None;
+            }
+        }
         self.runtime_agent
     }
 }
@@ -696,6 +720,38 @@ mod tests {
         assert_eq!(
             system_prompt_count, 1,
             "Should have exactly one <system-prompt> tag, not double-wrapped"
+        );
+    }
+
+    #[test]
+    fn test_build_clears_tool_search_for_unsupported_model() {
+        let agent = RuntimeAgentBuilder::new()
+            .model("gpt-5.2")
+            .tool_search(ToolSearchConfig {
+                enabled: true,
+                threshold: 15,
+            })
+            .build();
+
+        assert!(
+            agent.tool_search.is_none(),
+            "tool_search should be cleared for gpt-5.2 (unsupported)"
+        );
+    }
+
+    #[test]
+    fn test_build_keeps_tool_search_for_supported_model() {
+        let agent = RuntimeAgentBuilder::new()
+            .model("gpt-5.4")
+            .tool_search(ToolSearchConfig {
+                enabled: true,
+                threshold: 15,
+            })
+            .build();
+
+        assert!(
+            agent.tool_search.is_some(),
+            "tool_search should be kept for gpt-5.4 (supported)"
         );
     }
 }

--- a/crates/core/src/runtime_agent.rs
+++ b/crates/core/src/runtime_agent.rs
@@ -754,4 +754,20 @@ mod tests {
             "tool_search should be kept for gpt-5.4 (supported)"
         );
     }
+
+    #[test]
+    fn test_build_clears_tool_search_for_non_openai_model() {
+        let agent = RuntimeAgentBuilder::new()
+            .model("claude-sonnet-4-5-20250514")
+            .tool_search(ToolSearchConfig {
+                enabled: true,
+                threshold: 15,
+            })
+            .build();
+
+        assert!(
+            agent.tool_search.is_none(),
+            "tool_search should be cleared for non-OpenAI models"
+        );
+    }
 }

--- a/specs/tool-search.md
+++ b/specs/tool-search.md
@@ -85,23 +85,28 @@ MCP Server("github", "GitHub integration")
     → Functions: mcp_github__search_repos, mcp_github__create_issue, ...
 ```
 
-### Decision: Transparent Deferral Logic in LLM Driver
+### Decision: Model Gate in RuntimeAgentBuilder, Deferral in Driver
 
-The deferral decision lives in the OpenAI driver's `convert_tools()`, not in capability code. Capabilities don't need to know about tool_search — they just provide tools as today. The driver checks the model profile and restructures the tools array accordingly.
+The model compatibility check lives in `RuntimeAgentBuilder::build()` — if the model doesn't support tool_search (per `LlmModelProfile`), `tool_search` is cleared before reaching the driver. This prevents unsupported API parameters from ever reaching the LLM provider.
+
+The deferral logic (namespace grouping, defer_loading) lives in the OpenAI driver's `convert_tools()`. Capabilities don't need to know about tool_search — they just provide tools as today.
 
 ```
-Capability.tools()  →  RuntimeAgent.tools  →  LlmCallConfig.tools
-                                                      ↓
-                                            LlmDriver checks profile.tool_search
-                                                      ↓
-                                    ┌─────────────────┴──────────────────┐
-                                    │ tool_search=false                   │ tool_search=true
-                                    │ (current behavior)                  │ (new behavior)
-                                    ↓                                     ↓
-                            Vec<ResponsesTool::Function>          Vec<ResponsesTool> with:
-                            (full schemas)                        - Namespace groupings
-                                                                  - defer_loading: true
-                                                                  - { "type": "tool_search" }
+Capability.tools()  →  collect_capabilities() sets tool_search config
+                               ↓
+                      RuntimeAgentBuilder::build()
+                      checks model profile.tool_search
+                               ↓
+                    ┌──────────┴──────────┐
+                    │ unsupported model    │ supported model
+                    │ (clears tool_search) │ (keeps config)
+                    ↓                      ↓
+              RuntimeAgent.tool_search=None    RuntimeAgent.tool_search=Some(config)
+                    ↓                      ↓
+              LlmCallConfig.tools    LlmDriver restructures:
+              (full schemas)         - Namespace groupings
+                                     - defer_loading: true
+                                     - { "type": "tool_search" }
 ```
 
 ### Decision: ToolDefinition Metadata for Grouping


### PR DESCRIPTION
## What
Move the tool_search model compatibility check from the OpenResponses driver to `RuntimeAgentBuilder::build()`. If the model doesn't support tool_search (per `LlmModelProfile`), the config is cleared before it reaches the driver.

## Why
The guard was at the wrong abstraction level — the driver shouldn't need to check model compatibility for a capability-level concern. By gating in `RuntimeAgentBuilder::build()`, unsupported tool_search configs never propagate to `RuntimeAgent` or `LlmCallConfig`, preventing 400 errors from OpenAI for non-GPT-5.4 models.

## How
- `RuntimeAgentBuilder::build()` checks `get_model_profile()` for `tool_search` support
- If unsupported, clears `tool_search` config with a debug log
- Reverts the driver-level guard (net simplification in openresponses_protocol.rs)
- Adds `tool_search()` setter on builder for ergonomic config
- Updates tool-search spec diagram to reflect new architecture

## Risk
- Low
- Behavioral change is minimal: tool_search was already being silently ignored for unsupported models at the driver level; now it is cleared earlier at build time

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered