### PR TITLE
feat(ui): collapse durable execution sidebar by default

### DIFF
--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { Sidebar } from "@/components/layout/sidebar";
 import type { SidebarConfig, NavigationSection } from "@/components/layout/sidebar";
 import { Settings, Zap } from "lucide-react";
@@ -161,13 +161,36 @@ describe("Sidebar", () => {
     expect(screen.getByText("Durable Execution")).toBeInTheDocument();
   });
 
-  it("renders Durable Execution navigation items", () => {
+  it("hides Durable Execution navigation items by default (collapsed)", () => {
     render(<Sidebar />);
+
+    expect(screen.queryByText("Overview")).not.toBeInTheDocument();
+    expect(screen.queryByText("Workers")).not.toBeInTheDocument();
+    expect(screen.queryByText("Workflows")).not.toBeInTheDocument();
+    expect(screen.queryByText("Schedules")).not.toBeInTheDocument();
+  });
+
+  it("shows Durable Execution navigation items when expanded", () => {
+    render(<Sidebar />);
+
+    const toggle = screen.getByRole("button", { name: /durable execution/i });
+    fireEvent.click(toggle);
 
     expect(screen.getByText("Overview")).toBeInTheDocument();
     expect(screen.getByText("Workers")).toBeInTheDocument();
     expect(screen.getByText("Workflows")).toBeInTheDocument();
     expect(screen.getByText("Schedules")).toBeInTheDocument();
+  });
+
+  it("collapses Durable Execution section again on second click", () => {
+    render(<Sidebar />);
+
+    const toggle = screen.getByRole("button", { name: /durable execution/i });
+    fireEvent.click(toggle);
+    expect(screen.getByText("Workers")).toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(screen.queryByText("Workers")).not.toBeInTheDocument();
   });
 
   it("nav element has overflow-y-auto and min-h-0 to prevent sidebar overflow", () => {
@@ -181,6 +204,10 @@ describe("Sidebar", () => {
   it("highlights durable navigation for nested routes", () => {
     mockPathname.mockReturnValue("/durable/workers");
     render(<Sidebar />);
+
+    // Expand the collapsed durable section first
+    const toggle = screen.getByRole("button", { name: /durable execution/i });
+    fireEvent.click(toggle);
 
     const workersLink = screen.getByRole("link", { name: /workers/i });
     expect(workersLink).toHaveClass("border-l-primary");

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -56,6 +56,7 @@ import {
   Key,
   ChevronUp,
   ChevronDown,
+  ChevronRight,
   FlaskConical,
   Calendar,
   MessageCircle,
@@ -96,6 +97,8 @@ export type NavigationSection = {
   items: NavigationItem[];
   /** Only show in development mode */
   devOnly?: boolean;
+  /** Start collapsed. Requires a label. */
+  defaultCollapsed?: boolean;
 };
 
 export interface SidebarConfig {
@@ -146,7 +149,7 @@ export const defaultNavigationSections: NavigationSection[] = [
   { items: defaultTopNavigation },
   { label: "Building Blocks", items: defaultBuildingBlocksNavigation },
   { items: defaultBottomNavigation },
-  { label: "Durable Execution", items: defaultDurableNavigation },
+  { label: "Durable Execution", items: defaultDurableNavigation, defaultCollapsed: true },
   { label: "Dev", items: defaultDevNavigation, devOnly: true },
 ];
 
@@ -206,19 +209,39 @@ function NavSection({
   featureFlags: FeatureFlags;
   isFirst: boolean;
 }) {
+  const [collapsed, setCollapsed] = useState(section.defaultCollapsed ?? false);
+  const toggle = () => setCollapsed((c) => !c);
+
   if (section.devOnly && !isDev) return null;
+
+  const isCollapsible = section.defaultCollapsed !== undefined && section.label;
 
   return (
     <>
       {!isFirst && <div className="my-3 border-t" />}
-      {section.label && (
-        <p className="px-3 py-1 text-[10px] font-medium uppercase tracking-[0.22em] text-muted-foreground">
-          {section.label}
-        </p>
-      )}
-      {section.items.map((item) => (
-        <NavLink key={item.name} item={item} pathname={pathname} featureFlags={featureFlags} />
-      ))}
+      {section.label &&
+        (isCollapsible ? (
+          <button
+            type="button"
+            onClick={toggle}
+            className="flex w-full items-center justify-between px-3 py-1 text-[10px] font-medium uppercase tracking-[0.22em] text-muted-foreground hover:text-foreground transition-colors"
+          >
+            {section.label}
+            {collapsed ? (
+              <ChevronRight className="h-3.5 w-3.5" />
+            ) : (
+              <ChevronDown className="h-3.5 w-3.5" />
+            )}
+          </button>
+        ) : (
+          <p className="px-3 py-1 text-[10px] font-medium uppercase tracking-[0.22em] text-muted-foreground">
+            {section.label}
+          </p>
+        ))}
+      {!collapsed &&
+        section.items.map((item) => (
+          <NavLink key={item.name} item={item} pathname={pathname} featureFlags={featureFlags} />
+        ))}
     </>
   );
 }


### PR DESCRIPTION
## What
Durable Execution sidebar section is now collapsed by default with a clickable chevron toggle to expand/collapse.

## Why
Reduce sidebar noise for users who don't frequently use durable execution features.

## How
Added `defaultCollapsed` option to `NavigationSection` type. Sections with this flag render a clickable label with a chevron toggle instead of a static header. Items are hidden when collapsed.

## Risk
- Low
- Only affects sidebar rendering; no backend or data changes

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered