### PR TITLE
feat(ui): unify chat and shell slate styling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,7 @@ cd apps/ui
 ./node_modules/.bin/next dev --port 9120
 ```
 
-- If `apps/ui/node_modules` is shared into the worktree via symlink, use `--webpack`; Turbopack rejects node_modules outside the worktree root
+- If `apps/ui/node_modules` is shared into the worktree via symlink, use webpack for Next.js dev/build paths; Turbopack rejects node_modules outside the worktree root
 - If the worktree does not have UI deps yet, install them in `apps/ui` before starting Next
 
 ### Rust

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,34 @@ just start-all          # Full mode (PostgreSQL)
 just --list             # All commands
 ```
 
+#### Worktrees
+
+Use a port prefix per worktree/session. Convention:
+
+- `PORT_PREFIX=xyz`
+- proxy/app: `xyz00`
+- server: `xyz01`
+- frontend: `xyz05`
+- postgres: `xyz32` (when needed)
+
+```bash
+PORT_PREFIX=271 just start-dev
+PORT_PREFIX=271 just start-all
+```
+
+- `scripts/lib/services.sh`, `scripts/lib/docker.sh`, `scripts/lib/bench.sh`, and `local/Caddyfile` read `PORT_PREFIX`
+- Explicit `API_PORT`, `UI_PORT`, `PROXY_PORT`, and `DB_PORT` still override individual ports if needed
+- If `PORT_PREFIX` is unset, repo defaults stay `9000` (API), `9100` (UI), `9300` (proxy), `5432` (Postgres)
+- UI-only worktree iteration:
+
+```bash
+cd apps/ui
+./node_modules/.bin/next dev --port 9120
+```
+
+- If `apps/ui/node_modules` is shared into the worktree via symlink, use `--webpack`; Turbopack rejects node_modules outside the worktree root
+- If the worktree does not have UI deps yet, install them in `apps/ui` before starting Next
+
 ### Rust
 
 - Stable Rust (edition 2024), toolchain in `rust-toolchain.toml`

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "dev": "next dev --port 9100",
-    "build": "next build",
+    "build": "node ./scripts/next-build.mjs",
     "start": "next start",
     "lint": "oxlint -c oxlint.json ./src",
     "format": "oxfmt --write ./src",

--- a/apps/ui/scripts/next-build.mjs
+++ b/apps/ui/scripts/next-build.mjs
@@ -1,0 +1,27 @@
+import { lstatSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+function hasSymlinkedNodeModules() {
+  try {
+    return lstatSync(new URL("../node_modules", import.meta.url)).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+const args = ["build"];
+if (hasSymlinkedNodeModules()) {
+  args.push("--webpack");
+}
+
+const result = spawnSync("./node_modules/.bin/next", args, {
+  cwd: new URL("..", import.meta.url),
+  stdio: "inherit",
+  shell: true,
+});
+
+if (result.error) {
+  throw result.error;
+}
+
+process.exit(result.status ?? 1);

--- a/apps/ui/src/__tests__/session-layout.test.tsx
+++ b/apps/ui/src/__tests__/session-layout.test.tsx
@@ -27,15 +27,6 @@ jest.mock("next/link", () => ({
   ),
 }));
 
-// Mock UI components
-jest.mock("@/components/ui/button", () => ({
-  buttonVariants: ({ variant }: { variant: string; size: string }) =>
-    variant === "default" ? "btn-default" : "btn-ghost",
-  Button: ({ children, ...props }: { children: React.ReactNode }) => (
-    <button {...props}>{children}</button>
-  ),
-}));
-
 jest.mock("@/components/ui/badge", () => ({
   Badge: ({
     children,
@@ -222,7 +213,8 @@ describe("SessionLayout", () => {
 
     await waitFor(() => {
       const chatLink = screen.getByRole("link", { name: /chat/i });
-      expect(chatLink).toHaveClass("btn-default");
+      expect(chatLink).toHaveClass("border-primary");
+      expect(chatLink).toHaveClass("bg-card");
     });
   });
 
@@ -232,7 +224,8 @@ describe("SessionLayout", () => {
 
     await waitFor(() => {
       const filesLink = screen.getByRole("link", { name: /workspace/i });
-      expect(filesLink).toHaveClass("btn-default");
+      expect(filesLink).toHaveClass("border-primary");
+      expect(filesLink).toHaveClass("bg-card");
     });
   });
 
@@ -242,7 +235,8 @@ describe("SessionLayout", () => {
 
     await waitFor(() => {
       const eventsLink = screen.getByRole("link", { name: /events/i });
-      expect(eventsLink).toHaveClass("btn-ghost");
+      expect(eventsLink).toHaveClass("border-transparent");
+      expect(eventsLink).toHaveClass("bg-transparent");
     });
   });
 

--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -117,7 +117,8 @@ describe("Sidebar", () => {
     render(<Sidebar />);
 
     const agentsLink = screen.getByRole("link", { name: /agents/i });
-    expect(agentsLink).toHaveClass("border-accent");
+    expect(agentsLink).toHaveClass("border-l-primary");
+    expect(agentsLink).toHaveClass("bg-card");
   });
 
   it("highlights navigation for nested routes", () => {
@@ -125,7 +126,8 @@ describe("Sidebar", () => {
     render(<Sidebar />);
 
     const agentsLink = screen.getByRole("link", { name: /agents/i });
-    expect(agentsLink).toHaveClass("border-accent");
+    expect(agentsLink).toHaveClass("border-l-primary");
+    expect(agentsLink).toHaveClass("bg-card");
   });
 
   it("renders version in footer", () => {
@@ -181,7 +183,8 @@ describe("Sidebar", () => {
     render(<Sidebar />);
 
     const workersLink = screen.getByRole("link", { name: /workers/i });
-    expect(workersLink).toHaveClass("border-accent");
+    expect(workersLink).toHaveClass("border-l-primary");
+    expect(workersLink).toHaveClass("bg-card");
   });
 });
 
@@ -281,7 +284,8 @@ describe("Sidebar with config", () => {
     render(<Sidebar config={{ navigation: customNav }} />);
 
     const exactLink = screen.getByRole("link", { name: /exact match/i });
-    expect(exactLink).toHaveClass("border-accent");
+    expect(exactLink).toHaveClass("border-l-primary");
+    expect(exactLink).toHaveClass("bg-card");
   });
 
   it("does not highlight exact-match item on child route", () => {
@@ -295,7 +299,8 @@ describe("Sidebar with config", () => {
     render(<Sidebar config={{ navigation: customNav }} />);
 
     const link = screen.getByRole("link", { name: /exact only/i });
-    expect(link).not.toHaveClass("border-accent");
+    expect(link).not.toHaveClass("border-l-primary");
+    expect(link).toHaveClass("border-l-transparent");
   });
 
   it("renders empty config same as no config", () => {

--- a/apps/ui/src/__tests__/todo-list-renderer.test.tsx
+++ b/apps/ui/src/__tests__/todo-list-renderer.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { TodoListRenderer } from "@/components/chat/todo-list-renderer";
+
+describe("TodoListRenderer", () => {
+  it("renders a progress header and uses activeForm for in-progress items", () => {
+    render(
+      <TodoListRenderer
+        arguments={{
+          todos: [
+            {
+              content: "Review code changes",
+              activeForm: "Reviewing code changes",
+              status: "completed",
+            },
+            {
+              content: "Run tests",
+              activeForm: "Running tests",
+              status: "in_progress",
+            },
+            {
+              content: "Update docs",
+              activeForm: "Updating docs",
+              status: "pending",
+            },
+          ],
+        }}
+        isExecuting
+      />,
+    );
+
+    expect(screen.getByText("1 of 3 todos completed")).toBeInTheDocument();
+    expect(screen.getAllByText("Running tests")).toHaveLength(2);
+    expect(screen.getByText("Update docs")).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/__tests__/tool-activity-group.test.tsx
+++ b/apps/ui/src/__tests__/tool-activity-group.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { ToolActivityGroup } from "@/components/chat/tool-activity-group";
+import type { ToolCompletedData } from "@/lib/api/types";
+import type { ToolCallContent } from "@/components/chat/tool-call-utils";
+
+describe("ToolActivityGroup", () => {
+  it("groups tool calls into an exploration summary with readable labels", () => {
+    const toolCalls: ToolCallContent[] = [
+      {
+        id: "tool-1",
+        name: "list_files",
+        arguments: { path: "." },
+      },
+      {
+        id: "tool-2",
+        name: "read_file",
+        arguments: { path: "README.md" },
+      },
+      {
+        id: "tool-3",
+        name: "grep_files",
+        arguments: { pattern: "**/README*" },
+      },
+      {
+        id: "tool-4",
+        name: "search_web",
+        arguments: { query: "project architecture" },
+      },
+    ];
+
+    const toolResultsMap = new Map<string, ToolCompletedData>([
+      [
+        "tool-1",
+        {
+          tool_call_id: "tool-1",
+          tool_name: "list_files",
+          success: true,
+          status: "success",
+        },
+      ],
+    ]);
+
+    render(<ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} />);
+
+    expect(screen.getByText("Exploring 2 reads, 2 searches")).toBeInTheDocument();
+    expect(screen.getByText("List files in current directory")).toBeInTheDocument();
+    expect(screen.getByText("Read README.md")).toBeInTheDocument();
+    expect(screen.getByText("Find **/README*")).toBeInTheDocument();
+    expect(screen.getByText("Search web for project architecture")).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/app/(main)/capabilities/page.tsx
+++ b/apps/ui/src/app/(main)/capabilities/page.tsx
@@ -38,11 +38,11 @@ function CapabilityCard({ capability }: { capability: Capability }) {
 
   return (
     <Link href={`/capabilities/${capability.id}`}>
-      <Card className="hover:shadow-md transition-shadow cursor-pointer h-full">
+      <Card className="h-full cursor-pointer bg-background transition-colors hover:bg-card">
         <CardHeader className="flex flex-row items-start justify-between space-y-0">
           <div className="flex items-center gap-3">
-            <div className="p-2 bg-muted rounded-lg">
-              <IconComponent className="w-5 h-5" />
+            <div className="border bg-muted p-2">
+              <IconComponent className="icon-sharp h-5 w-5" />
             </div>
             <div className="flex items-center gap-2">
               <CardTitle className="text-lg">{capability.name}</CardTitle>
@@ -84,21 +84,21 @@ function CapabilitySummary({ capabilities }: { capabilities: Capability[] }) {
         <CardContent className="space-y-3">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2 text-sm">
-              <CheckCircle2 className="h-4 w-4 text-green-500" />
+              <CheckCircle2 className="icon-sharp h-4 w-4 text-primary" />
               <span>Available</span>
             </div>
             <span className="font-medium">{available}</span>
           </div>
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2 text-sm">
-              <Clock className="h-4 w-4 text-yellow-500" />
+              <Clock className="icon-sharp h-4 w-4 text-accent-foreground" />
               <span>Coming Soon</span>
             </div>
             <span className="font-medium">{comingSoon}</span>
           </div>
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2 text-sm">
-              <AlertCircle className="h-4 w-4 text-muted-foreground" />
+              <AlertCircle className="icon-sharp h-4 w-4 text-muted-foreground" />
               <span>Deprecated</span>
             </div>
             <span className="font-medium">{deprecated}</span>

--- a/apps/ui/src/app/(main)/chat/page.tsx
+++ b/apps/ui/src/app/(main)/chat/page.tsx
@@ -42,9 +42,9 @@ export default function GlobalChatPage() {
   }
 
   return (
-    <div className="flex flex-col h-full">
-      <div className="flex items-center justify-between px-6 pt-4 pb-0">
-        <h1 className="text-2xl font-bold flex items-center gap-3">
+    <div className="flex h-full flex-col bg-background bg-brand-dots">
+      <div className="flex items-center justify-between border-b border-border px-6 py-4">
+        <h1 className="flex items-center gap-3 text-2xl font-semibold tracking-tight">
           Chat
           <ExperimentalPageBadge />
         </h1>

--- a/apps/ui/src/app/(main)/dashboard/page.tsx
+++ b/apps/ui/src/app/(main)/dashboard/page.tsx
@@ -124,7 +124,9 @@ export default function DashboardPage() {
           </Card>
         </div>
 
-        <RecentSessions sessions={sessions} agents={agents} models={llmModels} />
+        <div className="mt-6">
+          <RecentSessions sessions={sessions} agents={agents} models={llmModels} />
+        </div>
       </div>
 
       {/* New Session Dialog */}

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
@@ -3,7 +3,6 @@
 import { use, useEffect, useMemo, useRef, useState } from "react";
 import { usePathname } from "next/navigation";
 import Link from "next/link";
-import { buttonVariants } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
@@ -158,6 +157,13 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
   const activeTab = getActiveTab();
 
   const basePath = `/sessions/${sessionId}`;
+  const getTabClassName = (isActive: boolean) =>
+    cn(
+      "inline-flex h-9 items-center gap-2 border px-3 text-sm transition-colors",
+      isActive
+        ? "border-primary bg-card text-foreground"
+        : "border-transparent bg-transparent text-muted-foreground hover:border-border hover:bg-card hover:text-foreground",
+    );
 
   // Compute active feature set from session capabilities
   const features = useMemo(() => new Set(session?.features ?? []), [session?.features]);
@@ -176,8 +182,8 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
   if (!session) {
     return (
       <div className="container mx-auto p-6">
-        <div className="text-red-500">Session not found</div>
-        <Link href="/sessions" className="text-blue-500 hover:underline">
+        <div className="text-destructive">Session not found</div>
+        <Link href="/sessions" className="text-sm text-muted-foreground hover:text-foreground">
           Back to sessions
         </Link>
       </div>
@@ -187,12 +193,12 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
-      <div className="border-b p-4">
+      <div className="border-b bg-background/90 p-4">
         <Link
           href="/sessions"
           className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-2"
         >
-          <ArrowLeft className="w-4 h-4 mr-2" />
+          <ArrowLeft className="icon-sharp mr-2 h-4 w-4" />
           Back to Sessions
         </Link>
 
@@ -209,7 +215,7 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
                   href={`/agents/${agentId}`}
                   className="inline-flex items-center gap-1 hover:text-foreground"
                 >
-                  <Bot className="w-3 h-3" />
+                  <Bot className="icon-sharp h-3 w-3" />
                   {agent.name}
                 </Link>
               )}
@@ -227,7 +233,7 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
                 <Tooltip>
                   <TooltipTrigger>
                     <Badge variant="outline" className="gap-1 cursor-help">
-                      <Zap className="w-3 h-3" />
+                      <Zap className="icon-sharp h-3 w-3" />
                       {formatTokens(liveUsage.input_tokens)} /{" "}
                       {formatTokens(liveUsage.output_tokens)}
                     </Badge>
@@ -257,7 +263,7 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
             )}
             {llmModel && (
               <Badge variant="outline" className="gap-1">
-                <Sparkles className="w-3 h-3" />
+                <Sparkles className="icon-sharp h-3 w-3" />
                 {llmModel.display_name}
               </Badge>
             )}
@@ -271,59 +277,35 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
         <div className="flex gap-1 mt-4">
           <Link
             href={`${basePath}/chat`}
-            className={cn(
-              buttonVariants({
-                variant: activeTab === "chat" ? "default" : "ghost",
-                size: "sm",
-              }),
-              "gap-2",
-            )}
+            className={getTabClassName(activeTab === "chat")}
           >
-            <MessageSquare className="h-4 w-4" />
+            <MessageSquare className="icon-sharp h-4 w-4" />
             Chat
           </Link>
           {hasFeature("file_system") && (
             <Link
               href={`${basePath}/files`}
-              className={cn(
-                buttonVariants({
-                  variant: activeTab === "files" ? "default" : "ghost",
-                  size: "sm",
-                }),
-                "gap-2",
-              )}
+              className={getTabClassName(activeTab === "files")}
             >
-              <Folder className="h-4 w-4" />
+              <Folder className="icon-sharp h-4 w-4" />
               Workspace
             </Link>
           )}
           {(hasFeature("secrets") || hasFeature("key_value")) && (
             <Link
               href={`${basePath}/storage`}
-              className={cn(
-                buttonVariants({
-                  variant: activeTab === "storage" ? "default" : "ghost",
-                  size: "sm",
-                }),
-                "gap-2",
-              )}
+              className={getTabClassName(activeTab === "storage")}
             >
-              <Database className="h-4 w-4" />
+              <Database className="icon-sharp h-4 w-4" />
               Storage
             </Link>
           )}
           {hasFeature("schedules") && (
             <Link
               href={`${basePath}/schedules`}
-              className={cn(
-                buttonVariants({
-                  variant: activeTab === "schedules" ? "default" : "ghost",
-                  size: "sm",
-                }),
-                "gap-2",
-              )}
+              className={getTabClassName(activeTab === "schedules")}
             >
-              <CalendarClock className="h-4 w-4" />
+              <CalendarClock className="icon-sharp h-4 w-4" />
               Schedules
               {(session.active_schedule_count ?? 0) > 0 && (
                 <Badge variant="secondary" className="h-5 min-w-5 px-1 text-xs">
@@ -334,28 +316,16 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
           )}
           <Link
             href={`${basePath}/events`}
-            className={cn(
-              buttonVariants({
-                variant: activeTab === "events" ? "default" : "ghost",
-                size: "sm",
-              }),
-              "gap-2",
-            )}
+            className={getTabClassName(activeTab === "events")}
           >
-            <Activity className="h-4 w-4" />
+            <Activity className="icon-sharp h-4 w-4" />
             Events
           </Link>
           <Link
             href={`${basePath}/trajectory`}
-            className={cn(
-              buttonVariants({
-                variant: activeTab === "trajectory" ? "default" : "ghost",
-                size: "sm",
-              }),
-              "gap-2",
-            )}
+            className={getTabClassName(activeTab === "trajectory")}
           >
-            <GitBranch className="h-4 w-4" />
+            <GitBranch className="icon-sharp h-4 w-4" />
             Trajectory
           </Link>
         </div>

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
@@ -275,27 +275,18 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
 
         {/* Tabs */}
         <div className="flex gap-1 mt-4">
-          <Link
-            href={`${basePath}/chat`}
-            className={getTabClassName(activeTab === "chat")}
-          >
+          <Link href={`${basePath}/chat`} className={getTabClassName(activeTab === "chat")}>
             <MessageSquare className="icon-sharp h-4 w-4" />
             Chat
           </Link>
           {hasFeature("file_system") && (
-            <Link
-              href={`${basePath}/files`}
-              className={getTabClassName(activeTab === "files")}
-            >
+            <Link href={`${basePath}/files`} className={getTabClassName(activeTab === "files")}>
               <Folder className="icon-sharp h-4 w-4" />
               Workspace
             </Link>
           )}
           {(hasFeature("secrets") || hasFeature("key_value")) && (
-            <Link
-              href={`${basePath}/storage`}
-              className={getTabClassName(activeTab === "storage")}
-            >
+            <Link href={`${basePath}/storage`} className={getTabClassName(activeTab === "storage")}>
               <Database className="icon-sharp h-4 w-4" />
               Storage
             </Link>
@@ -314,10 +305,7 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
               )}
             </Link>
           )}
-          <Link
-            href={`${basePath}/events`}
-            className={getTabClassName(activeTab === "events")}
-          >
+          <Link href={`${basePath}/events`} className={getTabClassName(activeTab === "events")}>
             <Activity className="icon-sharp h-4 w-4" />
             Events
           </Link>

--- a/apps/ui/src/app/dev/chat-components/page.tsx
+++ b/apps/ui/src/app/dev/chat-components/page.tsx
@@ -1,841 +1,199 @@
 "use client";
 
 import Link from "next/link";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import { Bot, ArrowLeft } from "lucide-react";
-import { ToolCallCard } from "@/components/chat/tool-call-card";
-import { ToolCallCardFromEvent } from "@/components/chat/tool-call-card-from-event";
+import { ArrowLeft } from "lucide-react";
+import { ToolActivityGroup } from "@/components/chat/tool-activity-group";
 import { TodoListRenderer } from "@/components/chat/todo-list-renderer";
 import { MessageInfoIcon } from "@/components/chat/message-info-icon";
-import { ImageAttachments, MessageImage } from "@/components/chat/image-attachments";
-import type { Message, Event, ToolCompletedData } from "@/lib/api/types";
+import { ImageAttachments } from "@/components/chat/image-attachments";
+import type { Event, ToolCompletedData } from "@/lib/api/types";
 import type { ToolCallContent } from "@/components/chat/tool-call-utils";
 import type { PendingImage } from "@/lib/api/images";
 
-// Check if we're in development mode
 const isDev = process.env.NODE_ENV === "development";
 
-// ============================================
-// Showcase Section Components
-// ============================================
+const infoEvent: Event = {
+  id: "evt-chat-components",
+  type: "output.message.completed",
+  ts: "2026-03-07T21:45:00Z",
+  session_id: "session-chat-components",
+  context: {},
+  data: {
+    message: {
+      id: "msg-chat-components",
+      session_id: "session-chat-components",
+      sequence: 1,
+      role: "agent",
+      content: [{ type: "text", text: "Components now follow the canonical chat style." }],
+      tool_call_id: null,
+      created_at: "2026-03-07T21:45:00Z",
+      metadata: { model: "kimi-k2.5", reasoning_effort: "medium" },
+    },
+    metadata: { model: "kimi-k2.5" },
+    usage: { input_tokens: 318, output_tokens: 52 },
+  },
+};
 
-function ShowcaseSection({
+const toolCalls: ToolCallContent[] = [
+  { id: "component-list", name: "list_files", arguments: { path: "." } },
+  { id: "component-read", name: "read_file", arguments: { path: "/workspace/AGENTS.md" } },
+  { id: "component-search", name: "search_web", arguments: { query: "chat ui reference" } },
+];
+
+const toolResults = new Map<string, ToolCompletedData>([
+  [
+    "component-list",
+    {
+      tool_call_id: "component-list",
+      tool_name: "list_files",
+      success: true,
+      status: "success",
+      result: [{ type: "text", text: "apps/\ncrates/\nscripts/\nAGENTS.md" }],
+    },
+  ],
+  [
+    "component-read",
+    {
+      tool_call_id: "component-read",
+      tool_name: "read_file",
+      success: true,
+      status: "success",
+      result: [{ type: "text", text: "Use a port prefix per worktree/session." }],
+    },
+  ],
+]);
+
+const pendingImages: PendingImage[] = [
+  {
+    tempId: "pending-1",
+    file: null,
+    uploadPromise: null,
+    imageId: "img-uploaded-1",
+    filename: "layout.png",
+    previewUrl:
+      "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='80' height='80' viewBox='0 0 80 80'%3E%3Crect fill='%23ece7db' width='80' height='80'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%230a1636' font-size='10'%3EPNG%3C/text%3E%3C/svg%3E",
+    status: "uploaded",
+  },
+  {
+    tempId: "pending-2",
+    file: null,
+    uploadPromise: null,
+    imageId: null,
+    filename: "annotated.jpg",
+    previewUrl:
+      "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='80' height='80' viewBox='0 0 80 80'%3E%3Crect fill='%23f6e7c1' width='80' height='80'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%23d4a43a' font-size='10'%3EJPG%3C/text%3E%3C/svg%3E",
+    status: "uploading",
+  },
+];
+
+function Section({
   title,
   description,
   children,
 }: {
   title: string;
-  description?: string;
+  description: string;
   children: React.ReactNode;
 }) {
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="text-lg">{title}</CardTitle>
-        {description && <CardDescription>{description}</CardDescription>}
-      </CardHeader>
-      <CardContent className="space-y-4">{children}</CardContent>
-    </Card>
-  );
-}
-
-function ShowcaseItem({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div className="space-y-2">
-      <div className="text-sm font-medium text-muted-foreground">{label}</div>
-      <div className="border rounded-lg p-4 bg-background">{children}</div>
-    </div>
-  );
-}
-
-// ============================================
-// Message Rendering (Minimal + Icon style)
-// These match the new styling in sessions/[sessionId]/chat/page.tsx
-// ============================================
-
-function UserMessage({ content }: { content: string }) {
-  return (
-    <div className="flex justify-end">
-      <div className="max-w-[85%] border border-border/60 rounded-xl px-3 py-2">
-        <p className="text-sm whitespace-pre-wrap">{content}</p>
+    <section className="border border-border bg-card">
+      <div className="border-b border-border px-4 py-4">
+        <div className="text-[10px] uppercase tracking-[0.24em] text-muted-foreground">{title}</div>
+        <p className="mt-1 text-sm text-muted-foreground">{description}</p>
       </div>
-    </div>
+      <div className="p-4">{children}</div>
+    </section>
   );
 }
-
-function AssistantMessage({ content }: { content: string }) {
-  return (
-    <div className="w-full flex items-start gap-2">
-      <Bot className="w-4 h-4 mt-0.5 flex-shrink-0 text-muted-foreground/60" />
-      <p className="text-sm whitespace-pre-wrap text-foreground/90">{content}</p>
-    </div>
-  );
-}
-
-// ============================================
-// Sample Data for ToolCallCard
-// ============================================
-
-const sampleToolCallMessages = {
-  // List files tool - completed with result
-  listFiles: {
-    toolCall: {
-      id: "msg-tc-1",
-      session_id: "session-1",
-      sequence: 5,
-      role: "agent" as const,
-      content: [
-        {
-          type: "tool_call" as const,
-          id: "tc-1",
-          name: "list_files",
-          arguments: { path: "/home/user/project", recursive: true },
-        },
-      ],
-      tool_call_id: null,
-      created_at: new Date().toISOString(),
-    },
-    toolResult: {
-      id: "msg-tr-1",
-      session_id: "session-1",
-      sequence: 6,
-      role: "tool_result" as const,
-      content: [
-        {
-          type: "tool_result" as const,
-          tool_call_id: "tc-1",
-          result: ["src/", "src/main.rs", "src/lib.rs", "Cargo.toml", "README.md"],
-        },
-      ],
-      tool_call_id: "tc-1",
-      created_at: new Date().toISOString(),
-    },
-  },
-  // Bash command - completed with longer result
-  bashCommand: {
-    toolCall: {
-      id: "msg-tc-2",
-      session_id: "session-1",
-      sequence: 7,
-      role: "agent" as const,
-      content: [
-        {
-          type: "tool_call" as const,
-          id: "tc-2",
-          name: "bash",
-          arguments: { command: "cargo test --workspace" },
-        },
-      ],
-      tool_call_id: null,
-      created_at: new Date().toISOString(),
-    },
-    toolResult: {
-      id: "msg-tr-2",
-      session_id: "session-1",
-      sequence: 8,
-      role: "tool_result" as const,
-      content: [
-        {
-          type: "tool_result" as const,
-          tool_call_id: "tc-2",
-          result:
-            "running 24 tests\ntest storage::tests::test_create_agent ... ok\ntest storage::tests::test_list_agents ... ok\ntest api::tests::test_health_endpoint ... ok\ntest api::tests::test_create_session ... ok\n\ntest result: ok. 24 passed; 0 failed; 0 ignored",
-        },
-      ],
-      tool_call_id: "tc-2",
-      created_at: new Date().toISOString(),
-    },
-  },
-  // Tool currently executing
-  executing: {
-    toolCall: {
-      id: "msg-tc-3",
-      session_id: "session-1",
-      sequence: 9,
-      role: "agent" as const,
-      content: [
-        {
-          type: "tool_call" as const,
-          id: "tc-3",
-          name: "read_file",
-          arguments: { path: "/home/user/project/src/main.rs" },
-        },
-      ],
-      tool_call_id: null,
-      created_at: new Date().toISOString(),
-    },
-    // No toolResult - still executing
-  },
-  // Tool with error
-  error: {
-    toolCall: {
-      id: "msg-tc-4",
-      session_id: "session-1",
-      sequence: 10,
-      role: "agent" as const,
-      content: [
-        {
-          type: "tool_call" as const,
-          id: "tc-4",
-          name: "write_file",
-          arguments: { path: "/etc/protected/config.json", content: "{}" },
-        },
-      ],
-      tool_call_id: null,
-      created_at: new Date().toISOString(),
-    },
-    toolResult: {
-      id: "msg-tr-4",
-      session_id: "session-1",
-      sequence: 11,
-      role: "tool_result" as const,
-      content: [
-        {
-          type: "tool_result" as const,
-          tool_call_id: "tc-4",
-          error: "Permission denied: Cannot write to /etc/protected/config.json",
-        },
-      ],
-      tool_call_id: "tc-4",
-      created_at: new Date().toISOString(),
-    },
-  },
-  // write_todos tool - shows TodoListRenderer
-  writeTodos: {
-    toolCall: {
-      id: "msg-tc-5",
-      session_id: "session-1",
-      sequence: 12,
-      role: "agent" as const,
-      content: [
-        {
-          type: "tool_call" as const,
-          id: "tc-5",
-          name: "write_todos",
-          arguments: {
-            todos: [
-              {
-                content: "Review code changes",
-                activeForm: "Reviewing code changes",
-                status: "completed",
-              },
-              { content: "Run tests", activeForm: "Running tests", status: "in_progress" },
-              {
-                content: "Update documentation",
-                activeForm: "Updating documentation",
-                status: "pending",
-              },
-              {
-                content: "Create pull request",
-                activeForm: "Creating pull request",
-                status: "pending",
-              },
-            ],
-          },
-        },
-      ],
-      tool_call_id: null,
-      created_at: new Date().toISOString(),
-    },
-    toolResult: {
-      id: "msg-tr-5",
-      session_id: "session-1",
-      sequence: 13,
-      role: "tool_result" as const,
-      content: [
-        {
-          type: "tool_result" as const,
-          tool_call_id: "tc-5",
-          result: {
-            success: true,
-            total_tasks: 4,
-            pending: 2,
-            in_progress: 1,
-            completed: 1,
-            todos: [
-              {
-                content: "Review code changes",
-                activeForm: "Reviewing code changes",
-                status: "completed",
-              },
-              { content: "Run tests", activeForm: "Running tests", status: "in_progress" },
-              {
-                content: "Update documentation",
-                activeForm: "Updating documentation",
-                status: "pending",
-              },
-              {
-                content: "Create pull request",
-                activeForm: "Creating pull request",
-                status: "pending",
-              },
-            ],
-          },
-        },
-      ],
-      tool_call_id: "tc-5",
-      created_at: new Date().toISOString(),
-    },
-  },
-} satisfies Record<string, { toolCall: Message; toolResult?: Message }>;
-
-// Sample todo data for TodoListRenderer directly
-const sampleTodoData = {
-  executing: {
-    arguments: {
-      todos: [
-        {
-          content: "Analyze requirements",
-          activeForm: "Analyzing requirements",
-          status: "completed",
-        },
-        { content: "Implement feature", activeForm: "Implementing feature", status: "in_progress" },
-        { content: "Write tests", activeForm: "Writing tests", status: "pending" },
-      ],
-    },
-    isExecuting: true,
-  },
-  completed: {
-    arguments: {
-      todos: [
-        { content: "Set up database", activeForm: "Setting up database", status: "completed" },
-        {
-          content: "Create API endpoints",
-          activeForm: "Creating API endpoints",
-          status: "completed",
-        },
-        { content: "Add authentication", activeForm: "Adding authentication", status: "completed" },
-      ],
-    },
-    result: {
-      success: true,
-      total_tasks: 3,
-      pending: 0,
-      in_progress: 0,
-      completed: 3,
-      todos: [
-        { content: "Set up database", activeForm: "Setting up database", status: "completed" },
-        {
-          content: "Create API endpoints",
-          activeForm: "Creating API endpoints",
-          status: "completed",
-        },
-        { content: "Add authentication", activeForm: "Adding authentication", status: "completed" },
-      ],
-    },
-    isExecuting: false,
-  },
-  withWarning: {
-    arguments: {
-      todos: [
-        { content: "Task 1", activeForm: "Working on task 1", status: "in_progress" },
-        { content: "Task 2", activeForm: "Working on task 2", status: "in_progress" },
-      ],
-    },
-    result: {
-      success: true,
-      total_tasks: 2,
-      pending: 0,
-      in_progress: 2,
-      completed: 0,
-      todos: [
-        { content: "Task 1", activeForm: "Working on task 1", status: "in_progress" },
-        { content: "Task 2", activeForm: "Working on task 2", status: "in_progress" },
-      ],
-      warning: "Multiple tasks are in progress simultaneously",
-    },
-    isExecuting: false,
-  },
-  error: {
-    arguments: {
-      todos: [],
-    },
-    error: "Invalid todo list format",
-    isExecuting: false,
-  },
-};
-
-// Sample image attachment data
-const samplePendingImages: PendingImage[] = [
-  {
-    tempId: "temp-1",
-    file: null,
-    uploadPromise: null,
-    imageId: "img-uploaded-1",
-    filename: "screenshot.png",
-    previewUrl:
-      "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='80' height='80' viewBox='0 0 80 80'%3E%3Crect fill='%23e2e8f0' width='80' height='80'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%2394a3b8' font-size='10'%3EPNG%3C/text%3E%3C/svg%3E",
-    status: "uploaded",
-  },
-  {
-    tempId: "temp-2",
-    file: new File([], "photo.jpg"),
-    uploadPromise: Promise.resolve({
-      id: "",
-      filename: "",
-      content_type: "",
-      size_bytes: 0,
-      created_at: "",
-    }),
-    imageId: null,
-    filename: "photo.jpg",
-    previewUrl:
-      "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='80' height='80' viewBox='0 0 80 80'%3E%3Crect fill='%23fef3c7' width='80' height='80'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%23d97706' font-size='10'%3EJPG%3C/text%3E%3C/svg%3E",
-    status: "uploading",
-  },
-  {
-    tempId: "temp-3",
-    file: null,
-    uploadPromise: null,
-    imageId: null,
-    filename: "failed.gif",
-    previewUrl:
-      "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='80' height='80' viewBox='0 0 80 80'%3E%3Crect fill='%23fee2e2' width='80' height='80'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%23dc2626' font-size='10'%3EGIF%3C/text%3E%3C/svg%3E",
-    status: "error",
-    error: "Upload failed",
-  },
-];
-
-// Sample data for BashToolCallCard (event-based)
-const sampleBashEventData: Record<
-  string,
-  { toolCall: ToolCallContent; toolResult?: ToolCompletedData }
-> = {
-  // Successful command with stdout only
-  success: {
-    toolCall: {
-      id: "tc-bash-1",
-      name: "bash",
-      arguments: {
-        command: "cargo test --workspace",
-        description: "Run all workspace tests",
-      },
-    },
-    toolResult: {
-      tool_call_id: "tc-bash-1",
-      tool_name: "bash",
-      success: true,
-      status: "success",
-      result: [
-        {
-          type: "text" as const,
-          text: JSON.stringify({
-            stdout:
-              "running 24 tests\ntest storage::tests::test_create_agent ... ok\ntest storage::tests::test_list_agents ... ok\ntest api::tests::test_health_endpoint ... ok\ntest api::tests::test_create_session ... ok\n\ntest result: ok. 24 passed; 0 failed; 0 ignored",
-            stderr: "",
-            exit_code: 0,
-            success: true,
-          }),
-        },
-      ],
-      duration_ms: 4523,
-    },
-  },
-  // Failed command with stderr
-  withStderr: {
-    toolCall: {
-      id: "tc-bash-2",
-      name: "bash",
-      arguments: {
-        command: "cargo clippy -- -D warnings",
-        description: "Run clippy linter",
-      },
-    },
-    toolResult: {
-      tool_call_id: "tc-bash-2",
-      tool_name: "bash",
-      success: true,
-      status: "success",
-      result: [
-        {
-          type: "text" as const,
-          text: JSON.stringify({
-            stdout: "    Checking everruns-core v0.1.0\n",
-            stderr:
-              'error[E0308]: mismatched types\n  --> src/lib.rs:42:5\n   |\n42 |     let x: u32 = "hello";\n   |                  ^^^^^^^ expected `u32`, found `&str`\n\nerror: aborting due to 1 previous error',
-            exit_code: 1,
-            success: false,
-          }),
-        },
-      ],
-      duration_ms: 12340,
-    },
-  },
-  // Currently executing
-  executing: {
-    toolCall: {
-      id: "tc-bash-3",
-      name: "bash",
-      arguments: {
-        command: "npm run build",
-      },
-    },
-  },
-  // Simple short command
-  shortOutput: {
-    toolCall: {
-      id: "tc-bash-4",
-      name: "bash",
-      arguments: { command: "echo hello" },
-    },
-    toolResult: {
-      tool_call_id: "tc-bash-4",
-      tool_name: "bash",
-      success: true,
-      status: "success",
-      result: [
-        {
-          type: "text" as const,
-          text: JSON.stringify({
-            stdout: "hello\n",
-            stderr: "",
-            exit_code: 0,
-            success: true,
-          }),
-        },
-      ],
-      duration_ms: 45,
-    },
-  },
-};
-
-// Sample event data for MessageInfoIcon
-const sampleEvents = {
-  userMessage: {
-    id: "evt-user-123e4567-e89b-12d3-a456-426614174000",
-    type: "input.message",
-    ts: new Date().toISOString(),
-    session_id: "session-1",
-    context: { turn_id: "turn-1" },
-    data: {
-      message: {
-        id: "msg-user-1",
-        session_id: "session-1",
-        sequence: 1,
-        role: "user" as const,
-        content: [{ type: "text" as const, text: "Hello!" }],
-        tool_call_id: null,
-        created_at: new Date().toISOString(),
-      },
-    },
-  } satisfies Event,
-  agentMessage: {
-    id: "evt-agent-987fcdeb-51a2-4bc3-8def-012345678901",
-    type: "output.message.completed",
-    ts: new Date().toISOString(),
-    session_id: "session-1",
-    context: { turn_id: "turn-1" },
-    data: {
-      message: {
-        id: "msg-agent-1",
-        session_id: "session-1",
-        sequence: 2,
-        role: "agent" as const,
-        content: [{ type: "text" as const, text: "Hi there! How can I help?" }],
-        tool_call_id: null,
-        created_at: new Date().toISOString(),
-      },
-      metadata: {
-        model: "claude-sonnet-4-20250514",
-        model_id: "model-uuid-123",
-        provider_id: "provider-anthropic",
-      },
-      usage: {
-        input_tokens: 128,
-        output_tokens: 45,
-      },
-    },
-    metadata: {
-      reasoning_effort: "medium",
-    },
-  } satisfies Event,
-};
-
-// ============================================
-// Main Page Component
-// ============================================
 
 export default function DevChatComponentsPage() {
-  // Show 404-like message in production
   if (!isDev) {
     return (
-      <div className="flex items-center justify-center min-h-screen">
+      <div className="flex min-h-screen items-center justify-center">
         <div className="text-center">
           <h1 className="text-4xl font-bold text-muted-foreground">404</h1>
-          <p className="text-muted-foreground mt-2">Page not found</p>
+          <p className="mt-2 text-muted-foreground">Page not found</p>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-muted/30">
-      <div className="container mx-auto py-8 px-4">
-        <div className="mb-8">
-          <Link
-            href="/dev"
-            className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-4"
-          >
-            <ArrowLeft className="w-4 h-4 mr-2" />
-            Back to Developer Tools
-          </Link>
-          <h1 className="text-3xl font-bold">Chat Components</h1>
-          <p className="text-muted-foreground mt-2">
-            Chat-specific components: messages, tool calls, todo lists, and attachments
+    <div className="min-h-screen bg-background bg-brand-dots px-4 py-8">
+      <div className="mx-auto max-w-6xl">
+        <Link
+          href="/dev"
+          className="mb-6 inline-flex items-center gap-2 border border-border bg-card px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-muted/35 hover:text-foreground"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Developer Tools
+        </Link>
+
+        <div className="mb-8 max-w-2xl space-y-2">
+          <p className="text-[11px] uppercase tracking-[0.3em] text-muted-foreground">
+            Chat Components
           </p>
-          <Badge variant="outline" className="mt-2">
-            Development Mode
-          </Badge>
+          <h1 className="text-3xl font-semibold tracking-tight text-foreground">
+            Canonical component gallery
+          </h1>
+          <p className="text-sm leading-6 text-muted-foreground">
+            These are the chat-specific primitives in the style now used by the main application.
+          </p>
         </div>
 
-        <ScrollArea className="h-[calc(100vh-12rem)]">
-          <div className="space-y-8 pr-4">
-            {/* Message Rendering Section */}
-            <ShowcaseSection
-              title="Message Rendering (Minimal + Icon Style)"
-              description="Current message styles used in the Chat UI"
-            >
-              <ShowcaseItem label="User Message">
-                <UserMessage content="Hello! Can you help me analyze this code?" />
-              </ShowcaseItem>
+        <div className="grid gap-6 lg:grid-cols-2">
+          <Section
+            title="Message Info"
+            description="Metadata affordance for user and assistant messages."
+          >
+            <div className="flex items-center justify-between border border-border bg-background px-4 py-3">
+              <div className="text-sm text-foreground">Components now follow the canonical chat style.</div>
+              <MessageInfoIcon event={infoEvent} />
+            </div>
+          </Section>
 
-              <ShowcaseItem label="User Message (Long)">
-                <UserMessage content="I need to refactor the authentication system to support OAuth 2.0 in addition to the existing session-based auth. The new system should maintain backward compatibility." />
-              </ShowcaseItem>
+          <Section
+            title="Attachments"
+            description="Pending image attachments now use the same sharp surface treatment."
+          >
+            <ImageAttachments images={pendingImages} onRemove={() => undefined} />
+          </Section>
 
-              <ShowcaseItem label="Assistant Message">
-                <AssistantMessage content="I'll help you with that. Let me start by examining the current authentication implementation." />
-              </ShowcaseItem>
+          <Section
+            title="Tool Activity"
+            description="Grouped execution cards used inline in transcripts."
+          >
+            <ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResults} />
+          </Section>
 
-              <ShowcaseItem label="Assistant Message (Multiline)">
-                <AssistantMessage
-                  content={
-                    "Here's my analysis:\n\n1. Current auth uses session cookies\n2. User model has email/password fields\n3. No OAuth support exists yet\n\nI recommend starting with the OAuth provider abstraction."
-                  }
-                />
-              </ShowcaseItem>
-            </ShowcaseSection>
-
-            {/* MessageInfoIcon Section */}
-            <ShowcaseSection
-              title="MessageInfoIcon Component"
-              description="Small info icon showing message metadata on hover"
-            >
-              <ShowcaseItem label="User Message with Info (Light Variant)">
-                <div className="flex justify-end">
-                  <div className="max-w-[85%] border border-border/60 rounded-xl px-3 py-2">
-                    <div className="flex items-start gap-2">
-                      <p className="text-sm whitespace-pre-wrap flex-1">Hello! Can you help me?</p>
-                      <MessageInfoIcon event={sampleEvents.userMessage} variant="light" />
-                    </div>
-                  </div>
-                </div>
-              </ShowcaseItem>
-
-              <ShowcaseItem label="Agent Message with Info">
-                <div className="w-full flex items-start gap-2">
-                  <Bot className="w-4 h-4 mt-0.5 flex-shrink-0 text-muted-foreground/60" />
-                  <div className="flex-1 flex items-start gap-2">
-                    <p className="text-sm whitespace-pre-wrap flex-1 text-foreground/90">
-                      Hi there! How can I help?
-                    </p>
-                    <MessageInfoIcon event={sampleEvents.agentMessage} />
-                  </div>
-                </div>
-              </ShowcaseItem>
-            </ShowcaseSection>
-
-            {/* ToolCallCard Section */}
-            <ShowcaseSection
-              title="ToolCallCard Component"
-              description="Compact tool call display with status and output toggle"
-            >
-              <ShowcaseItem label="Completed with Result">
-                <div className="ml-6">
-                  <ToolCallCard
-                    toolCall={sampleToolCallMessages.listFiles.toolCall}
-                    toolResult={sampleToolCallMessages.listFiles.toolResult}
-                  />
-                </div>
-              </ShowcaseItem>
-
-              <ShowcaseItem label="Completed with Long Result (Expandable)">
-                <div className="ml-6">
-                  <ToolCallCard
-                    toolCall={sampleToolCallMessages.bashCommand.toolCall}
-                    toolResult={sampleToolCallMessages.bashCommand.toolResult}
-                  />
-                </div>
-              </ShowcaseItem>
-
-              <ShowcaseItem label="Executing">
-                <div className="ml-6">
-                  <ToolCallCard toolCall={sampleToolCallMessages.executing.toolCall} />
-                </div>
-              </ShowcaseItem>
-
-              <ShowcaseItem label="Error">
-                <div className="ml-6">
-                  <ToolCallCard
-                    toolCall={sampleToolCallMessages.error.toolCall}
-                    toolResult={sampleToolCallMessages.error.toolResult}
-                  />
-                </div>
-              </ShowcaseItem>
-
-              <ShowcaseItem label="write_todos Tool (Special Rendering)">
-                <div className="ml-6">
-                  <ToolCallCard
-                    toolCall={sampleToolCallMessages.writeTodos.toolCall}
-                    toolResult={sampleToolCallMessages.writeTodos.toolResult}
-                  />
-                </div>
-              </ShowcaseItem>
-            </ShowcaseSection>
-
-            {/* BashToolCallCard Section */}
-            <ShowcaseSection
-              title="BashToolCallCard Component"
-              description="Claude Code-style bash rendering: $ command, structured stdout/stderr"
-            >
-              <ShowcaseItem label="Successful Command (Collapsed)">
-                <div className="ml-6">
-                  <ToolCallCardFromEvent
-                    toolCall={sampleBashEventData.success.toolCall}
-                    toolResult={sampleBashEventData.success.toolResult}
-                  />
-                </div>
-              </ShowcaseItem>
-
-              <ShowcaseItem label="Failed Command with stderr">
-                <div className="ml-6">
-                  <ToolCallCardFromEvent
-                    toolCall={sampleBashEventData.withStderr.toolCall}
-                    toolResult={sampleBashEventData.withStderr.toolResult}
-                  />
-                </div>
-              </ShowcaseItem>
-
-              <ShowcaseItem label="Executing">
-                <div className="ml-6">
-                  <ToolCallCardFromEvent
-                    toolCall={sampleBashEventData.executing.toolCall}
-                    toolResult={sampleBashEventData.executing.toolResult}
-                  />
-                </div>
-              </ShowcaseItem>
-
-              <ShowcaseItem label="Short Output">
-                <div className="ml-6">
-                  <ToolCallCardFromEvent
-                    toolCall={sampleBashEventData.shortOutput.toolCall}
-                    toolResult={sampleBashEventData.shortOutput.toolResult}
-                  />
-                </div>
-              </ShowcaseItem>
-            </ShowcaseSection>
-
-            {/* TodoListRenderer Section */}
-            <ShowcaseSection
-              title="TodoListRenderer Component"
-              description="Compact task list renderer for write_todos tool"
-            >
-              <ShowcaseItem label="Executing (Updating)">
-                <TodoListRenderer
-                  arguments={sampleTodoData.executing.arguments}
-                  isExecuting={sampleTodoData.executing.isExecuting}
-                />
-              </ShowcaseItem>
-
-              <ShowcaseItem label="Completed (All Done)">
-                <TodoListRenderer
-                  arguments={sampleTodoData.completed.arguments}
-                  result={sampleTodoData.completed.result}
-                  isExecuting={sampleTodoData.completed.isExecuting}
-                />
-              </ShowcaseItem>
-
-              <ShowcaseItem label="With Warning">
-                <TodoListRenderer
-                  arguments={sampleTodoData.withWarning.arguments}
-                  result={sampleTodoData.withWarning.result}
-                  isExecuting={sampleTodoData.withWarning.isExecuting}
-                />
-              </ShowcaseItem>
-
-              <ShowcaseItem label="Error State">
-                <TodoListRenderer
-                  arguments={sampleTodoData.error.arguments}
-                  error={sampleTodoData.error.error}
-                  isExecuting={sampleTodoData.error.isExecuting}
-                />
-              </ShowcaseItem>
-            </ShowcaseSection>
-
-            {/* Combined Chat View */}
-            <ShowcaseSection
-              title="Combined Chat View"
-              description="Example conversation showing how components work together"
-            >
-              <ShowcaseItem label="Full Conversation">
-                <div className="space-y-4">
-                  <UserMessage content="Can you list the files in my project and run the tests?" />
-                  <AssistantMessage content="I'll check the project structure and run the test suite for you." />
-                  <div className="ml-6 space-y-2">
-                    <ToolCallCard
-                      toolCall={sampleToolCallMessages.listFiles.toolCall}
-                      toolResult={sampleToolCallMessages.listFiles.toolResult}
-                    />
-                    <ToolCallCard
-                      toolCall={sampleToolCallMessages.bashCommand.toolCall}
-                      toolResult={sampleToolCallMessages.bashCommand.toolResult}
-                    />
-                  </div>
-                  <AssistantMessage content="Your project has 5 files and all 24 tests passed successfully." />
-                </div>
-              </ShowcaseItem>
-            </ShowcaseSection>
-
-            {/* Image Attachments Section */}
-            <ShowcaseSection
-              title="Image Attachments"
-              description="Components for uploading and displaying image attachments"
-            >
-              <ShowcaseItem label="Pending Images (Upload Status)">
-                <ImageAttachments
-                  images={samplePendingImages}
-                  onRemove={(tempId) => console.log("Remove:", tempId)}
-                />
-              </ShowcaseItem>
-
-              <ShowcaseItem label="MessageImage (In Chat History)">
-                <div className="flex gap-2">
-                  <MessageImage imageId="sample-image-1" filename="screenshot.png" />
-                  <MessageImage imageId="sample-image-2" filename="diagram.png" />
-                </div>
-              </ShowcaseItem>
-
-              <ShowcaseItem label="User Message with Image">
-                <div className="flex justify-end">
-                  <div className="max-w-[85%] border border-border/60 rounded-xl px-3 py-2">
-                    <div className="flex-1 space-y-2">
-                      <p className="text-sm whitespace-pre-wrap">
-                        Here is a screenshot of the error.
-                      </p>
-                      <div className="flex flex-wrap gap-2 mt-2">
-                        <div className="w-20 h-20 rounded-md overflow-hidden bg-muted/50 flex items-center justify-center">
-                          <span className="text-[10px] text-muted-foreground">Preview</span>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </ShowcaseItem>
-            </ShowcaseSection>
-          </div>
-        </ScrollArea>
+          <Section
+            title="Execution Plan"
+            description="Persistent todo card for long-running turns."
+          >
+            <TodoListRenderer
+              arguments={{
+                todos: [
+                  {
+                    content: "Read current implementation",
+                    activeForm: "Reading current implementation",
+                    status: "completed",
+                  },
+                  {
+                    content: "Apply canonical styling",
+                    activeForm: "Applying canonical styling",
+                    status: "in_progress",
+                  },
+                  {
+                    content: "Verify main routes",
+                    activeForm: "Verifying main routes",
+                    status: "pending",
+                  },
+                ],
+              }}
+              isExecuting
+            />
+          </Section>
+        </div>
       </div>
     </div>
   );

--- a/apps/ui/src/app/dev/chat-components/page.tsx
+++ b/apps/ui/src/app/dev/chat-components/page.tsx
@@ -147,7 +147,9 @@ export default function DevChatComponentsPage() {
             description="Metadata affordance for user and assistant messages."
           >
             <div className="flex items-center justify-between border border-border bg-background px-4 py-3">
-              <div className="text-sm text-foreground">Components now follow the canonical chat style.</div>
+              <div className="text-sm text-foreground">
+                Components now follow the canonical chat style.
+              </div>
               <MessageInfoIcon event={infoEvent} />
             </div>
           </Section>

--- a/apps/ui/src/app/dev/chat-styles/page.tsx
+++ b/apps/ui/src/app/dev/chat-styles/page.tsx
@@ -76,7 +76,11 @@ const toolResults = new Map<string, ToolCompletedData>([
 ]);
 
 function Note({ children }: { children: React.ReactNode }) {
-  return <div className="border border-border bg-card px-4 py-3 text-sm text-muted-foreground">{children}</div>;
+  return (
+    <div className="border border-border bg-card px-4 py-3 text-sm text-muted-foreground">
+      {children}
+    </div>
+  );
 }
 
 export default function ChatStylesPage() {
@@ -108,8 +112,8 @@ export default function ChatStylesPage() {
             Canonical chat surface
           </h1>
           <p className="text-sm leading-6 text-muted-foreground">
-            The application now uses this single style: sharp surfaces, left and right border accents,
-            muted chrome, and info affordances on message rows.
+            The application now uses this single style: sharp surfaces, left and right border
+            accents, muted chrome, and info affordances on message rows.
           </p>
         </div>
 
@@ -119,7 +123,9 @@ export default function ChatStylesPage() {
               <div className="text-[10px] uppercase tracking-[0.24em] text-muted-foreground">
                 Live transcript pattern
               </div>
-              <div className="mt-1 text-sm font-medium text-foreground">Default chat composition</div>
+              <div className="mt-1 text-sm font-medium text-foreground">
+                Default chat composition
+              </div>
             </div>
 
             <div className="space-y-6 bg-background/80 px-4 py-5 sm:px-6">
@@ -168,12 +174,16 @@ export default function ChatStylesPage() {
                     <ImagePlus className="icon-sharp h-4 w-4" />
                   </button>
                   <div className="flex h-10 items-center gap-2 border border-border bg-background px-3 text-sm">
-                    <span className="text-[10px] uppercase tracking-[0.22em] text-muted-foreground">Model</span>
+                    <span className="text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+                      Model
+                    </span>
                     <span className="text-foreground">Kimi K2.5</span>
                   </div>
                   <div className="flex h-10 items-center gap-2 border border-border bg-background px-3 text-sm">
                     <Brain className="icon-sharp h-3.5 w-3.5 text-muted-foreground" />
-                    <span className="text-[10px] uppercase tracking-[0.22em] text-muted-foreground">Reasoning</span>
+                    <span className="text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+                      Reasoning
+                    </span>
                     <span className="text-foreground">Default</span>
                   </div>
                 </div>
@@ -199,8 +209,13 @@ export default function ChatStylesPage() {
 
           <div className="space-y-4">
             <Note>User messages anchor on a right gold border, not a rounded bubble.</Note>
-            <Note>Agent messages stay flatter: icon rail, left primary border, metadata icon on the side.</Note>
-            <Note>Tool execution and todos inherit the same surface rules, so chat reads as one system.</Note>
+            <Note>
+              Agent messages stay flatter: icon rail, left primary border, metadata icon on the
+              side.
+            </Note>
+            <Note>
+              Tool execution and todos inherit the same surface rules, so chat reads as one system.
+            </Note>
           </div>
         </div>
       </div>

--- a/apps/ui/src/app/dev/chat-styles/page.tsx
+++ b/apps/ui/src/app/dev/chat-styles/page.tsx
@@ -1,902 +1,206 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
-import { Badge } from "@/components/ui/badge";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import {
-  Bot,
-  ArrowLeft,
-  ChevronDown,
-  ChevronRight,
-  Check,
-  Loader2,
-  Circle,
-  CheckCircle2,
-  CircleDot,
-  ListTodo,
-  Info,
-  ImageIcon,
-} from "lucide-react";
-import { cn } from "@/lib/utils";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { ArrowLeft, Bot, Brain, CalendarClock, ImagePlus, Send, StopCircle } from "lucide-react";
+import { MessageInfoIcon } from "@/components/chat/message-info-icon";
+import { ToolActivityGroup } from "@/components/chat/tool-activity-group";
+import type { Event, ToolCompletedData } from "@/lib/api/types";
+import type { ToolCallContent } from "@/components/chat/tool-call-utils";
 
 const isDev = process.env.NODE_ENV === "development";
 
-// Tool call type
-interface ToolCallData {
-  name: string;
-  args: string;
-  status: "completed" | "executing";
-  result?: string | string[];
-  todos?: Array<{ content: string; status: string }>;
-}
-
-// Message metadata for info tooltip
-interface MessageMeta {
-  id?: string;
-  model?: string;
-  tokens?: { input: number; output: number };
-  time?: string;
-}
-
-// Conversation item types
-type UserItem = { role: "user"; content: string; images?: string[]; meta?: MessageMeta };
-type AgentItem = { role: "agent"; content: string; meta?: MessageMeta };
-type ToolItem = { role: "tool"; calls: ToolCallData[] };
-type ThinkingItem = { role: "thinking"; model?: string };
-type ConversationItem = UserItem | AgentItem | ToolItem | ThinkingItem;
-
-// Info icon component
-function MessageInfo({
-  meta,
-  variant = "default",
-}: {
-  meta?: MessageMeta;
-  variant?: "default" | "light";
-}) {
-  if (!meta) return null;
-  return (
-    <Tooltip>
-      <TooltipTrigger
-        className={cn(
-          "p-0.5 rounded opacity-40 hover:opacity-70 transition-opacity",
-          variant === "light" ? "text-white" : "text-muted-foreground",
-        )}
-      >
-        <Info className="h-3 w-3" />
-      </TooltipTrigger>
-      <TooltipContent className="text-xs space-y-0.5">
-        {meta.id && <div>ID: {meta.id}</div>}
-        {meta.model && <div>Model: {meta.model}</div>}
-        {meta.time && <div>Time: {meta.time}</div>}
-        {meta.tokens && (
-          <div>
-            Tokens: {meta.tokens.input} in / {meta.tokens.output} out
-          </div>
-        )}
-      </TooltipContent>
-    </Tooltip>
-  );
-}
-
-// Image placeholder component
-function ImagePlaceholder({ count = 1 }: { count?: number }) {
-  return (
-    <div className="flex gap-1 mt-1.5">
-      {Array.from({ length: count }).map((_, i) => (
-        <div
-          key={i}
-          className="w-16 h-12 bg-muted/50 rounded border border-border/50 flex items-center justify-center"
-        >
-          <ImageIcon className="h-4 w-4 text-muted-foreground/40" />
-        </div>
-      ))}
-    </div>
-  );
-}
-
-// Sample conversation data
-const sampleConversation: ConversationItem[] = [
-  {
-    role: "user",
-    content: "Can you list the files in my project and run the tests?",
-    meta: { id: "msg_01", time: "2:34 PM" },
-  },
-  {
-    role: "agent",
-    content: "I'll check the project structure and run the test suite for you.",
-    meta: {
-      id: "msg_02",
-      model: "claude-3-5-sonnet",
-      tokens: { input: 156, output: 42 },
-      time: "2:34 PM",
+const userEvent: Event = {
+  id: "evt-chat-style-user",
+  type: "input.message",
+  ts: "2026-03-07T21:40:00Z",
+  session_id: "session-chat-style",
+  context: {},
+  data: {
+    message: {
+      id: "msg-chat-style-user",
+      session_id: "session-chat-style",
+      sequence: 1,
+      role: "user",
+      content: [{ type: "text", text: "Inspect this repo and summarize the rewrite plan." }],
+      tool_call_id: null,
+      created_at: "2026-03-07T21:40:00Z",
+      metadata: { source: "schedule" },
     },
   },
-  {
-    role: "tool",
-    calls: [
-      {
-        name: "list_files",
-        args: "path: /home/user/project",
-        status: "completed" as const,
-        result: ["src/", "src/main.rs", "Cargo.toml"],
-      },
-      {
-        name: "bash",
-        args: 'command: "cargo test"',
-        status: "completed" as const,
-        result:
-          "running 24 tests\ntest storage::tests::test_create ... ok\ntest api::tests::test_health ... ok\n\ntest result: ok. 24 passed",
-      },
-    ],
-  },
-  {
-    role: "agent",
-    content: "Your project has 3 files and all 24 tests passed successfully.",
-    meta: {
-      id: "msg_03",
-      model: "claude-3-5-sonnet",
-      tokens: { input: 892, output: 28 },
-      time: "2:35 PM",
+};
+
+const agentEvent: Event = {
+  id: "evt-chat-style-agent",
+  type: "output.message.completed",
+  ts: "2026-03-07T21:40:05Z",
+  session_id: "session-chat-style",
+  context: {},
+  data: {
+    message: {
+      id: "msg-chat-style-agent",
+      session_id: "session-chat-style",
+      sequence: 2,
+      role: "agent",
+      content: [
+        {
+          type: "text",
+          text: "I'm checking the structure first, then I'll outline the smallest safe rewrite path.",
+        },
+      ],
+      tool_call_id: null,
+      created_at: "2026-03-07T21:40:05Z",
+      metadata: { model: "kimi-k2.5", reasoning_effort: "medium" },
     },
+    metadata: { model: "kimi-k2.5" },
+    usage: { input_tokens: 954, output_tokens: 126 },
   },
-  {
-    role: "user",
-    content: "Great! Now create a todo list for the remaining tasks.",
-    meta: { id: "msg_04", time: "2:36 PM" },
-  },
-  {
-    role: "agent",
-    content: "I'll create a task list to track the remaining work.",
-    meta: {
-      id: "msg_05",
-      model: "claude-3-5-sonnet",
-      tokens: { input: 1024, output: 35 },
-      time: "2:36 PM",
-    },
-  },
-  {
-    role: "tool",
-    calls: [
-      {
-        name: "write_todos",
-        args: "",
-        status: "completed" as const,
-        todos: [
-          { content: "Review code changes", status: "completed" },
-          { content: "Run tests", status: "in_progress" },
-          { content: "Update documentation", status: "pending" },
-          { content: "Create pull request", status: "pending" },
-        ],
-      },
-    ],
-  },
-  {
-    role: "agent",
-    content:
-      "I've created a task list. The code review is done and I'm currently running the tests.",
-    meta: {
-      id: "msg_06",
-      model: "claude-3-5-sonnet",
-      tokens: { input: 1256, output: 48 },
-      time: "2:36 PM",
-    },
-  },
+};
+
+const toolCalls: ToolCallContent[] = [
+  { id: "style-list", name: "list_files", arguments: { path: "." } },
+  { id: "style-read", name: "read_file", arguments: { path: "/workspace/README.md" } },
+  { id: "style-search", name: "grep_files", arguments: { pattern: "**/package.json" } },
 ];
 
-// Conversation with images
-const imageConversation: ConversationItem[] = [
-  {
-    role: "user",
-    content: "Here's a screenshot of the error I'm seeing:",
-    images: ["error.png", "console.png"],
-    meta: { id: "msg_img", time: "3:15 PM" },
-  },
-  {
-    role: "agent",
-    content: "I can see the issue - the error shows a null pointer exception. Let me fix that.",
-    meta: {
-      id: "msg_resp",
-      model: "claude-3-5-sonnet",
-      tokens: { input: 2048, output: 156 },
-      time: "3:15 PM",
+const toolResults = new Map<string, ToolCompletedData>([
+  [
+    "style-list",
+    {
+      tool_call_id: "style-list",
+      tool_name: "list_files",
+      success: true,
+      status: "success",
+      result: [{ type: "text", text: "README.md\napps/\ncrates/\njustfile" }],
     },
-  },
-];
+  ],
+]);
 
-// Tool call with executing state
-const executingConversation: ConversationItem[] = [
-  { role: "user", content: "Read the main configuration file" },
-  { role: "agent", content: "Let me read that file for you." },
-  {
-    role: "tool",
-    calls: [
-      {
-        name: "read_file",
-        args: "path: /home/user/project/config.json",
-        status: "executing",
-      },
-    ],
-  },
-];
-
-// Thinking state
-const thinkingConversation: ConversationItem[] = [
-  { role: "user", content: "What's the best approach to refactor this function?" },
-  { role: "thinking", model: "claude-3-5-sonnet" },
-];
-
-// ============================================
-// Current Style (Option A)
-// ============================================
-
-function CurrentUserMessage({
-  content,
-  images,
-  meta,
-}: {
-  content: string;
-  images?: string[];
-  meta?: MessageMeta;
-}) {
-  return (
-    <div className="flex justify-end">
-      <div className="max-w-[90%] bg-gray-500 text-white rounded-lg p-3">
-        <div className="flex items-start gap-2">
-          <div className="flex-1">
-            <p className="text-sm whitespace-pre-wrap">{content}</p>
-            {images && images.length > 0 && <ImagePlaceholder count={images.length} />}
-          </div>
-          <MessageInfo meta={meta} variant="light" />
-        </div>
-      </div>
-    </div>
-  );
+function Note({ children }: { children: React.ReactNode }) {
+  return <div className="border border-border bg-card px-4 py-3 text-sm text-muted-foreground">{children}</div>;
 }
-
-function CurrentAgentMessage({ content, meta }: { content: string; meta?: MessageMeta }) {
-  return (
-    <div className="flex justify-start">
-      <div className="w-full bg-muted/60 rounded-lg p-3">
-        <div className="flex items-start gap-2">
-          <Bot className="w-4 h-4 mt-0.5 flex-shrink-0 text-muted-foreground" />
-          <p className="flex-1 text-sm whitespace-pre-wrap">{content}</p>
-          <MessageInfo meta={meta} />
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function CurrentToolCall({ call }: { call: ToolCallData }) {
-  const [expanded, setExpanded] = useState(false);
-
-  if (call.name === "write_todos" && "todos" in call) {
-    return (
-      <div className="pl-6 text-sm text-muted-foreground">
-        <div className="flex items-center gap-2 mb-1">
-          <ListTodo className="h-4 w-4" />
-          <span className="font-medium">Tasks</span>
-        </div>
-        <div className="space-y-0.5 ml-6">
-          {call.todos?.map((todo, i) => (
-            <div key={i} className="flex items-center gap-2">
-              {todo.status === "completed" && (
-                <CheckCircle2 className="h-3.5 w-3.5 text-green-600" />
-              )}
-              {todo.status === "in_progress" && <CircleDot className="h-3.5 w-3.5 text-blue-600" />}
-              {todo.status === "pending" && (
-                <Circle className="h-3.5 w-3.5 text-muted-foreground" />
-              )}
-              <span
-                className={cn(
-                  "text-sm",
-                  todo.status === "completed" && "text-muted-foreground line-through",
-                  todo.status === "in_progress" && "font-medium",
-                )}
-              >
-                {todo.content}
-              </span>
-            </div>
-          ))}
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <div className="pl-6 text-sm text-muted-foreground space-y-0.5">
-      <div>
-        <span className="font-medium">{call.name}:</span>
-        {call.args && <span className="ml-1">{call.args}</span>}
-      </div>
-      {call.status === "executing" ? (
-        <div>&gt; ... executing ...</div>
-      ) : call.result ? (
-        <div>
-          <div className="whitespace-pre-wrap">
-            &gt; {String(call.result).substring(0, 100)}
-            {String(call.result).length > 100 ? "..." : ""}
-          </div>
-          {String(call.result).length > 100 && (
-            <button
-              onClick={() => setExpanded(!expanded)}
-              className="text-xs text-blue-600 hover:underline"
-            >
-              {expanded ? "show less" : "> see more..."}
-            </button>
-          )}
-          {expanded && <pre className="text-xs bg-muted/50 p-2 rounded mt-1">{call.result}</pre>}
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function CurrentThinking({ model }: { model?: string }) {
-  return (
-    <div className="flex justify-start">
-      <div className="w-full bg-muted/60 rounded-lg p-3">
-        <div className="flex items-start gap-2">
-          <Bot className="w-4 h-4 mt-0.5 flex-shrink-0 text-muted-foreground" />
-          <div className="flex items-center gap-1.5">
-            <span className="text-sm text-muted-foreground">Thinking</span>
-            {model && <span className="text-xs text-muted-foreground/60">with {model}</span>}
-            <span className="flex gap-0.5 ml-1">
-              <span
-                className="w-1.5 h-1.5 bg-muted-foreground/60 rounded-full animate-bounce"
-                style={{ animationDelay: "0ms" }}
-              />
-              <span
-                className="w-1.5 h-1.5 bg-muted-foreground/60 rounded-full animate-bounce"
-                style={{ animationDelay: "150ms" }}
-              />
-              <span
-                className="w-1.5 h-1.5 bg-muted-foreground/60 rounded-full animate-bounce"
-                style={{ animationDelay: "300ms" }}
-              />
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ============================================
-// Option B: Flat Agent, Boxed User
-// ============================================
-
-function FlatUserMessage({
-  content,
-  images,
-  meta,
-}: {
-  content: string;
-  images?: string[];
-  meta?: MessageMeta;
-}) {
-  return (
-    <div className="flex justify-end">
-      <div className="max-w-[85%] bg-primary text-primary-foreground rounded-2xl px-4 py-2.5">
-        <div className="flex items-start gap-2">
-          <div className="flex-1">
-            <p className="text-sm">{content}</p>
-            {images && images.length > 0 && <ImagePlaceholder count={images.length} />}
-          </div>
-          <MessageInfo meta={meta} variant="light" />
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function FlatAgentMessage({ content, meta }: { content: string; meta?: MessageMeta }) {
-  return (
-    <div className="flex justify-start">
-      <div className="w-full flex items-start gap-2">
-        <p className="flex-1 text-sm whitespace-pre-wrap">{content}</p>
-        <MessageInfo meta={meta} />
-      </div>
-    </div>
-  );
-}
-
-function FlatToolCall({ call }: { call: ToolCallData }) {
-  const [expanded, setExpanded] = useState(false);
-
-  if (call.name === "write_todos" && "todos" in call) {
-    return (
-      <div className="text-sm border-l-2 border-muted-foreground/20 pl-3 py-1">
-        <div className="space-y-0.5">
-          {call.todos?.map((todo, i) => (
-            <div key={i} className="flex items-center gap-2">
-              {todo.status === "completed" && <Check className="h-3.5 w-3.5 text-green-600" />}
-              {todo.status === "in_progress" && (
-                <Loader2 className="h-3.5 w-3.5 text-blue-600 animate-spin" />
-              )}
-              {todo.status === "pending" && (
-                <Circle className="h-3.5 w-3.5 text-muted-foreground/40" />
-              )}
-              <span
-                className={cn(
-                  todo.status === "completed" && "text-muted-foreground",
-                  todo.status === "in_progress" && "text-foreground",
-                  todo.status === "pending" && "text-muted-foreground",
-                )}
-              >
-                {todo.content}
-              </span>
-            </div>
-          ))}
-        </div>
-      </div>
-    );
-  }
-
-  const statusIcon =
-    call.status === "executing" ? (
-      <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
-    ) : (
-      <Check className="h-3.5 w-3.5 text-green-600" />
-    );
-
-  return (
-    <div className="text-sm text-muted-foreground">
-      <div className="flex items-center gap-1.5">
-        {statusIcon}
-        <span className="font-mono text-xs">{call.name}</span>
-        {call.args && (
-          <span className="text-muted-foreground/60 text-xs truncate max-w-[300px]">
-            {call.args}
-          </span>
-        )}
-      </div>
-      {expanded && call.result && (
-        <pre className="text-xs bg-muted/30 p-2 rounded mt-1 ml-5">{call.result}</pre>
-      )}
-      {call.result && String(call.result).length > 50 && (
-        <button
-          onClick={() => setExpanded(!expanded)}
-          className="ml-5 text-xs text-muted-foreground/60 hover:text-muted-foreground flex items-center gap-0.5"
-        >
-          {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-          {expanded ? "hide" : "output"}
-        </button>
-      )}
-    </div>
-  );
-}
-
-function FlatThinking({ model }: { model?: string }) {
-  return (
-    <div className="flex justify-start">
-      <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
-        <Loader2 className="h-3.5 w-3.5 animate-spin" />
-        <span>Thinking</span>
-        {model && <span className="text-xs opacity-60">with {model}</span>}
-      </div>
-    </div>
-  );
-}
-
-// ============================================
-// Option C: Minimal - subtle everything
-// ============================================
-
-function MinimalUserMessage({
-  content,
-  images,
-  meta,
-}: {
-  content: string;
-  images?: string[];
-  meta?: MessageMeta;
-}) {
-  return (
-    <div className="flex justify-end">
-      <div className="max-w-[85%] border border-border/60 rounded-xl px-3 py-2">
-        <div className="flex items-start gap-2">
-          <div className="flex-1">
-            <p className="text-sm">{content}</p>
-            {images && images.length > 0 && <ImagePlaceholder count={images.length} />}
-          </div>
-          <MessageInfo meta={meta} />
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function MinimalAgentMessage({ content, meta }: { content: string; meta?: MessageMeta }) {
-  return (
-    <div className="flex justify-start pl-1">
-      <div className="flex items-start gap-2 w-full">
-        <p className="flex-1 text-sm whitespace-pre-wrap text-foreground/90">{content}</p>
-        <MessageInfo meta={meta} />
-      </div>
-    </div>
-  );
-}
-
-function MinimalToolCall({ call }: { call: ToolCallData }) {
-  const [expanded, setExpanded] = useState(false);
-
-  if (call.name === "write_todos" && "todos" in call) {
-    return (
-      <div className="text-xs text-muted-foreground/80 pl-1 space-y-0.5">
-        {call.todos?.map((todo, i) => (
-          <div key={i} className="flex items-center gap-1.5">
-            {todo.status === "completed" && <span className="text-green-600">✓</span>}
-            {todo.status === "in_progress" && <span className="text-blue-600">○</span>}
-            {todo.status === "pending" && <span className="text-muted-foreground/40">○</span>}
-            <span className={cn(todo.status === "completed" && "line-through opacity-60")}>
-              {todo.content}
-            </span>
-          </div>
-        ))}
-      </div>
-    );
-  }
-
-  const status = call.status === "executing" ? "..." : "✓";
-
-  return (
-    <div className="text-xs text-muted-foreground/70 pl-1">
-      <span className="inline-flex items-center gap-1">
-        <span className={call.status === "executing" ? "text-muted-foreground" : "text-green-600"}>
-          {status}
-        </span>
-        <span className="font-mono">{call.name}</span>
-        {call.args && <span className="opacity-60">{call.args}</span>}
-        {call.result && String(call.result).length > 30 && (
-          <button onClick={() => setExpanded(!expanded)} className="opacity-50 hover:opacity-100">
-            [{expanded ? "−" : "+"}]
-          </button>
-        )}
-      </span>
-      {expanded && call.result && (
-        <pre className="mt-1 p-1.5 bg-muted/20 rounded text-[10px] leading-tight">
-          {call.result}
-        </pre>
-      )}
-    </div>
-  );
-}
-
-function MinimalThinking({ model }: { model?: string }) {
-  return (
-    <div className="flex justify-start pl-1">
-      <div className="flex items-center gap-1">
-        <span className="text-xs text-muted-foreground/60">thinking</span>
-        {model && <span className="text-xs text-muted-foreground/40">{model}</span>}
-        <span className="flex gap-0.5 ml-0.5">
-          <span
-            className="w-1 h-1 bg-muted-foreground/40 rounded-full animate-bounce"
-            style={{ animationDelay: "0ms" }}
-          />
-          <span
-            className="w-1 h-1 bg-muted-foreground/40 rounded-full animate-bounce"
-            style={{ animationDelay: "150ms" }}
-          />
-          <span
-            className="w-1 h-1 bg-muted-foreground/40 rounded-full animate-bounce"
-            style={{ animationDelay: "300ms" }}
-          />
-        </span>
-      </div>
-    </div>
-  );
-}
-
-// ============================================
-// Option D: Minimal + Icon
-// ============================================
-
-function MinimalIconUserMessage({
-  content,
-  images,
-  meta,
-}: {
-  content: string;
-  images?: string[];
-  meta?: MessageMeta;
-}) {
-  return (
-    <div className="flex justify-end">
-      <div className="max-w-[85%] border border-border/60 rounded-xl px-3 py-2">
-        <div className="flex items-start gap-2">
-          <div className="flex-1">
-            <p className="text-sm">{content}</p>
-            {images && images.length > 0 && <ImagePlaceholder count={images.length} />}
-          </div>
-          <MessageInfo meta={meta} />
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function MinimalIconAgentMessage({ content, meta }: { content: string; meta?: MessageMeta }) {
-  return (
-    <div className="flex justify-start gap-2">
-      <Bot className="w-4 h-4 mt-0.5 flex-shrink-0 text-muted-foreground/60" />
-      <div className="flex items-start gap-2 flex-1">
-        <p className="flex-1 text-sm whitespace-pre-wrap text-foreground/90">{content}</p>
-        <MessageInfo meta={meta} />
-      </div>
-    </div>
-  );
-}
-
-function MinimalIconToolCall({ call }: { call: ToolCallData }) {
-  const [expanded, setExpanded] = useState(false);
-
-  if (call.name === "write_todos" && "todos" in call) {
-    return (
-      <div className="text-xs text-muted-foreground/80 ml-6 space-y-0.5">
-        {call.todos?.map((todo, i) => (
-          <div key={i} className="flex items-center gap-1.5">
-            {todo.status === "completed" && <span className="text-green-600">✓</span>}
-            {todo.status === "in_progress" && <span className="text-blue-600">○</span>}
-            {todo.status === "pending" && <span className="text-muted-foreground/40">○</span>}
-            <span className={cn(todo.status === "completed" && "line-through opacity-60")}>
-              {todo.content}
-            </span>
-          </div>
-        ))}
-      </div>
-    );
-  }
-
-  const statusIcon =
-    call.status === "executing" ? (
-      <Loader2 className="h-3 w-3 animate-spin text-muted-foreground/60" />
-    ) : (
-      <Check className="h-3 w-3 text-green-600/80" />
-    );
-
-  return (
-    <div className="text-xs text-muted-foreground/70 ml-6">
-      <div className="flex items-center gap-1">
-        {statusIcon}
-        <span className="font-mono">{call.name}</span>
-        {call.args && <span className="opacity-60">{call.args}</span>}
-      </div>
-      {expanded && call.result && (
-        <pre className="mt-1 p-1.5 bg-muted/20 rounded text-[10px] leading-tight ml-4">
-          {call.result}
-        </pre>
-      )}
-      {call.result && String(call.result).length > 30 && (
-        <button
-          onClick={() => setExpanded(!expanded)}
-          className="ml-4 text-[10px] text-muted-foreground/50 hover:text-muted-foreground/80 flex items-center gap-0.5"
-        >
-          {expanded ? (
-            <ChevronDown className="h-2.5 w-2.5" />
-          ) : (
-            <ChevronRight className="h-2.5 w-2.5" />
-          )}
-          {expanded ? "hide" : "output"}
-        </button>
-      )}
-    </div>
-  );
-}
-
-function MinimalIconThinking({ model }: { model?: string }) {
-  return (
-    <div className="flex justify-start gap-2">
-      <Bot className="w-4 h-4 mt-0.5 flex-shrink-0 text-muted-foreground/60" />
-      <div className="flex items-center gap-1">
-        <span className="text-xs text-muted-foreground/60">thinking</span>
-        {model && <span className="text-xs text-muted-foreground/40">{model}</span>}
-        <span className="flex gap-0.5 ml-0.5">
-          <span
-            className="w-1 h-1 bg-muted-foreground/40 rounded-full animate-bounce"
-            style={{ animationDelay: "0ms" }}
-          />
-          <span
-            className="w-1 h-1 bg-muted-foreground/40 rounded-full animate-bounce"
-            style={{ animationDelay: "150ms" }}
-          />
-          <span
-            className="w-1 h-1 bg-muted-foreground/40 rounded-full animate-bounce"
-            style={{ animationDelay: "300ms" }}
-          />
-        </span>
-      </div>
-    </div>
-  );
-}
-
-// ============================================
-// Render helpers
-// ============================================
-
-type StyleOption = "current" | "flat" | "minimal" | "minimal-icon";
-
-function renderConversation(conversation: ConversationItem[], style: StyleOption) {
-  const components = {
-    current: {
-      User: CurrentUserMessage,
-      Agent: CurrentAgentMessage,
-      Tool: CurrentToolCall,
-      Thinking: CurrentThinking,
-    },
-    flat: {
-      User: FlatUserMessage,
-      Agent: FlatAgentMessage,
-      Tool: FlatToolCall,
-      Thinking: FlatThinking,
-    },
-    minimal: {
-      User: MinimalUserMessage,
-      Agent: MinimalAgentMessage,
-      Tool: MinimalToolCall,
-      Thinking: MinimalThinking,
-    },
-    "minimal-icon": {
-      User: MinimalIconUserMessage,
-      Agent: MinimalIconAgentMessage,
-      Tool: MinimalIconToolCall,
-      Thinking: MinimalIconThinking,
-    },
-  };
-
-  const { User, Agent, Tool, Thinking } = components[style];
-
-  return conversation.map((item, i) => {
-    switch (item.role) {
-      case "user":
-        return <User key={i} content={item.content} images={item.images} meta={item.meta} />;
-      case "agent":
-        return <Agent key={i} content={item.content} meta={item.meta} />;
-      case "tool":
-        return (
-          <div key={i} className="space-y-1">
-            {item.calls.map((call, j) => (
-              <Tool key={j} call={call} />
-            ))}
-          </div>
-        );
-      case "thinking":
-        return <Thinking key={i} model={item.model} />;
-    }
-  });
-}
-
-// ============================================
-// Main Page
-// ============================================
 
 export default function ChatStylesPage() {
-  const [selectedStyle, setSelectedStyle] = useState<StyleOption>("flat");
-
   if (!isDev) {
     return (
-      <div className="flex items-center justify-center min-h-screen">
+      <div className="flex min-h-screen items-center justify-center">
         <div className="text-center">
           <h1 className="text-4xl font-bold text-muted-foreground">404</h1>
-          <p className="text-muted-foreground mt-2">Page not found</p>
+          <p className="mt-2 text-muted-foreground">Page not found</p>
         </div>
       </div>
     );
   }
 
-  const styles: { id: StyleOption; name: string; description: string }[] = [
-    {
-      id: "current",
-      name: "Current",
-      description: "Existing design with backgrounds for both user and agent",
-    },
-    {
-      id: "flat",
-      name: "Flat Agent",
-      description: "User bubble, agent on flat background, compact tools",
-    },
-    {
-      id: "minimal",
-      name: "Minimal",
-      description: "Subtle borders, completely flat, inline tools",
-    },
-    {
-      id: "minimal-icon",
-      name: "Minimal + Icon",
-      description: "Minimal style with robot icon for agent messages",
-    },
-  ];
-
   return (
-    <div className="min-h-screen bg-background">
-      <div className="container mx-auto py-8 px-4 max-w-5xl">
-        <div className="mb-6">
-          <Link
-            href="/dev"
-            className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-4"
-          >
-            <ArrowLeft className="w-4 h-4 mr-2" />
-            Back to Developer Tools
-          </Link>
-          <h1 className="text-2xl font-bold">Chat UI Styles</h1>
-          <p className="text-muted-foreground mt-1 text-sm">
-            Compare different chat styling approaches
+    <div className="min-h-screen bg-background bg-brand-dots px-4 py-8">
+      <div className="mx-auto max-w-6xl">
+        <Link
+          href="/dev"
+          className="mb-6 inline-flex items-center gap-2 border border-border bg-card px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-muted/35 hover:text-foreground"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Developer Tools
+        </Link>
+
+        <div className="mb-8 max-w-2xl space-y-2">
+          <p className="text-[11px] uppercase tracking-[0.3em] text-muted-foreground">Chat Style</p>
+          <h1 className="text-3xl font-semibold tracking-tight text-foreground">
+            Canonical chat surface
+          </h1>
+          <p className="text-sm leading-6 text-muted-foreground">
+            The application now uses this single style: sharp surfaces, left and right border accents,
+            muted chrome, and info affordances on message rows.
           </p>
-          <Badge variant="outline" className="mt-2">
-            Development Mode
-          </Badge>
         </div>
 
-        {/* Style selector */}
-        <div className="flex gap-2 mb-6 flex-wrap">
-          {styles.map((style) => (
-            <button
-              key={style.id}
-              onClick={() => setSelectedStyle(style.id)}
-              className={cn(
-                "px-3 py-1.5 rounded-md text-sm transition-colors",
-                selectedStyle === style.id
-                  ? "bg-primary text-primary-foreground"
-                  : "bg-muted hover:bg-muted/80",
-              )}
-            >
-              {style.name}
-            </button>
-          ))}
-        </div>
-
-        {/* Description */}
-        <p className="text-sm text-muted-foreground mb-4">
-          {styles.find((s) => s.id === selectedStyle)?.description}
-        </p>
-
-        {/* Chat preview */}
-        <ScrollArea className="h-[calc(100vh-20rem)]">
-          <div className="border rounded-lg bg-background">
-            {/* Main conversation */}
-            <div className="p-4 space-y-4">
-              <div className="text-xs text-muted-foreground text-center mb-6">
-                Full Conversation
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px]">
+          <div className="overflow-hidden border border-border bg-card">
+            <div className="border-b border-border px-5 py-4">
+              <div className="text-[10px] uppercase tracking-[0.24em] text-muted-foreground">
+                Live transcript pattern
               </div>
-              {renderConversation(sampleConversation, selectedStyle)}
+              <div className="mt-1 text-sm font-medium text-foreground">Default chat composition</div>
             </div>
 
-            {/* Executing state */}
-            <div className="border-t p-4 space-y-4">
-              <div className="text-xs text-muted-foreground text-center mb-4">Executing State</div>
-              {renderConversation(executingConversation, selectedStyle)}
+            <div className="space-y-6 bg-background/80 px-4 py-5 sm:px-6">
+              <div className="flex justify-end">
+                <div className="max-w-[78%] border-r-2 border-r-accent bg-[hsl(var(--accent)/0.1)] px-4 py-3 text-sm text-foreground">
+                  <div className="mb-1 flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-1 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+                      <CalendarClock className="h-3 w-3" />
+                      Scheduled
+                    </div>
+                    <MessageInfoIcon event={userEvent} />
+                  </div>
+                  Inspect this repo and summarize the rewrite plan.
+                </div>
+              </div>
+
+              <div className="flex items-start gap-3 pr-2">
+                <div className="mt-1 flex h-6 w-6 flex-shrink-0 items-center justify-center border border-border bg-primary text-primary-foreground">
+                  <Bot className="h-3.5 w-3.5" />
+                </div>
+                <div className="flex flex-1 items-start gap-2">
+                  <div className="flex-1 border-l-2 border-l-primary bg-card px-4 py-3 text-sm leading-7 text-foreground">
+                    I&apos;m checking the structure first, then I&apos;ll outline the smallest safe
+                    rewrite path.
+                  </div>
+                  <MessageInfoIcon event={agentEvent} />
+                </div>
+              </div>
+
+              <div className="ml-9">
+                <ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResults} />
+              </div>
             </div>
 
-            {/* Thinking state */}
-            <div className="border-t p-4 space-y-4">
-              <div className="text-xs text-muted-foreground text-center mb-4">Thinking State</div>
-              {renderConversation(thinkingConversation, selectedStyle)}
-            </div>
-
-            {/* Images */}
-            <div className="border-t p-4 space-y-4">
-              <div className="text-xs text-muted-foreground text-center mb-4">With Images</div>
-              {renderConversation(imageConversation, selectedStyle)}
+            <div className="border-t border-border bg-muted/30 p-4">
+              <div className="border border-border bg-background px-4 py-4 text-sm text-foreground">
+                Type a message or <span className="font-mono">/</span> for commands...
+              </div>
+              <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
+                <div className="flex flex-wrap items-center gap-3">
+                  <button
+                    type="button"
+                    className="inline-flex h-10 w-10 items-center justify-center border border-border bg-background"
+                    aria-label="Attach images"
+                  >
+                    <ImagePlus className="icon-sharp h-4 w-4" />
+                  </button>
+                  <div className="flex h-10 items-center gap-2 border border-border bg-background px-3 text-sm">
+                    <span className="text-[10px] uppercase tracking-[0.22em] text-muted-foreground">Model</span>
+                    <span className="text-foreground">Kimi K2.5</span>
+                  </div>
+                  <div className="flex h-10 items-center gap-2 border border-border bg-background px-3 text-sm">
+                    <Brain className="icon-sharp h-3.5 w-3.5 text-muted-foreground" />
+                    <span className="text-[10px] uppercase tracking-[0.22em] text-muted-foreground">Reasoning</span>
+                    <span className="text-foreground">Default</span>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    className="inline-flex h-10 w-10 items-center justify-center border border-destructive/30 bg-destructive/[0.08] text-destructive"
+                    aria-label="Cancel current turn"
+                  >
+                    <StopCircle className="icon-sharp h-4 w-4" />
+                  </button>
+                  <button
+                    type="button"
+                    className="inline-flex h-10 w-10 items-center justify-center bg-primary text-primary-foreground"
+                    aria-label="Send message"
+                  >
+                    <Send className="icon-sharp h-4 w-4" />
+                  </button>
+                </div>
+              </div>
             </div>
           </div>
-        </ScrollArea>
 
-        {/* Side by side comparison */}
-        <div className="mt-8">
-          <h2 className="text-lg font-semibold mb-4">Side-by-Side Comparison</h2>
-          <div className="grid grid-cols-2 gap-4">
-            {styles.map((style) => (
-              <div key={style.id} className="border rounded-lg overflow-hidden">
-                <div className="bg-muted/30 px-3 py-2 border-b">
-                  <span className="font-medium text-sm">{style.name}</span>
-                </div>
-                <div className="p-3 space-y-3 text-sm">
-                  {renderConversation(sampleConversation.slice(0, 4), style.id)}
-                </div>
-              </div>
-            ))}
+          <div className="space-y-4">
+            <Note>User messages anchor on a right gold border, not a rounded bubble.</Note>
+            <Note>Agent messages stay flatter: icon rail, left primary border, metadata icon on the side.</Note>
+            <Note>Tool execution and todos inherit the same surface rules, so chat reads as one system.</Note>
           </div>
         </div>
       </div>

--- a/apps/ui/src/app/dev/page.tsx
+++ b/apps/ui/src/app/dev/page.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import {
   FlaskConical,
   MessageSquare,
@@ -29,6 +27,12 @@ const devPages = [
     title: "Chat Components",
     description: "Chat-specific: messages, tool calls, todo lists, image attachments",
     href: "/dev/chat-components",
+    icon: MessageSquare,
+  },
+  {
+    title: "Tool Activity",
+    description: "Grouped tool execution with animations, summaries, and todo progress cards",
+    href: "/dev/tool-activity",
     icon: MessageSquare,
   },
   {
@@ -78,35 +82,34 @@ export default function DevPage() {
   }
 
   return (
-    <div className="min-h-screen bg-muted/30">
-      <div className="container mx-auto py-8 px-4">
-        <div className="mb-8">
-          <div className="flex items-center gap-2 mb-2">
-            <FlaskConical className="h-8 w-8" />
-            <h1 className="text-3xl font-bold">Developer Tools</h1>
+    <div className="min-h-screen bg-background bg-brand-dots px-4 py-8">
+      <div className="mx-auto max-w-6xl">
+        <div className="mb-8 max-w-2xl space-y-2">
+          <div className="flex items-center gap-3">
+            <FlaskConical className="h-7 w-7 text-primary" />
+            <p className="text-[11px] uppercase tracking-[0.3em] text-muted-foreground">
+              Developer Tools
+            </p>
           </div>
-          <p className="text-muted-foreground">
-            Development-only pages for testing and previewing UI components
+          <h1 className="text-3xl font-semibold tracking-tight text-foreground">UI reference pages</h1>
+          <p className="text-sm leading-6 text-muted-foreground">
+            Development-only previews for the application’s canonical component styles and behaviors.
           </p>
-          <Badge variant="outline" className="mt-2">
-            Development Mode
-          </Badge>
         </div>
 
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           {devPages.map((page) => (
             <Link key={page.href} href={page.href}>
-              <Card className="h-full hover:border-primary transition-colors cursor-pointer">
-                <CardHeader>
-                  <div className="flex items-center justify-between">
-                    <page.icon className="h-5 w-5 text-muted-foreground" />
-                    <ArrowRight className="h-4 w-4 text-muted-foreground" />
-                  </div>
-                  <CardTitle className="text-lg">{page.title}</CardTitle>
-                  <CardDescription>{page.description}</CardDescription>
-                </CardHeader>
-                <CardContent />
-              </Card>
+              <div className="flex h-full cursor-pointer flex-col justify-between border border-border bg-card px-5 py-5 transition-colors hover:border-primary">
+                <div className="flex items-center justify-between">
+                  <page.icon className="h-5 w-5 text-muted-foreground" />
+                  <ArrowRight className="h-4 w-4 text-muted-foreground" />
+                </div>
+                <div className="mt-8">
+                  <h2 className="text-lg font-medium text-foreground">{page.title}</h2>
+                  <p className="mt-2 text-sm leading-6 text-muted-foreground">{page.description}</p>
+                </div>
+              </div>
             </Link>
           ))}
         </div>

--- a/apps/ui/src/app/dev/page.tsx
+++ b/apps/ui/src/app/dev/page.tsx
@@ -91,9 +91,12 @@ export default function DevPage() {
               Developer Tools
             </p>
           </div>
-          <h1 className="text-3xl font-semibold tracking-tight text-foreground">UI reference pages</h1>
+          <h1 className="text-3xl font-semibold tracking-tight text-foreground">
+            UI reference pages
+          </h1>
           <p className="text-sm leading-6 text-muted-foreground">
-            Development-only previews for the application’s canonical component styles and behaviors.
+            Development-only previews for the application’s canonical component styles and
+            behaviors.
           </p>
         </div>
 

--- a/apps/ui/src/app/dev/tool-activity/page.tsx
+++ b/apps/ui/src/app/dev/tool-activity/page.tsx
@@ -1,0 +1,439 @@
+"use client";
+
+import Link from "next/link";
+import {
+  ArrowLeft,
+  Bot,
+  Brain,
+  CalendarClock,
+  ImagePlus,
+  Send,
+  Sparkles,
+  StopCircle,
+  Terminal,
+} from "lucide-react";
+import { MessageInfoIcon } from "@/components/chat/message-info-icon";
+import { ToolActivityGroup } from "@/components/chat/tool-activity-group";
+import { TodoListRenderer } from "@/components/chat/todo-list-renderer";
+import type { Event, ToolCompletedData } from "@/lib/api/types";
+import type { ToolCallContent } from "@/components/chat/tool-call-utils";
+
+const isDev = process.env.NODE_ENV === "development";
+
+const activeToolCalls: ToolCallContent[] = [
+  {
+    id: "tool-list",
+    name: "list_files",
+    arguments: { path: "." },
+  },
+  {
+    id: "tool-read",
+    name: "read_file",
+    arguments: { path: "/workspace/README.md" },
+  },
+  {
+    id: "tool-grep",
+    name: "grep_files",
+    arguments: { pattern: "**/package.json" },
+  },
+  {
+    id: "tool-search",
+    name: "search_web",
+    arguments: { query: "next.js structured tool activity ui" },
+  },
+];
+
+const activeToolResults = new Map<string, ToolCompletedData>([
+  [
+    "tool-list",
+    {
+      tool_call_id: "tool-list",
+      tool_name: "list_files",
+      success: true,
+      status: "success",
+      result: [
+        {
+          type: "text",
+          text: "README.md\npackage.json\nsrc/\napps/\ncrates/",
+        },
+      ],
+    },
+  ],
+  [
+    "tool-read",
+    {
+      tool_call_id: "tool-read",
+      tool_name: "read_file",
+      success: true,
+      status: "success",
+      result: [
+        {
+          type: "text",
+          text: "# Everruns\nDurable agent runtime and UI for long-running tasks.",
+        },
+      ],
+    },
+  ],
+]);
+
+const completedToolCalls: ToolCallContent[] = [
+  {
+    id: "tool-shell",
+    name: "bash",
+    arguments: { command: "mv apps/web/src projects/ui/src" },
+  },
+  {
+    id: "tool-edit",
+    name: "write_file",
+    arguments: { path: "/workspace/README.md" },
+  },
+];
+
+const completedToolResults = new Map<string, ToolCompletedData>([
+  [
+    "tool-shell",
+    {
+      tool_call_id: "tool-shell",
+      tool_name: "bash",
+      success: true,
+      status: "success",
+      result: [
+        {
+          type: "text",
+          text: "$ mv apps/web/src projects/ui/src\nRenamed 18 files successfully.",
+        },
+      ],
+      duration_ms: 380,
+    },
+  ],
+  [
+    "tool-edit",
+    {
+      tool_call_id: "tool-edit",
+      tool_name: "write_file",
+      success: true,
+      status: "success",
+      result: [
+        {
+          type: "text",
+          text: "Updated README.md with the new project structure and setup notes.",
+        },
+      ],
+      duration_ms: 95,
+    },
+  ],
+]);
+
+const clientToolCalls: ToolCallContent[] = [
+  {
+    id: "tool-picker",
+    name: "pick_file",
+    display_name: "Pick File",
+    arguments: { accept: ".png,.jpg" },
+  },
+];
+
+const planTodos = [
+  {
+    content: "Update schema for rock collection domain",
+    activeForm: "Updating schema for rock collection domain",
+    status: "completed" as const,
+  },
+  {
+    content: "Rename Convex functions and routes",
+    activeForm: "Renaming Convex functions and routes",
+    status: "completed" as const,
+  },
+  {
+    content: "Update UI copy for rock collection",
+    activeForm: "Updating UI copy for rock collection",
+    status: "in_progress" as const,
+  },
+  {
+    content: "Refresh README examples",
+    activeForm: "Refreshing README examples",
+    status: "pending" as const,
+  },
+];
+
+const scheduledInputEvent: Event = {
+  id: "evt-user-1",
+  type: "input.message",
+  ts: "2026-03-07T21:20:00Z",
+  session_id: "session-dev-tool-activity",
+  context: {},
+  data: {
+    message: {
+      id: "msg-user-1",
+      session_id: "session-dev-tool-activity",
+      sequence: 1,
+      role: "user",
+      content: [{ type: "text", text: "Can you inspect this project and sketch the rewrite steps?" }],
+      tool_call_id: null,
+      created_at: "2026-03-07T21:20:00Z",
+      metadata: { source: "schedule" },
+    },
+  },
+};
+
+const rewriteInputEvent: Event = {
+  id: "evt-user-2",
+  type: "input.message",
+  ts: "2026-03-07T21:21:00Z",
+  session_id: "session-dev-tool-activity",
+  context: {},
+  data: {
+    message: {
+      id: "msg-user-2",
+      session_id: "session-dev-tool-activity",
+      sequence: 2,
+      role: "user",
+      content: [{ type: "text", text: "Rewrite it so it supports a rock collection instead." }],
+      tool_call_id: null,
+      created_at: "2026-03-07T21:21:00Z",
+    },
+  },
+};
+
+const agentPlanningEvent: Event = {
+  id: "evt-agent-1",
+  type: "output.message.completed",
+  ts: "2026-03-07T21:20:08Z",
+  session_id: "session-dev-tool-activity",
+  context: {},
+  data: {
+    message: {
+      id: "msg-agent-1",
+      session_id: "session-dev-tool-activity",
+      sequence: 3,
+      role: "agent",
+      content: [
+        {
+          type: "text",
+          text: "I'm checking the codebase shape first, then I'll summarize the likely rewrite path.",
+        },
+      ],
+      tool_call_id: null,
+      created_at: "2026-03-07T21:20:08Z",
+      metadata: {
+        model: "kimi-k2.5",
+        reasoning_effort: "medium",
+      },
+    },
+    metadata: { model: "kimi-k2.5" },
+    usage: { input_tokens: 1220, output_tokens: 188 },
+  },
+};
+
+export default function ToolActivityDevPage() {
+  if (!isDev) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-4xl font-bold text-muted-foreground">404</h1>
+          <p className="mt-2 text-muted-foreground">Page not found</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background bg-brand-dots px-4 py-8">
+      <div className="mx-auto max-w-6xl">
+        <Link
+          href="/dev"
+          className="mb-6 inline-flex items-center gap-2 border border-border bg-card px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-muted/35 hover:text-foreground"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Developer Tools
+        </Link>
+
+        <div className="mb-8 max-w-2xl space-y-2">
+          <p className="text-[11px] uppercase tracking-[0.3em] text-muted-foreground">
+            Tool Activity
+          </p>
+          <h1 className="text-3xl font-semibold tracking-tight text-foreground">
+            Minimal execution states
+          </h1>
+          <p className="text-sm leading-6 text-muted-foreground">
+            Sharper, quieter, closer to the final chat surface.
+          </p>
+        </div>
+
+        <div className="mx-auto max-w-5xl">
+          <div className="overflow-hidden border border-border bg-card">
+            <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-5 py-4">
+              <div>
+                <div className="text-[10px] uppercase tracking-[0.24em] text-muted-foreground">
+                  Everruns Chat
+                </div>
+                <div className="mt-1 text-sm font-medium text-foreground">
+                  Tool activity preview
+                </div>
+              </div>
+              <div className="flex items-center gap-2 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+                <span className="inline-flex h-2 w-2 bg-accent" />
+                Preview
+              </div>
+            </div>
+
+            <div className="min-h-[760px] bg-background/80">
+              <div className="flex flex-col">
+                <div className="flex-1 space-y-6 px-4 py-5 sm:px-6">
+                  <div className="flex justify-end">
+                    <div className="max-w-[78%] border-r-2 border-r-accent bg-[hsl(var(--accent)/0.1)] px-4 py-3 text-sm text-foreground">
+                      <div className="mb-1 flex items-center justify-between gap-2">
+                        <div className="flex items-center gap-1 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+                          <CalendarClock className="h-3 w-3" />
+                          Scheduled
+                        </div>
+                        <MessageInfoIcon event={scheduledInputEvent} />
+                      </div>
+                      Can you inspect this project and sketch the rewrite steps?
+                    </div>
+                  </div>
+
+                  <div className="flex items-start gap-3">
+                    <div className="mt-1 flex h-6 w-6 items-center justify-center border border-border bg-primary text-primary-foreground">
+                      <Bot className="h-3.5 w-3.5" />
+                    </div>
+                    <div className="flex-1 space-y-3">
+                      <div className="flex items-start gap-2">
+                        <p className="flex-1 border-l-2 border-l-primary bg-card px-4 py-3 text-sm leading-7 text-foreground">
+                          I&apos;m checking the codebase shape first, then I&apos;ll summarize the
+                          likely rewrite path.
+                        </p>
+                        <MessageInfoIcon event={agentPlanningEvent} />
+                      </div>
+                      <ToolActivityGroup
+                        toolCalls={activeToolCalls}
+                        toolResultsMap={activeToolResults}
+                      />
+                    </div>
+                  </div>
+
+                  <div className="flex justify-end">
+                    <div className="max-w-[78%] border-r-2 border-r-accent bg-[hsl(var(--accent)/0.1)] px-4 py-3 text-sm text-foreground">
+                      <div className="mb-1 flex items-center justify-end">
+                        <MessageInfoIcon event={rewriteInputEvent} />
+                      </div>
+                      Rewrite it so it supports a rock collection instead.
+                    </div>
+                  </div>
+
+                  <div className="flex items-start gap-3">
+                    <div className="mt-1 flex h-6 w-6 items-center justify-center border border-border bg-primary text-primary-foreground">
+                      <Bot className="h-3.5 w-3.5" />
+                    </div>
+                    <div className="flex-1 space-y-3">
+                      <ToolActivityGroup
+                        toolCalls={completedToolCalls}
+                        toolResultsMap={completedToolResults}
+                      />
+                      <TodoListRenderer arguments={{ todos: planTodos }} isExecuting />
+                    </div>
+                  </div>
+
+                  <div className="flex items-start gap-3">
+                    <div className="mt-1 flex h-6 w-6 items-center justify-center border border-border bg-primary text-primary-foreground">
+                      <Bot className="h-3.5 w-3.5" />
+                    </div>
+                    <div className="flex-1">
+                      <ToolActivityGroup
+                        toolCalls={clientToolCalls}
+                        toolResultsMap={new Map()}
+                        mode="client"
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                <div className="border-t border-border bg-muted/30 p-4">
+                  <div className="mb-3 flex flex-wrap gap-2">
+                    <div className="border border-border bg-background px-2 py-1 text-xs text-muted-foreground">
+                      architecture.png
+                    </div>
+                    <div className="border border-border bg-background px-2 py-1 text-xs text-muted-foreground">
+                      schema-draft.png
+                    </div>
+                  </div>
+
+                  <div className="relative border border-border bg-background">
+                    <div className="absolute bottom-full left-0 right-0 border border-border bg-card p-1">
+                      <button
+                        type="button"
+                        className="flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm text-foreground"
+                      >
+                        <Terminal className="h-3.5 w-3.5 text-muted-foreground" />
+                        <span className="font-mono text-xs">/ship</span>
+                        <span className="truncate text-xs text-muted-foreground">
+                          Run the shipping workflow
+                        </span>
+                      </button>
+                      <button
+                        type="button"
+                        className="flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm text-muted-foreground"
+                      >
+                        <Sparkles className="h-3.5 w-3.5 text-muted-foreground" />
+                        <span className="font-mono text-xs">/process-issues</span>
+                        <span className="truncate text-xs text-muted-foreground">
+                          Batch-process open issues
+                        </span>
+                      </button>
+                    </div>
+
+                    <div className="px-4 py-5 text-sm text-foreground">
+                      Type a message or <span className="font-mono">/</span> for commands...
+                    </div>
+                  </div>
+
+                  <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
+                    <div className="flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
+                      <button
+                        type="button"
+                        className="inline-flex h-10 w-10 items-center justify-center border border-border bg-background"
+                        aria-label="Attach images"
+                      >
+                        <ImagePlus className="icon-sharp h-4 w-4" />
+                      </button>
+                      <div className="inline-flex h-10 items-center gap-2 border border-border bg-background px-3">
+                        <span className="text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+                          Model
+                        </span>
+                        <span className="text-sm text-foreground">Kimi K2.5</span>
+                      </div>
+                      <div className="inline-flex h-10 items-center gap-2 border border-border bg-background px-3">
+                        <Brain className="icon-sharp h-3.5 w-3.5" />
+                        <span className="text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+                          Reasoning
+                        </span>
+                        <span className="text-sm text-foreground">Default</span>
+                      </div>
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        className="inline-flex h-10 w-10 items-center justify-center border border-destructive/30 bg-destructive/[0.08] text-destructive"
+                        aria-label="Cancel current turn"
+                      >
+                        <StopCircle className="icon-sharp h-4 w-4" />
+                      </button>
+                      <button
+                        type="button"
+                        className="inline-flex h-10 w-10 items-center justify-center bg-primary text-primary-foreground"
+                        aria-label="Send message"
+                      >
+                        <Send className="icon-sharp h-4 w-4" />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/app/dev/tool-activity/page.tsx
+++ b/apps/ui/src/app/dev/tool-activity/page.tsx
@@ -168,7 +168,9 @@ const scheduledInputEvent: Event = {
       session_id: "session-dev-tool-activity",
       sequence: 1,
       role: "user",
-      content: [{ type: "text", text: "Can you inspect this project and sketch the rewrite steps?" }],
+      content: [
+        { type: "text", text: "Can you inspect this project and sketch the rewrite steps?" },
+      ],
       tool_call_id: null,
       created_at: "2026-03-07T21:20:00Z",
       metadata: { source: "schedule" },

--- a/apps/ui/src/app/globals.css
+++ b/apps/ui/src/app/globals.css
@@ -192,11 +192,6 @@
   position: absolute;
   inset: 0;
   width: 45%;
-  background: linear-gradient(
-    90deg,
-    transparent,
-    hsl(var(--accent) / 0.14),
-    transparent
-  );
+  background: linear-gradient(90deg, transparent, hsl(var(--accent) / 0.14), transparent);
   animation: tool-progress-sheen 1.8s ease-in-out infinite;
 }

--- a/apps/ui/src/app/globals.css
+++ b/apps/ui/src/app/globals.css
@@ -115,6 +115,12 @@
   background-image: radial-gradient(circle at center, hsl(43 60% 53% / 0.1) 1px, transparent 1px);
 }
 
+.icon-sharp {
+  stroke-linecap: square;
+  stroke-linejoin: miter;
+  shape-rendering: geometricPrecision;
+}
+
 /* Experimental page badge — hand-drawn stamp with Caveat font */
 .experimental-page-badge {
   font-family: "Caveat", cursive;
@@ -136,4 +142,61 @@
   border: 1.5px solid #d97706;
   border-radius: 50% 40% 45% 42% / 50% 45% 40% 48%;
   opacity: 0.45;
+}
+
+@keyframes tool-row-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes tool-pulse {
+  0%,
+  100% {
+    opacity: 0.45;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes tool-progress-sheen {
+  from {
+    transform: translateX(-120%);
+  }
+  to {
+    transform: translateX(220%);
+  }
+}
+
+.animate-tool-row-in {
+  animation: tool-row-enter 220ms ease-out both;
+}
+
+.animate-tool-pulse {
+  animation: tool-pulse 1.6s ease-in-out infinite;
+}
+
+.animate-tool-progress-active {
+  position: relative;
+  overflow: hidden;
+}
+
+.animate-tool-progress-active::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: 45%;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    hsl(var(--accent) / 0.14),
+    transparent
+  );
+  animation: tool-progress-sheen 1.8s ease-in-out infinite;
 }

--- a/apps/ui/src/components/agents/agent-card.tsx
+++ b/apps/ui/src/components/agents/agent-card.tsx
@@ -32,7 +32,7 @@ export function AgentCard({
   const agentCapabilities = agent.capabilities ?? [];
 
   return (
-    <Card className="hover:shadow-md transition-shadow">
+    <Card className="bg-background transition-colors hover:bg-card">
       <CardHeader className="flex flex-row items-start justify-between space-y-0">
         <div className="flex items-center gap-2">
           <CardTitle className="text-lg">
@@ -64,8 +64,8 @@ export function AgentCard({
 
                 return (
                   <Tooltip key={capConfig.ref}>
-                    <TooltipTrigger className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-muted text-xs cursor-default">
-                      <IconComponent className="w-3 h-3" />
+                    <TooltipTrigger className="inline-flex cursor-default items-center gap-1 border bg-muted px-2 py-0.5 text-xs">
+                      <IconComponent className="icon-sharp h-3 w-3" />
                       {!compact && <span>{cap.name}</span>}
                     </TooltipTrigger>
                     <TooltipContent>
@@ -98,7 +98,7 @@ export function AgentCard({
           {showEditButton && (
             <Link href={`/agents/${agent.id}/edit`}>
               <Button variant="ghost" size="icon" className="h-8 w-8">
-                <Pencil className="w-4 h-4" />
+                <Pencil className="icon-sharp h-4 w-4" />
               </Button>
             </Link>
           )}

--- a/apps/ui/src/components/chat/chat-panel.tsx
+++ b/apps/ui/src/components/chat/chat-panel.tsx
@@ -21,7 +21,6 @@ import type {
   CommandDescriptor,
 } from "@/lib/api/types";
 import { isImageFilePart } from "@/lib/api/types";
-import { ToolCallCardFromEvent } from "@/components/chat/tool-call-card-from-event";
 import { MessageInfoIcon } from "@/components/chat/message-info-icon";
 import { ImageAttachments, MessageImage } from "@/components/chat/image-attachments";
 import {
@@ -31,6 +30,7 @@ import {
 import { ThinkingIndicator } from "@/components/thinking-indicator";
 import { StreamingMessage } from "@/components/streaming-message";
 import { StreamdownMessage } from "@/components/chat/streamdown-message";
+import { ToolActivityGroup } from "@/components/chat/tool-activity-group";
 import { useSessionContext } from "@/app/(main)/sessions/[sessionId]/session-context";
 import { useLlmModels, useImageAttachments, useSessionCommands } from "@/hooks";
 import { sendUserMessageWithImages } from "@/lib/api/messages";
@@ -88,6 +88,18 @@ export function ChatPanel() {
   const commands = commandsData?.commands ?? [];
   const [showCommands, setShowCommands] = useState(false);
 
+  const clientRequestedToolCallIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const event of chatEvents) {
+      if (event.type !== "tool.call_requested") continue;
+      const data = event.data as ToolCallRequestedData;
+      for (const toolCall of data.tool_calls ?? []) {
+        ids.add(toolCall.id);
+      }
+    }
+    return ids;
+  }, [chatEvents]);
+
   const handleCommandSelect = useCallback(
     (cmd: CommandDescriptor) => {
       setShowCommands(false);
@@ -142,6 +154,10 @@ export function ChatPanel() {
   const defaultEffortName = reasoningEffortConfig?.default
     ? getReasoningEffortName(reasoningEffortConfig.default)
     : "Medium";
+  const modelTriggerLabel = selectedModel?.display_name ?? "Default";
+  const defaultModelOptionLabel = llmModel?.display_name
+    ? `Default (${llmModel.display_name})`
+    : "Default";
 
   useEffect(() => {
     if (!supportsReasoning) {
@@ -268,141 +284,142 @@ export function ChatPanel() {
 
   return (
     <>
-      {/* Messages area */}
-      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+      <div className="flex-1 overflow-y-auto bg-background bg-brand-dots px-4 py-5 sm:px-6">
         {eventsLoading ? (
           <div className="space-y-4">
+            <Skeleton className="ml-auto h-20 w-3/4" />
             <Skeleton className="h-20 w-3/4" />
-            <Skeleton className="h-20 w-3/4 ml-auto" />
-            <Skeleton className="h-20 w-3/4" />
+            <Skeleton className="h-20 w-2/3" />
           </div>
         ) : chatEvents.length === 0 ? (
-          <div className="flex flex-col items-center justify-center h-full text-center text-muted-foreground">
-            <Bot className="w-12 h-12 mb-4 opacity-50" />
-            <p className="text-lg font-medium">No messages yet</p>
-            <p className="text-sm">Send a message to start the conversation</p>
+          <div className="flex h-full flex-col items-center justify-center text-center text-muted-foreground">
+            <div className="border border-border bg-card px-10 py-10">
+              <Bot className="mx-auto mb-4 h-10 w-10 opacity-50" />
+              <p className="text-lg font-medium text-foreground">No messages yet</p>
+              <p className="mt-1 text-sm">Send a message to start the conversation</p>
+            </div>
           </div>
         ) : (
-          chatEvents.map((event) => {
-            // Skip tool.completed - rendered inline with agent messages
-            if (event.type === "tool.completed") {
-              return null;
-            }
+          <div className="space-y-6">
+            {chatEvents.map((event) => {
+              if (event.type === "tool.completed") {
+                return null;
+              }
 
-            // Render tool.call_requested as client-side tool call cards
-            if (event.type === "tool.call_requested") {
-              const reqData = event.data as ToolCallRequestedData;
-              if (!reqData.tool_calls || reqData.tool_calls.length === 0) return null;
+              if (event.type === "tool.call_requested") {
+                const reqData = event.data as ToolCallRequestedData;
+                if (!reqData.tool_calls || reqData.tool_calls.length === 0) return null;
+                return (
+                  <div key={event.id} className="ml-9 space-y-1">
+                    <ToolActivityGroup
+                      toolCalls={reqData.tool_calls}
+                      toolResultsMap={toolResultsMap}
+                      mode="client"
+                    />
+                  </div>
+                );
+              }
+
+              const isUser = event.type === "input.message";
+              const data = event.data as InputMessageData | OutputMessageCompletedData;
+              const textContent = getMessageText(data);
+              const toolCalls = isUser
+                ? []
+                : getToolCalls(data as OutputMessageCompletedData).filter(
+                    (toolCall) => !clientRequestedToolCallIds.has(toolCall.id),
+                  );
+              const images = data.message?.content ? getMessageImages(data.message.content) : [];
+              const isScheduleTriggered = isUser && data.message?.metadata?.source === "schedule";
+              const isToolOnlyMessage =
+                !isUser && toolCalls.length > 0 && !textContent && images.length === 0;
+
+              if (isToolOnlyMessage) {
+                return (
+                  <div key={event.id} className="ml-9 space-y-1">
+                    <ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} />
+                  </div>
+                );
+              }
+
               return (
-                <div key={event.id} className="ml-6 space-y-1">
-                  {reqData.tool_calls.map((tc) => {
-                    const toolResult = toolResultsMap.get(tc.id);
-                    return (
-                      <ToolCallCardFromEvent
-                        key={tc.id}
-                        toolCall={tc}
-                        toolResult={toolResult}
-                        isClientSide
-                      />
-                    );
-                  })}
+                <div key={event.id} className="space-y-2">
+                  {(textContent || images.length > 0) && (
+                    <div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
+                      {isUser ? (
+                        <div className="max-w-[78%] border-r-2 border-r-accent bg-[hsl(var(--accent)/0.1)] px-4 py-3 text-sm text-foreground">
+                          {isScheduleTriggered && (
+                            <div className="mb-1 flex items-center gap-1 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+                              <CalendarClock className="h-3 w-3" />
+                              <span>Scheduled</span>
+                            </div>
+                          )}
+                          <div className="flex items-start gap-2">
+                            <div className="flex-1 space-y-2">
+                              {textContent && <p className="whitespace-pre-wrap">{textContent}</p>}
+                              {images.length > 0 && (
+                                <div className="mt-2 flex flex-wrap gap-2">
+                                  {images.map((img) => (
+                                    <MessageImage
+                                      key={img.image_id}
+                                      imageId={img.image_id}
+                                      filename={img.filename}
+                                    />
+                                  ))}
+                                </div>
+                              )}
+                            </div>
+                            <MessageInfoIcon event={event} />
+                          </div>
+                        </div>
+                      ) : (
+                        <div className="flex w-full items-start gap-3 pr-2">
+                          <div className="mt-1 flex h-6 w-6 flex-shrink-0 items-center justify-center border border-border bg-primary text-primary-foreground">
+                            <Bot className="h-3.5 w-3.5" />
+                          </div>
+                          <div className="flex flex-1 items-start gap-2">
+                            <div className="flex-1 space-y-2 border-l-2 border-l-primary bg-card px-4 py-3">
+                              {textContent && (
+                                <StreamdownMessage variant="inline" className="text-foreground">
+                                  {textContent}
+                                </StreamdownMessage>
+                              )}
+                              {images.length > 0 && (
+                                <div className="mt-2 flex flex-wrap gap-2">
+                                  {images.map((img) => (
+                                    <MessageImage
+                                      key={img.image_id}
+                                      imageId={img.image_id}
+                                      filename={img.filename}
+                                    />
+                                  ))}
+                                </div>
+                              )}
+                            </div>
+                            <MessageInfoIcon event={event} />
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  )}
+
+                  {toolCalls.length > 0 && (
+                    <div className="ml-9 space-y-1">
+                      <ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} />
+                    </div>
+                  )}
                 </div>
               );
-            }
-
-            const isUser = event.type === "input.message";
-            const data = event.data as InputMessageData | OutputMessageCompletedData;
-            const textContent = getMessageText(data);
-            const toolCalls = isUser ? [] : getToolCalls(data as OutputMessageCompletedData);
-            const images = data.message?.content ? getMessageImages(data.message.content) : [];
-            const isScheduleTriggered = isUser && data.message?.metadata?.source === "schedule";
-
-            return (
-              <div key={event.id} className="space-y-2">
-                {/* Render text content and images */}
-                {(textContent || images.length > 0) && (
-                  <div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
-                    {isUser ? (
-                      /* User message - subtle border, rounded */
-                      <div className="max-w-[85%] border border-border/60 rounded-xl px-3 py-2">
-                        {isScheduleTriggered && (
-                          <div className="flex items-center gap-1 text-xs text-muted-foreground mb-1">
-                            <CalendarClock className="w-3 h-3" />
-                            <span>Scheduled</span>
-                          </div>
-                        )}
-                        <div className="flex items-start gap-2">
-                          <div className="flex-1 space-y-2">
-                            {textContent && (
-                              <p className="text-sm whitespace-pre-wrap">{textContent}</p>
-                            )}
-                            {images.length > 0 && (
-                              <div className="flex flex-wrap gap-2 mt-2">
-                                {images.map((img) => (
-                                  <MessageImage
-                                    key={img.image_id}
-                                    imageId={img.image_id}
-                                    filename={img.filename}
-                                  />
-                                ))}
-                              </div>
-                            )}
-                          </div>
-                          <MessageInfoIcon event={event} />
-                        </div>
-                      </div>
-                    ) : (
-                      /* Agent message - flat with robot icon, pr-3 matches user bubble padding */
-                      <div className="w-full flex items-start gap-2 pr-3">
-                        <Bot className="w-4 h-4 mt-0.5 flex-shrink-0 text-muted-foreground/60" />
-                        <div className="flex-1 flex items-start gap-2">
-                          <div className="flex-1 space-y-2">
-                            {textContent && (
-                              <StreamdownMessage variant="inline" className="text-foreground/90">
-                                {textContent}
-                              </StreamdownMessage>
-                            )}
-                            {images.length > 0 && (
-                              <div className="flex flex-wrap gap-2 mt-2">
-                                {images.map((img) => (
-                                  <MessageImage
-                                    key={img.image_id}
-                                    imageId={img.image_id}
-                                    filename={img.filename}
-                                  />
-                                ))}
-                              </div>
-                            )}
-                          </div>
-                          <MessageInfoIcon event={event} />
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                )}
-
-                {/* Render tool calls from agent message */}
-                {toolCalls.length > 0 && (
-                  <div className="ml-6 space-y-1">
-                    {toolCalls.map((tc) => {
-                      const toolResult = toolResultsMap.get(tc.id);
-                      return (
-                        <ToolCallCardFromEvent key={tc.id} toolCall={tc} toolResult={toolResult} />
-                      );
-                    })}
-                  </div>
-                )}
-              </div>
-            );
-          })
+            })}
+          </div>
         )}
 
-        {/* Streaming content - thinking indicator or streaming text */}
         {(isThinking || streamingText) && (
-          <div className="flex justify-start">
-            <div className="w-full flex items-start gap-2">
-              <Bot className="w-4 h-4 mt-0.5 flex-shrink-0 text-muted-foreground/60" />
-              <div className="flex-1">
+          <div className="mt-6 flex justify-start">
+            <div className="flex w-full items-start gap-3 pr-2">
+              <div className="mt-1 flex h-6 w-6 flex-shrink-0 items-center justify-center border border-border bg-primary text-primary-foreground">
+                <Bot className="h-3.5 w-3.5" />
+              </div>
+              <div className="flex-1 border-l-2 border-l-primary bg-card px-4 py-3">
                 {isThinking && !streamingText ? (
                   <ThinkingIndicator />
                 ) : streamingText ? (
@@ -416,17 +433,8 @@ export function ChatPanel() {
         <div ref={messagesEndRef} />
       </div>
 
-      {/* Input area */}
-      <div className="border-t p-4">
-        {/* Image attachments preview */}
-        {hasImages && (
-          <div className="mb-2">
-            <ImageAttachments images={pendingImages} onRemove={removeImage} />
-          </div>
-        )}
-
-        <form onSubmit={handleSubmit} className="flex gap-2">
-          {/* Hidden file input */}
+      <div className="border-t border-border bg-muted/30 p-4 sm:p-5">
+        <form onSubmit={handleSubmit} className="space-y-3">
           <input
             ref={fileInputRef}
             type="file"
@@ -436,22 +444,11 @@ export function ChatPanel() {
             onChange={handleFileChange}
           />
 
-          {/* Image attachment button */}
-          <Button
-            type="button"
-            variant="outline"
-            size="icon"
-            className="h-[60px] w-[60px] flex-shrink-0"
-            onClick={() => fileInputRef.current?.click()}
-            title="Attach images (PNG, JPEG, GIF, WebP)"
-          >
-            <ImagePlus className="h-5 w-5" />
-          </Button>
+          {hasImages && <ImageAttachments images={pendingImages} onRemove={removeImage} />}
 
-          {/* Textarea with drag-drop wrapper */}
           <div
-            className={`flex-1 relative rounded-md transition-colors ${
-              isDraggingOver ? "bg-primary/10 ring-2 ring-primary/50 ring-offset-2" : ""
+            className={`relative border border-border bg-background transition-colors ${
+              isDraggingOver ? "bg-[hsl(var(--accent)/0.08)] ring-1 ring-accent" : ""
             }`}
             onDragOver={(e) => {
               e.preventDefault();
@@ -465,7 +462,6 @@ export function ChatPanel() {
             onDragLeave={(e) => {
               e.preventDefault();
               e.stopPropagation();
-              // Only set to false if leaving the container (not entering a child)
               if (!e.currentTarget.contains(e.relatedTarget as Node)) {
                 setIsDraggingOver(false);
               }
@@ -515,105 +511,119 @@ export function ChatPanel() {
                 }
               }}
               placeholder="Type a message or / for commands... (Enter to send)"
-              className="w-full min-h-[60px] max-h-[200px] resize-none"
+              className="min-h-[120px] max-h-[260px] w-full resize-none border-0 bg-transparent px-4 py-4 text-sm shadow-none focus-visible:ring-0"
             />
           </div>
 
-          {/* Show cancel button when turn is active and no input typed */}
-          {isActive && !inputValue.trim() && !hasImages ? (
-            <Button
-              type="button"
-              size="icon"
-              variant="destructive"
-              className="h-[60px] w-[60px]"
-              disabled={cancelCurrentTurn.isPending}
-              onClick={() => cancelCurrentTurn.mutate()}
-              title="Cancel current turn"
-            >
-              {cancelCurrentTurn.isPending ? (
-                <Loader2 className="h-5 w-5 animate-spin" />
-              ) : (
-                <StopCircle className="h-5 w-5" />
-              )}
-            </Button>
-          ) : (
-            <Button
-              type="submit"
-              size="icon"
-              className="h-[60px] w-[60px]"
-              disabled={!canSubmit}
-              title={isUploading ? "Uploading images..." : undefined}
-            >
-              {sendMessage.isPending || sendMessageWithImages.isPending ? (
-                <Loader2 className="h-5 w-5 animate-spin" />
-              ) : isUploading ? (
-                <Loader2 className="h-5 w-5 animate-spin" />
-              ) : (
-                <Send className="h-5 w-5" />
-              )}
-            </Button>
-          )}
-        </form>
-        <div className="flex flex-wrap items-center gap-4 mt-2">
-          <div className="flex items-center gap-2">
-            <span className="text-sm text-muted-foreground">Model:</span>
-            <Select
-              value={selectedModelId}
-              onValueChange={(value) => {
-                hasUserSelectedModel.current = true;
-                setSelectedModelId(value);
-              }}
-            >
-              <SelectTrigger size="sm" className="w-[220px]">
-                <SelectValue>
-                  {selectedModelId
-                    ? (selectedModel?.display_name ?? "Select model")
-                    : llmModel?.display_name
-                      ? `Session default (${llmModel.display_name})`
-                      : "Session default"}
-                </SelectValue>
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="">
-                  {llmModel?.display_name
-                    ? `Session default (${llmModel.display_name})`
-                    : "Session default"}
-                </SelectItem>
-                {llmModels.map((model) => (
-                  <SelectItem key={model.id} value={model.id}>
-                    {model.display_name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          {supportsReasoning && reasoningEffortConfig && (
-            <div className="flex items-center gap-2">
-              <Brain className="h-4 w-4 text-muted-foreground" />
-              <span className="text-sm text-muted-foreground">Reasoning:</span>
-              <Select
-                value={reasoningEffort}
-                onValueChange={(value) => setReasoningEffort(value as typeof reasoningEffort)}
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex flex-wrap items-center gap-3">
+              <Button
+                type="button"
+                variant="outline"
+                size="icon-lg"
+                className="h-10 w-10 border-border bg-background"
+                onClick={() => fileInputRef.current?.click()}
+                title="Attach images (PNG, JPEG, GIF, WebP)"
               >
-                <SelectTrigger size="sm" className="w-[180px]">
-                  <SelectValue>
-                    {reasoningEffort
-                      ? getReasoningEffortName(reasoningEffort)
-                      : `Default (${defaultEffortName})`}
-                  </SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="">{`Default (${defaultEffortName})`}</SelectItem>
-                  {reasoningEffortConfig.values.map((effort) => (
-                    <SelectItem key={effort.value} value={effort.value}>
-                      {effort.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                <ImagePlus className="icon-sharp h-4 w-4" />
+              </Button>
+
+              <div className="flex h-10 items-center gap-2 border border-border bg-background px-3">
+                <span className="shrink-0 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+                  Model
+                </span>
+                <Select
+                  value={selectedModelId}
+                  onValueChange={(value) => {
+                    hasUserSelectedModel.current = true;
+                    setSelectedModelId(value);
+                  }}
+                >
+                  <SelectTrigger
+                    size="sm"
+                    className="h-7 w-[156px] min-w-0 border-0 bg-transparent px-0 py-0 text-sm shadow-none focus-visible:ring-0 data-[size=sm]:h-7 [&_svg]:icon-sharp"
+                  >
+                    <SelectValue>{modelTriggerLabel}</SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="">{defaultModelOptionLabel}</SelectItem>
+                    {llmModels.map((model) => (
+                      <SelectItem key={model.id} value={model.id}>
+                        {model.display_name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {supportsReasoning && reasoningEffortConfig && (
+                <div className="flex h-10 items-center gap-2 border border-border bg-background px-3">
+                  <Brain className="icon-sharp h-3.5 w-3.5 text-muted-foreground" />
+                  <span className="shrink-0 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+                    Reasoning
+                  </span>
+                  <Select
+                    value={reasoningEffort}
+                    onValueChange={(value) => setReasoningEffort(value as typeof reasoningEffort)}
+                  >
+                    <SelectTrigger
+                      size="sm"
+                      className="h-7 w-[116px] min-w-0 border-0 bg-transparent px-0 py-0 text-sm shadow-none focus-visible:ring-0 data-[size=sm]:h-7 [&_svg]:icon-sharp"
+                    >
+                      <SelectValue>
+                        {reasoningEffort ? getReasoningEffortName(reasoningEffort) : "Default"}
+                      </SelectValue>
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="">{`Default (${defaultEffortName})`}</SelectItem>
+                      {reasoningEffortConfig.values.map((effort) => (
+                        <SelectItem key={effort.value} value={effort.value}>
+                          {effort.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
             </div>
-          )}
-        </div>
+
+            <div className="flex items-center gap-2">
+              {isActive && !inputValue.trim() && !hasImages && (
+                <Button
+                  type="button"
+                  size="icon-lg"
+                  variant="destructive"
+                  className="h-10 w-10 border border-destructive/30 bg-destructive/[0.08] text-destructive shadow-none hover:bg-destructive/[0.14]"
+                  disabled={cancelCurrentTurn.isPending}
+                  onClick={() => cancelCurrentTurn.mutate()}
+                  title="Cancel current turn"
+                >
+                  {cancelCurrentTurn.isPending ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <StopCircle className="icon-sharp h-4 w-4" />
+                  )}
+                </Button>
+              )}
+
+              <Button
+                type="submit"
+                size="icon-lg"
+                className="h-10 w-10"
+                disabled={!canSubmit}
+                title={isUploading ? "Uploading images..." : undefined}
+              >
+                {sendMessage.isPending || sendMessageWithImages.isPending ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : isUploading ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Send className="icon-sharp h-4 w-4" />
+                )}
+              </Button>
+            </div>
+          </div>
+        </form>
       </div>
     </>
   );

--- a/apps/ui/src/components/chat/command-autocomplete.tsx
+++ b/apps/ui/src/components/chat/command-autocomplete.tsx
@@ -75,7 +75,7 @@ export function CommandAutocomplete({
   return (
     <div
       ref={listRef}
-      className="absolute bottom-full left-0 right-0 mb-1 z-50 max-h-[240px] overflow-y-auto rounded-md border bg-popover p-1 shadow-md"
+      className="absolute bottom-full left-0 right-0 z-50 mb-2 max-h-[240px] overflow-y-auto border border-border bg-card p-1"
     >
       {filtered.map((cmd, i) => (
         <button
@@ -83,8 +83,8 @@ export function CommandAutocomplete({
           data-command-item
           type="button"
           className={cn(
-            "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none select-none",
-            i === selectedIndex ? "bg-muted text-foreground" : "text-popover-foreground",
+            "flex w-full items-center gap-2 px-2 py-2 text-sm outline-none select-none",
+            i === selectedIndex ? "border-l-2 border-l-accent bg-[hsl(var(--accent)/0.08)] text-foreground" : "text-popover-foreground",
           )}
           onMouseEnter={() => setSelectedIndex(i)}
           onMouseDown={(e) => {
@@ -93,9 +93,9 @@ export function CommandAutocomplete({
           }}
         >
           {cmd.source === "system" ? (
-            <Terminal className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
+            <Terminal className="icon-sharp h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
           ) : (
-            <Sparkles className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
+            <Sparkles className="icon-sharp h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
           )}
           <span className="font-mono text-xs text-foreground">/{cmd.name}</span>
           <span className="text-xs text-muted-foreground truncate">{cmd.description}</span>

--- a/apps/ui/src/components/chat/command-autocomplete.tsx
+++ b/apps/ui/src/components/chat/command-autocomplete.tsx
@@ -84,7 +84,9 @@ export function CommandAutocomplete({
           type="button"
           className={cn(
             "flex w-full items-center gap-2 px-2 py-2 text-sm outline-none select-none",
-            i === selectedIndex ? "border-l-2 border-l-accent bg-[hsl(var(--accent)/0.08)] text-foreground" : "text-popover-foreground",
+            i === selectedIndex
+              ? "border-l-2 border-l-accent bg-[hsl(var(--accent)/0.08)] text-foreground"
+              : "text-popover-foreground",
           )}
           onMouseEnter={() => setSelectedIndex(i)}
           onMouseDown={(e) => {

--- a/apps/ui/src/components/chat/image-attachments.tsx
+++ b/apps/ui/src/components/chat/image-attachments.tsx
@@ -19,7 +19,7 @@ export function ImageAttachments({ images, onRemove }: ImageAttachmentsProps) {
   if (images.length === 0) return null;
 
   return (
-    <div className="flex flex-wrap gap-2 p-2 bg-muted/30 rounded-lg">
+    <div className="flex flex-wrap gap-2 border border-border bg-background px-3 py-3">
       {images.map((img) => (
         <ImageAttachmentItem key={img.tempId} image={img} onRemove={onRemove} />
       ))}
@@ -38,9 +38,9 @@ function ImageAttachmentItem({ image, onRemove }: ImageAttachmentItemProps) {
 
   return (
     <div className="relative group">
-      <div className="w-20 h-20 rounded-md overflow-hidden bg-muted border">
+      <div className="h-20 w-20 overflow-hidden border border-border bg-muted/20">
         {image.status === "error" ? (
-          <div className="w-full h-full flex flex-col items-center justify-center text-destructive p-1">
+          <div className="flex h-full w-full flex-col items-center justify-center p-1 text-destructive">
             <AlertCircle className="w-6 h-6 mb-1" />
             <span className="text-[10px] text-center line-clamp-2">{image.error || "Error"}</span>
           </div>
@@ -59,7 +59,7 @@ function ImageAttachmentItem({ image, onRemove }: ImageAttachmentItemProps) {
       {/* Remove button - monochrome style */}
       <button
         type="button"
-        className="absolute -top-2 -right-2 w-5 h-5 rounded-full bg-background border border-border flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity hover:bg-muted"
+        className="absolute -right-2 -top-2 flex h-5 w-5 items-center justify-center border border-border bg-background opacity-0 transition-opacity group-hover:opacity-100 hover:bg-muted"
         onClick={() => onRemove(image.tempId)}
       >
         <X className="w-3 h-3 text-muted-foreground" />
@@ -102,7 +102,7 @@ export function MessageImage({ imageId, filename }: MessageImageProps) {
           <img
             src={thumbnailUrl}
             alt={filename || "Image"}
-            className="max-w-[200px] max-h-[200px] rounded-md border hover:opacity-90 transition-opacity"
+            className="max-h-[200px] max-w-[200px] border border-border hover:opacity-90 transition-opacity"
             title={filename || "Click to view full size"}
           />
         </button>
@@ -153,7 +153,7 @@ export function MessageImage({ imageId, filename }: MessageImageProps) {
  */
 export function ImagePlaceholder({ filename }: { filename?: string }) {
   return (
-    <div className="inline-flex flex-col items-center justify-center w-20 h-20 bg-muted rounded-md border">
+    <div className="inline-flex h-20 w-20 flex-col items-center justify-center border border-border bg-muted/20">
       <ImageIcon className="w-6 h-6 text-muted-foreground" />
       {filename && (
         <span className="text-[10px] text-muted-foreground mt-1 truncate max-w-[70px]">

--- a/apps/ui/src/components/chat/message-info-icon.tsx
+++ b/apps/ui/src/components/chat/message-info-icon.tsx
@@ -37,16 +37,16 @@ export function MessageInfoIcon({ event, variant = "default" }: MessageInfoIconP
     <Tooltip>
       <TooltipTrigger
         className={cn(
-          "p-0.5 rounded transition-colors flex-shrink-0",
+          "flex-shrink-0 rounded p-0.5 transition-colors",
           variant === "light"
-            ? "text-white/50 hover:text-white hover:bg-white/10"
-            : "text-muted-foreground/50 hover:text-muted-foreground hover:bg-muted/80",
+            ? "text-white/55 hover:bg-white/12 hover:text-white"
+            : "text-muted-foreground/55 hover:bg-muted hover:text-foreground",
         )}
         aria-label="Message info"
       >
         <Info className="w-3 h-3" />
       </TooltipTrigger>
-      <TooltipContent className="max-w-sm">
+      <TooltipContent className="max-w-sm border-border bg-popover px-3 py-2">
         <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
           <dt className="text-muted-foreground">ID</dt>
           <dd className="font-mono text-[10px] break-all">{event.id}</dd>

--- a/apps/ui/src/components/chat/todo-list-renderer.tsx
+++ b/apps/ui/src/components/chat/todo-list-renderer.tsx
@@ -1,7 +1,17 @@
 "use client";
 
-import { Circle, CircleDot } from "lucide-react";
+/**
+ * Decisions:
+ * - Render todos as a persistent progress card so long-running tool work has a clear anchor near the composer.
+ * - Prefer low-key motion: progress bar width changes and active-row pulse instead of a heavy animated widget.
+ * - Match the Slate system: sharp corners, muted surfaces, and gold accents only for active state and progress.
+ */
+
+import { useState } from "react";
+import { CheckSquare2, ChevronDown, ChevronRight, Info, Loader2, Square } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import type { ContentPart } from "@/lib/api/types";
 
 // Todo item structure from write_todos tool
 interface TodoItem {
@@ -32,20 +42,60 @@ interface TodoListRendererProps {
   error?: string;
 }
 
+function extractResultObject(result: unknown): WriteTodosResult | null {
+  if (!result) return null;
+
+  if (typeof result === "object" && !Array.isArray(result)) {
+    const candidate = result as WriteTodosResult;
+    return Array.isArray(candidate.todos) ? candidate : null;
+  }
+
+  if (Array.isArray(result)) {
+    const textParts = result
+      .filter(
+        (part): part is Extract<ContentPart, { type: "text" }> =>
+          typeof part === "object" && part !== null && "type" in part && part.type === "text",
+      )
+      .map((part) => part.text);
+
+    const text = textParts.join("\n").trim();
+    if (!text) return null;
+
+    try {
+      const parsed = JSON.parse(text) as WriteTodosResult;
+      return Array.isArray(parsed.todos) ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
 function getStatusIcon(status: string, isActive: boolean = false) {
   switch (status) {
     case "completed":
-      return <span className="text-green-600 text-xs shrink-0">✓</span>;
+      return <CheckSquare2 className="h-4 w-4 shrink-0 text-accent" />;
     case "in_progress":
-      return (
-        <CircleDot
-          className={cn("h-3.5 w-3.5 text-blue-600 shrink-0", isActive && "animate-pulse")}
-        />
-      );
+      return <Loader2 className={cn("h-4 w-4 shrink-0 text-accent", isActive && "animate-spin")} />;
     case "pending":
     default:
-      return <Circle className="h-3.5 w-3.5 text-muted-foreground/40 shrink-0" />;
+      return <Square className="h-4 w-4 shrink-0 text-muted-foreground/35" />;
   }
+}
+
+function InfoHint({ text }: { text: string }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        className="rounded p-0.5 text-muted-foreground/55 transition-colors hover:bg-muted hover:text-foreground"
+        aria-label="Execution plan info"
+      >
+        <Info className="h-3 w-3" />
+      </TooltipTrigger>
+      <TooltipContent className="max-w-56 text-xs leading-5">{text}</TooltipContent>
+    </Tooltip>
+  );
 }
 
 function TodoItemRow({ todo, isActive }: { todo: TodoItem; isActive?: boolean }) {
@@ -56,11 +106,17 @@ function TodoItemRow({ todo, isActive }: { todo: TodoItem; isActive?: boolean })
   const displayText = isInProgress ? todo.activeForm : todo.content;
 
   return (
-    <div className="flex items-start gap-1.5 py-0.5">
+    <div
+      className={cn(
+        "flex items-start gap-2 border px-3 py-2.5 transition-all duration-300",
+        isInProgress && "border-border/70 border-l-2 border-l-accent bg-[hsl(var(--accent)/0.08)]",
+        !isInProgress && "border-transparent",
+      )}
+    >
       {getStatusIcon(todo.status, isActive)}
       <span
         className={cn(
-          "text-xs",
+          "text-sm",
           isCompleted && "text-muted-foreground/60 line-through",
           isInProgress && "text-foreground",
           !isCompleted && !isInProgress && "text-muted-foreground/80",
@@ -78,7 +134,7 @@ function TodoListFromItems({ todos, isActive }: { todos: TodoItem[]; isActive?: 
   }
 
   return (
-    <div className="space-y-0.5">
+    <div className="space-y-1">
       {todos.map((todo, index) => (
         <TodoItemRow
           key={`${todo.content}-${index}`}
@@ -96,17 +152,16 @@ export function TodoListRenderer({
   isExecuting,
   error,
 }: TodoListRendererProps) {
+  const [isExpanded, setIsExpanded] = useState(true);
+
   // Parse todos from arguments (tool_call) or result (tool_result)
   let todos: TodoItem[] = [];
   let parsedResult: WriteTodosResult | null = null;
 
   // Try to get todos from result first (it has the validated data)
-  if (result && typeof result === "object" && !Array.isArray(result)) {
-    const resultObj = result as WriteTodosResult;
-    if (resultObj.todos && Array.isArray(resultObj.todos)) {
-      todos = resultObj.todos;
-      parsedResult = resultObj;
-    }
+  parsedResult = extractResultObject(result);
+  if (parsedResult?.todos) {
+    todos = parsedResult.todos;
   }
 
   // Fall back to arguments if no result yet (executing state)
@@ -124,11 +179,74 @@ export function TodoListRenderer({
 
   // Handle warning from result
   const warning = parsedResult?.warning;
+  const completedCount = todos.filter((todo) => todo.status === "completed").length;
+  const totalCount = todos.length;
+  const progressPercent = totalCount === 0 ? 0 : Math.round((completedCount / totalCount) * 100);
+  const activeTodo = todos.find((todo) => todo.status === "in_progress");
 
   return (
-    <div className="space-y-0.5">
-      <TodoListFromItems todos={todos} isActive={isExecuting} />
-      {warning && <div className="text-xs text-amber-600 mt-0.5">{warning}</div>}
+    <div
+      className={cn(
+        "overflow-hidden border bg-card/95",
+        isExecuting ? "border-border border-l-2 border-l-accent" : "border-border",
+      )}
+    >
+      <div className="flex items-center justify-between gap-3 px-4 py-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <div className="text-sm text-foreground">
+              {completedCount} of {totalCount} todos completed
+            </div>
+            <InfoHint text="The execution plan persists while tools run so users can see current intent and remaining work." />
+          </div>
+          <div className="mt-0.5 text-xs text-muted-foreground/70">
+            {activeTodo ? activeTodo.activeForm : "Plan captured from write_todos"}
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {isExecuting && (
+            <span className="animate-tool-pulse inline-flex h-1.5 w-1.5 bg-accent" aria-hidden />
+          )}
+          <button
+            type="button"
+            onClick={() => setIsExpanded((current) => !current)}
+            className="rounded p-1 text-muted-foreground/60 transition-colors hover:bg-muted hover:text-foreground"
+            aria-label={isExpanded ? "Collapse execution plan" : "Expand execution plan"}
+          >
+            {isExpanded ? (
+              <ChevronDown className="h-4 w-4" />
+            ) : (
+              <ChevronRight className="h-4 w-4" />
+            )}
+          </button>
+        </div>
+      </div>
+
+      <div className="border-y border-border/60 px-4 py-3">
+        <div className="h-1.5 overflow-hidden bg-muted/80">
+          <div
+            className={cn(
+              "h-full bg-accent transition-[width] duration-500 ease-out",
+              isExecuting && "animate-tool-progress-active",
+            )}
+            style={{ width: `${progressPercent}%` }}
+          />
+        </div>
+      </div>
+
+      <div
+        className={cn(
+          "grid transition-all duration-300 ease-out",
+          isExpanded ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0",
+        )}
+      >
+        <div className="min-h-0 overflow-hidden">
+          <div className="space-y-1 px-3 py-2">
+            <TodoListFromItems todos={todos} isActive={isExecuting} />
+            {warning && <div className="mt-0.5 text-xs text-amber-600">{warning}</div>}
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/ui/src/components/chat/tool-activity-group.tsx
+++ b/apps/ui/src/components/chat/tool-activity-group.tsx
@@ -1,0 +1,405 @@
+"use client";
+
+/**
+ * Decisions:
+ * - Group tool-only assistant steps into a single activity block so the transcript reads like progress, not raw logs.
+ * - Keep motion CSS-only: fade/slide in, status transitions, and collapsible output without adding another runtime dependency.
+ * - Match the Slate system: sharp corners, grayscale surfaces, and gold border accents for active work.
+ */
+
+import { useMemo, useState } from "react";
+import {
+  AlertCircle,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Info,
+  Loader2,
+  MonitorSmartphone,
+  Terminal,
+} from "lucide-react";
+import type { ToolCompletedData } from "@/lib/api/types";
+import { cn } from "@/lib/utils";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { isBashTool } from "./bash-tool-call-card";
+import { getFullText, type ToolCallContent } from "./tool-call-utils";
+import { TodoListRenderer, isWriteTodosTool } from "./todo-list-renderer";
+
+interface ToolActivityGroupProps {
+  toolCalls: ToolCallContent[];
+  toolResultsMap: Map<string, ToolCompletedData>;
+  mode?: "server" | "client";
+}
+
+type ToolCategory = "read" | "search" | "write" | "shell" | "tool";
+
+function pluralize(count: number, singular: string, plural: string) {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function toTitleCase(value: string): string {
+  return value
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function getCategory(name: string): ToolCategory {
+  if (isBashTool(name)) return "shell";
+  if (
+    [
+      "list_files",
+      "read_file",
+      "read_many_files",
+      "session_read_file",
+      "list_capabilities",
+    ].includes(name)
+  ) {
+    return "read";
+  }
+  if (
+    name === "search" ||
+    name === "search_web" ||
+    name === "grep_files" ||
+    name.endsWith("__search")
+  ) {
+    return "search";
+  }
+  if (
+    [
+      "write_file",
+      "edit_file",
+      "replace_in_file",
+      "append_file",
+      "move_file",
+      "delete_file",
+      "mkdir",
+    ].includes(name)
+  ) {
+    return "write";
+  }
+  return "tool";
+}
+
+function formatLocation(value: unknown): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return "current directory";
+  }
+  if (value === "." || value === "/workspace") {
+    return "current directory";
+  }
+  return value;
+}
+
+function basename(value: string): string {
+  const clean = value.replace(/\/+$/, "");
+  const parts = clean.split("/");
+  return parts[parts.length - 1] || clean;
+}
+
+function getToolLabel(toolCall: ToolCallContent): string {
+  const { arguments: args, name } = toolCall;
+
+  if (isBashTool(name)) {
+    const command = args.command;
+    return typeof command === "string" && command.trim().length > 0 ? `$ ${command}` : "Shell";
+  }
+
+  if (name === "list_files") {
+    return `List files in ${formatLocation(args.path)}`;
+  }
+
+  if (name === "read_file") {
+    const path = args.path;
+    return typeof path === "string" && path.trim().length > 0
+      ? `Read ${basename(path)}`
+      : "Read file";
+  }
+
+  if (name === "grep_files") {
+    const pattern = args.pattern;
+    return typeof pattern === "string" && pattern.trim().length > 0
+      ? `Find ${pattern}`
+      : "Search files";
+  }
+
+  if (name === "search_web" || name === "search" || name.endsWith("__search")) {
+    const query = args.query ?? args.search ?? args.q;
+    return typeof query === "string" && query.trim().length > 0
+      ? `Search web for ${query}`
+      : "Search web";
+  }
+
+  if (name === "write_file") {
+    const path = args.path;
+    return typeof path === "string" && path.trim().length > 0
+      ? `Write ${basename(path)}`
+      : "Write file";
+  }
+
+  if (name === "replace_in_file" || name === "edit_file") {
+    const path = args.path;
+    return typeof path === "string" && path.trim().length > 0
+      ? `Edit ${basename(path)}`
+      : "Edit file";
+  }
+
+  return toolCall.display_name ?? toTitleCase(name);
+}
+
+function summarizeToolCalls(toolCalls: ToolCallContent[]): string {
+  if (toolCalls.length === 0) return "Working";
+
+  if (toolCalls.length === 1) {
+    const [toolCall] = toolCalls;
+    if (isBashTool(toolCall.name)) return "Shell";
+    return getToolLabel(toolCall);
+  }
+
+  const counts = {
+    read: 0,
+    search: 0,
+    write: 0,
+    shell: 0,
+    tool: 0,
+  };
+
+  for (const toolCall of toolCalls) {
+    counts[getCategory(toolCall.name)] += 1;
+  }
+
+  const parts: string[] = [];
+  if (counts.read > 0) parts.push(pluralize(counts.read, "read", "reads"));
+  if (counts.search > 0) parts.push(pluralize(counts.search, "search", "searches"));
+  if (counts.write > 0) parts.push(pluralize(counts.write, "write", "writes"));
+  if (counts.shell > 0) parts.push(pluralize(counts.shell, "shell", "shells"));
+  if (counts.tool > 0) parts.push(pluralize(counts.tool, "tool", "tools"));
+
+  return `Exploring ${parts.join(", ")}`;
+}
+
+function getResultPreview(result: ToolCompletedData | undefined): string | null {
+  const fullText = getFullText(result?.result);
+  if (!fullText) return null;
+
+  const previewLine = fullText
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+
+  if (!previewLine) return null;
+  return previewLine.length > 120 ? `${previewLine.slice(0, 120)}...` : previewLine;
+}
+
+function InfoHint({ text }: { text: string }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        className="rounded p-0.5 text-muted-foreground/55 transition-colors hover:bg-muted hover:text-foreground"
+        aria-label="Tool activity info"
+      >
+        <Info className="h-3 w-3" />
+      </TooltipTrigger>
+      <TooltipContent className="max-w-56 text-xs leading-5">{text}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+function ToolActivityRow({
+  toolCall,
+  toolResult,
+  mode,
+}: {
+  toolCall: ToolCallContent;
+  toolResult?: ToolCompletedData;
+  mode: "server" | "client";
+}) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const fullText = getFullText(toolResult?.result);
+  const hasOutput = fullText.length > 0;
+  const hasError = !!toolResult?.error;
+  const isComplete = !!toolResult;
+  const isRunning = !isComplete && !hasError;
+
+  return (
+    <div
+      className={cn(
+        "animate-tool-row-in border px-3 py-2.5 transition-all duration-300",
+        isComplete && !hasError && "border-transparent bg-transparent",
+        isRunning &&
+          "border-border/70 border-l-2 border-l-accent bg-[hsl(var(--accent)/0.06)]",
+        hasError && "border-red-200 bg-red-500/[0.04] dark:border-red-900/70 dark:bg-red-950/20",
+      )}
+    >
+      <div className="flex items-start gap-2">
+        <div className="mt-0.5 flex h-4 w-4 items-center justify-center">
+          {hasError ? (
+            <AlertCircle className="h-3.5 w-3.5 text-red-500" />
+          ) : isComplete ? (
+            <Check className="h-3.5 w-3.5 text-accent" />
+          ) : (
+            <Loader2 className="h-3.5 w-3.5 animate-spin text-accent" />
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            {mode === "client" && (
+              <MonitorSmartphone className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-primary/75" />
+            )}
+            {isBashTool(toolCall.name) && mode === "server" && (
+              <Terminal className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-primary/55" />
+            )}
+            <span className="truncate text-sm text-foreground">{getToolLabel(toolCall)}</span>
+            {isRunning && (
+              <span className="animate-tool-pulse text-[10px] uppercase tracking-[0.18em] text-accent-foreground/70">
+                {mode === "client" ? "waiting" : "running"}
+              </span>
+            )}
+          </div>
+
+          {hasError && <div className="mt-1 text-xs text-red-600 dark:text-red-400">{toolResult?.error}</div>}
+
+          {!hasError && !isExpanded && hasOutput && (
+            <div className="mt-1 truncate text-xs text-muted-foreground/70">
+              {getResultPreview(toolResult)}
+            </div>
+          )}
+
+          {hasOutput && (
+            <button
+              type="button"
+              onClick={() => setIsExpanded((current) => !current)}
+              className="mt-1.5 inline-flex items-center gap-1 text-[10px] uppercase tracking-[0.18em] text-muted-foreground/65 transition-colors hover:text-foreground"
+            >
+              {isExpanded ? (
+                <ChevronDown className="h-3 w-3" />
+              ) : (
+                <ChevronRight className="h-3 w-3" />
+              )}
+              {isExpanded ? "hide details" : "details"}
+            </button>
+          )}
+
+          <div
+            className={cn(
+              "grid transition-all duration-300 ease-out",
+              isExpanded ? "mt-2 grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0",
+            )}
+          >
+            <div className="min-h-0 overflow-hidden">
+              {hasOutput && (
+                <pre className="overflow-x-auto border border-border/60 bg-background px-3 py-3 font-mono text-[11px] leading-relaxed text-muted-foreground/85">
+                  {fullText}
+                </pre>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ToolActivityGroup({
+  toolCalls,
+  toolResultsMap,
+  mode = "server",
+}: ToolActivityGroupProps) {
+  const [isExpanded, setIsExpanded] = useState(true);
+  const todoToolCalls = toolCalls.filter((toolCall) => isWriteTodosTool(toolCall.name));
+  const activityToolCalls = toolCalls.filter((toolCall) => !isWriteTodosTool(toolCall.name));
+
+  const activityCompletedCount = useMemo(
+    () => activityToolCalls.filter((toolCall) => toolResultsMap.has(toolCall.id)).length,
+    [activityToolCalls, toolResultsMap],
+  );
+  const isActive = activityCompletedCount < activityToolCalls.length;
+
+  if (toolCalls.length === 0) return null;
+
+  return (
+    <div className="space-y-3">
+      {activityToolCalls.length > 0 && (
+        <div
+          className={cn(
+            "overflow-hidden border bg-card/95",
+            isActive ? "border-border border-l-2 border-l-accent" : "border-border",
+          )}
+        >
+          <div className="flex items-center justify-between gap-3 px-4 py-3">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <div className="text-sm text-foreground">
+                  {summarizeToolCalls(activityToolCalls)}
+                </div>
+                <InfoHint
+                  text={
+                    mode === "client"
+                      ? "Client-side tools wait for a browser action before the assistant continues."
+                      : "Grouped tool execution keeps intermediate reads, searches, and edits compact inside the transcript."
+                  }
+                />
+              </div>
+              <div className="mt-0.5 text-xs text-muted-foreground/70">
+                {activityCompletedCount} of {activityToolCalls.length} complete
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              {isActive ? (
+                <div className="flex items-center gap-2 text-[10px] uppercase tracking-[0.22em] text-accent-foreground/70">
+                  <span className="animate-tool-pulse inline-flex h-1.5 w-1.5 bg-accent" />
+                </div>
+              ) : null}
+              <button
+                type="button"
+                onClick={() => setIsExpanded((current) => !current)}
+                className="rounded p-1 text-muted-foreground/60 transition-colors hover:bg-muted hover:text-foreground"
+                aria-label={isExpanded ? "Collapse tool activity" : "Expand tool activity"}
+              >
+                {isExpanded ? (
+                  <ChevronDown className="h-4 w-4" />
+                ) : (
+                  <ChevronRight className="h-4 w-4" />
+                )}
+              </button>
+            </div>
+          </div>
+
+          <div
+            className={cn(
+              "grid transition-all duration-300 ease-out",
+              isExpanded ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0",
+            )}
+          >
+            <div className="min-h-0 overflow-hidden">
+              <div className="space-y-1 px-3 py-2">
+                {activityToolCalls.map((toolCall) => (
+                  <ToolActivityRow
+                    key={toolCall.id}
+                    toolCall={toolCall}
+                    toolResult={toolResultsMap.get(toolCall.id)}
+                    mode={mode}
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {todoToolCalls.map((toolCall) => {
+        const toolResult = toolResultsMap.get(toolCall.id);
+        return (
+          <TodoListRenderer
+            key={toolCall.id}
+            arguments={toolCall.arguments}
+            result={toolResult?.result}
+            isExecuting={!toolResult}
+            error={toolResult?.error}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/ui/src/components/chat/tool-activity-group.tsx
+++ b/apps/ui/src/components/chat/tool-activity-group.tsx
@@ -227,8 +227,7 @@ function ToolActivityRow({
       className={cn(
         "animate-tool-row-in border px-3 py-2.5 transition-all duration-300",
         isComplete && !hasError && "border-transparent bg-transparent",
-        isRunning &&
-          "border-border/70 border-l-2 border-l-accent bg-[hsl(var(--accent)/0.06)]",
+        isRunning && "border-border/70 border-l-2 border-l-accent bg-[hsl(var(--accent)/0.06)]",
         hasError && "border-red-200 bg-red-500/[0.04] dark:border-red-900/70 dark:bg-red-950/20",
       )}
     >
@@ -258,7 +257,9 @@ function ToolActivityRow({
             )}
           </div>
 
-          {hasError && <div className="mt-1 text-xs text-red-600 dark:text-red-400">{toolResult?.error}</div>}
+          {hasError && (
+            <div className="mt-1 text-xs text-red-600 dark:text-red-400">{toolResult?.error}</div>
+          )}
 
           {!hasError && !isExpanded && hasOutput && (
             <div className="mt-1 truncate text-xs text-muted-foreground/70">

--- a/apps/ui/src/components/dashboard/agent-list-widget.tsx
+++ b/apps/ui/src/components/dashboard/agent-list-widget.tsx
@@ -27,7 +27,7 @@ export function AgentListWidget({ agents, allCapabilities }: AgentListWidgetProp
         <CardTitle>Active Agents</CardTitle>
         <Link href="/agents/new">
           <Button variant="accent" size="sm">
-            <Plus className="h-4 w-4 mr-1" />
+            <Plus className="icon-sharp mr-1 h-4 w-4" />
             New Agent
           </Button>
         </Link>
@@ -35,7 +35,7 @@ export function AgentListWidget({ agents, allCapabilities }: AgentListWidgetProp
       <CardContent>
         {activeAgents.length === 0 ? (
           <div className="text-center py-8">
-            <Boxes className="h-12 w-12 mx-auto text-muted-foreground mb-2" />
+            <Boxes className="icon-sharp mx-auto mb-2 h-12 w-12 text-muted-foreground" />
             <p className="text-muted-foreground">No agents yet.</p>
             <Link href="/agents/new">
               <Button variant="link">Create your first agent</Button>
@@ -51,10 +51,10 @@ export function AgentListWidget({ agents, allCapabilities }: AgentListWidgetProp
                 <Link
                   key={agent.id}
                   href={`/agents/${agent.id}`}
-                  className="flex items-center justify-between p-3 rounded-lg border hover:bg-accent transition-colors"
+                  className="flex items-center justify-between border bg-card p-3 transition-colors hover:bg-muted/50"
                 >
                   <div className="flex items-center gap-3">
-                    <Boxes className="h-5 w-5 text-muted-foreground" />
+                    <Boxes className="icon-sharp h-5 w-5 text-muted-foreground" />
                     <div>
                       <div className="flex items-center gap-1">
                         <p className="font-medium">{agent.name}</p>
@@ -72,8 +72,8 @@ export function AgentListWidget({ agents, allCapabilities }: AgentListWidgetProp
 
                                 return (
                                   <Tooltip key={capConfig.ref}>
-                                    <TooltipTrigger className="p-0.5 rounded bg-muted cursor-default">
-                                      <IconComponent className="w-3 h-3 text-muted-foreground" />
+                                    <TooltipTrigger className="cursor-default border bg-muted p-0.5">
+                                      <IconComponent className="icon-sharp h-3 w-3 text-muted-foreground" />
                                     </TooltipTrigger>
                                     <TooltipContent>
                                       <p>{cap.name}</p>
@@ -92,7 +92,7 @@ export function AgentListWidget({ agents, allCapabilities }: AgentListWidgetProp
                       </div>
                     </div>
                   </div>
-                  <Badge variant="outline" className="bg-green-100 text-green-800">
+                  <Badge variant="outline" className="border-border bg-muted text-foreground">
                     Active
                   </Badge>
                 </Link>

--- a/apps/ui/src/components/dashboard/recent-sessions.tsx
+++ b/apps/ui/src/components/dashboard/recent-sessions.tsx
@@ -74,14 +74,14 @@ export function RecentSessions({ sessions, agents, models = [] }: RecentSessions
                 <Link
                   key={session.id}
                   href={`/sessions/${session.id}`}
-                  className="flex items-start gap-3 p-3 rounded-md border hover:bg-muted transition-colors"
+                  className="flex items-start gap-3 border bg-card p-3 transition-colors hover:bg-muted/50"
                 >
                   {/* Icon */}
                   <div className="flex-shrink-0 mt-0.5">
                     {isRunning(session) ? (
                       <Loader2 className="w-4 h-4 text-primary animate-spin" />
                     ) : (
-                      <MessageSquare className="w-4 h-4 text-muted-foreground" />
+                      <MessageSquare className="icon-sharp h-4 w-4 text-muted-foreground" />
                     )}
                   </div>
 
@@ -95,7 +95,7 @@ export function RecentSessions({ sessions, agents, models = [] }: RecentSessions
                       {getStatusBadge(session)}
                       {agent && (
                         <span className="text-xs text-muted-foreground flex items-center gap-1">
-                          <Bot className="w-3 h-3" />
+                          <Bot className="icon-sharp h-3 w-3" />
                           {agent.name}
                         </span>
                       )}
@@ -120,14 +120,14 @@ export function RecentSessions({ sessions, agents, models = [] }: RecentSessions
                       <span>{formatRelativeTime(session.created_at)}</span>
                       {model && (
                         <span className="flex items-center gap-1">
-                          <Sparkles className="w-3 h-3" />
+                          <Sparkles className="icon-sharp h-3 w-3" />
                           {model.display_name}
                         </span>
                       )}
                       {session.usage &&
                         (session.usage.input_tokens > 0 || session.usage.output_tokens > 0) && (
                           <span className="flex items-center gap-1">
-                            <Zap className="w-3 h-3" />
+                            <Zap className="icon-sharp h-3 w-3" />
                             {formatTotalTokens(session.usage)}
                           </span>
                         )}

--- a/apps/ui/src/components/dashboard/stats-cards.tsx
+++ b/apps/ui/src/components/dashboard/stats-cards.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Boxes, MessageSquare, CheckCircle, Clock, Hash } from "lucide-react";
+import { Boxes, MessageSquare, CheckCircle, Hash } from "lucide-react";
 import type { Agent, SessionStats } from "@/lib/api/types";
 
 interface StatsCardsProps {
@@ -18,38 +18,38 @@ export function StatsCards({ agents, sessionStats }: StatsCardsProps) {
       value: agents.length,
       description: `${activeAgents} active`,
       icon: Boxes,
-      color: "text-blue-600",
+      color: "text-primary",
     },
     {
       title: "Total Sessions",
       value: sessionStats?.total ?? 0,
       description: "All sessions",
       icon: Hash,
-      color: "text-purple-600",
+      color: "text-muted-foreground",
     },
     {
       title: "Active Sessions",
       value: sessionStats?.active ?? 0,
       description: "Currently processing",
       icon: MessageSquare,
-      color: "text-yellow-600",
+      color: "text-accent-foreground",
     },
     {
       title: "Idle Sessions",
       value: sessionStats?.idle ?? 0,
       description: "Ready for input",
       icon: CheckCircle,
-      color: "text-green-600",
+      color: "text-muted-foreground",
     },
   ];
 
   return (
     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
       {stats.map((stat) => (
-        <Card key={stat.title}>
+        <Card key={stat.title} className="bg-background">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">{stat.title}</CardTitle>
-            <stat.icon className={`h-4 w-4 ${stat.color}`} />
+            <stat.icon className={`icon-sharp h-4 w-4 ${stat.color}`} />
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">{stat.value}</div>

--- a/apps/ui/src/components/harnesses/harness-card.tsx
+++ b/apps/ui/src/components/harnesses/harness-card.tsx
@@ -30,7 +30,7 @@ export function HarnessCard({
   const harnessCapabilities = harness.capabilities ?? [];
 
   return (
-    <Card className="hover:shadow-md transition-shadow">
+    <Card className="bg-background transition-colors hover:bg-card">
       <CardHeader className="flex flex-row items-start justify-between space-y-0">
         <div className="flex items-center gap-2">
           <CardTitle className="text-lg">
@@ -64,8 +64,8 @@ export function HarnessCard({
 
                 return (
                   <Tooltip key={capConfig.ref}>
-                    <TooltipTrigger className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-muted text-xs cursor-default">
-                      <IconComponent className="w-3 h-3" />
+                    <TooltipTrigger className="inline-flex cursor-default items-center gap-1 border bg-muted px-2 py-0.5 text-xs">
+                      <IconComponent className="icon-sharp h-3 w-3" />
                       {!compact && <span>{cap.name}</span>}
                     </TooltipTrigger>
                     <TooltipContent>
@@ -98,7 +98,7 @@ export function HarnessCard({
           {showEditButton && (
             <Link href={`/harnesses/${harness.id}/edit`}>
               <Button variant="ghost" size="icon" className="h-8 w-8">
-                <Pencil className="w-4 h-4" />
+                <Pencil className="icon-sharp h-4 w-4" />
               </Button>
             </Link>
           )}

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -14,7 +14,7 @@
 "use client";
 
 import { useState } from "react";
-import { version } from "../../../package.json";
+import packageJson from "../../../package.json";
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname, useRouter } from "next/navigation";
@@ -73,6 +73,7 @@ import { ExperimentalBadge } from "@/components/ui/experimental-badge";
 import type { FeatureFlags } from "@/lib/api/types";
 
 const isDev = process.env.NODE_ENV === "development";
+const { version } = packageJson;
 
 // --- Public types ---
 

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -179,13 +179,13 @@ function NavLink({
     <Link
       href={item.href}
       className={cn(
-        "flex items-center gap-3 px-3 py-2 text-sm font-medium transition-colors",
+        "flex items-center gap-3 border-l-2 px-3 py-2.5 text-sm font-medium transition-colors",
         isActive
-          ? "bg-accent/10 text-accent-foreground border-l-2 border-accent"
-          : "text-muted-foreground hover:bg-muted hover:text-foreground border-l-2 border-transparent",
+          ? "border-l-primary bg-card text-foreground"
+          : "border-l-transparent text-muted-foreground hover:border-l-border hover:bg-card hover:text-foreground",
       )}
     >
-      <item.icon className="h-5 w-5" />
+      <item.icon className="icon-sharp h-[18px] w-[18px] shrink-0 stroke-[2.15]" />
       {item.name}
       {item.experimental && <ExperimentalBadge />}
     </Link>
@@ -209,7 +209,9 @@ function NavSection({
     <>
       {!isFirst && <div className="my-3 border-t" />}
       {section.label && (
-        <p className="px-3 py-1 text-xs font-medium text-muted-foreground">{section.label}</p>
+        <p className="px-3 py-1 text-[10px] font-medium uppercase tracking-[0.22em] text-muted-foreground">
+          {section.label}
+        </p>
       )}
       {section.items.map((item) => (
         <NavLink key={item.name} item={item} pathname={pathname} featureFlags={featureFlags} />
@@ -311,9 +313,9 @@ export function Sidebar({ config }: { config?: Partial<SidebarConfig> }) {
   let visibleIndex = 0;
 
   return (
-    <div className="flex h-full w-64 flex-col border-r bg-card">
+    <div className="flex h-full w-64 flex-col border-r bg-background">
       {/* Logo */}
-      <div className="flex h-16 items-center border-b px-6">
+      <div className="flex h-16 items-center border-b bg-card px-6">
         <Link href="/dashboard" className="flex items-center gap-2">
           <Image src="/logo.svg" alt="Everruns" width={32} height={32} />
           <span className="text-xl font-bold">Everruns</span>
@@ -324,12 +326,12 @@ export function Sidebar({ config }: { config?: Partial<SidebarConfig> }) {
       {organizations.length > 0 && (
         <div className="border-b px-3 py-2">
           <DropdownMenu>
-            <DropdownMenuTrigger className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-muted transition-colors">
-              <Building2 className="h-4 w-4 text-muted-foreground" />
+            <DropdownMenuTrigger className="flex w-full items-center gap-2 border border-transparent px-3 py-2 text-sm transition-colors hover:border-border hover:bg-card">
+              <Building2 className="icon-sharp h-4 w-4 text-muted-foreground" />
               <span className="flex-1 text-left truncate font-medium">
                 {currentOrg?.name ?? "Select Organization"}
               </span>
-              <ChevronDown className="h-4 w-4 text-muted-foreground" />
+              <ChevronDown className="icon-sharp h-4 w-4 text-muted-foreground" />
             </DropdownMenuTrigger>
             <DropdownMenuPositioner side="bottom" align="start">
               <DropdownMenuContent className="w-56">
@@ -343,14 +345,14 @@ export function Sidebar({ config }: { config?: Partial<SidebarConfig> }) {
                     >
                       <span className="truncate">{org.name}</span>
                       {currentOrg?.public_id === org.public_id && (
-                        <Check className="h-4 w-4 text-primary" />
+                        <Check className="icon-sharp h-4 w-4 text-primary" />
                       )}
                     </DropdownMenuItem>
                   ))}
                 </DropdownMenuGroup>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem onClick={handleCreateOrg}>
-                  <Plus className="mr-2 h-4 w-4" />
+                  <Plus className="icon-sharp mr-2 h-4 w-4" />
                   Create Organisation
                 </DropdownMenuItem>
               </DropdownMenuContent>
@@ -360,7 +362,7 @@ export function Sidebar({ config }: { config?: Partial<SidebarConfig> }) {
       )}
 
       {/* Navigation */}
-      <nav className="flex-1 min-h-0 overflow-y-auto space-y-1 py-4">
+      <nav className="flex-1 min-h-0 overflow-y-auto space-y-1 bg-background py-4">
         {allSections.map((section, i) => {
           if (section.devOnly && !isDev) return null;
           const isFirst = visibleIndex === 0;
@@ -381,7 +383,7 @@ export function Sidebar({ config }: { config?: Partial<SidebarConfig> }) {
       <div className="border-t p-3">
         {requiresAuth && user ? (
           <DropdownMenu>
-            <DropdownMenuTrigger className="flex w-full items-center gap-3 px-3 py-2 text-sm hover:bg-muted transition-colors">
+            <DropdownMenuTrigger className="flex w-full items-center gap-3 border border-transparent px-3 py-2 text-sm transition-colors hover:border-border hover:bg-card">
               <Avatar className="h-8 w-8">
                 {user.avatar_url && (
                   <AvatarImage src={user.avatar_url} alt={user.name || user.email} />
@@ -396,18 +398,18 @@ export function Sidebar({ config }: { config?: Partial<SidebarConfig> }) {
                   <p className="text-xs text-muted-foreground truncate">{user.email}</p>
                 )}
               </div>
-              <ChevronUp className="h-4 w-4 text-muted-foreground" />
+              <ChevronUp className="icon-sharp h-4 w-4 text-muted-foreground" />
             </DropdownMenuTrigger>
             <DropdownMenuPositioner side="top" align="start">
               <DropdownMenuContent className="w-56">
                 <DropdownMenuGroup>
                   <DropdownMenuLabel>My Account</DropdownMenuLabel>
                   <DropdownMenuItem onClick={() => router.push("/settings")}>
-                    <User className="mr-2 h-4 w-4" />
+                    <User className="icon-sharp mr-2 h-4 w-4" />
                     Profile
                   </DropdownMenuItem>
                   <DropdownMenuItem onClick={() => router.push("/settings/api-keys")}>
-                    <Key className="mr-2 h-4 w-4" />
+                    <Key className="icon-sharp mr-2 h-4 w-4" />
                     API Keys
                   </DropdownMenuItem>
                 </DropdownMenuGroup>
@@ -417,7 +419,7 @@ export function Sidebar({ config }: { config?: Partial<SidebarConfig> }) {
                   onClick={handleLogout}
                   disabled={logoutPending}
                 >
-                  <LogOut className="mr-2 h-4 w-4" />
+                  <LogOut className="icon-sharp mr-2 h-4 w-4" />
                   {logoutPending ? "Signing out..." : "Sign out"}
                 </DropdownMenuItem>
               </DropdownMenuContent>

--- a/apps/ui/src/components/ui/card.tsx
+++ b/apps/ui/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 border py-6 shadow-sm",
+        "bg-card text-card-foreground flex flex-col gap-6 border py-6",
         className,
       )}
       {...props}

--- a/apps/ui/src/components/ui/card.tsx
+++ b/apps/ui/src/components/ui/card.tsx
@@ -6,10 +6,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card"
-      className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 border py-6",
-        className,
-      )}
+      className={cn("bg-card text-card-foreground flex flex-col gap-6 border py-6", className)}
       {...props}
     />
   );

--- a/local/Caddyfile
+++ b/local/Caddyfile
@@ -1,30 +1,34 @@
 # Local development reverse proxy
-# Unifies API (9000) and UI (9100) behind a single port (9300)
+# Unifies API and UI behind a single port.
+# Recommended:
+#   PORT_PREFIX=271  -> proxy 27100, api 27101, ui 27105
+# Override individual ports with:
+#   API_PORT=9000 UI_PORT=9100 PROXY_PORT=9300
 #
 # Routes:
-#   /api/*     -> API server at :9000 (strips /api prefix)
-#   /api-doc/* -> API server at :9000
-#   /health    -> API server at :9000
-#   /*         -> UI dev server at :9100
+#   /api/*     -> API server at :API_PORT (strips /api prefix)
+#   /api-doc/* -> API server at :API_PORT
+#   /health    -> API server at :API_PORT
+#   /*         -> UI dev server at :UI_PORT
 #
 # SSE/Proxy Notes:
 #   - flush_interval -1: disables response buffering (required for SSE)
 #   - Server handles its own 5-min connection cycling with disconnecting events
 #   - SDK reconnects transparently on disconnecting events (no retry budget cost)
-:9300 {
+:{$PROXY_PORT:9300} {
 	handle_path /api/* {
-		reverse_proxy localhost:9000 {
+		reverse_proxy localhost:{$API_PORT:9000} {
 			# Disable response buffering for SSE streaming
 			flush_interval -1
 		}
 	}
 	handle /api-doc/* {
-		reverse_proxy localhost:9000
+		reverse_proxy localhost:{$API_PORT:9000}
 	}
 	handle /health {
-		reverse_proxy localhost:9000
+		reverse_proxy localhost:{$API_PORT:9000}
 	}
 	handle {
-		reverse_proxy localhost:9100
+		reverse_proxy localhost:{$UI_PORT:9100}
 	}
 }

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -1,13 +1,12 @@
 services:
   postgres:
     image: postgres:17-alpine
-    container_name: everruns-postgres
     environment:
       POSTGRES_USER: everruns
       POSTGRES_PASSWORD: everruns
       POSTGRES_DB: everruns
     ports:
-      - "5432:5432"
+      - "${DB_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -18,7 +17,6 @@ services:
 
   valkey:
     image: valkey/valkey:8-alpine
-    container_name: everruns-valkey
     ports:
       - "6379:6379"
     volumes:
@@ -31,7 +29,6 @@ services:
 
   jaeger:
     image: jaegertracing/jaeger:2.4.0
-    container_name: everruns-jaeger
     ports:
       # OTLP gRPC receiver
       - "4317:4317"

--- a/scripts/lib/bench.sh
+++ b/scripts/lib/bench.sh
@@ -6,6 +6,8 @@ source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 cmd="${1:-}"
 shift || true
 
+apply_port_prefix_defaults
+
 parse_bench_args() {
   SAVE_ARG=""
   MONIKER_ARG=""
@@ -68,23 +70,12 @@ case "$cmd" in
     echo ""
 
     DB_HOST="${DB_HOST:-localhost}"
-    DB_PORT="${DB_PORT:-5432}"
     DB_NAME="${DB_NAME:-everruns_test}"
     USING_DOCKER_POSTGRES=false
 
     echo "1️⃣  Checking PostgreSQL connection..."
 
-    if command -v docker &> /dev/null && docker ps 2>/dev/null | grep -q everruns-postgres; then
-      echo "   Found Docker PostgreSQL container"
-      USING_DOCKER_POSTGRES=true
-      DB_USER="everruns"
-      DB_PASS="everruns"
-      echo "   Waiting for PostgreSQL to be ready..."
-      until docker exec everruns-postgres pg_isready -U everruns -d everruns > /dev/null 2>&1; do
-        sleep 1
-      done
-      echo "   ✅ PostgreSQL is ready"
-    elif check_postgres_ready "$DB_HOST" "$DB_PORT" "${DB_USER:-postgres}"; then
+    if check_postgres_ready "$DB_HOST" "$DB_PORT" "${DB_USER:-postgres}"; then
       echo "   ✅ Local PostgreSQL is ready"
       DB_USER="${DB_USER:-postgres}"
       DB_PASS="${DB_PASS:-postgres}"
@@ -96,7 +87,7 @@ case "$cmd" in
         "${DOCKER_COMPOSE[@]}" up -d postgres
         cd "$PROJECT_ROOT"
         sleep 3
-        until docker exec everruns-postgres pg_isready -U everruns -d everruns > /dev/null 2>&1; do
+        until check_postgres_ready "$DB_HOST" "$DB_PORT" everruns; do
           echo "   Waiting for Postgres to be ready..."
           sleep 1
         done

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -62,6 +62,24 @@ ensure_docker_daemon() {
   return 1
 }
 
+apply_port_prefix_defaults() {
+  if [ -n "${PORT_PREFIX:-}" ]; then
+    : "${PROXY_PORT:=${PORT_PREFIX}00}"
+    : "${API_PORT:=${PORT_PREFIX}01}"
+    : "${UI_PORT:=${PORT_PREFIX}05}"
+    : "${DB_PORT:=${PORT_PREFIX}32}"
+    : "${COMPOSE_PROJECT_NAME:=everruns-${PORT_PREFIX}}"
+  else
+    : "${API_PORT:=9000}"
+    : "${UI_PORT:=9100}"
+    : "${PROXY_PORT:=9300}"
+    : "${DB_PORT:=5432}"
+    : "${COMPOSE_PROJECT_NAME:=everruns}"
+  fi
+
+  export PORT_PREFIX API_PORT UI_PORT PROXY_PORT DB_PORT COMPOSE_PROJECT_NAME
+}
+
 # Check if npm dependencies need to be installed/updated
 # Usage: check_npm_deps <app_name> <install_command>
 # Example: check_npm_deps "UI" "cd apps/ui && npm install"

--- a/scripts/lib/docker.sh
+++ b/scripts/lib/docker.sh
@@ -5,6 +5,8 @@ source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 cmd="${1:-}"
 
+apply_port_prefix_defaults
+
 case "$cmd" in
   start)
     echo "🚀 Starting Everrun development environment..."
@@ -12,7 +14,7 @@ case "$cmd" in
     cd "$PROJECT_ROOT/local"
     "${DOCKER_COMPOSE[@]}" up -d
     echo "✅ Services started!"
-    echo "   - Postgres: localhost:5432"
+    echo "   - Postgres: localhost:${DB_PORT}"
     echo "   - Valkey:   localhost:6379"
     echo "   - Jaeger UI: http://localhost:16686"
     echo "   - OTLP gRPC: localhost:4317"

--- a/scripts/lib/services.sh
+++ b/scripts/lib/services.sh
@@ -18,12 +18,37 @@ for arg in "$@"; do
   esac
 done
 
+apply_port_prefix_defaults
+API_ADDR_DEFAULT="0.0.0.0:${API_PORT}"
+PROXY_URL_DEFAULT="http://localhost:${PROXY_PORT}"
+DB_URL_DEFAULT="postgres://everruns:everruns@localhost:${DB_PORT}/everruns"
+
 # require_command is defined in common.sh (sourced above)
+
+ui_dev_args=()
+if [ -L "${PROJECT_ROOT:-$(pwd)}/apps/ui/node_modules" ]; then
+  ui_dev_args+=(--webpack)
+fi
+if [ -n "${UI_DEV_ARGS:-}" ]; then
+  read -r -a ui_dev_args_extra <<< "$UI_DEV_ARGS"
+  ui_dev_args+=("${ui_dev_args_extra[@]}")
+fi
+
+run_ui_dev() {
+  PORT="$UI_PORT" ./node_modules/.bin/next dev --port "$UI_PORT" "${ui_dev_args[@]}"
+}
+
+run_ui_start() {
+  PORT="$UI_PORT" ./node_modules/.bin/next start --port "$UI_PORT"
+}
 
 case "$cmd" in
   server)
     echo "🌐 Starting server..."
-    export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:9300}
+    export ADDR=${ADDR:-$API_ADDR_DEFAULT}
+    export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-$PROXY_URL_DEFAULT}
+    export PUBLIC_APP_URL=${PUBLIC_APP_URL:-$PROXY_URL_DEFAULT}
+    export APP_URL=${APP_URL:-$PUBLIC_APP_URL}
     cargo run -p everruns-server
     ;;
 
@@ -35,7 +60,10 @@ case "$cmd" in
   watch-server)
     echo "👀 Starting server with auto-reload..."
     require_command cargo-watch "Run: just init"
-    export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:9300}
+    export ADDR=${ADDR:-$API_ADDR_DEFAULT}
+    export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-$PROXY_URL_DEFAULT}
+    export PUBLIC_APP_URL=${PUBLIC_APP_URL:-$PROXY_URL_DEFAULT}
+    export APP_URL=${APP_URL:-$PUBLIC_APP_URL}
     cargo watch -w crates -x 'run -p everruns-server'
     ;;
 
@@ -113,9 +141,13 @@ case "$cmd" in
     # Enable dev mode
     export DEV_MODE=true
     export DEPLOYMENT_GRADE=dev
-    export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:9300}
-    export AUTH_BASE_URL=${AUTH_BASE_URL:-http://localhost:9300/api}
-    export FRONTEND_URL=${FRONTEND_URL:-http://localhost:9300}
+    export API_PORT UI_PORT PROXY_PORT
+    export ADDR=${ADDR:-$API_ADDR_DEFAULT}
+    export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-$PROXY_URL_DEFAULT}
+    export PUBLIC_APP_URL=${PUBLIC_APP_URL:-$PROXY_URL_DEFAULT}
+    export APP_URL=${APP_URL:-$PUBLIC_APP_URL}
+    export AUTH_BASE_URL=${AUTH_BASE_URL:-${PROXY_URL_DEFAULT}/api}
+    export FRONTEND_URL=${FRONTEND_URL:-$PROXY_URL_DEFAULT}
     export RUST_LOG=${RUST_LOG:-info}
 
     # Set encryption key if not provided (standard dev key from .env.example)
@@ -167,7 +199,7 @@ case "$cmd" in
     # Wait for server
     echo "2️⃣  Waiting for server to be ready..."
     for i in {1..30}; do
-      if curl -s http://localhost:9000/health > /dev/null 2>&1; then
+      if curl -s "http://localhost:${API_PORT}/health" > /dev/null 2>&1; then
         echo "   ✅ Server is ready"
         break
       fi
@@ -183,7 +215,7 @@ case "$cmd" in
     # Start UI
     echo "5️⃣  Starting UI server..."
     cd "$PROJECT_ROOT/apps/ui"
-    npm run dev &
+    run_ui_dev &
     UI_PID=$!
     CHILD_PIDS+=("$UI_PID")
     cd "$PROJECT_ROOT"
@@ -196,14 +228,14 @@ case "$cmd" in
     CADDY_PID=$!
     CHILD_PIDS+=("$CADDY_PID")
     sleep 1
-    echo "   ✅ Reverse proxy is running on :9300 (PID: $CADDY_PID)"
+    echo "   ✅ Reverse proxy is running on :${PROXY_PORT} (PID: $CADDY_PID)"
 
     echo ""
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     echo "✅ DEV MODE started (fully functional, in-memory storage)!"
     echo ""
-    echo "   🌐 App:           http://localhost:9300"
-    echo "   🔌 API:           http://localhost:9300/api/..."
+    echo "   🌐 App:           http://localhost:${PROXY_PORT}"
+    echo "   🔌 API:           http://localhost:${PROXY_PORT}/api/..."
     echo "   ⚙️  Worker:        Running in-process (no separate process)"
     echo ""
     echo "⚠️  DEV MODE notes:"
@@ -294,19 +326,19 @@ case "$cmd" in
     echo "1️⃣  Checking PostgreSQL..."
     if [ "$NO_DOCKER" = true ]; then
       # No Docker mode - require local PostgreSQL
-      if check_postgres_ready localhost 5432 everruns; then
+      if check_postgres_ready localhost "$DB_PORT" everruns; then
         echo "   ✅ Local PostgreSQL is ready"
-        export DATABASE_URL=${DATABASE_URL:-postgres://everruns:everruns@localhost:5432/everruns}
+        export DATABASE_URL=${DATABASE_URL:-$DB_URL_DEFAULT}
       else
-        echo "   ❌ PostgreSQL not running or not responding on localhost:5432"
+        echo "   ❌ PostgreSQL not running or not responding on localhost:${DB_PORT}"
         echo "   Start PostgreSQL or remove --no-docker flag"
         exit 1
       fi
       export OTEL_SDK_DISABLED=true
       echo "   ℹ️  OpenTelemetry disabled (--no-docker)"
-    elif check_postgres_ready localhost 5432 postgres; then
+    elif check_postgres_ready localhost "$DB_PORT" postgres; then
       echo "   ✅ Local PostgreSQL is ready"
-      export DATABASE_URL=${DATABASE_URL:-postgres://postgres:postgres@localhost/everruns}
+      export DATABASE_URL=${DATABASE_URL:-postgres://postgres:postgres@localhost:${DB_PORT}/everruns}
       if resolve_docker_compose 2>/dev/null; then
         if ! docker ps 2>/dev/null | grep -q jaeger; then
           echo "   ℹ️  Starting Jaeger for tracing..."
@@ -320,7 +352,7 @@ case "$cmd" in
       fi
     elif command -v docker &> /dev/null && docker ps 2>/dev/null | grep -q postgres; then
       echo "   ✅ Docker PostgreSQL is ready"
-      export DATABASE_URL=${DATABASE_URL:-postgres://everruns:everruns@localhost:5432/everruns}
+      export DATABASE_URL=${DATABASE_URL:-$DB_URL_DEFAULT}
       if ! docker ps 2>/dev/null | grep -q jaeger; then
         echo "   ℹ️  Starting Jaeger for tracing..."
         if resolve_docker_compose 2>/dev/null; then
@@ -339,11 +371,11 @@ case "$cmd" in
         "${DOCKER_COMPOSE[@]}" up -d postgres jaeger
         cd "$PROJECT_ROOT"
         sleep 3
-        until docker exec everruns-postgres pg_isready -U everruns -d everruns > /dev/null 2>&1; do
+        until check_postgres_ready localhost "$DB_PORT" everruns; do
           echo "   Waiting for Postgres to be ready..."
           sleep 1
         done
-        export DATABASE_URL=${DATABASE_URL:-postgres://everruns:everruns@localhost:5432/everruns}
+        export DATABASE_URL=${DATABASE_URL:-$DB_URL_DEFAULT}
         echo "   ✅ Docker PostgreSQL and Jaeger started"
         JAEGER_STARTED=true
       else
@@ -405,9 +437,13 @@ case "$cmd" in
     fi
 
     # Start API
-    export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:9300}
-    export AUTH_BASE_URL=${AUTH_BASE_URL:-http://localhost:9300/api}
-    export FRONTEND_URL=${FRONTEND_URL:-http://localhost:9300}
+    export API_PORT UI_PORT PROXY_PORT
+    export ADDR=${ADDR:-$API_ADDR_DEFAULT}
+    export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-$PROXY_URL_DEFAULT}
+    export PUBLIC_APP_URL=${PUBLIC_APP_URL:-$PROXY_URL_DEFAULT}
+    export APP_URL=${APP_URL:-$PUBLIC_APP_URL}
+    export AUTH_BASE_URL=${AUTH_BASE_URL:-${PROXY_URL_DEFAULT}/api}
+    export FRONTEND_URL=${FRONTEND_URL:-$PROXY_URL_DEFAULT}
     export DEPLOYMENT_GRADE=dev
     export RUST_LOG=${RUST_LOG:-info}
     if [ "$NO_WATCH" = true ]; then
@@ -424,7 +460,7 @@ case "$cmd" in
     # Wait for API
     echo "4️⃣  Waiting for API to be ready..."
     for i in {1..30}; do
-      if curl -s http://localhost:9000/health > /dev/null 2>&1; then
+      if curl -s "http://localhost:${API_PORT}/health" > /dev/null 2>&1; then
         echo "   ✅ API is ready"
         break
       fi
@@ -491,7 +527,7 @@ case "$cmd" in
       # Start UI
       echo "8️⃣  Starting UI server..."
       cd "$PROJECT_ROOT/apps/ui"
-      npm run dev &
+      run_ui_dev &
       UI_PID=$!
       CHILD_PIDS+=("$UI_PID")
       cd "$PROJECT_ROOT"
@@ -504,7 +540,7 @@ case "$cmd" in
       CADDY_PID=$!
       CHILD_PIDS+=("$CADDY_PID")
       sleep 1
-      echo "   ✅ Reverse proxy is running on :9300 (PID: $CADDY_PID)"
+      echo "   ✅ Reverse proxy is running on :${PROXY_PORT} (PID: $CADDY_PID)"
     else
       echo "7️⃣  Skipping UI (--no-ui)"
     fi
@@ -518,10 +554,10 @@ case "$cmd" in
     fi
     echo ""
     if [ "$NO_UI" = false ]; then
-      echo "   🌐 App:         http://localhost:9300"
-      echo "   🔌 API:         http://localhost:9300/api/..."
+      echo "   🌐 App:         http://localhost:${PROXY_PORT}"
+      echo "   🔌 API:         http://localhost:${PROXY_PORT}/api/..."
     else
-      echo "   🌐 API:         http://localhost:9000"
+      echo "   🌐 API:         http://localhost:${API_PORT}"
     fi
     if [ "$NO_WATCH" = false ]; then
       echo "   ⚙️ Worker:      running (auto-reload)"
@@ -602,19 +638,19 @@ case "$cmd" in
     # Check PostgreSQL (same as start-all)
     echo "1️⃣  Checking PostgreSQL..."
     if [ "$NO_DOCKER" = true ]; then
-      if check_postgres_ready localhost 5432 everruns; then
+      if check_postgres_ready localhost "$DB_PORT" everruns; then
         echo "   ✅ Local PostgreSQL is ready"
-        export DATABASE_URL=${DATABASE_URL:-postgres://everruns:everruns@localhost:5432/everruns}
+        export DATABASE_URL=${DATABASE_URL:-$DB_URL_DEFAULT}
       else
-        echo "   ❌ PostgreSQL not running or not responding on localhost:5432"
+        echo "   ❌ PostgreSQL not running or not responding on localhost:${DB_PORT}"
         echo "   Start PostgreSQL or remove --no-docker flag"
         exit 1
       fi
       export OTEL_SDK_DISABLED=true
       echo "   ℹ️  OpenTelemetry disabled (--no-docker)"
-    elif check_postgres_ready localhost 5432 postgres; then
+    elif check_postgres_ready localhost "$DB_PORT" postgres; then
       echo "   ✅ Local PostgreSQL is ready"
-      export DATABASE_URL=${DATABASE_URL:-postgres://postgres:postgres@localhost/everruns}
+      export DATABASE_URL=${DATABASE_URL:-postgres://postgres:postgres@localhost:${DB_PORT}/everruns}
       if resolve_docker_compose 2>/dev/null; then
         if ! docker ps 2>/dev/null | grep -q jaeger; then
           echo "   ℹ️  Starting Jaeger for tracing..."
@@ -628,7 +664,7 @@ case "$cmd" in
       fi
     elif command -v docker &> /dev/null && docker ps 2>/dev/null | grep -q postgres; then
       echo "   ✅ Docker PostgreSQL is ready"
-      export DATABASE_URL=${DATABASE_URL:-postgres://everruns:everruns@localhost:5432/everruns}
+      export DATABASE_URL=${DATABASE_URL:-$DB_URL_DEFAULT}
       if ! docker ps 2>/dev/null | grep -q jaeger; then
         echo "   ℹ️  Starting Jaeger for tracing..."
         if resolve_docker_compose 2>/dev/null; then
@@ -647,11 +683,11 @@ case "$cmd" in
         "${DOCKER_COMPOSE[@]}" up -d postgres jaeger
         cd "$PROJECT_ROOT"
         sleep 3
-        until docker exec everruns-postgres pg_isready -U everruns -d everruns > /dev/null 2>&1; do
+        until check_postgres_ready localhost "$DB_PORT" everruns; do
           echo "   Waiting for Postgres to be ready..."
           sleep 1
         done
-        export DATABASE_URL=${DATABASE_URL:-postgres://everruns:everruns@localhost:5432/everruns}
+        export DATABASE_URL=${DATABASE_URL:-$DB_URL_DEFAULT}
         echo "   ✅ Docker PostgreSQL and Jaeger started"
         JAEGER_STARTED=true
       else
@@ -728,9 +764,13 @@ case "$cmd" in
     fi
 
     # Start server
-    export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:9300}
-    export AUTH_BASE_URL=${AUTH_BASE_URL:-http://localhost:9300/api}
-    export FRONTEND_URL=${FRONTEND_URL:-http://localhost:9300}
+    export API_PORT UI_PORT PROXY_PORT
+    export ADDR=${ADDR:-$API_ADDR_DEFAULT}
+    export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-$PROXY_URL_DEFAULT}
+    export PUBLIC_APP_URL=${PUBLIC_APP_URL:-$PROXY_URL_DEFAULT}
+    export APP_URL=${APP_URL:-$PUBLIC_APP_URL}
+    export AUTH_BASE_URL=${AUTH_BASE_URL:-${PROXY_URL_DEFAULT}/api}
+    export FRONTEND_URL=${FRONTEND_URL:-$PROXY_URL_DEFAULT}
     export DEPLOYMENT_GRADE=dev
     export RUST_LOG=${RUST_LOG:-info}
 
@@ -743,7 +783,7 @@ case "$cmd" in
     # Wait for server
     echo "6️⃣  Waiting for server to be ready..."
     for i in {1..30}; do
-      if curl -s http://localhost:9000/health > /dev/null 2>&1; then
+      if curl -s "http://localhost:${API_PORT}/health" > /dev/null 2>&1; then
         echo "   ✅ Server is ready"
         break
       fi
@@ -762,7 +802,7 @@ case "$cmd" in
       # Start UI production server
       echo "8️⃣  Starting UI server (production)..."
       cd "$PROJECT_ROOT/apps/ui"
-      PORT=9100 npm run start &
+      run_ui_start &
       UI_PID=$!
       CHILD_PIDS+=("$UI_PID")
       cd "$PROJECT_ROOT"
@@ -775,7 +815,7 @@ case "$cmd" in
       CADDY_PID=$!
       CHILD_PIDS+=("$CADDY_PID")
       sleep 1
-      echo "   ✅ Reverse proxy is running on :9300 (PID: $CADDY_PID)"
+      echo "   ✅ Reverse proxy is running on :${PROXY_PORT} (PID: $CADDY_PID)"
     fi
 
     echo ""
@@ -783,10 +823,10 @@ case "$cmd" in
     echo "✅ PRODUCTION MODE started (release builds, no watchers)!"
     echo ""
     if [ "$NO_UI" = false ]; then
-      echo "   🌐 App:         http://localhost:9300"
-      echo "   🔌 API:         http://localhost:9300/api/..."
+      echo "   🌐 App:         http://localhost:${PROXY_PORT}"
+      echo "   🔌 API:         http://localhost:${PROXY_PORT}/api/..."
     else
-      echo "   🌐 API:         http://localhost:9000"
+      echo "   🌐 API:         http://localhost:${API_PORT}"
     fi
     echo "   ⚙️ Worker:      running (release)"
     if [ "$JAEGER_STARTED" = true ]; then


### PR DESCRIPTION
## What
Apply the Slate chat/tooling style across the main chat surfaces, dashboard shell, and dev showcase pages. This also adds grouped tool activity rendering, the rebuilt todo/progress card, and worktree-safe Next.js build behavior.

## Why
The chat mockup and production UI had drifted. Tool execution, composer controls, shell chrome, and dev references were not using one consistent visual system, and worktree builds still broke because Turbopack rejects symlinked `node_modules`.

## How
- restyled the real chat panel, sidebar, session shell, dashboard widgets, and dev pages to the Slate system
- introduced grouped tool activity rendering and improved todo progress rendering with tests
- flattened shared card/surface primitives and sharpened icon treatment
- added prefix-based worktree port handling plus automatic public URL wiring
- wrapped `apps/ui` build to auto-use webpack when `node_modules` is symlinked in a worktree

## Risk
- Medium
- Main risk is visual regression across chat/dashboard/shell surfaces and worktree-specific Next.js behavior

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
