### PR TITLE
fix(session-files): return 409 instead of 500 on duplicate file creation

### DIFF
--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -1891,4 +1891,168 @@ mod tests {
             panic!("Expected success, got: {:?}", result);
         }
     }
+
+    // ========================================================================
+    // Overwrite / existing-file tests
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_bash_overwrite_existing_file() {
+        let (context, _) = create_context_with_mock_store();
+        let tool = BashTool;
+
+        // Write a file
+        let result = tool
+            .execute_with_context(
+                json!({"command": "echo 'first' > /workspace/overwrite.txt"}),
+                &context,
+            )
+            .await;
+        assert!(matches!(result, ToolExecutionResult::Success(_)));
+
+        // Overwrite with new content
+        let result = tool
+            .execute_with_context(
+                json!({"command": "echo 'second' > /workspace/overwrite.txt"}),
+                &context,
+            )
+            .await;
+        if let ToolExecutionResult::Success(output) = &result {
+            assert_eq!(output["exit_code"], 0, "Overwrite should succeed");
+        } else {
+            panic!("Expected success on overwrite, got: {:?}", result);
+        }
+
+        // Read back — should have new content
+        let result = tool
+            .execute_with_context(json!({"command": "cat /workspace/overwrite.txt"}), &context)
+            .await;
+        if let ToolExecutionResult::Success(output) = result {
+            assert_eq!(output["stdout"], "second\n");
+        } else {
+            panic!("Expected success on read, got: {:?}", result);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_bash_append_to_existing_file() {
+        let (context, _) = create_context_with_mock_store();
+        let tool = BashTool;
+
+        // Create file
+        let result = tool
+            .execute_with_context(
+                json!({"command": "echo 'line1' > /workspace/append.txt"}),
+                &context,
+            )
+            .await;
+        assert!(matches!(result, ToolExecutionResult::Success(_)));
+
+        // Append
+        let result = tool
+            .execute_with_context(
+                json!({"command": "echo 'line2' >> /workspace/append.txt"}),
+                &context,
+            )
+            .await;
+        if let ToolExecutionResult::Success(output) = &result {
+            assert_eq!(output["exit_code"], 0, "Append should succeed");
+        } else {
+            panic!("Expected success on append, got: {:?}", result);
+        }
+
+        // Verify combined content
+        let result = tool
+            .execute_with_context(json!({"command": "cat /workspace/append.txt"}), &context)
+            .await;
+        if let ToolExecutionResult::Success(output) = result {
+            assert_eq!(output["stdout"], "line1\nline2\n");
+        } else {
+            panic!("Expected success on read");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_adapter_overwrite_existing_file() {
+        let session_id = SessionId::new();
+        let store: Arc<dyn SessionFileStore> = Arc::new(MockFileStore::new());
+        let adapter = SessionFileSystemAdapter::new(session_id, store);
+
+        // Write initial
+        adapter
+            .write_file(Path::new("/workspace/ow.txt"), b"original")
+            .await
+            .unwrap();
+
+        // Overwrite
+        adapter
+            .write_file(Path::new("/workspace/ow.txt"), b"updated")
+            .await
+            .unwrap();
+
+        // Verify new content
+        let content = adapter
+            .read_file(Path::new("/workspace/ow.txt"))
+            .await
+            .unwrap();
+        assert_eq!(content, b"updated");
+    }
+
+    #[tokio::test]
+    async fn test_adapter_append_to_existing_file() {
+        let session_id = SessionId::new();
+        let store: Arc<dyn SessionFileStore> = Arc::new(MockFileStore::new());
+        let adapter = SessionFileSystemAdapter::new(session_id, store);
+
+        // Write initial
+        adapter
+            .write_file(Path::new("/workspace/ap.txt"), b"AAA")
+            .await
+            .unwrap();
+
+        // Append
+        adapter
+            .append_file(Path::new("/workspace/ap.txt"), b"BBB")
+            .await
+            .unwrap();
+
+        // Verify combined
+        let content = adapter
+            .read_file(Path::new("/workspace/ap.txt"))
+            .await
+            .unwrap();
+        assert_eq!(content, b"AAABBB");
+    }
+
+    #[tokio::test]
+    async fn test_bash_redirect_creates_parent_dirs() {
+        let (context, _) = create_context_with_mock_store();
+        let tool = BashTool;
+
+        // Write to a nested path — parent dirs should be auto-created
+        let result = tool
+            .execute_with_context(
+                json!({"command": "echo 'deep' > /workspace/a/b/c/deep.txt"}),
+                &context,
+            )
+            .await;
+        if let ToolExecutionResult::Success(output) = &result {
+            assert_eq!(output["exit_code"], 0, "Nested write should succeed");
+        } else {
+            panic!("Expected success, got: {:?}", result);
+        }
+
+        // Read back
+        let result = tool
+            .execute_with_context(
+                json!({"command": "cat /workspace/a/b/c/deep.txt"}),
+                &context,
+            )
+            .await;
+        if let ToolExecutionResult::Success(output) = result {
+            assert_eq!(output["stdout"], "deep\n");
+        } else {
+            panic!("Expected success on read");
+        }
+    }
 }

--- a/crates/server/src/api/session_files.rs
+++ b/crates/server/src/api/session_files.rs
@@ -459,13 +459,13 @@ pub async fn create_path(
             )
             .await
             .map_err(|e| {
-                tracing::error!("Failed to create file: {}", e);
                 let msg = e.to_string();
                 if msg.contains("already exists") {
                     (StatusCode::CONFLICT, msg)
                 } else if msg.contains("Invalid") || msg.contains("cannot") {
                     (StatusCode::BAD_REQUEST, msg)
                 } else {
+                    tracing::error!("Failed to create file: {}", e);
                     (
                         StatusCode::INTERNAL_SERVER_ERROR,
                         "Internal server error".to_string(),

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -150,11 +150,30 @@ impl DirectWorkerAdapters {
             is_readonly: false,
         };
 
-        self.db
-            .create_session_file(input)
-            .await
-            .map_err(|e| store_error(format!("Failed to create directory: {}", e)))?;
-        Ok(())
+        match self.db.create_session_file(input).await {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("duplicate key")
+                    || msg.contains("unique constraint")
+                    || msg.contains("UNIQUE constraint")
+                {
+                    // Race: directory was created concurrently; verify it's a directory
+                    if let Some(existing) = self
+                        .db
+                        .get_session_file(session_id, path)
+                        .await
+                        .map_err(|e| store_error(format!("Failed to check directory: {}", e)))?
+                        && existing.is_directory
+                    {
+                        return Ok(());
+                    }
+                    Err(store_error(format!("A file exists at path: {}", path)))
+                } else {
+                    Err(store_error(format!("Failed to create directory: {}", e)))
+                }
+            }
+        }
     }
 }
 
@@ -489,10 +508,33 @@ impl WorkerAdapters for DirectWorkerAdapters {
                 is_directory: false,
                 is_readonly: false,
             };
-            self.db.create_session_file(create).await.map_err(|e| {
-                tracing::error!("Failed to create file: {}", e);
-                store_error("Failed to write file")
-            })?
+            match self.db.create_session_file(create).await {
+                Ok(row) => row,
+                Err(e) => {
+                    let msg = e.to_string();
+                    if msg.contains("duplicate key")
+                        || msg.contains("unique constraint")
+                        || msg.contains("UNIQUE constraint")
+                    {
+                        // Race: file was created concurrently; fall back to update
+                        let update = UpdateSessionFile {
+                            content: Some(content_bytes.clone()),
+                            ..Default::default()
+                        };
+                        self.db
+                            .update_session_file(session_id, path, update)
+                            .await
+                            .map_err(|e| {
+                                tracing::error!("Failed to update file after race: {}", e);
+                                store_error("Failed to write file")
+                            })?
+                            .ok_or_else(|| store_error("File disappeared during update"))?
+                    } else {
+                        tracing::error!("Failed to create file: {}", e);
+                        return Err(store_error("Failed to write file"));
+                    }
+                }
+            }
         };
 
         Ok(SessionFile {

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -1519,8 +1519,13 @@ impl WorkerService for WorkerServiceImpl {
                 .create_file(session_id, create)
                 .await
                 .map_err(|e| {
-                    tracing::error!("Failed to create file: {}", e);
-                    Status::internal("Failed to create file")
+                    let msg = e.to_string();
+                    if msg.contains("already exists") {
+                        Status::already_exists(msg)
+                    } else {
+                        tracing::error!("Failed to create file: {}", e);
+                        Status::internal("Failed to create file")
+                    }
                 })?
         };
 

--- a/crates/server/src/services/session_file.rs
+++ b/crates/server/src/services/session_file.rs
@@ -128,7 +128,7 @@ impl SessionFileService {
             self.ensure_directory_exists(session_id, &parent).await?;
         }
 
-        // Check if file already exists
+        // Fast-path check (non-racy for in-memory; Postgres constraint catches races)
         if self.db.session_file_exists(session_id, &path).await? {
             return Err(anyhow!("File already exists at path: {}", path));
         }
@@ -141,7 +141,17 @@ impl SessionFileService {
             is_readonly: req.is_readonly.unwrap_or(false),
         };
 
-        let row = self.db.create_session_file(input).await?;
+        let row = self.db.create_session_file(input).await.map_err(|e| {
+            let msg = e.to_string();
+            if msg.contains("duplicate key")
+                || msg.contains("unique constraint")
+                || msg.contains("UNIQUE constraint")
+            {
+                anyhow!("File already exists at path: {}", path)
+            } else {
+                e
+            }
+        })?;
         Ok(Self::row_to_session_file(row))
     }
 
@@ -176,7 +186,25 @@ impl SessionFileService {
             is_readonly: false,
         };
 
-        let row = self.db.create_session_file(input).await?;
+        let row = match self.db.create_session_file(input).await {
+            Ok(row) => row,
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("duplicate key")
+                    || msg.contains("unique constraint")
+                    || msg.contains("UNIQUE constraint")
+                {
+                    // Race: another request created it concurrently; return existing
+                    if let Some(existing) = self.db.get_session_file(session_id, &path).await?
+                        && existing.is_directory
+                    {
+                        return Ok(Self::row_to_file_info(existing));
+                    }
+                    return Err(anyhow!("A file exists at path: {}", path));
+                }
+                return Err(e);
+            }
+        };
         Ok(Self::row_to_file_info(row))
     }
 
@@ -209,8 +237,26 @@ impl SessionFileService {
             is_readonly: false,
         };
 
-        self.db.create_session_file(input).await?;
-        Ok(())
+        match self.db.create_session_file(input).await {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("duplicate key")
+                    || msg.contains("unique constraint")
+                    || msg.contains("UNIQUE constraint")
+                {
+                    // Race: another request created it concurrently; check it's a directory
+                    if let Some(existing) = self.db.get_session_file(session_id, path).await?
+                        && existing.is_directory
+                    {
+                        return Ok(());
+                    }
+                    Err(anyhow!("A file exists at path: {}", path))
+                } else {
+                    Err(e)
+                }
+            }
+        }
     }
 
     /// Read a file
