### PR TITLE
chore(migrations): squash post-0.8.4 migrations into 006_v0.8.5

### DIFF
--- a/crates/server/migrations/006_v0.8.5.sql
+++ b/crates/server/migrations/006_v0.8.5.sql
@@ -1,5 +1,13 @@
--- Full-text search on events (EVE-87)
+-- Everruns v0.8.5
+-- Squashed migration for changes between v0.8.4 and v0.8.5
+-- BREAKING CHANGE: Requires fresh database (drop existing _sqlx_migrations table)
 --
+-- Includes:
+-- - Full-text search on events (EVE-87)
+
+-- ============================================
+-- Event full-text search (EVE-87)
+-- ============================================
 -- Replaces `data::text ILIKE '%query%'` (sequential scan) with a tsvector
 -- generated column + GIN index for indexed full-text search.
 --


### PR DESCRIPTION
## Summary

- Rename `006_event_search_vector.sql` → `006_v0.8.5.sql` with standard squashed migration header format
- Consistent with existing naming convention (`004_v0.8.3.sql`, `005_v0.8.4.sql`)
- No SQL changes — same event full-text search column and GIN index (EVE-87)

## Test plan

- [x] `just pre-push` passes (fmt, clippy, lockfile)
- [ ] CI green
- [ ] Verify `just start-all` runs migrations successfully with fresh database

https://claude.ai/code/session_01MGQa3t2DYFzkjvvxuy2rcF