### PR TITLE
feat(brave-search): add connection provider, seed agent, and Doppler CI

### DIFF
--- a/.github/workflows/brave-search-integration.yml
+++ b/.github/workflows/brave-search-integration.yml
@@ -44,8 +44,11 @@ jobs:
           shared-key: "brave-search-integration"
 
       - name: Fetch Brave Search API key from Doppler
-        if: env.DOPPLER_TOKEN != ''
         run: |
+          if [ -z "$DOPPLER_TOKEN" ]; then
+            echo "::error::DOPPLER_TOKEN secret is not set"
+            exit 1
+          fi
           if ! command -v doppler &>/dev/null; then
             curl -sLf --retry 3 https://cli.doppler.com/install.sh | sudo sh >/dev/null 2>&1
           fi

--- a/.github/workflows/brave-search-integration.yml
+++ b/.github/workflows/brave-search-integration.yml
@@ -21,15 +21,13 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   CARGO_INCREMENTAL: 0
+  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
 jobs:
   integration-test:
     name: Brave Search API Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 5
-
-    env:
-      BRAVE_SEARCH_API_KEY: ${{ secrets.BRAVE_SEARCH_API_KEY }}
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v4
@@ -44,6 +42,14 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "brave-search-integration"
+
+      - name: Fetch Brave Search API key from Doppler
+        if: env.DOPPLER_TOKEN != ''
+        run: |
+          if ! command -v doppler &>/dev/null; then
+            curl -sLf --retry 3 https://cli.doppler.com/install.sh | sudo sh >/dev/null 2>&1
+          fi
+          echo "BRAVE_SEARCH_API_KEY=$(doppler secrets get BRAVE_SEARCH_API_KEY --plain)" >> "$GITHUB_ENV"
 
       - name: Run integration tests
         run: cargo test -p everruns-integrations-brave-search --features integration

--- a/apps/ui/src/app/(main)/settings/connections/page.tsx
+++ b/apps/ui/src/app/(main)/settings/connections/page.tsx
@@ -23,7 +23,16 @@ import {
   useCreateApiKeyConnection,
 } from "@/hooks/use-user-connections";
 import { getBackendUrl } from "@/lib/api/client";
-import { ExternalLink, Github, LinkIcon, Trash2, Check, Cloud, Search, AlertCircle } from "lucide-react";
+import {
+  ExternalLink,
+  Github,
+  LinkIcon,
+  Trash2,
+  Check,
+  Cloud,
+  Search,
+  AlertCircle,
+} from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { UserConnection, ConnectionProvider as ConnectionProviderType } from "@/lib/api/types";
 import { InlineStreamdownMessage } from "@/components/chat/streamdown-message";

--- a/apps/ui/src/app/(main)/settings/connections/page.tsx
+++ b/apps/ui/src/app/(main)/settings/connections/page.tsx
@@ -23,7 +23,7 @@ import {
   useCreateApiKeyConnection,
 } from "@/hooks/use-user-connections";
 import { getBackendUrl } from "@/lib/api/client";
-import { ExternalLink, Github, LinkIcon, Trash2, Check, Cloud, AlertCircle } from "lucide-react";
+import { ExternalLink, Github, LinkIcon, Trash2, Check, Cloud, Search, AlertCircle } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { UserConnection, ConnectionProvider as ConnectionProviderType } from "@/lib/api/types";
 import { InlineStreamdownMessage } from "@/components/chat/streamdown-message";
@@ -33,6 +33,7 @@ import { getCapabilityIcon } from "@/lib/capability-icons";
 const iconMap: Record<string, LucideIcon> = {
   github: Github,
   cloud: Cloud,
+  search: Search,
   daytona: getCapabilityIcon("daytona"),
 };
 

--- a/crates/server/src/api/user_connections.rs
+++ b/crates/server/src/api/user_connections.rs
@@ -102,8 +102,8 @@ pub struct ApiKeyConnectionRequest {
     pub api_key: String,
 }
 
-/// Providers that support API-key-based connections.
-const API_KEY_PROVIDERS: &[&str] = &["brave_search"];
+/// Providers that support API-key-based connections (legacy, prefer ConnectionProviderPlugin).
+const API_KEY_PROVIDERS: &[&str] = &[];
 
 /// GitHub App installation callback query params
 #[derive(Debug, Deserialize)]

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -54,6 +54,7 @@ mod seed_ids {
     pub const CLOUD_INFRA_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000109);
     pub const PLATFORM_MANAGER_AGENT: Uuid =
         Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000010a);
+    pub const WEB_RESEARCHER_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000010b);
 
     // MCP Servers (0x500-0x5FF)
     pub const MS_LEARN_MCP: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000501);
@@ -845,6 +846,49 @@ All tool results include UI links so you can point users to the web interface."#
             "current_time",
         ],
         dev_only: false,
+    },
+    SeedAgent {
+        id: seed_ids::WEB_RESEARCHER_AGENT,
+        name: "Web Researcher",
+        description: "An agent that searches the web using Brave Search to find current information, news, and documentation. Always cites sources with links.",
+        system_prompt: r#"You are a Web Researcher Agent. You search the web using Brave Search to find
+current, accurate information for any topic.
+
+## How You Work
+
+1. **Search the web** using `brave_web_search` to find relevant results
+2. **Synthesize** findings into clear, well-organized responses
+3. **Always cite sources** — include the URL for every piece of information
+
+## Guidelines
+
+- Use multiple searches to cross-reference information when needed
+- Use the `freshness` parameter for time-sensitive queries (e.g., "pd" for past day, "pw" for past week)
+- Always include source URLs so the user can verify information
+- Format citations as markdown links: [Title](url)
+- If search results are insufficient, say so honestly rather than speculating
+- For broad topics, break them into specific sub-queries for better results
+
+## Response Format
+
+Structure your responses with:
+- A concise summary at the top
+- Detailed findings organized by subtopic
+- A **Sources** section at the bottom listing all referenced URLs
+
+## Example Sources Section
+
+**Sources:**
+- [Article Title](https://example.com/article)
+- [Another Source](https://example.com/source)
+
+## Prerequisites
+
+Brave Search API key must be configured in Settings > Connections.
+Get a free key at https://brave.com/search/api/"#,
+        tags: &["research", "search", "web", "demo", "seed"],
+        capabilities: &["brave_search", "stateless_todo_list", "current_time"],
+        dev_only: true,
     },
 ];
 

--- a/docs/integrations/brave-search.md
+++ b/docs/integrations/brave-search.md
@@ -1,0 +1,95 @@
+---
+title: Brave Search
+description: Web search for agents via the Brave Search API
+---
+
+Everruns integrates with [Brave Search](https://brave.com/search/api/) to give agents full web search capabilities. Agents can search the web and get relevant results including titles, URLs, and descriptions — perfect for research, fact-checking, and finding current information.
+
+## What You Get
+
+- **Full Web Search**: Query the web and get ranked results with titles, URLs, and descriptions
+- **Freshness Filters**: Filter results by time (past day, week, month, year)
+- **Pagination**: Navigate through large result sets
+- **Source Attribution**: Every result includes a URL for citation and verification
+- **Free Tier**: Brave Search offers a free plan with 2,000 queries/month
+
+## Quick Start
+
+### 1. Get Your API Key
+
+1. Go to [Brave Search API](https://brave.com/search/api/)
+2. Sign up for a **free** plan (2,000 queries/month)
+3. Copy your **API Key** from the dashboard
+
+### 2. Connect in Everruns
+
+1. Go to **Settings** > **Connections**
+2. Find **Brave Search** in the available providers
+3. Click **Connect** and paste your API key
+
+Once connected, the Brave Search capability is automatically available in agent sessions.
+
+### 3. Use in Sessions
+
+Agents with the Brave Search capability can use this tool:
+
+| Tool | Description |
+|------|-------------|
+| `brave_web_search` | Search the web and return relevant results |
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | string | Yes | Search query |
+| `count` | integer | No | Number of results (1-20, default: 10) |
+| `offset` | integer | No | Pagination offset |
+| `freshness` | string | No | Time filter: `pd` (past day), `pw` (past week), `pm` (past month), `py` (past year) |
+
+### Response Fields
+
+The tool returns a JSON object with:
+
+| Field | Description |
+|-------|-------------|
+| `query` | The original query |
+| `results` | Array of result objects |
+| `count` | Number of results returned |
+
+Each result object contains:
+
+| Field | Description |
+|-------|-------------|
+| `title` | Page title |
+| `url` | Page URL (use for citations) |
+| `description` | Snippet/description of the page |
+| `age` | How old the result is (e.g., "2 hours ago") — optional |
+
+## When to Use Brave Search vs DuckDuckGo
+
+| Use Case | Brave Search | DuckDuckGo |
+|----------|--------------|------------|
+| Full web search results | Best choice | Not available |
+| Current news and articles | Best choice | Limited |
+| Quick facts and definitions | Works but slower | Best choice |
+| Wikipedia-style summaries | Not available | Best choice |
+| Calculations and conversions | Not available | Direct answers |
+| API key required | Yes (free tier available) | No |
+
+Both capabilities can be enabled simultaneously — the agent will choose the right tool based on the task.
+
+## Security
+
+- API keys are encrypted at rest (AES-256-GCM envelope encryption)
+- Keys are validated on connection (test query to Brave Search API)
+- API key never appears in tool results or message history
+- Rate limiting deferred to Brave Search API (returns 429 on limit)
+
+## Status
+
+**Experimental** — available in dev mode only. This capability may change in future releases.
+
+## Links
+
+- [Brave Search API](https://brave.com/search/api/)
+- [Brave Search API Documentation](https://api.search.brave.com/app/#/documentation/web-search)

--- a/integrations/brave-search/src/connection.rs
+++ b/integrations/brave-search/src/connection.rs
@@ -1,0 +1,104 @@
+// Brave Search Connection Provider
+//
+// Decision: API-key-based connection (not OAuth). User enters key from brave.com/search/api.
+// Decision: Validate key by calling GET /web/search?q=test — 200 means valid, 401/403 means invalid.
+// Decision: All Brave Search connection config (form schema, instructions, validation)
+//   lives in this crate, not in the server crate.
+
+use async_trait::async_trait;
+use everruns_core::connection_provider::{
+    ConnectionFormSchema, ConnectionProvider, ConnectionType, ConnectionValidation, FieldType,
+    FormField,
+};
+
+use crate::BRAVE_SEARCH_API_BASE;
+
+pub struct BraveSearchConnectionProvider;
+
+#[async_trait]
+impl ConnectionProvider for BraveSearchConnectionProvider {
+    fn provider_id(&self) -> &str {
+        "brave_search"
+    }
+
+    fn display_name(&self) -> &str {
+        "Brave Search"
+    }
+
+    fn description(&self) -> &str {
+        "Web search for agents via Brave Search API"
+    }
+
+    fn icon(&self) -> &str {
+        "search"
+    }
+
+    fn connection_type(&self) -> ConnectionType {
+        ConnectionType::ApiKey
+    }
+
+    fn form_schema(&self) -> Option<ConnectionFormSchema> {
+        Some(ConnectionFormSchema {
+            fields: vec![FormField {
+                name: "api_key".to_string(),
+                label: "API Key".to_string(),
+                field_type: FieldType::Password,
+                required: true,
+                placeholder: Some("BSA...".to_string()),
+                help_text: None,
+            }],
+            instructions_markdown: "\
+1. Go to [Brave Search API](https://brave.com/search/api/)\n\
+2. Sign up for a **free** plan (2,000 queries/month)\n\
+3. Copy your **API Key** from the dashboard\n\
+4. Paste it below"
+                .to_string(),
+        })
+    }
+
+    async fn validate(&self, credential: &str) -> Result<ConnectionValidation, String> {
+        let client = reqwest::Client::new();
+        let response = client
+            .get(format!("{BRAVE_SEARCH_API_BASE}/web/search?q=test&count=1"))
+            .header("X-Subscription-Token", credential)
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .map_err(|e| format!("Failed to reach Brave Search API: {e}"))?;
+
+        match response.status().as_u16() {
+            200 => Ok(ConnectionValidation {
+                provider_username: None,
+            }),
+            401 | 403 => Err("Invalid API key. Check that the key is correct and active.".into()),
+            429 => Err("API key is valid but rate-limited. Try again in a moment.".into()),
+            status => Err(format!(
+                "Unexpected response from Brave Search API (HTTP {status})"
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_provider_metadata() {
+        let p = BraveSearchConnectionProvider;
+        assert_eq!(p.provider_id(), "brave_search");
+        assert_eq!(p.display_name(), "Brave Search");
+        assert_eq!(p.connection_type(), ConnectionType::ApiKey);
+        assert_eq!(p.icon(), "search");
+    }
+
+    #[test]
+    fn test_form_schema() {
+        let p = BraveSearchConnectionProvider;
+        let schema = p.form_schema().expect("should have form schema");
+        assert_eq!(schema.fields.len(), 1);
+        assert_eq!(schema.fields[0].name, "api_key");
+        assert!(schema.fields[0].required);
+        assert!(schema.instructions_markdown.contains("brave.com"));
+    }
+}

--- a/integrations/brave-search/src/lib.rs
+++ b/integrations/brave-search/src/lib.rs
@@ -8,21 +8,31 @@
 //! Decision: Stateless — no per-resource state management needed
 
 pub mod client;
+pub mod connection;
 mod tools;
 
 use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin};
+use everruns_core::connection_provider::ConnectionProviderPlugin;
 use everruns_core::tools::Tool;
 
+use connection::BraveSearchConnectionProvider;
 use tools::BraveWebSearchTool;
 
 // ============================================================================
-// Integration Plugin Registration
+// Plugin Registration
 // ============================================================================
 
 inventory::submit! {
     IntegrationPlugin {
         experimental_only: true,
         factory: || Box::new(BraveSearchCapability),
+    }
+}
+
+inventory::submit! {
+    ConnectionProviderPlugin {
+        experimental_only: true,
+        factory: || Box::new(BraveSearchConnectionProvider),
     }
 }
 

--- a/integrations/brave-search/tests/plugin_registration.rs
+++ b/integrations/brave-search/tests/plugin_registration.rs
@@ -1,6 +1,7 @@
 //! Integration test: verify Brave Search plugin registers via inventory.
 
 use everruns_core::capabilities::{CapabilityRegistry, IntegrationPlugin};
+use everruns_core::connection_provider::ConnectionProviderPlugin;
 use everruns_core::deployment::DeploymentGrade;
 
 // Force linker to include the integration crate's inventory submissions.
@@ -66,4 +67,53 @@ fn test_brave_search_capability_metadata() {
     assert_eq!(cap.category(), Some("Network"));
     assert!(cap.dependencies().is_empty());
     assert_eq!(cap.tools().len(), 1);
+}
+
+#[test]
+fn test_brave_search_connection_provider_is_submitted() {
+    let plugins: Vec<&ConnectionProviderPlugin> =
+        inventory::iter::<ConnectionProviderPlugin>().collect();
+    assert!(
+        plugins.iter().any(|p| {
+            let provider = (p.factory)();
+            provider.provider_id() == "brave_search"
+        }),
+        "Brave Search ConnectionProviderPlugin should be submitted via inventory"
+    );
+}
+
+#[test]
+fn test_brave_search_connection_provider_is_experimental() {
+    let plugins: Vec<&ConnectionProviderPlugin> =
+        inventory::iter::<ConnectionProviderPlugin>().collect();
+    let brave_search = plugins
+        .iter()
+        .find(|p| {
+            let provider = (p.factory)();
+            provider.provider_id() == "brave_search"
+        })
+        .expect("Brave Search connection plugin not found");
+
+    assert!(
+        brave_search.experimental_only,
+        "Brave Search connection provider should be marked experimental_only"
+    );
+}
+
+#[test]
+fn test_brave_search_connection_provider_has_form_schema() {
+    let plugins: Vec<&ConnectionProviderPlugin> =
+        inventory::iter::<ConnectionProviderPlugin>().collect();
+    let plugin = plugins
+        .iter()
+        .find(|p| {
+            let provider = (p.factory)();
+            provider.provider_id() == "brave_search"
+        })
+        .expect("Brave Search connection plugin not found");
+
+    let provider = (plugin.factory)();
+    let schema = provider.form_schema().expect("should have form schema");
+    assert_eq!(schema.fields.len(), 1);
+    assert_eq!(schema.fields[0].name, "api_key");
 }

--- a/integrations/brave-search/tests/smoke_real_api.rs
+++ b/integrations/brave-search/tests/smoke_real_api.rs
@@ -3,9 +3,8 @@
 //! Gated behind `integration` feature — only compiled when run with:
 //!   cargo test -p everruns-integrations-brave-search --features integration
 //!
-//! CI workflow passes BRAVE_SEARCH_API_KEY and enables the feature automatically.
-//! Tests skip gracefully if the key is missing (avoids CI failures when secret
-//! is not yet configured).
+//! CI workflow passes BRAVE_SEARCH_API_KEY via Doppler and enables the feature
+//! automatically. Tests panic if the key is missing to prevent silent failures.
 
 #![cfg(feature = "integration")]
 
@@ -15,10 +14,7 @@ macro_rules! require_api_key {
     () => {
         match std::env::var("BRAVE_SEARCH_API_KEY") {
             Ok(k) if !k.is_empty() => k,
-            _ => {
-                eprintln!("BRAVE_SEARCH_API_KEY not set — skipping");
-                return;
-            }
+            _ => panic!("BRAVE_SEARCH_API_KEY not set — cannot run integration tests"),
         }
     };
 }

--- a/specs/brave-search.md
+++ b/specs/brave-search.md
@@ -129,18 +129,18 @@ BRAVE_SEARCH_API_KEY=<key> cargo test -p everruns-integrations-brave-search --fe
 
 Tests: `smoke_basic_search`, `smoke_freshness_filter`, `smoke_pagination` in `tests/smoke_real_api.rs`.
 
-Tests use a `require_api_key!` macro that gracefully skips (returns early with a message) when `BRAVE_SEARCH_API_KEY` is unset or empty. This prevents CI failures when the secret is not yet configured while still compiling the test code.
+Tests use a `require_api_key!` macro that panics when `BRAVE_SEARCH_API_KEY` is unset or empty, preventing silent failures in CI.
 
 ### CI
 
 Dedicated workflow `.github/workflows/brave-search-integration.yml`:
 
 - **Path-filtered**: only triggers when `integrations/brave-search/**` changes.
-- Reads `BRAVE_SEARCH_API_KEY` from GitHub Actions secrets.
+- Fetches `BRAVE_SEARCH_API_KEY` from Doppler via `DOPPLER_TOKEN` GitHub Actions secret.
+- Fails if `DOPPLER_TOKEN` is not set (required, not optional).
 - Passes `--features integration` to compile and run the real-API tests.
-- If the secret is missing, tests compile and pass (skipped), ensuring CI stays green.
 
-Adding a new API-key-gated integration crate should follow this pattern: feature-gate the tests, use a skip macro for missing keys, add a path-filtered workflow, store the key in GitHub secrets.
+Adding a new API-key-gated integration crate should follow this pattern: feature-gate the tests, use a panic macro for missing keys, add a path-filtered workflow, fetch the key from Doppler.
 
 ## Crate Structure
 
@@ -152,8 +152,9 @@ External integration crate, auto-registered via `inventory::submit!` plugin syst
 
 | File | Purpose |
 |------|---------|
-| `src/lib.rs` | Plugin registration, constants, `BraveSearchCapability` impl |
+| `src/lib.rs` | Plugin registration (capability + connection provider), constants, `BraveSearchCapability` impl |
 | `src/client.rs` | `BraveSearchClient` HTTP client, API response types |
+| `src/connection.rs` | `BraveSearchConnectionProvider` — form schema, validation |
 | `src/tools.rs` | `BraveWebSearchTool` implementation, API key resolution |
 | `tests/plugin_registration.rs` | Integration tests for inventory registration and dev/prod gating |
 | `tests/smoke_real_api.rs` | Real-API smoke tests (behind `integration` feature) |


### PR DESCRIPTION
## What
Add Brave Search connection provider plugin, Web Researcher seed agent, integration docs, and switch CI from GitHub secrets to Doppler for API key management.

## Why
- Connection provider plugin enables self-service API key setup via Settings > Connections UI
- Seed agent provides a ready-to-use web research demo
- CI was referencing a non-existent `BRAVE_SEARCH_API_KEY` GitHub secret; Doppler is the project standard for secrets

## How
- `BraveSearchConnectionProvider` registered via `inventory::submit!` with form schema and key validation
- Web Researcher seed agent (dev-only) with brave_search capability
- CI workflow fetches `BRAVE_SEARCH_API_KEY` from Doppler at runtime, fails hard if `DOPPLER_TOKEN` missing
- Smoke tests panic instead of silently skipping when API key is missing
- Emptied legacy `API_KEY_PROVIDERS` list (connection provider plugin handles it now)

## Risk
- Low
- Connection provider follows existing patterns (Daytona, DuckDuckGo)
- Seed agent is dev-only
- CI change only affects brave-search integration workflow

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered