### PR TITLE
fix(ui): simplify inline tool transcript

### DIFF
--- a/apps/ui/src/__tests__/todo-list-renderer.test.tsx
+++ b/apps/ui/src/__tests__/todo-list-renderer.test.tsx
@@ -3,7 +3,7 @@ import { TodoListRenderer } from "@/components/chat/todo-list-renderer";
 
 describe("TodoListRenderer", () => {
   it("renders a progress header and uses activeForm for in-progress items", () => {
-    render(
+    const { container } = render(
       <TodoListRenderer
         arguments={{
           todos: [
@@ -28,8 +28,12 @@ describe("TodoListRenderer", () => {
       />,
     );
 
+    const root = container.firstElementChild as HTMLElement;
+
     expect(screen.getByText("1 of 3 todos completed")).toBeInTheDocument();
     expect(screen.getAllByText("Running tests")).toHaveLength(2);
     expect(screen.getByText("Update docs")).toBeInTheDocument();
+    expect(root).not.toHaveClass("border");
+    expect(root.className).not.toContain("bg-card/95");
   });
 });

--- a/apps/ui/src/__tests__/tool-activity-group.test.tsx
+++ b/apps/ui/src/__tests__/tool-activity-group.test.tsx
@@ -42,11 +42,12 @@ describe("ToolActivityGroup", () => {
 
     render(<ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} />);
 
-    expect(screen.getByText("Exploring 2 reads, 2 searches")).toBeInTheDocument();
     expect(screen.getByText("List files in current directory")).toBeInTheDocument();
     expect(screen.getByText("Read README.md")).toBeInTheDocument();
     expect(screen.getByText("Find **/README*")).toBeInTheDocument();
     expect(screen.getByText("Search web for project architecture")).toBeInTheDocument();
+    expect(screen.getByText("Exploring 2 searches")).toBeInTheDocument();
+    expect(screen.queryByText("1 of 1 complete")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Tool activity info")).not.toBeInTheDocument();
   });
 
@@ -143,6 +144,188 @@ describe("ToolActivityGroup", () => {
     expect(shellCard.className).not.toContain("bg-card/95");
     expect(shellCard.className).not.toContain("border-red");
     expect(shellCard.className).not.toContain("bg-red");
+  });
+
+  it("renders read_file as a standalone row and shows parsed file content", () => {
+    const toolCalls: ToolCallContent[] = [
+      {
+        id: "tool-read",
+        name: "read_file",
+        arguments: { path: "/workspace/AGENTS.md" },
+      },
+    ];
+
+    const toolResultsMap = new Map<string, ToolCompletedData>([
+      [
+        "tool-read",
+        {
+          tool_call_id: "tool-read",
+          tool_name: "read_file",
+          success: true,
+          status: "success",
+          result: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                path: "/workspace/AGENTS.md",
+                content: "# Coding-agent guidance\n\nUse Doppler.",
+                encoding: "text",
+                size_bytes: 38,
+              }),
+            },
+          ],
+        },
+      ],
+    ]);
+
+    const { container } = render(
+      <ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} />,
+    );
+
+    const root = container.firstElementChild as HTMLElement;
+    const readFileRow = root.firstElementChild as HTMLElement;
+
+    expect(screen.getByText("Read AGENTS.md")).toBeInTheDocument();
+    expect(screen.queryByText("1 of 1 complete")).not.toBeInTheDocument();
+    expect(readFileRow).not.toHaveClass("border");
+
+    fireEvent.click(screen.getByLabelText("Expand file output"));
+
+    expect(screen.getByText(/# Coding-agent guidance/)).toBeInTheDocument();
+    expect(screen.getByText(/Use Doppler\./)).toBeInTheDocument();
+    expect(screen.queryByText(/"content":/)).not.toBeInTheDocument();
+  });
+
+  it("renders read_file image outputs inline", () => {
+    const toolCalls: ToolCallContent[] = [
+      {
+        id: "tool-image",
+        name: "read_file",
+        arguments: { path: "/workspace/diagram.png" },
+      },
+    ];
+
+    const toolResultsMap = new Map<string, ToolCompletedData>([
+      [
+        "tool-image",
+        {
+          tool_call_id: "tool-image",
+          tool_name: "read_file",
+          success: true,
+          status: "success",
+          result: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                path: "/workspace/diagram.png",
+                media_type: "image/png",
+                size_bytes: 68,
+              }),
+            },
+            {
+              type: "image",
+              base64:
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO2pQwAAAABJRU5ErkJggg==",
+              media_type: "image/png",
+            },
+          ],
+        },
+      ],
+    ]);
+
+    render(<ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} />);
+
+    const image = screen.getByRole("img", { name: "diagram.png" });
+    expect(image).toHaveAttribute("src", expect.stringContaining("data:image/png;base64,"));
+    expect(screen.queryByText("1 of 1 complete")).not.toBeInTheDocument();
+  });
+
+  it("renders write_file as a standalone row with compact metadata", () => {
+    const toolCalls: ToolCallContent[] = [
+      {
+        id: "tool-write",
+        name: "write_file",
+        arguments: { path: "/workspace/README.md", content: "hello" },
+      },
+    ];
+
+    const toolResultsMap = new Map<string, ToolCompletedData>([
+      [
+        "tool-write",
+        {
+          tool_call_id: "tool-write",
+          tool_name: "write_file",
+          success: true,
+          status: "success",
+          result: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                path: "/workspace/README.md",
+                size_bytes: 1584,
+                created: true,
+              }),
+            },
+          ],
+          duration_ms: 95,
+        },
+      ],
+    ]);
+
+    const { container } = render(
+      <ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} />,
+    );
+
+    const root = container.firstElementChild as HTMLElement;
+    const writeRow = root.firstElementChild as HTMLElement;
+
+    expect(screen.getByText("Write README.md")).toBeInTheDocument();
+    expect(screen.getByText("created · 1.5 KB")).toBeInTheDocument();
+    expect(screen.getByText("95ms")).toBeInTheDocument();
+    expect(screen.queryByText("1 of 1 complete")).not.toBeInTheDocument();
+    expect(screen.queryByText(/"size_bytes":/)).not.toBeInTheDocument();
+    expect(writeRow).not.toHaveClass("border");
+  });
+
+  it("simplifies generic secret_store rendering", () => {
+    const toolCalls: ToolCallContent[] = [
+      {
+        id: "tool-secret",
+        name: "secret_store",
+        arguments: { operation: "get", name: "DAYTONA_API_KEY" },
+      },
+    ];
+
+    const toolResultsMap = new Map<string, ToolCompletedData>([
+      [
+        "tool-secret",
+        {
+          tool_call_id: "tool-secret",
+          tool_name: "secret_store",
+          success: true,
+          status: "success",
+          result: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                operation: "get",
+                name: "DAYTONA_API_KEY",
+                value: null,
+                found: false,
+              }),
+            },
+          ],
+        },
+      ],
+    ]);
+
+    render(<ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} />);
+
+    expect(screen.getByText("Get DAYTONA_API_KEY")).toBeInTheDocument();
+    expect(screen.getByText("DAYTONA_API_KEY not found")).toBeInTheDocument();
+    expect(screen.queryByText("Secret Store")).not.toBeInTheDocument();
+    expect(screen.queryByText("1 of 1 complete")).not.toBeInTheDocument();
+    expect(screen.queryByText(/"found":false/)).not.toBeInTheDocument();
   });
 
   it("keeps bash rows inline while grouping neighboring non-shell activity", () => {

--- a/apps/ui/src/app/dev/tool-activity/page.tsx
+++ b/apps/ui/src/app/dev/tool-activity/page.tsx
@@ -69,7 +69,12 @@ const activeToolResults = new Map<string, ToolCompletedData>([
       result: [
         {
           type: "text",
-          text: "# Everruns\nDurable agent runtime and UI for long-running tasks.",
+          text: JSON.stringify({
+            path: "/workspace/README.md",
+            content: "# Everruns\nDurable agent runtime and UI for long-running tasks.",
+            encoding: "text",
+            size_bytes: 63,
+          }),
         },
       ],
     },
@@ -121,7 +126,11 @@ const completedToolResults = new Map<string, ToolCompletedData>([
       result: [
         {
           type: "text",
-          text: "Updated README.md with the new project structure and setup notes.",
+          text: JSON.stringify({
+            path: "/workspace/README.md",
+            size_bytes: 1584,
+            created: true,
+          }),
         },
       ],
       duration_ms: 95,

--- a/apps/ui/src/components/chat/read-file-tool-call-card.tsx
+++ b/apps/ui/src/components/chat/read-file-tool-call-card.tsx
@@ -26,12 +26,17 @@ interface ReadFilePayload {
   media_type?: string;
 }
 
+interface ParsedReadFileImage {
+  src: string;
+  mediaType?: string;
+}
+
 interface ParsedReadFileResult {
   path?: string;
   content: string | null;
   encoding?: string;
   sizeBytes?: number;
-  images: Array<{ src: string; mediaType?: string }>;
+  images: ParsedReadFileImage[];
 }
 
 function basename(value: string): string {
@@ -90,13 +95,15 @@ function parseReadFileResult(
 ): ParsedReadFileResult {
   const rawText = getFullText(result);
   const payload = parseReadFilePayload(rawText);
-  const images = (result ?? [])
-    .filter(isImagePart)
-    .map((part) => ({
-      src: buildImageSrc(part),
+  const images = (result ?? []).filter(isImagePart).reduce<ParsedReadFileImage[]>((all, part) => {
+    const src = buildImageSrc(part);
+    if (!src) return all;
+    all.push({
+      src,
       mediaType: part.media_type,
-    }))
-    .filter((part): part is { src: string; mediaType?: string } => part.src !== null);
+    });
+    return all;
+  }, []);
 
   return {
     path:
@@ -225,6 +232,7 @@ export function ReadFileToolCallCard({ toolCall, toolResult }: ReadFileToolCallC
           {hasImages && (
             <div className="space-y-2">
               {parsed.images.map((image, index) => (
+                // eslint-disable-next-line @next/next/no-img-element -- tool output can be data URLs or arbitrary remote images.
                 <img
                   key={`${image.src}-${index}`}
                   src={image.src}

--- a/apps/ui/src/components/chat/read-file-tool-call-card.tsx
+++ b/apps/ui/src/components/chat/read-file-tool-call-card.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+/**
+ * Decisions:
+ * - `read_file` should read like shell output: one inline row, no outer activity card.
+ * - The tool emits structured JSON in the text part; parse it and render the actual file body.
+ * - Native image content parts are first-class output and must render inline instead of being dropped.
+ */
+
+import { useMemo, useState } from "react";
+import { Check, ChevronDown, ChevronRight, FileText, Loader2 } from "lucide-react";
+import type { ContentPart, ToolCompletedData } from "@/lib/api/types";
+import { cn } from "@/lib/utils";
+import { getFullText, type ToolCallContent } from "./tool-call-utils";
+
+interface ReadFileToolCallCardProps {
+  toolCall: ToolCallContent;
+  toolResult?: ToolCompletedData;
+}
+
+interface ReadFilePayload {
+  path?: string;
+  content?: string | null;
+  encoding?: string;
+  size_bytes?: number;
+  media_type?: string;
+}
+
+interface ParsedReadFileResult {
+  path?: string;
+  content: string | null;
+  encoding?: string;
+  sizeBytes?: number;
+  images: Array<{ src: string; mediaType?: string }>;
+}
+
+function basename(value: string): string {
+  const clean = value.replace(/\/+$/, "");
+  const parts = clean.split("/");
+  return parts[parts.length - 1] || clean;
+}
+
+function getPathFromArguments(toolCall: ToolCallContent): string | undefined {
+  const path = toolCall.arguments.path;
+  return typeof path === "string" && path.trim().length > 0 ? path : undefined;
+}
+
+function isImagePart(
+  part: ContentPart,
+): part is { type: "image"; url?: string; base64?: string; media_type?: string } {
+  return part.type === "image";
+}
+
+function buildImageSrc(part: {
+  url?: string;
+  base64?: string;
+  media_type?: string;
+}): string | null {
+  if (typeof part.url === "string" && part.url.length > 0) {
+    return part.url;
+  }
+  if (typeof part.base64 === "string" && part.base64.length > 0) {
+    const mediaType =
+      typeof part.media_type === "string" && part.media_type.length > 0
+        ? part.media_type
+        : "image/png";
+    return `data:${mediaType};base64,${part.base64}`;
+  }
+  return null;
+}
+
+function parseReadFilePayload(text: string): ReadFilePayload | null {
+  if (!text) return null;
+
+  try {
+    const parsed = JSON.parse(text);
+    if (typeof parsed === "object" && parsed !== null) {
+      return parsed as ReadFilePayload;
+    }
+  } catch {
+    // Fall back to raw text for older or malformed payloads.
+  }
+
+  return null;
+}
+
+function parseReadFileResult(
+  toolCall: ToolCallContent,
+  result: ContentPart[] | undefined,
+): ParsedReadFileResult {
+  const rawText = getFullText(result);
+  const payload = parseReadFilePayload(rawText);
+  const images = (result ?? [])
+    .filter(isImagePart)
+    .map((part) => ({
+      src: buildImageSrc(part),
+      mediaType: part.media_type,
+    }))
+    .filter((part): part is { src: string; mediaType?: string } => part.src !== null);
+
+  return {
+    path:
+      (typeof payload?.path === "string" && payload.path.length > 0 ? payload.path : undefined) ??
+      getPathFromArguments(toolCall),
+    content:
+      typeof payload?.content === "string" ? payload.content : payload ? null : (rawText ?? null),
+    encoding: typeof payload?.encoding === "string" ? payload.encoding : undefined,
+    sizeBytes: typeof payload?.size_bytes === "number" ? payload.size_bytes : undefined,
+    images,
+  };
+}
+
+function getContentPreview(content: string | null): string | null {
+  if (!content) return null;
+
+  const firstNonEmptyLine = content
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+
+  if (!firstNonEmptyLine) return null;
+  return firstNonEmptyLine.length > 120
+    ? `${firstNonEmptyLine.slice(0, 120)}...`
+    : firstNonEmptyLine;
+}
+
+function formatSize(sizeBytes: number | undefined): string | null {
+  if (typeof sizeBytes !== "number" || sizeBytes < 0) return null;
+  if (sizeBytes < 1024) return `${sizeBytes} B`;
+  if (sizeBytes < 1024 * 1024) return `${(sizeBytes / 1024).toFixed(1)} KB`;
+  return `${(sizeBytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function isReadFileTool(toolName: string): boolean {
+  return toolName === "read_file" || toolName === "session_read_file";
+}
+
+export function ReadFileToolCallCard({ toolCall, toolResult }: ReadFileToolCallCardProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const parsed = useMemo(
+    () => parseReadFileResult(toolCall, toolResult?.result),
+    [toolCall, toolResult?.result],
+  );
+
+  const isComplete = !!toolResult;
+  const hasError = toolResult?.error !== undefined && toolResult?.error !== null;
+  const hasImages = parsed.images.length > 0;
+  const hasTextContent = typeof parsed.content === "string" && parsed.content.length > 0;
+  const hasOutput = hasImages || hasTextContent;
+  const isBinaryWithoutPreview = parsed.encoding === "base64" && !hasImages && !hasTextContent;
+  const durationLabel = toolResult?.duration_ms
+    ? toolResult.duration_ms < 1000
+      ? `${toolResult.duration_ms}ms`
+      : `${(toolResult.duration_ms / 1000).toFixed(1)}s`
+    : null;
+  const preview =
+    getContentPreview(parsed.content) ??
+    (hasImages ? `${parsed.images.length} image${parsed.images.length === 1 ? "" : "s"}` : null) ??
+    (isBinaryWithoutPreview
+      ? `binary file${formatSize(parsed.sizeBytes) ? ` (${formatSize(parsed.sizeBytes)})` : ""}`
+      : null);
+  const title = parsed.path ? `Read ${basename(parsed.path)}` : "Read file";
+  const showDetails = hasImages || isExpanded;
+
+  const statusIcon = isComplete ? (
+    hasError ? (
+      <span className="text-red-500 text-xs font-bold">!</span>
+    ) : (
+      <Check className="h-3 w-3 text-green-600/80" />
+    )
+  ) : (
+    <Loader2 className="h-3 w-3 animate-spin text-muted-foreground/60" />
+  );
+
+  return (
+    <div className="text-xs text-muted-foreground/70">
+      <div className="flex items-center gap-1.5">
+        {statusIcon}
+        <FileText className="h-3 w-3 opacity-50" />
+        <button
+          type="button"
+          onClick={() => hasTextContent && setIsExpanded((current) => !current)}
+          className={cn(
+            "flex min-w-0 items-center gap-1",
+            hasTextContent ? "cursor-pointer hover:text-muted-foreground" : "cursor-default",
+          )}
+        >
+          <span className="truncate text-sm text-foreground">{title}</span>
+        </button>
+        {durationLabel && (
+          <span className="flex-shrink-0 text-[10px] opacity-40">{durationLabel}</span>
+        )}
+        {hasTextContent && (
+          <button
+            type="button"
+            onClick={() => setIsExpanded((current) => !current)}
+            className="flex-shrink-0 opacity-40 transition-opacity hover:opacity-70"
+            aria-label={isExpanded ? "Collapse file output" : "Expand file output"}
+          >
+            {isExpanded ? (
+              <ChevronDown className="h-3 w-3" />
+            ) : (
+              <ChevronRight className="h-3 w-3" />
+            )}
+          </button>
+        )}
+      </div>
+
+      {hasError && (
+        <div className="ml-[22px] mt-0.5 text-[10px] text-red-600">Error: {toolResult?.error}</div>
+      )}
+
+      {!hasError && preview && !showDetails && (
+        <div className="ml-[22px] mt-0.5 truncate text-[10px] opacity-70">{preview}</div>
+      )}
+
+      {showDetails && hasOutput && !hasError && (
+        <div className="ml-[22px] mt-1.5 space-y-3">
+          {hasTextContent && isExpanded && (
+            <pre className="overflow-x-auto whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-muted-foreground/85">
+              {parsed.content}
+            </pre>
+          )}
+
+          {hasImages && (
+            <div className="space-y-2">
+              {parsed.images.map((image, index) => (
+                <img
+                  key={`${image.src}-${index}`}
+                  src={image.src}
+                  alt={parsed.path ? basename(parsed.path) : `Read file image ${index + 1}`}
+                  className="max-h-80 max-w-full object-contain"
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/components/chat/todo-list-renderer.tsx
+++ b/apps/ui/src/components/chat/todo-list-renderer.tsx
@@ -2,15 +2,14 @@
 
 /**
  * Decisions:
- * - Render todos as a persistent progress card so long-running tool work has a clear anchor near the composer.
- * - Prefer low-key motion: progress bar width changes and active-row pulse instead of a heavy animated widget.
- * - Match the Slate system: sharp corners, muted surfaces, and gold accents only for active state and progress.
+ * - Keep todos in the transcript flow: one inline progress block, not a nested card with its own chrome.
+ * - Prefer low-key motion: progress width changes and active-row pulse instead of a heavyweight widget.
+ * - Reserve borders for the active item; avoid stacking box-on-box surfaces inside the chat transcript.
  */
 
 import { useState } from "react";
-import { CheckSquare2, ChevronDown, ChevronRight, Info, Loader2, Square } from "lucide-react";
+import { CheckSquare2, ChevronDown, ChevronRight, Loader2, Square } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { ContentPart } from "@/lib/api/types";
 
 // Todo item structure from write_todos tool
@@ -84,20 +83,6 @@ function getStatusIcon(status: string, isActive: boolean = false) {
   }
 }
 
-function InfoHint({ text }: { text: string }) {
-  return (
-    <Tooltip>
-      <TooltipTrigger
-        className="rounded p-0.5 text-muted-foreground/55 transition-colors hover:bg-muted hover:text-foreground"
-        aria-label="Execution plan info"
-      >
-        <Info className="h-3 w-3" />
-      </TooltipTrigger>
-      <TooltipContent className="max-w-56 text-xs leading-5">{text}</TooltipContent>
-    </Tooltip>
-  );
-}
-
 function TodoItemRow({ todo, isActive }: { todo: TodoItem; isActive?: boolean }) {
   const isCompleted = todo.status === "completed";
   const isInProgress = todo.status === "in_progress";
@@ -108,9 +93,9 @@ function TodoItemRow({ todo, isActive }: { todo: TodoItem; isActive?: boolean })
   return (
     <div
       className={cn(
-        "flex items-start gap-2 border px-3 py-2.5 transition-all duration-300",
-        isInProgress && "border-border/70 border-l-2 border-l-accent bg-[hsl(var(--accent)/0.08)]",
-        !isInProgress && "border-transparent",
+        "flex items-start gap-2 py-1.5 transition-all duration-300",
+        isInProgress && "border-l-2 border-l-accent bg-[hsl(var(--accent)/0.08)] pl-2",
+        !isInProgress && "pl-[10px]",
       )}
     >
       {getStatusIcon(todo.status, isActive)}
@@ -134,7 +119,7 @@ function TodoListFromItems({ todos, isActive }: { todos: TodoItem[]; isActive?: 
   }
 
   return (
-    <div className="space-y-1">
+    <div className="space-y-0.5">
       {todos.map((todo, index) => (
         <TodoItemRow
           key={`${todo.content}-${index}`}
@@ -185,53 +170,39 @@ export function TodoListRenderer({
   const activeTodo = todos.find((todo) => todo.status === "in_progress");
 
   return (
-    <div
-      className={cn(
-        "overflow-hidden border bg-card/95",
-        isExecuting ? "border-border border-l-2 border-l-accent" : "border-border",
-      )}
-    >
-      <div className="flex items-center justify-between gap-3 px-4 py-3">
+    <div className="space-y-2">
+      <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
           <div className="flex items-center gap-2">
             <div className="text-sm text-foreground">
               {completedCount} of {totalCount} todos completed
             </div>
-            <InfoHint text="The execution plan persists while tools run so users can see current intent and remaining work." />
+            {isExecuting && (
+              <span className="animate-tool-pulse inline-flex h-1.5 w-1.5 bg-accent" aria-hidden />
+            )}
           </div>
           <div className="mt-0.5 text-xs text-muted-foreground/70">
             {activeTodo ? activeTodo.activeForm : "Plan captured from write_todos"}
           </div>
         </div>
-        <div className="flex items-center gap-2">
-          {isExecuting && (
-            <span className="animate-tool-pulse inline-flex h-1.5 w-1.5 bg-accent" aria-hidden />
-          )}
-          <button
-            type="button"
-            onClick={() => setIsExpanded((current) => !current)}
-            className="rounded p-1 text-muted-foreground/60 transition-colors hover:bg-muted hover:text-foreground"
-            aria-label={isExpanded ? "Collapse execution plan" : "Expand execution plan"}
-          >
-            {isExpanded ? (
-              <ChevronDown className="h-4 w-4" />
-            ) : (
-              <ChevronRight className="h-4 w-4" />
-            )}
-          </button>
-        </div>
+        <button
+          type="button"
+          onClick={() => setIsExpanded((current) => !current)}
+          className="rounded p-1 text-muted-foreground/60 transition-colors hover:bg-muted hover:text-foreground"
+          aria-label={isExpanded ? "Collapse execution plan" : "Expand execution plan"}
+        >
+          {isExpanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+        </button>
       </div>
 
-      <div className="border-y border-border/60 px-4 py-3">
-        <div className="h-1.5 overflow-hidden bg-muted/80">
-          <div
-            className={cn(
-              "h-full bg-accent transition-[width] duration-500 ease-out",
-              isExecuting && "animate-tool-progress-active",
-            )}
-            style={{ width: `${progressPercent}%` }}
-          />
-        </div>
+      <div className="h-1.5 overflow-hidden bg-muted/80">
+        <div
+          className={cn(
+            "h-full bg-accent transition-[width] duration-500 ease-out",
+            isExecuting && "animate-tool-progress-active",
+          )}
+          style={{ width: `${progressPercent}%` }}
+        />
       </div>
 
       <div
@@ -241,7 +212,7 @@ export function TodoListRenderer({
         )}
       >
         <div className="min-h-0 overflow-hidden">
-          <div className="space-y-1 px-3 py-2">
+          <div className="space-y-1">
             <TodoListFromItems todos={todos} isActive={isExecuting} />
             {warning && <div className="mt-0.5 text-xs text-amber-600">{warning}</div>}
           </div>

--- a/apps/ui/src/components/chat/tool-activity-group.tsx
+++ b/apps/ui/src/components/chat/tool-activity-group.tsx
@@ -481,7 +481,15 @@ function GroupedActivityCard({
   toolResultsMap,
   mode = "server",
 }: ToolActivityGroupProps) {
-  if (toolCalls.length === 1) {
+  const isSingleRow = toolCalls.length === 1;
+  const [isExpanded, setIsExpanded] = useState(true);
+  const activityCompletedCount = useMemo(
+    () => toolCalls.filter((toolCall) => toolResultsMap.has(toolCall.id)).length,
+    [toolCalls, toolResultsMap],
+  );
+  const isActive = activityCompletedCount < toolCalls.length;
+
+  if (isSingleRow) {
     const toolCall = toolCalls[0];
     return (
       <ToolActivityRow
@@ -491,13 +499,6 @@ function GroupedActivityCard({
       />
     );
   }
-
-  const [isExpanded, setIsExpanded] = useState(true);
-  const activityCompletedCount = useMemo(
-    () => toolCalls.filter((toolCall) => toolResultsMap.has(toolCall.id)).length,
-    [toolCalls, toolResultsMap],
-  );
-  const isActive = activityCompletedCount < toolCalls.length;
 
   return (
     <div className="space-y-1.5">

--- a/apps/ui/src/components/chat/tool-activity-group.tsx
+++ b/apps/ui/src/components/chat/tool-activity-group.tsx
@@ -20,14 +20,11 @@ import {
 } from "lucide-react";
 import type { ToolCompletedData } from "@/lib/api/types";
 import { cn } from "@/lib/utils";
-import {
-  BashToolCallCard,
-  BashToolResultDetails,
-  isBashTool,
-  parseBashOutput,
-} from "./bash-tool-call-card";
+import { BashToolCallCard, isBashTool, parseBashOutput } from "./bash-tool-call-card";
+import { ReadFileToolCallCard, isReadFileTool } from "./read-file-tool-call-card";
 import { getFullText, type ToolCallContent } from "./tool-call-utils";
 import { TodoListRenderer, isWriteTodosTool } from "./todo-list-renderer";
+import { WriteFileToolCallCard, isWriteLikeTool } from "./write-file-tool-call-card";
 
 interface ToolActivityGroupProps {
   toolCalls: ToolCallContent[];
@@ -37,7 +34,9 @@ interface ToolActivityGroupProps {
 
 type ActivitySegment =
   | { type: "group"; toolCalls: ToolCallContent[] }
-  | { type: "shell"; toolCall: ToolCallContent };
+  | { type: "shell"; toolCall: ToolCallContent }
+  | { type: "read_file"; toolCall: ToolCallContent }
+  | { type: "write_file"; toolCall: ToolCallContent };
 
 type ToolCategory = "read" | "search" | "write" | "shell" | "tool";
 
@@ -118,7 +117,7 @@ function getToolLabel(toolCall: ToolCallContent): string {
     return `List files in ${formatLocation(args.path)}`;
   }
 
-  if (name === "read_file") {
+  if (isReadFileTool(name)) {
     const path = args.path;
     return typeof path === "string" && path.trim().length > 0
       ? `Read ${basename(path)}`
@@ -153,6 +152,30 @@ function getToolLabel(toolCall: ToolCallContent): string {
       : "Edit file";
   }
 
+  if (name === "secret_store") {
+    const operation = args.operation;
+    const secretName = args.name;
+    if (operation === "list") return "List secrets";
+    if (
+      typeof operation === "string" &&
+      typeof secretName === "string" &&
+      secretName.trim().length > 0
+    ) {
+      return `${toTitleCase(operation)} ${secretName}`;
+    }
+    return "Secret Store";
+  }
+
+  if (name === "kv_store") {
+    const operation = args.operation;
+    const key = args.key;
+    if (operation === "list") return "List stored values";
+    if (typeof operation === "string" && typeof key === "string" && key.trim().length > 0) {
+      return `${toTitleCase(operation)} ${key}`;
+    }
+    return "Key Value Store";
+  }
+
   return toolCall.display_name ?? toTitleCase(name);
 }
 
@@ -185,7 +208,102 @@ function summarizeToolCalls(toolCalls: ToolCallContent[]): string {
   return `Exploring ${parts.join(", ")}`;
 }
 
-function getResultPreview(result: ToolCompletedData | undefined): string | null {
+function parseStructuredText(text: string): unknown | null {
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function maskSensitiveFields(toolName: string, value: unknown): unknown {
+  if (
+    toolName !== "secret_store" ||
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value)
+  ) {
+    return value;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (!("value" in record) || record.value == null) {
+    return value;
+  }
+
+  return {
+    ...record,
+    value: "[hidden]",
+  };
+}
+
+function summarizeStructuredResult(toolCall: ToolCallContent, parsed: unknown): string | null {
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return null;
+  }
+
+  const record = parsed as Record<string, unknown>;
+
+  if (toolCall.name === "secret_store") {
+    const operation = record.operation;
+    const name = record.name;
+    if (operation === "get" && typeof name === "string") {
+      return record.found ? `${name} found` : `${name} not found`;
+    }
+    if (operation === "set" && typeof name === "string") {
+      return `${name} saved`;
+    }
+    if (operation === "delete" && typeof name === "string") {
+      return record.deleted ? `${name} deleted` : `${name} not found`;
+    }
+    if (operation === "list" && typeof record.count === "number") {
+      return `${record.count} secret${record.count === 1 ? "" : "s"}`;
+    }
+  }
+
+  if (toolCall.name === "kv_store") {
+    const operation = record.operation;
+    const key = record.key;
+    if (operation === "get" && typeof key === "string") {
+      return record.found ? `${key} found` : `${key} not found`;
+    }
+    if ((operation === "set" || operation === "delete") && typeof key === "string") {
+      return `${key} ${operation === "set" ? "saved" : "deleted"}`;
+    }
+    if (operation === "list" && typeof record.count === "number") {
+      return `${record.count} value${record.count === 1 ? "" : "s"}`;
+    }
+  }
+
+  if (typeof record.message === "string" && record.message.trim().length > 0) {
+    return record.message;
+  }
+
+  const scalarEntries = Object.entries(record).filter(
+    ([, value]) => ["string", "number", "boolean"].includes(typeof value) || value === null,
+  );
+  if (scalarEntries.length === 0) return null;
+
+  const preview = scalarEntries
+    .slice(0, 2)
+    .map(([key, value]) => `${key}: ${value === null ? "null" : String(value)}`)
+    .join(" · ");
+
+  return preview.length > 120 ? `${preview.slice(0, 120)}...` : preview;
+}
+
+function formatResultDetails(toolCall: ToolCallContent, fullText: string): string {
+  const parsed = parseStructuredText(fullText);
+  if (!parsed) return fullText;
+
+  return JSON.stringify(maskSensitiveFields(toolCall.name, parsed), null, 2);
+}
+
+function getResultPreview(
+  toolCall: ToolCallContent,
+  result: ToolCompletedData | undefined,
+): string | null {
   const fullText = getFullText(result?.result);
   if (!fullText) return null;
 
@@ -207,6 +325,10 @@ function getResultPreview(result: ToolCompletedData | undefined): string | null 
 
     return null;
   }
+
+  const parsed = parseStructuredText(fullText);
+  const structuredPreview = summarizeStructuredResult(toolCall, parsed);
+  if (structuredPreview) return structuredPreview;
 
   const previewLine = fullText
     .split("\n")
@@ -243,6 +365,18 @@ function buildActivitySegments(
       continue;
     }
 
+    if (isReadFileTool(toolCall.name)) {
+      pushGroup();
+      segments.push({ type: "read_file", toolCall });
+      continue;
+    }
+
+    if (isWriteLikeTool(toolCall.name)) {
+      pushGroup();
+      segments.push({ type: "write_file", toolCall });
+      continue;
+    }
+
     currentGroup.push(toolCall);
   }
 
@@ -261,22 +395,17 @@ function ToolActivityRow({
 }) {
   const [isExpanded, setIsExpanded] = useState(false);
   const fullText = getFullText(toolResult?.result);
-  const bashOutput = isBashTool(toolCall.name) ? parseBashOutput(fullText) : null;
-  const hasOutput = bashOutput
-    ? !!bashOutput.stdout || !!bashOutput.stderr || bashOutput.exit_code !== 0
-    : fullText.length > 0;
+  const hasOutput = fullText.length > 0;
   const hasToolError = !!toolResult?.error;
-  const hasError = hasToolError || (bashOutput ? !bashOutput.success : false);
+  const hasError = hasToolError;
   const isComplete = !!toolResult;
   const isRunning = !isComplete && !hasError;
-  const exitCodeLabel =
-    bashOutput && bashOutput.exit_code !== 0 ? `exit ${bashOutput.exit_code}` : null;
 
   return (
     <div
       className={cn(
-        "animate-tool-row-in px-3 py-2.5 transition-all duration-300",
-        isRunning && "border-border/70 border-l-2 border-l-accent bg-[hsl(var(--accent)/0.06)]",
+        "animate-tool-row-in py-2 transition-all duration-300",
+        isRunning && "border-l-2 border-l-accent bg-[hsl(var(--accent)/0.06)] pl-2",
       )}
     >
       <div className="flex items-start gap-2">
@@ -294,14 +423,7 @@ function ToolActivityRow({
             {mode === "client" && (
               <MonitorSmartphone className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-primary/75" />
             )}
-            <div className="min-w-0 inline-flex items-baseline gap-2">
-              <span className="truncate text-sm text-foreground">{getToolLabel(toolCall)}</span>
-              {exitCodeLabel && (
-                <span className="flex-shrink-0 text-[10px] leading-none uppercase tracking-[0.16em] text-red-500/75">
-                  {exitCodeLabel}
-                </span>
-              )}
-            </div>
+            <span className="truncate text-sm text-foreground">{getToolLabel(toolCall)}</span>
             {isRunning && (
               <span className="animate-tool-pulse text-[10px] uppercase tracking-[0.18em] text-accent-foreground/70">
                 {mode === "client" ? "waiting" : "running"}
@@ -315,7 +437,7 @@ function ToolActivityRow({
 
           {!hasError && !isExpanded && hasOutput && (
             <div className="mt-1 truncate text-xs text-muted-foreground/70">
-              {getResultPreview(toolResult)}
+              {getResultPreview(toolCall, toolResult)}
             </div>
           )}
 
@@ -323,7 +445,7 @@ function ToolActivityRow({
             <button
               type="button"
               onClick={() => setIsExpanded((current) => !current)}
-              className="mt-1.5 inline-flex items-center gap-1 text-[10px] uppercase tracking-[0.18em] text-muted-foreground/65 transition-colors hover:text-foreground"
+              className="mt-1 inline-flex items-center gap-1 text-[10px] uppercase tracking-[0.18em] text-muted-foreground/65 transition-colors hover:text-foreground"
             >
               {isExpanded ? (
                 <ChevronDown className="h-3 w-3" />
@@ -337,20 +459,14 @@ function ToolActivityRow({
           <div
             className={cn(
               "grid transition-all duration-300 ease-out",
-              isExpanded ? "mt-2 grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0",
+              isExpanded ? "mt-1.5 grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0",
             )}
           >
             <div className="min-h-0 overflow-hidden">
               {hasOutput && (
-                <div className="font-mono text-[11px] leading-relaxed text-muted-foreground/85">
-                  <BashToolResultDetails
-                    fullText={fullText}
-                    containerClassName="border border-border/60 bg-background px-3 py-3 text-[11px] leading-relaxed text-muted-foreground/85 max-h-80"
-                    stdoutClassName="text-[11px] leading-relaxed text-muted-foreground/85"
-                    stderrClassName="border-red-400/25 pt-3 text-[11px] leading-relaxed text-red-700/85 dark:text-red-300/85"
-                    showExitCode={false}
-                  />
-                </div>
+                <pre className="max-h-80 overflow-x-auto whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-muted-foreground/85">
+                  {formatResultDetails(toolCall, fullText)}
+                </pre>
               )}
             </div>
           </div>
@@ -365,6 +481,17 @@ function GroupedActivityCard({
   toolResultsMap,
   mode = "server",
 }: ToolActivityGroupProps) {
+  if (toolCalls.length === 1) {
+    const toolCall = toolCalls[0];
+    return (
+      <ToolActivityRow
+        toolCall={toolCall}
+        toolResult={toolResultsMap.get(toolCall.id)}
+        mode={mode}
+      />
+    );
+  }
+
   const [isExpanded, setIsExpanded] = useState(true);
   const activityCompletedCount = useMemo(
     () => toolCalls.filter((toolCall) => toolResultsMap.has(toolCall.id)).length,
@@ -373,17 +500,16 @@ function GroupedActivityCard({
   const isActive = activityCompletedCount < toolCalls.length;
 
   return (
-    <div
-      className={cn(
-        "overflow-hidden border bg-card/95",
-        isActive ? "border-border border-l-2 border-l-accent" : "border-border",
-      )}
-    >
-      <div className="flex items-center justify-between gap-3 px-4 py-3">
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between gap-3 py-1">
         <div className="min-w-0">
-          <div className="text-sm text-foreground">{summarizeToolCalls(toolCalls)}</div>
-          <div className="mt-0.5 text-xs text-muted-foreground/70">
-            {activityCompletedCount} of {toolCalls.length} complete
+          <div className="flex items-center gap-2">
+            <div className="text-[11px] uppercase tracking-[0.22em] text-muted-foreground/70">
+              {summarizeToolCalls(toolCalls)}
+            </div>
+            <div className="text-[10px] text-muted-foreground/50">
+              {activityCompletedCount}/{toolCalls.length}
+            </div>
           </div>
         </div>
         <div className="flex items-center gap-2">
@@ -414,7 +540,7 @@ function GroupedActivityCard({
         )}
       >
         <div className="min-h-0 overflow-hidden">
-          <div className="space-y-1 px-3 py-2">
+          <div className="space-y-1 border-l border-border/60 pl-3">
             {toolCalls.map((toolCall) => (
               <ToolActivityRow
                 key={toolCall.id}
@@ -450,6 +576,26 @@ export function ToolActivityGroup({
         if (segment.type === "shell") {
           return (
             <BashToolCallCard
+              key={segment.toolCall.id}
+              toolCall={segment.toolCall}
+              toolResult={toolResultsMap.get(segment.toolCall.id)}
+            />
+          );
+        }
+
+        if (segment.type === "read_file") {
+          return (
+            <ReadFileToolCallCard
+              key={segment.toolCall.id}
+              toolCall={segment.toolCall}
+              toolResult={toolResultsMap.get(segment.toolCall.id)}
+            />
+          );
+        }
+
+        if (segment.type === "write_file") {
+          return (
+            <WriteFileToolCallCard
               key={segment.toolCall.id}
               toolCall={segment.toolCall}
               toolResult={toolResultsMap.get(segment.toolCall.id)}

--- a/apps/ui/src/components/chat/tool-call-card-from-event.tsx
+++ b/apps/ui/src/components/chat/tool-call-card-from-event.tsx
@@ -5,8 +5,10 @@ import { Check, Loader2, ChevronDown, ChevronRight } from "lucide-react";
 import type { ToolCompletedData } from "@/lib/api/types";
 import { TodoListRenderer, isWriteTodosTool } from "./todo-list-renderer";
 import { BashToolCallCard, isBashTool } from "./bash-tool-call-card";
+import { ReadFileToolCallCard, isReadFileTool } from "./read-file-tool-call-card";
 import { formatArguments, getFullText, type ToolCallContent } from "./tool-call-utils";
 import { ClientToolCallCard } from "./client-tool-call-card";
+import { WriteFileToolCallCard, isWriteLikeTool } from "./write-file-tool-call-card";
 
 interface ToolCallCardFromEventProps {
   toolCall: ToolCallContent;
@@ -54,6 +56,14 @@ export function ToolCallCardFromEvent({
   // Special rendering for bash/shell tool
   if (isBashTool(toolCall.name)) {
     return <BashToolCallCard toolCall={toolCall} toolResult={toolResult} />;
+  }
+
+  if (isReadFileTool(toolCall.name)) {
+    return <ReadFileToolCallCard toolCall={toolCall} toolResult={toolResult} />;
+  }
+
+  if (isWriteLikeTool(toolCall.name)) {
+    return <WriteFileToolCallCard toolCall={toolCall} toolResult={toolResult} />;
   }
 
   const statusIcon = isComplete ? (

--- a/apps/ui/src/components/chat/write-file-tool-call-card.tsx
+++ b/apps/ui/src/components/chat/write-file-tool-call-card.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+/**
+ * Decisions:
+ * - Write-like file mutations should stay inline, matching bash/read_file instead of reopening the grouped activity chrome.
+ * - Structured JSON tool output is reduced to a compact status line so file writes read like transcript events, not raw payload dumps.
+ * - When a write tool returns freeform text instead of metadata, keep an expandable fallback instead of forcing JSON-only handling.
+ */
+
+import { useMemo, useState } from "react";
+import { Check, ChevronDown, ChevronRight, FilePenLine, Loader2 } from "lucide-react";
+import type { ContentPart, ToolCompletedData } from "@/lib/api/types";
+import { cn } from "@/lib/utils";
+import { getFullText, type ToolCallContent } from "./tool-call-utils";
+
+interface WriteFileToolCallCardProps {
+  toolCall: ToolCallContent;
+  toolResult?: ToolCompletedData;
+}
+
+interface WriteFilePayload {
+  path?: string;
+  size_bytes?: number;
+  created?: boolean;
+}
+
+interface ParsedWriteFileResult {
+  path?: string;
+  sizeBytes?: number;
+  created?: boolean;
+  textContent: string | null;
+}
+
+function basename(value: string): string {
+  const clean = value.replace(/\/+$/, "");
+  const parts = clean.split("/");
+  return parts[parts.length - 1] || clean;
+}
+
+function getPathFromArguments(toolCall: ToolCallContent): string | undefined {
+  const path = toolCall.arguments.path;
+  return typeof path === "string" && path.trim().length > 0 ? path : undefined;
+}
+
+function parseWriteFilePayload(
+  toolCall: ToolCallContent,
+  result: ContentPart[] | undefined,
+): ParsedWriteFileResult {
+  const rawText = getFullText(result);
+  try {
+    const parsed = JSON.parse(rawText) as WriteFilePayload;
+    if (typeof parsed === "object" && parsed !== null) {
+      return {
+        path:
+          (typeof parsed.path === "string" && parsed.path.length > 0 ? parsed.path : undefined) ??
+          getPathFromArguments(toolCall),
+        sizeBytes: typeof parsed.size_bytes === "number" ? parsed.size_bytes : undefined,
+        created: typeof parsed.created === "boolean" ? parsed.created : undefined,
+        textContent: null,
+      };
+    }
+  } catch {
+    // Fall back to raw text below.
+  }
+
+  return {
+    path: getPathFromArguments(toolCall),
+    sizeBytes: undefined,
+    created: undefined,
+    textContent: rawText || null,
+  };
+}
+
+function formatSize(sizeBytes: number | undefined): string | null {
+  if (typeof sizeBytes !== "number" || sizeBytes < 0) return null;
+  if (sizeBytes < 1024) return `${sizeBytes} B`;
+  if (sizeBytes < 1024 * 1024) return `${(sizeBytes / 1024).toFixed(1)} KB`;
+  return `${(sizeBytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function getToolVerb(toolName: string): string {
+  switch (toolName) {
+    case "edit_file":
+      return "Edit";
+    case "replace_in_file":
+      return "Replace in";
+    case "append_file":
+      return "Append to";
+    default:
+      return "Write";
+  }
+}
+
+function getTextPreview(text: string | null): string | null {
+  if (!text) return null;
+  const firstLine = text
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+  if (!firstLine) return null;
+  return firstLine.length > 120 ? `${firstLine.slice(0, 120)}...` : firstLine;
+}
+
+export function isWriteLikeTool(toolName: string): boolean {
+  return (
+    toolName === "write_file" ||
+    toolName === "edit_file" ||
+    toolName === "replace_in_file" ||
+    toolName === "append_file"
+  );
+}
+
+export function WriteFileToolCallCard({ toolCall, toolResult }: WriteFileToolCallCardProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const parsed = useMemo(
+    () => parseWriteFilePayload(toolCall, toolResult?.result),
+    [toolCall, toolResult?.result],
+  );
+
+  const isComplete = !!toolResult;
+  const hasError = toolResult?.error !== undefined && toolResult?.error !== null;
+  const resolvedPath = parsed.path ?? getPathFromArguments(toolCall);
+  const title = resolvedPath
+    ? `${getToolVerb(toolCall.name)} ${basename(resolvedPath)}`
+    : `${getToolVerb(toolCall.name)} file`;
+  const durationLabel = toolResult?.duration_ms
+    ? toolResult.duration_ms < 1000
+      ? `${toolResult.duration_ms}ms`
+      : `${(toolResult.duration_ms / 1000).toFixed(1)}s`
+    : null;
+  const metadataPreview = [parsed.created ? "created" : "updated", formatSize(parsed.sizeBytes)]
+    .filter(Boolean)
+    .join(" · ");
+  const preview = metadataPreview || getTextPreview(parsed.textContent);
+  const hasTextDetails = !!parsed.textContent;
+
+  const statusIcon = isComplete ? (
+    hasError ? (
+      <span className="text-red-500 text-xs font-bold">!</span>
+    ) : (
+      <Check className="h-3 w-3 text-green-600/80" />
+    )
+  ) : (
+    <Loader2 className="h-3 w-3 animate-spin text-muted-foreground/60" />
+  );
+
+  return (
+    <div className="text-xs text-muted-foreground/70">
+      <div className="flex items-center gap-1.5">
+        {statusIcon}
+        <FilePenLine className="h-3 w-3 opacity-50" />
+        <button
+          type="button"
+          onClick={() => hasTextDetails && setIsExpanded((current) => !current)}
+          className={cn(
+            "flex min-w-0 items-center gap-1",
+            hasTextDetails ? "cursor-pointer hover:text-muted-foreground" : "cursor-default",
+          )}
+        >
+          <span className="truncate text-sm text-foreground">{title}</span>
+        </button>
+        {durationLabel && (
+          <span className="flex-shrink-0 text-[10px] opacity-40">{durationLabel}</span>
+        )}
+        {hasTextDetails && (
+          <button
+            type="button"
+            onClick={() => setIsExpanded((current) => !current)}
+            className="flex-shrink-0 opacity-40 transition-opacity hover:opacity-70"
+            aria-label={isExpanded ? "Collapse write output" : "Expand write output"}
+          >
+            {isExpanded ? (
+              <ChevronDown className="h-3 w-3" />
+            ) : (
+              <ChevronRight className="h-3 w-3" />
+            )}
+          </button>
+        )}
+      </div>
+
+      {hasError && (
+        <div className="ml-[22px] mt-0.5 text-[10px] text-red-600">Error: {toolResult?.error}</div>
+      )}
+
+      {!hasError && preview && !isExpanded && (
+        <div className="ml-[22px] mt-0.5 truncate text-[10px] opacity-70">{preview}</div>
+      )}
+
+      {!hasError && isExpanded && parsed.textContent && (
+        <div className="ml-[22px] mt-1.5">
+          <pre className="overflow-x-auto whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-muted-foreground/85">
+            {parsed.textContent}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/specs/brand.md
+++ b/specs/brand.md
@@ -190,6 +190,15 @@ background-size: 24px 24px;
 - Left/right border accents for active navigation and messages
 - Muted gray for hover states (not accent colors)
 
+#### Transcript Surfaces
+
+Chat transcript styling stays **inline and single-surface**:
+
+- Tool activity rows (`read_file`, `write_file`, `list_files`, search, bash, client tools) should render as lightweight transcript lines, not nested cards inside message cards.
+- Todo/progress state should render as one inline block with a thin progress indicator and rows beneath it, not a card containing more boxed rows.
+- Avoid **double-wrapped boxes** in the transcript. If a message already establishes a surface, tool and todo content inside that area should not introduce another bordered card unless the content truly needs an isolated canvas (for example, a full image preview or modal).
+- Prefer status glyphs, border accents, spacing, and muted text over stacked borders/background panels.
+
 #### Primary Action Buttons
 
 Primary "create new" actions (New Session, New Agent, etc.) use consistent styling:

--- a/specs/markdown-messages.md
+++ b/specs/markdown-messages.md
@@ -81,6 +81,11 @@ components/
    - Migrate from `Markdown` to `StreamdownMessage`
    - Unified component for all markdown rendering
 
+4. **Transcript tool/todo surfaces**
+   - Message markdown, tool activity, and todo progress must read as one transcript system
+   - Tool rows should stay inline with the surrounding message rhythm
+   - Do not nest bordered tool/todo cards inside another transcript card unless the content requires a dedicated viewport
+
 ## Usage
 
 ### Basic Streaming Message
@@ -121,6 +126,7 @@ Must integrate with existing design system:
 - Links: Navy color (`--primary`)
 - Syntax highlighting: Theme compatible with light/dark mode
 - Tailwind integration via `@source` directive in globals.css
+- Message-adjacent tool/todo UI should avoid double-wrapped boxes and favor spacing, dividers, and accent borders
 
 ### Tailwind Setup
 


### PR DESCRIPTION
## What
Simplify chat tool activity rendering so file reads, file writes, generic tool rows, and todo updates render inline instead of inside stacked card wrappers.

## Why
The transcript was visually over-boxed, especially for `read_file`, `write_file`, generic tools like `secret_store`, and todo activity. That made the chat feel heavier and exposed raw JSON payloads instead of readable summaries.

## How
- add dedicated inline renderers for `read_file` and write-like file tools
- flatten grouped tool activity and generic tool details to a single surface
- improve generic summaries for structured tool results like `secret_store` and `kv_store`
- render inline images returned by `read_file`
- simplify todo rendering and update the dev harness/specs/tests to match

## Risk
- Medium
- Transcript rendering changed in the shared chat path, so regressions would affect tool-call display in session chat

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

## Validation
- `./node_modules/.bin/jest --runInBand src/__tests__/tool-activity-group.test.tsx src/__tests__/todo-list-renderer.test.tsx`
- `cd apps/ui && npm run format:check`
- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run build`
- `just pre-push`
- Browser smoke test on `/dev/tool-activity` with Playwright