### PR TITLE
fix(slack): expose external_actor in API Message response

### DIFF
--- a/crates/server/src/api/messages.rs
+++ b/crates/server/src/api/messages.rs
@@ -91,6 +91,9 @@ pub struct Message {
     /// Message-level metadata (locale, etc.)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<HashMap<String, serde_json::Value>>,
+    /// External actor identity (for messages from external channels like Slack)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_actor: Option<everruns_core::ExternalActor>,
     pub created_at: DateTime<Utc>,
 }
 

--- a/crates/server/src/services/message.rs
+++ b/crates/server/src/services/message.rs
@@ -106,6 +106,7 @@ impl MessageService {
             content,
             controls: req.controls,
             metadata: req.metadata,
+            external_actor: req.external_actor,
             created_at: now,
         };
 
@@ -234,6 +235,7 @@ impl MessageService {
                             content: msg.content,
                             controls: None,
                             metadata: None,
+                            external_actor: None,
                             created_at: msg.created_at,
                         });
                     }
@@ -248,6 +250,7 @@ impl MessageService {
                     content: core_message.content.clone(),
                     controls: core_message.controls.clone(),
                     metadata: core_message.metadata.clone(),
+                    external_actor: core_message.external_actor.clone(),
                     created_at: core_message.created_at,
                 })
             };

--- a/crates/server/src/storage/message_store.rs
+++ b/crates/server/src/storage/message_store.rs
@@ -510,4 +510,64 @@ mod tests {
         assert_eq!(parsed.tool_calls().len(), 1);
         assert_eq!(parsed.tool_calls()[0].name, "search");
     }
+
+    #[test]
+    fn test_parse_input_message_preserves_external_actor() {
+        let session_id = SessionId::new();
+        let mut message = Message::user("Hello from Slack!");
+        message.external_actor = Some(everruns_core::ExternalActor {
+            actor_id: "U0123456789".to_string(),
+            actor_name: Some("Alice".to_string()),
+            source: "slack".to_string(),
+            metadata: None,
+        });
+
+        let event = Event::new(
+            session_id,
+            EventContext::empty(),
+            InputMessageData::new(message),
+        );
+
+        let stored = serde_json::to_value(&event).unwrap();
+        let result = event_to_message(&stored, "input.message");
+
+        assert!(result.is_ok());
+        let parsed = result.unwrap();
+        assert_eq!(parsed.role, MessageRole::User);
+        assert_eq!(parsed.text(), Some("Hello from Slack!"));
+
+        let actor = parsed
+            .external_actor
+            .expect("external_actor should be preserved");
+        assert_eq!(actor.actor_id, "U0123456789");
+        assert_eq!(actor.actor_name.as_deref(), Some("Alice"));
+        assert_eq!(actor.source, "slack");
+        assert_eq!(actor.display_label(), "Alice");
+    }
+
+    #[test]
+    fn test_parse_input_message_external_actor_fallback_to_id() {
+        let session_id = SessionId::new();
+        let mut message = Message::user("Hello!");
+        message.external_actor = Some(everruns_core::ExternalActor {
+            actor_id: "U0123456789".to_string(),
+            actor_name: None,
+            source: "slack".to_string(),
+            metadata: None,
+        });
+
+        let event = Event::new(
+            session_id,
+            EventContext::empty(),
+            InputMessageData::new(message),
+        );
+
+        let stored = serde_json::to_value(&event).unwrap();
+        let parsed = event_to_message(&stored, "input.message").unwrap();
+
+        let actor = parsed
+            .external_actor
+            .expect("external_actor should be preserved");
+        assert_eq!(actor.display_label(), "U0123456789");
+    }
 }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -6690,6 +6690,17 @@
                   "type": "string",
                   "format": "date-time"
                 },
+                "external_actor": {
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ExternalActor",
+                      "description": "External actor identity (for messages from external channels like Slack)"
+                    }
+                  ]
+                },
                 "id": {
                   "type": "string",
                   "description": "Unique message ID (format: message_{32-hex})",

--- a/specs/slack-integration.md
+++ b/specs/slack-integration.md
@@ -108,12 +108,15 @@ Display name resolution uses an in-memory cache with:
 - Permanent API errors (`missing_scope`, `invalid_auth`, etc.) cached as `None` to avoid repeated calls
 - Transient network errors not cached (allow retry)
 
+The API `Message` response includes `external_actor` (optional) so clients can display user identity for externally-originated messages.
+
 This is channel-agnostic — any future channel adapter (Discord, Teams) populates the same `ExternalActor` struct and gets the same LLM prefix behavior.
 
 ## Files
 
 - `crates/core/src/app.rs` - `SlackChannelConfig`, `SessionStrategy` types
 - `crates/core/src/message.rs` - `ExternalActor` struct
+- `crates/server/src/api/messages.rs` - API `Message` response includes `external_actor`
 - `crates/server/src/api/slack_events.rs` - Webhook endpoint, manifest generation, signing verification, session routing, user name resolution
 - `crates/server/src/slack_delivery.rs` - Event-driven Slack delivery dispatcher with retry and startup recovery
 - `crates/server/src/services/app.rs` - `get_by_public_id_unscoped()` method


### PR DESCRIPTION
## What
Expose `external_actor` field in the API `Message` response so clients can display Slack user identity for externally-originated messages.

## Why
The `ExternalActor` was stored on core messages but not surfaced in the API response, making it impossible for UI clients to show who sent a message from Slack (or other external channels).

## How
- Added `external_actor: Option<ExternalActor>` to the API `Message` struct
- Threaded the field through `MessageService` conversion paths (create, list, get)
- Added two unit tests: one verifying `external_actor` preservation through serialization, one verifying fallback to `actor_id` when `actor_name` is absent
- Updated `specs/slack-integration.md` to document the API response field

## Risk
- Low
- Purely additive optional field — existing clients unaffected (field is `skip_serializing_if = "Option::is_none"`)

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered