### PR TITLE
fix(ui): replace naked IDs with CopyButton and use Hash icon

### DIFF
--- a/apps/ui/src/app/(main)/apps/page.tsx
+++ b/apps/ui/src/app/(main)/apps/page.tsx
@@ -5,7 +5,8 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
-import { Plus, Rocket, Globe, GlobeLock, Copy } from "lucide-react";
+import { Plus, Rocket, Globe, GlobeLock } from "lucide-react";
+import { CopyButton } from "@/components/ui/copy-button";
 import Link from "next/link";
 import type { App } from "@/lib/api/types";
 import { ExperimentalPageBadge } from "@/components/ui/experimental-badge";
@@ -80,6 +81,7 @@ function AppCard({ app }: { app: App }) {
             <div className="flex items-center gap-2">
               <Rocket className="w-5 h-5 text-muted-foreground" />
               <h3 className="font-semibold text-lg">{app.name}</h3>
+              <CopyButton value={app.id} />
             </div>
             <Badge variant={isPublished ? "default" : "secondary"}>{app.status}</Badge>
           </div>
@@ -90,23 +92,13 @@ function AppCard({ app }: { app: App }) {
             <Badge variant="outline" className="text-xs">
               Slack
             </Badge>
-            <span>Agent: {app.agent_id}</span>
           </div>
 
           {isPublished && (
             <div className="flex items-center gap-1 text-xs text-muted-foreground bg-muted p-2 rounded">
               <Globe className="w-3 h-3 shrink-0" />
               <span className="truncate font-mono">{webhookUrl}</span>
-              <button
-                className="shrink-0 ml-1 hover:text-foreground"
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  navigator.clipboard.writeText(webhookUrl);
-                }}
-              >
-                <Copy className="w-3 h-3" />
-              </button>
+              <CopyButton value={webhookUrl} className="shrink-0 ml-1" />
             </div>
           )}
 

--- a/apps/ui/src/app/(main)/apps/page.tsx
+++ b/apps/ui/src/app/(main)/apps/page.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
-import { Plus, Rocket, Globe, GlobeLock } from "lucide-react";
+import { Plus, Rocket, Globe, GlobeLock, Copy } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import Link from "next/link";
 import type { App } from "@/lib/api/types";
@@ -98,7 +98,16 @@ function AppCard({ app }: { app: App }) {
             <div className="flex items-center gap-1 text-xs text-muted-foreground bg-muted p-2 rounded">
               <Globe className="w-3 h-3 shrink-0" />
               <span className="truncate font-mono">{webhookUrl}</span>
-              <CopyButton value={webhookUrl} className="shrink-0 ml-1" />
+              <button
+                className="shrink-0 ml-1 hover:text-foreground"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  navigator.clipboard.writeText(webhookUrl);
+                }}
+              >
+                <Copy className="w-3 h-3" />
+              </button>
             </div>
           )}
 

--- a/apps/ui/src/app/(main)/durable/page.tsx
+++ b/apps/ui/src/app/(main)/durable/page.tsx
@@ -26,6 +26,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import { CopyButton } from "@/components/ui/copy-button";
 
 function getHealthStatusColor(status: string) {
   switch (status) {
@@ -338,8 +339,9 @@ export default function DurableDashboardPage() {
                             }`}
                           />
                           <span className="text-sm font-medium truncate max-w-[150px]">
-                            {worker.id.slice(0, 12)}
+                            {worker.hostname || worker.id.slice(0, 12)}
                           </span>
+                          <CopyButton value={worker.id} />
                         </div>
                         <div className="flex items-center gap-2">
                           <span className="text-xs text-muted-foreground">
@@ -391,9 +393,7 @@ export default function DurableDashboardPage() {
                         <WorkflowStatusIcon status={workflow.status} />
                         <div>
                           <p className="text-sm font-medium">{workflow.workflow_type}</p>
-                          <p className="text-xs text-muted-foreground">
-                            {workflow.id.slice(0, 8)}...
-                          </p>
+                          <CopyButton value={workflow.id} />
                         </div>
                       </div>
                       <Badge variant={getWorkflowStatusVariant(workflow.status)}>

--- a/apps/ui/src/app/(main)/durable/workers/page.tsx
+++ b/apps/ui/src/app/(main)/durable/workers/page.tsx
@@ -25,6 +25,7 @@ import {
   Play,
   CheckCircle,
 } from "lucide-react";
+import { CopyButton } from "@/components/ui/copy-button";
 
 function formatDistanceToNow(date: Date, options?: { addSuffix?: boolean }): string {
   const now = new Date();
@@ -103,7 +104,7 @@ function WorkerRow({
           <div className={`w-2 h-2 rounded-full ${getStatusColor(worker.status)}`} />
           <div>
             <p className="font-medium">{worker.hostname || worker.id.slice(0, 20)}</p>
-            <p className="text-xs text-muted-foreground font-mono">{worker.id.slice(0, 16)}...</p>
+            <CopyButton value={worker.id} />
           </div>
         </div>
       </TableCell>

--- a/apps/ui/src/components/chat/message-info-icon.tsx
+++ b/apps/ui/src/components/chat/message-info-icon.tsx
@@ -2,6 +2,7 @@
 
 import { Info } from "lucide-react";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+import { CopyButton } from "@/components/ui/copy-button";
 import { cn } from "@/lib/utils";
 import type { Event, OutputMessageCompletedData, TokenUsage } from "@/lib/api/types";
 
@@ -49,7 +50,9 @@ export function MessageInfoIcon({ event, variant = "default" }: MessageInfoIconP
       <TooltipContent className="max-w-sm border-border bg-popover px-3 py-2">
         <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
           <dt className="text-muted-foreground">ID</dt>
-          <dd className="font-mono text-[10px] break-all">{event.id}</dd>
+          <dd>
+            <CopyButton value={event.id} />
+          </dd>
           {model && (
             <>
               <dt className="text-muted-foreground">Model</dt>

--- a/apps/ui/src/components/session/session-card.tsx
+++ b/apps/ui/src/components/session/session-card.tsx
@@ -86,9 +86,9 @@ function SessionInfoIcon({ session }: { session: Session }) {
       </TooltipTrigger>
       <TooltipContent className="max-w-sm">
         <div className="space-y-1 text-xs">
-          <div className="flex gap-2">
+          <div className="flex items-center gap-2">
             <span className="text-muted-foreground">ID:</span>
-            <span className="font-mono text-[10px] break-all">{session.id}</span>
+            <CopyButton value={session.id} />
           </div>
           <div className="flex gap-2">
             <span className="text-muted-foreground">Status:</span>

--- a/apps/ui/src/components/ui/copy-button.tsx
+++ b/apps/ui/src/components/ui/copy-button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Copy, Check } from "lucide-react";
+import { Hash, Check } from "lucide-react";
 import { Button } from "./button";
 import { cn } from "@/lib/utils";
 
@@ -32,7 +32,7 @@ export function CopyButton({ value, className }: CopyButtonProps) {
       {copied ? (
         <Check className="h-3 w-3 text-green-500" />
       ) : (
-        <Copy className="h-3 w-3 text-muted-foreground" />
+        <Hash className="h-3 w-3 text-muted-foreground" />
       )}
     </Button>
   );

--- a/specs/code-organization.md
+++ b/specs/code-organization.md
@@ -519,7 +519,7 @@ export function AgentFilterMenu({ value, onValueChange, className }) {
 **Why:** IDs are for programmatic use (API calls, debugging). Users need to copy them occasionally but don't need to see them constantly. This keeps the UI clean while maintaining accessibility.
 
 **Components:**
-- `CopyButton` - `components/ui/copy-button.tsx` - Icon button that copies value to clipboard
+- `CopyButton` - `components/ui/copy-button.tsx` - Hash (`#`) icon button that copies value to clipboard. Uses `Hash` icon (not generic `Copy`) to visually distinguish "copy ID" from other copy actions (e.g., URL copy buttons). Shows green `Check` icon after copying.
 
 ### List Page Structure
 


### PR DESCRIPTION
## What
Replace raw entity ID text rendering with `CopyButton` across the UI, and change the `CopyButton` icon from generic `Copy` to `Hash` (#) to visually distinguish "copy ID" from other copy actions.

## Why
App cards rendered full agent IDs inline (e.g., `agent_01933b5a000070008000000000000101`) causing layout overflow. Other pages (durable dashboard, workers, session tooltips, message info) also displayed raw or truncated IDs without a copy mechanism.

## How
- **`CopyButton` icon**: `Copy` → `Hash` — the `#` symbol is a developer convention for identifiers
- **App card** (`apps/page.tsx`): removed inline `agent_id` text, added `CopyButton` for app ID next to title, kept generic `Copy` icon for webhook URL
- **Session tooltip** (`session-card.tsx`): replaced raw `session.id` with `CopyButton`
- **Message info tooltip** (`message-info-icon.tsx`): replaced raw `event.id` with `CopyButton`
- **Durable dashboard** (`durable/page.tsx`): replaced sliced worker/workflow IDs with `CopyButton`
- **Workers table** (`durable/workers/page.tsx`): replaced sliced worker ID with `CopyButton`
- **Spec** (`specs/code-organization.md`): documented Hash icon convention

## Risk
Low — UI-only changes, no backend/API modifications. All changes swap text for an existing, well-tested component.

## Checklist
- [x] Lint passes (0 errors)
- [x] UI builds successfully
- [x] No new dependencies
- [x] Spec updated
- [x] Follows existing CopyButton pattern from agent/harness cards