### PR TITLE
test(slack): enforce credentials, add Slack integration tests to CI

### DIFF
--- a/crates/server/tests/slack_integration_test.rs
+++ b/crates/server/tests/slack_integration_test.rs
@@ -697,46 +697,28 @@ async fn test_slack_manifest_endpoint() {
 // Real Slack API Tests (require credentials)
 // ============================================
 
-/// Get real Slack credentials from environment. Returns None if not set.
+/// Get real Slack credentials from environment.
 /// Checks TEST_-prefixed vars first (Doppler convention), then unprefixed.
 ///
-/// **In CI** (`CI=true`), panics if any variable is missing — credentials
-/// must always be available via Doppler so real-API tests never silently skip.
-fn real_slack_credentials() -> Option<(String, String, String)> {
-    let in_ci = std::env::var("CI").is_ok_and(|v| v == "true");
-
+/// Panics if any variable is missing — these tests require real credentials.
+fn real_slack_credentials() -> (String, String, String) {
     let token = std::env::var("TEST_SLACK_BOT_TOKEN")
         .or_else(|_| std::env::var("SLACK_BOT_TOKEN"))
-        .ok();
+        .expect("TEST_SLACK_BOT_TOKEN or SLACK_BOT_TOKEN must be set");
     let secret = std::env::var("TEST_SLACK_SIGNING_SECRET")
         .or_else(|_| std::env::var("SLACK_SIGNING_SECRET"))
-        .ok();
+        .expect("TEST_SLACK_SIGNING_SECRET or SLACK_SIGNING_SECRET must be set");
     let channel = std::env::var("TEST_SLACK_TEST_CHANNEL")
         .or_else(|_| std::env::var("SLACK_TEST_CHANNEL"))
-        .ok();
-
-    if in_ci {
-        let token = token.expect("CI requires TEST_SLACK_BOT_TOKEN or SLACK_BOT_TOKEN to be set");
-        let secret = secret
-            .expect("CI requires TEST_SLACK_SIGNING_SECRET or SLACK_SIGNING_SECRET to be set");
-        let channel =
-            channel.expect("CI requires TEST_SLACK_TEST_CHANNEL or SLACK_TEST_CHANNEL to be set");
-        return Some((token, secret, channel));
-    }
-
-    Some((token?, secret?, channel?))
+        .expect("TEST_SLACK_TEST_CHANNEL or SLACK_TEST_CHANNEL must be set");
+    (token, secret, channel)
 }
 
 /// Test posting a real message to Slack and verifying the response.
 /// Requires: SLACK_BOT_TOKEN, SLACK_SIGNING_SECRET, SLACK_TEST_CHANNEL
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_real_slack_post_message() {
-    let Some((bot_token, _signing_secret, channel)) = real_slack_credentials() else {
-        eprintln!(
-            "Skipping real Slack test: SLACK_BOT_TOKEN / SLACK_SIGNING_SECRET / SLACK_TEST_CHANNEL not set"
-        );
-        return;
-    };
+    let (bot_token, _signing_secret, channel) = real_slack_credentials();
 
     let client = reqwest::Client::new();
     let resp = client
@@ -789,10 +771,7 @@ async fn test_real_slack_post_message() {
 /// Requires: SLACK_BOT_TOKEN (and a real user in the workspace)
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_real_slack_users_info() {
-    let Some((bot_token, _, _)) = real_slack_credentials() else {
-        eprintln!("Skipping real Slack test: credentials not set");
-        return;
-    };
+    let (bot_token, _, _) = real_slack_credentials();
 
     // First, get a user from the workspace
     let client = reqwest::Client::new();
@@ -851,10 +830,7 @@ async fn test_real_slack_users_info() {
 /// Requires: SLACK_BOT_TOKEN, SLACK_SIGNING_SECRET, SLACK_TEST_CHANNEL
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_real_slack_webhook_to_session() {
-    let Some((bot_token, signing_secret, channel)) = real_slack_credentials() else {
-        eprintln!("Skipping real Slack webhook test: credentials not set");
-        return;
-    };
+    let (bot_token, signing_secret, channel) = real_slack_credentials();
 
     let server = TestServer::new().await;
 

--- a/specs/slack-integration.md
+++ b/specs/slack-integration.md
@@ -119,7 +119,7 @@ Integration tests in `crates/server/tests/slack_integration_test.rs`:
 - **Webhook tests** (always run): URL verification, signature rejection, session creation/reuse, bot message filtering, session strategies, manifest endpoint, replay attack prevention
 - **Real Slack API tests** (require credentials): `chat.postMessage`, `users.info`, full webhook→session flow with real signing secret
 
-CI runs all tests via `doppler run` in the `integration-test` job (PostgreSQL required). `real_slack_credentials()` panics when `CI=true` and any `TEST_SLACK_*` env var is missing — real-API tests never silently skip in CI.
+CI runs all tests via `doppler run` in the `integration-test` job (PostgreSQL required). `real_slack_credentials()` always panics if any `TEST_SLACK_*` env var is missing — real-API tests never silently skip.
 
 Doppler vars: `TEST_SLACK_BOT_TOKEN`, `TEST_SLACK_SIGNING_SECRET`, `TEST_SLACK_TEST_CHANNEL`.
 


### PR DESCRIPTION
## What
- Slack integration tests always crash if `TEST_SLACK_*` env vars are missing (no silent skip)
- Added Slack integration test step to CI via Doppler
- Tests use poll-based session waiting instead of fixed sleeps
- Fresh agents created per test to avoid FK violations from soft-deleted seed data

## Why
Real Slack API tests were silently skipping when credentials were absent. This hid failures and gave false confidence in CI.

## How
- `real_slack_credentials()` unconditionally panics on missing env vars
- CI runs `doppler run --preserve-env="DATABASE_URL" -- cargo test` for Slack tests
- Replaced `tokio::time::sleep` with `wait_for_sessions_with_tag()` (exponential backoff)
- `create_test_agent()` helper creates fresh agents via API

## Risk
- Low
- Slack tests will fail if Doppler credentials are removed (intentional)

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered