### PR TITLE
chore(specs): clarify full /ship flow required for each Linear issue PR

### DIFF
--- a/specs/linear-issues.md
+++ b/specs/linear-issues.md
@@ -24,7 +24,7 @@ This repository manages issues in the **OSS** project within the Everruns Linear
 
 ### Workflow Summary
 
-Each issue follows: pick up → analyze → branch → implement → ship → close. The `/process-issues` command orchestrates this, delegating implementation and shipping to `/ship`.
+Each issue follows: pick up → analyze → branch → implement → ship → close. The `/process-issues` command orchestrates this, delegating each issue's shipping to `/ship`. **Every PR must go through the full `/ship` flow** (test coverage, code simplification, security review, artifact updates, smoke testing, quality gates, CI green, merge). No shortcuts — partial quality checks or skipping `/ship` phases is not acceptable.
 
 **Concurrency:** process up to 5 issues in parallel.
 


### PR DESCRIPTION
## What
Updated `specs/linear-issues.md` to explicitly state that every PR created from a Linear issue must go through the complete `/ship` flow.

## Why
The existing spec mentioned delegating to `/ship` but didn't make it clear that all phases (test coverage, code simplification, security review, artifact updates, smoke testing, quality gates) are mandatory for each PR. This could lead to shortcuts.

## How
Added explicit language in the Workflow Summary section stating that every PR must go through the full `/ship` flow with all phases, and that partial quality checks or skipping phases is not acceptable.

## Risk
- Low
- Documentation-only change, no runtime impact

## Checklist
- [x] Tests added or updated (N/A — spec-only change)
- [x] Backward compatibility considered (N/A)