### PR TITLE
fix(storage): clear existing default model before setting new one

### DIFF
--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -1683,7 +1683,16 @@ impl InMemoryDatabase {
             created_at: now,
             updated_at: now,
         };
-        self.llm_models.write().insert(id, row.clone());
+        let mut models = self.llm_models.write();
+        if input.is_default {
+            for m in models.values_mut() {
+                if m.org_id == org_id && m.is_default {
+                    m.is_default = false;
+                    m.updated_at = now;
+                }
+            }
+        }
+        models.insert(id, row.clone());
         Ok(row)
     }
 
@@ -1701,7 +1710,7 @@ impl InMemoryDatabase {
         let mut models = self.llm_models.write();
         let now = Self::now();
 
-        if let Some(existing) = models.get(&id) {
+        if let Some(existing) = models.get(&id).cloned() {
             // Check if seed-controlled fields differ
             if existing.display_name == input.display_name
                 && existing.is_default == input.is_default
@@ -1709,17 +1718,33 @@ impl InMemoryDatabase {
             {
                 return Ok(None); // Unchanged
             }
+            if input.is_default {
+                for m in models.values_mut() {
+                    if m.org_id == org_id && m.is_default && m.id != id {
+                        m.is_default = false;
+                        m.updated_at = now;
+                    }
+                }
+            }
             let row = LlmModelRow {
                 display_name: input.display_name,
                 is_default: input.is_default,
                 is_favorite: input.is_favorite,
                 updated_at: now,
-                ..existing.clone()
+                ..existing
             };
             models.insert(id, row.clone());
             return Ok(Some(row));
         }
 
+        if input.is_default {
+            for m in models.values_mut() {
+                if m.org_id == org_id && m.is_default {
+                    m.is_default = false;
+                    m.updated_at = now;
+                }
+            }
+        }
         let row = LlmModelRow {
             id,
             org_id,
@@ -1848,29 +1873,38 @@ impl InMemoryDatabase {
     ) -> Result<Option<LlmModelRow>> {
         let id = ModelId::from_uuid(id);
         let mut models = self.llm_models.write();
-        if let Some(model) = models.get_mut(&id) {
-            if model.org_id != org_id {
-                return Ok(None);
-            }
-            if let Some(display_name) = input.display_name {
-                model.display_name = display_name;
-            }
-            if let Some(capabilities) = input.capabilities {
-                model.capabilities = serde_json::to_value(&capabilities)?;
-            }
-            if let Some(is_default) = input.is_default {
-                model.is_default = is_default;
-            }
-            if let Some(is_favorite) = input.is_favorite {
-                model.is_favorite = is_favorite;
-            }
-            if let Some(status) = input.status {
-                model.status = status;
-            }
-            model.updated_at = Self::now();
-            return Ok(Some(model.clone()));
+        // Check existence and org ownership
+        if models.get(&id).is_none_or(|m| m.org_id != org_id) {
+            return Ok(None);
         }
-        Ok(None)
+        // Clear default on other models if setting this one as default
+        if input.is_default == Some(true) {
+            let now = Self::now();
+            for m in models.values_mut() {
+                if m.org_id == org_id && m.is_default && m.id != id {
+                    m.is_default = false;
+                    m.updated_at = now;
+                }
+            }
+        }
+        let model = models.get_mut(&id).unwrap();
+        if let Some(display_name) = input.display_name {
+            model.display_name = display_name;
+        }
+        if let Some(capabilities) = input.capabilities {
+            model.capabilities = serde_json::to_value(&capabilities)?;
+        }
+        if let Some(is_default) = input.is_default {
+            model.is_default = is_default;
+        }
+        if let Some(is_favorite) = input.is_favorite {
+            model.is_favorite = is_favorite;
+        }
+        if let Some(status) = input.status {
+            model.status = status;
+        }
+        model.updated_at = Self::now();
+        Ok(Some(model.clone()))
     }
 
     pub async fn delete_llm_model(&self, org_id: i64, id: Uuid) -> Result<bool> {

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -2051,6 +2051,11 @@ impl Database {
 
         let row = sqlx::query_as::<_, LlmModelRow>(
             r#"
+            WITH clear_default AS (
+                UPDATE llm_models
+                SET is_default = FALSE, updated_at = NOW()
+                WHERE is_default = TRUE AND org_id = $1 AND $6 = TRUE
+            )
             INSERT INTO llm_models (org_id, provider_id, model_id, display_name, capabilities, is_default, is_favorite, source, provider_metadata)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
             RETURNING id, org_id, provider_id, model_id, display_name, capabilities, is_default, is_favorite, status, source, last_seen_at, provider_metadata, created_at, updated_at
@@ -2083,6 +2088,11 @@ impl Database {
 
         let row = sqlx::query_as::<_, LlmModelRow>(
             r#"
+            WITH clear_default AS (
+                UPDATE llm_models
+                SET is_default = FALSE, updated_at = NOW()
+                WHERE is_default = TRUE AND id != $1 AND $7 = TRUE
+            )
             INSERT INTO llm_models (id, org_id, provider_id, model_id, display_name, capabilities, is_default, is_favorite, source, provider_metadata)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
             ON CONFLICT (id) DO UPDATE SET
@@ -2203,6 +2213,11 @@ impl Database {
 
         let row = sqlx::query_as::<_, LlmModelRow>(
             r#"
+            WITH clear_default AS (
+                UPDATE llm_models
+                SET is_default = FALSE, updated_at = NOW()
+                WHERE is_default = TRUE AND org_id = $1 AND id != $2 AND $6 = TRUE
+            )
             UPDATE llm_models
             SET
                 model_id = COALESCE($3, model_id),

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -2091,7 +2091,7 @@ impl Database {
             WITH clear_default AS (
                 UPDATE llm_models
                 SET is_default = FALSE, updated_at = NOW()
-                WHERE is_default = TRUE AND id != $1 AND $7 = TRUE
+                WHERE is_default = TRUE AND org_id = $2 AND id != $1 AND $7 = TRUE
             )
             INSERT INTO llm_models (id, org_id, provider_id, model_id, display_name, capabilities, is_default, is_favorite, source, provider_metadata)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)

--- a/crates/server/tests/llm_model_default_test.rs
+++ b/crates/server/tests/llm_model_default_test.rs
@@ -33,7 +33,11 @@ async fn setup() -> (InMemoryDatabase, everruns_core::ProviderId) {
     (db, provider.id)
 }
 
-fn model_input(provider_id: everruns_core::ProviderId, name: &str, is_default: bool) -> CreateLlmModelRow {
+fn model_input(
+    provider_id: everruns_core::ProviderId,
+    name: &str,
+    is_default: bool,
+) -> CreateLlmModelRow {
     CreateLlmModelRow {
         provider_id,
         model_id: name.to_string(),
@@ -130,7 +134,10 @@ async fn test_update_model_to_default_clears_previous() {
         .await
         .expect("get model-a")
         .expect("model-a exists");
-    assert!(!m1_fetched.is_default, "previous default should be cleared after update");
+    assert!(
+        !m1_fetched.is_default,
+        "previous default should be cleared after update"
+    );
 }
 
 #[tokio::test]
@@ -147,11 +154,7 @@ async fn test_seed_upsert_clears_previous_default() {
     // Seed inserts a model with is_default=true using a fixed ID
     let seed_id = Uuid::new_v4();
     let seed_result = db
-        .create_llm_model_with_id(
-            TEST_ORG_ID,
-            seed_id,
-            model_input(pid, "seed-default", true),
-        )
+        .create_llm_model_with_id(TEST_ORG_ID, seed_id, model_input(pid, "seed-default", true))
         .await
         .expect("seed model");
     assert!(seed_result.is_some(), "seed should create the model");
@@ -163,7 +166,10 @@ async fn test_seed_upsert_clears_previous_default() {
         .await
         .expect("get user model")
         .expect("user model exists");
-    assert!(!user_fetched.is_default, "user default should be cleared by seed");
+    assert!(
+        !user_fetched.is_default,
+        "user default should be cleared by seed"
+    );
 }
 
 #[tokio::test]
@@ -172,13 +178,9 @@ async fn test_seed_upsert_update_path_clears_previous_default() {
 
     // First seed: model-a is default
     let seed_id = Uuid::new_v4();
-    db.create_llm_model_with_id(
-        TEST_ORG_ID,
-        seed_id,
-        model_input(pid, "seed-model", true),
-    )
-    .await
-    .expect("first seed");
+    db.create_llm_model_with_id(TEST_ORG_ID, seed_id, model_input(pid, "seed-model", true))
+        .await
+        .expect("first seed");
 
     // User sets another model as default
     let user_model = db
@@ -196,11 +198,7 @@ async fn test_seed_upsert_update_path_clears_previous_default() {
 
     // Re-seed: updates existing seed model back to default
     let reseed = db
-        .create_llm_model_with_id(
-            TEST_ORG_ID,
-            seed_id,
-            model_input(pid, "seed-model", true),
-        )
+        .create_llm_model_with_id(TEST_ORG_ID, seed_id, model_input(pid, "seed-model", true))
         .await
         .expect("re-seed");
     assert!(reseed.is_some(), "should detect is_default changed");

--- a/crates/server/tests/llm_model_default_test.rs
+++ b/crates/server/tests/llm_model_default_test.rs
@@ -1,0 +1,216 @@
+//! Tests for LLM model is_default uniqueness constraint
+//!
+//! Verifies that only one model can be the default at a time,
+//! and that setting a new default clears the previous one.
+//!
+//! Uses in-memory backend (no PostgreSQL required).
+//!
+//! Run with: cargo test -p everruns-server --test llm_model_default_test
+
+use uuid::Uuid;
+
+use everruns_server::storage::{
+    CreateLlmModelRow, CreateLlmProviderRow, InMemoryDatabase, UpdateLlmModel,
+};
+
+const TEST_ORG_ID: i64 = 1;
+
+async fn setup() -> (InMemoryDatabase, everruns_core::ProviderId) {
+    let db = InMemoryDatabase::default();
+    let provider = db
+        .create_llm_provider(
+            TEST_ORG_ID,
+            CreateLlmProviderRow {
+                name: "Test Provider".to_string(),
+                provider_type: "openai".to_string(),
+                base_url: None,
+                api_key_encrypted: None,
+                settings: None,
+            },
+        )
+        .await
+        .expect("create provider");
+    (db, provider.id)
+}
+
+fn model_input(provider_id: everruns_core::ProviderId, name: &str, is_default: bool) -> CreateLlmModelRow {
+    CreateLlmModelRow {
+        provider_id,
+        model_id: name.to_string(),
+        display_name: name.to_string(),
+        capabilities: vec![],
+        is_default,
+        is_favorite: false,
+        source: "manual".to_string(),
+        provider_metadata: None,
+    }
+}
+
+#[tokio::test]
+async fn test_create_model_clears_previous_default() {
+    let (db, pid) = setup().await;
+
+    // Create first model as default
+    let m1 = db
+        .create_llm_model(TEST_ORG_ID, model_input(pid, "model-a", true))
+        .await
+        .expect("create model-a");
+    assert!(m1.is_default);
+
+    // Create second model as default — should clear the first
+    let m2 = db
+        .create_llm_model(TEST_ORG_ID, model_input(pid, "model-b", true))
+        .await
+        .expect("create model-b");
+    assert!(m2.is_default);
+
+    // Verify first model is no longer default
+    let m1_fetched = db
+        .get_llm_model(TEST_ORG_ID, m1.id.into())
+        .await
+        .expect("get model-a")
+        .expect("model-a exists");
+    assert!(!m1_fetched.is_default, "previous default should be cleared");
+}
+
+#[tokio::test]
+async fn test_create_non_default_does_not_clear_existing_default() {
+    let (db, pid) = setup().await;
+
+    let m1 = db
+        .create_llm_model(TEST_ORG_ID, model_input(pid, "model-a", true))
+        .await
+        .expect("create model-a");
+    assert!(m1.is_default);
+
+    // Create non-default model — should not affect existing default
+    db.create_llm_model(TEST_ORG_ID, model_input(pid, "model-b", false))
+        .await
+        .expect("create model-b");
+
+    let m1_fetched = db
+        .get_llm_model(TEST_ORG_ID, m1.id.into())
+        .await
+        .expect("get model-a")
+        .expect("model-a exists");
+    assert!(m1_fetched.is_default, "default should remain unchanged");
+}
+
+#[tokio::test]
+async fn test_update_model_to_default_clears_previous() {
+    let (db, pid) = setup().await;
+
+    let m1 = db
+        .create_llm_model(TEST_ORG_ID, model_input(pid, "model-a", true))
+        .await
+        .expect("create model-a");
+    let m2 = db
+        .create_llm_model(TEST_ORG_ID, model_input(pid, "model-b", false))
+        .await
+        .expect("create model-b");
+
+    // Update m2 to be default
+    let updated = db
+        .update_llm_model(
+            TEST_ORG_ID,
+            m2.id.into(),
+            UpdateLlmModel {
+                is_default: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("update model-b")
+        .expect("model-b exists");
+    assert!(updated.is_default);
+
+    // m1 should no longer be default
+    let m1_fetched = db
+        .get_llm_model(TEST_ORG_ID, m1.id.into())
+        .await
+        .expect("get model-a")
+        .expect("model-a exists");
+    assert!(!m1_fetched.is_default, "previous default should be cleared after update");
+}
+
+#[tokio::test]
+async fn test_seed_upsert_clears_previous_default() {
+    let (db, pid) = setup().await;
+
+    // Simulate: user manually set a model as default
+    let user_model = db
+        .create_llm_model(TEST_ORG_ID, model_input(pid, "user-model", true))
+        .await
+        .expect("create user model");
+    assert!(user_model.is_default);
+
+    // Seed inserts a model with is_default=true using a fixed ID
+    let seed_id = Uuid::new_v4();
+    let seed_result = db
+        .create_llm_model_with_id(
+            TEST_ORG_ID,
+            seed_id,
+            model_input(pid, "seed-default", true),
+        )
+        .await
+        .expect("seed model");
+    assert!(seed_result.is_some(), "seed should create the model");
+    assert!(seed_result.unwrap().is_default);
+
+    // User's model should no longer be default
+    let user_fetched = db
+        .get_llm_model(TEST_ORG_ID, user_model.id.into())
+        .await
+        .expect("get user model")
+        .expect("user model exists");
+    assert!(!user_fetched.is_default, "user default should be cleared by seed");
+}
+
+#[tokio::test]
+async fn test_seed_upsert_update_path_clears_previous_default() {
+    let (db, pid) = setup().await;
+
+    // First seed: model-a is default
+    let seed_id = Uuid::new_v4();
+    db.create_llm_model_with_id(
+        TEST_ORG_ID,
+        seed_id,
+        model_input(pid, "seed-model", true),
+    )
+    .await
+    .expect("first seed");
+
+    // User sets another model as default
+    let user_model = db
+        .create_llm_model(TEST_ORG_ID, model_input(pid, "user-choice", true))
+        .await
+        .expect("user creates default");
+
+    // Verify seed model lost default
+    let seed_fetched = db
+        .get_llm_model(TEST_ORG_ID, seed_id)
+        .await
+        .expect("get seed")
+        .expect("seed exists");
+    assert!(!seed_fetched.is_default);
+
+    // Re-seed: updates existing seed model back to default
+    let reseed = db
+        .create_llm_model_with_id(
+            TEST_ORG_ID,
+            seed_id,
+            model_input(pid, "seed-model", true),
+        )
+        .await
+        .expect("re-seed");
+    assert!(reseed.is_some(), "should detect is_default changed");
+    assert!(reseed.unwrap().is_default);
+
+    // User model should no longer be default
+    let user_fetched = db
+        .get_llm_model(TEST_ORG_ID, user_model.id.into())
+        .await
+        .expect("get user model")
+        .expect("user model exists");
+    assert!(!user_fetched.is_default, "user default cleared by re-seed");
+}


### PR DESCRIPTION
## What
Fix `duplicate key value violates unique constraint "idx_llm_models_default"` error during database seeding by clearing existing default models before setting a new one.

## Why
The unique partial index `idx_llm_models_default` enforces only one `is_default=TRUE` row in `llm_models`. When seeding or creating/updating a model with `is_default=TRUE` while another model already held that flag, the `ON CONFLICT (id)` clause could not catch the conflict on the partial index, causing the constraint violation.

## How
- **PostgreSQL**: Added a CTE (`WITH clear_default AS (...)`) to atomically clear existing defaults before insert/update in all three model write operations (`create_llm_model`, `create_llm_model_with_id`, `update_llm_model`)
- **In-memory backend**: Added equivalent pre-mutation loops to clear default flags
- All CTEs are scoped by `org_id` to prevent cross-org side effects in multitenancy
- Added 5 in-memory tests covering create, update, seed insert, and seed upsert paths

## Risk
- Low
- Only affects behavior when `is_default=TRUE` is passed; existing non-default model operations are unchanged

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered