### PR TITLE
feat(permissions): fine-grained permissions model with #[policy] macro

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ Fix root cause. Unsure: read more code; if stuck, ask w/ short options. Unrecogn
 - `specs/brand.md` - Brand identity, colors, typography
 - `specs/dismissed-options.md` - Technical options considered but dismissed
 - `specs/multitenancy.md` - Organization-based multitenancy
+- `specs/permissions.md` - Fine-grained permissions model (policies, rules, `#[policy]` macro)
 - `specs/release-process.md` - Release workflow with CHANGELOG.md
 - `specs/id-schema.md` - Standardized prefixed ID format
 - `specs/braintrust-integration.md` - Braintrust observability

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1483,6 +1483,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "everruns-macros"
+version = "0.8.4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "tokio",
+]
+
+[[package]]
 name = "everruns-openai"
 version = "0.8.5"
 dependencies = [
@@ -1547,6 +1557,7 @@ dependencies = [
  "everruns-integrations-docker",
  "everruns-integrations-duckduckgo",
  "everruns-internal-protocol",
+ "everruns-macros",
  "everruns-sdk",
  "everruns-session-sqldb",
  "everruns-worker",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1484,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/server",
     "crates/worker",
     "crates/core",
+    "crates/macros",
     "crates/openai",
     "crates/anthropic",
     "crates/gemini",

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -57,6 +57,9 @@ pub mod session_schedule;
 pub mod session_sqldb;
 pub mod skill;
 
+// Permissions model (policies, rules, caller context)
+pub mod permissions;
+
 // URL validation for SSRF prevention (shared utility)
 pub mod url_validation;
 
@@ -240,6 +243,12 @@ pub use skill::{
 pub use typed_id::{
     AgentId, AppId, EventId, ExecId, HarnessId, IdMarker, IdParseError, ImageId, McpServerId,
     MessageId, ModelId, OrgId, ProviderId, ScheduleId, SessionId, SkillId, TurnId, TypedId,
+};
+
+// Permissions re-exports
+pub use permissions::{
+    Caller, Permission, Policy, PolicyConfigResponse, PolicyError, Rule, evaluate_policies,
+    role_has_permission, role_permissions,
 };
 
 // URL validation re-exports

--- a/crates/core/src/organization.rs
+++ b/crates/core/src/organization.rs
@@ -47,9 +47,9 @@ pub struct Organization {
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "lowercase")]
 pub enum OrgRole {
-    #[default]
     Member,
     Admin,
+    #[default]
     Owner,
 }
 
@@ -221,6 +221,6 @@ mod tests {
 
     #[test]
     fn test_org_role_default() {
-        assert_eq!(OrgRole::default(), OrgRole::Member);
+        assert_eq!(OrgRole::default(), OrgRole::Owner);
     }
 }

--- a/crates/core/src/permissions.rs
+++ b/crates/core/src/permissions.rs
@@ -204,6 +204,7 @@ impl Caller {
     ///
     /// Used for gRPC service calls (worker ↔ server) and other internal
     /// operations that should bypass all policy checks.
+    // THREAT[TM-AUTHZ-002]: Internal caller bypasses policies; only use for gRPC/internal paths
     pub fn internal(org_id: i64) -> Self {
         Self {
             org_id,

--- a/crates/core/src/permissions.rs
+++ b/crates/core/src/permissions.rs
@@ -1,0 +1,541 @@
+// Permissions model for fine-grained access control
+//
+// Decision: Permissions are hardcoded per OrgRole (no DB storage in phase 1).
+// Decision: Policies are const values evaluated at service method entry via #[policy] macro.
+// Decision: Permission format is `org:<resource>:<action>`.
+// See specs/permissions.md for full design.
+
+use crate::organization::OrgRole;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::fmt;
+use uuid::Uuid;
+
+/// A permission identifier representing an action on a resource.
+///
+/// Format: `org:<resource>:<action>`
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Permission {
+    /// CRUD on harnesses
+    OrgHarnessesManage,
+    /// Delete, reset, and other dangerous harness operations
+    OrgHarnessesDangerous,
+    /// CRUD on agents
+    OrgAgentsManage,
+    /// CRUD on sessions
+    OrgSessionsManage,
+    /// CRUD on LLM providers
+    OrgLlmProvidersManage,
+    /// Organization settings
+    OrgSettingsManage,
+    /// Invite/remove members
+    OrgMembersManage,
+    /// CRUD on API keys
+    OrgApiKeysManage,
+}
+
+impl Permission {
+    /// String identifier for this permission.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Permission::OrgHarnessesManage => "org:harnesses:manage",
+            Permission::OrgHarnessesDangerous => "org:harnesses:dangerous",
+            Permission::OrgAgentsManage => "org:agents:manage",
+            Permission::OrgSessionsManage => "org:sessions:manage",
+            Permission::OrgLlmProvidersManage => "org:llm-providers:manage",
+            Permission::OrgSettingsManage => "org:settings:manage",
+            Permission::OrgMembersManage => "org:members:manage",
+            Permission::OrgApiKeysManage => "org:api-keys:manage",
+        }
+    }
+
+    /// All defined permissions.
+    pub const ALL: &'static [Permission] = &[
+        Permission::OrgHarnessesManage,
+        Permission::OrgHarnessesDangerous,
+        Permission::OrgAgentsManage,
+        Permission::OrgSessionsManage,
+        Permission::OrgLlmProvidersManage,
+        Permission::OrgSettingsManage,
+        Permission::OrgMembersManage,
+        Permission::OrgApiKeysManage,
+    ];
+}
+
+impl fmt::Display for Permission {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+// ============================================================================
+// Role → Permission mapping
+// ============================================================================
+
+/// Permissions granted to Owner role.
+const OWNER_PERMISSIONS: &[Permission] = &[
+    Permission::OrgHarnessesManage,
+    Permission::OrgHarnessesDangerous,
+    Permission::OrgAgentsManage,
+    Permission::OrgSessionsManage,
+    Permission::OrgLlmProvidersManage,
+    Permission::OrgSettingsManage,
+    Permission::OrgMembersManage,
+    Permission::OrgApiKeysManage,
+];
+
+/// Permissions granted to Admin role.
+const ADMIN_PERMISSIONS: &[Permission] = &[
+    Permission::OrgHarnessesManage,
+    Permission::OrgAgentsManage,
+    Permission::OrgSessionsManage,
+    Permission::OrgLlmProvidersManage,
+    Permission::OrgSettingsManage,
+    Permission::OrgMembersManage,
+    Permission::OrgApiKeysManage,
+];
+
+/// Permissions granted to Member role.
+const MEMBER_PERMISSIONS: &[Permission] =
+    &[Permission::OrgAgentsManage, Permission::OrgSessionsManage];
+
+/// Check whether a role grants a specific permission.
+pub fn role_has_permission(role: OrgRole, permission: &Permission) -> bool {
+    let perms = match role {
+        OrgRole::Owner => OWNER_PERMISSIONS,
+        OrgRole::Admin => ADMIN_PERMISSIONS,
+        OrgRole::Member => MEMBER_PERMISSIONS,
+    };
+    perms.contains(permission)
+}
+
+/// List all permissions granted to a role.
+pub fn role_permissions(role: OrgRole) -> &'static [Permission] {
+    match role {
+        OrgRole::Owner => OWNER_PERMISSIONS,
+        OrgRole::Admin => ADMIN_PERMISSIONS,
+        OrgRole::Member => MEMBER_PERMISSIONS,
+    }
+}
+
+// ============================================================================
+// Rule
+// ============================================================================
+
+/// A single predicate evaluated against a Caller context.
+/// All rules in a Policy must pass (AND logic).
+#[derive(Debug, Clone)]
+pub enum Rule {
+    /// Caller's role must grant this permission.
+    UserHasPermission(Permission),
+    /// Caller must have at least this OrgRole level.
+    UserHasRole(OrgRole),
+}
+
+impl fmt::Display for Rule {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Rule::UserHasPermission(p) => write!(f, "UserHasPermission({})", p),
+            Rule::UserHasRole(r) => write!(f, "UserHasRole({})", r),
+        }
+    }
+}
+
+// ============================================================================
+// Policy
+// ============================================================================
+
+/// A named set of rules that must all pass for access.
+///
+/// Policies are defined as `const` values and attached to service methods
+/// via the `#[policy]` macro.
+#[derive(Debug, Clone)]
+pub struct Policy {
+    /// Unique identifier for this policy (e.g. "harness.manage").
+    pub id: &'static str,
+    /// Rules that must all pass. AND logic.
+    pub rules: &'static [Rule],
+}
+
+impl Policy {
+    /// Evaluate all rules against the caller. Returns `Ok(())` if all pass,
+    /// or `Err(PolicyError)` on the first failing rule.
+    pub fn evaluate(&self, caller: &Caller) -> Result<(), PolicyError> {
+        for rule in self.rules {
+            match rule {
+                Rule::UserHasPermission(perm) => {
+                    if !role_has_permission(caller.role, perm) {
+                        return Err(PolicyError::denied(self.id, perm.as_str()));
+                    }
+                }
+                Rule::UserHasRole(required) => {
+                    if !caller.role.has_permission(*required) {
+                        return Err(PolicyError::denied(self.id, &format!("role:{}", required)));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Caller
+// ============================================================================
+
+/// Auth context passed from API handler to service layer.
+///
+/// Replaces raw `org_id: i64` parameter on service methods. Carries all
+/// information needed for policy evaluation.
+#[derive(Debug, Clone)]
+pub struct Caller {
+    /// Internal organization ID (for database queries).
+    pub org_id: i64,
+    /// External organization public ID.
+    pub org_public_id: String,
+    /// Authenticated user ID (`None` for API key auth without user context).
+    pub user_id: Option<Uuid>,
+    /// User's role in the organization.
+    pub role: OrgRole,
+}
+
+impl Caller {
+    /// Create an internal/platform caller with Owner role.
+    ///
+    /// Used for gRPC service calls (worker ↔ server) and other internal
+    /// operations that should bypass all policy checks.
+    pub fn internal(org_id: i64) -> Self {
+        Self {
+            org_id,
+            org_public_id: crate::organization::org_public_id_from_internal(org_id),
+            user_id: None,
+            role: OrgRole::Owner,
+        }
+    }
+}
+
+// ============================================================================
+// PolicyError
+// ============================================================================
+
+/// Error returned when a policy evaluation fails.
+#[derive(Debug, Clone)]
+pub struct PolicyError {
+    /// Which policy failed.
+    pub policy_id: String,
+    /// Human-readable message.
+    pub message: String,
+}
+
+impl PolicyError {
+    pub fn denied(policy_id: &str, detail: &str) -> Self {
+        Self {
+            policy_id: policy_id.to_string(),
+            message: format!(
+                "Access denied: policy '{}' requires '{}'",
+                policy_id, detail
+            ),
+        }
+    }
+}
+
+impl fmt::Display for PolicyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for PolicyError {}
+
+// ============================================================================
+// Policy evaluation helpers (for config endpoints)
+// ============================================================================
+
+/// Evaluate multiple policies against a caller and return a map of results.
+/// Used by `/config` endpoints to expose policy results to the UI.
+pub fn evaluate_policies(caller: &Caller, policies: &[&Policy]) -> HashMap<String, bool> {
+    policies
+        .iter()
+        .map(|p| (p.id.to_string(), p.evaluate(caller).is_ok()))
+        .collect()
+}
+
+/// Response type for config endpoints.
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct PolicyConfigResponse {
+    /// Map of policy ID → whether the caller satisfies it.
+    pub policies: HashMap<String, bool>,
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn owner_caller() -> Caller {
+        Caller {
+            org_id: 1,
+            org_public_id: "org_00000000000000000000000000000001".to_string(),
+            user_id: Some(Uuid::new_v4()),
+            role: OrgRole::Owner,
+        }
+    }
+
+    fn admin_caller() -> Caller {
+        Caller {
+            org_id: 1,
+            org_public_id: "org_00000000000000000000000000000001".to_string(),
+            user_id: Some(Uuid::new_v4()),
+            role: OrgRole::Admin,
+        }
+    }
+
+    fn member_caller() -> Caller {
+        Caller {
+            org_id: 1,
+            org_public_id: "org_00000000000000000000000000000001".to_string(),
+            user_id: Some(Uuid::new_v4()),
+            role: OrgRole::Member,
+        }
+    }
+
+    // -- role_has_permission tests --
+
+    #[test]
+    fn owner_has_all_permissions() {
+        for perm in Permission::ALL {
+            assert!(
+                role_has_permission(OrgRole::Owner, perm),
+                "Owner should have {:?}",
+                perm
+            );
+        }
+    }
+
+    #[test]
+    fn admin_has_manage_but_not_dangerous() {
+        assert!(role_has_permission(
+            OrgRole::Admin,
+            &Permission::OrgHarnessesManage
+        ));
+        assert!(!role_has_permission(
+            OrgRole::Admin,
+            &Permission::OrgHarnessesDangerous
+        ));
+        assert!(role_has_permission(
+            OrgRole::Admin,
+            &Permission::OrgAgentsManage
+        ));
+        assert!(role_has_permission(
+            OrgRole::Admin,
+            &Permission::OrgSettingsManage
+        ));
+    }
+
+    #[test]
+    fn member_has_only_basic_permissions() {
+        assert!(role_has_permission(
+            OrgRole::Member,
+            &Permission::OrgAgentsManage
+        ));
+        assert!(role_has_permission(
+            OrgRole::Member,
+            &Permission::OrgSessionsManage
+        ));
+        assert!(!role_has_permission(
+            OrgRole::Member,
+            &Permission::OrgHarnessesManage
+        ));
+        assert!(!role_has_permission(
+            OrgRole::Member,
+            &Permission::OrgSettingsManage
+        ));
+        assert!(!role_has_permission(
+            OrgRole::Member,
+            &Permission::OrgApiKeysManage
+        ));
+    }
+
+    // -- Policy evaluation tests --
+
+    const TEST_MANAGE: Policy = Policy {
+        id: "harness.manage",
+        rules: &[Rule::UserHasPermission(Permission::OrgHarnessesManage)],
+    };
+
+    const TEST_DANGEROUS: Policy = Policy {
+        id: "harness.dangerous",
+        rules: &[
+            Rule::UserHasPermission(Permission::OrgHarnessesManage),
+            Rule::UserHasPermission(Permission::OrgHarnessesDangerous),
+        ],
+    };
+
+    const TEST_ROLE_ADMIN: Policy = Policy {
+        id: "require.admin",
+        rules: &[Rule::UserHasRole(OrgRole::Admin)],
+    };
+
+    #[test]
+    fn owner_passes_all_policies() {
+        let caller = owner_caller();
+        assert!(TEST_MANAGE.evaluate(&caller).is_ok());
+        assert!(TEST_DANGEROUS.evaluate(&caller).is_ok());
+        assert!(TEST_ROLE_ADMIN.evaluate(&caller).is_ok());
+    }
+
+    #[test]
+    fn admin_passes_manage_but_not_dangerous() {
+        let caller = admin_caller();
+        assert!(TEST_MANAGE.evaluate(&caller).is_ok());
+        assert!(TEST_DANGEROUS.evaluate(&caller).is_err());
+        assert!(TEST_ROLE_ADMIN.evaluate(&caller).is_ok());
+    }
+
+    #[test]
+    fn member_fails_manage_and_dangerous() {
+        let caller = member_caller();
+        assert!(TEST_MANAGE.evaluate(&caller).is_err());
+        assert!(TEST_DANGEROUS.evaluate(&caller).is_err());
+        assert!(TEST_ROLE_ADMIN.evaluate(&caller).is_err());
+    }
+
+    #[test]
+    fn policy_error_contains_useful_info() {
+        let caller = member_caller();
+        let err = TEST_MANAGE.evaluate(&caller).unwrap_err();
+        assert_eq!(err.policy_id, "harness.manage");
+        assert!(err.message.contains("org:harnesses:manage"));
+        assert!(err.to_string().contains("Access denied"));
+    }
+
+    // -- evaluate_policies (config endpoint helper) tests --
+
+    #[test]
+    fn evaluate_policies_returns_correct_map() {
+        let caller = admin_caller();
+        let result = evaluate_policies(&caller, &[&TEST_MANAGE, &TEST_DANGEROUS]);
+
+        assert_eq!(result.get("harness.manage"), Some(&true));
+        assert_eq!(result.get("harness.dangerous"), Some(&false));
+    }
+
+    #[test]
+    fn evaluate_policies_owner_all_true() {
+        let caller = owner_caller();
+        let result = evaluate_policies(&caller, &[&TEST_MANAGE, &TEST_DANGEROUS, &TEST_ROLE_ADMIN]);
+
+        assert!(result.values().all(|&v| v));
+    }
+
+    #[test]
+    fn evaluate_policies_member_all_false_for_admin_policies() {
+        let caller = member_caller();
+        let result = evaluate_policies(&caller, &[&TEST_MANAGE, &TEST_DANGEROUS, &TEST_ROLE_ADMIN]);
+
+        assert!(result.values().all(|&v| !v));
+    }
+
+    // -- Permission display --
+
+    #[test]
+    fn permission_display() {
+        assert_eq!(
+            Permission::OrgHarnessesManage.to_string(),
+            "org:harnesses:manage"
+        );
+        assert_eq!(
+            Permission::OrgHarnessesDangerous.to_string(),
+            "org:harnesses:dangerous"
+        );
+        assert_eq!(Permission::OrgAgentsManage.to_string(), "org:agents:manage");
+    }
+
+    // -- role_permissions --
+
+    #[test]
+    fn role_permissions_returns_correct_sets() {
+        assert_eq!(role_permissions(OrgRole::Owner).len(), 8);
+        assert_eq!(role_permissions(OrgRole::Admin).len(), 7);
+        assert_eq!(role_permissions(OrgRole::Member).len(), 2);
+    }
+
+    // -- Caller --
+
+    #[test]
+    fn caller_without_user_id() {
+        let caller = Caller {
+            org_id: 1,
+            org_public_id: "org_00000000000000000000000000000001".to_string(),
+            user_id: None,
+            role: OrgRole::Admin,
+        };
+        // API key callers without user_id should still evaluate policies
+        assert!(TEST_MANAGE.evaluate(&caller).is_ok());
+    }
+
+    // -- Edge cases --
+
+    #[test]
+    fn empty_policy_always_passes() {
+        const EMPTY: Policy = Policy {
+            id: "empty",
+            rules: &[],
+        };
+        let caller = member_caller();
+        assert!(EMPTY.evaluate(&caller).is_ok());
+    }
+
+    #[test]
+    fn caller_internal_has_owner_role() {
+        let caller = Caller::internal(42);
+        assert_eq!(caller.org_id, 42);
+        assert_eq!(caller.role, OrgRole::Owner);
+        assert!(caller.user_id.is_none());
+        // Internal callers should pass all policies
+        assert!(TEST_MANAGE.evaluate(&caller).is_ok());
+        assert!(TEST_DANGEROUS.evaluate(&caller).is_ok());
+        assert!(TEST_ROLE_ADMIN.evaluate(&caller).is_ok());
+    }
+
+    #[test]
+    fn caller_internal_generates_public_id() {
+        let caller = Caller::internal(1);
+        assert_eq!(caller.org_public_id, "org_00000000000000000000000000000001");
+
+        let caller = Caller::internal(99);
+        assert!(caller.org_public_id.starts_with("org_"));
+    }
+
+    #[test]
+    fn policy_error_is_std_error() {
+        let err = PolicyError::denied("test", "detail");
+        let _: &dyn std::error::Error = &err;
+    }
+
+    #[test]
+    fn policy_error_downcast_from_anyhow() {
+        let err = PolicyError::denied("test.policy", "org:harnesses:manage");
+        let anyhow_err: anyhow::Error = err.into();
+        let downcasted = anyhow_err.downcast_ref::<PolicyError>();
+        assert!(downcasted.is_some());
+        assert_eq!(downcasted.unwrap().policy_id, "test.policy");
+    }
+
+    // -- PolicyConfigResponse serialization --
+
+    #[test]
+    fn policy_config_response_serializes() {
+        let mut policies = HashMap::new();
+        policies.insert("harness.manage".to_string(), true);
+        policies.insert("harness.dangerous".to_string(), false);
+        let response = PolicyConfigResponse { policies };
+        let json = serde_json::to_value(&response).unwrap();
+        assert_eq!(json["policies"]["harness.manage"], true);
+        assert_eq!(json["policies"]["harness.dangerous"], false);
+    }
+}

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "everruns-macros"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Proc macros for Everruns (policy enforcement, etc.)"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2", features = ["full"] }
+quote = "1"
+proc-macro2 = "1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -1,0 +1,97 @@
+// Proc macros for Everruns
+//
+// Decision: #[policy] attribute macro for declarative policy enforcement at the service layer.
+// The macro injects `POLICY.evaluate(caller)?;` at the top of the function body,
+// finding the `caller: &Caller` parameter by type automatically.
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{FnArg, ItemFn, PatType, Type, TypeReference, parse_macro_input};
+
+/// Declarative policy enforcement for service methods.
+///
+/// Injects a policy evaluation check at the start of the function body.
+/// The function must have a `caller: &Caller` parameter (the name can vary,
+/// but the type must be `&Caller`).
+///
+/// # Usage
+///
+/// ```rust,ignore
+/// use everruns_macros::policy;
+///
+/// const HARNESS_MANAGE: Policy = Policy {
+///     id: "harness.manage",
+///     rules: &[Rule::UserHasPermission(Permission::OrgHarnessesManage)],
+/// };
+///
+/// impl HarnessService {
+///     #[policy(HARNESS_MANAGE)]
+///     pub async fn create(&self, caller: &Caller, req: CreateHarnessRequest) -> Result<Harness> {
+///         // policy check is injected here automatically
+///     }
+/// }
+/// ```
+///
+/// # Multiple Policies
+///
+/// Stack multiple `#[policy]` attributes for methods requiring several checks:
+///
+/// ```rust,ignore
+/// #[policy(POLICY_A)]
+/// #[policy(POLICY_B)]
+/// pub async fn special_op(&self, caller: &Caller) -> Result<()> {
+///     // both policies checked in order (A first, then B)
+/// }
+/// ```
+///
+/// # Compile Errors
+///
+/// - If the function has no `&Caller` parameter, a compile error is raised.
+#[proc_macro_attribute]
+pub fn policy(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let policy_path = parse_macro_input!(attr as syn::Path);
+    let mut func = parse_macro_input!(item as ItemFn);
+
+    // Find the &Caller parameter by scanning for `&Caller` type
+    let caller_ident = func.sig.inputs.iter().find_map(|arg| {
+        let FnArg::Typed(PatType { pat, ty, .. }) = arg else {
+            return None;
+        };
+        let Type::Reference(TypeReference { elem, .. }) = ty.as_ref() else {
+            return None;
+        };
+        let Type::Path(tp) = elem.as_ref() else {
+            return None;
+        };
+        let is_caller = tp
+            .path
+            .segments
+            .last()
+            .is_some_and(|s| s.ident == "Caller");
+        if is_caller && let syn::Pat::Ident(pi) = pat.as_ref() {
+            return Some(pi.ident.clone());
+        }
+        None
+    });
+
+    let caller = match caller_ident {
+        Some(ident) => ident,
+        None => {
+            return syn::Error::new_spanned(
+                &func.sig,
+                "#[policy] requires a `caller: &Caller` parameter",
+            )
+            .to_compile_error()
+            .into();
+        }
+    };
+
+    // Prepend policy evaluation to the function body
+    let original_stmts = &func.block.stmts;
+    func.block = syn::parse_quote!({
+        #policy_path.evaluate(#caller)?;
+        #(#original_stmts)*
+    });
+
+    quote!(#func).into()
+}

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -63,11 +63,7 @@ pub fn policy(attr: TokenStream, item: TokenStream) -> TokenStream {
         let Type::Path(tp) = elem.as_ref() else {
             return None;
         };
-        let is_caller = tp
-            .path
-            .segments
-            .last()
-            .is_some_and(|s| s.ident == "Caller");
+        let is_caller = tp.path.segments.last().is_some_and(|s| s.ident == "Caller");
         if is_caller && let syn::Pat::Ident(pi) = pat.as_ref() {
             return Some(pi.ident.clone());
         }

--- a/crates/macros/tests/policy_macro_tests.rs
+++ b/crates/macros/tests/policy_macro_tests.rs
@@ -1,0 +1,126 @@
+// Integration tests for the #[policy] proc macro.
+//
+// These tests verify that the macro correctly injects policy evaluation
+// into function bodies. Uses a minimal Policy/Caller implementation
+// to test macro behavior independently of the full permissions system.
+
+use std::fmt;
+
+/// Minimal Caller type for testing the macro.
+#[derive(Debug)]
+struct Caller {
+    allowed: bool,
+}
+
+/// Minimal error type for testing.
+#[derive(Debug)]
+struct PolicyError(String);
+
+impl fmt::Display for PolicyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "PolicyError: {}", self.0)
+    }
+}
+
+impl std::error::Error for PolicyError {}
+
+/// Minimal Policy type for testing the macro.
+struct Policy {
+    id: &'static str,
+}
+
+impl Policy {
+    fn evaluate(&self, caller: &Caller) -> Result<(), PolicyError> {
+        if caller.allowed {
+            Ok(())
+        } else {
+            Err(PolicyError(format!("denied by {}", self.id)))
+        }
+    }
+}
+
+const TEST_POLICY: Policy = Policy { id: "test.policy" };
+const STRICT_POLICY: Policy = Policy {
+    id: "strict.policy",
+};
+
+// -- Tests --
+
+struct MyService;
+
+impl MyService {
+    #[everruns_macros::policy(TEST_POLICY)]
+    async fn do_work(&self, caller: &Caller) -> Result<String, PolicyError> {
+        Ok("work done".to_string())
+    }
+
+    #[everruns_macros::policy(TEST_POLICY)]
+    async fn do_work_with_args(&self, caller: &Caller, name: &str) -> Result<String, PolicyError> {
+        Ok(format!("hello {}", name))
+    }
+
+    #[everruns_macros::policy(TEST_POLICY)]
+    #[everruns_macros::policy(STRICT_POLICY)]
+    async fn do_restricted(&self, caller: &Caller) -> Result<String, PolicyError> {
+        Ok("restricted work".to_string())
+    }
+}
+
+// Free function (not a method)
+#[everruns_macros::policy(TEST_POLICY)]
+async fn free_function(caller: &Caller, value: i32) -> Result<i32, PolicyError> {
+    Ok(value * 2)
+}
+
+#[tokio::test]
+async fn policy_allows_when_caller_permitted() {
+    let svc = MyService;
+    let caller = Caller { allowed: true };
+    let result = svc.do_work(&caller).await;
+    assert_eq!(result.unwrap(), "work done");
+}
+
+#[tokio::test]
+async fn policy_denies_when_caller_not_permitted() {
+    let svc = MyService;
+    let caller = Caller { allowed: false };
+    let result = svc.do_work(&caller).await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().0.contains("denied by test.policy"));
+}
+
+#[tokio::test]
+async fn policy_passes_args_through() {
+    let svc = MyService;
+    let caller = Caller { allowed: true };
+    let result = svc.do_work_with_args(&caller, "world").await;
+    assert_eq!(result.unwrap(), "hello world");
+}
+
+#[tokio::test]
+async fn stacked_policies_both_checked() {
+    let svc = MyService;
+    let allowed = Caller { allowed: true };
+    let denied = Caller { allowed: false };
+
+    // Both policies pass
+    assert!(svc.do_restricted(&allowed).await.is_ok());
+
+    // Both policies fail (outermost runs first)
+    let err = svc.do_restricted(&denied).await.unwrap_err();
+    assert!(
+        err.0.contains("denied by"),
+        "Expected 'denied by' in: {}",
+        err.0
+    );
+}
+
+#[tokio::test]
+async fn policy_works_on_free_functions() {
+    let caller = Caller { allowed: true };
+    let result = free_function(&caller, 21).await;
+    assert_eq!(result.unwrap(), 42);
+
+    let denied = Caller { allowed: false };
+    assert!(free_function(&denied, 21).await.is_err());
+}

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -61,6 +61,7 @@ moka.workspace = true
 zip = { version = "2", default-features = false, features = ["deflate"] }
 
 everruns-core = { path = "../core", features = ["openapi", "sqlx"] }
+everruns-macros = { path = "../macros" }
 everruns-integrations-docker = { path = "../../integrations/docker" }
 everruns-integrations-brave-search = { path = "../../integrations/brave-search" }
 everruns-integrations-duckduckgo = { path = "../../integrations/duckduckgo" }

--- a/crates/server/src/api/common.rs
+++ b/crates/server/src/api/common.rs
@@ -50,6 +50,36 @@ impl ErrorResponse {
 // Error handling extension traits
 // ============================================================================
 
+/// Extension trait for anyhow::Result to handle PolicyError as 403.
+///
+/// If the error is a `PolicyError`, returns 403 Forbidden.
+/// Otherwise logs and returns 500 Internal Server Error.
+pub trait ApiPolicyResultExt<T> {
+    fn map_policy_or_internal(
+        self,
+        operation: &str,
+    ) -> Result<T, (StatusCode, Json<ErrorResponse>)>;
+}
+
+impl<T> ApiPolicyResultExt<T> for Result<T, anyhow::Error> {
+    fn map_policy_or_internal(
+        self,
+        operation: &str,
+    ) -> Result<T, (StatusCode, Json<ErrorResponse>)> {
+        self.map_err(|e| {
+            if let Some(policy_err) = e.downcast_ref::<everruns_core::PolicyError>() {
+                (
+                    StatusCode::FORBIDDEN,
+                    Json(ErrorResponse::new(&policy_err.message)),
+                )
+            } else {
+                tracing::error!("Failed to {}: {}", operation, e);
+                ErrorResponse::internal_error()
+            }
+        })
+    }
+}
+
 /// Extension trait for Result to simplify API error handling.
 ///
 /// Provides methods to log errors and convert to appropriate HTTP responses.

--- a/crates/server/src/api/harnesses.rs
+++ b/crates/server/src/api/harnesses.rs
@@ -1,7 +1,9 @@
 // Harness CRUD HTTP routes
 // Routes use ResolvedOrg: org derived from auth context (API key or cookie)
+// Policy enforcement happens at the service layer via #[policy] macro.
 
 use crate::auth::{AuthState, ResolvedOrg};
+use crate::services::harness::{HARNESS_DANGEROUS, HARNESS_MANAGE};
 use crate::storage::StorageBackend;
 use axum::extract::FromRef;
 use axum::{
@@ -11,9 +13,12 @@ use axum::{
     routing::{get, post},
 };
 use everruns_core::typed_id::{HarnessId, ModelId};
-use everruns_core::{AgentCapabilityConfig, Harness, HarnessStatus, ToolDefinition};
+use everruns_core::{
+    AgentCapabilityConfig, Caller, Harness, HarnessStatus, PolicyConfigResponse, ToolDefinition,
+    evaluate_policies,
+};
 
-use super::common::{ApiOptionExt, ApiResultExt, ErrorResponse, ListResponse};
+use super::common::{ApiOptionExt, ApiPolicyResultExt, ErrorResponse, ListResponse};
 use super::validation::{validate_create_agent_input, validate_update_agent_input};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -121,10 +126,21 @@ impl FromRef<AppState> for AuthState {
     }
 }
 
+/// Create Caller from ResolvedOrg
+fn caller_from_org(org: &ResolvedOrg) -> Caller {
+    Caller {
+        org_id: org.org_id,
+        org_public_id: org.public_id.clone(),
+        user_id: org.user_id,
+        role: org.role,
+    }
+}
+
 /// Create harness routes (no import/export)
 pub fn routes(state: AppState) -> Router {
     Router::new()
         .route("/v1/harnesses", post(create_harness).get(list_harnesses))
+        .route("/v1/harnesses/config", get(harness_config))
         .route("/v1/harnesses/preview", post(preview_harness))
         .route(
             "/v1/harnesses/{harness_id}",
@@ -136,6 +152,24 @@ pub fn routes(state: AppState) -> Router {
         .with_state(state)
 }
 
+/// GET /v1/harnesses/config
+///
+/// Returns which harness policies the caller satisfies.
+/// UI uses this to show/hide controls (e.g. delete button).
+#[utoipa::path(
+    get,
+    path = "/v1/harnesses/config",
+    responses(
+        (status = 200, description = "Policy config for harnesses", body = PolicyConfigResponse),
+    ),
+    tag = "harnesses"
+)]
+pub async fn harness_config(org: ResolvedOrg) -> Json<PolicyConfigResponse> {
+    let caller = caller_from_org(&org);
+    let policies = evaluate_policies(&caller, &[&HARNESS_MANAGE, &HARNESS_DANGEROUS]);
+    Json(PolicyConfigResponse { policies })
+}
+
 /// POST /v1/harnesses
 #[utoipa::path(
     post,
@@ -144,6 +178,7 @@ pub fn routes(state: AppState) -> Router {
     responses(
         (status = 201, description = "Harness created", body = Harness),
         (status = 400, description = "Invalid input", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
     tag = "harnesses"
@@ -161,11 +196,12 @@ pub async fn create_harness(
         req.capabilities.len(),
     )?;
 
+    let caller = caller_from_org(&org);
     let harness = state
         .service
-        .create(org.org_id, req)
+        .create(&caller, req)
         .await
-        .log_internal_error_json("create harness")?;
+        .map_policy_or_internal("create harness")?;
 
     Ok((StatusCode::CREATED, Json(harness)))
 }
@@ -176,6 +212,7 @@ pub async fn create_harness(
     path = "/v1/harnesses",
     responses(
         (status = 200, description = "List of harnesses", body = ListResponse<Harness>),
+        (status = 403, description = "Forbidden"),
         (status = 500, description = "Internal server error")
     ),
     params(ListHarnessesQuery),
@@ -185,12 +222,13 @@ pub async fn list_harnesses(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListHarnessesQuery>,
-) -> Result<Json<ListResponse<Harness>>, StatusCode> {
+) -> Result<Json<ListResponse<Harness>>, (StatusCode, Json<ErrorResponse>)> {
+    let caller = caller_from_org(&org);
     let harnesses = state
         .service
-        .list(org.org_id, query.search.as_deref())
+        .list(&caller, query.search.as_deref())
         .await
-        .log_internal_error("list harnesses")?;
+        .map_policy_or_internal("list harnesses")?;
 
     Ok(Json(ListResponse::new(harnesses)))
 }
@@ -205,6 +243,7 @@ pub async fn list_harnesses(
     responses(
         (status = 200, description = "Harness found", body = Harness),
         (status = 400, description = "Invalid harness ID"),
+        (status = 403, description = "Forbidden"),
         (status = 404, description = "Harness not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -224,11 +263,12 @@ pub async fn get_harness(
         )
     })?;
 
+    let caller = caller_from_org(&org);
     let harness = state
         .service
-        .get(org.org_id, harness_id.uuid())
+        .get(&caller, harness_id.uuid())
         .await
-        .log_internal_error_json("get harness")?
+        .map_policy_or_internal("get harness")?
         .ok_or_not_found_json("Harness")?;
 
     Ok(Json(harness))
@@ -245,6 +285,7 @@ pub async fn get_harness(
     responses(
         (status = 200, description = "Harness updated", body = Harness),
         (status = 400, description = "Invalid input", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
         (status = 404, description = "Harness not found", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
@@ -273,11 +314,12 @@ pub async fn update_harness(
         req.capabilities.as_ref().map(|c| c.len()),
     )?;
 
+    let caller = caller_from_org(&org);
     let harness = state
         .service
-        .update(org.org_id, harness_id.uuid(), req)
+        .update(&caller, harness_id.uuid(), req)
         .await
-        .log_internal_error_json("update harness")?
+        .map_policy_or_internal("update harness")?
         .ok_or_not_found_json("Harness")?;
 
     Ok(Json(harness))
@@ -293,6 +335,7 @@ pub async fn update_harness(
     responses(
         (status = 204, description = "Harness archived"),
         (status = 400, description = "Invalid harness ID"),
+        (status = 403, description = "Forbidden"),
         (status = 404, description = "Harness not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -312,11 +355,12 @@ pub async fn delete_harness(
         )
     })?;
 
+    let caller = caller_from_org(&org);
     let deleted = state
         .service
-        .delete(org.org_id, harness_id.uuid())
+        .delete(&caller, harness_id.uuid())
         .await
-        .log_internal_error_json("delete harness")?;
+        .map_policy_or_internal("delete harness")?;
 
     if deleted {
         Ok(StatusCode::NO_CONTENT)
@@ -343,6 +387,7 @@ pub async fn delete_harness(
     responses(
         (status = 201, description = "Harness copied successfully", body = Harness),
         (status = 400, description = "Invalid harness ID", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
         (status = 404, description = "Source harness not found", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
@@ -362,11 +407,12 @@ pub async fn copy_harness(
         )
     })?;
 
+    let caller = caller_from_org(&org);
     let harness = state
         .service
-        .copy(org.org_id, harness_id.uuid())
+        .copy(&caller, harness_id.uuid())
         .await
-        .log_internal_error_json("copy harness")?
+        .map_policy_or_internal("copy harness")?
         .ok_or_not_found_json("Harness")?;
 
     Ok((StatusCode::CREATED, Json(harness)))

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -751,9 +751,10 @@ impl WorkerService for WorkerServiceImpl {
         };
 
         // Load harness
+        let internal_caller = everruns_core::Caller::internal(req.org_id);
         let harness = self
             .harness_service
-            .get(req.org_id, session.harness_id.uuid())
+            .get(&internal_caller, session.harness_id.uuid())
             .await
             .map_err(|e| {
                 tracing::error!("Failed to get harness: {}", e);
@@ -980,9 +981,10 @@ impl WorkerService for WorkerServiceImpl {
         let req = request.into_inner();
         let harness_id = parse_uuid(req.harness_id.as_ref())?;
 
+        let internal_caller = everruns_core::Caller::internal(req.org_id);
         let harness = self
             .harness_service
-            .get(req.org_id, harness_id)
+            .get(&internal_caller, harness_id)
             .await
             .map_err(|e| Status::internal(format!("Failed to get harness: {}", e)))?;
 
@@ -3009,9 +3011,10 @@ impl WorkerService for WorkerServiceImpl {
         request: Request<PlatformListHarnessesRequest>,
     ) -> Result<Response<PlatformListHarnessesResponse>, Status> {
         let req = request.into_inner();
+        let internal_caller = everruns_core::Caller::internal(req.org_id);
         let harnesses = self
             .harness_service
-            .list(req.org_id, None)
+            .list(&internal_caller, None)
             .await
             .map_err(|e| Status::internal(format!("Failed to list harnesses: {}", e)))?;
 
@@ -3041,9 +3044,10 @@ impl WorkerService for WorkerServiceImpl {
             capabilities,
         };
 
+        let internal_caller = everruns_core::Caller::internal(req.org_id);
         let harness = self
             .harness_service
-            .create(req.org_id, create_req)
+            .create(&internal_caller, create_req)
             .await
             .map_err(|e| Status::internal(format!("Failed to create harness: {}", e)))?;
 
@@ -3069,9 +3073,10 @@ impl WorkerService for WorkerServiceImpl {
             status: None,
         };
 
+        let internal_caller = everruns_core::Caller::internal(req.org_id);
         let harness = self
             .harness_service
-            .update(req.org_id, harness_id, update_req)
+            .update(&internal_caller, harness_id, update_req)
             .await
             .map_err(|e| Status::internal(format!("Failed to update harness: {}", e)))?
             .ok_or_else(|| Status::not_found("Harness not found"))?;
@@ -3088,8 +3093,9 @@ impl WorkerService for WorkerServiceImpl {
         let req = request.into_inner();
         let harness_id = parse_uuid(req.harness_id.as_ref())?;
 
+        let internal_caller = everruns_core::Caller::internal(req.org_id);
         self.harness_service
-            .delete(req.org_id, harness_id)
+            .delete(&internal_caller, harness_id)
             .await
             .map_err(|e| Status::internal(format!("Failed to delete harness: {}", e)))?;
 
@@ -3103,9 +3109,10 @@ impl WorkerService for WorkerServiceImpl {
         let req = request.into_inner();
         let harness_id = parse_uuid(req.harness_id.as_ref())?;
 
+        let internal_caller = everruns_core::Caller::internal(req.org_id);
         let harness = self
             .harness_service
-            .copy(req.org_id, harness_id)
+            .copy(&internal_caller, harness_id)
             .await
             .map_err(|e| Status::internal(format!("Failed to copy harness: {}", e)))?
             .ok_or_else(|| Status::not_found("Harness not found"))?;
@@ -3122,7 +3129,7 @@ impl WorkerService for WorkerServiceImpl {
                 status: None,
             };
             self.harness_service
-                .update(req.org_id, harness.id.uuid(), update_req)
+                .update(&internal_caller, harness.id.uuid(), update_req)
                 .await
                 .map_err(|e| Status::internal(format!("Failed to rename copied harness: {}", e)))?
                 .unwrap_or(harness)

--- a/crates/server/src/services/harness.rs
+++ b/crates/server/src/services/harness.rs
@@ -1,6 +1,7 @@
 // Harness service for business logic
 //
 // Manages harness CRUD operations, capability lifecycle.
+// Policy enforcement via #[policy] macro — see specs/permissions.md.
 
 use crate::api::harnesses::{CreateHarnessRequest, UpdateHarnessRequest};
 use crate::storage::{
@@ -8,9 +9,27 @@ use crate::storage::{
     models::{CreateHarnessRow, UpdateHarness},
 };
 use anyhow::Result;
-use everruns_core::{AgentCapabilityConfig, Harness, HarnessId, HarnessStatus};
+use everruns_core::{
+    AgentCapabilityConfig, Caller, Harness, HarnessId, HarnessStatus, Permission, Policy, Rule,
+};
+use everruns_macros::policy;
 use std::sync::Arc;
 use uuid::Uuid;
+
+/// Policy: CRUD on harnesses (create, read, update, copy).
+pub const HARNESS_MANAGE: Policy = Policy {
+    id: "harness.manage",
+    rules: &[Rule::UserHasPermission(Permission::OrgHarnessesManage)],
+};
+
+/// Policy: Dangerous harness operations (delete).
+pub const HARNESS_DANGEROUS: Policy = Policy {
+    id: "harness.dangerous",
+    rules: &[
+        Rule::UserHasPermission(Permission::OrgHarnessesManage),
+        Rule::UserHasPermission(Permission::OrgHarnessesDangerous),
+    ],
+};
 
 pub struct HarnessService {
     db: Arc<StorageBackend>,
@@ -21,7 +40,8 @@ impl HarnessService {
         Self { db }
     }
 
-    pub async fn create(&self, org_id: i64, req: CreateHarnessRequest) -> Result<Harness> {
+    #[policy(HARNESS_MANAGE)]
+    pub async fn create(&self, caller: &Caller, req: CreateHarnessRequest) -> Result<Harness> {
         let input = CreateHarnessRow {
             name: req.name,
             description: req.description,
@@ -29,7 +49,7 @@ impl HarnessService {
             default_model_id: req.default_model_id,
             tags: req.tags,
         };
-        let row = self.db.create_harness(org_id, input).await?;
+        let row = self.db.create_harness(caller.org_id, input).await?;
         let harness_id = row.id;
 
         // Set capabilities if provided
@@ -57,10 +77,11 @@ impl HarnessService {
         Ok(Self::row_to_harness(row, capabilities))
     }
 
-    pub async fn get(&self, org_id: i64, id: Uuid) -> Result<Option<Harness>> {
+    #[policy(HARNESS_MANAGE)]
+    pub async fn get(&self, caller: &Caller, id: Uuid) -> Result<Option<Harness>> {
         let row = self
             .db
-            .get_harness(org_id, HarnessId::from_uuid(id))
+            .get_harness(caller.org_id, HarnessId::from_uuid(id))
             .await?;
         match row {
             Some(row) => {
@@ -71,8 +92,9 @@ impl HarnessService {
         }
     }
 
-    pub async fn list(&self, org_id: i64, search: Option<&str>) -> Result<Vec<Harness>> {
-        let rows = self.db.list_harnesses(org_id, search).await?;
+    #[policy(HARNESS_MANAGE)]
+    pub async fn list(&self, caller: &Caller, search: Option<&str>) -> Result<Vec<Harness>> {
+        let rows = self.db.list_harnesses(caller.org_id, search).await?;
 
         let mut harnesses = Vec::with_capacity(rows.len());
         for row in rows {
@@ -83,9 +105,10 @@ impl HarnessService {
         Ok(harnesses)
     }
 
+    #[policy(HARNESS_MANAGE)]
     pub async fn update(
         &self,
-        org_id: i64,
+        caller: &Caller,
         id: Uuid,
         req: UpdateHarnessRequest,
     ) -> Result<Option<Harness>> {
@@ -99,7 +122,7 @@ impl HarnessService {
         };
         let row = self
             .db
-            .update_harness(org_id, HarnessId::from_uuid(id), input)
+            .update_harness(caller.org_id, HarnessId::from_uuid(id), input)
             .await?;
 
         match row {
@@ -130,8 +153,9 @@ impl HarnessService {
 
     /// Copy a harness by UUID. Creates a new harness with "{name} (copy)" and
     /// duplicates description, system_prompt, default_model_id, tags, capabilities.
-    pub async fn copy(&self, org_id: i64, id: Uuid) -> Result<Option<Harness>> {
-        let source = self.get(org_id, id).await?;
+    #[policy(HARNESS_MANAGE)]
+    pub async fn copy(&self, caller: &Caller, id: Uuid) -> Result<Option<Harness>> {
+        let source = self.get(caller, id).await?;
         let Some(source) = source else {
             return Ok(None);
         };
@@ -145,13 +169,14 @@ impl HarnessService {
             capabilities: source.capabilities,
         };
 
-        let harness = self.create(org_id, req).await?;
+        let harness = self.create(caller, req).await?;
         Ok(Some(harness))
     }
 
-    pub async fn delete(&self, org_id: i64, id: Uuid) -> Result<bool> {
+    #[policy(HARNESS_DANGEROUS)]
+    pub async fn delete(&self, caller: &Caller, id: Uuid) -> Result<bool> {
         self.db
-            .delete_harness(org_id, HarnessId::from_uuid(id))
+            .delete_harness(caller.org_id, HarnessId::from_uuid(id))
             .await
     }
 

--- a/specs/permissions.md
+++ b/specs/permissions.md
@@ -1,0 +1,239 @@
+# Permissions Model
+
+## Overview
+
+Fine-grained permission system built on top of existing OrgRole hierarchy. Roles grant default permission sets. Policies (sets of rules) enforce access at the service layer. Policy results are exposed to UI via per-resource config endpoints.
+
+## Concepts
+
+### Permission
+
+Identifier for an action. Format: `org:<resource>:<action>`.
+
+```
+org:harnesses:manage              # CRUD on harnesses
+org:harnesses:dangerous           # Delete, reset, etc.
+org:agents:manage                 # CRUD on agents
+org:sessions:manage               # CRUD on sessions
+org:llm-providers:manage          # CRUD on LLM providers
+org:settings:manage               # Org settings
+org:members:manage                # Invite/remove members
+org:api-keys:manage               # CRUD on API keys
+```
+
+### Rule
+
+Single predicate that evaluates to true/false given an auth context.
+
+Hardcoded enum variants (no dynamic rules):
+
+| Rule | Description |
+|------|-------------|
+| `UserHasPermission(perm)` | User's role grants the permission |
+| `UserHasRole(role)` | User has at least this OrgRole |
+| `UserIsResourceOwner` | User created the resource (future) |
+| `IsPlatformUser` | User is in platform allowlist (future) |
+
+Rules are **additive within a policy** — all rules must pass (AND logic).
+
+### Policy
+
+Named set of rules. Attached to service operations. All rules must pass for access.
+
+```rust
+Policy {
+    id: "harness.manage",
+    rules: [UserHasPermission("org:harnesses:manage")],
+}
+
+Policy {
+    id: "harness.dangerous",
+    rules: [
+        UserHasPermission("org:harnesses:manage"),
+        UserHasPermission("org:harnesses:dangerous"),
+    ],
+}
+
+Policy {
+    id: "durable.access",
+    rules: [IsPlatformUser],
+}
+```
+
+## Role → Permission Mapping
+
+Hardcoded. No DB storage (phase 1).
+
+| Permission | Owner | Admin | Member |
+|------------|-------|-------|--------|
+| `org:harnesses:manage` | yes | yes | no |
+| `org:harnesses:dangerous` | yes | no | no |
+| `org:agents:manage` | yes | yes | yes |
+| `org:sessions:manage` | yes | yes | yes |
+| `org:llm-providers:manage` | yes | yes | no |
+| `org:settings:manage` | yes | yes | no |
+| `org:members:manage` | yes | yes | no |
+| `org:api-keys:manage` | yes | yes | no |
+
+Owner inherits all Admin permissions. Admin inherits all Member permissions.
+
+## Enforcement
+
+### Service Layer
+
+Services receive a `Caller` context (replacing raw `org_id`). Policy checks happen at the start of each service method.
+
+```rust
+/// Auth context passed from API handler to service.
+pub struct Caller {
+    pub org_id: i64,
+    pub org_public_id: String,
+    pub user_id: Option<Uuid>,
+    pub role: OrgRole,
+}
+
+impl From<&ResolvedOrg> for Caller {
+    fn from(org: &ResolvedOrg) -> Self { ... }
+}
+```
+
+### Policy Evaluation
+
+```rust
+pub enum Rule {
+    UserHasPermission(Permission),
+    UserHasRole(OrgRole),
+}
+
+pub struct Policy {
+    pub id: &'static str,
+    pub rules: &'static [Rule],
+}
+
+impl Policy {
+    /// Returns Ok(()) or Err(PolicyDenied).
+    pub fn evaluate(&self, caller: &Caller) -> Result<(), PolicyError> {
+        for rule in self.rules {
+            match rule {
+                Rule::UserHasPermission(perm) => {
+                    if !caller.role.has_permission(perm) {
+                        return Err(PolicyError::denied(self.id, rule));
+                    }
+                }
+                Rule::UserHasRole(required) => {
+                    if !caller.role.has_org_role(*required) {
+                        return Err(PolicyError::denied(self.id, rule));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+```
+
+### Service Usage
+
+```rust
+// Policies defined as constants
+const HARNESS_MANAGE: Policy = Policy {
+    id: "harness.manage",
+    rules: &[Rule::UserHasPermission(Permission::OrgHarnessesManage)],
+};
+
+const HARNESS_DANGEROUS: Policy = Policy {
+    id: "harness.dangerous",
+    rules: &[
+        Rule::UserHasPermission(Permission::OrgHarnessesManage),
+        Rule::UserHasPermission(Permission::OrgHarnessesDangerous),
+    ],
+};
+
+impl HarnessService {
+    pub async fn create(&self, caller: &Caller, req: CreateHarnessRequest) -> Result<Harness> {
+        HARNESS_MANAGE.evaluate(caller)?;
+        // ... existing logic using caller.org_id ...
+    }
+
+    pub async fn delete(&self, caller: &Caller, id: Uuid) -> Result<bool> {
+        HARNESS_DANGEROUS.evaluate(caller)?;
+        // ...
+    }
+}
+```
+
+### Error Mapping
+
+`PolicyError` maps to HTTP 403 at the API layer.
+
+```rust
+pub struct PolicyError {
+    pub policy_id: String,
+    pub message: String,
+}
+```
+
+API handler converts via `impl IntoResponse for PolicyError` or the existing error pipeline.
+
+## UI: Policy Results API
+
+Per-resource config endpoints return which policies the caller satisfies.
+
+### Endpoint Pattern
+
+```
+GET /v1/harnesses/config
+GET /v1/agents/config
+GET /v1/sessions/config
+```
+
+### Response
+
+```json
+{
+  "policies": {
+    "harness.manage": true,
+    "harness.dangerous": false
+  }
+}
+```
+
+UI uses this on load to show/hide controls (delete buttons, admin panels, etc.).
+
+### Implementation
+
+Each resource module defines its relevant policies. The config handler evaluates all of them against the caller:
+
+```rust
+pub async fn harness_config(org: ResolvedOrg) -> Json<ConfigResponse> {
+    let caller = Caller::from(&org);
+    Json(ConfigResponse {
+        policies: evaluate_policies(&caller, &[HARNESS_MANAGE, HARNESS_DANGEROUS]),
+    })
+}
+```
+
+## Migration Path
+
+### Phase 1 (this spec)
+- Permission enum, Rule enum, Policy struct
+- Caller context type
+- Role → permission mapping (hardcoded)
+- Service-layer enforcement
+- Config endpoints for UI
+- No DB changes
+
+### Phase 2 (future)
+- `user_permissions` table for per-user grants beyond role defaults
+- `UserIsResourceOwner` rule (needs `created_by` on resources)
+- `IsPlatformUser` rule with allowlist
+- Admin UI for permission management
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `crates/core/src/permissions.rs` | Permission enum, Rule, Policy, Caller, evaluation logic |
+| `crates/server/src/services/*.rs` | Policy enforcement at method entry |
+| `crates/server/src/api/*_config.rs` | Config endpoints returning policy results |
+| `crates/server/src/auth/middleware.rs` | Caller extraction from ResolvedOrg |

--- a/specs/permissions.md
+++ b/specs/permissions.md
@@ -77,6 +77,8 @@ Hardcoded. No DB storage (phase 1).
 
 Owner inherits all Admin permissions. Admin inherits all Member permissions.
 
+**Default role:** `Owner` (phase 1). All users get full permissions by default. Future phases will assign roles via invitation/admin UI.
+
 ## Enforcement
 
 ### Service Layer

--- a/specs/permissions.md
+++ b/specs/permissions.md
@@ -132,7 +132,13 @@ impl Policy {
 }
 ```
 
-### Service Usage
+### Declarative Enforcement via `#[policy]` Macro
+
+New proc macro crate: `crates/macros` (`everruns-macros`).
+
+The `#[policy(...)]` attribute macro injects `POLICY.evaluate(caller)?;` at the top of the function body. It finds the `caller: &Caller` parameter by type automatically.
+
+#### Usage
 
 ```rust
 // Policies defined as constants
@@ -150,17 +156,106 @@ const HARNESS_DANGEROUS: Policy = Policy {
 };
 
 impl HarnessService {
+    #[policy(HARNESS_MANAGE)]
     pub async fn create(&self, caller: &Caller, req: CreateHarnessRequest) -> Result<Harness> {
-        HARNESS_MANAGE.evaluate(caller)?;
-        // ... existing logic using caller.org_id ...
+        // just business logic — policy check injected by macro
     }
 
+    #[policy(HARNESS_DANGEROUS)]
     pub async fn delete(&self, caller: &Caller, id: Uuid) -> Result<bool> {
-        HARNESS_DANGEROUS.evaluate(caller)?;
         // ...
     }
 }
 ```
+
+#### Macro Expansion
+
+```rust
+// #[policy(HARNESS_MANAGE)]
+// pub async fn create(&self, caller: &Caller, req: CreateHarnessRequest) -> Result<Harness> {
+//     let row = self.db.create_harness(caller.org_id, input).await?;
+//     Ok(harness)
+// }
+//
+// expands to:
+//
+// pub async fn create(&self, caller: &Caller, req: CreateHarnessRequest) -> Result<Harness> {
+//     HARNESS_MANAGE.evaluate(caller)?;
+//     let row = self.db.create_harness(caller.org_id, input).await?;
+//     Ok(harness)
+// }
+```
+
+#### Macro Implementation
+
+The proc macro:
+
+1. Parses the attribute argument as a path to a `Policy` constant (e.g. `HARNESS_MANAGE`)
+2. Scans the function signature for a parameter with type `&Caller` — extracts its name (usually `caller`)
+3. Prepends `#policy_path.evaluate(#caller_ident)?;` to the function body
+4. Compile error if no `&Caller` parameter found
+
+```rust
+// crates/macros/src/lib.rs
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, ItemFn, FnArg, PatType, Type, TypeReference, Path};
+
+#[proc_macro_attribute]
+pub fn policy(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let policy_path = parse_macro_input!(attr as Path);
+    let mut func = parse_macro_input!(item as ItemFn);
+
+    // Find the &Caller parameter
+    let caller_ident = func.sig.inputs.iter().find_map(|arg| {
+        if let FnArg::Typed(PatType { pat, ty, .. }) = arg {
+            if let Type::Reference(TypeReference { elem, .. }) = ty.as_ref() {
+                if let Type::Path(tp) = elem.as_ref() {
+                    if tp.path.segments.last().map(|s| s.ident == "Caller").unwrap_or(false) {
+                        if let syn::Pat::Ident(pi) = pat.as_ref() {
+                            return Some(pi.ident.clone());
+                        }
+                    }
+                }
+            }
+        }
+        None
+    });
+
+    let caller = caller_ident.expect("Expected a `caller: &Caller` parameter");
+
+    let original_body = &func.block;
+    func.block = syn::parse_quote!({
+        #policy_path.evaluate(#caller)?;
+        #original_body
+    });
+
+    quote!(#func).into()
+}
+```
+
+#### Multiple Policies
+
+Stack multiple attributes for methods needing several independent policy checks:
+
+```rust
+#[policy(HARNESS_MANAGE)]
+#[policy(SOME_OTHER_POLICY)]
+pub async fn special_operation(&self, caller: &Caller) -> Result<()> {
+    // both policies checked in order
+}
+```
+
+#### Crate Structure
+
+```
+crates/macros/
+├── Cargo.toml    # proc-macro = true, deps: syn, quote, proc-macro2
+└── src/
+    └── lib.rs    # #[policy] macro
+```
+
+Added to workspace `Cargo.toml` members. `crates/server` depends on `everruns-macros`.
 
 ### Error Mapping
 
@@ -234,6 +329,7 @@ pub async fn harness_config(org: ResolvedOrg) -> Json<ConfigResponse> {
 | File | Purpose |
 |------|---------|
 | `crates/core/src/permissions.rs` | Permission enum, Rule, Policy, Caller, evaluation logic |
-| `crates/server/src/services/*.rs` | Policy enforcement at method entry |
+| `crates/macros/src/lib.rs` | `#[policy]` proc macro |
+| `crates/server/src/services/*.rs` | `#[policy(..)]` on service methods |
 | `crates/server/src/api/*_config.rs` | Config endpoints returning policy results |
 | `crates/server/src/auth/middleware.rs` | Caller extraction from ResolvedOrg |

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -13,6 +13,7 @@ Format: `TM-<CATEGORY>-<NNN>`
 | TM-AUTH | Authentication | Credential theft, session hijack, brute force |
 | TM-CRYPTO | Cryptography | Key compromise, encryption weakness |
 | TM-TENANT | Tenant Isolation | Cross-org data access, enumeration |
+| TM-AUTHZ | Permissions / Authorization | Policy bypass, privilege escalation, missing enforcement |
 | TM-API | API Security | Injection, input validation, SSRF |
 | TM-FS | Filesystem | Path traversal, data leakage in session files |
 | TM-SQL | SQL Database | SQLite sandbox escape, resource exhaustion |
@@ -204,6 +205,23 @@ WHERE a.org_id = $1 AND e.session_id = $2;
 ApiError::NotFound("Agent not found")    // ✓ No information leakage
 ApiError::Forbidden("No access")         // ✗ Reveals resource exists
 ```
+
+## 3b. Permissions / Authorization (TM-AUTHZ)
+
+| ID | Threat | Severity | Mitigation | Status |
+|----|--------|----------|------------|--------|
+| TM-AUTHZ-001 | Default Owner role grants full access | Medium | By design for phase 1; all users are Owners. Future phases will assign roles via admin UI/invitation flow | **BY DESIGN** |
+| TM-AUTHZ-002 | Policy bypass via internal Caller | Medium | `Caller::internal()` bypasses policies with Owner role; only used in gRPC service (worker ↔ server), not HTTP-accessible | MITIGATED |
+| TM-AUTHZ-003 | Policy error reveals permission names | Low | 403 response includes policy ID and required permission; acceptable for debugging, no internal state leaked | **ACCEPTED** |
+| TM-AUTHZ-004 | Missing policy on service method | Medium | Compile-time enforcement via `#[policy]` macro; code review required to ensure coverage | MITIGATED |
+
+### Mitigation Details
+
+**TM-AUTHZ-001 — Default Owner Role (BY DESIGN):**
+Phase 1 assigns `OrgRole::Owner` as the default for all users. This means no permission-based restrictions are active in practice. This is intentional to avoid breaking existing workflows while the role assignment infrastructure is built in phase 2.
+
+**TM-AUTHZ-002 — Internal Caller:**
+`Caller::internal(org_id)` is used exclusively in `grpc_service.rs` for worker-to-server calls. The gRPC endpoint requires a bearer token in production (`TM-DURABLE-002`). HTTP handlers always construct `Caller` from `ResolvedOrg` with the user's actual role.
 
 ## 4. API Security (TM-API)
 
@@ -870,7 +888,7 @@ Search results from Brave Search are returned as tool results. Adversarial conte
 | Control | Category | Implementation |
 |---------|----------|----------------|
 | Authentication | TM-AUTH | JWT (15 min), API keys (SHA-256), OAuth, Argon2id passwords |
-| Authorization | TM-TENANT | Org-scoped queries, ResolvedOrg extractor, 404 on cross-org |
+| Authorization | TM-TENANT, TM-AUTHZ | Org-scoped queries, ResolvedOrg extractor, 404 on cross-org; `#[policy]` macro enforcement, role→permission mapping |
 | Encryption at rest | TM-CRYPTO | AES-256-GCM envelope encryption for API keys |
 | Encryption in transit | TM-LLM | HTTPS for all external communication |
 | Input validation | TM-API | Size limits, path validation, regex constraints |


### PR DESCRIPTION
## What
Fine-grained permissions model with declarative policy enforcement. Introduces:
- `Permission` enum (8 org-scoped permissions)
- `Rule` / `Policy` types for composable access rules
- `Caller` context type replacing raw `org_id: i64` on service methods
- `#[policy]` proc macro for declarative enforcement at service layer
- `PolicyError` → 403 Forbidden mapping at API layer
- Per-resource `/config` endpoints for UI policy exposure
- Harness service fully migrated as reference implementation

## Why
Need authorization beyond org-scoped isolation. This enables role-based access control where Owner > Admin > Member, with different permission sets per role. UI needs to know which actions are allowed to show/hide controls.

## How
- New `crates/macros` proc-macro crate with `#[policy]` attribute
- `crates/core/src/permissions.rs` — Permission, Rule, Policy, Caller, PolicyError, role→permission mapping
- Service methods take `&Caller` instead of `org_id: i64`; macro injects `POLICY.evaluate(caller)?;`
- API layer uses `ApiPolicyResultExt` to downcast PolicyError → 403, else 500
- gRPC uses `Caller::internal(org_id)` (Owner role) for worker↔server calls
- Default OrgRole changed to Owner (phase 1: all users get full access)
- Harness endpoints (create, get, list, update, delete, copy, config) fully migrated

## Risk
- Low
- Default role is Owner so no user-facing restrictions in phase 1. Harness service is the only migrated service. gRPC callers use internal bypass. All existing tests pass.

## Checklist
- [x] Tests added or updated (19 permissions unit tests, 5 macro integration tests, all 700+ existing tests pass)
- [x] Backward compatibility considered (default Owner role means no behavior change for existing users)