### PR TITLE
fix(multitenancy): remove DEFAULT_ORG_ID fallbacks from worker runtime paths

### DIFF
--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -841,6 +841,8 @@ message CheckCircuitBreakerResponse {
 // Request to resolve an image by ID
 message ResolveImageRequest {
     Uuid image_id = 1;
+    // Organization ID for scoped image access
+    int64 org_id = 2;
 }
 
 // Response with resolved image data
@@ -859,6 +861,8 @@ message ResolveImageResponse {
 // Batch request to resolve multiple images
 message ResolveImagesRequest {
     repeated Uuid image_ids = 1;
+    // Organization ID for scoped image access
+    int64 org_id = 2;
 }
 
 // Batch response with resolved images
@@ -1081,6 +1085,7 @@ message CreateSessionScheduleRequest {
     optional string cron_expression = 3;
     optional Timestamp scheduled_at = 4;
     string timezone = 5;
+    int64 org_id = 6;
 }
 
 message CreateSessionScheduleResponse {
@@ -1090,6 +1095,7 @@ message CreateSessionScheduleResponse {
 message CancelSessionScheduleRequest {
     Uuid session_id = 1;
     Uuid schedule_id = 2;
+    int64 org_id = 3;
 }
 
 message CancelSessionScheduleResponse {
@@ -1098,6 +1104,7 @@ message CancelSessionScheduleResponse {
 
 message ListSessionSchedulesRequest {
     Uuid session_id = 1;
+    int64 org_id = 2;
 }
 
 message ListSessionSchedulesResponse {
@@ -1106,6 +1113,7 @@ message ListSessionSchedulesResponse {
 
 message CountActiveSessionSchedulesRequest {
     Uuid session_id = 1;
+    int64 org_id = 2;
 }
 
 message CountActiveSessionSchedulesResponse {

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -22,7 +22,6 @@ use anyhow::{Context, Result};
 use axum::http::{Method, header};
 use axum::{Json, Router, extract::State, routing::get};
 use everruns_core::CapabilityRegistry;
-use everruns_core::DEFAULT_ORG_ID;
 use everruns_core::{BraintrustListener, EventListener, OtelEventListener};
 use everruns_durable::{
     InMemoryWorkflowEventStore, PostgresWorkflowEventStore, WorkflowEventStore,
@@ -842,10 +841,6 @@ impl ServerAppBuilder {
                     sqldb_store.clone(),
                 )
                 .with_storage_store(session_storage_store)
-                .with_schedule_store(Arc::new(crate::storage::DbSessionScheduleStore::new(
-                    db.clone(),
-                    DEFAULT_ORG_ID,
-                )))
                 .with_runner(runner.clone());
 
                 // Wire lazy connection resolver (requires encryption for token decryption)

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -17,9 +17,9 @@ use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
 use everruns_core::traits::ResolvedImage;
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId};
 use everruns_core::{
-    Agent, AgentStatus, ContentPart, DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, DriverRegistry,
-    EventData, Harness, HarnessStatus, LlmProviderType, Message, MessageRole, Session,
-    SessionStatus, ToolDefinition, ToolRegistry, ToolResultContentPart,
+    Agent, AgentStatus, ContentPart, DEFAULT_ORG_PUBLIC_ID, DriverRegistry, EventData, Harness,
+    HarnessStatus, LlmProviderType, Message, MessageRole, Session, SessionStatus, ToolDefinition,
+    ToolRegistry, ToolResultContentPart,
 };
 use everruns_worker::create_driver_registry;
 use everruns_worker::mcp_executor::McpServerInfo;
@@ -64,7 +64,6 @@ pub struct DirectWorkerAdapters {
     sqldb_store: everruns_core::traits::SessionSqlDbStoreRef,
     storage_store: Option<Arc<dyn everruns_core::traits::SessionStorageStore>>,
     connection_resolver: Option<Arc<dyn everruns_core::traits::UserConnectionResolver>>,
-    schedule_store: Option<Arc<dyn everruns_core::traits::SessionScheduleStore>>,
     runner: Option<Arc<dyn everruns_worker::AgentRunner>>,
 }
 
@@ -87,7 +86,6 @@ impl DirectWorkerAdapters {
             sqldb_store,
             storage_store: None,
             connection_resolver: None,
-            schedule_store: None,
             runner: None,
         }
     }
@@ -113,15 +111,6 @@ impl DirectWorkerAdapters {
         resolver: Arc<dyn everruns_core::traits::UserConnectionResolver>,
     ) -> Self {
         self.connection_resolver = Some(resolver);
-        self
-    }
-
-    /// Set the session schedule store for scheduling tools
-    pub fn with_schedule_store(
-        mut self,
-        store: Arc<dyn everruns_core::traits::SessionScheduleStore>,
-    ) -> Self {
-        self.schedule_store = Some(store);
         self
     }
 
@@ -372,17 +361,11 @@ impl WorkerAdapters for DirectWorkerAdapters {
     // Image Resolution Operations
     // =========================================================================
 
-    async fn resolve_image(&self, image_id: Uuid) -> Result<Option<ResolvedImage>> {
-        // Get the image from storage
-        // TODO: Thread org_id through WorkerAdapters trait for image resolution
-        let image_row = self
-            .db
-            .get_image(DEFAULT_ORG_ID, image_id)
-            .await
-            .map_err(|e| {
-                tracing::error!("Failed to get image: {}", e);
-                store_error("Failed to get image")
-            })?;
+    async fn resolve_image(&self, org_id: i64, image_id: Uuid) -> Result<Option<ResolvedImage>> {
+        let image_row = self.db.get_image(org_id, image_id).await.map_err(|e| {
+            tracing::error!("Failed to get image: {}", e);
+            store_error("Failed to get image")
+        })?;
 
         match image_row {
             Some(row) => {
@@ -397,11 +380,12 @@ impl WorkerAdapters for DirectWorkerAdapters {
 
     async fn resolve_images_batch(
         &self,
+        org_id: i64,
         image_ids: &[Uuid],
     ) -> Result<HashMap<Uuid, ResolvedImage>> {
         let mut result = HashMap::new();
         for &image_id in image_ids {
-            if let Some(resolved) = self.resolve_image(image_id).await? {
+            if let Some(resolved) = self.resolve_image(org_id, image_id).await? {
                 result.insert(image_id, resolved);
             }
         }
@@ -836,24 +820,23 @@ impl WorkerAdapters for DirectWorkerAdapters {
         )
     }
 
-    fn schedule_store(&self) -> Arc<dyn everruns_core::traits::SessionScheduleStore> {
-        self.schedule_store
-            .clone()
-            .expect("DirectWorkerAdapters: schedule_store not set (call with_schedule_store)")
+    fn schedule_store(&self, org_id: i64) -> Arc<dyn everruns_core::traits::SessionScheduleStore> {
+        Arc::new(crate::storage::DbSessionScheduleStore::new(
+            self.db.clone(),
+            org_id,
+        ))
     }
 
-    fn platform_store(
-        &self,
-        _org_id: i64,
-    ) -> Arc<dyn everruns_core::platform_store::PlatformStore> {
+    fn platform_store(&self, org_id: i64) -> Arc<dyn everruns_core::platform_store::PlatformStore> {
         Arc::new(DirectPlatformStore::new(
+            org_id,
             self.db.clone(),
             self.event_service.clone(),
             self.runner.clone(),
         ))
     }
 
-    async fn build_tool_registry(&self, agent_id: Uuid) -> Result<ToolRegistry> {
+    async fn build_tool_registry(&self, _org_id: i64, agent_id: Uuid) -> Result<ToolRegistry> {
         let capability_rows = self
             .db
             .get_agent_capabilities(agent_id)
@@ -1114,6 +1097,7 @@ fn event_to_message(event: Event) -> Option<Message> {
 /// Direct PlatformStore backed by StorageBackend + EventService + AgentRunner.
 // THREAT[TM-AGENT-017]: All ops org-scoped via org_id field
 pub struct DirectPlatformStore {
+    org_id: i64,
     db: Arc<StorageBackend>,
     event_service: Arc<EventService>,
     runner: Option<Arc<dyn everruns_worker::AgentRunner>>,
@@ -1122,12 +1106,14 @@ pub struct DirectPlatformStore {
 
 impl DirectPlatformStore {
     pub fn new(
+        org_id: i64,
         db: Arc<StorageBackend>,
         event_service: Arc<EventService>,
         runner: Option<Arc<dyn everruns_worker::AgentRunner>>,
     ) -> Self {
         let capability_service = crate::services::CapabilityService::new(db.clone(), None);
         Self {
+            org_id,
             db,
             event_service,
             runner,
@@ -1220,7 +1206,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
     async fn list_harnesses(&self) -> everruns_core::error::Result<Vec<Harness>> {
         let rows = self
             .db
-            .list_harnesses(DEFAULT_ORG_ID)
+            .list_harnesses(self.org_id)
             .await
             .map_err(|e| store_error(format!("Failed to list harnesses: {e}")))?;
 
@@ -1244,7 +1230,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
     async fn get_harness(&self, id: HarnessId) -> everruns_core::error::Result<Option<Harness>> {
         let row = self
             .db
-            .get_harness(DEFAULT_ORG_ID, id)
+            .get_harness(self.org_id, id)
             .await
             .map_err(|e| store_error(format!("Failed to get harness: {e}")))?;
 
@@ -1284,7 +1270,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
         };
         let row = self
             .db
-            .create_harness(DEFAULT_ORG_ID, input)
+            .create_harness(self.org_id, input)
             .await
             .map_err(|e| store_error(format!("Failed to create harness: {e}")))?;
 
@@ -1328,7 +1314,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
             ..Default::default()
         };
         self.db
-            .update_harness(DEFAULT_ORG_ID, id, update)
+            .update_harness(self.org_id, id, update)
             .await
             .map_err(|e| store_error(format!("Failed to update harness: {e}")))?;
 
@@ -1339,7 +1325,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
 
     async fn delete_harness(&self, id: HarnessId) -> everruns_core::error::Result<()> {
         self.db
-            .delete_harness(DEFAULT_ORG_ID, id)
+            .delete_harness(self.org_id, id)
             .await
             .map_err(|e| store_error(format!("Failed to delete harness: {e}")))?;
         Ok(())
@@ -1382,7 +1368,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
     async fn list_agents(&self) -> everruns_core::error::Result<Vec<Agent>> {
         let rows = self
             .db
-            .list_agents(DEFAULT_ORG_ID)
+            .list_agents(self.org_id)
             .await
             .map_err(|e| store_error(format!("Failed to list agents: {e}")))?;
 
@@ -1406,7 +1392,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
     async fn get_agent_by_id(&self, id: AgentId) -> everruns_core::error::Result<Option<Agent>> {
         let row = self
             .db
-            .get_agent(DEFAULT_ORG_ID, id)
+            .get_agent(self.org_id, id)
             .await
             .map_err(|e| store_error(format!("Failed to get agent: {e}")))?;
 
@@ -1449,7 +1435,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
         };
         let row = self
             .db
-            .create_agent(DEFAULT_ORG_ID, input)
+            .create_agent(self.org_id, input)
             .await
             .map_err(|e| store_error(format!("Failed to create agent: {e}")))?;
 
@@ -1493,7 +1479,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
             ..Default::default()
         };
         self.db
-            .update_agent(DEFAULT_ORG_ID, id, update)
+            .update_agent(self.org_id, id, update)
             .await
             .map_err(|e| store_error(format!("Failed to update agent: {e}")))?;
 
@@ -1504,7 +1490,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
 
     async fn delete_agent(&self, id: AgentId) -> everruns_core::error::Result<()> {
         self.db
-            .delete_agent(DEFAULT_ORG_ID, id)
+            .delete_agent(self.org_id, id)
             .await
             .map_err(|e| store_error(format!("Failed to delete agent: {e}")))?;
         Ok(())
@@ -1527,7 +1513,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
         };
         let (rows, _total) = self
             .db
-            .list_sessions(DEFAULT_ORG_ID, agent_id, pagination)
+            .list_sessions(self.org_id, agent_id, pagination)
             .await
             .map_err(|e| store_error(format!("Failed to list sessions: {e}")))?;
 
@@ -1543,7 +1529,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
         use crate::storage::models::CreateSessionRow;
 
         let input = CreateSessionRow {
-            org_id: DEFAULT_ORG_ID,
+            org_id: self.org_id,
             harness_id: Some(harness_id),
             agent_id,
             title: title.map(|s| s.to_string()),
@@ -1567,7 +1553,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
     ) -> everruns_core::error::Result<Option<Session>> {
         let row = self
             .db
-            .get_session(DEFAULT_ORG_ID, id)
+            .get_session(self.org_id, id)
             .await
             .map_err(|e| store_error(format!("Failed to get session: {e}")))?;
 
@@ -1576,7 +1562,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
 
     async fn delete_session(&self, id: SessionId) -> everruns_core::error::Result<()> {
         self.db
-            .delete_session(DEFAULT_ORG_ID, id)
+            .delete_session(self.org_id, id)
             .await
             .map_err(|e| store_error(format!("Failed to delete session: {e}")))?;
         Ok(())
@@ -1629,7 +1615,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
         if let Some(ref runner) = self.runner {
             runner
                 .start_run(
-                    DEFAULT_ORG_ID,
+                    self.org_id,
                     session_id,
                     session.harness_id,
                     session.agent_id,
@@ -1753,7 +1739,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
     ) -> everruns_core::error::Result<Vec<everruns_core::CapabilityInfo>> {
         let mut caps = self
             .capability_service
-            .list_all(DEFAULT_ORG_ID)
+            .list_all(self.org_id)
             .await
             .map_err(|e| store_error(format!("Failed to list capabilities: {e}")))?;
 
@@ -2031,6 +2017,60 @@ mod tests {
             .await
             .expect("seed agent");
         row.id.uuid()
+    }
+
+    // =========================================================================
+    // Cross-org isolation regression tests (EVE-56)
+    // =========================================================================
+
+    /// Regression test: schedule_store must be scoped to the provided org_id,
+    /// not a hardcoded default. Before EVE-56, schedule_store() had no org_id
+    /// parameter and used DEFAULT_ORG_ID for all calls.
+    #[test]
+    fn schedule_store_is_scoped_to_org_id() {
+        let adapters = test_adapters();
+        let store_org1 = adapters.schedule_store(1);
+        let store_org2 = adapters.schedule_store(2);
+        // Verify these are distinct instances (different Arc pointers)
+        assert!(!Arc::ptr_eq(&store_org1, &store_org2));
+    }
+
+    /// Regression test: platform_store must use the provided org_id, not
+    /// DEFAULT_ORG_ID. Agents created in org 1 must not be visible through
+    /// org 2's platform store.
+    #[tokio::test]
+    async fn platform_store_cross_org_isolation() {
+        use everruns_core::platform_store::PlatformStore;
+
+        let adapters = test_adapters();
+        let agent_id = seed_agent(&adapters.db).await;
+
+        // Agent seeded in org 1 should be visible via org 1's platform store
+        let store_org1 = adapters.platform_store(everruns_core::DEFAULT_ORG_ID);
+        let agent = store_org1
+            .get_agent_by_id(everruns_core::AgentId::from_uuid(agent_id))
+            .await
+            .unwrap();
+        assert!(agent.is_some(), "agent should be visible in org 1");
+
+        // Same agent must NOT be visible via org 2's platform store
+        let store_org2 = adapters.platform_store(999);
+        let agent = store_org2
+            .get_agent_by_id(everruns_core::AgentId::from_uuid(agent_id))
+            .await
+            .unwrap();
+        assert!(agent.is_none(), "agent must NOT be visible in org 999");
+    }
+
+    /// Regression test: image resolution must receive org_id so the gRPC
+    /// service scopes the lookup. Before EVE-56, resolve_image had no org_id
+    /// parameter.
+    #[tokio::test]
+    async fn resolve_image_requires_org_id() {
+        let adapters = test_adapters();
+        // resolve_image now requires org_id — compile-time proof the parameter exists
+        let result = adapters.resolve_image(1, Uuid::new_v4()).await.unwrap();
+        assert!(result.is_none());
     }
 
     /// Build a fake `AgentCapabilityRow` for testing.

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -2040,8 +2040,6 @@ mod tests {
     /// org 2's platform store.
     #[tokio::test]
     async fn platform_store_cross_org_isolation() {
-        use everruns_core::platform_store::PlatformStore;
-
         let adapters = test_adapters();
         let agent_id = seed_agent(&adapters.db).await;
 

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -13,7 +13,6 @@ use crate::services::{
 use crate::storage::{EncryptionService, StorageBackend};
 use crate::task_notifications::TaskNotificationBroadcaster;
 use base64::Engine;
-use everruns_core::DEFAULT_ORG_ID;
 use everruns_durable::{
     ActivityOptions, CircuitBreakerConfig, CircuitState, DistributedCircuitBreaker,
     PostgresWorkflowEventStore, StoreError, TaskDefinition, TaskFailureOutcome, WorkerInfo,
@@ -315,8 +314,6 @@ pub struct WorkerServiceImpl {
     runner: Option<Arc<dyn everruns_worker::AgentRunner>>,
     /// Lazy connection token resolver (decrypts stored tokens / mints GitHub App tokens)
     connection_resolver: Option<Arc<dyn everruns_core::traits::UserConnectionResolver>>,
-    /// Session schedule store for schedule CRUD
-    schedule_store: Option<Arc<dyn everruns_core::traits::SessionScheduleStore>>,
 }
 
 impl WorkerServiceImpl {
@@ -370,17 +367,6 @@ impl WorkerServiceImpl {
                 )) as Arc<dyn everruns_core::traits::UserConnectionResolver>
             });
 
-        // Create schedule store (PostgreSQL mode only)
-        let schedule_store: Option<Arc<dyn everruns_core::traits::SessionScheduleStore>> =
-            if db.pool().is_some() {
-                Some(Arc::new(crate::storage::DbSessionScheduleStore::new(
-                    db.clone(),
-                    DEFAULT_ORG_ID,
-                )))
-            } else {
-                None
-            };
-
         // Create session SQL database store (always available, in-memory backend)
         let sqldb_backend = Arc::new(everruns_session_sqldb::InMemorySqlDbBackend::new());
         let sqldb_store: Option<Arc<dyn everruns_core::session_sqldb::SessionSqlDbStore>> =
@@ -404,7 +390,6 @@ impl WorkerServiceImpl {
             sqldb_store,
             runner,
             connection_resolver,
-            schedule_store,
         }
     }
 
@@ -441,14 +426,22 @@ impl WorkerServiceImpl {
             .ok_or_else(|| Status::unavailable("Connection resolver not available (no encryption)"))
     }
 
-    /// Get schedule store or return unavailable error
+    /// Create schedule store scoped to the given org_id, or return unavailable if no pool.
     #[allow(clippy::result_large_err)]
     fn schedule_store(
         &self,
-    ) -> Result<&Arc<dyn everruns_core::traits::SessionScheduleStore>, Status> {
-        self.schedule_store
-            .as_ref()
-            .ok_or_else(|| Status::unavailable("Schedule store not available"))
+        org_id: i64,
+    ) -> Result<Arc<dyn everruns_core::traits::SessionScheduleStore>, Status> {
+        if self.db.pool().is_some() {
+            Ok(Arc::new(crate::storage::DbSessionScheduleStore::new(
+                self.db.clone(),
+                org_id,
+            )))
+        } else {
+            Err(Status::unavailable(
+                "Schedule store not available (requires PostgreSQL)",
+            ))
+        }
     }
 
     /// Build a GitHubAppTokenMinter from environment variables (if configured).
@@ -2439,9 +2432,8 @@ impl WorkerService for WorkerServiceImpl {
         let req = request.into_inner();
         let image_id = parse_uuid(req.image_id.as_ref())?;
 
-        // Get image from storage
-        // TODO: Thread org_id through image resolution proto messages
-        let image_row = match self.db.get_image(DEFAULT_ORG_ID, image_id).await {
+        // Get image from storage (org-scoped)
+        let image_row = match self.db.get_image(req.org_id, image_id).await {
             Ok(Some(row)) => row,
             Ok(None) => {
                 return Ok(Response::new(ResolveImageResponse {
@@ -2481,8 +2473,8 @@ impl WorkerService for WorkerServiceImpl {
         for proto_id in req.image_ids {
             let image_id = parse_uuid(Some(&proto_id))?;
 
-            // Get image from storage
-            match self.db.get_image(DEFAULT_ORG_ID, image_id).await {
+            // Get image from storage (org-scoped)
+            match self.db.get_image(req.org_id, image_id).await {
                 Ok(Some(row)) => {
                     let base64_data = base64::engine::general_purpose::STANDARD.encode(&row.data);
                     images.insert(
@@ -2782,7 +2774,7 @@ impl WorkerService for WorkerServiceImpl {
     ) -> Result<Response<CreateSessionScheduleResponse>, Status> {
         let req = request.into_inner();
         let session_id = parse_uuid(req.session_id.as_ref())?;
-        let store = self.schedule_store()?;
+        let store = self.schedule_store(req.org_id)?;
 
         let scheduled_at = req
             .scheduled_at
@@ -2815,7 +2807,7 @@ impl WorkerService for WorkerServiceImpl {
         let req = request.into_inner();
         let session_id = parse_uuid(req.session_id.as_ref())?;
         let schedule_id = parse_uuid(req.schedule_id.as_ref())?;
-        let store = self.schedule_store()?;
+        let store = self.schedule_store(req.org_id)?;
 
         let schedule = store
             .cancel_schedule(
@@ -2839,7 +2831,7 @@ impl WorkerService for WorkerServiceImpl {
     ) -> Result<Response<ListSessionSchedulesResponse>, Status> {
         let req = request.into_inner();
         let session_id = parse_uuid(req.session_id.as_ref())?;
-        let store = self.schedule_store()?;
+        let store = self.schedule_store(req.org_id)?;
 
         let schedules = store.list_schedules(session_id.into()).await.map_err(|e| {
             tracing::error!("Failed to list schedules: {}", e);
@@ -2859,7 +2851,7 @@ impl WorkerService for WorkerServiceImpl {
     ) -> Result<Response<CountActiveSessionSchedulesResponse>, Status> {
         let req = request.into_inner();
         let session_id = parse_uuid(req.session_id.as_ref())?;
-        let store = self.schedule_store()?;
+        let store = self.schedule_store(req.org_id)?;
 
         let count = store
             .count_active_schedules(session_id.into())

--- a/crates/server/src/services/usage_tracking.rs
+++ b/crates/server/src/services/usage_tracking.rs
@@ -8,7 +8,7 @@
 // (see specs/architecture.md for rationale on no-trigger policy).
 
 use async_trait::async_trait;
-use everruns_core::{DEFAULT_ORG_ID, Event, EventData, EventListener, LLM_GENERATION};
+use everruns_core::{Event, EventData, EventListener, LLM_GENERATION};
 use std::sync::Arc;
 use tracing::{error, instrument};
 
@@ -53,8 +53,8 @@ impl EventListener for UsageTrackingListener {
         let cache_read_tokens = usage.cache_read_tokens.unwrap_or(0) as i64;
         let cache_creation_tokens = usage.cache_creation_tokens.unwrap_or(0) as i64;
 
-        // Get session to determine org_id
-        let session = match self.db.get_session(DEFAULT_ORG_ID, event.session_id).await {
+        // Get session to determine org_id (unscoped lookup - internal system use)
+        let session = match self.db.get_session_unscoped(event.session_id).await {
             Ok(Some(s)) => s,
             Ok(None) => {
                 error!("Session not found for usage tracking: {}", event.session_id);
@@ -66,22 +66,8 @@ impl EventListener for UsageTrackingListener {
             }
         };
 
-        // Get org_id from agent (sessions don't have direct org_id)
-        let org_id = if let Some(agent_id) = session.agent_id {
-            match self.db.get_agent(DEFAULT_ORG_ID, agent_id).await {
-                Ok(Some(agent)) => agent.org_id,
-                Ok(None) => {
-                    error!("Agent not found for usage tracking: {}", agent_id);
-                    DEFAULT_ORG_ID
-                }
-                Err(e) => {
-                    error!("Failed to get agent for usage tracking: {}", e);
-                    DEFAULT_ORG_ID
-                }
-            }
-        } else {
-            DEFAULT_ORG_ID
-        };
+        // org_id comes directly from the session row
+        let org_id = session.org_id;
 
         // Insert into llm_generations with org_id
         if let Err(e) = self

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -287,6 +287,11 @@ impl StorageBackend {
         dispatch!(self, get_session, org_id, id)
     }
 
+    /// Get session without org scoping. For internal system use only (e.g. usage tracking).
+    pub async fn get_session_unscoped(&self, id: SessionId) -> Result<Option<SessionRow>> {
+        dispatch!(self, get_session_unscoped, id)
+    }
+
     /// List sessions for an agent with pagination, validating org ownership.
     /// Returns (sessions, total_count).
     pub async fn list_sessions(

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -829,6 +829,12 @@ impl InMemoryDatabase {
         Ok(None)
     }
 
+    /// Get session without org scoping. For internal system use only (e.g. usage tracking).
+    pub async fn get_session_unscoped(&self, id: SessionId) -> Result<Option<SessionRow>> {
+        let sessions = self.sessions.read();
+        Ok(sessions.get(&id).cloned())
+    }
+
     /// List sessions for an agent with pagination, validating org ownership.
     /// Returns (sessions, total_count).
     pub async fn list_sessions(

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -941,6 +941,23 @@ impl Database {
         Ok(row)
     }
 
+    /// Get session without org scoping. For internal system use only (e.g. usage tracking).
+    pub async fn get_session_unscoped(&self, id: SessionId) -> Result<Option<SessionRow>> {
+        let row = sqlx::query_as::<_, SessionRow>(
+            r#"
+            SELECT id, org_id, harness_id, agent_id, title, tags, model_id, capabilities, tools, status, created_at, updated_at, started_at, finished_at,
+                   total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens
+            FROM sessions
+            WHERE id = $1
+            "#,
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
     /// List sessions for an organization with optional agent filter.
     /// Returns (sessions, total_count).
     pub async fn list_sessions(

--- a/crates/server/src/storage/session_schedule_store.rs
+++ b/crates/server/src/storage/session_schedule_store.rs
@@ -38,7 +38,7 @@ pub fn row_to_domain(row: &SessionScheduleRow) -> SessionSchedule {
 /// Database-backed session schedule store.
 ///
 /// Used by scheduling tools (create_schedule, cancel_schedule, list_schedules).
-/// Requires org_id for multitenancy — uses DEFAULT_ORG_ID for now (worker context).
+/// Requires org_id for multitenancy — callers must provide the correct org_id.
 #[derive(Clone)]
 pub struct DbSessionScheduleStore {
     db: Arc<StorageBackend>,

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -172,7 +172,7 @@ pub async fn reason_activity(
     let event_emitter = GrpcEventEmitter::new(grpc_client.clone());
 
     // Create image resolver for multimodal image support
-    let image_resolver = Arc::new(GrpcImageResolver::new(grpc_client.clone()));
+    let image_resolver = Arc::new(GrpcImageResolver::new(grpc_client.clone(), org_id));
 
     // Create file store for AGENTS.md reading (agent_instructions capability)
     let file_store = Arc::new(GrpcSessionFileStore::new(grpc_client.clone()));

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -1094,12 +1094,13 @@ use std::collections::HashMap;
 /// image data before sending messages to LLM providers.
 pub struct GrpcImageResolver {
     client: GrpcClient,
+    org_id: i64,
 }
 
 impl GrpcImageResolver {
-    /// Create a new GrpcImageResolver
-    pub fn new(client: GrpcClient) -> Self {
-        Self { client }
+    /// Create a new GrpcImageResolver scoped to an organization
+    pub fn new(client: GrpcClient, org_id: i64) -> Self {
+        Self { client, org_id }
     }
 
     /// Resolve multiple images in a batch (more efficient)
@@ -1118,6 +1119,7 @@ impl GrpcImageResolver {
 
         let request = proto::ResolveImagesRequest {
             image_ids: image_ids.iter().map(|id| uuid_to_proto(*id)).collect(),
+            org_id: self.org_id,
         };
 
         let response = client
@@ -1146,6 +1148,7 @@ impl ImageResolver for GrpcImageResolver {
 
         let request = proto::ResolveImageRequest {
             image_id: Some(uuid_to_proto(image_id)),
+            org_id: self.org_id,
         };
 
         let response = client
@@ -1372,11 +1375,12 @@ impl everruns_core::traits::UserConnectionResolver for GrpcConnectionResolver {
 /// Proxies schedule CRUD to the control-plane via gRPC RPCs.
 pub struct GrpcScheduleStore {
     client: GrpcClient,
+    org_id: i64,
 }
 
 impl GrpcScheduleStore {
-    pub fn new(client: GrpcClient) -> Self {
-        Self { client }
+    pub fn new(client: GrpcClient, org_id: i64) -> Self {
+        Self { client, org_id }
     }
 }
 
@@ -1431,6 +1435,7 @@ impl everruns_core::traits::SessionScheduleStore for GrpcScheduleStore {
             cron_expression,
             scheduled_at: scheduled_at.map(everruns_internal_protocol::datetime_to_proto_timestamp),
             timezone,
+            org_id: self.org_id,
         };
         let response = client
             .create_session_schedule(request)
@@ -1452,6 +1457,7 @@ impl everruns_core::traits::SessionScheduleStore for GrpcScheduleStore {
         let request = proto::CancelSessionScheduleRequest {
             session_id: Some(uuid_to_proto(session_id.uuid())),
             schedule_id: Some(uuid_to_proto(schedule_id.uuid())),
+            org_id: self.org_id,
         };
         let response = client
             .cancel_session_schedule(request)
@@ -1471,6 +1477,7 @@ impl everruns_core::traits::SessionScheduleStore for GrpcScheduleStore {
         let mut client = self.client.inner.lock().await;
         let request = proto::ListSessionSchedulesRequest {
             session_id: Some(uuid_to_proto(session_id.uuid())),
+            org_id: self.org_id,
         };
         let response = client
             .list_session_schedules(request)
@@ -1488,6 +1495,7 @@ impl everruns_core::traits::SessionScheduleStore for GrpcScheduleStore {
         let mut client = self.client.inner.lock().await;
         let request = proto::CountActiveSessionSchedulesRequest {
             session_id: Some(uuid_to_proto(session_id.uuid())),
+            org_id: self.org_id,
         };
         let response = client
             .count_active_session_schedules(request)

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -169,16 +169,17 @@ impl WorkerAdapters for GrpcWorkerAdapters {
     // Image Resolution Operations
     // =========================================================================
 
-    async fn resolve_image(&self, image_id: Uuid) -> Result<Option<ResolvedImage>> {
-        let resolver = GrpcImageResolver::new(self.client.clone());
+    async fn resolve_image(&self, org_id: i64, image_id: Uuid) -> Result<Option<ResolvedImage>> {
+        let resolver = GrpcImageResolver::new(self.client.clone(), org_id);
         everruns_core::traits::ImageResolver::resolve_image(&resolver, image_id).await
     }
 
     async fn resolve_images_batch(
         &self,
+        org_id: i64,
         image_ids: &[Uuid],
     ) -> Result<HashMap<Uuid, ResolvedImage>> {
-        let resolver = GrpcImageResolver::new(self.client.clone());
+        let resolver = GrpcImageResolver::new(self.client.clone(), org_id);
         resolver
             .resolve_images_batch(image_ids)
             .await
@@ -346,22 +347,18 @@ impl WorkerAdapters for GrpcWorkerAdapters {
         ))
     }
 
-    fn schedule_store(&self) -> Arc<dyn everruns_core::traits::SessionScheduleStore> {
+    fn schedule_store(&self, org_id: i64) -> Arc<dyn everruns_core::traits::SessionScheduleStore> {
         Arc::new(crate::grpc_adapters::GrpcScheduleStore::new(
             self.client.clone(),
+            org_id,
         ))
     }
 
-    async fn build_tool_registry(&self, agent_id: Uuid) -> Result<ToolRegistry> {
+    async fn build_tool_registry(&self, org_id: i64, agent_id: Uuid) -> Result<ToolRegistry> {
         let mut registry = ToolRegistry::with_defaults();
 
         // Get agent to access capabilities
-        // Note: We use DEFAULT_ORG_ID here since tool building doesn't need org context
-        // The agent lookup will work because agent_id is globally unique
-        if let Ok(Some(agent)) = self
-            .get_agent(everruns_core::DEFAULT_ORG_ID, agent_id)
-            .await
-        {
+        if let Ok(Some(agent)) = self.get_agent(org_id, agent_id).await {
             let builtin_cap_ids: Vec<String> = agent
                 .capabilities
                 .iter()

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -429,7 +429,9 @@ where
 
             // Create DurableTurnInput from ActInput context
             let turn_input = DurableTurnInput {
-                org_id: everruns_core::DEFAULT_ORG_ID,
+                org_id: act_input
+                    .org_id
+                    .expect("ActInput.org_id must be set for durable turns"),
                 session_id: act_input.context.session_id,
                 harness_id: act_input.harness_id,
                 agent_id: act_input.agent_id,
@@ -627,7 +629,7 @@ async fn execute_reason_activity<A: WorkerAdapters>(
     let capability_registry = adapters.capability_registry();
     let driver_registry = adapters.driver_registry();
     let event_emitter = AdapterEventEmitter::new(adapters.clone());
-    let image_resolver = Arc::new(AdapterImageResolver::new(adapters.clone()));
+    let image_resolver = Arc::new(AdapterImageResolver::new(adapters.clone(), input.org_id));
 
     let atom = ReasonAtom::new(
         harness_store,
@@ -770,14 +772,20 @@ async fn execute_act_activity<A: WorkerAdapters>(
         "Executing act activity"
     );
 
+    // Extract org_id early — must be set by callers for proper tenant isolation.
+    let org_id = input
+        .org_id
+        .expect("ActInput.org_id must be set for act activities");
+
     // Build tool registry with defaults and capability tools.
     // When agent_id is present, use agent capabilities.
     // When agent_id is absent, fall back to harness capabilities so that
     // harness-provided tools (e.g. bash) are still registered.
     let tool_registry = if let Some(agent_id) = input.agent_id {
-        adapters.build_tool_registry(agent_id.uuid()).await?
+        adapters
+            .build_tool_registry(org_id, agent_id.uuid())
+            .await?
     } else {
-        let org_id = input.org_id.unwrap_or(1);
         adapters
             .build_tool_registry_for_harness(org_id, input.harness_id.uuid())
             .await?
@@ -785,7 +793,6 @@ async fn execute_act_activity<A: WorkerAdapters>(
 
     let event_emitter = AdapterEventEmitter::new(adapters.clone());
     let file_store = Arc::new(AdapterSessionFileStore::new(adapters.clone()));
-    let org_id = input.org_id.unwrap_or(1);
     let session_store = Arc::new(AdapterSessionStore::new(adapters.clone(), org_id));
     let session_mutator = Arc::new(AdapterSessionMutator::new(adapters.clone(), org_id));
     let agent_store = Arc::new(AdapterAgentStore::new(adapters.clone(), org_id));
@@ -798,7 +805,7 @@ async fn execute_act_activity<A: WorkerAdapters>(
         .with_sqldb_store(adapters.sqldb_store())
         .with_storage_store(adapters.storage_store())
         .with_connection_resolver(adapters.connection_resolver())
-        .with_schedule_store(adapters.schedule_store())
+        .with_schedule_store(adapters.schedule_store(org_id))
         .with_platform_store(adapters.platform_store(org_id));
 
     let result = atom.execute(input.clone()).await?;

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -104,11 +104,12 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
     // =========================================================================
 
     /// Resolve a single image by ID
-    async fn resolve_image(&self, image_id: Uuid) -> Result<Option<ResolvedImage>>;
+    async fn resolve_image(&self, org_id: i64, image_id: Uuid) -> Result<Option<ResolvedImage>>;
 
     /// Resolve multiple images in a batch
     async fn resolve_images_batch(
         &self,
+        org_id: i64,
         image_ids: &[Uuid],
     ) -> Result<HashMap<Uuid, ResolvedImage>>;
 
@@ -178,7 +179,7 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
     fn driver_registry(&self) -> DriverRegistry;
 
     /// Create a tool registry with defaults and agent capabilities
-    async fn build_tool_registry(&self, agent_id: Uuid) -> Result<ToolRegistry>;
+    async fn build_tool_registry(&self, org_id: i64, agent_id: Uuid) -> Result<ToolRegistry>;
 
     /// Create a tool registry with defaults and harness capabilities.
     ///
@@ -240,7 +241,8 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
     fn connection_resolver(&self) -> Arc<dyn everruns_core::traits::UserConnectionResolver>;
 
     /// Get the session schedule store for scheduling tools.
-    fn schedule_store(&self) -> Arc<dyn everruns_core::traits::SessionScheduleStore>;
+    /// Takes org_id so the store is scoped to the current session's organization.
+    fn schedule_store(&self, org_id: i64) -> Arc<dyn everruns_core::traits::SessionScheduleStore>;
 }
 
 // =============================================================================
@@ -439,18 +441,19 @@ impl<A: WorkerAdapters> everruns_core::traits::EventEmitter for AdapterEventEmit
 /// Adapter-based ImageResolver implementation
 pub struct AdapterImageResolver<A: WorkerAdapters> {
     adapters: A,
+    org_id: i64,
 }
 
 impl<A: WorkerAdapters> AdapterImageResolver<A> {
-    pub fn new(adapters: A) -> Self {
-        Self { adapters }
+    pub fn new(adapters: A, org_id: i64) -> Self {
+        Self { adapters, org_id }
     }
 }
 
 #[async_trait]
 impl<A: WorkerAdapters> ImageResolver for AdapterImageResolver<A> {
     async fn resolve_image(&self, image_id: Uuid) -> Result<Option<ResolvedImage>> {
-        self.adapters.resolve_image(image_id).await
+        self.adapters.resolve_image(self.org_id, image_id).await
     }
 }
 


### PR DESCRIPTION
## Summary
- Make `org_id` mandatory through worker/runtime interfaces (trait methods, proto messages)
- Replace `DEFAULT_ORG_ID` fallbacks with proper org-scoped resolution in usage tracking, image resolution, schedule stores, and tool registry
- Add `get_session_unscoped` for usage tracking to read org from session row itself

## Why
Fixes EVE-56. Several runtime paths used `DEFAULT_ORG_ID` instead of request/session org, causing wrong-tenant reads and usage accounting in multi-org deployments.

## Test plan
- [x] 3 new regression tests for cross-org isolation
- [x] All 465 server tests pass
- [x] 56/57 worker tests pass (1 pre-existing flaky test on main)
- [x] `cargo clippy -- -D warnings` clean