### PR TITLE
feat(ui): add exponential backoff to SSE reconnection

### DIFF
--- a/apps/ui/src/__tests__/sse-reconnect.test.ts
+++ b/apps/ui/src/__tests__/sse-reconnect.test.ts
@@ -1,0 +1,123 @@
+import { createReconnectTracker } from "@/lib/sse-reconnect";
+
+describe("createReconnectTracker", () => {
+  beforeEach(() => {
+    jest.spyOn(Math, "random").mockReturnValue(0.5);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns initial state with zero attempts", () => {
+    const tracker = createReconnectTracker();
+    expect(tracker.state).toEqual({ attempt: 0, exhausted: false });
+  });
+
+  it("computes exponential backoff delays on error", () => {
+    const tracker = createReconnectTracker({ initialDelayMs: 1000, jitter: 0 });
+
+    expect(tracker.onError()).toBe(1000); // 1s
+    expect(tracker.onError()).toBe(2000); // 2s
+    expect(tracker.onError()).toBe(4000); // 4s
+    expect(tracker.onError()).toBe(8000); // 8s
+  });
+
+  it("caps delay at maxDelayMs", () => {
+    const tracker = createReconnectTracker({
+      initialDelayMs: 1000,
+      maxDelayMs: 5000,
+      jitter: 0,
+    });
+
+    tracker.onError(); // 1s
+    tracker.onError(); // 2s
+    tracker.onError(); // 4s
+    expect(tracker.onError()).toBe(5000); // capped at 5s, not 8s
+  });
+
+  it("returns null after max retries exhausted", () => {
+    const tracker = createReconnectTracker({ maxRetries: 3, jitter: 0 });
+
+    expect(tracker.onError()).not.toBeNull(); // attempt 0
+    expect(tracker.onError()).not.toBeNull(); // attempt 1
+    expect(tracker.onError()).not.toBeNull(); // attempt 2
+    expect(tracker.onError()).toBeNull(); // exhausted
+
+    expect(tracker.state).toEqual({ attempt: 3, exhausted: true });
+  });
+
+  it("resets backoff on successful connection", () => {
+    const tracker = createReconnectTracker({ jitter: 0 });
+
+    tracker.onError(); // attempt 0
+    tracker.onError(); // attempt 1
+    expect(tracker.state.attempt).toBe(2);
+
+    tracker.reset();
+    expect(tracker.state).toEqual({ attempt: 0, exhausted: false });
+
+    // Next error starts from beginning
+    expect(tracker.onError()).toBe(1000);
+  });
+
+  it("graceful disconnect uses server retry hint", () => {
+    const tracker = createReconnectTracker();
+
+    expect(tracker.onGraceful(500)).toBe(500);
+    expect(tracker.onGraceful(2000)).toBe(2000);
+  });
+
+  it("graceful disconnect does not count against max retries", () => {
+    const tracker = createReconnectTracker({ maxRetries: 2 });
+
+    // Many graceful disconnects
+    tracker.onGraceful(100);
+    tracker.onGraceful(100);
+    tracker.onGraceful(100);
+    tracker.onGraceful(100);
+
+    expect(tracker.state.attempt).toBe(0);
+    expect(tracker.state.exhausted).toBe(false);
+
+    // Error retries still available
+    expect(tracker.onError()).not.toBeNull();
+    expect(tracker.onError()).not.toBeNull();
+  });
+
+  it("graceful disconnect falls back to initialDelayMs when no hint", () => {
+    const tracker = createReconnectTracker({ initialDelayMs: 750 });
+
+    expect(tracker.onGraceful()).toBe(750);
+    expect(tracker.onGraceful(undefined)).toBe(750);
+  });
+
+  it("applies jitter to delay", () => {
+    // random=0.5 → jitter offset = base * 0.2 * (2*0.5 - 1) = 0
+    jest.spyOn(Math, "random").mockReturnValue(0.5);
+    const tracker1 = createReconnectTracker({ initialDelayMs: 1000, jitter: 0.2 });
+    expect(tracker1.onError()).toBe(1000); // 1000 + 0
+
+    // random=1.0 → jitter offset = 1000 * 0.2 * (2*1 - 1) = +200
+    jest.spyOn(Math, "random").mockReturnValue(1.0);
+    const tracker2 = createReconnectTracker({ initialDelayMs: 1000, jitter: 0.2 });
+    expect(tracker2.onError()).toBe(1200);
+
+    // random=0.0 → jitter offset = 1000 * 0.2 * (2*0 - 1) = -200
+    jest.spyOn(Math, "random").mockReturnValue(0.0);
+    const tracker3 = createReconnectTracker({ initialDelayMs: 1000, jitter: 0.2 });
+    expect(tracker3.onError()).toBe(800);
+  });
+
+  it("forceReset allows retry after exhaustion", () => {
+    const tracker = createReconnectTracker({ maxRetries: 1, jitter: 0 });
+
+    tracker.onError(); // attempt 0
+    expect(tracker.onError()).toBeNull(); // exhausted
+    expect(tracker.state.exhausted).toBe(true);
+
+    tracker.forceReset();
+    expect(tracker.state).toEqual({ attempt: 0, exhausted: false });
+    expect(tracker.onError()).toBe(1000); // works again
+  });
+});

--- a/apps/ui/src/hooks/use-durable.ts
+++ b/apps/ui/src/hooks/use-durable.ts
@@ -3,6 +3,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { createReconnectTracker } from "@/lib/sse-reconnect";
 import {
   getDurableHealth,
   listWorkers,
@@ -73,6 +74,7 @@ interface WorkflowSnapshot {
 export function useDurableSSE(options?: { enabled?: boolean }) {
   const queryClient = useQueryClient();
   const eventSourceRef = useRef<EventSource | null>(null);
+  const reconnectRef = useRef(createReconnectTracker());
   const [isConnected, setIsConnected] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const isEnabled = options?.enabled !== false;
@@ -91,6 +93,8 @@ export function useDurableSSE(options?: { enabled?: boolean }) {
       return;
     }
 
+    reconnectRef.current = createReconnectTracker();
+
     const connectSSE = () => {
       cleanup();
 
@@ -99,6 +103,7 @@ export function useDurableSSE(options?: { enabled?: boolean }) {
       eventSourceRef.current = eventSource;
 
       eventSource.addEventListener("connected", () => {
+        reconnectRef.current.reset();
         setIsConnected(true);
         setError(null);
       });
@@ -107,7 +112,7 @@ export function useDurableSSE(options?: { enabled?: boolean }) {
       eventSource.addEventListener("disconnecting", (event) => {
         try {
           const data = JSON.parse(event.data);
-          const retryMs = data.retry_ms ?? 1000;
+          const retryMs = reconnectRef.current.onGraceful(data.retry_ms ?? 1000);
           console.debug("Durable SSE disconnecting, reconnecting in", retryMs, "ms");
           cleanup();
           setTimeout(() => {
@@ -161,15 +166,19 @@ export function useDurableSSE(options?: { enabled?: boolean }) {
       });
 
       eventSource.onerror = () => {
-        setError(new Error("Durable SSE connection error"));
         setIsConnected(false);
         cleanup();
-        // Reconnect after delay
+        const delayMs = reconnectRef.current.onError();
+        if (delayMs === null) {
+          setError(new Error("Durable SSE connection failed after max retries"));
+          return;
+        }
+        setError(new Error("Durable SSE connection error, reconnecting..."));
         setTimeout(() => {
           if (isEnabled) {
             connectSSE();
           }
-        }, 2000);
+        }, delayMs);
       };
     };
 
@@ -192,6 +201,7 @@ export function useDurableSSE(options?: { enabled?: boolean }) {
 export function useWorkflowSSE(workflowId: string | undefined, options?: { enabled?: boolean }) {
   const queryClient = useQueryClient();
   const eventSourceRef = useRef<EventSource | null>(null);
+  const reconnectRef = useRef(createReconnectTracker());
   const [isConnected, setIsConnected] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const isEnabled = options?.enabled !== false && !!workflowId;
@@ -207,6 +217,7 @@ export function useWorkflowSSE(workflowId: string | undefined, options?: { enabl
   useEffect(() => {
     setIsConnected(false);
     setError(null);
+    reconnectRef.current = createReconnectTracker();
   }, [workflowId]);
 
   useEffect(() => {
@@ -216,6 +227,8 @@ export function useWorkflowSSE(workflowId: string | undefined, options?: { enabl
       return;
     }
 
+    reconnectRef.current = createReconnectTracker();
+
     const connectSSE = () => {
       cleanup();
 
@@ -224,6 +237,7 @@ export function useWorkflowSSE(workflowId: string | undefined, options?: { enabl
       eventSourceRef.current = eventSource;
 
       eventSource.addEventListener("connected", () => {
+        reconnectRef.current.reset();
         setIsConnected(true);
         setError(null);
       });
@@ -232,7 +246,7 @@ export function useWorkflowSSE(workflowId: string | undefined, options?: { enabl
       eventSource.addEventListener("disconnecting", (event) => {
         try {
           const data = JSON.parse(event.data);
-          const retryMs = data.retry_ms ?? 1000;
+          const retryMs = reconnectRef.current.onGraceful(data.retry_ms ?? 1000);
           console.debug("Workflow SSE disconnecting, reconnecting in", retryMs, "ms");
           cleanup();
           setTimeout(() => {
@@ -261,15 +275,19 @@ export function useWorkflowSSE(workflowId: string | undefined, options?: { enabl
       });
 
       eventSource.onerror = () => {
-        setError(new Error("Workflow SSE connection error"));
         setIsConnected(false);
         cleanup();
-        // Reconnect after delay
+        const delayMs = reconnectRef.current.onError();
+        if (delayMs === null) {
+          setError(new Error("Workflow SSE connection failed after max retries"));
+          return;
+        }
+        setError(new Error("Workflow SSE connection error, reconnecting..."));
         setTimeout(() => {
           if (isEnabled && workflowId) {
             connectSSE();
           }
-        }, 2000);
+        }, delayMs);
       };
     };
 

--- a/apps/ui/src/hooks/use-durable.ts
+++ b/apps/ui/src/hooks/use-durable.ts
@@ -217,7 +217,6 @@ export function useWorkflowSSE(workflowId: string | undefined, options?: { enabl
   useEffect(() => {
     setIsConnected(false);
     setError(null);
-    reconnectRef.current = createReconnectTracker();
   }, [workflowId]);
 
   useEffect(() => {

--- a/apps/ui/src/hooks/use-sessions.ts
+++ b/apps/ui/src/hooks/use-sessions.ts
@@ -24,6 +24,7 @@ import type {
   PaginationParams,
 } from "@/lib/api/types";
 import { useOrg } from "@/providers/org-provider";
+import { createReconnectTracker } from "@/lib/sse-reconnect";
 
 /**
  * Fetch paginated sessions for an organization.
@@ -230,8 +231,10 @@ export function useEvents(sessionId: string | undefined, options?: { enabled?: b
   const [events, setEvents] = useState<Event[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+  const [isReconnecting, setIsReconnecting] = useState(false);
   const eventSourceRef = useRef<EventSource | null>(null);
   const lastEventIdRef = useRef<string | null>(null);
+  const reconnectRef = useRef(createReconnectTracker());
   const isEnabled = options?.enabled !== false;
 
   // Track events by ID to avoid duplicates
@@ -253,8 +256,10 @@ export function useEvents(sessionId: string | undefined, options?: { enabled?: b
     setEvents([]);
     setIsLoading(true);
     setError(null);
+    setIsReconnecting(false);
     lastEventIdRef.current = null;
     eventIdsRef.current.clear();
+    reconnectRef.current = createReconnectTracker();
     setRestLoaded(false);
     cleanup();
   }, [org, sessionId, cleanup]);
@@ -309,19 +314,23 @@ export function useEvents(sessionId: string | undefined, options?: { enabled?: b
       eventSourceRef.current = eventSource;
 
       eventSource.addEventListener("connected", () => {
+        reconnectRef.current.reset();
         setError(null);
+        setIsReconnecting(false);
       });
 
       eventSource.addEventListener("disconnecting", (messageEvent) => {
         try {
           const data = JSON.parse(messageEvent.data);
-          const retryMs = data.retry_ms ?? 100;
+          const retryMs = reconnectRef.current.onGraceful(data.retry_ms ?? 100);
           cleanup();
+          setIsReconnecting(true);
           setTimeout(() => {
             if (isEnabled) connectSSE();
           }, retryMs);
         } catch {
           cleanup();
+          setIsReconnecting(true);
           if (isEnabled) connectSSE();
         }
       });
@@ -347,11 +356,18 @@ export function useEvents(sessionId: string | undefined, options?: { enabled?: b
       }
 
       eventSource.onerror = () => {
-        setError(new Error("SSE connection error"));
         cleanup();
+        const delayMs = reconnectRef.current.onError();
+        if (delayMs === null) {
+          setError(new Error("SSE connection failed after max retries"));
+          setIsReconnecting(false);
+          return;
+        }
+        setError(new Error("SSE connection error, reconnecting..."));
+        setIsReconnecting(true);
         setTimeout(() => {
           if (isEnabled) connectSSE();
-        }, 2000);
+        }, delayMs);
       };
     };
 
@@ -363,6 +379,7 @@ export function useEvents(sessionId: string | undefined, options?: { enabled?: b
   return {
     data: events,
     isLoading,
+    isReconnecting,
     error,
   };
 }

--- a/apps/ui/src/lib/sse-reconnect.ts
+++ b/apps/ui/src/lib/sse-reconnect.ts
@@ -1,0 +1,84 @@
+// SSE reconnection with exponential backoff
+//
+// Native EventSource handles basic reconnection, but its retry behavior
+// is opaque and doesn't support backoff. This utility wraps EventSource
+// lifecycle with configurable exponential backoff, max retries, and
+// backoff reset on successful connection.
+//
+// Heartbeat-based idle detection is NOT possible with native EventSource
+// (SSE comments are invisible to the JS API). If we need that in the
+// future, we'd switch to fetch-based SSE parsing.
+
+export interface ReconnectState {
+  /** Number of consecutive failed reconnection attempts */
+  attempt: number;
+  /** Whether we've exhausted max retries */
+  exhausted: boolean;
+}
+
+export interface ReconnectConfig {
+  /** Initial backoff delay in ms (default: 1000) */
+  initialDelayMs?: number;
+  /** Maximum backoff delay in ms (default: 30000) */
+  maxDelayMs?: number;
+  /** Maximum consecutive error retries before giving up (default: 10) */
+  maxRetries?: number;
+  /** Jitter factor 0-1 to randomize delay (default: 0.2) */
+  jitter?: number;
+}
+
+const DEFAULTS: Required<ReconnectConfig> = {
+  initialDelayMs: 1000,
+  maxDelayMs: 30_000,
+  maxRetries: 10,
+  jitter: 0.2,
+};
+
+/**
+ * Stateful reconnection tracker. Create one per SSE connection lifecycle.
+ * Call `onError()` for unexpected disconnects, `onGraceful(retryMs)` for
+ * server-initiated disconnects, and `reset()` on successful connection.
+ */
+export function createReconnectTracker(config?: ReconnectConfig) {
+  const cfg = { ...DEFAULTS, ...config };
+  let attempt = 0;
+
+  return {
+    /** Call when connection is established successfully. Resets backoff. */
+    reset() {
+      attempt = 0;
+    },
+
+    /** Current state (for UI display). */
+    get state(): ReconnectState {
+      return { attempt, exhausted: attempt >= cfg.maxRetries };
+    },
+
+    /**
+     * Compute delay for an unexpected error reconnect.
+     * Returns delay in ms, or null if max retries exhausted.
+     */
+    onError(): number | null {
+      if (attempt >= cfg.maxRetries) return null;
+      const base = Math.min(cfg.initialDelayMs * 2 ** attempt, cfg.maxDelayMs);
+      const jitterRange = base * cfg.jitter;
+      const delay = base + (Math.random() * 2 - 1) * jitterRange;
+      attempt++;
+      return Math.round(delay);
+    },
+
+    /**
+     * Compute delay for a graceful server-initiated disconnect.
+     * Uses server hint, does NOT count against max retries.
+     */
+    onGraceful(serverRetryMs?: number): number {
+      // Don't increment attempt — graceful disconnects are expected
+      return serverRetryMs ?? cfg.initialDelayMs;
+    },
+
+    /** Force reset for manual retry after exhaustion. */
+    forceReset() {
+      attempt = 0;
+    },
+  };
+}


### PR DESCRIPTION
## What

Add exponential backoff with jitter to all SSE reconnection across the UI. Replaces the fixed 2s retry delay in `useEvents`, `useDurableSSE`, and `useWorkflowSSE` hooks with a shared `createReconnectTracker` utility.

## Why

Fixed 2s retry creates thundering herd on server recovery and hammers a down server with rapid retries. Exponential backoff (1s→30s cap) is standard practice and aligns with the SDK's approach.

## How

- New `sse-reconnect.ts` utility: stateful tracker with exponential backoff, jitter, max retries (10), and separate handling for graceful vs unexpected disconnects
- Graceful server disconnects (`disconnecting` event) use the server-provided `retry_ms` hint and do NOT count against max retries
- Unexpected errors use exponential backoff and stop after 10 consecutive failures
- Backoff resets on successful `connected` event
- `useEvents` exposes `isReconnecting` state for UI feedback
- 10 unit tests covering all edge cases

## Risk

- Low
- Reconnection timing changes. Graceful disconnects behave identically (server hint passthrough). Error retries are slower (1s+ vs fixed 2s) which is intentional — prevents server hammering. After 10 consecutive failures the stream stops retrying, surfacing the error instead of retrying forever.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered