### PR TITLE
feat(connections): inline connection setup via client-side tool call

### DIFF
--- a/apps/ui/src/__tests__/chat-panel.test.tsx
+++ b/apps/ui/src/__tests__/chat-panel.test.tsx
@@ -125,6 +125,10 @@ jest.mock("@/components/chat/tool-activity-timeline-group", () => ({
   ToolActivityTimelineGroup: () => null,
 }));
 
+jest.mock("@/components/chat/setup-connection-tool-call", () => ({
+  SetupConnectionToolCall: () => null,
+}));
+
 beforeAll(() => {
   Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", {
     configurable: true,

--- a/apps/ui/src/app/(main)/settings/connections/page.tsx
+++ b/apps/ui/src/app/(main)/settings/connections/page.tsx
@@ -5,56 +5,27 @@ import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import {
   useUserConnections,
   useDeleteUserConnection,
   useConnectionProviders,
-  useCreateApiKeyConnection,
   useVerifyConnection,
 } from "@/hooks/use-user-connections";
 import { getBackendUrl } from "@/lib/api/client";
 import {
   ExternalLink,
-  Github,
   LinkIcon,
   Trash2,
   Check,
   CheckCircle,
-  Cloud,
-  Search,
-  AlertCircle,
   ShieldCheck,
   XCircle,
   Loader2,
 } from "lucide-react";
-import type { LucideIcon } from "lucide-react";
 import type { UserConnection, ConnectionProvider as ConnectionProviderType } from "@/lib/api/types";
-import { InlineStreamdownMessage } from "@/components/chat/streamdown-message";
-import { getCapabilityIcon } from "@/lib/capability-icons";
-
-/** Icon mapping — lucide icon name to component */
-const iconMap: Record<string, LucideIcon> = {
-  github: Github,
-  cloud: Cloud,
-  search: Search,
-  daytona: getCapabilityIcon("daytona"),
-};
-
-function ProviderIcon({ iconName, className }: { iconName: string; className?: string }) {
-  const Icon = iconMap[iconName] ?? LinkIcon;
-  return <Icon className={className} />;
-}
+import { ProviderIcon } from "@/components/connections/provider-icon";
+import { ApiKeyDialog } from "@/components/connections/api-key-dialog";
 
 function ConnectionRow({
   connection,
@@ -181,119 +152,6 @@ function AvailableProviderRow({
         Connect
       </Button>
     </div>
-  );
-}
-
-/** Dialog for entering an API key */
-function ApiKeyDialog({
-  provider,
-  open,
-  onOpenChange,
-}: {
-  provider: ConnectionProviderType | null;
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-}) {
-  const [formValues, setFormValues] = useState<Record<string, string>>({});
-  const [error, setError] = useState<string | null>(null);
-  const createConnection = useCreateApiKeyConnection();
-
-  // Reset form when dialog opens/closes
-  useEffect(() => {
-    if (open) {
-      setFormValues({});
-      setError(null);
-    }
-  }, [open]);
-
-  if (!provider?.form_schema) return null;
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError(null);
-
-    const apiKey = formValues["api_key"] ?? "";
-    if (!apiKey.trim()) {
-      setError("API key is required");
-      return;
-    }
-
-    try {
-      await createConnection.mutateAsync({
-        provider: provider.provider_id,
-        apiKey,
-      });
-      onOpenChange(false);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to save connection";
-      // Extract error message from API response if available
-      const apiError = (err as { response?: { data?: string } })?.response?.data;
-      setError(typeof apiError === "string" ? apiError : message);
-    }
-  };
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[480px]">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <ProviderIcon iconName={provider.icon} className="h-5 w-5" />
-            Connect {provider.display_name}
-          </DialogTitle>
-          <DialogDescription>{provider.description}</DialogDescription>
-        </DialogHeader>
-
-        <form onSubmit={handleSubmit}>
-          {/* Instructions */}
-          <InlineStreamdownMessage className="text-sm text-muted-foreground mb-4 leading-relaxed">
-            {provider.form_schema.instructions_markdown}
-          </InlineStreamdownMessage>
-
-          {/* Form fields */}
-          <div className="space-y-4 mb-4">
-            {provider.form_schema.fields.map((field) => (
-              <div key={field.name} className="space-y-2">
-                <Label htmlFor={field.name}>{field.label}</Label>
-                <Input
-                  id={field.name}
-                  type={field.field_type}
-                  required={field.required}
-                  placeholder={field.placeholder}
-                  value={formValues[field.name] ?? ""}
-                  onChange={(e) =>
-                    setFormValues((prev) => ({
-                      ...prev,
-                      [field.name]: e.target.value,
-                    }))
-                  }
-                  autoComplete="off"
-                />
-                {field.help_text && (
-                  <p className="text-xs text-muted-foreground">{field.help_text}</p>
-                )}
-              </div>
-            ))}
-          </div>
-
-          {/* Error */}
-          {error && (
-            <div className="flex items-center gap-2 text-destructive text-sm mb-4">
-              <AlertCircle className="h-4 w-4 flex-shrink-0" />
-              {error}
-            </div>
-          )}
-
-          <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-              Cancel
-            </Button>
-            <Button type="submit" disabled={createConnection.isPending}>
-              {createConnection.isPending ? "Validating..." : "Connect"}
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
   );
 }
 

--- a/apps/ui/src/components/chat/chat-panel.tsx
+++ b/apps/ui/src/components/chat/chat-panel.tsx
@@ -45,6 +45,7 @@ import { ThinkingIndicator } from "@/components/thinking-indicator";
 import { StreamingMessage } from "@/components/streaming-message";
 import { MessageContent } from "@/components/chat/message-content";
 import { ToolActivityGroup } from "@/components/chat/tool-activity-group";
+import { SetupConnectionToolCall } from "@/components/chat/setup-connection-tool-call";
 import {
   ToolActivityTimelineGroup,
   type TimelineToolRow,
@@ -609,14 +610,33 @@ export function ChatPanel() {
                   }
                 }
 
+                // Check for setup_connection tool calls (inline connection prompt)
+                const connectionCalls = reqData.tool_calls.filter(
+                  (tc) => tc.name === "setup_connection",
+                );
+                const otherCalls = reqData.tool_calls.filter(
+                  (tc) => tc.name !== "setup_connection",
+                );
+
                 return (
                   <div key={event.id} className="space-y-3">
                     <div className="ml-9 space-y-1">
-                      <ToolActivityGroup
-                        toolCalls={reqData.tool_calls}
-                        toolResultsMap={toolResultsMap}
-                        mode="client"
-                      />
+                      {connectionCalls.map((tc) => (
+                        <SetupConnectionToolCall
+                          key={tc.id}
+                          sessionId={sessionId}
+                          toolCallId={tc.id}
+                          provider={(tc.arguments as { provider?: string })?.provider ?? "unknown"}
+                          toolResultsMap={toolResultsMap}
+                        />
+                      ))}
+                      {otherCalls.length > 0 && (
+                        <ToolActivityGroup
+                          toolCalls={otherCalls}
+                          toolResultsMap={toolResultsMap}
+                          mode="client"
+                        />
+                      )}
                     </div>
                     {renderTurnDivider(event.id)}
                   </div>

--- a/apps/ui/src/components/chat/setup-connection-tool-call.tsx
+++ b/apps/ui/src/components/chat/setup-connection-tool-call.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+/**
+ * Inline connection setup card rendered when a tool call requires a user connection.
+ *
+ * The worker emits a synthetic `setup_connection` client-side tool call when a
+ * server-side tool (e.g. daytona_create_sandbox) discovers no connection is
+ * configured. This component renders an inline card with a "Connect" button;
+ * clicking it opens the shared ApiKeyDialog. After the user saves (or cancels),
+ * a tool result is submitted via the API and the workflow resumes.
+ */
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Check, LinkIcon, X } from "lucide-react";
+import { useConnectionProviders } from "@/hooks/use-user-connections";
+import { ApiKeyDialog } from "@/components/connections/api-key-dialog";
+import { ProviderIcon } from "@/components/connections/provider-icon";
+import { submitToolResults } from "@/lib/api/sessions";
+import { cn } from "@/lib/utils";
+import type { ToolCompletedData } from "@/lib/api/types";
+
+interface SetupConnectionToolCallProps {
+  sessionId: string;
+  toolCallId: string;
+  /** Provider id from the tool call arguments (e.g. "daytona") */
+  provider: string;
+  /** Existing tool results map — if a result already exists, show completed state */
+  toolResultsMap: Map<string, ToolCompletedData>;
+}
+
+export function SetupConnectionToolCall({
+  sessionId,
+  toolCallId,
+  provider,
+  toolResultsMap,
+}: SetupConnectionToolCallProps) {
+  const { data: providers = [] } = useConnectionProviders();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [status, setStatus] = useState<"idle" | "connected" | "cancelled" | "submitting">("idle");
+
+  const providerInfo = providers.find((p) => p.provider_id === provider);
+  const displayName = providerInfo?.display_name ?? provider;
+  const icon = providerInfo?.icon ?? "link";
+
+  // If we already have a tool result for this call, show completed state
+  const existingResult = toolResultsMap.get(toolCallId);
+  const isCompleted = existingResult != null || status === "connected" || status === "cancelled";
+
+  const handleConnected = async () => {
+    setStatus("submitting");
+    try {
+      await submitToolResults(sessionId, [
+        {
+          tool_call_id: toolCallId,
+          result: { connected: true, provider },
+        },
+      ]);
+      setStatus("connected");
+    } catch {
+      // Even if submit fails, the dialog already saved the connection
+      setStatus("connected");
+    }
+  };
+
+  const handleCancelled = async () => {
+    setStatus("submitting");
+    try {
+      await submitToolResults(sessionId, [
+        {
+          tool_call_id: toolCallId,
+          error: "Connection setup cancelled by user",
+        },
+      ]);
+    } catch {
+      // best-effort
+    }
+    setStatus("cancelled");
+  };
+
+  if (isCompleted) {
+    const wasSuccess = status === "connected" || existingResult?.success;
+    return (
+      <div
+        className={cn(
+          "flex items-center gap-2 rounded-lg border px-3 py-2 text-sm",
+          wasSuccess
+            ? "border-green-200 bg-green-50 text-green-700 dark:border-green-900 dark:bg-green-950/30 dark:text-green-400"
+            : "border-border bg-muted/30 text-muted-foreground",
+        )}
+      >
+        {wasSuccess ? <Check className="h-4 w-4" /> : <X className="h-4 w-4" />}
+        <ProviderIcon iconName={icon} className="h-4 w-4" />
+        {wasSuccess ? `${displayName} connected` : `${displayName} connection cancelled`}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="flex items-center gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-900 dark:bg-amber-950/30">
+        <ProviderIcon iconName={icon} className="h-5 w-5 text-amber-600 dark:text-amber-400" />
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
+            {displayName} connection required
+          </p>
+          <p className="text-xs text-amber-600 dark:text-amber-400">
+            Connect your {displayName} account to continue
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={handleCancelled}
+            disabled={status === "submitting"}
+            className="text-muted-foreground"
+          >
+            Skip
+          </Button>
+          <Button size="sm" onClick={() => setDialogOpen(true)} disabled={status === "submitting"}>
+            <LinkIcon className="h-3.5 w-3.5 mr-1" />
+            Connect
+          </Button>
+        </div>
+      </div>
+
+      <ApiKeyDialog
+        provider={providerInfo ?? null}
+        open={dialogOpen}
+        onOpenChange={(open) => {
+          setDialogOpen(open);
+          // If dialog was closed without connecting (no onConnected callback fired)
+          // we don't submit cancellation — user might reopen
+        }}
+        onConnected={handleConnected}
+      />
+    </>
+  );
+}

--- a/apps/ui/src/components/connections/api-key-dialog.tsx
+++ b/apps/ui/src/components/connections/api-key-dialog.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+/**
+ * Shared ApiKeyDialog for entering API key connections.
+ * Used by both the Settings > Connections page and inline chat connection prompts.
+ */
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useCreateApiKeyConnection } from "@/hooks/use-user-connections";
+import { AlertCircle } from "lucide-react";
+import type { ConnectionProvider } from "@/lib/api/types";
+import { InlineStreamdownMessage } from "@/components/chat/streamdown-message";
+import { ProviderIcon } from "./provider-icon";
+
+interface ApiKeyDialogProps {
+  provider: ConnectionProvider | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Called after a successful connection is created */
+  onConnected?: () => void;
+}
+
+export function ApiKeyDialog({ provider, open, onOpenChange, onConnected }: ApiKeyDialogProps) {
+  const [formValues, setFormValues] = useState<Record<string, string>>({});
+  const [error, setError] = useState<string | null>(null);
+  const createConnection = useCreateApiKeyConnection();
+
+  // Reset form when dialog opens/closes
+  useEffect(() => {
+    if (open) {
+      setFormValues({});
+      setError(null);
+    }
+  }, [open]);
+
+  if (!provider?.form_schema) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    const apiKey = formValues["api_key"] ?? "";
+    if (!apiKey.trim()) {
+      setError("API key is required");
+      return;
+    }
+
+    try {
+      await createConnection.mutateAsync({
+        provider: provider.provider_id,
+        apiKey,
+      });
+      onOpenChange(false);
+      onConnected?.();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to save connection";
+      const apiError = (err as { response?: { data?: string } })?.response?.data;
+      setError(typeof apiError === "string" ? apiError : message);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <ProviderIcon iconName={provider.icon} className="h-5 w-5" />
+            Connect {provider.display_name}
+          </DialogTitle>
+          <DialogDescription>{provider.description}</DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit}>
+          {/* Instructions */}
+          <InlineStreamdownMessage className="text-sm text-muted-foreground mb-4 leading-relaxed">
+            {provider.form_schema.instructions_markdown}
+          </InlineStreamdownMessage>
+
+          {/* Form fields */}
+          <div className="space-y-4 mb-4">
+            {provider.form_schema.fields.map((field) => (
+              <div key={field.name} className="space-y-2">
+                <Label htmlFor={field.name}>{field.label}</Label>
+                <Input
+                  id={field.name}
+                  type={field.field_type}
+                  required={field.required}
+                  placeholder={field.placeholder}
+                  value={formValues[field.name] ?? ""}
+                  onChange={(e) =>
+                    setFormValues((prev) => ({
+                      ...prev,
+                      [field.name]: e.target.value,
+                    }))
+                  }
+                  autoComplete="off"
+                />
+                {field.help_text && (
+                  <p className="text-xs text-muted-foreground">{field.help_text}</p>
+                )}
+              </div>
+            ))}
+          </div>
+
+          {/* Error */}
+          {error && (
+            <div className="flex items-center gap-2 text-destructive text-sm mb-4">
+              <AlertCircle className="h-4 w-4 flex-shrink-0" />
+              {error}
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={createConnection.isPending}>
+              {createConnection.isPending ? "Validating..." : "Connect"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/ui/src/components/connections/provider-icon.tsx
+++ b/apps/ui/src/components/connections/provider-icon.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { Github, Cloud, Search, LinkIcon } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { getCapabilityIcon } from "@/lib/capability-icons";
+
+const iconMap: Record<string, LucideIcon> = {
+  github: Github,
+  cloud: Cloud,
+  search: Search,
+  daytona: getCapabilityIcon("daytona"),
+};
+
+export function ProviderIcon({ iconName, className }: { iconName: string; className?: string }) {
+  const Icon = iconMap[iconName] ?? LinkIcon;
+  return <Icon className={className} />;
+}

--- a/apps/ui/src/lib/api/sessions.ts
+++ b/apps/ui/src/lib/api/sessions.ts
@@ -104,6 +104,25 @@ export async function unpinSession(sessionId: string): Promise<void> {
 }
 
 // ============================================
+// Client-Side Tool Results
+// ============================================
+
+/**
+ * Submit tool results for client-side tool calls.
+ * Resumes a session that is paused in `waiting_for_tool_results` status.
+ */
+export async function submitToolResults(
+  sessionId: string,
+  toolResults: Array<{ tool_call_id: string; result?: unknown; error?: string }>,
+): Promise<{ status: string; tool_results_count: number }> {
+  const response = await api.post<{ status: string; tool_results_count: number }>(
+    `/v1/sessions/${sessionId}/tool-results`,
+    { tool_results: toolResults },
+  );
+  return response.data;
+}
+
+// ============================================
 // Global Chat
 // ============================================
 

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -78,6 +78,9 @@ pub struct ToolCallResult {
     pub success: bool,
     /// Status: "success", "error", "timeout", or "cancelled"
     pub status: String,
+    /// If set, the tool requires a user connection for this provider before it can execute.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub connection_required: Option<String>,
 }
 
 /// Result of the ActAtom
@@ -91,6 +94,11 @@ pub struct ActResult {
     pub success_count: u32,
     /// Number of failed tool calls
     pub error_count: u32,
+    /// Providers that require user connection setup before the tool can run.
+    /// When non-empty, the worker should pause and emit a client-side tool call
+    /// to prompt the user to configure the connection.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub connection_required: Vec<String>,
 }
 
 // ============================================================================
@@ -279,6 +287,7 @@ where
                 completed: true,
                 success_count: 0,
                 error_count: 0,
+                connection_required: vec![],
             });
         }
 
@@ -358,6 +367,12 @@ where
         let success_count = results.iter().filter(|r| r.success).count() as u32;
         let error_count = results.iter().filter(|r| !r.success).count() as u32;
 
+        // Collect providers that need connection setup
+        let connection_required: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.connection_required.clone())
+            .collect();
+
         // Calculate act phase duration
         let act_duration_ms = act_start.elapsed().as_millis() as u64;
 
@@ -419,6 +434,7 @@ where
             completed: true,
             success_count,
             error_count,
+            connection_required,
         })
     }
 }
@@ -532,9 +548,11 @@ where
                     result: None,
                     images: None,
                     error: Some(error_msg),
+                    connection_required: None,
                 },
                 success: false,
                 status: "error".to_string(),
+                connection_required: None,
             };
         };
 
@@ -667,11 +685,13 @@ where
                     "ActAtom: tool execution completed"
                 );
 
+                let conn_req = tool_result.connection_required.clone();
                 ToolCallResult {
                     tool_call,
                     result: tool_result,
                     success,
                     status: status.to_string(),
+                    connection_required: conn_req,
                 }
             }
             Err(e) => {
@@ -723,9 +743,11 @@ where
                         result: None,
                         images: None,
                         error: Some(error_msg),
+                        connection_required: None,
                     },
                     success: false,
                     status: "error".to_string(),
+                    connection_required: None,
                 }
             }
         }
@@ -907,5 +929,55 @@ mod tests {
             err_msg.contains("requires context"),
             "Expected 'requires context' error, got: {err_msg}"
         );
+    }
+
+    #[test]
+    fn test_act_result_connection_required_serialization() {
+        let result = ActResult {
+            results: vec![ToolCallResult {
+                tool_call: ToolCall {
+                    id: "call_1".to_string(),
+                    name: "daytona_create_sandbox".to_string(),
+                    arguments: json!({}),
+                },
+                result: ToolResult {
+                    tool_call_id: "call_1".to_string(),
+                    result: Some(json!({"connection_required": "daytona"})),
+                    images: None,
+                    error: None,
+                    connection_required: Some("daytona".to_string()),
+                },
+                success: false,
+                status: "success".to_string(),
+                connection_required: Some("daytona".to_string()),
+            }],
+            completed: true,
+            success_count: 0,
+            error_count: 0,
+            connection_required: vec!["daytona".to_string()],
+        };
+
+        let json_str = serde_json::to_string(&result).unwrap();
+        let parsed: ActResult = serde_json::from_str(&json_str).unwrap();
+
+        assert_eq!(parsed.connection_required, vec!["daytona".to_string()]);
+        assert_eq!(
+            parsed.results[0].connection_required,
+            Some("daytona".to_string())
+        );
+    }
+
+    #[test]
+    fn test_act_result_without_connection_required_backward_compat() {
+        // Old JSON without connection_required fields still deserializes
+        let json_str = r#"{
+            "results": [],
+            "completed": true,
+            "success_count": 0,
+            "error_count": 0
+        }"#;
+        let parsed: ActResult = serde_json::from_str(json_str).unwrap();
+
+        assert!(parsed.connection_required.is_empty());
     }
 }

--- a/crates/core/src/memory.rs
+++ b/crates/core/src/memory.rs
@@ -510,6 +510,7 @@ impl ToolExecutor for MockToolExecutor {
             result: Some(result),
             images: None,
             error: None,
+            connection_required: None,
         })
     }
 }
@@ -545,6 +546,7 @@ impl ToolExecutor for EchoToolExecutor {
             })),
             images: None,
             error: None,
+            connection_required: None,
         })
     }
 }
@@ -587,6 +589,7 @@ impl ToolExecutor for FailingToolExecutor {
             result: None,
             images: None,
             error: Some(self.error_message.clone()),
+            connection_required: None,
         })
     }
 }

--- a/crates/core/src/tool_types.rs
+++ b/crates/core/src/tool_types.rs
@@ -213,6 +213,10 @@ pub struct ToolResult {
     pub images: Option<Vec<crate::tools::ToolResultImage>>,
     /// Error message (failure)
     pub error: Option<String>,
+    /// When set, indicates the tool requires a user connection for this provider.
+    /// The workflow should pause and prompt the user to configure the connection.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub connection_required: Option<String>,
 }
 
 #[cfg(test)]
@@ -279,6 +283,7 @@ mod tests {
             result: Some(serde_json::json!({"temperature": 72})),
             images: None,
             error: None,
+            connection_required: None,
         };
 
         let json = serde_json::to_string(&result).unwrap();

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -81,6 +81,17 @@ pub enum ToolExecutionResult {
     /// or other internal issues. The error details will be logged but replaced
     /// with a generic message when returned to the LLM.
     InternalError(ToolInternalError),
+
+    /// A user connection is required to execute this tool.
+    ///
+    /// Instead of returning an error, this signals that the workflow should
+    /// pause and ask the client to set up a connection for the given provider.
+    /// The UI renders an inline connection dialog; once the user saves (or
+    /// cancels), a tool result is submitted and execution resumes.
+    ConnectionRequired {
+        /// Connection provider id (e.g. "daytona", "brave_search")
+        provider: String,
+    },
 }
 
 impl ToolExecutionResult {
@@ -112,6 +123,13 @@ impl ToolExecutionResult {
         ToolExecutionResult::InternalError(ToolInternalError::from_message(message))
     }
 
+    /// Signal that a user connection is required before this tool can execute.
+    pub fn connection_required(provider: impl Into<String>) -> Self {
+        ToolExecutionResult::ConnectionRequired {
+            provider: provider.into(),
+        }
+    }
+
     /// Check if this is a successful result
     pub fn is_success(&self) -> bool {
         matches!(
@@ -122,7 +140,15 @@ impl ToolExecutionResult {
 
     /// Check if this is an error (either tool error or internal error)
     pub fn is_error(&self) -> bool {
-        !self.is_success()
+        matches!(
+            self,
+            ToolExecutionResult::ToolError(_) | ToolExecutionResult::InternalError(_)
+        )
+    }
+
+    /// Check if this requires a user connection setup
+    pub fn is_connection_required(&self) -> bool {
+        matches!(self, ToolExecutionResult::ConnectionRequired { .. })
     }
 
     /// Convert to a ToolResult for the agent loop
@@ -139,6 +165,7 @@ impl ToolExecutionResult {
                 result: Some(value),
                 images: None,
                 error: None,
+                connection_required: None,
             },
             ToolExecutionResult::SuccessWithImages { result, images } => ToolResult {
                 tool_call_id: tool_call_id.to_string(),
@@ -149,12 +176,14 @@ impl ToolExecutionResult {
                     Some(images)
                 },
                 error: None,
+                connection_required: None,
             },
             ToolExecutionResult::ToolError(message) => ToolResult {
                 tool_call_id: tool_call_id.to_string(),
                 result: Some(serde_json::json!({ "error": message })),
                 images: None,
                 error: None,
+                connection_required: None,
             },
             ToolExecutionResult::InternalError(err) => {
                 // Log the full error details for debugging
@@ -173,8 +202,18 @@ impl ToolExecutionResult {
                     })),
                     images: None,
                     error: None,
+                    connection_required: None,
                 }
             }
+            ToolExecutionResult::ConnectionRequired { ref provider } => ToolResult {
+                tool_call_id: tool_call_id.to_string(),
+                result: Some(serde_json::json!({
+                    "connection_required": provider,
+                })),
+                images: None,
+                error: None,
+                connection_required: Some(provider.clone()),
+            },
         }
     }
 }

--- a/crates/core/tests/tool_calling_test.rs
+++ b/crates/core/tests/tool_calling_test.rs
@@ -718,6 +718,7 @@ fn test_tool_result_with_images_serialization() {
             media_type: "image/png".to_string(),
         }]),
         error: None,
+        connection_required: None,
     };
 
     let json_str = serde_json::to_string(&result).unwrap();
@@ -735,4 +736,71 @@ fn test_tool_result_without_images_backward_compat() {
 
     assert!(parsed.images.is_none());
     assert_eq!(parsed.tool_call_id, "call_1");
+}
+
+// ============================================================================
+// ConnectionRequired tests
+// ============================================================================
+
+#[test]
+fn test_connection_required_into_tool_result() {
+    use everruns_core::tools::ToolExecutionResult;
+
+    let result = ToolExecutionResult::connection_required("daytona");
+    assert!(result.is_connection_required());
+    assert!(!result.is_success());
+    assert!(!result.is_error());
+
+    let tool_result = result.into_tool_result("call_conn", "daytona_create_sandbox");
+    assert_eq!(tool_result.tool_call_id, "call_conn");
+    assert_eq!(tool_result.connection_required, Some("daytona".to_string()));
+    assert!(tool_result.error.is_none());
+
+    // Result JSON contains connection_required key
+    let result_json = tool_result.result.unwrap();
+    assert_eq!(result_json["connection_required"], "daytona");
+}
+
+#[test]
+fn test_connection_required_serialization_roundtrip() {
+    let result = everruns_core::ToolResult {
+        tool_call_id: "call_conn".to_string(),
+        result: Some(json!({"connection_required": "daytona"})),
+        images: None,
+        error: None,
+        connection_required: Some("daytona".to_string()),
+    };
+
+    let json_str = serde_json::to_string(&result).unwrap();
+    let parsed: everruns_core::ToolResult = serde_json::from_str(&json_str).unwrap();
+
+    assert_eq!(parsed.connection_required, Some("daytona".to_string()));
+    assert_eq!(parsed.result.unwrap()["connection_required"], "daytona");
+}
+
+#[test]
+fn test_tool_result_without_connection_required_backward_compat() {
+    // Old JSON without connection_required field still deserializes
+    let json_str = r#"{"tool_call_id":"call_1","result":{"ok":true},"error":null}"#;
+    let parsed: everruns_core::ToolResult = serde_json::from_str(json_str).unwrap();
+
+    assert!(parsed.connection_required.is_none());
+}
+
+#[test]
+fn test_connection_required_not_classified_as_error() {
+    use everruns_core::tools::ToolExecutionResult;
+
+    let success = ToolExecutionResult::success(json!({"ok": true}));
+    assert!(success.is_success());
+    assert!(!success.is_error());
+
+    let error = ToolExecutionResult::tool_error("bad input");
+    assert!(!error.is_success());
+    assert!(error.is_error());
+
+    let conn = ToolExecutionResult::connection_required("daytona");
+    assert!(!conn.is_success());
+    assert!(!conn.is_error());
+    assert!(conn.is_connection_required());
 }

--- a/crates/server/tests/client_side_tools_test.rs
+++ b/crates/server/tests/client_side_tools_test.rs
@@ -338,6 +338,7 @@ fn test_tool_call_and_result_correlation() {
         result: Some(json!({"output": "total 42\n..."})),
         images: None,
         error: None,
+        connection_required: None,
     };
 
     // IDs correlate

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -524,13 +524,16 @@ mod tests {
                     result: Some(json!({"temp": 72})),
                     images: None,
                     error: None,
+                    connection_required: None,
                 },
                 success: true,
                 status: "success".to_string(),
+                connection_required: None,
             }],
             completed: true,
             success_count: 1,
             error_count: 0,
+            connection_required: vec![],
         };
 
         let json = serde_json::to_string(&result).unwrap();

--- a/crates/worker/src/mcp_executor.rs
+++ b/crates/worker/src/mcp_executor.rs
@@ -73,6 +73,7 @@ impl McpToolExecutor {
                 Some(images)
             },
             error: None,
+            connection_required: None,
         })
     }
 

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -517,6 +517,8 @@ where
                                 EventContext::turn(turn_id, ti.input_message_id),
                                 everruns_core::ToolCallRequestedData {
                                     tool_calls: synthetic_tool_calls,
+                                    tool_summaries: vec![],
+                                    headline: None,
                                 },
                             );
                             if let Err(e) = adapters.emit_event(requested_event).await {

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -486,6 +486,57 @@ where
                         "Task completed successfully"
                     );
 
+                    // After act activity: if tools need a connection, emit
+                    // tool.call_requested and set session to waiting_for_tool_results.
+                    // This must happen before schedule_next_activity (which completes
+                    // the workflow) because we need adapter access for events/status.
+                    if task.activity_type == "act"
+                        && let Some(ref ti) = turn_input_opt
+                    {
+                        let act_result: Option<everruns_core::ActResult> =
+                            serde_json::from_value(output.clone()).ok();
+                        let conn_providers: Vec<String> = act_result
+                            .as_ref()
+                            .map(|r| r.connection_required.clone())
+                            .unwrap_or_default();
+
+                        if !conn_providers.is_empty() {
+                            // Build synthetic setup_connection tool calls
+                            let synthetic_tool_calls: Vec<everruns_core::ToolCall> = conn_providers
+                                .iter()
+                                .map(|provider| everruns_core::ToolCall {
+                                    id: format!("setup_conn_{}", Uuid::now_v7()),
+                                    name: "setup_connection".to_string(),
+                                    arguments: serde_json::json!({ "provider": provider }),
+                                })
+                                .collect();
+
+                            let turn_id = ti.turn_id.unwrap_or_default();
+                            let requested_event = EventRequest::new(
+                                ti.session_id,
+                                EventContext::turn(turn_id, ti.input_message_id),
+                                everruns_core::ToolCallRequestedData {
+                                    tool_calls: synthetic_tool_calls,
+                                },
+                            );
+                            if let Err(e) = adapters.emit_event(requested_event).await {
+                                warn!(error = %e, "Failed to emit tool.call_requested event for connection setup");
+                            }
+
+                            // Set session status to waiting_for_tool_results
+                            if let Err(e) = adapters
+                                .set_session_status(
+                                    ti.org_id,
+                                    ti.session_id.uuid(),
+                                    "waiting_for_tool_results",
+                                )
+                                .await
+                            {
+                                warn!(error = %e, "Failed to set session status to waiting_for_tool_results");
+                            }
+                        }
+                    }
+
                     // Schedule next activity if needed (only for workflow-bound tasks)
                     if let (Some(turn_input), Some(wf_id)) = (turn_input_opt, task.workflow_id) {
                         schedule_next_activity(
@@ -991,33 +1042,53 @@ async fn schedule_next_activity<S: WorkflowEventStore>(
             }
         }
         "act" => {
-            // Use input as-is; previous_response_id was set by the reason→act transition
-            let input_json = serde_json::to_value(input)?;
+            // Check if any tools require a user connection setup.
+            // If so, complete the workflow — the event emission and session status
+            // change were already handled by the caller (process_claimed_task).
+            let act_result: Option<everruns_core::ActResult> =
+                serde_json::from_value(output.clone()).ok();
+            let has_connection_required = act_result
+                .as_ref()
+                .is_some_and(|r| !r.connection_required.is_empty());
 
-            // Schedule another reason activity
-            let activity_id = format!("reason_{}", Uuid::now_v7());
-            let task = TaskDefinition {
-                workflow_id: Some(workflow_id),
-                activity_id: activity_id.clone(),
-                activity_type: "reason".to_string(),
-                input: input_json.clone(),
-                options: Default::default(),
-            };
-            store
-                .enqueue_task(task)
-                .await
-                .map_err(|e| anyhow::anyhow!("Failed to enqueue reason task: {}", e))?;
+            if has_connection_required {
+                // Complete workflow — it will be resumed by tool-results endpoint
+                record_workflow_completed(store.as_ref(), workflow_id, output.clone()).await;
+                store
+                    .update_workflow_status(workflow_id, WorkflowStatus::Completed, None, None)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to update workflow status: {}", e))?;
 
-            // Record ActivityScheduled event
-            let scheduled_event = WorkflowEvent::ActivityScheduled {
-                activity_id,
-                activity_type: "reason".to_string(),
-                input: input_json,
-                options: ActivityOptions::default(),
-            };
-            let _ = append_event(store.as_ref(), workflow_id, scheduled_event).await;
+                info!(
+                    workflow_id = %workflow_id,
+                    "Workflow completed — waiting for user to set up connection"
+                );
+            } else {
+                // Normal flow: schedule another reason activity
+                let input_json = serde_json::to_value(input)?;
+                let activity_id = format!("reason_{}", Uuid::now_v7());
+                let task = TaskDefinition {
+                    workflow_id: Some(workflow_id),
+                    activity_id: activity_id.clone(),
+                    activity_type: "reason".to_string(),
+                    input: input_json.clone(),
+                    options: Default::default(),
+                };
+                store
+                    .enqueue_task(task)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to enqueue reason task: {}", e))?;
 
-            debug!(workflow_id = %workflow_id, turn_id = ?input.turn_id, "Scheduled reason activity after act");
+                let scheduled_event = WorkflowEvent::ActivityScheduled {
+                    activity_id,
+                    activity_type: "reason".to_string(),
+                    input: input_json,
+                    options: ActivityOptions::default(),
+                };
+                let _ = append_event(store.as_ref(), workflow_id, scheduled_event).await;
+
+                debug!(workflow_id = %workflow_id, turn_id = ?input.turn_id, "Scheduled reason activity after act");
+            }
         }
         _ => {
             warn!(

--- a/integrations/daytona/src/state.rs
+++ b/integrations/daytona/src/state.rs
@@ -71,12 +71,9 @@ pub async fn get_api_key(context: &ToolContext) -> Result<String, ToolExecutionR
     }
 
     // THREAT[TM-AGENT-016]: Asking secrets in chat stores them plaintext in events.
-    // Prefer Settings UI for credential entry.
-    Err(ToolExecutionResult::tool_error(
-        "Daytona API key not configured.\n\n\
-         Set up your API key in **Settings > Connections > Daytona**.\n\n\
-         Get your key at https://app.daytona.io/ under API Keys.",
-    ))
+    // Return ConnectionRequired so the UI renders an inline connection dialog
+    // instead of a plain error message.
+    Err(ToolExecutionResult::connection_required("daytona"))
 }
 
 pub async fn get_sandbox_state(

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -1754,13 +1754,10 @@ mod tests {
             .execute_with_context(json!({"sandbox_id": "sb_test"}), &context)
             .await;
         match result {
-            ToolExecutionResult::ToolError(msg) => {
-                assert!(
-                    msg.contains("not configured") || msg.contains("Settings > Connections"),
-                    "Expected API key error, got: {msg}"
-                );
+            ToolExecutionResult::ConnectionRequired { provider } => {
+                assert_eq!(provider, "daytona");
             }
-            _ => panic!("Expected ToolError for missing API key"),
+            _ => panic!("Expected ConnectionRequired for missing API key, got: {result:?}"),
         }
     }
 
@@ -1912,19 +1909,16 @@ mod tests {
     async fn test_git_credentials_no_storage_store() {
         let tool = DaytonaGitCredentialsTool;
         let session_id = SessionId::new();
-        // No storage store at all
+        // No storage store at all — get_api_key() returns ConnectionRequired
         let context = ToolContext::new(session_id);
         let result = tool
             .execute_with_context(json!({"sandbox_id": "sb_test"}), &context)
             .await;
         match result {
-            ToolExecutionResult::ToolError(msg) => {
-                assert!(
-                    msg.contains("not available") || msg.contains("not configured"),
-                    "Expected storage/config error, got: {msg}"
-                );
+            ToolExecutionResult::ConnectionRequired { provider } => {
+                assert_eq!(provider, "daytona");
             }
-            _ => panic!("Expected ToolError for missing storage store"),
+            _ => panic!("Expected ConnectionRequired for missing API key, got: {result:?}"),
         }
     }
 
@@ -1966,13 +1960,10 @@ mod tests {
             )
             .await;
         match result {
-            ToolExecutionResult::ToolError(msg) => {
-                assert!(
-                    msg.contains("not configured") || msg.contains("Settings > Connections"),
-                    "Expected API key error, got: {msg}"
-                );
+            ToolExecutionResult::ConnectionRequired { provider } => {
+                assert_eq!(provider, "daytona");
             }
-            _ => panic!("Expected ToolError for missing API key"),
+            _ => panic!("Expected ConnectionRequired for missing API key, got: {result:?}"),
         }
     }
 

--- a/integrations/daytona/tests/tool_integration.rs
+++ b/integrations/daytona/tests/tool_integration.rs
@@ -332,13 +332,10 @@ async fn test_exec_tool_missing_api_key() {
         .await;
 
     match result {
-        ToolExecutionResult::ToolError(msg) => {
-            assert!(
-                msg.contains("not configured") || msg.contains("Settings > Connections"),
-                "Got: {msg}"
-            );
+        ToolExecutionResult::ConnectionRequired { provider } => {
+            assert_eq!(provider, "daytona");
         }
-        other => panic!("Expected ToolError, got: {other:?}"),
+        other => panic!("Expected ConnectionRequired, got: {other:?}"),
     }
 }
 


### PR DESCRIPTION
## Summary

- When a server-side tool (e.g. `daytona_create_sandbox`) needs a user connection but none is configured, instead of returning a plain error, the system pauses execution and renders an inline connection card in the chat
- User clicks "Connect" → shared `ApiKeyDialog` opens → saves connection → tool result submitted → workflow resumes automatically
- Reuses existing client-side tool call infrastructure (`tool.call_requested` / `tool-results` endpoint)

## Changes

### Core (Rust)
- Add `ConnectionRequired { provider }` variant to `ToolExecutionResult` — neither success nor error, signals a connection is needed
- Add `connection_required` field to `ToolResult`, `ToolCallResult`, `ActResult` for propagation
- Worker detects `connection_required` in act output → emits synthetic `setup_connection` `tool.call_requested` event → sets session to `waiting_for_tool_results`
- Daytona `get_api_key()` returns `ConnectionRequired` instead of `ToolError`

### UI (TypeScript/React)
- Extract `ApiKeyDialog` + `ProviderIcon` from settings page into shared `components/connections/`
- New `SetupConnectionToolCall` component: inline amber card with Connect/Skip buttons
- `submitToolResults()` API function for submitting client-side tool results
- `chat-panel.tsx` routes `setup_connection` tool calls to the new component

## Test plan

- [x] `ConnectionRequired` variant serialization roundtrip
- [x] `ActResult.connection_required` aggregation and backward compat
- [x] `is_connection_required()` / `is_error()` / `is_success()` classification
- [x] `cargo test --all-features` passes
- [x] UI build passes (`npm run build`)
- [x] `just pre-push` passes
- [ ] Smoke test: create session with Daytona capability, no API key → inline card appears
- [ ] Smoke test: click Connect, enter key, save → workflow resumes
- [ ] Smoke test: click Skip → cancellation result submitted, LLM informed