### PR TITLE
fix(durable): use SELECT COUNT(*) for event counting

### DIFF
--- a/crates/durable/src/persistence/postgres.rs
+++ b/crates/durable/src/persistence/postgres.rs
@@ -1885,6 +1885,21 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
         Ok(events)
     }
 
+    #[instrument(skip(self))]
+    async fn count_workflow_events(&self, workflow_id: Uuid) -> Result<i64, StoreError> {
+        let (count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM durable_workflow_events WHERE workflow_id = $1")
+                .bind(workflow_id)
+                .fetch_one(&self.pool)
+                .await
+                .map_err(|e| {
+                    error!("Failed to count workflow events: {}", e);
+                    StoreError::Database(e.to_string())
+                })?;
+
+        Ok(count)
+    }
+
     // =========================================================================
     // Schedule Operations
     // =========================================================================

--- a/crates/durable/src/persistence/store.rs
+++ b/crates/durable/src/persistence/store.rs
@@ -723,6 +723,13 @@ pub trait WorkflowEventStore: Send + Sync + 'static {
             .collect())
     }
 
+    /// Count workflow events without materializing them.
+    /// Uses SELECT COUNT(*) in PostgreSQL; falls back to load_events().len() by default.
+    async fn count_workflow_events(&self, workflow_id: Uuid) -> Result<i64, StoreError> {
+        let events = self.load_events(workflow_id).await?;
+        Ok(events.len() as i64)
+    }
+
     // =========================================================================
     // Schedule Operations (optional, default no-op)
     // =========================================================================

--- a/crates/durable/tests/postgres_repository_test.rs
+++ b/crates/durable/tests/postgres_repository_test.rs
@@ -302,6 +302,43 @@ async fn test_get_workflow_events() {
     cleanup_workflow(&store, workflow_id).await;
 }
 
+#[tokio::test]
+async fn test_count_workflow_events() {
+    let store = create_test_store().await;
+    let workflow_id = Uuid::now_v7();
+
+    store
+        .create_workflow(workflow_id, "count_test", json!({"input": "data"}), None)
+        .await
+        .unwrap();
+
+    // Empty workflow should have 0 events
+    let count = store.count_workflow_events(workflow_id).await.unwrap();
+    assert_eq!(count, 0);
+
+    // Append some events
+    use everruns_durable::workflow::WorkflowEvent;
+    let events = vec![
+        WorkflowEvent::ActivityScheduled {
+            activity_id: "act1".to_string(),
+            activity_type: "test_activity".to_string(),
+            input: json!({}),
+            options: ActivityOptions::default(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: "act1".to_string(),
+            result: json!({"done": true}),
+        },
+    ];
+    store.append_events(workflow_id, 0, events).await.unwrap();
+
+    // Count should match without materializing events
+    let count = store.count_workflow_events(workflow_id).await.unwrap();
+    assert_eq!(count, 2);
+
+    cleanup_workflow(&store, workflow_id).await;
+}
+
 // ============================================
 // Task Query Tests
 // ============================================

--- a/crates/server/src/api/durable.rs
+++ b/crates/server/src/api/durable.rs
@@ -2094,23 +2094,26 @@ pub async fn stream_workflow_sse(
                     }
                 };
 
-                // Fetch events
-                let events: Vec<WorkflowEventResponse> = fetch_or_disconnect!(
-                    store.get_workflow_events(stream_state.workflow_id).await,
-                    "Failed to fetch workflow events"
-                )
-                .into_iter()
-                .map(WorkflowEventResponse::from)
-                .collect();
-
-                // Detect changes
+                // Detect changes using COUNT(*) — avoids materializing all events
+                let event_count = fetch_or_disconnect!(
+                    store.count_workflow_events(stream_state.workflow_id).await,
+                    "Failed to count workflow events"
+                ) as usize;
                 let status_changed = stream_state.last_status.as_ref() != Some(&workflow.status);
-                let events_changed = events.len() != stream_state.last_event_count;
+                let events_changed = event_count != stream_state.last_event_count;
                 let has_changes = status_changed || events_changed;
 
                 if has_changes {
+                    // Only fetch full events when changes detected
+                    let events: Vec<WorkflowEventResponse> = fetch_or_disconnect!(
+                        store.get_workflow_events(stream_state.workflow_id).await,
+                        "Failed to fetch workflow events"
+                    )
+                    .into_iter()
+                    .map(WorkflowEventResponse::from)
+                    .collect();
+
                     let new_status = workflow.status.clone();
-                    let event_count = events.len();
                     let new_backoff = stream_state.config.min_backoff_ms;
                     let snapshot = WorkflowSnapshot { workflow, events };
                     let json = serde_json::to_string(&snapshot).unwrap_or_else(|_| "{}".to_string());

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -402,6 +402,15 @@ impl StorageBackend {
         )
     }
 
+    /// Count events for a session using SELECT COUNT(*) — no row materialization.
+    pub async fn count_events(
+        &self,
+        session_id: SessionId,
+        exclude_types: &[String],
+    ) -> Result<i64> {
+        dispatch!(self, count_events, session_id, exclude_types)
+    }
+
     pub async fn list_message_events(&self, session_id: SessionId) -> Result<Vec<EventRow>> {
         dispatch!(self, list_message_events, session_id)
     }

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -1128,6 +1128,23 @@ impl InMemoryDatabase {
         Ok(found)
     }
 
+    /// Count events for a session without materializing rows.
+    pub async fn count_events(
+        &self,
+        session_id: SessionId,
+        exclude_types: &[String],
+    ) -> Result<i64> {
+        let events = self.events.read();
+        let count = events
+            .values()
+            .filter(|e| {
+                e.session_id == session_id
+                    && (exclude_types.is_empty() || !exclude_types.contains(&e.event_type))
+            })
+            .count();
+        Ok(count as i64)
+    }
+
     pub async fn list_message_events(&self, session_id: SessionId) -> Result<Vec<EventRow>> {
         self.list_message_events_limited(session_id, None).await
     }
@@ -4144,6 +4161,34 @@ mod tests {
         }
 
         session.id
+    }
+
+    #[tokio::test]
+    async fn test_count_events_no_materialization() {
+        let db = InMemoryDatabase::new();
+        let session_id = create_session_with_events(&db).await;
+
+        // Total count (6 events created by helper)
+        let count = db.count_events(session_id, &[]).await.unwrap();
+        assert_eq!(count, 6);
+
+        // Count excluding delta types
+        let count = db
+            .count_events(
+                session_id,
+                &[
+                    "output.message.delta".to_string(),
+                    "reason.thinking.delta".to_string(),
+                ],
+            )
+            .await
+            .unwrap();
+        assert_eq!(count, 4); // 6 - 2 delta types
+
+        // Count for non-existent session
+        let other_session = SessionId::new();
+        let count = db.count_events(other_session, &[]).await.unwrap();
+        assert_eq!(count, 0);
     }
 
     #[tokio::test]

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -1398,6 +1398,29 @@ impl Database {
         Ok(rows)
     }
 
+    /// Count events for a session using SELECT COUNT(*) — no row materialization.
+    /// When `exclude_types` is non-empty, excludes matching event types from the count.
+    pub async fn count_events(
+        &self,
+        session_id: SessionId,
+        exclude_types: &[String],
+    ) -> Result<i64> {
+        let (count,): (i64,) = sqlx::query_as(
+            r#"
+            SELECT COUNT(*)
+            FROM events
+            WHERE session_id = $1
+              AND (cardinality($2::text[]) = 0 OR event_type <> ALL($2))
+            "#,
+        )
+        .bind(session_id.uuid())
+        .bind(exclude_types)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(count)
+    }
+
     /// List only message events for a session (for MessageStore implementation)
     ///
     /// Returns events with types: input.message, output.message.completed, tool.completed


### PR DESCRIPTION
## Summary

- Add count_workflow_events() to WorkflowEventStore trait with SELECT COUNT(*) in PostgreSQL — avoids materializing all event rows just to get a count
- SSE streaming change-detection now uses count_workflow_events() first, only fetching full events when changes are actually detected
- Add count_events() to server StorageBackend for session event counting with exclude_types support

## Why

Event count operations were loading ALL events into memory and calling .len(). At 1M events this materializes ~1-10 GB of data just to return a number. SELECT COUNT(*) uses the existing index and returns a single integer — zero materialization.

Fixes EVE-85

## Test plan

- [x] Unit test: test_count_events_no_materialization — verifies total count, filtered count (excluding delta types), and empty session
- [x] Integration test: test_count_workflow_events — verifies count on PostgreSQL with 0 and 2 events
- [x] just pre-push passes (fmt, clippy, lockfile)