### PR TITLE
docs(slack): add overview video

### DIFF
--- a/docs/integrations/slack.md
+++ b/docs/integrations/slack.md
@@ -249,6 +249,18 @@ sequenceDiagram
 - Confirm the signing secret in Everruns matches the one in Slack's **Basic Information** page
 - Check that your server clock is accurate (signing verification uses timestamps)
 
+## Overview Video
+
+<iframe
+  width="100%"
+  style="aspect-ratio: 16 / 9; border-radius: 8px; margin-top: 1rem;"
+  src="https://www.youtube.com/embed/RuNeh8i6Bdk"
+  title="Slack Integration Overview"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen>
+</iframe>
+
 ## Links
 
 - [Slack API Documentation](https://api.slack.com/docs)


### PR DESCRIPTION
## What
Add embedded YouTube overview video to the Slack integration docs page.

## Why
Provides a visual walkthrough of the Slack integration setup and usage.

## How
Added an iframe YouTube embed (https://youtu.be/RuNeh8i6Bdk) in a new Overview Video section above the Links section in docs/integrations/slack.md. Uses the same iframe pattern as existing docs.

## Risk
- Low
- Docs-only change, no code impact

## Checklist
- [x] Tests added or updated (N/A — docs only, verified docs build passes)
- [x] Backward compatibility considered (N/A)