### PR TITLE
chore(deps): bump fetchkit from 0.1.2 to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1705,9 +1705,9 @@ dependencies = [
 
 [[package]]
 name = "fetchkit"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1613575f52ffed08a5d0149e2dfcffce17dde3f2359827daa270bfc894df5653"
+checksum = "f1dbd70d72547e6a531e7d8d862a29809cb95aaf0558be91020ae74687884eff"
 dependencies = [
  "async-trait",
  "bytes",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -51,7 +51,7 @@ base64.workspace = true
 url = "2"
 
 # Web fetching
-fetchkit = "0.1.2"
+fetchkit = "0.1.3"
 
 # Virtual bash interpreter
 bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.1.8" }

--- a/crates/core/src/capabilities/web_fetch.rs
+++ b/crates/core/src/capabilities/web_fetch.rs
@@ -16,6 +16,7 @@ use fetchkit::{
     FetchError, FetchOptions, FetchRequest, TOOL_DESCRIPTION, TOOL_LLMTXT, fetch_with_options,
 };
 use serde_json::Value;
+use std::ops::Deref;
 
 /// WebFetch capability - provides tools to fetch web content
 pub struct WebFetchCapability;
@@ -52,7 +53,7 @@ impl Capability for WebFetchCapability {
 
     fn system_prompt_addition(&self) -> Option<&str> {
         // Use the LLM-optimized documentation from fetchkit
-        Some(TOOL_LLMTXT)
+        Some(TOOL_LLMTXT.deref())
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
@@ -140,6 +141,7 @@ impl Tool for WebFetchTool {
             method: Some(method),
             as_markdown: if as_markdown { Some(true) } else { None },
             as_text: if as_text { Some(true) } else { None },
+            ..Default::default()
         };
 
         // Execute the fetch using fetchkit with configured options (SSRF protection)
@@ -168,6 +170,8 @@ impl Tool for WebFetchTool {
                     FetchError::ConnectError(_) => "Failed to connect to server".to_string(),
                     FetchError::RequestError(msg) => format!("Request failed: {}", msg),
                     FetchError::FetcherError(msg) => format!("Fetch error: {}", msg),
+                    FetchError::SaveError(msg) => format!("Failed to save file: {}", msg),
+                    FetchError::SaverNotAvailable => "File saving not available".to_string(),
                 };
                 ToolExecutionResult::tool_error(error_message)
             }


### PR DESCRIPTION
## What
Bump fetchkit dependency from 0.1.2 to 0.1.3 and adapt to API changes.

## Why
fetchkit 0.1.3 includes security hardening (SSRF redirect following with per-hop IP validation, max_body_size limit, URL-aware prefix matching) and new FileSaver trait for file downloads.

## How
- Updated `crates/core/Cargo.toml` to fetchkit 0.1.3
- `TOOL_LLMTXT` changed from `&str` const to `LazyLock<String>` — use `Deref`
- `FetchRequest` gained `save_to_file` field — use `..Default::default()`
- `FetchError` gained `SaveError`/`SaverNotAvailable` variants — added match arms

## Risk
- Low
- Dependency bump with backward-compatible API adaptation
- File saving feature is opt-in and disabled by default (`enable_save_to_file: false`)

## Checklist
- [x] Tests added or updated (39 existing web_fetch tests all pass)
- [x] Backward compatibility considered (no behavior changes, only API adaptation)