### PR TITLE
refactor(multitenancy): thread org_id through worker and image-resolution interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 **/target/
 **/*.rs.bk
 
+# Claude Code agent worktrees
+.claude/worktrees/
+
 # IDE
 .idea/
 .vscode/

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -222,7 +222,7 @@ pub use mcp_server::{
 pub use organization::{
     ANONYMOUS_USER_EMAIL, ANONYMOUS_USER_ID, ANONYMOUS_USER_NAME, DEFAULT_ORG_ID,
     DEFAULT_ORG_PUBLIC_ID, OrgMembership, OrgRole, Organization, generate_org_public_id,
-    validate_org_public_id,
+    org_public_id_from_internal, validate_org_public_id,
 };
 pub use session::{Session, SessionStatus};
 pub use session_file::{FileInfo, FileStat, GrepMatch, GrepResult, SessionFile};

--- a/crates/core/src/organization.rs
+++ b/crates/core/src/organization.rs
@@ -112,6 +112,18 @@ pub struct OrgMembership {
     pub role: OrgRole,
 }
 
+/// Derive a deterministic public_id from an internal org_id.
+///
+/// For `DEFAULT_ORG_ID` this returns `DEFAULT_ORG_PUBLIC_ID`.
+/// For other IDs it produces `org_<032x>` so callers can avoid
+/// an async DB lookup when only the public_id format is needed.
+pub fn org_public_id_from_internal(org_id: i64) -> String {
+    if org_id == DEFAULT_ORG_ID {
+        return DEFAULT_ORG_PUBLIC_ID.to_string();
+    }
+    format!("org_{:032x}", org_id)
+}
+
 /// Generate a new organization public ID
 /// Format: org_<32-hex-chars> (UUIDv4 lowercase hex, no dashes)
 pub fn generate_org_public_id() -> String {

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -497,7 +497,10 @@ message GetModelWithProviderResponse {
     optional ModelWithProvider model = 1;
 }
 
-message GetDefaultModelRequest {}
+message GetDefaultModelRequest {
+    // Organization ID for resource scoping
+    int64 org_id = 1;
+}
 
 message GetDefaultModelResponse {
     optional ModelWithProvider model = 1;

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -17,9 +17,9 @@ use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
 use everruns_core::traits::ResolvedImage;
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId};
 use everruns_core::{
-    Agent, AgentStatus, ContentPart, DEFAULT_ORG_PUBLIC_ID, DriverRegistry, EventData, Harness,
-    HarnessStatus, LlmProviderType, Message, MessageRole, Session, SessionStatus, ToolDefinition,
-    ToolRegistry, ToolResultContentPart,
+    Agent, AgentStatus, ContentPart, DriverRegistry, EventData, Harness, HarnessStatus,
+    LlmProviderType, Message, MessageRole, Session, SessionStatus, ToolDefinition, ToolRegistry,
+    ToolResultContentPart,
 };
 use everruns_worker::create_driver_registry;
 use everruns_worker::mcp_executor::McpServerInfo;
@@ -199,7 +199,7 @@ impl WorkerAdapters for DirectWorkerAdapters {
             let capabilities = serde_json::from_value(r.capabilities).unwrap_or_default();
             Session {
                 id: r.id,
-                organization_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
+                organization_id: everruns_core::org_public_id_from_internal(org_id),
                 harness_id: r.harness_id.unwrap_or_else(|| HarnessId::from_seed(1)),
                 agent_id: r.agent_id,
                 title: r.title,
@@ -319,12 +319,12 @@ impl WorkerAdapters for DirectWorkerAdapters {
 
     async fn get_model_with_provider(
         &self,
-        _org_id: i64,
+        org_id: i64,
         model_id: Uuid,
     ) -> Result<Option<ModelWithProvider>> {
         let resolved = self
             .llm_resolver
-            .resolve_model(model_id)
+            .resolve_model(org_id, model_id)
             .await
             .map_err(|e| {
                 tracing::error!("Failed to resolve model: {}", e);
@@ -339,10 +339,10 @@ impl WorkerAdapters for DirectWorkerAdapters {
         }))
     }
 
-    async fn get_default_model(&self, _org_id: i64) -> Result<Option<ModelWithProvider>> {
+    async fn get_default_model(&self, org_id: i64) -> Result<Option<ModelWithProvider>> {
         let resolved = self
             .llm_resolver
-            .resolve_default_model()
+            .resolve_default_model(org_id)
             .await
             .map_err(|e| {
                 tracing::error!("Failed to resolve default model: {}", e);
@@ -1119,11 +1119,11 @@ impl DirectPlatformStore {
         }
     }
 
-    fn row_to_session(row: crate::storage::SessionRow) -> Session {
+    fn row_to_session(&self, row: crate::storage::SessionRow) -> Session {
         let capabilities = serde_json::from_value(row.capabilities).unwrap_or_default();
         Session {
             id: row.id,
-            organization_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
+            organization_id: everruns_core::org_public_id_from_internal(self.org_id),
             harness_id: row.harness_id.unwrap_or_else(|| HarnessId::from_seed(1)),
             agent_id: row.agent_id,
             title: row.title,
@@ -1466,7 +1466,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
             .await
             .map_err(|e| store_error(format!("Failed to list sessions: {e}")))?;
 
-        Ok(rows.into_iter().map(Self::row_to_session).collect())
+        Ok(rows.into_iter().map(|r| self.row_to_session(r)).collect())
     }
 
     async fn create_session(
@@ -1493,7 +1493,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
             .await
             .map_err(|e| store_error(format!("Failed to create session: {e}")))?;
 
-        Ok(Self::row_to_session(row))
+        Ok(self.row_to_session(row))
     }
 
     async fn get_session_by_id(
@@ -1506,7 +1506,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
             .await
             .map_err(|e| store_error(format!("Failed to get session: {e}")))?;
 
-        Ok(row.map(Self::row_to_session))
+        Ok(row.map(|r| self.row_to_session(r)))
     }
 
     async fn delete_session(&self, id: SessionId) -> everruns_core::error::Result<()> {
@@ -2457,6 +2457,47 @@ mod tests {
                 .await
                 .is_err(),
             "MCP server must not be visible in wrong org"
+        );
+    }
+
+    // =========================================================================
+    // Cross-org isolation regression tests (EVE-59)
+    // =========================================================================
+
+    /// Regression: get_session must populate organization_id from org_id,
+    /// not hardcode DEFAULT_ORG_PUBLIC_ID.
+    #[tokio::test]
+    async fn get_session_carries_org_public_id() {
+        use crate::storage::models::CreateSessionRow;
+
+        let adapters = test_adapters();
+        let agent_id = seed_agent(&adapters.db).await;
+
+        let row = adapters
+            .db
+            .create_session(CreateSessionRow {
+                org_id: everruns_core::DEFAULT_ORG_ID,
+                agent_id: Some(AgentId::from_uuid(agent_id)),
+                harness_id: Some(HarnessId::from_seed(1)),
+                title: None,
+                tags: vec![],
+                model_id: None,
+                capabilities: serde_json::Value::Array(vec![]),
+                tools: serde_json::Value::Array(vec![]),
+            })
+            .await
+            .expect("create session");
+
+        let session = adapters
+            .get_session(everruns_core::DEFAULT_ORG_ID, row.id.uuid())
+            .await
+            .unwrap()
+            .expect("session should exist");
+
+        assert_eq!(
+            session.organization_id,
+            everruns_core::DEFAULT_ORG_PUBLIC_ID,
+            "session must carry the correct org public_id"
         );
     }
 

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -870,7 +870,7 @@ impl WorkerService for WorkerServiceImpl {
 
         let model: Option<proto::ModelWithProvider> = if let Some(mid) = model_id {
             self.llm_resolver_service
-                .resolve_model(mid.uuid())
+                .resolve_model(req.org_id, mid.uuid())
                 .await
                 .map_err(|e| {
                     tracing::error!("Failed to resolve model: {}", e);
@@ -880,7 +880,7 @@ impl WorkerService for WorkerServiceImpl {
         } else {
             // Try to get the default model
             self.llm_resolver_service
-                .resolve_default_model()
+                .resolve_default_model(req.org_id)
                 .await
                 .map_err(|e| {
                     tracing::error!("Failed to resolve default model: {}", e);
@@ -1381,7 +1381,7 @@ impl WorkerService for WorkerServiceImpl {
         // Resolve model via LlmResolverService
         let resolved = self
             .llm_resolver_service
-            .resolve_model(model_id)
+            .resolve_model(req.org_id, model_id)
             .await
             .map_err(|e| {
                 tracing::error!("Failed to resolve model: {}", e);
@@ -1395,8 +1395,9 @@ impl WorkerService for WorkerServiceImpl {
 
     async fn get_default_model(
         &self,
-        _request: Request<GetDefaultModelRequest>,
+        request: Request<GetDefaultModelRequest>,
     ) -> Result<Response<GetDefaultModelResponse>, Status> {
+        let req = request.into_inner();
         // Check if encryption service is available
         if !self.llm_resolver_service.has_encryption() {
             tracing::error!("gRPC get_default_model: encryption service not available");
@@ -1408,7 +1409,7 @@ impl WorkerService for WorkerServiceImpl {
         // Resolve default model via LlmResolverService
         let resolved = self
             .llm_resolver_service
-            .resolve_default_model()
+            .resolve_default_model(req.org_id)
             .await
             .map_err(|e| {
                 tracing::error!("Failed to resolve default model: {}", e);

--- a/crates/server/src/services/llm_resolver.rs
+++ b/crates/server/src/services/llm_resolver.rs
@@ -15,7 +15,6 @@
 
 use crate::storage::{EncryptionService, StorageBackend, models::LlmProviderRow};
 use anyhow::Result;
-use everruns_core::DEFAULT_ORG_ID;
 use moka::future::Cache;
 use std::sync::Arc;
 use std::time::Duration;
@@ -130,8 +129,11 @@ impl LlmResolverService {
 
     /// Resolve a model by ID with decrypted provider credentials.
     /// Results are cached per (org_id, model_id) with 1-hour TTL.
-    pub async fn resolve_model(&self, model_id: Uuid) -> Result<Option<ResolvedModel>> {
-        let org_id = DEFAULT_ORG_ID;
+    pub async fn resolve_model(
+        &self,
+        org_id: i64,
+        model_id: Uuid,
+    ) -> Result<Option<ResolvedModel>> {
         let key = (org_id, model_id);
 
         if let Some(cached) = self.cache.get(&key).await {
@@ -145,8 +147,7 @@ impl LlmResolverService {
 
     /// Resolve the default model with decrypted provider credentials.
     /// Cached under sentinel key (org_id, nil UUID).
-    pub async fn resolve_default_model(&self) -> Result<Option<ResolvedModel>> {
-        let org_id = DEFAULT_ORG_ID;
+    pub async fn resolve_default_model(&self, org_id: i64) -> Result<Option<ResolvedModel>> {
         let key = (org_id, DEFAULT_MODEL_SENTINEL);
 
         if let Some(cached) = self.cache.get(&key).await {
@@ -248,6 +249,7 @@ impl LlmResolverService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use everruns_core::DEFAULT_ORG_ID;
 
     fn mock_env<'a>(vars: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<String> + 'a {
         move |name| {
@@ -394,7 +396,10 @@ mod tests {
         assert_eq!(resolver.cache_entry_count(), 0);
 
         // First call: cache miss -> populates cache
-        let result = resolver.resolve_model(model_id).await.unwrap();
+        let result = resolver
+            .resolve_model(DEFAULT_ORG_ID, model_id)
+            .await
+            .unwrap();
         assert!(result.is_some());
         let resolved = result.unwrap();
         assert_eq!(resolved.model_id, "gpt-4o");
@@ -405,7 +410,10 @@ mod tests {
         assert_eq!(resolver.cache_entry_count(), 1);
 
         // Second call: cache hit (same result)
-        let result2 = resolver.resolve_model(model_id).await.unwrap();
+        let result2 = resolver
+            .resolve_model(DEFAULT_ORG_ID, model_id)
+            .await
+            .unwrap();
         assert!(result2.is_some());
         assert_eq!(result2.unwrap().model_id, "gpt-4o");
 
@@ -421,14 +429,20 @@ mod tests {
         let missing_id = Uuid::new_v4();
 
         // First call: miss, returns None, caches it
-        let result = resolver.resolve_model(missing_id).await.unwrap();
+        let result = resolver
+            .resolve_model(DEFAULT_ORG_ID, missing_id)
+            .await
+            .unwrap();
         assert!(result.is_none());
 
         resolver.cache.run_pending_tasks().await;
         assert_eq!(resolver.cache_entry_count(), 1);
 
         // Second call: cache hit (still None)
-        let result2 = resolver.resolve_model(missing_id).await.unwrap();
+        let result2 = resolver
+            .resolve_model(DEFAULT_ORG_ID, missing_id)
+            .await
+            .unwrap();
         assert!(result2.is_none());
     }
 
@@ -437,7 +451,10 @@ mod tests {
         let (resolver, model_id) = setup_resolver_with_model().await;
 
         // Populate cache
-        resolver.resolve_model(model_id).await.unwrap();
+        resolver
+            .resolve_model(DEFAULT_ORG_ID, model_id)
+            .await
+            .unwrap();
         resolver.cache.run_pending_tasks().await;
         assert_eq!(resolver.cache_entry_count(), 1);
 
@@ -502,8 +519,14 @@ mod tests {
             .unwrap();
 
         // Resolve both models
-        let ra = resolver.resolve_model(model_a.id.uuid()).await.unwrap();
-        let rb = resolver.resolve_model(model_b.id.uuid()).await.unwrap();
+        let ra = resolver
+            .resolve_model(DEFAULT_ORG_ID, model_a.id.uuid())
+            .await
+            .unwrap();
+        let rb = resolver
+            .resolve_model(DEFAULT_ORG_ID, model_b.id.uuid())
+            .await
+            .unwrap();
 
         assert_eq!(ra.unwrap().model_id, "claude-3-opus");
         assert_eq!(rb.unwrap().model_id, "claude-3-sonnet");
@@ -549,7 +572,10 @@ mod tests {
         .unwrap();
 
         // First call: populates cache
-        let result = resolver.resolve_default_model().await.unwrap();
+        let result = resolver
+            .resolve_default_model(DEFAULT_ORG_ID)
+            .await
+            .unwrap();
         assert!(result.is_some());
         assert_eq!(result.unwrap().model_id, "gpt-4o");
 
@@ -557,7 +583,10 @@ mod tests {
         assert_eq!(resolver.cache_entry_count(), 1);
 
         // Second call: cache hit
-        let result2 = resolver.resolve_default_model().await.unwrap();
+        let result2 = resolver
+            .resolve_default_model(DEFAULT_ORG_ID)
+            .await
+            .unwrap();
         assert!(result2.is_some());
         assert_eq!(result2.unwrap().model_id, "gpt-4o");
     }
@@ -570,7 +599,10 @@ mod tests {
 
         // Resolve a missing model -> cached as None
         let missing_id = Uuid::new_v4();
-        let result = resolver.resolve_model(missing_id).await.unwrap();
+        let result = resolver
+            .resolve_model(DEFAULT_ORG_ID, missing_id)
+            .await
+            .unwrap();
         assert!(result.is_none());
 
         resolver.cache.run_pending_tasks().await;
@@ -582,7 +614,10 @@ mod tests {
         assert_eq!(resolver.cache_entry_count(), 0);
 
         // Next resolve goes to DB again (still None since model doesn't exist)
-        let result2 = resolver.resolve_model(missing_id).await.unwrap();
+        let result2 = resolver
+            .resolve_model(DEFAULT_ORG_ID, missing_id)
+            .await
+            .unwrap();
         assert!(result2.is_none());
 
         // But entry is re-cached
@@ -669,5 +704,82 @@ mod tests {
         // No encrypted key, no env var -> None
         let result = resolve_provider_api_key(&db, None, &provider).unwrap();
         assert!(result.is_none());
+    }
+
+    // =========================================================================
+    // Cross-org isolation regression tests (EVE-59)
+    // =========================================================================
+
+    /// Regression: resolve_model must scope lookups to the given org_id.
+    /// A model created in org 1 must not be visible when resolved with org 999.
+    #[tokio::test]
+    async fn resolve_model_scoped_to_org() {
+        let (resolver, model_id) = setup_resolver_with_model().await;
+
+        // Model belongs to DEFAULT_ORG_ID — should resolve
+        let result = resolver
+            .resolve_model(DEFAULT_ORG_ID, model_id)
+            .await
+            .unwrap();
+        assert!(result.is_some(), "model should resolve in its own org");
+
+        // Same model UUID with a different org — should NOT resolve
+        let result = resolver.resolve_model(999, model_id).await.unwrap();
+        assert!(result.is_none(), "model must not resolve in another org");
+    }
+
+    /// Regression: resolve_default_model must scope to the given org_id.
+    #[tokio::test]
+    async fn resolve_default_model_scoped_to_org() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let resolver = LlmResolverService::new(db.clone(), None);
+        let org_id = DEFAULT_ORG_ID;
+
+        let provider_row = db
+            .create_llm_provider(
+                org_id,
+                CreateLlmProviderRow {
+                    name: "OpenAI".to_string(),
+                    provider_type: "openai".to_string(),
+                    base_url: None,
+                    api_key_encrypted: None,
+                    settings: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        db.create_llm_model(
+            org_id,
+            CreateLlmModelRow {
+                provider_id: provider_row.id,
+                model_id: "gpt-4o".to_string(),
+                display_name: "GPT-4o".to_string(),
+                capabilities: vec![],
+                is_default: true,
+                is_favorite: false,
+                source: "manual".to_string(),
+                provider_metadata: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        // Default model belongs to DEFAULT_ORG_ID — should resolve
+        let result = resolver
+            .resolve_default_model(DEFAULT_ORG_ID)
+            .await
+            .unwrap();
+        assert!(
+            result.is_some(),
+            "default model should resolve in its own org"
+        );
+
+        // Different org — should NOT resolve
+        let result = resolver.resolve_default_model(999).await.unwrap();
+        assert!(
+            result.is_none(),
+            "default model must not resolve in another org"
+        );
     }
 }

--- a/crates/server/src/storage/agent_store.rs
+++ b/crates/server/src/storage/agent_store.rs
@@ -2,10 +2,14 @@
 //
 // This module implements the core AgentStore trait for retrieving
 // agent configurations from the database.
+//
+// Decision: org_id is baked into the struct at construction time,
+// matching the Grpc/Adapter store pattern. Callers must provide
+// the correct org_id when creating the store.
 
 use async_trait::async_trait;
 use everruns_core::{
-    AgentCapabilityConfig, AgentId, AgentLoopError, DEFAULT_ORG_ID, Result,
+    AgentCapabilityConfig, AgentId, AgentLoopError, Result,
     agent::{Agent, AgentStatus},
     traits::AgentStore,
 };
@@ -23,21 +27,21 @@ use super::repositories::Database;
 #[derive(Clone)]
 pub struct DbAgentStore {
     db: Database,
+    org_id: i64,
 }
 
 impl DbAgentStore {
-    pub fn new(db: Database) -> Self {
-        Self { db }
+    pub fn new(db: Database, org_id: i64) -> Self {
+        Self { db, org_id }
     }
 }
 
 #[async_trait]
 impl AgentStore for DbAgentStore {
     async fn get_agent(&self, agent_id: AgentId) -> Result<Option<Agent>> {
-        // TODO: Get org_id from context after Phase 3
         let agent_row = self
             .db
-            .get_agent(DEFAULT_ORG_ID, agent_id)
+            .get_agent(self.org_id, agent_id)
             .await
             .map_err(|e| AgentLoopError::store(e.to_string()))?;
 
@@ -83,7 +87,7 @@ impl AgentStore for DbAgentStore {
 // Factory functions
 // ============================================================================
 
-/// Create a database-backed agent store
-pub fn create_db_agent_store(db: Database) -> DbAgentStore {
-    DbAgentStore::new(db)
+/// Create a database-backed agent store scoped to the given org
+pub fn create_db_agent_store(db: Database, org_id: i64) -> DbAgentStore {
+    DbAgentStore::new(db, org_id)
 }

--- a/crates/server/src/storage/harness_store.rs
+++ b/crates/server/src/storage/harness_store.rs
@@ -2,10 +2,13 @@
 //
 // Implements the core HarnessStore trait for retrieving
 // harness configurations from the database.
+//
+// Decision: org_id is baked into the struct at construction time,
+// matching the Grpc/Adapter store pattern.
 
 use async_trait::async_trait;
 use everruns_core::{
-    AgentCapabilityConfig, AgentLoopError, DEFAULT_ORG_ID, HarnessId, Result,
+    AgentCapabilityConfig, AgentLoopError, HarnessId, Result,
     harness::{Harness, HarnessStatus},
     traits::HarnessStore,
 };
@@ -23,11 +26,12 @@ use super::repositories::Database;
 #[derive(Clone)]
 pub struct DbHarnessStore {
     db: Database,
+    org_id: i64,
 }
 
 impl DbHarnessStore {
-    pub fn new(db: Database) -> Self {
-        Self { db }
+    pub fn new(db: Database, org_id: i64) -> Self {
+        Self { db, org_id }
     }
 }
 
@@ -36,7 +40,7 @@ impl HarnessStore for DbHarnessStore {
     async fn get_harness(&self, harness_id: HarnessId) -> Result<Option<Harness>> {
         let harness_row = self
             .db
-            .get_harness(DEFAULT_ORG_ID, harness_id)
+            .get_harness(self.org_id, harness_id)
             .await
             .map_err(|e| AgentLoopError::store(e.to_string()))?;
 
@@ -75,7 +79,7 @@ impl HarnessStore for DbHarnessStore {
 // Factory functions
 // ============================================================================
 
-/// Create a database-backed harness store
-pub fn create_db_harness_store(db: Database) -> DbHarnessStore {
-    DbHarnessStore::new(db)
+/// Create a database-backed harness store scoped to the given org
+pub fn create_db_harness_store(db: Database, org_id: i64) -> DbHarnessStore {
+    DbHarnessStore::new(db, org_id)
 }

--- a/crates/server/src/storage/llm_provider_store.rs
+++ b/crates/server/src/storage/llm_provider_store.rs
@@ -2,10 +2,13 @@
 //
 // This module implements the core LlmProviderStore trait for retrieving
 // LLM provider and model configurations from the database.
+//
+// Decision: org_id is baked into the struct at construction time,
+// matching the Grpc/Adapter store pattern.
 
 use async_trait::async_trait;
 use everruns_core::{
-    AgentLoopError, DEFAULT_ORG_ID, ModelId, Result,
+    AgentLoopError, ModelId, Result,
     llm_models::LlmProviderType,
     traits::{LlmProviderStore, ModelWithProvider},
 };
@@ -26,11 +29,16 @@ use super::{encryption::EncryptionService, repositories::Database};
 pub struct DbLlmProviderStore {
     db: Database,
     encryption: EncryptionService,
+    org_id: i64,
 }
 
 impl DbLlmProviderStore {
-    pub fn new(db: Database, encryption: EncryptionService) -> Self {
-        Self { db, encryption }
+    pub fn new(db: Database, encryption: EncryptionService, org_id: i64) -> Self {
+        Self {
+            db,
+            encryption,
+            org_id,
+        }
     }
 }
 
@@ -43,7 +51,7 @@ impl LlmProviderStore for DbLlmProviderStore {
         // Look up the model
         let model_row = self
             .db
-            .get_llm_model(DEFAULT_ORG_ID, model_id.uuid())
+            .get_llm_model(self.org_id, model_id.uuid())
             .await
             .map_err(|e| AgentLoopError::store(e.to_string()))?;
 
@@ -55,7 +63,7 @@ impl LlmProviderStore for DbLlmProviderStore {
         // Look up the provider
         let provider_row = self
             .db
-            .get_llm_provider(DEFAULT_ORG_ID, model_row.provider_id.uuid())
+            .get_llm_provider(self.org_id, model_row.provider_id.uuid())
             .await
             .map_err(|e| AgentLoopError::store(e.to_string()))?;
 
@@ -83,10 +91,9 @@ impl LlmProviderStore for DbLlmProviderStore {
 
     async fn get_default_model(&self) -> Result<Option<ModelWithProvider>> {
         // Look up the default model (is_default = true)
-        // TODO: Get org_id from context after Phase 3
         let model_row = self
             .db
-            .get_default_llm_model(DEFAULT_ORG_ID)
+            .get_default_llm_model(self.org_id)
             .await
             .map_err(|e| AgentLoopError::store(e.to_string()))?;
 
@@ -98,7 +105,7 @@ impl LlmProviderStore for DbLlmProviderStore {
         // Look up the provider
         let provider_row = self
             .db
-            .get_llm_provider(DEFAULT_ORG_ID, model_row.provider_id.uuid())
+            .get_llm_provider(self.org_id, model_row.provider_id.uuid())
             .await
             .map_err(|e| AgentLoopError::store(e.to_string()))?;
 
@@ -144,12 +151,13 @@ fn parse_provider_type(provider_type_str: &str) -> Result<LlmProviderType> {
 // Factory functions
 // ============================================================================
 
-/// Create a database-backed LLM provider store
+/// Create a database-backed LLM provider store scoped to the given org
 pub fn create_db_llm_provider_store(
     db: Database,
     encryption: EncryptionService,
+    org_id: i64,
 ) -> DbLlmProviderStore {
-    DbLlmProviderStore::new(db, encryption)
+    DbLlmProviderStore::new(db, encryption, org_id)
 }
 
 #[cfg(test)]

--- a/crates/server/src/storage/session_store.rs
+++ b/crates/server/src/storage/session_store.rs
@@ -2,11 +2,13 @@
 //
 // This module implements the core SessionStore trait for retrieving
 // session configurations from the database.
+//
+// Decision: org_id and org_public_id are baked into the struct at
+// construction time, matching the Grpc/Adapter store pattern.
 
 use async_trait::async_trait;
 use everruns_core::{
-    AgentLoopError, DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, HarnessId, Result, SessionId,
-    TokenUsage,
+    AgentLoopError, HarnessId, Result, SessionId, TokenUsage,
     session::{Session, SessionStatus},
     traits::SessionStore,
 };
@@ -24,21 +26,26 @@ use super::repositories::Database;
 #[derive(Clone)]
 pub struct DbSessionStore {
     db: Database,
+    org_id: i64,
+    org_public_id: String,
 }
 
 impl DbSessionStore {
-    pub fn new(db: Database) -> Self {
-        Self { db }
+    pub fn new(db: Database, org_id: i64, org_public_id: String) -> Self {
+        Self {
+            db,
+            org_id,
+            org_public_id,
+        }
     }
 }
 
 #[async_trait]
 impl SessionStore for DbSessionStore {
     async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>> {
-        // TODO: Get org_id from context after Phase 3
         let session_row = self
             .db
-            .get_session(DEFAULT_ORG_ID, session_id)
+            .get_session(self.org_id, session_id)
             .await
             .map_err(|e| AgentLoopError::store(e.to_string()))?;
 
@@ -69,12 +76,12 @@ impl SessionStore for DbSessionStore {
 
                 Ok(Some(Session {
                     id: row.id,
-                    organization_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
+                    organization_id: self.org_public_id.clone(),
                     harness_id: row.harness_id.unwrap_or_else(|| HarnessId::from_seed(1)),
                     agent_id: row.agent_id,
                     title: row.title,
-                    preview: None, // Preview populated separately when listing sessions
-                    output_preview: None, // Output preview populated separately when listing sessions
+                    preview: None,
+                    output_preview: None,
                     tags: row.tags,
                     model_id: row.model_id,
                     capabilities,
@@ -99,7 +106,7 @@ impl SessionStore for DbSessionStore {
 // Factory functions
 // ============================================================================
 
-/// Create a database-backed session store
-pub fn create_db_session_store(db: Database) -> DbSessionStore {
-    DbSessionStore::new(db)
+/// Create a database-backed session store scoped to the given org
+pub fn create_db_session_store(db: Database, org_id: i64, org_public_id: String) -> DbSessionStore {
+    DbSessionStore::new(db, org_id, org_public_id)
 }

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -659,7 +659,9 @@ impl LlmProviderStore for GrpcLlmProviderStore {
     async fn get_default_model(&self) -> Result<Option<ModelWithProvider>> {
         let mut client = self.client.inner.lock().await;
 
-        let request = proto::GetDefaultModelRequest {};
+        let request = proto::GetDefaultModelRequest {
+            org_id: self.org_id,
+        };
 
         let response = client
             .get_default_model(request)


### PR DESCRIPTION
## Summary
- Remove `DEFAULT_ORG_ID` fallbacks from `DbAgentStore`, `DbSessionStore`, `DbHarnessStore`, `DbLlmProviderStore`, `LlmResolverService`, `DirectWorkerAdapters`, `DirectPlatformStore`, and gRPC service handlers
- All runtime paths now receive `org_id` explicitly at construction or call time, ensuring tenant context is carried instead of recovered implicitly
- Add `org_public_id_from_internal()` helper to derive deterministic public IDs from internal org IDs without async DB lookup
- Add `org_id` field to `GetDefaultModelRequest` proto message for gRPC worker communication
- Add cross-org isolation regression tests

Closes EVE-59

## Test plan
- [x] All 496 server unit tests pass (5 new regression tests added)
- [x] Core, worker, protocol tests pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [ ] CI green