### PR TITLE
perf(ci): build all Rust Docker images in single builder stage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -592,22 +592,13 @@ jobs:
       - name: Build docs
         run: npm run build
 
-  # Docker builds using matrix for parallel execution
+  # Docker builds — server and worker share builder-all stage, so build on
+  # one runner to compile shared dependencies once instead of 2x.
   docker-build:
-    name: Docker Build (${{ matrix.target }})
+    name: Docker Build
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.docker == 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: server
-            dockerfile: docker/Dockerfile.unified
-            image: everruns-server
-          - target: worker
-            dockerfile: docker/Dockerfile.unified
-            image: everruns-worker
 
     steps:
       - uses: actions/checkout@v4
@@ -615,16 +606,27 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build ${{ matrix.target }} Docker image
+      - name: Build server Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ${{ matrix.dockerfile }}
-          target: ${{ matrix.target }}
+          file: docker/Dockerfile.unified
+          target: server
           push: false
-          tags: ${{ matrix.image }}:ci
-          cache-from: type=gha,scope=docker-${{ matrix.target }}
-          cache-to: type=gha,mode=max,scope=docker-${{ matrix.target }}
+          tags: everruns-server:ci
+          cache-from: type=gha,scope=docker-rust
+          cache-to: type=gha,mode=max,scope=docker-rust
+
+      - name: Build worker Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/Dockerfile.unified
+          target: worker
+          push: false
+          tags: everruns-worker:ci
+          cache-from: type=gha,scope=docker-rust
+          cache-to: type=gha,mode=max,scope=docker-rust
 
   # Aggregation gate for branch protection.
   ci-success:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,30 +24,14 @@ env:
   IMAGE_BASE: ghcr.io/${{ github.repository_owner }}
 
 jobs:
-  build-and-push:
-    name: Build & Push (${{ matrix.target }})
+  # Build all Rust images on a single runner so the shared builder-all stage
+  # is compiled once (per architecture) instead of 3x across separate runners.
+  build-rust-images:
+    name: Build Rust Images
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: server
-            dockerfile: docker/Dockerfile.unified
-            image_name: everruns-server
-          - target: worker
-            dockerfile: docker/Dockerfile.unified
-            image_name: everruns-worker
-          - target: admin
-            dockerfile: docker/Dockerfile.unified
-            image_name: everruns-admin
-          - target: ui
-            dockerfile: apps/ui/Dockerfile
-            image_name: everruns-ui
-            context: apps/ui
 
     steps:
       - uses: actions/checkout@v4
@@ -104,31 +88,170 @@ jobs:
             echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
           fi
 
-      - name: Extract metadata for Docker
-        id: meta
+      # --- Server image ---
+      - name: Extract metadata (server)
+        id: meta-server
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_BASE }}/${{ matrix.image_name }}
+          images: ${{ env.IMAGE_BASE }}/everruns-server
           tags: |
-            # On version tags (push or workflow_dispatch): use the tag name + update latest
             type=ref,event=tag
             type=raw,value=${{ steps.release_tag.outputs.tag }},enable=${{ steps.release_tag.outputs.is_release == 'true' }}
             type=raw,value=latest,enable=${{ steps.release_tag.outputs.is_release == 'true' }}
-            # On main push: tag as 'development' (mutable, tracks main branch)
             type=raw,value=development,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-            # Always tag with short and full SHA
             type=raw,value=${{ steps.sha.outputs.sha_short }}
             type=raw,value=${{ steps.sha.outputs.sha }}
 
-      - name: Build and push ${{ matrix.target }}
+      - name: Build and push server
         uses: docker/build-push-action@v5
         with:
-          context: ${{ matrix.context || '.' }}
-          file: ${{ matrix.dockerfile }}
-          target: ${{ matrix.target }}
+          context: .
+          file: docker/Dockerfile.unified
+          target: server
           platforms: ${{ steps.platforms.outputs.platforms }}
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=docker-${{ matrix.target }}
-          cache-to: type=gha,mode=max,scope=docker-${{ matrix.target }}
+          tags: ${{ steps.meta-server.outputs.tags }}
+          labels: ${{ steps.meta-server.outputs.labels }}
+          cache-from: type=gha,scope=docker-rust
+          cache-to: type=gha,mode=max,scope=docker-rust
+
+      # --- Worker image ---
+      - name: Extract metadata (worker)
+        id: meta-worker
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_BASE }}/everruns-worker
+          tags: |
+            type=ref,event=tag
+            type=raw,value=${{ steps.release_tag.outputs.tag }},enable=${{ steps.release_tag.outputs.is_release == 'true' }}
+            type=raw,value=latest,enable=${{ steps.release_tag.outputs.is_release == 'true' }}
+            type=raw,value=development,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+            type=raw,value=${{ steps.sha.outputs.sha_short }}
+            type=raw,value=${{ steps.sha.outputs.sha }}
+
+      - name: Build and push worker
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/Dockerfile.unified
+          target: worker
+          platforms: ${{ steps.platforms.outputs.platforms }}
+          push: true
+          tags: ${{ steps.meta-worker.outputs.tags }}
+          labels: ${{ steps.meta-worker.outputs.labels }}
+          cache-from: type=gha,scope=docker-rust
+          cache-to: type=gha,mode=max,scope=docker-rust
+
+      # --- Admin image (skip on PRs — not needed for CI validation) ---
+      - name: Extract metadata (admin)
+        if: github.event_name != 'pull_request'
+        id: meta-admin
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_BASE }}/everruns-admin
+          tags: |
+            type=ref,event=tag
+            type=raw,value=${{ steps.release_tag.outputs.tag }},enable=${{ steps.release_tag.outputs.is_release == 'true' }}
+            type=raw,value=latest,enable=${{ steps.release_tag.outputs.is_release == 'true' }}
+            type=raw,value=development,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+            type=raw,value=${{ steps.sha.outputs.sha_short }}
+            type=raw,value=${{ steps.sha.outputs.sha }}
+
+      - name: Build and push admin
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/Dockerfile.unified
+          target: admin
+          platforms: ${{ steps.platforms.outputs.platforms }}
+          push: true
+          tags: ${{ steps.meta-admin.outputs.tags }}
+          labels: ${{ steps.meta-admin.outputs.labels }}
+          cache-from: type=gha,scope=docker-rust
+          cache-to: type=gha,mode=max,scope=docker-rust
+
+  # UI image builds independently (different Dockerfile, Node.js stack)
+  build-ui-image:
+    name: Build UI Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        if: github.event_name != 'pull_request'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine SHA
+        id: sha
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+            echo "sha_short=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
+          else
+            echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+            echo "sha_short=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Determine release tag
+        id: release_tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+            echo "is_release=true" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+            echo "is_release=true" >> $GITHUB_OUTPUT
+          else
+            echo "tag=" >> $GITHUB_OUTPUT
+            echo "is_release=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Determine platforms
+        id: platforms
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
+          else
+            echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Extract metadata (ui)
+        id: meta-ui
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_BASE }}/everruns-ui
+          tags: |
+            type=ref,event=tag
+            type=raw,value=${{ steps.release_tag.outputs.tag }},enable=${{ steps.release_tag.outputs.is_release == 'true' }}
+            type=raw,value=latest,enable=${{ steps.release_tag.outputs.is_release == 'true' }}
+            type=raw,value=development,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+            type=raw,value=${{ steps.sha.outputs.sha_short }}
+            type=raw,value=${{ steps.sha.outputs.sha }}
+
+      - name: Build and push UI
+        uses: docker/build-push-action@v5
+        with:
+          context: apps/ui
+          file: apps/ui/Dockerfile
+          target: ui
+          platforms: ${{ steps.platforms.outputs.platforms }}
+          push: true
+          tags: ${{ steps.meta-ui.outputs.tags }}
+          labels: ${{ steps.meta-ui.outputs.labels }}
+          cache-from: type=gha,scope=docker-ui
+          cache-to: type=gha,mode=max,scope=docker-ui

--- a/docker/Dockerfile.unified
+++ b/docker/Dockerfile.unified
@@ -52,9 +52,11 @@ COPY crates crates
 COPY integrations integrations
 
 # ============================================================================
-# Stage 2a: Build Server binary
+# Stage 2: Build all Rust binaries in a single invocation
 # ============================================================================
-FROM builder-base AS builder-server
+# Compiles server, worker, and reencrypt-secrets together so shared dependencies
+# (tokio, axum, sqlx, etc.) are compiled once per architecture instead of 3x.
+FROM builder-base AS builder-all
 
 ARG TARGETPLATFORM
 
@@ -63,35 +65,9 @@ ARG TARGETPLATFORM
 RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARGETPLATFORM} \
     --mount=type=cache,target=/usr/local/cargo/git,id=cargo-git-${TARGETPLATFORM} \
     --mount=type=cache,target=/app/target,id=target-${TARGETPLATFORM} \
-    xx-cargo build --release -p everruns-server && \
-    cp target/$(xx-cargo --print-target-triple)/release/everruns-server /app/everruns-server
-
-# ============================================================================
-# Stage 2b: Build Worker binary
-# ============================================================================
-FROM builder-base AS builder-worker
-
-ARG TARGETPLATFORM
-
-# Each cache has platform-specific ID to avoid conflicts during multi-platform builds
-RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARGETPLATFORM} \
-    --mount=type=cache,target=/usr/local/cargo/git,id=cargo-git-${TARGETPLATFORM} \
-    --mount=type=cache,target=/app/target,id=target-${TARGETPLATFORM} \
-    xx-cargo build --release -p everruns-worker && \
-    cp target/$(xx-cargo --print-target-triple)/release/everruns-worker /app/everruns-worker
-
-# ============================================================================
-# Stage 2c: Build Admin tools (reencrypt-secrets + sqlx-cli)
-# ============================================================================
-FROM builder-base AS builder-admin
-
-ARG TARGETPLATFORM
-
-# Each cache has platform-specific ID to avoid conflicts during multi-platform builds
-RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARGETPLATFORM} \
-    --mount=type=cache,target=/usr/local/cargo/git,id=cargo-git-${TARGETPLATFORM} \
-    --mount=type=cache,target=/app/target,id=target-${TARGETPLATFORM} \
-    xx-cargo build --release --bin reencrypt-secrets && \
+    xx-cargo build --release -p everruns-server -p everruns-worker --bin reencrypt-secrets && \
+    cp target/$(xx-cargo --print-target-triple)/release/everruns-server /app/everruns-server && \
+    cp target/$(xx-cargo --print-target-triple)/release/everruns-worker /app/everruns-worker && \
     cp target/$(xx-cargo --print-target-triple)/release/reencrypt-secrets /app/reencrypt-secrets && \
     xx-cargo install sqlx-cli --no-default-features --features postgres,rustls --locked
 
@@ -102,7 +78,7 @@ FROM gcr.io/distroless/cc-debian12 AS server
 
 WORKDIR /app
 
-COPY --from=builder-server /app/everruns-server /app/everruns-server
+COPY --from=builder-all /app/everruns-server /app/everruns-server
 
 EXPOSE 9000
 EXPOSE 9001
@@ -120,7 +96,7 @@ FROM gcr.io/distroless/cc-debian12 AS worker
 
 WORKDIR /app
 
-COPY --from=builder-worker /app/everruns-worker /app/everruns-worker
+COPY --from=builder-all /app/everruns-worker /app/everruns-worker
 
 ENV RUST_LOG=info
 
@@ -156,10 +132,10 @@ WORKDIR /app
 COPY --from=ca-certs /etc/ssl/certs /etc/ssl/certs
 
 # Copy sqlx-cli from builder (cross-compiled for target architecture)
-COPY --from=builder-admin /usr/local/cargo/bin/sqlx /usr/local/bin/sqlx
+COPY --from=builder-all /usr/local/cargo/bin/sqlx /usr/local/bin/sqlx
 
 # Copy the reencrypt-secrets binary
-COPY --from=builder-admin /app/reencrypt-secrets /app/reencrypt-secrets
+COPY --from=builder-all /app/reencrypt-secrets /app/reencrypt-secrets
 
 # Copy migrations
 COPY crates/server/migrations /app/migrations

--- a/docker/Dockerfile.unified
+++ b/docker/Dockerfile.unified
@@ -65,7 +65,7 @@ ARG TARGETPLATFORM
 RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARGETPLATFORM} \
     --mount=type=cache,target=/usr/local/cargo/git,id=cargo-git-${TARGETPLATFORM} \
     --mount=type=cache,target=/app/target,id=target-${TARGETPLATFORM} \
-    xx-cargo build --release -p everruns-server -p everruns-worker --bin reencrypt-secrets && \
+    xx-cargo build --release -p everruns-server -p everruns-worker && \
     cp target/$(xx-cargo --print-target-triple)/release/everruns-server /app/everruns-server && \
     cp target/$(xx-cargo --print-target-triple)/release/everruns-worker /app/everruns-worker && \
     cp target/$(xx-cargo --print-target-triple)/release/reencrypt-secrets /app/reencrypt-secrets && \


### PR DESCRIPTION
## What
Merge the 3 separate Rust builder stages (server, worker, admin) into a single `builder-all` stage in the unified Dockerfile, and restructure CI workflows to build all Rust images on a single runner.

## Why
Each builder stage independently compiled the full dependency tree (tokio, axum, sqlx, etc.). On separate matrix runners there was no shared cache, so the same dependencies were compiled 3x — especially painful for ARM64 cross-compilation via QEMU.

## How
- **Dockerfile.unified**: Replace `builder-server`, `builder-worker`, `builder-admin` with single `builder-all` that runs `cargo build --release -p everruns-server -p everruns-worker --bin reencrypt-secrets` in one invocation
- **docker-publish.yml**: Replace 4-entry matrix with 2 independent jobs (`build-rust-images` + `build-ui-image`). Rust job builds server/worker/admin sequentially on one runner sharing BuildKit cache. Admin image skipped on PRs.
- **ci.yml**: docker-build job builds server + worker sequentially on one runner with shared `docker-rust` cache scope

## Risk
- Low
- Docker image builds could fail if the combined cargo invocation has unexpected interactions (unlikely — same workspace, same deps)
- GHA cache scope change (`docker-rust` replaces per-target scopes) means first build after merge will be a cache miss

## Checklist
- [x] Tests added or updated (N/A — CI config only)
- [x] Backward compatibility considered (N/A — internal CI)