### PR TITLE
fix(ui): move Event Subscriptions card inside grid layout

### DIFF
--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -435,6 +435,93 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
               )}
             </CardContent>
           </Card>
+
+          {/* Webhook URL Card - shown when published and configured */}
+          {isPublished && hasSlackConfig && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Globe className="w-5 h-5" />
+                  Event Subscriptions
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {isLocalhost ? (
+                  <>
+                    <p className="text-sm text-muted-foreground">
+                      Slack can&apos;t reach <code className="text-xs">localhost</code>. Use{" "}
+                      <a
+                        href="https://ngrok.com"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline"
+                      >
+                        ngrok
+                      </a>{" "}
+                      to expose your local server:
+                    </p>
+                    <div className="bg-muted p-3 rounded-md space-y-1">
+                      <p className="text-xs font-medium text-muted-foreground">1. Start ngrok:</p>
+                      <code className="text-xs block">
+                        ngrok http{" "}
+                        {typeof window !== "undefined" ? window.location.port || "9300" : "9300"}
+                      </code>
+                      <p className="text-xs font-medium text-muted-foreground mt-2">
+                        2. Copy your Request URL:
+                      </p>
+                      <code className="text-xs block">
+                        https://&lt;your-id&gt;.ngrok-free.app{webhookPath}
+                      </code>
+                    </div>
+                    <p className="text-sm text-muted-foreground">
+                      Paste that URL in your Slack app &rarr; <strong>Event Subscriptions</strong>{" "}
+                      &rarr; <strong>Request URL</strong>. Then subscribe to bot events:{" "}
+                      <code className="text-xs">message.channels</code>,{" "}
+                      <code className="text-xs">message.groups</code>,{" "}
+                      <code className="text-xs">message.im</code>,{" "}
+                      <code className="text-xs">app_mention</code>.
+                    </p>
+                    <div className="flex items-center gap-2 bg-muted p-2 rounded-md">
+                      <code className="text-xs flex-1 truncate text-muted-foreground">
+                        {webhookPath}
+                      </code>
+                      <button
+                        className="shrink-0 hover:text-foreground text-muted-foreground"
+                        onClick={() => navigator.clipboard.writeText(webhookPath)}
+                      >
+                        <Copy className="w-4 h-4" />
+                      </button>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <p className="text-sm text-muted-foreground">
+                      Paste this URL in your Slack app &rarr; <strong>Event Subscriptions</strong>{" "}
+                      &rarr; <strong>Request URL</strong>. Then subscribe to bot events:{" "}
+                      <code className="text-xs">message.channels</code>,{" "}
+                      <code className="text-xs">message.groups</code>,{" "}
+                      <code className="text-xs">message.im</code>,{" "}
+                      <code className="text-xs">app_mention</code>.
+                    </p>
+                    <div className="flex items-center gap-2 bg-muted p-3 rounded-md">
+                      <Globe className="w-4 h-4 shrink-0 text-muted-foreground" />
+                      <code className="text-sm flex-1 truncate">{webhookUrl}</code>
+                      <button
+                        className="shrink-0 hover:text-foreground text-muted-foreground"
+                        onClick={() => navigator.clipboard.writeText(webhookUrl)}
+                      >
+                        <Copy className="w-4 h-4" />
+                      </button>
+                    </div>
+                  </>
+                )}
+                <p className="text-xs text-muted-foreground">
+                  After saving, invite the bot to a channel (<code>/invite @{app?.name}</code>) and
+                  send a message to test.
+                </p>
+              </CardContent>
+            </Card>
+          )}
         </div>
 
         {/* Sidebar */}
@@ -541,93 +628,6 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
           </Card>
         </div>
       </div>
-
-      {/* Webhook URL Card - shown when published and configured */}
-      {isPublished && hasSlackConfig && (
-        <Card className="lg:col-span-2">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Globe className="w-5 h-5" />
-              Event Subscriptions
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {isLocalhost ? (
-              <>
-                <p className="text-sm text-muted-foreground">
-                  Slack can&apos;t reach <code className="text-xs">localhost</code>. Use{" "}
-                  <a
-                    href="https://ngrok.com"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="underline"
-                  >
-                    ngrok
-                  </a>{" "}
-                  to expose your local server:
-                </p>
-                <div className="bg-muted p-3 rounded-md space-y-1">
-                  <p className="text-xs font-medium text-muted-foreground">1. Start ngrok:</p>
-                  <code className="text-xs block">
-                    ngrok http{" "}
-                    {typeof window !== "undefined" ? window.location.port || "9300" : "9300"}
-                  </code>
-                  <p className="text-xs font-medium text-muted-foreground mt-2">
-                    2. Copy your Request URL:
-                  </p>
-                  <code className="text-xs block">
-                    https://&lt;your-id&gt;.ngrok-free.app{webhookPath}
-                  </code>
-                </div>
-                <p className="text-sm text-muted-foreground">
-                  Paste that URL in your Slack app &rarr; <strong>Event Subscriptions</strong>{" "}
-                  &rarr; <strong>Request URL</strong>. Then subscribe to bot events:{" "}
-                  <code className="text-xs">message.channels</code>,{" "}
-                  <code className="text-xs">message.groups</code>,{" "}
-                  <code className="text-xs">message.im</code>,{" "}
-                  <code className="text-xs">app_mention</code>.
-                </p>
-                <div className="flex items-center gap-2 bg-muted p-2 rounded-md">
-                  <code className="text-xs flex-1 truncate text-muted-foreground">
-                    {webhookPath}
-                  </code>
-                  <button
-                    className="shrink-0 hover:text-foreground text-muted-foreground"
-                    onClick={() => navigator.clipboard.writeText(webhookPath)}
-                  >
-                    <Copy className="w-4 h-4" />
-                  </button>
-                </div>
-              </>
-            ) : (
-              <>
-                <p className="text-sm text-muted-foreground">
-                  Paste this URL in your Slack app &rarr; <strong>Event Subscriptions</strong>{" "}
-                  &rarr; <strong>Request URL</strong>. Then subscribe to bot events:{" "}
-                  <code className="text-xs">message.channels</code>,{" "}
-                  <code className="text-xs">message.groups</code>,{" "}
-                  <code className="text-xs">message.im</code>,{" "}
-                  <code className="text-xs">app_mention</code>.
-                </p>
-                <div className="flex items-center gap-2 bg-muted p-3 rounded-md">
-                  <Globe className="w-4 h-4 shrink-0 text-muted-foreground" />
-                  <code className="text-sm flex-1 truncate">{webhookUrl}</code>
-                  <button
-                    className="shrink-0 hover:text-foreground text-muted-foreground"
-                    onClick={() => navigator.clipboard.writeText(webhookUrl)}
-                  >
-                    <Copy className="w-4 h-4" />
-                  </button>
-                </div>
-              </>
-            )}
-            <p className="text-xs text-muted-foreground">
-              After saving, invite the bot to a channel (<code>/invite @{app?.name}</code>) and send
-              a message to test.
-            </p>
-          </CardContent>
-        </Card>
-      )}
 
       {/* Delete confirmation dialog */}
       <Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>


### PR DESCRIPTION
## What
Move the Event Subscriptions card from outside the grid layout into the main content column on the app detail page.

## Why
The card was rendered outside the grid, breaking the page layout. It should sit below the Slack Integration card within the grid.

## How
Moved the Event Subscriptions JSX block from after the grid closing `</div>` to inside the grid, below the Slack Integration card. Removed the now-unnecessary `lg:col-span-2` class. Preserved the localhost/ngrok detection logic from main during rebase conflict resolution.

## Risk
- Low
- Visual-only change; no logic changes

## Checklist
- [x] Tests added or updated (UI lint + build verified)
- [x] Backward compatibility considered (N/A — layout fix only)