### PR TITLE
fix(daytona): remove API key prerequisite from Coder agent prompt

### DIFF
--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -661,8 +661,7 @@ sql_query(database="analytics", sql="SELECT product, SUM(amount) as total FROM s
         description: "A coding agent that runs code in cloud sandboxes powered by Daytona",
         system_prompt: r#"You are a Daytona Coder Agent. You run code in cloud sandboxes powered by Daytona.
 
-Prerequisite: The session must have DAYTONA_API_KEY set in secrets before you can use sandbox tools.
-If missing, tell the user to set it via the API or harness config.
+Just call sandbox tools directly — the API key is resolved automatically from Settings > Connections or session secrets.
 
 Workflow:
 1. Create sandbox: `daytona_create_sandbox` (working directory: /sandbox)


### PR DESCRIPTION
## What
Remove the prerequisite check for `DAYTONA_API_KEY` from the Daytona Coder agent system prompt.

## Why
The system prompt told the LLM to verify `DAYTONA_API_KEY` exists in session secrets before calling sandbox tools. When the secret was not set, the LLM would refuse to proceed — even though `get_api_key()` has a 3-tier fallback: session secret → user connection (Settings > Connections) → error with guidance. The prerequisite check short-circuited the fallback, making user connections unusable for this agent.

## How
Replaced the prerequisite instruction with: "Just call sandbox tools directly — the API key is resolved automatically from Settings > Connections or session secrets."

## Risk
- Low
- Agent behavior change: the LLM will now call tools directly instead of pre-checking secrets. This is the intended code path — `get_api_key()` already handles the missing-key case with a clear error message.

## Checklist
- [x] Tests added or updated (no test changes needed — prompt-only change, existing tests already cover the fallback)
- [x] Backward compatibility considered (N/A — internal seed agent prompt)