### PR TITLE
fix(ui): hide slash command hint without commands

### DIFF
--- a/apps/ui/src/__tests__/chat-panel.test.tsx
+++ b/apps/ui/src/__tests__/chat-panel.test.tsx
@@ -1,0 +1,166 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { ChatPanel } from "@/components/chat/chat-panel";
+
+const mockUseSessionCommands = jest.fn();
+
+const mockSessionContext = {
+  agentId: "agent-1",
+  events: [],
+  sessionId: "session-1",
+  llmModel: null,
+  chatEvents: [],
+  toolResultsMap: new Map(),
+  eventsLoading: false,
+  isActive: false,
+  reasoningEffort: "",
+  setReasoningEffort: jest.fn(),
+  setIsWaitingForResponse: jest.fn(),
+  isThinking: false,
+  streamingText: "",
+  streamingIteration: 0,
+  sendMessage: {
+    mutateAsync: jest.fn(),
+    isPending: false,
+  },
+  cancelCurrentTurn: jest.fn(),
+  hasMoreEvents: false,
+  loadingOlderEvents: false,
+  loadOlderEvents: jest.fn(),
+  getMessageText: jest.fn(() => ""),
+  getToolCalls: jest.fn(() => []),
+};
+
+jest.mock("@/app/(main)/sessions/[sessionId]/session-context", () => ({
+  useSessionContext: () => mockSessionContext,
+}));
+
+jest.mock("@/hooks", () => ({
+  useLlmModels: () => ({ data: [] }),
+  useImageAttachments: () => ({
+    pendingImages: [],
+    allUploaded: true,
+    uploadedImageIds: [],
+    addFiles: jest.fn(),
+    removeImage: jest.fn(),
+    clearImages: jest.fn(),
+    hasImages: false,
+    isUploading: false,
+  }),
+  useSessionCommands: (...args: unknown[]) => mockUseSessionCommands(...args),
+}));
+
+jest.mock("@tanstack/react-query", () => ({
+  useMutation: () => ({
+    mutateAsync: jest.fn(),
+    isPending: false,
+  }),
+}));
+
+jest.mock("@/lib/api/messages", () => ({
+  sendUserMessageWithImages: jest.fn(),
+}));
+
+jest.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & { children?: React.ReactNode }) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+jest.mock("@/components/ui/skeleton", () => ({
+  Skeleton: ({ className }: { className?: string }) => <div className={className} />,
+}));
+
+jest.mock("@/components/ui/textarea", () => ({
+  Textarea: React.forwardRef<
+    HTMLTextAreaElement,
+    React.TextareaHTMLAttributes<HTMLTextAreaElement>
+  >(function MockTextarea(props, ref) {
+    return <textarea ref={ref} {...props} />;
+  }),
+}));
+
+jest.mock("@/components/ui/select", () => ({
+  Select: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectValue: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock("@/components/chat/message-info-icon", () => ({
+  MessageInfoIcon: () => null,
+}));
+
+jest.mock("@/components/chat/image-attachments", () => ({
+  ImageAttachments: () => null,
+  MessageImage: () => null,
+}));
+
+jest.mock("@/components/chat/command-autocomplete", () => ({
+  CommandAutocomplete: () => null,
+  shouldShowCommandAutocomplete: (input: string) => /^\/\S*$/.test(input),
+}));
+
+jest.mock("@/components/thinking-indicator", () => ({
+  ThinkingIndicator: () => null,
+}));
+
+jest.mock("@/components/streaming-message", () => ({
+  StreamingMessage: () => null,
+}));
+
+jest.mock("@/components/chat/message-content", () => ({
+  MessageContent: ({ text }: { text: string }) => <div>{text}</div>,
+}));
+
+jest.mock("@/components/chat/tool-activity-group", () => ({
+  ToolActivityGroup: () => null,
+}));
+
+beforeAll(() => {
+  Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", {
+    configurable: true,
+    value: jest.fn(),
+  });
+});
+
+describe("ChatPanel placeholder", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does not advertise slash commands when none are available", () => {
+    mockUseSessionCommands.mockReturnValue({ data: { commands: [] } });
+
+    render(<ChatPanel />);
+
+    expect(screen.getByPlaceholderText("Type a message... (Enter to send)")).toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText("Type a message or / for commands... (Enter to send)"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps slash command hint when commands are available", () => {
+    mockUseSessionCommands.mockReturnValue({
+      data: {
+        commands: [
+          {
+            name: "clear",
+            description: "Clear the session",
+            source: "system",
+          },
+        ],
+      },
+    });
+
+    render(<ChatPanel />);
+
+    expect(
+      screen.getByPlaceholderText("Type a message or / for commands... (Enter to send)"),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/components/chat/chat-panel.tsx
+++ b/apps/ui/src/components/chat/chat-panel.tsx
@@ -112,7 +112,11 @@ export function ChatPanel() {
   // Commands autocomplete
   const { data: commandsData } = useSessionCommands(sessionId);
   const commands = commandsData?.commands ?? [];
+  const hasCommands = commands.length > 0;
   const [showCommands, setShowCommands] = useState(false);
+  const inputPlaceholder = hasCommands
+    ? "Type a message or / for commands... (Enter to send)"
+    : "Type a message... (Enter to send)";
 
   const clientRequestedToolCallIds = useMemo(() => {
     const ids = new Set<string>();
@@ -165,6 +169,12 @@ export function ChatPanel() {
       setSelectedModelId(storedSelection);
     }
   }, [modelSelectionStorageKey]);
+
+  useEffect(() => {
+    if (!hasCommands && showCommands) {
+      setShowCommands(false);
+    }
+  }, [hasCommands, showCommands]);
 
   const selectedModel = useMemo(
     () => llmModels.find((model) => model.id === selectedModelId),
@@ -661,7 +671,7 @@ export function ChatPanel() {
               onChange={(e) => {
                 const val = e.target.value;
                 setInputValue(val);
-                setShowCommands(shouldShowCommandAutocomplete(val));
+                setShowCommands(hasCommands && shouldShowCommandAutocomplete(val));
               }}
               onKeyDown={handleKeyDown}
               onPaste={(e) => {
@@ -679,7 +689,7 @@ export function ChatPanel() {
                   addFiles(imageFiles);
                 }
               }}
-              placeholder="Type a message or / for commands... (Enter to send)"
+              placeholder={inputPlaceholder}
               className="min-h-[120px] max-h-[260px] w-full resize-none border-0 bg-transparent px-4 py-4 text-sm shadow-none focus-visible:ring-0"
             />
           </div>


### PR DESCRIPTION
## What
Hide the chat input slash-command hint when a session has no commands available.

## Why
The composer was suggesting "/ for commands" even when the commands list was empty, which is misleading and exposes a dead-end affordance.

## How
Gate chat command affordances on actual command availability in `ChatPanel`, updating both the placeholder copy and autocomplete visibility.
Add a focused UI regression test covering both zero-command and command-available states.

## Risk
- Low
- Chat input placeholder/autocomplete behavior in sessions without commands

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
