### PR TITLE
fix(daytona): use /home/daytona as workspace path

### DIFF
--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -664,8 +664,8 @@ sql_query(database="analytics", sql="SELECT product, SUM(amount) as total FROM s
 Just call sandbox tools directly — the API key is resolved automatically from Settings > Connections or session secrets.
 
 Workflow:
-1. Create sandbox: `daytona_create_sandbox` (working directory: /sandbox)
-2. Clone repos: `daytona_git_clone` (clones to /sandbox/owner/repo)
+1. Create sandbox: `daytona_create_sandbox` (working directory: /home/daytona)
+2. Clone repos: `daytona_git_clone` (clones to /home/daytona/owner/repo)
 3. Write code / install deps: `daytona_write_file`, `daytona_exec`
 4. Read results: `daytona_read_file`
 5. Save results: `daytona_download_workspace`

--- a/integrations/daytona/src/lib.rs
+++ b/integrations/daytona/src/lib.rs
@@ -58,6 +58,8 @@ const SANDBOX_READY_POLL_INTERVAL: Duration = Duration::from_secs(2);
 const SANDBOX_READY_MAX_WAIT: Duration = Duration::from_secs(60);
 /// Auto-stop after 5 minutes of inactivity (safety net)
 const AUTO_STOP_INTERVAL_MINUTES: u64 = 5;
+/// Default workspace path inside Daytona sandboxes
+const DAYTONA_WORKSPACE_PATH: &str = "/home/daytona";
 
 // ============================================================================
 // DaytonaCapability
@@ -121,10 +123,10 @@ All tools except `daytona_create_sandbox` and `daytona_list_sandboxes` require a
 Sandboxes auto-stop after 5 minutes of inactivity.
 Always DELETE sandboxes when done (stop leaves them on the dashboard).
 
-Git cloning: Use `daytona_git_clone` to clone repositories into `/sandbox/owner/repo`.
+Git cloning: Use `daytona_git_clone` to clone repositories into `/home/daytona/owner/repo`.
 If the user has connected their GitHub account (Settings > Connections), private repos
 are automatically authenticated. For public repos, no credentials are needed.
-Supports "user/repo" shorthand. Working directory is `/sandbox`.
+Supports "user/repo" shorthand. Working directory is `/home/daytona`.
 
 Git push/pull/fetch: After cloning, call `daytona_git_credentials` once to configure
 credentials in the sandbox. Then use `daytona_exec` for any git command (push, pull,

--- a/integrations/daytona/src/state.rs
+++ b/integrations/daytona/src/state.rs
@@ -215,25 +215,25 @@ mod tests {
     fn test_sandbox_state_roundtrip() {
         let state = SandboxState {
             sandbox_id: "sb_123".to_string(),
-            workspace_path: "/sandbox".to_string(),
+            workspace_path: "/home/daytona".to_string(),
             started_at: "2026-02-16T10:00:00Z".to_string(),
         };
         let json = serde_json::to_string(&state).unwrap();
         let deserialized: SandboxState = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.sandbox_id, "sb_123");
-        assert_eq!(deserialized.workspace_path, "/sandbox");
+        assert_eq!(deserialized.workspace_path, "/home/daytona");
     }
 
     #[test]
     fn test_sandbox_state_with_special_chars() {
         let state = SandboxState {
             sandbox_id: "sb-test_123".to_string(),
-            workspace_path: "/sandbox/my project".to_string(),
+            workspace_path: "/home/daytona/my project".to_string(),
             started_at: "2026-02-16T10:00:00+05:30".to_string(),
         };
         let json = serde_json::to_string(&state).unwrap();
         let deserialized: SandboxState = serde_json::from_str(&json).unwrap();
-        assert_eq!(deserialized.workspace_path, "/sandbox/my project");
+        assert_eq!(deserialized.workspace_path, "/home/daytona/my project");
     }
 
     #[test]
@@ -311,7 +311,7 @@ mod tests {
     fn test_sandbox_state_json_has_all_fields() {
         let state = SandboxState {
             sandbox_id: "sb_x".to_string(),
-            workspace_path: "/sandbox".to_string(),
+            workspace_path: "/home/daytona".to_string(),
             started_at: "2026-01-01T00:00:00Z".to_string(),
         };
         let val: serde_json::Value = serde_json::to_value(&state).unwrap();

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -106,14 +106,19 @@ impl Tool for DaytonaCreateSandboxTool {
             // Continue anyway — the sandbox was created, agent can retry later
         }
 
-        let workspace_path = "/sandbox".to_string();
+        let workspace_path = crate::DAYTONA_WORKSPACE_PATH.to_string();
 
-        // Ensure /sandbox directory exists
+        // Ensure workspace directory exists
         if let Err(e) = client
-            .exec(sandbox_id, "mkdir -p /sandbox", None, None)
+            .exec(
+                sandbox_id,
+                &format!("mkdir -p {}", crate::DAYTONA_WORKSPACE_PATH),
+                None,
+                None,
+            )
             .await
         {
-            warn!("Failed to create /sandbox directory: {e}");
+            warn!("Failed to create workspace directory: {e}");
         }
 
         // Save state
@@ -303,7 +308,7 @@ impl Tool for DaytonaReadFileTool {
                 },
                 "path": {
                     "type": "string",
-                    "description": "Path to file in sandbox (e.g., '/sandbox/main.py')"
+                    "description": "Path to file in sandbox (e.g., '/home/daytona/main.py')"
                 }
             },
             "required": ["sandbox_id", "path"],
@@ -384,7 +389,7 @@ impl Tool for DaytonaWriteFileTool {
                 },
                 "path": {
                     "type": "string",
-                    "description": "Path for file in sandbox (e.g., '/sandbox/main.py')"
+                    "description": "Path for file in sandbox (e.g., '/home/daytona/main.py')"
                 },
                 "content": {
                     "type": "string",
@@ -812,7 +817,7 @@ impl Tool for DaytonaGitCloneTool {
                 },
                 "path": {
                     "type": "string",
-                    "description": "Clone destination path inside sandbox (optional, defaults to /sandbox/<owner>/<repo>)"
+                    "description": "Clone destination path inside sandbox (optional, defaults to /home/daytona/<owner>/<repo>)"
                 }
             },
             "required": ["sandbox_id", "repo_url"],
@@ -854,7 +859,7 @@ impl Tool for DaytonaGitCloneTool {
         // Normalize repo URL: "user/repo" → "https://github.com/user/repo.git"
         let repo_url = normalize_repo_url(repo_url_raw);
 
-        // Build default clone path: /sandbox/owner/repo (preserves user/repo structure)
+        // Build default clone path: <workspace>/owner/repo (preserves user/repo structure)
         let default_path = if let Some(owner_repo) = extract_owner_repo(repo_url_raw) {
             format!("{}/{}", state.workspace_path, owner_repo)
         } else {
@@ -1699,7 +1704,7 @@ mod tests {
         // Seed sandbox state
         let state = SandboxState {
             sandbox_id: "sb_test".to_string(),
-            workspace_path: "/sandbox".to_string(),
+            workspace_path: "/home/daytona".to_string(),
             started_at: "2026-01-01T00:00:00Z".to_string(),
         };
         store
@@ -1743,7 +1748,7 @@ mod tests {
             .await;
         let state = SandboxState {
             sandbox_id: "sb_test".to_string(),
-            workspace_path: "/sandbox".to_string(),
+            workspace_path: "/home/daytona".to_string(),
             started_at: "2026-01-01T00:00:00Z".to_string(),
         };
         store
@@ -1786,7 +1791,7 @@ mod tests {
             .await;
         let state = SandboxState {
             sandbox_id: "sb_test".to_string(),
-            workspace_path: "/sandbox".to_string(),
+            workspace_path: "/home/daytona".to_string(),
             started_at: "2026-01-01T00:00:00Z".to_string(),
         };
         store

--- a/integrations/daytona/tests/tool_integration.rs
+++ b/integrations/daytona/tests/tool_integration.rs
@@ -113,7 +113,7 @@ async fn setup_context_with_sandbox(
         .await;
     let state = SandboxState {
         sandbox_id: sandbox_id.to_string(),
-        workspace_path: "/sandbox".to_string(),
+        workspace_path: "/home/daytona".to_string(),
         started_at: "2026-02-18T10:00:00Z".to_string(),
     };
     store
@@ -460,7 +460,7 @@ async fn test_list_sandboxes_with_entries() {
     setup_context_with_sandbox(session_id, &store, "sb_one").await;
     let state2 = SandboxState {
         sandbox_id: "sb_two".to_string(),
-        workspace_path: "/sandbox".to_string(),
+        workspace_path: "/home/daytona".to_string(),
         started_at: "2026-02-18T11:00:00Z".to_string(),
     };
     store
@@ -659,7 +659,7 @@ async fn test_sandbox_state_persistence_roundtrip() {
             assert_eq!(val["count"], 1);
             let sandbox = &val["sandboxes"][0];
             assert_eq!(sandbox["sandbox_id"], "sb_persist");
-            assert_eq!(sandbox["workspace_path"], "/sandbox");
+            assert_eq!(sandbox["workspace_path"], "/home/daytona");
         }
         other => panic!("Expected Success, got: {other:?}"),
     }

--- a/specs/daytona.md
+++ b/specs/daytona.md
@@ -170,7 +170,7 @@ Clone a git repository into a sandbox. Automatically uses the user's connected G
   - `sandbox_id`: string (required)
   - `repo_url`: string (required) — supports `https://`, `git@`, or `user/repo` shorthand
   - `branch`: string (optional) — branch to clone (defaults to default branch)
-  - `path`: string (optional) — destination inside sandbox (defaults to `/sandbox/<owner>/<repo>`)
+  - `path`: string (optional) — destination inside sandbox (defaults to `/home/daytona/<owner>/<repo>`)
 - **Returns**: `{ sandbox_id, repo_url, path, branch, commit, authenticated }`
 
 **Implementation:** Uses Daytona's native `POST /git/clone` Toolbox API endpoint. Credentials are passed directly in the request body (`username`/`password` fields) — no credential helper scripts needed.


### PR DESCRIPTION
## What
Fix the Daytona sandbox workspace path from hardcoded `/sandbox` to `/home/daytona`.

## Why
Daytona sandboxes use `/home/daytona` as their default home directory. The `/sandbox` path does not exist, causing `mkdir -p /sandbox` to create a non-standard directory that conflicts with Daytona's actual filesystem layout.

## How
- Added `DAYTONA_WORKSPACE_PATH` constant (`/home/daytona`) in `lib.rs`
- Updated `create_sandbox` tool to use the constant instead of hardcoded `/sandbox`
- Updated tool parameter descriptions, system prompts, seed agent prompt, spec, and all tests

## Risk
- Low
- Only affects new sandbox creation; existing sandbox states store their own workspace_path

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered