### PR TITLE
fix(security): prevent SSRF via MCP server URLs

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -57,6 +57,9 @@ pub mod session_schedule;
 pub mod session_sqldb;
 pub mod skill;
 
+// URL validation for SSRF prevention (shared utility)
+pub mod url_validation;
+
 pub mod atoms;
 pub mod capabilities;
 pub mod command;
@@ -238,6 +241,9 @@ pub use typed_id::{
     AgentId, AppId, EventId, ExecId, HarnessId, IdMarker, IdParseError, ImageId, McpServerId,
     MessageId, ModelId, OrgId, ProviderId, ScheduleId, SessionId, SkillId, TurnId, TypedId,
 };
+
+// URL validation re-exports
+pub use url_validation::{UrlValidationError, validate_safe_url};
 
 // Deployment configuration
 pub use deployment::DeploymentGrade;

--- a/crates/core/src/url_validation.rs
+++ b/crates/core/src/url_validation.rs
@@ -1,0 +1,418 @@
+// Shared URL validation for SSRF prevention
+//
+// THREAT[TM-API-008]: Blocks requests to internal/private networks.
+// Used by MCP server registration (create/update) and execution-time checks.
+//
+// Validates:
+// - Scheme restricted to https/http
+// - Hostname not localhost, loopback, or private IP
+// - Blocks link-local (169.254.x.x), cloud metadata (169.254.169.254)
+// - Blocks RFC1918 (10.x, 172.16-31.x, 192.168.x)
+// - Blocks IPv6 loopback (::1) and link-local (fe80::)
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use url::Url;
+
+/// Errors from URL safety validation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UrlValidationError {
+    /// URL could not be parsed.
+    InvalidUrl(String),
+    /// Scheme not allowed (must be http or https).
+    DisallowedScheme(String),
+    /// Hostname is missing.
+    MissingHostname,
+    /// Hostname resolves to or is a blocked target.
+    BlockedHost(String),
+}
+
+impl std::fmt::Display for UrlValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidUrl(msg) => write!(f, "Invalid URL: {msg}"),
+            Self::DisallowedScheme(scheme) => {
+                write!(f, "Disallowed URL scheme: {scheme} (must be http or https)")
+            }
+            Self::MissingHostname => write!(f, "URL must have a hostname"),
+            Self::BlockedHost(host) => {
+                write!(f, "Blocked host: {host} (private/internal address)")
+            }
+        }
+    }
+}
+
+impl std::error::Error for UrlValidationError {}
+
+/// Validate a URL is safe for server-side requests (anti-SSRF).
+///
+/// Checks scheme, hostname patterns, and IP address ranges.
+/// Does NOT perform DNS resolution — this is a static check suitable for
+/// write-time validation. Complement with runtime DNS-pinned checks where possible.
+pub fn validate_safe_url(raw_url: &str) -> Result<Url, UrlValidationError> {
+    let url = Url::parse(raw_url).map_err(|e| UrlValidationError::InvalidUrl(e.to_string()))?;
+
+    // Scheme check
+    match url.scheme() {
+        "http" | "https" => {}
+        other => return Err(UrlValidationError::DisallowedScheme(other.to_string())),
+    }
+
+    // Must have a host
+    let host = url.host_str().ok_or(UrlValidationError::MissingHostname)?;
+
+    // Check hostname patterns
+    if is_blocked_host(host) {
+        return Err(UrlValidationError::BlockedHost(host.to_string()));
+    }
+
+    Ok(url)
+}
+
+/// Check if a hostname string is blocked (localhost, private IPs, metadata endpoints).
+fn is_blocked_host(host: &str) -> bool {
+    let host_lower = host.to_lowercase();
+
+    // Localhost variants
+    if host_lower == "localhost"
+        || host_lower == "localhost."
+        || host_lower.ends_with(".localhost")
+        || host_lower.ends_with(".localhost.")
+    {
+        return true;
+    }
+
+    // Strip brackets from IPv6
+    let bare = host_lower
+        .strip_prefix('[')
+        .and_then(|s| s.strip_suffix(']'))
+        .unwrap_or(&host_lower);
+
+    // Try parsing as IP
+    if let Ok(ip) = bare.parse::<IpAddr>() {
+        return is_blocked_ip(ip);
+    }
+
+    // Cloud metadata hostname
+    if host_lower == "metadata.google.internal" || host_lower == "metadata.google.internal." {
+        return true;
+    }
+
+    false
+}
+
+/// Check if an IP address is in a blocked range.
+fn is_blocked_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => is_blocked_ipv4(v4),
+        IpAddr::V6(v6) => is_blocked_ipv6(v6),
+    }
+}
+
+fn is_blocked_ipv4(ip: Ipv4Addr) -> bool {
+    let octets = ip.octets();
+
+    // Loopback 127.0.0.0/8
+    if octets[0] == 127 {
+        return true;
+    }
+
+    // 0.0.0.0
+    if ip.is_unspecified() {
+        return true;
+    }
+
+    // RFC1918: 10.0.0.0/8
+    if octets[0] == 10 {
+        return true;
+    }
+
+    // RFC1918: 172.16.0.0/12
+    if octets[0] == 172 && (16..=31).contains(&octets[1]) {
+        return true;
+    }
+
+    // RFC1918: 192.168.0.0/16
+    if octets[0] == 192 && octets[1] == 168 {
+        return true;
+    }
+
+    // Link-local 169.254.0.0/16 (includes cloud metadata 169.254.169.254)
+    if octets[0] == 169 && octets[1] == 254 {
+        return true;
+    }
+
+    // RFC6598 Carrier-grade NAT: 100.64.0.0/10
+    if octets[0] == 100 && (64..=127).contains(&octets[1]) {
+        return true;
+    }
+
+    // RFC5737 Documentation: 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24
+    if (octets[0] == 192 && octets[1] == 0 && octets[2] == 2)
+        || (octets[0] == 198 && octets[1] == 51 && octets[2] == 100)
+        || (octets[0] == 203 && octets[1] == 0 && octets[2] == 113)
+    {
+        return true;
+    }
+
+    false
+}
+
+fn is_blocked_ipv6(ip: Ipv6Addr) -> bool {
+    // Loopback ::1
+    if ip.is_loopback() {
+        return true;
+    }
+
+    // Unspecified ::
+    if ip.is_unspecified() {
+        return true;
+    }
+
+    // Link-local fe80::/10
+    let segments = ip.segments();
+    if segments[0] & 0xffc0 == 0xfe80 {
+        return true;
+    }
+
+    // Unique local fc00::/7
+    if segments[0] & 0xfe00 == 0xfc00 {
+        return true;
+    }
+
+    // IPv4-mapped IPv6 (::ffff:x.x.x.x) — check the embedded v4
+    if let Some(v4) = ip.to_ipv4_mapped() {
+        return is_blocked_ipv4(v4);
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- Positive: valid public URLs ---
+
+    #[test]
+    fn accepts_https_public_url() {
+        assert!(validate_safe_url("https://mcp.example.com/v1/mcp").is_ok());
+    }
+
+    #[test]
+    fn accepts_http_public_url() {
+        assert!(validate_safe_url("http://mcp.example.com/v1/mcp").is_ok());
+    }
+
+    #[test]
+    fn accepts_url_with_port() {
+        assert!(validate_safe_url("https://mcp.example.com:8443/v1/mcp").is_ok());
+    }
+
+    #[test]
+    fn accepts_url_with_path_and_query() {
+        assert!(validate_safe_url("https://api.example.com/mcp?key=val").is_ok());
+    }
+
+    // --- Negative: blocked schemes ---
+
+    #[test]
+    fn rejects_ftp_scheme() {
+        let err = validate_safe_url("ftp://evil.com/file").unwrap_err();
+        assert!(matches!(err, UrlValidationError::DisallowedScheme(_)));
+    }
+
+    #[test]
+    fn rejects_file_scheme() {
+        let err = validate_safe_url("file:///etc/passwd").unwrap_err();
+        assert!(matches!(err, UrlValidationError::DisallowedScheme(_)));
+    }
+
+    #[test]
+    fn rejects_javascript_scheme() {
+        let err = validate_safe_url("javascript:alert(1)").unwrap_err();
+        // url crate may parse this as opaque or as scheme error
+        assert!(
+            matches!(err, UrlValidationError::DisallowedScheme(_))
+                || matches!(err, UrlValidationError::MissingHostname)
+        );
+    }
+
+    #[test]
+    fn rejects_data_scheme() {
+        let err = validate_safe_url("data:text/plain,hello").unwrap_err();
+        assert!(
+            matches!(err, UrlValidationError::DisallowedScheme(_))
+                || matches!(err, UrlValidationError::MissingHostname)
+        );
+    }
+
+    // --- Negative: invalid URLs ---
+
+    #[test]
+    fn rejects_empty_string() {
+        assert!(validate_safe_url("").is_err());
+    }
+
+    #[test]
+    fn rejects_not_a_url() {
+        assert!(validate_safe_url("not a url").is_err());
+    }
+
+    // --- Negative: localhost ---
+
+    #[test]
+    fn rejects_localhost() {
+        let err = validate_safe_url("http://localhost/path").unwrap_err();
+        assert!(matches!(err, UrlValidationError::BlockedHost(_)));
+    }
+
+    #[test]
+    fn rejects_localhost_with_port() {
+        let err = validate_safe_url("http://localhost:8080/path").unwrap_err();
+        assert!(matches!(err, UrlValidationError::BlockedHost(_)));
+    }
+
+    #[test]
+    fn rejects_subdomain_of_localhost() {
+        let err = validate_safe_url("http://foo.localhost/path").unwrap_err();
+        assert!(matches!(err, UrlValidationError::BlockedHost(_)));
+    }
+
+    // --- Negative: loopback IPs ---
+
+    #[test]
+    fn rejects_127_0_0_1() {
+        let err = validate_safe_url("http://127.0.0.1/path").unwrap_err();
+        assert!(matches!(err, UrlValidationError::BlockedHost(_)));
+    }
+
+    #[test]
+    fn rejects_127_x_x_x() {
+        let err = validate_safe_url("http://127.255.0.1/path").unwrap_err();
+        assert!(matches!(err, UrlValidationError::BlockedHost(_)));
+    }
+
+    #[test]
+    fn rejects_ipv6_loopback() {
+        let err = validate_safe_url("http://[::1]/path").unwrap_err();
+        assert!(matches!(err, UrlValidationError::BlockedHost(_)));
+    }
+
+    // --- Negative: private RFC1918 ---
+
+    #[test]
+    fn rejects_10_x() {
+        let err = validate_safe_url("http://10.0.0.1/path").unwrap_err();
+        assert!(matches!(err, UrlValidationError::BlockedHost(_)));
+    }
+
+    #[test]
+    fn rejects_172_16_x() {
+        let err = validate_safe_url("http://172.16.0.1/path").unwrap_err();
+        assert!(matches!(err, UrlValidationError::BlockedHost(_)));
+    }
+
+    #[test]
+    fn rejects_172_31_x() {
+        let err = validate_safe_url("http://172.31.255.255/path").unwrap_err();
+        assert!(matches!(err, UrlValidationError::BlockedHost(_)));
+    }
+
+    #[test]
+    fn accepts_172_32_x() {
+        // 172.32.x.x is NOT private
+        assert!(validate_safe_url("http://172.32.0.1/path").is_ok());
+    }
+
+    #[test]
+    fn rejects_192_168_x() {
+        let err = validate_safe_url("http://192.168.1.1/path").unwrap_err();
+        assert!(matches!(err, UrlValidationError::BlockedHost(_)));
+    }
+
+    // --- Negative: link-local / cloud metadata ---
+
+    #[test]
+    fn rejects_link_local() {
+        let err = validate_safe_url("http://169.254.1.1/path").unwrap_err();
+        assert!(matches!(err, UrlValidationError::BlockedHost(_)));
+    }
+
+    #[test]
+    fn rejects_cloud_metadata_ip() {
+        let err = validate_safe_url("http://169.254.169.254/latest/meta-data/").unwrap_err();
+        assert!(matches!(err, UrlValidationError::BlockedHost(_)));
+    }
+
+    #[test]
+    fn rejects_gce_metadata_hostname() {
+        let err =
+            validate_safe_url("http://metadata.google.internal/computeMetadata/v1/").unwrap_err();
+        assert!(matches!(err, UrlValidationError::BlockedHost(_)));
+    }
+
+    // --- Negative: 0.0.0.0 ---
+
+    #[test]
+    fn rejects_unspecified_v4() {
+        let err = validate_safe_url("http://0.0.0.0/path").unwrap_err();
+        assert!(matches!(err, UrlValidationError::BlockedHost(_)));
+    }
+
+    // --- Negative: IPv6 special ---
+
+    #[test]
+    fn rejects_ipv6_unspecified() {
+        let err = validate_safe_url("http://[::]/path").unwrap_err();
+        assert!(matches!(err, UrlValidationError::BlockedHost(_)));
+    }
+
+    #[test]
+    fn rejects_ipv6_link_local() {
+        let err = validate_safe_url("http://[fe80::1]/path").unwrap_err();
+        assert!(matches!(err, UrlValidationError::BlockedHost(_)));
+    }
+
+    #[test]
+    fn rejects_ipv6_unique_local() {
+        let err = validate_safe_url("http://[fd00::1]/path").unwrap_err();
+        assert!(matches!(err, UrlValidationError::BlockedHost(_)));
+    }
+
+    #[test]
+    fn rejects_ipv4_mapped_ipv6_private() {
+        let err = validate_safe_url("http://[::ffff:127.0.0.1]/path").unwrap_err();
+        assert!(matches!(err, UrlValidationError::BlockedHost(_)));
+    }
+
+    #[test]
+    fn rejects_ipv4_mapped_ipv6_metadata() {
+        let err =
+            validate_safe_url("http://[::ffff:169.254.169.254]/latest/meta-data/").unwrap_err();
+        assert!(matches!(err, UrlValidationError::BlockedHost(_)));
+    }
+
+    // --- Negative: carrier-grade NAT ---
+
+    #[test]
+    fn rejects_cgnat() {
+        let err = validate_safe_url("http://100.64.0.1/path").unwrap_err();
+        assert!(matches!(err, UrlValidationError::BlockedHost(_)));
+    }
+
+    // --- Display ---
+
+    #[test]
+    fn error_display_messages() {
+        assert!(
+            UrlValidationError::BlockedHost("localhost".into())
+                .to_string()
+                .contains("private/internal")
+        );
+        assert!(
+            UrlValidationError::DisallowedScheme("ftp".into())
+                .to_string()
+                .contains("http or https")
+        );
+    }
+}

--- a/crates/server/src/api/mcp_servers.rs
+++ b/crates/server/src/api/mcp_servers.rs
@@ -12,7 +12,7 @@ use axum::{
     routing::{get, post},
 };
 use everruns_core::typed_id::McpServerId;
-use everruns_core::{McpServer, McpServerStatus, McpServerTransportType};
+use everruns_core::{McpServer, McpServerStatus, McpServerTransportType, validate_safe_url};
 
 use super::common::{ApiOptionExt, ApiResultExt, ErrorResponse, ListResponse};
 use serde::{Deserialize, Serialize};
@@ -153,12 +153,16 @@ pub async fn create_mcp_server(
         );
     }
 
-    // Validate URL is not empty
+    // Validate URL: non-empty, safe scheme, no private/internal targets (SSRF)
     if req.url.trim().is_empty() {
         return Err(
             ErrorResponse::new("URL cannot be empty").into_response(StatusCode::BAD_REQUEST)
         );
     }
+    validate_safe_url(&req.url).map_err(|e| {
+        ErrorResponse::new(format!("Invalid MCP server URL: {e}"))
+            .into_response(StatusCode::BAD_REQUEST)
+    })?;
 
     let server = state.service.create(org.org_id, req).await.map_err(|e| {
         // Check if it's a duplicate name error
@@ -276,13 +280,17 @@ pub async fn update_mcp_server(
         );
     }
 
-    // Validate URL if provided
-    if let Some(ref url) = req.url
-        && url.trim().is_empty()
-    {
-        return Err(
-            ErrorResponse::new("URL cannot be empty").into_response(StatusCode::BAD_REQUEST)
-        );
+    // Validate URL if provided: non-empty, safe scheme, no private/internal targets (SSRF)
+    if let Some(ref url) = req.url {
+        if url.trim().is_empty() {
+            return Err(
+                ErrorResponse::new("URL cannot be empty").into_response(StatusCode::BAD_REQUEST)
+            );
+        }
+        validate_safe_url(url).map_err(|e| {
+            ErrorResponse::new(format!("Invalid MCP server URL: {e}"))
+                .into_response(StatusCode::BAD_REQUEST)
+        })?;
     }
 
     let server = state
@@ -418,5 +426,57 @@ mod tests {
     #[test]
     fn test_default_transport_type() {
         assert_eq!(default_transport_type(), McpServerTransportType::Http);
+    }
+
+    // --- SSRF validation tests (URL safety) ---
+
+    use everruns_core::validate_safe_url;
+
+    #[test]
+    fn ssrf_rejects_localhost_url() {
+        assert!(validate_safe_url("http://localhost/mcp").is_err());
+        assert!(validate_safe_url("http://localhost:8080/mcp").is_err());
+    }
+
+    #[test]
+    fn ssrf_rejects_loopback_ip() {
+        assert!(validate_safe_url("http://127.0.0.1/mcp").is_err());
+        assert!(validate_safe_url("http://127.0.0.2:9999/mcp").is_err());
+    }
+
+    #[test]
+    fn ssrf_rejects_private_ips() {
+        assert!(validate_safe_url("http://10.0.0.1/mcp").is_err());
+        assert!(validate_safe_url("http://172.16.0.1/mcp").is_err());
+        assert!(validate_safe_url("http://192.168.1.1/mcp").is_err());
+    }
+
+    #[test]
+    fn ssrf_rejects_cloud_metadata() {
+        assert!(validate_safe_url("http://169.254.169.254/latest/meta-data/").is_err());
+        assert!(validate_safe_url("http://metadata.google.internal/computeMetadata/v1/").is_err());
+    }
+
+    #[test]
+    fn ssrf_rejects_ipv6_loopback() {
+        assert!(validate_safe_url("http://[::1]/mcp").is_err());
+    }
+
+    #[test]
+    fn ssrf_rejects_ipv4_mapped_ipv6() {
+        assert!(validate_safe_url("http://[::ffff:127.0.0.1]/mcp").is_err());
+        assert!(validate_safe_url("http://[::ffff:169.254.169.254]/mcp").is_err());
+    }
+
+    #[test]
+    fn ssrf_rejects_disallowed_schemes() {
+        assert!(validate_safe_url("ftp://example.com/mcp").is_err());
+        assert!(validate_safe_url("file:///etc/passwd").is_err());
+    }
+
+    #[test]
+    fn ssrf_allows_valid_public_https() {
+        assert!(validate_safe_url("https://mcp.atlassian.com/v1/mcp").is_ok());
+        assert!(validate_safe_url("https://mcp.example.com:8443/v1").is_ok());
     }
 }

--- a/crates/server/src/services/mcp_server.rs
+++ b/crates/server/src/services/mcp_server.rs
@@ -16,6 +16,8 @@ use std::sync::Arc;
 use std::time::Duration;
 use uuid::Uuid;
 
+use everruns_core::validate_safe_url;
+
 use crate::api::mcp_servers::{CreateMcpServerRequest, UpdateMcpServerRequest};
 
 /// How long cached tools are considered fresh (1 hour)
@@ -351,6 +353,9 @@ async fn fetch_mcp_tools(
     api_key: Option<&str>,
     headers: &HashMap<String, String>,
 ) -> Result<Vec<McpToolDefinition>> {
+    // Re-validate URL at fetch time (SSRF defense-in-depth)
+    validate_safe_url(url).map_err(|e| anyhow!("MCP server URL blocked: {}", e))?;
+
     let client = reqwest::Client::builder()
         .timeout(MCP_CLIENT_TIMEOUT)
         .build()?;
@@ -562,6 +567,35 @@ mod tests {
         let resolved = svc.resolve_by_prefix(1, "auth_server").await.unwrap();
         assert!(resolved.is_some());
         assert_eq!(resolved.unwrap().api_key.as_deref(), Some("sk-mcp-secret"));
+    }
+
+    // --- SSRF: fetch_mcp_tools blocks unsafe URLs ---
+
+    #[tokio::test]
+    async fn fetch_tools_blocks_localhost() {
+        let result =
+            super::fetch_mcp_tools("http://localhost:9999/mcp", None, &HashMap::new()).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("blocked"));
+    }
+
+    #[tokio::test]
+    async fn fetch_tools_blocks_private_ip() {
+        let result = super::fetch_mcp_tools("http://10.0.0.1/mcp", None, &HashMap::new()).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("blocked"));
+    }
+
+    #[tokio::test]
+    async fn fetch_tools_blocks_metadata_endpoint() {
+        let result = super::fetch_mcp_tools(
+            "http://169.254.169.254/latest/meta-data/",
+            None,
+            &HashMap::new(),
+        )
+        .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("blocked"));
     }
 
     #[tokio::test]

--- a/crates/worker/src/mcp_executor.rs
+++ b/crates/worker/src/mcp_executor.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use everruns_core::traits::{ToolContext, ToolExecutor};
 use everruns_core::{
     McpContent, McpToolCallRequest, McpToolCallResponse, ToolCall, ToolDefinition, ToolResult,
-    ToolResultImage, is_mcp_tool, parse_mcp_tool_name,
+    ToolResultImage, is_mcp_tool, parse_mcp_tool_name, validate_safe_url,
 };
 use serde_json::json;
 use std::collections::HashMap;
@@ -114,6 +114,17 @@ async fn call_mcp_tool(
     tool_name: &str,
     arguments: serde_json::Value,
 ) -> Result<(serde_json::Value, Vec<ToolResultImage>)> {
+    // Re-validate URL at execution time to catch TOCTOU / post-registration changes
+    validate_safe_url(&server_info.url).map_err(|e| {
+        tracing::warn!(
+            mcp_server = %server_info.name,
+            url = %server_info.url,
+            error = %e,
+            "Blocked MCP tool execution: URL failed SSRF validation"
+        );
+        anyhow!("MCP server URL blocked: {}", e)
+    })?;
+
     let client = reqwest::Client::builder()
         .timeout(MCP_TOOL_TIMEOUT)
         .build()?;
@@ -457,6 +468,68 @@ data: {"result":{"tools":[{"name":"search","description":"Search docs"}]},"id":1
         assert_eq!(images[0].media_type, "image/png");
         assert_eq!(images[0].base64, "iVBORw0KGgo=");
         assert_eq!(text_parts, vec!["Here's the chart"]);
+    }
+
+    // --- SSRF validation at execution time ---
+
+    #[tokio::test]
+    async fn ssrf_blocks_localhost_at_execution_time() {
+        let server = McpServerInfo {
+            id: uuid::Uuid::new_v4(),
+            name: "evil-server".into(),
+            url: "http://localhost:9999/mcp".into(),
+            api_key: None,
+            headers: HashMap::new(),
+        };
+        let result = call_mcp_tool(&server, "test_tool", serde_json::json!({})).await;
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("blocked"),
+            "expected 'blocked' in: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn ssrf_blocks_private_ip_at_execution_time() {
+        let server = McpServerInfo {
+            id: uuid::Uuid::new_v4(),
+            name: "internal-server".into(),
+            url: "http://10.0.0.1/mcp".into(),
+            api_key: None,
+            headers: HashMap::new(),
+        };
+        let result = call_mcp_tool(&server, "test_tool", serde_json::json!({})).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("blocked"));
+    }
+
+    #[tokio::test]
+    async fn ssrf_blocks_metadata_endpoint_at_execution_time() {
+        let server = McpServerInfo {
+            id: uuid::Uuid::new_v4(),
+            name: "metadata-probe".into(),
+            url: "http://169.254.169.254/latest/meta-data/".into(),
+            api_key: None,
+            headers: HashMap::new(),
+        };
+        let result = call_mcp_tool(&server, "test_tool", serde_json::json!({})).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("blocked"));
+    }
+
+    #[tokio::test]
+    async fn ssrf_blocks_ipv6_loopback_at_execution_time() {
+        let server = McpServerInfo {
+            id: uuid::Uuid::new_v4(),
+            name: "ipv6-loopback".into(),
+            url: "http://[::1]:8080/mcp".into(),
+            api_key: None,
+            headers: HashMap::new(),
+        };
+        let result = call_mcp_tool(&server, "test_tool", serde_json::json!({})).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("blocked"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add shared `url_validation` module in `everruns-core` to block SSRF attacks via URL validation
- Validate MCP server URLs on create and update (API layer) — blocks private IPs, localhost, link-local, cloud metadata endpoints, non-http(s) schemes
- Re-validate URLs at execution time in both worker (`mcp_executor.rs`) and server (`fetch_mcp_tools`) for defense-in-depth
- 47 new tests covering positive and negative paths across all three crates

Fixes EVE-70

## Test plan
- [x] MCP server creation with localhost URL is rejected
- [x] MCP server creation with private IP URL is rejected (10.x, 172.16.x, 192.168.x)
- [x] MCP server creation with cloud metadata URL is rejected (169.254.169.254, metadata.google.internal)
- [x] MCP server creation with valid public URL succeeds
- [x] MCP server creation with IPv6 loopback/link-local rejected
- [x] MCP server creation with IPv4-mapped IPv6 private IPs rejected
- [x] MCP server creation with disallowed schemes (ftp, file) rejected
- [x] Execution-time validation blocks unsafe URLs (localhost, private IP, metadata, IPv6)
- [x] Service-level fetch_mcp_tools blocks unsafe URLs