### PR TITLE
fix(dev): isolate worktree port layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,9 +158,9 @@ PORT_PREFIX=271 just start-dev
 PORT_PREFIX=271 just start-all
 ```
 
-- `scripts/lib/services.sh`, `scripts/lib/docker.sh`, `scripts/lib/bench.sh`, and `local/Caddyfile` read `PORT_PREFIX`
-- Explicit `API_PORT`, `UI_PORT`, `PROXY_PORT`, and `DB_PORT` still override individual ports if needed
-- If `PORT_PREFIX` is unset, repo defaults stay `9000` (API), `9100` (UI), `9300` (proxy), `5432` (Postgres)
+- `scripts/lib/services.sh`, `scripts/lib/docker.sh`, `scripts/lib/bench.sh`, `example.just`, and `local/Caddyfile` read `PORT_PREFIX`
+- Explicit `API_PORT`, `WORKER_GRPC_PORT`, `UI_PORT`, `PROXY_PORT`, `VALKEY_PORT`, and `DB_PORT` still override individual ports if needed
+- If `PORT_PREFIX` is unset, repo defaults are `9300` (proxy), `9301` (API), `9001` (worker gRPC), `9305` (UI), `6379` (Valkey), `9332` (Postgres)
 - UI-only worktree iteration:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ docker compose up -d
 Access the platform:
 - **Web UI**: http://localhost:9300
 - **API**: http://localhost:9300/api/...
+- **Jaeger UI**: http://localhost:16686
+
+The published example compose file defaults to `9300` for the app entry point and `16686` for Jaeger. If you need to avoid host-port conflicts, override them with `EXAMPLE_PROXY_PORT` and `EXAMPLE_JAEGER_UI_PORT` before `docker compose up`.
 
 For detailed setup instructions, see the [Docker Compose Quickstart](https://docs.everruns.com/getting-started/docker-compose/).
 

--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -21,12 +21,12 @@ just start-all  # Start PostgreSQL, API, Worker, UI
 
 Migrations are applied automatically on server startup.
 
-The API will be available at `http://localhost:9000`
+The API will be available at `http://localhost:9301`
 
 ### 3. Access the API
 
-- **API**: http://localhost:9000/v1/...
-- **OpenAPI Spec**: http://localhost:9000/api-doc/openapi.json
+- **API**: http://localhost:9301/v1/...
+- **OpenAPI Spec**: http://localhost:9301/api-doc/openapi.json
 
 ## Examples
 
@@ -155,7 +155,7 @@ Default: `postgres://everruns:everruns@localhost:5432/everruns`
 ### Create an Agent
 
 ```bash
-curl -X POST http://localhost:9000/v1/agents \
+curl -X POST http://localhost:9301/v1/agents \
   -H "Content-Type: application/json" \
   -d '{
     "name": "Test Agent",
@@ -166,7 +166,7 @@ curl -X POST http://localhost:9000/v1/agents \
 ### List Agents
 
 ```bash
-curl http://localhost:9000/v1/agents | jq
+curl http://localhost:9301/v1/agents | jq
 ```
 
 ## Troubleshooting
@@ -188,7 +188,7 @@ just start-all
 
 ### Port Already in Use
 
-Check if another process is using port 9000:
+Check if another process is using port 9301:
 ```bash
-lsof -i :9000
+lsof -i :9301
 ```

--- a/crates/worker/src/durable_runner.rs
+++ b/crates/worker/src/durable_runner.rs
@@ -718,9 +718,9 @@ mod tests {
         assert!(runner.is_running(session_id).await);
     }
 
-    /// Test that start_run skips if workflow is already running
+    /// Test that start_run waits for the prior workflow to finish before reusing it.
     #[tokio::test]
-    async fn test_start_run_skips_if_running() {
+    async fn test_start_run_waits_for_running_workflow_to_finish() {
         use everruns_core::DEFAULT_ORG_ID;
 
         let runner = DurableRunner::new_in_memory();
@@ -745,7 +745,18 @@ mod tests {
 
         assert!(runner.is_running(session_id).await);
 
-        // Second message while still running - should skip (not error)
+        let store = runner.store.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+            let mut store = store.lock().await;
+            store
+                .update_workflow_status(session_id.uuid(), WorkflowStatus::Completed, None, None)
+                .await
+                .expect("Should complete existing workflow");
+        });
+
+        // Second message while still running - should wait, then reuse the workflow.
+        let start = std::time::Instant::now();
         runner
             .start_run(
                 DEFAULT_ORG_ID,
@@ -755,10 +766,16 @@ mod tests {
                 message_id2,
             )
             .await
-            .expect("Second start_run should skip gracefully");
+            .expect("Second start_run should wait and then succeed");
 
-        // Still running (not double-started)
-        assert!(runner.is_running(session_id).await);
+        assert!(
+            start.elapsed() >= std::time::Duration::from_millis(200),
+            "Second start_run should wait for the running workflow to finish"
+        );
+        assert!(
+            runner.is_running(session_id).await,
+            "Workflow should be running again after reuse"
+        );
     }
 
     /// Test that start_run resets a completed workflow for a second message

--- a/crates/worker/src/grpc_durable_store.rs
+++ b/crates/worker/src/grpc_durable_store.rs
@@ -662,7 +662,64 @@ fn proto_state_to_circuit_state(state: proto::CircuitBreakerState) -> CircuitSta
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{LazyLock, Mutex, MutexGuard};
     use tonic::service::Interceptor;
+
+    static TLS_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    struct TlsEnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        ca_cert: Option<String>,
+        cert: Option<String>,
+        key: Option<String>,
+        domain: Option<String>,
+    }
+
+    impl TlsEnvGuard {
+        fn new() -> Self {
+            let lock = TLS_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
+            Self {
+                _lock: lock,
+                ca_cert: std::env::var("WORKER_GRPC_TLS_CA_CERT").ok(),
+                cert: std::env::var("WORKER_GRPC_TLS_CERT").ok(),
+                key: std::env::var("WORKER_GRPC_TLS_KEY").ok(),
+                domain: std::env::var("WORKER_GRPC_TLS_DOMAIN").ok(),
+            }
+        }
+
+        fn set_var(&self, key: &str, value: &str) {
+            unsafe {
+                std::env::set_var(key, value);
+            }
+        }
+
+        fn remove_var(&self, key: &str) {
+            unsafe {
+                std::env::remove_var(key);
+            }
+        }
+    }
+
+    impl Drop for TlsEnvGuard {
+        fn drop(&mut self) {
+            restore_env_var("WORKER_GRPC_TLS_CA_CERT", self.ca_cert.as_deref());
+            restore_env_var("WORKER_GRPC_TLS_CERT", self.cert.as_deref());
+            restore_env_var("WORKER_GRPC_TLS_KEY", self.key.as_deref());
+            restore_env_var("WORKER_GRPC_TLS_DOMAIN", self.domain.as_deref());
+        }
+    }
+
+    fn restore_env_var(key: &str, value: Option<&str>) {
+        unsafe {
+            if let Some(value) = value {
+                std::env::set_var(key, value);
+            } else {
+                std::env::remove_var(key);
+            }
+        }
+    }
 
     #[test]
     fn test_workflow_status_is_terminal() {
@@ -675,6 +732,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_connect_fails_after_timeout_on_unavailable_server() {
+        let env = TlsEnvGuard::new();
+        env.remove_var("WORKER_GRPC_TLS_CA_CERT");
+        env.remove_var("WORKER_GRPC_TLS_CERT");
+        env.remove_var("WORKER_GRPC_TLS_KEY");
+        env.remove_var("WORKER_GRPC_TLS_DOMAIN");
+
         // Verify connection fails with clear error after retry timeout
         // when control-plane is unavailable
         let timeout = Duration::from_secs(5);
@@ -736,12 +799,11 @@ mod tests {
 
     #[test]
     fn test_grpc_client_tls_returns_none_when_no_env_vars() {
-        // SAFETY: single-threaded test; no other thread reads these vars concurrently
-        unsafe {
-            std::env::remove_var("WORKER_GRPC_TLS_CA_CERT");
-            std::env::remove_var("WORKER_GRPC_TLS_CERT");
-            std::env::remove_var("WORKER_GRPC_TLS_KEY");
-        }
+        let env = TlsEnvGuard::new();
+        env.remove_var("WORKER_GRPC_TLS_CA_CERT");
+        env.remove_var("WORKER_GRPC_TLS_CERT");
+        env.remove_var("WORKER_GRPC_TLS_KEY");
+        env.remove_var("WORKER_GRPC_TLS_DOMAIN");
 
         let config = grpc_client_tls_from_env();
         assert!(
@@ -752,64 +814,58 @@ mod tests {
 
     #[test]
     fn test_grpc_client_tls_returns_none_when_ca_cert_empty() {
-        unsafe {
-            std::env::set_var("WORKER_GRPC_TLS_CA_CERT", "");
-        }
+        let env = TlsEnvGuard::new();
+        env.set_var("WORKER_GRPC_TLS_CA_CERT", "");
         let config = grpc_client_tls_from_env();
         assert!(config.is_none());
-        unsafe { std::env::remove_var("WORKER_GRPC_TLS_CA_CERT") };
     }
 
     #[test]
     fn test_grpc_client_tls_returns_config_with_valid_ca() {
+        let env = TlsEnvGuard::new();
         let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
         let ca_path = format!("{}/tests/fixtures/test-ca.pem", manifest);
 
-        unsafe {
-            std::env::set_var("WORKER_GRPC_TLS_CA_CERT", &ca_path);
-            std::env::remove_var("WORKER_GRPC_TLS_CERT");
-            std::env::remove_var("WORKER_GRPC_TLS_KEY");
-        }
+        env.set_var("WORKER_GRPC_TLS_CA_CERT", &ca_path);
+        env.remove_var("WORKER_GRPC_TLS_CERT");
+        env.remove_var("WORKER_GRPC_TLS_KEY");
+        env.remove_var("WORKER_GRPC_TLS_DOMAIN");
 
         let config = grpc_client_tls_from_env();
         assert!(
             config.is_some(),
             "Should return Some when CA cert is configured"
         );
-
-        unsafe { std::env::remove_var("WORKER_GRPC_TLS_CA_CERT") };
     }
 
     #[test]
     fn test_grpc_client_tls_with_client_cert() {
+        let env = TlsEnvGuard::new();
         let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
         let ca_path = format!("{}/tests/fixtures/test-ca.pem", manifest);
         let cert_path = format!("{}/tests/fixtures/test-client-cert.pem", manifest);
         let key_path = format!("{}/tests/fixtures/test-client-key.pem", manifest);
 
-        unsafe {
-            std::env::set_var("WORKER_GRPC_TLS_CA_CERT", &ca_path);
-            std::env::set_var("WORKER_GRPC_TLS_CERT", &cert_path);
-            std::env::set_var("WORKER_GRPC_TLS_KEY", &key_path);
-        }
+        env.set_var("WORKER_GRPC_TLS_CA_CERT", &ca_path);
+        env.set_var("WORKER_GRPC_TLS_CERT", &cert_path);
+        env.set_var("WORKER_GRPC_TLS_KEY", &key_path);
+        env.remove_var("WORKER_GRPC_TLS_DOMAIN");
 
         let config = grpc_client_tls_from_env();
         assert!(
             config.is_some(),
             "Should return Some when CA+cert+key are configured"
         );
-
-        unsafe {
-            std::env::remove_var("WORKER_GRPC_TLS_CA_CERT");
-            std::env::remove_var("WORKER_GRPC_TLS_CERT");
-            std::env::remove_var("WORKER_GRPC_TLS_KEY");
-        }
     }
 
     #[test]
     #[should_panic(expected = "Failed to read WORKER_GRPC_TLS_CA_CERT")]
     fn test_grpc_client_tls_panics_on_missing_ca_file() {
-        unsafe { std::env::set_var("WORKER_GRPC_TLS_CA_CERT", "/nonexistent/ca.pem") };
+        let env = TlsEnvGuard::new();
+        env.set_var("WORKER_GRPC_TLS_CA_CERT", "/nonexistent/ca.pem");
+        env.remove_var("WORKER_GRPC_TLS_CERT");
+        env.remove_var("WORKER_GRPC_TLS_KEY");
+        env.remove_var("WORKER_GRPC_TLS_DOMAIN");
         let _config = grpc_client_tls_from_env();
     }
 }

--- a/docs/features/skills-registry.md
+++ b/docs/features/skills-registry.md
@@ -14,7 +14,7 @@ For an introduction to skills and the workspace-based workflow, see [Agent Skill
 Create a skill from a SKILL.md file:
 
 ```bash
-curl -X POST http://localhost:9000/v1/skills \
+curl -X POST http://localhost:9300/api/v1/skills \
   -H "Content-Type: application/json" \
   -d '{
     "skill_md": "---\nname: hello-world\ndescription: A simple greeting skill.\n---\n\n# Hello World\n\nGreet the user warmly."
@@ -26,7 +26,7 @@ curl -X POST http://localhost:9000/v1/skills \
 For skills with bundled scripts, references, or assets:
 
 ```bash
-curl -X POST http://localhost:9000/v1/skills/upload \
+curl -X POST http://localhost:9300/api/v1/skills/upload \
   -F "file=@csv-analyzer.zip"
 ```
 
@@ -50,7 +50,7 @@ Registry skills integrate into the capability system as virtual capabilities, ap
 ### Assigning to Agents
 
 ```bash
-curl -X POST http://localhost:9000/v1/agents \
+curl -X POST http://localhost:9300/api/v1/agents \
   -H "Content-Type: application/json" \
   -d '{
     "name": "Analyst Agent",
@@ -81,7 +81,7 @@ Skills automatically depend on `session_file_system` for reading bundled files.
 Use the validation endpoint to check a SKILL.md before creating:
 
 ```bash
-curl -X POST http://localhost:9000/v1/skills/validate \
+curl -X POST http://localhost:9300/api/v1/skills/validate \
   -H "Content-Type: application/json" \
   -d '{"skill_md": "---\nname: my-skill\ndescription: Does things.\n---\n\n# Instructions"}'
 ```

--- a/docs/features/skills.mdx
+++ b/docs/features/skills.mdx
@@ -87,7 +87,7 @@ Skills can be simple (just a `SKILL.md`) or include bundled scripts, references,
 Add the built-in `skills` capability to your agent to enable filesystem-based skill discovery:
 
 ```bash
-curl -X POST http://localhost:9000/v1/agents \
+curl -X POST http://localhost:9300/api/v1/agents \
   -H "Content-Type: application/json" \
   -d '{
     "name": "My Agent",

--- a/docs/getting-started/docker-compose.md
+++ b/docs/getting-started/docker-compose.md
@@ -50,6 +50,16 @@ docker compose pull  # Fetch latest images
 docker compose up -d
 ```
 
+The published compose file defaults to:
+- App entry point on `9300`
+- Jaeger UI on `16686`
+
+If those ports are busy, override them before startup:
+
+```bash
+EXAMPLE_PROXY_PORT=10300 EXAMPLE_JAEGER_UI_PORT=16687 docker compose up -d
+```
+
 This starts:
 - PostgreSQL database
 - Control plane API
@@ -68,6 +78,17 @@ This starts:
 | **Jaeger Tracing** | http://localhost:16686 |
 
 ## Configuration
+
+### Run Multiple Copies
+
+If you want multiple Everruns compose stacks on the same machine, set both a Compose project name and host-port overrides:
+
+```bash
+COMPOSE_PROJECT_NAME=everruns-demo-2 \
+EXAMPLE_PROXY_PORT=10300 \
+EXAMPLE_JAEGER_UI_PORT=16687 \
+docker compose up -d
+```
 
 ### Configure LLM Provider
 
@@ -120,7 +141,7 @@ Or modify `docker-compose.yaml` to add more worker services.
 docker compose logs -f
 
 # Specific service
-docker compose logs -f api
+docker compose logs -f server
 docker compose logs -f worker-1
 ```
 

--- a/docs/sre/environment-variables.md
+++ b/docs/sre/environment-variables.md
@@ -202,8 +202,8 @@ DEFAULT_GEMINI_API_KEY=AIza...
 The UI makes all API requests (including SSE) to `/api/*` paths. Caddy reverse proxy strips `/api` and forwards to the backend.
 
 **Local Development:**
-- Caddy on `:9300` routes `/api/*` to backend at `:9000` (strips `/api` prefix)
-- Example: `/api/v1/agents` → `http://localhost:9000/v1/agents`
+- Caddy on `:9300` routes `/api/*` to backend at `:9301` (strips `/api` prefix)
+- Example: `/api/v1/agents` → `http://localhost:9301/v1/agents`
 - SSE streaming works via `flush_interval -1` in Caddy config
 - No CORS needed (same-origin through Caddy)
 
@@ -249,7 +249,7 @@ WORKER_GRPC_ADDRESS=127.0.0.1:9001
 
 **Notes:**
 - Workers communicate with the control-plane via gRPC for all database operations
-- The control-plane exposes both HTTP (port 9000) and gRPC (port 9001) interfaces
+- The control-plane exposes both HTTP (local dev default `9301`) and gRPC (default `9001`) interfaces
 - Workers are stateless and do not connect directly to the database
 
 ### WORKER_GRPC_AUTH_TOKEN
@@ -472,7 +472,7 @@ The `local/docker-compose.yml` includes Jaeger for local trace visualization:
 
 ```bash
 # Start all services including Jaeger
-just start
+just start-all
 
 # Set OTLP endpoint for API and Worker
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
@@ -480,6 +480,8 @@ export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 # View traces at
 open http://localhost:16686
 ```
+
+These are the default host ports. When using `PORT_PREFIX`, the dev scripts remap them to isolated ports per worktree.
 
 ### Jaeger Ports
 
@@ -546,4 +548,3 @@ For setup instructions and configuration details, see the [Braintrust Integratio
 | `BRAINTRUST_PROJECT_NAME` | No | `My Project` | Project name for organizing traces |
 | `BRAINTRUST_PROJECT_ID` | No | - | Direct project UUID (skips name lookup) |
 | `BRAINTRUST_API_URL` | No | `https://api.braintrust.dev` | API base URL |
-

--- a/docs/tutorials/building-agents-using-sdk/index.md
+++ b/docs/tutorials/building-agents-using-sdk/index.md
@@ -577,7 +577,7 @@ graph TB
     end
 
     subgraph Control["Control Plane (Server)"]
-        REST["REST API<br/>:9000"]
+        REST["REST API<br/>:9301"]
         GRPC["gRPC Server<br/>:9001"]
         Services[Service Layer]
         DB[(PostgreSQL)]
@@ -616,7 +616,7 @@ graph TB
 ```
 
 **Control Plane** (Server) owns all state. It exposes two interfaces:
-- **REST API** (port 9000) — Internal API server
+- **REST API** (local direct port 9301) — Internal API server behind the local Caddy proxy
 - **gRPC** (port 9001) — Workers connect here (internal)
 
 A **Caddy reverse proxy** (port 9300) unifies the API and UI behind a single port. The SDK connects to `http://localhost:9300/api`.

--- a/example.just
+++ b/example.just
@@ -5,12 +5,17 @@
 start tag="latest":
     #!/usr/bin/env bash
     set -euo pipefail
+    source scripts/lib/common.sh
+    apply_port_prefix_defaults
+    : "${EXAMPLE_PROXY_PORT:=$PROXY_PORT}"
+    : "${EXAMPLE_JAEGER_UI_PORT:=$JAEGER_UI_PORT}"
+    : "${EXAMPLE_COMPOSE_PROJECT_NAME:=${COMPOSE_PROJECT_NAME}-example}"
     # Check if local docker compose containers are running (not from example compose)
     # We check the com.docker.compose.project label to distinguish local vs example containers
-    local_postgres=$(docker ps --filter "name=^everruns-postgres$" --filter "label=com.docker.compose.project=local" --format '{{"{{"}}.Names{{"}}"}}' 2>/dev/null || true)
-    local_jaeger=$(docker ps --filter "name=^everruns-jaeger$" --filter "label=com.docker.compose.project=local" --format '{{"{{"}}.Names{{"}}"}}' 2>/dev/null || true)
+    local_postgres=$(docker ps --filter "label=com.docker.compose.project=$COMPOSE_PROJECT_NAME" --filter "label=com.docker.compose.service=postgres" --format '{{"{{"}}.Names{{"}}"}}' 2>/dev/null || true)
+    local_jaeger=$(docker ps --filter "label=com.docker.compose.project=$COMPOSE_PROJECT_NAME" --filter "label=com.docker.compose.service=jaeger" --format '{{"{{"}}.Names{{"}}"}}' 2>/dev/null || true)
     if [[ -n "$local_postgres" || -n "$local_jaeger" ]]; then
-        echo "❌ Local docker compose appears to be running (found containers from 'local' project)."
+        echo "❌ Local docker compose appears to be running (project '$COMPOSE_PROJECT_NAME')."
         echo "   Stop it first with: just stop-docker"
         exit 1
     fi
@@ -41,24 +46,49 @@ start tag="latest":
 
     echo "✅ Local docker compose not running, starting example full stack..."
     cd examples
-    docker compose -f docker-compose-full.yaml up --pull always -d
+    docker compose --project-name "$EXAMPLE_COMPOSE_PROJECT_NAME" -f docker-compose-full.yaml up --pull always -d
     echo "✅ Example full stack started!"
-    echo "   - UI: http://localhost:9300"
-    echo "   - Jaeger UI: http://localhost:16686"
+    echo "   - UI: http://localhost:${EXAMPLE_PROXY_PORT}"
+    echo "   - Jaeger UI: http://localhost:${EXAMPLE_JAEGER_UI_PORT}"
 
 # Stop example docker-compose-full
 stop:
-    cd examples && docker compose -f docker-compose-full.yaml down
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source scripts/lib/common.sh
+    apply_port_prefix_defaults
+    export EXAMPLE_COMPOSE_PROJECT_NAME="${EXAMPLE_COMPOSE_PROJECT_NAME:-${COMPOSE_PROJECT_NAME}-example}"
+    cd examples
+    docker compose --project-name "$EXAMPLE_COMPOSE_PROJECT_NAME" -f docker-compose-full.yaml down
 
 # Reset example docker-compose-full (removes volumes)
 reset:
-    cd examples && docker compose -f docker-compose-full.yaml down -v
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source scripts/lib/common.sh
+    apply_port_prefix_defaults
+    export EXAMPLE_COMPOSE_PROJECT_NAME="${EXAMPLE_COMPOSE_PROJECT_NAME:-${COMPOSE_PROJECT_NAME}-example}"
+    cd examples
+    docker compose --project-name "$EXAMPLE_COMPOSE_PROJECT_NAME" -f docker-compose-full.yaml down -v
 
 # Follow logs from example docker-compose-full
 logs *args:
-    cd examples && docker compose -f docker-compose-full.yaml logs -f {{args}}
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source scripts/lib/common.sh
+    apply_port_prefix_defaults
+    export EXAMPLE_COMPOSE_PROJECT_NAME="${EXAMPLE_COMPOSE_PROJECT_NAME:-${COMPOSE_PROJECT_NAME}-example}"
+    cd examples
+    docker compose --project-name "$EXAMPLE_COMPOSE_PROJECT_NAME" -f docker-compose-full.yaml logs -f {{args}}
 
 # Pull latest images for example docker-compose-full
 # Optional: specify image tag (e.g., `just example pull v0.1.0`)
 pull tag="latest":
-    export EVERRUNS_TAG={{tag}} && cd examples && docker compose -f docker-compose-full.yaml pull
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source scripts/lib/common.sh
+    apply_port_prefix_defaults
+    export EVERRUNS_TAG={{tag}}
+    export EXAMPLE_COMPOSE_PROJECT_NAME="${EXAMPLE_COMPOSE_PROJECT_NAME:-${COMPOSE_PROJECT_NAME}-example}"
+    cd examples
+    docker compose --project-name "$EXAMPLE_COMPOSE_PROJECT_NAME" -f docker-compose-full.yaml pull

--- a/examples/agent_api_example.ipynb
+++ b/examples/agent_api_example.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "# Everruns Agent API Example\n\nThis notebook demonstrates how to use the Everruns API to:\n1. Create an agent with a system prompt\n2. Create a session (conversation)\n3. Send a message to trigger the agentic loop\n4. Read events until the assistant response appears\n5. Continue the conversation\n\n## Prerequisites\n\n- Everruns API server running at `http://localhost:9000`\n- Python packages: `requests`"
+   "source": "# Everruns Agent API Example\n\nThis notebook demonstrates how to use the Everruns API to:\n1. Create an agent with a system prompt\n2. Create a session (conversation)\n3. Send a message to trigger the agentic loop\n4. Read events until the assistant response appears\n5. Continue the conversation\n\n## Prerequisites\n\n- Everruns API server running at `http://localhost:9301`\n- Python packages: `requests`"
   },
   {
    "cell_type": "code",
@@ -17,7 +17,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "import requests\nimport json\nimport time\n\n# Configuration\nBASE_URL = \"http://localhost:9000\"\nAPI_V1 = f\"{BASE_URL}/v1\"\n\ndef print_json(data):\n    \"\"\"Pretty print JSON data.\"\"\"\n    print(json.dumps(data, indent=2, default=str))"
+   "source": "import requests\nimport json\nimport time\n\n# Configuration\nBASE_URL = \"http://localhost:9301\"\nAPI_V1 = f\"{BASE_URL}/v1\"\n\ndef print_json(data):\n    \"\"\"Pretty print JSON data.\"\"\"\n    print(json.dumps(data, indent=2, default=str))"
   },
   {
    "cell_type": "markdown",
@@ -144,7 +144,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Summary\n\nCore API workflow:\n\n1. `POST /v1/agents` - Create agent\n2. `POST /v1/sessions` - Create session (with agent_id in body)\n3. `POST /v1/sessions/{id}/messages` - Send user message (triggers agentic loop)\n4. `GET /v1/sessions/{id}/events` - Poll events to get agent response\n\n### Event Types\n\nEvents follow the pattern `{entity}.{action}` and contain all session activity:\n\n**Message Events:**\n- `message.user` - User message\n- `message.agent` - Agent response with content\n- `message.tool_call` - Tool invocation by agent\n- `message.tool_result` - Result of tool execution\n\n**Session Events:**\n- `session.started`, `session.completed`, `session.failed` - Session lifecycle\n\n**Step Events:**\n- `step.started`, `step.generating`, `step.generated`, `step.error` - Processing steps\n\nAPI docs: http://localhost:9000/swagger-ui/"
+   "source": "## Summary\n\nCore API workflow:\n\n1. `POST /v1/agents` - Create agent\n2. `POST /v1/sessions` - Create session (with agent_id in body)\n3. `POST /v1/sessions/{id}/messages` - Send user message (triggers agentic loop)\n4. `GET /v1/sessions/{id}/events` - Poll events to get agent response\n\n### Event Types\n\nEvents follow the pattern `{entity}.{action}` and contain all session activity:\n\n**Message Events:**\n- `message.user` - User message\n- `message.agent` - Agent response with content\n- `message.tool_call` - Tool invocation by agent\n- `message.tool_result` - Result of tool execution\n\n**Session Events:**\n- `session.started`, `session.completed`, `session.failed` - Session lifecycle\n\n**Step Events:**\n- `step.started`, `step.generating`, `step.generated`, `step.error` - Processing steps\n\nAPI docs: http://localhost:9301/swagger-ui/"
   }
  ],
  "metadata": {

--- a/examples/client_side_tools.sh
+++ b/examples/client_side_tools.sh
@@ -12,16 +12,16 @@
 #
 # Prerequisites:
 #   - jq installed (https://stedolan.github.io/jq/)
-#   - Everruns server running (default: http://localhost:9000)
+#   - Everruns server running (default: http://localhost:9301)
 #   - An LLM provider configured with an API key
 #
 # Usage:
 #   ./examples/client_side_tools.sh
-#   BASE_URL=http://my-server:9000 ./examples/client_side_tools.sh
+#   BASE_URL=http://my-server:9301 ./examples/client_side_tools.sh
 
 set -euo pipefail
 
-BASE_URL="${BASE_URL:-http://localhost:9000}"
+BASE_URL="${BASE_URL:-http://localhost:9301}"
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/examples/docker-compose-full.yaml
+++ b/examples/docker-compose-full.yaml
@@ -37,7 +37,6 @@ services:
   # ==========================================================================
   postgres:
     image: postgres:17-alpine
-    container_name: everruns-postgres
     environment:
       POSTGRES_USER: everruns
       POSTGRES_PASSWORD: everruns
@@ -55,7 +54,6 @@ services:
   # ==========================================================================
   valkey:
     image: valkey/valkey:8-alpine
-    container_name: everruns-valkey
     volumes:
       - valkey_data:/data
     healthcheck:
@@ -71,7 +69,6 @@ services:
   # ==========================================================================
   server:
     image: ghcr.io/everruns/everruns-server:${EVERRUNS_TAG:-latest}
-    container_name: everruns-server
     environment:
       DATABASE_URL: postgres://everruns:everruns@postgres:5432/everruns
       VALKEY_URL: redis://valkey:6379
@@ -81,7 +78,7 @@ services:
       DEFAULT_GEMINI_API_KEY: ${DEFAULT_GEMINI_API_KEY:-}
       WORKER_GRPC_AUTH_TOKEN: ${WORKER_GRPC_AUTH_TOKEN:-}
       HOST: 0.0.0.0
-      PORT: "9000"
+      PORT: "9301"
       RUST_LOG: info
       OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4318
     depends_on:
@@ -103,7 +100,6 @@ services:
   # ==========================================================================
   worker-1:
     image: ghcr.io/everruns/everruns-worker:${EVERRUNS_TAG:-latest}
-    container_name: everruns-worker-1
     environment:
       WORKER_GRPC_ADDRESS: server:9001
       WORKER_GRPC_AUTH_TOKEN: ${WORKER_GRPC_AUTH_TOKEN:-}
@@ -116,7 +112,6 @@ services:
 
   worker-2:
     image: ghcr.io/everruns/everruns-worker:${EVERRUNS_TAG:-latest}
-    container_name: everruns-worker-2
     environment:
       WORKER_GRPC_ADDRESS: server:9001
       WORKER_GRPC_AUTH_TOKEN: ${WORKER_GRPC_AUTH_TOKEN:-}
@@ -129,7 +124,6 @@ services:
 
   worker-3:
     image: ghcr.io/everruns/everruns-worker:${EVERRUNS_TAG:-latest}
-    container_name: everruns-worker-3
     environment:
       WORKER_GRPC_ADDRESS: server:9001
       WORKER_GRPC_AUTH_TOKEN: ${WORKER_GRPC_AUTH_TOKEN:-}
@@ -145,9 +139,8 @@ services:
   # ==========================================================================
   ui:
     image: ghcr.io/everruns/everruns-ui:${EVERRUNS_TAG:-latest}
-    container_name: everruns-ui
     environment:
-      PORT: "9100"
+      PORT: "9305"
       HOSTNAME: 0.0.0.0
     depends_on:
       server:
@@ -158,9 +151,8 @@ services:
   # ==========================================================================
   caddy:
     image: caddy:2-alpine
-    container_name: everruns-caddy
     ports:
-      - "9300:9300"
+      - "${EXAMPLE_PROXY_PORT:-9300}:9300"
     configs:
       - source: caddyfile
         target: /etc/caddy/Caddyfile
@@ -174,9 +166,8 @@ services:
   # ==========================================================================
   jaeger:
     image: jaegertracing/jaeger:2.4.0
-    container_name: everruns-jaeger
     ports:
-      - "16686:16686" # Jaeger UI
+      - "${EXAMPLE_JAEGER_UI_PORT:-16686}:16686" # Jaeger UI
     # OTLP ports exposed only to internal network
     expose:
       - "4317" # OTLP gRPC
@@ -205,19 +196,19 @@ configs:
       # SDK reconnects transparently (no retry budget cost).
       :9300 {
         handle_path /api/* {
-          reverse_proxy server:9000 {
+          reverse_proxy server:9301 {
             # Disable response buffering for SSE streaming
             flush_interval -1
           }
         }
         handle /api-doc/* {
-          reverse_proxy server:9000
+          reverse_proxy server:9301
         }
         handle /health {
-          reverse_proxy server:9000
+          reverse_proxy server:9301
         }
         handle {
-          reverse_proxy ui:9100
+          reverse_proxy ui:9305
         }
       }
 

--- a/examples/hackernews-reader/run.py
+++ b/examples/hackernews-reader/run.py
@@ -20,7 +20,7 @@ Usage:
     python examples/hackernews-reader/run.py "Show me the top 3 Ask HN posts"
 
     # With a custom server URL:
-    EVERRUNS_API_URL=http://localhost:9000 python examples/hackernews-reader/run.py
+    EVERRUNS_API_URL=http://localhost:9301 python examples/hackernews-reader/run.py
 """
 
 import asyncio
@@ -39,7 +39,7 @@ DEFAULT_PROMPT = (
 
 # Dev mode needs no real key; use EVERRUNS_API_KEY env var in production
 DEFAULT_API_KEY = "dev"
-DEFAULT_BASE_URL = "http://localhost:9000"
+DEFAULT_BASE_URL = "http://localhost:9301"
 
 
 async def main():

--- a/justfile
+++ b/justfile
@@ -61,7 +61,7 @@ test-integration: start-docker
     set -e
     # Wait for postgres
     for i in {1..30}; do
-        if pg_isready -h localhost -p 5432 -U everruns 2>/dev/null; then break; fi
+        if pg_isready -h localhost -p "${DB_PORT:-9332}" -U everruns 2>/dev/null; then break; fi
         sleep 1
     done
     # Run migrations

--- a/local/Caddyfile
+++ b/local/Caddyfile
@@ -1,9 +1,13 @@
 # Local development reverse proxy
 # Unifies API and UI behind a single port.
+admin :{$CADDY_ADMIN_PORT:2019}
+
 # Recommended:
 #   PORT_PREFIX=271  -> proxy 27100, api 27101, ui 27105
+# Default main checkout uses the same schema:
+#   proxy 9300, api 9301, ui 9305
 # Override individual ports with:
-#   API_PORT=9000 UI_PORT=9100 PROXY_PORT=9300
+#   API_PORT=9301 UI_PORT=9305 PROXY_PORT=9300 CADDY_ADMIN_PORT=2019
 #
 # Routes:
 #   /api/*     -> API server at :API_PORT (strips /api prefix)
@@ -17,18 +21,18 @@
 #   - SDK reconnects transparently on disconnecting events (no retry budget cost)
 :{$PROXY_PORT:9300} {
 	handle_path /api/* {
-		reverse_proxy localhost:{$API_PORT:9000} {
+		reverse_proxy localhost:{$API_PORT:9301} {
 			# Disable response buffering for SSE streaming
 			flush_interval -1
 		}
 	}
 	handle /api-doc/* {
-		reverse_proxy localhost:{$API_PORT:9000}
+		reverse_proxy localhost:{$API_PORT:9301}
 	}
 	handle /health {
-		reverse_proxy localhost:{$API_PORT:9000}
+		reverse_proxy localhost:{$API_PORT:9301}
 	}
 	handle {
-		reverse_proxy localhost:{$UI_PORT:9100}
+		reverse_proxy localhost:{$UI_PORT:9305}
 	}
 }

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       POSTGRES_PASSWORD: everruns
       POSTGRES_DB: everruns
     ports:
-      - "${DB_PORT:-5432}:5432"
+      - "${DB_PORT:-9332}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -18,7 +18,7 @@ services:
   valkey:
     image: valkey/valkey:8-alpine
     ports:
-      - "6379:6379"
+      - "${VALKEY_PORT:-6379}:6379"
     volumes:
       - valkey_data:/data
     healthcheck:
@@ -31,11 +31,11 @@ services:
     image: jaegertracing/jaeger:2.4.0
     ports:
       # OTLP gRPC receiver
-      - "4317:4317"
+      - "${OTEL_GRPC_PORT:-4317}:4317"
       # OTLP HTTP receiver
-      - "4318:4318"
+      - "${OTEL_HTTP_PORT:-4318}:4318"
       # Jaeger UI
-      - "16686:16686"
+      - "${JAEGER_UI_PORT:-16686}:16686"
 
 volumes:
   postgres_data:

--- a/scripts/cli-e2e-test.sh
+++ b/scripts/cli-e2e-test.sh
@@ -230,11 +230,7 @@ log_pass "agents delete completed"
 
 # Verify agent is archived or inaccessible after delete
 log_test "agents get (verify archived)"
-VERIFY_DELETE_OUTPUT=$($CLI --api-url "$API_URL" agents get "$AGENT_ID" --output json 2>&1) || {
-  log_pass "agents get correctly fails for deleted agent"
-}
-
-if [ -n "${VERIFY_DELETE_OUTPUT:-}" ]; then
+if VERIFY_DELETE_OUTPUT=$($CLI --api-url "$API_URL" agents get "$AGENT_ID" --output json 2>&1); then
   AGENT_STATUS=$(echo "$VERIFY_DELETE_OUTPUT" | jq -r '.status // empty')
   if [ "$AGENT_STATUS" = "archived" ]; then
     log_pass "agents get returned archived status after delete"
@@ -242,6 +238,8 @@ if [ -n "${VERIFY_DELETE_OUTPUT:-}" ]; then
     log_fail "agents get returned unexpected post-delete response"
     echo "$VERIFY_DELETE_OUTPUT"
   fi
+else
+  log_pass "agents get correctly fails for deleted agent"
 fi
 
 # ========================================

--- a/scripts/cli-e2e-test.sh
+++ b/scripts/cli-e2e-test.sh
@@ -3,7 +3,7 @@
 # Tests the everruns CLI against a running server
 #
 # Prerequisites:
-# - Server running at localhost:9000 (with worker)
+# - Server running at localhost:9301 (with worker)
 # - CLI binary built: cargo build -p everruns-cli
 # - EVERRUNS_API_KEY set (any value works with AUTH_MODE=none)
 #
@@ -18,7 +18,7 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$PROJECT_ROOT"
 
 # Configuration
-API_URL="${EVERRUNS_API_URL:-http://localhost:9000}"
+API_URL="${EVERRUNS_API_URL:-http://localhost:9301}"
 CLI="./target/debug/everruns"
 SKIP_CHAT="${1:-}"
 

--- a/scripts/cli-e2e-test.sh
+++ b/scripts/cli-e2e-test.sh
@@ -3,7 +3,7 @@
 # Tests the everruns CLI against a running server
 #
 # Prerequisites:
-# - Server running at localhost:9301 (with worker)
+# - Server running via local dev scripts (`localhost:9301` by default) or raw binary defaults (`localhost:9000`)
 # - CLI binary built: cargo build -p everruns-cli
 # - EVERRUNS_API_KEY set (any value works with AUTH_MODE=none)
 #
@@ -18,7 +18,34 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$PROJECT_ROOT"
 
 # Configuration
-API_URL="${EVERRUNS_API_URL:-http://localhost:9301}"
+detect_api_url() {
+  if [ -n "${EVERRUNS_API_URL:-}" ]; then
+    echo "$EVERRUNS_API_URL"
+    return
+  fi
+
+  if [ -n "${API_PORT:-}" ]; then
+    echo "http://localhost:${API_PORT}"
+    return
+  fi
+
+  if [ -n "${PORT_PREFIX:-}" ]; then
+    echo "http://localhost:${PORT_PREFIX}01"
+    return
+  fi
+
+  for candidate in "http://localhost:9301" "http://localhost:9000"; do
+    if curl -s "$candidate/health" > /dev/null 2>&1; then
+      echo "$candidate"
+      return
+    fi
+  done
+
+  # Prefer script-managed local dev defaults when nothing is up yet.
+  echo "http://localhost:9301"
+}
+
+API_URL="$(detect_api_url)"
 CLI="./target/debug/everruns"
 SKIP_CHAT="${1:-}"
 
@@ -201,12 +228,20 @@ DELETE_OUTPUT=$($CLI --api-url "$API_URL" agents delete "$AGENT_ID" --output jso
 }
 log_pass "agents delete completed"
 
-# Verify agent is deleted (should fail to get)
-log_test "agents get (verify deleted)"
-if $CLI --api-url "$API_URL" agents get "$AGENT_ID" --output json 2>&1; then
-  log_fail "agents get should fail for deleted agent"
-else
+# Verify agent is archived or inaccessible after delete
+log_test "agents get (verify archived)"
+VERIFY_DELETE_OUTPUT=$($CLI --api-url "$API_URL" agents get "$AGENT_ID" --output json 2>&1) || {
   log_pass "agents get correctly fails for deleted agent"
+}
+
+if [ -n "${VERIFY_DELETE_OUTPUT:-}" ]; then
+  AGENT_STATUS=$(echo "$VERIFY_DELETE_OUTPUT" | jq -r '.status // empty')
+  if [ "$AGENT_STATUS" = "archived" ]; then
+    log_pass "agents get returned archived status after delete"
+  else
+    log_fail "agents get returned unexpected post-delete response"
+    echo "$VERIFY_DELETE_OUTPUT"
+  fi
 fi
 
 # ========================================

--- a/scripts/lib/bench.sh
+++ b/scripts/lib/bench.sh
@@ -75,7 +75,11 @@ case "$cmd" in
 
     echo "1️⃣  Checking PostgreSQL connection..."
 
-    if check_postgres_ready "$DB_HOST" "$DB_PORT" "${DB_USER:-postgres}"; then
+    if docker_compose_service_running postgres && check_postgres_ready "$DB_HOST" "$DB_PORT" everruns; then
+      echo "   ✅ Docker PostgreSQL is ready"
+      DB_USER="everruns"
+      DB_PASS="everruns"
+    elif check_postgres_ready "$DB_HOST" "$DB_PORT" "${DB_USER:-postgres}"; then
       echo "   ✅ Local PostgreSQL is ready"
       DB_USER="${DB_USER:-postgres}"
       DB_PASS="${DB_PASS:-postgres}"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 # Get project root (two levels up from lib/)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
+RUN_STATE_DIR="${TMPDIR:-/tmp}/everruns-run-$(printf '%s' "$PROJECT_ROOT" | cksum | awk '{print $1}')"
 
 cd "$PROJECT_ROOT"
 
@@ -62,22 +63,47 @@ ensure_docker_daemon() {
   return 1
 }
 
+docker_compose_service_running() {
+  local service="$1"
+
+  if ! command -v docker &> /dev/null; then
+    return 1
+  fi
+
+  docker ps \
+    --filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME}" \
+    --filter "label=com.docker.compose.service=${service}" \
+    -q 2>/dev/null | grep -q .
+}
+
 apply_port_prefix_defaults() {
   if [ -n "${PORT_PREFIX:-}" ]; then
     : "${PROXY_PORT:=${PORT_PREFIX}00}"
     : "${API_PORT:=${PORT_PREFIX}01}"
+    : "${WORKER_GRPC_PORT:=${PORT_PREFIX}02}"
+    : "${CADDY_ADMIN_PORT:=${PORT_PREFIX}03}"
     : "${UI_PORT:=${PORT_PREFIX}05}"
+    : "${OTEL_GRPC_PORT:=${PORT_PREFIX}17}"
+    : "${OTEL_HTTP_PORT:=${PORT_PREFIX}18}"
+    : "${VALKEY_PORT:=${PORT_PREFIX}79}"
+    : "${JAEGER_UI_PORT:=${PORT_PREFIX}86}"
     : "${DB_PORT:=${PORT_PREFIX}32}"
     : "${COMPOSE_PROJECT_NAME:=everruns-${PORT_PREFIX}}"
   else
-    : "${API_PORT:=9000}"
-    : "${UI_PORT:=9100}"
     : "${PROXY_PORT:=9300}"
-    : "${DB_PORT:=5432}"
+    : "${API_PORT:=9301}"
+    : "${WORKER_GRPC_PORT:=9001}"
+    : "${CADDY_ADMIN_PORT:=2019}"
+    : "${UI_PORT:=9305}"
+    : "${OTEL_GRPC_PORT:=4317}"
+    : "${OTEL_HTTP_PORT:=4318}"
+    : "${VALKEY_PORT:=6379}"
+    : "${JAEGER_UI_PORT:=16686}"
+    : "${DB_PORT:=9332}"
     : "${COMPOSE_PROJECT_NAME:=everruns}"
   fi
 
-  export PORT_PREFIX API_PORT UI_PORT PROXY_PORT DB_PORT COMPOSE_PROJECT_NAME
+  export PORT_PREFIX API_PORT WORKER_GRPC_PORT CADDY_ADMIN_PORT UI_PORT PROXY_PORT OTEL_GRPC_PORT OTEL_HTTP_PORT VALKEY_PORT JAEGER_UI_PORT DB_PORT COMPOSE_PROJECT_NAME RUN_STATE_DIR
 }
 
 # Check if npm dependencies need to be installed/updated

--- a/scripts/lib/docker.sh
+++ b/scripts/lib/docker.sh
@@ -15,9 +15,9 @@ case "$cmd" in
     "${DOCKER_COMPOSE[@]}" up -d
     echo "✅ Services started!"
     echo "   - Postgres: localhost:${DB_PORT}"
-    echo "   - Valkey:   localhost:6379"
-    echo "   - Jaeger UI: http://localhost:16686"
-    echo "   - OTLP gRPC: localhost:4317"
+    echo "   - Valkey:   localhost:${VALKEY_PORT}"
+    echo "   - Jaeger UI: http://localhost:${JAEGER_UI_PORT}"
+    echo "   - OTLP gRPC: localhost:${OTEL_GRPC_PORT}"
     ;;
 
   stop)

--- a/scripts/lib/services.sh
+++ b/scripts/lib/services.sh
@@ -20,8 +20,68 @@ done
 
 apply_port_prefix_defaults
 API_ADDR_DEFAULT="0.0.0.0:${API_PORT}"
+WORKER_GRPC_ADDR_DEFAULT="0.0.0.0:${WORKER_GRPC_PORT}"
+WORKER_GRPC_ADDRESS_DEFAULT="127.0.0.1:${WORKER_GRPC_PORT}"
 PROXY_URL_DEFAULT="http://localhost:${PROXY_PORT}"
+VALKEY_URL_DEFAULT="redis://localhost:${VALKEY_PORT}"
 DB_URL_DEFAULT="postgres://everruns:everruns@localhost:${DB_PORT}/everruns"
+
+ensure_run_state_dir() {
+  mkdir -p "$RUN_STATE_DIR"
+}
+
+clear_run_state_dir() {
+  rm -rf "$RUN_STATE_DIR"
+}
+
+record_pid() {
+  local name="$1"
+  local pid="$2"
+
+  ensure_run_state_dir
+  printf '%s\n' "$pid" > "$RUN_STATE_DIR/${name}.pid"
+}
+
+check_valkey_ready() {
+  local port="${1:?port required}"
+
+  if command -v valkey-cli &> /dev/null; then
+    valkey-cli -p "$port" ping 2>/dev/null | grep -q PONG
+    return $?
+  fi
+
+  if command -v redis-cli &> /dev/null; then
+    redis-cli -p "$port" ping 2>/dev/null | grep -q PONG
+    return $?
+  fi
+
+  if command -v nc &> /dev/null; then
+    nc -z localhost "$port" >/dev/null 2>&1
+    return $?
+  fi
+
+  if (echo >"/dev/tcp/127.0.0.1/$port") >/dev/null 2>&1; then
+    return 0
+  fi
+
+  return 1
+}
+
+signal_recorded_pids() {
+  local signal="$1"
+
+  [ -d "$RUN_STATE_DIR" ] || return 0
+
+  local pid_file pid
+  for pid_file in "$RUN_STATE_DIR"/*.pid; do
+    [ -e "$pid_file" ] || continue
+    pid="$(cat "$pid_file" 2>/dev/null || true)"
+    [ -n "$pid" ] || continue
+    if kill -0 "$pid" 2>/dev/null; then
+      kill "-$signal" "$pid" 2>/dev/null || true
+    fi
+  done
+}
 
 # require_command is defined in common.sh (sourced above)
 
@@ -46,6 +106,7 @@ case "$cmd" in
   server)
     echo "🌐 Starting server..."
     export ADDR=${ADDR:-$API_ADDR_DEFAULT}
+    export WORKER_GRPC_ADDR=${WORKER_GRPC_ADDR:-$WORKER_GRPC_ADDR_DEFAULT}
     export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-$PROXY_URL_DEFAULT}
     export PUBLIC_APP_URL=${PUBLIC_APP_URL:-$PROXY_URL_DEFAULT}
     export APP_URL=${APP_URL:-$PUBLIC_APP_URL}
@@ -54,6 +115,7 @@ case "$cmd" in
 
   worker)
     echo "⚙️  Starting worker..."
+    export WORKER_GRPC_ADDRESS=${WORKER_GRPC_ADDRESS:-$WORKER_GRPC_ADDRESS_DEFAULT}
     cargo run -p everruns-worker
     ;;
 
@@ -61,6 +123,7 @@ case "$cmd" in
     echo "👀 Starting server with auto-reload..."
     require_command cargo-watch "Run: just init"
     export ADDR=${ADDR:-$API_ADDR_DEFAULT}
+    export WORKER_GRPC_ADDR=${WORKER_GRPC_ADDR:-$WORKER_GRPC_ADDR_DEFAULT}
     export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-$PROXY_URL_DEFAULT}
     export PUBLIC_APP_URL=${PUBLIC_APP_URL:-$PROXY_URL_DEFAULT}
     export APP_URL=${APP_URL:-$PUBLIC_APP_URL}
@@ -70,6 +133,7 @@ case "$cmd" in
   watch-worker)
     echo "👀 Starting worker with auto-reload..."
     require_command cargo-watch "Run: just init"
+    export WORKER_GRPC_ADDRESS=${WORKER_GRPC_ADDRESS:-$WORKER_GRPC_ADDRESS_DEFAULT}
     cargo watch -w crates -x 'run -p everruns-worker'
     ;;
 
@@ -86,6 +150,7 @@ case "$cmd" in
     # Track child PIDs for cleanup
     CHILD_PIDS=()
     CLEANUP_DONE=false
+    clear_run_state_dir
 
     cleanup() {
       # Prevent multiple cleanup runs
@@ -108,12 +173,7 @@ case "$cmd" in
         fi
       done
 
-      # Kill by name (catches any child processes we didn't track directly)
-      pkill -TERM -f "caddy run" 2>/dev/null || true
-      pkill -TERM -f "cargo-watch" 2>/dev/null || true
-      pkill -TERM -f "everruns-server" 2>/dev/null || true
-      pkill -TERM -f "next dev" 2>/dev/null || true
-      pkill -TERM -f "next-router-worker" 2>/dev/null || true
+      signal_recorded_pids TERM
 
       # Give processes time to terminate gracefully
       sleep 1
@@ -124,11 +184,8 @@ case "$cmd" in
           kill -KILL "$pid" 2>/dev/null || true
         fi
       done
-      pkill -KILL -f "caddy run" 2>/dev/null || true
-      pkill -KILL -f "cargo-watch" 2>/dev/null || true
-      pkill -KILL -f "everruns-server" 2>/dev/null || true
-      pkill -KILL -f "next dev" 2>/dev/null || true
-      pkill -KILL -f "next-router-worker" 2>/dev/null || true
+      signal_recorded_pids KILL
+      clear_run_state_dir
 
       # Restore terminal state
       stty sane 2>/dev/null || true
@@ -141,8 +198,9 @@ case "$cmd" in
     # Enable dev mode
     export DEV_MODE=true
     export DEPLOYMENT_GRADE=dev
-    export API_PORT UI_PORT PROXY_PORT
+    export API_PORT WORKER_GRPC_PORT CADDY_ADMIN_PORT UI_PORT PROXY_PORT VALKEY_PORT
     export ADDR=${ADDR:-$API_ADDR_DEFAULT}
+    export WORKER_GRPC_ADDR=${WORKER_GRPC_ADDR:-$WORKER_GRPC_ADDR_DEFAULT}
     export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-$PROXY_URL_DEFAULT}
     export PUBLIC_APP_URL=${PUBLIC_APP_URL:-$PROXY_URL_DEFAULT}
     export APP_URL=${APP_URL:-$PUBLIC_APP_URL}
@@ -194,6 +252,7 @@ case "$cmd" in
     fi
     API_PID=$!
     CHILD_PIDS+=("$API_PID")
+    record_pid api "$API_PID"
     sleep 3
 
     # Wait for server
@@ -218,6 +277,7 @@ case "$cmd" in
     run_ui_dev &
     UI_PID=$!
     CHILD_PIDS+=("$UI_PID")
+    record_pid ui "$UI_PID"
     cd "$PROJECT_ROOT"
     sleep 5
     echo "   ✅ UI is starting (PID: $UI_PID)"
@@ -227,6 +287,7 @@ case "$cmd" in
     caddy run --config "$PROJECT_ROOT/local/Caddyfile" --adapter caddyfile &
     CADDY_PID=$!
     CHILD_PIDS+=("$CADDY_PID")
+    record_pid caddy "$CADDY_PID"
     sleep 1
     echo "   ✅ Reverse proxy is running on :${PROXY_PORT} (PID: $CADDY_PID)"
 
@@ -268,6 +329,7 @@ case "$cmd" in
     CHILD_PIDS=()
     JAEGER_STARTED=false
     CLEANUP_DONE=false
+    clear_run_state_dir
 
     cleanup() {
       # Prevent multiple cleanup runs
@@ -290,13 +352,7 @@ case "$cmd" in
         fi
       done
 
-      # Kill by name (catches any child processes we didn't track directly)
-      pkill -TERM -f "caddy run" 2>/dev/null || true
-      pkill -TERM -f "cargo-watch" 2>/dev/null || true
-      pkill -TERM -f "everruns-server" 2>/dev/null || true
-      pkill -TERM -f "everruns-worker" 2>/dev/null || true
-      pkill -TERM -f "next dev" 2>/dev/null || true
-      pkill -TERM -f "next-router-worker" 2>/dev/null || true
+      signal_recorded_pids TERM
 
       # Give processes time to terminate gracefully
       sleep 1
@@ -307,12 +363,8 @@ case "$cmd" in
           kill -KILL "$pid" 2>/dev/null || true
         fi
       done
-      pkill -KILL -f "caddy run" 2>/dev/null || true
-      pkill -KILL -f "cargo-watch" 2>/dev/null || true
-      pkill -KILL -f "everruns-server" 2>/dev/null || true
-      pkill -KILL -f "everruns-worker" 2>/dev/null || true
-      pkill -KILL -f "next dev" 2>/dev/null || true
-      pkill -KILL -f "next-router-worker" 2>/dev/null || true
+      signal_recorded_pids KILL
+      clear_run_state_dir
 
       # Restore terminal state
       stty sane 2>/dev/null || true
@@ -336,24 +388,10 @@ case "$cmd" in
       fi
       export OTEL_SDK_DISABLED=true
       echo "   ℹ️  OpenTelemetry disabled (--no-docker)"
-    elif check_postgres_ready localhost "$DB_PORT" postgres; then
-      echo "   ✅ Local PostgreSQL is ready"
-      export DATABASE_URL=${DATABASE_URL:-postgres://postgres:postgres@localhost:${DB_PORT}/everruns}
-      if resolve_docker_compose 2>/dev/null; then
-        if ! docker ps 2>/dev/null | grep -q jaeger; then
-          echo "   ℹ️  Starting Jaeger for tracing..."
-          ensure_docker_daemon || true
-          cd "$PROJECT_ROOT/local"
-          "${DOCKER_COMPOSE[@]}" up -d jaeger 2>/dev/null && JAEGER_STARTED=true
-          cd "$PROJECT_ROOT"
-        else
-          JAEGER_STARTED=true
-        fi
-      fi
-    elif command -v docker &> /dev/null && docker ps 2>/dev/null | grep -q postgres; then
+    elif docker_compose_service_running postgres && check_postgres_ready localhost "$DB_PORT" everruns; then
       echo "   ✅ Docker PostgreSQL is ready"
       export DATABASE_URL=${DATABASE_URL:-$DB_URL_DEFAULT}
-      if ! docker ps 2>/dev/null | grep -q jaeger; then
+      if ! docker_compose_service_running jaeger; then
         echo "   ℹ️  Starting Jaeger for tracing..."
         if resolve_docker_compose 2>/dev/null; then
           cd "$PROJECT_ROOT/local"
@@ -362,6 +400,20 @@ case "$cmd" in
         fi
       else
         JAEGER_STARTED=true
+      fi
+    elif check_postgres_ready localhost "$DB_PORT" postgres; then
+      echo "   ✅ Local PostgreSQL is ready"
+      export DATABASE_URL=${DATABASE_URL:-postgres://postgres:postgres@localhost:${DB_PORT}/everruns}
+      if resolve_docker_compose 2>/dev/null; then
+        if ! docker_compose_service_running jaeger; then
+          echo "   ℹ️  Starting Jaeger for tracing..."
+          ensure_docker_daemon || true
+          cd "$PROJECT_ROOT/local"
+          "${DOCKER_COMPOSE[@]}" up -d jaeger 2>/dev/null && JAEGER_STARTED=true
+          cd "$PROJECT_ROOT"
+        else
+          JAEGER_STARTED=true
+        fi
       fi
     else
       echo "   ⚠️  PostgreSQL not found. Starting via Docker..."
@@ -391,24 +443,25 @@ case "$cmd" in
 
     # Start Valkey for distributed rate limiting
     if [ "$NO_DOCKER" = true ]; then
-      if command -v valkey-cli &> /dev/null && valkey-cli ping 2>/dev/null | grep -q PONG; then
-        export VALKEY_URL=${VALKEY_URL:-redis://localhost:6379}
+      if check_valkey_ready "$VALKEY_PORT"; then
+        export VALKEY_URL=${VALKEY_URL:-$VALKEY_URL_DEFAULT}
         echo "   ✅ Local Valkey ready (distributed rate limiting enabled)"
-      elif command -v redis-cli &> /dev/null && redis-cli ping 2>/dev/null | grep -q PONG; then
-        export VALKEY_URL=${VALKEY_URL:-redis://localhost:6379}
-        echo "   ✅ Local Redis-compatible server ready (distributed rate limiting enabled)"
       else
         echo "   ℹ️  Valkey not available — using per-instance rate limiting"
       fi
     elif [ -z "${VALKEY_URL:-}" ]; then
       if resolve_docker_compose 2>/dev/null; then
-        if ! docker ps 2>/dev/null | grep -q valkey; then
+        if ! docker_compose_service_running valkey; then
           echo "   ℹ️  Starting Valkey for distributed rate limiting..."
           cd "$PROJECT_ROOT/local"
           "${DOCKER_COMPOSE[@]}" up -d valkey 2>/dev/null
           cd "$PROJECT_ROOT"
         fi
-        export VALKEY_URL=${VALKEY_URL:-redis://localhost:6379}
+        until check_valkey_ready "$VALKEY_PORT"; do
+          echo "   Waiting for Valkey to be ready..."
+          sleep 1
+        done
+        export VALKEY_URL=${VALKEY_URL:-$VALKEY_URL_DEFAULT}
         echo "   ✅ Valkey started (distributed rate limiting enabled)"
       fi
     fi
@@ -437,8 +490,10 @@ case "$cmd" in
     fi
 
     # Start API
-    export API_PORT UI_PORT PROXY_PORT
+    export API_PORT WORKER_GRPC_PORT CADDY_ADMIN_PORT UI_PORT PROXY_PORT VALKEY_PORT
     export ADDR=${ADDR:-$API_ADDR_DEFAULT}
+    export WORKER_GRPC_ADDR=${WORKER_GRPC_ADDR:-$WORKER_GRPC_ADDR_DEFAULT}
+    export WORKER_GRPC_ADDRESS=${WORKER_GRPC_ADDRESS:-$WORKER_GRPC_ADDRESS_DEFAULT}
     export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-$PROXY_URL_DEFAULT}
     export PUBLIC_APP_URL=${PUBLIC_APP_URL:-$PROXY_URL_DEFAULT}
     export APP_URL=${APP_URL:-$PUBLIC_APP_URL}
@@ -455,6 +510,7 @@ case "$cmd" in
     fi
     API_PID=$!
     CHILD_PIDS+=("$API_PID")
+    record_pid api "$API_PID"
     sleep 3
 
     # Wait for API
@@ -516,6 +572,7 @@ case "$cmd" in
     start_worker_with_restart &
     WORKER_PID=$!
     CHILD_PIDS+=("$WORKER_PID")
+    record_pid worker "$WORKER_PID"
     sleep 2
     echo "   ✅ Worker is starting (PID: $WORKER_PID)"
 
@@ -530,6 +587,7 @@ case "$cmd" in
       run_ui_dev &
       UI_PID=$!
       CHILD_PIDS+=("$UI_PID")
+      record_pid ui "$UI_PID"
       cd "$PROJECT_ROOT"
       sleep 5
       echo "   ✅ UI is starting (PID: $UI_PID)"
@@ -539,6 +597,7 @@ case "$cmd" in
       caddy run --config "$PROJECT_ROOT/local/Caddyfile" --adapter caddyfile &
       CADDY_PID=$!
       CHILD_PIDS+=("$CADDY_PID")
+      record_pid caddy "$CADDY_PID"
       sleep 1
       echo "   ✅ Reverse proxy is running on :${PROXY_PORT} (PID: $CADDY_PID)"
     else
@@ -565,7 +624,7 @@ case "$cmd" in
       echo "   ⚙️ Worker:      running"
     fi
     if [ "$JAEGER_STARTED" = true ]; then
-      echo "   🔍 Jaeger UI:   http://localhost:16686"
+      echo "   🔍 Jaeger UI:   http://localhost:${JAEGER_UI_PORT}"
     elif [ "$NO_DOCKER" = false ]; then
       echo "   🔍 Jaeger:      disabled (no Docker)"
     fi
@@ -611,10 +670,7 @@ case "$cmd" in
         fi
       done
 
-      pkill -TERM -f "caddy run" 2>/dev/null || true
-      pkill -TERM -f "everruns-server" 2>/dev/null || true
-      pkill -TERM -f "everruns-worker" 2>/dev/null || true
-      pkill -TERM -f "next-server" 2>/dev/null || true
+      signal_recorded_pids TERM
 
       sleep 1
 
@@ -623,10 +679,8 @@ case "$cmd" in
           kill -KILL "$pid" 2>/dev/null || true
         fi
       done
-      pkill -KILL -f "caddy run" 2>/dev/null || true
-      pkill -KILL -f "everruns-server" 2>/dev/null || true
-      pkill -KILL -f "everruns-worker" 2>/dev/null || true
-      pkill -KILL -f "next-server" 2>/dev/null || true
+      signal_recorded_pids KILL
+      clear_run_state_dir
 
       stty sane 2>/dev/null || true
       echo "✅ Services stopped (Docker still running if started)"
@@ -648,11 +702,11 @@ case "$cmd" in
       fi
       export OTEL_SDK_DISABLED=true
       echo "   ℹ️  OpenTelemetry disabled (--no-docker)"
-    elif check_postgres_ready localhost "$DB_PORT" postgres; then
-      echo "   ✅ Local PostgreSQL is ready"
-      export DATABASE_URL=${DATABASE_URL:-postgres://postgres:postgres@localhost:${DB_PORT}/everruns}
+    elif docker_compose_service_running postgres && check_postgres_ready localhost "$DB_PORT" everruns; then
+      echo "   ✅ Docker PostgreSQL is ready"
+      export DATABASE_URL=${DATABASE_URL:-$DB_URL_DEFAULT}
       if resolve_docker_compose 2>/dev/null; then
-        if ! docker ps 2>/dev/null | grep -q jaeger; then
+        if ! docker_compose_service_running jaeger; then
           echo "   ℹ️  Starting Jaeger for tracing..."
           ensure_docker_daemon || true
           cd "$PROJECT_ROOT/local"
@@ -662,18 +716,19 @@ case "$cmd" in
           JAEGER_STARTED=true
         fi
       fi
-    elif command -v docker &> /dev/null && docker ps 2>/dev/null | grep -q postgres; then
-      echo "   ✅ Docker PostgreSQL is ready"
-      export DATABASE_URL=${DATABASE_URL:-$DB_URL_DEFAULT}
-      if ! docker ps 2>/dev/null | grep -q jaeger; then
-        echo "   ℹ️  Starting Jaeger for tracing..."
-        if resolve_docker_compose 2>/dev/null; then
+    elif check_postgres_ready localhost "$DB_PORT" postgres; then
+      echo "   ✅ Local PostgreSQL is ready"
+      export DATABASE_URL=${DATABASE_URL:-postgres://postgres:postgres@localhost:${DB_PORT}/everruns}
+      if resolve_docker_compose 2>/dev/null; then
+        if ! docker_compose_service_running jaeger; then
+          echo "   ℹ️  Starting Jaeger for tracing..."
+          ensure_docker_daemon || true
           cd "$PROJECT_ROOT/local"
           "${DOCKER_COMPOSE[@]}" up -d jaeger 2>/dev/null && JAEGER_STARTED=true
           cd "$PROJECT_ROOT"
+        else
+          JAEGER_STARTED=true
         fi
-      else
-        JAEGER_STARTED=true
       fi
     else
       echo "   ⚠️  PostgreSQL not found. Starting via Docker..."
@@ -703,24 +758,25 @@ case "$cmd" in
 
     # Start Valkey for distributed rate limiting
     if [ "$NO_DOCKER" = true ]; then
-      if command -v valkey-cli &> /dev/null && valkey-cli ping 2>/dev/null | grep -q PONG; then
-        export VALKEY_URL=${VALKEY_URL:-redis://localhost:6379}
+      if check_valkey_ready "$VALKEY_PORT"; then
+        export VALKEY_URL=${VALKEY_URL:-$VALKEY_URL_DEFAULT}
         echo "   ✅ Local Valkey ready (distributed rate limiting enabled)"
-      elif command -v redis-cli &> /dev/null && redis-cli ping 2>/dev/null | grep -q PONG; then
-        export VALKEY_URL=${VALKEY_URL:-redis://localhost:6379}
-        echo "   ✅ Local Redis-compatible server ready (distributed rate limiting enabled)"
       else
         echo "   ℹ️  Valkey not available — using per-instance rate limiting"
       fi
     elif [ -z "${VALKEY_URL:-}" ]; then
       if resolve_docker_compose 2>/dev/null; then
-        if ! docker ps 2>/dev/null | grep -q valkey; then
+        if ! docker_compose_service_running valkey; then
           echo "   ℹ️  Starting Valkey for distributed rate limiting..."
           cd "$PROJECT_ROOT/local"
           "${DOCKER_COMPOSE[@]}" up -d valkey 2>/dev/null
           cd "$PROJECT_ROOT"
         fi
-        export VALKEY_URL=${VALKEY_URL:-redis://localhost:6379}
+        until check_valkey_ready "$VALKEY_PORT"; do
+          echo "   Waiting for Valkey to be ready..."
+          sleep 1
+        done
+        export VALKEY_URL=${VALKEY_URL:-$VALKEY_URL_DEFAULT}
         echo "   ✅ Valkey started (distributed rate limiting enabled)"
       fi
     fi
@@ -764,8 +820,10 @@ case "$cmd" in
     fi
 
     # Start server
-    export API_PORT UI_PORT PROXY_PORT
+    export API_PORT WORKER_GRPC_PORT CADDY_ADMIN_PORT UI_PORT PROXY_PORT VALKEY_PORT
     export ADDR=${ADDR:-$API_ADDR_DEFAULT}
+    export WORKER_GRPC_ADDR=${WORKER_GRPC_ADDR:-$WORKER_GRPC_ADDR_DEFAULT}
+    export WORKER_GRPC_ADDRESS=${WORKER_GRPC_ADDRESS:-$WORKER_GRPC_ADDRESS_DEFAULT}
     export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-$PROXY_URL_DEFAULT}
     export PUBLIC_APP_URL=${PUBLIC_APP_URL:-$PROXY_URL_DEFAULT}
     export APP_URL=${APP_URL:-$PUBLIC_APP_URL}
@@ -778,6 +836,7 @@ case "$cmd" in
     "$PROJECT_ROOT/target/release/everruns-server" &
     API_PID=$!
     CHILD_PIDS+=("$API_PID")
+    record_pid api "$API_PID"
     sleep 3
 
     # Wait for server
@@ -795,6 +854,7 @@ case "$cmd" in
     "$PROJECT_ROOT/target/release/everruns-worker" &
     WORKER_PID=$!
     CHILD_PIDS+=("$WORKER_PID")
+    record_pid worker "$WORKER_PID"
     sleep 2
     echo "   ✅ Worker is running (PID: $WORKER_PID)"
 
@@ -805,6 +865,7 @@ case "$cmd" in
       run_ui_start &
       UI_PID=$!
       CHILD_PIDS+=("$UI_PID")
+      record_pid ui "$UI_PID"
       cd "$PROJECT_ROOT"
       sleep 3
       echo "   ✅ UI is running (PID: $UI_PID)"
@@ -814,6 +875,7 @@ case "$cmd" in
       caddy run --config "$PROJECT_ROOT/local/Caddyfile" --adapter caddyfile &
       CADDY_PID=$!
       CHILD_PIDS+=("$CADDY_PID")
+      record_pid caddy "$CADDY_PID"
       sleep 1
       echo "   ✅ Reverse proxy is running on :${PROXY_PORT} (PID: $CADDY_PID)"
     fi
@@ -830,7 +892,7 @@ case "$cmd" in
     fi
     echo "   ⚙️ Worker:      running (release)"
     if [ "$JAEGER_STARTED" = true ]; then
-      echo "   🔍 Jaeger UI:   http://localhost:16686"
+      echo "   🔍 Jaeger UI:   http://localhost:${JAEGER_UI_PORT}"
     fi
     echo ""
     echo "💡 Press Ctrl+C to stop services"
@@ -842,10 +904,10 @@ case "$cmd" in
   stop-all)
     echo "🛑 Stopping all Everruns services..."
 
-    pkill -f "caddy run" 2>/dev/null || true
-    pkill -f "everruns-server" 2>/dev/null || true
-    pkill -f "everruns-worker" 2>/dev/null || true
-    pkill -f "next dev" 2>/dev/null || true
+    signal_recorded_pids TERM
+    sleep 1
+    signal_recorded_pids KILL
+    clear_run_state_dir
 
     if resolve_docker_compose 2>/dev/null; then
       cd "$PROJECT_ROOT/local"

--- a/scripts/lib/setup.sh
+++ b/scripts/lib/setup.sh
@@ -6,6 +6,8 @@ source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 cmd="${1:-}"
 shift || true
 
+apply_port_prefix_defaults
+
 case "$cmd" in
   init)
     echo "🔧 Installing all development dependencies..."
@@ -111,7 +113,7 @@ case "$cmd" in
 
   upload-agents)
     echo "📤 Uploading example agents..."
-    API_URL="${API_URL:-http://localhost:9000}"
+    API_URL="${API_URL:-http://localhost:${API_PORT}}"
     EXAMPLES_DIR="$PROJECT_ROOT/examples/agents"
 
     # Check API is healthy

--- a/scripts/patch-provider-keys.sh
+++ b/scripts/patch-provider-keys.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 # Environment Variables:
 #   OPENAI_API_KEY    - API key for OpenAI provider
 #   ANTHROPIC_API_KEY - API key for Anthropic provider
-#   API_URL           - API base URL (default: http://localhost:9000)
+#   API_URL           - API base URL (default: http://localhost:9301)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
@@ -26,7 +26,7 @@ if [ -f "$PROJECT_ROOT/.env" ]; then
   set +a
 fi
 
-API_URL="${API_URL:-http://localhost:9000}"
+API_URL="${API_URL:-http://localhost:9301}"
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do

--- a/scripts/repro-sse-caddy.sh
+++ b/scripts/repro-sse-caddy.sh
@@ -14,7 +14,7 @@
 # max_retries(5), sessions running >25 min would exhaust retries.
 #
 # Prerequisites:
-#   - Running server on :9000 (via `just start-dev` or no-docker setup)
+#   - Running server on :9301 (via `just start-dev` or no-docker setup)
 #   - Caddy installed (`apt install caddy` or via no-docker setup)
 #   - curl, jq
 #
@@ -37,9 +37,15 @@ YELLOW='\033[1;33m'
 CYAN='\033[0;36m'
 NC='\033[0m'
 
-API_PORT="${API_PORT:-9000}"
-PROXY_PORT="${PROXY_PORT:-9300}"
-CADDY_ADMIN_PORT=2019
+if [ -n "${PORT_PREFIX:-}" ]; then
+    API_PORT="${API_PORT:-${PORT_PREFIX}01}"
+    PROXY_PORT="${PROXY_PORT:-${PORT_PREFIX}00}"
+    CADDY_ADMIN_PORT="${CADDY_ADMIN_PORT:-${PORT_PREFIX}03}"
+else
+    API_PORT="${API_PORT:-9301}"
+    PROXY_PORT="${PROXY_PORT:-9300}"
+    CADDY_ADMIN_PORT="${CADDY_ADMIN_PORT:-2019}"
+fi
 SSE_CYCLE_SECS="${SSE_CYCLE_SECS:-15}"  # Short cycle for faster repro
 
 log() { echo -e "${CYAN}[repro]${NC} $1"; }
@@ -73,6 +79,8 @@ start_caddy_proxy() {
 
     if [ "$mode" = "h2c" ]; then
         cat > "$caddyfile" <<EOF
+admin :${CADDY_ADMIN_PORT}
+
 :${PROXY_PORT} {
     handle_path /api/* {
         reverse_proxy localhost:${API_PORT} {
@@ -91,6 +99,8 @@ EOF
     else
         # HTTP/1.1 default (the buggy config)
         cat > "$caddyfile" <<EOF
+admin :${CADDY_ADMIN_PORT}
+
 :${PROXY_PORT} {
     handle_path /api/* {
         reverse_proxy localhost:${API_PORT} {

--- a/scripts/test-port-layout.sh
+++ b/scripts/test-port-layout.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# shellcheck disable=SC1091
+source "$PROJECT_ROOT/scripts/lib/common.sh"
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+
+  if [ "$expected" != "$actual" ]; then
+    echo "FAIL: $label expected '$expected', got '$actual'" >&2
+    exit 1
+  fi
+}
+
+check_default_ports() {
+  unset PORT_PREFIX API_PORT WORKER_GRPC_PORT CADDY_ADMIN_PORT UI_PORT PROXY_PORT OTEL_GRPC_PORT OTEL_HTTP_PORT VALKEY_PORT JAEGER_UI_PORT DB_PORT COMPOSE_PROJECT_NAME
+  apply_port_prefix_defaults
+
+  assert_eq "9300" "$PROXY_PORT" "default proxy port"
+  assert_eq "9301" "$API_PORT" "default api port"
+  assert_eq "9001" "$WORKER_GRPC_PORT" "default worker gRPC port"
+  assert_eq "2019" "$CADDY_ADMIN_PORT" "default caddy admin port"
+  assert_eq "9305" "$UI_PORT" "default ui port"
+  assert_eq "4317" "$OTEL_GRPC_PORT" "default OTLP gRPC port"
+  assert_eq "4318" "$OTEL_HTTP_PORT" "default OTLP HTTP port"
+  assert_eq "6379" "$VALKEY_PORT" "default valkey port"
+  assert_eq "16686" "$JAEGER_UI_PORT" "default jaeger ui port"
+  assert_eq "9332" "$DB_PORT" "default db port"
+  assert_eq "everruns" "$COMPOSE_PROJECT_NAME" "default compose project"
+}
+
+check_prefixed_ports() {
+  export PORT_PREFIX=271
+  unset API_PORT WORKER_GRPC_PORT CADDY_ADMIN_PORT UI_PORT PROXY_PORT OTEL_GRPC_PORT OTEL_HTTP_PORT VALKEY_PORT JAEGER_UI_PORT DB_PORT COMPOSE_PROJECT_NAME
+  apply_port_prefix_defaults
+
+  assert_eq "27100" "$PROXY_PORT" "prefixed proxy port"
+  assert_eq "27101" "$API_PORT" "prefixed api port"
+  assert_eq "27102" "$WORKER_GRPC_PORT" "prefixed worker gRPC port"
+  assert_eq "27103" "$CADDY_ADMIN_PORT" "prefixed caddy admin port"
+  assert_eq "27105" "$UI_PORT" "prefixed ui port"
+  assert_eq "27117" "$OTEL_GRPC_PORT" "prefixed OTLP gRPC port"
+  assert_eq "27118" "$OTEL_HTTP_PORT" "prefixed OTLP HTTP port"
+  assert_eq "27179" "$VALKEY_PORT" "prefixed valkey port"
+  assert_eq "27186" "$JAEGER_UI_PORT" "prefixed jaeger ui port"
+  assert_eq "27132" "$DB_PORT" "prefixed db port"
+  assert_eq "everruns-271" "$COMPOSE_PROJECT_NAME" "prefixed compose project"
+}
+
+check_example_ports() {
+  local compose_file="$PROJECT_ROOT/examples/docker-compose-full.yaml"
+  local local_compose_file="$PROJECT_ROOT/local/docker-compose.yml"
+
+  if rg -q '^    container_name:' "$compose_file"; then
+    echo "FAIL: example compose should not hardcode container_name" >&2
+    exit 1
+  fi
+  rg -q 'PORT: "9301"' "$compose_file"
+  rg -q 'PORT: "9305"' "$compose_file"
+  rg -q 'reverse_proxy server:9301' "$compose_file"
+  rg -q 'reverse_proxy ui:9305' "$compose_file"
+  rg -q '\$\{EXAMPLE_PROXY_PORT:-9300\}:9300' "$compose_file"
+  rg -q '\$\{EXAMPLE_JAEGER_UI_PORT:-16686\}:16686' "$compose_file"
+  rg -q '\$\{VALKEY_PORT:-6379\}:6379' "$local_compose_file"
+  rg -q '\$\{OTEL_GRPC_PORT:-4317\}:4317' "$local_compose_file"
+  rg -q '\$\{OTEL_HTTP_PORT:-4318\}:4318' "$local_compose_file"
+  rg -q '\$\{JAEGER_UI_PORT:-16686\}:16686' "$local_compose_file"
+}
+
+check_default_ports
+check_prefixed_ports
+check_example_ports
+
+echo "port layout checks passed"

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -14,7 +14,7 @@ graph TB
     end
 
     subgraph Server["Server (Control Plane)"]
-        REST[REST API<br/>:9000]
+        REST[REST API<br/>:9301]
         GRPC[gRPC Server<br/>:9001]
         Services[Services Layer]
         Storage[(PostgreSQL)]
@@ -464,7 +464,7 @@ The control-plane follows a strict layered architecture:
 │                    Transport Layer                       │
 │  ┌─────────────────────┐  ┌─────────────────────────┐  │
 │  │   HTTP API (axum)   │  │   gRPC Server (tonic)   │  │
-│  │     Port 9000       │  │       Port 9001         │  │
+│  │     Port 9301       │  │       Port 9001         │  │
 │  │   (Public REST)     │  │   (Internal Workers)    │  │
 │  │  HTTP/2 flow ctrl   │  │                         │  │
 │  └──────────┬──────────┘  └────────────┬────────────┘  │
@@ -540,7 +540,7 @@ Adaptive flow control is enabled (hyper auto-adjusts windows based on throughput
      - `CapabilityService` - Capability listing
 
 4. **Transport Layer** (`server/src/api/`, `server/src/grpc_service.rs`):
-   - **HTTP API** (axum) on port 9000 - public REST API
+   - **HTTP API** (axum) on local direct port 9301 - public REST API behind Caddy in local dev
    - **gRPC Server** (tonic) on port 9001 - internal WorkerService
    - API contracts (DTOs) are collocated with their routes in the same module
    - Handlers handle protocol concerns only, delegating ALL business logic to services


### PR DESCRIPTION
## What
Align local main/dev defaults with the worktree port schema and isolate worktree resources beyond just API/UI ports.

## Why
Running multiple worktrees could still collide on Docker resources, shutdown behavior, Valkey, worker gRPC, observability ports, and copy-pasted example compose usage. Public docs also still pointed at stale local ports in a few places.

## How
- move default local ports to the new main schema and extend `PORT_PREFIX` mapping to worker gRPC, Valkey, Caddy admin, OTLP, and Jaeger
- scope local/example Docker projects and service naming so multiple worktrees can run concurrently without conflicts
- replace broad process shutdown matching with per-worktree PID tracking
- update examples and public docs to reflect the current local/proxy API ports
- add regression coverage for port layout and fix unrelated flaky worker tests uncovered by the ship gate

## Risk
- Medium
- touches local dev orchestration, example compose defaults, and worker test harness code; regressions would primarily affect local startup or test reliability

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered