### PR TITLE
fix(ui): show completed turn duration in chat

### DIFF
--- a/apps/ui/src/__tests__/turn-delimiter.test.ts
+++ b/apps/ui/src/__tests__/turn-delimiter.test.ts
@@ -1,0 +1,169 @@
+import {
+  getCompletedTurnDurationsByEvent,
+  formatWorkedDuration,
+} from "@/components/chat/turn-delimiter";
+import type { Event, EventContext } from "@/lib/api/types";
+
+let seqCounter = 0;
+
+function resetSeq() {
+  seqCounter = 0;
+}
+
+function emptyContext(): EventContext {
+  return {};
+}
+
+function turnContext(turnId: string, inputMessageId: string): EventContext {
+  return { turn_id: turnId, input_message_id: inputMessageId };
+}
+
+function makeEvent(
+  type: string,
+  data: Record<string, unknown>,
+  context: EventContext = emptyContext(),
+): Event {
+  seqCounter++;
+  return {
+    id: `evt-${seqCounter}`,
+    type,
+    ts: `2026-03-11T12:00:${String(seqCounter).padStart(2, "0")}Z`,
+    session_id: "session-1",
+    context,
+    data,
+    sequence: seqCounter,
+  };
+}
+
+function inputMessageEvent(messageId: string, text: string, context?: EventContext): Event {
+  return makeEvent(
+    "input.message",
+    {
+      message: {
+        id: messageId,
+        session_id: "session-1",
+        sequence: seqCounter + 1,
+        role: "user",
+        content: [{ type: "text", text }],
+        tool_call_id: null,
+        created_at: "2026-03-11T12:00:00Z",
+      },
+    },
+    context,
+  );
+}
+
+function turnStartedEvent(turnId: string, inputMessageId: string): Event {
+  return makeEvent(
+    "turn.started",
+    { turn_id: turnId, input_message_id: inputMessageId },
+    turnContext(turnId, inputMessageId),
+  );
+}
+
+function outputMessageCompletedEvent(turnId: string, inputMessageId: string, text: string): Event {
+  return makeEvent(
+    "output.message.completed",
+    {
+      message: {
+        id: `msg-out-${seqCounter + 1}`,
+        session_id: "session-1",
+        sequence: seqCounter + 1,
+        role: "agent",
+        content: [{ type: "text", text }],
+        tool_call_id: null,
+        created_at: "2026-03-11T12:00:00Z",
+      },
+    },
+    turnContext(turnId, inputMessageId),
+  );
+}
+
+function outputMessageWithClientToolCallEvent(turnId: string, inputMessageId: string): Event {
+  return makeEvent(
+    "output.message.completed",
+    {
+      message: {
+        id: `msg-out-tool-${seqCounter + 1}`,
+        session_id: "session-1",
+        sequence: seqCounter + 1,
+        role: "agent",
+        content: [
+          {
+            type: "tool_call",
+            id: "client-tool-1",
+            name: "browser.prompt",
+            arguments: { prompt: "Approve" },
+          },
+        ],
+        tool_call_id: null,
+        created_at: "2026-03-11T12:00:00Z",
+      },
+    },
+    turnContext(turnId, inputMessageId),
+  );
+}
+
+function toolCallRequestedEvent(turnId: string, inputMessageId: string): Event {
+  return makeEvent(
+    "tool.call_requested",
+    {
+      tool_calls: [
+        {
+          id: "client-tool-1",
+          name: "browser.prompt",
+          arguments: { prompt: "Approve" },
+        },
+      ],
+    },
+    turnContext(turnId, inputMessageId),
+  );
+}
+
+function turnCompletedEvent(turnId: string, inputMessageId: string, durationMs: number): Event {
+  return makeEvent(
+    "turn.completed",
+    { turn_id: turnId, iterations: 1, duration_ms: durationMs },
+    turnContext(turnId, inputMessageId),
+  );
+}
+
+describe("turn-delimiter", () => {
+  beforeEach(resetSeq);
+
+  it("attaches completed turn duration to the last visible assistant event", () => {
+    const events = [
+      inputMessageEvent("msg-1", "Hello"),
+      turnStartedEvent("turn-1", "msg-1"),
+      outputMessageCompletedEvent("turn-1", "msg-1", "Hi there"),
+      turnCompletedEvent("turn-1", "msg-1", 203000),
+    ];
+
+    const durations = getCompletedTurnDurationsByEvent(events);
+
+    expect(durations.get("evt-3")).toBe(203000);
+    expect(durations.size).toBe(1);
+  });
+
+  it("uses the client tool request row when embedded tool calls are hidden", () => {
+    const events = [
+      inputMessageEvent("msg-1", "Need approval"),
+      turnStartedEvent("turn-1", "msg-1"),
+      outputMessageWithClientToolCallEvent("turn-1", "msg-1"),
+      toolCallRequestedEvent("turn-1", "msg-1"),
+      turnCompletedEvent("turn-1", "msg-1", 4500),
+    ];
+
+    const durations = getCompletedTurnDurationsByEvent(events);
+
+    expect(durations.get("evt-4")).toBe(4500);
+    expect(durations.has("evt-3")).toBe(false);
+  });
+
+  it("formats worked durations for the divider label", () => {
+    expect(formatWorkedDuration(950)).toBe("950ms");
+    expect(formatWorkedDuration(4500)).toBe("5s");
+    expect(formatWorkedDuration(203000)).toBe("3m 23s");
+    expect(formatWorkedDuration(3600000)).toBe("1h");
+  });
+});

--- a/apps/ui/src/components/chat/chat-panel.tsx
+++ b/apps/ui/src/components/chat/chat-panel.tsx
@@ -31,6 +31,10 @@ import { ThinkingIndicator } from "@/components/thinking-indicator";
 import { StreamingMessage } from "@/components/streaming-message";
 import { StreamdownMessage } from "@/components/chat/streamdown-message";
 import { ToolActivityGroup } from "@/components/chat/tool-activity-group";
+import {
+  formatWorkedDuration,
+  getCompletedTurnDurationsByEvent,
+} from "@/components/chat/turn-delimiter";
 import { useSessionContext } from "@/app/(main)/sessions/[sessionId]/session-context";
 import { useLlmModels, useImageAttachments, useSessionCommands } from "@/hooks";
 import { sendUserMessageWithImages } from "@/lib/api/messages";
@@ -40,6 +44,7 @@ import { ALLOWED_IMAGE_TYPES } from "@/lib/api/types";
 export function ChatPanel() {
   const {
     agentId,
+    events,
     sessionId,
     llmModel,
     chatEvents,
@@ -100,6 +105,11 @@ export function ChatPanel() {
     }
     return ids;
   }, [chatEvents]);
+
+  const turnDurationByEventId = useMemo(
+    () => getCompletedTurnDurationsByEvent(events ?? []),
+    [events],
+  );
 
   const handleCommandSelect = useCallback(
     (cmd: CommandDescriptor) => {
@@ -283,6 +293,22 @@ export function ChatPanel() {
     }));
   };
 
+  const renderTurnDivider = (eventId: string) => {
+    const durationMs = turnDurationByEventId.get(eventId);
+
+    if (durationMs == null) {
+      return null;
+    }
+
+    return (
+      <div className="flex items-center gap-4 pt-3 text-xs font-medium text-muted-foreground sm:text-sm">
+        <div className="h-px flex-1 bg-border" />
+        <span className="whitespace-nowrap">{`Worked for ${formatWorkedDuration(durationMs)}`}</span>
+        <div className="h-px flex-1 bg-border" />
+      </div>
+    );
+  };
+
   return (
     <>
       <div className="flex-1 overflow-y-auto bg-background bg-brand-dots px-4 py-5 sm:px-6">
@@ -311,12 +337,15 @@ export function ChatPanel() {
                 const reqData = event.data as ToolCallRequestedData;
                 if (!reqData.tool_calls || reqData.tool_calls.length === 0) return null;
                 return (
-                  <div key={event.id} className="ml-9 space-y-1">
-                    <ToolActivityGroup
-                      toolCalls={reqData.tool_calls}
-                      toolResultsMap={toolResultsMap}
-                      mode="client"
-                    />
+                  <div key={event.id} className="space-y-3">
+                    <div className="ml-9 space-y-1">
+                      <ToolActivityGroup
+                        toolCalls={reqData.tool_calls}
+                        toolResultsMap={toolResultsMap}
+                        mode="client"
+                      />
+                    </div>
+                    {renderTurnDivider(event.id)}
                   </div>
                 );
               }
@@ -336,8 +365,11 @@ export function ChatPanel() {
 
               if (isToolOnlyMessage) {
                 return (
-                  <div key={event.id} className="ml-9 space-y-1">
-                    <ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} />
+                  <div key={event.id} className="space-y-3">
+                    <div className="ml-9 space-y-1">
+                      <ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} />
+                    </div>
+                    {renderTurnDivider(event.id)}
                   </div>
                 );
               }
@@ -408,6 +440,8 @@ export function ChatPanel() {
                       <ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} />
                     </div>
                   )}
+
+                  {renderTurnDivider(event.id)}
                 </div>
               );
             })}

--- a/apps/ui/src/components/chat/turn-delimiter.ts
+++ b/apps/ui/src/components/chat/turn-delimiter.ts
@@ -1,0 +1,140 @@
+// Important decision: derive completed-turn dividers from raw SSE events so
+// optimistic input rows never show a fake duration and client tool requests
+// can take over as the last visible item when embedded tool calls are hidden.
+
+import type {
+  Event,
+  InputMessageData,
+  OutputMessageCompletedData,
+  ToolCallRequestedData,
+  TurnCompletedData,
+  TurnStartedData,
+} from "@/lib/api/types";
+import { getTextFromContent, getToolCallsFromContent, isImageFilePart } from "@/lib/api/types";
+
+function getClientRequestedToolCallIds(events: Event[]): Set<string> {
+  const ids = new Set<string>();
+
+  for (const event of events) {
+    if (event.type !== "tool.call_requested") continue;
+
+    const data = event.data as ToolCallRequestedData;
+    for (const toolCall of data.tool_calls ?? []) {
+      ids.add(toolCall.id);
+    }
+  }
+
+  return ids;
+}
+
+function getInputMessageTurnIds(events: Event[]): Map<string, string> {
+  const turnIds = new Map<string, string>();
+
+  for (const event of events) {
+    if (event.type !== "turn.started") continue;
+
+    const data = event.data as TurnStartedData;
+    turnIds.set(data.input_message_id, data.turn_id);
+  }
+
+  return turnIds;
+}
+
+function isVisibleChatEvent(event: Event, clientRequestedToolCallIds: Set<string>): boolean {
+  if (event.type === "input.message") {
+    return true;
+  }
+
+  if (event.type === "tool.call_requested") {
+    const data = event.data as ToolCallRequestedData;
+    return (data.tool_calls?.length ?? 0) > 0;
+  }
+
+  if (event.type !== "output.message.completed") {
+    return false;
+  }
+
+  const data = event.data as OutputMessageCompletedData;
+  const content = data.message?.content ?? [];
+  const text = getTextFromContent(content);
+  const hasImages = content.some(isImageFilePart);
+  const visibleToolCalls = getToolCallsFromContent(content).filter(
+    (toolCall) => !clientRequestedToolCallIds.has(toolCall.id),
+  );
+
+  return !!text || hasImages || visibleToolCalls.length > 0;
+}
+
+function getEventTurnId(
+  event: Event,
+  inputMessageTurnIds: Map<string, string>,
+): string | undefined {
+  if (event.context.turn_id) {
+    return event.context.turn_id;
+  }
+
+  if (event.type !== "input.message") {
+    return undefined;
+  }
+
+  const data = event.data as InputMessageData;
+  return data.message?.id ? inputMessageTurnIds.get(data.message.id) : undefined;
+}
+
+export function getCompletedTurnDurationsByEvent(events: Event[]): Map<string, number> {
+  const clientRequestedToolCallIds = getClientRequestedToolCallIds(events);
+  const inputMessageTurnIds = getInputMessageTurnIds(events);
+  const lastVisibleEventIdByTurn = new Map<string, string>();
+  const durationMsByTurn = new Map<string, number>();
+
+  for (const event of events) {
+    if (isVisibleChatEvent(event, clientRequestedToolCallIds)) {
+      const turnId = getEventTurnId(event, inputMessageTurnIds);
+      if (turnId) {
+        lastVisibleEventIdByTurn.set(turnId, event.id);
+      }
+    }
+
+    if (event.type === "turn.completed") {
+      const data = event.data as TurnCompletedData;
+      if (data.duration_ms != null) {
+        durationMsByTurn.set(data.turn_id, data.duration_ms);
+      }
+    }
+  }
+
+  const durationsByEvent = new Map<string, number>();
+
+  for (const [turnId, durationMs] of durationMsByTurn) {
+    const eventId = lastVisibleEventIdByTurn.get(turnId);
+    if (eventId) {
+      durationsByEvent.set(eventId, durationMs);
+    }
+  }
+
+  return durationsByEvent;
+}
+
+export function formatWorkedDuration(durationMs: number): string {
+  if (durationMs < 1000) {
+    return `${durationMs}ms`;
+  }
+
+  const totalSeconds = Math.round(durationMs / 1000);
+
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`;
+  }
+
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const remainingSeconds = totalSeconds % 60;
+
+  if (totalMinutes < 60) {
+    return remainingSeconds > 0 ? `${totalMinutes}m ${remainingSeconds}s` : `${totalMinutes}m`;
+  }
+
+  const hours = Math.floor(totalMinutes / 60);
+  const remainingMinutes = totalMinutes % 60;
+
+  return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
+}


### PR DESCRIPTION
## What
Add a turn-end divider to the session chat transcript that shows how long the completed turn took.

## Why
The chat view already has turn lifecycle data from SSE events, but it did not surface completed turn duration in the transcript. The new divider makes long-running turns easier to scan.

## How
- derive the completed turn duration from raw `turn.started` / `turn.completed` / message events
- map each completed turn to the last visible chat row, including tool-only and client tool request rows
- render a centered `Worked for …` divider beneath that row
- add focused unit coverage for event mapping and duration formatting

## Risk
- Low
- Rendering could place the divider on the wrong row if turn-to-event mapping is wrong; covered with helper tests for normal assistant replies and client tool request turns

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
