### PR TITLE
chore(release): prepare v0.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.8.5] - 2026-03-12
+
+### Highlights
+
+- **Slack Thread Context** — Bot receives full thread context when first mentioned mid-thread ([#768](https://github.com/everruns/everruns/pull/768))
+- **Preview of OpenUI Generative UI** — Dynamic generative UI capability for agents ([#790](https://github.com/everruns/everruns/pull/790))
+- **Global Search & Command Palette** — Cmd+K to search sessions, navigate, and run commands ([#767](https://github.com/everruns/everruns/pull/767))
+- **Performance Improvements** — GIN-indexed tsvector event search, durable snapshot checkpointing, paginated event loading ([#787](https://github.com/everruns/everruns/pull/787), [#794](https://github.com/everruns/everruns/pull/794))
+
+### What's Changed
+
+- feat(durable): add snapshot checkpointing for workflow event replay ([#794](https://github.com/everruns/everruns/pull/794)) by [@chaliy](https://github.com/chaliy)
+- feat(openui): implement OpenUI generative UI capability ([#790](https://github.com/everruns/everruns/pull/790)) by [@chaliy](https://github.com/chaliy)
+- feat: paginated event loading for large sessions (EVE-82, EVE-83) by [@chaliy](https://github.com/chaliy)
+- feat(ui): bottom-anchored chat scroll with new messages indicator ([#781](https://github.com/everruns/everruns/pull/781)) by [@chaliy](https://github.com/chaliy)
+- feat(ui): add exponential backoff to SSE reconnection ([#779](https://github.com/everruns/everruns/pull/779)) by [@chaliy](https://github.com/chaliy)
+- feat(browserless): add Browserless browser automation integration ([#776](https://github.com/everruns/everruns/pull/776)) by [@chaliy](https://github.com/chaliy)
+- feat(search): global search & command palette (Cmd+K) ([#767](https://github.com/everruns/everruns/pull/767)) by [@chaliy](https://github.com/chaliy)
+- feat(daytona): add ownership metadata labels to sandbox creation ([#772](https://github.com/everruns/everruns/pull/772)) by [@chaliy](https://github.com/chaliy)
+- feat(slack): inject thread context when bot is first mentioned mid-thread ([#768](https://github.com/everruns/everruns/pull/768)) by [@chaliy](https://github.com/chaliy)
+- feat(core): set GPT-5.4 as default model ([#762](https://github.com/everruns/everruns/pull/762)) by [@chaliy](https://github.com/chaliy)
+- feat(connections): add generic API key verification for connected accounts ([#760](https://github.com/everruns/everruns/pull/760)) by [@chaliy](https://github.com/chaliy)
+- feat(ui): move MCP Servers from Settings to Building Blocks ([#761](https://github.com/everruns/everruns/pull/761)) by [@chaliy](https://github.com/chaliy)
+- feat(core): add execution phases and iteration tracking ([#759](https://github.com/everruns/everruns/pull/759)) by [@chaliy](https://github.com/chaliy)
+- feat(ui): add durable queues management page ([#754](https://github.com/everruns/everruns/pull/754)) by [@chaliy](https://github.com/chaliy)
+- feat(ui): collapse durable execution sidebar by default ([#756](https://github.com/everruns/everruns/pull/756)) by [@chaliy](https://github.com/chaliy)
+- fix(server): log migration errors through tracing before propagating ([#800](https://github.com/everruns/everruns/pull/800)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): fix duplicate React key in command palette navigation ([#798](https://github.com/everruns/everruns/pull/798)) by [@chaliy](https://github.com/chaliy)
+- fix(storage): clear existing default model before setting new one ([#797](https://github.com/everruns/everruns/pull/797)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): close global search on ESC and route navigation ([#795](https://github.com/everruns/everruns/pull/795)) by [@chaliy](https://github.com/chaliy)
+- fix(storage): replace ILIKE event search with GIN-indexed tsvector ([#787](https://github.com/everruns/everruns/pull/787)) by [@chaliy](https://github.com/chaliy)
+- fix(durable): use SELECT COUNT(*) for event counting ([#782](https://github.com/everruns/everruns/pull/782)) by [@chaliy](https://github.com/chaliy)
+- fix(slack): ensure long_description meets Slack's 174-char minimum ([#780](https://github.com/everruns/everruns/pull/780)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): show completed turn duration in chat ([#778](https://github.com/everruns/everruns/pull/778)) by [@chaliy](https://github.com/chaliy)
+- fix(docs): upgrade Astro docs site to v6 ([#777](https://github.com/everruns/everruns/pull/777)) by [@chaliy](https://github.com/chaliy)
+- fix(slack): expose external_actor in API Message response ([#771](https://github.com/everruns/everruns/pull/771)) by [@chaliy](https://github.com/chaliy)
+- fix(apps): auto-complete Slack setup checklist steps 4 and 5 ([#770](https://github.com/everruns/everruns/pull/770)) by [@chaliy](https://github.com/chaliy)
+- fix(daytona): use git clone via exec instead of broken /git/clone endpoint ([#766](https://github.com/everruns/everruns/pull/766)) by [@chaliy](https://github.com/chaliy)
+- fix(worker): wire all stores into durable act_activity ([#763](https://github.com/everruns/everruns/pull/763)) by [@chaliy](https://github.com/chaliy)
+- fix(daytona): use /home/daytona as workspace path ([#765](https://github.com/everruns/everruns/pull/765)) by [@chaliy](https://github.com/chaliy)
+- fix(daytona): remove API key prerequisite from Coder agent prompt ([#757](https://github.com/everruns/everruns/pull/757)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): simplify inline tool transcript ([#758](https://github.com/everruns/everruns/pull/758)) by [@chaliy](https://github.com/chaliy)
+- fix(session-files): return 409 instead of 500 on duplicate file creation ([#755](https://github.com/everruns/everruns/pull/755)) by [@chaliy](https://github.com/chaliy)
+- fix(server): increase session files upload body limit to 10MB ([#751](https://github.com/everruns/everruns/pull/751)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): render folder action icons inline with folder name ([#752](https://github.com/everruns/everruns/pull/752)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): fix code block rendering in chat messages ([#753](https://github.com/everruns/everruns/pull/753)) by [@chaliy](https://github.com/chaliy)
+- fix(vfs): correct folder detection in stat() ([#749](https://github.com/everruns/everruns/pull/749)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): prevent workspace file tree from overflowing viewport ([#750](https://github.com/everruns/everruns/pull/750)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump fetchkit from 0.1.2 to 0.1.3 ([#802](https://github.com/everruns/everruns/pull/802))
+- chore(migrations): squash post-0.8.4 migrations into 006_v0.8.5 ([#792](https://github.com/everruns/everruns/pull/792)) by [@chaliy](https://github.com/chaliy)
+- test(slack): enforce credentials, add Slack integration tests to CI ([#789](https://github.com/everruns/everruns/pull/789)) by [@chaliy](https://github.com/chaliy)
+- test(daytona): add live API integration tests ([#774](https://github.com/everruns/everruns/pull/774)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.8.4] - 2026-03-08
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Highlights
 
+- **Browserless Integration** — Browser automation for agents via Browserless ([#776](https://github.com/everruns/everruns/pull/776))
 - **Slack Thread Context** — Bot receives full thread context when first mentioned mid-thread ([#768](https://github.com/everruns/everruns/pull/768))
 - **Preview of OpenUI Generative UI** — Dynamic generative UI capability for agents ([#790](https://github.com/everruns/everruns/pull/790))
 - **Global Search & Command Palette** — Cmd+K to search sessions, navigate, and run commands ([#767](https://github.com/everruns/everruns/pull/767))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1353,7 +1353,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "sysinfo 0.38.3",
+ "sysinfo 0.38.4",
  "test-log",
  "thiserror 2.0.18",
  "tokio",
@@ -1368,7 +1368,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1386,7 +1386,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1402,7 +1402,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "async-trait",
  "base64",
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "async-trait",
  "base64",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -1484,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.8.4"
+version = "0.8.5"
 
 [[package]]
 name = "everruns-sdk"
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1611,7 +1611,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2500,9 +2500,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.9"
+version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -3083,9 +3083,9 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
-version = "0.7.11"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -3278,18 +3278,18 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-foundation"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.0",
 ]
 
 [[package]]
 name = "objc2-io-kit"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
@@ -3297,9 +3297,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -3315,9 +3315,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
@@ -3347,9 +3347,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
 dependencies = [
  "cc",
  "libc",
@@ -4570,9 +4570,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -5233,9 +5233,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.38.3"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03c61d2a49c649a15c407338afe7accafde9dac869995dccb73e5f7ef7d9034"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
 dependencies = [
  "libc",
  "memchr",
@@ -5274,9 +5274,9 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.2",
@@ -7035,18 +7035,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7156,9 +7156,9 @@ checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "410e9ecef634c709e3831c2cfdb8d9c32164fae1c67496d5b68fff728eec37fe"
+checksum = "ec5f41c76397b7da451efd19915684f727d7e1d516384ca6bd0ec43ec94de23c"
 dependencies = [
  "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.4"
+version = "0.8.5"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns Contributors"]

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "everruns-ui",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@openuidev/react-lang": "^0.1.3",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "private": true,
   "exports": {
     "./providers/*": "./src/providers/*.tsx",


### PR DESCRIPTION
## Release v0.8.5

This PR prepares the v0.8.5 release.

### Highlights

- **Slack Thread Context** — Bot receives full thread context when first mentioned mid-thread
- **Preview of OpenUI Generative UI** — Dynamic generative UI capability for agents
- **Global Search & Command Palette** — Cmd+K to search sessions, navigate, and run commands
- **Performance Improvements** — GIN-indexed tsvector event search, durable snapshot checkpointing, paginated event loading

### Checklist
- [ ] Review CHANGELOG.md entries
- [ ] Add highlights/screenshots if needed
- [ ] Verify version numbers updated
- [ ] CI passes

### Post-merge
After merging, the release workflow will automatically:
- Create git tag `v0.8.5`
- Create GitHub Release with notes from CHANGELOG.md
- Trigger Docker image build with version tag