### PR TITLE
feat(ui): add title and experimental badge to Chat page

### DIFF
--- a/apps/ui/src/app/(main)/chat/page.tsx
+++ b/apps/ui/src/app/(main)/chat/page.tsx
@@ -43,8 +43,11 @@ export default function GlobalChatPage() {
 
   return (
     <div className="flex flex-col h-full">
-      <div className="flex justify-end px-4 pt-2 pb-0">
-        <ExperimentalPageBadge />
+      <div className="flex items-center justify-between px-6 pt-4 pb-0">
+        <h1 className="text-2xl font-bold flex items-center gap-3">
+          Chat
+          <ExperimentalPageBadge />
+        </h1>
       </div>
       <SessionProvider sessionId={sessionId}>
         <ChatPanel />


### PR DESCRIPTION
## What
Add a "Chat" page title with an inline ExperimentalPageBadge, matching the pattern used on the Apps page.

## Why
The Chat page had no title — just a floating experimental badge in the top-right corner. This aligns it with the rest of the app which uses proper h1 headings.

## How
Replaced the bare ExperimentalPageBadge div with an h1 containing "Chat" text and the badge inline, using flex + gap-3 layout.

## Risk
- Low
- Purely cosmetic change to a feature-flagged page (global_chat). No logic or data flow changes.

## Checklist
- [x] Tests added or updated (N/A — cosmetic layout change, no logic)
- [x] Backward compatibility considered (N/A — internal UI)