### PR TITLE
fix(mcp): pass decrypted API keys to MCP tool execution

### DIFF
--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -677,13 +677,24 @@ impl WorkerAdapters for DirectWorkerAdapters {
             })
             .ok_or_else(|| store_error(format!("MCP server not found: {}", server_prefix)))?;
 
+        // Decrypt API key if set
+        let api_key = if server.api_key_set {
+            self.mcp_server_service
+                .decrypt_api_key(org_id, server.id.uuid())
+                .await
+                .map_err(|e| {
+                    tracing::error!("Failed to decrypt MCP server API key: {}", e);
+                    store_error("Failed to decrypt MCP server API key")
+                })?
+        } else {
+            None
+        };
+
         Ok(McpServerInfo {
             id: server.id.uuid(),
             name: server.name,
             url: server.url,
-            // API key is encrypted - would need decryption service access
-            // TODO: Add decryption support when needed for MCP tool execution
-            api_key: None,
+            api_key,
             headers: server.headers,
         })
     }
@@ -1875,5 +1886,117 @@ mod tests {
             config: serde_json::Value::Object(Default::default()),
             created_at: chrono::Utc::now(),
         }
+    }
+
+    // =========================================================================
+    // MCP server API key decryption tests (EVE-55)
+    // =========================================================================
+
+    fn test_encryption() -> Arc<crate::storage::EncryptionService> {
+        Arc::new(
+            crate::storage::EncryptionService::new(
+                "kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=",
+                &[],
+            )
+            .unwrap(),
+        )
+    }
+
+    fn test_adapters_with_encryption() -> DirectWorkerAdapters {
+        let encryption = test_encryption();
+        let db = Arc::new(crate::storage::StorageBackend::in_memory());
+        let event_service = Arc::new(crate::services::EventService::new(db.clone()));
+        let llm_resolver = Arc::new(crate::services::LlmResolverService::new(db.clone(), None));
+        let mcp_server_service = Arc::new(crate::services::McpServerService::new(
+            db.clone(),
+            Some(encryption),
+        ));
+        let cap_registry = CapabilityRegistry::new();
+        let sqldb_backend = Arc::new(everruns_session_sqldb::InMemorySqlDbBackend::new());
+        let sqldb_store: everruns_core::traits::SessionSqlDbStoreRef = Arc::new(
+            everruns_session_sqldb::InMemorySqlDbStore::new(sqldb_backend),
+        );
+
+        DirectWorkerAdapters::new(
+            db,
+            event_service,
+            llm_resolver,
+            mcp_server_service,
+            cap_registry,
+            sqldb_store,
+        )
+    }
+
+    /// Seed an MCP server with an optional encrypted API key. Returns server UUID.
+    async fn seed_mcp_server(
+        db: &crate::storage::StorageBackend,
+        name: &str,
+        api_key_encrypted: Option<Vec<u8>>,
+    ) -> Uuid {
+        use crate::storage::models::CreateMcpServerRow;
+        let row = db
+            .create_mcp_server(
+                everruns_core::DEFAULT_ORG_ID,
+                CreateMcpServerRow {
+                    name: name.to_string(),
+                    description: None,
+                    url: "https://example.com/mcp".to_string(),
+                    transport_type: "streamable_http".to_string(),
+                    api_key_encrypted,
+                    headers: None,
+                    settings: None,
+                },
+            )
+            .await
+            .expect("seed mcp server");
+        row.id.uuid()
+    }
+
+    #[tokio::test]
+    async fn get_mcp_server_by_prefix_returns_none_api_key_when_not_set() {
+        let adapters = test_adapters();
+        seed_mcp_server(&adapters.db, "My Server", None).await;
+
+        let info = adapters
+            .get_mcp_server_by_prefix(everruns_core::DEFAULT_ORG_ID, "my_server")
+            .await
+            .unwrap();
+        assert!(info.api_key.is_none());
+        assert_eq!(info.name, "My Server");
+    }
+
+    #[tokio::test]
+    async fn get_mcp_server_by_prefix_returns_decrypted_api_key() {
+        let adapters = test_adapters_with_encryption();
+        let encrypted = test_encryption().encrypt_string("sk-live-key").unwrap();
+        seed_mcp_server(&adapters.db, "Auth Server", Some(encrypted)).await;
+
+        let info = adapters
+            .get_mcp_server_by_prefix(everruns_core::DEFAULT_ORG_ID, "auth_server")
+            .await
+            .unwrap();
+        assert_eq!(info.api_key.as_deref(), Some("sk-live-key"));
+    }
+
+    #[tokio::test]
+    async fn get_mcp_server_by_prefix_errors_when_encryption_not_configured() {
+        // Adapters without encryption
+        let adapters = test_adapters();
+        let encrypted = test_encryption().encrypt_string("sk-secret").unwrap();
+        seed_mcp_server(&adapters.db, "No Enc Server", Some(encrypted)).await;
+
+        let result = adapters
+            .get_mcp_server_by_prefix(everruns_core::DEFAULT_ORG_ID, "no_enc_server")
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn get_mcp_server_by_prefix_errors_when_server_not_found() {
+        let adapters = test_adapters();
+        let result = adapters
+            .get_mcp_server_by_prefix(everruns_core::DEFAULT_ORG_ID, "nonexistent")
+            .await;
+        assert!(result.is_err());
     }
 }

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -2540,12 +2540,15 @@ impl WorkerService for WorkerServiceImpl {
         });
 
         let server_info = if let Some(server_with_tools) = matching_server {
-            // Get API key if set (already decrypted in the service)
+            // Decrypt API key if set
             let api_key = if server_with_tools.server.api_key_set {
-                // We need to fetch the full server info with decrypted API key
-                // For now, we don't have direct access to the decrypted key in McpServerWithTools
-                // This would need enhancement in the MCP service to include decrypted key
-                None // TODO: Return decrypted API key when available
+                self.mcp_server_service
+                    .decrypt_api_key(req.org_id, server_with_tools.server.id.uuid())
+                    .await
+                    .map_err(|e| {
+                        tracing::error!("Failed to decrypt MCP server API key: {}", e);
+                        Status::internal("Failed to decrypt MCP server API key")
+                    })?
             } else {
                 None
             };

--- a/crates/server/src/services/mcp_server.rs
+++ b/crates/server/src/services/mcp_server.rs
@@ -225,6 +225,31 @@ impl McpServerService {
         }
     }
 
+    /// Decrypt API key for an MCP server by ID.
+    /// Returns None if server has no API key set.
+    pub async fn decrypt_api_key(&self, org_id: i64, id: Uuid) -> Result<Option<String>> {
+        let row = self
+            .db
+            .get_mcp_server(org_id, id)
+            .await?
+            .ok_or_else(|| anyhow!("MCP server not found"))?;
+
+        if !row.api_key_set {
+            return Ok(None);
+        }
+
+        match &row.api_key_encrypted {
+            Some(encrypted) => {
+                let encryption = self
+                    .encryption
+                    .as_ref()
+                    .ok_or_else(|| anyhow!("Encryption not configured"))?;
+                Ok(Some(encryption.decrypt_to_string(encrypted)?))
+            }
+            None => Ok(None),
+        }
+    }
+
     fn row_to_mcp_server(row: &McpServerRow) -> McpServer {
         // Parse headers from JSON
         let headers: HashMap<String, String> =
@@ -313,4 +338,108 @@ async fn fetch_mcp_tools(
         .ok_or_else(|| anyhow!("MCP server returned empty result"))?;
 
     Ok(result.tools)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::{EncryptionService, StorageBackend, models::CreateMcpServerRow};
+
+    fn test_encryption() -> Arc<EncryptionService> {
+        Arc::new(
+            EncryptionService::new("kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=", &[])
+                .unwrap(),
+        )
+    }
+
+    #[tokio::test]
+    async fn decrypt_api_key_returns_none_when_no_key_set() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let svc = McpServerService::new(db.clone(), Some(test_encryption()));
+
+        let row = db
+            .create_mcp_server(
+                1,
+                CreateMcpServerRow {
+                    name: "test-server".into(),
+                    description: None,
+                    url: "https://example.com".into(),
+                    transport_type: "streamable_http".into(),
+                    api_key_encrypted: None,
+                    headers: None,
+                    settings: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let result = svc.decrypt_api_key(1, row.id.uuid()).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn decrypt_api_key_returns_decrypted_key() {
+        let encryption = test_encryption();
+        let db = Arc::new(StorageBackend::in_memory());
+        let svc = McpServerService::new(db.clone(), Some(encryption.clone()));
+
+        let encrypted = encryption.encrypt_string("sk-secret-123").unwrap();
+
+        let row = db
+            .create_mcp_server(
+                1,
+                CreateMcpServerRow {
+                    name: "authed-server".into(),
+                    description: None,
+                    url: "https://example.com".into(),
+                    transport_type: "streamable_http".into(),
+                    api_key_encrypted: Some(encrypted),
+                    headers: None,
+                    settings: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let result = svc.decrypt_api_key(1, row.id.uuid()).await.unwrap();
+        assert_eq!(result.as_deref(), Some("sk-secret-123"));
+    }
+
+    #[tokio::test]
+    async fn decrypt_api_key_errors_without_encryption_service() {
+        let encryption = test_encryption();
+        let db = Arc::new(StorageBackend::in_memory());
+
+        // Create server WITH encrypted key
+        let encrypted = encryption.encrypt_string("sk-secret").unwrap();
+        let row = db
+            .create_mcp_server(
+                1,
+                CreateMcpServerRow {
+                    name: "no-enc-server".into(),
+                    description: None,
+                    url: "https://example.com".into(),
+                    transport_type: "streamable_http".into(),
+                    api_key_encrypted: Some(encrypted),
+                    headers: None,
+                    settings: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Service WITHOUT encryption configured
+        let svc = McpServerService::new(db, None);
+        let result = svc.decrypt_api_key(1, row.id.uuid()).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn decrypt_api_key_errors_for_missing_server() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let svc = McpServerService::new(db, Some(test_encryption()));
+
+        let result = svc.decrypt_api_key(1, Uuid::new_v4()).await;
+        assert!(result.is_err());
+    }
 }


### PR DESCRIPTION
## Summary
- Add `McpServerService::decrypt_api_key()` as centralized decryption method
- Replace `api_key: None` in both direct and gRPC worker paths with actual decrypted keys
- Both execution paths now send `Authorization: Bearer` headers for auth-required MCP servers

## Why
Fixes EVE-55. MCP tool execution was broken for auth-required servers — both worker paths discarded API keys while management paths used them correctly.

## Test plan
- [x] 8 new tests: decrypt_api_key (4 cases), DirectWorkerAdapters::get_mcp_server_by_prefix (4 cases)
- [x] All 17 MCP-related tests pass
- [x] `cargo clippy -- -D warnings` clean