### PR TITLE
fix: deduplicate moka workspace dep + add sequential merge spec

### DIFF
--- a/.claude/commands/process-issues.md
+++ b/.claude/commands/process-issues.md
@@ -63,7 +63,18 @@ Run `/ship` to implement, test, validate, create PR, and merge. Pass the Linear 
 
 `/ship` handles: test coverage, code simplification, security review, artifact updates, smoke testing, quality gates (including rebase on main), PR creation, CI wait, and merge.
 
-#### 3e. Close Issue
+#### 3e. Merge PRs Sequentially
+
+When multiple issues produce PRs, merge them one at a time with rebase between each:
+
+1. Merge the first PR (CI must be green)
+2. Before merging the next PR, rebase it onto the updated `main`: `git fetch origin main && git rebase origin/main`
+3. Push the rebased branch and wait for CI to pass
+4. Repeat until all PRs are merged
+
+This prevents combined-merge breakage (e.g., duplicate Cargo.toml workspace deps, overlapping file edits).
+
+#### 3f. Close Issue
 
 After PR is merged:
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,20 +120,14 @@ prost-types = "0.14"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "gif", "webp"] }
 
 # In-process caching
-moka = { version = "0.12", features = ["future"] }
+moka = { version = "0.12", features = ["future", "sync"] }
 
 # Fault injection testing
 fail = "0.5"
 rstest = "0.25"
 
-# In-process caching
-moka = { version = "0.12", features = ["future", "sync"] }
-
 # Plugin system for external integrations
 inventory = "0.3"
-
-# In-process caching (async-aware)
-moka = { version = "0.12", features = ["future"] }
 
 [profile.dev]
 opt-level = 0

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -59,7 +59,6 @@ cron = "0.15"
 inventory.workspace = true
 moka.workspace = true
 zip = { version = "2", default-features = false, features = ["deflate"] }
-moka.workspace = true
 
 everruns-core = { path = "../core", features = ["openapi", "sqlx"] }
 everruns-integrations-codesandbox = { path = "../../integrations/codesandbox" }

--- a/specs/linear-issues.md
+++ b/specs/linear-issues.md
@@ -30,6 +30,14 @@ Each issue follows: pick up → analyze → branch → implement → ship → cl
 
 **Branch naming:** `{issue-id}-{short-description}` from `main` (lowercase kebab-case).
 
+### Merge Conflict Prevention
+
+When processing multiple issues in parallel, PRs that merge independently can create conflicts on `main` (e.g., duplicate workspace dependencies, overlapping file edits). To prevent this:
+
+1. **Sequential merging with rebase:** After merging each PR, rebase remaining open PRs onto the updated `main` before merging the next one. Do not merge multiple PRs without rebasing in between.
+2. **Workspace dependency deduplication:** When multiple PRs add the same workspace dependency, the second merge creates a duplicate key error. After merging a PR that touches `Cargo.toml` workspace deps, check remaining PRs for conflicts and rebase them.
+3. **CI validation after rebase:** After rebasing a PR onto updated `main`, wait for CI to pass before merging. Never merge a PR whose CI ran against a stale base.
+
 ### Issue Prioritization
 
 Process issues in this order:


### PR DESCRIPTION
## Summary
- Fix duplicate `moka` key in workspace `Cargo.toml` and `crates/server/Cargo.toml` that broke CI on main after merging multiple parallel PRs
- Update `specs/linear-issues.md` and `.claude/commands/process-issues.md` to require sequential merging with rebase between each PR

## Test plan
- [ ] `cargo check` passes (no duplicate key error)
- [ ] CI green on this PR
- [ ] Main CI green after merge

https://claude.ai/code/session_01BmKFd6DHK5Disy9dwuBYW7