### PR TITLE
feat(connections): add generic API key verification for connected accounts

### DIFF
--- a/apps/ui/src/app/(main)/settings/connections/page.tsx
+++ b/apps/ui/src/app/(main)/settings/connections/page.tsx
@@ -124,12 +124,7 @@ function ConnectionRow({
       </div>
       <div className="flex items-center gap-2">
         {isApiKey && (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleVerify}
-            disabled={verify.isPending}
-          >
+          <Button variant="outline" size="sm" onClick={handleVerify} disabled={verify.isPending}>
             {verify.isPending ? (
               <Loader2 className="h-4 w-4 mr-1 animate-spin" />
             ) : (

--- a/apps/ui/src/app/(main)/settings/connections/page.tsx
+++ b/apps/ui/src/app/(main)/settings/connections/page.tsx
@@ -21,6 +21,7 @@ import {
   useDeleteUserConnection,
   useConnectionProviders,
   useCreateApiKeyConnection,
+  useVerifyConnection,
 } from "@/hooks/use-user-connections";
 import { getBackendUrl } from "@/lib/api/client";
 import {
@@ -29,9 +30,13 @@ import {
   LinkIcon,
   Trash2,
   Check,
+  CheckCircle,
   Cloud,
   Search,
   AlertCircle,
+  ShieldCheck,
+  XCircle,
+  Loader2,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { UserConnection, ConnectionProvider as ConnectionProviderType } from "@/lib/api/types";
@@ -64,6 +69,27 @@ function ConnectionRow({
 }) {
   const displayName = provider?.display_name ?? connection.provider;
   const icon = provider?.icon ?? "link";
+  const isApiKey = connection.connection_type === "api_key";
+  const verify = useVerifyConnection();
+  const [verifyStatus, setVerifyStatus] = useState<"idle" | "valid" | "invalid">("idle");
+  const [verifyError, setVerifyError] = useState<string | null>(null);
+
+  const handleVerify = async () => {
+    setVerifyStatus("idle");
+    setVerifyError(null);
+    try {
+      const result = await verify.mutateAsync(connection.provider);
+      if (result.valid) {
+        setVerifyStatus("valid");
+      } else {
+        setVerifyStatus("invalid");
+        setVerifyError(result.error ?? "Verification failed");
+      }
+    } catch {
+      setVerifyStatus("invalid");
+      setVerifyError("Failed to verify connection");
+    }
+  };
 
   return (
     <div className="flex items-center justify-between p-4 border rounded-lg">
@@ -82,18 +108,47 @@ function ConnectionRow({
             Connected {new Date(connection.connected_at).toLocaleDateString()}
             {connection.scopes && <span className="ml-2">({connection.scopes})</span>}
           </div>
+          {verifyStatus === "valid" && (
+            <div className="flex items-center gap-1 text-green-600 dark:text-green-400 text-xs mt-1">
+              <CheckCircle className="h-3 w-3" />
+              API key is valid
+            </div>
+          )}
+          {verifyStatus === "invalid" && (
+            <div className="flex items-center gap-1 text-destructive text-xs mt-1">
+              <XCircle className="h-3 w-3" />
+              {verifyError}
+            </div>
+          )}
         </div>
       </div>
-      <Button
-        variant="ghost"
-        size="sm"
-        className="text-destructive"
-        onClick={() => onDisconnect(connection.provider)}
-        disabled={isDisconnecting}
-      >
-        <Trash2 className="h-4 w-4 mr-1" />
-        Disconnect
-      </Button>
+      <div className="flex items-center gap-2">
+        {isApiKey && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleVerify}
+            disabled={verify.isPending}
+          >
+            {verify.isPending ? (
+              <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+            ) : (
+              <ShieldCheck className="h-4 w-4 mr-1" />
+            )}
+            {verify.isPending ? "Verifying..." : "Verify"}
+          </Button>
+        )}
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-destructive"
+          onClick={() => onDisconnect(connection.provider)}
+          disabled={isDisconnecting}
+        >
+          <Trash2 className="h-4 w-4 mr-1" />
+          Disconnect
+        </Button>
+      </div>
     </div>
   );
 }

--- a/apps/ui/src/hooks/use-user-connections.ts
+++ b/apps/ui/src/hooks/use-user-connections.ts
@@ -6,6 +6,7 @@ import {
   getConnectionProviders,
   createApiKeyConnection,
   deleteUserConnection,
+  verifyConnection,
 } from "@/lib/api/user-connections";
 import { queryKeys } from "@/lib/query-keys";
 
@@ -36,6 +37,12 @@ export function useCreateApiKeyConnection() {
         queryKey: queryKeys.userConnections.all,
       });
     },
+  });
+}
+
+export function useVerifyConnection() {
+  return useMutation({
+    mutationFn: (provider: string) => verifyConnection(provider),
   });
 }
 

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -1660,6 +1660,11 @@ export interface ConnectionFormField {
   help_text?: string;
 }
 
+export interface VerifyConnectionResponse {
+  valid: boolean;
+  error?: string;
+}
+
 // ============================================
 // Command types
 // ============================================

--- a/apps/ui/src/lib/api/user-connections.ts
+++ b/apps/ui/src/lib/api/user-connections.ts
@@ -2,7 +2,7 @@
 // User-scoped (not org-scoped) — connections represent user's identity
 
 import { api } from "./client";
-import type { UserConnection, ConnectionProvider } from "./types";
+import type { UserConnection, ConnectionProvider, VerifyConnectionResponse } from "./types";
 
 export async function getUserConnections(): Promise<UserConnection[]> {
   const response = await api.get<UserConnection[]>("/v1/user/connections");
@@ -26,4 +26,11 @@ export async function createApiKeyConnection(
 
 export async function deleteUserConnection(provider: string): Promise<void> {
   await api.delete(`/v1/user/connections/${provider}`);
+}
+
+export async function verifyConnection(provider: string): Promise<VerifyConnectionResponse> {
+  const response = await api.post<VerifyConnectionResponse>(
+    `/v1/user/connections/${provider}/verify`,
+  );
+  return response.data;
 }

--- a/crates/server/src/api/user_connections.rs
+++ b/crates/server/src/api/user_connections.rs
@@ -13,7 +13,7 @@ use axum::{
     extract::{FromRef, Path, Query, State},
     http::StatusCode,
     response::Redirect,
-    routing::{delete, get, put},
+    routing::{delete, get, post, put},
 };
 use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 use chrono::{DateTime, Utc};
@@ -133,6 +133,10 @@ pub fn routes(state: AppState) -> Router {
         .route(
             "/v1/user/connections/{provider}",
             delete(delete_connection).post(create_api_key_connection),
+        )
+        .route(
+            "/v1/user/connections/{provider}/verify",
+            post(verify_connection),
         )
         .route(
             "/v1/user/connections/github/authorize",
@@ -335,6 +339,103 @@ pub async fn delete_connection(
         Ok(StatusCode::NO_CONTENT)
     } else {
         Err(StatusCode::NOT_FOUND)
+    }
+}
+
+/// Response for connection verification
+#[derive(Debug, Serialize)]
+pub struct VerifyConnectionResponse {
+    pub valid: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// POST /v1/user/connections/:provider/verify — Verify stored API key still works
+///
+/// Generic endpoint: decrypts the stored credential and calls the provider's
+/// validate() method. Works for any API-key provider that implements
+/// ConnectionProvider::validate().
+pub async fn verify_connection(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Path(provider_id): Path<String>,
+) -> Result<Json<VerifyConnectionResponse>, (StatusCode, String)> {
+    let grade = DeploymentGrade::from_env();
+
+    // Look up the stored connection
+    let row = state
+        .db
+        .get_user_connection(auth.id, &provider_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to look up connection for verify: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to look up connection".to_string(),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                format!("No connection found for provider: {provider_id}"),
+            )
+        })?;
+
+    // Only API-key connections can be verified this way
+    if row.connection_type != "api_key" {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("Provider '{provider_id}' does not support API key verification"),
+        ));
+    }
+
+    let encrypted = row.access_token_encrypted.ok_or_else(|| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "No stored credential found".to_string(),
+        )
+    })?;
+
+    // Decrypt
+    let encryption = state.encryption.as_ref().ok_or_else(|| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Encryption not configured".to_string(),
+        )
+    })?;
+    let credential = encryption.decrypt_to_string(&encrypted).map_err(|e| {
+        tracing::error!("Failed to decrypt credential for verify: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to decrypt credential".to_string(),
+        )
+    })?;
+
+    // Find the provider plugin
+    let provider: Option<Box<dyn everruns_core::connection_provider::ConnectionProvider>> =
+        inventory::iter::<ConnectionProviderPlugin>
+            .into_iter()
+            .filter(|p| !p.experimental_only || grade.experimental_features_enabled())
+            .map(|p| (p.factory)())
+            .find(|p| p.provider_id() == provider_id);
+
+    let provider = provider.ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            format!("Unknown connection provider: {provider_id}"),
+        )
+    })?;
+
+    // Call provider's validate()
+    match provider.validate(&credential).await {
+        Ok(_) => Ok(Json(VerifyConnectionResponse {
+            valid: true,
+            error: None,
+        })),
+        Err(msg) => Ok(Json(VerifyConnectionResponse {
+            valid: false,
+            error: Some(msg),
+        })),
     }
 }
 

--- a/crates/server/src/api/user_connections.rs
+++ b/crates/server/src/api/user_connections.rs
@@ -846,7 +846,10 @@ mod tests {
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["valid"], true);
-        assert!(json.get("error").is_none(), "error field should be skipped when None");
+        assert!(
+            json.get("error").is_none(),
+            "error field should be skipped when None"
+        );
     }
 
     #[test]

--- a/crates/server/src/api/user_connections.rs
+++ b/crates/server/src/api/user_connections.rs
@@ -833,4 +833,30 @@ mod tests {
         let (status, _) = validate_install_state(&jar, Some("y")).unwrap_err();
         assert_eq!(status, StatusCode::BAD_REQUEST);
     }
+
+    // =========================================================================
+    // VerifyConnectionResponse serialization tests
+    // =========================================================================
+
+    #[test]
+    fn verify_response_valid_serializes_without_error() {
+        let resp = VerifyConnectionResponse {
+            valid: true,
+            error: None,
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["valid"], true);
+        assert!(json.get("error").is_none(), "error field should be skipped when None");
+    }
+
+    #[test]
+    fn verify_response_invalid_serializes_with_error() {
+        let resp = VerifyConnectionResponse {
+            valid: false,
+            error: Some("Invalid API key".to_string()),
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["valid"], false);
+        assert_eq!(json["error"], "Invalid API key");
+    }
 }

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -2052,3 +2052,44 @@ async fn test_can_delete_non_readonly_file() {
         .json();
     assert_eq!(result["deleted"], true);
 }
+
+// ============================================
+// User Connection Verify Endpoint Tests
+// ============================================
+
+#[tokio::test]
+async fn test_verify_connection_no_connection_returns_404() {
+    let server = TestServer::in_memory().await;
+
+    server
+        .post("/v1/user/connections/nonexistent/verify", json!({}))
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_verify_connection_providers_listed() {
+    let server = TestServer::in_memory().await;
+
+    let resp: Value = server
+        .get("/v1/user/connections/providers")
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+
+    // Should be an array (may include plugin-registered providers)
+    assert!(resp.is_array());
+}
+
+#[tokio::test]
+async fn test_list_connections_initially_empty() {
+    let server = TestServer::in_memory().await;
+
+    let resp: Vec<Value> = server
+        .get("/v1/user/connections")
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+
+    assert!(resp.is_empty());
+}

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -198,6 +198,12 @@ impl TestServer {
         let feature_flags_state = api::feature_flags::AppState {
             flags: feature_flags,
         };
+        let user_connections_state = api::user_connections::AppState {
+            db: db.clone(),
+            encryption: encryption.clone(),
+            auth: auth_state.clone(),
+            auth_config: auth_config.clone(),
+        };
 
         // Build API routes
         let api_routes = Router::new()
@@ -220,6 +226,7 @@ impl TestServer {
             .merge(api::images::routes(images_state))
             .merge(api::organizations::routes(organizations_state))
             .merge(api::feature_flags::routes(feature_flags_state))
+            .merge(api::user_connections::routes(user_connections_state))
             .merge(auth::routes(auth_backend));
 
         // Build main router with health endpoint

--- a/specs/user-connections.md
+++ b/specs/user-connections.md
@@ -187,6 +187,23 @@ Create an API-key connection. Validates the key, encrypts, and stores.
 - `404` — Unknown provider
 - `400` — Provider uses OAuth (not API key), or validation failed
 
+#### POST /v1/user/connections/{provider}/verify
+
+Verify a stored API key still works. Decrypts the stored credential and calls the provider's `validate()` method. Generic — works for any API-key provider.
+
+**Response:** `200 OK`
+```json
+{ "valid": true }
+```
+or
+```json
+{ "valid": false, "error": "Invalid API key. Check that the key is correct and active." }
+```
+
+**Errors:**
+- `404` — No connection found or unknown provider
+- `400` — Provider is not API-key type
+
 #### DELETE /v1/user/connections/{provider}
 
 Disconnect. Deletes the stored installation_id/token.


### PR DESCRIPTION
## What
Add a generic "Verify" capability for API-key-based user connections (Daytona, Brave Search, etc.). Users can check if their stored API key still works directly from the Settings > Connections page.

## Why
Users had no way to confirm whether a stored API key was still valid without attempting to use it in a session. This adds a quick verification button that re-validates the credential against the provider.

## How
- **Backend**: New `POST /v1/user/connections/{provider}/verify` endpoint that decrypts the stored API key and calls the provider's existing `validate()` method. Returns `{ valid: true }` or `{ valid: false, error: "..." }`.
- **Frontend**: "Verify" button on `ConnectionRow` for API-key connections with inline status feedback (loading spinner, green checkmark, red X with error message).
- **Generic**: Works automatically for any provider implementing `ConnectionProvider::validate()` — no per-provider code needed.

## Risk
- Low
- Only affects existing connection verification flow. Uses the same `validate()` method already called at connection creation time. No new external dependencies.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered