### PR TITLE
feat(daytona): add ownership metadata labels to sandbox creation

### DIFF
--- a/integrations/daytona/src/client.rs
+++ b/integrations/daytona/src/client.rs
@@ -953,4 +953,48 @@ mod tests {
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0]["name"], "only.txt");
     }
+
+    #[tokio::test]
+    async fn test_client_create_sandbox_forwards_labels() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/sandbox"))
+            .and(wiremock::matchers::body_json(json!({
+                "name": "Labeled Sandbox",
+                "autoStopInterval": 5,
+                "labels": {
+                    "everruns": "true",
+                    "everruns.session_id": "session_abc",
+                    "everruns.org_id": "org_123"
+                }
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "sb_labeled",
+                "name": "Labeled Sandbox",
+                "state": "started"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = DaytonaClient::with_base_urls(
+            "test_key".to_string(),
+            mock_server.uri(),
+            mock_server.uri(),
+        );
+        let result = client
+            .create_sandbox(json!({
+                "name": "Labeled Sandbox",
+                "autoStopInterval": 5,
+                "labels": {
+                    "everruns": "true",
+                    "everruns.session_id": "session_abc",
+                    "everruns.org_id": "org_123"
+                }
+            }))
+            .await;
+        assert!(result.is_ok());
+        let info = result.unwrap();
+        assert_eq!(info.id, "sb_labeled");
+    }
 }

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -82,9 +82,34 @@ impl Tool for DaytonaCreateSandboxTool {
             .get("title")
             .and_then(|v| v.as_str())
             .unwrap_or("Everruns Sandbox");
+
+        // Build ownership labels for audit/cleanup traceability
+        let mut labels = serde_json::Map::new();
+        labels.insert("everruns".to_string(), json!("true"));
+        labels.insert(
+            "everruns.session_id".to_string(),
+            json!(context.session_id.to_string()),
+        );
+        if let Some(session_store) = &context.session_store
+            && let Ok(Some(session)) = session_store.get_session(context.session_id).await
+        {
+            labels.insert(
+                "everruns.harness_id".to_string(),
+                json!(session.harness_id.to_string()),
+            );
+            labels.insert(
+                "everruns.org_id".to_string(),
+                json!(&session.organization_id),
+            );
+            if let Some(agent_id) = &session.agent_id {
+                labels.insert("everruns.agent_id".to_string(), json!(agent_id.to_string()));
+            }
+        }
+
         let mut create_body = json!({
             "name": title,
             "autoStopInterval": AUTO_STOP_INTERVAL_MINUTES,
+            "labels": labels,
         });
         if let Some(image) = arguments.get("image").and_then(|v| v.as_str()) {
             create_body["image"] = json!(image);

--- a/specs/daytona.md
+++ b/specs/daytona.md
@@ -77,7 +77,7 @@ This avoids entering the key in chat (see TM-AGENT-016).
 
 | Method | Path | Purpose | Request Body |
 |--------|------|---------|-------------|
-| POST | `/sandbox` | Create sandbox | `{ name?, image?, autoStopInterval }` |
+| POST | `/sandbox` | Create sandbox | `{ name?, image?, autoStopInterval, labels? }` |
 | GET | `/sandbox/{id}` | Get sandbox info | — |
 | POST | `/sandbox/{id}/start` | Start sandbox | — |
 | POST | `/sandbox/{id}/stop` | Stop sandbox | — |
@@ -213,6 +213,27 @@ See [threat-model.md](threat-model.md#16-daytona-cloud-sandbox-tm-daytona) for f
 | No context | `ToolError` | "{tool_name} requires context." |
 
 ## Design Decisions
+
+### Sandbox metadata labels (required)
+
+All sandboxes **must** include Daytona `labels` at creation time for audit, dashboard visibility, and orphan cleanup. Labels are `Record<string, string>` key-value pairs stored on the Daytona side.
+
+Required labels:
+
+| Label key | Value | Source |
+|-----------|-------|--------|
+| `everruns` | `"true"` | Static — identifies Everruns-owned sandboxes |
+| `everruns.session_id` | Session ID | `context.session_id` |
+| `everruns.harness_id` | Harness ID | `session.harness_id` |
+| `everruns.org_id` | Organization ID | `session.organization_id` |
+| `everruns.agent_id` | Agent ID (if set) | `session.agent_id` |
+
+This enables:
+- Filtering sandboxes by org/agent/session in the Daytona dashboard
+- Automated cleanup of orphaned sandboxes via label queries
+- Audit trail linking sandboxes back to their Everruns origin
+
+Any new sandbox integration (Daytona or otherwise) must attach equivalent ownership metadata.
 
 ### Synchronous exec only
 


### PR DESCRIPTION
## What
Add Daytona `labels` to sandbox creation requests with ownership metadata (everruns marker, session_id, harness_id, org_id, agent_id).

## Why
Sandboxes created via Daytona had no metadata linking them back to their Everruns origin. This made it impossible to:
- Filter sandboxes by org/agent/session in the Daytona dashboard
- Automate cleanup of orphaned sandboxes
- Audit which agent/session created a sandbox

## How
- Build a `labels` map in `DaytonaCreateSandboxTool::execute_with_context` from `context.session_id` and session metadata (harness_id, org_id, agent_id via session_store)
- Pass labels in the `POST /sandbox` request body
- Add spec requirement in `specs/daytona.md` for all future sandbox integrations to include equivalent metadata
- Added wiremock test verifying labels are forwarded in the API request

## Risk
- Low
- If Daytona API rejects the `labels` field, sandbox creation will fail with a clear API error. Daytona SDK docs confirm `labels` is supported.
- Labels degrade gracefully: if session_store is unavailable, only `everruns` and `session_id` labels are sent.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered