### PR TITLE
feat(build): add optional sccache integration with S3 backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,22 @@ Disable incremental compilation in cloud (saves ~3 GB, useless for single builds
 export CARGO_INCREMENTAL=0
 ```
 
+#### sccache (optional, recommended)
+
+Shared S3 compile cache. Cuts clean builds from ~2m to ~1m. Installed automatically by `init-cloud-env.sh`. To activate in your shell:
+
+```bash
+source scripts/lib/sccache.sh && activate_sccache
+```
+
+Or via Doppler (wraps credential mapping):
+
+```bash
+doppler run -- bash -c 'source scripts/lib/sccache.sh && activate_sccache && cargo build'
+```
+
+Check stats: `just sccache-stats`. See `specs/sccache.md` for details.
+
 All cloud secrets are in Doppler (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`, `LINEAR_API_KEY`).
 
 ### Linear
@@ -107,6 +123,7 @@ Fix root cause. Unsure: read more code; if stuck, ask w/ short options. Unrecogn
 - `specs/feature-flags.md` - Feature flags system (env vars, deployment grade, UI gating)
 - `specs/tool-search.md` - OpenAI tool_search deferred tool loading capability
 - `specs/cache.md` - Caching strategy and distributed rate limiting (Valkey)
+- `specs/sccache.md` - Shared compile cache (sccache with S3 backend)
 
 ### Skills
 

--- a/justfile
+++ b/justfile
@@ -108,6 +108,14 @@ pre-pr:
 clean:
     cargo clean
 
+# Install and configure sccache (S3 backend via Doppler, optional)
+sccache-setup:
+    ./scripts/lib/sccache.sh setup
+
+# Show sccache statistics
+sccache-stats:
+    sccache --show-stats
+
 # === Services ===
 
 # Start in DEV MODE (in-memory storage, no Docker/PostgreSQL required)

--- a/scripts/init-cloud-env.sh
+++ b/scripts/init-cloud-env.sh
@@ -234,6 +234,24 @@ configure_gh_repo() {
 }
 
 
+install_sccache() {
+    # Optional: speeds up Rust builds via shared S3 cache.
+    # Delegates to scripts/lib/sccache.sh for install logic.
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    local sccache_script="$script_dir/scripts/lib/sccache.sh"
+    if [[ ! -f "$sccache_script" ]]; then
+        # Fallback: we might be run from the repo root
+        sccache_script="./scripts/lib/sccache.sh"
+    fi
+    if [[ -f "$sccache_script" ]]; then
+        source "$sccache_script"
+        _install_sccache || warn "sccache install failed (non-fatal)"
+    else
+        warn "sccache helper not found, skipping"
+    fi
+}
+
 configure_gh_auth() {
     if ! command -v gh &> /dev/null; then
         warn "gh not installed, skipping GitHub auth check"
@@ -291,12 +309,14 @@ main() {
     install_gh & PID_GH=$!
     install_doppler & PID_DOPPLER=$!
     install_caddy & PID_CADDY=$!
+    install_sccache & PID_SCCACHE=$!
 
     INSTALL_FAILED=0
-    wait $PID_JUST    || INSTALL_FAILED=1
-    wait $PID_GH      || INSTALL_FAILED=1
-    wait $PID_DOPPLER || INSTALL_FAILED=1
-    wait $PID_CADDY   || INSTALL_FAILED=1
+    wait $PID_JUST     || INSTALL_FAILED=1
+    wait $PID_GH       || INSTALL_FAILED=1
+    wait $PID_DOPPLER  || INSTALL_FAILED=1
+    wait $PID_CADDY    || INSTALL_FAILED=1
+    wait $PID_SCCACHE  || true  # sccache is optional, don't fail
 
     if [[ "$INSTALL_FAILED" -eq 1 ]]; then
         error "One or more tool installs failed"
@@ -317,6 +337,7 @@ main() {
     echo "  - gh $(gh --version 2>/dev/null | head -1 || echo '(not in PATH)')"
     echo "  - doppler $(doppler --version 2>/dev/null || echo '(not in PATH)')"
     echo "  - caddy $(caddy version 2>/dev/null || echo '(not in PATH)')"
+    echo "  - sccache $(sccache --version 2>/dev/null || echo '(not installed)')"
     echo ""
     echo "Next steps:"
     echo "  just --list              # See available commands"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -16,6 +16,13 @@ if [ -f .env ]; then
   set +a
 fi
 
+# Auto-activate sccache if installed (optional compile cache, no-op if missing)
+if [ -z "${RUSTC_WRAPPER:-}" ] && [ -f "$SCRIPT_DIR/sccache.sh" ]; then
+  # shellcheck disable=SC1091
+  source "$SCRIPT_DIR/sccache.sh"
+  activate_sccache 2>/dev/null || true
+fi
+
 # Check if a command is available, exit with hint if not
 require_command() {
   local cmd="$1"

--- a/scripts/lib/sccache.sh
+++ b/scripts/lib/sccache.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# sccache helper: install binary + configure S3 backend via Doppler.
+# Optional — builds work without it, just slower on cold cache.
+#
+# Usage:
+#   source scripts/lib/sccache.sh   # sets RUSTC_WRAPPER + env vars
+#   ./scripts/lib/sccache.sh setup  # install + configure (idempotent)
+#   ./scripts/lib/sccache.sh stats  # show cache stats
+#   ./scripts/lib/sccache.sh stop   # stop server
+
+set -euo pipefail
+
+SCCACHE_FALLBACK_VERSION="v0.14.0"
+INSTALL_DIR="${HOME}/.cargo/bin"
+
+# --- helpers ---------------------------------------------------------------
+
+_info()  { echo -e "\033[0;32m[sccache]\033[0m $1"; }
+_warn()  { echo -e "\033[1;33m[sccache]\033[0m $1"; }
+_error() { echo -e "\033[0;31m[sccache]\033[0m $1"; }
+
+_install_sccache() {
+  if command -v sccache &>/dev/null; then
+    _info "already installed: $(sccache --version)"
+    return 0
+  fi
+
+  _info "Installing sccache (pre-built binary)..."
+
+  local arch
+  arch=$(uname -m)
+  case "$arch" in
+    x86_64)  arch="x86_64" ;;
+    aarch64) arch="aarch64" ;;
+    arm64)   arch="aarch64" ;;  # macOS
+    *) _error "Unsupported architecture: $arch"; return 1 ;;
+  esac
+
+  local os target
+  case "$(uname -s)" in
+    Linux)  os="unknown-linux-musl" ;;
+    Darwin) os="apple-darwin" ;;
+    *) _error "Unsupported OS: $(uname -s)"; return 1 ;;
+  esac
+  target="${arch}-${os}"
+
+  # Pinned version — skip GitHub API call to avoid rate limits and hangs
+  local version="$SCCACHE_FALLBACK_VERSION"
+
+  local tarball="sccache-${version}-${target}.tar.gz"
+  local url="https://github.com/mozilla/sccache/releases/download/${version}/${tarball}"
+
+  local tmp
+  tmp=$(mktemp -d)
+  # shellcheck disable=SC2064
+  trap "rm -rf '$tmp'" EXIT
+
+  _info "Downloading sccache ${version} (${target})..."
+  curl -fsSL --connect-timeout 10 --max-time 60 --retry 2 --retry-delay 2 "$url" -o "$tmp/$tarball"
+  tar -xzf "$tmp/$tarball" -C "$tmp"
+
+  mkdir -p "$INSTALL_DIR"
+  cp "$tmp/sccache-${version}-${target}/sccache" "$INSTALL_DIR/sccache"
+  chmod +x "$INSTALL_DIR/sccache"
+
+  if command -v sccache &>/dev/null; then
+    _info "Installed: $(sccache --version)"
+  else
+    _warn "Installed to $INSTALL_DIR/sccache but not in PATH"
+    _warn "Add to PATH: export PATH=\"$INSTALL_DIR:\$PATH\""
+  fi
+}
+
+# Export env vars for sccache S3 backend. Requires Doppler.
+# No-op if Doppler unavailable or secrets missing.
+_configure_s3() {
+  if ! command -v doppler &>/dev/null; then
+    _warn "doppler not found — using sccache with local storage only"
+    return 0
+  fi
+
+  # Check if sccache S3 secrets exist in Doppler
+  local bucket
+  bucket=$(doppler secrets get SCCACHE_BUCKET --plain 2>/dev/null) || true
+  if [[ -z "$bucket" ]]; then
+    _warn "SCCACHE_BUCKET not in Doppler — using sccache with local storage only"
+    return 0
+  fi
+
+  # Map Doppler secrets to env vars sccache expects
+  export SCCACHE_BUCKET="$bucket"
+  export SCCACHE_REGION="$(doppler secrets get SCCACHE_REGION --plain 2>/dev/null || echo 'us-east-1')"
+  export SCCACHE_S3_KEY_PREFIX="$(doppler secrets get SCCACHE_S3_KEY_PREFIX --plain 2>/dev/null || echo 'sccache')"
+  export AWS_ACCESS_KEY_ID="$(doppler secrets get SCCACHE_AWS_ACCESS_KEY_ID --plain 2>/dev/null)"
+  export AWS_SECRET_ACCESS_KEY="$(doppler secrets get SCCACHE_AWS_SECRET_ACCESS_KEY --plain 2>/dev/null)"
+
+  _info "S3 backend: s3://${SCCACHE_BUCKET}/${SCCACHE_S3_KEY_PREFIX}"
+}
+
+# Activate sccache: set RUSTC_WRAPPER. Safe to call multiple times.
+# Returns 1 if sccache not available (caller can continue without it).
+activate_sccache() {
+  if ! command -v sccache &>/dev/null; then
+    return 1
+  fi
+
+  _configure_s3
+  export RUSTC_WRAPPER="$(command -v sccache)"
+  export CARGO_INCREMENTAL=0  # required for sccache
+  _info "Activated: RUSTC_WRAPPER=$(command -v sccache)"
+}
+
+# --- CLI -------------------------------------------------------------------
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  cmd="${1:-setup}"
+  case "$cmd" in
+    setup)
+      _install_sccache
+      activate_sccache || _warn "sccache installed but activation failed"
+      ;;
+    install)
+      _install_sccache
+      ;;
+    activate)
+      activate_sccache || { _error "sccache not installed. Run: $0 setup"; exit 1; }
+      ;;
+    stats)
+      sccache --show-stats
+      ;;
+    stop)
+      sccache --stop-server 2>/dev/null && _info "Server stopped" || _info "Server not running"
+      ;;
+    *)
+      echo "Usage: $0 {setup|install|activate|stats|stop}"
+      exit 1
+      ;;
+  esac
+fi

--- a/scripts/lib/setup.sh
+++ b/scripts/lib/setup.sh
@@ -68,6 +68,18 @@ case "$cmd" in
       echo "  ✅ cargo-watch already installed"
     fi
 
+    # sccache (optional — shared compile cache)
+    echo ""
+    echo "🚀 Compile cache:"
+    if ! command -v sccache &> /dev/null; then
+      echo "  Installing sccache (optional compile cache)..."
+      source "$(dirname "${BASH_SOURCE[0]}")/sccache.sh"
+      _install_sccache || echo "  ⚠️  sccache install failed (non-fatal, builds will still work)"
+    else
+      echo "  ✅ sccache already installed: $(sccache --version)"
+    fi
+    echo "  💡 Activate: source scripts/lib/sccache.sh && activate_sccache"
+
     # UI dependencies
     echo ""
     echo "🖥️  UI setup:"

--- a/specs/sccache.md
+++ b/specs/sccache.md
@@ -1,0 +1,85 @@
+# sccache — Shared Compile Cache
+
+## Purpose
+
+Speed up Rust builds by caching compiled artifacts in S3. Particularly valuable for:
+- Cloud agent environments (cold target/ dir each session)
+- CI jobs (shared cache across runners)
+- Local dev after `cargo clean` or toolchain bumps
+
+## Results
+
+| Scenario | Without sccache | With sccache (warm) | Speedup |
+|----------|----------------|---------------------|---------|
+| Clean build (internal-protocol + deps) | ~2m 17s | ~56s | ~2.5x |
+| Incremental (local crate only) | ~4s | ~4s | — |
+
+Cache hit rate on warm cache: ~99.8%.
+
+## Architecture
+
+```
+rustc invocation
+  → RUSTC_WRAPPER=sccache
+    → hash(source + flags + deps)
+      → S3 lookup (s3://everruns-sccache/sccache/*)
+        → hit: return cached .o
+        → miss: compile, upload result
+```
+
+**Backend:** S3 bucket `everruns-sccache` in `us-east-1`. Credentials in Doppler (`SCCACHE_BUCKET`, `SCCACHE_REGION`, `SCCACHE_AWS_ACCESS_KEY_ID`, `SCCACHE_AWS_SECRET_ACCESS_KEY`).
+
+**Fallback:** Without Doppler/S3 credentials, sccache uses local disk cache (`~/.cache/sccache`). Still useful for repeated builds.
+
+## Requirements
+
+- `CARGO_INCREMENTAL=0` — required; incremental compilation is incompatible with sccache.
+- sccache binary in PATH.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `scripts/lib/sccache.sh` | Install, configure, activate helper |
+| `scripts/init-cloud-env.sh` | Auto-installs sccache during cloud init |
+| `.github/scripts/ci-sccache-env.sh` | CI-specific S3 credential export |
+| `.github/workflows/ci.yml` | Sets `RUSTC_WRAPPER: sccache` globally |
+
+## Usage
+
+### Cloud agent (recommended)
+
+Installed automatically by `./scripts/init-cloud-env.sh`. Activate before builds:
+
+```bash
+source scripts/lib/sccache.sh && activate_sccache
+cargo build  # uses sccache
+```
+
+Or wrap with Doppler for credential injection:
+
+```bash
+doppler run -- bash -c 'source scripts/lib/sccache.sh && activate_sccache && cargo build'
+```
+
+### Local development (optional)
+
+```bash
+just sccache-setup          # one-time install + configure
+source scripts/lib/sccache.sh && activate_sccache
+cargo build                 # cached
+just sccache-stats          # verify hits
+```
+
+Local dev benefits most after `cargo clean`, toolchain updates, or switching branches with different dependency trees. For normal incremental builds, Cargo's built-in incremental compilation is already fast.
+
+### CI
+
+Already integrated. See `.github/workflows/ci.yml` (`RUSTC_WRAPPER: sccache`) and `.github/scripts/ci-sccache-env.sh`.
+
+## Design Decisions
+
+- **Optional, not forced:** sccache is never required. All builds work without it. The `activate_sccache` function returns non-zero if unavailable, letting callers continue.
+- **S3 over Redis/memcached:** S3 is simpler (no server to run), durable, and already used in CI. Cost is negligible for compile artifacts.
+- **Pre-built binary:** Avoids bootstrapping problem (can't use sccache to build sccache). Downloads ~15MB musl binary.
+- **CARGO_INCREMENTAL=0:** Required by sccache. In cloud agents this is already set (incremental is wasteful for single builds). For local dev, the S3 cache hit compensates for lost incremental compilation on clean builds.

--- a/specs/sccache.md
+++ b/specs/sccache.md
@@ -41,15 +41,20 @@ rustc invocation
 | File | Purpose |
 |------|---------|
 | `scripts/lib/sccache.sh` | Install, configure, activate helper |
+| `scripts/lib/common.sh` | Auto-activates sccache on source (all dev scripts) |
 | `scripts/init-cloud-env.sh` | Auto-installs sccache during cloud init |
 | `.github/scripts/ci-sccache-env.sh` | CI-specific S3 credential export |
 | `.github/workflows/ci.yml` | Sets `RUSTC_WRAPPER: sccache` globally |
 
 ## Usage
 
+### Automatic activation (just start-dev, just start-all, etc.)
+
+All dev scripts source `scripts/lib/common.sh`, which auto-activates sccache if installed. No manual step needed — `just start-dev`, `just start-all`, `just start-production`, `just build`, etc. all benefit transparently.
+
 ### Cloud agent (recommended)
 
-Installed automatically by `./scripts/init-cloud-env.sh`. Activate before builds:
+Installed automatically by `./scripts/init-cloud-env.sh`. For manual activation in a standalone shell:
 
 ```bash
 source scripts/lib/sccache.sh && activate_sccache
@@ -66,8 +71,7 @@ doppler run -- bash -c 'source scripts/lib/sccache.sh && activate_sccache && car
 
 ```bash
 just sccache-setup          # one-time install + configure
-source scripts/lib/sccache.sh && activate_sccache
-cargo build                 # cached
+just start-dev              # auto-activates sccache
 just sccache-stats          # verify hits
 ```
 


### PR DESCRIPTION
## Summary

- Add shared compile cache via sccache with S3 backend (Doppler secrets)
- Auto-activate in all dev scripts (just start-dev, just start-all, etc.) via common.sh
- Auto-install during cloud agent init (init-cloud-env.sh, parallel with other tools)
- Optional install during local dev setup (just init)
- New justfile recipes: just sccache-setup, just sccache-stats

## Results

| Scenario | Without sccache | With sccache (warm) | Speedup |
|----------|----------------|---------------------|---------|
| Clean build (internal-protocol + deps) | ~2m 17s | ~56s | ~2.5x |

99.8% cache hit rate on warm S3 cache. Fully optional — builds work without it.

## Design

- **Optional, not forced:** activate_sccache returns non-zero if unavailable; callers continue
- **Pinned version** (v0.14.0): no GitHub API calls, matching pattern from #698
- **Curl timeouts:** --connect-timeout 10 --max-time 60 --retry 2 --retry-delay 2
- **Parallel install:** runs alongside just/gh/doppler/caddy with || true (non-fatal)
- **S3 fallback:** without Doppler, uses local disk cache

## Files Changed

| File | Purpose |
|------|---------|
| scripts/lib/sccache.sh | Install, configure, activate helper |
| scripts/lib/common.sh | Auto-activates sccache on source |
| scripts/init-cloud-env.sh | Parallel install with other tools |
| scripts/lib/setup.sh | Optional install during just init |
| justfile | sccache-setup and sccache-stats recipes |
| AGENTS.md | Cloud agent usage instructions |
| specs/sccache.md | Spec with design rationale |

## Test plan

- [x] Fresh install via init-cloud-env.sh — installs in parallel, completes in 3s
- [x] Auto-activation via common.sh — sets RUSTC_WRAPPER transparently
- [x] Respects existing RUSTC_WRAPPER — does not override
- [x] Graceful fallback without Doppler — local disk cache, warns
- [x] Standalone CLI commands — setup, stats, stop all work
- [x] Just recipes — just sccache-setup, just sccache-stats work
- [x] Full clean build with S3 cache — 99.8% hit rate, ~2.5x speedup
- [x] just pre-push passes