### PR TITLE
fix(ui): keep app publish state and setup guidance in sync

### DIFF
--- a/apps/ui/src/__tests__/slack-setup-guidance.test.tsx
+++ b/apps/ui/src/__tests__/slack-setup-guidance.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { SlackSetupGuidance } from "@/components/apps/slack-setup-guidance";
+
+describe("SlackSetupGuidance", () => {
+  const baseProps = {
+    hasSlackConfig: true,
+    isPublished: false,
+    webhookUrl: "https://example.com/api/v1/apps/app-123/slack/events",
+    webhookPath: "/api/v1/apps/app-123/slack/events",
+    isLocalhost: false,
+    onCreateSlackApp: jest.fn(),
+    creatingSlackApp: false,
+    onConfigure: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("keeps the setup checklist visible after publish", () => {
+    render(<SlackSetupGuidance {...baseProps} isPublished={true} />);
+
+    expect(screen.getByText("3. Publish the app")).toBeInTheDocument();
+    expect(screen.getByText("4. Configure Event Subscriptions")).toBeInTheDocument();
+    expect(screen.getByText(baseProps.webhookUrl)).toBeInTheDocument();
+    expect(screen.getByText("5. Invite the bot and test")).toBeInTheDocument();
+  });
+
+  it("shows create and configure actions before Slack credentials exist", () => {
+    render(<SlackSetupGuidance {...baseProps} hasSlackConfig={false} />);
+
+    expect(screen.getByRole("button", { name: "Create Slack App" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Configure" })).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/__tests__/use-apps.test.tsx
+++ b/apps/ui/src/__tests__/use-apps.test.tsx
@@ -1,0 +1,136 @@
+import { renderHook, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { usePublishApp, useUnpublishApp, useUpdateApp } from "@/hooks/use-apps";
+import { queryKeys } from "@/lib/query-keys";
+import type { App, UpdateAppRequest } from "@/lib/api/types";
+
+jest.mock("@/lib/api/apps", () => ({
+  createApp: jest.fn(),
+  deleteApp: jest.fn(),
+  getApp: jest.fn(),
+  getApps: jest.fn(),
+  publishApp: jest.fn(),
+  unpublishApp: jest.fn(),
+  updateApp: jest.fn(),
+}));
+
+const mockUseOrg = jest.fn();
+jest.mock("@/providers/org-provider", () => ({
+  useOrg: () => mockUseOrg(),
+}));
+
+import * as appsApi from "@/lib/api/apps";
+
+const mockPublishApp = appsApi.publishApp as jest.MockedFunction<typeof appsApi.publishApp>;
+const mockUnpublishApp = appsApi.unpublishApp as jest.MockedFunction<typeof appsApi.unpublishApp>;
+const mockUpdateApp = appsApi.updateApp as jest.MockedFunction<typeof appsApi.updateApp>;
+
+function makeApp(overrides: Partial<App> = {}): App {
+  return {
+    id: "app-123",
+    name: "Test App",
+    description: "Slack bot",
+    harness_id: "hrs-123",
+    agent_id: "agt-123",
+    channel_type: "slack",
+    channel_config: {
+      signing_secret: "secret",
+      bot_token: "xoxb-test",
+      session_strategy: "per_thread",
+    },
+    status: "draft",
+    published_at: null,
+    created_at: "2026-03-08T22:23:38Z",
+    updated_at: "2026-03-08T22:24:23Z",
+    ...overrides,
+  };
+}
+
+describe("use-apps mutations", () => {
+  let queryClient: QueryClient;
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    jest.clearAllMocks();
+
+    mockUseOrg.mockReturnValue({
+      currentOrg: { public_id: "org-123" },
+      isLoading: false,
+    });
+  });
+
+  it.each([
+    {
+      name: "update",
+      useHook: useUpdateApp,
+      mutationFn: mockUpdateApp,
+      args: { appId: "app-123", data: { name: "Updated App" } satisfies UpdateAppRequest },
+      response: makeApp({ name: "Updated App" }),
+    },
+    {
+      name: "publish",
+      useHook: usePublishApp,
+      mutationFn: mockPublishApp,
+      args: "app-123",
+      response: makeApp({
+        status: "published",
+        published_at: "2026-03-08T22:30:00Z",
+      }),
+    },
+    {
+      name: "unpublish",
+      useHook: useUnpublishApp,
+      mutationFn: mockUnpublishApp,
+      args: "app-123",
+      response: makeApp({
+        status: "draft",
+        published_at: null,
+      }),
+    },
+  ])("invalidates list and detail queries after $name succeeds", async (testCase) => {
+    const invalidateSpy = jest.spyOn(queryClient, "invalidateQueries");
+    const existingApp = makeApp();
+    queryClient.setQueryData(queryKeys.apps.detail(existingApp.id), existingApp);
+    queryClient.setQueryData(queryKeys.apps.list(), [existingApp]);
+    testCase.mutationFn.mockResolvedValueOnce(testCase.response);
+
+    const { result } = renderHook(() => testCase.useHook(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync(testCase.args as never);
+    });
+
+    expect(queryClient.getQueryData(queryKeys.apps.detail(testCase.response.id))).toEqual(
+      testCase.response,
+    );
+    expect(queryClient.getQueryData(queryKeys.apps.list())).toEqual([testCase.response]);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.apps.all });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: queryKeys.apps.detail(testCase.response.id),
+    });
+  });
+
+  it("does not invalidate app queries when publish fails", async () => {
+    const invalidateSpy = jest.spyOn(queryClient, "invalidateQueries");
+    mockPublishApp.mockRejectedValueOnce(new Error("publish failed"));
+
+    const { result } = renderHook(() => usePublishApp(), { wrapper });
+
+    await act(async () => {
+      await expect(result.current.mutateAsync("app-123")).rejects.toThrow("publish failed");
+    });
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -37,21 +37,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import {
-  ArrowLeft,
-  Globe,
-  GlobeLock,
-  Copy,
-  Trash2,
-  Pencil,
-  Check,
-  X,
-  Rocket,
-  ExternalLink,
-  CircleCheck,
-  Circle,
-} from "lucide-react";
+import { ArrowLeft, Globe, GlobeLock, Copy, Trash2, Pencil, Check, X, Rocket } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
+import { SlackSetupGuidance } from "@/components/apps/slack-setup-guidance";
 import type { SessionStrategy, SlackChannelConfig, UpdateAppRequest } from "@/lib/api/types";
 
 export default function AppDetailPage({ params }: { params: Promise<{ appId: string }> }) {
@@ -216,7 +204,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
               disabled={unpublishApp.isPending}
             >
               <GlobeLock className="w-4 h-4 mr-2" />
-              Unpublish
+              {unpublishApp.isPending ? "Unpublishing..." : "Unpublish"}
             </Button>
           ) : (
             <Button
@@ -225,7 +213,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
               disabled={publishApp.isPending || !hasSlackConfig}
             >
               <Globe className="w-4 h-4 mr-2" />
-              Publish
+              {publishApp.isPending ? "Publishing..." : "Publish"}
             </Button>
           )}
           <Button
@@ -404,25 +392,19 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                     </p>
                   </div>
 
-                  {/* Remaining setup steps after credentials are saved */}
-                  {!isPublished && (
-                    <>
-                      <Separator />
-                      <SetupSteps
-                        hasSlackConfig={true}
-                        isPublished={false}
-                        webhookUrl={webhookUrl}
-                        webhookPath={webhookPath}
-                        isLocalhost={isLocalhost}
-                        onCreateSlackApp={handleCreateSlackApp}
-                        creatingSlackApp={creatingSlackApp}
-                        onConfigure={startEditSlack}
-                      />
-                    </>
-                  )}
+                  <SlackSetupGuidance
+                    hasSlackConfig={true}
+                    isPublished={isPublished}
+                    webhookUrl={webhookUrl}
+                    webhookPath={webhookPath}
+                    isLocalhost={isLocalhost}
+                    onCreateSlackApp={handleCreateSlackApp}
+                    creatingSlackApp={creatingSlackApp}
+                    onConfigure={startEditSlack}
+                  />
                 </div>
               ) : (
-                <SetupSteps
+                <SlackSetupGuidance
                   hasSlackConfig={false}
                   isPublished={isPublished}
                   webhookUrl={webhookUrl}
@@ -653,194 +635,6 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
-  );
-}
-
-// =========================================================================
-// Setup Steps — inline guide for Slack integration setup
-// =========================================================================
-
-function StepIcon({ done }: { done: boolean }) {
-  return done ? (
-    <CircleCheck className="w-5 h-5 text-green-600 shrink-0" />
-  ) : (
-    <Circle className="w-5 h-5 text-muted-foreground shrink-0" />
-  );
-}
-
-function SetupSteps({
-  hasSlackConfig,
-  isPublished,
-  webhookUrl,
-  webhookPath,
-  isLocalhost,
-  onCreateSlackApp,
-  creatingSlackApp,
-  onConfigure,
-}: {
-  hasSlackConfig: boolean;
-  isPublished: boolean;
-  webhookUrl: string;
-  webhookPath: string;
-  isLocalhost: boolean;
-  onCreateSlackApp: () => void;
-  creatingSlackApp: boolean;
-  onConfigure: () => void;
-}) {
-  // Determine the current active step
-  const currentStep = !hasSlackConfig ? 1 : !isPublished ? 3 : 4;
-
-  return (
-    <div className="space-y-4">
-      {!hasSlackConfig && (
-        <p className="text-sm text-muted-foreground">
-          Follow these steps to connect a Slack bot to this app.
-        </p>
-      )}
-
-      {/* Step 1: Create Slack App */}
-      <div className="flex gap-3">
-        <StepIcon done={hasSlackConfig} />
-        <div className="flex-1 space-y-1">
-          <p
-            className={`text-sm font-medium ${hasSlackConfig ? "text-muted-foreground line-through" : ""}`}
-          >
-            1. Create a Slack App
-          </p>
-          {currentStep === 1 && (
-            <div className="space-y-2">
-              <p className="text-xs text-muted-foreground">
-                Opens Slack with a pre-filled manifest (bot scopes and settings are already
-                configured). Review and click <strong>Create</strong>, then install to your
-                workspace.
-              </p>
-              <Button size="sm" onClick={onCreateSlackApp} disabled={creatingSlackApp}>
-                <ExternalLink className="w-3 h-3 mr-1" />
-                {creatingSlackApp ? "Opening..." : "Create Slack App"}
-              </Button>
-            </div>
-          )}
-        </div>
-      </div>
-
-      {/* Step 2: Copy credentials */}
-      <div className="flex gap-3">
-        <StepIcon done={hasSlackConfig} />
-        <div className="flex-1 space-y-1">
-          <p
-            className={`text-sm font-medium ${hasSlackConfig ? "text-muted-foreground line-through" : ""}`}
-          >
-            2. Copy credentials back
-          </p>
-          {currentStep === 1 && (
-            <div className="space-y-2">
-              <p className="text-xs text-muted-foreground">
-                After creating the Slack app, copy two values back here:
-              </p>
-              <ul className="text-xs text-muted-foreground list-disc pl-4 space-y-1">
-                <li>
-                  <strong>Signing Secret</strong> — Slack app &rarr; Basic Information &rarr; App
-                  Credentials
-                </li>
-                <li>
-                  <strong>Bot Token</strong> (<code>xoxb-...</code>) — Slack app &rarr; OAuth &amp;
-                  Permissions
-                </li>
-              </ul>
-              <Button size="sm" variant="outline" onClick={onConfigure}>
-                <Pencil className="w-3 h-3 mr-1" />
-                Configure
-              </Button>
-            </div>
-          )}
-        </div>
-      </div>
-
-      {/* Step 3: Publish */}
-      <div className="flex gap-3">
-        <StepIcon done={isPublished} />
-        <div className="flex-1 space-y-1">
-          <p
-            className={`text-sm font-medium ${isPublished ? "text-muted-foreground line-through" : ""}`}
-          >
-            3. Publish the app
-          </p>
-          {currentStep === 3 && (
-            <p className="text-xs text-muted-foreground">
-              Click the <strong>Publish</strong> button above to activate the webhook endpoint.
-            </p>
-          )}
-        </div>
-      </div>
-
-      {/* Step 4: Event Subscriptions */}
-      <div className="flex gap-3">
-        <Circle className="w-5 h-5 text-muted-foreground shrink-0" />
-        <div className="flex-1 space-y-1">
-          <p className="text-sm font-medium">4. Configure Event Subscriptions</p>
-          {currentStep === 4 ? (
-            <div className="space-y-2">
-              {isLocalhost ? (
-                <>
-                  <p className="text-xs text-muted-foreground">
-                    Slack can&apos;t reach localhost. Run{" "}
-                    <code>
-                      ngrok http{" "}
-                      {typeof window !== "undefined" ? window.location.port || "9300" : "9300"}
-                    </code>{" "}
-                    then use the ngrok URL with this path as your Request URL:
-                  </p>
-                  <div className="flex items-center gap-2 bg-muted p-2 rounded-md">
-                    <code className="text-xs flex-1 truncate">{webhookPath}</code>
-                    <button
-                      className="shrink-0 hover:text-foreground text-muted-foreground"
-                      onClick={() => navigator.clipboard.writeText(webhookPath)}
-                    >
-                      <Copy className="w-3 h-3" />
-                    </button>
-                  </div>
-                </>
-              ) : (
-                <>
-                  <p className="text-xs text-muted-foreground">
-                    In your Slack app settings, go to <strong>Event Subscriptions</strong>, enable
-                    events, and paste this Request URL:
-                  </p>
-                  <div className="flex items-center gap-2 bg-muted p-2 rounded-md">
-                    <code className="text-xs flex-1 truncate">{webhookUrl}</code>
-                    <button
-                      className="shrink-0 hover:text-foreground text-muted-foreground"
-                      onClick={() => navigator.clipboard.writeText(webhookUrl)}
-                    >
-                      <Copy className="w-3 h-3" />
-                    </button>
-                  </div>
-                </>
-              )}
-              <p className="text-xs text-muted-foreground">
-                Then subscribe to bot events: <code>message.channels</code>,{" "}
-                <code>message.groups</code>, <code>message.im</code>, <code>app_mention</code>
-              </p>
-            </div>
-          ) : (
-            <p className="text-xs text-muted-foreground">
-              Add the webhook URL to your Slack app&apos;s Event Subscriptions.
-            </p>
-          )}
-        </div>
-      </div>
-
-      {/* Step 5: Invite bot */}
-      <div className="flex gap-3">
-        <Circle className="w-5 h-5 text-muted-foreground shrink-0" />
-        <div className="flex-1 space-y-1">
-          <p className="text-sm font-medium">5. Invite the bot and test</p>
-          <p className="text-xs text-muted-foreground">
-            In Slack, use <code>/invite @botname</code> in a channel, then send a message.
-          </p>
-        </div>
-      </div>
     </div>
   );
 }

--- a/apps/ui/src/components/apps/slack-setup-guidance.tsx
+++ b/apps/ui/src/components/apps/slack-setup-guidance.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+// Keep the Slack checklist in one component so publish-state guidance is testable.
+
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { Copy, CircleCheck, Circle, ExternalLink, Pencil } from "lucide-react";
+
+interface SlackSetupGuidanceProps {
+  hasSlackConfig: boolean;
+  isPublished: boolean;
+  webhookUrl: string;
+  webhookPath: string;
+  isLocalhost: boolean;
+  onCreateSlackApp: () => void;
+  creatingSlackApp: boolean;
+  onConfigure: () => void;
+}
+
+export function SlackSetupGuidance({
+  hasSlackConfig,
+  isPublished,
+  webhookUrl,
+  webhookPath,
+  isLocalhost,
+  onCreateSlackApp,
+  creatingSlackApp,
+  onConfigure,
+}: SlackSetupGuidanceProps) {
+  return (
+    <>
+      {hasSlackConfig && <Separator />}
+      <SetupSteps
+        hasSlackConfig={hasSlackConfig}
+        isPublished={isPublished}
+        webhookUrl={webhookUrl}
+        webhookPath={webhookPath}
+        isLocalhost={isLocalhost}
+        onCreateSlackApp={onCreateSlackApp}
+        creatingSlackApp={creatingSlackApp}
+        onConfigure={onConfigure}
+      />
+    </>
+  );
+}
+
+function StepIcon({ done }: { done: boolean }) {
+  return done ? (
+    <CircleCheck className="w-5 h-5 text-green-600 shrink-0" />
+  ) : (
+    <Circle className="w-5 h-5 text-muted-foreground shrink-0" />
+  );
+}
+
+function SetupSteps({
+  hasSlackConfig,
+  isPublished,
+  webhookUrl,
+  webhookPath,
+  isLocalhost,
+  onCreateSlackApp,
+  creatingSlackApp,
+  onConfigure,
+}: SlackSetupGuidanceProps) {
+  const currentStep = !hasSlackConfig ? 1 : !isPublished ? 3 : 4;
+
+  return (
+    <div className="space-y-4">
+      {!hasSlackConfig && (
+        <p className="text-sm text-muted-foreground">
+          Follow these steps to connect a Slack bot to this app.
+        </p>
+      )}
+
+      <div className="flex gap-3">
+        <StepIcon done={hasSlackConfig} />
+        <div className="flex-1 space-y-1">
+          <p
+            className={`text-sm font-medium ${hasSlackConfig ? "text-muted-foreground line-through" : ""}`}
+          >
+            1. Create a Slack App
+          </p>
+          {currentStep === 1 && (
+            <div className="space-y-2">
+              <p className="text-xs text-muted-foreground">
+                Opens Slack with a pre-filled manifest (bot scopes and settings are already
+                configured). Review and click <strong>Create</strong>, then install to your
+                workspace.
+              </p>
+              <Button size="sm" onClick={onCreateSlackApp} disabled={creatingSlackApp}>
+                <ExternalLink className="w-3 h-3 mr-1" />
+                {creatingSlackApp ? "Opening..." : "Create Slack App"}
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="flex gap-3">
+        <StepIcon done={hasSlackConfig} />
+        <div className="flex-1 space-y-1">
+          <p
+            className={`text-sm font-medium ${hasSlackConfig ? "text-muted-foreground line-through" : ""}`}
+          >
+            2. Copy credentials back
+          </p>
+          {currentStep === 1 && (
+            <div className="space-y-2">
+              <p className="text-xs text-muted-foreground">
+                After creating the Slack app, copy two values back here:
+              </p>
+              <ul className="text-xs text-muted-foreground list-disc pl-4 space-y-1">
+                <li>
+                  <strong>Signing Secret</strong> - Slack app &rarr; Basic Information &rarr; App
+                  Credentials
+                </li>
+                <li>
+                  <strong>Bot Token</strong> (<code>xoxb-...</code>) - Slack app &rarr; OAuth &amp;
+                  Permissions
+                </li>
+              </ul>
+              <Button size="sm" variant="outline" onClick={onConfigure}>
+                <Pencil className="w-3 h-3 mr-1" />
+                Configure
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="flex gap-3">
+        <StepIcon done={isPublished} />
+        <div className="flex-1 space-y-1">
+          <p
+            className={`text-sm font-medium ${isPublished ? "text-muted-foreground line-through" : ""}`}
+          >
+            3. Publish the app
+          </p>
+          {currentStep === 3 && (
+            <p className="text-xs text-muted-foreground">
+              Click the <strong>Publish</strong> button above to activate the webhook endpoint.
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex gap-3">
+        <Circle className="w-5 h-5 text-muted-foreground shrink-0" />
+        <div className="flex-1 space-y-1">
+          <p className="text-sm font-medium">4. Configure Event Subscriptions</p>
+          {currentStep === 4 ? (
+            <div className="space-y-2">
+              {isLocalhost ? (
+                <>
+                  <p className="text-xs text-muted-foreground">
+                    Slack can&apos;t reach localhost. Run{" "}
+                    <code>
+                      ngrok http{" "}
+                      {typeof window !== "undefined" ? window.location.port || "9300" : "9300"}
+                    </code>{" "}
+                    then use the ngrok URL with this path as your Request URL:
+                  </p>
+                  <div className="flex items-center gap-2 bg-muted p-2 rounded-md">
+                    <code className="text-xs flex-1 truncate">{webhookPath}</code>
+                    <button
+                      className="shrink-0 hover:text-foreground text-muted-foreground"
+                      onClick={() => navigator.clipboard.writeText(webhookPath)}
+                    >
+                      <Copy className="w-3 h-3" />
+                    </button>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <p className="text-xs text-muted-foreground">
+                    In your Slack app settings, go to <strong>Event Subscriptions</strong>, enable
+                    events, and paste this Request URL:
+                  </p>
+                  <div className="flex items-center gap-2 bg-muted p-2 rounded-md">
+                    <code className="text-xs flex-1 truncate">{webhookUrl}</code>
+                    <button
+                      className="shrink-0 hover:text-foreground text-muted-foreground"
+                      onClick={() => navigator.clipboard.writeText(webhookUrl)}
+                    >
+                      <Copy className="w-3 h-3" />
+                    </button>
+                  </div>
+                </>
+              )}
+              <p className="text-xs text-muted-foreground">
+                Then subscribe to bot events: <code>message.channels</code>,{" "}
+                <code>message.groups</code>, <code>message.im</code>, <code>app_mention</code>
+              </p>
+            </div>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              Add the webhook URL to your Slack app&apos;s Event Subscriptions.
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex gap-3">
+        <Circle className="w-5 h-5 text-muted-foreground shrink-0" />
+        <div className="flex-1 space-y-1">
+          <p className="text-sm font-medium">5. Invite the bot and test</p>
+          <p className="text-xs text-muted-foreground">
+            In Slack, use <code>/invite @botname</code> in a channel, then send a message.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/hooks/use-apps.ts
+++ b/apps/ui/src/hooks/use-apps.ts
@@ -1,7 +1,7 @@
 // App hooks for Slack bot integration
 "use client";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import {
   createApp,
   deleteApp,
@@ -12,8 +12,21 @@ import {
   updateApp,
 } from "@/lib/api/apps";
 import { queryKeys } from "@/lib/query-keys";
-import type { CreateAppRequest, UpdateAppRequest } from "@/lib/api/types";
+import type { App, CreateAppRequest, UpdateAppRequest } from "@/lib/api/types";
 import { useOrg } from "@/providers/org-provider";
+
+// Keep list/detail app caches in sync so detail pages do not wait for a background refetch.
+function syncAppCache(queryClient: QueryClient, app: App) {
+  queryClient.setQueriesData<App | undefined>(
+    { queryKey: queryKeys.apps.detail(app.id) },
+    () => app,
+  );
+  queryClient.setQueriesData<App[] | undefined>(
+    { queryKey: queryKeys.apps.list() },
+    (existing) =>
+      existing?.map((candidate) => (candidate.id === app.id ? app : candidate)) ?? existing,
+  );
+}
 
 export function useApps() {
   const { currentOrg, isLoading: orgLoading } = useOrg();
@@ -64,8 +77,12 @@ export function useUpdateApp() {
   return useMutation({
     mutationFn: ({ appId, data }: { appId: string; data: UpdateAppRequest }) =>
       updateApp(appId, data),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.apps.all });
+    onSuccess: async (app) => {
+      syncAppCache(queryClient, app);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.apps.all }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.apps.detail(app.id) }),
+      ]);
     },
   });
 }
@@ -86,8 +103,12 @@ export function usePublishApp() {
 
   return useMutation({
     mutationFn: (appId: string) => publishApp(appId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.apps.all });
+    onSuccess: async (app) => {
+      syncAppCache(queryClient, app);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.apps.all }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.apps.detail(app.id) }),
+      ]);
     },
   });
 }
@@ -97,8 +118,12 @@ export function useUnpublishApp() {
 
   return useMutation({
     mutationFn: (appId: string) => unpublishApp(appId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.apps.all });
+    onSuccess: async (app) => {
+      syncAppCache(queryClient, app);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.apps.all }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.apps.detail(app.id) }),
+      ]);
     },
   });
 }


### PR DESCRIPTION
## What
Keep app publish state and Slack setup guidance in sync on the app detail page.

## Why
Publishing looked like a no-op because the detail query stayed stale until a later refetch. After publish, the Slack wizard also disappeared, so users lost the next-step instructions.

## How
Update the app mutation hooks to write the returned app into the list and detail React Query caches before invalidating. Extract the Slack setup checklist into a dedicated component that stays visible after publish, add pending button labels, and cover both regressions with UI tests.

## Risk
- Low
- Limited to app detail/list cache updates and Slack setup rendering in the UI

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered