### PR TITLE
feat(browserless): add Browserless browser automation integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,7 @@ Fix root cause. Unsure: read more code; if stuck, ask w/ short options. Unrecogn
 - `specs/tool-search.md` - OpenAI tool_search deferred tool loading capability
 - `specs/cache.md` - Caching strategy and distributed rate limiting (Valkey)
 - `specs/sccache.md` - Shared compile cache (sccache with S3 backend)
+- `specs/browserless.md` - Browserless browser automation integration
 
 ### Skills
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,6 +1013,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1401,11 +1407,13 @@ dependencies = [
  "base64",
  "chrono",
  "everruns-core",
+ "futures-util",
  "inventory",
  "reqwest 0.13.1",
  "serde",
  "serde_json",
  "tokio",
+ "tokio-tungstenite",
  "tracing",
  "wiremock",
 ]
@@ -5550,6 +5558,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5815,6 +5839,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
 name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5951,6 +5994,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,6 +1394,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "everruns-integrations-browserless"
+version = "0.8.4"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "everruns-core",
+ "inventory",
+ "reqwest 0.13.1",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "wiremock",
+]
+
+[[package]]
 name = "everruns-integrations-daytona"
 version = "0.8.4"
 dependencies = [
@@ -1512,6 +1529,7 @@ dependencies = [
  "everruns-core",
  "everruns-durable",
  "everruns-integrations-brave-search",
+ "everruns-integrations-browserless",
  "everruns-integrations-daytona",
  "everruns-integrations-docker",
  "everruns-integrations-duckduckgo",
@@ -1590,6 +1608,7 @@ dependencies = [
  "everruns-durable",
  "everruns-gemini",
  "everruns-integrations-brave-search",
+ "everruns-integrations-browserless",
  "everruns-integrations-daytona",
  "everruns-integrations-docker",
  "everruns-integrations-duckduckgo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "integrations/daytona",
     "integrations/brave-search",
     "integrations/duckduckgo",
+    "integrations/browserless",
 ]
 
 exclude = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,10 @@ regex = "1.11"
 time = "0.3"
 parking_lot = "0.12"
 
+# WebSocket (CDP sessions)
+tokio-tungstenite = { version = "0.26", features = ["rustls-tls-native-roots"] }
+futures-util = "0.3"
+
 # Everruns SDK
 everruns-sdk = { git = "https://github.com/everruns/sdk", tag = "v0.1.3" }
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -65,6 +65,7 @@ everruns-integrations-docker = { path = "../../integrations/docker" }
 everruns-integrations-brave-search = { path = "../../integrations/brave-search" }
 everruns-integrations-duckduckgo = { path = "../../integrations/duckduckgo" }
 everruns-integrations-daytona = { path = "../../integrations/daytona" }
+everruns-integrations-browserless = { path = "../../integrations/browserless" }
 everruns-session-sqldb = { path = "../session-sqldb" }
 everruns-worker = { path = "../worker" }  # For AgentRunner trait
 everruns-internal-protocol = { path = "../internal-protocol" }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -8,6 +8,7 @@ extern crate everruns_integrations_brave_search;
 extern crate everruns_integrations_daytona;
 extern crate everruns_integrations_docker;
 extern crate everruns_integrations_duckduckgo;
+extern crate everruns_integrations_browserless;
 
 // API routes and types (shared for OpenAPI generation)
 pub mod api;

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -5,10 +5,10 @@
 
 // Force-link integration crates so inventory::submit! registrations are included
 extern crate everruns_integrations_brave_search;
+extern crate everruns_integrations_browserless;
 extern crate everruns_integrations_daytona;
 extern crate everruns_integrations_docker;
 extern crate everruns_integrations_duckduckgo;
-extern crate everruns_integrations_browserless;
 
 // API routes and types (shared for OpenAPI generation)
 pub mod api;

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -53,6 +53,8 @@ mod seed_ids {
     pub const PLATFORM_MANAGER_AGENT: Uuid =
         Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000010a);
     pub const WEB_RESEARCHER_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000010b);
+    pub const BROWSER_TESTER_AGENT: Uuid =
+        Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000010c);
 
     // MCP Servers (0x500-0x5FF)
     pub const MS_LEARN_MCP: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000501);
@@ -865,6 +867,57 @@ Get a free key at https://brave.com/search/api/"#,
         tags: &["research", "search", "web", "demo", "seed"],
         capabilities: &["brave_search", "stateless_todo_list", "current_time"],
         dev_only: true,
+    },
+    SeedAgent {
+        id: seed_ids::BROWSER_TESTER_AGENT,
+        name: "Browser Tester",
+        description: "An agent that automates browser testing: navigates web pages, takes screenshots, reads DOM content, scrapes data, and interacts with UI elements (click, type, keyboard, mouse, touch). Useful for accessibility testing, regression testing, and web automation.",
+        system_prompt: r#"You are a Browser Tester Agent. You automate browser interactions using Browserless.
+
+## How You Work
+
+1. **Navigate** to a URL with `browserless_navigate` to explore its structure (links, headings, meta)
+2. **Screenshot** the page with `browserless_screenshot` for visual validation
+3. **Read DOM** with `browserless_content` to inspect rendered HTML
+4. **Scrape data** with `browserless_scrape` to extract structured information via CSS selectors
+5. **Interact** with `browserless_interact` for multi-step flows (login, form filling, menu navigation)
+
+## Interaction Capabilities
+
+The `browserless_interact` tool supports:
+- `click` — Click by CSS selector or x,y coordinates
+- `type` — Type text into input fields
+- `keyboard` — Press keys (Enter, Tab, Escape, etc.)
+- `mouse_move` — Move mouse to coordinates
+- `touch` — Tap elements (mobile simulation)
+- `scroll` — Scroll the page
+- `wait` / `wait_for_selector` — Wait for content to load
+- `navigate` — Go to a different URL mid-interaction
+
+Set `return_screenshot: true` to get a screenshot after interactions.
+
+## Use Cases
+
+- **Accessibility testing**: Navigate pages, read DOM, check ARIA attributes and heading structure
+- **Regression testing**: Screenshot pages, compare with expected state, verify content
+- **Login flows**: Use `browserless_interact` to fill login forms and verify post-login state
+- **Content verification**: Scrape specific elements and validate their text/attributes
+- **Visual QA**: Take screenshots before/after interactions to verify UI changes
+
+## Guidelines
+
+- Each tool call uses a fresh browser — no state carries between calls
+- Use `wait_for_selector` or `wait_for_timeout` for pages with dynamic content
+- For login-protected pages, use `browserless_interact` with type/click steps
+- Always clean up: Browserless handles this automatically (no resources to manage)
+
+## Prerequisites
+
+Browserless API token must be configured in Settings > Connections.
+Get a token at https://cloud.browserless.io/"#,
+        tags: &["browser", "testing", "automation", "a11y", "regression", "demo", "seed"],
+        capabilities: &["browserless"],
+        dev_only: false,
     },
 ];
 

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -53,8 +53,7 @@ mod seed_ids {
     pub const PLATFORM_MANAGER_AGENT: Uuid =
         Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000010a);
     pub const WEB_RESEARCHER_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000010b);
-    pub const BROWSER_TESTER_AGENT: Uuid =
-        Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000010c);
+    pub const BROWSER_TESTER_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000010c);
 
     // MCP Servers (0x500-0x5FF)
     pub const MS_LEARN_MCP: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000501);
@@ -915,7 +914,15 @@ Set `return_screenshot: true` to get a screenshot after interactions.
 
 Browserless API token must be configured in Settings > Connections.
 Get a token at https://cloud.browserless.io/"#,
-        tags: &["browser", "testing", "automation", "a11y", "regression", "demo", "seed"],
+        tags: &[
+            "browser",
+            "testing",
+            "automation",
+            "a11y",
+            "regression",
+            "demo",
+            "seed",
+        ],
         capabilities: &["browserless"],
         dev_only: false,
     },

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -19,6 +19,7 @@ everruns-integrations-docker = { path = "../../integrations/docker" }
 everruns-integrations-brave-search = { path = "../../integrations/brave-search" }
 everruns-integrations-duckduckgo = { path = "../../integrations/duckduckgo" }
 everruns-integrations-daytona = { path = "../../integrations/daytona" }
+everruns-integrations-browserless = { path = "../../integrations/browserless" }
 everruns-openai = { path = "../openai" }
 everruns-anthropic = { path = "../anthropic" }
 everruns-gemini = { path = "../gemini" }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -3,6 +3,7 @@ extern crate everruns_integrations_brave_search;
 extern crate everruns_integrations_daytona;
 extern crate everruns_integrations_docker;
 extern crate everruns_integrations_duckduckgo;
+extern crate everruns_integrations_browserless;
 
 pub mod activities;
 pub mod adapters;

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -1,9 +1,9 @@
 // Force-link integration crates so inventory::submit! registrations are included
 extern crate everruns_integrations_brave_search;
+extern crate everruns_integrations_browserless;
 extern crate everruns_integrations_daytona;
 extern crate everruns_integrations_docker;
 extern crate everruns_integrations_duckduckgo;
-extern crate everruns_integrations_browserless;
 
 pub mod activities;
 pub mod adapters;

--- a/docs/capabilities/browserless.md
+++ b/docs/capabilities/browserless.md
@@ -1,0 +1,123 @@
+---
+title: Browserless
+description: Cloud browser automation for screenshots, DOM reading, scraping, and interactions
+---
+
+| | |
+|---|---|
+| **ID** | `browserless` |
+| **Category** | Browser |
+| **Features** | None |
+| **Dependencies** | None (session_storage used opportunistically for CDP sessions) |
+
+Cloud browser automation powered by Browserless. Take screenshots, read DOM content, scrape structured data, and interact with web pages using click, type, keyboard, mouse, and touch events.
+
+## Tools
+
+### `browserless_open_browser`
+
+Open a persistent browser session via CDP. The browser stays alive between tool calls.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `url` | string | no | Initial URL to navigate to |
+| `timeout_ms` | integer | no | How long the browser stays alive between calls (default: 60000) |
+
+### `browserless_close_browser`
+
+Close the persistent browser session and release resources.
+
+No parameters.
+
+### `browserless_navigate`
+
+Navigate to a URL and return page metadata (title, links, headings, meta tags).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `url` | string | yes | The URL to navigate to |
+| `wait_for_selector` | string | no | Wait for this CSS selector to appear |
+| `wait_for_timeout` | integer | no | Wait this many milliseconds after page load |
+
+### `browserless_screenshot`
+
+Take a PNG screenshot of a page. Returns base64-encoded image data.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `url` | string | yes | The URL to screenshot |
+| `full_page` | boolean | no | Capture the full scrollable page (default: true) |
+| `selector` | string | no | CSS selector to screenshot a specific element |
+| `wait_for_selector` | string | no | Wait for this CSS selector before taking screenshot |
+| `wait_for_timeout` | integer | no | Wait this many milliseconds before taking screenshot |
+
+### `browserless_content`
+
+Get the fully rendered HTML content (DOM) of a page, including JavaScript-rendered content.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `url` | string | yes | The URL to read |
+| `wait_for_selector` | string | no | Wait for this CSS selector before reading content |
+| `wait_for_timeout` | integer | no | Wait this many milliseconds before reading content |
+| `best_attempt` | boolean | no | Continue even if async events fail or timeout (default: false) |
+
+### `browserless_scrape`
+
+Extract structured data from a page using CSS selectors. Returns JSON with matched elements.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `url` | string | yes | The URL to scrape |
+| `elements` | array | yes | Array of `{selector}` objects to extract |
+| `wait_for_selector` | string | no | Wait for this CSS selector before scraping |
+| `wait_for_timeout` | integer | no | Wait this many milliseconds before scraping |
+
+### `browserless_interact`
+
+Multi-step browser interactions. Navigate to a URL, then perform a sequence of actions.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `url` | string | yes | The initial URL to navigate to |
+| `steps` | array | yes | Ordered list of interaction steps |
+| `return_screenshot` | boolean | no | Return screenshot after steps (default: false = DOM content) |
+
+**Supported step actions:**
+
+| Action | Key Parameters | Description |
+|---|---|---|
+| `click` | `selector` or `x`,`y` | Click element or coordinates |
+| `type` | `selector`, `value` | Type text into input field |
+| `keyboard` | `key` | Press a key (Enter, Tab, Escape, etc.) |
+| `mouse_move` | `x`, `y` | Move mouse to coordinates |
+| `touch` | `selector` | Tap element (mobile touch simulation) |
+| `scroll` | `value` | Scroll page by pixel amount |
+| `wait` | `wait_ms` | Wait for milliseconds |
+| `wait_for_selector` | `selector`, `wait_ms` | Wait for element to appear |
+| `navigate` | `value` | Navigate to a different URL |
+
+## Authentication
+
+Browserless API token is resolved automatically from **Settings > Connections > Browserless**.
+
+## Use Cases
+
+- **Accessibility testing** — read DOM, check ARIA attributes and heading structure
+- **Regression testing** — screenshot pages and compare visual state
+- **Login-protected testing** — use CDP sessions to authenticate and browse
+- **Web scraping** — extract structured data from any website
+- **Visual QA** — screenshot before/after interactions
+
+## Notes
+
+- Stateless mode: each tool call uses a fresh browser (no cleanup needed)
+- CDP mode: browser persists across calls (close when done)
+- Large DOM responses are truncated to 100KB
+- Session-aware: tools automatically use CDP session when active, REST otherwise
+- `browserless_scrape` always uses REST API (no CDP equivalent)
+
+## See Also
+
+- [Browserless integration guide](/integrations/browserless/) — setup and configuration
+- [Capabilities Overview](/capabilities/)

--- a/docs/integrations/browserless.md
+++ b/docs/integrations/browserless.md
@@ -1,0 +1,87 @@
+---
+title: Browserless
+description: Cloud browser automation for screenshots, scraping, and testing with Browserless
+---
+
+Everruns integrates with [Browserless](https://www.browserless.io/) to provide cloud-based browser automation. Agents can navigate web pages, take screenshots, read DOM content, scrape structured data, and interact with UI elements (click, type, keyboard, mouse, touch).
+
+## What You Get
+
+- **Screenshots**: Capture full-page or element-specific PNG screenshots
+- **DOM Reading**: Get fully rendered HTML including JavaScript-generated content
+- **Structured Scraping**: Extract data from pages using CSS selectors
+- **Browser Interactions**: Click, type, press keys, use mouse/touch events
+- **Persistent Sessions**: Keep a browser alive across tool calls for login-protected pages (CDP mode)
+
+## Quick Start
+
+### 1. Get Your API Token
+
+1. Go to the [Browserless Dashboard](https://cloud.browserless.io)
+2. Navigate to **API Keys** in your account settings
+3. Copy your API token
+
+### 2. Connect in Everruns
+
+1. Go to **Settings** > **Connections**
+2. Find **Browserless** in the available providers
+3. Click **Connect** and paste your API token
+
+Once connected, the Browserless capability is automatically available in agent sessions.
+
+### 3. Use in Sessions
+
+Agents with the Browserless capability can use these tools:
+
+| Tool | Description |
+|------|-------------|
+| `browserless_open_browser` | Open a persistent browser session (CDP mode) |
+| `browserless_close_browser` | Close the persistent browser session |
+| `browserless_navigate` | Navigate to a URL and get page metadata |
+| `browserless_screenshot` | Take a PNG screenshot of a page |
+| `browserless_content` | Get the fully rendered HTML/DOM content |
+| `browserless_scrape` | Extract structured data via CSS selectors |
+| `browserless_interact` | Multi-step interactions (click, type, keyboard, mouse, touch) |
+
+## Two Operating Modes
+
+### Stateless Mode (Default)
+
+Each tool call launches a fresh browser that is destroyed after the response. No state persists between calls. Best for one-shot operations like screenshots or scraping.
+
+### Persistent Session Mode (CDP)
+
+Use `browserless_open_browser` to create a persistent browser via Chrome DevTools Protocol. The browser stays alive between tool calls, preserving login state, cookies, and navigation history. Use `browserless_close_browser` when done.
+
+**Example workflow for login-protected pages:**
+1. `browserless_open_browser` with the login page URL
+2. `browserless_interact` to fill credentials and submit the form
+3. `browserless_navigate` to browse authenticated pages
+4. `browserless_screenshot` to capture authenticated page state
+5. `browserless_close_browser` to release resources
+
+## Use Cases
+
+- **Accessibility testing** — Navigate pages, read DOM, check ARIA attributes and heading structure
+- **Regression testing** — Screenshot pages and verify content after changes
+- **Login flows** — Use persistent sessions to authenticate and test protected pages
+- **Web scraping** — Extract structured data from any website
+- **Visual QA** — Take before/after screenshots to verify UI changes
+
+## Resource Management
+
+- **Stateless mode**: No cleanup needed — browsers are ephemeral
+- **CDP mode**: Browsers auto-expire after 60 seconds of inactivity. Always call `browserless_close_browser` when done for immediate cleanup.
+
+## Security
+
+- API tokens are encrypted at rest (AES-256-GCM envelope encryption)
+- Browser sessions are fully isolated on Browserless servers
+- CDP session state is stored as encrypted secrets, scoped per session
+- Large DOM responses are truncated to 100KB to prevent context flooding
+
+## Links
+
+- [Browserless Website](https://www.browserless.io/)
+- [Browserless Dashboard](https://cloud.browserless.io)
+- [Browserless Documentation](https://docs.browserless.io/)

--- a/docs/integrations/browserless.md
+++ b/docs/integrations/browserless.md
@@ -77,7 +77,7 @@ Use `browserless_open_browser` to create a persistent browser via Chrome DevTool
 
 - API tokens are encrypted at rest (AES-256-GCM envelope encryption)
 - Browser sessions are fully isolated on Browserless servers
-- CDP session state is stored as encrypted secrets, scoped per session
+- CDP session state stores only the WebSocket endpoint (no secrets), scoped per session
 - Large DOM responses are truncated to 100KB to prevent context flooding
 
 ## Links

--- a/integrations/browserless/Cargo.toml
+++ b/integrations/browserless/Cargo.toml
@@ -1,6 +1,6 @@
 # Browserless Integration
 # Decision: External integration crate, auto-registered via inventory plugin system
-# Decision: REST API only (no WebSocket/Puppeteer), each request is a fresh browser session
+# Decision: REST API for one-shot operations, CDP (WebSocket) for persistent browser sessions
 # Decision: /function endpoint for multi-step interactions (click, type, navigate)
 
 [package]
@@ -15,8 +15,12 @@ description = "Browserless browser automation integration for Everruns"
 everruns-core = { path = "../../crates/core" }
 inventory.workspace = true
 
-# HTTP client for Browserless API
+# HTTP client for Browserless REST API
 reqwest.workspace = true
+
+# WebSocket client for CDP sessions
+tokio-tungstenite.workspace = true
+futures-util.workspace = true
 
 # Serialization
 serde.workspace = true

--- a/integrations/browserless/Cargo.toml
+++ b/integrations/browserless/Cargo.toml
@@ -1,0 +1,39 @@
+# Browserless Integration
+# Decision: External integration crate, auto-registered via inventory plugin system
+# Decision: REST API only (no WebSocket/Puppeteer), each request is a fresh browser session
+# Decision: /function endpoint for multi-step interactions (click, type, navigate)
+
+[package]
+name = "everruns-integrations-browserless"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Browserless browser automation integration for Everruns"
+
+[dependencies]
+everruns-core = { path = "../../crates/core" }
+inventory.workspace = true
+
+# HTTP client for Browserless API
+reqwest.workspace = true
+
+# Serialization
+serde.workspace = true
+serde_json.workspace = true
+
+# Async
+async-trait.workspace = true
+tokio.workspace = true
+chrono.workspace = true
+tracing.workspace = true
+
+# Base64 encoding for screenshot data
+base64.workspace = true
+
+[features]
+browserless-live-tests = []
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full", "test-util"] }
+wiremock = "0.6"

--- a/integrations/browserless/src/cdp.rs
+++ b/integrations/browserless/src/cdp.rs
@@ -200,64 +200,45 @@ impl CdpSession {
             .ok_or_else(|| "CDP screenshot returned no data".to_string())
     }
 
-    /// Get the page's rendered HTML content (outerHTML of document element).
-    pub async fn get_content(&mut self) -> Result<String, String> {
+    /// Evaluate a JS expression and return the string result.
+    async fn eval_string(&mut self, expression: &str) -> Result<String, String> {
         let result = self
             .send_command(
                 "Runtime.evaluate",
                 json!({
-                    "expression": "document.documentElement.outerHTML",
+                    "expression": expression,
                     "returnByValue": true
                 }),
             )
             .await?;
 
-        result
+        Ok(result
             .get("result")
             .and_then(|r| r.get("value"))
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
-            .ok_or_else(|| "CDP getContent returned no data".to_string())
+            .unwrap_or("")
+            .to_string())
+    }
+
+    /// Get the page's rendered HTML content (outerHTML of document element).
+    pub async fn get_content(&mut self) -> Result<String, String> {
+        let html = self
+            .eval_string("document.documentElement.outerHTML")
+            .await?;
+        if html.is_empty() {
+            return Err("CDP getContent returned no data".to_string());
+        }
+        Ok(html)
     }
 
     /// Get the page title.
     pub async fn get_title(&mut self) -> Result<String, String> {
-        let result = self
-            .send_command(
-                "Runtime.evaluate",
-                json!({
-                    "expression": "document.title",
-                    "returnByValue": true
-                }),
-            )
-            .await?;
-
-        Ok(result
-            .get("result")
-            .and_then(|r| r.get("value"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string())
+        self.eval_string("document.title").await
     }
 
     /// Get the current page URL.
     pub async fn get_url(&mut self) -> Result<String, String> {
-        let result = self
-            .send_command(
-                "Runtime.evaluate",
-                json!({
-                    "expression": "window.location.href",
-                    "returnByValue": true
-                }),
-            )
-            .await?;
-
-        Ok(result
-            .get("result")
-            .and_then(|r| r.get("value"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string())
+        self.eval_string("window.location.href").await
     }
 
     /// Evaluate a JavaScript expression and return the result.
@@ -289,28 +270,20 @@ impl CdpSession {
         Ok(())
     }
 
-    /// Click an element by CSS selector. Finds center coordinates via JS, then dispatches mouse events.
-    pub async fn click_selector(&mut self, selector: &str) -> Result<(), String> {
+    /// Find the center coordinates of an element by CSS selector.
+    async fn get_element_center(&mut self, selector: &str) -> Result<(f64, f64), String> {
         let selector_js = serde_json::to_string(selector).unwrap();
-        let coords = self
-            .send_command(
-                "Runtime.evaluate",
-                json!({
-                    "expression": format!(
-                        "(() => {{ const el = document.querySelector({selector_js}); if (!el) throw new Error('Element not found: ' + {selector_js}); const r = el.getBoundingClientRect(); return JSON.stringify({{ x: r.x + r.width/2, y: r.y + r.height/2 }}); }})()"
-                    ),
-                    "returnByValue": true
-                }),
-            )
+        let coord_str = self
+            .eval_string(&format!(
+                "(() => {{ const el = document.querySelector({selector_js}); if (!el) throw new Error('Element not found: ' + {selector_js}); const r = el.getBoundingClientRect(); return JSON.stringify({{ x: r.x + r.width/2, y: r.y + r.height/2 }}); }})()"
+            ))
             .await?;
 
-        let coord_str = coords
-            .get("result")
-            .and_then(|r| r.get("value"))
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| format!("Element not found: {selector}"))?;
+        if coord_str.is_empty() {
+            return Err(format!("Element not found: {selector}"));
+        }
 
-        let coord_val: Value = serde_json::from_str(coord_str)
+        let coord_val: Value = serde_json::from_str(&coord_str)
             .map_err(|e| format!("Failed to parse coordinates: {e}"))?;
 
         let x = coord_val
@@ -322,6 +295,12 @@ impl CdpSession {
             .and_then(|v| v.as_f64())
             .ok_or("No y coordinate")?;
 
+        Ok((x, y))
+    }
+
+    /// Click an element by CSS selector. Finds center coordinates via JS, then dispatches mouse events.
+    pub async fn click_selector(&mut self, selector: &str) -> Result<(), String> {
+        let (x, y) = self.get_element_center(selector).await?;
         self.click_at(x, y).await
     }
 
@@ -402,36 +381,7 @@ impl CdpSession {
 
     /// Tap an element (touch simulation).
     pub async fn tap_selector(&mut self, selector: &str) -> Result<(), String> {
-        let selector_js = serde_json::to_string(selector).unwrap();
-        let coords = self
-            .send_command(
-                "Runtime.evaluate",
-                json!({
-                    "expression": format!(
-                        "(() => {{ const el = document.querySelector({selector_js}); if (!el) throw new Error('Element not found: ' + {selector_js}); const r = el.getBoundingClientRect(); return JSON.stringify({{ x: r.x + r.width/2, y: r.y + r.height/2 }}); }})()"
-                    ),
-                    "returnByValue": true
-                }),
-            )
-            .await?;
-
-        let coord_str = coords
-            .get("result")
-            .and_then(|r| r.get("value"))
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| format!("Element not found: {selector}"))?;
-
-        let coord_val: Value = serde_json::from_str(coord_str)
-            .map_err(|e| format!("Failed to parse coordinates: {e}"))?;
-
-        let x = coord_val
-            .get("x")
-            .and_then(|v| v.as_f64())
-            .ok_or("No x coordinate")?;
-        let y = coord_val
-            .get("y")
-            .and_then(|v| v.as_f64())
-            .ok_or("No y coordinate")?;
+        let (x, y) = self.get_element_center(selector).await?;
 
         self.send_command(
             "Input.dispatchTouchEvent",
@@ -550,25 +500,9 @@ impl CdpSession {
 // Helpers
 // ============================================================================
 
-/// Map common key names to their key codes for CDP Input.dispatchKeyEvent.
+/// Map key names to CDP key codes. Most keys map to themselves; only " " needs special handling.
 fn key_to_code(key: &str) -> &str {
-    match key {
-        "Enter" => "Enter",
-        "Tab" => "Tab",
-        "Escape" => "Escape",
-        "Backspace" => "Backspace",
-        "Delete" => "Delete",
-        "ArrowUp" => "ArrowUp",
-        "ArrowDown" => "ArrowDown",
-        "ArrowLeft" => "ArrowLeft",
-        "ArrowRight" => "ArrowRight",
-        "Home" => "Home",
-        "End" => "End",
-        "PageUp" => "PageUp",
-        "PageDown" => "PageDown",
-        "Space" | " " => "Space",
-        other => other,
-    }
+    if key == " " { "Space" } else { key }
 }
 
 // ============================================================================

--- a/integrations/browserless/src/cdp.rs
+++ b/integrations/browserless/src/cdp.rs
@@ -38,7 +38,7 @@ impl CdpSession {
     ///   `wss://production-sfo.browserless.io?token=TOKEN`
     ///   or a reconnect endpoint returned by `Browserless.reconnect`.
     pub async fn connect(ws_url: &str) -> Result<Self, String> {
-        // Redact token from log output to avoid leaking credentials
+        // THREAT[TM-TOOL-017]: Redact token from log output to avoid leaking credentials
         let redacted = if let Some(idx) = ws_url.find("token=") {
             format!("{}token=<REDACTED>", &ws_url[..idx])
         } else {

--- a/integrations/browserless/src/cdp.rs
+++ b/integrations/browserless/src/cdp.rs
@@ -1,0 +1,592 @@
+//! Minimal Chrome DevTools Protocol (CDP) client over WebSocket.
+//!
+//! Decision: Minimal CDP client — just JSON-RPC over WebSocket. No external CDP crate.
+//! Decision: Short-lived connections. Connect, do work, call Browserless.reconnect, disconnect.
+//!   The browser stays alive on Browserless servers between tool calls.
+//! Decision: 60s default reconnect timeout. Covers LLM thinking time between tool calls.
+
+use futures_util::stream::SplitSink;
+use futures_util::stream::SplitStream;
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{Value, json};
+use tokio::net::TcpStream;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async};
+use tracing::debug;
+
+/// Default reconnect timeout in milliseconds (60 seconds).
+pub const DEFAULT_RECONNECT_TIMEOUT_MS: u64 = 60_000;
+
+type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
+type WsSink = SplitSink<WsStream, Message>;
+type WsSource = SplitStream<WsStream>;
+
+// ============================================================================
+// CdpSession — a single CDP connection to a Browserless browser
+// ============================================================================
+
+pub struct CdpSession {
+    sink: WsSink,
+    source: WsSource,
+    next_id: u32,
+}
+
+impl CdpSession {
+    /// Connect to a Browserless WebSocket endpoint.
+    ///
+    /// `ws_url` should be a full WebSocket URL, e.g.:
+    ///   `wss://production-sfo.browserless.io?token=TOKEN`
+    ///   or a reconnect endpoint returned by `Browserless.reconnect`.
+    pub async fn connect(ws_url: &str) -> Result<Self, String> {
+        debug!("CDP connecting to {ws_url}");
+        let (ws_stream, _response) = connect_async(ws_url)
+            .await
+            .map_err(|e| format!("CDP WebSocket connection failed: {e}"))?;
+
+        let (sink, source) = ws_stream.split();
+        Ok(Self {
+            sink,
+            source,
+            next_id: 1,
+        })
+    }
+
+    /// Send a CDP command and wait for the response with the matching ID.
+    /// Events (messages without an `id` field) are silently skipped.
+    pub async fn send_command(&mut self, method: &str, params: Value) -> Result<Value, String> {
+        let id = self.next_id;
+        self.next_id += 1;
+
+        let msg = json!({
+            "id": id,
+            "method": method,
+            "params": params
+        });
+
+        debug!("CDP send: {method} (id={id})");
+        self.sink
+            .send(Message::Text(msg.to_string().into()))
+            .await
+            .map_err(|e| format!("CDP send failed: {e}"))?;
+
+        // Read messages until we find the response with matching id
+        loop {
+            match self.source.next().await {
+                Some(Ok(Message::Text(text))) => {
+                    let parsed: Value = serde_json::from_str(&text)
+                        .map_err(|e| format!("CDP invalid JSON response: {e}"))?;
+
+                    // Check if this is our response (has matching id)
+                    if parsed.get("id").and_then(|v| v.as_u64()) == Some(id as u64) {
+                        // Check for CDP error
+                        if let Some(error) = parsed.get("error") {
+                            let msg = error
+                                .get("message")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("Unknown CDP error");
+                            return Err(format!("CDP error in {method}: {msg}"));
+                        }
+                        return Ok(parsed.get("result").cloned().unwrap_or(json!({})));
+                    }
+
+                    // Otherwise it's an event — skip it
+                    if let Some(event_method) = parsed.get("method").and_then(|v| v.as_str()) {
+                        debug!("CDP event (skipped): {event_method}");
+                    }
+                }
+                Some(Ok(Message::Binary(_))) => {
+                    // Binary frames — skip
+                    continue;
+                }
+                Some(Ok(Message::Ping(_))) | Some(Ok(Message::Pong(_))) => {
+                    continue;
+                }
+                Some(Ok(Message::Close(_))) => {
+                    return Err("CDP WebSocket closed unexpectedly".to_string());
+                }
+                Some(Ok(Message::Frame(_))) => {
+                    continue;
+                }
+                Some(Err(e)) => {
+                    return Err(format!("CDP WebSocket error: {e}"));
+                }
+                None => {
+                    return Err("CDP WebSocket stream ended".to_string());
+                }
+            }
+        }
+    }
+
+    /// Disconnect the WebSocket gracefully.
+    /// Important: Call `reconnect()` before this if you want the browser to stay alive.
+    pub async fn disconnect(mut self) {
+        let _ = self.sink.close().await;
+    }
+
+    // ========================================================================
+    // High-level CDP helpers
+    // ========================================================================
+
+    /// Navigate to a URL and wait for the page to load.
+    pub async fn navigate(&mut self, url: &str) -> Result<Value, String> {
+        self.send_command("Page.enable", json!({})).await?;
+        let result = self
+            .send_command("Page.navigate", json!({ "url": url }))
+            .await?;
+
+        // Wait for page to finish loading
+        let _ = self
+            .send_command("Page.setLifecycleEventsEnabled", json!({ "enabled": true }))
+            .await;
+        // Give the page time to load. We use Runtime.evaluate with a load-wait.
+        let _ = self
+            .send_command(
+                "Runtime.evaluate",
+                json!({
+                    "expression": "new Promise(r => { if (document.readyState === 'complete') r(); else window.addEventListener('load', r); })",
+                    "awaitPromise": true,
+                    "timeout": 30000
+                }),
+            )
+            .await;
+
+        Ok(result)
+    }
+
+    /// Take a screenshot. Returns base64-encoded PNG data.
+    pub async fn screenshot(&mut self, full_page: bool) -> Result<String, String> {
+        // If full_page, get the full page dimensions first
+        let clip = if full_page {
+            let metrics = self
+                .send_command(
+                    "Runtime.evaluate",
+                    json!({
+                        "expression": "JSON.stringify({ width: document.documentElement.scrollWidth, height: document.documentElement.scrollHeight })",
+                        "returnByValue": true
+                    }),
+                )
+                .await?;
+
+            if let Some(value_str) = metrics
+                .get("result")
+                .and_then(|r| r.get("value"))
+                .and_then(|v| v.as_str())
+            {
+                if let Ok(dims) = serde_json::from_str::<Value>(value_str) {
+                    let w = dims.get("width").and_then(|v| v.as_f64()).unwrap_or(1280.0);
+                    let h = dims.get("height").and_then(|v| v.as_f64()).unwrap_or(800.0);
+                    Some(json!({ "x": 0, "y": 0, "width": w, "height": h, "scale": 1 }))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let mut params = json!({ "format": "png" });
+        if let Some(clip) = clip {
+            params["clip"] = clip;
+            params["captureBeyondViewport"] = json!(true);
+        }
+
+        let result = self.send_command("Page.captureScreenshot", params).await?;
+        result
+            .get("data")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .ok_or_else(|| "CDP screenshot returned no data".to_string())
+    }
+
+    /// Get the page's rendered HTML content (outerHTML of document element).
+    pub async fn get_content(&mut self) -> Result<String, String> {
+        let result = self
+            .send_command(
+                "Runtime.evaluate",
+                json!({
+                    "expression": "document.documentElement.outerHTML",
+                    "returnByValue": true
+                }),
+            )
+            .await?;
+
+        result
+            .get("result")
+            .and_then(|r| r.get("value"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .ok_or_else(|| "CDP getContent returned no data".to_string())
+    }
+
+    /// Get the page title.
+    pub async fn get_title(&mut self) -> Result<String, String> {
+        let result = self
+            .send_command(
+                "Runtime.evaluate",
+                json!({
+                    "expression": "document.title",
+                    "returnByValue": true
+                }),
+            )
+            .await?;
+
+        Ok(result
+            .get("result")
+            .and_then(|r| r.get("value"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string())
+    }
+
+    /// Get the current page URL.
+    pub async fn get_url(&mut self) -> Result<String, String> {
+        let result = self
+            .send_command(
+                "Runtime.evaluate",
+                json!({
+                    "expression": "window.location.href",
+                    "returnByValue": true
+                }),
+            )
+            .await?;
+
+        Ok(result
+            .get("result")
+            .and_then(|r| r.get("value"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string())
+    }
+
+    /// Evaluate a JavaScript expression and return the result.
+    pub async fn evaluate(&mut self, expression: &str) -> Result<Value, String> {
+        self.send_command(
+            "Runtime.evaluate",
+            json!({
+                "expression": expression,
+                "returnByValue": true,
+                "awaitPromise": true,
+                "timeout": 30000
+            }),
+        )
+        .await
+    }
+
+    /// Click at specific coordinates.
+    pub async fn click_at(&mut self, x: f64, y: f64) -> Result<(), String> {
+        self.send_command(
+            "Input.dispatchMouseEvent",
+            json!({ "type": "mousePressed", "x": x, "y": y, "button": "left", "clickCount": 1 }),
+        )
+        .await?;
+        self.send_command(
+            "Input.dispatchMouseEvent",
+            json!({ "type": "mouseReleased", "x": x, "y": y, "button": "left", "clickCount": 1 }),
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Click an element by CSS selector. Finds center coordinates via JS, then dispatches mouse events.
+    pub async fn click_selector(&mut self, selector: &str) -> Result<(), String> {
+        let selector_js = serde_json::to_string(selector).unwrap();
+        let coords = self
+            .send_command(
+                "Runtime.evaluate",
+                json!({
+                    "expression": format!(
+                        "(() => {{ const el = document.querySelector({selector_js}); if (!el) throw new Error('Element not found: ' + {selector_js}); const r = el.getBoundingClientRect(); return JSON.stringify({{ x: r.x + r.width/2, y: r.y + r.height/2 }}); }})()"
+                    ),
+                    "returnByValue": true
+                }),
+            )
+            .await?;
+
+        let coord_str = coords
+            .get("result")
+            .and_then(|r| r.get("value"))
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| format!("Element not found: {selector}"))?;
+
+        let coord_val: Value = serde_json::from_str(coord_str)
+            .map_err(|e| format!("Failed to parse coordinates: {e}"))?;
+
+        let x = coord_val
+            .get("x")
+            .and_then(|v| v.as_f64())
+            .ok_or("No x coordinate")?;
+        let y = coord_val
+            .get("y")
+            .and_then(|v| v.as_f64())
+            .ok_or("No y coordinate")?;
+
+        self.click_at(x, y).await
+    }
+
+    /// Type text by dispatching key events for each character.
+    pub async fn type_text(&mut self, text: &str) -> Result<(), String> {
+        for ch in text.chars() {
+            self.send_command(
+                "Input.dispatchKeyEvent",
+                json!({
+                    "type": "keyDown",
+                    "text": ch.to_string(),
+                    "key": ch.to_string(),
+                }),
+            )
+            .await?;
+            self.send_command(
+                "Input.dispatchKeyEvent",
+                json!({
+                    "type": "keyUp",
+                    "key": ch.to_string(),
+                }),
+            )
+            .await?;
+        }
+        Ok(())
+    }
+
+    /// Type text into a specific element (focus + type).
+    pub async fn type_into_selector(&mut self, selector: &str, text: &str) -> Result<(), String> {
+        // Focus the element
+        let selector_js = serde_json::to_string(selector).unwrap();
+        self.send_command(
+            "Runtime.evaluate",
+            json!({
+                "expression": format!(
+                    "(() => {{ const el = document.querySelector({selector_js}); if (!el) throw new Error('Element not found: ' + {selector_js}); el.focus(); }})()"
+                ),
+                "returnByValue": true
+            }),
+        )
+        .await?;
+
+        self.type_text(text).await
+    }
+
+    /// Press a special key (Enter, Tab, Escape, etc.).
+    pub async fn press_key(&mut self, key: &str) -> Result<(), String> {
+        self.send_command(
+            "Input.dispatchKeyEvent",
+            json!({
+                "type": "keyDown",
+                "key": key,
+                "code": key_to_code(key),
+            }),
+        )
+        .await?;
+        self.send_command(
+            "Input.dispatchKeyEvent",
+            json!({
+                "type": "keyUp",
+                "key": key,
+                "code": key_to_code(key),
+            }),
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Move mouse to coordinates.
+    pub async fn mouse_move(&mut self, x: f64, y: f64) -> Result<(), String> {
+        self.send_command(
+            "Input.dispatchMouseEvent",
+            json!({ "type": "mouseMoved", "x": x, "y": y }),
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Tap an element (touch simulation).
+    pub async fn tap_selector(&mut self, selector: &str) -> Result<(), String> {
+        let selector_js = serde_json::to_string(selector).unwrap();
+        let coords = self
+            .send_command(
+                "Runtime.evaluate",
+                json!({
+                    "expression": format!(
+                        "(() => {{ const el = document.querySelector({selector_js}); if (!el) throw new Error('Element not found: ' + {selector_js}); const r = el.getBoundingClientRect(); return JSON.stringify({{ x: r.x + r.width/2, y: r.y + r.height/2 }}); }})()"
+                    ),
+                    "returnByValue": true
+                }),
+            )
+            .await?;
+
+        let coord_str = coords
+            .get("result")
+            .and_then(|r| r.get("value"))
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| format!("Element not found: {selector}"))?;
+
+        let coord_val: Value = serde_json::from_str(coord_str)
+            .map_err(|e| format!("Failed to parse coordinates: {e}"))?;
+
+        let x = coord_val
+            .get("x")
+            .and_then(|v| v.as_f64())
+            .ok_or("No x coordinate")?;
+        let y = coord_val
+            .get("y")
+            .and_then(|v| v.as_f64())
+            .ok_or("No y coordinate")?;
+
+        self.send_command(
+            "Input.dispatchTouchEvent",
+            json!({
+                "type": "touchStart",
+                "touchPoints": [{ "x": x, "y": y }]
+            }),
+        )
+        .await?;
+        self.send_command(
+            "Input.dispatchTouchEvent",
+            json!({
+                "type": "touchEnd",
+                "touchPoints": []
+            }),
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Scroll the page by a pixel amount.
+    pub async fn scroll(&mut self, delta_y: i64) -> Result<(), String> {
+        self.evaluate(&format!("window.scrollBy(0, {delta_y})"))
+            .await?;
+        Ok(())
+    }
+
+    /// Wait for a CSS selector to appear on the page.
+    pub async fn wait_for_selector(
+        &mut self,
+        selector: &str,
+        timeout_ms: u64,
+    ) -> Result<(), String> {
+        let selector_js = serde_json::to_string(selector).unwrap();
+        let result = self
+            .send_command(
+                "Runtime.evaluate",
+                json!({
+                    "expression": format!(
+                        "new Promise((resolve, reject) => {{ \
+                            const el = document.querySelector({selector_js}); \
+                            if (el) return resolve(true); \
+                            const observer = new MutationObserver(() => {{ \
+                                if (document.querySelector({selector_js})) {{ observer.disconnect(); resolve(true); }} \
+                            }}); \
+                            observer.observe(document.body, {{ childList: true, subtree: true }}); \
+                            setTimeout(() => {{ observer.disconnect(); reject(new Error('Timeout waiting for ' + {selector_js})); }}, {timeout_ms}); \
+                        }})"
+                    ),
+                    "awaitPromise": true,
+                    "timeout": timeout_ms + 1000
+                }),
+            )
+            .await?;
+
+        // Check for exception
+        if let Some(exception) = result.get("exceptionDetails") {
+            let msg = exception
+                .get("exception")
+                .and_then(|e| e.get("description"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("Timeout");
+            return Err(format!("wait_for_selector failed: {msg}"));
+        }
+
+        Ok(())
+    }
+
+    /// Call Browserless.reconnect to keep the browser alive after disconnect.
+    /// Returns the new WebSocket endpoint to use for reconnection.
+    pub async fn reconnect(&mut self, timeout_ms: u64) -> Result<String, String> {
+        let result = self
+            .send_command("Browserless.reconnect", json!({ "timeout": timeout_ms }))
+            .await?;
+
+        if let Some(error) = result.get("error").and_then(|v| v.as_str()) {
+            return Err(format!("Browserless.reconnect failed: {error}"));
+        }
+
+        result
+            .get("browserWSEndpoint")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .ok_or_else(|| "Browserless.reconnect returned no endpoint".to_string())
+    }
+
+    /// Get page metadata (title, URL, headings, links).
+    pub async fn get_page_info(&mut self) -> Result<Value, String> {
+        let result = self
+            .send_command(
+                "Runtime.evaluate",
+                json!({
+                    "expression": r#"JSON.stringify({
+                        title: document.title,
+                        url: window.location.href,
+                        headings: Array.from(document.querySelectorAll('h1, h2, h3')).slice(0, 20).map(h => ({ tag: h.tagName, text: h.textContent?.trim()?.substring(0, 200) })),
+                        links: Array.from(document.querySelectorAll('a[href]')).slice(0, 50).map(a => ({ text: a.textContent?.trim()?.substring(0, 100), href: a.href })),
+                        meta: Array.from(document.querySelectorAll('meta[name], meta[property]')).slice(0, 20).map(m => ({ name: m.getAttribute('name') || m.getAttribute('property'), content: m.getAttribute('content')?.substring(0, 200) }))
+                    })"#,
+                    "returnByValue": true
+                }),
+            )
+            .await?;
+
+        let json_str = result
+            .get("result")
+            .and_then(|r| r.get("value"))
+            .and_then(|v| v.as_str())
+            .ok_or("Failed to get page info")?;
+
+        serde_json::from_str(json_str).map_err(|e| format!("Invalid page info JSON: {e}"))
+    }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Map common key names to their key codes for CDP Input.dispatchKeyEvent.
+fn key_to_code(key: &str) -> &str {
+    match key {
+        "Enter" => "Enter",
+        "Tab" => "Tab",
+        "Escape" => "Escape",
+        "Backspace" => "Backspace",
+        "Delete" => "Delete",
+        "ArrowUp" => "ArrowUp",
+        "ArrowDown" => "ArrowDown",
+        "ArrowLeft" => "ArrowLeft",
+        "ArrowRight" => "ArrowRight",
+        "Home" => "Home",
+        "End" => "End",
+        "PageUp" => "PageUp",
+        "PageDown" => "PageDown",
+        "Space" | " " => "Space",
+        other => other,
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_key_to_code() {
+        assert_eq!(key_to_code("Enter"), "Enter");
+        assert_eq!(key_to_code("Tab"), "Tab");
+        assert_eq!(key_to_code("Escape"), "Escape");
+        assert_eq!(key_to_code("Space"), "Space");
+        assert_eq!(key_to_code(" "), "Space");
+        assert_eq!(key_to_code("ArrowUp"), "ArrowUp");
+        assert_eq!(key_to_code("SomeOtherKey"), "SomeOtherKey");
+    }
+}

--- a/integrations/browserless/src/cdp.rs
+++ b/integrations/browserless/src/cdp.rs
@@ -38,7 +38,13 @@ impl CdpSession {
     ///   `wss://production-sfo.browserless.io?token=TOKEN`
     ///   or a reconnect endpoint returned by `Browserless.reconnect`.
     pub async fn connect(ws_url: &str) -> Result<Self, String> {
-        debug!("CDP connecting to {ws_url}");
+        // Redact token from log output to avoid leaking credentials
+        let redacted = if let Some(idx) = ws_url.find("token=") {
+            format!("{}token=<REDACTED>", &ws_url[..idx])
+        } else {
+            ws_url.to_string()
+        };
+        debug!("CDP connecting to {redacted}");
         let (ws_stream, _response) = connect_async(ws_url)
             .await
             .map_err(|e| format!("CDP WebSocket connection failed: {e}"))?;

--- a/integrations/browserless/src/client.rs
+++ b/integrations/browserless/src/client.rs
@@ -1,0 +1,440 @@
+//! Browserless API client.
+//!
+//! Decision: REST-only approach. Each API call spins up a fresh browser, performs one
+//! operation, and tears down. No persistent browser sessions to leak.
+//! Decision: /function endpoint for interactions (click, type) since Browserless
+//! REST APIs don't expose standalone click/type endpoints.
+
+use serde_json::{Value, json};
+use tracing::debug;
+
+// ============================================================================
+// BrowserlessClient - HTTP client for Browserless REST APIs
+// ============================================================================
+
+pub struct BrowserlessClient {
+    http: reqwest::Client,
+    api_token: String,
+    api_base: String,
+}
+
+impl BrowserlessClient {
+    pub fn new(api_token: String) -> Self {
+        Self::with_base_url(api_token, crate::BROWSERLESS_API_BASE.to_string())
+    }
+
+    pub fn with_base_url(api_token: String, api_base: String) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            api_token,
+            api_base,
+        }
+    }
+
+    /// Build URL with token query parameter.
+    fn endpoint(&self, path: &str) -> String {
+        format!("{}{}?token={}", self.api_base, path, self.api_token)
+    }
+
+    // --- Screenshot API ---
+
+    /// Take a screenshot of a URL. Returns PNG bytes.
+    pub async fn screenshot(
+        &self,
+        url: &str,
+        full_page: bool,
+        selector: Option<&str>,
+        wait_for_selector: Option<&str>,
+        wait_for_timeout: Option<u64>,
+    ) -> Result<Vec<u8>, String> {
+        let mut body = json!({
+            "url": url,
+            "options": {
+                "fullPage": full_page,
+                "type": "png"
+            }
+        });
+
+        if let Some(sel) = selector {
+            body["selector"] = json!(sel);
+        }
+        if let Some(wfs) = wait_for_selector {
+            body["waitForSelector"] = json!({"selector": wfs, "timeout": 30000});
+        }
+        if let Some(timeout) = wait_for_timeout {
+            body["waitForTimeout"] = json!(timeout);
+        }
+
+        debug!("Browserless screenshot: {url}");
+
+        let resp = self
+            .http
+            .post(self.endpoint("/screenshot"))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| format!("Failed to connect to Browserless API: {e}"))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body_text = resp.text().await.unwrap_or_default();
+            return Err(format!("Browserless API error ({status}): {body_text}"));
+        }
+
+        resp.bytes()
+            .await
+            .map(|b| b.to_vec())
+            .map_err(|e| format!("Failed to read screenshot bytes: {e}"))
+    }
+
+    // --- Content API ---
+
+    /// Get fully rendered HTML content of a URL.
+    pub async fn content(
+        &self,
+        url: &str,
+        wait_for_selector: Option<&str>,
+        wait_for_timeout: Option<u64>,
+        best_attempt: bool,
+    ) -> Result<String, String> {
+        let mut body = json!({ "url": url });
+
+        if let Some(wfs) = wait_for_selector {
+            body["waitForSelector"] = json!({"selector": wfs, "timeout": 30000});
+        }
+        if let Some(timeout) = wait_for_timeout {
+            body["waitForTimeout"] = json!(timeout);
+        }
+        if best_attempt {
+            body["bestAttempt"] = json!(true);
+        }
+
+        debug!("Browserless content: {url}");
+
+        let resp = self
+            .http
+            .post(self.endpoint("/content"))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| format!("Failed to connect to Browserless API: {e}"))?;
+
+        let status = resp.status();
+        let body_text = resp
+            .text()
+            .await
+            .map_err(|e| format!("Failed to read response: {e}"))?;
+
+        if !status.is_success() {
+            return Err(format!("Browserless API error ({status}): {body_text}"));
+        }
+
+        Ok(body_text)
+    }
+
+    // --- Scrape API ---
+
+    /// Scrape structured data from a URL using CSS selectors.
+    pub async fn scrape(
+        &self,
+        url: &str,
+        elements: &[Value],
+        wait_for_selector: Option<&str>,
+        wait_for_timeout: Option<u64>,
+    ) -> Result<Value, String> {
+        let mut body = json!({
+            "url": url,
+            "elements": elements
+        });
+
+        if let Some(wfs) = wait_for_selector {
+            body["waitForSelector"] = json!({"selector": wfs, "timeout": 30000});
+        }
+        if let Some(timeout) = wait_for_timeout {
+            body["waitForTimeout"] = json!(timeout);
+        }
+
+        debug!("Browserless scrape: {url}");
+
+        let resp = self
+            .http
+            .post(self.endpoint("/scrape"))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| format!("Failed to connect to Browserless API: {e}"))?;
+
+        let status = resp.status();
+        let body_text = resp
+            .text()
+            .await
+            .map_err(|e| format!("Failed to read response: {e}"))?;
+
+        if !status.is_success() {
+            return Err(format!("Browserless API error ({status}): {body_text}"));
+        }
+
+        serde_json::from_str(&body_text).map_err(|e| format!("Invalid JSON from Browserless: {e}"))
+    }
+
+    // --- Function API ---
+
+    /// Execute custom Puppeteer code. Used for multi-step interactions
+    /// (click, type, keyboard, mouse, touch, then screenshot/read DOM).
+    pub async fn function(&self, code: &str, context: Option<&Value>) -> Result<Value, String> {
+        let mut body = json!({ "code": code });
+        if let Some(ctx) = context {
+            body["context"] = ctx.clone();
+        }
+
+        debug!("Browserless function call");
+
+        let resp = self
+            .http
+            .post(self.endpoint("/function"))
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| format!("Failed to connect to Browserless API: {e}"))?;
+
+        let status = resp.status();
+        let body_text = resp
+            .text()
+            .await
+            .map_err(|e| format!("Failed to read response: {e}"))?;
+
+        if !status.is_success() {
+            return Err(format!("Browserless API error ({status}): {body_text}"));
+        }
+
+        if body_text.is_empty() {
+            return Ok(json!({}));
+        }
+
+        serde_json::from_str(&body_text).map_err(|e| format!("Invalid JSON from Browserless: {e}"))
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn test_client_screenshot() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/screenshot"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"PNG_BYTES".to_vec()))
+            .mount(&mock_server)
+            .await;
+
+        let client = BrowserlessClient::with_base_url("test_token".to_string(), mock_server.uri());
+        let result = client
+            .screenshot("https://example.com", true, None, None, None)
+            .await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), b"PNG_BYTES");
+    }
+
+    #[tokio::test]
+    async fn test_client_content() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/content"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string("<html><body>Hello</body></html>"),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let client = BrowserlessClient::with_base_url("test_token".to_string(), mock_server.uri());
+        let result = client
+            .content("https://example.com", None, None, false)
+            .await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().contains("Hello"));
+    }
+
+    #[tokio::test]
+    async fn test_client_scrape() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/scrape"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": [{"results": [{"text": "found"}]}]
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = BrowserlessClient::with_base_url("test_token".to_string(), mock_server.uri());
+        let elements = vec![json!({"selector": "h1"})];
+        let result = client
+            .scrape("https://example.com", &elements, None, None)
+            .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_client_function() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/function"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": "clicked",
+                "type": "application/json"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = BrowserlessClient::with_base_url("test_token".to_string(), mock_server.uri());
+        let result = client
+            .function(
+                "export default async ({ page }) => { return { data: 'clicked', type: 'application/json' }; }",
+                None,
+            )
+            .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_client_screenshot_error() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/screenshot"))
+            .respond_with(ResponseTemplate::new(400).set_body_string("Bad Request"))
+            .mount(&mock_server)
+            .await;
+
+        let client = BrowserlessClient::with_base_url("test_token".to_string(), mock_server.uri());
+        let result = client
+            .screenshot("https://example.com", false, None, None, None)
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("400"));
+    }
+
+    #[tokio::test]
+    async fn test_client_content_error() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/content"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("Unauthorized"))
+            .mount(&mock_server)
+            .await;
+
+        let client = BrowserlessClient::with_base_url("bad_token".to_string(), mock_server.uri());
+        let result = client
+            .content("https://example.com", None, None, false)
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("401"));
+    }
+
+    #[tokio::test]
+    async fn test_client_scrape_error() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/scrape"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("Internal Error"))
+            .mount(&mock_server)
+            .await;
+
+        let client = BrowserlessClient::with_base_url("test_token".to_string(), mock_server.uri());
+        let result = client.scrape("https://example.com", &[], None, None).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("500"));
+    }
+
+    #[tokio::test]
+    async fn test_client_function_error() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/function"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("Script error"))
+            .mount(&mock_server)
+            .await;
+
+        let client = BrowserlessClient::with_base_url("test_token".to_string(), mock_server.uri());
+        let result = client.function("bad code", None).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("500"));
+    }
+
+    #[tokio::test]
+    async fn test_client_function_empty_response() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/function"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(""))
+            .mount(&mock_server)
+            .await;
+
+        let client = BrowserlessClient::with_base_url("test_token".to_string(), mock_server.uri());
+        let result = client
+            .function("export default async ({ page }) => {}", None)
+            .await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), json!({}));
+    }
+
+    #[tokio::test]
+    async fn test_client_screenshot_with_options() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/screenshot"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"PNG".to_vec()))
+            .mount(&mock_server)
+            .await;
+
+        let client = BrowserlessClient::with_base_url("test_token".to_string(), mock_server.uri());
+        let result = client
+            .screenshot(
+                "https://example.com",
+                false,
+                Some("#main"),
+                Some("h1"),
+                Some(5000),
+            )
+            .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_client_content_with_options() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/content"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("<html></html>"))
+            .mount(&mock_server)
+            .await;
+
+        let client = BrowserlessClient::with_base_url("test_token".to_string(), mock_server.uri());
+        let result = client
+            .content("https://example.com", Some("body"), Some(3000), true)
+            .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_client_scrape_malformed_json() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/scrape"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not valid json"))
+            .mount(&mock_server)
+            .await;
+
+        let client = BrowserlessClient::with_base_url("test_token".to_string(), mock_server.uri());
+        let result = client.scrape("https://example.com", &[], None, None).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid JSON"));
+    }
+}

--- a/integrations/browserless/src/connection.rs
+++ b/integrations/browserless/src/connection.rs
@@ -1,0 +1,104 @@
+// Browserless Connection Provider
+//
+// Decision: API-token-based connection (not OAuth). User enters token from Browserless dashboard.
+// Decision: Validate token by calling GET /active — 200 means valid, 401 means invalid.
+
+use async_trait::async_trait;
+use everruns_core::connection_provider::{
+    ConnectionFormSchema, ConnectionProvider, ConnectionType, ConnectionValidation, FieldType,
+    FormField,
+};
+
+use crate::BROWSERLESS_API_BASE;
+
+pub struct BrowserlessConnectionProvider;
+
+#[async_trait]
+impl ConnectionProvider for BrowserlessConnectionProvider {
+    fn provider_id(&self) -> &str {
+        "browserless"
+    }
+
+    fn display_name(&self) -> &str {
+        "Browserless"
+    }
+
+    fn description(&self) -> &str {
+        "Cloud browser automation for screenshots, scraping, and testing"
+    }
+
+    fn icon(&self) -> &str {
+        "browserless"
+    }
+
+    fn connection_type(&self) -> ConnectionType {
+        ConnectionType::ApiKey
+    }
+
+    fn form_schema(&self) -> Option<ConnectionFormSchema> {
+        Some(ConnectionFormSchema {
+            fields: vec![FormField {
+                name: "api_key".to_string(),
+                label: "API Token".to_string(),
+                field_type: FieldType::Password,
+                required: true,
+                placeholder: Some("your-browserless-api-token".to_string()),
+                help_text: None,
+            }],
+            instructions_markdown: "\
+1. Go to [Browserless Dashboard](https://cloud.browserless.io)\n\
+2. Navigate to **API Keys** in your account settings\n\
+3. Copy your API token and paste it below"
+                .to_string(),
+        })
+    }
+
+    async fn validate(&self, credential: &str) -> Result<ConnectionValidation, String> {
+        let client = reqwest::Client::new();
+        let response = client
+            .get(format!("{BROWSERLESS_API_BASE}/active?token={credential}"))
+            .send()
+            .await
+            .map_err(|e| format!("Failed to reach Browserless API: {e}"))?;
+
+        match response.status().as_u16() {
+            200 => Ok(ConnectionValidation {
+                provider_username: None,
+            }),
+            401 | 403 => {
+                Err("Invalid API token. Check that the token is correct and active.".into())
+            }
+            status => Err(format!(
+                "Unexpected response from Browserless API (HTTP {status})"
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_provider_metadata() {
+        let p = BrowserlessConnectionProvider;
+        assert_eq!(p.provider_id(), "browserless");
+        assert_eq!(p.display_name(), "Browserless");
+        assert_eq!(p.connection_type(), ConnectionType::ApiKey);
+        assert_eq!(p.icon(), "browserless");
+    }
+
+    #[test]
+    fn test_form_schema() {
+        let p = BrowserlessConnectionProvider;
+        let schema = p.form_schema().expect("should have form schema");
+        assert_eq!(schema.fields.len(), 1);
+        assert_eq!(schema.fields[0].name, "api_key");
+        assert!(schema.fields[0].required);
+        assert!(
+            schema
+                .instructions_markdown
+                .contains("cloud.browserless.io")
+        );
+    }
+}

--- a/integrations/browserless/src/lib.rs
+++ b/integrations/browserless/src/lib.rs
@@ -1,0 +1,212 @@
+//! Browserless Integration
+//!
+//! Cloud browser automation via Browserless REST API.
+//! Supports screenshots, DOM reading, structured scraping, and multi-step
+//! interactions (click, type, keyboard, mouse, touch).
+//!
+//! Decision: External integration crate, auto-registered via inventory plugin system
+//! Decision: REST-only (no WebSocket/Puppeteer sessions). Each call spins up a fresh
+//!   browser and tears it down — no resources left behind.
+//! Decision: /function endpoint for multi-step interactions (click, type, navigate)
+//! Decision: No persistent browser sessions to manage = no state to track per session
+
+pub mod client;
+pub mod connection;
+pub mod state;
+mod tools;
+
+use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin, RiskLevel};
+use everruns_core::connection_provider::ConnectionProviderPlugin;
+use everruns_core::tools::Tool;
+
+use connection::BrowserlessConnectionProvider;
+
+use tools::{
+    BrowserlessContentTool, BrowserlessInteractTool, BrowserlessNavigateTool,
+    BrowserlessScrapeTool, BrowserlessScreenshotTool,
+};
+
+// ============================================================================
+// Plugin Registration
+// ============================================================================
+
+inventory::submit! {
+    IntegrationPlugin {
+        experimental_only: false,
+        factory: || Box::new(BrowserlessCapability),
+    }
+}
+
+inventory::submit! {
+    ConnectionProviderPlugin {
+        experimental_only: true,
+        factory: || Box::new(BrowserlessConnectionProvider),
+    }
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const BROWSERLESS_API_BASE: &str = "https://production-sfo.browserless.io";
+
+// ============================================================================
+// BrowserlessCapability
+// ============================================================================
+
+pub struct BrowserlessCapability;
+
+impl Capability for BrowserlessCapability {
+    fn id(&self) -> &str {
+        "browserless"
+    }
+
+    fn name(&self) -> &str {
+        "Browserless"
+    }
+
+    fn description(&self) -> &str {
+        "Cloud browser automation powered by Browserless. Take screenshots, read DOM content, \
+         scrape structured data, and interact with web pages (click, type, keyboard, mouse, touch). \
+         Use cases: accessibility testing, regression testing, web scraping, UI validation."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn risk_level(&self) -> RiskLevel {
+        RiskLevel::Medium
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("browserless")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Browser")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(
+            r#"## Browserless
+
+Cloud browser automation via Browserless. Each tool call uses a fresh browser session that is
+automatically destroyed after completion — no resources are left behind.
+
+Authentication: Browserless API token is resolved automatically from Settings > Connections > Browserless.
+If not configured, guide the user to set up their token in Settings > Connections.
+
+Tools:
+- `browserless_navigate` - Open a URL and get page metadata (title, links, headings, meta tags)
+- `browserless_screenshot` - Take a PNG screenshot of a page (full page or specific element)
+- `browserless_content` - Get the fully rendered HTML/DOM of a page (including JS-rendered content)
+- `browserless_scrape` - Extract structured data using CSS selectors
+- `browserless_interact` - Multi-step interactions: click, type, keyboard, mouse, touch, scroll, then capture result
+
+Typical workflow:
+1. `browserless_navigate` to explore a page and discover its structure
+2. `browserless_screenshot` to capture the visual state
+3. `browserless_content` or `browserless_scrape` to read specific content
+4. `browserless_interact` for multi-step flows (login, form filling, menu navigation)
+
+The `browserless_interact` tool supports these actions in its `steps` array:
+- `click` - Click an element by CSS selector or x,y coordinates
+- `type` - Type text into an input field (selector + value)
+- `keyboard` - Press a key (Enter, Tab, Escape, etc.)
+- `mouse_move` - Move mouse to x,y coordinates
+- `touch` - Tap an element (mobile touch simulation)
+- `scroll` - Scroll the page by a pixel amount
+- `wait` - Wait for a specified number of milliseconds
+- `wait_for_selector` - Wait for a CSS selector to appear
+- `navigate` - Navigate to a different URL mid-interaction
+
+Set `return_screenshot: true` on `browserless_interact` to get a screenshot after all steps,
+or leave it false to get the DOM content instead."#,
+        )
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(BrowserlessNavigateTool),
+            Box::new(BrowserlessScreenshotTool),
+            Box::new(BrowserlessContentTool),
+            Box::new(BrowserlessScrapeTool),
+            Box::new(BrowserlessInteractTool),
+        ]
+    }
+
+    fn dependencies(&self) -> Vec<&'static str> {
+        vec![]
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::capabilities::CapabilityStatus;
+
+    #[test]
+    fn test_capability_metadata() {
+        let cap = BrowserlessCapability;
+        assert_eq!(cap.id(), "browserless");
+        assert_eq!(cap.name(), "Browserless");
+        assert_eq!(cap.status(), CapabilityStatus::Available);
+        assert_eq!(cap.icon(), Some("browserless"));
+        assert_eq!(cap.category(), Some("Browser"));
+    }
+
+    #[test]
+    fn test_capability_has_all_tools() {
+        let cap = BrowserlessCapability;
+        let tools = cap.tools();
+        assert_eq!(tools.len(), 5);
+
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(names.contains(&"browserless_navigate"));
+        assert!(names.contains(&"browserless_screenshot"));
+        assert!(names.contains(&"browserless_content"));
+        assert!(names.contains(&"browserless_scrape"));
+        assert!(names.contains(&"browserless_interact"));
+    }
+
+    #[test]
+    fn test_capability_has_system_prompt() {
+        let cap = BrowserlessCapability;
+        let prompt = cap.system_prompt_addition().unwrap();
+        assert!(prompt.contains("browserless_navigate"));
+        assert!(prompt.contains("browserless_screenshot"));
+        assert!(prompt.contains("browserless_content"));
+        assert!(prompt.contains("browserless_scrape"));
+        assert!(prompt.contains("browserless_interact"));
+        assert!(prompt.contains("Settings > Connections"));
+    }
+
+    #[test]
+    fn test_all_tools_require_context() {
+        let cap = BrowserlessCapability;
+        for tool in cap.tools() {
+            assert!(
+                tool.requires_context(),
+                "Tool {} should require context",
+                tool.name()
+            );
+        }
+    }
+
+    #[test]
+    fn test_capability_no_dependencies() {
+        let cap = BrowserlessCapability;
+        assert!(cap.dependencies().is_empty());
+    }
+
+    #[test]
+    fn test_capability_risk_level() {
+        let cap = BrowserlessCapability;
+        assert_eq!(cap.risk_level(), RiskLevel::Medium);
+    }
+}

--- a/integrations/browserless/src/lib.rs
+++ b/integrations/browserless/src/lib.rs
@@ -1,17 +1,24 @@
 //! Browserless Integration
 //!
-//! Cloud browser automation via Browserless REST API.
+//! Cloud browser automation via Browserless REST API and CDP (WebSocket) sessions.
 //! Supports screenshots, DOM reading, structured scraping, and multi-step
 //! interactions (click, type, keyboard, mouse, touch).
 //!
+//! Two modes:
+//! - **REST** (default): Each tool call uses a fresh ephemeral browser. No state, no cleanup.
+//! - **CDP sessions**: `browserless_open_browser` opens a persistent browser via WebSocket.
+//!   Subsequent tool calls reuse it (preserving login, cookies, navigation history).
+//!   `browserless_close_browser` releases the browser.
+//!
 //! Decision: External integration crate, auto-registered via inventory plugin system
-//! Decision: REST-only (no WebSocket/Puppeteer sessions). Each call spins up a fresh
-//!   browser and tears it down — no resources left behind.
+//! Decision: REST for one-shot operations, CDP WebSocket for persistent browser sessions
 //! Decision: /function endpoint for multi-step interactions (click, type, navigate)
-//! Decision: No persistent browser sessions to manage = no state to track per session
+//! Decision: CDP sessions use Browserless.reconnect to keep browser alive between tool calls
 
+pub mod cdp;
 pub mod client;
 pub mod connection;
+pub mod session_tools;
 pub mod state;
 mod tools;
 
@@ -21,6 +28,7 @@ use everruns_core::tools::Tool;
 
 use connection::BrowserlessConnectionProvider;
 
+use session_tools::{BrowserlessCloseBrowserTool, BrowserlessOpenBrowserTool};
 use tools::{
     BrowserlessContentTool, BrowserlessInteractTool, BrowserlessNavigateTool,
     BrowserlessScrapeTool, BrowserlessScreenshotTool,
@@ -49,6 +57,7 @@ inventory::submit! {
 // ============================================================================
 
 const BROWSERLESS_API_BASE: &str = "https://production-sfo.browserless.io";
+const BROWSERLESS_WS_BASE: &str = "wss://production-sfo.browserless.io";
 
 // ============================================================================
 // BrowserlessCapability
@@ -68,6 +77,7 @@ impl Capability for BrowserlessCapability {
     fn description(&self) -> &str {
         "Cloud browser automation powered by Browserless. Take screenshots, read DOM content, \
          scrape structured data, and interact with web pages (click, type, keyboard, mouse, touch). \
+         Supports persistent browser sessions via CDP for login flows. \
          Use cases: accessibility testing, regression testing, web scraping, UI validation."
     }
 
@@ -91,33 +101,56 @@ impl Capability for BrowserlessCapability {
         Some(
             r#"## Browserless
 
-Cloud browser automation via Browserless. Each tool call uses a fresh browser session that is
-automatically destroyed after completion — no resources are left behind.
+Cloud browser automation via Browserless. Two modes of operation:
+
+### Stateless Mode (default)
+Each tool call uses a fresh browser session that is automatically destroyed after completion.
+No resources are left behind.
+
+### Persistent Session Mode (CDP)
+Use `browserless_open_browser` to create a persistent browser session via Chrome DevTools Protocol.
+The browser stays alive between tool calls, preserving login state, cookies, and navigation history.
+Use `browserless_close_browser` when done to release the browser.
+
+When a persistent session is active, the navigate/screenshot/content/interact tools will
+automatically use it instead of creating fresh browsers.
 
 Authentication: Browserless API token is resolved automatically from Settings > Connections > Browserless.
 If not configured, guide the user to set up their token in Settings > Connections.
 
-Tools:
+### Session Management Tools
+- `browserless_open_browser` - Open a persistent browser session (stays alive between tool calls)
+- `browserless_close_browser` - Close the persistent browser session and release resources
+
+### Browser Tools
 - `browserless_navigate` - Open a URL and get page metadata (title, links, headings, meta tags)
 - `browserless_screenshot` - Take a PNG screenshot of a page (full page or specific element)
 - `browserless_content` - Get the fully rendered HTML/DOM of a page (including JS-rendered content)
 - `browserless_scrape` - Extract structured data using CSS selectors
 - `browserless_interact` - Multi-step interactions: click, type, keyboard, mouse, touch, scroll, then capture result
 
-Typical workflow:
+### Typical Workflows
+
+**One-shot (no persistent session needed):**
 1. `browserless_navigate` to explore a page and discover its structure
 2. `browserless_screenshot` to capture the visual state
 3. `browserless_content` or `browserless_scrape` to read specific content
-4. `browserless_interact` for multi-step flows (login, form filling, menu navigation)
 
-The `browserless_interact` tool supports these actions in its `steps` array:
-- `click` - Click an element by CSS selector or x,y coordinates
+**Login-protected pages (use persistent session):**
+1. `browserless_open_browser` with the login page URL
+2. `browserless_interact` to fill in credentials and submit the form
+3. `browserless_navigate` to browse authenticated pages
+4. `browserless_screenshot` / `browserless_content` to inspect pages
+5. `browserless_close_browser` when done
+
+### Interaction Actions (browserless_interact)
+- `click` - Click by CSS selector or x,y coordinates
 - `type` - Type text into an input field (selector + value)
 - `keyboard` - Press a key (Enter, Tab, Escape, etc.)
 - `mouse_move` - Move mouse to x,y coordinates
 - `touch` - Tap an element (mobile touch simulation)
 - `scroll` - Scroll the page by a pixel amount
-- `wait` - Wait for a specified number of milliseconds
+- `wait` - Wait for milliseconds
 - `wait_for_selector` - Wait for a CSS selector to appear
 - `navigate` - Navigate to a different URL mid-interaction
 
@@ -128,6 +161,8 @@ or leave it false to get the DOM content instead."#,
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
         vec![
+            Box::new(BrowserlessOpenBrowserTool),
+            Box::new(BrowserlessCloseBrowserTool),
             Box::new(BrowserlessNavigateTool),
             Box::new(BrowserlessScreenshotTool),
             Box::new(BrowserlessContentTool),
@@ -164,9 +199,11 @@ mod tests {
     fn test_capability_has_all_tools() {
         let cap = BrowserlessCapability;
         let tools = cap.tools();
-        assert_eq!(tools.len(), 5);
+        assert_eq!(tools.len(), 7);
 
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(names.contains(&"browserless_open_browser"));
+        assert!(names.contains(&"browserless_close_browser"));
         assert!(names.contains(&"browserless_navigate"));
         assert!(names.contains(&"browserless_screenshot"));
         assert!(names.contains(&"browserless_content"));
@@ -178,12 +215,16 @@ mod tests {
     fn test_capability_has_system_prompt() {
         let cap = BrowserlessCapability;
         let prompt = cap.system_prompt_addition().unwrap();
+        assert!(prompt.contains("browserless_open_browser"));
+        assert!(prompt.contains("browserless_close_browser"));
         assert!(prompt.contains("browserless_navigate"));
         assert!(prompt.contains("browserless_screenshot"));
         assert!(prompt.contains("browserless_content"));
         assert!(prompt.contains("browserless_scrape"));
         assert!(prompt.contains("browserless_interact"));
         assert!(prompt.contains("Settings > Connections"));
+        assert!(prompt.contains("Persistent Session Mode"));
+        assert!(prompt.contains("CDP"));
     }
 
     #[test]

--- a/integrations/browserless/src/session_tools.rs
+++ b/integrations/browserless/src/session_tools.rs
@@ -1,0 +1,339 @@
+//! CDP session management tools: open_browser and close_browser.
+//!
+//! Decision: Persistent browser sessions via CDP WebSocket + Browserless.reconnect.
+//! Decision: Session state stored in session_storage (encrypted at rest).
+//! Decision: Each tool call reconnects → does work → calls reconnect → disconnects.
+//!   No long-lived WebSocket connections. The browser stays alive on Browserless servers.
+
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::traits::ToolContext;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use tracing::{debug, warn};
+
+use crate::cdp::{CdpSession, DEFAULT_RECONNECT_TIMEOUT_MS};
+use crate::state::{
+    BrowserSessionState, delete_browser_session, get_api_token, get_browser_session,
+    save_browser_session,
+};
+
+// ============================================================================
+// BrowserlessOpenBrowserTool
+// ============================================================================
+
+pub struct BrowserlessOpenBrowserTool;
+
+#[async_trait]
+impl Tool for BrowserlessOpenBrowserTool {
+    fn name(&self) -> &str {
+        "browserless_open_browser"
+    }
+
+    fn description(&self) -> &str {
+        "Open a persistent browser session. The browser stays alive between tool calls, \
+         allowing multi-step workflows (e.g., login once, then navigate multiple pages). \
+         Use browserless_close_browser when done to release the browser."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "Optional initial URL to navigate to after opening the browser"
+                },
+                "timeout_ms": {
+                    "type": "integer",
+                    "description": "How long the browser stays alive between tool calls, in milliseconds (default: 60000 = 60 seconds)"
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("browserless_open_browser requires context.")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let api_token = match get_api_token(context).await {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+
+        // Check if there's already an active session
+        if let Ok(Some(existing)) = get_browser_session(context).await {
+            // Try to reconnect to verify it's still alive
+            let url = existing.reconnect_url();
+            match CdpSession::connect(&url).await {
+                Ok(mut session) => {
+                    let title = session.get_title().await.unwrap_or_default();
+                    let current_url = session.get_url().await.unwrap_or_default();
+
+                    // Keep it alive
+                    let timeout_ms = arguments
+                        .get("timeout_ms")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(DEFAULT_RECONNECT_TIMEOUT_MS);
+
+                    match session.reconnect(timeout_ms).await {
+                        Ok(new_endpoint) => {
+                            let mut state = existing;
+                            state.ws_endpoint = new_endpoint;
+                            state.last_active_at = chrono::Utc::now().to_rfc3339();
+                            if let Err(e) = save_browser_session(context, &state).await {
+                                warn!("Failed to update session state: {e:?}");
+                            }
+                            session.disconnect().await;
+
+                            return ToolExecutionResult::Success(json!({
+                                "status": "already_open",
+                                "message": "Browser session is already active.",
+                                "title": title,
+                                "url": current_url
+                            }));
+                        }
+                        Err(_) => {
+                            // Session died, clean up and open a new one
+                            session.disconnect().await;
+                            let _ = delete_browser_session(context).await;
+                        }
+                    }
+                }
+                Err(_) => {
+                    // Can't connect — session expired, clean up
+                    let _ = delete_browser_session(context).await;
+                }
+            }
+        }
+
+        // Open a new browser session
+        let ws_url = format!("{}?token={}", crate::BROWSERLESS_WS_BASE, api_token);
+
+        let mut session = match CdpSession::connect(&ws_url).await {
+            Ok(s) => s,
+            Err(e) => return ToolExecutionResult::tool_error(e),
+        };
+
+        // Navigate to initial URL if provided
+        if let Some(url) = arguments.get("url").and_then(|v| v.as_str())
+            && let Err(e) = session.navigate(url).await
+        {
+            session.disconnect().await;
+            return ToolExecutionResult::tool_error(format!("Failed to navigate to {url}: {e}"));
+        }
+
+        // Get page info
+        let title = session.get_title().await.unwrap_or_default();
+        let current_url = session.get_url().await.unwrap_or_default();
+
+        // Call reconnect to keep browser alive after we disconnect
+        let timeout_ms = arguments
+            .get("timeout_ms")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(DEFAULT_RECONNECT_TIMEOUT_MS);
+
+        let ws_endpoint = match session.reconnect(timeout_ms).await {
+            Ok(endpoint) => endpoint,
+            Err(e) => {
+                session.disconnect().await;
+                return ToolExecutionResult::tool_error(format!(
+                    "Failed to register browser for reconnection: {e}"
+                ));
+            }
+        };
+
+        // Save state and disconnect
+        let state = BrowserSessionState::new(ws_endpoint, api_token);
+        if let Err(e) = save_browser_session(context, &state).await {
+            session.disconnect().await;
+            return e;
+        }
+
+        session.disconnect().await;
+        debug!("Browser session opened and registered for reconnection");
+
+        ToolExecutionResult::Success(json!({
+            "status": "opened",
+            "message": "Browser session opened. It will stay alive between tool calls. Use browserless_close_browser when done.",
+            "title": title,
+            "url": current_url,
+            "timeout_ms": timeout_ms
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// BrowserlessCloseBrowserTool
+// ============================================================================
+
+pub struct BrowserlessCloseBrowserTool;
+
+#[async_trait]
+impl Tool for BrowserlessCloseBrowserTool {
+    fn name(&self) -> &str {
+        "browserless_close_browser"
+    }
+
+    fn description(&self) -> &str {
+        "Close the persistent browser session opened by browserless_open_browser. \
+         This releases the browser resources on Browserless servers."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("browserless_close_browser requires context.")
+    }
+
+    async fn execute_with_context(
+        &self,
+        _arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let session_state = match get_browser_session(context).await {
+            Ok(Some(state)) => state,
+            Ok(None) => {
+                return ToolExecutionResult::Success(json!({
+                    "status": "no_session",
+                    "message": "No active browser session to close."
+                }));
+            }
+            Err(e) => return e,
+        };
+
+        // Reconnect and close (don't call reconnect — browser will be destroyed)
+        let url = session_state.reconnect_url();
+        match CdpSession::connect(&url).await {
+            Ok(session) => {
+                // Just disconnect without calling reconnect — browser will be destroyed
+                session.disconnect().await;
+                debug!("Browser session closed (disconnected without reconnect)");
+            }
+            Err(e) => {
+                // Connection failed — session already expired, which is fine
+                debug!("Browser session already expired: {e}");
+            }
+        }
+
+        // Clean up state
+        if let Err(e) = delete_browser_session(context).await {
+            return e;
+        }
+
+        ToolExecutionResult::Success(json!({
+            "status": "closed",
+            "message": "Browser session closed. Resources have been released."
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// CDP Session Helpers (for use by other tools)
+// ============================================================================
+
+/// Try to get an active CDP session for the current context.
+/// Returns None if no session exists or if reconnection fails.
+pub async fn try_get_cdp_session(context: &ToolContext) -> Option<CdpSession> {
+    let state = get_browser_session(context).await.ok()??;
+    let url = state.reconnect_url();
+
+    match CdpSession::connect(&url).await {
+        Ok(session) => Some(session),
+        Err(e) => {
+            debug!("CDP reconnect failed (session may have expired): {e}");
+            // Clean up stale state
+            let _ = delete_browser_session(context).await;
+            None
+        }
+    }
+}
+
+/// After using a CDP session, call reconnect to keep the browser alive
+/// and update the stored endpoint.
+pub async fn keep_session_alive(context: &ToolContext, session: &mut CdpSession) {
+    match session.reconnect(DEFAULT_RECONNECT_TIMEOUT_MS).await {
+        Ok(new_endpoint) => {
+            if let Ok(Some(mut state)) = get_browser_session(context).await {
+                state.ws_endpoint = new_endpoint;
+                state.last_active_at = chrono::Utc::now().to_rfc3339();
+                let _ = save_browser_session(context, &state).await;
+            }
+        }
+        Err(e) => {
+            warn!("Failed to keep browser session alive: {e}");
+            let _ = delete_browser_session(context).await;
+        }
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_open_browser_metadata() {
+        let tool = BrowserlessOpenBrowserTool;
+        assert_eq!(tool.name(), "browserless_open_browser");
+        assert!(tool.requires_context());
+        let schema = tool.parameters_schema();
+        assert_eq!(schema["additionalProperties"], false);
+    }
+
+    #[test]
+    fn test_close_browser_metadata() {
+        let tool = BrowserlessCloseBrowserTool;
+        assert_eq!(tool.name(), "browserless_close_browser");
+        assert!(tool.requires_context());
+        let schema = tool.parameters_schema();
+        assert_eq!(schema["additionalProperties"], false);
+    }
+
+    #[tokio::test]
+    async fn test_open_browser_no_context() {
+        let tool = BrowserlessOpenBrowserTool;
+        let result = tool.execute(json!({})).await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("requires context"));
+            }
+            other => panic!("Expected ToolError, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_close_browser_no_context() {
+        let tool = BrowserlessCloseBrowserTool;
+        let result = tool.execute(json!({})).await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("requires context"));
+            }
+            other => panic!("Expected ToolError, got: {other:?}"),
+        }
+    }
+}

--- a/integrations/browserless/src/session_tools.rs
+++ b/integrations/browserless/src/session_tools.rs
@@ -1,7 +1,8 @@
 //! CDP session management tools: open_browser and close_browser.
 //!
 //! Decision: Persistent browser sessions via CDP WebSocket + Browserless.reconnect.
-//! Decision: Session state stored in session_storage (encrypted at rest).
+//! Decision: Session state stores only WS endpoint (no secrets). API token always
+//!   resolved from user connection at call time.
 //! Decision: Each tool call reconnects → does work → calls reconnect → disconnects.
 //!   No long-lived WebSocket connections. The browser stays alive on Browserless servers.
 
@@ -69,14 +70,12 @@ impl Tool for BrowserlessOpenBrowserTool {
 
         // Check if there's already an active session
         if let Ok(Some(existing)) = get_browser_session(context).await {
-            // Try to reconnect to verify it's still alive
-            let url = existing.reconnect_url();
+            let url = existing.reconnect_url(&api_token);
             match CdpSession::connect(&url).await {
                 Ok(mut session) => {
                     let title = session.get_title().await.unwrap_or_default();
                     let current_url = session.get_url().await.unwrap_or_default();
 
-                    // Keep it alive
                     let timeout_ms = arguments
                         .get("timeout_ms")
                         .and_then(|v| v.as_u64())
@@ -100,14 +99,12 @@ impl Tool for BrowserlessOpenBrowserTool {
                             }));
                         }
                         Err(_) => {
-                            // Session died, clean up and open a new one
                             session.disconnect().await;
                             let _ = delete_browser_session(context).await;
                         }
                     }
                 }
                 Err(_) => {
-                    // Can't connect — session expired, clean up
                     let _ = delete_browser_session(context).await;
                 }
             }
@@ -129,11 +126,9 @@ impl Tool for BrowserlessOpenBrowserTool {
             return ToolExecutionResult::tool_error(format!("Failed to navigate to {url}: {e}"));
         }
 
-        // Get page info
         let title = session.get_title().await.unwrap_or_default();
         let current_url = session.get_url().await.unwrap_or_default();
 
-        // Call reconnect to keep browser alive after we disconnect
         let timeout_ms = arguments
             .get("timeout_ms")
             .and_then(|v| v.as_u64())
@@ -149,8 +144,8 @@ impl Tool for BrowserlessOpenBrowserTool {
             }
         };
 
-        // Save state and disconnect
-        let state = BrowserSessionState::new(ws_endpoint, api_token);
+        // Save state (only WS endpoint, no token)
+        let state = BrowserSessionState::new(ws_endpoint);
         if let Err(e) = save_browser_session(context, &state).await {
             session.disconnect().await;
             return e;
@@ -218,21 +213,28 @@ impl Tool for BrowserlessCloseBrowserTool {
             Err(e) => return e,
         };
 
+        // Resolve token from connection to build reconnect URL
+        let api_token = match get_api_token(context).await {
+            Ok(v) => v,
+            Err(e) => {
+                // Can't resolve token — just clean up state, browser will expire on its own
+                let _ = delete_browser_session(context).await;
+                return e;
+            }
+        };
+
         // Reconnect and close (don't call reconnect — browser will be destroyed)
-        let url = session_state.reconnect_url();
+        let url = session_state.reconnect_url(&api_token);
         match CdpSession::connect(&url).await {
             Ok(session) => {
-                // Just disconnect without calling reconnect — browser will be destroyed
                 session.disconnect().await;
                 debug!("Browser session closed (disconnected without reconnect)");
             }
             Err(e) => {
-                // Connection failed — session already expired, which is fine
                 debug!("Browser session already expired: {e}");
             }
         }
 
-        // Clean up state
         if let Err(e) = delete_browser_session(context).await {
             return e;
         }
@@ -253,16 +255,19 @@ impl Tool for BrowserlessCloseBrowserTool {
 // ============================================================================
 
 /// Try to get an active CDP session for the current context.
-/// Returns None if no session exists or if reconnection fails.
+/// Resolves API token from connection provider. Returns None if no session exists
+/// or if reconnection fails.
 pub async fn try_get_cdp_session(context: &ToolContext) -> Option<CdpSession> {
     let state = get_browser_session(context).await.ok()??;
-    let url = state.reconnect_url();
+
+    // Resolve token from connection — never from session state
+    let api_token = get_api_token(context).await.ok()?;
+    let url = state.reconnect_url(&api_token);
 
     match CdpSession::connect(&url).await {
         Ok(session) => Some(session),
         Err(e) => {
             debug!("CDP reconnect failed (session may have expired): {e}");
-            // Clean up stale state
             let _ = delete_browser_session(context).await;
             None
         }

--- a/integrations/browserless/src/state.rs
+++ b/integrations/browserless/src/state.rs
@@ -1,0 +1,78 @@
+//! Browserless API key resolution and parameter helpers.
+
+use everruns_core::tools::ToolExecutionResult;
+use everruns_core::traits::ToolContext;
+
+use serde_json::Value;
+use tracing::error;
+
+// ============================================================================
+// API Key Resolution
+// ============================================================================
+
+/// Resolve Browserless API token via user connection (Settings > Connections > Browserless).
+pub async fn get_api_token(context: &ToolContext) -> Result<String, ToolExecutionResult> {
+    if let Some(resolver) = context.connection_resolver.as_ref() {
+        match resolver
+            .get_connection_token(context.session_id, "browserless")
+            .await
+        {
+            Ok(Some(key)) => return Ok(key),
+            Ok(None) => {} // fall through to error
+            Err(e) => {
+                error!("Failed to resolve Browserless user connection: {e}");
+            }
+        }
+    }
+
+    Err(ToolExecutionResult::tool_error(
+        "Browserless API token not configured.\n\n\
+         Set up your API token in **Settings > Connections > Browserless**.\n\n\
+         Get your token at https://cloud.browserless.io/ under API Keys.",
+    ))
+}
+
+/// Extract a required string parameter from tool arguments.
+pub fn required_str<'a>(args: &'a Value, name: &str) -> Result<&'a str, ToolExecutionResult> {
+    args.get(name).and_then(|v| v.as_str()).ok_or_else(|| {
+        ToolExecutionResult::tool_error(format!("Missing required parameter: {name}"))
+    })
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_required_str_present() {
+        let args = serde_json::json!({"url": "https://example.com"});
+        let result = required_str(&args, "url");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "https://example.com");
+    }
+
+    #[test]
+    fn test_required_str_missing() {
+        let args = serde_json::json!({"other": "value"});
+        let result = required_str(&args, "url");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_required_str_null_value() {
+        let args = serde_json::json!({"url": null});
+        let result = required_str(&args, "url");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_required_str_non_string_value() {
+        let args = serde_json::json!({"url": 42});
+        let result = required_str(&args, "url");
+        assert!(result.is_err());
+    }
+}

--- a/integrations/browserless/src/state.rs
+++ b/integrations/browserless/src/state.rs
@@ -240,4 +240,28 @@ mod tests {
         // No api_token in serialized state
         assert!(!json.contains("api_token"));
     }
+
+    /// Structural verification: session state must contain exactly 3 fields
+    /// and never include any secret/token/credential data.
+    #[test]
+    fn test_browser_session_state_no_secrets_structural() {
+        let state = BrowserSessionState::new("wss://example.com/browser/abc123".to_string());
+        let json: serde_json::Value = serde_json::to_value(&state).unwrap();
+        let obj = json.as_object().unwrap();
+
+        // Exactly 3 fields: ws_endpoint, created_at, last_active_at
+        assert_eq!(obj.len(), 3, "Session state must have exactly 3 fields");
+        assert!(obj.contains_key("ws_endpoint"));
+        assert!(obj.contains_key("created_at"));
+        assert!(obj.contains_key("last_active_at"));
+
+        // No field should contain secret-like names
+        for key in obj.keys() {
+            assert!(
+                !key.contains("token") && !key.contains("secret") && !key.contains("password")
+                    && !key.contains("credential") && !key.contains("key"),
+                "Session state must not contain secret-like field: {key}"
+            );
+        }
+    }
 }

--- a/integrations/browserless/src/state.rs
+++ b/integrations/browserless/src/state.rs
@@ -1,10 +1,18 @@
-//! Browserless API key resolution and parameter helpers.
+//! Browserless API key resolution, browser session state, and parameter helpers.
 
 use everruns_core::tools::ToolExecutionResult;
 use everruns_core::traits::ToolContext;
 
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tracing::error;
+use tracing::{debug, error};
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/// Session storage key prefix for browser session state.
+const BROWSER_SESSION_KEY: &str = "browserless_browser_session";
 
 // ============================================================================
 // API Key Resolution
@@ -31,6 +39,122 @@ pub async fn get_api_token(context: &ToolContext) -> Result<String, ToolExecutio
          Get your token at https://cloud.browserless.io/ under API Keys.",
     ))
 }
+
+// ============================================================================
+// Browser Session State (CDP persistent sessions)
+// ============================================================================
+
+/// State for an active CDP browser session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BrowserSessionState {
+    /// The WebSocket endpoint to reconnect to.
+    pub ws_endpoint: String,
+    /// The API token (needed to append to reconnect URL).
+    pub api_token: String,
+    /// When this session was created.
+    pub created_at: String,
+    /// Last reconnect time.
+    pub last_active_at: String,
+}
+
+impl BrowserSessionState {
+    pub fn new(ws_endpoint: String, api_token: String) -> Self {
+        let now = chrono::Utc::now().to_rfc3339();
+        Self {
+            ws_endpoint,
+            api_token,
+            created_at: now.clone(),
+            last_active_at: now,
+        }
+    }
+
+    /// Build the full reconnect URL (endpoint + token query param).
+    pub fn reconnect_url(&self) -> String {
+        let sep = if self.ws_endpoint.contains('?') {
+            "&"
+        } else {
+            "?"
+        };
+        format!("{}{}token={}", self.ws_endpoint, sep, self.api_token)
+    }
+}
+
+/// Save browser session state to session storage.
+pub async fn save_browser_session(
+    context: &ToolContext,
+    state: &BrowserSessionState,
+) -> Result<(), ToolExecutionResult> {
+    let storage = context.storage_store.as_ref().ok_or_else(|| {
+        ToolExecutionResult::tool_error(
+            "Session storage not available. The 'session_storage' capability may be required.",
+        )
+    })?;
+
+    let json_str = serde_json::to_string(state).map_err(|e| {
+        ToolExecutionResult::tool_error(format!("Failed to serialize browser session: {e}"))
+    })?;
+
+    storage
+        .set_secret(context.session_id, BROWSER_SESSION_KEY, &json_str)
+        .await
+        .map_err(|e| {
+            ToolExecutionResult::tool_error(format!("Failed to save browser session: {e}"))
+        })?;
+
+    debug!("Saved browser session state");
+    Ok(())
+}
+
+/// Load browser session state from session storage. Returns None if no active session.
+pub async fn get_browser_session(
+    context: &ToolContext,
+) -> Result<Option<BrowserSessionState>, ToolExecutionResult> {
+    let storage = match context.storage_store.as_ref() {
+        Some(s) => s,
+        None => return Ok(None),
+    };
+
+    let json_str = storage
+        .get_secret(context.session_id, BROWSER_SESSION_KEY)
+        .await
+        .map_err(|e| {
+            ToolExecutionResult::tool_error(format!("Failed to load browser session: {e}"))
+        })?;
+
+    match json_str {
+        Some(s) => {
+            let state: BrowserSessionState = serde_json::from_str(&s).map_err(|e| {
+                ToolExecutionResult::tool_error(format!(
+                    "Failed to deserialize browser session: {e}"
+                ))
+            })?;
+            Ok(Some(state))
+        }
+        None => Ok(None),
+    }
+}
+
+/// Delete browser session state from session storage.
+pub async fn delete_browser_session(context: &ToolContext) -> Result<(), ToolExecutionResult> {
+    let storage = match context.storage_store.as_ref() {
+        Some(s) => s,
+        None => return Ok(()),
+    };
+
+    storage
+        .delete_secret(context.session_id, BROWSER_SESSION_KEY)
+        .await
+        .map_err(|e| {
+            ToolExecutionResult::tool_error(format!("Failed to delete browser session: {e}"))
+        })?;
+
+    debug!("Deleted browser session state");
+    Ok(())
+}
+
+// ============================================================================
+// Parameter Helpers
+// ============================================================================
 
 /// Extract a required string parameter from tool arguments.
 pub fn required_str<'a>(args: &'a Value, name: &str) -> Result<&'a str, ToolExecutionResult> {
@@ -74,5 +198,54 @@ mod tests {
         let args = serde_json::json!({"url": 42});
         let result = required_str(&args, "url");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_browser_session_state_new() {
+        let state = BrowserSessionState::new(
+            "wss://example.com/browser/abc123".to_string(),
+            "my_token".to_string(),
+        );
+        assert_eq!(state.ws_endpoint, "wss://example.com/browser/abc123");
+        assert_eq!(state.api_token, "my_token");
+        assert!(!state.created_at.is_empty());
+        assert!(!state.last_active_at.is_empty());
+    }
+
+    #[test]
+    fn test_browser_session_reconnect_url_no_query() {
+        let state = BrowserSessionState::new(
+            "wss://example.com/browser/abc123".to_string(),
+            "my_token".to_string(),
+        );
+        assert_eq!(
+            state.reconnect_url(),
+            "wss://example.com/browser/abc123?token=my_token"
+        );
+    }
+
+    #[test]
+    fn test_browser_session_reconnect_url_with_query() {
+        let state = BrowserSessionState::new(
+            "wss://example.com/browser/abc123?param=1".to_string(),
+            "my_token".to_string(),
+        );
+        assert_eq!(
+            state.reconnect_url(),
+            "wss://example.com/browser/abc123?param=1&token=my_token"
+        );
+    }
+
+    #[test]
+    fn test_browser_session_serialization_roundtrip() {
+        let state = BrowserSessionState::new(
+            "wss://example.com/browser/abc123".to_string(),
+            "my_token".to_string(),
+        );
+        let json = serde_json::to_string(&state).unwrap();
+        let deserialized: BrowserSessionState = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.ws_endpoint, state.ws_endpoint);
+        assert_eq!(deserialized.api_token, state.api_token);
+        assert_eq!(deserialized.created_at, state.created_at);
     }
 }

--- a/integrations/browserless/src/state.rs
+++ b/integrations/browserless/src/state.rs
@@ -258,8 +258,11 @@ mod tests {
         // No field should contain secret-like names
         for key in obj.keys() {
             assert!(
-                !key.contains("token") && !key.contains("secret") && !key.contains("password")
-                    && !key.contains("credential") && !key.contains("key"),
+                !key.contains("token")
+                    && !key.contains("secret")
+                    && !key.contains("password")
+                    && !key.contains("credential")
+                    && !key.contains("key"),
                 "Session state must not contain secret-like field: {key}"
             );
         }

--- a/integrations/browserless/src/state.rs
+++ b/integrations/browserless/src/state.rs
@@ -1,4 +1,7 @@
 //! Browserless API key resolution, browser session state, and parameter helpers.
+//!
+//! Decision: API token ONLY comes from user connection (Settings > Connections > Browserless).
+//!   Never stored in session secrets. Session state only tracks the WS endpoint.
 
 use everruns_core::tools::ToolExecutionResult;
 use everruns_core::traits::ToolContext;
@@ -11,7 +14,7 @@ use tracing::{debug, error};
 // Constants
 // ============================================================================
 
-/// Session storage key prefix for browser session state.
+/// Session storage key for browser session state.
 const BROWSER_SESSION_KEY: &str = "browserless_browser_session";
 
 // ============================================================================
@@ -45,12 +48,12 @@ pub async fn get_api_token(context: &ToolContext) -> Result<String, ToolExecutio
 // ============================================================================
 
 /// State for an active CDP browser session.
+/// Only stores the WS endpoint — the API token is always resolved from the
+/// connection provider, never stored in session state.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BrowserSessionState {
     /// The WebSocket endpoint to reconnect to.
     pub ws_endpoint: String,
-    /// The API token (needed to append to reconnect URL).
-    pub api_token: String,
     /// When this session was created.
     pub created_at: String,
     /// Last reconnect time.
@@ -58,28 +61,28 @@ pub struct BrowserSessionState {
 }
 
 impl BrowserSessionState {
-    pub fn new(ws_endpoint: String, api_token: String) -> Self {
+    pub fn new(ws_endpoint: String) -> Self {
         let now = chrono::Utc::now().to_rfc3339();
         Self {
             ws_endpoint,
-            api_token,
             created_at: now.clone(),
             last_active_at: now,
         }
     }
 
     /// Build the full reconnect URL (endpoint + token query param).
-    pub fn reconnect_url(&self) -> String {
+    /// Token is passed in — never stored in session state.
+    pub fn reconnect_url(&self, api_token: &str) -> String {
         let sep = if self.ws_endpoint.contains('?') {
             "&"
         } else {
             "?"
         };
-        format!("{}{}token={}", self.ws_endpoint, sep, self.api_token)
+        format!("{}{}token={}", self.ws_endpoint, sep, api_token)
     }
 }
 
-/// Save browser session state to session storage.
+/// Save browser session state to session storage (plain key-value, not secret).
 pub async fn save_browser_session(
     context: &ToolContext,
     state: &BrowserSessionState,
@@ -95,7 +98,7 @@ pub async fn save_browser_session(
     })?;
 
     storage
-        .set_secret(context.session_id, BROWSER_SESSION_KEY, &json_str)
+        .set_value(context.session_id, BROWSER_SESSION_KEY, &json_str)
         .await
         .map_err(|e| {
             ToolExecutionResult::tool_error(format!("Failed to save browser session: {e}"))
@@ -115,7 +118,7 @@ pub async fn get_browser_session(
     };
 
     let json_str = storage
-        .get_secret(context.session_id, BROWSER_SESSION_KEY)
+        .get_value(context.session_id, BROWSER_SESSION_KEY)
         .await
         .map_err(|e| {
             ToolExecutionResult::tool_error(format!("Failed to load browser session: {e}"))
@@ -142,7 +145,7 @@ pub async fn delete_browser_session(context: &ToolContext) -> Result<(), ToolExe
     };
 
     storage
-        .delete_secret(context.session_id, BROWSER_SESSION_KEY)
+        .delete_value(context.session_id, BROWSER_SESSION_KEY)
         .await
         .map_err(|e| {
             ToolExecutionResult::tool_error(format!("Failed to delete browser session: {e}"))
@@ -202,50 +205,39 @@ mod tests {
 
     #[test]
     fn test_browser_session_state_new() {
-        let state = BrowserSessionState::new(
-            "wss://example.com/browser/abc123".to_string(),
-            "my_token".to_string(),
-        );
+        let state = BrowserSessionState::new("wss://example.com/browser/abc123".to_string());
         assert_eq!(state.ws_endpoint, "wss://example.com/browser/abc123");
-        assert_eq!(state.api_token, "my_token");
         assert!(!state.created_at.is_empty());
         assert!(!state.last_active_at.is_empty());
     }
 
     #[test]
     fn test_browser_session_reconnect_url_no_query() {
-        let state = BrowserSessionState::new(
-            "wss://example.com/browser/abc123".to_string(),
-            "my_token".to_string(),
-        );
+        let state = BrowserSessionState::new("wss://example.com/browser/abc123".to_string());
         assert_eq!(
-            state.reconnect_url(),
+            state.reconnect_url("my_token"),
             "wss://example.com/browser/abc123?token=my_token"
         );
     }
 
     #[test]
     fn test_browser_session_reconnect_url_with_query() {
-        let state = BrowserSessionState::new(
-            "wss://example.com/browser/abc123?param=1".to_string(),
-            "my_token".to_string(),
-        );
+        let state =
+            BrowserSessionState::new("wss://example.com/browser/abc123?param=1".to_string());
         assert_eq!(
-            state.reconnect_url(),
+            state.reconnect_url("my_token"),
             "wss://example.com/browser/abc123?param=1&token=my_token"
         );
     }
 
     #[test]
     fn test_browser_session_serialization_roundtrip() {
-        let state = BrowserSessionState::new(
-            "wss://example.com/browser/abc123".to_string(),
-            "my_token".to_string(),
-        );
+        let state = BrowserSessionState::new("wss://example.com/browser/abc123".to_string());
         let json = serde_json::to_string(&state).unwrap();
         let deserialized: BrowserSessionState = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.ws_endpoint, state.ws_endpoint);
-        assert_eq!(deserialized.api_token, state.api_token);
         assert_eq!(deserialized.created_at, state.created_at);
+        // No api_token in serialized state
+        assert!(!json.contains("api_token"));
     }
 }

--- a/integrations/browserless/src/tools.rs
+++ b/integrations/browserless/src/tools.rs
@@ -1,0 +1,990 @@
+//! Tool implementations for Browserless browser automation.
+//!
+//! Decision: 5 tools covering the user's requirements:
+//!   1. browserless_screenshot - Take screenshot of a page
+//!   2. browserless_content   - Read rendered DOM/HTML of a page
+//!   3. browserless_scrape    - Extract structured data via CSS selectors
+//!   4. browserless_interact  - Click, type, navigate with keyboard/mouse/touch
+//!   5. browserless_navigate  - Open a URL and get page info (title, URL, status)
+//!
+//! Decision: No persistent browser sessions. Each tool call is a fresh browser.
+//!   This means no resources are left behind — the browser is destroyed after each call.
+//! Decision: browserless_interact uses the /function endpoint for multi-step Puppeteer code.
+//!   Supports click, type, keyboard shortcuts, mouse events, touch, and can return
+//!   a screenshot or DOM content after the interaction.
+
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::traits::ToolContext;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use tracing::debug;
+
+use crate::client::BrowserlessClient;
+use crate::state::{get_api_token, required_str};
+
+// ============================================================================
+// BrowserlessScreenshotTool
+// ============================================================================
+
+pub struct BrowserlessScreenshotTool;
+
+#[async_trait]
+impl Tool for BrowserlessScreenshotTool {
+    fn name(&self) -> &str {
+        "browserless_screenshot"
+    }
+
+    fn description(&self) -> &str {
+        "Take a screenshot of a web page. Returns a base64-encoded PNG image."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "The URL to screenshot"
+                },
+                "full_page": {
+                    "type": "boolean",
+                    "description": "Capture the full scrollable page (default: true)"
+                },
+                "selector": {
+                    "type": "string",
+                    "description": "CSS selector to screenshot a specific element (optional)"
+                },
+                "wait_for_selector": {
+                    "type": "string",
+                    "description": "Wait for this CSS selector to appear before taking screenshot (optional)"
+                },
+                "wait_for_timeout": {
+                    "type": "integer",
+                    "description": "Wait this many milliseconds before taking screenshot (optional)"
+                }
+            },
+            "required": ["url"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("browserless_screenshot requires context.")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let url = match required_str(&arguments, "url") {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+
+        let api_token = match get_api_token(context).await {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+
+        let full_page = arguments
+            .get("full_page")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+        let selector = arguments.get("selector").and_then(|v| v.as_str());
+        let wait_for_selector = arguments.get("wait_for_selector").and_then(|v| v.as_str());
+        let wait_for_timeout = arguments.get("wait_for_timeout").and_then(|v| v.as_u64());
+
+        let client = BrowserlessClient::new(api_token);
+        match client
+            .screenshot(
+                url,
+                full_page,
+                selector,
+                wait_for_selector,
+                wait_for_timeout,
+            )
+            .await
+        {
+            Ok(bytes) => {
+                use base64::Engine;
+                let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+                ToolExecutionResult::Success(json!({
+                    "url": url,
+                    "format": "png",
+                    "size_bytes": bytes.len(),
+                    "image_base64": b64
+                }))
+            }
+            Err(e) => ToolExecutionResult::tool_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// BrowserlessContentTool
+// ============================================================================
+
+pub struct BrowserlessContentTool;
+
+#[async_trait]
+impl Tool for BrowserlessContentTool {
+    fn name(&self) -> &str {
+        "browserless_content"
+    }
+
+    fn description(&self) -> &str {
+        "Get the fully rendered HTML content (DOM) of a web page, including JavaScript-rendered content."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "The URL to read"
+                },
+                "wait_for_selector": {
+                    "type": "string",
+                    "description": "Wait for this CSS selector to appear before reading content (optional)"
+                },
+                "wait_for_timeout": {
+                    "type": "integer",
+                    "description": "Wait this many milliseconds before reading content (optional)"
+                },
+                "best_attempt": {
+                    "type": "boolean",
+                    "description": "Continue even if async events fail or timeout (default: false)"
+                }
+            },
+            "required": ["url"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("browserless_content requires context.")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let url = match required_str(&arguments, "url") {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+
+        let api_token = match get_api_token(context).await {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+
+        let wait_for_selector = arguments.get("wait_for_selector").and_then(|v| v.as_str());
+        let wait_for_timeout = arguments.get("wait_for_timeout").and_then(|v| v.as_u64());
+        let best_attempt = arguments
+            .get("best_attempt")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        let client = BrowserlessClient::new(api_token);
+        match client
+            .content(url, wait_for_selector, wait_for_timeout, best_attempt)
+            .await
+        {
+            Ok(html) => {
+                let len = html.len();
+                // Truncate very large pages to avoid overwhelming the LLM context
+                let truncated = if len > 100_000 {
+                    format!(
+                        "{}...\n\n[Truncated: {} total bytes]",
+                        &html[..100_000],
+                        len
+                    )
+                } else {
+                    html
+                };
+                ToolExecutionResult::Success(json!({
+                    "url": url,
+                    "content": truncated,
+                    "size_bytes": len,
+                    "truncated": len > 100_000
+                }))
+            }
+            Err(e) => ToolExecutionResult::tool_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// BrowserlessScrapeTool
+// ============================================================================
+
+pub struct BrowserlessScrapeTool;
+
+#[async_trait]
+impl Tool for BrowserlessScrapeTool {
+    fn name(&self) -> &str {
+        "browserless_scrape"
+    }
+
+    fn description(&self) -> &str {
+        "Extract structured data from a web page using CSS selectors. Returns JSON with matched elements."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "The URL to scrape"
+                },
+                "elements": {
+                    "type": "array",
+                    "description": "Array of element selectors to extract",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "selector": {
+                                "type": "string",
+                                "description": "CSS selector to match elements"
+                            }
+                        },
+                        "required": ["selector"]
+                    }
+                },
+                "wait_for_selector": {
+                    "type": "string",
+                    "description": "Wait for this CSS selector before scraping (optional)"
+                },
+                "wait_for_timeout": {
+                    "type": "integer",
+                    "description": "Wait this many milliseconds before scraping (optional)"
+                }
+            },
+            "required": ["url", "elements"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("browserless_scrape requires context.")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let url = match required_str(&arguments, "url") {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+
+        let elements = match arguments.get("elements").and_then(|v| v.as_array()) {
+            Some(arr) => arr.clone(),
+            None => {
+                return ToolExecutionResult::tool_error(
+                    "Missing required parameter: elements (must be an array)",
+                );
+            }
+        };
+
+        let api_token = match get_api_token(context).await {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+
+        let wait_for_selector = arguments.get("wait_for_selector").and_then(|v| v.as_str());
+        let wait_for_timeout = arguments.get("wait_for_timeout").and_then(|v| v.as_u64());
+
+        let client = BrowserlessClient::new(api_token);
+        match client
+            .scrape(url, &elements, wait_for_selector, wait_for_timeout)
+            .await
+        {
+            Ok(data) => ToolExecutionResult::Success(json!({
+                "url": url,
+                "data": data
+            })),
+            Err(e) => ToolExecutionResult::tool_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// BrowserlessInteractTool
+// ============================================================================
+
+pub struct BrowserlessInteractTool;
+
+/// Build Puppeteer function code from a list of interaction steps.
+/// Each step is executed sequentially in a fresh browser session.
+fn build_interaction_code(url: &str, steps: &[Value], return_screenshot: bool) -> String {
+    let mut code = String::new();
+    code.push_str("export default async ({ page }) => {\n");
+    code.push_str(&format!(
+        "  await page.goto({}, {{ waitUntil: 'networkidle2', timeout: 30000 }});\n",
+        serde_json::to_string(url).unwrap_or_else(|_| format!("\"{}\"", url))
+    ));
+
+    for step in steps {
+        let action = step
+            .get("action")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+        let selector = step.get("selector").and_then(|v| v.as_str());
+        let value = step.get("value").and_then(|v| v.as_str());
+        let key = step.get("key").and_then(|v| v.as_str());
+        let x = step.get("x").and_then(|v| v.as_f64());
+        let y = step.get("y").and_then(|v| v.as_f64());
+        let wait_ms = step.get("wait_ms").and_then(|v| v.as_u64());
+
+        match action {
+            "click" => {
+                if let Some(sel) = selector {
+                    code.push_str(&format!(
+                        "  await page.waitForSelector({sel_js}, {{ timeout: 10000 }});\n\
+                         \x20 await page.click({sel_js});\n",
+                        sel_js = serde_json::to_string(sel).unwrap()
+                    ));
+                } else if let (Some(cx), Some(cy)) = (x, y) {
+                    code.push_str(&format!("  await page.mouse.click({cx}, {cy});\n"));
+                }
+            }
+            "type" => {
+                if let (Some(sel), Some(text)) = (selector, value) {
+                    code.push_str(&format!(
+                        "  await page.waitForSelector({sel_js}, {{ timeout: 10000 }});\n\
+                         \x20 await page.type({sel_js}, {val_js});\n",
+                        sel_js = serde_json::to_string(sel).unwrap(),
+                        val_js = serde_json::to_string(text).unwrap()
+                    ));
+                }
+            }
+            "keyboard" => {
+                if let Some(k) = key {
+                    code.push_str(&format!(
+                        "  await page.keyboard.press({key_js});\n",
+                        key_js = serde_json::to_string(k).unwrap()
+                    ));
+                }
+            }
+            "mouse_move" => {
+                if let (Some(mx), Some(my)) = (x, y) {
+                    code.push_str(&format!("  await page.mouse.move({mx}, {my});\n"));
+                }
+            }
+            "touch" => {
+                if let Some(sel) = selector {
+                    code.push_str(&format!(
+                        "  await page.waitForSelector({sel_js}, {{ timeout: 10000 }});\n\
+                         \x20 await page.tap({sel_js});\n",
+                        sel_js = serde_json::to_string(sel).unwrap()
+                    ));
+                }
+            }
+            "scroll" => {
+                let scroll_y = step.get("value").and_then(|v| v.as_i64()).unwrap_or(500);
+                code.push_str(&format!(
+                    "  await page.evaluate(() => window.scrollBy(0, {scroll_y}));\n"
+                ));
+            }
+            "wait" => {
+                let ms = wait_ms.unwrap_or(1000);
+                code.push_str(&format!("  await new Promise(r => setTimeout(r, {ms}));\n"));
+            }
+            "wait_for_selector" => {
+                if let Some(sel) = selector {
+                    let timeout = wait_ms.unwrap_or(10000);
+                    code.push_str(&format!(
+                        "  await page.waitForSelector({sel_js}, {{ timeout: {timeout} }});\n",
+                        sel_js = serde_json::to_string(sel).unwrap()
+                    ));
+                }
+            }
+            "navigate" => {
+                if let Some(nav_url) = value {
+                    code.push_str(&format!(
+                        "  await page.goto({url_js}, {{ waitUntil: 'networkidle2', timeout: 30000 }});\n",
+                        url_js = serde_json::to_string(nav_url).unwrap()
+                    ));
+                }
+            }
+            other => {
+                debug!("Unknown interaction action: {other}");
+            }
+        }
+
+        // Optional per-step wait
+        if action != "wait"
+            && let Some(ms) = wait_ms
+        {
+            code.push_str(&format!("  await new Promise(r => setTimeout(r, {ms}));\n"));
+        }
+    }
+
+    // Capture final state
+    code.push_str("  const title = await page.title();\n");
+    code.push_str("  const url = page.url();\n");
+
+    if return_screenshot {
+        code.push_str(
+            "  const screenshot = await page.screenshot({ encoding: 'base64', fullPage: true });\n",
+        );
+        code.push_str(
+            "  return { data: JSON.stringify({ title, url, screenshot }), type: 'application/json' };\n",
+        );
+    } else {
+        code.push_str("  const content = await page.content();\n");
+        code.push_str(
+            "  return { data: JSON.stringify({ title, url, content }), type: 'application/json' };\n",
+        );
+    }
+
+    code.push_str("};\n");
+    code
+}
+
+#[async_trait]
+impl Tool for BrowserlessInteractTool {
+    fn name(&self) -> &str {
+        "browserless_interact"
+    }
+
+    fn description(&self) -> &str {
+        "Interact with a web page: navigate to a URL, then perform a sequence of actions \
+         (click, type, keyboard, mouse, touch, scroll, wait). Returns the page title, \
+         final URL, and optionally a screenshot or DOM content after all steps complete."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "The initial URL to navigate to"
+                },
+                "steps": {
+                    "type": "array",
+                    "description": "Ordered list of interaction steps to perform",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "action": {
+                                "type": "string",
+                                "description": "Action type: click, type, keyboard, mouse_move, touch, scroll, wait, wait_for_selector, navigate",
+                                "enum": ["click", "type", "keyboard", "mouse_move", "touch", "scroll", "wait", "wait_for_selector", "navigate"]
+                            },
+                            "selector": {
+                                "type": "string",
+                                "description": "CSS selector for the target element (for click, type, touch, wait_for_selector)"
+                            },
+                            "value": {
+                                "type": "string",
+                                "description": "Text to type (for type action), URL (for navigate), or scroll amount (for scroll)"
+                            },
+                            "key": {
+                                "type": "string",
+                                "description": "Key to press (for keyboard action, e.g. 'Enter', 'Tab', 'Escape')"
+                            },
+                            "x": {
+                                "type": "number",
+                                "description": "X coordinate (for click with coordinates, mouse_move)"
+                            },
+                            "y": {
+                                "type": "number",
+                                "description": "Y coordinate (for click with coordinates, mouse_move)"
+                            },
+                            "wait_ms": {
+                                "type": "integer",
+                                "description": "Milliseconds to wait after this step (or duration for wait/wait_for_selector actions)"
+                            }
+                        },
+                        "required": ["action"]
+                    }
+                },
+                "return_screenshot": {
+                    "type": "boolean",
+                    "description": "If true, return a base64 screenshot after all steps. If false, return DOM content. (default: false)"
+                }
+            },
+            "required": ["url", "steps"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("browserless_interact requires context.")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let url = match required_str(&arguments, "url") {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+
+        let steps = match arguments.get("steps").and_then(|v| v.as_array()) {
+            Some(arr) => arr.clone(),
+            None => {
+                return ToolExecutionResult::tool_error(
+                    "Missing required parameter: steps (must be an array)",
+                );
+            }
+        };
+
+        let api_token = match get_api_token(context).await {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+
+        let return_screenshot = arguments
+            .get("return_screenshot")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        let code = build_interaction_code(url, &steps, return_screenshot);
+        debug!("Generated interaction code ({} bytes)", code.len());
+
+        let client = BrowserlessClient::new(api_token);
+        match client.function(&code, None).await {
+            Ok(result) => {
+                // The function returns JSON-stringified data in the "data" field
+                if let Some(data_str) = result.get("data").and_then(|v| v.as_str()) {
+                    match serde_json::from_str::<Value>(data_str) {
+                        Ok(data) => ToolExecutionResult::Success(data),
+                        Err(_) => ToolExecutionResult::Success(json!({
+                            "result": data_str
+                        })),
+                    }
+                } else {
+                    ToolExecutionResult::Success(result)
+                }
+            }
+            Err(e) => ToolExecutionResult::tool_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// BrowserlessNavigateTool
+// ============================================================================
+
+pub struct BrowserlessNavigateTool;
+
+#[async_trait]
+impl Tool for BrowserlessNavigateTool {
+    fn name(&self) -> &str {
+        "browserless_navigate"
+    }
+
+    fn description(&self) -> &str {
+        "Navigate to a URL and return page metadata (title, final URL after redirects, \
+         and a summary of the page content). Use this as a first step to explore a website."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "The URL to navigate to"
+                },
+                "wait_for_selector": {
+                    "type": "string",
+                    "description": "Wait for this CSS selector to appear (optional)"
+                },
+                "wait_for_timeout": {
+                    "type": "integer",
+                    "description": "Wait this many milliseconds after page load (optional)"
+                }
+            },
+            "required": ["url"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("browserless_navigate requires context.")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let url = match required_str(&arguments, "url") {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+
+        let api_token = match get_api_token(context).await {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+
+        let wait_for_selector = arguments.get("wait_for_selector").and_then(|v| v.as_str());
+        let wait_for_timeout = arguments.get("wait_for_timeout").and_then(|v| v.as_u64());
+
+        // Use the /function endpoint to get rich metadata
+        let mut code = String::new();
+        code.push_str("export default async ({ page }) => {\n");
+        code.push_str(&format!(
+            "  const response = await page.goto({}, {{ waitUntil: 'networkidle2', timeout: 30000 }});\n",
+            serde_json::to_string(url).unwrap_or_else(|_| format!("\"{}\"", url))
+        ));
+
+        if let Some(sel) = wait_for_selector {
+            code.push_str(&format!(
+                "  await page.waitForSelector({}, {{ timeout: 30000 }});\n",
+                serde_json::to_string(sel).unwrap()
+            ));
+        }
+        if let Some(timeout) = wait_for_timeout {
+            code.push_str(&format!(
+                "  await new Promise(r => setTimeout(r, {timeout}));\n"
+            ));
+        }
+
+        code.push_str(
+            "  const title = await page.title();\n\
+             \x20 const finalUrl = page.url();\n\
+             \x20 const status = response ? response.status() : null;\n\
+             \x20 const links = await page.$$eval('a[href]', els => els.slice(0, 50).map(a => ({ text: a.textContent?.trim()?.substring(0, 100), href: a.href })));\n\
+             \x20 const headings = await page.$$eval('h1, h2, h3', els => els.slice(0, 20).map(h => ({ tag: h.tagName, text: h.textContent?.trim()?.substring(0, 200) })));\n\
+             \x20 const meta = await page.$$eval('meta[name], meta[property]', els => els.slice(0, 20).map(m => ({ name: m.getAttribute('name') || m.getAttribute('property'), content: m.getAttribute('content')?.substring(0, 200) })));\n\
+             \x20 return { data: JSON.stringify({ title, url: finalUrl, status, links, headings, meta }), type: 'application/json' };\n",
+        );
+        code.push_str("};\n");
+
+        let client = BrowserlessClient::new(api_token);
+        match client.function(&code, None).await {
+            Ok(result) => {
+                if let Some(data_str) = result.get("data").and_then(|v| v.as_str()) {
+                    match serde_json::from_str::<Value>(data_str) {
+                        Ok(data) => ToolExecutionResult::Success(data),
+                        Err(_) => ToolExecutionResult::Success(json!({
+                            "result": data_str
+                        })),
+                    }
+                } else {
+                    ToolExecutionResult::Success(result)
+                }
+            }
+            Err(e) => ToolExecutionResult::tool_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::capabilities::Capability;
+
+    #[test]
+    fn test_screenshot_tool_metadata() {
+        let tool = BrowserlessScreenshotTool;
+        assert_eq!(tool.name(), "browserless_screenshot");
+        assert!(tool.requires_context());
+        let schema = tool.parameters_schema();
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.contains(&json!("url")));
+        assert_eq!(schema["additionalProperties"], false);
+    }
+
+    #[test]
+    fn test_content_tool_metadata() {
+        let tool = BrowserlessContentTool;
+        assert_eq!(tool.name(), "browserless_content");
+        assert!(tool.requires_context());
+        let schema = tool.parameters_schema();
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.contains(&json!("url")));
+    }
+
+    #[test]
+    fn test_scrape_tool_metadata() {
+        let tool = BrowserlessScrapeTool;
+        assert_eq!(tool.name(), "browserless_scrape");
+        assert!(tool.requires_context());
+        let schema = tool.parameters_schema();
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.contains(&json!("url")));
+        assert!(required.contains(&json!("elements")));
+    }
+
+    #[test]
+    fn test_interact_tool_metadata() {
+        let tool = BrowserlessInteractTool;
+        assert_eq!(tool.name(), "browserless_interact");
+        assert!(tool.requires_context());
+        let schema = tool.parameters_schema();
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.contains(&json!("url")));
+        assert!(required.contains(&json!("steps")));
+    }
+
+    #[test]
+    fn test_navigate_tool_metadata() {
+        let tool = BrowserlessNavigateTool;
+        assert_eq!(tool.name(), "browserless_navigate");
+        assert!(tool.requires_context());
+        let schema = tool.parameters_schema();
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.contains(&json!("url")));
+    }
+
+    #[test]
+    fn test_all_schemas_have_no_additional_properties() {
+        let cap = crate::BrowserlessCapability;
+        for tool in cap.tools() {
+            let schema = tool.parameters_schema();
+            assert_eq!(
+                schema["additionalProperties"],
+                false,
+                "Tool {} should disallow additional properties",
+                tool.name()
+            );
+        }
+    }
+
+    #[test]
+    fn test_build_interaction_code_click() {
+        let steps = vec![json!({
+            "action": "click",
+            "selector": "#submit-btn"
+        })];
+        let code = build_interaction_code("https://example.com", &steps, false);
+        assert!(code.contains("page.goto"));
+        assert!(code.contains("page.click"));
+        assert!(code.contains("#submit-btn"));
+        assert!(code.contains("page.content()"));
+    }
+
+    #[test]
+    fn test_build_interaction_code_type() {
+        let steps = vec![json!({
+            "action": "type",
+            "selector": "#username",
+            "value": "admin"
+        })];
+        let code = build_interaction_code("https://example.com", &steps, false);
+        assert!(code.contains("page.type"));
+        assert!(code.contains("#username"));
+        assert!(code.contains("admin"));
+    }
+
+    #[test]
+    fn test_build_interaction_code_keyboard() {
+        let steps = vec![json!({
+            "action": "keyboard",
+            "key": "Enter"
+        })];
+        let code = build_interaction_code("https://example.com", &steps, false);
+        assert!(code.contains("page.keyboard.press"));
+        assert!(code.contains("Enter"));
+    }
+
+    #[test]
+    fn test_build_interaction_code_mouse_move() {
+        let steps = vec![json!({
+            "action": "mouse_move",
+            "x": 100.0,
+            "y": 200.0
+        })];
+        let code = build_interaction_code("https://example.com", &steps, false);
+        assert!(code.contains("page.mouse.move(100, 200)"));
+    }
+
+    #[test]
+    fn test_build_interaction_code_touch() {
+        let steps = vec![json!({
+            "action": "touch",
+            "selector": ".menu-item"
+        })];
+        let code = build_interaction_code("https://example.com", &steps, false);
+        assert!(code.contains("page.tap"));
+    }
+
+    #[test]
+    fn test_build_interaction_code_scroll() {
+        let steps = vec![json!({
+            "action": "scroll",
+            "value": 1000
+        })];
+        let code = build_interaction_code("https://example.com", &steps, false);
+        assert!(code.contains("window.scrollBy(0, 1000)"));
+    }
+
+    #[test]
+    fn test_build_interaction_code_with_screenshot() {
+        let steps = vec![json!({
+            "action": "click",
+            "selector": "button"
+        })];
+        let code = build_interaction_code("https://example.com", &steps, true);
+        assert!(code.contains("page.screenshot"));
+        assert!(!code.contains("page.content()"));
+    }
+
+    #[test]
+    fn test_build_interaction_code_navigate_step() {
+        let steps = vec![json!({
+            "action": "navigate",
+            "value": "https://other.com/page"
+        })];
+        let code = build_interaction_code("https://example.com", &steps, false);
+        // Should have two page.goto calls: initial + navigate step
+        assert!(code.contains("https://other.com/page"));
+    }
+
+    #[test]
+    fn test_build_interaction_code_wait() {
+        let steps = vec![json!({
+            "action": "wait",
+            "wait_ms": 2000
+        })];
+        let code = build_interaction_code("https://example.com", &steps, false);
+        assert!(code.contains("setTimeout(r, 2000)"));
+    }
+
+    #[test]
+    fn test_build_interaction_code_wait_for_selector() {
+        let steps = vec![json!({
+            "action": "wait_for_selector",
+            "selector": ".loaded",
+            "wait_ms": 5000
+        })];
+        let code = build_interaction_code("https://example.com", &steps, false);
+        assert!(code.contains("waitForSelector"));
+        assert!(code.contains(".loaded"));
+        assert!(code.contains("5000"));
+    }
+
+    #[test]
+    fn test_build_interaction_code_click_by_coordinates() {
+        let steps = vec![json!({
+            "action": "click",
+            "x": 50.0,
+            "y": 75.0
+        })];
+        let code = build_interaction_code("https://example.com", &steps, false);
+        assert!(code.contains("page.mouse.click(50, 75)"));
+    }
+
+    #[test]
+    fn test_build_interaction_code_multi_step() {
+        let steps = vec![
+            json!({"action": "click", "selector": "#login-link"}),
+            json!({"action": "wait_for_selector", "selector": "#username"}),
+            json!({"action": "type", "selector": "#username", "value": "admin"}),
+            json!({"action": "type", "selector": "#password", "value": "secret"}),
+            json!({"action": "click", "selector": "#submit"}),
+            json!({"action": "wait", "wait_ms": 2000}),
+        ];
+        let code = build_interaction_code("https://example.com/home", &steps, true);
+        assert!(code.contains("#login-link"));
+        assert!(code.contains("#username"));
+        assert!(code.contains("#password"));
+        assert!(code.contains("#submit"));
+        assert!(code.contains("page.screenshot"));
+    }
+
+    #[tokio::test]
+    async fn test_screenshot_tool_no_context_error() {
+        let tool = BrowserlessScreenshotTool;
+        let result = tool.execute(json!({"url": "https://example.com"})).await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("requires context"));
+            }
+            other => panic!("Expected ToolError, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_content_tool_no_context_error() {
+        let tool = BrowserlessContentTool;
+        let result = tool.execute(json!({"url": "https://example.com"})).await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("requires context"));
+            }
+            other => panic!("Expected ToolError, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_scrape_tool_no_context_error() {
+        let tool = BrowserlessScrapeTool;
+        let result = tool
+            .execute(json!({"url": "https://example.com", "elements": []}))
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("requires context"));
+            }
+            other => panic!("Expected ToolError, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_interact_tool_no_context_error() {
+        let tool = BrowserlessInteractTool;
+        let result = tool
+            .execute(json!({"url": "https://example.com", "steps": []}))
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("requires context"));
+            }
+            other => panic!("Expected ToolError, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_navigate_tool_no_context_error() {
+        let tool = BrowserlessNavigateTool;
+        let result = tool.execute(json!({"url": "https://example.com"})).await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("requires context"));
+            }
+            other => panic!("Expected ToolError, got: {other:?}"),
+        }
+    }
+}

--- a/integrations/browserless/src/tools.rs
+++ b/integrations/browserless/src/tools.rs
@@ -1,17 +1,15 @@
 //! Tool implementations for Browserless browser automation.
 //!
-//! Decision: 5 tools covering the user's requirements:
-//!   1. browserless_screenshot - Take screenshot of a page
-//!   2. browserless_content   - Read rendered DOM/HTML of a page
-//!   3. browserless_scrape    - Extract structured data via CSS selectors
-//!   4. browserless_interact  - Click, type, navigate with keyboard/mouse/touch
-//!   5. browserless_navigate  - Open a URL and get page info (title, URL, status)
+//! Decision: 5 REST tools + session-aware behavior:
+//!   1. browserless_screenshot - Take screenshot (CDP if session active, REST otherwise)
+//!   2. browserless_content   - Read DOM/HTML (CDP if session active, REST otherwise)
+//!   3. browserless_scrape    - Extract structured data via CSS selectors (REST only)
+//!   4. browserless_interact  - Click, type, navigate (CDP if session active, REST otherwise)
+//!   5. browserless_navigate  - Open URL and get page info (CDP if session active, REST otherwise)
 //!
-//! Decision: No persistent browser sessions. Each tool call is a fresh browser.
-//!   This means no resources are left behind — the browser is destroyed after each call.
-//! Decision: browserless_interact uses the /function endpoint for multi-step Puppeteer code.
-//!   Supports click, type, keyboard shortcuts, mouse events, touch, and can return
-//!   a screenshot or DOM content after the interaction.
+//! When a CDP session is active (via browserless_open_browser), tools navigate within
+//! the persistent browser, preserving login state and cookies across tool calls.
+//! When no session exists, each tool call uses a fresh browser via REST API.
 
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
@@ -21,6 +19,7 @@ use serde_json::{Value, json};
 use tracing::debug;
 
 use crate::client::BrowserlessClient;
+use crate::session_tools::{keep_session_alive, try_get_cdp_session};
 use crate::state::{get_api_token, required_str};
 
 // ============================================================================
@@ -83,15 +82,56 @@ impl Tool for BrowserlessScreenshotTool {
             Err(e) => return e,
         };
 
+        let full_page = arguments
+            .get("full_page")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+
+        // Try CDP session first
+        if let Some(mut session) = try_get_cdp_session(context).await {
+            debug!("Using CDP session for screenshot");
+            if let Err(e) = session.navigate(url).await {
+                keep_session_alive(context, &mut session).await;
+                session.disconnect().await;
+                return ToolExecutionResult::tool_error(format!("CDP navigate failed: {e}"));
+            }
+
+            // Wait for selector if specified
+            if let Some(sel) = arguments.get("wait_for_selector").and_then(|v| v.as_str()) {
+                let _ = session.wait_for_selector(sel, 30000).await;
+            }
+            if let Some(ms) = arguments.get("wait_for_timeout").and_then(|v| v.as_u64()) {
+                tokio::time::sleep(tokio::time::Duration::from_millis(ms)).await;
+            }
+
+            let result = session.screenshot(full_page).await;
+            keep_session_alive(context, &mut session).await;
+            session.disconnect().await;
+
+            return match result {
+                Ok(b64) => {
+                    use base64::Engine;
+                    let bytes = base64::engine::general_purpose::STANDARD
+                        .decode(&b64)
+                        .unwrap_or_default();
+                    ToolExecutionResult::Success(json!({
+                        "url": url,
+                        "format": "png",
+                        "size_bytes": bytes.len(),
+                        "image_base64": b64,
+                        "session": "cdp"
+                    }))
+                }
+                Err(e) => ToolExecutionResult::tool_error(format!("CDP screenshot failed: {e}")),
+            };
+        }
+
+        // Fallback: REST API
         let api_token = match get_api_token(context).await {
             Ok(v) => v,
             Err(e) => return e,
         };
 
-        let full_page = arguments
-            .get("full_page")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(true);
         let selector = arguments.get("selector").and_then(|v| v.as_str());
         let wait_for_selector = arguments.get("wait_for_selector").and_then(|v| v.as_str());
         let wait_for_timeout = arguments.get("wait_for_timeout").and_then(|v| v.as_u64());
@@ -182,6 +222,51 @@ impl Tool for BrowserlessContentTool {
             Err(e) => return e,
         };
 
+        // Try CDP session first
+        if let Some(mut session) = try_get_cdp_session(context).await {
+            debug!("Using CDP session for content");
+            if let Err(e) = session.navigate(url).await {
+                keep_session_alive(context, &mut session).await;
+                session.disconnect().await;
+                return ToolExecutionResult::tool_error(format!("CDP navigate failed: {e}"));
+            }
+
+            if let Some(sel) = arguments.get("wait_for_selector").and_then(|v| v.as_str()) {
+                let _ = session.wait_for_selector(sel, 30000).await;
+            }
+            if let Some(ms) = arguments.get("wait_for_timeout").and_then(|v| v.as_u64()) {
+                tokio::time::sleep(tokio::time::Duration::from_millis(ms)).await;
+            }
+
+            let result = session.get_content().await;
+            keep_session_alive(context, &mut session).await;
+            session.disconnect().await;
+
+            return match result {
+                Ok(html) => {
+                    let len = html.len();
+                    let truncated = if len > 100_000 {
+                        format!(
+                            "{}...\n\n[Truncated: {} total bytes]",
+                            &html[..100_000],
+                            len
+                        )
+                    } else {
+                        html
+                    };
+                    ToolExecutionResult::Success(json!({
+                        "url": url,
+                        "content": truncated,
+                        "size_bytes": len,
+                        "truncated": len > 100_000,
+                        "session": "cdp"
+                    }))
+                }
+                Err(e) => ToolExecutionResult::tool_error(format!("CDP content failed: {e}")),
+            };
+        }
+
+        // Fallback: REST API
         let api_token = match get_api_token(context).await {
             Ok(v) => v,
             Err(e) => return e,
@@ -201,7 +286,6 @@ impl Tool for BrowserlessContentTool {
         {
             Ok(html) => {
                 let len = html.len();
-                // Truncate very large pages to avoid overwhelming the LLM context
                 let truncated = if len > 100_000 {
                     format!(
                         "{}...\n\n[Truncated: {} total bytes]",
@@ -554,15 +638,159 @@ impl Tool for BrowserlessInteractTool {
             }
         };
 
-        let api_token = match get_api_token(context).await {
-            Ok(v) => v,
-            Err(e) => return e,
-        };
-
         let return_screenshot = arguments
             .get("return_screenshot")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
+
+        // Try CDP session first
+        if let Some(mut session) = try_get_cdp_session(context).await {
+            debug!("Using CDP session for interact");
+            if let Err(e) = session.navigate(url).await {
+                keep_session_alive(context, &mut session).await;
+                session.disconnect().await;
+                return ToolExecutionResult::tool_error(format!("CDP navigate failed: {e}"));
+            }
+
+            // Execute each step via CDP
+            for step in &steps {
+                let action = step
+                    .get("action")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown");
+                let selector = step.get("selector").and_then(|v| v.as_str());
+                let value = step.get("value").and_then(|v| v.as_str());
+                let key = step.get("key").and_then(|v| v.as_str());
+                let x = step.get("x").and_then(|v| v.as_f64());
+                let y = step.get("y").and_then(|v| v.as_f64());
+                let wait_ms = step.get("wait_ms").and_then(|v| v.as_u64());
+
+                let step_result = match action {
+                    "click" => {
+                        if let Some(sel) = selector {
+                            session.click_selector(sel).await
+                        } else if let (Some(cx), Some(cy)) = (x, y) {
+                            session.click_at(cx, cy).await
+                        } else {
+                            Err("click requires selector or x,y coordinates".to_string())
+                        }
+                    }
+                    "type" => {
+                        if let (Some(sel), Some(text)) = (selector, value) {
+                            session.type_into_selector(sel, text).await
+                        } else {
+                            Err("type requires selector and value".to_string())
+                        }
+                    }
+                    "keyboard" => {
+                        if let Some(k) = key {
+                            session.press_key(k).await
+                        } else {
+                            Err("keyboard requires key".to_string())
+                        }
+                    }
+                    "mouse_move" => {
+                        if let (Some(mx), Some(my)) = (x, y) {
+                            session.mouse_move(mx, my).await
+                        } else {
+                            Err("mouse_move requires x and y".to_string())
+                        }
+                    }
+                    "touch" => {
+                        if let Some(sel) = selector {
+                            session.tap_selector(sel).await
+                        } else {
+                            Err("touch requires selector".to_string())
+                        }
+                    }
+                    "scroll" => {
+                        let dy = step.get("value").and_then(|v| v.as_i64()).unwrap_or(500);
+                        session.scroll(dy).await
+                    }
+                    "wait" => {
+                        let ms = wait_ms.unwrap_or(1000);
+                        tokio::time::sleep(tokio::time::Duration::from_millis(ms)).await;
+                        Ok(())
+                    }
+                    "wait_for_selector" => {
+                        if let Some(sel) = selector {
+                            let timeout = wait_ms.unwrap_or(10000);
+                            session.wait_for_selector(sel, timeout).await
+                        } else {
+                            Err("wait_for_selector requires selector".to_string())
+                        }
+                    }
+                    "navigate" => {
+                        if let Some(nav_url) = value {
+                            session.navigate(nav_url).await.map(|_| ())
+                        } else {
+                            Err("navigate requires value (URL)".to_string())
+                        }
+                    }
+                    other => Err(format!("Unknown action: {other}")),
+                };
+
+                if let Err(e) = step_result {
+                    keep_session_alive(context, &mut session).await;
+                    session.disconnect().await;
+                    return ToolExecutionResult::tool_error(format!(
+                        "Interaction step '{action}' failed: {e}"
+                    ));
+                }
+
+                // Per-step wait
+                if action != "wait"
+                    && let Some(ms) = wait_ms
+                {
+                    tokio::time::sleep(tokio::time::Duration::from_millis(ms)).await;
+                }
+            }
+
+            // Capture result
+            let title = session.get_title().await.unwrap_or_default();
+            let final_url = session.get_url().await.unwrap_or_default();
+            let result = if return_screenshot {
+                match session.screenshot(true).await {
+                    Ok(b64) => json!({
+                        "title": title,
+                        "url": final_url,
+                        "screenshot": b64,
+                        "session": "cdp"
+                    }),
+                    Err(e) => {
+                        keep_session_alive(context, &mut session).await;
+                        session.disconnect().await;
+                        return ToolExecutionResult::tool_error(format!(
+                            "CDP screenshot failed: {e}"
+                        ));
+                    }
+                }
+            } else {
+                match session.get_content().await {
+                    Ok(content) => json!({
+                        "title": title,
+                        "url": final_url,
+                        "content": content,
+                        "session": "cdp"
+                    }),
+                    Err(e) => {
+                        keep_session_alive(context, &mut session).await;
+                        session.disconnect().await;
+                        return ToolExecutionResult::tool_error(format!("CDP content failed: {e}"));
+                    }
+                }
+            };
+
+            keep_session_alive(context, &mut session).await;
+            session.disconnect().await;
+            return ToolExecutionResult::Success(result);
+        }
+
+        // Fallback: REST API
+        let api_token = match get_api_token(context).await {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
 
         let code = build_interaction_code(url, &steps, return_screenshot);
         debug!("Generated interaction code ({} bytes)", code.len());
@@ -570,7 +798,6 @@ impl Tool for BrowserlessInteractTool {
         let client = BrowserlessClient::new(api_token);
         match client.function(&code, None).await {
             Ok(result) => {
-                // The function returns JSON-stringified data in the "data" field
                 if let Some(data_str) = result.get("data").and_then(|v| v.as_str()) {
                     match serde_json::from_str::<Value>(data_str) {
                         Ok(data) => ToolExecutionResult::Success(data),
@@ -644,6 +871,36 @@ impl Tool for BrowserlessNavigateTool {
             Err(e) => return e,
         };
 
+        // Try CDP session first
+        if let Some(mut session) = try_get_cdp_session(context).await {
+            debug!("Using CDP session for navigate");
+            if let Err(e) = session.navigate(url).await {
+                keep_session_alive(context, &mut session).await;
+                session.disconnect().await;
+                return ToolExecutionResult::tool_error(format!("CDP navigate failed: {e}"));
+            }
+
+            if let Some(sel) = arguments.get("wait_for_selector").and_then(|v| v.as_str()) {
+                let _ = session.wait_for_selector(sel, 30000).await;
+            }
+            if let Some(ms) = arguments.get("wait_for_timeout").and_then(|v| v.as_u64()) {
+                tokio::time::sleep(tokio::time::Duration::from_millis(ms)).await;
+            }
+
+            let result = session.get_page_info().await;
+            keep_session_alive(context, &mut session).await;
+            session.disconnect().await;
+
+            return match result {
+                Ok(mut info) => {
+                    info["session"] = json!("cdp");
+                    ToolExecutionResult::Success(info)
+                }
+                Err(e) => ToolExecutionResult::tool_error(format!("CDP get_page_info failed: {e}")),
+            };
+        }
+
+        // Fallback: REST API
         let api_token = match get_api_token(context).await {
             Ok(v) => v,
             Err(e) => return e,
@@ -652,7 +909,6 @@ impl Tool for BrowserlessNavigateTool {
         let wait_for_selector = arguments.get("wait_for_selector").and_then(|v| v.as_str());
         let wait_for_timeout = arguments.get("wait_for_timeout").and_then(|v| v.as_u64());
 
-        // Use the /function endpoint to get rich metadata
         let mut code = String::new();
         code.push_str("export default async ({ page }) => {\n");
         code.push_str(&format!(

--- a/integrations/browserless/src/tools.rs
+++ b/integrations/browserless/src/tools.rs
@@ -45,7 +45,7 @@ fn truncate_html(html: String) -> (String, bool) {
     }
 }
 
-/// Validate that a URL uses http or https scheme.
+/// Validate that a URL uses http or https scheme. // THREAT[TM-TOOL-015]
 fn validate_url(url: &str) -> Result<(), ToolExecutionResult> {
     if url.starts_with("http://") || url.starts_with("https://") {
         Ok(())
@@ -56,7 +56,7 @@ fn validate_url(url: &str) -> Result<(), ToolExecutionResult> {
     }
 }
 
-/// Cap a wait/timeout value to MAX_WAIT_MS.
+/// Cap a wait/timeout value to MAX_WAIT_MS. // THREAT[TM-TOOL-016]
 fn cap_wait_ms(ms: u64) -> u64 {
     ms.min(MAX_WAIT_MS)
 }

--- a/integrations/browserless/src/tools.rs
+++ b/integrations/browserless/src/tools.rs
@@ -23,20 +23,42 @@ use crate::session_tools::{keep_session_alive, try_get_cdp_session};
 use crate::state::{get_api_token, required_str};
 
 const MAX_HTML_BYTES: usize = 100_000;
+const MAX_WAIT_MS: u64 = 120_000;
 
-/// Truncate HTML content if it exceeds MAX_HTML_BYTES.
+/// Truncate HTML content if it exceeds MAX_HTML_BYTES. Safe for multi-byte UTF-8.
 fn truncate_html(html: String) -> (String, bool) {
     let len = html.len();
     if len > MAX_HTML_BYTES {
+        // Find a valid UTF-8 char boundary at or before MAX_HTML_BYTES
+        let mut boundary = MAX_HTML_BYTES;
+        while boundary > 0 && !html.is_char_boundary(boundary) {
+            boundary -= 1;
+        }
         let truncated = format!(
             "{}...\n\n[Truncated: {} total bytes]",
-            &html[..MAX_HTML_BYTES],
+            &html[..boundary],
             len
         );
         (truncated, true)
     } else {
         (html, false)
     }
+}
+
+/// Validate that a URL uses http or https scheme.
+fn validate_url(url: &str) -> Result<(), ToolExecutionResult> {
+    if url.starts_with("http://") || url.starts_with("https://") {
+        Ok(())
+    } else {
+        Err(ToolExecutionResult::tool_error(
+            "Invalid URL scheme. Only http:// and https:// URLs are allowed.",
+        ))
+    }
+}
+
+/// Cap a wait/timeout value to MAX_WAIT_MS.
+fn cap_wait_ms(ms: u64) -> u64 {
+    ms.min(MAX_WAIT_MS)
 }
 
 // ============================================================================
@@ -98,6 +120,9 @@ impl Tool for BrowserlessScreenshotTool {
             Ok(v) => v,
             Err(e) => return e,
         };
+        if let Err(e) = validate_url(url) {
+            return e;
+        }
 
         let full_page = arguments
             .get("full_page")
@@ -118,7 +143,7 @@ impl Tool for BrowserlessScreenshotTool {
                 let _ = session.wait_for_selector(sel, 30000).await;
             }
             if let Some(ms) = arguments.get("wait_for_timeout").and_then(|v| v.as_u64()) {
-                tokio::time::sleep(tokio::time::Duration::from_millis(ms)).await;
+                tokio::time::sleep(tokio::time::Duration::from_millis(cap_wait_ms(ms))).await;
             }
 
             let result = session.screenshot(full_page).await;
@@ -238,6 +263,9 @@ impl Tool for BrowserlessContentTool {
             Ok(v) => v,
             Err(e) => return e,
         };
+        if let Err(e) = validate_url(url) {
+            return e;
+        }
 
         // Try CDP session first
         if let Some(mut session) = try_get_cdp_session(context).await {
@@ -252,7 +280,7 @@ impl Tool for BrowserlessContentTool {
                 let _ = session.wait_for_selector(sel, 30000).await;
             }
             if let Some(ms) = arguments.get("wait_for_timeout").and_then(|v| v.as_u64()) {
-                tokio::time::sleep(tokio::time::Duration::from_millis(ms)).await;
+                tokio::time::sleep(tokio::time::Duration::from_millis(cap_wait_ms(ms))).await;
             }
 
             let result = session.get_content().await;
@@ -377,6 +405,9 @@ impl Tool for BrowserlessScrapeTool {
             Ok(v) => v,
             Err(e) => return e,
         };
+        if let Err(e) = validate_url(url) {
+            return e;
+        }
 
         let elements = match arguments.get("elements").and_then(|v| v.as_array()) {
             Some(arr) => arr.clone(),
@@ -492,12 +523,12 @@ fn build_interaction_code(url: &str, steps: &[Value], return_screenshot: bool) -
                 ));
             }
             "wait" => {
-                let ms = wait_ms.unwrap_or(1000);
+                let ms = cap_wait_ms(wait_ms.unwrap_or(1000));
                 code.push_str(&format!("  await new Promise(r => setTimeout(r, {ms}));\n"));
             }
             "wait_for_selector" => {
                 if let Some(sel) = selector {
-                    let timeout = wait_ms.unwrap_or(10000);
+                    let timeout = cap_wait_ms(wait_ms.unwrap_or(10000));
                     code.push_str(&format!(
                         "  await page.waitForSelector({sel_js}, {{ timeout: {timeout} }});\n",
                         sel_js = serde_json::to_string(sel).unwrap()
@@ -521,7 +552,10 @@ fn build_interaction_code(url: &str, steps: &[Value], return_screenshot: bool) -
         if action != "wait"
             && let Some(ms) = wait_ms
         {
-            code.push_str(&format!("  await new Promise(r => setTimeout(r, {ms}));\n"));
+            let capped = cap_wait_ms(ms);
+            code.push_str(&format!(
+                "  await new Promise(r => setTimeout(r, {capped}));\n"
+            ));
         }
     }
 
@@ -629,6 +663,9 @@ impl Tool for BrowserlessInteractTool {
             Ok(v) => v,
             Err(e) => return e,
         };
+        if let Err(e) = validate_url(url) {
+            return e;
+        }
 
         let steps = match arguments.get("steps").and_then(|v| v.as_array()) {
             Some(arr) => arr.clone(),
@@ -710,7 +747,8 @@ impl Tool for BrowserlessInteractTool {
                     }
                     "wait" => {
                         let ms = wait_ms.unwrap_or(1000);
-                        tokio::time::sleep(tokio::time::Duration::from_millis(ms)).await;
+                        tokio::time::sleep(tokio::time::Duration::from_millis(cap_wait_ms(ms)))
+                            .await;
                         Ok(())
                     }
                     "wait_for_selector" => {
@@ -743,7 +781,7 @@ impl Tool for BrowserlessInteractTool {
                 if action != "wait"
                     && let Some(ms) = wait_ms
                 {
-                    tokio::time::sleep(tokio::time::Duration::from_millis(ms)).await;
+                    tokio::time::sleep(tokio::time::Duration::from_millis(cap_wait_ms(ms))).await;
                 }
             }
 
@@ -871,6 +909,9 @@ impl Tool for BrowserlessNavigateTool {
             Ok(v) => v,
             Err(e) => return e,
         };
+        if let Err(e) = validate_url(url) {
+            return e;
+        }
 
         // Try CDP session first
         if let Some(mut session) = try_get_cdp_session(context).await {
@@ -885,7 +926,7 @@ impl Tool for BrowserlessNavigateTool {
                 let _ = session.wait_for_selector(sel, 30000).await;
             }
             if let Some(ms) = arguments.get("wait_for_timeout").and_then(|v| v.as_u64()) {
-                tokio::time::sleep(tokio::time::Duration::from_millis(ms)).await;
+                tokio::time::sleep(tokio::time::Duration::from_millis(cap_wait_ms(ms))).await;
             }
 
             let result = session.get_page_info().await;
@@ -924,8 +965,9 @@ impl Tool for BrowserlessNavigateTool {
             ));
         }
         if let Some(timeout) = wait_for_timeout {
+            let capped = cap_wait_ms(timeout);
             code.push_str(&format!(
-                "  await new Promise(r => setTimeout(r, {timeout}));\n"
+                "  await new Promise(r => setTimeout(r, {capped}));\n"
             ));
         }
 

--- a/integrations/browserless/src/tools.rs
+++ b/integrations/browserless/src/tools.rs
@@ -22,6 +22,23 @@ use crate::client::BrowserlessClient;
 use crate::session_tools::{keep_session_alive, try_get_cdp_session};
 use crate::state::{get_api_token, required_str};
 
+const MAX_HTML_BYTES: usize = 100_000;
+
+/// Truncate HTML content if it exceeds MAX_HTML_BYTES.
+fn truncate_html(html: String) -> (String, bool) {
+    let len = html.len();
+    if len > MAX_HTML_BYTES {
+        let truncated = format!(
+            "{}...\n\n[Truncated: {} total bytes]",
+            &html[..MAX_HTML_BYTES],
+            len
+        );
+        (truncated, true)
+    } else {
+        (html, false)
+    }
+}
+
 // ============================================================================
 // BrowserlessScreenshotTool
 // ============================================================================
@@ -245,20 +262,12 @@ impl Tool for BrowserlessContentTool {
             return match result {
                 Ok(html) => {
                     let len = html.len();
-                    let truncated = if len > 100_000 {
-                        format!(
-                            "{}...\n\n[Truncated: {} total bytes]",
-                            &html[..100_000],
-                            len
-                        )
-                    } else {
-                        html
-                    };
+                    let (content, was_truncated) = truncate_html(html);
                     ToolExecutionResult::Success(json!({
                         "url": url,
-                        "content": truncated,
+                        "content": content,
                         "size_bytes": len,
-                        "truncated": len > 100_000,
+                        "truncated": was_truncated,
                         "session": "cdp"
                     }))
                 }
@@ -286,20 +295,12 @@ impl Tool for BrowserlessContentTool {
         {
             Ok(html) => {
                 let len = html.len();
-                let truncated = if len > 100_000 {
-                    format!(
-                        "{}...\n\n[Truncated: {} total bytes]",
-                        &html[..100_000],
-                        len
-                    )
-                } else {
-                    html
-                };
+                let (content, was_truncated) = truncate_html(html);
                 ToolExecutionResult::Success(json!({
                     "url": url,
-                    "content": truncated,
+                    "content": content,
                     "size_bytes": len,
-                    "truncated": len > 100_000
+                    "truncated": was_truncated
                 }))
             }
             Err(e) => ToolExecutionResult::tool_error(e),

--- a/integrations/browserless/tests/live_api.rs
+++ b/integrations/browserless/tests/live_api.rs
@@ -1,0 +1,273 @@
+//! Live API tests against the real Browserless service.
+//!
+//! These tests require a valid `BROWSERLESS_API_KEY` environment variable.
+//! Run via: doppler run -- cargo test -p everruns-integrations-browserless --features browserless-live-tests
+//!
+//! All tests are gated behind the `browserless-live-tests` feature flag.
+//! They are NOT run in regular CI — only for manual verification and Doppler environments.
+
+#![cfg(feature = "browserless-live-tests")]
+
+use everruns_integrations_browserless::cdp::CdpSession;
+use everruns_integrations_browserless::client::BrowserlessClient;
+
+fn api_token() -> String {
+    std::env::var("BROWSERLESS_API_KEY")
+        .expect("BROWSERLESS_API_KEY must be set for live API tests")
+}
+
+// ============================================================================
+// REST API live tests
+// ============================================================================
+
+#[tokio::test]
+async fn live_screenshot() {
+    let client = BrowserlessClient::new(api_token());
+    let bytes = client
+        .screenshot("https://example.com", true, None, None, None)
+        .await
+        .expect("Screenshot should succeed");
+
+    assert!(!bytes.is_empty(), "Screenshot bytes should not be empty");
+    // PNG magic bytes
+    assert_eq!(&bytes[..4], b"\x89PNG", "Should be valid PNG");
+}
+
+#[tokio::test]
+async fn live_content() {
+    let client = BrowserlessClient::new(api_token());
+    let html = client
+        .content("https://example.com", None, None, false)
+        .await
+        .expect("Content should succeed");
+
+    assert!(html.contains("Example Domain"), "Should contain page text");
+    assert!(html.contains("<html"), "Should be HTML");
+}
+
+#[tokio::test]
+async fn live_scrape() {
+    let client = BrowserlessClient::new(api_token());
+    let result = client
+        .scrape(
+            "https://example.com",
+            &[serde_json::json!({"selector": "h1"})],
+            None,
+            None,
+        )
+        .await
+        .expect("Scrape should succeed");
+
+    assert!(result.get("data").is_some(), "Should have data field");
+}
+
+#[tokio::test]
+async fn live_function() {
+    let client = BrowserlessClient::new(api_token());
+    let result = client
+        .function(
+            r#"export default async ({ page }) => {
+                await page.goto('https://example.com', { waitUntil: 'networkidle2' });
+                const title = await page.title();
+                return { data: JSON.stringify({ title }), type: 'application/json' };
+            }"#,
+            None,
+        )
+        .await
+        .expect("Function should succeed");
+
+    let data_str = result
+        .get("data")
+        .and_then(|v| v.as_str())
+        .expect("Should have data");
+    let data: serde_json::Value = serde_json::from_str(data_str).expect("Should be valid JSON");
+    assert_eq!(data["title"], "Example Domain");
+}
+
+// ============================================================================
+// CDP session live tests
+// ============================================================================
+
+#[tokio::test]
+async fn live_cdp_session_navigate_and_screenshot() {
+    let token = api_token();
+    let ws_url = format!("wss://production-sfo.browserless.io?token={token}");
+
+    let mut session = CdpSession::connect(&ws_url)
+        .await
+        .expect("CDP connect should succeed");
+
+    // Navigate
+    session
+        .navigate("https://example.com")
+        .await
+        .expect("Navigate should succeed");
+
+    // Get title
+    let title = session.get_title().await.expect("get_title should succeed");
+    assert_eq!(title, "Example Domain");
+
+    // Get URL
+    let url = session.get_url().await.expect("get_url should succeed");
+    assert!(url.contains("example.com"));
+
+    // Screenshot
+    let b64 = session
+        .screenshot(false)
+        .await
+        .expect("Screenshot should succeed");
+    assert!(!b64.is_empty(), "Screenshot should not be empty");
+
+    // Content
+    let content = session
+        .get_content()
+        .await
+        .expect("get_content should succeed");
+    assert!(content.contains("Example Domain"));
+
+    // Page info
+    let info = session
+        .get_page_info()
+        .await
+        .expect("get_page_info should succeed");
+    assert_eq!(info["title"], "Example Domain");
+
+    // Don't call reconnect — browser will be destroyed (cleanup)
+    session.disconnect().await;
+}
+
+#[tokio::test]
+async fn live_cdp_session_reconnect() {
+    let token = api_token();
+    let ws_url = format!("wss://production-sfo.browserless.io?token={token}");
+
+    // Open session, navigate, reconnect, disconnect
+    let mut session = CdpSession::connect(&ws_url)
+        .await
+        .expect("CDP connect should succeed");
+
+    session
+        .navigate("https://example.com")
+        .await
+        .expect("Navigate should succeed");
+
+    let new_endpoint = session
+        .reconnect(30000)
+        .await
+        .expect("Reconnect should succeed");
+
+    session.disconnect().await;
+
+    // Reconnect using the returned endpoint
+    let reconnect_url = if new_endpoint.contains('?') {
+        format!("{new_endpoint}&token={token}")
+    } else {
+        format!("{new_endpoint}?token={token}")
+    };
+
+    let mut session2 = CdpSession::connect(&reconnect_url)
+        .await
+        .expect("Reconnect should succeed");
+
+    // The page should still be at example.com
+    let title = session2
+        .get_title()
+        .await
+        .expect("get_title should succeed");
+    assert_eq!(
+        title, "Example Domain",
+        "Page state should persist across reconnect"
+    );
+
+    // Clean up (no reconnect = browser destroyed)
+    session2.disconnect().await;
+}
+
+#[tokio::test]
+async fn live_cdp_session_interact() {
+    let token = api_token();
+    let ws_url = format!("wss://production-sfo.browserless.io?token={token}");
+
+    let mut session = CdpSession::connect(&ws_url)
+        .await
+        .expect("CDP connect should succeed");
+
+    session
+        .navigate("https://example.com")
+        .await
+        .expect("Navigate should succeed");
+
+    // Click the "More information..." link
+    session
+        .click_selector("a")
+        .await
+        .expect("Click should succeed");
+
+    // Wait for navigation
+    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+
+    // Check we navigated away
+    let url = session.get_url().await.expect("get_url should succeed");
+    assert!(
+        url != "https://example.com/" && url != "https://example.com",
+        "Should have navigated away from example.com, got: {url}"
+    );
+
+    // Clean up
+    session.disconnect().await;
+}
+
+// ============================================================================
+// Resource cleanup verification
+// ============================================================================
+
+#[tokio::test]
+async fn live_no_resources_leaked_rest() {
+    // REST calls are stateless. Verify multiple independent calls work fine.
+    let client = BrowserlessClient::new(api_token());
+
+    let r1 = client
+        .content("https://example.com", None, None, false)
+        .await;
+    let r2 = client
+        .content("https://example.com", None, None, false)
+        .await;
+
+    assert!(r1.is_ok());
+    assert!(r2.is_ok());
+}
+
+#[tokio::test]
+async fn live_no_resources_leaked_cdp() {
+    // Open a CDP session, then let it expire without explicitly closing.
+    // Verify no resources are leaked (browser destroyed after timeout).
+    let token = api_token();
+    let ws_url = format!("wss://production-sfo.browserless.io?token={token}");
+
+    let mut session = CdpSession::connect(&ws_url)
+        .await
+        .expect("CDP connect should succeed");
+
+    session
+        .navigate("https://example.com")
+        .await
+        .expect("Navigate should succeed");
+
+    // Reconnect with a very short timeout (5s)
+    let new_endpoint = session
+        .reconnect(5000)
+        .await
+        .expect("Reconnect should work");
+    session.disconnect().await;
+
+    // Wait for the timeout to expire
+    tokio::time::sleep(tokio::time::Duration::from_secs(7)).await;
+
+    // Try to reconnect — should fail because the browser was destroyed
+    let reconnect_url = format!("{new_endpoint}?token={token}");
+    let result = CdpSession::connect(&reconnect_url).await;
+    assert!(
+        result.is_err(),
+        "Should fail to reconnect after timeout — browser was cleaned up"
+    );
+}

--- a/integrations/browserless/tests/live_api.rs
+++ b/integrations/browserless/tests/live_api.rs
@@ -1,6 +1,6 @@
 //! Live API tests against the real Browserless service.
 //!
-//! These tests require a valid `BROWSERLESS_API_KEY` environment variable.
+//! These tests require a valid `BROWSERLESS_KEY` environment variable (set via Doppler).
 //! Run via: doppler run -- cargo test -p everruns-integrations-browserless --features browserless-live-tests
 //!
 //! All tests are gated behind the `browserless-live-tests` feature flag.
@@ -12,8 +12,8 @@ use everruns_integrations_browserless::cdp::CdpSession;
 use everruns_integrations_browserless::client::BrowserlessClient;
 
 fn api_token() -> String {
-    std::env::var("BROWSERLESS_API_KEY")
-        .expect("BROWSERLESS_API_KEY must be set for live API tests")
+    std::env::var("BROWSERLESS_KEY")
+        .expect("BROWSERLESS_KEY must be set for live API tests (available via Doppler)")
 }
 
 // ============================================================================

--- a/integrations/browserless/tests/plugin_registration.rs
+++ b/integrations/browserless/tests/plugin_registration.rs
@@ -1,0 +1,69 @@
+//! Integration tests for Browserless plugin registration and capability.
+
+use everruns_core::capabilities::{CapabilityRegistry, IntegrationPlugin};
+use everruns_core::deployment::DeploymentGrade;
+
+// Force linker to include the integration crate's inventory submissions.
+use everruns_integrations_browserless as _;
+
+#[test]
+fn test_browserless_plugin_is_submitted() {
+    let plugins: Vec<&IntegrationPlugin> = inventory::iter::<IntegrationPlugin>().collect();
+    assert!(
+        plugins.iter().any(|p| {
+            let cap = (p.factory)();
+            cap.id() == "browserless"
+        }),
+        "Browserless IntegrationPlugin should be submitted via inventory"
+    );
+}
+
+#[test]
+fn test_browserless_plugin_is_not_experimental() {
+    let plugins: Vec<&IntegrationPlugin> = inventory::iter::<IntegrationPlugin>().collect();
+    let browserless = plugins
+        .iter()
+        .find(|p| {
+            let cap = (p.factory)();
+            cap.id() == "browserless"
+        })
+        .expect("Browserless plugin not found");
+
+    assert!(
+        !browserless.experimental_only,
+        "Browserless should NOT be marked experimental_only"
+    );
+}
+
+#[test]
+fn test_browserless_registered_in_dev_registry() {
+    let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
+    assert!(
+        registry.has("browserless"),
+        "Browserless should be in dev registry"
+    );
+}
+
+#[test]
+fn test_browserless_registered_in_prod_registry() {
+    let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Prod);
+    assert!(
+        registry.has("browserless"),
+        "Browserless should be in prod registry"
+    );
+}
+
+#[test]
+fn test_browserless_capability_metadata() {
+    let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
+    let cap = registry
+        .get("browserless")
+        .expect("Browserless capability not found");
+
+    assert_eq!(cap.id(), "browserless");
+    assert_eq!(cap.name(), "Browserless");
+    assert_eq!(cap.icon(), Some("browserless"));
+    assert_eq!(cap.category(), Some("Browser"));
+    assert!(cap.dependencies().is_empty());
+    assert_eq!(cap.tools().len(), 5);
+}

--- a/integrations/browserless/tests/plugin_registration.rs
+++ b/integrations/browserless/tests/plugin_registration.rs
@@ -65,5 +65,5 @@ fn test_browserless_capability_metadata() {
     assert_eq!(cap.icon(), Some("browserless"));
     assert_eq!(cap.category(), Some("Browser"));
     assert!(cap.dependencies().is_empty());
-    assert_eq!(cap.tools().len(), 5);
+    assert_eq!(cap.tools().len(), 7);
 }

--- a/integrations/browserless/tests/tool_integration.rs
+++ b/integrations/browserless/tests/tool_integration.rs
@@ -1,0 +1,371 @@
+//! Integration tests: tool execute_with_context against wiremock Browserless API.
+//!
+//! These tests exercise the full tool execution flow:
+//! MockConnectionResolver → tool.execute_with_context() → BrowserlessClient → wiremock
+
+use async_trait::async_trait;
+use everruns_core::error::Result;
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::traits::{ToolContext, UserConnectionResolver};
+use everruns_core::typed_id::SessionId;
+use serde_json::json;
+use std::sync::Arc;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// Force linker to include the integration crate.
+use everruns_integrations_browserless as _;
+
+use everruns_integrations_browserless::client::BrowserlessClient;
+
+// ============================================================================
+// Mock ConnectionResolver
+// ============================================================================
+
+struct MockConnectionResolver {
+    token: Option<String>,
+}
+
+#[async_trait]
+impl UserConnectionResolver for MockConnectionResolver {
+    async fn get_connection_token(
+        &self,
+        _session_id: SessionId,
+        _provider: &str,
+    ) -> Result<Option<String>> {
+        Ok(self.token.clone())
+    }
+}
+
+fn browserless_resolver() -> Arc<dyn UserConnectionResolver> {
+    Arc::new(MockConnectionResolver {
+        token: Some("test_api_token".to_string()),
+    })
+}
+
+fn no_token_resolver() -> Arc<dyn UserConnectionResolver> {
+    Arc::new(MockConnectionResolver { token: None })
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn get_tool(name: &str) -> Box<dyn Tool> {
+    let cap = everruns_integrations_browserless::BrowserlessCapability;
+    use everruns_core::capabilities::Capability;
+    cap.tools()
+        .into_iter()
+        .find(|t| t.name() == name)
+        .unwrap_or_else(|| panic!("Tool {name} not found"))
+}
+
+// ============================================================================
+// BrowserlessClient integration tests (wiremock)
+// ============================================================================
+
+#[tokio::test]
+async fn test_screenshot_client_flow() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/screenshot"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_bytes(b"\x89PNG\r\n\x1a\n_FAKE_PNG_DATA".to_vec()),
+        )
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client = BrowserlessClient::with_base_url("test_token".to_string(), mock_server.uri());
+    let bytes = client
+        .screenshot("https://example.com", true, None, None, None)
+        .await
+        .unwrap();
+    assert!(!bytes.is_empty());
+}
+
+#[tokio::test]
+async fn test_content_client_flow() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/content"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            "<html><head><title>Test</title></head><body>Hello World</body></html>",
+        ))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client = BrowserlessClient::with_base_url("test_token".to_string(), mock_server.uri());
+    let html = client
+        .content("https://example.com", None, None, false)
+        .await
+        .unwrap();
+    assert!(html.contains("Hello World"));
+    assert!(html.contains("<title>Test</title>"));
+}
+
+#[tokio::test]
+async fn test_scrape_client_flow() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/scrape"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [
+                {
+                    "selector": "h1",
+                    "results": [
+                        {"text": "Welcome", "attributes": []}
+                    ]
+                }
+            ]
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client = BrowserlessClient::with_base_url("test_token".to_string(), mock_server.uri());
+    let result = client
+        .scrape(
+            "https://example.com",
+            &[json!({"selector": "h1"})],
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(result["data"][0]["results"][0]["text"] == "Welcome");
+}
+
+#[tokio::test]
+async fn test_function_client_flow() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/function"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": "{\"title\":\"Test Page\",\"url\":\"https://example.com\"}",
+            "type": "application/json"
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client = BrowserlessClient::with_base_url("test_token".to_string(), mock_server.uri());
+    let result = client
+        .function(
+            "export default async ({ page }) => { return { data: 'test', type: 'application/json' }; }",
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(result.get("data").is_some());
+}
+
+// ============================================================================
+// Tool execute_with_context tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_screenshot_tool_missing_api_token() {
+    let tool = get_tool("browserless_screenshot");
+    let session_id = SessionId::new();
+    let context = ToolContext::new(session_id).with_connection_resolver(no_token_resolver());
+
+    let result = tool
+        .execute_with_context(json!({"url": "https://example.com"}), &context)
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(
+                msg.contains("not configured") || msg.contains("Settings > Connections"),
+                "Got: {msg}"
+            );
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_content_tool_missing_url() {
+    let tool = get_tool("browserless_content");
+    let session_id = SessionId::new();
+    let context = ToolContext::new(session_id).with_connection_resolver(browserless_resolver());
+
+    let result = tool.execute_with_context(json!({}), &context).await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("Missing required parameter"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_scrape_tool_missing_elements() {
+    let tool = get_tool("browserless_scrape");
+    let session_id = SessionId::new();
+    let context = ToolContext::new(session_id).with_connection_resolver(browserless_resolver());
+
+    let result = tool
+        .execute_with_context(json!({"url": "https://example.com"}), &context)
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("Missing required parameter"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_interact_tool_missing_steps() {
+    let tool = get_tool("browserless_interact");
+    let session_id = SessionId::new();
+    let context = ToolContext::new(session_id).with_connection_resolver(browserless_resolver());
+
+    let result = tool
+        .execute_with_context(json!({"url": "https://example.com"}), &context)
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("Missing required parameter"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_navigate_tool_missing_url() {
+    let tool = get_tool("browserless_navigate");
+    let session_id = SessionId::new();
+    let context = ToolContext::new(session_id).with_connection_resolver(browserless_resolver());
+
+    let result = tool.execute_with_context(json!({}), &context).await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("Missing required parameter"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_navigate_tool_no_connection_resolver() {
+    let tool = get_tool("browserless_navigate");
+    let session_id = SessionId::new();
+    let context = ToolContext::new(session_id); // No connection resolver
+
+    let result = tool
+        .execute_with_context(json!({"url": "https://example.com"}), &context)
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(
+                msg.contains("not configured") || msg.contains("Settings > Connections"),
+                "Got: {msg}"
+            );
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+// ============================================================================
+// Client error handling integration tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_client_401_unauthorized() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/screenshot"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("Unauthorized"))
+        .mount(&mock_server)
+        .await;
+
+    let client = BrowserlessClient::with_base_url("bad_token".to_string(), mock_server.uri());
+    let result = client
+        .screenshot("https://example.com", false, None, None, None)
+        .await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("401"));
+}
+
+#[tokio::test]
+async fn test_client_500_server_error() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/content"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("Internal Server Error"))
+        .mount(&mock_server)
+        .await;
+
+    let client = BrowserlessClient::with_base_url("test_token".to_string(), mock_server.uri());
+    let result = client
+        .content("https://example.com", None, None, false)
+        .await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("500"));
+}
+
+// ============================================================================
+// Bearer auth verification
+// ============================================================================
+
+#[tokio::test]
+async fn test_client_sends_token_in_query() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/content"))
+        .and(wiremock::matchers::query_param("token", "secret_token_123"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("<html></html>"))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client =
+        BrowserlessClient::with_base_url("secret_token_123".to_string(), mock_server.uri());
+    let result = client
+        .content("https://example.com", None, None, false)
+        .await;
+    assert!(result.is_ok());
+}
+
+// ============================================================================
+// Resource cleanup verification
+// ============================================================================
+
+#[tokio::test]
+async fn test_no_resources_left_behind() {
+    // Browserless REST API is stateless — each call starts and destroys a browser.
+    // Verify that our client doesn't maintain any persistent state.
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/content"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("<html>1</html>"))
+        .mount(&mock_server)
+        .await;
+
+    // Make multiple calls — each should be independent
+    let client = BrowserlessClient::with_base_url("test_token".to_string(), mock_server.uri());
+
+    let r1 = client
+        .content("https://example.com/page1", None, None, false)
+        .await
+        .unwrap();
+    let r2 = client
+        .content("https://example.com/page2", None, None, false)
+        .await
+        .unwrap();
+
+    // Both succeed independently
+    assert!(!r1.is_empty());
+    assert!(!r2.is_empty());
+    // Client itself has no session state to clean up
+}

--- a/specs/browserless.md
+++ b/specs/browserless.md
@@ -179,8 +179,11 @@ No long-lived WebSocket connections from our side — we connect/disconnect for 
 - **API Token**: Stored in user connections (Settings > Connections > Browserless), encrypted at rest
 - **CDP session state**: Stored as plain key-value in `session_storage` (only WS endpoint, no secrets), per-session scoped
 - **No secrets in chat**: Token resolved via connection provider, never exposed in conversation
+- **No secrets in logs**: CDP debug logging redacts API tokens from WebSocket URLs
+- **URL validation**: Only `http://` and `https://` URLs allowed (blocks `file://`, `javascript:`, etc.)
+- **Timeout caps**: All wait/timeout values capped at 120s to prevent unbounded resource consumption
 - **Ephemeral by default**: REST mode has no cross-request data leakage
-- **Content truncation**: Large DOM responses truncated to 100KB to prevent context flooding
+- **Content truncation**: Large DOM responses truncated to 100KB (UTF-8 safe boundary) to prevent context flooding
 
 ## Testing
 

--- a/specs/browserless.md
+++ b/specs/browserless.md
@@ -1,0 +1,196 @@
+# Browserless Capability Specification
+
+## Abstract
+
+The Browserless capability integrates [Browserless](https://www.browserless.io/) cloud browser automation as an agent tool set. Agents can take screenshots, read rendered DOM, scrape structured data, and perform multi-step browser interactions (click, type, keyboard, mouse, touch) via the Browserless REST API.
+
+**Status**: Available (All environments)
+
+## Architecture
+
+### Stateless REST API
+
+Browserless REST API is inherently stateless: each request launches a fresh browser, performs one task, and destroys the session. No persistent browser instances to manage or clean up.
+
+```
+┌──────────────────────────────────────────┐
+│              Agent Session                │
+│                                           │
+│  Tool Call (browserless_screenshot, etc.) │
+│         ↓                                 │
+│  Resolve API token from Connections       │
+│         ↓                                 │
+│  ┌───────────────────────────────────┐   │
+│  │ BrowserlessClient                 │   │
+│  │  - /screenshot                    │   │
+│  │  - /content                       │   │
+│  │  - /scrape                        │   │
+│  │  - /function (interactions)       │   │
+│  └───────────────────────────────────┘   │
+│         ↓                                 │
+│  Return result to agent                  │
+└──────────────────────────────────────────┘
+```
+
+### No State Management
+
+Unlike Daytona (which tracks sandbox lifecycle), Browserless needs no per-session state. Each tool call is self-contained. The API token is the only credential needed.
+
+### API Token Resolution
+
+The Browserless API token is resolved via **user connection** for the `browserless` provider (Settings > Connections). If not configured, a `ToolError` guides the user to set up in Settings.
+
+### User Connection
+
+Browserless registers as a `ConnectionProviderPlugin` (API-key type). Users configure their token in **Settings > Connections > Browserless**:
+
+1. User enters API token (from [Browserless Dashboard](https://cloud.browserless.io))
+2. Token validated via `GET /active` endpoint
+3. Token encrypted and stored in `user_connections` table
+
+## API Integration
+
+### Browserless REST Endpoints
+
+Base URL: `https://production-sfo.browserless.io`
+
+Auth: `?token=<api_token>` query parameter on all requests.
+
+| Method | Path | Purpose | Request Body | Response |
+|--------|------|---------|-------------|----------|
+| POST | `/screenshot` | Screenshot | `{ url, options, selector?, waitFor* }` | `image/png` bytes |
+| POST | `/content` | Rendered HTML | `{ url, waitFor*, bestAttempt? }` | `text/html` |
+| POST | `/scrape` | Structured data | `{ url, elements, waitFor* }` | `application/json` |
+| POST | `/function` | Custom Puppeteer | `{ code, context? }` | Variable |
+
+## Tools
+
+### browserless_navigate
+
+Open a URL and return page metadata.
+
+- **Parameters**: `url` (required), `wait_for_selector` (optional), `wait_for_timeout` (optional)
+- **Returns**: `{ title, url, status, links[], headings[], meta[] }`
+- **Implementation**: Uses `/function` endpoint to extract rich metadata
+
+### browserless_screenshot
+
+Take a PNG screenshot of a page.
+
+- **Parameters**: `url` (required), `full_page` (optional, default true), `selector` (optional), `wait_for_selector` (optional), `wait_for_timeout` (optional)
+- **Returns**: `{ url, format, size_bytes, image_base64 }`
+- **Implementation**: Uses `/screenshot` endpoint
+
+### browserless_content
+
+Get fully rendered HTML/DOM content.
+
+- **Parameters**: `url` (required), `wait_for_selector` (optional), `wait_for_timeout` (optional), `best_attempt` (optional)
+- **Returns**: `{ url, content, size_bytes, truncated }`
+- **Implementation**: Uses `/content` endpoint. Truncates at 100KB to avoid overwhelming LLM context.
+
+### browserless_scrape
+
+Extract structured data using CSS selectors.
+
+- **Parameters**: `url` (required), `elements` (required, array of `{selector}`), `wait_for_selector` (optional), `wait_for_timeout` (optional)
+- **Returns**: `{ url, data }`
+- **Implementation**: Uses `/scrape` endpoint
+
+### browserless_interact
+
+Multi-step browser interactions. Navigate to a URL, then execute a sequence of actions.
+
+- **Parameters**:
+  - `url` (required) — initial URL
+  - `steps` (required) — array of interaction steps
+  - `return_screenshot` (optional, default false) — return screenshot vs DOM after steps
+- **Returns**: `{ title, url, screenshot? | content? }`
+- **Implementation**: Generates Puppeteer code and executes via `/function` endpoint
+
+**Supported step actions**:
+
+| Action | Parameters | Description |
+|--------|-----------|-------------|
+| `click` | `selector` or `x`,`y` | Click element or coordinates |
+| `type` | `selector`, `value` | Type text into input |
+| `keyboard` | `key` | Press key (Enter, Tab, Escape, etc.) |
+| `mouse_move` | `x`, `y` | Move mouse to coordinates |
+| `touch` | `selector` | Tap element (mobile simulation) |
+| `scroll` | `value` (pixels) | Scroll page vertically |
+| `wait` | `wait_ms` | Wait for milliseconds |
+| `wait_for_selector` | `selector`, `wait_ms` | Wait for element to appear |
+| `navigate` | `value` (URL) | Navigate to different URL |
+
+## Resource Management
+
+**No resources to clean up.** Each Browserless REST call launches an ephemeral browser that is automatically destroyed after the response is returned. There are no persistent sessions, containers, or sandboxes to track or delete.
+
+## Security
+
+- **API Token**: Stored in user connections (Settings > Connections > Browserless), encrypted at rest
+- **No secrets in chat**: Token resolved via connection provider, never exposed in conversation
+- **Ephemeral browsers**: Each request gets a fresh browser — no cross-request data leakage
+- **Content truncation**: Large DOM responses truncated to 100KB to prevent context flooding
+
+## Error Handling
+
+| Scenario | Result Type | Message |
+|----------|-------------|---------|
+| Missing required param | `ToolError` | "Missing required parameter: {name}" |
+| API token not configured | `ToolError` | "Browserless API token not configured." |
+| HTTP 4xx/5xx | `ToolError` | "Browserless API error ({status}): {body}" |
+| No context | `ToolError` | "{tool_name} requires context." |
+
+## Design Decisions
+
+### REST-only, no WebSocket sessions
+
+Browserless supports WebSocket connections for persistent Puppeteer/Playwright sessions. We chose REST-only because:
+- No persistent state to manage or leak
+- Each call is atomic and self-cleaning
+- Simpler error handling (no session reconnection)
+- The `/function` endpoint covers multi-step interactions
+
+### /function for interactions
+
+The Browserless REST API doesn't expose standalone click/type endpoints. The `/function` endpoint accepts custom Puppeteer code, which we generate from the structured `steps` array. This gives full flexibility while keeping the tool interface simple.
+
+### No state management
+
+Unlike Daytona sandboxes (which need lifecycle tracking), Browserless browsers are ephemeral. No `session_storage` dependency, no state persistence, no cleanup needed.
+
+### Content truncation
+
+DOM content can be very large. We truncate at 100KB to prevent flooding the LLM context window while still providing enough content for analysis.
+
+## Crate Structure
+
+`integrations/browserless/` → `everruns-integrations-browserless`
+
+| File | Purpose |
+|------|---------|
+| `src/lib.rs` | Plugin registration, constants, `BrowserlessCapability` impl |
+| `src/client.rs` | `BrowserlessClient` HTTP client (screenshot, content, scrape, function) |
+| `src/connection.rs` | `BrowserlessConnectionProvider` — API-token connection plugin |
+| `src/state.rs` | API token resolution, parameter helpers |
+| `src/tools.rs` | 5 tool implementations + interaction code generator |
+| `tests/plugin_registration.rs` | Integration tests for inventory registration |
+| `tests/tool_integration.rs` | Integration tests: tool execution + wiremock |
+
+## Capability Registration
+
+- **ID**: `browserless`
+- **Name**: `Browserless`
+- **Status**: Available
+- **Icon**: `browserless`
+- **Category**: `Browser`
+- **Risk Level**: Medium
+- **Dependencies**: none
+
+## Seeded Agent: Browser Tester
+
+A pre-configured seed agent (`Browser Tester`) demonstrates the capability:
+- **Capabilities**: `browserless`
+- **Dev-only**: false
+- **Use cases**: Accessibility testing, regression testing, web automation

--- a/specs/browserless.md
+++ b/specs/browserless.md
@@ -2,43 +2,54 @@
 
 ## Abstract
 
-The Browserless capability integrates [Browserless](https://www.browserless.io/) cloud browser automation as an agent tool set. Agents can take screenshots, read rendered DOM, scrape structured data, and perform multi-step browser interactions (click, type, keyboard, mouse, touch) via the Browserless REST API.
+The Browserless capability integrates [Browserless](https://www.browserless.io/) cloud browser automation as an agent tool set. Agents can take screenshots, read rendered DOM, scrape structured data, and perform multi-step browser interactions (click, type, keyboard, mouse, touch).
+
+Two operating modes:
+- **REST** (default): Each tool call uses a fresh ephemeral browser. No state, no cleanup.
+- **CDP** (persistent sessions): `browserless_open_browser` opens a persistent browser via Chrome DevTools Protocol WebSocket. Subsequent tools reuse it, preserving login state and cookies. `browserless_close_browser` releases the browser.
 
 **Status**: Available (All environments)
 
 ## Architecture
 
-### Stateless REST API
-
-Browserless REST API is inherently stateless: each request launches a fresh browser, performs one task, and destroys the session. No persistent browser instances to manage or clean up.
+### Dual-Mode Architecture
 
 ```
-┌──────────────────────────────────────────┐
-│              Agent Session                │
-│                                           │
-│  Tool Call (browserless_screenshot, etc.) │
-│         ↓                                 │
-│  Resolve API token from Connections       │
-│         ↓                                 │
-│  ┌───────────────────────────────────┐   │
-│  │ BrowserlessClient                 │   │
-│  │  - /screenshot                    │   │
-│  │  - /content                       │   │
-│  │  - /scrape                        │   │
-│  │  - /function (interactions)       │   │
-│  └───────────────────────────────────┘   │
-│         ↓                                 │
-│  Return result to agent                  │
-└──────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────┐
+│                      Agent Session                            │
+│                                                               │
+│  Tool Call (browserless_screenshot, etc.)                     │
+│         ↓                                                     │
+│  Resolve API token from User Connections                     │
+│         ↓                                                     │
+│  ┌─────────────────┐     ┌──────────────────────────────┐   │
+│  │ CDP session      │     │ REST Client                  │   │
+│  │ active?          │──no─│  - /screenshot               │   │
+│  │  ↓ yes           │     │  - /content                  │   │
+│  │ Reconnect via WS │     │  - /scrape                   │   │
+│  │ Do work via CDP  │     │  - /function (interactions)  │   │
+│  │ Call reconnect   │     └──────────────────────────────┘   │
+│  │ Disconnect       │                                         │
+│  │ Store endpoint   │                                         │
+│  └─────────────────┘                                         │
+│         ↓                                                     │
+│  Return result to agent                                      │
+└──────────────────────────────────────────────────────────────┘
 ```
 
-### No State Management
+### CDP Session Lifecycle
 
-Unlike Daytona (which tracks sandbox lifecycle), Browserless needs no per-session state. Each tool call is self-contained. The API token is the only credential needed.
+The CDP session uses Browserless's `Browserless.reconnect` command to keep the browser alive between tool calls without maintaining a persistent WebSocket connection:
+
+1. **Open**: Connect via WebSocket → call `Browserless.reconnect(timeout)` → store endpoint → disconnect
+2. **Use**: Reconnect via stored endpoint → do work → call `Browserless.reconnect` → disconnect
+3. **Close**: Reconnect → disconnect without calling reconnect → browser destroyed → clean up state
+
+Session state (`ws_endpoint`, `api_token`, timestamps) stored as encrypted secret in `session_storage`.
 
 ### API Token Resolution
 
-The Browserless API token is resolved via **user connection** for the `browserless` provider (Settings > Connections). If not configured, a `ToolError` guides the user to set up in Settings.
+The Browserless API token is resolved via **user connection** for the `browserless` provider (Settings > Connections). See `src/connection.rs` for the `ConnectionProviderPlugin`.
 
 ### User Connection
 
@@ -50,7 +61,7 @@ Browserless registers as a `ConnectionProviderPlugin` (API-key type). Users conf
 
 ## API Integration
 
-### Browserless REST Endpoints
+### REST Endpoints
 
 Base URL: `https://production-sfo.browserless.io`
 
@@ -63,7 +74,39 @@ Auth: `?token=<api_token>` query parameter on all requests.
 | POST | `/scrape` | Structured data | `{ url, elements, waitFor* }` | `application/json` |
 | POST | `/function` | Custom Puppeteer | `{ code, context? }` | Variable |
 
+### CDP (WebSocket) Protocol
+
+Base URL: `wss://production-sfo.browserless.io`
+
+Auth: `?token=<api_token>` query parameter on WebSocket URL.
+
+CDP commands used:
+- `Page.enable` — Enable page events
+- `Page.navigate` — Navigate to URL
+- `Page.captureScreenshot` — Take screenshot (returns base64 PNG)
+- `Runtime.evaluate` — Execute JavaScript (DOM access, page info, wait logic)
+- `Input.dispatchMouseEvent` — Click, mouse move
+- `Input.dispatchKeyEvent` — Keyboard input
+- `Input.dispatchTouchEvent` — Touch/tap simulation
+- `Browserless.reconnect` — Keep browser alive after disconnect (returns new WS endpoint)
+
 ## Tools
+
+### browserless_open_browser
+
+Open a persistent browser session via CDP WebSocket.
+
+- **Parameters**: `url` (optional, initial URL), `timeout_ms` (optional, default 60000)
+- **Returns**: `{ status, message, title, url, timeout_ms }`
+- **Behavior**: If a session already exists and is alive, returns `already_open`. Otherwise opens a new browser.
+
+### browserless_close_browser
+
+Close the persistent browser session.
+
+- **Parameters**: none
+- **Returns**: `{ status, message }`
+- **Behavior**: Reconnects and disconnects without calling `Browserless.reconnect` — browser is destroyed.
 
 ### browserless_navigate
 
@@ -71,7 +114,7 @@ Open a URL and return page metadata.
 
 - **Parameters**: `url` (required), `wait_for_selector` (optional), `wait_for_timeout` (optional)
 - **Returns**: `{ title, url, status, links[], headings[], meta[] }`
-- **Implementation**: Uses `/function` endpoint to extract rich metadata
+- **Session-aware**: Uses CDP if active session exists, REST `/function` otherwise.
 
 ### browserless_screenshot
 
@@ -79,7 +122,7 @@ Take a PNG screenshot of a page.
 
 - **Parameters**: `url` (required), `full_page` (optional, default true), `selector` (optional), `wait_for_selector` (optional), `wait_for_timeout` (optional)
 - **Returns**: `{ url, format, size_bytes, image_base64 }`
-- **Implementation**: Uses `/screenshot` endpoint
+- **Session-aware**: Uses CDP `Page.captureScreenshot` if session exists, REST `/screenshot` otherwise.
 
 ### browserless_content
 
@@ -87,28 +130,24 @@ Get fully rendered HTML/DOM content.
 
 - **Parameters**: `url` (required), `wait_for_selector` (optional), `wait_for_timeout` (optional), `best_attempt` (optional)
 - **Returns**: `{ url, content, size_bytes, truncated }`
-- **Implementation**: Uses `/content` endpoint. Truncates at 100KB to avoid overwhelming LLM context.
+- **Session-aware**: Uses CDP `Runtime.evaluate` if session exists, REST `/content` otherwise. Truncates at 100KB.
 
 ### browserless_scrape
 
-Extract structured data using CSS selectors.
+Extract structured data using CSS selectors. REST-only (no CDP equivalent).
 
 - **Parameters**: `url` (required), `elements` (required, array of `{selector}`), `wait_for_selector` (optional), `wait_for_timeout` (optional)
 - **Returns**: `{ url, data }`
-- **Implementation**: Uses `/scrape` endpoint
 
 ### browserless_interact
 
-Multi-step browser interactions. Navigate to a URL, then execute a sequence of actions.
+Multi-step browser interactions.
 
-- **Parameters**:
-  - `url` (required) — initial URL
-  - `steps` (required) — array of interaction steps
-  - `return_screenshot` (optional, default false) — return screenshot vs DOM after steps
+- **Parameters**: `url` (required), `steps` (required), `return_screenshot` (optional, default false)
 - **Returns**: `{ title, url, screenshot? | content? }`
-- **Implementation**: Generates Puppeteer code and executes via `/function` endpoint
+- **Session-aware**: Uses CDP session (click, type, keyboard, mouse, touch via CDP commands) if active, generates Puppeteer code for REST `/function` otherwise.
 
-**Supported step actions**:
+**Supported step actions**: See `src/tools.rs:build_interaction_code()` for REST and `execute_with_context()` for CDP.
 
 | Action | Parameters | Description |
 |--------|-----------|-------------|
@@ -124,45 +163,45 @@ Multi-step browser interactions. Navigate to a URL, then execute a sequence of a
 
 ## Resource Management
 
-**No resources to clean up.** Each Browserless REST call launches an ephemeral browser that is automatically destroyed after the response is returned. There are no persistent sessions, containers, or sandboxes to track or delete.
+### REST Mode
+No resources to clean up. Each call launches an ephemeral browser that is automatically destroyed.
+
+### CDP Mode
+Browser stays alive on Browserless servers between tool calls via `Browserless.reconnect` with a configurable timeout (default 60s). Resources are released when:
+1. Agent calls `browserless_close_browser`
+2. Reconnect timeout expires (browser auto-destroyed by Browserless)
+3. Session ends (stored state becomes stale, browser auto-destroyed by timeout)
+
+No long-lived WebSocket connections from our side — we connect/disconnect for each tool call.
 
 ## Security
 
 - **API Token**: Stored in user connections (Settings > Connections > Browserless), encrypted at rest
+- **CDP session state**: Stored as encrypted secret in `session_storage`, per-session scoped
 - **No secrets in chat**: Token resolved via connection provider, never exposed in conversation
-- **Ephemeral browsers**: Each request gets a fresh browser — no cross-request data leakage
+- **Ephemeral by default**: REST mode has no cross-request data leakage
 - **Content truncation**: Large DOM responses truncated to 100KB to prevent context flooding
 
-## Error Handling
+## Testing
 
-| Scenario | Result Type | Message |
-|----------|-------------|---------|
-| Missing required param | `ToolError` | "Missing required parameter: {name}" |
-| API token not configured | `ToolError` | "Browserless API token not configured." |
-| HTTP 4xx/5xx | `ToolError` | "Browserless API error ({status}): {body}" |
-| No context | `ToolError` | "{tool_name} requires context." |
+### Unit Tests (in crate)
+- Client: wiremock-based HTTP tests for all REST endpoints (success + error paths)
+- Tools: metadata validation, schema validation, context-required checks
+- Interaction code generation: all action types, multi-step, screenshot vs content
+- CDP: key-to-code mapping
+- State: serialization roundtrip, reconnect URL construction
+- Session tools: metadata, context-required checks
 
-## Design Decisions
+### Integration Tests (`tests/`)
+- `plugin_registration.rs`: inventory submission, dev/prod registry, capability metadata
+- `tool_integration.rs`: full tool execution flow via wiremock, parameter validation, auth, error handling, resource cleanup
 
-### REST-only, no WebSocket sessions
+### Live API Tests
+Tests against the real Browserless API require `BROWSERLESS_API_KEY` in Doppler. Gated behind `browserless-live-tests` feature flag:
 
-Browserless supports WebSocket connections for persistent Puppeteer/Playwright sessions. We chose REST-only because:
-- No persistent state to manage or leak
-- Each call is atomic and self-cleaning
-- Simpler error handling (no session reconnection)
-- The `/function` endpoint covers multi-step interactions
-
-### /function for interactions
-
-The Browserless REST API doesn't expose standalone click/type endpoints. The `/function` endpoint accepts custom Puppeteer code, which we generate from the structured `steps` array. This gives full flexibility while keeping the tool interface simple.
-
-### No state management
-
-Unlike Daytona sandboxes (which need lifecycle tracking), Browserless browsers are ephemeral. No `session_storage` dependency, no state persistence, no cleanup needed.
-
-### Content truncation
-
-DOM content can be very large. We truncate at 100KB to prevent flooding the LLM context window while still providing enough content for analysis.
+```bash
+doppler run -- cargo test -p everruns-integrations-browserless --features browserless-live-tests
+```
 
 ## Crate Structure
 
@@ -171,10 +210,12 @@ DOM content can be very large. We truncate at 100KB to prevent flooding the LLM 
 | File | Purpose |
 |------|---------|
 | `src/lib.rs` | Plugin registration, constants, `BrowserlessCapability` impl |
-| `src/client.rs` | `BrowserlessClient` HTTP client (screenshot, content, scrape, function) |
+| `src/cdp.rs` | `CdpSession` — minimal CDP client over WebSocket |
+| `src/client.rs` | `BrowserlessClient` — REST HTTP client |
 | `src/connection.rs` | `BrowserlessConnectionProvider` — API-token connection plugin |
-| `src/state.rs` | API token resolution, parameter helpers |
-| `src/tools.rs` | 5 tool implementations + interaction code generator |
+| `src/state.rs` | API token resolution, browser session state, parameter helpers |
+| `src/session_tools.rs` | `browserless_open_browser` / `browserless_close_browser` tools |
+| `src/tools.rs` | 5 session-aware tool implementations + interaction code generator |
 | `tests/plugin_registration.rs` | Integration tests for inventory registration |
 | `tests/tool_integration.rs` | Integration tests: tool execution + wiremock |
 
@@ -186,11 +227,35 @@ DOM content can be very large. We truncate at 100KB to prevent flooding the LLM 
 - **Icon**: `browserless`
 - **Category**: `Browser`
 - **Risk Level**: Medium
-- **Dependencies**: none
+- **Dependencies**: none (session_storage used opportunistically for CDP state)
 
 ## Seeded Agent: Browser Tester
 
 A pre-configured seed agent (`Browser Tester`) demonstrates the capability:
+- **ID**: `0x10c`
 - **Capabilities**: `browserless`
 - **Dev-only**: false
-- **Use cases**: Accessibility testing, regression testing, web automation
+- **Tags**: browser, testing, automation, a11y, regression, demo, seed
+- **Use cases**: Accessibility testing, regression testing, web automation, login flows
+- **System prompt**: Guides the agent through navigate → screenshot → content → scrape → interact workflows
+
+## Design Decisions
+
+### Dual-mode: REST + CDP
+
+REST for simple one-shot operations, CDP for persistent sessions. CDP sessions preserve login state, cookies, and navigation history across tool calls — essential for testing login-protected pages.
+
+### Minimal CDP client
+
+Custom implementation in `cdp.rs` using `tokio-tungstenite`. No external CDP crate dependency. Implements only the CDP commands we need (Page, Runtime, Input, Browserless.reconnect). Keeps the dependency footprint small.
+
+### Reconnect pattern (not persistent WebSocket)
+
+We don't keep long-lived WebSocket connections. Each tool call: reconnect → work → reconnect → disconnect. The browser stays alive on Browserless servers. This avoids:
+- Managing WebSocket lifecycle across async tool calls
+- Dealing with connection drops during LLM thinking time
+- Complexity of multiplexing WebSocket messages
+
+### Content truncation
+
+DOM content can be very large. We truncate at 100KB to prevent flooding the LLM context window while still providing enough content for analysis.

--- a/specs/browserless.md
+++ b/specs/browserless.md
@@ -45,7 +45,7 @@ The CDP session uses Browserless's `Browserless.reconnect` command to keep the b
 2. **Use**: Reconnect via stored endpoint → do work → call `Browserless.reconnect` → disconnect
 3. **Close**: Reconnect → disconnect without calling reconnect → browser destroyed → clean up state
 
-Session state (`ws_endpoint`, `api_token`, timestamps) stored as encrypted secret in `session_storage`.
+Session state (`ws_endpoint`, timestamps) stored as plain key-value in `session_storage` (not encrypted secrets). API token is always resolved from user connection at call time — never stored in session state.
 
 ### API Token Resolution
 
@@ -177,7 +177,7 @@ No long-lived WebSocket connections from our side — we connect/disconnect for 
 ## Security
 
 - **API Token**: Stored in user connections (Settings > Connections > Browserless), encrypted at rest
-- **CDP session state**: Stored as encrypted secret in `session_storage`, per-session scoped
+- **CDP session state**: Stored as plain key-value in `session_storage` (only WS endpoint, no secrets), per-session scoped
 - **No secrets in chat**: Token resolved via connection provider, never exposed in conversation
 - **Ephemeral by default**: REST mode has no cross-request data leakage
 - **Content truncation**: Large DOM responses truncated to 100KB to prevent context flooding
@@ -197,7 +197,7 @@ No long-lived WebSocket connections from our side — we connect/disconnect for 
 - `tool_integration.rs`: full tool execution flow via wiremock, parameter validation, auth, error handling, resource cleanup
 
 ### Live API Tests
-Tests against the real Browserless API require `BROWSERLESS_API_KEY` in Doppler. Gated behind `browserless-live-tests` feature flag:
+Tests against the real Browserless API require `BROWSERLESS_KEY` in Doppler. Gated behind `browserless-live-tests` feature flag:
 
 ```bash
 doppler run -- cargo test -p everruns-integrations-browserless --features browserless-live-tests

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -372,6 +372,9 @@ fn authorizer(action: AuthAction) -> Authorization {
 | TM-TOOL-012 | Skill archive zip bomb | High | Decompressed size capped at 10 MB; file count capped at 100; individual file size capped at 1 MB | MITIGATED |
 | TM-TOOL-013 | Skill name collision across orgs | Medium | Skill names are unique per organization; capability IDs include UUID for global uniqueness | MITIGATED |
 | TM-TOOL-014 | Disabled skill still activatable | Medium | `CapabilityService.list_all()` filters out disabled skills; disabled skills not included in `<available_skills>` | MITIGATED |
+| TM-TOOL-015 | Browserless SSRF via tool URL | Medium | URL scheme validation: only `http://` and `https://` allowed; `file://`, `javascript:`, internal IPs blocked at URL level | MITIGATED |
+| TM-TOOL-016 | Browserless timeout DoS | Medium | All wait/timeout values capped at 120s; prevents unbounded resource consumption | MITIGATED |
+| TM-TOOL-017 | Browserless API token in logs | Medium | CDP debug logging redacts token from WebSocket URLs before logging | MITIGATED |
 
 ### Mitigation Details
 


### PR DESCRIPTION
## What
Add Browserless integration for cloud browser automation. Provides 7 tools for screenshots, DOM reading, structured scraping, and multi-step browser interactions (click, type, keyboard, mouse, touch). Supports both stateless REST API and persistent CDP (Chrome DevTools Protocol) browser sessions.

## Why
Agents need browser automation capabilities for accessibility testing, regression testing, web scraping, and interacting with login-protected pages.

## How
- New `everruns-integrations-browserless` crate under `integrations/browserless/`
- REST API client for one-shot operations (`/screenshot`, `/content`, `/scrape`, `/function`)
- Minimal CDP client over WebSocket for persistent browser sessions
- 7 session-aware tools that auto-detect CDP session or fall back to REST
- `ConnectionProvider` for API token management (Settings > Connections)
- Seeded Browser Tester agent for demo/testing
- Security hardening: URL validation, timeout caps, token redaction in logs, UTF-8 safe truncation
- API token resolved from user connection at call time, never stored in session state

## Risk
- Medium
- New integration crate — no changes to existing code paths beyond extern crate links and seed agent
- External service dependency failures are isolated

## Checklist
- [x] Tests added or updated (76 tests: 57 unit, 14 wiremock integration, 5 plugin registration)
- [x] Backward compatibility considered (new crate, no breaking changes)
- [x] Security review completed (URL validation, timeout caps, token redaction, SSRF protection)
- [x] Threat model updated (TM-TOOL-015/016/017)
- [x] Spec added (specs/browserless.md)
- [x] Docs added (docs/integrations/, docs/capabilities/)