### PR TITLE
feat(search): global search & command palette (Cmd+K)

### DIFF
--- a/apps/ui/src/app/(main)/layout.tsx
+++ b/apps/ui/src/app/(main)/layout.tsx
@@ -8,6 +8,7 @@ import { CommandPalette } from "@/components/command-palette";
 import { CommandPaletteContext, useCommandPaletteState } from "@/hooks/use-command-palette";
 import { useAuth } from "@/providers/auth-provider";
 import { useOrg } from "@/providers/org-provider";
+import { useFeatureFlag } from "@/providers/feature-flags-provider";
 import { Loader2 } from "lucide-react";
 
 interface MainLayoutProps {
@@ -20,6 +21,7 @@ function MainLayoutInner({ children }: MainLayoutProps) {
   const searchParams = useSearchParams();
   const { isAuthenticated, isLoading: authLoading, requiresAuth } = useAuth();
   const { isLoading: orgLoading } = useOrg();
+  const globalSearchEnabled = useFeatureFlag("global_search");
   const commandPalette = useCommandPaletteState();
 
   // Combined loading state - wait for both auth and org to initialize
@@ -61,15 +63,19 @@ function MainLayoutInner({ children }: MainLayoutProps) {
     return null;
   }
 
-  return (
-    <CommandPaletteContext value={commandPalette}>
-      <div className="flex h-screen">
-        <Sidebar />
-        <main className="flex-1 overflow-auto bg-background bg-brand-dots">{children}</main>
-        <CommandPalette />
-      </div>
-    </CommandPaletteContext>
+  const content = (
+    <div className="flex h-screen">
+      <Sidebar />
+      <main className="flex-1 overflow-auto bg-background bg-brand-dots">{children}</main>
+      {globalSearchEnabled && <CommandPalette />}
+    </div>
   );
+
+  if (globalSearchEnabled) {
+    return <CommandPaletteContext value={commandPalette}>{content}</CommandPaletteContext>;
+  }
+
+  return content;
 }
 
 export default function MainLayout({ children }: MainLayoutProps) {

--- a/apps/ui/src/app/(main)/layout.tsx
+++ b/apps/ui/src/app/(main)/layout.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-// Main app layout with sidebar and auth guard
+// Main app layout with sidebar, auth guard, and global command palette
 import { Suspense, useEffect } from "react";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { Sidebar } from "@/components/layout/sidebar";
+import { CommandPalette } from "@/components/command-palette";
+import { CommandPaletteContext, useCommandPaletteState } from "@/hooks/use-command-palette";
 import { useAuth } from "@/providers/auth-provider";
 import { useOrg } from "@/providers/org-provider";
 import { Loader2 } from "lucide-react";
@@ -18,6 +20,7 @@ function MainLayoutInner({ children }: MainLayoutProps) {
   const searchParams = useSearchParams();
   const { isAuthenticated, isLoading: authLoading, requiresAuth } = useAuth();
   const { isLoading: orgLoading } = useOrg();
+  const commandPalette = useCommandPaletteState();
 
   // Combined loading state - wait for both auth and org to initialize
   const isLoading = authLoading || orgLoading;
@@ -59,10 +62,13 @@ function MainLayoutInner({ children }: MainLayoutProps) {
   }
 
   return (
-    <div className="flex h-screen">
-      <Sidebar />
-      <main className="flex-1 overflow-auto bg-background bg-brand-dots">{children}</main>
-    </div>
+    <CommandPaletteContext value={commandPalette}>
+      <div className="flex h-screen">
+        <Sidebar />
+        <main className="flex-1 overflow-auto bg-background bg-brand-dots">{children}</main>
+        <CommandPalette />
+      </div>
+    </CommandPaletteContext>
   );
 }
 

--- a/apps/ui/src/components/command-palette.tsx
+++ b/apps/ui/src/components/command-palette.tsx
@@ -25,6 +25,7 @@ const CATEGORY_LABELS: Record<SearchResultCategory, string> = {
   session: "Sessions",
   harness: "Harnesses",
   skill: "Skills",
+  mcp_server: "MCP Servers",
   id: "Go to",
 };
 
@@ -35,6 +36,7 @@ const CATEGORY_ORDER: SearchResultCategory[] = [
   "session",
   "harness",
   "skill",
+  "mcp_server",
 ];
 
 function groupResults(

--- a/apps/ui/src/components/command-palette.tsx
+++ b/apps/ui/src/components/command-palette.tsx
@@ -1,0 +1,225 @@
+/**
+ * Global command palette (Cmd+K / Ctrl+K).
+ *
+ * Combines navigation and entity search in a single modal.
+ * Keyboard navigation: Arrow Up/Down to move, Enter to select, Escape to close.
+ * Results are grouped by category with section headers.
+ */
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { cn } from "@/lib/utils";
+import { useCommandPalette } from "@/hooks/use-command-palette";
+import {
+  useGlobalSearch,
+  type SearchResult,
+  type SearchResultCategory,
+} from "@/hooks/use-global-search";
+import { Dialog, DialogOverlay, DialogPortal } from "@/components/ui/dialog";
+import { Search, CornerDownLeft, ArrowUp, ArrowDown } from "lucide-react";
+
+const CATEGORY_LABELS: Record<SearchResultCategory, string> = {
+  navigation: "Pages",
+  agent: "Agents",
+  session: "Sessions",
+  harness: "Harnesses",
+  skill: "Skills",
+  id: "Go to",
+};
+
+const CATEGORY_ORDER: SearchResultCategory[] = [
+  "id",
+  "navigation",
+  "agent",
+  "session",
+  "harness",
+  "skill",
+];
+
+function groupResults(
+  results: SearchResult[],
+): { category: SearchResultCategory; items: SearchResult[] }[] {
+  const groups = new Map<SearchResultCategory, SearchResult[]>();
+  for (const result of results) {
+    const existing = groups.get(result.category);
+    if (existing) {
+      existing.push(result);
+    } else {
+      groups.set(result.category, [result]);
+    }
+  }
+  return CATEGORY_ORDER.filter((cat) => groups.has(cat)).map((cat) => ({
+    category: cat,
+    items: groups.get(cat)!,
+  }));
+}
+
+export function CommandPalette() {
+  const { open, setOpen } = useCommandPalette();
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const results = useGlobalSearch(query);
+  const grouped = groupResults(results);
+
+  // Flat list for keyboard navigation
+  const flatResults = grouped.flatMap((g) => g.items);
+
+  // Reset state when opening
+  useEffect(() => {
+    if (open) {
+      setQuery("");
+      setSelectedIndex(0);
+      // Focus input after dialog renders
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [open]);
+
+  // Reset selected index when results change
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [query]);
+
+  const navigate = useCallback(
+    (result: SearchResult) => {
+      setOpen(false);
+      router.push(result.href);
+    },
+    [router, setOpen],
+  );
+
+  // Scroll selected item into view
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const selected = list.querySelector("[data-selected='true']");
+    if (selected) {
+      selected.scrollIntoView({ block: "nearest" });
+    }
+  }, [selectedIndex]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          setSelectedIndex((prev) => Math.min(prev + 1, flatResults.length - 1));
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          setSelectedIndex((prev) => Math.max(prev - 1, 0));
+          break;
+        case "Enter":
+          e.preventDefault();
+          if (flatResults[selectedIndex]) {
+            navigate(flatResults[selectedIndex]);
+          }
+          break;
+        case "Escape":
+          e.preventDefault();
+          setOpen(false);
+          break;
+      }
+    },
+    [flatResults, selectedIndex, navigate, setOpen],
+  );
+
+  // Track which category boundary each flat index falls under
+  let flatIndex = 0;
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogPortal>
+        <DialogOverlay />
+        {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+        <div
+          className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh]"
+          onKeyDown={handleKeyDown}
+        >
+          <div className="bg-background w-full max-w-lg border shadow-2xl animate-in fade-in-0 zoom-in-95 duration-150">
+            {/* Search input */}
+            <div className="flex items-center gap-3 border-b px-4">
+              <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <input
+                ref={inputRef}
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search pages, agents, sessions..."
+                className="flex-1 bg-transparent py-3.5 text-sm outline-none placeholder:text-muted-foreground"
+              />
+              <kbd className="hidden sm:inline-flex h-5 items-center gap-1 border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
+                ESC
+              </kbd>
+            </div>
+
+            {/* Results */}
+            <div ref={listRef} className="max-h-[min(50vh,400px)] overflow-y-auto p-1.5">
+              {flatResults.length === 0 && query.trim() ? (
+                <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+                  No results for &ldquo;{query}&rdquo;
+                </div>
+              ) : (
+                grouped.map((group) => (
+                  <div key={group.category}>
+                    <div className="px-3 py-1.5 text-[10px] font-medium uppercase tracking-[0.2em] text-muted-foreground">
+                      {CATEGORY_LABELS[group.category]}
+                    </div>
+                    {group.items.map((result) => {
+                      const idx = flatIndex++;
+                      const isSelected = idx === selectedIndex;
+                      return (
+                        <button
+                          key={result.id}
+                          type="button"
+                          data-selected={isSelected}
+                          className={cn(
+                            "flex w-full items-center gap-3 px-3 py-2 text-sm transition-colors",
+                            isSelected
+                              ? "bg-accent text-accent-foreground"
+                              : "text-foreground hover:bg-accent/50",
+                          )}
+                          onClick={() => navigate(result)}
+                          onMouseEnter={() => setSelectedIndex(idx)}
+                        >
+                          <result.icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                          <div className="flex-1 text-left min-w-0">
+                            <span className="truncate block">{result.title}</span>
+                            {result.subtitle && (
+                              <span className="truncate block text-xs text-muted-foreground">
+                                {result.subtitle}
+                              </span>
+                            )}
+                          </div>
+                          {isSelected && (
+                            <CornerDownLeft className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                          )}
+                        </button>
+                      );
+                    })}
+                  </div>
+                ))
+              )}
+            </div>
+
+            {/* Footer hints */}
+            <div className="flex items-center gap-4 border-t px-4 py-2 text-[11px] text-muted-foreground">
+              <span className="inline-flex items-center gap-1">
+                <ArrowUp className="h-3 w-3" />
+                <ArrowDown className="h-3 w-3" />
+                navigate
+              </span>
+              <span className="inline-flex items-center gap-1">
+                <CornerDownLeft className="h-3 w-3" />
+                select
+              </span>
+            </div>
+          </div>
+        </div>
+      </DialogPortal>
+    </Dialog>
+  );
+}

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -393,20 +393,22 @@ export function Sidebar({ config }: { config?: Partial<SidebarConfig> }) {
         </div>
       )}
 
-      {/* Search trigger */}
-      <div className="px-3 py-2">
-        <button
-          type="button"
-          onClick={() => openCommandPalette(true)}
-          className="flex w-full items-center gap-3 border border-input bg-transparent px-3 py-2 text-sm text-muted-foreground transition-colors hover:border-border hover:bg-card hover:text-foreground"
-        >
-          <Search className="h-4 w-4 shrink-0" />
-          <span className="flex-1 text-left">Search...</span>
-          <kbd className="hidden sm:inline-flex h-5 items-center gap-0.5 border bg-muted px-1.5 font-mono text-[10px] font-medium">
-            <span className="text-xs">⌘</span>K
-          </kbd>
-        </button>
-      </div>
+      {/* Search trigger (gated by global_search feature flag) */}
+      {featureFlags.global_search && (
+        <div className="px-3 py-2">
+          <button
+            type="button"
+            onClick={() => openCommandPalette(true)}
+            className="flex w-full items-center gap-3 border border-input bg-transparent px-3 py-2 text-sm text-muted-foreground transition-colors hover:border-border hover:bg-card hover:text-foreground"
+          >
+            <Search className="h-4 w-4 shrink-0" />
+            <span className="flex-1 text-left">Search...</span>
+            <kbd className="hidden sm:inline-flex h-5 items-center gap-0.5 border bg-muted px-1.5 font-mono text-[10px] font-medium">
+              <span className="text-xs">⌘</span>K
+            </kbd>
+          </button>
+        </div>
+      )}
 
       {/* Navigation */}
       <nav className="flex-1 min-h-0 overflow-y-auto space-y-1 bg-background py-4">

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -70,9 +70,11 @@ import {
   Plus,
   Rocket,
   ListTodo,
+  Search,
 } from "lucide-react";
 import { capabilityIconMap } from "@/lib/capability-icons";
 import { ExperimentalBadge } from "@/components/ui/experimental-badge";
+import { useCommandPalette } from "@/hooks/use-command-palette";
 import type { FeatureFlags } from "@/lib/api/types";
 
 const isDev = process.env.NODE_ENV === "development";
@@ -328,6 +330,8 @@ export function Sidebar({ config }: { config?: Partial<SidebarConfig> }) {
   const sections = config?.navigation ?? defaultNavigationSections;
   const allSections = config?.extraSections ? [...sections, ...config.extraSections] : sections;
 
+  const { setOpen: openCommandPalette } = useCommandPalette();
+
   const handleCreateOrg =
     config?.orgActions?.createOrg ?? createOrgOverride ?? (() => setCreateOrgOpen(true));
   const useDefaultCreateOrgDialog = !config?.orgActions?.createOrg && !createOrgOverride;
@@ -388,6 +392,21 @@ export function Sidebar({ config }: { config?: Partial<SidebarConfig> }) {
           </DropdownMenu>
         </div>
       )}
+
+      {/* Search trigger */}
+      <div className="px-3 py-2">
+        <button
+          type="button"
+          onClick={() => openCommandPalette(true)}
+          className="flex w-full items-center gap-3 border border-input bg-transparent px-3 py-2 text-sm text-muted-foreground transition-colors hover:border-border hover:bg-card hover:text-foreground"
+        >
+          <Search className="h-4 w-4 shrink-0" />
+          <span className="flex-1 text-left">Search...</span>
+          <kbd className="hidden sm:inline-flex h-5 items-center gap-0.5 border bg-muted px-1.5 font-mono text-[10px] font-medium">
+            <span className="text-xs">⌘</span>K
+          </kbd>
+        </button>
+      </div>
 
       {/* Navigation */}
       <nav className="flex-1 min-h-0 overflow-y-auto space-y-1 bg-background py-4">

--- a/apps/ui/src/hooks/use-command-palette.ts
+++ b/apps/ui/src/hooks/use-command-palette.ts
@@ -1,0 +1,40 @@
+/**
+ * Global command palette state + keyboard shortcut.
+ *
+ * Opens with Cmd+K (Mac) / Ctrl+K (other). Provides a context so any
+ * component in the tree can open/close the palette programmatically.
+ */
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+
+export interface CommandPaletteState {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+export const CommandPaletteContext = createContext<CommandPaletteState>({
+  open: false,
+  setOpen: () => {},
+});
+
+export function useCommandPaletteState(): CommandPaletteState {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        setOpen((prev) => !prev);
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  return { open, setOpen };
+}
+
+export function useCommandPalette(): CommandPaletteState {
+  return useContext(CommandPaletteContext);
+}

--- a/apps/ui/src/hooks/use-global-search.ts
+++ b/apps/ui/src/hooks/use-global-search.ts
@@ -191,7 +191,7 @@ export function useGlobalSearch(query: string) {
           resolvedName = agents.find((a) => a.id === idValue)?.name;
         } else if (prefix === "session_") {
           const s = sessions.find((s) => s.id === idValue);
-          resolvedName = s?.title || s?.preview;
+          resolvedName = s?.title ?? s?.preview ?? undefined;
         } else if (prefix === "harness_") {
           resolvedName = harnesses.find((h) => h.id === idValue)?.name;
         } else if (prefix === "skill_") {

--- a/apps/ui/src/hooks/use-global-search.ts
+++ b/apps/ui/src/hooks/use-global-search.ts
@@ -7,10 +7,11 @@
  * 3. Sessions (client-side filter over first page)
  * 4. Harnesses (client-side filter over cached list)
  * 5. Skills (client-side filter over cached list)
- * 6. ID-based lookup (detects prefixed IDs and provides direct navigation)
+ * 6. MCP Servers (client-side filter over cached list)
+ * 7. ID-based lookup (detects prefixed IDs and provides direct navigation)
  *
  * All entity searches are client-side over already-fetched React Query data.
- * Backend search endpoints will be added incrementally.
+ * Backend search endpoints are available for server-side filtering when needed.
  */
 "use client";
 
@@ -37,8 +38,16 @@ import { useAgents } from "@/hooks/use-agents";
 import { useSessions } from "@/hooks/use-sessions";
 import { useHarnesses } from "@/hooks/use-harnesses";
 import { useSkills } from "@/hooks/use-skills";
+import { useMcpServers } from "@/hooks/use-mcp-servers";
 
-export type SearchResultCategory = "navigation" | "agent" | "session" | "harness" | "skill" | "id";
+export type SearchResultCategory =
+  | "navigation"
+  | "agent"
+  | "session"
+  | "harness"
+  | "skill"
+  | "mcp_server"
+  | "id";
 
 export interface SearchResult {
   id: string;
@@ -119,6 +128,7 @@ const ID_PREFIX_MAP: Record<
   session_: { category: "session", label: "Session", path: "/sessions" },
   harness_: { category: "harness", label: "Harness", path: "/harnesses" },
   skill_: { category: "skill", label: "Skill", path: "/skills" },
+  mcp_: { category: "mcp_server", label: "MCP Server", path: "/settings/mcp-servers" },
 };
 
 function matchesQuery(text: string, query: string): boolean {
@@ -132,11 +142,13 @@ export function useGlobalSearch(query: string) {
   const { data: sessionsData } = useSessions(undefined, { limit: 100 });
   const { data: harnessesData } = useHarnesses();
   const { data: skillsData } = useSkills();
+  const { data: mcpServersData } = useMcpServers();
 
   const agents = agentsData ?? EMPTY_ARRAY;
   const sessions = sessionsData?.data ?? EMPTY_ARRAY;
   const harnesses = harnessesData ?? EMPTY_ARRAY;
   const skills = skillsData ?? EMPTY_ARRAY;
+  const mcpServers = mcpServersData ?? EMPTY_ARRAY;
 
   return useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -156,16 +168,32 @@ export function useGlobalSearch(query: string) {
     const results: SearchResult[] = [];
     const MAX_PER_CATEGORY = 5;
 
-    // 1. ID-based lookup
+    // 1. ID-based lookup — resolve entity name from cached data when possible
     for (const [prefix, meta] of Object.entries(ID_PREFIX_MAP)) {
       if (q.startsWith(prefix) || q.startsWith(prefix.replace("_", ""))) {
         // Normalize: allow "session3242" or "session_3242"
         const idValue = q.startsWith(prefix) ? q : `${prefix}${q.slice(prefix.length - 1)}`;
+
+        // Try to resolve a friendly name from cached data
+        let resolvedName: string | undefined;
+        if (prefix === "agent_") {
+          resolvedName = agents.find((a) => a.id === idValue)?.name;
+        } else if (prefix === "session_") {
+          const s = sessions.find((s) => s.id === idValue);
+          resolvedName = s?.title || s?.preview;
+        } else if (prefix === "harness_") {
+          resolvedName = harnesses.find((h) => h.id === idValue)?.name;
+        } else if (prefix === "skill_") {
+          resolvedName = skills.find((s) => s.id === idValue)?.name;
+        } else if (prefix === "mcp_") {
+          resolvedName = mcpServers.find((m) => m.id === idValue)?.name;
+        }
+
         results.push({
           id: `id:${idValue}`,
           category: "id",
           icon: Boxes,
-          title: `Go to ${meta.label}`,
+          title: resolvedName ? `${meta.label}: ${resolvedName}` : `Go to ${meta.label}`,
           subtitle: idValue,
           href: `${meta.path}/${idValue}`,
         });
@@ -275,6 +303,27 @@ export function useGlobalSearch(query: string) {
       }
     }
 
+    // 7. MCP Servers
+    let mcpCount = 0;
+    for (const server of mcpServers) {
+      if (mcpCount >= MAX_PER_CATEGORY) break;
+      if (
+        matchesQuery(server.name, q) ||
+        (server.description && matchesQuery(server.description, q)) ||
+        matchesQuery(server.id, q)
+      ) {
+        results.push({
+          id: `mcp:${server.id}`,
+          category: "mcp_server",
+          icon: Server,
+          title: server.name,
+          subtitle: `MCP Servers > ${server.name}`,
+          href: `/settings/mcp-servers/${server.id}`,
+        });
+        mcpCount++;
+      }
+    }
+
     return results;
-  }, [query, agents, sessions, harnesses, skills]);
+  }, [query, agents, sessions, harnesses, skills, mcpServers]);
 }

--- a/apps/ui/src/hooks/use-global-search.ts
+++ b/apps/ui/src/hooks/use-global-search.ts
@@ -1,0 +1,280 @@
+/**
+ * Aggregates search results from multiple sources for the command palette.
+ *
+ * Sources:
+ * 1. Static navigation pages (always available, no fetch)
+ * 2. Agents (client-side filter over cached list)
+ * 3. Sessions (client-side filter over first page)
+ * 4. Harnesses (client-side filter over cached list)
+ * 5. Skills (client-side filter over cached list)
+ * 6. ID-based lookup (detects prefixed IDs and provides direct navigation)
+ *
+ * All entity searches are client-side over already-fetched React Query data.
+ * Backend search endpoints will be added incrementally.
+ */
+"use client";
+
+import { useMemo } from "react";
+import {
+  LayoutDashboard,
+  MessageSquare,
+  Shield,
+  Boxes,
+  BookOpen,
+  Puzzle,
+  Rocket,
+  Settings,
+  Cog,
+  Server,
+  Workflow,
+  ListTodo,
+  Calendar,
+  MessageCircle,
+  FlaskConical,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { useAgents } from "@/hooks/use-agents";
+import { useSessions } from "@/hooks/use-sessions";
+import { useHarnesses } from "@/hooks/use-harnesses";
+import { useSkills } from "@/hooks/use-skills";
+
+export type SearchResultCategory = "navigation" | "agent" | "session" | "harness" | "skill" | "id";
+
+export interface SearchResult {
+  id: string;
+  category: SearchResultCategory;
+  icon: LucideIcon;
+  title: string;
+  /** Breadcrumb-style subtitle, e.g. "Agents > Daytona Coder" */
+  subtitle?: string;
+  href: string;
+}
+
+interface NavigationPage {
+  title: string;
+  href: string;
+  icon: LucideIcon;
+  keywords?: string[];
+}
+
+const NAVIGATION_PAGES: NavigationPage[] = [
+  { title: "Dashboard", href: "/dashboard", icon: LayoutDashboard, keywords: ["home", "overview"] },
+  { title: "Sessions", href: "/sessions", icon: MessageSquare, keywords: ["chat", "conversation"] },
+  { title: "Chat", href: "/chat", icon: MessageCircle, keywords: ["global chat"] },
+  { title: "Agents", href: "/agents", icon: Boxes, keywords: ["bot", "assistant"] },
+  { title: "Harnesses", href: "/harnesses", icon: Shield, keywords: ["template", "config"] },
+  { title: "Skills", href: "/skills", icon: BookOpen, keywords: ["ability", "tool"] },
+  { title: "Capabilities", href: "/capabilities", icon: Puzzle },
+  { title: "Apps", href: "/apps", icon: Rocket, keywords: ["deploy", "channel"] },
+  { title: "Settings", href: "/settings", icon: Settings, keywords: ["preferences", "config"] },
+  {
+    title: "Settings > Profile",
+    href: "/settings",
+    icon: Settings,
+    keywords: ["account", "profile"],
+  },
+  {
+    title: "Settings > API Keys",
+    href: "/settings/api-keys",
+    icon: Settings,
+    keywords: ["token", "key"],
+  },
+  {
+    title: "Settings > Connections",
+    href: "/settings/connections",
+    icon: Settings,
+    keywords: ["github", "gitlab"],
+  },
+  {
+    title: "Settings > LLM Providers",
+    href: "/settings/llm-providers",
+    icon: Settings,
+    keywords: ["openai", "anthropic", "model"],
+  },
+  {
+    title: "Settings > MCP Servers",
+    href: "/settings/mcp-servers",
+    icon: Settings,
+    keywords: ["mcp", "server"],
+  },
+  {
+    title: "Durable Execution",
+    href: "/durable",
+    icon: Cog,
+    keywords: ["workflow", "worker", "queue"],
+  },
+  { title: "Durable > Workers", href: "/durable/workers", icon: Server },
+  { title: "Durable > Workflows", href: "/durable/workflows", icon: Workflow },
+  { title: "Durable > Queues", href: "/durable/queues", icon: ListTodo },
+  { title: "Durable > Schedules", href: "/durable/schedules", icon: Calendar },
+  { title: "Dev Tools", href: "/dev", icon: FlaskConical },
+];
+
+/** Known ID prefixes and where they resolve. */
+const ID_PREFIX_MAP: Record<
+  string,
+  { category: SearchResultCategory; label: string; path: string }
+> = {
+  agent_: { category: "agent", label: "Agent", path: "/agents" },
+  session_: { category: "session", label: "Session", path: "/sessions" },
+  harness_: { category: "harness", label: "Harness", path: "/harnesses" },
+  skill_: { category: "skill", label: "Skill", path: "/skills" },
+};
+
+function matchesQuery(text: string, query: string): boolean {
+  return text.toLowerCase().includes(query);
+}
+
+const EMPTY_ARRAY: never[] = [];
+
+export function useGlobalSearch(query: string) {
+  const { data: agentsData } = useAgents();
+  const { data: sessionsData } = useSessions(undefined, { limit: 100 });
+  const { data: harnessesData } = useHarnesses();
+  const { data: skillsData } = useSkills();
+
+  const agents = agentsData ?? EMPTY_ARRAY;
+  const sessions = sessionsData?.data ?? EMPTY_ARRAY;
+  const harnesses = harnessesData ?? EMPTY_ARRAY;
+  const skills = skillsData ?? EMPTY_ARRAY;
+
+  return useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) {
+      // Show top navigation pages when empty
+      return NAVIGATION_PAGES.slice(0, 6).map(
+        (page): SearchResult => ({
+          id: `nav:${page.href}`,
+          category: "navigation",
+          icon: page.icon,
+          title: page.title,
+          href: page.href,
+        }),
+      );
+    }
+
+    const results: SearchResult[] = [];
+    const MAX_PER_CATEGORY = 5;
+
+    // 1. ID-based lookup
+    for (const [prefix, meta] of Object.entries(ID_PREFIX_MAP)) {
+      if (q.startsWith(prefix) || q.startsWith(prefix.replace("_", ""))) {
+        // Normalize: allow "session3242" or "session_3242"
+        const idValue = q.startsWith(prefix) ? q : `${prefix}${q.slice(prefix.length - 1)}`;
+        results.push({
+          id: `id:${idValue}`,
+          category: "id",
+          icon: Boxes,
+          title: `Go to ${meta.label}`,
+          subtitle: idValue,
+          href: `${meta.path}/${idValue}`,
+        });
+      }
+    }
+
+    // 2. Navigation pages
+    let navCount = 0;
+    for (const page of NAVIGATION_PAGES) {
+      if (navCount >= MAX_PER_CATEGORY) break;
+      const matches =
+        matchesQuery(page.title, q) || page.keywords?.some((kw) => matchesQuery(kw, q));
+      if (matches) {
+        results.push({
+          id: `nav:${page.href}`,
+          category: "navigation",
+          icon: page.icon,
+          title: page.title,
+          href: page.href,
+        });
+        navCount++;
+      }
+    }
+
+    // 3. Agents
+    let agentCount = 0;
+    for (const agent of agents) {
+      if (agentCount >= MAX_PER_CATEGORY) break;
+      if (
+        matchesQuery(agent.name, q) ||
+        (agent.description && matchesQuery(agent.description, q)) ||
+        matchesQuery(agent.id, q)
+      ) {
+        results.push({
+          id: `agent:${agent.id}`,
+          category: "agent",
+          icon: Boxes,
+          title: agent.name,
+          subtitle: `Agents > ${agent.name}`,
+          href: `/agents/${agent.id}`,
+        });
+        agentCount++;
+      }
+    }
+
+    // 4. Sessions
+    let sessionCount = 0;
+    for (const session of sessions) {
+      if (sessionCount >= MAX_PER_CATEGORY) break;
+      const title = session.title || session.preview || session.id;
+      if (
+        matchesQuery(title, q) ||
+        matchesQuery(session.id, q) ||
+        (session.preview && matchesQuery(session.preview, q))
+      ) {
+        results.push({
+          id: `session:${session.id}`,
+          category: "session",
+          icon: MessageSquare,
+          title: title,
+          subtitle: `Sessions > ${title.length > 40 ? title.slice(0, 40) + "..." : title}`,
+          href: `/sessions/${session.id}`,
+        });
+        sessionCount++;
+      }
+    }
+
+    // 5. Harnesses
+    let harnessCount = 0;
+    for (const harness of harnesses) {
+      if (harnessCount >= MAX_PER_CATEGORY) break;
+      if (
+        matchesQuery(harness.name, q) ||
+        (harness.description && matchesQuery(harness.description, q)) ||
+        matchesQuery(harness.id, q)
+      ) {
+        results.push({
+          id: `harness:${harness.id}`,
+          category: "harness",
+          icon: Shield,
+          title: harness.name,
+          subtitle: `Harnesses > ${harness.name}`,
+          href: `/harnesses/${harness.id}`,
+        });
+        harnessCount++;
+      }
+    }
+
+    // 6. Skills
+    let skillCount = 0;
+    for (const skill of skills) {
+      if (skillCount >= MAX_PER_CATEGORY) break;
+      if (
+        matchesQuery(skill.name, q) ||
+        (skill.description && matchesQuery(skill.description, q)) ||
+        matchesQuery(skill.id, q)
+      ) {
+        results.push({
+          id: `skill:${skill.id}`,
+          category: "skill",
+          icon: BookOpen,
+          title: skill.name,
+          subtitle: `Skills > ${skill.name}`,
+          href: `/skills/${skill.id}`,
+        });
+        skillCount++;
+      }
+    }
+
+    return results;
+  }, [query, agents, sessions, harnesses, skills]);
+}

--- a/apps/ui/src/hooks/use-global-search.ts
+++ b/apps/ui/src/hooks/use-global-search.ts
@@ -131,8 +131,18 @@ const ID_PREFIX_MAP: Record<
   mcp_: { category: "mcp_server", label: "MCP Server", path: "/settings/mcp-servers" },
 };
 
-function matchesQuery(text: string, query: string): boolean {
-  return text.toLowerCase().includes(query);
+/**
+ * Tokenized multi-word search. Every word in the query must appear
+ * somewhere in the combined searchable text. This means "Daytona Agent"
+ * matches an agent named "Daytona Coder" because "daytona" hits the name
+ * and "agent" hits the category context passed via `extraContext`.
+ */
+function matchesTokens(tokens: string[], ...texts: (string | undefined | null)[]): boolean {
+  const combined = texts
+    .filter(Boolean)
+    .map((t) => t!.toLowerCase())
+    .join(" ");
+  return tokens.every((token) => combined.includes(token));
 }
 
 const EMPTY_ARRAY: never[] = [];
@@ -165,6 +175,7 @@ export function useGlobalSearch(query: string) {
       );
     }
 
+    const tokens = q.split(/\s+/).filter(Boolean);
     const results: SearchResult[] = [];
     const MAX_PER_CATEGORY = 5;
 
@@ -204,9 +215,7 @@ export function useGlobalSearch(query: string) {
     let navCount = 0;
     for (const page of NAVIGATION_PAGES) {
       if (navCount >= MAX_PER_CATEGORY) break;
-      const matches =
-        matchesQuery(page.title, q) || page.keywords?.some((kw) => matchesQuery(kw, q));
-      if (matches) {
+      if (matchesTokens(tokens, page.title, ...(page.keywords ?? []))) {
         results.push({
           id: `nav:${page.href}`,
           category: "navigation",
@@ -222,11 +231,7 @@ export function useGlobalSearch(query: string) {
     let agentCount = 0;
     for (const agent of agents) {
       if (agentCount >= MAX_PER_CATEGORY) break;
-      if (
-        matchesQuery(agent.name, q) ||
-        (agent.description && matchesQuery(agent.description, q)) ||
-        matchesQuery(agent.id, q)
-      ) {
+      if (matchesTokens(tokens, agent.name, agent.description, agent.id, "agent")) {
         results.push({
           id: `agent:${agent.id}`,
           category: "agent",
@@ -244,11 +249,7 @@ export function useGlobalSearch(query: string) {
     for (const session of sessions) {
       if (sessionCount >= MAX_PER_CATEGORY) break;
       const title = session.title || session.preview || session.id;
-      if (
-        matchesQuery(title, q) ||
-        matchesQuery(session.id, q) ||
-        (session.preview && matchesQuery(session.preview, q))
-      ) {
+      if (matchesTokens(tokens, title, session.id, session.preview, "session")) {
         results.push({
           id: `session:${session.id}`,
           category: "session",
@@ -265,11 +266,7 @@ export function useGlobalSearch(query: string) {
     let harnessCount = 0;
     for (const harness of harnesses) {
       if (harnessCount >= MAX_PER_CATEGORY) break;
-      if (
-        matchesQuery(harness.name, q) ||
-        (harness.description && matchesQuery(harness.description, q)) ||
-        matchesQuery(harness.id, q)
-      ) {
+      if (matchesTokens(tokens, harness.name, harness.description, harness.id, "harness")) {
         results.push({
           id: `harness:${harness.id}`,
           category: "harness",
@@ -286,11 +283,7 @@ export function useGlobalSearch(query: string) {
     let skillCount = 0;
     for (const skill of skills) {
       if (skillCount >= MAX_PER_CATEGORY) break;
-      if (
-        matchesQuery(skill.name, q) ||
-        (skill.description && matchesQuery(skill.description, q)) ||
-        matchesQuery(skill.id, q)
-      ) {
+      if (matchesTokens(tokens, skill.name, skill.description, skill.id, "skill")) {
         results.push({
           id: `skill:${skill.id}`,
           category: "skill",
@@ -307,11 +300,7 @@ export function useGlobalSearch(query: string) {
     let mcpCount = 0;
     for (const server of mcpServers) {
       if (mcpCount >= MAX_PER_CATEGORY) break;
-      if (
-        matchesQuery(server.name, q) ||
-        (server.description && matchesQuery(server.description, q)) ||
-        matchesQuery(server.id, q)
-      ) {
+      if (matchesTokens(tokens, server.name, server.description, server.id, "mcp server")) {
         results.push({
           id: `mcp:${server.id}`,
           category: "mcp_server",

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -717,6 +717,7 @@ export type AuthMode = "none" | "admin" | "full" | "external";
 export interface FeatureFlags {
   global_chat: boolean;
   apps: boolean;
+  global_search: boolean;
 }
 
 export interface AuthConfigResponse {

--- a/apps/ui/src/providers/feature-flags-provider.tsx
+++ b/apps/ui/src/providers/feature-flags-provider.tsx
@@ -14,6 +14,7 @@ import type { FeatureFlags } from "@/lib/api/types";
 const DEFAULT_FLAGS: FeatureFlags = {
   global_chat: false,
   apps: false,
+  global_search: false,
 };
 
 export interface FeatureFlagsContextValue {

--- a/crates/core/src/feature_flags.rs
+++ b/crates/core/src/feature_flags.rs
@@ -21,6 +21,8 @@ pub struct FeatureFlags {
     pub global_chat: bool,
     /// Apps (agent deployment to distribution channels). Experimental.
     pub apps: bool,
+    /// Global search / command palette (Cmd+K). Experimental.
+    pub global_search: bool,
 }
 
 impl FeatureFlags {
@@ -29,6 +31,7 @@ impl FeatureFlags {
         Self {
             global_chat: experimental_flag("FEATURE_GLOBAL_CHAT", grade),
             apps: experimental_flag("FEATURE_APPS", grade),
+            global_search: experimental_flag("FEATURE_GLOBAL_SEARCH", grade),
         }
     }
 
@@ -37,6 +40,7 @@ impl FeatureFlags {
         match flag {
             "global_chat" => self.global_chat,
             "apps" => self.apps,
+            "global_search" => self.global_search,
             _ => false,
         }
     }
@@ -47,6 +51,7 @@ impl FeatureFlags {
         Self {
             global_chat: true,
             apps: true,
+            global_search: true,
         }
     }
 }
@@ -80,6 +85,7 @@ mod tests {
         let flags = FeatureFlags::default();
         assert!(!flags.global_chat);
         assert!(!flags.apps);
+        assert!(!flags.global_search);
     }
 
     // SAFETY: env var tests must run single-threaded (--test-threads=1).
@@ -89,18 +95,22 @@ mod tests {
     fn test_experimental_enabled_in_dev() {
         unsafe { std::env::remove_var("FEATURE_GLOBAL_CHAT") };
         unsafe { std::env::remove_var("FEATURE_APPS") };
+        unsafe { std::env::remove_var("FEATURE_GLOBAL_SEARCH") };
         let flags = FeatureFlags::from_env(&DeploymentGrade::Dev);
         assert!(flags.global_chat);
         assert!(flags.apps);
+        assert!(flags.global_search);
     }
 
     #[test]
     fn test_experimental_disabled_in_prod() {
         unsafe { std::env::remove_var("FEATURE_GLOBAL_CHAT") };
         unsafe { std::env::remove_var("FEATURE_APPS") };
+        unsafe { std::env::remove_var("FEATURE_GLOBAL_SEARCH") };
         let flags = FeatureFlags::from_env(&DeploymentGrade::Prod);
         assert!(!flags.global_chat);
         assert!(!flags.apps);
+        assert!(!flags.global_search);
     }
 
     #[test]
@@ -124,9 +134,11 @@ mod tests {
         let flags = FeatureFlags {
             global_chat: true,
             apps: true,
+            global_search: true,
         };
         assert!(flags.is_enabled("global_chat"));
         assert!(flags.is_enabled("apps"));
+        assert!(flags.is_enabled("global_search"));
         assert!(!flags.is_enabled("nonexistent"));
     }
 
@@ -135,9 +147,11 @@ mod tests {
         let flags = FeatureFlags {
             global_chat: true,
             apps: true,
+            global_search: true,
         };
         let json = serde_json::to_string(&flags).unwrap();
         assert!(json.contains("\"global_chat\":true"));
+        assert!(json.contains("\"global_search\":true"));
 
         let parsed: FeatureFlags = serde_json::from_str(&json).unwrap();
         assert_eq!(flags, parsed);

--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -7,7 +7,7 @@ use axum::extract::FromRef;
 use axum::{
     Json, Router,
     body::Body,
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::{StatusCode, header},
     response::Response,
     routing::{get, post},
@@ -22,7 +22,7 @@ use super::validation::{
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use utoipa::ToSchema;
+use utoipa::{IntoParams, ToSchema};
 
 /// Request to create a new agent
 #[derive(Debug, Clone, Deserialize, ToSchema)]
@@ -170,6 +170,13 @@ struct AgentFile {
 
 use crate::services::{AgentService, CapabilityService};
 
+/// Query parameters for listing agents.
+#[derive(Debug, Clone, Deserialize, IntoParams)]
+pub struct ListAgentsQuery {
+    /// Search by name or description (case-insensitive substring match).
+    pub search: Option<String>,
+}
+
 /// App state for agents routes
 #[derive(Clone)]
 pub struct AppState {
@@ -290,6 +297,7 @@ pub async fn create_agent(
 #[utoipa::path(
     get,
     path = "/v1/agents",
+    params(ListAgentsQuery),
     responses(
         (status = 200, description = "List of agents", body = ListResponse<Agent>),
         (status = 500, description = "Internal server error")
@@ -299,10 +307,11 @@ pub async fn create_agent(
 pub async fn list_agents(
     org: ResolvedOrg,
     State(state): State<AppState>,
+    Query(query): Query<ListAgentsQuery>,
 ) -> Result<Json<ListResponse<Agent>>, StatusCode> {
     let agents = state
         .service
-        .list(org.org_id)
+        .list(org.org_id, query.search.as_deref())
         .await
         .log_internal_error("list agents")?;
 

--- a/crates/server/src/api/apps.rs
+++ b/crates/server/src/api/apps.rs
@@ -6,7 +6,7 @@ use crate::storage::StorageBackend;
 use axum::extract::FromRef;
 use axum::{
     Json, Router,
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     routing::{get, post},
 };
@@ -16,7 +16,7 @@ use everruns_core::{App, AppStatus, ChannelType};
 use super::common::{ApiOptionExt, ApiResultExt, ErrorResponse, ListResponse};
 use serde::Deserialize;
 use std::sync::Arc;
-use utoipa::ToSchema;
+use utoipa::{IntoParams, ToSchema};
 
 use crate::services::AppService;
 
@@ -69,6 +69,13 @@ pub struct UpdateAppRequest {
     /// Lifecycle status (draft or archived). Use publish/unpublish endpoints for publishing.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<AppStatus>,
+}
+
+/// Query parameters for listing apps.
+#[derive(Debug, Clone, Deserialize, IntoParams)]
+pub struct ListAppsQuery {
+    /// Search by name or description (case-insensitive substring match).
+    pub search: Option<String>,
 }
 
 /// App state for routes
@@ -143,15 +150,17 @@ pub async fn create_app(
         (status = 200, description = "List of apps", body = ListResponse<App>),
         (status = 500, description = "Internal server error")
     ),
+    params(ListAppsQuery),
     tag = "apps"
 )]
 pub async fn list_apps(
     org: ResolvedOrg,
     State(state): State<AppState>,
+    Query(query): Query<ListAppsQuery>,
 ) -> Result<Json<ListResponse<App>>, StatusCode> {
     let apps = state
         .service
-        .list(org.org_id)
+        .list(org.org_id, query.search.as_deref())
         .await
         .log_internal_error("list apps")?;
 

--- a/crates/server/src/api/harnesses.rs
+++ b/crates/server/src/api/harnesses.rs
@@ -6,7 +6,7 @@ use crate::storage::StorageBackend;
 use axum::extract::FromRef;
 use axum::{
     Json, Router,
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     routing::{get, post},
 };
@@ -17,7 +17,7 @@ use super::common::{ApiOptionExt, ApiResultExt, ErrorResponse, ListResponse};
 use super::validation::{validate_create_agent_input, validate_update_agent_input};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use utoipa::ToSchema;
+use utoipa::{IntoParams, ToSchema};
 
 use crate::services::{CapabilityService, HarnessService};
 
@@ -84,6 +84,13 @@ pub struct HarnessPreviewResponse {
     pub system_prompt: String,
     #[schema(value_type = Vec<Object>)]
     pub tools: Vec<ToolDefinition>,
+}
+
+/// Query parameters for listing harnesses.
+#[derive(Debug, Clone, Deserialize, IntoParams)]
+pub struct ListHarnessesQuery {
+    /// Search by name or description (case-insensitive substring match).
+    pub search: Option<String>,
 }
 
 /// App state for harness routes
@@ -171,15 +178,17 @@ pub async fn create_harness(
         (status = 200, description = "List of harnesses", body = ListResponse<Harness>),
         (status = 500, description = "Internal server error")
     ),
+    params(ListHarnessesQuery),
     tag = "harnesses"
 )]
 pub async fn list_harnesses(
     org: ResolvedOrg,
     State(state): State<AppState>,
+    Query(query): Query<ListHarnessesQuery>,
 ) -> Result<Json<ListResponse<Harness>>, StatusCode> {
     let harnesses = state
         .service
-        .list(org.org_id)
+        .list(org.org_id, query.search.as_deref())
         .await
         .log_internal_error("list harnesses")?;
 

--- a/crates/server/src/api/mcp_servers.rs
+++ b/crates/server/src/api/mcp_servers.rs
@@ -7,7 +7,7 @@ use crate::storage::{EncryptionService, StorageBackend};
 use axum::extract::FromRef;
 use axum::{
     Json, Router,
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     routing::{get, post},
 };
@@ -18,7 +18,14 @@ use super::common::{ApiOptionExt, ApiResultExt, ErrorResponse, ListResponse};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
-use utoipa::ToSchema;
+use utoipa::{IntoParams, ToSchema};
+
+/// Query parameters for listing MCP servers.
+#[derive(Debug, Clone, Deserialize, IntoParams)]
+pub struct ListMcpServersQuery {
+    /// Search by name or description (case-insensitive substring match).
+    pub search: Option<String>,
+}
 
 /// Request to create a new MCP server
 #[derive(Debug, Clone, Deserialize, ToSchema)]
@@ -186,15 +193,17 @@ pub async fn create_mcp_server(
         (status = 200, description = "List of MCP servers", body = ListResponse<McpServer>),
         (status = 500, description = "Internal server error")
     ),
+    params(ListMcpServersQuery),
     tag = "mcp-servers"
 )]
 pub async fn list_mcp_servers(
     org: ResolvedOrg,
     State(state): State<AppState>,
+    Query(query): Query<ListMcpServersQuery>,
 ) -> Result<Json<ListResponse<McpServer>>, StatusCode> {
     let servers = state
         .service
-        .list(org.org_id)
+        .list(org.org_id, query.search.as_deref())
         .await
         .log_internal_error("list MCP servers")?;
 

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -95,6 +95,8 @@ pub struct ListSessionsQuery {
     /// Filter sessions by agent ID.
     #[param(value_type = Option<String>, example = "agent_01933b5a00007000800000000000001")]
     pub agent_id: Option<AgentId>,
+    /// Search by title (case-insensitive substring match).
+    pub search: Option<String>,
     /// Number of items to skip (for pagination).
     #[param(minimum = 0, default = 0)]
     pub offset: Option<u32>,
@@ -302,6 +304,7 @@ pub async fn list_sessions(
             &org.public_id,
             agent_internal_id,
             org.user_id,
+            query.search.as_deref(),
             pagination,
         )
         .await

--- a/crates/server/src/api/skills.rs
+++ b/crates/server/src/api/skills.rs
@@ -11,7 +11,7 @@ use crate::storage::StorageBackend;
 use axum::extract::FromRef;
 use axum::{
     Json, Router,
-    extract::{DefaultBodyLimit, Path, State},
+    extract::{DefaultBodyLimit, Path, Query, State},
     http::StatusCode,
     routing::{get, post},
 };
@@ -19,7 +19,7 @@ use axum_extra::extract::Multipart;
 use everruns_core::{Skill, SkillContent, SkillId, SkillStatus, SkillValidationResult};
 use serde::Deserialize;
 use std::sync::Arc;
-use utoipa::ToSchema;
+use utoipa::{IntoParams, ToSchema};
 
 // ============================================
 // Constants
@@ -63,6 +63,13 @@ pub struct ValidateSkillRequest {
 // ============================================
 // App State
 // ============================================
+
+/// Query parameters for listing skills.
+#[derive(Debug, Clone, Deserialize, IntoParams)]
+pub struct ListSkillsQuery {
+    /// Search by name or description (case-insensitive substring match).
+    pub search: Option<String>,
+}
 
 #[derive(Clone)]
 pub struct AppState {
@@ -210,15 +217,17 @@ pub async fn upload_skill(
     responses(
         (status = 200, description = "List of skills", body = ListResponse<Skill>),
     ),
+    params(ListSkillsQuery),
     tag = "skills"
 )]
 pub async fn list_skills(
     org: ResolvedOrg,
     State(state): State<AppState>,
+    Query(query): Query<ListSkillsQuery>,
 ) -> Result<Json<ListResponse<Skill>>, StatusCode> {
     let skills = state
         .service
-        .list(org.org_id)
+        .list(org.org_id, query.search.as_deref())
         .await
         .log_internal_error("list skills")?;
 

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1198,7 +1198,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
     async fn list_harnesses(&self) -> everruns_core::error::Result<Vec<Harness>> {
         let rows = self
             .db
-            .list_harnesses(self.org_id)
+            .list_harnesses(self.org_id, None)
             .await
             .map_err(|e| store_error(format!("Failed to list harnesses: {e}")))?;
 
@@ -1360,7 +1360,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
     async fn list_agents(&self) -> everruns_core::error::Result<Vec<Agent>> {
         let rows = self
             .db
-            .list_agents(self.org_id)
+            .list_agents(self.org_id, None)
             .await
             .map_err(|e| store_error(format!("Failed to list agents: {e}")))?;
 
@@ -1505,7 +1505,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
         };
         let (rows, _total) = self
             .db
-            .list_sessions(self.org_id, agent_id, pagination)
+            .list_sessions(self.org_id, agent_id, None, pagination)
             .await
             .map_err(|e| store_error(format!("Failed to list sessions: {e}")))?;
 

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -3011,7 +3011,7 @@ impl WorkerService for WorkerServiceImpl {
         let req = request.into_inner();
         let harnesses = self
             .harness_service
-            .list(req.org_id)
+            .list(req.org_id, None)
             .await
             .map_err(|e| Status::internal(format!("Failed to list harnesses: {}", e)))?;
 
@@ -3142,7 +3142,7 @@ impl WorkerService for WorkerServiceImpl {
         let req = request.into_inner();
         let agents = self
             .agent_service
-            .list(req.org_id)
+            .list(req.org_id, None)
             .await
             .map_err(|e| Status::internal(format!("Failed to list agents: {}", e)))?;
 
@@ -3263,7 +3263,7 @@ impl WorkerService for WorkerServiceImpl {
 
         let (sessions, _total) = self
             .session_service
-            .list(req.org_id, &org_public_id, agent_id, None, pagination)
+            .list(req.org_id, &org_public_id, agent_id, None, None, pagination)
             .await
             .map_err(|e| Status::internal(format!("Failed to list sessions: {}", e)))?;
 

--- a/crates/server/src/services/agent.rs
+++ b/crates/server/src/services/agent.rs
@@ -114,8 +114,8 @@ impl AgentService {
         }
     }
 
-    pub async fn list(&self, org_id: i64) -> Result<Vec<Agent>> {
-        let rows = self.db.list_agents(org_id).await?;
+    pub async fn list(&self, org_id: i64, search: Option<&str>) -> Result<Vec<Agent>> {
+        let rows = self.db.list_agents(org_id, search).await?;
 
         // Fetch capabilities for each agent
         let mut agents = Vec::with_capacity(rows.len());

--- a/crates/server/src/services/app.rs
+++ b/crates/server/src/services/app.rs
@@ -73,8 +73,8 @@ impl AppService {
         }
     }
 
-    pub async fn list(&self, org_id: i64) -> Result<Vec<App>> {
-        let rows = self.db.list_apps(org_id).await?;
+    pub async fn list(&self, org_id: i64, search: Option<&str>) -> Result<Vec<App>> {
+        let rows = self.db.list_apps(org_id, search).await?;
         let mut apps = Vec::with_capacity(rows.len());
         for row in rows {
             apps.push(self.row_to_app(row, org_id).await);

--- a/crates/server/src/services/capability.rs
+++ b/crates/server/src/services/capability.rs
@@ -86,7 +86,7 @@ impl CapabilityService {
         }
 
         // Get skill capabilities from the registry (mount-only, no prompt/tools)
-        let skills = self.skill_service.list(org_id).await?;
+        let skills = self.skill_service.list(org_id, None).await?;
         for skill in &skills {
             if skill.status != everruns_core::SkillStatus::Active {
                 continue;
@@ -257,7 +257,7 @@ impl CapabilityService {
         &self,
         org_id: i64,
     ) -> Result<Vec<everruns_core::command::CommandDescriptor>> {
-        let skills = self.skill_service.list(org_id).await?;
+        let skills = self.skill_service.list(org_id, None).await?;
         let commands = skills
             .into_iter()
             .filter(|s| s.status == everruns_core::SkillStatus::Active && s.user_invocable)

--- a/crates/server/src/services/harness.rs
+++ b/crates/server/src/services/harness.rs
@@ -71,8 +71,8 @@ impl HarnessService {
         }
     }
 
-    pub async fn list(&self, org_id: i64) -> Result<Vec<Harness>> {
-        let rows = self.db.list_harnesses(org_id).await?;
+    pub async fn list(&self, org_id: i64, search: Option<&str>) -> Result<Vec<Harness>> {
+        let rows = self.db.list_harnesses(org_id, search).await?;
 
         let mut harnesses = Vec::with_capacity(rows.len());
         for row in rows {

--- a/crates/server/src/services/mcp_server.rs
+++ b/crates/server/src/services/mcp_server.rs
@@ -88,8 +88,8 @@ impl McpServerService {
             .collect())
     }
 
-    pub async fn list(&self, org_id: i64) -> Result<Vec<McpServer>> {
-        let rows = self.db.list_mcp_servers(org_id).await?;
+    pub async fn list(&self, org_id: i64, search: Option<&str>) -> Result<Vec<McpServer>> {
+        let rows = self.db.list_mcp_servers(org_id, search).await?;
         Ok(rows.iter().map(Self::row_to_mcp_server).collect())
     }
 
@@ -261,7 +261,7 @@ impl McpServerService {
         org_id: i64,
         server_prefix: &str,
     ) -> Result<Option<McpServerResolved>> {
-        let servers = self.list(org_id).await?;
+        let servers = self.list(org_id, None).await?;
         let server_prefix_lower = server_prefix.to_lowercase();
 
         let server = servers.into_iter().find(|s| {

--- a/crates/server/src/services/session.rs
+++ b/crates/server/src/services/session.rs
@@ -236,10 +236,14 @@ impl SessionService {
         org_public_id: &str,
         agent_id: Option<Uuid>,
         user_id: Option<Uuid>,
+        search: Option<&str>,
         pagination: Pagination,
     ) -> Result<(Vec<Session>, u32)> {
         let agent_id = agent_id.map(AgentId::from_uuid);
-        let (rows, total) = self.db.list_sessions(org_id, agent_id, pagination).await?;
+        let (rows, total) = self
+            .db
+            .list_sessions(org_id, agent_id, search, pagination)
+            .await?;
         let mut sessions: Vec<Session> = rows
             .into_iter()
             .map(|r| Self::row_to_session(r, org_public_id))

--- a/crates/server/src/services/skill.rs
+++ b/crates/server/src/services/skill.rs
@@ -180,16 +180,23 @@ impl SkillService {
         Ok(row.as_ref().map(Self::row_to_skill))
     }
 
-    pub async fn list(&self, org_id: i64) -> Result<Vec<Skill>> {
-        if let Some(cached) = self.list_cache.get(&org_id).await {
+    pub async fn list(&self, org_id: i64, search: Option<&str>) -> Result<Vec<Skill>> {
+        // Only use cache for unfiltered list
+        if search.is_none()
+            && let Some(cached) = self.list_cache.get(&org_id).await
+        {
             return Ok((*cached).clone());
         }
 
-        let rows = self.db.list_skills(org_id).await?;
+        let rows = self.db.list_skills(org_id, search).await?;
         let skills: Vec<Skill> = rows.iter().map(Self::row_to_skill).collect();
-        self.list_cache
-            .insert(org_id, Arc::new(skills.clone()))
-            .await;
+
+        // Only populate cache for unfiltered list
+        if search.is_none() {
+            self.list_cache
+                .insert(org_id, Arc::new(skills.clone()))
+                .await;
+        }
         Ok(skills)
     }
 
@@ -586,7 +593,7 @@ mod tests {
         assert!(!is_cached(&svc, org_id).await);
 
         // First list call populates cache
-        let skills = svc.list(org_id).await.unwrap();
+        let skills = svc.list(org_id, None).await.unwrap();
         assert_eq!(skills.len(), 1);
         assert_eq!(skills[0].name, "cache-test");
 
@@ -606,7 +613,7 @@ mod tests {
         svc.create(org_id, req).await.unwrap();
 
         // First list populates cache
-        let first = svc.list(org_id).await.unwrap();
+        let first = svc.list(org_id, None).await.unwrap();
         assert_eq!(first.len(), 1);
 
         // Insert a skill directly into DB to prove cache is being used
@@ -627,7 +634,7 @@ mod tests {
         svc.db.create_skill(org_id, input).await.unwrap();
 
         // Second list should return cached result (1 skill, not 2)
-        let second = svc.list(org_id).await.unwrap();
+        let second = svc.list(org_id, None).await.unwrap();
         assert_eq!(second.len(), 1);
         assert_eq!(second[0].name, "cached-skill");
     }
@@ -642,7 +649,7 @@ mod tests {
             skill_md: test_skill_md("skill-one"),
         };
         svc.create(org_id, req).await.unwrap();
-        let skills = svc.list(org_id).await.unwrap();
+        let skills = svc.list(org_id, None).await.unwrap();
         assert_eq!(skills.len(), 1);
         assert!(is_cached(&svc, org_id).await);
 
@@ -654,7 +661,7 @@ mod tests {
         assert!(!is_cached(&svc, org_id).await);
 
         // Next list should show both skills
-        let skills = svc.list(org_id).await.unwrap();
+        let skills = svc.list(org_id, None).await.unwrap();
         assert_eq!(skills.len(), 2);
     }
 
@@ -669,7 +676,7 @@ mod tests {
         let skill = svc.create(org_id, req).await.unwrap();
 
         // Populate cache
-        svc.list(org_id).await.unwrap();
+        svc.list(org_id, None).await.unwrap();
         assert!(is_cached(&svc, org_id).await);
 
         // Update skill - should invalidate cache
@@ -683,7 +690,7 @@ mod tests {
         assert!(!is_cached(&svc, org_id).await);
 
         // Next list should reflect the update
-        let skills = svc.list(org_id).await.unwrap();
+        let skills = svc.list(org_id, None).await.unwrap();
         assert_eq!(skills.len(), 1);
         assert_eq!(skills[0].name, "updated-name");
     }
@@ -699,7 +706,7 @@ mod tests {
         let skill = svc.create(org_id, req).await.unwrap();
 
         // Populate cache
-        svc.list(org_id).await.unwrap();
+        svc.list(org_id, None).await.unwrap();
         assert!(is_cached(&svc, org_id).await);
 
         // Delete skill - should invalidate cache
@@ -708,7 +715,7 @@ mod tests {
         assert!(!is_cached(&svc, org_id).await);
 
         // Next list should be empty
-        let skills = svc.list(org_id).await.unwrap();
+        let skills = svc.list(org_id, None).await.unwrap();
         assert!(skills.is_empty());
     }
 
@@ -731,8 +738,8 @@ mod tests {
         svc.create(org_b, req_b).await.unwrap();
 
         // Populate both caches
-        let skills_a = svc.list(org_a).await.unwrap();
-        let skills_b = svc.list(org_b).await.unwrap();
+        let skills_a = svc.list(org_a, None).await.unwrap();
+        let skills_b = svc.list(org_b, None).await.unwrap();
         assert_eq!(skills_a.len(), 1);
         assert_eq!(skills_b.len(), 1);
         assert_eq!(skills_a[0].name, "org-a-skill");
@@ -747,7 +754,7 @@ mod tests {
         assert!(is_cached(&svc, org_b).await);
 
         // Org B still returns cached result
-        let skills_b_cached = svc.list(org_b).await.unwrap();
+        let skills_b_cached = svc.list(org_b, None).await.unwrap();
         assert_eq!(skills_b_cached.len(), 1);
         assert_eq!(skills_b_cached[0].name, "org-b-skill");
     }

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -204,8 +204,8 @@ impl StorageBackend {
         dispatch!(self, get_agent_by_public_id, org_id, public_id)
     }
 
-    pub async fn list_agents(&self, org_id: i64) -> Result<Vec<AgentRow>> {
-        dispatch!(self, list_agents, org_id)
+    pub async fn list_agents(&self, org_id: i64, search: Option<&str>) -> Result<Vec<AgentRow>> {
+        dispatch!(self, list_agents, org_id, search)
     }
 
     pub async fn get_agent_by_name(&self, org_id: i64, name: &str) -> Result<Option<AgentRow>> {
@@ -258,8 +258,12 @@ impl StorageBackend {
         dispatch!(self, get_harness, org_id, id)
     }
 
-    pub async fn list_harnesses(&self, org_id: i64) -> Result<Vec<HarnessRow>> {
-        dispatch!(self, list_harnesses, org_id)
+    pub async fn list_harnesses(
+        &self,
+        org_id: i64,
+        search: Option<&str>,
+    ) -> Result<Vec<HarnessRow>> {
+        dispatch!(self, list_harnesses, org_id, search)
     }
 
     pub async fn update_harness(
@@ -298,9 +302,10 @@ impl StorageBackend {
         &self,
         org_id: i64,
         agent_id: Option<AgentId>,
+        search: Option<&str>,
         pagination: Pagination,
     ) -> Result<(Vec<SessionRow>, u32)> {
-        dispatch!(self, list_sessions, org_id, agent_id, pagination)
+        dispatch!(self, list_sessions, org_id, agent_id, search, pagination)
     }
 
     /// Count sessions grouped by status for an organization.
@@ -781,8 +786,12 @@ impl StorageBackend {
         dispatch!(self, get_mcp_server_by_name, org_id, name)
     }
 
-    pub async fn list_mcp_servers(&self, org_id: i64) -> Result<Vec<McpServerRow>> {
-        dispatch!(self, list_mcp_servers, org_id)
+    pub async fn list_mcp_servers(
+        &self,
+        org_id: i64,
+        search: Option<&str>,
+    ) -> Result<Vec<McpServerRow>> {
+        dispatch!(self, list_mcp_servers, org_id, search)
     }
 
     pub async fn list_active_mcp_servers(&self, org_id: i64) -> Result<Vec<McpServerRow>> {
@@ -827,8 +836,8 @@ impl StorageBackend {
         dispatch!(self, get_skill_by_name, org_id, name)
     }
 
-    pub async fn list_skills(&self, org_id: i64) -> Result<Vec<SkillRow>> {
-        dispatch!(self, list_skills, org_id)
+    pub async fn list_skills(&self, org_id: i64, search: Option<&str>) -> Result<Vec<SkillRow>> {
+        dispatch!(self, list_skills, org_id, search)
     }
 
     pub async fn update_skill(
@@ -1289,8 +1298,8 @@ impl StorageBackend {
         dispatch!(self, get_app_by_public_id_unscoped, public_id)
     }
 
-    pub async fn list_apps(&self, org_id: i64) -> Result<Vec<AppRow>> {
-        dispatch!(self, list_apps, org_id)
+    pub async fn list_apps(&self, org_id: i64, search: Option<&str>) -> Result<Vec<AppRow>> {
+        dispatch!(self, list_apps, org_id, search)
     }
 
     pub async fn update_app(

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -18,8 +18,12 @@ use uuid::Uuid;
 
 use super::models::*;
 
+/// Max search tokens to prevent performance degradation from long inputs.
+const MAX_SEARCH_TOKENS: usize = 8;
+
 /// Multi-word tokenized search. Each whitespace-separated token must match
-/// somewhere in the combined text (case-insensitive).
+/// somewhere in the combined text (case-insensitive). Tokens beyond
+/// [`MAX_SEARCH_TOKENS`] are ignored.
 fn matches_search_tokens(search: Option<&str>, texts: &[&str]) -> bool {
     let Some(q) = search.filter(|q| !q.trim().is_empty()) else {
         return true;
@@ -32,6 +36,7 @@ fn matches_search_tokens(search: Option<&str>, texts: &[&str]) -> bool {
     q.trim()
         .to_lowercase()
         .split_whitespace()
+        .take(MAX_SEARCH_TOKENS)
         .all(|token| combined.contains(token))
 }
 
@@ -4746,5 +4751,441 @@ mod tests {
             .await
             .unwrap();
         assert!(logs.is_empty());
+    }
+
+    // ─── Search / command-palette tests ───
+
+    /// Helper: create an agent with given name + description
+    async fn create_test_agent(
+        db: &InMemoryDatabase,
+        name: &str,
+        description: Option<&str>,
+    ) -> AgentRow {
+        db.create_agent(
+            DEFAULT_ORG_ID,
+            CreateAgentRow {
+                public_id: AgentId::new().to_string(),
+                name: name.to_string(),
+                description: description.map(|d| d.to_string()),
+                system_prompt: String::new(),
+                default_model_id: None,
+                tags: vec![],
+                tools: serde_json::json!([]),
+            },
+        )
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_search_agents_no_filter_returns_all() {
+        let db = InMemoryDatabase::new();
+        create_test_agent(&db, "Alpha", None).await;
+        create_test_agent(&db, "Beta", None).await;
+
+        let results = db.list_agents(DEFAULT_ORG_ID, None).await.unwrap();
+        assert_eq!(results.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_search_agents_empty_string_returns_all() {
+        let db = InMemoryDatabase::new();
+        create_test_agent(&db, "Alpha", None).await;
+
+        let results = db.list_agents(DEFAULT_ORG_ID, Some("")).await.unwrap();
+        assert_eq!(results.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_search_agents_single_word_match() {
+        let db = InMemoryDatabase::new();
+        create_test_agent(&db, "Customer Support Bot", None).await;
+        create_test_agent(&db, "Code Reviewer", None).await;
+
+        let results = db
+            .list_agents(DEFAULT_ORG_ID, Some("customer"))
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "Customer Support Bot");
+    }
+
+    #[tokio::test]
+    async fn test_search_agents_case_insensitive() {
+        let db = InMemoryDatabase::new();
+        create_test_agent(&db, "Customer Support Bot", None).await;
+
+        let results = db
+            .list_agents(DEFAULT_ORG_ID, Some("CUSTOMER"))
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_search_agents_multi_word_all_must_match() {
+        let db = InMemoryDatabase::new();
+        create_test_agent(&db, "Customer Support Bot", None).await;
+        create_test_agent(&db, "Customer Feedback Analyzer", None).await;
+
+        let results = db
+            .list_agents(DEFAULT_ORG_ID, Some("customer bot"))
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "Customer Support Bot");
+    }
+
+    #[tokio::test]
+    async fn test_search_agents_matches_description() {
+        let db = InMemoryDatabase::new();
+        create_test_agent(&db, "Helper", Some("Handles billing inquiries")).await;
+
+        let results = db
+            .list_agents(DEFAULT_ORG_ID, Some("billing"))
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "Helper");
+    }
+
+    #[tokio::test]
+    async fn test_search_agents_cross_field_match() {
+        let db = InMemoryDatabase::new();
+        create_test_agent(&db, "Daytona Coder", Some("cloud sandbox agent")).await;
+
+        // "daytona" in name, "sandbox" in description → both must match
+        let results = db
+            .list_agents(DEFAULT_ORG_ID, Some("daytona sandbox"))
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_search_agents_no_match() {
+        let db = InMemoryDatabase::new();
+        create_test_agent(&db, "Customer Support Bot", None).await;
+
+        let results = db
+            .list_agents(DEFAULT_ORG_ID, Some("zzz_nonexistent"))
+            .await
+            .unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_search_agents_poem_does_not_crash() {
+        let db = InMemoryDatabase::new();
+        create_test_agent(&db, "Alpha", None).await;
+
+        // A full poem pasted into search — should not crash or hang
+        let poem = "Roses are red, violets are blue, \
+                    sugar is sweet, and so are you. \
+                    The sky is wide, the ocean deep, \
+                    these memories I shall forever keep. \
+                    Through winding roads and starlit nights, \
+                    we chase our dreams to greater heights.";
+        let results = db.list_agents(DEFAULT_ORG_ID, Some(poem)).await.unwrap();
+        // No agent should match a poem
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_search_agents_poem_token_cap() {
+        let db = InMemoryDatabase::new();
+        // Agent whose name contains many words from the poem
+        create_test_agent(&db, "roses are red violets are blue sugar is sweet", None).await;
+
+        // Query with >MAX_SEARCH_TOKENS words — only first 8 tokens used
+        let long_query = "roses are red violets are blue sugar is sweet and so are you forever";
+        let results = db
+            .list_agents(DEFAULT_ORG_ID, Some(long_query))
+            .await
+            .unwrap();
+        // First 8 tokens: "roses are red violets are blue sugar is"
+        // All present in agent name → should match
+        assert_eq!(results.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_search_agents_special_characters() {
+        let db = InMemoryDatabase::new();
+        create_test_agent(&db, "Agent v2.0 (beta)", None).await;
+        create_test_agent(&db, "my-agent_v1", None).await;
+
+        let results = db.list_agents(DEFAULT_ORG_ID, Some("v2.0")).await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "Agent v2.0 (beta)");
+    }
+
+    #[tokio::test]
+    async fn test_search_agents_unicode() {
+        let db = InMemoryDatabase::new();
+        create_test_agent(&db, "日本語エージェント", Some("テスト用")).await;
+        create_test_agent(&db, "English Agent", None).await;
+
+        let results = db
+            .list_agents(DEFAULT_ORG_ID, Some("日本語"))
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "日本語エージェント");
+    }
+
+    #[tokio::test]
+    async fn test_search_agents_emoji() {
+        let db = InMemoryDatabase::new();
+        create_test_agent(&db, "🤖 Robot Helper", None).await;
+        create_test_agent(&db, "Normal Agent", None).await;
+
+        let results = db.list_agents(DEFAULT_ORG_ID, Some("🤖")).await.unwrap();
+        assert_eq!(results.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_search_agents_whitespace_normalization() {
+        let db = InMemoryDatabase::new();
+        create_test_agent(&db, "Customer Support Bot", None).await;
+
+        // Extra spaces, tabs, etc.
+        let results = db
+            .list_agents(DEFAULT_ORG_ID, Some("  customer   bot  "))
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_search_sessions_by_title() {
+        let db = InMemoryDatabase::new();
+        let agent = create_test_agent(&db, "Agent", None).await;
+
+        db.create_session(CreateSessionRow {
+            org_id: DEFAULT_ORG_ID,
+            harness_id: None,
+            agent_id: Some(agent.id),
+            title: Some("Debug production memory leak".to_string()),
+            tags: vec![],
+            model_id: None,
+            capabilities: serde_json::json!([]),
+            tools: serde_json::json!([]),
+        })
+        .await
+        .unwrap();
+
+        db.create_session(CreateSessionRow {
+            org_id: DEFAULT_ORG_ID,
+            harness_id: None,
+            agent_id: Some(agent.id),
+            title: Some("Refactor auth module".to_string()),
+            tags: vec![],
+            model_id: None,
+            capabilities: serde_json::json!([]),
+            tools: serde_json::json!([]),
+        })
+        .await
+        .unwrap();
+
+        let pagination = crate::api::common::Pagination::new(0, 20);
+        let (results, total) = db
+            .list_sessions(DEFAULT_ORG_ID, None, Some("memory leak"), pagination)
+            .await
+            .unwrap();
+        assert_eq!(total, 1);
+        assert_eq!(results.len(), 1);
+        assert!(results[0].title.as_ref().unwrap().contains("memory leak"));
+    }
+
+    #[tokio::test]
+    async fn test_search_sessions_with_agent_filter() {
+        let db = InMemoryDatabase::new();
+        let agent1 = create_test_agent(&db, "Agent1", None).await;
+        let agent2 = create_test_agent(&db, "Agent2", None).await;
+
+        db.create_session(CreateSessionRow {
+            org_id: DEFAULT_ORG_ID,
+            harness_id: None,
+            agent_id: Some(agent1.id),
+            title: Some("Shared keyword session".to_string()),
+            tags: vec![],
+            model_id: None,
+            capabilities: serde_json::json!([]),
+            tools: serde_json::json!([]),
+        })
+        .await
+        .unwrap();
+
+        db.create_session(CreateSessionRow {
+            org_id: DEFAULT_ORG_ID,
+            harness_id: None,
+            agent_id: Some(agent2.id),
+            title: Some("Shared keyword session".to_string()),
+            tags: vec![],
+            model_id: None,
+            capabilities: serde_json::json!([]),
+            tools: serde_json::json!([]),
+        })
+        .await
+        .unwrap();
+
+        let pagination = crate::api::common::Pagination::new(0, 20);
+        // Search + agent filter combined
+        let (results, total) = db
+            .list_sessions(
+                DEFAULT_ORG_ID,
+                Some(agent1.id),
+                Some("shared keyword"),
+                pagination,
+            )
+            .await
+            .unwrap();
+        assert_eq!(total, 1);
+        assert_eq!(results.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_search_sessions_poem_input() {
+        let db = InMemoryDatabase::new();
+
+        let pagination = crate::api::common::Pagination::new(0, 20);
+        let poem = "Shall I compare thee to a summer's day? \
+                    Thou art more lovely and more temperate. \
+                    Rough winds do shake the darling buds of May, \
+                    And summer's lease hath all too short a date.";
+        let (results, total) = db
+            .list_sessions(DEFAULT_ORG_ID, None, Some(poem), pagination)
+            .await
+            .unwrap();
+        assert_eq!(total, 0);
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_matches_search_tokens_unit() {
+        // Direct unit tests on the helper function
+        assert!(matches_search_tokens(None, &["anything"]));
+        assert!(matches_search_tokens(Some(""), &["anything"]));
+        assert!(matches_search_tokens(Some("  "), &["anything"]));
+        assert!(matches_search_tokens(Some("hello"), &["hello world"]));
+        assert!(matches_search_tokens(
+            Some("hello world"),
+            &["hello", "world"]
+        ));
+        assert!(!matches_search_tokens(Some("missing"), &["hello world"]));
+        // Multi-word: all tokens must match
+        assert!(!matches_search_tokens(
+            Some("hello missing"),
+            &["hello world"]
+        ));
+        // Case insensitive
+        assert!(matches_search_tokens(Some("HELLO"), &["hello"]));
+    }
+
+    #[tokio::test]
+    async fn test_search_skills() {
+        let db = InMemoryDatabase::new();
+
+        db.create_skill(
+            DEFAULT_ORG_ID,
+            CreateSkillRow {
+                public_id: SkillId::new().to_string(),
+                name: "Web Scraper".to_string(),
+                description: "Scrapes web pages for data".to_string(),
+                license: Some("MIT".to_string()),
+                compatibility: Some("*".to_string()),
+                metadata: serde_json::json!({}),
+                allowed_tools: None,
+                instructions: "scrape it".to_string(),
+                source_type: "inline".to_string(),
+                archive_data: None,
+                version: "1.0.0".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+        db.create_skill(
+            DEFAULT_ORG_ID,
+            CreateSkillRow {
+                public_id: SkillId::new().to_string(),
+                name: "Code Formatter".to_string(),
+                description: "Formats code using prettier".to_string(),
+                license: Some("MIT".to_string()),
+                compatibility: Some("*".to_string()),
+                metadata: serde_json::json!({}),
+                allowed_tools: None,
+                instructions: "format it".to_string(),
+                source_type: "inline".to_string(),
+                archive_data: None,
+                version: "1.0.0".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let results = db
+            .list_skills(DEFAULT_ORG_ID, Some("scraper"))
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "Web Scraper");
+
+        // Cross-field: "code prettier"
+        let results = db
+            .list_skills(DEFAULT_ORG_ID, Some("code prettier"))
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "Code Formatter");
+    }
+
+    #[tokio::test]
+    async fn test_search_apps() {
+        let db = InMemoryDatabase::new();
+        let agent = create_test_agent(&db, "Agent", None).await;
+        let harness_id = Uuid::now_v7();
+
+        db.create_app(
+            DEFAULT_ORG_ID,
+            CreateAppRow {
+                public_id: "app_test1".to_string(),
+                name: "Slack Bot".to_string(),
+                description: Some("Slack integration for support".to_string()),
+                harness_id,
+                agent_id: agent.id.into(),
+                channel_type: "slack".to_string(),
+                channel_config: serde_json::json!({}),
+            },
+        )
+        .await
+        .unwrap();
+
+        db.create_app(
+            DEFAULT_ORG_ID,
+            CreateAppRow {
+                public_id: "app_test2".to_string(),
+                name: "Web Widget".to_string(),
+                description: Some("Embeddable chat widget".to_string()),
+                harness_id,
+                agent_id: agent.id.into(),
+                channel_type: "web".to_string(),
+                channel_config: serde_json::json!({}),
+            },
+        )
+        .await
+        .unwrap();
+
+        let results = db.list_apps(DEFAULT_ORG_ID, Some("slack")).await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "Slack Bot");
+
+        // Multi-word across name + description
+        let results = db
+            .list_apps(DEFAULT_ORG_ID, Some("widget chat"))
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "Web Widget");
     }
 }

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -518,11 +518,25 @@ impl InMemoryDatabase {
             .cloned())
     }
 
-    pub async fn list_agents(&self, org_id: i64) -> Result<Vec<AgentRow>> {
+    pub async fn list_agents(&self, org_id: i64, search: Option<&str>) -> Result<Vec<AgentRow>> {
         let agents = self.agents.read();
+        let pattern = search
+            .filter(|q| !q.trim().is_empty())
+            .map(|q| q.trim().to_lowercase());
         let mut result: Vec<_> = agents
             .values()
             .filter(|a| a.org_id == org_id && a.status == "active")
+            .filter(|a| match &pattern {
+                Some(p) => {
+                    a.name.to_lowercase().contains(p)
+                        || a.description
+                            .as_deref()
+                            .unwrap_or("")
+                            .to_lowercase()
+                            .contains(p)
+                }
+                None => true,
+            })
             .cloned()
             .collect();
         result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
@@ -726,11 +740,29 @@ impl InMemoryDatabase {
             .cloned())
     }
 
-    pub async fn list_harnesses(&self, org_id: i64) -> Result<Vec<HarnessRow>> {
+    pub async fn list_harnesses(
+        &self,
+        org_id: i64,
+        search: Option<&str>,
+    ) -> Result<Vec<HarnessRow>> {
         let harnesses = self.harnesses.read();
+        let pattern = search
+            .filter(|q| !q.trim().is_empty())
+            .map(|q| q.trim().to_lowercase());
         let mut result: Vec<_> = harnesses
             .values()
             .filter(|h| h.org_id == org_id && h.status == "active")
+            .filter(|h| match &pattern {
+                Some(p) => {
+                    h.name.to_lowercase().contains(p)
+                        || h.description
+                            .as_deref()
+                            .unwrap_or("")
+                            .to_lowercase()
+                            .contains(p)
+                }
+                None => true,
+            })
             .cloned()
             .collect();
         result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
@@ -841,6 +873,7 @@ impl InMemoryDatabase {
         &self,
         org_id: i64,
         agent_id: Option<AgentId>,
+        search: Option<&str>,
         pagination: crate::api::common::Pagination,
     ) -> Result<(Vec<SessionRow>, u32)> {
         // If agent_id is provided, validate it belongs to the org
@@ -855,6 +888,9 @@ impl InMemoryDatabase {
             }
         }
 
+        let pattern = search
+            .filter(|q| !q.trim().is_empty())
+            .map(|q| q.trim().to_lowercase());
         let sessions = self.sessions.read();
         let mut result: Vec<_> = sessions
             .values()
@@ -863,6 +899,10 @@ impl InMemoryDatabase {
                 s.org_id == org_id
                     // Optionally filter by agent_id
                     && agent_id.is_none_or(|aid| s.agent_id == Some(aid))
+            })
+            .filter(|s| match &pattern {
+                Some(p) => s.title.as_deref().unwrap_or("").to_lowercase().contains(p),
+                None => true,
             })
             .cloned()
             .collect();
@@ -2431,12 +2471,27 @@ impl InMemoryDatabase {
             .cloned())
     }
 
-    pub async fn list_mcp_servers(&self, org_id: i64) -> Result<Vec<McpServerRow>> {
+    pub async fn list_mcp_servers(
+        &self,
+        org_id: i64,
+        search: Option<&str>,
+    ) -> Result<Vec<McpServerRow>> {
+        let pattern = search
+            .filter(|q| !q.trim().is_empty())
+            .map(|q| q.trim().to_lowercase());
         let mut servers: Vec<_> = self
             .mcp_servers
             .read()
             .values()
             .filter(|s| s.org_id == org_id)
+            .filter(|s| {
+                pattern.as_ref().is_none_or(|p| {
+                    s.name.to_lowercase().contains(p)
+                        || s.description
+                            .as_deref()
+                            .is_some_and(|d| d.to_lowercase().contains(p))
+                })
+            })
             .cloned()
             .collect();
         servers.sort_by(|a, b| b.created_at.cmp(&a.created_at));
@@ -2749,12 +2804,21 @@ impl InMemoryDatabase {
             .cloned())
     }
 
-    pub async fn list_skills(&self, org_id: i64) -> Result<Vec<SkillRow>> {
+    pub async fn list_skills(&self, org_id: i64, search: Option<&str>) -> Result<Vec<SkillRow>> {
+        let pattern = search
+            .filter(|q| !q.trim().is_empty())
+            .map(|q| q.trim().to_lowercase());
         let mut skills: Vec<_> = self
             .skills
             .read()
             .values()
             .filter(|s| s.org_id == org_id)
+            .filter(|s| match &pattern {
+                Some(p) => {
+                    s.name.to_lowercase().contains(p) || s.description.to_lowercase().contains(p)
+                }
+                None => true,
+            })
             .cloned()
             .collect();
         skills.sort_by(|a, b| b.created_at.cmp(&a.created_at));
@@ -3787,11 +3851,25 @@ impl InMemoryDatabase {
         Ok(apps.values().find(|a| a.public_id == public_id).cloned())
     }
 
-    pub async fn list_apps(&self, org_id: i64) -> Result<Vec<AppRow>> {
+    pub async fn list_apps(&self, org_id: i64, search: Option<&str>) -> Result<Vec<AppRow>> {
         let apps = self.apps.read();
+        let pattern = search
+            .filter(|q| !q.trim().is_empty())
+            .map(|q| q.trim().to_lowercase());
         let mut result: Vec<AppRow> = apps
             .values()
             .filter(|a| a.org_id == org_id && a.status != "archived")
+            .filter(|a| match &pattern {
+                Some(p) => {
+                    a.name.to_lowercase().contains(p)
+                        || a.description
+                            .as_deref()
+                            .unwrap_or("")
+                            .to_lowercase()
+                            .contains(p)
+                }
+                None => true,
+            })
             .cloned()
             .collect();
         result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
@@ -3921,7 +3999,7 @@ mod tests {
 
         let pagination = crate::api::common::Pagination::new(0, 20);
         let (sessions, total) = db
-            .list_sessions(DEFAULT_ORG_ID, Some(agent.id), pagination)
+            .list_sessions(DEFAULT_ORG_ID, Some(agent.id), None, pagination)
             .await
             .unwrap();
         assert_eq!(sessions.len(), 1);
@@ -4375,7 +4453,7 @@ mod tests {
         // Test default pagination (all sessions fit within limit)
         let pagination = crate::api::common::Pagination::new(0, 20);
         let (sessions, total) = db
-            .list_sessions(DEFAULT_ORG_ID, Some(agent.id), pagination)
+            .list_sessions(DEFAULT_ORG_ID, Some(agent.id), None, pagination)
             .await
             .unwrap();
         assert_eq!(total, 15);
@@ -4384,7 +4462,7 @@ mod tests {
         // Test with limit=5
         let pagination = crate::api::common::Pagination::new(0, 5);
         let (sessions, total) = db
-            .list_sessions(DEFAULT_ORG_ID, Some(agent.id), pagination)
+            .list_sessions(DEFAULT_ORG_ID, Some(agent.id), None, pagination)
             .await
             .unwrap();
         assert_eq!(total, 15);
@@ -4393,7 +4471,7 @@ mod tests {
         // Test with offset=5, limit=5
         let pagination = crate::api::common::Pagination::new(5, 5);
         let (sessions, total) = db
-            .list_sessions(DEFAULT_ORG_ID, Some(agent.id), pagination)
+            .list_sessions(DEFAULT_ORG_ID, Some(agent.id), None, pagination)
             .await
             .unwrap();
         assert_eq!(total, 15);
@@ -4402,7 +4480,7 @@ mod tests {
         // Test last partial page (offset=10, limit=10 should return 5)
         let pagination = crate::api::common::Pagination::new(10, 10);
         let (sessions, total) = db
-            .list_sessions(DEFAULT_ORG_ID, Some(agent.id), pagination)
+            .list_sessions(DEFAULT_ORG_ID, Some(agent.id), None, pagination)
             .await
             .unwrap();
         assert_eq!(total, 15);
@@ -4411,7 +4489,7 @@ mod tests {
         // Test beyond range (offset=20)
         let pagination = crate::api::common::Pagination::new(20, 10);
         let (sessions, total) = db
-            .list_sessions(DEFAULT_ORG_ID, Some(agent.id), pagination)
+            .list_sessions(DEFAULT_ORG_ID, Some(agent.id), None, pagination)
             .await
             .unwrap();
         assert_eq!(total, 15);
@@ -4459,7 +4537,7 @@ mod tests {
         // Sessions should be ordered by created_at DESC (newest first)
         let pagination = crate::api::common::Pagination::new(0, 10);
         let (sessions, _) = db
-            .list_sessions(DEFAULT_ORG_ID, Some(agent.id), pagination)
+            .list_sessions(DEFAULT_ORG_ID, Some(agent.id), None, pagination)
             .await
             .unwrap();
 

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -18,6 +18,23 @@ use uuid::Uuid;
 
 use super::models::*;
 
+/// Multi-word tokenized search. Each whitespace-separated token must match
+/// somewhere in the combined text (case-insensitive).
+fn matches_search_tokens(search: Option<&str>, texts: &[&str]) -> bool {
+    let Some(q) = search.filter(|q| !q.trim().is_empty()) else {
+        return true;
+    };
+    let combined: String = texts
+        .iter()
+        .map(|t| t.to_lowercase())
+        .collect::<Vec<_>>()
+        .join(" ");
+    q.trim()
+        .to_lowercase()
+        .split_whitespace()
+        .all(|token| combined.contains(token))
+}
+
 /// Stored data for a pinned session: (org_id, pinned_at)
 type PinnedSessionData = (i64, DateTime<Utc>);
 
@@ -520,22 +537,11 @@ impl InMemoryDatabase {
 
     pub async fn list_agents(&self, org_id: i64, search: Option<&str>) -> Result<Vec<AgentRow>> {
         let agents = self.agents.read();
-        let pattern = search
-            .filter(|q| !q.trim().is_empty())
-            .map(|q| q.trim().to_lowercase());
         let mut result: Vec<_> = agents
             .values()
             .filter(|a| a.org_id == org_id && a.status == "active")
-            .filter(|a| match &pattern {
-                Some(p) => {
-                    a.name.to_lowercase().contains(p)
-                        || a.description
-                            .as_deref()
-                            .unwrap_or("")
-                            .to_lowercase()
-                            .contains(p)
-                }
-                None => true,
+            .filter(|a| {
+                matches_search_tokens(search, &[&a.name, a.description.as_deref().unwrap_or("")])
             })
             .cloned()
             .collect();
@@ -746,22 +752,11 @@ impl InMemoryDatabase {
         search: Option<&str>,
     ) -> Result<Vec<HarnessRow>> {
         let harnesses = self.harnesses.read();
-        let pattern = search
-            .filter(|q| !q.trim().is_empty())
-            .map(|q| q.trim().to_lowercase());
         let mut result: Vec<_> = harnesses
             .values()
             .filter(|h| h.org_id == org_id && h.status == "active")
-            .filter(|h| match &pattern {
-                Some(p) => {
-                    h.name.to_lowercase().contains(p)
-                        || h.description
-                            .as_deref()
-                            .unwrap_or("")
-                            .to_lowercase()
-                            .contains(p)
-                }
-                None => true,
+            .filter(|h| {
+                matches_search_tokens(search, &[&h.name, h.description.as_deref().unwrap_or("")])
             })
             .cloned()
             .collect();
@@ -888,22 +883,11 @@ impl InMemoryDatabase {
             }
         }
 
-        let pattern = search
-            .filter(|q| !q.trim().is_empty())
-            .map(|q| q.trim().to_lowercase());
         let sessions = self.sessions.read();
         let mut result: Vec<_> = sessions
             .values()
-            .filter(|s| {
-                // Filter by org_id
-                s.org_id == org_id
-                    // Optionally filter by agent_id
-                    && agent_id.is_none_or(|aid| s.agent_id == Some(aid))
-            })
-            .filter(|s| match &pattern {
-                Some(p) => s.title.as_deref().unwrap_or("").to_lowercase().contains(p),
-                None => true,
-            })
+            .filter(|s| s.org_id == org_id && agent_id.is_none_or(|aid| s.agent_id == Some(aid)))
+            .filter(|s| matches_search_tokens(search, &[s.title.as_deref().unwrap_or("")]))
             .cloned()
             .collect();
         result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
@@ -2476,21 +2460,13 @@ impl InMemoryDatabase {
         org_id: i64,
         search: Option<&str>,
     ) -> Result<Vec<McpServerRow>> {
-        let pattern = search
-            .filter(|q| !q.trim().is_empty())
-            .map(|q| q.trim().to_lowercase());
         let mut servers: Vec<_> = self
             .mcp_servers
             .read()
             .values()
             .filter(|s| s.org_id == org_id)
             .filter(|s| {
-                pattern.as_ref().is_none_or(|p| {
-                    s.name.to_lowercase().contains(p)
-                        || s.description
-                            .as_deref()
-                            .is_some_and(|d| d.to_lowercase().contains(p))
-                })
+                matches_search_tokens(search, &[&s.name, s.description.as_deref().unwrap_or("")])
             })
             .cloned()
             .collect();
@@ -2805,20 +2781,12 @@ impl InMemoryDatabase {
     }
 
     pub async fn list_skills(&self, org_id: i64, search: Option<&str>) -> Result<Vec<SkillRow>> {
-        let pattern = search
-            .filter(|q| !q.trim().is_empty())
-            .map(|q| q.trim().to_lowercase());
         let mut skills: Vec<_> = self
             .skills
             .read()
             .values()
             .filter(|s| s.org_id == org_id)
-            .filter(|s| match &pattern {
-                Some(p) => {
-                    s.name.to_lowercase().contains(p) || s.description.to_lowercase().contains(p)
-                }
-                None => true,
-            })
+            .filter(|s| matches_search_tokens(search, &[&s.name, &s.description]))
             .cloned()
             .collect();
         skills.sort_by(|a, b| b.created_at.cmp(&a.created_at));
@@ -3853,22 +3821,11 @@ impl InMemoryDatabase {
 
     pub async fn list_apps(&self, org_id: i64, search: Option<&str>) -> Result<Vec<AppRow>> {
         let apps = self.apps.read();
-        let pattern = search
-            .filter(|q| !q.trim().is_empty())
-            .map(|q| q.trim().to_lowercase());
         let mut result: Vec<AppRow> = apps
             .values()
             .filter(|a| a.org_id == org_id && a.status != "archived")
-            .filter(|a| match &pattern {
-                Some(p) => {
-                    a.name.to_lowercase().contains(p)
-                        || a.description
-                            .as_deref()
-                            .unwrap_or("")
-                            .to_lowercase()
-                            .contains(p)
-                }
-                None => true,
+            .filter(|a| {
+                matches_search_tokens(search, &[&a.name, a.description.as_deref().unwrap_or("")])
             })
             .cloned()
             .collect();

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -57,15 +57,37 @@ impl DatabasePoolConfig {
     }
 }
 
+/// Max search tokens to prevent oversized queries from long inputs (e.g. a poem).
+const MAX_SEARCH_TOKENS: usize = 8;
+
+/// Escape SQL LIKE special characters (`%`, `_`, `\`) so user input is treated
+/// as literal text.
+fn escape_like(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '%' | '_' | '\\' => {
+                out.push('\\');
+                out.push(ch);
+            }
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
 /// Build multi-word search SQL conditions. Each whitespace-separated token must
 /// match somewhere in the concatenated fields (case-insensitive).
 ///
 /// Returns `(sql_fragment, patterns)` where `sql_fragment` looks like
-/// ` AND (lower_expr LIKE $2) AND (lower_expr LIKE $3)` and `patterns` is
-/// `["%token1%", "%token2%"]`.
+/// ` AND (lower_expr LIKE $2 ESCAPE '\') AND (lower_expr LIKE $3 ESCAPE '\')`
+/// and `patterns` is `["%token1%", "%token2%"]`.
 ///
 /// `lower_expr` should be a SQL expression like
 /// `LOWER(name || ' ' || COALESCE(description, ''))`.
+///
+/// Tokens are capped at [`MAX_SEARCH_TOKENS`] to prevent performance
+/// degradation from excessively long queries.
 fn build_search_sql(
     search: Option<&str>,
     lower_expr: &str,
@@ -77,7 +99,8 @@ fn build_search_sql(
             q.trim()
                 .to_lowercase()
                 .split_whitespace()
-                .map(|t| format!("%{t}%"))
+                .take(MAX_SEARCH_TOKENS)
+                .map(|t| format!("%{}%", escape_like(t)))
                 .collect()
         })
         .unwrap_or_default();
@@ -91,7 +114,7 @@ fn build_search_sql(
         use std::fmt::Write;
         write!(
             sql,
-            " AND ({lower_expr} LIKE ${idx})",
+            " AND ({lower_expr} LIKE ${idx} ESCAPE '\\')",
             idx = start_param + i
         )
         .unwrap();
@@ -4416,5 +4439,132 @@ mod tests {
         unsafe {
             std::env::remove_var("DATABASE_POOL_MAX");
         }
+    }
+
+    // ─── build_search_sql / escape_like tests ───
+
+    #[test]
+    fn escape_like_leaves_normal_text_unchanged() {
+        assert_eq!(escape_like("hello world"), "hello world");
+    }
+
+    #[test]
+    fn escape_like_escapes_percent() {
+        assert_eq!(escape_like("100%"), "100\\%");
+    }
+
+    #[test]
+    fn escape_like_escapes_underscore() {
+        assert_eq!(escape_like("a_b"), "a\\_b");
+    }
+
+    #[test]
+    fn escape_like_escapes_backslash() {
+        assert_eq!(escape_like("c:\\path"), "c:\\\\path");
+    }
+
+    #[test]
+    fn escape_like_handles_all_special_chars_together() {
+        assert_eq!(escape_like("%_\\"), "\\%\\_\\\\");
+    }
+
+    #[test]
+    fn build_search_sql_none_returns_empty() {
+        let (sql, patterns) = build_search_sql(None, "LOWER(name)", 2);
+        assert!(sql.is_empty());
+        assert!(patterns.is_empty());
+    }
+
+    #[test]
+    fn build_search_sql_empty_string_returns_empty() {
+        let (sql, patterns) = build_search_sql(Some(""), "LOWER(name)", 2);
+        assert!(sql.is_empty());
+        assert!(patterns.is_empty());
+    }
+
+    #[test]
+    fn build_search_sql_whitespace_only_returns_empty() {
+        let (sql, patterns) = build_search_sql(Some("   "), "LOWER(name)", 2);
+        assert!(sql.is_empty());
+        assert!(patterns.is_empty());
+    }
+
+    #[test]
+    fn build_search_sql_single_word() {
+        let (sql, patterns) = build_search_sql(Some("hello"), "LOWER(name)", 2);
+        assert_eq!(patterns, vec!["%hello%"]);
+        assert!(sql.contains("LIKE $2 ESCAPE"));
+        assert!(!sql.contains("$3"));
+    }
+
+    #[test]
+    fn build_search_sql_multi_word() {
+        let (sql, patterns) = build_search_sql(Some("hello world"), "LOWER(name)", 2);
+        assert_eq!(patterns, vec!["%hello%", "%world%"]);
+        assert!(sql.contains("LIKE $2 ESCAPE"));
+        assert!(sql.contains("LIKE $3 ESCAPE"));
+    }
+
+    #[test]
+    fn build_search_sql_escapes_like_wildcards() {
+        let (_, patterns) = build_search_sql(Some("100% done"), "LOWER(name)", 2);
+        assert_eq!(patterns, vec!["%100\\%%", "%done%"]);
+    }
+
+    #[test]
+    fn build_search_sql_escapes_underscore() {
+        let (_, patterns) = build_search_sql(Some("my_var"), "LOWER(name)", 2);
+        assert_eq!(patterns, vec!["%my\\_var%"]);
+    }
+
+    #[test]
+    fn build_search_sql_caps_tokens_at_max() {
+        // A poem or long query should be capped
+        let poem = "roses are red violets are blue sugar is sweet and so are you extra words here";
+        let (_, patterns) = build_search_sql(Some(poem), "LOWER(name)", 2);
+        assert_eq!(patterns.len(), MAX_SEARCH_TOKENS);
+    }
+
+    #[test]
+    fn build_search_sql_unicode_tokens() {
+        let (_, patterns) = build_search_sql(Some("日本語 テスト"), "LOWER(name)", 2);
+        assert_eq!(patterns, vec!["%日本語%", "%テスト%"]);
+    }
+
+    #[test]
+    fn build_search_sql_emoji_input() {
+        let (_, patterns) = build_search_sql(Some("🤖 bot"), "LOWER(name)", 2);
+        assert_eq!(patterns, vec!["%🤖%", "%bot%"]);
+    }
+
+    #[test]
+    fn build_search_sql_sql_injection_attempt() {
+        // SQL injection via search should be harmless — values are parameterized
+        let (sql, patterns) = build_search_sql(Some("'; DROP TABLE agents; --"), "LOWER(name)", 2);
+        // The tokens are just words, bound as parameters
+        assert_eq!(patterns.len(), 5); // "';", "drop", "table", "agents;", "--"
+        // SQL structure is safe — only LIKE clauses
+        assert!(sql.contains("LIKE $2"));
+        assert!(!sql.contains("DROP"));
+    }
+
+    #[test]
+    fn build_search_sql_param_offset() {
+        // When starting at param 4 (e.g. after org_id, agent_id, other filters)
+        let (sql, _) = build_search_sql(Some("test query"), "LOWER(name)", 4);
+        assert!(sql.contains("$4"));
+        assert!(sql.contains("$5"));
+    }
+
+    #[test]
+    fn build_search_sql_case_insensitive() {
+        let (_, patterns) = build_search_sql(Some("HeLLo WoRLd"), "LOWER(name)", 2);
+        assert_eq!(patterns, vec!["%hello%", "%world%"]);
+    }
+
+    #[test]
+    fn build_search_sql_extra_whitespace_collapsed() {
+        let (_, patterns) = build_search_sql(Some("  hello    world  "), "LOWER(name)", 2);
+        assert_eq!(patterns, vec!["%hello%", "%world%"]);
     }
 }

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -57,6 +57,48 @@ impl DatabasePoolConfig {
     }
 }
 
+/// Build multi-word search SQL conditions. Each whitespace-separated token must
+/// match somewhere in the concatenated fields (case-insensitive).
+///
+/// Returns `(sql_fragment, patterns)` where `sql_fragment` looks like
+/// ` AND (lower_expr LIKE $2) AND (lower_expr LIKE $3)` and `patterns` is
+/// `["%token1%", "%token2%"]`.
+///
+/// `lower_expr` should be a SQL expression like
+/// `LOWER(name || ' ' || COALESCE(description, ''))`.
+fn build_search_sql(
+    search: Option<&str>,
+    lower_expr: &str,
+    start_param: usize,
+) -> (String, Vec<String>) {
+    let tokens: Vec<String> = search
+        .filter(|q| !q.trim().is_empty())
+        .map(|q| {
+            q.trim()
+                .to_lowercase()
+                .split_whitespace()
+                .map(|t| format!("%{t}%"))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if tokens.is_empty() {
+        return (String::new(), Vec::new());
+    }
+
+    let mut sql = String::new();
+    for (i, _) in tokens.iter().enumerate() {
+        use std::fmt::Write;
+        write!(
+            sql,
+            " AND ({lower_expr} LIKE ${idx})",
+            idx = start_param + i
+        )
+        .unwrap();
+    }
+    (sql, tokens)
+}
+
 #[derive(Clone)]
 pub struct Database {
     pool: PgPool,
@@ -604,41 +646,20 @@ impl Database {
     }
 
     pub async fn list_agents(&self, org_id: i64, search: Option<&str>) -> Result<Vec<AgentRow>> {
-        let rows = match search {
-            Some(q) if !q.trim().is_empty() => {
-                let pattern = format!("%{}%", q.trim().to_lowercase());
-                sqlx::query_as::<_, AgentRow>(
-                    r#"
-                    SELECT id, public_id, org_id, name, description, system_prompt, default_model_id, tags, status, created_at, updated_at, tools,
-                           total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens
-                    FROM agents
-                    WHERE org_id = $1 AND status = 'active'
-                      AND (LOWER(name) LIKE $2 OR LOWER(COALESCE(description, '')) LIKE $2)
-                    ORDER BY created_at DESC
-                    "#,
-                )
-                .bind(org_id)
-                .bind(&pattern)
-                .fetch_all(&self.pool)
-                .await?
-            }
-            _ => {
-                sqlx::query_as::<_, AgentRow>(
-                    r#"
-                    SELECT id, public_id, org_id, name, description, system_prompt, default_model_id, tags, status, created_at, updated_at, tools,
-                           total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens
-                    FROM agents
-                    WHERE org_id = $1 AND status = 'active'
-                    ORDER BY created_at DESC
-                    "#,
-                )
-                .bind(org_id)
-                .fetch_all(&self.pool)
-                .await?
-            }
-        };
-
-        Ok(rows)
+        let (search_sql, patterns) =
+            build_search_sql(search, "LOWER(name || ' ' || COALESCE(description, ''))", 2);
+        let sql = format!(
+            r#"SELECT id, public_id, org_id, name, description, system_prompt, default_model_id, tags, status, created_at, updated_at, tools,
+                       total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens
+                FROM agents
+                WHERE org_id = $1 AND status = 'active'{search_sql}
+                ORDER BY created_at DESC"#
+        );
+        let mut query = sqlx::query_as::<_, AgentRow>(&sql).bind(org_id);
+        for pat in &patterns {
+            query = query.bind(pat);
+        }
+        Ok(query.fetch_all(&self.pool).await?)
     }
 
     pub async fn get_agent_by_name(&self, org_id: i64, name: &str) -> Result<Option<AgentRow>> {
@@ -854,39 +875,19 @@ impl Database {
         org_id: i64,
         search: Option<&str>,
     ) -> Result<Vec<HarnessRow>> {
-        let rows = match search {
-            Some(q) if !q.trim().is_empty() => {
-                let pattern = format!("%{}%", q.trim().to_lowercase());
-                sqlx::query_as::<_, HarnessRow>(
-                    r#"
-                    SELECT id, org_id, name, description, system_prompt, default_model_id, tags, status, created_at, updated_at
-                    FROM harnesses
-                    WHERE org_id = $1 AND status = 'active'
-                      AND (LOWER(name) LIKE $2 OR LOWER(COALESCE(description, '')) LIKE $2)
-                    ORDER BY created_at DESC
-                    "#,
-                )
-                .bind(org_id)
-                .bind(&pattern)
-                .fetch_all(&self.pool)
-                .await?
-            }
-            _ => {
-                sqlx::query_as::<_, HarnessRow>(
-                    r#"
-                    SELECT id, org_id, name, description, system_prompt, default_model_id, tags, status, created_at, updated_at
-                    FROM harnesses
-                    WHERE org_id = $1 AND status = 'active'
-                    ORDER BY created_at DESC
-                    "#,
-                )
-                .bind(org_id)
-                .fetch_all(&self.pool)
-                .await?
-            }
-        };
-
-        Ok(rows)
+        let (search_sql, patterns) =
+            build_search_sql(search, "LOWER(name || ' ' || COALESCE(description, ''))", 2);
+        let sql = format!(
+            r#"SELECT id, org_id, name, description, system_prompt, default_model_id, tags, status, created_at, updated_at
+                FROM harnesses
+                WHERE org_id = $1 AND status = 'active'{search_sql}
+                ORDER BY created_at DESC"#
+        );
+        let mut query = sqlx::query_as::<_, HarnessRow>(&sql).bind(org_id);
+        for pat in &patterns {
+            query = query.bind(pat);
+        }
+        Ok(query.fetch_all(&self.pool).await?)
     }
 
     pub async fn update_harness(
@@ -1012,41 +1013,37 @@ impl Database {
         search: Option<&str>,
         pagination: crate::api::common::Pagination,
     ) -> Result<(Vec<SessionRow>, u32)> {
-        let search_pattern = search
-            .filter(|q| !q.trim().is_empty())
-            .map(|q| format!("%{}%", q.trim().to_lowercase()));
-
         // Build WHERE clause dynamically
         let mut where_clause = "WHERE org_id = $1".to_string();
         let mut param_idx = 2;
 
-        let agent_param_idx = if agent_id.is_some() {
-            let idx = param_idx;
-            where_clause.push_str(&format!(" AND agent_id = ${idx}"));
+        if agent_id.is_some() {
+            where_clause.push_str(&format!(" AND agent_id = ${param_idx}"));
             param_idx += 1;
-            Some(idx)
-        } else {
-            None
-        };
+        }
 
-        let search_param_idx = if search_pattern.is_some() {
-            let idx = param_idx;
-            where_clause.push_str(&format!(" AND (LOWER(COALESCE(title, '')) LIKE ${idx})"));
-            param_idx += 1;
-            Some(idx)
-        } else {
-            None
-        };
+        let (search_sql, patterns) =
+            build_search_sql(search, "LOWER(COALESCE(title, ''))", param_idx);
+        where_clause.push_str(&search_sql);
+        param_idx += patterns.len();
+
+        // Helper: bind org_id, agent_id, and search patterns to a query
+        macro_rules! bind_params {
+            ($q:expr) => {{
+                let mut q = $q.bind(org_id);
+                if let Some(aid) = agent_id {
+                    q = q.bind(aid);
+                }
+                for pat in &patterns {
+                    q = q.bind(pat);
+                }
+                q
+            }};
+        }
 
         // Get total count
         let count_sql = format!("SELECT COUNT(*) as count FROM sessions {where_clause}");
-        let mut count_query = sqlx::query_as::<_, (i64,)>(&count_sql).bind(org_id);
-        if let Some(aid) = agent_id {
-            count_query = count_query.bind(aid);
-        }
-        if let Some(ref pat) = search_pattern {
-            count_query = count_query.bind(pat);
-        }
+        let count_query = bind_params!(sqlx::query_as::<_, (i64,)>(&count_sql));
         let total: (i64,) = count_query.fetch_one(&self.pool).await?;
 
         // Get paginated results
@@ -1059,21 +1056,12 @@ impl Database {
             ORDER BY created_at DESC
             LIMIT ${limit_idx} OFFSET ${offset_idx}"#,
         );
-        let mut data_query = sqlx::query_as::<_, SessionRow>(&select_sql).bind(org_id);
-        if let Some(aid) = agent_id {
-            data_query = data_query.bind(aid);
-        }
-        if let Some(ref pat) = search_pattern {
-            data_query = data_query.bind(pat);
-        }
+        let data_query = bind_params!(sqlx::query_as::<_, SessionRow>(&select_sql));
         let rows: Vec<SessionRow> = data_query
             .bind(pagination.limit as i64)
             .bind(pagination.offset as i64)
             .fetch_all(&self.pool)
             .await?;
-
-        // Suppress unused variable warnings for the param index tracking
-        let _ = (agent_param_idx, search_param_idx);
 
         Ok((rows, total.0 as u32))
     }
@@ -2820,41 +2808,19 @@ impl Database {
         org_id: i64,
         search: Option<&str>,
     ) -> Result<Vec<McpServerRow>> {
-        let search_pattern = search
-            .filter(|q| !q.trim().is_empty())
-            .map(|q| format!("%{}%", q.trim().to_lowercase()));
-
-        let rows = match &search_pattern {
-            Some(pattern) => {
-                sqlx::query_as::<_, McpServerRow>(
-                    r#"
-                    SELECT id, org_id, name, description, url, transport_type, status, api_key_encrypted, api_key_set, headers, settings, cached_tools, tools_cached_at, created_at, updated_at
-                    FROM mcp_servers
-                    WHERE org_id = $1 AND (LOWER(name) LIKE $2 OR LOWER(COALESCE(description, '')) LIKE $2)
-                    ORDER BY created_at DESC
-                    "#,
-                )
-                .bind(org_id)
-                .bind(pattern)
-                .fetch_all(&self.pool)
-                .await?
-            }
-            None => {
-                sqlx::query_as::<_, McpServerRow>(
-                    r#"
-                    SELECT id, org_id, name, description, url, transport_type, status, api_key_encrypted, api_key_set, headers, settings, cached_tools, tools_cached_at, created_at, updated_at
-                    FROM mcp_servers
-                    WHERE org_id = $1
-                    ORDER BY created_at DESC
-                    "#,
-                )
-                .bind(org_id)
-                .fetch_all(&self.pool)
-                .await?
-            }
-        };
-
-        Ok(rows)
+        let (search_sql, patterns) =
+            build_search_sql(search, "LOWER(name || ' ' || COALESCE(description, ''))", 2);
+        let sql = format!(
+            r#"SELECT id, org_id, name, description, url, transport_type, status, api_key_encrypted, api_key_set, headers, settings, cached_tools, tools_cached_at, created_at, updated_at
+                FROM mcp_servers
+                WHERE org_id = $1{search_sql}
+                ORDER BY created_at DESC"#
+        );
+        let mut query = sqlx::query_as::<_, McpServerRow>(&sql).bind(org_id);
+        for pat in &patterns {
+            query = query.bind(pat);
+        }
+        Ok(query.fetch_all(&self.pool).await?)
     }
 
     /// List only active MCP servers (for capability listing)
@@ -3016,39 +2982,19 @@ impl Database {
     }
 
     pub async fn list_skills(&self, org_id: i64, search: Option<&str>) -> Result<Vec<SkillRow>> {
-        let rows = match search {
-            Some(q) if !q.trim().is_empty() => {
-                let pattern = format!("%{}%", q.trim().to_lowercase());
-                sqlx::query_as::<_, SkillRow>(
-                    r#"
-                    SELECT id, public_id, org_id, name, description, license, compatibility, metadata, allowed_tools, instructions, source_type, archive_data, status, version, created_at, updated_at
-                    FROM skills
-                    WHERE org_id = $1
-                      AND (LOWER(name) LIKE $2 OR LOWER(COALESCE(description, '')) LIKE $2)
-                    ORDER BY created_at DESC
-                    "#,
-                )
-                .bind(org_id)
-                .bind(&pattern)
-                .fetch_all(&self.pool)
-                .await?
-            }
-            _ => {
-                sqlx::query_as::<_, SkillRow>(
-                    r#"
-                    SELECT id, public_id, org_id, name, description, license, compatibility, metadata, allowed_tools, instructions, source_type, archive_data, status, version, created_at, updated_at
-                    FROM skills
-                    WHERE org_id = $1
-                    ORDER BY created_at DESC
-                    "#,
-                )
-                .bind(org_id)
-                .fetch_all(&self.pool)
-                .await?
-            }
-        };
-
-        Ok(rows)
+        let (search_sql, patterns) =
+            build_search_sql(search, "LOWER(name || ' ' || COALESCE(description, ''))", 2);
+        let sql = format!(
+            r#"SELECT id, public_id, org_id, name, description, license, compatibility, metadata, allowed_tools, instructions, source_type, archive_data, status, version, created_at, updated_at
+                FROM skills
+                WHERE org_id = $1{search_sql}
+                ORDER BY created_at DESC"#
+        );
+        let mut query = sqlx::query_as::<_, SkillRow>(&sql).bind(org_id);
+        for pat in &patterns {
+            query = query.bind(pat);
+        }
+        Ok(query.fetch_all(&self.pool).await?)
     }
 
     pub async fn update_skill(
@@ -4348,39 +4294,19 @@ impl Database {
     }
 
     pub async fn list_apps(&self, org_id: i64, search: Option<&str>) -> Result<Vec<AppRow>> {
-        let rows = match search {
-            Some(q) if !q.trim().is_empty() => {
-                let pattern = format!("%{}%", q.trim().to_lowercase());
-                sqlx::query_as::<_, AppRow>(
-                    r#"
-                    SELECT id, org_id, public_id, name, description, harness_id, agent_id, channel_type, channel_config, status, published_at, created_at, updated_at
-                    FROM apps
-                    WHERE org_id = $1 AND status != 'archived'
-                      AND (LOWER(name) LIKE $2 OR LOWER(COALESCE(description, '')) LIKE $2)
-                    ORDER BY created_at DESC
-                    "#,
-                )
-                .bind(org_id)
-                .bind(&pattern)
-                .fetch_all(&self.pool)
-                .await?
-            }
-            _ => {
-                sqlx::query_as::<_, AppRow>(
-                    r#"
-                    SELECT id, org_id, public_id, name, description, harness_id, agent_id, channel_type, channel_config, status, published_at, created_at, updated_at
-                    FROM apps
-                    WHERE org_id = $1 AND status != 'archived'
-                    ORDER BY created_at DESC
-                    "#,
-                )
-                .bind(org_id)
-                .fetch_all(&self.pool)
-                .await?
-            }
-        };
-
-        Ok(rows)
+        let (search_sql, patterns) =
+            build_search_sql(search, "LOWER(name || ' ' || COALESCE(description, ''))", 2);
+        let sql = format!(
+            r#"SELECT id, org_id, public_id, name, description, harness_id, agent_id, channel_type, channel_config, status, published_at, created_at, updated_at
+                FROM apps
+                WHERE org_id = $1 AND status != 'archived'{search_sql}
+                ORDER BY created_at DESC"#
+        );
+        let mut query = sqlx::query_as::<_, AppRow>(&sql).bind(org_id);
+        for pat in &patterns {
+            query = query.bind(pat);
+        }
+        Ok(query.fetch_all(&self.pool).await?)
     }
 
     pub async fn update_app(

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -603,19 +603,40 @@ impl Database {
         Ok(row)
     }
 
-    pub async fn list_agents(&self, org_id: i64) -> Result<Vec<AgentRow>> {
-        let rows = sqlx::query_as::<_, AgentRow>(
-            r#"
-            SELECT id, public_id, org_id, name, description, system_prompt, default_model_id, tags, status, created_at, updated_at, tools,
-                   total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens
-            FROM agents
-            WHERE org_id = $1 AND status = 'active'
-            ORDER BY created_at DESC
-            "#,
-        )
-        .bind(org_id)
-        .fetch_all(&self.pool)
-        .await?;
+    pub async fn list_agents(&self, org_id: i64, search: Option<&str>) -> Result<Vec<AgentRow>> {
+        let rows = match search {
+            Some(q) if !q.trim().is_empty() => {
+                let pattern = format!("%{}%", q.trim().to_lowercase());
+                sqlx::query_as::<_, AgentRow>(
+                    r#"
+                    SELECT id, public_id, org_id, name, description, system_prompt, default_model_id, tags, status, created_at, updated_at, tools,
+                           total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens
+                    FROM agents
+                    WHERE org_id = $1 AND status = 'active'
+                      AND (LOWER(name) LIKE $2 OR LOWER(COALESCE(description, '')) LIKE $2)
+                    ORDER BY created_at DESC
+                    "#,
+                )
+                .bind(org_id)
+                .bind(&pattern)
+                .fetch_all(&self.pool)
+                .await?
+            }
+            _ => {
+                sqlx::query_as::<_, AgentRow>(
+                    r#"
+                    SELECT id, public_id, org_id, name, description, system_prompt, default_model_id, tags, status, created_at, updated_at, tools,
+                           total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens
+                    FROM agents
+                    WHERE org_id = $1 AND status = 'active'
+                    ORDER BY created_at DESC
+                    "#,
+                )
+                .bind(org_id)
+                .fetch_all(&self.pool)
+                .await?
+            }
+        };
 
         Ok(rows)
     }
@@ -828,18 +849,42 @@ impl Database {
         Ok(row)
     }
 
-    pub async fn list_harnesses(&self, org_id: i64) -> Result<Vec<HarnessRow>> {
-        let rows = sqlx::query_as::<_, HarnessRow>(
-            r#"
-            SELECT id, org_id, name, description, system_prompt, default_model_id, tags, status, created_at, updated_at
-            FROM harnesses
-            WHERE org_id = $1 AND status = 'active'
-            ORDER BY created_at DESC
-            "#,
-        )
-        .bind(org_id)
-        .fetch_all(&self.pool)
-        .await?;
+    pub async fn list_harnesses(
+        &self,
+        org_id: i64,
+        search: Option<&str>,
+    ) -> Result<Vec<HarnessRow>> {
+        let rows = match search {
+            Some(q) if !q.trim().is_empty() => {
+                let pattern = format!("%{}%", q.trim().to_lowercase());
+                sqlx::query_as::<_, HarnessRow>(
+                    r#"
+                    SELECT id, org_id, name, description, system_prompt, default_model_id, tags, status, created_at, updated_at
+                    FROM harnesses
+                    WHERE org_id = $1 AND status = 'active'
+                      AND (LOWER(name) LIKE $2 OR LOWER(COALESCE(description, '')) LIKE $2)
+                    ORDER BY created_at DESC
+                    "#,
+                )
+                .bind(org_id)
+                .bind(&pattern)
+                .fetch_all(&self.pool)
+                .await?
+            }
+            _ => {
+                sqlx::query_as::<_, HarnessRow>(
+                    r#"
+                    SELECT id, org_id, name, description, system_prompt, default_model_id, tags, status, created_at, updated_at
+                    FROM harnesses
+                    WHERE org_id = $1 AND status = 'active'
+                    ORDER BY created_at DESC
+                    "#,
+                )
+                .bind(org_id)
+                .fetch_all(&self.pool)
+                .await?
+            }
+        };
 
         Ok(rows)
     }
@@ -958,75 +1003,77 @@ impl Database {
         Ok(row)
     }
 
-    /// List sessions for an organization with optional agent filter.
+    /// List sessions for an organization with optional agent and search filters.
     /// Returns (sessions, total_count).
     pub async fn list_sessions(
         &self,
         org_id: i64,
         agent_id: Option<AgentId>,
+        search: Option<&str>,
         pagination: crate::api::common::Pagination,
     ) -> Result<(Vec<SessionRow>, u32)> {
-        // Get total count
-        let total: (i64,) = if let Some(aid) = agent_id {
-            sqlx::query_as(
-                r#"
-                SELECT COUNT(*) as count
-                FROM sessions
-                WHERE org_id = $1 AND agent_id = $2
-                "#,
-            )
-            .bind(org_id)
-            .bind(aid)
-            .fetch_one(&self.pool)
-            .await?
+        let search_pattern = search
+            .filter(|q| !q.trim().is_empty())
+            .map(|q| format!("%{}%", q.trim().to_lowercase()));
+
+        // Build WHERE clause dynamically
+        let mut where_clause = "WHERE org_id = $1".to_string();
+        let mut param_idx = 2;
+
+        let agent_param_idx = if agent_id.is_some() {
+            let idx = param_idx;
+            where_clause.push_str(&format!(" AND agent_id = ${idx}"));
+            param_idx += 1;
+            Some(idx)
         } else {
-            sqlx::query_as(
-                r#"
-                SELECT COUNT(*) as count
-                FROM sessions
-                WHERE org_id = $1
-                "#,
-            )
-            .bind(org_id)
-            .fetch_one(&self.pool)
-            .await?
+            None
         };
 
-        // Get paginated results
-        let rows = if let Some(aid) = agent_id {
-            sqlx::query_as::<_, SessionRow>(
-                r#"
-                SELECT id, org_id, harness_id, agent_id, title, tags, model_id, capabilities, tools, status, created_at, updated_at, started_at, finished_at,
-                       total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens
-                FROM sessions
-                WHERE org_id = $1 AND agent_id = $2
-                ORDER BY created_at DESC
-                LIMIT $3 OFFSET $4
-                "#,
-            )
-            .bind(org_id)
-            .bind(aid)
-            .bind(pagination.limit as i64)
-            .bind(pagination.offset as i64)
-            .fetch_all(&self.pool)
-            .await?
+        let search_param_idx = if search_pattern.is_some() {
+            let idx = param_idx;
+            where_clause.push_str(&format!(" AND (LOWER(COALESCE(title, '')) LIKE ${idx})"));
+            param_idx += 1;
+            Some(idx)
         } else {
-            sqlx::query_as::<_, SessionRow>(
-                r#"
-                SELECT id, org_id, harness_id, agent_id, title, tags, model_id, capabilities, tools, status, created_at, updated_at, started_at, finished_at,
-                       total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens
-                FROM sessions
-                WHERE org_id = $1
-                ORDER BY created_at DESC
-                LIMIT $2 OFFSET $3
-                "#,
-            )
-            .bind(org_id)
+            None
+        };
+
+        // Get total count
+        let count_sql = format!("SELECT COUNT(*) as count FROM sessions {where_clause}");
+        let mut count_query = sqlx::query_as::<_, (i64,)>(&count_sql).bind(org_id);
+        if let Some(aid) = agent_id {
+            count_query = count_query.bind(aid);
+        }
+        if let Some(ref pat) = search_pattern {
+            count_query = count_query.bind(pat);
+        }
+        let total: (i64,) = count_query.fetch_one(&self.pool).await?;
+
+        // Get paginated results
+        let limit_idx = param_idx;
+        let offset_idx = param_idx + 1;
+        let select_sql = format!(
+            r#"SELECT id, org_id, harness_id, agent_id, title, tags, model_id, capabilities, tools, status, created_at, updated_at, started_at, finished_at,
+                   total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens
+            FROM sessions {where_clause}
+            ORDER BY created_at DESC
+            LIMIT ${limit_idx} OFFSET ${offset_idx}"#,
+        );
+        let mut data_query = sqlx::query_as::<_, SessionRow>(&select_sql).bind(org_id);
+        if let Some(aid) = agent_id {
+            data_query = data_query.bind(aid);
+        }
+        if let Some(ref pat) = search_pattern {
+            data_query = data_query.bind(pat);
+        }
+        let rows: Vec<SessionRow> = data_query
             .bind(pagination.limit as i64)
             .bind(pagination.offset as i64)
             .fetch_all(&self.pool)
-            .await?
-        };
+            .await?;
+
+        // Suppress unused variable warnings for the param index tracking
+        let _ = (agent_param_idx, search_param_idx);
 
         Ok((rows, total.0 as u32))
     }
@@ -2768,18 +2815,44 @@ impl Database {
         Ok(row)
     }
 
-    pub async fn list_mcp_servers(&self, org_id: i64) -> Result<Vec<McpServerRow>> {
-        let rows = sqlx::query_as::<_, McpServerRow>(
-            r#"
-            SELECT id, org_id, name, description, url, transport_type, status, api_key_encrypted, api_key_set, headers, settings, cached_tools, tools_cached_at, created_at, updated_at
-            FROM mcp_servers
-            WHERE org_id = $1
-            ORDER BY created_at DESC
-            "#,
-        )
-        .bind(org_id)
-        .fetch_all(&self.pool)
-        .await?;
+    pub async fn list_mcp_servers(
+        &self,
+        org_id: i64,
+        search: Option<&str>,
+    ) -> Result<Vec<McpServerRow>> {
+        let search_pattern = search
+            .filter(|q| !q.trim().is_empty())
+            .map(|q| format!("%{}%", q.trim().to_lowercase()));
+
+        let rows = match &search_pattern {
+            Some(pattern) => {
+                sqlx::query_as::<_, McpServerRow>(
+                    r#"
+                    SELECT id, org_id, name, description, url, transport_type, status, api_key_encrypted, api_key_set, headers, settings, cached_tools, tools_cached_at, created_at, updated_at
+                    FROM mcp_servers
+                    WHERE org_id = $1 AND (LOWER(name) LIKE $2 OR LOWER(COALESCE(description, '')) LIKE $2)
+                    ORDER BY created_at DESC
+                    "#,
+                )
+                .bind(org_id)
+                .bind(pattern)
+                .fetch_all(&self.pool)
+                .await?
+            }
+            None => {
+                sqlx::query_as::<_, McpServerRow>(
+                    r#"
+                    SELECT id, org_id, name, description, url, transport_type, status, api_key_encrypted, api_key_set, headers, settings, cached_tools, tools_cached_at, created_at, updated_at
+                    FROM mcp_servers
+                    WHERE org_id = $1
+                    ORDER BY created_at DESC
+                    "#,
+                )
+                .bind(org_id)
+                .fetch_all(&self.pool)
+                .await?
+            }
+        };
 
         Ok(rows)
     }
@@ -2942,18 +3015,38 @@ impl Database {
         Ok(row)
     }
 
-    pub async fn list_skills(&self, org_id: i64) -> Result<Vec<SkillRow>> {
-        let rows = sqlx::query_as::<_, SkillRow>(
-            r#"
-            SELECT id, public_id, org_id, name, description, license, compatibility, metadata, allowed_tools, instructions, source_type, archive_data, status, version, created_at, updated_at
-            FROM skills
-            WHERE org_id = $1
-            ORDER BY created_at DESC
-            "#,
-        )
-        .bind(org_id)
-        .fetch_all(&self.pool)
-        .await?;
+    pub async fn list_skills(&self, org_id: i64, search: Option<&str>) -> Result<Vec<SkillRow>> {
+        let rows = match search {
+            Some(q) if !q.trim().is_empty() => {
+                let pattern = format!("%{}%", q.trim().to_lowercase());
+                sqlx::query_as::<_, SkillRow>(
+                    r#"
+                    SELECT id, public_id, org_id, name, description, license, compatibility, metadata, allowed_tools, instructions, source_type, archive_data, status, version, created_at, updated_at
+                    FROM skills
+                    WHERE org_id = $1
+                      AND (LOWER(name) LIKE $2 OR LOWER(COALESCE(description, '')) LIKE $2)
+                    ORDER BY created_at DESC
+                    "#,
+                )
+                .bind(org_id)
+                .bind(&pattern)
+                .fetch_all(&self.pool)
+                .await?
+            }
+            _ => {
+                sqlx::query_as::<_, SkillRow>(
+                    r#"
+                    SELECT id, public_id, org_id, name, description, license, compatibility, metadata, allowed_tools, instructions, source_type, archive_data, status, version, created_at, updated_at
+                    FROM skills
+                    WHERE org_id = $1
+                    ORDER BY created_at DESC
+                    "#,
+                )
+                .bind(org_id)
+                .fetch_all(&self.pool)
+                .await?
+            }
+        };
 
         Ok(rows)
     }
@@ -4254,18 +4347,38 @@ impl Database {
         Ok(row)
     }
 
-    pub async fn list_apps(&self, org_id: i64) -> Result<Vec<AppRow>> {
-        let rows = sqlx::query_as::<_, AppRow>(
-            r#"
-            SELECT id, org_id, public_id, name, description, harness_id, agent_id, channel_type, channel_config, status, published_at, created_at, updated_at
-            FROM apps
-            WHERE org_id = $1 AND status != 'archived'
-            ORDER BY created_at DESC
-            "#,
-        )
-        .bind(org_id)
-        .fetch_all(&self.pool)
-        .await?;
+    pub async fn list_apps(&self, org_id: i64, search: Option<&str>) -> Result<Vec<AppRow>> {
+        let rows = match search {
+            Some(q) if !q.trim().is_empty() => {
+                let pattern = format!("%{}%", q.trim().to_lowercase());
+                sqlx::query_as::<_, AppRow>(
+                    r#"
+                    SELECT id, org_id, public_id, name, description, harness_id, agent_id, channel_type, channel_config, status, published_at, created_at, updated_at
+                    FROM apps
+                    WHERE org_id = $1 AND status != 'archived'
+                      AND (LOWER(name) LIKE $2 OR LOWER(COALESCE(description, '')) LIKE $2)
+                    ORDER BY created_at DESC
+                    "#,
+                )
+                .bind(org_id)
+                .bind(&pattern)
+                .fetch_all(&self.pool)
+                .await?
+            }
+            _ => {
+                sqlx::query_as::<_, AppRow>(
+                    r#"
+                    SELECT id, org_id, public_id, name, description, harness_id, agent_id, channel_type, channel_config, status, published_at, created_at, updated_at
+                    FROM apps
+                    WHERE org_id = $1 AND status != 'archived'
+                    ORDER BY created_at DESC
+                    "#,
+                )
+                .bind(org_id)
+                .fetch_all(&self.pool)
+                .await?
+            }
+        };
 
         Ok(rows)
     }

--- a/crates/server/tests/org_isolation_test.rs
+++ b/crates/server/tests/org_isolation_test.rs
@@ -72,7 +72,7 @@ async fn test_mcp_server_positive_own_org() {
             .unwrap()
             .is_some()
     );
-    assert_eq!(db.list_mcp_servers(ORG1).await.unwrap().len(), 1);
+    assert_eq!(db.list_mcp_servers(ORG1, None).await.unwrap().len(), 1);
     assert_eq!(db.list_active_mcp_servers(ORG1).await.unwrap().len(), 1);
 
     let updated = db
@@ -126,7 +126,7 @@ async fn test_mcp_server_negative_cross_org() {
             .unwrap()
             .is_none()
     );
-    assert!(db.list_mcp_servers(org2).await.unwrap().is_empty());
+    assert!(db.list_mcp_servers(org2, None).await.unwrap().is_empty());
     assert!(db.list_active_mcp_servers(org2).await.unwrap().is_empty());
     assert!(
         db.update_mcp_server(
@@ -630,7 +630,7 @@ async fn test_multi_org_full_isolation() {
     assert_eq!(org1_models.len(), 1);
     assert_eq!(org1_models[0].model_id, "gpt-4");
 
-    let org1_servers = db.list_mcp_servers(ORG1).await.unwrap();
+    let org1_servers = db.list_mcp_servers(ORG1, None).await.unwrap();
     assert_eq!(org1_servers.len(), 1);
     assert_eq!(org1_servers[0].name, "Org1 MCP");
 
@@ -647,7 +647,7 @@ async fn test_multi_org_full_isolation() {
     assert_eq!(org2_models.len(), 1);
     assert_eq!(org2_models[0].model_id, "claude-3");
 
-    let org2_servers = db.list_mcp_servers(org2).await.unwrap();
+    let org2_servers = db.list_mcp_servers(org2, None).await.unwrap();
     assert_eq!(org2_servers.len(), 1);
     assert_eq!(org2_servers[0].name, "Org2 MCP");
 

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -95,7 +95,7 @@ async fn test_agent_crud() {
 
     // List agents
     let agents = backend
-        .list_agents(TEST_ORG_ID)
+        .list_agents(TEST_ORG_ID, None)
         .await
         .expect("Failed to list agents");
     assert!(agents.iter().any(|a| a.id == agent.id));
@@ -221,6 +221,7 @@ async fn test_session_crud() {
         .list_sessions(
             TEST_ORG_ID,
             Some(agent.id),
+            None,
             Pagination {
                 limit: 10,
                 offset: 0,
@@ -828,7 +829,7 @@ async fn test_mcp_server_crud() {
 
     // List MCP servers
     let servers = backend
-        .list_mcp_servers(TEST_ORG_ID)
+        .list_mcp_servers(TEST_ORG_ID, None)
         .await
         .expect("Failed to list MCP servers");
     assert!(servers.iter().any(|s| s.id == server.id));
@@ -1290,7 +1291,7 @@ async fn test_mcp_server_org_isolation_postgres() {
     );
     assert!(
         backend
-            .list_mcp_servers(TEST_ORG_ID)
+            .list_mcp_servers(TEST_ORG_ID, None)
             .await
             .unwrap()
             .iter()
@@ -1314,7 +1315,7 @@ async fn test_mcp_server_org_isolation_postgres() {
     );
     assert!(
         !backend
-            .list_mcp_servers(org2)
+            .list_mcp_servers(org2, None)
             .await
             .unwrap()
             .iter()

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -23,6 +23,20 @@
         ],
         "summary": "GET /v1/agents - List all active agents",
         "operationId": "list_agents",
+        "parameters": [
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Search by name or description (case-insensitive substring match).",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "List of agents",
@@ -1907,6 +1921,20 @@
         ],
         "summary": "GET /v1/mcp-servers - List all MCP servers",
         "operationId": "list_mcp_servers",
+        "parameters": [
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Search by name or description (case-insensitive substring match).",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "List of MCP servers",
@@ -2320,6 +2348,18 @@
               ]
             },
             "example": "agent_01933b5a00007000800000000000001"
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Search by title (case-insensitive substring match).",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
           },
           {
             "name": "offset",
@@ -3713,6 +3753,20 @@
         ],
         "summary": "GET /v1/skills - List all skills",
         "operationId": "list_skills",
+        "parameters": [
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Search by name or description (case-insensitive substring match).",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "List of skills",

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -553,6 +553,23 @@ GET /v1/agents/{id}/sessions?offset=20&limit=20
 GET /v1/agents/{id}/sessions?limit=10
 ```
 
+### Search
+
+All entity list endpoints support an optional `?search=` query parameter for case-insensitive substring matching on name and description fields.
+
+**Supported endpoints:**
+
+| Endpoint | Fields searched |
+|----------|---------------|
+| `GET /v1/agents?search=` | `name`, `description` |
+| `GET /v1/sessions?search=` | `title`, `preview` |
+| `GET /v1/harnesses?search=` | `name`, `description` |
+| `GET /v1/skills?search=` | `name`, `description` |
+| `GET /v1/apps?search=` | `name`, `description` |
+| `GET /v1/mcp-servers?search=` | `name`, `description` |
+
+**Convention:** When adding new entity types, always include `?search=` support on the list endpoint. Search should match against `name` and `description` at minimum (case-insensitive substring). Empty or whitespace-only search values are treated as no filter.
+
 ### Error Responses
 
 ```json

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -555,20 +555,27 @@ GET /v1/agents/{id}/sessions?limit=10
 
 ### Search
 
-All entity list endpoints support an optional `?search=` query parameter for case-insensitive substring matching on name and description fields.
+All entity list endpoints support an optional `?search=` query parameter for tokenized multi-word search across name and description fields.
+
+**Behavior:**
+- The query is split on whitespace into tokens; each token must match somewhere in the concatenated searchable fields (case-insensitive).
+- Example: `?search=customer+bot` matches an agent named "Customer Support Bot" because both "customer" and "bot" appear.
+- Tokens are capped at 8 to prevent performance degradation from excessively long queries (e.g. pasting a poem).
+- LIKE wildcards (`%`, `_`, `\`) in user input are escaped so they are treated as literal characters.
+- Empty or whitespace-only search values are treated as no filter.
 
 **Supported endpoints:**
 
 | Endpoint | Fields searched |
 |----------|---------------|
 | `GET /v1/agents?search=` | `name`, `description` |
-| `GET /v1/sessions?search=` | `title`, `preview` |
+| `GET /v1/sessions?search=` | `title` |
 | `GET /v1/harnesses?search=` | `name`, `description` |
 | `GET /v1/skills?search=` | `name`, `description` |
 | `GET /v1/apps?search=` | `name`, `description` |
 | `GET /v1/mcp-servers?search=` | `name`, `description` |
 
-**Convention:** When adding new entity types, always include `?search=` support on the list endpoint. Search should match against `name` and `description` at minimum (case-insensitive substring). Empty or whitespace-only search values are treated as no filter.
+**Convention:** When adding new entity types, always include `?search=` support on the list endpoint. Search should match against `name` and `description` at minimum (case-insensitive, tokenized). Empty or whitespace-only search values are treated as no filter.
 
 ### Error Responses
 

--- a/specs/feature-flags.md
+++ b/specs/feature-flags.md
@@ -30,6 +30,7 @@ System-level feature flags that control feature availability across the platform
 |------|---------|------|-------------|
 | `global_chat` | `FEATURE_GLOBAL_CHAT` | Experimental | Per-user singleton chat session |
 | `apps` | `FEATURE_APPS` | Experimental | Apps (agent deployment to distribution channels) |
+| `global_search` | `FEATURE_GLOBAL_SEARCH` | Experimental | Global search / command palette (Cmd+K) |
 
 ## Architecture
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -222,6 +222,7 @@ ApiError::Forbidden("No access")         // ✗ Reveals resource exists
 | TM-API-011 | WebFetch internal port scanning | Medium | fetchkit v0.1.2 blocks private IP ranges; agents cannot reach internal hosts | MITIGATED |
 | TM-API-012 | WebFetch DNS rebinding | Medium | fetchkit v0.1.2 DNS pinning: resolves hostname, validates IP, pins to resolved address for connection | MITIGATED |
 | TM-API-013 | LLM provider base URL SSRF | High | `url_validation::validate_url()` blocks private IPs, loopback, link-local, cloud metadata, non-HTTPS on provider create/update (EVE-69) | MITIGATED |
+| TM-API-014 | Search query SQL wildcard injection | Low | LIKE wildcards (`%`, `_`, `\`) in `?search=` input are escaped; tokens capped at 8 to prevent query amplification from long inputs | MITIGATED |
 
 ### Mitigation Details
 

--- a/test_cases/global_search/TC001_search_basic.md
+++ b/test_cases/global_search/TC001_search_basic.md
@@ -1,0 +1,43 @@
+# TC001: Global Search - Basic Query
+
+## Description
+
+Verify that the `?search=` parameter on entity list endpoints performs case-insensitive substring matching and returns only matching results.
+
+## Preconditions
+
+- Control-plane running (DEV_MODE or full mode)
+- At least 2 agents with distinct names exist
+
+## Steps
+
+1. Create two agents:
+   ```bash
+   curl -s -X POST http://localhost:9000/v1/agents \
+     -H "Content-Type: application/json" \
+     -d '{"name": "Customer Support Bot", "system_prompt": "help"}'
+   curl -s -X POST http://localhost:9000/v1/agents \
+     -H "Content-Type: application/json" \
+     -d '{"name": "Code Reviewer", "system_prompt": "review"}'
+   ```
+
+2. Search for "customer":
+   ```bash
+   curl -s "http://localhost:9000/v1/agents?search=customer"
+   ```
+
+3. Search for "CUSTOMER" (uppercase):
+   ```bash
+   curl -s "http://localhost:9000/v1/agents?search=CUSTOMER"
+   ```
+
+4. Search with empty string:
+   ```bash
+   curl -s "http://localhost:9000/v1/agents?search="
+   ```
+
+## Expected Results
+
+- Step 2: Returns 1 agent ("Customer Support Bot")
+- Step 3: Returns same result (case-insensitive)
+- Step 4: Returns all agents (empty search = no filter)

--- a/test_cases/global_search/TC002_search_multiword.md
+++ b/test_cases/global_search/TC002_search_multiword.md
@@ -1,0 +1,43 @@
+# TC002: Global Search - Multi-Word Tokenized Search
+
+## Description
+
+Verify that multi-word search requires all tokens to match (AND semantics) and matches across name + description fields.
+
+## Preconditions
+
+- Control-plane running
+- At least 2 agents with overlapping keywords
+
+## Steps
+
+1. Create agents:
+   ```bash
+   curl -s -X POST http://localhost:9000/v1/agents \
+     -H "Content-Type: application/json" \
+     -d '{"name": "Customer Support Bot", "description": "Handles billing inquiries", "system_prompt": "help"}'
+   curl -s -X POST http://localhost:9000/v1/agents \
+     -H "Content-Type: application/json" \
+     -d '{"name": "Customer Feedback Analyzer", "description": "Analyzes NPS scores", "system_prompt": "analyze"}'
+   ```
+
+2. Multi-word search "customer bot":
+   ```bash
+   curl -s "http://localhost:9000/v1/agents?search=customer+bot"
+   ```
+
+3. Cross-field search "customer billing":
+   ```bash
+   curl -s "http://localhost:9000/v1/agents?search=customer+billing"
+   ```
+
+4. No-match multi-word "customer missing":
+   ```bash
+   curl -s "http://localhost:9000/v1/agents?search=customer+missing"
+   ```
+
+## Expected Results
+
+- Step 2: Returns 1 agent (only "Customer Support Bot" has both "customer" and "bot")
+- Step 3: Returns 1 agent ("Customer Support Bot" — "customer" in name, "billing" in description)
+- Step 4: Returns 0 agents (no entity contains both tokens)

--- a/test_cases/global_search/TC003_search_edge_cases.md
+++ b/test_cases/global_search/TC003_search_edge_cases.md
@@ -1,0 +1,50 @@
+# TC003: Global Search - Edge Cases and Robustness
+
+## Description
+
+Verify that search handles adversarial and unusual inputs without crashing or performance degradation: poems, special characters, SQL wildcards, unicode, emoji, very long queries.
+
+## Preconditions
+
+- Control-plane running
+- At least 1 agent exists
+
+## Steps
+
+1. Search with a poem (long query, many tokens):
+   ```bash
+   curl -s "http://localhost:9000/v1/agents?search=Roses+are+red+violets+are+blue+sugar+is+sweet+and+so+are+you+the+sky+is+wide+the+ocean+deep+these+memories+I+shall+forever+keep"
+   ```
+
+2. Search with SQL LIKE wildcards (`%`, `_`):
+   ```bash
+   curl -s "http://localhost:9000/v1/agents?search=%25_%5C"
+   ```
+
+3. Search with SQL injection attempt:
+   ```bash
+   curl -s "http://localhost:9000/v1/agents?search=';+DROP+TABLE+agents;+--"
+   ```
+
+4. Search with unicode:
+   ```bash
+   curl -s "http://localhost:9000/v1/agents?search=%E6%97%A5%E6%9C%AC%E8%AA%9E"
+   ```
+
+5. Search with emoji:
+   ```bash
+   curl -s "http://localhost:9000/v1/agents?search=%F0%9F%A4%96"
+   ```
+
+6. Search with excessive whitespace:
+   ```bash
+   curl -s "http://localhost:9000/v1/agents?search=+++hello+++world+++"
+   ```
+
+## Expected Results
+
+- All steps: Server returns 200 with valid JSON response (empty results array is fine)
+- Step 1: Response time < 500ms (tokens capped at 8, no query amplification)
+- Step 2: LIKE wildcards treated as literal characters, not SQL wildcards
+- Step 3: No SQL injection — parameterized queries prevent it
+- Step 6: Collapsed to 2 tokens ("hello", "world")

--- a/test_cases/global_search/TC004_command_palette_ui.md
+++ b/test_cases/global_search/TC004_command_palette_ui.md
@@ -1,0 +1,31 @@
+# TC004: Command Palette - UI Navigation
+
+## Description
+
+Verify the Cmd+K / Ctrl+K command palette opens, shows navigation pages by default, searches entities, and navigates on selection.
+
+## Preconditions
+
+- UI running (dev or full mode)
+- At least 1 agent and 1 session exist
+
+## Steps
+
+1. Press `Cmd+K` (macOS) or `Ctrl+K` (Linux/Windows)
+2. Verify palette opens with default navigation pages (Dashboard, Sessions, Agents, etc.)
+3. Type "agent" — verify agents appear in results alongside "Agents" navigation page
+4. Use Arrow Down/Up to navigate results
+5. Press Enter on a result — verify navigation to correct page
+6. Open palette again, press Escape — verify palette closes
+7. Type a long poem — verify no hang, shows "No results" message
+8. Type an entity ID prefix (e.g. `agent_`) — verify "Go to" section appears
+
+## Expected Results
+
+- Steps 1-2: Palette opens with 6 default navigation pages
+- Step 3: Results grouped by category (Pages, Agents)
+- Step 4: Selection highlight moves with arrow keys
+- Step 5: Palette closes and browser navigates to selected item's URL
+- Step 6: Palette closes on Escape
+- Step 7: "No results" displayed promptly (no lag)
+- Step 8: ID-based lookup result with "Go to Agent" label


### PR DESCRIPTION
## What
Global search / command palette (Cmd+K) across all entities, gated behind the `FEATURE_GLOBAL_SEARCH` experimental feature flag.

## Why
Users need a fast way to navigate to agents, sessions, harnesses, skills, MCP servers, and apps without clicking through sidebar navigation.

## How
- Backend: added `?search=` query param to 6 entity list endpoints with tokenized, case-insensitive matching (LIKE escaping, 8-token cap)
- Frontend: `CommandPalette` component with keyboard navigation, grouped results, and ID lookup
- Feature flag: `global_search` (experimental) — auto-enabled in dev, disabled in prod via `FEATURE_GLOBAL_SEARCH`
- Sidebar search button and command palette conditionally rendered based on flag
- Security: SQL LIKE wildcards escaped, search tokens capped at 8, threat model updated (TM-API-014)

## Risk
- Low
- Feature is behind a feature flag; when disabled, no UI change. Search uses existing list endpoints with additional WHERE clauses.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered