### PR TITLE
fix(storage): cap unbounded fetch_all() query paths

### DIFF
--- a/crates/server/src/api/events.rs
+++ b/crates/server/src/api/events.rs
@@ -431,7 +431,9 @@ pub async fn stream_sse(
                         return Some((stream::iter(vec![]), new_state));
                     }
 
-                    // Fetch events since last ID
+                    // Fetch events since last ID.
+                    // Forward queries are safety-capped at 10k rows in the repository layer;
+                    // any remaining events are picked up on the next poll cycle.
                     tracing::debug!(session_id = %session_id, last_id = ?state.last_id, "SSE: fetching events");
                     match event_service.list(session_id, None, state.last_id, &state.filter_types, &state.exclude_types, None, None).await {
                         Ok(events) if !events.is_empty() => {

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -439,6 +439,11 @@ impl StorageBackend {
         dispatch!(self, list_message_events_limited, session_id, limit)
     }
 
+    /// Count message events for a session using COUNT(*) — no row materialization.
+    pub async fn count_message_events(&self, session_id: SessionId) -> Result<i64> {
+        dispatch!(self, count_message_events, session_id)
+    }
+
     /// List message events with filters applied
     ///
     /// This method applies the filters from the MessageQuery to efficiently

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -1117,12 +1117,11 @@ impl InMemoryDatabase {
 
         result.sort_by_key(|e| e.sequence);
 
-        // Apply limit: take last N events (backward pagination)
-        if let Some(limit) = limit {
-            let limit = limit as usize;
-            if result.len() > limit {
-                result = result.split_off(result.len() - limit);
-            }
+        // Apply limit: take last N events (backward pagination).
+        // Safety cap of 10 000 when no explicit limit to prevent unbounded results.
+        let effective_limit = limit.map(|l| l as usize).unwrap_or(10_000);
+        if result.len() > effective_limit {
+            result = result.split_off(result.len() - effective_limit);
         }
 
         Ok(result)
@@ -1215,6 +1214,23 @@ impl InMemoryDatabase {
             }
         }
         Ok(result)
+    }
+
+    /// Count message events for a session — no row materialization.
+    pub async fn count_message_events(&self, session_id: SessionId) -> Result<i64> {
+        let message_types = [
+            "input.message",
+            "output.message.completed",
+            "tool.completed",
+        ];
+        let events = self.events.read();
+        let count = events
+            .values()
+            .filter(|e| {
+                e.session_id == session_id && message_types.contains(&e.event_type.as_str())
+            })
+            .count();
+        Ok(count as i64)
     }
 
     /// List message events for a session with filters applied.

--- a/crates/server/src/storage/message_store.rs
+++ b/crates/server/src/storage/message_store.rs
@@ -163,12 +163,12 @@ impl MessageRetriever for DbMessageRetriever {
     }
 
     async fn count(&self, session_id: SessionId) -> Result<usize> {
-        let events = self
+        let count = self
             .db
-            .list_message_events(session_id)
+            .count_message_events(session_id)
             .await
             .map_err(|e| AgentLoopError::store(e.to_string()))?;
-        Ok(events.len())
+        Ok(count as usize)
     }
 }
 

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -1396,7 +1396,9 @@ impl Database {
             return Ok(rows);
         }
 
-        // Original unbounded query (backward compat when no limit param)
+        // Safety-limited forward query (backward compat when no limit param).
+        // Cap at 10 000 rows to prevent unbounded result sets.
+        const FORWARD_SAFETY_LIMIT: i64 = 10_000;
         let rows = match (since_id, since_sequence) {
             (Some(id), _) => {
                 sqlx::query_as::<_, EventRow>(
@@ -1408,12 +1410,14 @@ impl Database {
                       AND (cardinality($3::text[]) = 0 OR event_type = ANY($3))
                       AND (cardinality($4::text[]) = 0 OR event_type <> ALL($4))
                     ORDER BY sequence ASC
+                    LIMIT $5
                     "#,
                 )
                 .bind(session_id.uuid())
                 .bind(id.uuid())
                 .bind(filter_types)
                 .bind(exclude_types)
+                .bind(FORWARD_SAFETY_LIMIT)
                 .fetch_all(&self.pool)
                 .await?
             }
@@ -1426,12 +1430,14 @@ impl Database {
                       AND (cardinality($3::text[]) = 0 OR event_type = ANY($3))
                       AND (cardinality($4::text[]) = 0 OR event_type <> ALL($4))
                     ORDER BY sequence ASC
+                    LIMIT $5
                     "#,
                 )
                 .bind(session_id.uuid())
                 .bind(seq)
                 .bind(filter_types)
                 .bind(exclude_types)
+                .bind(FORWARD_SAFETY_LIMIT)
                 .fetch_all(&self.pool)
                 .await?
             }
@@ -1444,11 +1450,13 @@ impl Database {
                       AND (cardinality($2::text[]) = 0 OR event_type = ANY($2))
                       AND (cardinality($3::text[]) = 0 OR event_type <> ALL($3))
                     ORDER BY sequence ASC
+                    LIMIT $4
                     "#,
                 )
                 .bind(session_id.uuid())
                 .bind(filter_types)
                 .bind(exclude_types)
+                .bind(FORWARD_SAFETY_LIMIT)
                 .fetch_all(&self.pool)
                 .await?
             }
@@ -1543,6 +1551,8 @@ impl Database {
             .fetch_all(&self.pool)
             .await?
         } else {
+            // Safety cap when no explicit limit — prevents unbounded result sets.
+            const MESSAGE_SAFETY_LIMIT: i64 = 5_000;
             sqlx::query_as::<_, EventRow>(
                 r#"
                 SELECT id, session_id, sequence, event_type, ts, context, data, metadata, tags, created_at
@@ -1550,14 +1560,32 @@ impl Database {
                 WHERE session_id = $1
                   AND event_type IN ('input.message', 'output.message.completed', 'tool.completed')
                 ORDER BY sequence ASC
+                LIMIT $2
                 "#,
             )
             .bind(session_id.uuid())
+            .bind(MESSAGE_SAFETY_LIMIT)
             .fetch_all(&self.pool)
             .await?
         };
 
         Ok(rows)
+    }
+
+    /// Count message events for a session using SELECT COUNT(*) — no row materialization.
+    pub async fn count_message_events(&self, session_id: SessionId) -> Result<i64> {
+        let (count,): (i64,) = sqlx::query_as(
+            r#"
+            SELECT COUNT(*)
+            FROM events
+            WHERE session_id = $1
+              AND event_type IN ('input.message', 'output.message.completed', 'tool.completed')
+            "#,
+        )
+        .bind(session_id.uuid())
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(count)
     }
 
     /// List message events for a session with filters applied.


### PR DESCRIPTION
## Summary
- Add `LIMIT 10000` safety cap to forward `list_events()` queries in both PostgreSQL and memory backends, preventing unbounded result sets on SSE catch-up and backward-compat API paths
- Add `LIMIT 5000` safety cap to `list_message_events_limited()` when no explicit limit is provided
- Add `count_message_events()` using `SELECT COUNT(*)` instead of materializing all rows just to count them

## Test plan
- [ ] Verify SSE catch-up after client disconnect fetches at most 10k events per poll cycle
- [ ] Verify `list_events()` API without explicit limit returns capped results
- [ ] Verify message count endpoint uses COUNT(*) query (check query logs)
- [ ] Smoke test in dev mode: create session, send messages, verify events load correctly
- [ ] Smoke test in full mode: same as above with PostgreSQL

Fixes EVE-82, EVE-83