### PR TITLE
fix(ui): render folder action icons inline with folder name

### DIFF
--- a/apps/ui/src/__tests__/file-tree.test.tsx
+++ b/apps/ui/src/__tests__/file-tree.test.tsx
@@ -231,6 +231,56 @@ describe("FileTreeFolder", () => {
       expect(screen.getByText("button.tsx")).toBeInTheDocument();
     });
   });
+
+  describe("actions prop", () => {
+    it("renders actions inline in the folder row", () => {
+      render(
+        <FileTree expanded={new Set(["/src"])}>
+          <FileTreeFolder
+            path="/src"
+            name="src"
+            actions={
+              <FileTreeActions>
+                <span data-testid="inline-action">Add</span>
+              </FileTreeActions>
+            }
+          >
+            <FileTreeFile path="/src/index.ts" name="index.ts" />
+          </FileTreeFolder>
+        </FileTree>,
+      );
+
+      const action = screen.getByTestId("inline-action");
+      expect(action).toBeInTheDocument();
+      // Action and folder name share the same row container (not in collapsible content)
+      const folderName = screen.getByText("src");
+      const row = folderName.closest("button")!.parentElement!;
+      expect(row).toContainElement(action);
+    });
+
+    it("keeps actions outside the trigger button (no nested buttons)", () => {
+      render(
+        <FileTree expanded={new Set(["/src"])}>
+          <FileTreeFolder
+            path="/src"
+            name="src"
+            actions={
+              <FileTreeActions>
+                <span data-testid="inline-action">Add</span>
+              </FileTreeActions>
+            }
+          >
+            <FileTreeFile path="/src/index.ts" name="index.ts" />
+          </FileTreeFolder>
+        </FileTree>,
+      );
+
+      // Actions should be a sibling of the trigger, not nested inside it
+      const trigger = screen.getByRole("button", { expanded: true });
+      const action = screen.getByTestId("inline-action");
+      expect(trigger).not.toContainElement(action);
+    });
+  });
 });
 
 describe("FileTreeFile", () => {

--- a/apps/ui/src/app/dev/file-tree/page.tsx
+++ b/apps/ui/src/app/dev/file-tree/page.tsx
@@ -134,15 +134,20 @@ export default function FileTreeDevPage() {
                     </FileTreeActions>
                   </FileTreeFile>
                 </FileTreeFolder>
-                <FileTreeFolder path="/project/assets" name="assets">
-                  <FileTreeActions>
-                    <Button variant="ghost" size="icon" className="size-5">
-                      <Plus className="size-3" />
-                    </Button>
-                    <Button variant="ghost" size="icon" className="size-5">
-                      <FolderPlus className="size-3" />
-                    </Button>
-                  </FileTreeActions>
+                <FileTreeFolder
+                  path="/project/assets"
+                  name="assets"
+                  actions={
+                    <FileTreeActions>
+                      <Button variant="ghost" size="icon" className="size-5">
+                        <Plus className="size-3" />
+                      </Button>
+                      <Button variant="ghost" size="icon" className="size-5">
+                        <FolderPlus className="size-3" />
+                      </Button>
+                    </FileTreeActions>
+                  }
+                >
                   <FileTreeFile
                     path="/project/assets/logo.png"
                     name="logo.png"

--- a/apps/ui/src/components/ai-elements/file-tree.tsx
+++ b/apps/ui/src/components/ai-elements/file-tree.tsx
@@ -122,33 +122,37 @@ export const FileTreeFolder = ({
     <FileTreeFolderContext.Provider value={{ isExpanded, name, path }}>
       <Collapsible onOpenChange={handleOpenChange} open={isExpanded}>
         <div className={cn("group", className)} role="treeitem" {...props}>
-          <CollapsibleTrigger asChild>
-            <button
-              className={cn(
-                "flex w-full items-center gap-1.5 px-2 py-1 text-left transition-colors",
-                "hover:bg-muted/60",
-                isSelected && "bg-accent/20 text-accent-foreground",
-              )}
-              onClick={handleSelect}
-              type="button"
-            >
-              <ChevronRightIcon
-                className={cn(
-                  "size-3.5 shrink-0 text-muted-foreground/70 transition-transform duration-150",
-                  isExpanded && "rotate-90",
-                )}
-              />
-              <FileTreeIcon>
-                {isExpanded ? (
-                  <FolderOpenIcon className="size-4 text-amber-500" />
-                ) : (
-                  <FolderIcon className="size-4 text-amber-500/80" />
-                )}
-              </FileTreeIcon>
-              <FileTreeName className="font-medium">{name}</FileTreeName>
-              {actions}
-            </button>
-          </CollapsibleTrigger>
+          <div
+            className={cn(
+              "flex items-center px-2 py-1 transition-colors",
+              "hover:bg-muted/60",
+              isSelected && "bg-accent/20 text-accent-foreground",
+            )}
+          >
+            <CollapsibleTrigger asChild>
+              <button
+                className="flex flex-1 min-w-0 items-center gap-1.5 text-left"
+                onClick={handleSelect}
+                type="button"
+              >
+                <ChevronRightIcon
+                  className={cn(
+                    "size-3.5 shrink-0 text-muted-foreground/70 transition-transform duration-150",
+                    isExpanded && "rotate-90",
+                  )}
+                />
+                <FileTreeIcon>
+                  {isExpanded ? (
+                    <FolderOpenIcon className="size-4 text-amber-500" />
+                  ) : (
+                    <FolderIcon className="size-4 text-amber-500/80" />
+                  )}
+                </FileTreeIcon>
+                <FileTreeName className="font-medium">{name}</FileTreeName>
+              </button>
+            </CollapsibleTrigger>
+            {actions}
+          </div>
           <CollapsibleContent>
             <div className="ml-3 border-l border-border/50 pl-2">{children}</div>
           </CollapsibleContent>

--- a/apps/ui/src/components/ai-elements/file-tree.tsx
+++ b/apps/ui/src/components/ai-elements/file-tree.tsx
@@ -94,11 +94,14 @@ const FileTreeFolderContext = createContext<FileTreeFolderContextType>({
 export type FileTreeFolderProps = HTMLAttributes<HTMLDivElement> & {
   path: string;
   name: string;
+  /** Actions rendered inline with the folder name (e.g. FileTreeActions) */
+  actions?: ReactNode;
 };
 
 export const FileTreeFolder = ({
   path,
   name,
+  actions,
   className,
   children,
   ...props
@@ -143,6 +146,7 @@ export const FileTreeFolder = ({
                 )}
               </FileTreeIcon>
               <FileTreeName className="font-medium">{name}</FileTreeName>
+              {actions}
             </button>
           </CollapsibleTrigger>
           <CollapsibleContent>

--- a/apps/ui/src/components/files/file-browser.tsx
+++ b/apps/ui/src/components/files/file-browser.tsx
@@ -300,45 +300,51 @@ export function FileBrowser({
     return sortedFiles.map((file) => {
       if (file.is_directory) {
         return (
-          <FileTreeFolder key={file.id} path={file.path} name={file.name}>
-            <FileTreeActions>
-              {file.is_readonly && <Lock className="size-3 text-muted-foreground" />}
-              <Button
-                variant="ghost"
-                size="icon"
-                className="size-5"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  openCreateFileDialog(file.path);
-                }}
-                title="New file"
-              >
-                <Plus className="size-3" />
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="size-5"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  openCreateDirDialog(file.path);
-                }}
-                title="New folder"
-              >
-                <FolderPlus className="size-3" />
-              </Button>
-              {!file.is_readonly && (
+          <FileTreeFolder
+            key={file.id}
+            path={file.path}
+            name={file.name}
+            actions={
+              <FileTreeActions>
+                {file.is_readonly && <Lock className="size-3 text-muted-foreground" />}
                 <Button
                   variant="ghost"
                   size="icon"
                   className="size-5"
-                  onClick={(e) => handleDelete(file, e)}
-                  title="Delete"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    openCreateFileDialog(file.path);
+                  }}
+                  title="New file"
                 >
-                  <Trash2 className="size-3 text-destructive" />
+                  <Plus className="size-3" />
                 </Button>
-              )}
-            </FileTreeActions>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="size-5"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    openCreateDirDialog(file.path);
+                  }}
+                  title="New folder"
+                >
+                  <FolderPlus className="size-3" />
+                </Button>
+                {!file.is_readonly && (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-5"
+                    onClick={(e) => handleDelete(file, e)}
+                    title="Delete"
+                  >
+                    <Trash2 className="size-3 text-destructive" />
+                  </Button>
+                )}
+              </FileTreeActions>
+            }
+          >
             {renderDirectoryContents(file.path, depth + 1)}
           </FileTreeFolder>
         );


### PR DESCRIPTION
## What
Fix folder action icons (+, new folder, delete) rendering on the next line below the folder name instead of inline.

## Why
`FileTreeFolder` rendered all children inside `CollapsibleContent`, so `FileTreeActions` appeared below the folder row instead of inline with the folder name.

## How
- Add `actions` prop to `FileTreeFolder` for inline rendering in the folder row
- Use a flex wrapper div so actions are siblings of the trigger button (avoids invalid nested `<button>` HTML)
- Update `FileBrowser` and dev page to use the new `actions` prop
- Add 2 tests for the `actions` prop (inline rendering, no nested buttons)

## Risk
- Low
- Only affects folder row layout in file tree; no logic changes

## Checklist
- [x] Tests added or updated (2 new tests for actions prop, 28 total pass)
- [x] Backward compatibility considered (actions prop is optional, existing usage unchanged)