### PR TITLE
fix: adopt PORT_PREFIX port schema for DATABASE_URL and test defaults

### DIFF
--- a/.claude/skills/no-docker-setup/scripts/_caddy.sh
+++ b/.claude/skills/no-docker-setup/scripts/_caddy.sh
@@ -2,7 +2,7 @@
 # Caddy reverse proxy setup for no-docker environment
 # Provides unified :9300 entry point matching docker-compose-full.yaml
 #
-# Routes /api/* -> :9000 (API), /* -> :9100 (UI)
+# Routes /api/* -> API_PORT, /* -> UI_PORT
 # SSE: h2c backend transport, no response buffering, no read timeout
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
@@ -41,23 +41,23 @@ install_caddy() {
 # Matches local/Caddyfile but with localhost backends
 generate_caddyfile() {
     local caddyfile="/tmp/Caddyfile"
-    cat > "$caddyfile" <<'CADDYEOF'
+    cat > "$caddyfile" <<CADDYEOF
 # No-docker reverse proxy (matches local/Caddyfile)
-# API on :9000, UI on :9100, unified on :9300
-:9300 {
+# API on :${API_PORT}, UI on :${UI_PORT}, unified on :${PROXY_PORT}
+:${PROXY_PORT} {
 	handle_path /api/* {
-		reverse_proxy localhost:9000 {
+		reverse_proxy localhost:${API_PORT} {
 			flush_interval -1
 		}
 	}
 	handle /api-doc/* {
-		reverse_proxy localhost:9000
+		reverse_proxy localhost:${API_PORT}
 	}
 	handle /health {
-		reverse_proxy localhost:9000
+		reverse_proxy localhost:${API_PORT}
 	}
 	handle {
-		reverse_proxy localhost:9100
+		reverse_proxy localhost:${UI_PORT}
 	}
 }
 CADDYEOF
@@ -72,13 +72,13 @@ start_caddy() {
     local caddyfile
     caddyfile=$(generate_caddyfile)
 
-    log_info "Starting Caddy reverse proxy on :9300..."
+    log_info "Starting Caddy reverse proxy on :${PROXY_PORT}..."
     caddy start --config "$caddyfile" --pidfile "$CADDY_PIDFILE" > "$CADDY_LOG" 2>&1
 
     # Wait for startup
     for i in {1..10}; do
-        if curl -s http://localhost:9300/health > /dev/null 2>&1; then
-            check_pass "Caddy - started on localhost:9300"
+        if curl -s http://localhost:${PROXY_PORT}/health > /dev/null 2>&1; then
+            check_pass "Caddy - started on localhost:${PROXY_PORT}"
             return 0
         fi
         sleep 1
@@ -86,7 +86,7 @@ start_caddy() {
 
     # May not have a backend yet - check if Caddy is running
     if [ -f "$CADDY_PIDFILE" ] && kill -0 "$(cat "$CADDY_PIDFILE")" 2>/dev/null; then
-        check_pass "Caddy - started on localhost:9300 (backend not ready yet)"
+        check_pass "Caddy - started on localhost:${PROXY_PORT} (backend not ready yet)"
         return 0
     fi
 
@@ -104,9 +104,9 @@ stop_caddy() {
         fi
         rm -f "$CADDY_PIDFILE"
     fi
-    # Kill any caddy on port 9300
+    # Kill any caddy on proxy port
     local port_pid
-    port_pid=$(lsof -ti :9300 2>/dev/null || true)
+    port_pid=$(lsof -ti :"${PROXY_PORT}" 2>/dev/null || true)
     if [ -n "$port_pid" ]; then
         kill -9 $port_pid 2>/dev/null || true
         sleep 1

--- a/.claude/skills/no-docker-setup/scripts/_postgres.sh
+++ b/.claude/skills/no-docker-setup/scripts/_postgres.sh
@@ -18,10 +18,10 @@ kill_existing_postgres() {
             sleep 2
         fi
     fi
-    # Also check for any postgres on port 5432
-    local port_pid=$(lsof -ti :5432 2>/dev/null || true)
+    # Also check for any postgres on our port
+    local port_pid=$(lsof -ti :"${DB_PORT}" 2>/dev/null || true)
     if [ -n "$port_pid" ]; then
-        log_warn "Killing process on port 5432 (PID: $port_pid)..."
+        log_warn "Killing process on port ${DB_PORT} (PID: $port_pid)..."
         kill -9 $port_pid 2>/dev/null || true
         sleep 1
     fi
@@ -51,7 +51,7 @@ init_postgres() {
     cat >> "$PGDATA/postgresql.conf" <<EOF
 unix_socket_directories = '$PGDATA'
 listen_addresses = 'localhost'
-port = 5432
+port = ${DB_PORT}
 EOF
 
     cat >> "$PGDATA/pg_hba.conf" <<EOF
@@ -74,8 +74,8 @@ start_postgres() {
 
     # Wait for startup
     for i in {1..15}; do
-        if pg_isready -h localhost -p 5432 > /dev/null 2>&1; then
-            check_pass "PostgreSQL - started on localhost:5432"
+        if pg_isready -h localhost -p "${DB_PORT}" > /dev/null 2>&1; then
+            check_pass "PostgreSQL - started on localhost:${DB_PORT}"
             return 0
         fi
         sleep 1

--- a/.claude/skills/no-docker-setup/scripts/_utils.sh
+++ b/.claude/skills/no-docker-setup/scripts/_utils.sh
@@ -7,7 +7,11 @@ export PGDATA="/tmp/pgdata"
 export PG_LOGFILE="$PGDATA/pg.log"
 export API_LOG="/tmp/api.log"
 export WORKER_LOG="/tmp/worker.log"
-export DATABASE_URL="postgres://everruns:everruns@localhost:5432/everruns"
+export PROXY_PORT="${PROXY_PORT:-9300}"
+export API_PORT="${API_PORT:-9301}"
+export UI_PORT="${UI_PORT:-9305}"
+export DB_PORT="${DB_PORT:-9332}"
+export DATABASE_URL="postgres://everruns:everruns@localhost:${DB_PORT}/everruns"
 
 # Detect PostgreSQL version (use highest available)
 detect_pg_version() {

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Database
 # Local development (no TLS):
-DATABASE_URL=postgres://everruns:everruns@localhost:5432/everruns
+DATABASE_URL=postgres://everruns:everruns@localhost:9332/everruns
 # Production (TLS required):
 # DATABASE_URL=postgres://user:pass@host:5432/db?sslmode=require
 

--- a/crates/durable/tests/postgres_integration_test.rs
+++ b/crates/durable/tests/postgres_integration_test.rs
@@ -4,7 +4,7 @@
 //!
 //! Requirements:
 //! - `postgres-tests` feature enabled
-//! - PostgreSQL running with DATABASE_URL set or default postgres://localhost:5432/everruns_test
+//! - PostgreSQL running with DATABASE_URL set or default postgres://localhost:{DB_PORT:-9332}/everruns_test
 //! - Migrations applied (run migrations from crates/server/migrations/)
 
 #![cfg(feature = "postgres-tests")]
@@ -26,8 +26,10 @@ use everruns_durable::workflow::{ActivityOptions, WorkflowError, WorkflowEvent, 
 
 /// Get test database URL from environment or use default
 fn get_database_url() -> String {
-    std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "postgres://postgres:postgres@localhost:5432/everruns_test".to_string())
+    std::env::var("DATABASE_URL").unwrap_or_else(|_| {
+        let port = std::env::var("DB_PORT").unwrap_or_else(|_| "9332".to_string());
+        format!("postgres://postgres:postgres@localhost:{port}/everruns_test")
+    })
 }
 
 async fn reset_durable_tables(pool: &PgPool) {

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -40,8 +40,10 @@ use everruns_worker::{RunnerBackend, create_driver_registry, create_runner_with_
 
 /// Get test database URL from environment or use default
 pub fn get_database_url() -> String {
-    std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "postgres://everruns:everruns@localhost:5432/everruns_test".to_string())
+    std::env::var("DATABASE_URL").unwrap_or_else(|_| {
+        let port = std::env::var("DB_PORT").unwrap_or_else(|_| "9332".to_string());
+        format!("postgres://everruns:everruns@localhost:{port}/everruns_test")
+    })
 }
 
 /// Create a PostgreSQL pool for tests


### PR DESCRIPTION
## What
Align DATABASE_URL and port defaults across the codebase with the PORT_PREFIX schema defined in `scripts/lib/common.sh`.

## Why
`.env.example`, test harnesses, and no-docker-setup scripts hardcoded port `5432` for PostgreSQL, while the dev default is `9332`. The no-docker Caddy script hardcoded `9000`/`9100`/`9300` instead of using `API_PORT`/`UI_PORT`/`PROXY_PORT`. This caused confusion and failures when using `PORT_PREFIX` for worktree isolation.

## How
- `.env.example`: change DATABASE_URL port from 5432 to 9332
- `crates/durable/tests/postgres_integration_test.rs` and `crates/server/tests/test_harness.rs`: read `DB_PORT` env var with `9332` default when `DATABASE_URL` is not set
- `.claude/skills/no-docker-setup/scripts/_utils.sh`: export `PROXY_PORT`, `API_PORT`, `UI_PORT`, `DB_PORT` with standard defaults
- `.claude/skills/no-docker-setup/scripts/_postgres.sh`: use `${DB_PORT}` instead of hardcoded `5432`
- `.claude/skills/no-docker-setup/scripts/_caddy.sh`: use `${PROXY_PORT}`, `${API_PORT}`, `${UI_PORT}` instead of hardcoded ports

## Risk
- Low
- CI uses GitHub Actions service containers with explicit `DATABASE_URL` pointing to port 5432, so CI is unaffected. Local dev workflows now consistently use 9332.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered