### PR TITLE
test(runtime): add adapter contract coverage and security-focused negative tests

### DIFF
--- a/crates/server/src/api/user_connections.rs
+++ b/crates/server/src/api/user_connections.rs
@@ -684,4 +684,52 @@ mod tests {
         assert_eq!(query.installation_id, 12345);
         assert_eq!(query.state, None);
     }
+
+    // =========================================================================
+    // GitHub installation callback security negative tests (EVE-54 / EVE-61)
+    // =========================================================================
+
+    #[test]
+    fn empty_cookie_does_not_match_nonempty_query() {
+        let jar = CookieJar::new().add(Cookie::new(GITHUB_INSTALL_STATE_COOKIE, "".to_string()));
+        let result = validate_install_state(&jar, Some("attacker_state"));
+        assert!(
+            result.is_err(),
+            "empty cookie must not match non-empty query"
+        );
+    }
+
+    #[test]
+    fn nonempty_cookie_does_not_match_empty_query() {
+        let jar = CookieJar::new().add(Cookie::new(
+            GITHUB_INSTALL_STATE_COOKIE,
+            "real_state".to_string(),
+        ));
+        let result = validate_install_state(&jar, Some(""));
+        assert!(
+            result.is_err(),
+            "non-empty cookie must not match empty query"
+        );
+    }
+
+    #[test]
+    fn whitespace_padded_state_rejected() {
+        let jar = CookieJar::new().add(Cookie::new(
+            GITHUB_INSTALL_STATE_COOKIE,
+            "abc123".to_string(),
+        ));
+        let result = validate_install_state(&jar, Some(" abc123 "));
+        assert!(result.is_err(), "whitespace-padded state must not match");
+    }
+
+    #[test]
+    fn all_state_failures_return_bad_request() {
+        let (status, _) = validate_install_state(&CookieJar::new(), Some("x")).unwrap_err();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let jar = CookieJar::new().add(Cookie::new(GITHUB_INSTALL_STATE_COOKIE, "x".to_string()));
+        let (status, _) = validate_install_state(&jar, None).unwrap_err();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let (status, _) = validate_install_state(&jar, Some("y")).unwrap_err();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
 }

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -2194,4 +2194,360 @@ mod tests {
             .await;
         assert!(result.is_err());
     }
+
+    // =========================================================================
+    // Adapter contract test harness (EVE-61)
+    //
+    // Reusable macro-driven suite that defines behavioral contracts for
+    // WorkerAdapters. Each test is parameterised by an adapter constructor,
+    // so it runs against DirectWorkerAdapters today and can be wired to
+    // GrpcWorkerAdapters once an in-process gRPC loopback is available.
+    // =========================================================================
+
+    macro_rules! adapter_contract_tests {
+        ($mod_name:ident, $make_adapters:expr) => {
+            mod $mod_name {
+                use super::*;
+
+                #[tokio::test]
+                async fn grep_single_match() {
+                    let (adapters, db) = $make_adapters;
+                    let sid = Uuid::new_v4();
+                    seed_file(&db, sid, "/hello.rs", "fn main() {\n    hello();\n}\n").await;
+                    let results = adapters.grep_files(sid, "hello", None).await.unwrap();
+                    assert_eq!(results.len(), 1);
+                    assert_eq!(results[0].path, "/hello.rs");
+                    assert_eq!(results[0].line_number, 2);
+                    assert!(results[0].line.contains("hello"));
+                }
+
+                #[tokio::test]
+                async fn grep_no_match_returns_empty() {
+                    let (adapters, db) = $make_adapters;
+                    let sid = Uuid::new_v4();
+                    seed_file(&db, sid, "/code.rs", "let x = 1;\n").await;
+                    let results = adapters
+                        .grep_files(sid, "no_such_pattern", None)
+                        .await
+                        .unwrap();
+                    assert!(results.is_empty());
+                }
+
+                #[tokio::test]
+                async fn grep_multiple_files_and_lines() {
+                    let (adapters, db) = $make_adapters;
+                    let sid = Uuid::new_v4();
+                    seed_file(&db, sid, "/a.txt", "ERR line1\nok\nERR line3\n").await;
+                    seed_file(&db, sid, "/b.txt", "ok\nERR line2\n").await;
+                    let results = adapters.grep_files(sid, "ERR", None).await.unwrap();
+                    assert_eq!(results.len(), 3);
+                    let a: Vec<_> = results.iter().filter(|m| m.path == "/a.txt").collect();
+                    assert_eq!(a.len(), 2);
+                    assert_eq!(a[0].line_number, 1);
+                    assert_eq!(a[1].line_number, 3);
+                    let b: Vec<_> = results.iter().filter(|m| m.path == "/b.txt").collect();
+                    assert_eq!(b.len(), 1);
+                    assert_eq!(b[0].line_number, 2);
+                }
+
+                #[tokio::test]
+                async fn grep_regex_pattern() {
+                    let (adapters, db) = $make_adapters;
+                    let sid = Uuid::new_v4();
+                    seed_file(&db, sid, "/nums.txt", "val 1\nval 22\nval 333\n").await;
+                    let results = adapters.grep_files(sid, r"\d{2,}", None).await.unwrap();
+                    assert_eq!(results.len(), 2);
+                }
+
+                #[tokio::test]
+                async fn grep_invalid_regex_is_error() {
+                    let (adapters, _db) = $make_adapters;
+                    let sid = Uuid::new_v4();
+                    assert!(adapters.grep_files(sid, "[bad", None).await.is_err());
+                }
+
+                #[tokio::test]
+                async fn grep_empty_session_returns_empty() {
+                    let (adapters, _db) = $make_adapters;
+                    let sid = Uuid::new_v4();
+                    let results = adapters.grep_files(sid, "anything", None).await.unwrap();
+                    assert!(results.is_empty());
+                }
+
+                #[tokio::test]
+                async fn write_then_read_file() {
+                    let (adapters, _db) = $make_adapters;
+                    let sid = Uuid::new_v4();
+                    let written = adapters
+                        .write_file(sid, "/test.txt", "content", "text")
+                        .await
+                        .unwrap();
+                    assert_eq!(written.path, "/test.txt");
+                    let read = adapters.read_file(sid, "/test.txt").await.unwrap();
+                    assert!(read.is_some());
+                    assert_eq!(read.unwrap().path, "/test.txt");
+                }
+
+                #[tokio::test]
+                async fn read_nonexistent_file_returns_none() {
+                    let (adapters, _db) = $make_adapters;
+                    let sid = Uuid::new_v4();
+                    assert!(
+                        adapters
+                            .read_file(sid, "/nope.txt")
+                            .await
+                            .unwrap()
+                            .is_none()
+                    );
+                }
+
+                #[tokio::test]
+                async fn delete_file_returns_true() {
+                    let (adapters, _db) = $make_adapters;
+                    let sid = Uuid::new_v4();
+                    adapters
+                        .write_file(sid, "/del.txt", "bye", "text")
+                        .await
+                        .unwrap();
+                    assert!(adapters.delete_file(sid, "/del.txt", false).await.unwrap());
+                    assert!(adapters.read_file(sid, "/del.txt").await.unwrap().is_none());
+                }
+
+                #[tokio::test]
+                async fn resolve_image_missing_returns_none() {
+                    let (adapters, _db) = $make_adapters;
+                    let result = adapters
+                        .resolve_image(everruns_core::DEFAULT_ORG_ID, Uuid::new_v4())
+                        .await
+                        .unwrap();
+                    assert!(result.is_none());
+                }
+
+                #[tokio::test]
+                async fn resolve_images_batch_empty_ids() {
+                    let (adapters, _db) = $make_adapters;
+                    let result = adapters
+                        .resolve_images_batch(everruns_core::DEFAULT_ORG_ID, &[])
+                        .await
+                        .unwrap();
+                    assert!(result.is_empty());
+                }
+
+                #[tokio::test]
+                async fn get_session_nonexistent_returns_none() {
+                    let (adapters, _db) = $make_adapters;
+                    let result = adapters
+                        .get_session(everruns_core::DEFAULT_ORG_ID, Uuid::new_v4())
+                        .await
+                        .unwrap();
+                    assert!(result.is_none());
+                }
+
+                #[tokio::test]
+                async fn get_agent_nonexistent_returns_none() {
+                    let (adapters, _db) = $make_adapters;
+                    let result = adapters
+                        .get_agent(everruns_core::DEFAULT_ORG_ID, Uuid::new_v4())
+                        .await
+                        .unwrap();
+                    assert!(result.is_none());
+                }
+
+                #[tokio::test]
+                async fn mcp_server_not_found_is_error() {
+                    let (adapters, _db) = $make_adapters;
+                    assert!(
+                        adapters
+                            .get_mcp_server_by_prefix(
+                                everruns_core::DEFAULT_ORG_ID,
+                                "no_such_prefix"
+                            )
+                            .await
+                            .is_err()
+                    );
+                }
+
+                #[tokio::test]
+                async fn mcp_server_no_api_key() {
+                    let (adapters, db) = $make_adapters;
+                    seed_mcp_server(&db, "Plain Server", None).await;
+                    let info = adapters
+                        .get_mcp_server_by_prefix(everruns_core::DEFAULT_ORG_ID, "plain_server")
+                        .await
+                        .unwrap();
+                    assert!(info.api_key.is_none());
+                    assert_eq!(info.name, "Plain Server");
+                }
+
+                #[tokio::test]
+                async fn mcp_server_with_encrypted_api_key() {
+                    let adapters = test_adapters_with_encryption();
+                    let encrypted = test_encryption().encrypt_string("sk-contract").unwrap();
+                    seed_mcp_server(&adapters.db, "Enc Server", Some(encrypted)).await;
+                    let info = adapters
+                        .get_mcp_server_by_prefix(everruns_core::DEFAULT_ORG_ID, "enc_server")
+                        .await
+                        .unwrap();
+                    assert_eq!(info.api_key.as_deref(), Some("sk-contract"));
+                }
+            }
+        };
+    }
+
+    adapter_contract_tests!(direct_adapter_contract, {
+        let a = test_adapters();
+        let db = a.db.clone();
+        (a, db)
+    });
+
+    // =========================================================================
+    // Cross-org image resolution regression (EVE-56 / EVE-61)
+    // =========================================================================
+
+    async fn seed_image(db: &StorageBackend, org_id: i64) -> Uuid {
+        use crate::storage::models::CreateImageRow;
+        let row = db
+            .create_image(
+                org_id,
+                CreateImageRow {
+                    org_id,
+                    filename: "test.png".to_string(),
+                    content_type: "image/png".to_string(),
+                    size_bytes: 4,
+                    data: vec![0x89, 0x50, 0x4E, 0x47],
+                    thumbnail_data: None,
+                    thumbnail_content_type: None,
+                    metadata: serde_json::json!({}),
+                },
+            )
+            .await
+            .expect("seed image");
+        row.id.into()
+    }
+
+    #[tokio::test]
+    async fn resolve_image_cross_org_isolation() {
+        let adapters = test_adapters();
+        let image_id = seed_image(&adapters.db, everruns_core::DEFAULT_ORG_ID).await;
+        let found = adapters
+            .resolve_image(everruns_core::DEFAULT_ORG_ID, image_id)
+            .await
+            .unwrap();
+        assert!(found.is_some(), "image should be visible in owning org");
+        let cross = adapters.resolve_image(999, image_id).await.unwrap();
+        assert!(
+            cross.is_none(),
+            "image must NOT be visible in different org"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_images_batch_cross_org_isolation() {
+        let adapters = test_adapters();
+        let img1 = seed_image(&adapters.db, everruns_core::DEFAULT_ORG_ID).await;
+        let img2 = seed_image(&adapters.db, everruns_core::DEFAULT_ORG_ID).await;
+        let batch = adapters
+            .resolve_images_batch(everruns_core::DEFAULT_ORG_ID, &[img1, img2])
+            .await
+            .unwrap();
+        assert_eq!(batch.len(), 2);
+        let cross = adapters
+            .resolve_images_batch(999, &[img1, img2])
+            .await
+            .unwrap();
+        assert!(cross.is_empty(), "images must not leak across orgs");
+    }
+
+    // =========================================================================
+    // MCP auth-required execution coverage (EVE-55 / EVE-61)
+    // =========================================================================
+
+    #[tokio::test]
+    async fn mcp_server_encrypted_key_decrypts_correctly() {
+        let adapters = test_adapters_with_encryption();
+        let enc = test_encryption();
+        let key = "sk-mcp-auth-test-12345";
+        let encrypted = enc.encrypt_string(key).unwrap();
+        seed_mcp_server(&adapters.db, "Auth Required MCP", Some(encrypted)).await;
+        let info = adapters
+            .get_mcp_server_by_prefix(everruns_core::DEFAULT_ORG_ID, "auth_required_mcp")
+            .await
+            .unwrap();
+        assert_eq!(info.api_key.as_deref(), Some(key));
+        assert_eq!(info.url, "https://example.com/mcp");
+    }
+
+    #[tokio::test]
+    async fn mcp_server_encrypted_key_without_encryption_service_fails() {
+        let adapters = test_adapters();
+        let enc = test_encryption();
+        let encrypted = enc.encrypt_string("sk-should-fail").unwrap();
+        seed_mcp_server(&adapters.db, "Fail MCP", Some(encrypted)).await;
+        let result = adapters
+            .get_mcp_server_by_prefix(everruns_core::DEFAULT_ORG_ID, "fail_mcp")
+            .await;
+        assert!(
+            result.is_err(),
+            "decryption without encryption service must fail"
+        );
+    }
+
+    #[tokio::test]
+    async fn mcp_server_wrong_org_not_found() {
+        let adapters = test_adapters();
+        seed_mcp_server(&adapters.db, "Org Scoped MCP", None).await;
+        assert!(
+            adapters
+                .get_mcp_server_by_prefix(everruns_core::DEFAULT_ORG_ID, "org_scoped_mcp")
+                .await
+                .is_ok()
+        );
+        assert!(
+            adapters
+                .get_mcp_server_by_prefix(999, "org_scoped_mcp")
+                .await
+                .is_err(),
+            "MCP server must not be visible in wrong org"
+        );
+    }
+
+    // =========================================================================
+    // Encrypted DB key model sync regression (EVE-57 / EVE-61)
+    // =========================================================================
+
+    #[tokio::test]
+    async fn get_model_with_provider_returns_none_for_missing() {
+        let adapters = test_adapters();
+        let result = adapters
+            .get_model_with_provider(everruns_core::DEFAULT_ORG_ID, Uuid::new_v4())
+            .await
+            .unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_default_model_returns_none_when_no_providers() {
+        let adapters = test_adapters();
+        let result = adapters
+            .get_default_model(everruns_core::DEFAULT_ORG_ID)
+            .await
+            .unwrap();
+        assert!(result.is_none());
+    }
+
+    // =========================================================================
+    // Usage attribution org scoping (EVE-56 / EVE-61)
+    // =========================================================================
+
+    #[tokio::test]
+    async fn platform_store_agent_count_isolated_per_org() {
+        let adapters = test_adapters();
+        seed_agent(&adapters.db).await;
+        let store_org1 = adapters.platform_store(everruns_core::DEFAULT_ORG_ID);
+        let agents_org1 = store_org1.list_agents().await.unwrap();
+        assert!(!agents_org1.is_empty(), "default org should have agents");
+        let store_org999 = adapters.platform_store(999);
+        let agents_org999 = store_org999.list_agents().await.unwrap();
+        assert!(agents_org999.is_empty(), "org 999 should have no agents");
+    }
 }

--- a/crates/server/src/services/model_sync.rs
+++ b/crates/server/src/services/model_sync.rs
@@ -605,4 +605,108 @@ mod tests {
         let results = service.sync_all().await.unwrap();
         assert_eq!(results.len(), 2);
     }
+
+    // =========================================================================
+    // Encrypted DB key model sync negative tests (EVE-57 / EVE-61)
+    // =========================================================================
+
+    #[tokio::test]
+    async fn resolve_api_key_corrupted_encrypted_data_fails() {
+        use everruns_core::DEFAULT_ORG_ID;
+        let db = Arc::new(StorageBackend::in_memory());
+        let encryption = Arc::new(
+            EncryptionService::new("kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=", &[])
+                .unwrap(),
+        );
+        let registry = Arc::new(DriverRegistry::new());
+        let service = ModelSyncService::new(db.clone(), registry, Some(encryption));
+        let provider = db
+            .create_llm_provider(
+                DEFAULT_ORG_ID,
+                CreateLlmProviderRow {
+                    name: "Corrupt Provider".to_string(),
+                    provider_type: "openai".to_string(),
+                    base_url: None,
+                    api_key_encrypted: Some(b"not-valid-encrypted-data".to_vec()),
+                    settings: None,
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            service.resolve_api_key(&provider).is_err(),
+            "corrupted data must error"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_api_key_wrong_key_id_fails() {
+        use everruns_core::DEFAULT_ORG_ID;
+        let db = Arc::new(StorageBackend::in_memory());
+        let enc_v1 = Arc::new(
+            EncryptionService::new("kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=", &[])
+                .unwrap(),
+        );
+        let encrypted = enc_v1.encrypt_string("sk-secret").unwrap();
+        let enc_v2 = Arc::new(
+            EncryptionService::new(
+                &crate::storage::encryption::generate_encryption_key("kek-v2"),
+                &[],
+            )
+            .unwrap(),
+        );
+        let registry = Arc::new(DriverRegistry::new());
+        let service = ModelSyncService::new(db.clone(), registry, Some(enc_v2));
+        let provider = db
+            .create_llm_provider(
+                DEFAULT_ORG_ID,
+                CreateLlmProviderRow {
+                    name: "Wrong Key Provider".to_string(),
+                    provider_type: "openai".to_string(),
+                    base_url: None,
+                    api_key_encrypted: Some(encrypted),
+                    settings: None,
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            service.resolve_api_key(&provider).is_err(),
+            "wrong key must error"
+        );
+    }
+
+    #[tokio::test]
+    async fn sync_all_provider_not_visible_cross_org() {
+        use everruns_core::DEFAULT_ORG_ID;
+        let db = Arc::new(StorageBackend::in_memory());
+        let registry = Arc::new(DriverRegistry::new());
+        let service = ModelSyncService::new(db.clone(), registry, None);
+        let _p1 = db
+            .create_llm_provider(
+                DEFAULT_ORG_ID,
+                CreateLlmProviderRow {
+                    name: "OpenAI".to_string(),
+                    provider_type: "openai".to_string(),
+                    base_url: None,
+                    api_key_encrypted: None,
+                    settings: None,
+                },
+            )
+            .await
+            .unwrap();
+        let _org2 = db
+            .create_organization_with_id(
+                2,
+                CreateOrganizationRow {
+                    public_id: "org-2".to_string(),
+                    name: "Org 2".to_string(),
+                    created_by: None,
+                },
+            )
+            .await
+            .unwrap();
+        let results = service.sync_all().await.unwrap();
+        assert_eq!(results.len(), 1, "org 2 has no providers");
+    }
 }

--- a/crates/server/src/storage/encryption.rs
+++ b/crates/server/src/storage/encryption.rs
@@ -887,4 +887,84 @@ mod tests {
             "rotated-secret"
         );
     }
+
+    // =========================================================================
+    // Encrypted DB key sync negative tests (EVE-57 / EVE-61)
+    // =========================================================================
+
+    #[test]
+    fn test_tampered_ciphertext_fails() {
+        let key = test_key("kek-v1");
+        let service = EncryptionService::new(&key, &[]).unwrap();
+        let encrypted = service.encrypt_string("secret").unwrap();
+        let mut payload: EncryptedPayload = serde_json::from_slice(&encrypted).unwrap();
+        let mut chars: Vec<char> = payload.ciphertext.chars().collect();
+        if !chars.is_empty() {
+            chars[0] = if chars[0] == 'A' { 'B' } else { 'A' };
+        }
+        payload.ciphertext = chars.into_iter().collect();
+        let tampered = serde_json::to_vec(&payload).unwrap();
+        assert!(
+            service.decrypt(&tampered).is_err(),
+            "tampered ciphertext must fail"
+        );
+    }
+
+    #[test]
+    fn test_tampered_dek_fails() {
+        let key = test_key("kek-v1");
+        let service = EncryptionService::new(&key, &[]).unwrap();
+        let encrypted = service.encrypt_string("secret").unwrap();
+        let mut payload: EncryptedPayload = serde_json::from_slice(&encrypted).unwrap();
+        let mut chars: Vec<char> = payload.dek_wrapped.chars().collect();
+        if !chars.is_empty() {
+            chars[0] = if chars[0] == 'A' { 'B' } else { 'A' };
+        }
+        payload.dek_wrapped = chars.into_iter().collect();
+        let tampered = serde_json::to_vec(&payload).unwrap();
+        assert!(
+            service.decrypt(&tampered).is_err(),
+            "tampered DEK must fail"
+        );
+    }
+
+    #[test]
+    fn test_truncated_payload_fails() {
+        let key = test_key("kek-v1");
+        let service = EncryptionService::new(&key, &[]).unwrap();
+        let encrypted = service.encrypt_string("secret").unwrap();
+        let truncated = &encrypted[..encrypted.len() / 2];
+        assert!(
+            service.decrypt(truncated).is_err(),
+            "truncated payload must fail"
+        );
+    }
+
+    #[test]
+    fn test_empty_payload_fails() {
+        let key = test_key("kek-v1");
+        let service = EncryptionService::new(&key, &[]).unwrap();
+        assert!(service.decrypt(&[]).is_err(), "empty payload must fail");
+    }
+
+    #[test]
+    fn test_non_json_payload_fails() {
+        let key = test_key("kek-v1");
+        let service = EncryptionService::new(&key, &[]).unwrap();
+        assert!(service.decrypt(b"not json").is_err(), "non-JSON must fail");
+    }
+
+    #[test]
+    fn test_cross_key_without_registration_fails() {
+        let key_v1 = test_key("kek-v1");
+        let key_v2 = test_key("kek-v2");
+        let key_v3 = test_key("kek-v3");
+        let svc_v1 = EncryptionService::new(&key_v1, &[]).unwrap();
+        let encrypted = svc_v1.encrypt_string("secret").unwrap();
+        let svc_v3 = EncryptionService::new(&key_v3, &[&key_v2]).unwrap();
+        assert!(
+            svc_v3.decrypt(&encrypted).is_err(),
+            "unknown key_id must fail"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Reusable `adapter_contract_tests!` macro generating 16 parameterised contract tests for `WorkerAdapters` trait (session-file grep parity, file CRUD, image resolution, MCP server lookup, session/agent retrieval)
- Security negative tests for GitHub installation callback state validation (EVE-54): empty/whitespace state, mismatched cookies, all failures return BAD_REQUEST
- Cross-org image isolation tests (EVE-56): `resolve_image` and `resolve_images_batch` enforce org scoping, plus platform store agent count isolation
- Encrypted DB key sync negative tests (EVE-57): tampered ciphertext/DEK, truncated/empty/non-JSON payloads, cross-key without registration, corrupted provider data, wrong key ID
- MCP auth-required execution coverage (EVE-55): encrypted key decryption, missing encryption service, wrong-org rejection

## Test plan
- [x] `cargo test -p everruns-server --lib --all-features` — 528 passed
- [x] `cargo clippy -p everruns-server --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] CI green

Closes EVE-61

https://claude.ai/code/session_01CSXnFmr6B5FE4QPrUTDgzE