### PR TITLE
chore(agents): add attribution settings and policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,6 +222,8 @@ Types: feat, fix, docs, refactor, test, chore
 
 Use `chore` for updates to `specs/` and `AGENTS.md`.
 
+**NEVER** add links to Claude sessions in PR body or commits. Never attribute commits or merge commits to coding agents — always use the real user as author.
+
 ### PRs
 
 **REQUIRED:** Use `.github/pull_request_template.md`. Squash and Merge.


### PR DESCRIPTION
## What
Add attribution settings to `.claude/settings.json` and attribution policy to `AGENTS.md`.

## Why
Ensure coding agents never attribute commits or merge commits to themselves — real users should always be the author.

## How
- `.claude/settings.json`: `attribution.commit` and `attribution.pr` set to empty strings (disables agent attribution)
- `AGENTS.md`: Added explicit rule in Commits section against agent attribution

## Risk
- Low
- Config/docs only change, no code impact

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered