### PR TITLE
fix(apps): auto-complete Slack setup checklist steps 4 and 5

### DIFF
--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -75,6 +75,8 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
   const isPublished = app?.status === "published";
   const slackConfig = app?.channel_config as SlackChannelConfig | undefined;
   const hasSlackConfig = slackConfig?.signing_secret && slackConfig?.bot_token;
+  const webhookVerified = !!slackConfig?.webhook_verified_at;
+  const firstMessageReceived = !!slackConfig?.first_message_received_at;
 
   const webhookUrl =
     typeof window !== "undefined"
@@ -395,6 +397,8 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                   <SlackSetupGuidance
                     hasSlackConfig={true}
                     isPublished={isPublished}
+                    webhookVerified={webhookVerified}
+                    firstMessageReceived={firstMessageReceived}
                     webhookUrl={webhookUrl}
                     webhookPath={webhookPath}
                     isLocalhost={isLocalhost}
@@ -407,6 +411,8 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                 <SlackSetupGuidance
                   hasSlackConfig={false}
                   isPublished={isPublished}
+                  webhookVerified={webhookVerified}
+                  firstMessageReceived={firstMessageReceived}
                   webhookUrl={webhookUrl}
                   webhookPath={webhookPath}
                   isLocalhost={isLocalhost}

--- a/apps/ui/src/components/apps/slack-setup-guidance.tsx
+++ b/apps/ui/src/components/apps/slack-setup-guidance.tsx
@@ -9,6 +9,8 @@ import { Copy, CircleCheck, Circle, ExternalLink, Pencil } from "lucide-react";
 interface SlackSetupGuidanceProps {
   hasSlackConfig: boolean;
   isPublished: boolean;
+  webhookVerified: boolean;
+  firstMessageReceived: boolean;
   webhookUrl: string;
   webhookPath: string;
   isLocalhost: boolean;
@@ -20,6 +22,8 @@ interface SlackSetupGuidanceProps {
 export function SlackSetupGuidance({
   hasSlackConfig,
   isPublished,
+  webhookVerified,
+  firstMessageReceived,
   webhookUrl,
   webhookPath,
   isLocalhost,
@@ -33,6 +37,8 @@ export function SlackSetupGuidance({
       <SetupSteps
         hasSlackConfig={hasSlackConfig}
         isPublished={isPublished}
+        webhookVerified={webhookVerified}
+        firstMessageReceived={firstMessageReceived}
         webhookUrl={webhookUrl}
         webhookPath={webhookPath}
         isLocalhost={isLocalhost}
@@ -55,6 +61,8 @@ function StepIcon({ done }: { done: boolean }) {
 function SetupSteps({
   hasSlackConfig,
   isPublished,
+  webhookVerified,
+  firstMessageReceived,
   webhookUrl,
   webhookPath,
   isLocalhost,
@@ -62,7 +70,15 @@ function SetupSteps({
   creatingSlackApp,
   onConfigure,
 }: SlackSetupGuidanceProps) {
-  const currentStep = !hasSlackConfig ? 1 : !isPublished ? 3 : 4;
+  const currentStep = !hasSlackConfig
+    ? 1
+    : !isPublished
+      ? 3
+      : !webhookVerified
+        ? 4
+        : !firstMessageReceived
+          ? 5
+          : 5;
 
   return (
     <div className="space-y-4">
@@ -145,9 +161,13 @@ function SetupSteps({
       </div>
 
       <div className="flex gap-3">
-        <Circle className="w-5 h-5 text-muted-foreground shrink-0" />
+        <StepIcon done={webhookVerified} />
         <div className="flex-1 space-y-1">
-          <p className="text-sm font-medium">4. Configure Event Subscriptions</p>
+          <p
+            className={`text-sm font-medium ${webhookVerified ? "text-muted-foreground line-through" : ""}`}
+          >
+            4. Configure Event Subscriptions
+          </p>
           {currentStep === 4 ? (
             <div className="space-y-2">
               {isLocalhost ? (
@@ -201,9 +221,13 @@ function SetupSteps({
       </div>
 
       <div className="flex gap-3">
-        <Circle className="w-5 h-5 text-muted-foreground shrink-0" />
+        <StepIcon done={firstMessageReceived} />
         <div className="flex-1 space-y-1">
-          <p className="text-sm font-medium">5. Invite the bot and test</p>
+          <p
+            className={`text-sm font-medium ${firstMessageReceived ? "text-muted-foreground line-through" : ""}`}
+          >
+            5. Invite the bot and test
+          </p>
           <p className="text-xs text-muted-foreground">
             In Slack, use <code>/invite @botname</code> in a channel, then send a message.
           </p>

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -1706,6 +1706,8 @@ export interface SlackChannelConfig {
   channel_id?: string;
   team_id?: string;
   session_strategy: SessionStrategy;
+  webhook_verified_at?: string | null;
+  first_message_received_at?: string | null;
 }
 
 export interface App {

--- a/crates/core/src/app.rs
+++ b/crates/core/src/app.rs
@@ -152,6 +152,12 @@ pub struct SlackChannelConfig {
     /// How incoming messages map to sessions.
     #[serde(default)]
     pub session_strategy: SessionStrategy,
+    /// Set when Slack successfully verifies the webhook URL (url_verification challenge).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub webhook_verified_at: Option<DateTime<Utc>>,
+    /// Set when the first real message is received from Slack.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_message_received_at: Option<DateTime<Utc>>,
 }
 
 impl App {
@@ -253,6 +259,42 @@ mod tests {
         assert!(config.channel_id.is_none());
         assert!(config.team_id.is_none());
         assert_eq!(config.session_strategy, SessionStrategy::PerThread);
+        assert!(config.webhook_verified_at.is_none());
+        assert!(config.first_message_received_at.is_none());
+    }
+
+    #[test]
+    fn test_slack_channel_config_with_verification_timestamps() {
+        let json = r#"{
+            "signing_secret": "s",
+            "bot_token": "t",
+            "webhook_verified_at": "2025-01-01T00:00:00Z",
+            "first_message_received_at": "2025-01-01T01:00:00Z"
+        }"#;
+        let config: SlackChannelConfig = serde_json::from_str(json).unwrap();
+        assert!(config.webhook_verified_at.is_some());
+        assert!(config.first_message_received_at.is_some());
+
+        // Round-trip: timestamps should be preserved
+        let serialized = serde_json::to_value(&config).unwrap();
+        assert!(serialized.get("webhook_verified_at").is_some());
+        assert!(serialized.get("first_message_received_at").is_some());
+    }
+
+    #[test]
+    fn test_slack_channel_config_timestamps_skipped_when_none() {
+        let config = SlackChannelConfig {
+            signing_secret: "s".into(),
+            bot_token: "t".into(),
+            channel_id: None,
+            team_id: None,
+            session_strategy: SessionStrategy::PerThread,
+            webhook_verified_at: None,
+            first_message_received_at: None,
+        };
+        let json = serde_json::to_value(&config).unwrap();
+        assert!(json.get("webhook_verified_at").is_none());
+        assert!(json.get("first_message_received_at").is_none());
     }
 
     #[test]

--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -24,6 +24,7 @@ use axum::{
     http::{HeaderMap, StatusCode},
     routing::{get, post},
 };
+use chrono::Utc;
 use everruns_core::{App, AppStatus, ChannelType, SessionStrategy, SlackChannelConfig};
 use everruns_worker::AgentRunner;
 use hmac::{Hmac, Mac};
@@ -38,6 +39,7 @@ use crate::api::sessions::CreateSessionRequest;
 use crate::services::{AppService, MessageService, SessionService};
 use crate::slack_delivery::SlackDeliveryDispatcher;
 use crate::storage::StorageBackend;
+use crate::storage::models::UpdateApp;
 
 use super::common::ErrorResponse;
 
@@ -277,6 +279,26 @@ async fn handle_slack_event(
         "url_verification" => {
             let challenge = envelope.challenge.unwrap_or_default();
             tracing::info!(app_id = %app_id, "Slack URL verification challenge received");
+
+            // Record webhook verification timestamp (idempotent — only sets if not already set)
+            if slack_config.webhook_verified_at.is_none() {
+                let mut updated_config = slack_config.clone();
+                updated_config.webhook_verified_at = Some(Utc::now());
+                if let Ok(config_json) = serde_json::to_value(&updated_config) {
+                    let input = UpdateApp {
+                        channel_config: Some(config_json),
+                        ..Default::default()
+                    };
+                    if let Err(e) = state
+                        .db
+                        .update_app(app.org_id, app.internal_id, input)
+                        .await
+                    {
+                        tracing::warn!(app_id = %app_id, error = %e, "Failed to record webhook verification");
+                    }
+                }
+            }
+
             Ok((
                 StatusCode::OK,
                 Json(serde_json::to_value(ChallengeResponse { challenge }).unwrap()),
@@ -309,6 +331,25 @@ async fn handle_slack_event(
                     thread_ts = ?event.thread_ts,
                     "Slack message received"
                 );
+
+                // Record first message timestamp (idempotent — only sets once)
+                if slack_config.first_message_received_at.is_none() {
+                    let mut updated_config = slack_config.clone();
+                    updated_config.first_message_received_at = Some(Utc::now());
+                    if let Ok(config_json) = serde_json::to_value(&updated_config) {
+                        let input = UpdateApp {
+                            channel_config: Some(config_json),
+                            ..Default::default()
+                        };
+                        if let Err(e) = state
+                            .db
+                            .update_app(app.org_id, app.internal_id, input)
+                            .await
+                        {
+                            tracing::warn!(app_id = %app_id, error = %e, "Failed to record first message timestamp");
+                        }
+                    }
+                }
 
                 // Process message in background (Slack requires 200 within 3 seconds)
                 let state = state.clone();
@@ -1377,6 +1418,8 @@ mod tests {
             channel_id: None,
             team_id: None,
             session_strategy: strategy,
+            webhook_verified_at: None,
+            first_message_received_at: None,
         }
     }
 


### PR DESCRIPTION
## What
Auto-detect completion of Slack setup checklist steps 4 (Configure Event Subscriptions) and 5 (Invite the bot and test). Previously these steps were always shown as incomplete regardless of actual state.

## Why
Steps 4 and 5 had hardcoded `<Circle>` icons — the system had no way to know when the user completed them in Slack's UI. This confused users who finished setup but still saw incomplete steps.

## How
Added two optional timestamp fields to `SlackChannelConfig` (stored in the existing `channel_config` JSON column — no migration needed):

- **`webhook_verified_at`** — set when Slack sends a `url_verification` challenge (the exact moment step 4 is completed in Slack's Event Subscriptions page)
- **`first_message_received_at`** — set when the first real user message arrives (confirms step 5: bot was invited and someone messaged it)

Both writes are idempotent (only set once) and non-blocking (failures are logged, not propagated).

Frontend reads these fields and renders `<StepIcon done={...}>` with line-through styling when complete.

## Risk
- Low
- Worst case: timestamp write fails silently and steps stay unchecked (same as before). No impact on message processing.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered