### PR TITLE
fix(worker): wire all stores into durable act_activity

### DIFF
--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -23,8 +23,9 @@ use std::sync::Arc;
 
 use crate::adapters::create_driver_registry;
 use crate::grpc_adapters::{
-    GrpcAgentStore, GrpcClient, GrpcEventEmitter, GrpcHarnessStore, GrpcImageResolver,
-    GrpcLlmProviderStore, GrpcMessageRetriever, GrpcPlatformStore, GrpcSessionFileStore,
+    GrpcAgentStore, GrpcClient, GrpcConnectionResolver, GrpcEventEmitter, GrpcHarnessStore,
+    GrpcImageResolver, GrpcLlmProviderStore, GrpcMessageRetriever, GrpcPlatformStore,
+    GrpcScheduleStore, GrpcSessionFileStore, GrpcSessionMutator, GrpcSessionSqlDbStore,
     GrpcSessionStorageStore, GrpcSessionStore,
 };
 
@@ -357,11 +358,29 @@ pub async fn act_activity(
     let file_store = Arc::new(GrpcSessionFileStore::new(grpc_client.clone()));
     let storage_store: Arc<dyn everruns_core::traits::SessionStorageStore> =
         Arc::new(GrpcSessionStorageStore::new(grpc_client.clone()));
+    let connection_resolver: Arc<dyn everruns_core::traits::UserConnectionResolver> =
+        Arc::new(GrpcConnectionResolver::new(grpc_client.clone()));
+    let session_store: Arc<dyn everruns_core::traits::SessionStore> =
+        Arc::new(GrpcSessionStore::new(grpc_client.clone(), org_id));
+    let session_mutator: Arc<dyn everruns_core::traits::SessionMutator> =
+        Arc::new(GrpcSessionMutator::new(grpc_client.clone(), org_id));
+    let agent_store: Arc<dyn everruns_core::traits::AgentStore> =
+        Arc::new(GrpcAgentStore::new(grpc_client.clone(), org_id));
+    let sqldb_store: everruns_core::traits::SessionSqlDbStoreRef =
+        Arc::new(GrpcSessionSqlDbStore::new(grpc_client.clone()));
+    let schedule_store: Arc<dyn everruns_core::traits::SessionScheduleStore> =
+        Arc::new(GrpcScheduleStore::new(grpc_client.clone(), org_id));
     let platform_store: Arc<dyn everruns_core::platform_store::PlatformStore> =
         Arc::new(GrpcPlatformStore::new(grpc_client, org_id));
 
     let atom = ActAtom::with_file_store(tool_executor, event_emitter, file_store)
         .with_storage_store(storage_store)
+        .with_connection_resolver(connection_resolver)
+        .with_session_store(session_store)
+        .with_session_mutator(session_mutator)
+        .with_agent_store(agent_store)
+        .with_sqldb_store(sqldb_store)
+        .with_schedule_store(schedule_store)
         .with_platform_store(platform_store);
 
     atom.execute(input)

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -1370,6 +1370,37 @@ impl everruns_core::traits::UserConnectionResolver for GrpcConnectionResolver {
 }
 
 // ============================================================================
+// GrpcSessionMutator - SessionMutator over gRPC
+// ============================================================================
+
+/// gRPC-backed session mutator.
+///
+/// Proxies session mutation calls to the control-plane.
+pub struct GrpcSessionMutator {
+    client: GrpcClient,
+    org_id: i64,
+}
+
+impl GrpcSessionMutator {
+    pub fn new(client: GrpcClient, org_id: i64) -> Self {
+        Self { client, org_id }
+    }
+}
+
+#[async_trait]
+impl everruns_core::traits::SessionMutator for GrpcSessionMutator {
+    async fn update_session_title(
+        &self,
+        session_id: everruns_core::SessionId,
+        title: String,
+    ) -> Result<everruns_core::session::Session> {
+        self.client
+            .set_session_title(self.org_id, session_id, &title)
+            .await
+    }
+}
+
+// ============================================================================
 // GrpcScheduleStore - SessionScheduleStore over gRPC
 // ============================================================================
 

--- a/docs/capabilities/daytona.md
+++ b/docs/capabilities/daytona.md
@@ -95,10 +95,7 @@ Configure git credentials for push/pull/fetch.
 
 ## Authentication
 
-Daytona API key is resolved automatically:
-
-1. Session secret `DAYTONA_API_KEY` (highest priority)
-2. User connection (Settings > Connections > Daytona)
+Daytona API key is resolved automatically from **Settings > Connections > Daytona**.
 
 ## Use Cases
 

--- a/integrations/daytona/src/lib.rs
+++ b/integrations/daytona/src/lib.rs
@@ -51,7 +51,6 @@ inventory::submit! {
 
 const DAYTONA_API_BASE: &str = "https://app.daytona.io/api";
 const DAYTONA_TOOLBOX_BASE: &str = "https://proxy.app.daytona.io/toolbox";
-const DAYTONA_API_KEY_SECRET: &str = "DAYTONA_API_KEY";
 const DAYTONA_SANDBOX_SECRET_PREFIX: &str = "daytona_sandbox:";
 const EXEC_TIMEOUT_MS: u64 = 120_000;
 const SANDBOX_READY_POLL_INTERVAL: Duration = Duration::from_secs(2);
@@ -104,10 +103,8 @@ impl Capability for DaytonaCapability {
 
 Cloud-based sandboxes via Daytona. Each sandbox is an isolated environment with full Linux and network access.
 
-Authentication: Daytona API key is resolved automatically:
-1. Session secret `DAYTONA_API_KEY` (if set for this session)
-2. User connection (if configured in Settings > Connections > Daytona)
-If neither is available, guide the user to set up their key in Settings > Connections.
+Authentication: Daytona API key is resolved automatically from Settings > Connections > Daytona.
+If not configured, guide the user to set up their key in Settings > Connections.
 
 Tools:
 - `daytona_create_sandbox` - Create and start a new sandbox
@@ -197,7 +194,6 @@ mod tests {
         assert!(prompt.contains("daytona_create_sandbox"));
         assert!(prompt.contains("daytona_git_clone"));
         assert!(prompt.contains("daytona_git_credentials"));
-        assert!(prompt.contains("DAYTONA_API_KEY"));
         assert!(prompt.contains("Daytona"));
         assert!(prompt.contains("Settings > Connections"));
     }

--- a/integrations/daytona/src/state.rs
+++ b/integrations/daytona/src/state.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::{error, warn};
 
-use crate::{DAYTONA_API_KEY_SECRET, DAYTONA_SANDBOX_SECRET_PREFIX};
+use crate::DAYTONA_SANDBOX_SECRET_PREFIX;
 
 // ============================================================================
 // API Response Types
@@ -47,48 +47,26 @@ pub struct SandboxState {
 // State Management Helpers
 // ============================================================================
 
-/// Resolve Daytona API key with fallback chain:
-/// 1. Session secret DAYTONA_API_KEY (highest priority — most local)
-/// 2. User connection for "daytona" provider (Settings > Connections)
-/// 3. Error with guidance to set up in Settings
+/// Resolve Daytona API key via user connection (Settings > Connections > Daytona).
 pub async fn get_api_key(context: &ToolContext) -> Result<String, ToolExecutionResult> {
-    // 1. Session secret (highest priority)
-    if let Some(storage) = context.storage_store.as_ref() {
-        match storage
-            .get_secret(context.session_id, DAYTONA_API_KEY_SECRET)
-            .await
-        {
-            Ok(Some(key)) => return Ok(key),
-            Ok(None) => {} // fall through
-            Err(e) => {
-                error!("Failed to read DAYTONA_API_KEY secret: {e}");
-                // Fall through to try user connection
-            }
-        }
-    }
-
-    // 2. User connection
     if let Some(resolver) = context.connection_resolver.as_ref() {
         match resolver
             .get_connection_token(context.session_id, "daytona")
             .await
         {
             Ok(Some(key)) => return Ok(key),
-            Ok(None) => {} // fall through
+            Ok(None) => {} // fall through to error
             Err(e) => {
                 error!("Failed to resolve Daytona user connection: {e}");
-                // Fall through to error
             }
         }
     }
 
-    // 3. Not found — guide to Settings
     // THREAT[TM-AGENT-016]: Asking secrets in chat stores them plaintext in events.
     // Prefer Settings UI for credential entry.
     Err(ToolExecutionResult::tool_error(
         "Daytona API key not configured.\n\n\
-         Set up your API key in **Settings > Connections > Daytona**, \
-         or use `secret_store set DAYTONA_API_KEY <key>` for this session only.\n\n\
+         Set up your API key in **Settings > Connections > Daytona**.\n\n\
          Get your key at https://app.daytona.io/ under API Keys.",
     ))
 }

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -1227,7 +1227,7 @@ mod tests {
         }
     }
 
-    /// Mock connection resolver that returns a fixed token.
+    /// Mock connection resolver that returns a fixed token for all providers.
     struct MockConnectionResolver {
         token: Option<String>,
     }
@@ -1240,6 +1240,30 @@ mod tests {
             _provider: &str,
         ) -> Result<Option<String>> {
             Ok(self.token.clone())
+        }
+    }
+
+    /// Mock connection resolver that returns tokens only for specific providers.
+    struct ProviderAwareResolver {
+        tokens: std::collections::HashMap<String, String>,
+    }
+
+    impl ProviderAwareResolver {
+        fn daytona_only(api_key: &str) -> Self {
+            let mut tokens = std::collections::HashMap::new();
+            tokens.insert("daytona".to_string(), api_key.to_string());
+            Self { tokens }
+        }
+    }
+
+    #[async_trait]
+    impl UserConnectionResolver for ProviderAwareResolver {
+        async fn get_connection_token(
+            &self,
+            _session_id: SessionId,
+            provider: &str,
+        ) -> Result<Option<String>> {
+            Ok(self.tokens.get(provider).cloned())
         }
     }
 
@@ -1653,7 +1677,7 @@ mod tests {
         let tool = DaytonaGitCredentialsTool;
         let session_id = SessionId::new();
         let store = Arc::new(MockStorageStore::new());
-        // No DAYTONA_API_KEY secret seeded
+        // No connection resolver — API key cannot be resolved
         let context = ToolContext::with_storage_store(session_id, store);
         let result = tool
             .execute_with_context(json!({"sandbox_id": "sb_test"}), &context)
@@ -1661,7 +1685,7 @@ mod tests {
         match result {
             ToolExecutionResult::ToolError(msg) => {
                 assert!(
-                    msg.contains("DAYTONA_API_KEY"),
+                    msg.contains("not configured") || msg.contains("Settings > Connections"),
                     "Expected API key error, got: {msg}"
                 );
             }
@@ -1674,11 +1698,10 @@ mod tests {
         let tool = DaytonaGitCredentialsTool;
         let session_id = SessionId::new();
         let store = Arc::new(MockStorageStore::new());
-        // Seed API key but no sandbox state
-        store
-            .seed_secret(session_id, "DAYTONA_API_KEY", "test_key")
-            .await;
-        let context = ToolContext::with_storage_store(session_id, store);
+        // Connection resolver provides Daytona API key but no sandbox state
+        let resolver = Arc::new(ProviderAwareResolver::daytona_only("test_key"));
+        let context =
+            ToolContext::with_storage_store(session_id, store).with_connection_resolver(resolver);
         let result = tool
             .execute_with_context(json!({"sandbox_id": "sb_test"}), &context)
             .await;
@@ -1698,9 +1721,6 @@ mod tests {
         let tool = DaytonaGitCredentialsTool;
         let session_id = SessionId::new();
         let store = Arc::new(MockStorageStore::new());
-        store
-            .seed_secret(session_id, "DAYTONA_API_KEY", "test_key")
-            .await;
         // Seed sandbox state
         let state = SandboxState {
             sandbox_id: "sb_test".to_string(),
@@ -1714,8 +1734,10 @@ mod tests {
                 &serde_json::to_string(&state).unwrap(),
             )
             .await;
-        // No GitHub token — neither connection resolver nor GITHUB_TOKEN secret
-        let context = ToolContext::with_storage_store(session_id, store);
+        // Daytona API key via connection resolver, but no GitHub token
+        let resolver = Arc::new(ProviderAwareResolver::daytona_only("test_key"));
+        let context =
+            ToolContext::with_storage_store(session_id, store).with_connection_resolver(resolver);
         let result = tool
             .execute_with_context(json!({"sandbox_id": "sb_test"}), &context)
             .await;
@@ -1737,15 +1759,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_git_credentials_with_github_token_secret() {
-        // When GITHUB_TOKEN session secret is set (but no connection resolver),
-        // the tool should attempt to upload credentials. It will fail because
-        // the Daytona API is not reachable, but the token resolution should succeed.
+        // When GITHUB_TOKEN session secret is set, the tool should attempt to
+        // upload credentials. It will fail because the Daytona API is not
+        // reachable, but the token resolution should succeed.
         let tool = DaytonaGitCredentialsTool;
         let session_id = SessionId::new();
         let store = Arc::new(MockStorageStore::new());
-        store
-            .seed_secret(session_id, "DAYTONA_API_KEY", "test_key")
-            .await;
         let state = SandboxState {
             sandbox_id: "sb_test".to_string(),
             workspace_path: "/home/daytona".to_string(),
@@ -1761,7 +1780,10 @@ mod tests {
         store
             .seed_secret(session_id, "GITHUB_TOKEN", "ghp_test_token_123")
             .await;
-        let context = ToolContext::with_storage_store(session_id, store);
+        // Daytona API key via connection resolver (but not GitHub — that comes from secret)
+        let resolver = Arc::new(ProviderAwareResolver::daytona_only("test_key"));
+        let context =
+            ToolContext::with_storage_store(session_id, store).with_connection_resolver(resolver);
         let result = tool
             .execute_with_context(json!({"sandbox_id": "sb_test"}), &context)
             .await;
@@ -1781,14 +1803,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_git_credentials_with_connection_resolver() {
-        // When connection resolver provides a token, it should be preferred
-        // over GITHUB_TOKEN session secret.
+        // When connection resolver provides a GitHub token, it should be used.
         let tool = DaytonaGitCredentialsTool;
         let session_id = SessionId::new();
         let store = Arc::new(MockStorageStore::new());
-        store
-            .seed_secret(session_id, "DAYTONA_API_KEY", "test_key")
-            .await;
         let state = SandboxState {
             sandbox_id: "sb_test".to_string(),
             workspace_path: "/home/daytona".to_string(),
@@ -1801,6 +1819,7 @@ mod tests {
                 &serde_json::to_string(&state).unwrap(),
             )
             .await;
+        // Connection resolver provides both Daytona key and GitHub token
         let resolver = Arc::new(MockConnectionResolver {
             token: Some("ghs_connection_token_456".to_string()),
         });
@@ -1830,8 +1849,8 @@ mod tests {
         match result {
             ToolExecutionResult::ToolError(msg) => {
                 assert!(
-                    msg.contains("not available") || msg.contains("DAYTONA_API_KEY"),
-                    "Expected storage error, got: {msg}"
+                    msg.contains("not available") || msg.contains("not configured"),
+                    "Expected storage/config error, got: {msg}"
                 );
             }
             _ => panic!("Expected ToolError for missing storage store"),
@@ -1867,6 +1886,7 @@ mod tests {
         let tool = DaytonaGitCloneTool;
         let session_id = SessionId::new();
         let store = Arc::new(MockStorageStore::new());
+        // No connection resolver — API key cannot be resolved
         let context = ToolContext::with_storage_store(session_id, store);
         let result = tool
             .execute_with_context(
@@ -1877,7 +1897,7 @@ mod tests {
         match result {
             ToolExecutionResult::ToolError(msg) => {
                 assert!(
-                    msg.contains("DAYTONA_API_KEY"),
+                    msg.contains("not configured") || msg.contains("Settings > Connections"),
                     "Expected API key error, got: {msg}"
                 );
             }

--- a/integrations/daytona/tests/tool_integration.rs
+++ b/integrations/daytona/tests/tool_integration.rs
@@ -10,7 +10,9 @@
 use async_trait::async_trait;
 use everruns_core::error::Result;
 use everruns_core::tools::{Tool, ToolExecutionResult};
-use everruns_core::traits::{KeyInfo, SecretInfo, SessionStorageStore, ToolContext};
+use everruns_core::traits::{
+    KeyInfo, SecretInfo, SessionStorageStore, ToolContext, UserConnectionResolver,
+};
 use everruns_core::typed_id::SessionId;
 use serde_json::json;
 use std::collections::HashMap;
@@ -89,28 +91,41 @@ impl SessionStorageStore for MockStorageStore {
 }
 
 // ============================================================================
+// Mock ConnectionResolver
+// ============================================================================
+
+struct MockConnectionResolver {
+    token: Option<String>,
+}
+
+#[async_trait]
+impl UserConnectionResolver for MockConnectionResolver {
+    async fn get_connection_token(
+        &self,
+        _session_id: SessionId,
+        _provider: &str,
+    ) -> Result<Option<String>> {
+        Ok(self.token.clone())
+    }
+}
+
+/// Create a mock connection resolver that returns a fixed Daytona API key.
+fn daytona_resolver() -> Arc<dyn UserConnectionResolver> {
+    Arc::new(MockConnectionResolver {
+        token: Some("test_api_key".to_string()),
+    })
+}
+
+// ============================================================================
 // Helpers
 // ============================================================================
 
-/// Seed a mock store with API key and sandbox state, returning the context.
-/// The `api_key_url` should be the wiremock server URI — but since tools use
-/// DaytonaClient::new() (hardcoded URLs), we need a different approach.
-///
-/// We seed the API key and sandbox state, then the test must override the
-/// client URL via environment or use a direct DaytonaClient test instead.
-/// For tools that construct DaytonaClient::new(api_key), the tests that need
-/// real HTTP go through the client module tests in src/client.rs.
-///
-/// These integration tests verify the tool orchestration layer: parameter
-/// validation, state lookups, and result formatting — against a real storage mock.
+/// Seed sandbox state into the store. API key comes via connection resolver.
 async fn setup_context_with_sandbox(
     session_id: SessionId,
     store: &Arc<MockStorageStore>,
     sandbox_id: &str,
 ) {
-    store
-        .seed_secret(session_id, "DAYTONA_API_KEY", "test_api_key")
-        .await;
     let state = SandboxState {
         sandbox_id: sandbox_id.to_string(),
         workspace_path: "/home/daytona".to_string(),
@@ -314,7 +329,10 @@ async fn test_exec_tool_missing_api_key() {
 
     match result {
         ToolExecutionResult::ToolError(msg) => {
-            assert!(msg.contains("DAYTONA_API_KEY"), "Got: {msg}");
+            assert!(
+                msg.contains("not configured") || msg.contains("Settings > Connections"),
+                "Got: {msg}"
+            );
         }
         other => panic!("Expected ToolError, got: {other:?}"),
     }
@@ -325,10 +343,8 @@ async fn test_exec_tool_missing_sandbox_state() {
     let tool = get_tool("daytona_exec");
     let session_id = SessionId::new();
     let store = Arc::new(MockStorageStore::new());
-    store
-        .seed_secret(session_id, "DAYTONA_API_KEY", "test_key")
-        .await;
-    let context = ToolContext::with_storage_store(session_id, store);
+    let context = ToolContext::with_storage_store(session_id, store)
+        .with_connection_resolver(daytona_resolver());
 
     let result = tool
         .execute_with_context(
@@ -411,7 +427,8 @@ async fn test_manage_sandbox_invalid_action() {
     let session_id = SessionId::new();
     let store = Arc::new(MockStorageStore::new());
     setup_context_with_sandbox(session_id, &store, "sb_test").await;
-    let context = ToolContext::with_storage_store(session_id, store);
+    let context = ToolContext::with_storage_store(session_id, store)
+        .with_connection_resolver(daytona_resolver());
 
     // Tool will pass validation, get API key, verify sandbox exists,
     // then reject invalid action before making HTTP call

--- a/specs/daytona.md
+++ b/specs/daytona.md
@@ -12,8 +12,8 @@ The Daytona capability integrates [Daytona](https://www.daytona.io/) cloud-based
 
 Daytona exposes two API layers:
 
-1. **Management API** (`https://app.daytona.io/api`) — sandbox lifecycle (create, start, stop, delete). Auth: `Bearer <DAYTONA_API_KEY>`.
-2. **Toolbox API** (`https://proxy.app.daytona.io/toolbox/{sandboxId}`) — in-sandbox operations (exec, files). Auth: `Bearer <DAYTONA_API_KEY>`.
+1. **Management API** (`https://app.daytona.io/api`) — sandbox lifecycle (create, start, stop, delete). Auth: `Bearer <api_key>`.
+2. **Toolbox API** (`https://proxy.app.daytona.io/toolbox/{sandboxId}`) — in-sandbox operations (exec, files). Auth: `Bearer <api_key>`.
 
 ```
 ┌────────────────────────────────────────────┐
@@ -41,11 +41,8 @@ Per-sandbox state is stored in session **secrets** (encrypted at rest via AES-25
 
 ### API Key Resolution
 
-The Daytona API key is resolved with fallback chain:
-
-1. **Session secret** `DAYTONA_API_KEY` — highest priority, local to session
-2. **User connection** for `daytona` provider — persistent, set up via Settings > Connections
-3. **Error** — guides user to Settings > Connections
+The Daytona API key is resolved via **user connection** for the `daytona` provider (Settings > Connections).
+If not configured, a `ToolError` guides the user to set up in Settings.
 
 ### User Connection
 
@@ -197,7 +194,7 @@ Configure git credentials in a sandbox so that all git operations (push, pull, f
 
 ## Security
 
-- **API Key**: Stored in user connections (preferred) or session secrets (`DAYTONA_API_KEY`), encrypted at rest (TM-DAYTONA-004)
+- **API Key**: Stored in user connections (Settings > Connections > Daytona), encrypted at rest (TM-DAYTONA-004)
 - **Single auth token**: Both Management and Toolbox APIs use the same Bearer token
 - **Sandbox Isolation**: Each sandbox is an isolated environment (TM-DAYTONA-005)
 - **Multi-tenancy**: Sandboxes scoped to session via secret name prefixes
@@ -212,7 +209,7 @@ See [threat-model.md](threat-model.md#16-daytona-cloud-sandbox-tm-daytona) for f
 |----------|-------------|---------|
 | Missing required param | `ToolError` | "Missing required parameter: {name}" |
 | Sandbox not found | `ToolError` | "Sandbox '{id}' not found. Create one first with daytona_create_sandbox." |
-| API key not configured | `ToolError` | "DAYTONA_API_KEY not set." |
+| API key not configured | `ToolError` | "Daytona API key not configured." |
 | HTTP 4xx | `ToolError` | "Daytona API error ({status}): {body}" |
 | No context | `ToolError` | "{tool_name} requires context." |
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -737,7 +737,7 @@ Daytona sandboxes are remote Linux environments managed via REST API. The agent 
 | TM-DAYTONA-001 | Git token persisted on sandbox disk | Medium | Token written to `/tmp/.git-credentials`; lost on sandbox stop/delete; same trust boundary as `daytona_exec` (anyone who can exec can already read the file) | **ACCEPTED** |
 | TM-DAYTONA-002 | Git token expiry — stale credentials | Low | GitHub App installation tokens expire in ~1 hour; tool hint tells agent to call `daytona_git_credentials` again to refresh | MITIGATED |
 | TM-DAYTONA-003 | Git token scope — over-privileged access | Medium | Token scoped by GitHub App installation permissions; user controls repo access via GitHub App settings | **CALLER RISK** |
-| TM-DAYTONA-004 | Daytona API key compromise | High | Stored as encrypted session secret (`DAYTONA_API_KEY`); envelope encryption (AES-256-GCM) at rest | MITIGATED |
+| TM-DAYTONA-004 | Daytona API key compromise | High | Stored in user connections (Settings > Connections); encrypted at rest via envelope encryption (AES-256-GCM) | MITIGATED |
 | TM-DAYTONA-005 | Cross-session sandbox access | Critical | Sandbox IDs stored in session-scoped secrets (`daytona_sandbox:{id}`); session isolation enforced by storage store | MITIGATED |
 | TM-DAYTONA-006 | Sandbox not deleted — resource leak | Low | Auto-stop after 5 min inactivity; system prompt instructs agent to delete when done | MITIGATED |
 | TM-DAYTONA-007 | Git credential helper persists after sandbox reuse | Low | Credential file in `/tmp` cleared on stop; sandbox stop resets environment | MITIGATED |


### PR DESCRIPTION
## What
Wire all missing stores into the durable execution engine's `act_activity`, add `GrpcSessionMutator`, and remove Daytona API key session secret support.

## Why
The durable execution path in `activities.rs` was missing 6 stores (`connection_resolver`, `session_store`, `session_mutator`, `agent_store`, `sqldb_store`, `schedule_store`) when constructing `ActAtom`. This caused tools to silently fail when executed via the durable workflow engine (`just start-all` mode). The non-durable path in `unified_worker.rs` had all stores wired correctly.

Additionally, the Daytona API key session secret (`DAYTONA_API_KEY`) was a weaker auth path — user connections (Settings > Connections) are encrypted and persistent, making session secrets redundant.

## How
- **`activities.rs`**: Added all missing gRPC store adapters to match `unified_worker.rs` exactly
- **`grpc_adapters.rs`**: Added `GrpcSessionMutator` implementing `SessionMutator` trait (delegates to `GrpcClient.set_session_title`)
- **`state.rs`**: Removed session secret fallback from `get_api_key()` — now only resolves via user connection resolver
- **`lib.rs`**: Removed `DAYTONA_API_KEY_SECRET` constant, updated system prompt
- **Tests**: Updated all tests to use `MockConnectionResolver`/`ProviderAwareResolver` instead of seeding `DAYTONA_API_KEY` session secret
- **Specs/docs**: Updated `specs/daytona.md`, `specs/threat-model.md`, `docs/capabilities/daytona.md`

## Risk
- Low
- Tools that previously relied on `DAYTONA_API_KEY` session secret will need to use Settings > Connections instead. No backward compat needed (internal code).

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
