### PR TITLE
fix(ui): fix code block rendering in chat messages

### DIFF
--- a/apps/ui/src/app/globals.css
+++ b/apps/ui/src/app/globals.css
@@ -3,6 +3,11 @@
 /* Enable Tailwind to scan Streamdown for classes */
 @source "../node_modules/streamdown/dist/*.js";
 
+/* Safelist Streamdown code block classes that Tailwind v4 @source misses from
+   minified JS (negative margins, color/opacity variants). Without these, the
+   code block toolbar positioning and background colors break. */
+@source inline("-mt-10 bg-sidebar/70 bg-sidebar/80 border-sidebar border-muted-foreground/30");
+
 /**
  * Slate Design System
  *
@@ -35,6 +40,9 @@
     --border: 0 0% 88%;
     --input: 0 0% 85%;
     --ring: 43 60% 53%;
+    /* Sidebar: used by Streamdown code blocks */
+    --sidebar: 0 0% 96%;
+    --sidebar-foreground: 0 0% 10%;
     /* Sharp corners */
     --radius: 0px;
   }
@@ -62,6 +70,9 @@
     --border: 220 15% 18%;
     --input: 220 15% 18%;
     --ring: 43 60% 53%;
+    /* Sidebar: used by Streamdown code blocks */
+    --sidebar: 220 15% 15%;
+    --sidebar-foreground: 0 0% 95%;
   }
 }
 
@@ -85,6 +96,8 @@
   --color-border: hsl(var(--border));
   --color-input: hsl(var(--input));
   --color-ring: hsl(var(--ring));
+  --color-sidebar: hsl(var(--sidebar));
+  --color-sidebar-foreground: hsl(var(--sidebar-foreground));
   /* Sharp corners - all radius values are 0 */
   --radius-sm: 0px;
   --radius-md: 0px;

--- a/apps/ui/src/components/chat/streamdown-message.tsx
+++ b/apps/ui/src/components/chat/streamdown-message.tsx
@@ -48,7 +48,19 @@ const streamdownStyles = `
   .streamdown th, .streamdown td { border: 1px solid var(--color-border); padding: 0.5em; text-align: left; }
   .streamdown th { background: var(--color-muted); font-weight: 600; }
   .streamdown img { max-width: 100%; height: auto; }
-  .streamdown [data-streamdown-code] { border-radius: 0; }
+
+  /* Streamdown code block overrides: sharp corners, no nested borders/backgrounds,
+     toolbar overlapping header (the Tailwind -mt-10 class may not be generated). */
+  .streamdown [data-streamdown="code-block"] { border-radius: 0; position: relative; }
+  .streamdown [data-streamdown="code-block-body"] { border-radius: 0; border: none; }
+  .streamdown [data-streamdown="code-block-body"] pre { background: none; padding: 0; margin: 0; }
+  .streamdown [data-streamdown="code-block-body"] pre code { background: none; padding: 0; }
+  .streamdown [data-streamdown="code-block-header"] { display: inline-flex; }
+  .streamdown [data-streamdown="code-block-actions"] {
+    position: absolute;
+    right: 0.5rem;
+    top: 0.5rem;
+  }
 
   /* GitHub-style alerts */
   .streamdown .markdown-alert { padding: 0.5em 1em; margin: 0.5em 0; border-left: 4px solid; }


### PR DESCRIPTION
## What
Fix code block rendering in chat messages — removes nested boxes, positions toolbar correctly, and applies sharp corners per brand spec.

## Why
Streamdown code blocks rendered with triple-nested borders (container + body border + pre background) and the copy/download toolbar appeared on a separate line below the language label instead of alongside it. The root causes:
1. Our custom `.streamdown pre` CSS conflicted with Streamdown's built-in `CodeBlockBody` styles
2. The `[data-streamdown-code]` CSS selector was wrong (correct: `[data-streamdown="code-block"]`)
3. Tailwind v4 `@source` scanner missed `-mt-10` and `bg-sidebar/*` classes from minified JS
4. The `sidebar` color was undefined in our theme (required by Streamdown)

## How
- **`streamdown-message.tsx`**: Fixed CSS selector, removed inner body border, stripped pre background/padding inside code blocks, positioned toolbar absolutely in top-right
- **`globals.css`**: Added `--sidebar` color variable to light/dark themes and `@theme inline`, added `@source inline()` safelist for Tailwind classes missed by scanner

## Risk
- Low
- CSS-only changes affecting code block appearance in chat messages and markdown preview

## Checklist
- [x] Tests added or updated (existing 435 tests pass, CSS-only change)
- [x] Backward compatibility considered (visual improvement only)