@@ -809,6 +855,7 @@ mod tests {
     use super::*;
     use crate::storage::StorageBackend;
     use crate::storage::models::CreateSessionFileRow;
+    use std::sync::Arc;
 
     /// Seed a text file into the in-memory store.
     async fn seed_file(db: &StorageBackend, session_id: Uuid, path: &str, content: &str) {
@@ -872,6 +919,33 @@ mod tests {
 
         let result = grep_session_files(&db, sid, "[invalid", None).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn create_duplicate_file_returns_already_exists_error() {
+        let db = StorageBackend::in_memory();
+        let sid = Uuid::new_v4();
+        let svc = SessionFileService::new(Arc::new(db.clone()));
+
+        let input = CreateFileInput {
+            path: "/test.txt".to_string(),
+            content: Some("hello".to_string()),
+            encoding: None,
+            is_readonly: None,
+        };
+        svc.create_file(sid, input).await.unwrap();
+
+        let input2 = CreateFileInput {
+            path: "/test.txt".to_string(),
+            content: Some("world".to_string()),
+            encoding: None,
+            is_readonly: None,
+        };
+        let err = svc.create_file(sid, input2).await.unwrap_err();
+        assert!(
+            err.to_string().contains("already exists"),
+            "Expected 'already exists' in: {err}"
+        );
     }
 
     #[tokio::test]

--- a/crates/server/src/storage/session_file_store.rs
+++ b/crates/server/src/storage/session_file_store.rs
@@ -85,8 +85,30 @@ impl DbSessionFileStore {
             is_readonly: false,
         };
 
-        self.db.create_session_file(input).await?;
-        Ok(())
+        match self.db.create_session_file(input).await {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("duplicate key")
+                    || msg.contains("unique constraint")
+                    || msg.contains("UNIQUE constraint")
+                {
+                    // Race: directory was created concurrently; verify it's a directory
+                    if let Some(existing) =
+                        self.db.get_session_file(session_id.uuid(), path).await?
+                        && existing.is_directory
+                    {
+                        return Ok(());
+                    }
+                    Err(AgentLoopError::store(format!(
+                        "A file exists at path: {}",
+                        path
+                    )))
+                } else {
+                    Err(AgentLoopError::store(e.to_string()))
+                }
+            }
+        }
     }
 }
 
@@ -481,11 +503,42 @@ impl SessionFileStore for DbSessionFileStore {
             is_readonly: false,
         };
 
-        let row = self
-            .db
-            .create_session_file(input)
-            .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+        let row = match self.db.create_session_file(input).await {
+            Ok(row) => row,
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("duplicate key")
+                    || msg.contains("unique constraint")
+                    || msg.contains("UNIQUE constraint")
+                {
+                    // Race: directory created concurrently; return existing
+                    if let Some(existing) = self
+                        .db
+                        .get_session_file(session_id.uuid(), &path)
+                        .await
+                        .map_err(|e| AgentLoopError::store(e.to_string()))?
+                        && existing.is_directory
+                    {
+                        return Ok(FileInfo {
+                            id: existing.id,
+                            session_id: existing.session_id.uuid(),
+                            path: existing.path.clone(),
+                            name: FileInfo::name_from_path(&existing.path),
+                            is_directory: existing.is_directory,
+                            is_readonly: existing.is_readonly,
+                            size_bytes: existing.size_bytes,
+                            created_at: existing.created_at,
+                            updated_at: existing.updated_at,
+                        });
+                    }
+                    return Err(AgentLoopError::store(format!(
+                        "A file exists at path: {}",
+                        path
+                    )));
+                }
+                return Err(AgentLoopError::store(e.to_string()));
+            }
+        };
 
         Ok(FileInfo {
             id: row.id,

--- a/crates/server/src/storage/session_file_store.rs
+++ b/crates/server/src/storage/session_file_store.rs
@@ -203,15 +203,39 @@ impl SessionFileStore for DbSessionFileStore {
             let input = CreateSessionFileRow {
                 session_id,
                 path: path.clone(),
-                content: Some(bytes),
+                content: Some(bytes.clone()),
                 is_directory: false,
                 is_readonly: false,
             };
 
-            self.db
-                .create_session_file(input)
-                .await
-                .map_err(|e| AgentLoopError::store(e.to_string()))?
+            match self.db.create_session_file(input).await {
+                Ok(row) => row,
+                Err(e) => {
+                    let msg = e.to_string();
+                    if msg.contains("duplicate key")
+                        || msg.contains("unique constraint")
+                        || msg.contains("UNIQUE constraint")
+                    {
+                        // Race: file was created concurrently; fall back to update
+                        self.db
+                            .update_session_file(
+                                session_id.uuid(),
+                                &path,
+                                UpdateSessionFile {
+                                    content: Some(bytes),
+                                    is_readonly: None,
+                                },
+                            )
+                            .await
+                            .map_err(|e| AgentLoopError::store(e.to_string()))?
+                            .ok_or_else(|| {
+                                AgentLoopError::store("File not found after race recovery")
+                            })?
+                    } else {
+                        return Err(AgentLoopError::store(e.to_string()));
+                    }
+                }
+            }
         };
 
         // Convert row to SessionFile


### PR DESCRIPTION
## What
Fix duplicate file creation errors across all session file store implementations to return proper "already exists" errors instead of raw database constraint violation errors.

## Why
When two concurrent requests created the same file path, the second request would hit a unique constraint violation and return an opaque 500 Internal Server Error (or raw DB error) instead of a clean 409 Conflict. This affected:
- `SessionFileService::create_file/create_directory/ensure_directory_exists`
- `DbSessionFileStore::write_file/ensure_directory_exists/create_directory`
- `DirectWorkerAdapters::ensure_directory_exists/write_file`
- gRPC `create_file` handler

## How
Added constraint-catch pattern at every `create_session_file` call site: detect `duplicate key` / `unique constraint` / `UNIQUE constraint` in error messages and either:
- Return "File already exists" error (for create-only operations)
- Fall back to update (for upsert operations like `write_file`)
- Return existing directory (for `create_directory` / `ensure_directory_exists`)

Also moved the `tracing::error!` log in the API handler to only fire for actual 500 errors, not expected 409s.

Added 5 new virtual bash tests covering overwrite, append, and nested-dir redirect semantics.

## Risk
- Low
- Pure error-handling change; no behavioral changes for non-error paths. The constraint-catch is a safety net that only fires during concurrent races.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered