### PR TITLE
fix(ui): simplify bash tool result details

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,7 +201,7 @@ Use the [`/ship`](.claude/commands/ship.md) command to execute the full shipping
 9. Rebase on main: `git fetch origin main && git rebase origin/main`
 10. Smoke test impacted functionality in both dev mode (`just start-dev`) and full mode (`just start-all`)
 11. Performance impact: no unindexed queries, no full table scans, no N+1 queries, no unbounded result sets; add pagination/limits where needed
-12. UI screenshots for UI changes
+12. UI screenshots for UI changes (validation/PR comments only; do not commit screenshot artifacts)
 13. Test coverage: extensive positive and negative tests; reproduce issue + verify fix, cover touched code paths
 14. Update relevant specs in `specs/`
 15. Update docs in `apps/docs/` if applicable

--- a/apps/ui/src/__tests__/tool-activity-group.test.tsx
+++ b/apps/ui/src/__tests__/tool-activity-group.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { ToolActivityGroup } from "@/components/chat/tool-activity-group";
 import type { ToolCompletedData } from "@/lib/api/types";
 import type { ToolCallContent } from "@/components/chat/tool-call-utils";
@@ -47,5 +47,51 @@ describe("ToolActivityGroup", () => {
     expect(screen.getByText("Read README.md")).toBeInTheDocument();
     expect(screen.getByText("Find **/README*")).toBeInTheDocument();
     expect(screen.getByText("Search web for project architecture")).toBeInTheDocument();
+  });
+
+  it("renders structured bash details with separate stdout and stderr", () => {
+    const toolCalls: ToolCallContent[] = [
+      {
+        id: "tool-shell",
+        name: "bash",
+        arguments: { command: "cargo test" },
+      },
+    ];
+
+    const toolResultsMap = new Map<string, ToolCompletedData>([
+      [
+        "tool-shell",
+        {
+          tool_call_id: "tool-shell",
+          tool_name: "bash",
+          success: false,
+          status: "error",
+          result: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                stdout: "running 4 tests\n3 passed",
+                stderr: "test suite failed",
+                exit_code: 101,
+                success: false,
+              }),
+            },
+          ],
+        },
+      ],
+    ]);
+
+    render(<ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} />);
+
+    expect(screen.getByText("exit 101")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /details/i }));
+
+    expect(screen.getByText(/running 4 tests\s+3 passed/)).toBeInTheDocument();
+    expect(screen.getByText("test suite failed")).toBeInTheDocument();
+    expect(screen.queryByText("exit code 101")).not.toBeInTheDocument();
+    expect(screen.queryByText(/^output$/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^stderr$/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/"stdout":/)).not.toBeInTheDocument();
   });
 });

--- a/apps/ui/src/app/dev/tool-activity/page.tsx
+++ b/apps/ui/src/app/dev/tool-activity/page.tsx
@@ -80,7 +80,7 @@ const completedToolCalls: ToolCallContent[] = [
   {
     id: "tool-shell",
     name: "bash",
-    arguments: { command: "mv apps/web/src projects/ui/src" },
+    arguments: { command: "cargo test -p everruns-ui" },
   },
   {
     id: "tool-edit",
@@ -95,15 +95,20 @@ const completedToolResults = new Map<string, ToolCompletedData>([
     {
       tool_call_id: "tool-shell",
       tool_name: "bash",
-      success: true,
-      status: "success",
+      success: false,
+      status: "error",
       result: [
         {
           type: "text",
-          text: "$ mv apps/web/src projects/ui/src\nRenamed 18 files successfully.",
+          text: JSON.stringify({
+            stdout: "running 4 tests\n3 passed",
+            stderr: "thread 'tool_activity' panicked at assertion failed: left == right",
+            exit_code: 101,
+            success: false,
+          }),
         },
       ],
-      duration_ms: 380,
+      duration_ms: 910,
     },
   ],
   [

--- a/apps/ui/src/components/chat/bash-tool-call-card.tsx
+++ b/apps/ui/src/components/chat/bash-tool-call-card.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Check, Loader2, ChevronDown, ChevronRight, Terminal } from "lucide-react";
 import type { ToolCompletedData } from "@/lib/api/types";
+import { cn } from "@/lib/utils";
 import { getFullText, type ToolCallContent } from "./tool-call-utils";
 
 interface BashToolCallCardProps {
@@ -10,7 +11,7 @@ interface BashToolCallCardProps {
   toolResult?: ToolCompletedData;
 }
 
-interface BashOutput {
+export interface BashOutput {
   stdout: string;
   stderr: string;
   exit_code: number;
@@ -20,7 +21,7 @@ interface BashOutput {
 /**
  * Try to parse bash JSON output: {"stdout":"...","stderr":"...","exit_code":0,"success":true}
  */
-function parseBashOutput(text: string): BashOutput | null {
+export function parseBashOutput(text: string): BashOutput | null {
   try {
     const parsed = JSON.parse(text);
     if (
@@ -40,6 +41,75 @@ function parseBashOutput(text: string): BashOutput | null {
     // Not JSON — fall through
   }
   return null;
+}
+
+interface BashToolResultDetailsProps {
+  fullText: string;
+  containerClassName?: string;
+  stdoutClassName?: string;
+  stderrClassName?: string;
+  showExitCode?: boolean;
+  exitCodeClassName?: string;
+}
+
+export function BashToolResultDetails({
+  fullText,
+  containerClassName,
+  stdoutClassName,
+  stderrClassName,
+  showExitCode = true,
+  exitCodeClassName,
+}: BashToolResultDetailsProps) {
+  const bashOutput = parseBashOutput(fullText);
+
+  if (!bashOutput) {
+    return (
+      <pre
+        className={cn(
+          "max-h-60 overflow-x-auto whitespace-pre-wrap break-all rounded bg-muted/20 p-1.5 text-[10px] leading-tight",
+          containerClassName,
+        )}
+      >
+        {fullText}
+      </pre>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "space-y-0 rounded bg-muted/20 p-1.5 text-[10px] leading-tight",
+        containerClassName,
+      )}
+    >
+      {bashOutput.stdout && (
+        <pre
+          className={cn(
+            "max-h-60 overflow-x-auto whitespace-pre-wrap break-all text-inherit",
+            stdoutClassName,
+          )}
+        >
+          {bashOutput.stdout}
+        </pre>
+      )}
+      {bashOutput.stderr && (
+        <pre
+          className={cn(
+            "max-h-40 overflow-x-auto whitespace-pre-wrap break-all text-red-600/80 dark:text-red-400/80",
+            bashOutput.stdout && "mt-3 border-t border-red-400/20 pt-3",
+            stderrClassName,
+          )}
+        >
+          {bashOutput.stderr}
+        </pre>
+      )}
+      {showExitCode && bashOutput.exit_code !== 0 && (
+        <div className={cn("mt-3 text-[10px] text-red-500/70", exitCodeClassName)}>
+          exit code {bashOutput.exit_code}
+        </div>
+      )}
+    </div>
+  );
 }
 
 /**
@@ -63,8 +133,12 @@ export function BashToolCallCard({ toolCall, toolResult }: BashToolCallCardProps
   // Determine if there's meaningful output to show
   const hasStdout = !!bashOutput?.stdout;
   const hasStderr = !!bashOutput?.stderr;
-  const hasOutput = bashOutput ? hasStdout || hasStderr : fullText.length > 0;
+  const hasOutput = bashOutput
+    ? hasStdout || hasStderr || bashOutput.exit_code !== 0
+    : fullText.length > 0;
   const exitedWithError = bashOutput ? !bashOutput.success : hasError;
+  const exitCodeLabel =
+    bashOutput && bashOutput.exit_code !== 0 ? `exit ${bashOutput.exit_code}` : null;
 
   // Status icon
   const statusIcon = isComplete ? (
@@ -94,9 +168,16 @@ export function BashToolCallCard({ toolCall, toolResult }: BashToolCallCardProps
           onClick={() => hasOutput && setIsExpanded(!isExpanded)}
           className={`flex items-center gap-1 min-w-0 ${hasOutput ? "cursor-pointer hover:text-muted-foreground" : "cursor-default"}`}
         >
-          <span className="font-mono truncate">
-            <span className="opacity-50">$ </span>
-            {command ?? "bash"}
+          <span className="inline-flex min-w-0 items-baseline gap-2 font-mono">
+            <span className="truncate">
+              <span className="opacity-50">$ </span>
+              {command ?? "bash"}
+            </span>
+            {exitCodeLabel && (
+              <span className="flex-shrink-0 text-[10px] leading-none text-red-500/70">
+                {exitCodeLabel}
+              </span>
+            )}
           </span>
         </button>
         {durationLabel && (
@@ -128,34 +209,8 @@ export function BashToolCallCard({ toolCall, toolResult }: BashToolCallCardProps
 
       {/* Expanded output */}
       {isExpanded && (
-        <div className="mt-1 ml-[22px] space-y-0">
-          {bashOutput ? (
-            <>
-              {/* stdout */}
-              {hasStdout && (
-                <pre className="p-1.5 bg-muted/20 rounded text-[10px] leading-tight overflow-x-auto max-h-60 whitespace-pre-wrap break-all">
-                  {bashOutput.stdout}
-                </pre>
-              )}
-              {/* stderr */}
-              {hasStderr && (
-                <pre className="p-1.5 bg-red-500/5 border-l-2 border-red-400/30 rounded-r text-[10px] leading-tight overflow-x-auto max-h-40 whitespace-pre-wrap break-all text-red-600/80 dark:text-red-400/80">
-                  {bashOutput.stderr}
-                </pre>
-              )}
-              {/* Non-zero exit code */}
-              {bashOutput.exit_code !== 0 && (
-                <div className="text-[10px] text-red-500/70 mt-0.5">
-                  exit code {bashOutput.exit_code}
-                </div>
-              )}
-            </>
-          ) : (
-            /* Fallback: raw text output */
-            <pre className="p-1.5 bg-muted/20 rounded text-[10px] leading-tight overflow-x-auto max-h-60 whitespace-pre-wrap break-all">
-              {fullText}
-            </pre>
-          )}
+        <div className="mt-1 ml-[22px] space-y-2">
+          <BashToolResultDetails fullText={fullText} showExitCode={false} />
         </div>
       )}
     </div>

--- a/apps/ui/src/components/chat/tool-activity-group.tsx
+++ b/apps/ui/src/components/chat/tool-activity-group.tsx
@@ -21,7 +21,7 @@ import {
 import type { ToolCompletedData } from "@/lib/api/types";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { isBashTool } from "./bash-tool-call-card";
+import { BashToolResultDetails, isBashTool, parseBashOutput } from "./bash-tool-call-card";
 import { getFullText, type ToolCallContent } from "./tool-call-utils";
 import { TodoListRenderer, isWriteTodosTool } from "./todo-list-renderer";
 
@@ -183,6 +183,25 @@ function getResultPreview(result: ToolCompletedData | undefined): string | null 
   const fullText = getFullText(result?.result);
   if (!fullText) return null;
 
+  const bashOutput = parseBashOutput(fullText);
+  if (bashOutput) {
+    const previewSource = bashOutput.stdout || bashOutput.stderr;
+    const previewLine = previewSource
+      .split("\n")
+      .map((line) => line.trim())
+      .find((line) => line.length > 0);
+
+    if (previewLine) {
+      return previewLine.length > 120 ? `${previewLine.slice(0, 120)}...` : previewLine;
+    }
+
+    if (bashOutput.exit_code !== 0) {
+      return `exit code ${bashOutput.exit_code}`;
+    }
+
+    return null;
+  }
+
   const previewLine = fullText
     .split("\n")
     .map((line) => line.trim())
@@ -217,10 +236,16 @@ function ToolActivityRow({
 }) {
   const [isExpanded, setIsExpanded] = useState(false);
   const fullText = getFullText(toolResult?.result);
-  const hasOutput = fullText.length > 0;
-  const hasError = !!toolResult?.error;
+  const bashOutput = isBashTool(toolCall.name) ? parseBashOutput(fullText) : null;
+  const hasOutput = bashOutput
+    ? !!bashOutput.stdout || !!bashOutput.stderr || bashOutput.exit_code !== 0
+    : fullText.length > 0;
+  const hasToolError = !!toolResult?.error;
+  const hasError = hasToolError || (bashOutput ? !bashOutput.success : false);
   const isComplete = !!toolResult;
   const isRunning = !isComplete && !hasError;
+  const exitCodeLabel =
+    bashOutput && bashOutput.exit_code !== 0 ? `exit ${bashOutput.exit_code}` : null;
 
   return (
     <div
@@ -249,7 +274,14 @@ function ToolActivityRow({
             {isBashTool(toolCall.name) && mode === "server" && (
               <Terminal className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-primary/55" />
             )}
-            <span className="truncate text-sm text-foreground">{getToolLabel(toolCall)}</span>
+            <div className="min-w-0 inline-flex items-baseline gap-2">
+              <span className="truncate text-sm text-foreground">{getToolLabel(toolCall)}</span>
+              {exitCodeLabel && (
+                <span className="flex-shrink-0 text-[10px] leading-none uppercase tracking-[0.16em] text-red-500/75">
+                  {exitCodeLabel}
+                </span>
+              )}
+            </div>
             {isRunning && (
               <span className="animate-tool-pulse text-[10px] uppercase tracking-[0.18em] text-accent-foreground/70">
                 {mode === "client" ? "waiting" : "running"}
@@ -257,7 +289,7 @@ function ToolActivityRow({
             )}
           </div>
 
-          {hasError && (
+          {hasToolError && (
             <div className="mt-1 text-xs text-red-600 dark:text-red-400">{toolResult?.error}</div>
           )}
 
@@ -290,9 +322,15 @@ function ToolActivityRow({
           >
             <div className="min-h-0 overflow-hidden">
               {hasOutput && (
-                <pre className="overflow-x-auto border border-border/60 bg-background px-3 py-3 font-mono text-[11px] leading-relaxed text-muted-foreground/85">
-                  {fullText}
-                </pre>
+                <div className="font-mono text-[11px] leading-relaxed text-muted-foreground/85">
+                  <BashToolResultDetails
+                    fullText={fullText}
+                    containerClassName="border border-border/60 bg-background px-3 py-3 text-[11px] leading-relaxed text-muted-foreground/85 max-h-80"
+                    stdoutClassName="text-[11px] leading-relaxed text-muted-foreground/85"
+                    stderrClassName="border-red-400/25 pt-3 text-[11px] leading-relaxed text-red-700/85 dark:text-red-300/85"
+                    showExitCode={false}
+                  />
+                </div>
               )}
             </div>
           </div>

--- a/specs/maintenance.md
+++ b/specs/maintenance.md
@@ -24,6 +24,7 @@ Update all dependencies to latest versions (including major).
 3. Run `npm install` to regenerate `package-lock.json`
 4. Run `npm run lint` and `npm run build` — must pass
 5. Run `npm test` — must pass
+6. Treat smoke-test screenshots as review artifacts only; do not commit generated screenshot files to the repo
 
 **Docs (apps/docs):**
 1. Run `npm outdated` in `apps/docs/`


### PR DESCRIPTION
## What
Simplify bash tool result rendering in the chat UI and grouped tool activity view.

## Why
The recent Slate styling work regressed bash tool output by showing raw JSON-shaped details instead of native shell output. The expanded view was also too heavy for this case, and screenshot artifacts created during smoke testing were easy to mistake for committed assets.

## How
- restore structured bash result parsing in grouped tool activity rows
- render stdout as plain text and stderr as red text in a single minimal details box
- move non-zero exit codes into the row header instead of adding a footer line
- update the dev tool-activity fixture and component test coverage for structured bash results
- clarify in repo guidance that UI screenshots are validation artifacts and should not be committed

## Risk
- Low
- Main risk is visual regression in bash tool rows in the chat transcript and dev showcase pages

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered