### PR TITLE
fix(ui): stop click propagation on session card pin button

### DIFF
--- a/apps/ui/src/components/session/session-card.tsx
+++ b/apps/ui/src/components/session/session-card.tsx
@@ -80,7 +80,10 @@ function SessionInfoIcon({ session }: { session: Session }) {
           "text-muted-foreground/50 hover:text-muted-foreground hover:bg-muted/80",
         )}
         aria-label="Session info"
-        onClick={(e) => e.preventDefault()} // Prevent link navigation when clicking info
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+        }}
       >
         <Info className="w-3 h-3" />
       </TooltipTrigger>
@@ -206,6 +209,7 @@ export function SessionCard({ session, agentName, model, summary, onTogglePin }:
               aria-label={isPinned ? "Unpin session" : "Pin session"}
               onClick={(e) => {
                 e.preventDefault();
+                e.stopPropagation();
                 onTogglePin(session.id, !isPinned);
               }}
             >


### PR DESCRIPTION
## What
Add `e.stopPropagation()` to pin button and info icon click handlers inside `SessionCard` component.

## Why
Pin/info buttons are inside a `<Link>` wrapper. Without `stopPropagation()`, clicks bubble up to the parent Link and navigate to the session detail page instead of toggling pin state. Users click pin and "nothing happens" because the page navigates away.

## How
Added `e.stopPropagation()` alongside existing `e.preventDefault()` in the `onClick` handlers for:
- Pin/unpin `TooltipTrigger` button
- `SessionInfoIcon` `TooltipTrigger` button

## Risk
- Low
- Standard DOM event handling pattern; no functional logic changes

## Checklist
- [x] Tests added or updated (UI lint + build verified; no component test suite exists for this component)
- [x] Backward compatibility considered (N/A - internal UI fix)