### PR TITLE
refactor: remove CodeSandbox integration

### DIFF
--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -44,11 +44,11 @@ use std::sync::Arc;
 /// # Example
 ///
 /// ```ignore
-/// // In integrations/docker/src/lib.rs:
+/// // In integrations/daytona/src/lib.rs:
 /// inventory::submit! {
 ///     everruns_core::capabilities::IntegrationPlugin {
-///         experimental_only: true,
-///         factory: || Box::new(DockerCapability),
+///         experimental_only: false,
+///         factory: || Box::new(DaytonaCapability),
 ///     }
 /// }
 /// ```
@@ -460,7 +460,7 @@ impl CapabilityRegistry {
     /// Create a registry with built-in capabilities for a specific deployment grade
     ///
     /// Experimental capabilities are included via integration plugins in dev environments.
-    /// Non-experimental integration plugins are included in all environments.
+    /// Non-experimental integration plugins (like Daytona) are included in all environments.
     pub fn with_builtins_for_grade(grade: DeploymentGrade) -> Self {
         let mut registry = Self::new();
 

--- a/specs/daytona.md
+++ b/specs/daytona.md
@@ -2,7 +2,7 @@
 
 ## Abstract
 
-The Daytona capability integrates [Daytona](https://www.daytona.io/) cloud-based sandboxes as an agent execution environment. Agents can create, manage, and interact with multiple isolated environments per session via the Daytona REST API. This supports multiple sandboxes per session, each identified by a `sandbox_id`.
+The Daytona capability integrates [Daytona](https://www.daytona.io/) cloud-based sandboxes as an agent execution environment. Agents can create, manage, and interact with multiple isolated environments per session via the Daytona REST API. Supports multiple sandboxes per session, each identified by a `sandbox_id`.
 
 **Status**: Available (All environments)
 
@@ -217,10 +217,6 @@ See [threat-model.md](threat-model.md#16-daytona-cloud-sandbox-tm-daytona) for f
 | No context | `ToolError` | "{tool_name} requires context." |
 
 ## Design Decisions
-
-### Integration pattern
-
-The Daytona integration uses prefix-based tool naming, state management via session secrets, and capability registration via inventory plugin.
 
 ### Synchronous exec only
 


### PR DESCRIPTION
## What
Remove the entire CodeSandbox cloud sandbox integration from the codebase.

## Why
CodeSandbox integration is no longer needed.

## How
- Deleted `integrations/codesandbox/` crate (9 tools, client, types, state management, tests — ~3,500 lines)
- Removed workspace member from root `Cargo.toml`
- Removed dependency and `extern crate` links from server and worker crates
- Removed CodeSandbox Coder seed agent
- Deleted `specs/codesandbox.md`
- Removed TM-CSB threat model section and open risk items
- Updated all remaining references in specs (architecture, capabilities, concepts, daytona, threat-model) and AGENTS.md
- Updated doc comments in `crates/core/src/capabilities/mod.rs`

## Risk
- Low
- Agents with `codesandbox` capability will fail to resolve at runtime. No existing production agents should be using this capability.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered