### PR TITLE
feat(ui): add capabilities to global search, remove global_search flag

### DIFF
--- a/apps/ui/src/app/(main)/layout.tsx
+++ b/apps/ui/src/app/(main)/layout.tsx
@@ -22,7 +22,6 @@ function MainLayoutInner({ children }: MainLayoutProps) {
   const searchParams = useSearchParams();
   const { isAuthenticated, isLoading: authLoading, requiresAuth } = useAuth();
   const { isLoading: orgLoading } = useOrg();
-  const globalSearchEnabled = useFeatureFlag("global_search");
   const notificationsEnabled = useFeatureFlag("notifications");
   const commandPalette = useCommandPaletteState();
 
@@ -69,7 +68,7 @@ function MainLayoutInner({ children }: MainLayoutProps) {
     <div className="flex h-screen">
       <Sidebar />
       <main className="flex-1 overflow-auto bg-background bg-brand-dots">{children}</main>
-      {globalSearchEnabled && <CommandPalette />}
+      <CommandPalette />
     </div>
   );
 
@@ -79,11 +78,7 @@ function MainLayoutInner({ children }: MainLayoutProps) {
     appChrome
   );
 
-  if (globalSearchEnabled) {
-    return <CommandPaletteContext value={commandPalette}>{content}</CommandPaletteContext>;
-  }
-
-  return content;
+  return <CommandPaletteContext value={commandPalette}>{content}</CommandPaletteContext>;
 }
 
 export default function MainLayout({ children }: MainLayoutProps) {

--- a/apps/ui/src/components/command-palette.tsx
+++ b/apps/ui/src/components/command-palette.tsx
@@ -25,6 +25,7 @@ const CATEGORY_LABELS: Record<SearchResultCategory, string> = {
   session: "Sessions",
   harness: "Harnesses",
   skill: "Skills",
+  capability: "Capabilities",
   mcp_server: "MCP Servers",
   id: "Go to",
 };
@@ -36,6 +37,7 @@ const CATEGORY_ORDER: SearchResultCategory[] = [
   "session",
   "harness",
   "skill",
+  "capability",
   "mcp_server",
 ];
 

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -395,22 +395,20 @@ export function Sidebar({ config }: { config?: Partial<SidebarConfig> }) {
         </div>
       )}
 
-      {/* Search trigger (gated by global_search feature flag) */}
-      {featureFlags.global_search && (
-        <div className="px-3 py-2">
-          <button
-            type="button"
-            onClick={() => openCommandPalette(true)}
-            className="flex w-full items-center gap-3 border border-input bg-transparent px-3 py-2 text-sm text-muted-foreground transition-colors hover:border-border hover:bg-card hover:text-foreground"
-          >
-            <Search className="h-4 w-4 shrink-0" />
-            <span className="flex-1 text-left">Search...</span>
-            <kbd className="hidden sm:inline-flex h-5 items-center gap-0.5 border bg-muted px-1.5 font-mono text-[10px] font-medium">
-              <span className="text-xs">⌘</span>K
-            </kbd>
-          </button>
-        </div>
-      )}
+      {/* Search trigger */}
+      <div className="px-3 py-2">
+        <button
+          type="button"
+          onClick={() => openCommandPalette(true)}
+          className="flex w-full items-center gap-3 border border-input bg-transparent px-3 py-2 text-sm text-muted-foreground transition-colors hover:border-border hover:bg-card hover:text-foreground"
+        >
+          <Search className="h-4 w-4 shrink-0" />
+          <span className="flex-1 text-left">Search...</span>
+          <kbd className="hidden sm:inline-flex h-5 items-center gap-0.5 border bg-muted px-1.5 font-mono text-[10px] font-medium">
+            <span className="text-xs">⌘</span>K
+          </kbd>
+        </button>
+      </div>
 
       {/* Navigation */}
       <nav className="flex-1 min-h-0 overflow-y-auto space-y-1 bg-background py-4">

--- a/apps/ui/src/hooks/use-global-search.ts
+++ b/apps/ui/src/hooks/use-global-search.ts
@@ -8,7 +8,8 @@
  * 4. Harnesses (client-side filter over cached list)
  * 5. Skills (client-side filter over cached list)
  * 6. MCP Servers (client-side filter over cached list)
- * 7. ID-based lookup (detects prefixed IDs and provides direct navigation)
+ * 7. Capabilities (client-side filter over cached list)
+ * 8. ID-based lookup (detects prefixed IDs and provides direct navigation)
  *
  * All entity searches are client-side over already-fetched React Query data.
  * Backend search endpoints are available for server-side filtering when needed.
@@ -39,6 +40,7 @@ import { useSessions } from "@/hooks/use-sessions";
 import { useHarnesses } from "@/hooks/use-harnesses";
 import { useSkills } from "@/hooks/use-skills";
 import { useMcpServers } from "@/hooks/use-mcp-servers";
+import { useCapabilities } from "@/hooks/use-capabilities";
 
 export type SearchResultCategory =
   | "navigation"
@@ -47,6 +49,7 @@ export type SearchResultCategory =
   | "harness"
   | "skill"
   | "mcp_server"
+  | "capability"
   | "id";
 
 export interface SearchResult {
@@ -159,12 +162,14 @@ export function useGlobalSearch(query: string) {
   const { data: harnessesData } = useHarnesses();
   const { data: skillsData } = useSkills();
   const { data: mcpServersData } = useMcpServers();
+  const { data: capabilitiesData } = useCapabilities();
 
   const agents = agentsData ?? EMPTY_ARRAY;
   const sessions = sessionsData?.data ?? EMPTY_ARRAY;
   const harnesses = harnessesData ?? EMPTY_ARRAY;
   const skills = skillsData ?? EMPTY_ARRAY;
   const mcpServers = mcpServersData ?? EMPTY_ARRAY;
+  const capabilities = capabilitiesData ?? EMPTY_ARRAY;
 
   return useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -319,6 +324,32 @@ export function useGlobalSearch(query: string) {
       }
     }
 
+    // 8. Capabilities
+    let capabilityCount = 0;
+    for (const capability of capabilities) {
+      if (capabilityCount >= MAX_PER_CATEGORY) break;
+      if (
+        matchesTokens(
+          tokens,
+          capability.name,
+          capability.description,
+          capability.id,
+          capability.category,
+          "capability",
+        )
+      ) {
+        results.push({
+          id: `capability:${capability.id}`,
+          category: "capability",
+          icon: Puzzle,
+          title: capability.name,
+          subtitle: `Capabilities > ${capability.name}`,
+          href: `/capabilities/${capability.id}`,
+        });
+        capabilityCount++;
+      }
+    }
+
     return results;
-  }, [query, agents, sessions, harnesses, skills, mcpServers]);
+  }, [query, agents, sessions, harnesses, skills, mcpServers, capabilities]);
 }

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -739,7 +739,6 @@ export type AuthMode = "none" | "admin" | "full" | "external";
 export interface FeatureFlags {
   global_chat: boolean;
   apps: boolean;
-  global_search: boolean;
   notifications: boolean;
 }
 

--- a/apps/ui/src/providers/feature-flags-provider.tsx
+++ b/apps/ui/src/providers/feature-flags-provider.tsx
@@ -14,7 +14,6 @@ import type { FeatureFlags } from "@/lib/api/types";
 const DEFAULT_FLAGS: FeatureFlags = {
   global_chat: false,
   apps: false,
-  global_search: false,
   notifications: false,
 };
 

--- a/crates/core/src/feature_flags.rs
+++ b/crates/core/src/feature_flags.rs
@@ -21,8 +21,6 @@ pub struct FeatureFlags {
     pub global_chat: bool,
     /// Apps (agent deployment to distribution channels). Experimental.
     pub apps: bool,
-    /// Global search / command palette (Cmd+K). Experimental.
-    pub global_search: bool,
     /// In-app notifications (bell, toasts, notification SSE). Standard.
     pub notifications: bool,
 }
@@ -33,7 +31,6 @@ impl FeatureFlags {
         Self {
             global_chat: experimental_flag("FEATURE_GLOBAL_CHAT", grade),
             apps: experimental_flag("FEATURE_APPS", grade),
-            global_search: experimental_flag("FEATURE_GLOBAL_SEARCH", grade),
             notifications: standard_flag("FEATURE_NOTIFICATIONS", false),
         }
     }
@@ -43,7 +40,6 @@ impl FeatureFlags {
         match flag {
             "global_chat" => self.global_chat,
             "apps" => self.apps,
-            "global_search" => self.global_search,
             "notifications" => self.notifications,
             _ => false,
         }
@@ -55,7 +51,6 @@ impl FeatureFlags {
         Self {
             global_chat: true,
             apps: true,
-            global_search: true,
             notifications: true,
         }
     }
@@ -97,7 +92,6 @@ mod tests {
         let flags = FeatureFlags::default();
         assert!(!flags.global_chat);
         assert!(!flags.apps);
-        assert!(!flags.global_search);
         assert!(!flags.notifications);
     }
 
@@ -109,11 +103,9 @@ mod tests {
         let _lock = lock_env();
         unsafe { std::env::remove_var("FEATURE_GLOBAL_CHAT") };
         unsafe { std::env::remove_var("FEATURE_APPS") };
-        unsafe { std::env::remove_var("FEATURE_GLOBAL_SEARCH") };
         let flags = FeatureFlags::from_env(&DeploymentGrade::Dev);
         assert!(flags.global_chat);
         assert!(flags.apps);
-        assert!(flags.global_search);
     }
 
     #[test]
@@ -121,11 +113,9 @@ mod tests {
         let _lock = lock_env();
         unsafe { std::env::remove_var("FEATURE_GLOBAL_CHAT") };
         unsafe { std::env::remove_var("FEATURE_APPS") };
-        unsafe { std::env::remove_var("FEATURE_GLOBAL_SEARCH") };
         let flags = FeatureFlags::from_env(&DeploymentGrade::Prod);
         assert!(!flags.global_chat);
         assert!(!flags.apps);
-        assert!(!flags.global_search);
     }
 
     #[test]
@@ -151,12 +141,10 @@ mod tests {
         let flags = FeatureFlags {
             global_chat: true,
             apps: true,
-            global_search: true,
             notifications: true,
         };
         assert!(flags.is_enabled("global_chat"));
         assert!(flags.is_enabled("apps"));
-        assert!(flags.is_enabled("global_search"));
         assert!(flags.is_enabled("notifications"));
         assert!(!flags.is_enabled("nonexistent"));
     }
@@ -166,12 +154,10 @@ mod tests {
         let flags = FeatureFlags {
             global_chat: true,
             apps: true,
-            global_search: true,
             notifications: true,
         };
         let json = serde_json::to_string(&flags).unwrap();
         assert!(json.contains("\"global_chat\":true"));
-        assert!(json.contains("\"global_search\":true"));
         assert!(json.contains("\"notifications\":true"));
 
         let parsed: FeatureFlags = serde_json::from_str(&json).unwrap();

--- a/specs/feature-flags.md
+++ b/specs/feature-flags.md
@@ -30,7 +30,6 @@ System-level feature flags that control feature availability across the platform
 |------|---------|------|-------------|
 | `global_chat` | `FEATURE_GLOBAL_CHAT` | Experimental | Per-user singleton chat session |
 | `apps` | `FEATURE_APPS` | Experimental | Apps (agent deployment to distribution channels) |
-| `global_search` | `FEATURE_GLOBAL_SEARCH` | Experimental | Global search / command palette (Cmd+K) |
 | `notifications` | `FEATURE_NOTIFICATIONS` | Standard | In-app notifications (bell, toast, notification SSE) |
 
 ## Architecture


### PR DESCRIPTION
## What
- Add capabilities as a searchable entity in the command palette (Cmd+K)
- Remove the `global_search` feature flag so search is always visible

## Why
Capabilities were missing from the global search, making them harder to discover. The search/command palette is mature enough to graduate from experimental status.

## How
- Added `capability` category to `useGlobalSearch` hook, matching by name, description, ID, and category
- Added `capability` to command palette category labels and ordering
- Removed `global_search` field from `FeatureFlags` (backend struct, frontend type, provider defaults)
- Search trigger in sidebar and `CommandPalette` in layout are now always rendered
- Updated `specs/feature-flags.md`

## Risk
- Low
- Search is additive (new source). Feature flag removal makes search always-on, which was already the behavior in dev mode.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered