### PR TITLE
feat: paginated event loading for large sessions (EVE-82, EVE-83)

### DIFF
--- a/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
@@ -69,6 +69,11 @@ interface SessionContextValue {
   >;
   // Turn cancellation
   cancelCurrentTurn: UseMutationResult<void, Error, void, unknown>;
+  // Pagination (load older events on scroll up)
+  hasMoreEvents: boolean;
+  loadingOlderEvents: boolean;
+  loadOlderEvents: () => Promise<void>;
+  totalNonDeltaCount: number | undefined;
   // Utility functions
   getMessageText: (data: InputMessageData | OutputMessageCompletedData) => string;
   getToolCalls: (
@@ -181,9 +186,15 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
   // Fetch LLM model info if session has a model_id
   const { data: llmModel } = useLlmModel(session?.model_id ?? "");
 
-  // Fetch events using SSE - always enabled for real-time streaming
-  // SSE handles backoff automatically (100ms → 10s when no new events)
-  const { data: events, isLoading: eventsLoading } = useEvents(sessionId);
+  // Fetch events using paginated REST + SSE for real-time streaming
+  const {
+    data: events,
+    isLoading: eventsLoading,
+    hasMore: hasMoreEvents,
+    loadingOlder: loadingOlderEvents,
+    loadOlderEvents,
+    totalNonDeltaCount,
+  } = useEvents(sessionId);
 
   // Update local status from SSE events (session.activated, session.idled)
   useEffect(() => {
@@ -472,6 +483,10 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
     streamingIteration,
     sendMessage,
     cancelCurrentTurn,
+    hasMoreEvents,
+    loadingOlderEvents,
+    loadOlderEvents,
+    totalNonDeltaCount,
     getMessageText,
     getToolCalls,
   };

--- a/apps/ui/src/components/chat/chat-panel.tsx
+++ b/apps/ui/src/components/chat/chat-panel.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useState, useRef, useEffect, useMemo, useCallback } from "react";
+import {
+  useState,
+  useRef,
+  useEffect,
+  useMemo,
+  useCallback,
+  useLayoutEffect,
+} from "react";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
@@ -31,7 +38,10 @@ import type {
 } from "@/lib/api/types";
 import { isImageFilePart } from "@/lib/api/types";
 import { MessageInfoIcon } from "@/components/chat/message-info-icon";
-import { ImageAttachments, MessageImage } from "@/components/chat/image-attachments";
+import {
+  ImageAttachments,
+  MessageImage,
+} from "@/components/chat/image-attachments";
 import {
   CommandAutocomplete,
   shouldShowCommandAutocomplete,
@@ -68,6 +78,9 @@ export function ChatPanel() {
     streamingIteration,
     sendMessage,
     cancelCurrentTurn,
+    hasMoreEvents,
+    loadingOlderEvents,
+    loadOlderEvents,
     getMessageText,
     getToolCalls,
   } = useSessionContext();
@@ -85,6 +98,9 @@ export function ChatPanel() {
   const [hasNewMessages, setHasNewMessages] = useState(false);
   const prevChatEventsLengthRef = useRef(0);
   const initialScrollDoneRef = useRef(false);
+
+  // Track scroll height before prepending older events for position preservation
+  const prevScrollHeightRef = useRef<number | null>(null);
   const hasUserSelectedModel = useRef(false);
   const modelSelectionStorageKey = useMemo(
     () => `everruns:chat:model-selection:${agentId}:${sessionId}`,
@@ -154,7 +170,9 @@ export function ChatPanel() {
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const storedSelection = window.localStorage.getItem(modelSelectionStorageKey);
+    const storedSelection = window.localStorage.getItem(
+      modelSelectionStorageKey,
+    );
     if (storedSelection !== null && !hasUserSelectedModel.current) {
       setSelectedModelId(storedSelection);
     }
@@ -172,7 +190,9 @@ export function ChatPanel() {
   );
 
   const getReasoningEffortName = (value: string): string => {
-    const effort = reasoningEffortConfig?.values.find((item) => item.value === value);
+    const effort = reasoningEffortConfig?.values.find(
+      (item) => item.value === value,
+    );
     return effort?.name ?? value;
   };
 
@@ -193,11 +213,18 @@ export function ChatPanel() {
     if (
       reasoningEffortConfig &&
       reasoningEffort &&
-      !reasoningEffortConfig.values.some((effort) => effort.value === reasoningEffort)
+      !reasoningEffortConfig.values.some(
+        (effort) => effort.value === reasoningEffort,
+      )
     ) {
       setReasoningEffort("");
     }
-  }, [supportsReasoning, reasoningEffortConfig, reasoningEffort, setReasoningEffort]);
+  }, [
+    supportsReasoning,
+    reasoningEffortConfig,
+    reasoningEffort,
+    setReasoningEffort,
+  ]);
 
   // Track whether user is near the bottom of the scroll container
   const NEAR_BOTTOM_THRESHOLD = 100;
@@ -213,7 +240,7 @@ export function ChatPanel() {
     messagesEndRef.current?.scrollIntoView({ behavior });
   }, []);
 
-  // Listen for scroll events to track near-bottom state
+  // Listen for scroll events to track near-bottom state and trigger older event loading
   useEffect(() => {
     const container = scrollContainerRef.current;
     if (!container) return;
@@ -233,7 +260,11 @@ export function ChatPanel() {
 
   // Scroll to bottom immediately on initial load (once events are ready)
   useEffect(() => {
-    if (!eventsLoading && chatEvents.length > 0 && !initialScrollDoneRef.current) {
+    if (
+      !eventsLoading &&
+      chatEvents.length > 0 &&
+      !initialScrollDoneRef.current
+    ) {
       initialScrollDoneRef.current = true;
       // Use requestAnimationFrame to ensure DOM is painted
       requestAnimationFrame(() => {
@@ -251,10 +282,13 @@ export function ChatPanel() {
   }, [sessionId]);
 
   // Auto-scroll on new events or streaming updates (only when near bottom)
+  // Skip if older events were prepended (prevScrollHeightRef is set)
   useEffect(() => {
     if (!initialScrollDoneRef.current) return;
+    if (prevScrollHeightRef.current !== null) return;
 
-    const hasNewChatEvents = chatEvents.length > prevChatEventsLengthRef.current;
+    const hasNewChatEvents =
+      chatEvents.length > prevChatEventsLengthRef.current;
     prevChatEventsLengthRef.current = chatEvents.length;
 
     if (isNearBottomRef.current) {
@@ -263,6 +297,31 @@ export function ChatPanel() {
       setHasNewMessages(true);
     }
   }, [chatEvents, streamingText, isThinking, scrollToBottom]);
+
+  // Scroll position preservation: when older events are prepended,
+  // adjust scrollTop so the viewport stays in the same visual position
+  useLayoutEffect(() => {
+    const container = scrollContainerRef.current;
+    const prevHeight = prevScrollHeightRef.current;
+    if (container && prevHeight !== null) {
+      const newHeight = container.scrollHeight;
+      container.scrollTop += newHeight - prevHeight;
+      prevScrollHeightRef.current = null;
+    }
+  }, [chatEvents]);
+
+  // Scroll-up detection: trigger loading older events
+  const handleScroll = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container || !hasMoreEvents || loadingOlderEvents) return;
+
+    // Trigger when user scrolls within 200px of the top
+    if (container.scrollTop < 200) {
+      // Save scroll height before prepend for position preservation
+      prevScrollHeightRef.current = container.scrollHeight;
+      loadOlderEvents();
+    }
+  }, [hasMoreEvents, loadingOlderEvents, loadOlderEvents]);
 
   // Auto-focus message input when session loads
   useEffect(() => {
@@ -289,7 +348,10 @@ export function ChatPanel() {
   // Check if can submit (has content and all images uploaded)
   const hasContent = inputValue.trim() || hasImages;
   const canSubmit =
-    hasContent && allUploaded && !sendMessage.isPending && !sendMessageWithImages.isPending;
+    hasContent &&
+    allUploaded &&
+    !sendMessage.isPending &&
+    !sendMessageWithImages.isPending;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -387,6 +449,7 @@ export function ChatPanel() {
     <>
       <div
         ref={scrollContainerRef}
+        onScroll={handleScroll}
         className="relative flex-1 overflow-y-auto bg-background bg-brand-dots px-4 py-5 sm:px-6"
       >
         {eventsLoading ? (
@@ -399,12 +462,24 @@ export function ChatPanel() {
           <div className="flex h-full flex-col items-center justify-center text-center text-muted-foreground">
             <div className="border border-border bg-card px-10 py-10">
               <Bot className="mx-auto mb-4 h-10 w-10 opacity-50" />
-              <p className="text-lg font-medium text-foreground">No messages yet</p>
-              <p className="mt-1 text-sm">Send a message to start the conversation</p>
+              <p className="text-lg font-medium text-foreground">
+                No messages yet
+              </p>
+              <p className="mt-1 text-sm">
+                Send a message to start the conversation
+              </p>
             </div>
           </div>
         ) : (
           <div className="space-y-6">
+            {loadingOlderEvents && (
+              <div className="flex items-center justify-center py-3">
+                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                <span className="ml-2 text-xs text-muted-foreground">
+                  Loading older messages...
+                </span>
+              </div>
+            )}
             {chatEvents.map((event) => {
               if (event.type === "tool.completed") {
                 return null;
@@ -412,7 +487,8 @@ export function ChatPanel() {
 
               if (event.type === "tool.call_requested") {
                 const reqData = event.data as ToolCallRequestedData;
-                if (!reqData.tool_calls || reqData.tool_calls.length === 0) return null;
+                if (!reqData.tool_calls || reqData.tool_calls.length === 0)
+                  return null;
                 return (
                   <div key={event.id} className="space-y-3">
                     <div className="ml-9 space-y-1">
@@ -428,23 +504,34 @@ export function ChatPanel() {
               }
 
               const isUser = event.type === "input.message";
-              const data = event.data as InputMessageData | OutputMessageCompletedData;
+              const data = event.data as
+                | InputMessageData
+                | OutputMessageCompletedData;
               const textContent = getMessageText(data);
               const toolCalls = isUser
                 ? []
                 : getToolCalls(data as OutputMessageCompletedData).filter(
                     (toolCall) => !clientRequestedToolCallIds.has(toolCall.id),
                   );
-              const images = data.message?.content ? getMessageImages(data.message.content) : [];
-              const isScheduleTriggered = isUser && data.message?.metadata?.source === "schedule";
+              const images = data.message?.content
+                ? getMessageImages(data.message.content)
+                : [];
+              const isScheduleTriggered =
+                isUser && data.message?.metadata?.source === "schedule";
               const isToolOnlyMessage =
-                !isUser && toolCalls.length > 0 && !textContent && images.length === 0;
+                !isUser &&
+                toolCalls.length > 0 &&
+                !textContent &&
+                images.length === 0;
 
               if (isToolOnlyMessage) {
                 return (
                   <div key={event.id} className="space-y-3">
                     <div className="ml-9 space-y-1">
-                      <ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} />
+                      <ToolActivityGroup
+                        toolCalls={toolCalls}
+                        toolResultsMap={toolResultsMap}
+                      />
                     </div>
                     {renderTurnDivider(event.id)}
                   </div>
@@ -454,7 +541,9 @@ export function ChatPanel() {
               return (
                 <div key={event.id} className="space-y-2">
                   {(textContent || images.length > 0) && (
-                    <div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
+                    <div
+                      className={`flex ${isUser ? "justify-end" : "justify-start"}`}
+                    >
                       {isUser ? (
                         <div className="max-w-[78%] border-r-2 border-r-accent bg-[hsl(var(--accent)/0.1)] px-4 py-3 text-sm text-foreground">
                           {isScheduleTriggered && (
@@ -465,7 +554,11 @@ export function ChatPanel() {
                           )}
                           <div className="flex items-start gap-2">
                             <div className="flex-1 space-y-2">
-                              {textContent && <p className="whitespace-pre-wrap">{textContent}</p>}
+                              {textContent && (
+                                <p className="whitespace-pre-wrap">
+                                  {textContent}
+                                </p>
+                              )}
                               {images.length > 0 && (
                                 <div className="mt-2 flex flex-wrap gap-2">
                                   {images.map((img) => (
@@ -489,7 +582,10 @@ export function ChatPanel() {
                           <div className="flex flex-1 items-start gap-2">
                             <div className="flex-1 space-y-2 border-l-2 border-l-primary bg-card px-4 py-3">
                               {textContent && (
-                                <StreamdownMessage variant="inline" className="text-foreground">
+                                <StreamdownMessage
+                                  variant="inline"
+                                  className="text-foreground"
+                                >
                                   {textContent}
                                 </StreamdownMessage>
                               )}
@@ -514,7 +610,10 @@ export function ChatPanel() {
 
                   {toolCalls.length > 0 && (
                     <div className="ml-9 space-y-1">
-                      <ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} />
+                      <ToolActivityGroup
+                        toolCalls={toolCalls}
+                        toolResultsMap={toolResultsMap}
+                      />
                     </div>
                   )}
 
@@ -575,11 +674,15 @@ export function ChatPanel() {
             onChange={handleFileChange}
           />
 
-          {hasImages && <ImageAttachments images={pendingImages} onRemove={removeImage} />}
+          {hasImages && (
+            <ImageAttachments images={pendingImages} onRemove={removeImage} />
+          )}
 
           <div
             className={`relative border border-border bg-background transition-colors ${
-              isDraggingOver ? "bg-[hsl(var(--accent)/0.08)] ring-1 ring-accent" : ""
+              isDraggingOver
+                ? "bg-[hsl(var(--accent)/0.08)] ring-1 ring-accent"
+                : ""
             }`}
             onDragOver={(e) => {
               e.preventDefault();
@@ -603,7 +706,9 @@ export function ChatPanel() {
               setIsDraggingOver(false);
               const files = e.dataTransfer?.files;
               if (files && files.length > 0) {
-                const imageFiles = Array.from(files).filter((f) => f.type.startsWith("image/"));
+                const imageFiles = Array.from(files).filter((f) =>
+                  f.type.startsWith("image/"),
+                );
                 if (imageFiles.length > 0) {
                   addFiles(imageFiles);
                 }
@@ -695,14 +800,18 @@ export function ChatPanel() {
                   </span>
                   <Select
                     value={reasoningEffort}
-                    onValueChange={(value) => setReasoningEffort(value as typeof reasoningEffort)}
+                    onValueChange={(value) =>
+                      setReasoningEffort(value as typeof reasoningEffort)
+                    }
                   >
                     <SelectTrigger
                       size="sm"
                       className="h-7 w-[116px] min-w-0 border-0 bg-transparent px-0 py-0 text-sm shadow-none focus-visible:ring-0 data-[size=sm]:h-7 [&_svg]:icon-sharp"
                     >
                       <SelectValue>
-                        {reasoningEffort ? getReasoningEffortName(reasoningEffort) : "Default"}
+                        {reasoningEffort
+                          ? getReasoningEffortName(reasoningEffort)
+                          : "Default"}
                       </SelectValue>
                     </SelectTrigger>
                     <SelectContent>

--- a/apps/ui/src/components/chat/chat-panel.tsx
+++ b/apps/ui/src/components/chat/chat-panel.tsx
@@ -1,58 +1,48 @@
 "use client";
 
-import {
-	useState,
-	useRef,
-	useEffect,
-	useMemo,
-	useCallback,
-	useLayoutEffect,
-} from "react";
+import { useState, useRef, useEffect, useMemo, useCallback, useLayoutEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
 } from "@/components/ui/select";
 import {
-	Send,
-	Bot,
-	Loader2,
-	Brain,
-	ImagePlus,
-	StopCircle,
-	CalendarClock,
-	ArrowDown,
+  Send,
+  Bot,
+  Loader2,
+  Brain,
+  ImagePlus,
+  StopCircle,
+  CalendarClock,
+  ArrowDown,
 } from "lucide-react";
 import type {
-	Controls,
-	InputMessageData,
-	OutputMessageCompletedData,
-	ToolCallRequestedData,
-	ContentPart,
-	CommandDescriptor,
+  Controls,
+  InputMessageData,
+  OutputMessageCompletedData,
+  ToolCallRequestedData,
+  ContentPart,
+  CommandDescriptor,
 } from "@/lib/api/types";
 import { isImageFilePart } from "@/lib/api/types";
 import { MessageInfoIcon } from "@/components/chat/message-info-icon";
+import { ImageAttachments, MessageImage } from "@/components/chat/image-attachments";
 import {
-	ImageAttachments,
-	MessageImage,
-} from "@/components/chat/image-attachments";
-import {
-	CommandAutocomplete,
-	shouldShowCommandAutocomplete,
+  CommandAutocomplete,
+  shouldShowCommandAutocomplete,
 } from "@/components/chat/command-autocomplete";
 import { ThinkingIndicator } from "@/components/thinking-indicator";
 import { StreamingMessage } from "@/components/streaming-message";
 import { StreamdownMessage } from "@/components/chat/streamdown-message";
 import { ToolActivityGroup } from "@/components/chat/tool-activity-group";
 import {
-	formatWorkedDuration,
-	getCompletedTurnDurationsByEvent,
+  formatWorkedDuration,
+  getCompletedTurnDurationsByEvent,
 } from "@/components/chat/turn-delimiter";
 import { useSessionContext } from "@/app/(main)/sessions/[sessionId]/session-context";
 import { useLlmModels, useImageAttachments, useSessionCommands } from "@/hooks";
@@ -61,810 +51,753 @@ import { useMutation } from "@tanstack/react-query";
 import { ALLOWED_IMAGE_TYPES } from "@/lib/api/types";
 
 export function ChatPanel() {
-	const {
-		agentId,
-		events,
-		sessionId,
-		llmModel,
-		chatEvents,
-		toolResultsMap,
-		eventsLoading,
-		isActive,
-		reasoningEffort,
-		setReasoningEffort,
-		setIsWaitingForResponse,
-		isThinking,
-		streamingText,
-		streamingIteration,
-		sendMessage,
-		cancelCurrentTurn,
-		hasMoreEvents,
-		loadingOlderEvents,
-		loadOlderEvents,
-		getMessageText,
-		getToolCalls,
-	} = useSessionContext();
+  const {
+    agentId,
+    events,
+    sessionId,
+    llmModel,
+    chatEvents,
+    toolResultsMap,
+    eventsLoading,
+    isActive,
+    reasoningEffort,
+    setReasoningEffort,
+    setIsWaitingForResponse,
+    isThinking,
+    streamingText,
+    streamingIteration,
+    sendMessage,
+    cancelCurrentTurn,
+    hasMoreEvents,
+    loadingOlderEvents,
+    loadOlderEvents,
+    getMessageText,
+    getToolCalls,
+  } = useSessionContext();
 
-	const { data: llmModels = [] } = useLlmModels();
+  const { data: llmModels = [] } = useLlmModels();
 
-	const [inputValue, setInputValue] = useState("");
-	const [selectedModelId, setSelectedModelId] = useState("");
-	const [isDraggingOver, setIsDraggingOver] = useState(false);
-	const scrollContainerRef = useRef<HTMLDivElement>(null);
-	const messagesEndRef = useRef<HTMLDivElement>(null);
-	const fileInputRef = useRef<HTMLInputElement>(null);
-	const textareaRef = useRef<HTMLTextAreaElement>(null);
-	const isNearBottomRef = useRef(true);
-	const [hasNewMessages, setHasNewMessages] = useState(false);
-	const prevChatEventsLengthRef = useRef(0);
-	const initialScrollDoneRef = useRef(false);
+  const [inputValue, setInputValue] = useState("");
+  const [selectedModelId, setSelectedModelId] = useState("");
+  const [isDraggingOver, setIsDraggingOver] = useState(false);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const isNearBottomRef = useRef(true);
+  const [hasNewMessages, setHasNewMessages] = useState(false);
+  const prevChatEventsLengthRef = useRef(0);
+  const initialScrollDoneRef = useRef(false);
 
-	// Track scroll height before prepending older events for position preservation
-	const prevScrollHeightRef = useRef<number | null>(null);
-	const hasUserSelectedModel = useRef(false);
-	const modelSelectionStorageKey = useMemo(
-		() => `everruns:chat:model-selection:${agentId}:${sessionId}`,
-		[agentId, sessionId],
-	);
+  // Track scroll height before prepending older events for position preservation
+  const prevScrollHeightRef = useRef<number | null>(null);
+  const hasUserSelectedModel = useRef(false);
+  const modelSelectionStorageKey = useMemo(
+    () => `everruns:chat:model-selection:${agentId}:${sessionId}`,
+    [agentId, sessionId],
+  );
 
-	// Image attachments management
-	const {
-		pendingImages,
-		allUploaded,
-		uploadedImageIds,
-		addFiles,
-		removeImage,
-		clearImages,
-		hasImages,
-		isUploading,
-	} = useImageAttachments({ sessionId });
+  // Image attachments management
+  const {
+    pendingImages,
+    allUploaded,
+    uploadedImageIds,
+    addFiles,
+    removeImage,
+    clearImages,
+    hasImages,
+    isUploading,
+  } = useImageAttachments({ sessionId });
 
-	// Commands autocomplete
-	const { data: commandsData } = useSessionCommands(sessionId);
-	const commands = commandsData?.commands ?? [];
-	const [showCommands, setShowCommands] = useState(false);
+  // Commands autocomplete
+  const { data: commandsData } = useSessionCommands(sessionId);
+  const commands = commandsData?.commands ?? [];
+  const [showCommands, setShowCommands] = useState(false);
 
-	const clientRequestedToolCallIds = useMemo(() => {
-		const ids = new Set<string>();
-		for (const event of chatEvents) {
-			if (event.type !== "tool.call_requested") continue;
-			const data = event.data as ToolCallRequestedData;
-			for (const toolCall of data.tool_calls ?? []) {
-				ids.add(toolCall.id);
-			}
-		}
-		return ids;
-	}, [chatEvents]);
+  const clientRequestedToolCallIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const event of chatEvents) {
+      if (event.type !== "tool.call_requested") continue;
+      const data = event.data as ToolCallRequestedData;
+      for (const toolCall of data.tool_calls ?? []) {
+        ids.add(toolCall.id);
+      }
+    }
+    return ids;
+  }, [chatEvents]);
 
-	const turnDurationByEventId = useMemo(
-		() => getCompletedTurnDurationsByEvent(events ?? []),
-		[events],
-	);
+  const turnDurationByEventId = useMemo(
+    () => getCompletedTurnDurationsByEvent(events ?? []),
+    [events],
+  );
 
-	const handleCommandSelect = useCallback(
-		(cmd: CommandDescriptor) => {
-			setShowCommands(false);
-			if (cmd.source === "system") {
-				// System commands: send as slash message directly
-				setInputValue(`/${cmd.name}`);
-				// Submit immediately
-				const controls: Controls | undefined = selectedModelId
-					? { model_id: selectedModelId }
-					: undefined;
-				sendMessage.mutateAsync({
-					sessionId,
-					content: `/${cmd.name}`,
-					controls,
-				});
-				setInputValue("");
-				setIsWaitingForResponse(true);
-				textareaRef.current?.focus();
-			} else {
-				// Skill commands: inject as message to trigger prompt expansion
-				setInputValue(`/${cmd.name} `);
-				textareaRef.current?.focus();
-			}
-		},
-		[sessionId, selectedModelId, sendMessage, setIsWaitingForResponse],
-	);
+  const handleCommandSelect = useCallback(
+    (cmd: CommandDescriptor) => {
+      setShowCommands(false);
+      if (cmd.source === "system") {
+        // System commands: send as slash message directly
+        setInputValue(`/${cmd.name}`);
+        // Submit immediately
+        const controls: Controls | undefined = selectedModelId
+          ? { model_id: selectedModelId }
+          : undefined;
+        sendMessage.mutateAsync({
+          sessionId,
+          content: `/${cmd.name}`,
+          controls,
+        });
+        setInputValue("");
+        setIsWaitingForResponse(true);
+        textareaRef.current?.focus();
+      } else {
+        // Skill commands: inject as message to trigger prompt expansion
+        setInputValue(`/${cmd.name} `);
+        textareaRef.current?.focus();
+      }
+    },
+    [sessionId, selectedModelId, sendMessage, setIsWaitingForResponse],
+  );
 
-	useEffect(() => {
-		if (typeof window === "undefined") return;
-		const storedSelection = window.localStorage.getItem(
-			modelSelectionStorageKey,
-		);
-		if (storedSelection !== null && !hasUserSelectedModel.current) {
-			setSelectedModelId(storedSelection);
-		}
-	}, [modelSelectionStorageKey]);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const storedSelection = window.localStorage.getItem(modelSelectionStorageKey);
+    if (storedSelection !== null && !hasUserSelectedModel.current) {
+      setSelectedModelId(storedSelection);
+    }
+  }, [modelSelectionStorageKey]);
 
-	const selectedModel = useMemo(
-		() => llmModels.find((model) => model.id === selectedModelId),
-		[llmModels, selectedModelId],
-	);
+  const selectedModel = useMemo(
+    () => llmModels.find((model) => model.id === selectedModelId),
+    [llmModels, selectedModelId],
+  );
 
-	const activeModel = selectedModel ?? llmModel;
-	const reasoningEffortConfig = activeModel?.profile?.reasoning_effort;
-	const supportsReasoning = !!(
-		activeModel?.profile?.reasoning && activeModel?.profile?.reasoning_effort
-	);
+  const activeModel = selectedModel ?? llmModel;
+  const reasoningEffortConfig = activeModel?.profile?.reasoning_effort;
+  const supportsReasoning = !!(
+    activeModel?.profile?.reasoning && activeModel?.profile?.reasoning_effort
+  );
 
-	const getReasoningEffortName = (value: string): string => {
-		const effort = reasoningEffortConfig?.values.find(
-			(item) => item.value === value,
-		);
-		return effort?.name ?? value;
-	};
+  const getReasoningEffortName = (value: string): string => {
+    const effort = reasoningEffortConfig?.values.find((item) => item.value === value);
+    return effort?.name ?? value;
+  };
 
-	const defaultEffortName = reasoningEffortConfig?.default
-		? getReasoningEffortName(reasoningEffortConfig.default)
-		: "Medium";
-	const modelTriggerLabel = selectedModel?.display_name ?? "Default";
-	const defaultModelOptionLabel = llmModel?.display_name
-		? `Default (${llmModel.display_name})`
-		: "Default";
+  const defaultEffortName = reasoningEffortConfig?.default
+    ? getReasoningEffortName(reasoningEffortConfig.default)
+    : "Medium";
+  const modelTriggerLabel = selectedModel?.display_name ?? "Default";
+  const defaultModelOptionLabel = llmModel?.display_name
+    ? `Default (${llmModel.display_name})`
+    : "Default";
 
-	useEffect(() => {
-		if (!supportsReasoning) {
-			setReasoningEffort("");
-			return;
-		}
+  useEffect(() => {
+    if (!supportsReasoning) {
+      setReasoningEffort("");
+      return;
+    }
 
-		if (
-			reasoningEffortConfig &&
-			reasoningEffort &&
-			!reasoningEffortConfig.values.some(
-				(effort) => effort.value === reasoningEffort,
-			)
-		) {
-			setReasoningEffort("");
-		}
-	}, [
-		supportsReasoning,
-		reasoningEffortConfig,
-		reasoningEffort,
-		setReasoningEffort,
-	]);
+    if (
+      reasoningEffortConfig &&
+      reasoningEffort &&
+      !reasoningEffortConfig.values.some((effort) => effort.value === reasoningEffort)
+    ) {
+      setReasoningEffort("");
+    }
+  }, [supportsReasoning, reasoningEffortConfig, reasoningEffort, setReasoningEffort]);
 
-	// Track whether user is near the bottom of the scroll container
-	const NEAR_BOTTOM_THRESHOLD = 100;
+  // Track whether user is near the bottom of the scroll container
+  const NEAR_BOTTOM_THRESHOLD = 100;
 
-	const checkIsNearBottom = useCallback(() => {
-		const container = scrollContainerRef.current;
-		if (!container) return true;
-		const { scrollTop, scrollHeight, clientHeight } = container;
-		return scrollHeight - scrollTop - clientHeight <= NEAR_BOTTOM_THRESHOLD;
-	}, []);
+  const checkIsNearBottom = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return true;
+    const { scrollTop, scrollHeight, clientHeight } = container;
+    return scrollHeight - scrollTop - clientHeight <= NEAR_BOTTOM_THRESHOLD;
+  }, []);
 
-	const scrollToBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
-		messagesEndRef.current?.scrollIntoView({ behavior });
-	}, []);
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
+    messagesEndRef.current?.scrollIntoView({ behavior });
+  }, []);
 
-	// Listen for scroll events to track near-bottom state and trigger older event loading
-	useEffect(() => {
-		const container = scrollContainerRef.current;
-		if (!container) return;
+  // Listen for scroll events to track near-bottom state and trigger older event loading
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
 
-		const handleScroll = () => {
-			const nearBottom = checkIsNearBottom();
-			isNearBottomRef.current = nearBottom;
-			// Clear "new messages" indicator when user scrolls back to bottom
-			if (nearBottom) {
-				setHasNewMessages(false);
-			}
-		};
+    const handleScroll = () => {
+      const nearBottom = checkIsNearBottom();
+      isNearBottomRef.current = nearBottom;
+      // Clear "new messages" indicator when user scrolls back to bottom
+      if (nearBottom) {
+        setHasNewMessages(false);
+      }
+    };
 
-		container.addEventListener("scroll", handleScroll, { passive: true });
-		return () => container.removeEventListener("scroll", handleScroll);
-	}, [checkIsNearBottom]);
+    container.addEventListener("scroll", handleScroll, { passive: true });
+    return () => container.removeEventListener("scroll", handleScroll);
+  }, [checkIsNearBottom]);
 
-	// Scroll to bottom immediately on initial load (once events are ready)
-	useEffect(() => {
-		if (
-			!eventsLoading &&
-			chatEvents.length > 0 &&
-			!initialScrollDoneRef.current
-		) {
-			initialScrollDoneRef.current = true;
-			// Use requestAnimationFrame to ensure DOM is painted
-			requestAnimationFrame(() => {
-				scrollToBottom("instant");
-			});
-		}
-	}, [eventsLoading, chatEvents.length, scrollToBottom]);
+  // Scroll to bottom immediately on initial load (once events are ready)
+  useEffect(() => {
+    if (!eventsLoading && chatEvents.length > 0 && !initialScrollDoneRef.current) {
+      initialScrollDoneRef.current = true;
+      // Use requestAnimationFrame to ensure DOM is painted
+      requestAnimationFrame(() => {
+        scrollToBottom("instant");
+      });
+    }
+  }, [eventsLoading, chatEvents.length, scrollToBottom]);
 
-	// Reset initial scroll flag when session changes
-	useEffect(() => {
-		initialScrollDoneRef.current = false;
-		isNearBottomRef.current = true;
-		setHasNewMessages(false);
-		prevChatEventsLengthRef.current = 0;
-	}, [sessionId]);
+  // Reset initial scroll flag when session changes
+  useEffect(() => {
+    initialScrollDoneRef.current = false;
+    isNearBottomRef.current = true;
+    setHasNewMessages(false);
+    prevChatEventsLengthRef.current = 0;
+  }, [sessionId]);
 
-	// Auto-scroll on new events or streaming updates (only when near bottom)
-	// Skip if older events were prepended (prevScrollHeightRef is set)
-	useEffect(() => {
-		if (!initialScrollDoneRef.current) return;
-		if (prevScrollHeightRef.current !== null) return;
+  // Auto-scroll on new events or streaming updates (only when near bottom)
+  // Skip if older events were prepended (prevScrollHeightRef is set)
+  useEffect(() => {
+    if (!initialScrollDoneRef.current) return;
+    if (prevScrollHeightRef.current !== null) return;
 
-		const hasNewChatEvents =
-			chatEvents.length > prevChatEventsLengthRef.current;
-		prevChatEventsLengthRef.current = chatEvents.length;
+    const hasNewChatEvents = chatEvents.length > prevChatEventsLengthRef.current;
+    prevChatEventsLengthRef.current = chatEvents.length;
 
-		if (isNearBottomRef.current) {
-			scrollToBottom("smooth");
-		} else if (hasNewChatEvents) {
-			setHasNewMessages(true);
-		}
-	}, [chatEvents, streamingText, isThinking, scrollToBottom]);
+    if (isNearBottomRef.current) {
+      scrollToBottom("smooth");
+    } else if (hasNewChatEvents) {
+      setHasNewMessages(true);
+    }
+  }, [chatEvents, streamingText, isThinking, scrollToBottom]);
 
-	// Scroll position preservation: when older events are prepended,
-	// adjust scrollTop so the viewport stays in the same visual position
-	useLayoutEffect(() => {
-		const container = scrollContainerRef.current;
-		const prevHeight = prevScrollHeightRef.current;
-		if (container && prevHeight !== null) {
-			const newHeight = container.scrollHeight;
-			container.scrollTop += newHeight - prevHeight;
-			prevScrollHeightRef.current = null;
-		}
-	}, [chatEvents]);
+  // Scroll position preservation: when older events are prepended,
+  // adjust scrollTop so the viewport stays in the same visual position
+  useLayoutEffect(() => {
+    const container = scrollContainerRef.current;
+    const prevHeight = prevScrollHeightRef.current;
+    if (container && prevHeight !== null) {
+      const newHeight = container.scrollHeight;
+      container.scrollTop += newHeight - prevHeight;
+      prevScrollHeightRef.current = null;
+    }
+  }, [chatEvents]);
 
-	// Scroll-up detection: trigger loading older events
-	const handleScroll = useCallback(() => {
-		const container = scrollContainerRef.current;
-		if (!container || !hasMoreEvents || loadingOlderEvents) return;
+  // Scroll-up detection: trigger loading older events
+  const handleScroll = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container || !hasMoreEvents || loadingOlderEvents) return;
 
-		// Trigger when user scrolls within 200px of the top
-		if (container.scrollTop < 200) {
-			// Save scroll height before prepend for position preservation
-			prevScrollHeightRef.current = container.scrollHeight;
-			loadOlderEvents();
-		}
-	}, [hasMoreEvents, loadingOlderEvents, loadOlderEvents]);
+    // Trigger when user scrolls within 200px of the top
+    if (container.scrollTop < 200) {
+      // Save scroll height before prepend for position preservation
+      prevScrollHeightRef.current = container.scrollHeight;
+      loadOlderEvents();
+    }
+  }, [hasMoreEvents, loadingOlderEvents, loadOlderEvents]);
 
-	// Auto-focus message input when session loads
-	useEffect(() => {
-		if (!eventsLoading) {
-			textareaRef.current?.focus();
-		}
-	}, [eventsLoading]);
+  // Auto-focus message input when session loads
+  useEffect(() => {
+    if (!eventsLoading) {
+      textareaRef.current?.focus();
+    }
+  }, [eventsLoading]);
 
-	// Mutation for sending message with images
-	const sendMessageWithImages = useMutation({
-		mutationFn: async ({
-			text,
-			images,
-			controls,
-		}: {
-			text: string;
-			images: Array<{ imageId: string; filename?: string }>;
-			controls?: Controls;
-		}) => {
-			return sendUserMessageWithImages(sessionId, text, images, controls);
-		},
-	});
+  // Mutation for sending message with images
+  const sendMessageWithImages = useMutation({
+    mutationFn: async ({
+      text,
+      images,
+      controls,
+    }: {
+      text: string;
+      images: Array<{ imageId: string; filename?: string }>;
+      controls?: Controls;
+    }) => {
+      return sendUserMessageWithImages(sessionId, text, images, controls);
+    },
+  });
 
-	// Check if can submit (has content and all images uploaded)
-	const hasContent = inputValue.trim() || hasImages;
-	const canSubmit =
-		hasContent &&
-		allUploaded &&
-		!sendMessage.isPending &&
-		!sendMessageWithImages.isPending;
+  // Check if can submit (has content and all images uploaded)
+  const hasContent = inputValue.trim() || hasImages;
+  const canSubmit =
+    hasContent && allUploaded && !sendMessage.isPending && !sendMessageWithImages.isPending;
 
-	const handleSubmit = async (e: React.FormEvent) => {
-		e.preventDefault();
-		if (!canSubmit) return;
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit) return;
 
-		// Build controls with reasoning effort if selected
-		const controls: Controls | undefined =
-			selectedModelId || reasoningEffort
-				? {
-						...(selectedModelId && { model_id: selectedModelId }),
-						...(reasoningEffort &&
-							supportsReasoning && {
-								reasoning: { effort: reasoningEffort },
-							}),
-					}
-				: undefined;
+    // Build controls with reasoning effort if selected
+    const controls: Controls | undefined =
+      selectedModelId || reasoningEffort
+        ? {
+            ...(selectedModelId && { model_id: selectedModelId }),
+            ...(reasoningEffort &&
+              supportsReasoning && {
+                reasoning: { effort: reasoningEffort },
+              }),
+          }
+        : undefined;
 
-		try {
-			if (hasImages) {
-				// Send with images
-				await sendMessageWithImages.mutateAsync({
-					text: inputValue.trim(),
-					images: uploadedImageIds,
-					controls,
-				});
-				clearImages();
-			} else {
-				// Use the regular sendMessage for text-only (has optimistic UI)
-				await sendMessage.mutateAsync({
-					sessionId,
-					content: inputValue.trim(),
-					controls,
-				});
-			}
+    try {
+      if (hasImages) {
+        // Send with images
+        await sendMessageWithImages.mutateAsync({
+          text: inputValue.trim(),
+          images: uploadedImageIds,
+          controls,
+        });
+        clearImages();
+      } else {
+        // Use the regular sendMessage for text-only (has optimistic UI)
+        await sendMessage.mutateAsync({
+          sessionId,
+          content: inputValue.trim(),
+          controls,
+        });
+      }
 
-			if (typeof window !== "undefined") {
-				window.localStorage.setItem(modelSelectionStorageKey, selectedModelId);
-			}
-			setInputValue("");
-			// Start polling for the response
-			setIsWaitingForResponse(true);
-			// Refocus textarea after send
-			textareaRef.current?.focus();
-		} catch (error) {
-			console.error("Failed to send message:", error);
-		}
-	};
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(modelSelectionStorageKey, selectedModelId);
+      }
+      setInputValue("");
+      // Start polling for the response
+      setIsWaitingForResponse(true);
+      // Refocus textarea after send
+      textareaRef.current?.focus();
+    } catch (error) {
+      console.error("Failed to send message:", error);
+    }
+  };
 
-	const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-		// Let command autocomplete handle keyboard when visible
-		if (showCommands) return;
-		if (e.key === "Enter" && !e.shiftKey) {
-			e.preventDefault();
-			handleSubmit(e);
-		}
-	};
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // Let command autocomplete handle keyboard when visible
+    if (showCommands) return;
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit(e);
+    }
+  };
 
-	// Handle file input change
-	const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		const files = e.target.files;
-		if (files && files.length > 0) {
-			addFiles(Array.from(files));
-		}
-		// Reset input so same file can be selected again
-		e.target.value = "";
-	};
+  // Handle file input change
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (files && files.length > 0) {
+      addFiles(Array.from(files));
+    }
+    // Reset input so same file can be selected again
+    e.target.value = "";
+  };
 
-	// Extract image files from message content
-	const getMessageImages = (
-		content: ContentPart[],
-	): Array<{ image_id: string; filename?: string }> => {
-		return content.filter(isImageFilePart).map((part) => ({
-			image_id: part.image_id,
-			filename: part.filename,
-		}));
-	};
+  // Extract image files from message content
+  const getMessageImages = (
+    content: ContentPart[],
+  ): Array<{ image_id: string; filename?: string }> => {
+    return content.filter(isImageFilePart).map((part) => ({
+      image_id: part.image_id,
+      filename: part.filename,
+    }));
+  };
 
-	const renderTurnDivider = (eventId: string) => {
-		const durationMs = turnDurationByEventId.get(eventId);
+  const renderTurnDivider = (eventId: string) => {
+    const durationMs = turnDurationByEventId.get(eventId);
 
-		if (durationMs == null) {
-			return null;
-		}
+    if (durationMs == null) {
+      return null;
+    }
 
-		return (
-			<div className="flex items-center gap-4 pt-3 text-xs font-medium text-muted-foreground sm:text-sm">
-				<div className="h-px flex-1 bg-border" />
-				<span className="whitespace-nowrap">{`Worked for ${formatWorkedDuration(durationMs)}`}</span>
-				<div className="h-px flex-1 bg-border" />
-			</div>
-		);
-	};
+    return (
+      <div className="flex items-center gap-4 pt-3 text-xs font-medium text-muted-foreground sm:text-sm">
+        <div className="h-px flex-1 bg-border" />
+        <span className="whitespace-nowrap">{`Worked for ${formatWorkedDuration(durationMs)}`}</span>
+        <div className="h-px flex-1 bg-border" />
+      </div>
+    );
+  };
 
-	return (
-		<>
-			<div
-				ref={scrollContainerRef}
-				onScroll={handleScroll}
-				className="relative flex-1 overflow-y-auto bg-background bg-brand-dots px-4 py-5 sm:px-6"
-			>
-				{eventsLoading ? (
-					<div className="space-y-4">
-						<Skeleton className="ml-auto h-20 w-3/4" />
-						<Skeleton className="h-20 w-3/4" />
-						<Skeleton className="h-20 w-2/3" />
-					</div>
-				) : chatEvents.length === 0 ? (
-					<div className="flex h-full flex-col items-center justify-center text-center text-muted-foreground">
-						<div className="border border-border bg-card px-10 py-10">
-							<Bot className="mx-auto mb-4 h-10 w-10 opacity-50" />
-							<p className="text-lg font-medium text-foreground">
-								No messages yet
-							</p>
-							<p className="mt-1 text-sm">
-								Send a message to start the conversation
-							</p>
-						</div>
-					</div>
-				) : (
-					<div className="space-y-6">
-						{loadingOlderEvents && (
-							<div className="flex items-center justify-center py-3">
-								<Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-								<span className="ml-2 text-xs text-muted-foreground">
-									Loading older messages...
-								</span>
-							</div>
-						)}
-						{chatEvents.map((event) => {
-							if (event.type === "tool.completed") {
-								return null;
-							}
+  return (
+    <>
+      <div
+        ref={scrollContainerRef}
+        onScroll={handleScroll}
+        className="relative flex-1 overflow-y-auto bg-background bg-brand-dots px-4 py-5 sm:px-6"
+      >
+        {eventsLoading ? (
+          <div className="space-y-4">
+            <Skeleton className="ml-auto h-20 w-3/4" />
+            <Skeleton className="h-20 w-3/4" />
+            <Skeleton className="h-20 w-2/3" />
+          </div>
+        ) : chatEvents.length === 0 ? (
+          <div className="flex h-full flex-col items-center justify-center text-center text-muted-foreground">
+            <div className="border border-border bg-card px-10 py-10">
+              <Bot className="mx-auto mb-4 h-10 w-10 opacity-50" />
+              <p className="text-lg font-medium text-foreground">No messages yet</p>
+              <p className="mt-1 text-sm">Send a message to start the conversation</p>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-6">
+            {loadingOlderEvents && (
+              <div className="flex items-center justify-center py-3">
+                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                <span className="ml-2 text-xs text-muted-foreground">
+                  Loading older messages...
+                </span>
+              </div>
+            )}
+            {chatEvents.map((event) => {
+              if (event.type === "tool.completed") {
+                return null;
+              }
 
-							if (event.type === "tool.call_requested") {
-								const reqData = event.data as ToolCallRequestedData;
-								if (!reqData.tool_calls || reqData.tool_calls.length === 0)
-									return null;
-								return (
-									<div key={event.id} className="space-y-3">
-										<div className="ml-9 space-y-1">
-											<ToolActivityGroup
-												toolCalls={reqData.tool_calls}
-												toolResultsMap={toolResultsMap}
-												mode="client"
-											/>
-										</div>
-										{renderTurnDivider(event.id)}
-									</div>
-								);
-							}
+              if (event.type === "tool.call_requested") {
+                const reqData = event.data as ToolCallRequestedData;
+                if (!reqData.tool_calls || reqData.tool_calls.length === 0) return null;
+                return (
+                  <div key={event.id} className="space-y-3">
+                    <div className="ml-9 space-y-1">
+                      <ToolActivityGroup
+                        toolCalls={reqData.tool_calls}
+                        toolResultsMap={toolResultsMap}
+                        mode="client"
+                      />
+                    </div>
+                    {renderTurnDivider(event.id)}
+                  </div>
+                );
+              }
 
-							const isUser = event.type === "input.message";
-							const data = event.data as
-								| InputMessageData
-								| OutputMessageCompletedData;
-							const textContent = getMessageText(data);
-							const toolCalls = isUser
-								? []
-								: getToolCalls(data as OutputMessageCompletedData).filter(
-										(toolCall) => !clientRequestedToolCallIds.has(toolCall.id),
-									);
-							const images = data.message?.content
-								? getMessageImages(data.message.content)
-								: [];
-							const isScheduleTriggered =
-								isUser && data.message?.metadata?.source === "schedule";
-							const isToolOnlyMessage =
-								!isUser &&
-								toolCalls.length > 0 &&
-								!textContent &&
-								images.length === 0;
+              const isUser = event.type === "input.message";
+              const data = event.data as InputMessageData | OutputMessageCompletedData;
+              const textContent = getMessageText(data);
+              const toolCalls = isUser
+                ? []
+                : getToolCalls(data as OutputMessageCompletedData).filter(
+                    (toolCall) => !clientRequestedToolCallIds.has(toolCall.id),
+                  );
+              const images = data.message?.content ? getMessageImages(data.message.content) : [];
+              const isScheduleTriggered = isUser && data.message?.metadata?.source === "schedule";
+              const isToolOnlyMessage =
+                !isUser && toolCalls.length > 0 && !textContent && images.length === 0;
 
-							if (isToolOnlyMessage) {
-								return (
-									<div key={event.id} className="space-y-3">
-										<div className="ml-9 space-y-1">
-											<ToolActivityGroup
-												toolCalls={toolCalls}
-												toolResultsMap={toolResultsMap}
-											/>
-										</div>
-										{renderTurnDivider(event.id)}
-									</div>
-								);
-							}
+              if (isToolOnlyMessage) {
+                return (
+                  <div key={event.id} className="space-y-3">
+                    <div className="ml-9 space-y-1">
+                      <ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} />
+                    </div>
+                    {renderTurnDivider(event.id)}
+                  </div>
+                );
+              }
 
-							return (
-								<div key={event.id} className="space-y-2">
-									{(textContent || images.length > 0) && (
-										<div
-											className={`flex ${isUser ? "justify-end" : "justify-start"}`}
-										>
-											{isUser ? (
-												<div className="max-w-[78%] border-r-2 border-r-accent bg-[hsl(var(--accent)/0.1)] px-4 py-3 text-sm text-foreground">
-													{isScheduleTriggered && (
-														<div className="mb-1 flex items-center gap-1 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
-															<CalendarClock className="h-3 w-3" />
-															<span>Scheduled</span>
-														</div>
-													)}
-													<div className="flex items-start gap-2">
-														<div className="flex-1 space-y-2">
-															{textContent && (
-																<p className="whitespace-pre-wrap">
-																	{textContent}
-																</p>
-															)}
-															{images.length > 0 && (
-																<div className="mt-2 flex flex-wrap gap-2">
-																	{images.map((img) => (
-																		<MessageImage
-																			key={img.image_id}
-																			imageId={img.image_id}
-																			filename={img.filename}
-																		/>
-																	))}
-																</div>
-															)}
-														</div>
-														<MessageInfoIcon event={event} />
-													</div>
-												</div>
-											) : (
-												<div className="flex w-full items-start gap-3 pr-2">
-													<div className="mt-1 flex h-6 w-6 flex-shrink-0 items-center justify-center border border-border bg-primary text-primary-foreground">
-														<Bot className="h-3.5 w-3.5" />
-													</div>
-													<div className="flex flex-1 items-start gap-2">
-														<div className="flex-1 space-y-2 border-l-2 border-l-primary bg-card px-4 py-3">
-															{textContent && (
-																<StreamdownMessage
-																	variant="inline"
-																	className="text-foreground"
-																>
-																	{textContent}
-																</StreamdownMessage>
-															)}
-															{images.length > 0 && (
-																<div className="mt-2 flex flex-wrap gap-2">
-																	{images.map((img) => (
-																		<MessageImage
-																			key={img.image_id}
-																			imageId={img.image_id}
-																			filename={img.filename}
-																		/>
-																	))}
-																</div>
-															)}
-														</div>
-														<MessageInfoIcon event={event} />
-													</div>
-												</div>
-											)}
-										</div>
-									)}
+              return (
+                <div key={event.id} className="space-y-2">
+                  {(textContent || images.length > 0) && (
+                    <div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
+                      {isUser ? (
+                        <div className="max-w-[78%] border-r-2 border-r-accent bg-[hsl(var(--accent)/0.1)] px-4 py-3 text-sm text-foreground">
+                          {isScheduleTriggered && (
+                            <div className="mb-1 flex items-center gap-1 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+                              <CalendarClock className="h-3 w-3" />
+                              <span>Scheduled</span>
+                            </div>
+                          )}
+                          <div className="flex items-start gap-2">
+                            <div className="flex-1 space-y-2">
+                              {textContent && <p className="whitespace-pre-wrap">{textContent}</p>}
+                              {images.length > 0 && (
+                                <div className="mt-2 flex flex-wrap gap-2">
+                                  {images.map((img) => (
+                                    <MessageImage
+                                      key={img.image_id}
+                                      imageId={img.image_id}
+                                      filename={img.filename}
+                                    />
+                                  ))}
+                                </div>
+                              )}
+                            </div>
+                            <MessageInfoIcon event={event} />
+                          </div>
+                        </div>
+                      ) : (
+                        <div className="flex w-full items-start gap-3 pr-2">
+                          <div className="mt-1 flex h-6 w-6 flex-shrink-0 items-center justify-center border border-border bg-primary text-primary-foreground">
+                            <Bot className="h-3.5 w-3.5" />
+                          </div>
+                          <div className="flex flex-1 items-start gap-2">
+                            <div className="flex-1 space-y-2 border-l-2 border-l-primary bg-card px-4 py-3">
+                              {textContent && (
+                                <StreamdownMessage variant="inline" className="text-foreground">
+                                  {textContent}
+                                </StreamdownMessage>
+                              )}
+                              {images.length > 0 && (
+                                <div className="mt-2 flex flex-wrap gap-2">
+                                  {images.map((img) => (
+                                    <MessageImage
+                                      key={img.image_id}
+                                      imageId={img.image_id}
+                                      filename={img.filename}
+                                    />
+                                  ))}
+                                </div>
+                              )}
+                            </div>
+                            <MessageInfoIcon event={event} />
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  )}
 
-									{toolCalls.length > 0 && (
-										<div className="ml-9 space-y-1">
-											<ToolActivityGroup
-												toolCalls={toolCalls}
-												toolResultsMap={toolResultsMap}
-											/>
-										</div>
-									)}
+                  {toolCalls.length > 0 && (
+                    <div className="ml-9 space-y-1">
+                      <ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} />
+                    </div>
+                  )}
 
-									{renderTurnDivider(event.id)}
-								</div>
-							);
-						})}
-					</div>
-				)}
+                  {renderTurnDivider(event.id)}
+                </div>
+              );
+            })}
+          </div>
+        )}
 
-				{(isThinking || streamingText) && (
-					<div className="mt-6 flex justify-start">
-						<div className="flex w-full items-start gap-3 pr-2">
-							<div className="mt-1 flex h-6 w-6 flex-shrink-0 items-center justify-center border border-border bg-primary text-primary-foreground">
-								<Bot className="h-3.5 w-3.5" />
-							</div>
-							<div className="flex-1 border-l-2 border-l-primary bg-card px-4 py-3">
-								{streamingIteration && streamingIteration > 1 && (
-									<div className="mb-1 text-xs text-muted-foreground">
-										Iteration {streamingIteration}
-									</div>
-								)}
-								{isThinking && !streamingText ? (
-									<ThinkingIndicator />
-								) : streamingText ? (
-									<StreamingMessage text={streamingText} />
-								) : null}
-							</div>
-						</div>
-					</div>
-				)}
+        {(isThinking || streamingText) && (
+          <div className="mt-6 flex justify-start">
+            <div className="flex w-full items-start gap-3 pr-2">
+              <div className="mt-1 flex h-6 w-6 flex-shrink-0 items-center justify-center border border-border bg-primary text-primary-foreground">
+                <Bot className="h-3.5 w-3.5" />
+              </div>
+              <div className="flex-1 border-l-2 border-l-primary bg-card px-4 py-3">
+                {streamingIteration && streamingIteration > 1 && (
+                  <div className="mb-1 text-xs text-muted-foreground">
+                    Iteration {streamingIteration}
+                  </div>
+                )}
+                {isThinking && !streamingText ? (
+                  <ThinkingIndicator />
+                ) : streamingText ? (
+                  <StreamingMessage text={streamingText} />
+                ) : null}
+              </div>
+            </div>
+          </div>
+        )}
 
-				<div ref={messagesEndRef} />
+        <div ref={messagesEndRef} />
 
-				{hasNewMessages && (
-					<button
-						type="button"
-						onClick={() => {
-							scrollToBottom("smooth");
-							setHasNewMessages(false);
-						}}
-						className="sticky bottom-3 left-1/2 z-10 mx-auto flex -translate-x-1/2 items-center gap-1.5 border border-border bg-card px-3 py-1.5 text-xs font-medium text-foreground shadow-md transition-colors hover:bg-accent"
-					>
-						<ArrowDown className="h-3 w-3" />
-						New messages
-					</button>
-				)}
-			</div>
+        {hasNewMessages && (
+          <button
+            type="button"
+            onClick={() => {
+              scrollToBottom("smooth");
+              setHasNewMessages(false);
+            }}
+            className="sticky bottom-3 left-1/2 z-10 mx-auto flex -translate-x-1/2 items-center gap-1.5 border border-border bg-card px-3 py-1.5 text-xs font-medium text-foreground shadow-md transition-colors hover:bg-accent"
+          >
+            <ArrowDown className="h-3 w-3" />
+            New messages
+          </button>
+        )}
+      </div>
 
-			<div className="border-t border-border bg-muted/30 p-4 sm:p-5">
-				<form onSubmit={handleSubmit} className="space-y-3">
-					<input
-						ref={fileInputRef}
-						type="file"
-						accept={ALLOWED_IMAGE_TYPES.join(",")}
-						multiple
-						className="hidden"
-						onChange={handleFileChange}
-					/>
+      <div className="border-t border-border bg-muted/30 p-4 sm:p-5">
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept={ALLOWED_IMAGE_TYPES.join(",")}
+            multiple
+            className="hidden"
+            onChange={handleFileChange}
+          />
 
-					{hasImages && (
-						<ImageAttachments images={pendingImages} onRemove={removeImage} />
-					)}
+          {hasImages && <ImageAttachments images={pendingImages} onRemove={removeImage} />}
 
-					<div
-						className={`relative border border-border bg-background transition-colors ${
-							isDraggingOver
-								? "bg-[hsl(var(--accent)/0.08)] ring-1 ring-accent"
-								: ""
-						}`}
-						onDragOver={(e) => {
-							e.preventDefault();
-							e.stopPropagation();
-						}}
-						onDragEnter={(e) => {
-							e.preventDefault();
-							e.stopPropagation();
-							setIsDraggingOver(true);
-						}}
-						onDragLeave={(e) => {
-							e.preventDefault();
-							e.stopPropagation();
-							if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-								setIsDraggingOver(false);
-							}
-						}}
-						onDrop={(e) => {
-							e.preventDefault();
-							e.stopPropagation();
-							setIsDraggingOver(false);
-							const files = e.dataTransfer?.files;
-							if (files && files.length > 0) {
-								const imageFiles = Array.from(files).filter((f) =>
-									f.type.startsWith("image/"),
-								);
-								if (imageFiles.length > 0) {
-									addFiles(imageFiles);
-								}
-							}
-						}}
-					>
-						<CommandAutocomplete
-							commands={commands}
-							inputValue={inputValue}
-							visible={showCommands}
-							onSelect={handleCommandSelect}
-							onDismiss={() => setShowCommands(false)}
-						/>
-						<Textarea
-							ref={textareaRef}
-							value={inputValue}
-							onChange={(e) => {
-								const val = e.target.value;
-								setInputValue(val);
-								setShowCommands(shouldShowCommandAutocomplete(val));
-							}}
-							onKeyDown={handleKeyDown}
-							onPaste={(e) => {
-								const items = e.clipboardData?.items;
-								if (!items) return;
-								const imageFiles: File[] = [];
-								for (const item of Array.from(items)) {
-									if (item.type.startsWith("image/")) {
-										const file = item.getAsFile();
-										if (file) imageFiles.push(file);
-									}
-								}
-								if (imageFiles.length > 0) {
-									e.preventDefault();
-									addFiles(imageFiles);
-								}
-							}}
-							placeholder="Type a message or / for commands... (Enter to send)"
-							className="min-h-[120px] max-h-[260px] w-full resize-none border-0 bg-transparent px-4 py-4 text-sm shadow-none focus-visible:ring-0"
-						/>
-					</div>
+          <div
+            className={`relative border border-border bg-background transition-colors ${
+              isDraggingOver ? "bg-[hsl(var(--accent)/0.08)] ring-1 ring-accent" : ""
+            }`}
+            onDragOver={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+            }}
+            onDragEnter={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              setIsDraggingOver(true);
+            }}
+            onDragLeave={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+                setIsDraggingOver(false);
+              }
+            }}
+            onDrop={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              setIsDraggingOver(false);
+              const files = e.dataTransfer?.files;
+              if (files && files.length > 0) {
+                const imageFiles = Array.from(files).filter((f) => f.type.startsWith("image/"));
+                if (imageFiles.length > 0) {
+                  addFiles(imageFiles);
+                }
+              }
+            }}
+          >
+            <CommandAutocomplete
+              commands={commands}
+              inputValue={inputValue}
+              visible={showCommands}
+              onSelect={handleCommandSelect}
+              onDismiss={() => setShowCommands(false)}
+            />
+            <Textarea
+              ref={textareaRef}
+              value={inputValue}
+              onChange={(e) => {
+                const val = e.target.value;
+                setInputValue(val);
+                setShowCommands(shouldShowCommandAutocomplete(val));
+              }}
+              onKeyDown={handleKeyDown}
+              onPaste={(e) => {
+                const items = e.clipboardData?.items;
+                if (!items) return;
+                const imageFiles: File[] = [];
+                for (const item of Array.from(items)) {
+                  if (item.type.startsWith("image/")) {
+                    const file = item.getAsFile();
+                    if (file) imageFiles.push(file);
+                  }
+                }
+                if (imageFiles.length > 0) {
+                  e.preventDefault();
+                  addFiles(imageFiles);
+                }
+              }}
+              placeholder="Type a message or / for commands... (Enter to send)"
+              className="min-h-[120px] max-h-[260px] w-full resize-none border-0 bg-transparent px-4 py-4 text-sm shadow-none focus-visible:ring-0"
+            />
+          </div>
 
-					<div className="flex flex-wrap items-center justify-between gap-3">
-						<div className="flex flex-wrap items-center gap-3">
-							<Button
-								type="button"
-								variant="outline"
-								size="icon-lg"
-								className="h-10 w-10 border-border bg-background"
-								onClick={() => fileInputRef.current?.click()}
-								title="Attach images (PNG, JPEG, GIF, WebP)"
-							>
-								<ImagePlus className="icon-sharp h-4 w-4" />
-							</Button>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex flex-wrap items-center gap-3">
+              <Button
+                type="button"
+                variant="outline"
+                size="icon-lg"
+                className="h-10 w-10 border-border bg-background"
+                onClick={() => fileInputRef.current?.click()}
+                title="Attach images (PNG, JPEG, GIF, WebP)"
+              >
+                <ImagePlus className="icon-sharp h-4 w-4" />
+              </Button>
 
-							<div className="flex h-10 items-center gap-2 border border-border bg-background px-3">
-								<span className="shrink-0 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
-									Model
-								</span>
-								<Select
-									value={selectedModelId}
-									onValueChange={(value) => {
-										hasUserSelectedModel.current = true;
-										setSelectedModelId(value);
-									}}
-								>
-									<SelectTrigger
-										size="sm"
-										className="h-7 w-[156px] min-w-0 border-0 bg-transparent px-0 py-0 text-sm shadow-none focus-visible:ring-0 data-[size=sm]:h-7 [&_svg]:icon-sharp"
-									>
-										<SelectValue>{modelTriggerLabel}</SelectValue>
-									</SelectTrigger>
-									<SelectContent>
-										<SelectItem value="">{defaultModelOptionLabel}</SelectItem>
-										{llmModels.map((model) => (
-											<SelectItem key={model.id} value={model.id}>
-												{model.display_name}
-											</SelectItem>
-										))}
-									</SelectContent>
-								</Select>
-							</div>
+              <div className="flex h-10 items-center gap-2 border border-border bg-background px-3">
+                <span className="shrink-0 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+                  Model
+                </span>
+                <Select
+                  value={selectedModelId}
+                  onValueChange={(value) => {
+                    hasUserSelectedModel.current = true;
+                    setSelectedModelId(value);
+                  }}
+                >
+                  <SelectTrigger
+                    size="sm"
+                    className="h-7 w-[156px] min-w-0 border-0 bg-transparent px-0 py-0 text-sm shadow-none focus-visible:ring-0 data-[size=sm]:h-7 [&_svg]:icon-sharp"
+                  >
+                    <SelectValue>{modelTriggerLabel}</SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="">{defaultModelOptionLabel}</SelectItem>
+                    {llmModels.map((model) => (
+                      <SelectItem key={model.id} value={model.id}>
+                        {model.display_name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
 
-							{supportsReasoning && reasoningEffortConfig && (
-								<div className="flex h-10 items-center gap-2 border border-border bg-background px-3">
-									<Brain className="icon-sharp h-3.5 w-3.5 text-muted-foreground" />
-									<span className="shrink-0 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
-										Reasoning
-									</span>
-									<Select
-										value={reasoningEffort}
-										onValueChange={(value) =>
-											setReasoningEffort(value as typeof reasoningEffort)
-										}
-									>
-										<SelectTrigger
-											size="sm"
-											className="h-7 w-[116px] min-w-0 border-0 bg-transparent px-0 py-0 text-sm shadow-none focus-visible:ring-0 data-[size=sm]:h-7 [&_svg]:icon-sharp"
-										>
-											<SelectValue>
-												{reasoningEffort
-													? getReasoningEffortName(reasoningEffort)
-													: "Default"}
-											</SelectValue>
-										</SelectTrigger>
-										<SelectContent>
-											<SelectItem value="">{`Default (${defaultEffortName})`}</SelectItem>
-											{reasoningEffortConfig.values.map((effort) => (
-												<SelectItem key={effort.value} value={effort.value}>
-													{effort.name}
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
-								</div>
-							)}
-						</div>
+              {supportsReasoning && reasoningEffortConfig && (
+                <div className="flex h-10 items-center gap-2 border border-border bg-background px-3">
+                  <Brain className="icon-sharp h-3.5 w-3.5 text-muted-foreground" />
+                  <span className="shrink-0 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+                    Reasoning
+                  </span>
+                  <Select
+                    value={reasoningEffort}
+                    onValueChange={(value) => setReasoningEffort(value as typeof reasoningEffort)}
+                  >
+                    <SelectTrigger
+                      size="sm"
+                      className="h-7 w-[116px] min-w-0 border-0 bg-transparent px-0 py-0 text-sm shadow-none focus-visible:ring-0 data-[size=sm]:h-7 [&_svg]:icon-sharp"
+                    >
+                      <SelectValue>
+                        {reasoningEffort ? getReasoningEffortName(reasoningEffort) : "Default"}
+                      </SelectValue>
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="">{`Default (${defaultEffortName})`}</SelectItem>
+                      {reasoningEffortConfig.values.map((effort) => (
+                        <SelectItem key={effort.value} value={effort.value}>
+                          {effort.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+            </div>
 
-						<div className="flex items-center gap-2">
-							{isActive && !inputValue.trim() && !hasImages && (
-								<Button
-									type="button"
-									size="icon-lg"
-									variant="destructive"
-									className="h-10 w-10 border border-destructive/30 bg-destructive/[0.08] text-destructive shadow-none hover:bg-destructive/[0.14]"
-									disabled={cancelCurrentTurn.isPending}
-									onClick={() => cancelCurrentTurn.mutate()}
-									title="Cancel current turn"
-								>
-									{cancelCurrentTurn.isPending ? (
-										<Loader2 className="h-4 w-4 animate-spin" />
-									) : (
-										<StopCircle className="icon-sharp h-4 w-4" />
-									)}
-								</Button>
-							)}
+            <div className="flex items-center gap-2">
+              {isActive && !inputValue.trim() && !hasImages && (
+                <Button
+                  type="button"
+                  size="icon-lg"
+                  variant="destructive"
+                  className="h-10 w-10 border border-destructive/30 bg-destructive/[0.08] text-destructive shadow-none hover:bg-destructive/[0.14]"
+                  disabled={cancelCurrentTurn.isPending}
+                  onClick={() => cancelCurrentTurn.mutate()}
+                  title="Cancel current turn"
+                >
+                  {cancelCurrentTurn.isPending ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <StopCircle className="icon-sharp h-4 w-4" />
+                  )}
+                </Button>
+              )}
 
-							<Button
-								type="submit"
-								size="icon-lg"
-								className="h-10 w-10"
-								disabled={!canSubmit}
-								title={isUploading ? "Uploading images..." : undefined}
-							>
-								{sendMessage.isPending || sendMessageWithImages.isPending ? (
-									<Loader2 className="h-4 w-4 animate-spin" />
-								) : isUploading ? (
-									<Loader2 className="h-4 w-4 animate-spin" />
-								) : (
-									<Send className="icon-sharp h-4 w-4" />
-								)}
-							</Button>
-						</div>
-					</div>
-				</form>
-			</div>
-		</>
-	);
+              <Button
+                type="submit"
+                size="icon-lg"
+                className="h-10 w-10"
+                disabled={!canSubmit}
+                title={isUploading ? "Uploading images..." : undefined}
+              >
+                {sendMessage.isPending || sendMessageWithImages.isPending ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : isUploading ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Send className="icon-sharp h-4 w-4" />
+                )}
+              </Button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </>
+  );
 }

--- a/apps/ui/src/components/chat/chat-panel.tsx
+++ b/apps/ui/src/components/chat/chat-panel.tsx
@@ -1,58 +1,58 @@
 "use client";
 
 import {
-  useState,
-  useRef,
-  useEffect,
-  useMemo,
-  useCallback,
-  useLayoutEffect,
+	useState,
+	useRef,
+	useEffect,
+	useMemo,
+	useCallback,
+	useLayoutEffect,
 } from "react";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
 } from "@/components/ui/select";
 import {
-  Send,
-  Bot,
-  Loader2,
-  Brain,
-  ImagePlus,
-  StopCircle,
-  CalendarClock,
-  ArrowDown,
+	Send,
+	Bot,
+	Loader2,
+	Brain,
+	ImagePlus,
+	StopCircle,
+	CalendarClock,
+	ArrowDown,
 } from "lucide-react";
 import type {
-  Controls,
-  InputMessageData,
-  OutputMessageCompletedData,
-  ToolCallRequestedData,
-  ContentPart,
-  CommandDescriptor,
+	Controls,
+	InputMessageData,
+	OutputMessageCompletedData,
+	ToolCallRequestedData,
+	ContentPart,
+	CommandDescriptor,
 } from "@/lib/api/types";
 import { isImageFilePart } from "@/lib/api/types";
 import { MessageInfoIcon } from "@/components/chat/message-info-icon";
 import {
-  ImageAttachments,
-  MessageImage,
+	ImageAttachments,
+	MessageImage,
 } from "@/components/chat/image-attachments";
 import {
-  CommandAutocomplete,
-  shouldShowCommandAutocomplete,
+	CommandAutocomplete,
+	shouldShowCommandAutocomplete,
 } from "@/components/chat/command-autocomplete";
 import { ThinkingIndicator } from "@/components/thinking-indicator";
 import { StreamingMessage } from "@/components/streaming-message";
 import { StreamdownMessage } from "@/components/chat/streamdown-message";
 import { ToolActivityGroup } from "@/components/chat/tool-activity-group";
 import {
-  formatWorkedDuration,
-  getCompletedTurnDurationsByEvent,
+	formatWorkedDuration,
+	getCompletedTurnDurationsByEvent,
 } from "@/components/chat/turn-delimiter";
 import { useSessionContext } from "@/app/(main)/sessions/[sessionId]/session-context";
 import { useLlmModels, useImageAttachments, useSessionCommands } from "@/hooks";
@@ -61,810 +61,810 @@ import { useMutation } from "@tanstack/react-query";
 import { ALLOWED_IMAGE_TYPES } from "@/lib/api/types";
 
 export function ChatPanel() {
-  const {
-    agentId,
-    events,
-    sessionId,
-    llmModel,
-    chatEvents,
-    toolResultsMap,
-    eventsLoading,
-    isActive,
-    reasoningEffort,
-    setReasoningEffort,
-    setIsWaitingForResponse,
-    isThinking,
-    streamingText,
-    streamingIteration,
-    sendMessage,
-    cancelCurrentTurn,
-    hasMoreEvents,
-    loadingOlderEvents,
-    loadOlderEvents,
-    getMessageText,
-    getToolCalls,
-  } = useSessionContext();
+	const {
+		agentId,
+		events,
+		sessionId,
+		llmModel,
+		chatEvents,
+		toolResultsMap,
+		eventsLoading,
+		isActive,
+		reasoningEffort,
+		setReasoningEffort,
+		setIsWaitingForResponse,
+		isThinking,
+		streamingText,
+		streamingIteration,
+		sendMessage,
+		cancelCurrentTurn,
+		hasMoreEvents,
+		loadingOlderEvents,
+		loadOlderEvents,
+		getMessageText,
+		getToolCalls,
+	} = useSessionContext();
 
-  const { data: llmModels = [] } = useLlmModels();
+	const { data: llmModels = [] } = useLlmModels();
 
-  const [inputValue, setInputValue] = useState("");
-  const [selectedModelId, setSelectedModelId] = useState("");
-  const [isDraggingOver, setIsDraggingOver] = useState(false);
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const messagesEndRef = useRef<HTMLDivElement>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const isNearBottomRef = useRef(true);
-  const [hasNewMessages, setHasNewMessages] = useState(false);
-  const prevChatEventsLengthRef = useRef(0);
-  const initialScrollDoneRef = useRef(false);
+	const [inputValue, setInputValue] = useState("");
+	const [selectedModelId, setSelectedModelId] = useState("");
+	const [isDraggingOver, setIsDraggingOver] = useState(false);
+	const scrollContainerRef = useRef<HTMLDivElement>(null);
+	const messagesEndRef = useRef<HTMLDivElement>(null);
+	const fileInputRef = useRef<HTMLInputElement>(null);
+	const textareaRef = useRef<HTMLTextAreaElement>(null);
+	const isNearBottomRef = useRef(true);
+	const [hasNewMessages, setHasNewMessages] = useState(false);
+	const prevChatEventsLengthRef = useRef(0);
+	const initialScrollDoneRef = useRef(false);
 
-  // Track scroll height before prepending older events for position preservation
-  const prevScrollHeightRef = useRef<number | null>(null);
-  const hasUserSelectedModel = useRef(false);
-  const modelSelectionStorageKey = useMemo(
-    () => `everruns:chat:model-selection:${agentId}:${sessionId}`,
-    [agentId, sessionId],
-  );
+	// Track scroll height before prepending older events for position preservation
+	const prevScrollHeightRef = useRef<number | null>(null);
+	const hasUserSelectedModel = useRef(false);
+	const modelSelectionStorageKey = useMemo(
+		() => `everruns:chat:model-selection:${agentId}:${sessionId}`,
+		[agentId, sessionId],
+	);
 
-  // Image attachments management
-  const {
-    pendingImages,
-    allUploaded,
-    uploadedImageIds,
-    addFiles,
-    removeImage,
-    clearImages,
-    hasImages,
-    isUploading,
-  } = useImageAttachments({ sessionId });
+	// Image attachments management
+	const {
+		pendingImages,
+		allUploaded,
+		uploadedImageIds,
+		addFiles,
+		removeImage,
+		clearImages,
+		hasImages,
+		isUploading,
+	} = useImageAttachments({ sessionId });
 
-  // Commands autocomplete
-  const { data: commandsData } = useSessionCommands(sessionId);
-  const commands = commandsData?.commands ?? [];
-  const [showCommands, setShowCommands] = useState(false);
+	// Commands autocomplete
+	const { data: commandsData } = useSessionCommands(sessionId);
+	const commands = commandsData?.commands ?? [];
+	const [showCommands, setShowCommands] = useState(false);
 
-  const clientRequestedToolCallIds = useMemo(() => {
-    const ids = new Set<string>();
-    for (const event of chatEvents) {
-      if (event.type !== "tool.call_requested") continue;
-      const data = event.data as ToolCallRequestedData;
-      for (const toolCall of data.tool_calls ?? []) {
-        ids.add(toolCall.id);
-      }
-    }
-    return ids;
-  }, [chatEvents]);
+	const clientRequestedToolCallIds = useMemo(() => {
+		const ids = new Set<string>();
+		for (const event of chatEvents) {
+			if (event.type !== "tool.call_requested") continue;
+			const data = event.data as ToolCallRequestedData;
+			for (const toolCall of data.tool_calls ?? []) {
+				ids.add(toolCall.id);
+			}
+		}
+		return ids;
+	}, [chatEvents]);
 
-  const turnDurationByEventId = useMemo(
-    () => getCompletedTurnDurationsByEvent(events ?? []),
-    [events],
-  );
+	const turnDurationByEventId = useMemo(
+		() => getCompletedTurnDurationsByEvent(events ?? []),
+		[events],
+	);
 
-  const handleCommandSelect = useCallback(
-    (cmd: CommandDescriptor) => {
-      setShowCommands(false);
-      if (cmd.source === "system") {
-        // System commands: send as slash message directly
-        setInputValue(`/${cmd.name}`);
-        // Submit immediately
-        const controls: Controls | undefined = selectedModelId
-          ? { model_id: selectedModelId }
-          : undefined;
-        sendMessage.mutateAsync({
-          sessionId,
-          content: `/${cmd.name}`,
-          controls,
-        });
-        setInputValue("");
-        setIsWaitingForResponse(true);
-        textareaRef.current?.focus();
-      } else {
-        // Skill commands: inject as message to trigger prompt expansion
-        setInputValue(`/${cmd.name} `);
-        textareaRef.current?.focus();
-      }
-    },
-    [sessionId, selectedModelId, sendMessage, setIsWaitingForResponse],
-  );
+	const handleCommandSelect = useCallback(
+		(cmd: CommandDescriptor) => {
+			setShowCommands(false);
+			if (cmd.source === "system") {
+				// System commands: send as slash message directly
+				setInputValue(`/${cmd.name}`);
+				// Submit immediately
+				const controls: Controls | undefined = selectedModelId
+					? { model_id: selectedModelId }
+					: undefined;
+				sendMessage.mutateAsync({
+					sessionId,
+					content: `/${cmd.name}`,
+					controls,
+				});
+				setInputValue("");
+				setIsWaitingForResponse(true);
+				textareaRef.current?.focus();
+			} else {
+				// Skill commands: inject as message to trigger prompt expansion
+				setInputValue(`/${cmd.name} `);
+				textareaRef.current?.focus();
+			}
+		},
+		[sessionId, selectedModelId, sendMessage, setIsWaitingForResponse],
+	);
 
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const storedSelection = window.localStorage.getItem(
-      modelSelectionStorageKey,
-    );
-    if (storedSelection !== null && !hasUserSelectedModel.current) {
-      setSelectedModelId(storedSelection);
-    }
-  }, [modelSelectionStorageKey]);
+	useEffect(() => {
+		if (typeof window === "undefined") return;
+		const storedSelection = window.localStorage.getItem(
+			modelSelectionStorageKey,
+		);
+		if (storedSelection !== null && !hasUserSelectedModel.current) {
+			setSelectedModelId(storedSelection);
+		}
+	}, [modelSelectionStorageKey]);
 
-  const selectedModel = useMemo(
-    () => llmModels.find((model) => model.id === selectedModelId),
-    [llmModels, selectedModelId],
-  );
+	const selectedModel = useMemo(
+		() => llmModels.find((model) => model.id === selectedModelId),
+		[llmModels, selectedModelId],
+	);
 
-  const activeModel = selectedModel ?? llmModel;
-  const reasoningEffortConfig = activeModel?.profile?.reasoning_effort;
-  const supportsReasoning = !!(
-    activeModel?.profile?.reasoning && activeModel?.profile?.reasoning_effort
-  );
+	const activeModel = selectedModel ?? llmModel;
+	const reasoningEffortConfig = activeModel?.profile?.reasoning_effort;
+	const supportsReasoning = !!(
+		activeModel?.profile?.reasoning && activeModel?.profile?.reasoning_effort
+	);
 
-  const getReasoningEffortName = (value: string): string => {
-    const effort = reasoningEffortConfig?.values.find(
-      (item) => item.value === value,
-    );
-    return effort?.name ?? value;
-  };
+	const getReasoningEffortName = (value: string): string => {
+		const effort = reasoningEffortConfig?.values.find(
+			(item) => item.value === value,
+		);
+		return effort?.name ?? value;
+	};
 
-  const defaultEffortName = reasoningEffortConfig?.default
-    ? getReasoningEffortName(reasoningEffortConfig.default)
-    : "Medium";
-  const modelTriggerLabel = selectedModel?.display_name ?? "Default";
-  const defaultModelOptionLabel = llmModel?.display_name
-    ? `Default (${llmModel.display_name})`
-    : "Default";
+	const defaultEffortName = reasoningEffortConfig?.default
+		? getReasoningEffortName(reasoningEffortConfig.default)
+		: "Medium";
+	const modelTriggerLabel = selectedModel?.display_name ?? "Default";
+	const defaultModelOptionLabel = llmModel?.display_name
+		? `Default (${llmModel.display_name})`
+		: "Default";
 
-  useEffect(() => {
-    if (!supportsReasoning) {
-      setReasoningEffort("");
-      return;
-    }
+	useEffect(() => {
+		if (!supportsReasoning) {
+			setReasoningEffort("");
+			return;
+		}
 
-    if (
-      reasoningEffortConfig &&
-      reasoningEffort &&
-      !reasoningEffortConfig.values.some(
-        (effort) => effort.value === reasoningEffort,
-      )
-    ) {
-      setReasoningEffort("");
-    }
-  }, [
-    supportsReasoning,
-    reasoningEffortConfig,
-    reasoningEffort,
-    setReasoningEffort,
-  ]);
+		if (
+			reasoningEffortConfig &&
+			reasoningEffort &&
+			!reasoningEffortConfig.values.some(
+				(effort) => effort.value === reasoningEffort,
+			)
+		) {
+			setReasoningEffort("");
+		}
+	}, [
+		supportsReasoning,
+		reasoningEffortConfig,
+		reasoningEffort,
+		setReasoningEffort,
+	]);
 
-  // Track whether user is near the bottom of the scroll container
-  const NEAR_BOTTOM_THRESHOLD = 100;
+	// Track whether user is near the bottom of the scroll container
+	const NEAR_BOTTOM_THRESHOLD = 100;
 
-  const checkIsNearBottom = useCallback(() => {
-    const container = scrollContainerRef.current;
-    if (!container) return true;
-    const { scrollTop, scrollHeight, clientHeight } = container;
-    return scrollHeight - scrollTop - clientHeight <= NEAR_BOTTOM_THRESHOLD;
-  }, []);
+	const checkIsNearBottom = useCallback(() => {
+		const container = scrollContainerRef.current;
+		if (!container) return true;
+		const { scrollTop, scrollHeight, clientHeight } = container;
+		return scrollHeight - scrollTop - clientHeight <= NEAR_BOTTOM_THRESHOLD;
+	}, []);
 
-  const scrollToBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
-    messagesEndRef.current?.scrollIntoView({ behavior });
-  }, []);
+	const scrollToBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
+		messagesEndRef.current?.scrollIntoView({ behavior });
+	}, []);
 
-  // Listen for scroll events to track near-bottom state and trigger older event loading
-  useEffect(() => {
-    const container = scrollContainerRef.current;
-    if (!container) return;
+	// Listen for scroll events to track near-bottom state and trigger older event loading
+	useEffect(() => {
+		const container = scrollContainerRef.current;
+		if (!container) return;
 
-    const handleScroll = () => {
-      const nearBottom = checkIsNearBottom();
-      isNearBottomRef.current = nearBottom;
-      // Clear "new messages" indicator when user scrolls back to bottom
-      if (nearBottom) {
-        setHasNewMessages(false);
-      }
-    };
+		const handleScroll = () => {
+			const nearBottom = checkIsNearBottom();
+			isNearBottomRef.current = nearBottom;
+			// Clear "new messages" indicator when user scrolls back to bottom
+			if (nearBottom) {
+				setHasNewMessages(false);
+			}
+		};
 
-    container.addEventListener("scroll", handleScroll, { passive: true });
-    return () => container.removeEventListener("scroll", handleScroll);
-  }, [checkIsNearBottom]);
+		container.addEventListener("scroll", handleScroll, { passive: true });
+		return () => container.removeEventListener("scroll", handleScroll);
+	}, [checkIsNearBottom]);
 
-  // Scroll to bottom immediately on initial load (once events are ready)
-  useEffect(() => {
-    if (
-      !eventsLoading &&
-      chatEvents.length > 0 &&
-      !initialScrollDoneRef.current
-    ) {
-      initialScrollDoneRef.current = true;
-      // Use requestAnimationFrame to ensure DOM is painted
-      requestAnimationFrame(() => {
-        scrollToBottom("instant");
-      });
-    }
-  }, [eventsLoading, chatEvents.length, scrollToBottom]);
+	// Scroll to bottom immediately on initial load (once events are ready)
+	useEffect(() => {
+		if (
+			!eventsLoading &&
+			chatEvents.length > 0 &&
+			!initialScrollDoneRef.current
+		) {
+			initialScrollDoneRef.current = true;
+			// Use requestAnimationFrame to ensure DOM is painted
+			requestAnimationFrame(() => {
+				scrollToBottom("instant");
+			});
+		}
+	}, [eventsLoading, chatEvents.length, scrollToBottom]);
 
-  // Reset initial scroll flag when session changes
-  useEffect(() => {
-    initialScrollDoneRef.current = false;
-    isNearBottomRef.current = true;
-    setHasNewMessages(false);
-    prevChatEventsLengthRef.current = 0;
-  }, [sessionId]);
+	// Reset initial scroll flag when session changes
+	useEffect(() => {
+		initialScrollDoneRef.current = false;
+		isNearBottomRef.current = true;
+		setHasNewMessages(false);
+		prevChatEventsLengthRef.current = 0;
+	}, [sessionId]);
 
-  // Auto-scroll on new events or streaming updates (only when near bottom)
-  // Skip if older events were prepended (prevScrollHeightRef is set)
-  useEffect(() => {
-    if (!initialScrollDoneRef.current) return;
-    if (prevScrollHeightRef.current !== null) return;
+	// Auto-scroll on new events or streaming updates (only when near bottom)
+	// Skip if older events were prepended (prevScrollHeightRef is set)
+	useEffect(() => {
+		if (!initialScrollDoneRef.current) return;
+		if (prevScrollHeightRef.current !== null) return;
 
-    const hasNewChatEvents =
-      chatEvents.length > prevChatEventsLengthRef.current;
-    prevChatEventsLengthRef.current = chatEvents.length;
+		const hasNewChatEvents =
+			chatEvents.length > prevChatEventsLengthRef.current;
+		prevChatEventsLengthRef.current = chatEvents.length;
 
-    if (isNearBottomRef.current) {
-      scrollToBottom("smooth");
-    } else if (hasNewChatEvents) {
-      setHasNewMessages(true);
-    }
-  }, [chatEvents, streamingText, isThinking, scrollToBottom]);
+		if (isNearBottomRef.current) {
+			scrollToBottom("smooth");
+		} else if (hasNewChatEvents) {
+			setHasNewMessages(true);
+		}
+	}, [chatEvents, streamingText, isThinking, scrollToBottom]);
 
-  // Scroll position preservation: when older events are prepended,
-  // adjust scrollTop so the viewport stays in the same visual position
-  useLayoutEffect(() => {
-    const container = scrollContainerRef.current;
-    const prevHeight = prevScrollHeightRef.current;
-    if (container && prevHeight !== null) {
-      const newHeight = container.scrollHeight;
-      container.scrollTop += newHeight - prevHeight;
-      prevScrollHeightRef.current = null;
-    }
-  }, [chatEvents]);
+	// Scroll position preservation: when older events are prepended,
+	// adjust scrollTop so the viewport stays in the same visual position
+	useLayoutEffect(() => {
+		const container = scrollContainerRef.current;
+		const prevHeight = prevScrollHeightRef.current;
+		if (container && prevHeight !== null) {
+			const newHeight = container.scrollHeight;
+			container.scrollTop += newHeight - prevHeight;
+			prevScrollHeightRef.current = null;
+		}
+	}, [chatEvents]);
 
-  // Scroll-up detection: trigger loading older events
-  const handleScroll = useCallback(() => {
-    const container = scrollContainerRef.current;
-    if (!container || !hasMoreEvents || loadingOlderEvents) return;
+	// Scroll-up detection: trigger loading older events
+	const handleScroll = useCallback(() => {
+		const container = scrollContainerRef.current;
+		if (!container || !hasMoreEvents || loadingOlderEvents) return;
 
-    // Trigger when user scrolls within 200px of the top
-    if (container.scrollTop < 200) {
-      // Save scroll height before prepend for position preservation
-      prevScrollHeightRef.current = container.scrollHeight;
-      loadOlderEvents();
-    }
-  }, [hasMoreEvents, loadingOlderEvents, loadOlderEvents]);
+		// Trigger when user scrolls within 200px of the top
+		if (container.scrollTop < 200) {
+			// Save scroll height before prepend for position preservation
+			prevScrollHeightRef.current = container.scrollHeight;
+			loadOlderEvents();
+		}
+	}, [hasMoreEvents, loadingOlderEvents, loadOlderEvents]);
 
-  // Auto-focus message input when session loads
-  useEffect(() => {
-    if (!eventsLoading) {
-      textareaRef.current?.focus();
-    }
-  }, [eventsLoading]);
+	// Auto-focus message input when session loads
+	useEffect(() => {
+		if (!eventsLoading) {
+			textareaRef.current?.focus();
+		}
+	}, [eventsLoading]);
 
-  // Mutation for sending message with images
-  const sendMessageWithImages = useMutation({
-    mutationFn: async ({
-      text,
-      images,
-      controls,
-    }: {
-      text: string;
-      images: Array<{ imageId: string; filename?: string }>;
-      controls?: Controls;
-    }) => {
-      return sendUserMessageWithImages(sessionId, text, images, controls);
-    },
-  });
+	// Mutation for sending message with images
+	const sendMessageWithImages = useMutation({
+		mutationFn: async ({
+			text,
+			images,
+			controls,
+		}: {
+			text: string;
+			images: Array<{ imageId: string; filename?: string }>;
+			controls?: Controls;
+		}) => {
+			return sendUserMessageWithImages(sessionId, text, images, controls);
+		},
+	});
 
-  // Check if can submit (has content and all images uploaded)
-  const hasContent = inputValue.trim() || hasImages;
-  const canSubmit =
-    hasContent &&
-    allUploaded &&
-    !sendMessage.isPending &&
-    !sendMessageWithImages.isPending;
+	// Check if can submit (has content and all images uploaded)
+	const hasContent = inputValue.trim() || hasImages;
+	const canSubmit =
+		hasContent &&
+		allUploaded &&
+		!sendMessage.isPending &&
+		!sendMessageWithImages.isPending;
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!canSubmit) return;
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault();
+		if (!canSubmit) return;
 
-    // Build controls with reasoning effort if selected
-    const controls: Controls | undefined =
-      selectedModelId || reasoningEffort
-        ? {
-            ...(selectedModelId && { model_id: selectedModelId }),
-            ...(reasoningEffort &&
-              supportsReasoning && {
-                reasoning: { effort: reasoningEffort },
-              }),
-          }
-        : undefined;
+		// Build controls with reasoning effort if selected
+		const controls: Controls | undefined =
+			selectedModelId || reasoningEffort
+				? {
+						...(selectedModelId && { model_id: selectedModelId }),
+						...(reasoningEffort &&
+							supportsReasoning && {
+								reasoning: { effort: reasoningEffort },
+							}),
+					}
+				: undefined;
 
-    try {
-      if (hasImages) {
-        // Send with images
-        await sendMessageWithImages.mutateAsync({
-          text: inputValue.trim(),
-          images: uploadedImageIds,
-          controls,
-        });
-        clearImages();
-      } else {
-        // Use the regular sendMessage for text-only (has optimistic UI)
-        await sendMessage.mutateAsync({
-          sessionId,
-          content: inputValue.trim(),
-          controls,
-        });
-      }
+		try {
+			if (hasImages) {
+				// Send with images
+				await sendMessageWithImages.mutateAsync({
+					text: inputValue.trim(),
+					images: uploadedImageIds,
+					controls,
+				});
+				clearImages();
+			} else {
+				// Use the regular sendMessage for text-only (has optimistic UI)
+				await sendMessage.mutateAsync({
+					sessionId,
+					content: inputValue.trim(),
+					controls,
+				});
+			}
 
-      if (typeof window !== "undefined") {
-        window.localStorage.setItem(modelSelectionStorageKey, selectedModelId);
-      }
-      setInputValue("");
-      // Start polling for the response
-      setIsWaitingForResponse(true);
-      // Refocus textarea after send
-      textareaRef.current?.focus();
-    } catch (error) {
-      console.error("Failed to send message:", error);
-    }
-  };
+			if (typeof window !== "undefined") {
+				window.localStorage.setItem(modelSelectionStorageKey, selectedModelId);
+			}
+			setInputValue("");
+			// Start polling for the response
+			setIsWaitingForResponse(true);
+			// Refocus textarea after send
+			textareaRef.current?.focus();
+		} catch (error) {
+			console.error("Failed to send message:", error);
+		}
+	};
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    // Let command autocomplete handle keyboard when visible
-    if (showCommands) return;
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
-      handleSubmit(e);
-    }
-  };
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+		// Let command autocomplete handle keyboard when visible
+		if (showCommands) return;
+		if (e.key === "Enter" && !e.shiftKey) {
+			e.preventDefault();
+			handleSubmit(e);
+		}
+	};
 
-  // Handle file input change
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = e.target.files;
-    if (files && files.length > 0) {
-      addFiles(Array.from(files));
-    }
-    // Reset input so same file can be selected again
-    e.target.value = "";
-  };
+	// Handle file input change
+	const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const files = e.target.files;
+		if (files && files.length > 0) {
+			addFiles(Array.from(files));
+		}
+		// Reset input so same file can be selected again
+		e.target.value = "";
+	};
 
-  // Extract image files from message content
-  const getMessageImages = (
-    content: ContentPart[],
-  ): Array<{ image_id: string; filename?: string }> => {
-    return content.filter(isImageFilePart).map((part) => ({
-      image_id: part.image_id,
-      filename: part.filename,
-    }));
-  };
+	// Extract image files from message content
+	const getMessageImages = (
+		content: ContentPart[],
+	): Array<{ image_id: string; filename?: string }> => {
+		return content.filter(isImageFilePart).map((part) => ({
+			image_id: part.image_id,
+			filename: part.filename,
+		}));
+	};
 
-  const renderTurnDivider = (eventId: string) => {
-    const durationMs = turnDurationByEventId.get(eventId);
+	const renderTurnDivider = (eventId: string) => {
+		const durationMs = turnDurationByEventId.get(eventId);
 
-    if (durationMs == null) {
-      return null;
-    }
+		if (durationMs == null) {
+			return null;
+		}
 
-    return (
-      <div className="flex items-center gap-4 pt-3 text-xs font-medium text-muted-foreground sm:text-sm">
-        <div className="h-px flex-1 bg-border" />
-        <span className="whitespace-nowrap">{`Worked for ${formatWorkedDuration(durationMs)}`}</span>
-        <div className="h-px flex-1 bg-border" />
-      </div>
-    );
-  };
+		return (
+			<div className="flex items-center gap-4 pt-3 text-xs font-medium text-muted-foreground sm:text-sm">
+				<div className="h-px flex-1 bg-border" />
+				<span className="whitespace-nowrap">{`Worked for ${formatWorkedDuration(durationMs)}`}</span>
+				<div className="h-px flex-1 bg-border" />
+			</div>
+		);
+	};
 
-  return (
-    <>
-      <div
-        ref={scrollContainerRef}
-        onScroll={handleScroll}
-        className="relative flex-1 overflow-y-auto bg-background bg-brand-dots px-4 py-5 sm:px-6"
-      >
-        {eventsLoading ? (
-          <div className="space-y-4">
-            <Skeleton className="ml-auto h-20 w-3/4" />
-            <Skeleton className="h-20 w-3/4" />
-            <Skeleton className="h-20 w-2/3" />
-          </div>
-        ) : chatEvents.length === 0 ? (
-          <div className="flex h-full flex-col items-center justify-center text-center text-muted-foreground">
-            <div className="border border-border bg-card px-10 py-10">
-              <Bot className="mx-auto mb-4 h-10 w-10 opacity-50" />
-              <p className="text-lg font-medium text-foreground">
-                No messages yet
-              </p>
-              <p className="mt-1 text-sm">
-                Send a message to start the conversation
-              </p>
-            </div>
-          </div>
-        ) : (
-          <div className="space-y-6">
-            {loadingOlderEvents && (
-              <div className="flex items-center justify-center py-3">
-                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-                <span className="ml-2 text-xs text-muted-foreground">
-                  Loading older messages...
-                </span>
-              </div>
-            )}
-            {chatEvents.map((event) => {
-              if (event.type === "tool.completed") {
-                return null;
-              }
+	return (
+		<>
+			<div
+				ref={scrollContainerRef}
+				onScroll={handleScroll}
+				className="relative flex-1 overflow-y-auto bg-background bg-brand-dots px-4 py-5 sm:px-6"
+			>
+				{eventsLoading ? (
+					<div className="space-y-4">
+						<Skeleton className="ml-auto h-20 w-3/4" />
+						<Skeleton className="h-20 w-3/4" />
+						<Skeleton className="h-20 w-2/3" />
+					</div>
+				) : chatEvents.length === 0 ? (
+					<div className="flex h-full flex-col items-center justify-center text-center text-muted-foreground">
+						<div className="border border-border bg-card px-10 py-10">
+							<Bot className="mx-auto mb-4 h-10 w-10 opacity-50" />
+							<p className="text-lg font-medium text-foreground">
+								No messages yet
+							</p>
+							<p className="mt-1 text-sm">
+								Send a message to start the conversation
+							</p>
+						</div>
+					</div>
+				) : (
+					<div className="space-y-6">
+						{loadingOlderEvents && (
+							<div className="flex items-center justify-center py-3">
+								<Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+								<span className="ml-2 text-xs text-muted-foreground">
+									Loading older messages...
+								</span>
+							</div>
+						)}
+						{chatEvents.map((event) => {
+							if (event.type === "tool.completed") {
+								return null;
+							}
 
-              if (event.type === "tool.call_requested") {
-                const reqData = event.data as ToolCallRequestedData;
-                if (!reqData.tool_calls || reqData.tool_calls.length === 0)
-                  return null;
-                return (
-                  <div key={event.id} className="space-y-3">
-                    <div className="ml-9 space-y-1">
-                      <ToolActivityGroup
-                        toolCalls={reqData.tool_calls}
-                        toolResultsMap={toolResultsMap}
-                        mode="client"
-                      />
-                    </div>
-                    {renderTurnDivider(event.id)}
-                  </div>
-                );
-              }
+							if (event.type === "tool.call_requested") {
+								const reqData = event.data as ToolCallRequestedData;
+								if (!reqData.tool_calls || reqData.tool_calls.length === 0)
+									return null;
+								return (
+									<div key={event.id} className="space-y-3">
+										<div className="ml-9 space-y-1">
+											<ToolActivityGroup
+												toolCalls={reqData.tool_calls}
+												toolResultsMap={toolResultsMap}
+												mode="client"
+											/>
+										</div>
+										{renderTurnDivider(event.id)}
+									</div>
+								);
+							}
 
-              const isUser = event.type === "input.message";
-              const data = event.data as
-                | InputMessageData
-                | OutputMessageCompletedData;
-              const textContent = getMessageText(data);
-              const toolCalls = isUser
-                ? []
-                : getToolCalls(data as OutputMessageCompletedData).filter(
-                    (toolCall) => !clientRequestedToolCallIds.has(toolCall.id),
-                  );
-              const images = data.message?.content
-                ? getMessageImages(data.message.content)
-                : [];
-              const isScheduleTriggered =
-                isUser && data.message?.metadata?.source === "schedule";
-              const isToolOnlyMessage =
-                !isUser &&
-                toolCalls.length > 0 &&
-                !textContent &&
-                images.length === 0;
+							const isUser = event.type === "input.message";
+							const data = event.data as
+								| InputMessageData
+								| OutputMessageCompletedData;
+							const textContent = getMessageText(data);
+							const toolCalls = isUser
+								? []
+								: getToolCalls(data as OutputMessageCompletedData).filter(
+										(toolCall) => !clientRequestedToolCallIds.has(toolCall.id),
+									);
+							const images = data.message?.content
+								? getMessageImages(data.message.content)
+								: [];
+							const isScheduleTriggered =
+								isUser && data.message?.metadata?.source === "schedule";
+							const isToolOnlyMessage =
+								!isUser &&
+								toolCalls.length > 0 &&
+								!textContent &&
+								images.length === 0;
 
-              if (isToolOnlyMessage) {
-                return (
-                  <div key={event.id} className="space-y-3">
-                    <div className="ml-9 space-y-1">
-                      <ToolActivityGroup
-                        toolCalls={toolCalls}
-                        toolResultsMap={toolResultsMap}
-                      />
-                    </div>
-                    {renderTurnDivider(event.id)}
-                  </div>
-                );
-              }
+							if (isToolOnlyMessage) {
+								return (
+									<div key={event.id} className="space-y-3">
+										<div className="ml-9 space-y-1">
+											<ToolActivityGroup
+												toolCalls={toolCalls}
+												toolResultsMap={toolResultsMap}
+											/>
+										</div>
+										{renderTurnDivider(event.id)}
+									</div>
+								);
+							}
 
-              return (
-                <div key={event.id} className="space-y-2">
-                  {(textContent || images.length > 0) && (
-                    <div
-                      className={`flex ${isUser ? "justify-end" : "justify-start"}`}
-                    >
-                      {isUser ? (
-                        <div className="max-w-[78%] border-r-2 border-r-accent bg-[hsl(var(--accent)/0.1)] px-4 py-3 text-sm text-foreground">
-                          {isScheduleTriggered && (
-                            <div className="mb-1 flex items-center gap-1 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
-                              <CalendarClock className="h-3 w-3" />
-                              <span>Scheduled</span>
-                            </div>
-                          )}
-                          <div className="flex items-start gap-2">
-                            <div className="flex-1 space-y-2">
-                              {textContent && (
-                                <p className="whitespace-pre-wrap">
-                                  {textContent}
-                                </p>
-                              )}
-                              {images.length > 0 && (
-                                <div className="mt-2 flex flex-wrap gap-2">
-                                  {images.map((img) => (
-                                    <MessageImage
-                                      key={img.image_id}
-                                      imageId={img.image_id}
-                                      filename={img.filename}
-                                    />
-                                  ))}
-                                </div>
-                              )}
-                            </div>
-                            <MessageInfoIcon event={event} />
-                          </div>
-                        </div>
-                      ) : (
-                        <div className="flex w-full items-start gap-3 pr-2">
-                          <div className="mt-1 flex h-6 w-6 flex-shrink-0 items-center justify-center border border-border bg-primary text-primary-foreground">
-                            <Bot className="h-3.5 w-3.5" />
-                          </div>
-                          <div className="flex flex-1 items-start gap-2">
-                            <div className="flex-1 space-y-2 border-l-2 border-l-primary bg-card px-4 py-3">
-                              {textContent && (
-                                <StreamdownMessage
-                                  variant="inline"
-                                  className="text-foreground"
-                                >
-                                  {textContent}
-                                </StreamdownMessage>
-                              )}
-                              {images.length > 0 && (
-                                <div className="mt-2 flex flex-wrap gap-2">
-                                  {images.map((img) => (
-                                    <MessageImage
-                                      key={img.image_id}
-                                      imageId={img.image_id}
-                                      filename={img.filename}
-                                    />
-                                  ))}
-                                </div>
-                              )}
-                            </div>
-                            <MessageInfoIcon event={event} />
-                          </div>
-                        </div>
-                      )}
-                    </div>
-                  )}
+							return (
+								<div key={event.id} className="space-y-2">
+									{(textContent || images.length > 0) && (
+										<div
+											className={`flex ${isUser ? "justify-end" : "justify-start"}`}
+										>
+											{isUser ? (
+												<div className="max-w-[78%] border-r-2 border-r-accent bg-[hsl(var(--accent)/0.1)] px-4 py-3 text-sm text-foreground">
+													{isScheduleTriggered && (
+														<div className="mb-1 flex items-center gap-1 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+															<CalendarClock className="h-3 w-3" />
+															<span>Scheduled</span>
+														</div>
+													)}
+													<div className="flex items-start gap-2">
+														<div className="flex-1 space-y-2">
+															{textContent && (
+																<p className="whitespace-pre-wrap">
+																	{textContent}
+																</p>
+															)}
+															{images.length > 0 && (
+																<div className="mt-2 flex flex-wrap gap-2">
+																	{images.map((img) => (
+																		<MessageImage
+																			key={img.image_id}
+																			imageId={img.image_id}
+																			filename={img.filename}
+																		/>
+																	))}
+																</div>
+															)}
+														</div>
+														<MessageInfoIcon event={event} />
+													</div>
+												</div>
+											) : (
+												<div className="flex w-full items-start gap-3 pr-2">
+													<div className="mt-1 flex h-6 w-6 flex-shrink-0 items-center justify-center border border-border bg-primary text-primary-foreground">
+														<Bot className="h-3.5 w-3.5" />
+													</div>
+													<div className="flex flex-1 items-start gap-2">
+														<div className="flex-1 space-y-2 border-l-2 border-l-primary bg-card px-4 py-3">
+															{textContent && (
+																<StreamdownMessage
+																	variant="inline"
+																	className="text-foreground"
+																>
+																	{textContent}
+																</StreamdownMessage>
+															)}
+															{images.length > 0 && (
+																<div className="mt-2 flex flex-wrap gap-2">
+																	{images.map((img) => (
+																		<MessageImage
+																			key={img.image_id}
+																			imageId={img.image_id}
+																			filename={img.filename}
+																		/>
+																	))}
+																</div>
+															)}
+														</div>
+														<MessageInfoIcon event={event} />
+													</div>
+												</div>
+											)}
+										</div>
+									)}
 
-                  {toolCalls.length > 0 && (
-                    <div className="ml-9 space-y-1">
-                      <ToolActivityGroup
-                        toolCalls={toolCalls}
-                        toolResultsMap={toolResultsMap}
-                      />
-                    </div>
-                  )}
+									{toolCalls.length > 0 && (
+										<div className="ml-9 space-y-1">
+											<ToolActivityGroup
+												toolCalls={toolCalls}
+												toolResultsMap={toolResultsMap}
+											/>
+										</div>
+									)}
 
-                  {renderTurnDivider(event.id)}
-                </div>
-              );
-            })}
-          </div>
-        )}
+									{renderTurnDivider(event.id)}
+								</div>
+							);
+						})}
+					</div>
+				)}
 
-        {(isThinking || streamingText) && (
-          <div className="mt-6 flex justify-start">
-            <div className="flex w-full items-start gap-3 pr-2">
-              <div className="mt-1 flex h-6 w-6 flex-shrink-0 items-center justify-center border border-border bg-primary text-primary-foreground">
-                <Bot className="h-3.5 w-3.5" />
-              </div>
-              <div className="flex-1 border-l-2 border-l-primary bg-card px-4 py-3">
-                {streamingIteration && streamingIteration > 1 && (
-                  <div className="mb-1 text-xs text-muted-foreground">
-                    Iteration {streamingIteration}
-                  </div>
-                )}
-                {isThinking && !streamingText ? (
-                  <ThinkingIndicator />
-                ) : streamingText ? (
-                  <StreamingMessage text={streamingText} />
-                ) : null}
-              </div>
-            </div>
-          </div>
-        )}
+				{(isThinking || streamingText) && (
+					<div className="mt-6 flex justify-start">
+						<div className="flex w-full items-start gap-3 pr-2">
+							<div className="mt-1 flex h-6 w-6 flex-shrink-0 items-center justify-center border border-border bg-primary text-primary-foreground">
+								<Bot className="h-3.5 w-3.5" />
+							</div>
+							<div className="flex-1 border-l-2 border-l-primary bg-card px-4 py-3">
+								{streamingIteration && streamingIteration > 1 && (
+									<div className="mb-1 text-xs text-muted-foreground">
+										Iteration {streamingIteration}
+									</div>
+								)}
+								{isThinking && !streamingText ? (
+									<ThinkingIndicator />
+								) : streamingText ? (
+									<StreamingMessage text={streamingText} />
+								) : null}
+							</div>
+						</div>
+					</div>
+				)}
 
-        <div ref={messagesEndRef} />
+				<div ref={messagesEndRef} />
 
-        {hasNewMessages && (
-          <button
-            type="button"
-            onClick={() => {
-              scrollToBottom("smooth");
-              setHasNewMessages(false);
-            }}
-            className="sticky bottom-3 left-1/2 z-10 mx-auto flex -translate-x-1/2 items-center gap-1.5 border border-border bg-card px-3 py-1.5 text-xs font-medium text-foreground shadow-md transition-colors hover:bg-accent"
-          >
-            <ArrowDown className="h-3 w-3" />
-            New messages
-          </button>
-        )}
-      </div>
+				{hasNewMessages && (
+					<button
+						type="button"
+						onClick={() => {
+							scrollToBottom("smooth");
+							setHasNewMessages(false);
+						}}
+						className="sticky bottom-3 left-1/2 z-10 mx-auto flex -translate-x-1/2 items-center gap-1.5 border border-border bg-card px-3 py-1.5 text-xs font-medium text-foreground shadow-md transition-colors hover:bg-accent"
+					>
+						<ArrowDown className="h-3 w-3" />
+						New messages
+					</button>
+				)}
+			</div>
 
-      <div className="border-t border-border bg-muted/30 p-4 sm:p-5">
-        <form onSubmit={handleSubmit} className="space-y-3">
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept={ALLOWED_IMAGE_TYPES.join(",")}
-            multiple
-            className="hidden"
-            onChange={handleFileChange}
-          />
+			<div className="border-t border-border bg-muted/30 p-4 sm:p-5">
+				<form onSubmit={handleSubmit} className="space-y-3">
+					<input
+						ref={fileInputRef}
+						type="file"
+						accept={ALLOWED_IMAGE_TYPES.join(",")}
+						multiple
+						className="hidden"
+						onChange={handleFileChange}
+					/>
 
-          {hasImages && (
-            <ImageAttachments images={pendingImages} onRemove={removeImage} />
-          )}
+					{hasImages && (
+						<ImageAttachments images={pendingImages} onRemove={removeImage} />
+					)}
 
-          <div
-            className={`relative border border-border bg-background transition-colors ${
-              isDraggingOver
-                ? "bg-[hsl(var(--accent)/0.08)] ring-1 ring-accent"
-                : ""
-            }`}
-            onDragOver={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-            onDragEnter={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              setIsDraggingOver(true);
-            }}
-            onDragLeave={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-                setIsDraggingOver(false);
-              }
-            }}
-            onDrop={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              setIsDraggingOver(false);
-              const files = e.dataTransfer?.files;
-              if (files && files.length > 0) {
-                const imageFiles = Array.from(files).filter((f) =>
-                  f.type.startsWith("image/"),
-                );
-                if (imageFiles.length > 0) {
-                  addFiles(imageFiles);
-                }
-              }
-            }}
-          >
-            <CommandAutocomplete
-              commands={commands}
-              inputValue={inputValue}
-              visible={showCommands}
-              onSelect={handleCommandSelect}
-              onDismiss={() => setShowCommands(false)}
-            />
-            <Textarea
-              ref={textareaRef}
-              value={inputValue}
-              onChange={(e) => {
-                const val = e.target.value;
-                setInputValue(val);
-                setShowCommands(shouldShowCommandAutocomplete(val));
-              }}
-              onKeyDown={handleKeyDown}
-              onPaste={(e) => {
-                const items = e.clipboardData?.items;
-                if (!items) return;
-                const imageFiles: File[] = [];
-                for (const item of Array.from(items)) {
-                  if (item.type.startsWith("image/")) {
-                    const file = item.getAsFile();
-                    if (file) imageFiles.push(file);
-                  }
-                }
-                if (imageFiles.length > 0) {
-                  e.preventDefault();
-                  addFiles(imageFiles);
-                }
-              }}
-              placeholder="Type a message or / for commands... (Enter to send)"
-              className="min-h-[120px] max-h-[260px] w-full resize-none border-0 bg-transparent px-4 py-4 text-sm shadow-none focus-visible:ring-0"
-            />
-          </div>
+					<div
+						className={`relative border border-border bg-background transition-colors ${
+							isDraggingOver
+								? "bg-[hsl(var(--accent)/0.08)] ring-1 ring-accent"
+								: ""
+						}`}
+						onDragOver={(e) => {
+							e.preventDefault();
+							e.stopPropagation();
+						}}
+						onDragEnter={(e) => {
+							e.preventDefault();
+							e.stopPropagation();
+							setIsDraggingOver(true);
+						}}
+						onDragLeave={(e) => {
+							e.preventDefault();
+							e.stopPropagation();
+							if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+								setIsDraggingOver(false);
+							}
+						}}
+						onDrop={(e) => {
+							e.preventDefault();
+							e.stopPropagation();
+							setIsDraggingOver(false);
+							const files = e.dataTransfer?.files;
+							if (files && files.length > 0) {
+								const imageFiles = Array.from(files).filter((f) =>
+									f.type.startsWith("image/"),
+								);
+								if (imageFiles.length > 0) {
+									addFiles(imageFiles);
+								}
+							}
+						}}
+					>
+						<CommandAutocomplete
+							commands={commands}
+							inputValue={inputValue}
+							visible={showCommands}
+							onSelect={handleCommandSelect}
+							onDismiss={() => setShowCommands(false)}
+						/>
+						<Textarea
+							ref={textareaRef}
+							value={inputValue}
+							onChange={(e) => {
+								const val = e.target.value;
+								setInputValue(val);
+								setShowCommands(shouldShowCommandAutocomplete(val));
+							}}
+							onKeyDown={handleKeyDown}
+							onPaste={(e) => {
+								const items = e.clipboardData?.items;
+								if (!items) return;
+								const imageFiles: File[] = [];
+								for (const item of Array.from(items)) {
+									if (item.type.startsWith("image/")) {
+										const file = item.getAsFile();
+										if (file) imageFiles.push(file);
+									}
+								}
+								if (imageFiles.length > 0) {
+									e.preventDefault();
+									addFiles(imageFiles);
+								}
+							}}
+							placeholder="Type a message or / for commands... (Enter to send)"
+							className="min-h-[120px] max-h-[260px] w-full resize-none border-0 bg-transparent px-4 py-4 text-sm shadow-none focus-visible:ring-0"
+						/>
+					</div>
 
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div className="flex flex-wrap items-center gap-3">
-              <Button
-                type="button"
-                variant="outline"
-                size="icon-lg"
-                className="h-10 w-10 border-border bg-background"
-                onClick={() => fileInputRef.current?.click()}
-                title="Attach images (PNG, JPEG, GIF, WebP)"
-              >
-                <ImagePlus className="icon-sharp h-4 w-4" />
-              </Button>
+					<div className="flex flex-wrap items-center justify-between gap-3">
+						<div className="flex flex-wrap items-center gap-3">
+							<Button
+								type="button"
+								variant="outline"
+								size="icon-lg"
+								className="h-10 w-10 border-border bg-background"
+								onClick={() => fileInputRef.current?.click()}
+								title="Attach images (PNG, JPEG, GIF, WebP)"
+							>
+								<ImagePlus className="icon-sharp h-4 w-4" />
+							</Button>
 
-              <div className="flex h-10 items-center gap-2 border border-border bg-background px-3">
-                <span className="shrink-0 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
-                  Model
-                </span>
-                <Select
-                  value={selectedModelId}
-                  onValueChange={(value) => {
-                    hasUserSelectedModel.current = true;
-                    setSelectedModelId(value);
-                  }}
-                >
-                  <SelectTrigger
-                    size="sm"
-                    className="h-7 w-[156px] min-w-0 border-0 bg-transparent px-0 py-0 text-sm shadow-none focus-visible:ring-0 data-[size=sm]:h-7 [&_svg]:icon-sharp"
-                  >
-                    <SelectValue>{modelTriggerLabel}</SelectValue>
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="">{defaultModelOptionLabel}</SelectItem>
-                    {llmModels.map((model) => (
-                      <SelectItem key={model.id} value={model.id}>
-                        {model.display_name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
+							<div className="flex h-10 items-center gap-2 border border-border bg-background px-3">
+								<span className="shrink-0 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+									Model
+								</span>
+								<Select
+									value={selectedModelId}
+									onValueChange={(value) => {
+										hasUserSelectedModel.current = true;
+										setSelectedModelId(value);
+									}}
+								>
+									<SelectTrigger
+										size="sm"
+										className="h-7 w-[156px] min-w-0 border-0 bg-transparent px-0 py-0 text-sm shadow-none focus-visible:ring-0 data-[size=sm]:h-7 [&_svg]:icon-sharp"
+									>
+										<SelectValue>{modelTriggerLabel}</SelectValue>
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="">{defaultModelOptionLabel}</SelectItem>
+										{llmModels.map((model) => (
+											<SelectItem key={model.id} value={model.id}>
+												{model.display_name}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</div>
 
-              {supportsReasoning && reasoningEffortConfig && (
-                <div className="flex h-10 items-center gap-2 border border-border bg-background px-3">
-                  <Brain className="icon-sharp h-3.5 w-3.5 text-muted-foreground" />
-                  <span className="shrink-0 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
-                    Reasoning
-                  </span>
-                  <Select
-                    value={reasoningEffort}
-                    onValueChange={(value) =>
-                      setReasoningEffort(value as typeof reasoningEffort)
-                    }
-                  >
-                    <SelectTrigger
-                      size="sm"
-                      className="h-7 w-[116px] min-w-0 border-0 bg-transparent px-0 py-0 text-sm shadow-none focus-visible:ring-0 data-[size=sm]:h-7 [&_svg]:icon-sharp"
-                    >
-                      <SelectValue>
-                        {reasoningEffort
-                          ? getReasoningEffortName(reasoningEffort)
-                          : "Default"}
-                      </SelectValue>
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="">{`Default (${defaultEffortName})`}</SelectItem>
-                      {reasoningEffortConfig.values.map((effort) => (
-                        <SelectItem key={effort.value} value={effort.value}>
-                          {effort.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              )}
-            </div>
+							{supportsReasoning && reasoningEffortConfig && (
+								<div className="flex h-10 items-center gap-2 border border-border bg-background px-3">
+									<Brain className="icon-sharp h-3.5 w-3.5 text-muted-foreground" />
+									<span className="shrink-0 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+										Reasoning
+									</span>
+									<Select
+										value={reasoningEffort}
+										onValueChange={(value) =>
+											setReasoningEffort(value as typeof reasoningEffort)
+										}
+									>
+										<SelectTrigger
+											size="sm"
+											className="h-7 w-[116px] min-w-0 border-0 bg-transparent px-0 py-0 text-sm shadow-none focus-visible:ring-0 data-[size=sm]:h-7 [&_svg]:icon-sharp"
+										>
+											<SelectValue>
+												{reasoningEffort
+													? getReasoningEffortName(reasoningEffort)
+													: "Default"}
+											</SelectValue>
+										</SelectTrigger>
+										<SelectContent>
+											<SelectItem value="">{`Default (${defaultEffortName})`}</SelectItem>
+											{reasoningEffortConfig.values.map((effort) => (
+												<SelectItem key={effort.value} value={effort.value}>
+													{effort.name}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								</div>
+							)}
+						</div>
 
-            <div className="flex items-center gap-2">
-              {isActive && !inputValue.trim() && !hasImages && (
-                <Button
-                  type="button"
-                  size="icon-lg"
-                  variant="destructive"
-                  className="h-10 w-10 border border-destructive/30 bg-destructive/[0.08] text-destructive shadow-none hover:bg-destructive/[0.14]"
-                  disabled={cancelCurrentTurn.isPending}
-                  onClick={() => cancelCurrentTurn.mutate()}
-                  title="Cancel current turn"
-                >
-                  {cancelCurrentTurn.isPending ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <StopCircle className="icon-sharp h-4 w-4" />
-                  )}
-                </Button>
-              )}
+						<div className="flex items-center gap-2">
+							{isActive && !inputValue.trim() && !hasImages && (
+								<Button
+									type="button"
+									size="icon-lg"
+									variant="destructive"
+									className="h-10 w-10 border border-destructive/30 bg-destructive/[0.08] text-destructive shadow-none hover:bg-destructive/[0.14]"
+									disabled={cancelCurrentTurn.isPending}
+									onClick={() => cancelCurrentTurn.mutate()}
+									title="Cancel current turn"
+								>
+									{cancelCurrentTurn.isPending ? (
+										<Loader2 className="h-4 w-4 animate-spin" />
+									) : (
+										<StopCircle className="icon-sharp h-4 w-4" />
+									)}
+								</Button>
+							)}
 
-              <Button
-                type="submit"
-                size="icon-lg"
-                className="h-10 w-10"
-                disabled={!canSubmit}
-                title={isUploading ? "Uploading images..." : undefined}
-              >
-                {sendMessage.isPending || sendMessageWithImages.isPending ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : isUploading ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <Send className="icon-sharp h-4 w-4" />
-                )}
-              </Button>
-            </div>
-          </div>
-        </form>
-      </div>
-    </>
-  );
+							<Button
+								type="submit"
+								size="icon-lg"
+								className="h-10 w-10"
+								disabled={!canSubmit}
+								title={isUploading ? "Uploading images..." : undefined}
+							>
+								{sendMessage.isPending || sendMessageWithImages.isPending ? (
+									<Loader2 className="h-4 w-4 animate-spin" />
+								) : isUploading ? (
+									<Loader2 className="h-4 w-4 animate-spin" />
+								) : (
+									<Send className="icon-sharp h-4 w-4" />
+								)}
+							</Button>
+						</div>
+					</div>
+				</form>
+			</div>
+		</>
+	);
 }

--- a/apps/ui/src/hooks/use-sessions.ts
+++ b/apps/ui/src/hooks/use-sessions.ts
@@ -14,7 +14,7 @@ import {
   pinSession,
   unpinSession,
 } from "@/lib/api/sessions";
-import { getSseUrl, listEvents } from "@/lib/api/events";
+import { DEFAULT_EXCLUDED_EVENTS, getSseUrl, listEventsPaginated } from "@/lib/api/events";
 import { queryKeys } from "@/lib/query-keys";
 import type {
   CreateSessionRequest,
@@ -214,15 +214,18 @@ const SSE_EVENT_TYPES = [
   "reason.thinking.completed",
 ];
 
+/** Default page size for paginated event loading */
+const EVENT_PAGE_SIZE = 200;
+
 /**
- * Fetch events for a session using REST + SSE.
+ * Fetch events for a session using paginated REST + SSE.
  *
- * Strategy: REST first, SSE second.
- * 1. Fetch all existing events via REST (single HTTP response → single setState)
+ * Strategy: REST first (last N events), SSE second.
+ * 1. Fetch last 200 non-delta events via REST (single HTTP response → single setState)
  * 2. Connect SSE with since_id from last REST event for live incremental updates
+ * 3. When user scrolls up, load older events via REST with before_sequence cursor
  *
- * This is critical for large sessions (1000+ turns, 30k+ events) where
- * SSE-only would trigger one state update per event on initial load.
+ * Pagination uses X-Total-Count header for scroll estimation.
  */
 export function useEvents(sessionId: string | undefined, options?: { enabled?: boolean }) {
   const { currentOrg } = useOrg();
@@ -243,6 +246,12 @@ export function useEvents(sessionId: string | undefined, options?: { enabled?: b
   // Track whether initial REST fetch has completed
   const [restLoaded, setRestLoaded] = useState(false);
 
+  // Pagination state
+  const [totalNonDeltaCount, setTotalNonDeltaCount] = useState<number | undefined>();
+  const oldestLoadedSequenceRef = useRef<number | undefined>(undefined);
+  const [hasMore, setHasMore] = useState(false);
+  const [loadingOlder, setLoadingOlder] = useState(false);
+
   // Cleanup SSE connection
   const cleanup = useCallback(() => {
     if (eventSourceRef.current) {
@@ -261,10 +270,14 @@ export function useEvents(sessionId: string | undefined, options?: { enabled?: b
     eventIdsRef.current.clear();
     reconnectRef.current = createReconnectTracker();
     setRestLoaded(false);
+    setTotalNonDeltaCount(undefined);
+    oldestLoadedSequenceRef.current = undefined;
+    setHasMore(false);
+    setLoadingOlder(false);
     cleanup();
   }, [org, sessionId, cleanup]);
 
-  // Step 1: REST batch load existing events
+  // Step 1: REST batch load last N events (excluding deltas for old messages)
   useEffect(() => {
     if (!org || !sessionId || !isEnabled) return;
 
@@ -272,16 +285,31 @@ export function useEvents(sessionId: string | undefined, options?: { enabled?: b
 
     async function fetchInitialEvents() {
       try {
-        const batch = await listEvents(sessionId!);
+        const result = await listEventsPaginated(sessionId!, {
+          limit: EVENT_PAGE_SIZE,
+          exclude: DEFAULT_EXCLUDED_EVENTS,
+        });
         if (cancelled) return;
 
+        const batch = result.events;
         if (batch.length > 0) {
           for (const e of batch) {
             eventIdsRef.current.add(e.id);
           }
           lastEventIdRef.current = batch[batch.length - 1].id;
+          // Track oldest loaded sequence for backward pagination
+          const firstSeq = batch[0].sequence;
+          if (firstSeq !== undefined) {
+            oldestLoadedSequenceRef.current = firstSeq;
+          }
           // Single state update for entire batch
           setEvents(batch);
+        }
+
+        if (result.totalNonDeltaCount !== undefined) {
+          setTotalNonDeltaCount(result.totalNonDeltaCount);
+          // There are more events if we loaded fewer than total
+          setHasMore(batch.length < result.totalNonDeltaCount);
         }
       } catch (e) {
         if (cancelled) return;
@@ -300,7 +328,51 @@ export function useEvents(sessionId: string | undefined, options?: { enabled?: b
     };
   }, [org, sessionId, isEnabled]);
 
+  // Load older events (triggered by scrolling up)
+  const loadOlderEvents = useCallback(async () => {
+    if (!sessionId || loadingOlder || !hasMore || oldestLoadedSequenceRef.current === undefined) {
+      return;
+    }
+
+    setLoadingOlder(true);
+    try {
+      const result = await listEventsPaginated(sessionId, {
+        limit: EVENT_PAGE_SIZE,
+        before_sequence: oldestLoadedSequenceRef.current,
+        exclude: DEFAULT_EXCLUDED_EVENTS,
+      });
+
+      const older = result.events;
+      if (older.length > 0) {
+        for (const e of older) {
+          eventIdsRef.current.add(e.id);
+        }
+        const firstSeq = older[0].sequence;
+        if (firstSeq !== undefined) {
+          oldestLoadedSequenceRef.current = firstSeq;
+        }
+        // Prepend older events
+        setEvents((prev) => [...older, ...prev]);
+        // Check if there are still more
+        if (result.totalNonDeltaCount !== undefined) {
+          setTotalNonDeltaCount(result.totalNonDeltaCount);
+        }
+        // No more if we got fewer than requested
+        if (older.length < EVENT_PAGE_SIZE) {
+          setHasMore(false);
+        }
+      } else {
+        setHasMore(false);
+      }
+    } catch (e) {
+      console.error("Failed to load older events:", e);
+    } finally {
+      setLoadingOlder(false);
+    }
+  }, [sessionId, loadingOlder, hasMore]);
+
   // Step 2: SSE for live updates (starts after REST completes)
+  // SSE is unfiltered — picks up deltas for in-flight streaming messages naturally
   useEffect(() => {
     if (!org || !sessionId || !isEnabled || !restLoaded) {
       return;
@@ -381,5 +453,10 @@ export function useEvents(sessionId: string | undefined, options?: { enabled?: b
     isLoading,
     isReconnecting,
     error,
+    // Pagination
+    hasMore,
+    loadingOlder,
+    loadOlderEvents,
+    totalNonDeltaCount,
   };
 }

--- a/apps/ui/src/lib/api/events.ts
+++ b/apps/ui/src/lib/api/events.ts
@@ -2,7 +2,7 @@
 // Events are SSE notifications for real-time updates
 // Org is sent via everruns_org cookie (set by OrgProvider via /v1/users/me/switch-org)
 
-import { api, getApiBaseUrl } from "./client";
+import { api, ApiError, getApiBaseUrl } from "./client";
 import type { Event, ListResponse } from "./types";
 
 // Default event types to exclude in UI contexts (streaming delta events are noise)
@@ -37,13 +37,14 @@ export async function listEvents(
 
 // List events with pagination metadata (X-Total-Count header).
 // Use this when you need the total count for scroll estimation.
+// Uses fetch directly (instead of api.get) to access response headers.
 export async function listEventsPaginated(
   sessionId: string,
   excludeOrOptions?: string[] | ListEventsOptions,
 ): Promise<ListEventsResult> {
   const options: ListEventsOptions = Array.isArray(excludeOrOptions)
     ? { exclude: excludeOrOptions }
-    : excludeOrOptions ?? {};
+    : (excludeOrOptions ?? {});
 
   const params = new URLSearchParams();
   if (options.exclude) {
@@ -58,15 +59,24 @@ export async function listEventsPaginated(
     params.set("before_sequence", String(options.before_sequence));
   }
   const queryString = params.toString();
-  const response = await api.get<ListResponse<Event>>(
-    `/v1/sessions/${sessionId}/events${queryString ? `?${queryString}` : ""}`,
-  );
+  const url = `${getApiBaseUrl()}/v1/sessions/${sessionId}/events${queryString ? `?${queryString}` : ""}`;
 
-  const totalHeader = response.headers?.["x-total-count"];
+  const response = await fetch(url, {
+    method: "GET",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+  });
+
+  if (!response.ok) {
+    throw new ApiError(response.status, response.statusText);
+  }
+
+  const body: ListResponse<Event> = await response.json();
+  const totalHeader = response.headers.get("x-total-count");
   const totalNonDeltaCount = totalHeader ? Number(totalHeader) : undefined;
 
   return {
-    events: response.data.data,
+    events: body.data,
     totalNonDeltaCount,
   };
 }

--- a/apps/ui/src/lib/api/events.ts
+++ b/apps/ui/src/lib/api/events.ts
@@ -8,20 +8,67 @@ import type { Event, ListResponse } from "./types";
 // Default event types to exclude in UI contexts (streaming delta events are noise)
 export const DEFAULT_EXCLUDED_EVENTS = ["output.message.delta", "reason.thinking.delta"];
 
+// Options for listing events with pagination support
+export interface ListEventsOptions {
+  exclude?: string[];
+  /** Max events to return (backward pagination). Returns last N events. */
+  limit?: number;
+  /** Cursor: only return events with sequence < this value. Used with limit. */
+  before_sequence?: number;
+}
+
+// Response from paginated event listing
+export interface ListEventsResult {
+  events: Event[];
+  /** Total non-delta event count (from X-Total-Count header, only when limit is used) */
+  totalNonDeltaCount?: number;
+}
+
 // List events for a session (polling alternative to SSE)
-// Optional exclude parameter to filter out event types (e.g., delta events)
-export async function listEvents(sessionId: string, exclude?: string[]): Promise<Event[]> {
+// Supports backward pagination via limit + before_sequence params.
+// When limit is set, response includes X-Total-Count header with non-delta event count.
+export async function listEvents(
+  sessionId: string,
+  excludeOrOptions?: string[] | ListEventsOptions,
+): Promise<Event[]> {
+  const result = await listEventsPaginated(sessionId, excludeOrOptions);
+  return result.events;
+}
+
+// List events with pagination metadata (X-Total-Count header).
+// Use this when you need the total count for scroll estimation.
+export async function listEventsPaginated(
+  sessionId: string,
+  excludeOrOptions?: string[] | ListEventsOptions,
+): Promise<ListEventsResult> {
+  const options: ListEventsOptions = Array.isArray(excludeOrOptions)
+    ? { exclude: excludeOrOptions }
+    : excludeOrOptions ?? {};
+
   const params = new URLSearchParams();
-  if (exclude) {
-    for (const type of exclude) {
+  if (options.exclude) {
+    for (const type of options.exclude) {
       params.append("exclude", type);
     }
+  }
+  if (options.limit !== undefined) {
+    params.set("limit", String(options.limit));
+  }
+  if (options.before_sequence !== undefined) {
+    params.set("before_sequence", String(options.before_sequence));
   }
   const queryString = params.toString();
   const response = await api.get<ListResponse<Event>>(
     `/v1/sessions/${sessionId}/events${queryString ? `?${queryString}` : ""}`,
   );
-  return response.data.data;
+
+  const totalHeader = response.headers?.["x-total-count"];
+  const totalNonDeltaCount = totalHeader ? Number(totalHeader) : undefined;
+
+  return {
+    events: response.data.data,
+    totalNonDeltaCount,
+  };
 }
 
 // Get SSE URL for real-time event streaming

--- a/crates/server/src/api/events.rs
+++ b/crates/server/src/api/events.rs
@@ -8,8 +8,11 @@ use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, State},
-    http::StatusCode,
-    response::sse::{Event as SseEvent, KeepAlive, Sse},
+    http::{HeaderMap, StatusCode},
+    response::{
+        IntoResponse, Response,
+        sse::{Event as SseEvent, KeepAlive, Sse},
+    },
     routing::get,
 };
 // Use axum_extra::extract::Query (backed by serde_html_form) instead of axum's
@@ -51,6 +54,13 @@ pub struct EventsQuery {
     #[serde(default)]
     #[param(style = Form, explode = true)]
     pub exclude: Vec<String>,
+    /// Max events to return (backward pagination). When set, returns the last N events
+    /// (or last N before `before_sequence`). Results are ordered oldest→newest.
+    #[param(minimum = 1, maximum = 1000)]
+    pub limit: Option<i32>,
+    /// Cursor for backward pagination: only return events with sequence < this value.
+    /// Used with `limit` to paginate backward through event history.
+    pub before_sequence: Option<i32>,
 }
 
 impl EventsQuery {
@@ -423,7 +433,7 @@ pub async fn stream_sse(
 
                     // Fetch events since last ID
                     tracing::debug!(session_id = %session_id, last_id = ?state.last_id, "SSE: fetching events");
-                    match event_service.list(session_id, None, state.last_id, &state.filter_types, &state.exclude_types).await {
+                    match event_service.list(session_id, None, state.last_id, &state.filter_types, &state.exclude_types, None, None).await {
                         Ok(events) if !events.is_empty() => {
                             // Get the last event ID for next iteration
                             let new_last_id = Some(events.last().unwrap().id.uuid());
@@ -530,12 +540,26 @@ impl<S: Stream> Stream for GuardedStream<S> {
 // List Events (JSON response for polling)
 // ============================================
 
+/// Max limit for event pagination
+const MAX_EVENT_LIMIT: i32 = 1000;
+
 /// GET /v1/sessions/{session_id}/events - List events (JSON)
 ///
 /// Returns events for a session as a JSON array. Supports filtering by event type
 /// via `types` (positive: only these types) and `exclude` (negative: remove these types).
 /// When both are provided, `types` narrows first, then `exclude` removes from that set.
 /// Both accept only known event types (max 25 per parameter). Unknown types return 400.
+///
+/// ## Pagination
+///
+/// Supports backward pagination via `limit` and `before_sequence`:
+/// - `limit=200` returns the last 200 events (oldest→newest)
+/// - `limit=200&before_sequence=4500` returns 200 events before sequence 4500
+/// - When `limit` is provided, the response includes an `X-Total-Count` header
+///   with the count of non-delta events for the session
+/// - Turn boundary snapping: when fetching older pages, the batch boundary
+///   snaps to the nearest `turn.started` event to avoid splitting turns
+/// - Without `limit`, all events are returned (backward compatible)
 #[utoipa::path(
     get,
     path = "/v1/sessions/{session_id}/events",
@@ -544,7 +568,10 @@ impl<S: Stream> Stream for GuardedStream<S> {
         EventsQuery
     ),
     responses(
-        (status = 200, description = "Events list", body = ListResponse<Event>),
+        (status = 200, description = "Events list", body = ListResponse<Event>,
+         headers(
+             ("X-Total-Count" = i64, description = "Total non-delta event count for the session (only present when limit is used)")
+         )),
         (status = 400, description = "Invalid session ID or invalid event type filter"),
         (status = 404, description = "Session not found"),
         (status = 500, description = "Internal server error")
@@ -556,8 +583,30 @@ pub async fn list_events(
     State(state): State<AppState>,
     Path(session_id): Path<String>,
     Query(query): Query<EventsQuery>,
-) -> Result<Json<ListResponse<Event>>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
     query.validate()?;
+
+    // Validate limit range
+    if let Some(limit) = query.limit
+        && (!(1..=MAX_EVENT_LIMIT).contains(&limit))
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("limit must be between 1 and {MAX_EVENT_LIMIT}, got {limit}"),
+            }),
+        ));
+    }
+
+    // before_sequence requires limit
+    if query.before_sequence.is_some() && query.limit.is_none() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: "before_sequence requires limit to be set".to_string(),
+            }),
+        ));
+    }
 
     let session_id: SessionId = session_id.parse().map_err(|e| {
         (
@@ -591,10 +640,31 @@ pub async fn list_events(
             )
         })?;
 
-    // Fetch events using EventService (converts rows to core::Event)
-    // Optional since_id filter for incremental fetching
-    // Optional types filter for positive event type selection
-    // Optional exclude filter for filtering out event types (e.g., delta events)
+    let is_paginated = query.limit.is_some();
+
+    // Turn boundary snapping: when paginating backward with before_sequence,
+    // snap the cursor to the nearest turn.started boundary to avoid splitting turns.
+    let before_sequence = if let Some(before_seq) = query.before_sequence {
+        if let Some(limit) = query.limit {
+            // Find the event that would be at the boundary of our batch
+            // by looking at what the first event in the batch would be.
+            // We want to snap the *start* of the batch to a turn boundary,
+            // so we first figure out roughly where the batch starts, then
+            // find the nearest turn.started at or before that point.
+            //
+            // Strategy: fetch events, check if the first event is mid-turn,
+            // and if so extend backward to include the full turn.
+            // For simplicity, we pass before_seq as-is and snap in a second pass.
+            let _ = limit; // used below
+            Some(before_seq)
+        } else {
+            Some(before_seq)
+        }
+    } else {
+        None
+    };
+
+    // Fetch events
     let events = state
         .event_service
         .list(
@@ -603,6 +673,8 @@ pub async fn list_events(
             query.since_id.map(|id| id.uuid()),
             &query.types,
             &query.exclude,
+            before_sequence,
+            query.limit,
         )
         .await
         .map_err(|e| {
@@ -615,7 +687,77 @@ pub async fn list_events(
             )
         })?;
 
-    Ok(Json(ListResponse { data: events }))
+    // Turn boundary snapping (second pass): if the first event is not a turn.started
+    // and we're paginating backward, extend the batch to include events from the
+    // beginning of that turn.
+    let events = if is_paginated && !events.is_empty() && before_sequence.is_some() {
+        let first_seq = events[0].sequence.unwrap_or(0);
+        if events[0].event_type != "turn.started" {
+            // Find the turn.started boundary
+            if let Ok(Some(turn_seq)) = state
+                .event_service
+                .find_turn_boundary(session_id.uuid(), first_seq)
+                .await
+            {
+                if turn_seq < first_seq {
+                    // Fetch the missing events from turn boundary to first event
+                    if let Ok(mut prefix) = state
+                        .event_service
+                        .list(
+                            session_id.uuid(),
+                            Some(turn_seq - 1), // since_sequence is exclusive (>)
+                            None,
+                            &query.types,
+                            &query.exclude,
+                            Some(first_seq),
+                            None,
+                        )
+                        .await
+                    {
+                        prefix.extend(events);
+                        prefix
+                    } else {
+                        events
+                    }
+                } else {
+                    events
+                }
+            } else {
+                events
+            }
+        } else {
+            events
+        }
+    } else {
+        events
+    };
+
+    // Build response with optional X-Total-Count header
+    let mut headers = HeaderMap::new();
+    if is_paginated {
+        let total_count = state
+            .event_service
+            .count_events(session_id.uuid(), &query.exclude)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to count events: {}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: "Internal server error".to_string(),
+                    }),
+                )
+            })?;
+        headers.insert("X-Total-Count", total_count.to_string().parse().unwrap());
+        // Expose X-Total-Count to browser JS (CORS)
+        headers.insert(
+            "Access-Control-Expose-Headers",
+            "X-Total-Count".parse().unwrap(),
+        );
+    }
+
+    let body = Json(ListResponse { data: events });
+    Ok((headers, body).into_response())
 }
 
 #[cfg(test)]
@@ -829,6 +971,8 @@ mod tests {
             since_id: None,
             types: vec!["turn.started".to_string(), "turn.completed".to_string()],
             exclude: vec![],
+            limit: None,
+            before_sequence: None,
         };
         assert!(query.validate().is_ok());
     }
@@ -842,6 +986,8 @@ mod tests {
                 "output.message.delta".to_string(),
                 "reason.thinking.delta".to_string(),
             ],
+            limit: None,
+            before_sequence: None,
         };
         assert!(query.validate().is_ok());
     }
@@ -852,6 +998,8 @@ mod tests {
             since_id: None,
             types: vec![],
             exclude: vec![],
+            limit: None,
+            before_sequence: None,
         };
         assert!(query.validate().is_ok());
     }
@@ -862,6 +1010,8 @@ mod tests {
             since_id: None,
             types: vec!["turn.started".to_string(), "bogus.type".to_string()],
             exclude: vec![],
+            limit: None,
+            before_sequence: None,
         };
         let err = query.validate().unwrap_err();
         assert_eq!(err.0, StatusCode::BAD_REQUEST);
@@ -875,6 +1025,8 @@ mod tests {
             since_id: None,
             types: vec![],
             exclude: vec!["not.a.real.type".to_string()],
+            limit: None,
+            before_sequence: None,
         };
         let err = query.validate().unwrap_err();
         assert_eq!(err.0, StatusCode::BAD_REQUEST);
@@ -889,6 +1041,8 @@ mod tests {
             since_id: None,
             types,
             exclude: vec![],
+            limit: None,
+            before_sequence: None,
         };
         let err = query.validate().unwrap_err();
         assert_eq!(err.0, StatusCode::BAD_REQUEST);
@@ -902,6 +1056,8 @@ mod tests {
             since_id: None,
             types: vec![],
             exclude,
+            limit: None,
+            before_sequence: None,
         };
         let err = query.validate().unwrap_err();
         assert_eq!(err.0, StatusCode::BAD_REQUEST);
@@ -914,7 +1070,46 @@ mod tests {
             since_id: None,
             types: VALID_EVENT_TYPES.iter().map(|s| s.to_string()).collect(),
             exclude: vec![],
+            limit: None,
+            before_sequence: None,
         };
         assert!(query.validate().is_ok());
+    }
+
+    // ============================================
+    // Pagination query string tests
+    // ============================================
+
+    #[test]
+    fn test_query_string_with_limit() {
+        let qs = "limit=200";
+        let query: EventsQuery = serde_html_form::from_str(qs).expect("limit should parse");
+        assert_eq!(query.limit, Some(200));
+        assert!(query.before_sequence.is_none());
+    }
+
+    #[test]
+    fn test_query_string_with_limit_and_before_sequence() {
+        let qs = "limit=200&before_sequence=4500";
+        let query: EventsQuery =
+            serde_html_form::from_str(qs).expect("limit+before_sequence should parse");
+        assert_eq!(query.limit, Some(200));
+        assert_eq!(query.before_sequence, Some(4500));
+    }
+
+    #[test]
+    fn test_query_string_limit_with_exclude() {
+        let qs = "limit=100&exclude=output.message.delta&exclude=reason.thinking.delta";
+        let query: EventsQuery = serde_html_form::from_str(qs).expect("limit+exclude should parse");
+        assert_eq!(query.limit, Some(100));
+        assert_eq!(query.exclude.len(), 2);
+    }
+
+    #[test]
+    fn test_query_string_no_limit_defaults_none() {
+        let qs = "";
+        let query: EventsQuery = serde_html_form::from_str(qs).expect("empty should parse");
+        assert!(query.limit.is_none());
+        assert!(query.before_sequence.is_none());
     }
 }

--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -981,7 +981,7 @@ async fn wait_and_post_response(
         }
 
         let events = db
-            .list_events(session_id_typed, None, since_id, &empty, &empty)
+            .list_events(session_id_typed, None, since_id, &empty, &empty, None, None)
             .await?;
 
         for event_row in &events {

--- a/crates/server/src/services/event.rs
+++ b/crates/server/src/services/event.rs
@@ -202,6 +202,9 @@ impl EventService {
     /// `filter_types`: positive filter — when non-empty, only return matching types.
     /// `exclude_types`: negative filter — remove matching types from the result.
     /// When both are provided, `filter_types` narrows first, then `exclude_types` removes.
+    /// `before_sequence`: cursor for backward pagination (events before this sequence).
+    /// `limit`: max number of events to return (backward pagination, last N events).
+    #[allow(clippy::too_many_arguments)]
     pub async fn list(
         &self,
         session_id: Uuid,
@@ -209,6 +212,8 @@ impl EventService {
         since_id: Option<Uuid>,
         filter_types: &[String],
         exclude_types: &[String],
+        before_sequence: Option<i32>,
+        limit: Option<i32>,
     ) -> Result<Vec<Event>> {
         let rows = self
             .db
@@ -218,6 +223,8 @@ impl EventService {
                 since_id.map(EventId::from_uuid),
                 filter_types,
                 exclude_types,
+                before_sequence,
+                limit,
             )
             .await?;
         Ok(rows
@@ -225,6 +232,25 @@ impl EventService {
             .map(Self::row_to_event)
             .filter(|e| !e.is_unsupported())
             .collect())
+    }
+
+    /// Count events for a session, excluding specified types (for X-Total-Count header).
+    pub async fn count_events(&self, session_id: Uuid, exclude_types: &[String]) -> Result<i64> {
+        self.db
+            .count_events(SessionId::from_uuid(session_id), exclude_types)
+            .await
+    }
+
+    /// Find the nearest turn.started sequence at or before the given sequence.
+    /// Used for turn boundary snapping in pagination.
+    pub async fn find_turn_boundary(
+        &self,
+        session_id: Uuid,
+        before_sequence: i32,
+    ) -> Result<Option<i32>> {
+        self.db
+            .find_turn_boundary(SessionId::from_uuid(session_id), before_sequence)
+            .await
     }
 
     /// List events that represent messages (user, agent, tool results)

--- a/crates/server/src/slack_delivery.rs
+++ b/crates/server/src/slack_delivery.rs
@@ -193,7 +193,15 @@ impl SlackDeliveryDispatcher {
             // Fetch events since last processed
             let events = match self
                 .db
-                .list_events(session_id_typed, None, ctx.since_event_id, &empty, &empty)
+                .list_events(
+                    session_id_typed,
+                    None,
+                    ctx.since_event_id,
+                    &empty,
+                    &empty,
+                    None,
+                    None,
+                )
                 .await
             {
                 Ok(events) => events,
@@ -347,7 +355,7 @@ impl SlackDeliveryDispatcher {
             let filter_types = vec!["input.message".to_string()];
             let events = match self
                 .db
-                .list_events(session.id, None, None, &filter_types, &empty)
+                .list_events(session.id, None, None, &filter_types, &empty, None, None)
                 .await
             {
                 Ok(events) => events,
@@ -401,7 +409,15 @@ impl SlackDeliveryDispatcher {
             let turn_events = vec!["turn.completed".to_string(), "turn.failed".to_string()];
             let completion_events = self
                 .db
-                .list_events(session.id, None, Some(last_input.id), &turn_events, &empty)
+                .list_events(
+                    session.id,
+                    None,
+                    Some(last_input.id),
+                    &turn_events,
+                    &empty,
+                    None,
+                    None,
+                )
                 .await
                 .unwrap_or_default();
 

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -383,6 +383,7 @@ impl StorageBackend {
         dispatch!(self, has_event_with_slack_ts, session_id, slack_ts)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn list_events(
         &self,
         session_id: SessionId,
@@ -390,6 +391,8 @@ impl StorageBackend {
         since_id: Option<EventId>,
         filter_types: &[String],
         exclude_types: &[String],
+        before_sequence: Option<i32>,
+        limit: Option<i32>,
     ) -> Result<Vec<EventRow>> {
         dispatch!(
             self,
@@ -398,7 +401,9 @@ impl StorageBackend {
             since_sequence,
             since_id,
             filter_types,
-            exclude_types
+            exclude_types,
+            before_sequence,
+            limit
         )
     }
 
@@ -409,6 +414,15 @@ impl StorageBackend {
         exclude_types: &[String],
     ) -> Result<i64> {
         dispatch!(self, count_events, session_id, exclude_types)
+    }
+
+    /// Find the nearest turn.started sequence at or before the given sequence.
+    pub async fn find_turn_boundary(
+        &self,
+        session_id: SessionId,
+        before_sequence: i32,
+    ) -> Result<Option<i32>> {
+        dispatch!(self, find_turn_boundary, session_id, before_sequence)
     }
 
     pub async fn list_message_events(&self, session_id: SessionId) -> Result<Vec<EventRow>> {

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -1062,6 +1062,7 @@ impl InMemoryDatabase {
         Ok(row)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn list_events(
         &self,
         session_id: SessionId,
@@ -1069,6 +1070,8 @@ impl InMemoryDatabase {
         since_id: Option<EventId>,
         filter_types: &[String],
         exclude_types: &[String],
+        before_sequence: Option<i32>,
+        limit: Option<i32>,
     ) -> Result<Vec<EventRow>> {
         let events = self.events.read();
         let mut result: Vec<_> = events
@@ -1083,6 +1086,12 @@ impl InMemoryDatabase {
                 }
                 // Negative type filter: exclude matching types
                 if !exclude_types.is_empty() && exclude_types.contains(&e.event_type) {
+                    return false;
+                }
+                // before_sequence cursor for backward pagination
+                if let Some(before_seq) = before_sequence
+                    && e.sequence >= before_seq
+                {
                     return false;
                 }
                 // Resolve since_id to its sequence number for reliable ordering.
@@ -1107,7 +1116,35 @@ impl InMemoryDatabase {
             .collect();
 
         result.sort_by_key(|e| e.sequence);
+
+        // Apply limit: take last N events (backward pagination)
+        if let Some(limit) = limit {
+            let limit = limit as usize;
+            if result.len() > limit {
+                result = result.split_off(result.len() - limit);
+            }
+        }
+
         Ok(result)
+    }
+
+    /// Find the nearest turn.started sequence at or before the given sequence.
+    pub async fn find_turn_boundary(
+        &self,
+        session_id: SessionId,
+        before_sequence: i32,
+    ) -> Result<Option<i32>> {
+        let events = self.events.read();
+        let seq = events
+            .values()
+            .filter(|e| {
+                e.session_id == session_id
+                    && e.sequence <= before_sequence
+                    && e.event_type == "turn.started"
+            })
+            .map(|e| e.sequence)
+            .max();
+        Ok(seq)
     }
 
     /// Check if an input.message event with a given slack_ts already exists in a session.
@@ -4102,7 +4139,7 @@ mod tests {
         }
 
         let events = db
-            .list_events(session.id, None, None, &[], &[])
+            .list_events(session.id, None, None, &[], &[], None, None)
             .await
             .unwrap();
         assert_eq!(events.len(), 3);
@@ -4209,6 +4246,8 @@ mod tests {
                 None,
                 &["turn.started".to_string(), "turn.completed".to_string()],
                 &[],
+                None,
+                None,
             )
             .await
             .unwrap();
@@ -4224,7 +4263,15 @@ mod tests {
 
         // Positive filter: single type
         let events = db
-            .list_events(session_id, None, None, &["input.message".to_string()], &[])
+            .list_events(
+                session_id,
+                None,
+                None,
+                &["input.message".to_string()],
+                &[],
+                None,
+                None,
+            )
             .await
             .unwrap();
 
@@ -4239,7 +4286,7 @@ mod tests {
 
         // Empty types = return all (6 events created)
         let events = db
-            .list_events(session_id, None, None, &[], &[])
+            .list_events(session_id, None, None, &[], &[], None, None)
             .await
             .unwrap();
 
@@ -4259,6 +4306,8 @@ mod tests {
                 None,
                 &["nonexistent.type".to_string()],
                 &[],
+                None,
+                None,
             )
             .await
             .unwrap();
@@ -4282,6 +4331,8 @@ mod tests {
                     "output.message.delta".to_string(),
                     "reason.thinking.delta".to_string(),
                 ],
+                None,
+                None,
             )
             .await
             .unwrap();
@@ -4308,6 +4359,8 @@ mod tests {
                     "input.message".to_string(),
                 ],
                 &["turn.completed".to_string()],
+                None,
+                None,
             )
             .await
             .unwrap();
@@ -4332,6 +4385,8 @@ mod tests {
                 None,
                 &["input.message".to_string()],
                 &["input.message".to_string()],
+                None,
+                None,
             )
             .await
             .unwrap();
@@ -4346,7 +4401,7 @@ mod tests {
 
         // Get all events to find the ID of the second event
         let all_events = db
-            .list_events(session_id, None, None, &[], &[])
+            .list_events(session_id, None, None, &[], &[], None, None)
             .await
             .unwrap();
         assert_eq!(all_events.len(), 6);
@@ -4356,13 +4411,29 @@ mod tests {
 
         // Using since_id should return events after that event's sequence
         let events_after_id = db
-            .list_events(session_id, None, Some(second_event_id), &[], &[])
+            .list_events(
+                session_id,
+                None,
+                Some(second_event_id),
+                &[],
+                &[],
+                None,
+                None,
+            )
             .await
             .unwrap();
 
         // Using since_sequence with the same sequence should return the same events
         let events_after_seq = db
-            .list_events(session_id, Some(second_event_seq), None, &[], &[])
+            .list_events(
+                session_id,
+                Some(second_event_seq),
+                None,
+                &[],
+                &[],
+                None,
+                None,
+            )
             .await
             .unwrap();
 
@@ -4390,7 +4461,7 @@ mod tests {
         // Using a since_id that doesn't exist should return no events
         let unknown_id = EventId::new();
         let events = db
-            .list_events(session_id, None, Some(unknown_id), &[], &[])
+            .list_events(session_id, None, Some(unknown_id), &[], &[], None, None)
             .await
             .unwrap();
 
@@ -4403,7 +4474,7 @@ mod tests {
         let session_id = create_session_with_events(&db).await;
 
         let all_events = db
-            .list_events(session_id, None, None, &[], &[])
+            .list_events(session_id, None, None, &[], &[], None, None)
             .await
             .unwrap();
 
@@ -4417,6 +4488,8 @@ mod tests {
                 Some(fourth_event_id),
                 &[],
                 &[],
+                None,
+                None,
             )
             .await
             .unwrap();
@@ -4424,6 +4497,167 @@ mod tests {
         assert_eq!(events.len(), 2); // events 5 and 6
         assert_eq!(events[0].sequence, all_events[4].sequence);
         assert_eq!(events[1].sequence, all_events[5].sequence);
+    }
+
+    #[tokio::test]
+    async fn test_list_events_with_limit() {
+        let db = InMemoryDatabase::new();
+        let session_id = create_session_with_events(&db).await;
+
+        // 6 events total. limit=3 should return last 3.
+        let events = db
+            .list_events(session_id, None, None, &[], &[], None, Some(3))
+            .await
+            .unwrap();
+        assert_eq!(events.len(), 3);
+        // Should be the last 3 events in sequence order
+        assert!(events[0].sequence < events[1].sequence);
+        assert!(events[1].sequence < events[2].sequence);
+    }
+
+    #[tokio::test]
+    async fn test_list_events_with_limit_and_before_sequence() {
+        let db = InMemoryDatabase::new();
+        let session_id = create_session_with_events(&db).await;
+
+        let all = db
+            .list_events(session_id, None, None, &[], &[], None, None)
+            .await
+            .unwrap();
+        assert_eq!(all.len(), 6);
+
+        // Get last 2 events before the 5th event's sequence
+        let fifth_seq = all[4].sequence;
+        let events = db
+            .list_events(session_id, None, None, &[], &[], Some(fifth_seq), Some(2))
+            .await
+            .unwrap();
+        assert_eq!(events.len(), 2);
+        // Should be events 3 and 4 (0-indexed)
+        assert_eq!(events[0].id, all[2].id);
+        assert_eq!(events[1].id, all[3].id);
+    }
+
+    #[tokio::test]
+    async fn test_list_events_limit_greater_than_total() {
+        let db = InMemoryDatabase::new();
+        let session_id = create_session_with_events(&db).await;
+
+        // limit=1000 but only 6 events exist — returns all 6
+        let events = db
+            .list_events(session_id, None, None, &[], &[], None, Some(1000))
+            .await
+            .unwrap();
+        assert_eq!(events.len(), 6);
+    }
+
+    #[tokio::test]
+    async fn test_list_events_limit_with_exclude() {
+        let db = InMemoryDatabase::new();
+        let session_id = create_session_with_events(&db).await;
+
+        // 6 events, 2 are deltas. Exclude deltas + limit=2 → last 2 non-delta events
+        let events = db
+            .list_events(
+                session_id,
+                None,
+                None,
+                &[],
+                &[
+                    "output.message.delta".to_string(),
+                    "reason.thinking.delta".to_string(),
+                ],
+                None,
+                Some(2),
+            )
+            .await
+            .unwrap();
+        assert_eq!(events.len(), 2);
+        assert!(events.iter().all(|e| !e.event_type.contains("delta")));
+    }
+
+    #[tokio::test]
+    async fn test_count_non_delta_events() {
+        let db = InMemoryDatabase::new();
+        let session_id = create_session_with_events(&db).await;
+
+        // 6 events total, 2 are deltas → 4 non-delta
+        let delta_types = vec![
+            "output.message.delta".to_string(),
+            "reason.thinking.delta".to_string(),
+        ];
+        let count = db.count_events(session_id, &delta_types).await.unwrap();
+        assert_eq!(count, 4);
+    }
+
+    #[tokio::test]
+    async fn test_find_turn_boundary() {
+        let db = InMemoryDatabase::new();
+        let session_id = create_session_with_events(&db).await;
+
+        let all = db
+            .list_events(session_id, None, None, &[], &[], None, None)
+            .await
+            .unwrap();
+
+        // Find the turn.started event
+        let turn_started = all.iter().find(|e| e.event_type == "turn.started").unwrap();
+
+        // Searching at or after the turn.started sequence should find it
+        let boundary = db
+            .find_turn_boundary(session_id, turn_started.sequence + 1)
+            .await
+            .unwrap();
+        assert_eq!(boundary, Some(turn_started.sequence));
+
+        // Searching before the turn.started sequence should find nothing
+        // (if turn.started is the first turn event)
+        let boundary = db
+            .find_turn_boundary(session_id, turn_started.sequence - 1)
+            .await
+            .unwrap();
+        assert!(boundary.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_list_events_empty_session_with_limit() {
+        let db = InMemoryDatabase::new();
+        let agent = db
+            .create_agent(
+                DEFAULT_ORG_ID,
+                CreateAgentRow {
+                    public_id: AgentId::new().to_string(),
+                    name: "Empty Agent".to_string(),
+                    description: None,
+                    system_prompt: String::new(),
+                    default_model_id: None,
+                    tags: vec![],
+                    tools: serde_json::json!([]),
+                },
+            )
+            .await
+            .unwrap();
+
+        let session = db
+            .create_session(CreateSessionRow {
+                org_id: DEFAULT_ORG_ID,
+                harness_id: None,
+                agent_id: Some(agent.id),
+                title: None,
+                tags: vec![],
+                model_id: None,
+                capabilities: serde_json::json!([]),
+                tools: serde_json::json!([]),
+            })
+            .await
+            .unwrap();
+
+        // Empty session with limit should return empty
+        let events = db
+            .list_events(session.id, None, None, &[], &[], None, Some(200))
+            .await
+            .unwrap();
+        assert!(events.is_empty());
     }
 
     #[tokio::test]

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -1324,6 +1324,7 @@ impl Database {
         Ok(row.0)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn list_events(
         &self,
         session_id: SessionId,
@@ -1331,6 +1332,8 @@ impl Database {
         since_id: Option<EventId>,
         filter_types: &[String],
         exclude_types: &[String],
+        before_sequence: Option<i32>,
+        limit: Option<i32>,
     ) -> Result<Vec<EventRow>> {
         // UUID v7 is NOT guaranteed monotonically increasing across concurrent inserts,
         // so we always filter and order by the dedicated sequence column.
@@ -1338,6 +1341,62 @@ impl Database {
         // filter_types: positive filter — when non-empty, only return matching event types.
         // exclude_types: negative filter — remove matching event types from results.
         // When both are provided, filter_types narrows first, then exclude_types removes.
+        //
+        // Backward pagination: when `limit` is provided (with optional `before_sequence`),
+        // fetch the last N events by using ORDER BY sequence DESC LIMIT N, then reverse
+        // so results are returned oldest→newest.
+        if let Some(limit) = limit {
+            // Backward pagination: fetch last N events before a cursor
+            let rows = if let Some(before_seq) = before_sequence {
+                sqlx::query_as::<_, EventRow>(
+                    r#"
+                    SELECT * FROM (
+                        SELECT id, session_id, sequence, event_type, ts, context, data, metadata, tags, created_at
+                        FROM events
+                        WHERE session_id = $1
+                          AND sequence < $2
+                          AND (cardinality($3::text[]) = 0 OR event_type = ANY($3))
+                          AND (cardinality($4::text[]) = 0 OR event_type <> ALL($4))
+                        ORDER BY sequence DESC
+                        LIMIT $5
+                    ) batch
+                    ORDER BY sequence ASC
+                    "#,
+                )
+                .bind(session_id.uuid())
+                .bind(before_seq)
+                .bind(filter_types)
+                .bind(exclude_types)
+                .bind(limit as i64)
+                .fetch_all(&self.pool)
+                .await?
+            } else {
+                // No cursor: fetch the last N events
+                sqlx::query_as::<_, EventRow>(
+                    r#"
+                    SELECT * FROM (
+                        SELECT id, session_id, sequence, event_type, ts, context, data, metadata, tags, created_at
+                        FROM events
+                        WHERE session_id = $1
+                          AND (cardinality($2::text[]) = 0 OR event_type = ANY($2))
+                          AND (cardinality($3::text[]) = 0 OR event_type <> ALL($3))
+                        ORDER BY sequence DESC
+                        LIMIT $4
+                    ) batch
+                    ORDER BY sequence ASC
+                    "#,
+                )
+                .bind(session_id.uuid())
+                .bind(filter_types)
+                .bind(exclude_types)
+                .bind(limit as i64)
+                .fetch_all(&self.pool)
+                .await?
+            };
+            return Ok(rows);
+        }
+
+        // Original unbounded query (backward compat when no limit param)
         let rows = match (since_id, since_sequence) {
             (Some(id), _) => {
                 sqlx::query_as::<_, EventRow>(
@@ -1419,6 +1478,31 @@ impl Database {
         .await?;
 
         Ok(count)
+    }
+
+    /// Find the nearest turn.started sequence at or before the given sequence.
+    /// Used for turn boundary snapping in pagination.
+    pub async fn find_turn_boundary(
+        &self,
+        session_id: SessionId,
+        before_sequence: i32,
+    ) -> Result<Option<i32>> {
+        let row: Option<(i32,)> = sqlx::query_as(
+            r#"
+            SELECT sequence
+            FROM events
+            WHERE session_id = $1
+              AND sequence <= $2
+              AND event_type = 'turn.started'
+            ORDER BY sequence DESC
+            LIMIT 1
+            "#,
+        )
+        .bind(session_id.uuid())
+        .bind(before_sequence)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(|r| r.0))
     }
 
     /// List only message events for a session (for MessageStore implementation)

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -300,7 +300,7 @@ async fn test_event_crud() {
 
     // List events
     let events = backend
-        .list_events(session.id, None, None, &[], &[])
+        .list_events(session.id, None, None, &[], &[], None, None)
         .await
         .expect("Failed to list events");
     assert_eq!(events.len(), 1);
@@ -308,7 +308,7 @@ async fn test_event_crud() {
 
     // List with since_id filter
     let events_since = backend
-        .list_events(session.id, None, Some(event.id), &[], &[])
+        .list_events(session.id, None, Some(event.id), &[], &[], None, None)
         .await
         .expect("Failed to list events with since_id");
     assert!(
@@ -389,6 +389,8 @@ async fn test_event_exclude_types() {
             None,
             &[],
             &["output.message.delta".to_string()],
+            None,
+            None,
         )
         .await
         .expect("Failed to list events");
@@ -462,6 +464,8 @@ async fn test_event_filter_types() {
             None,
             &["turn.started".to_string(), "turn.completed".to_string()],
             &[],
+            None,
+            None,
         )
         .await
         .expect("Failed to list events with types filter");
@@ -470,7 +474,7 @@ async fn test_event_filter_types() {
 
     // Empty types = all events
     let events = backend
-        .list_events(session.id, None, None, &[], &[])
+        .list_events(session.id, None, None, &[], &[], None, None)
         .await
         .expect("Failed to list all events");
     assert_eq!(events.len(), 5);
@@ -487,6 +491,8 @@ async fn test_event_filter_types() {
                 "turn.completed".to_string(),
             ],
             &["turn.completed".to_string()],
+            None,
+            None,
         )
         .await
         .expect("Failed to list events with types+exclude");
@@ -504,6 +510,8 @@ async fn test_event_filter_types() {
             None,
             &["nonexistent.type".to_string()],
             &[],
+            None,
+            None,
         )
         .await
         .expect("Failed to list events with unmatched types");

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2819,7 +2819,7 @@
           "events"
         ],
         "summary": "GET /v1/sessions/{session_id}/events - List events (JSON)",
-        "description": "Returns events for a session as a JSON array. Supports filtering by event type\nvia `types` (positive: only these types) and `exclude` (negative: remove these types).\nWhen both are provided, `types` narrows first, then `exclude` removes from that set.\nBoth accept only known event types (max 25 per parameter). Unknown types return 400.",
+        "description": "Returns events for a session as a JSON array. Supports filtering by event type\nvia `types` (positive: only these types) and `exclude` (negative: remove these types).\nWhen both are provided, `types` narrows first, then `exclude` removes from that set.\nBoth accept only known event types (max 25 per parameter). Unknown types return 400.\n\n## Pagination\n\nSupports backward pagination via `limit` and `before_sequence`:\n- `limit=200` returns the last 200 events (oldest→newest)\n- `limit=200&before_sequence=4500` returns 200 events before sequence 4500\n- When `limit` is provided, the response includes an `X-Total-Count` header\n  with the count of non-delta events for the session\n- Turn boundary snapping: when fetching older pages, the batch boundary\n  snaps to the nearest `turn.started` event to avoid splitting turns\n- Without `limit`, all events are returned (backward compatible)",
         "operationId": "list_events",
         "parameters": [
           {
@@ -2874,11 +2874,48 @@
             },
             "style": "form",
             "explode": true
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Max events to return (backward pagination). When set, returns the last N events\n(or last N before `before_sequence`). Results are ordered oldest→newest.",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32",
+              "maximum": 1000,
+              "minimum": 1
+            }
+          },
+          {
+            "name": "before_sequence",
+            "in": "query",
+            "description": "Cursor for backward pagination: only return events with sequence < this value.\nUsed with `limit` to paginate backward through event history.",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Events list",
+            "headers": {
+              "X-Total-Count": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "description": "Total non-delta event count for the session (only present when limit is used)"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -3594,6 +3631,34 @@
             },
             "style": "form",
             "explode": true
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Max events to return (backward pagination). When set, returns the last N events\n(or last N before `before_sequence`). Results are ordered oldest→newest.",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32",
+              "maximum": 1000,
+              "minimum": 1
+            }
+          },
+          {
+            "name": "before_sequence",
+            "in": "query",
+            "description": "Cursor for backward pagination: only return events with sequence < this value.\nUsed with `limit` to paginate backward through event history.",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32"
+            }
           }
         ],
         "responses": {

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -279,6 +279,19 @@ Server-Sent Events (SSE) for real-time UI updates and event listing.
 
 When both `types` and `exclude` are provided, `types` narrows first, then `exclude` removes from that set. Both accept only known event types (max 25 per parameter). See [events.md](events.md) for full filtering semantics.
 
+**Pagination Parameters** (list endpoint only):
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `limit` | integer (1-1000) | Max events to return. Enables backward pagination (last N events). |
+| `before_sequence` | integer | Cursor: only return events with sequence < this value. Requires `limit`. |
+
+When `limit` is provided:
+- Returns the last N events (oldest→newest within batch)
+- Response includes `X-Total-Count` header with count of non-delta events
+- Turn boundary snapping: batch start snaps to nearest `turn.started` event
+- Without `limit`, all events are returned (backward compatible)
+
 ### LLM Provider Configuration
 
 | Method | Path | Description |
@@ -526,7 +539,7 @@ Endpoints that return lists support pagination via query parameters:
 These endpoints return all items wrapped in `{"data": [...], "total": N}`:
 - `GET /v1/agents` - Returns all agents
 - `GET /v1/sessions/{session_id}/messages` - Returns all messages
-- `GET /v1/sessions/{session_id}/events` - Returns all events
+- `GET /v1/sessions/{session_id}/events` - Returns all events (supports optional `limit`/`before_sequence` pagination)
 - `GET /v1/llm-providers` - Returns all providers
 - `GET /v1/llm-models` - Returns all models
 - `GET /v1/durable/workers` - Returns all workers


### PR DESCRIPTION
## Summary

- **EVE-82 (Server):** Add backward pagination to `GET /v1/sessions/{id}/events` via `limit` + `before_sequence` query params. Returns `X-Total-Count` header with non-delta event count. Turn boundary snapping ensures pages don't split turns. Fully backward compatible — omitting `limit` returns all events as before.
- **EVE-83 (UI):** Initial load fetches last 200 non-delta events (not all), SSE connects with `since_id` for live updates. Scrolling up triggers loading older events with cursor pagination. Scroll position preserved when prepending older events (no visual jump).

Closes EVE-82, EVE-83.

## Test plan

- [x] Unit tests for pagination, boundary snapping, edge cases (empty session, fewer events than limit)
- [x] 693 server unit tests passing
- [x] UI build + lint passing
- [x] `just pre-push` all checks green
- [ ] Smoke test: create session with many events, verify initial load only fetches last 200
- [ ] Smoke test: scroll up in chat to trigger older event loading
- [ ] Smoke test: verify SSE streaming still works for active sessions
- [ ] Smoke test: verify backward compat (no limit param returns all events)