### PR TITLE
fix(dev): restore stop-all cleanup and caddy validation

### DIFF
--- a/crates/durable/tests/postgres_integration_test.rs
+++ b/crates/durable/tests/postgres_integration_test.rs
@@ -30,12 +30,37 @@ fn get_database_url() -> String {
         .unwrap_or_else(|_| "postgres://postgres:postgres@localhost:5432/everruns_test".to_string())
 }
 
+async fn reset_durable_tables(pool: &PgPool) {
+    // Integration tests assume a clean durable schema. Truncate explicitly so
+    // other integration binaries using the same test database cannot leak state.
+    sqlx::query(
+        r#"
+        TRUNCATE TABLE
+            durable_signals,
+            durable_dead_letter_queue,
+            durable_task_queue,
+            durable_workflow_events,
+            durable_workflow_instances,
+            durable_workers,
+            durable_circuit_breaker_state,
+            durable_schedule_executions,
+            durable_schedules,
+            durable_scheduler_instances
+        RESTART IDENTITY CASCADE
+        "#,
+    )
+    .execute(pool)
+    .await
+    .expect("Failed to reset durable test tables");
+}
+
 /// Create a test store with a fresh database connection
 async fn create_test_store() -> PostgresWorkflowEventStore {
     let database_url = get_database_url();
     let pool = PgPool::connect(&database_url)
         .await
         .expect("Failed to connect to PostgreSQL. Set DATABASE_URL or ensure postgres is running.");
+    reset_durable_tables(&pool).await;
     PostgresWorkflowEventStore::new(pool)
 }
 

--- a/local/Caddyfile
+++ b/local/Caddyfile
@@ -1,6 +1,8 @@
 # Local development reverse proxy
 # Unifies API and UI behind a single port.
-admin :{$CADDY_ADMIN_PORT:2019}
+{
+	admin :{$CADDY_ADMIN_PORT:2019}
+}
 
 # Recommended:
 #   PORT_PREFIX=271  -> proxy 27100, api 27101, ui 27105

--- a/scripts/lib/services.sh
+++ b/scripts/lib/services.sh
@@ -83,6 +83,81 @@ signal_recorded_pids() {
   done
 }
 
+append_unique_pid() {
+  local pid_list="$1"
+  local pid="$2"
+
+  case " $pid_list " in
+    *" $pid "*) printf '%s' "$pid_list" ;;
+    *)
+      if [ -n "$pid_list" ]; then
+        printf '%s %s' "$pid_list" "$pid"
+      else
+        printf '%s' "$pid"
+      fi
+      ;;
+  esac
+}
+
+managed_service_command() {
+  local command_line="$1"
+
+  case "$command_line" in
+    *"scripts/lib/services.sh start-dev"*|*"scripts/lib/services.sh start-all"*|*"scripts/lib/services.sh start-production"*|\
+    *"just start-dev"*|*"just start-all"*|*"just start-production"*|\
+    *"cargo-watch"*|*"caddy run"*|*"next dev"*|*"next start"*|\
+    *"everruns-server"*|*"everruns-worker"*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+listening_pids_on_port() {
+  local port="$1"
+
+  if command -v lsof &> /dev/null; then
+    lsof -nP -t -iTCP:"$port" -sTCP:LISTEN 2>/dev/null | sort -u
+  fi
+}
+
+signal_port_bound_services() {
+  local signal="$1"
+  local signal_name="SIG${signal}"
+  local pid_list=""
+  local port listener_pid current_pid command_line parent_pid
+
+  # Fall back to port-scoped discovery so stop-all still works when pid files
+  # are missing, while keeping cleanup isolated to this worktree's ports.
+  for port in "$API_PORT" "$WORKER_GRPC_PORT" "$UI_PORT" "$PROXY_PORT" "$CADDY_ADMIN_PORT"; do
+    while IFS= read -r listener_pid; do
+      [ -n "$listener_pid" ] || continue
+      current_pid="$listener_pid"
+
+      while [ -n "$current_pid" ] && [ "$current_pid" != "0" ] && [ "$current_pid" != "1" ]; do
+        command_line="$(ps -o command= -p "$current_pid" 2>/dev/null || true)"
+        [ -n "$command_line" ] || break
+        managed_service_command "$command_line" || break
+
+        pid_list="$(append_unique_pid "$pid_list" "$current_pid")"
+
+        parent_pid="$(ps -o ppid= -p "$current_pid" 2>/dev/null | tr -d ' ' || true)"
+        [ -n "$parent_pid" ] || break
+        [ "$parent_pid" != "$current_pid" ] || break
+        current_pid="$parent_pid"
+      done
+    done < <(listening_pids_on_port "$port")
+  done
+
+  for current_pid in $pid_list; do
+    if kill -0 "$current_pid" 2>/dev/null; then
+      kill "-$signal_name" "$current_pid" 2>/dev/null || true
+    fi
+  done
+}
+
 # require_command is defined in common.sh (sourced above)
 
 ui_dev_args=()
@@ -174,6 +249,7 @@ case "$cmd" in
       done
 
       signal_recorded_pids TERM
+      signal_port_bound_services TERM
 
       # Give processes time to terminate gracefully
       sleep 1
@@ -185,6 +261,7 @@ case "$cmd" in
         fi
       done
       signal_recorded_pids KILL
+      signal_port_bound_services KILL
       clear_run_state_dir
 
       # Restore terminal state
@@ -353,6 +430,7 @@ case "$cmd" in
       done
 
       signal_recorded_pids TERM
+      signal_port_bound_services TERM
 
       # Give processes time to terminate gracefully
       sleep 1
@@ -364,6 +442,7 @@ case "$cmd" in
         fi
       done
       signal_recorded_pids KILL
+      signal_port_bound_services KILL
       clear_run_state_dir
 
       # Restore terminal state
@@ -671,6 +750,7 @@ case "$cmd" in
       done
 
       signal_recorded_pids TERM
+      signal_port_bound_services TERM
 
       sleep 1
 
@@ -680,6 +760,7 @@ case "$cmd" in
         fi
       done
       signal_recorded_pids KILL
+      signal_port_bound_services KILL
       clear_run_state_dir
 
       stty sane 2>/dev/null || true
@@ -905,8 +986,10 @@ case "$cmd" in
     echo "🛑 Stopping all Everruns services..."
 
     signal_recorded_pids TERM
+    signal_port_bound_services TERM
     sleep 1
     signal_recorded_pids KILL
+    signal_port_bound_services KILL
     clear_run_state_dir
 
     if resolve_docker_compose 2>/dev/null; then

--- a/scripts/test-port-layout.sh
+++ b/scripts/test-port-layout.sh
@@ -73,8 +73,43 @@ check_example_ports() {
   rg -q '\$\{JAEGER_UI_PORT:-16686\}:16686' "$local_compose_file"
 }
 
+check_caddyfile() {
+  if ! command -v caddy >/dev/null 2>&1; then
+    echo "SKIP: caddy not installed, skipping Caddyfile validation"
+    return 0
+  fi
+
+  caddy validate --config "$PROJECT_ROOT/local/Caddyfile" --adapter caddyfile >/dev/null
+
+  local example_caddyfile
+  example_caddyfile="$(mktemp)"
+  python3 - <<'PY' "$PROJECT_ROOT/examples/docker-compose-full.yaml" "$example_caddyfile"
+from pathlib import Path
+import re
+import sys
+
+compose_file = Path(sys.argv[1])
+output_file = Path(sys.argv[2])
+text = compose_file.read_text()
+match = re.search(r"caddyfile:\n\s+content: \|\n(?P<body>(?:\s{6}.*\n)+)", text)
+if not match:
+    raise SystemExit("FAIL: example compose Caddyfile not found")
+
+body = []
+for line in match.group("body").splitlines():
+    if not line.startswith("      "):
+        raise SystemExit("FAIL: example compose Caddyfile indentation changed unexpectedly")
+    body.append(line[6:])
+
+output_file.write_text("\n".join(body) + "\n")
+PY
+  caddy validate --config "$example_caddyfile" --adapter caddyfile >/dev/null
+  rm -f "$example_caddyfile"
+}
+
 check_default_ports
 check_prefixed_ports
 check_example_ports
+check_caddyfile
 
 echo "port layout checks passed"

--- a/scripts/test-stop-all.sh
+++ b/scripts/test-stop-all.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# shellcheck disable=SC1091
+source "$PROJECT_ROOT/scripts/lib/common.sh"
+
+assert_dead() {
+  local pid="$1"
+  local label="$2"
+
+  if kill -0 "$pid" 2>/dev/null; then
+    echo "FAIL: $label still running (pid $pid)" >&2
+    exit 1
+  fi
+}
+
+wait_for_listener() {
+  local port="$1"
+
+  for _ in {1..20}; do
+    if lsof -nP -t -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.25
+  done
+
+  echo "FAIL: listener never started on port $port" >&2
+  exit 1
+}
+
+export PORT_PREFIX=278
+unset API_PORT WORKER_GRPC_PORT CADDY_ADMIN_PORT UI_PORT PROXY_PORT OTEL_GRPC_PORT OTEL_HTTP_PORT VALKEY_PORT JAEGER_UI_PORT DB_PORT COMPOSE_PROJECT_NAME
+apply_port_prefix_defaults
+
+rm -rf "$RUN_STATE_DIR"
+
+(exec -a everruns-server nc -lk 127.0.0.1 "$API_PORT" >/dev/null 2>&1) &
+listener_pid=$!
+
+cleanup() {
+  kill "$listener_pid" >/dev/null 2>&1 || true
+  wait "$listener_pid" 2>/dev/null || true
+  rm -rf "$RUN_STATE_DIR"
+}
+
+trap cleanup EXIT
+
+wait_for_listener "$API_PORT"
+
+"$PROJECT_ROOT/scripts/lib/services.sh" stop-all >/dev/null
+
+sleep 1
+assert_dead "$listener_pid" "managed listener without pid state"
+
+echo "stop-all fallback cleanup checks passed"


### PR DESCRIPTION
## What
Restore `just stop-all` cleanup when pid tracking state is missing, fix the local Caddy global options block, validate the example compose Caddy config too, and isolate the durable Postgres integration harness so the serialized test path stays deterministic.

## Why
The recent worktree-safe shutdown change could leave managed listeners alive if the pid state directory was missing or stale, which made follow-up `start-all` runs slower and less predictable. At the same time, the local Caddyfile had an invalid top-level `admin` directive, and the durable Postgres integration harness relied on ambient database state.

## How
Add a port-scoped fallback cleanup path in `services.sh`, wrap the local Caddy admin directive in a proper global options block, validate both local and example Caddy configs from shell tests, add a focused `stop-all` regression test, and reset durable integration tables in the serialized Postgres integration helper.

## Risk
- Medium
- Touches local dev orchestration, Caddy config, and durable test harness setup; regressions would primarily affect local startup/shutdown or Postgres integration tests.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
