### PR TITLE
fix(core): retry transient pre-output stream errors

### DIFF
--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -37,6 +37,7 @@ use crate::llm_driver_registry::{
     DriverRegistry, LlmCallConfigBuilder, LlmCompletionMetadata, LlmMessage, LlmMessageContent,
     LlmMessageRole, LlmStreamEvent, ProviderConfig, ProviderType,
 };
+use crate::llm_retry::{LlmRetryConfig, RetryMetadata, is_transient_error_message};
 use crate::message::{Message, MessageRole};
 use crate::message_retriever::MessageRetriever;
 use crate::openresponses_protocol::{
@@ -87,6 +88,41 @@ fn patch_dangling_tool_calls(messages: &[Message]) -> Vec<Message> {
     }
 
     result
+}
+
+fn should_retry_stream_error(
+    err: &str,
+    retry_attempts: u32,
+    max_retries: u32,
+    text: &str,
+    thinking: &str,
+    thinking_signature: Option<&str>,
+    tool_calls: &[ToolCall],
+) -> bool {
+    retry_attempts < max_retries
+        && text.is_empty()
+        && thinking.is_empty()
+        && thinking_signature.is_none()
+        && tool_calls.is_empty()
+        && is_transient_error_message(err)
+}
+
+fn merge_retry_metadata(
+    existing: Option<RetryMetadata>,
+    additional: &RetryMetadata,
+) -> Option<RetryMetadata> {
+    if !additional.had_retries() {
+        return existing;
+    }
+
+    let mut merged = existing.unwrap_or_default();
+    merged.attempts += additional.attempts;
+    merged.total_retry_wait += additional.total_retry_wait;
+    if additional.last_rate_limit_info.is_some() {
+        merged.last_rate_limit_info = additional.last_rate_limit_info.clone();
+    }
+
+    Some(merged)
 }
 
 // ============================================================================
@@ -798,336 +834,397 @@ where
         // Track LLM call timing
         let llm_start = Instant::now();
 
-        // Try LLM call with automatic compaction on RequestTooLarge
+        // Try LLM call with automatic compaction on RequestTooLarge.
+        // Stream-level provider errors can still arrive inside a 200/SSE response, so
+        // we also allow a bounded retry before any output is emitted.
+        let retry_config = LlmRetryConfig::default();
+        let mut stream_retry_metadata = RetryMetadata::default();
         let mut compaction_info: Option<LlmCompactionInfo> = None;
         let mut llm_messages_for_call = llm_messages.clone();
-
-        let mut stream = match llm_driver
-            .chat_completion_stream(llm_messages_for_call.clone(), &llm_config)
-            .await
-        {
-            Ok(stream) => stream,
-            Err(e) if e.is_request_too_large() && llm_driver.supports_compact() => {
-                // Context too large - try compacting
-                tracing::info!(
-                    session_id = %session_id,
-                    turn_id = %context.turn_id,
-                    "ReasonAtom: context too large, attempting compaction"
-                );
-
-                let compact_start = Instant::now();
-
-                // Convert messages to compact input format
-                // Skip the system message (index 0) as it's passed separately as instructions
-                let messages_to_compact = if has_system_prompt {
-                    &llm_messages_for_call[1..]
-                } else {
-                    &llm_messages_for_call[..]
-                };
-
-                let compact_input = messages_to_compact_input(messages_to_compact);
-                let input_count = compact_input.len();
-
-                // Build compact request
-                let compact_request = CompactRequest {
-                    model: runtime_agent.model.clone(),
-                    input: compact_input,
-                    previous_response_id: previous_response_id.clone(),
-                    instructions: if has_system_prompt {
-                        Some(runtime_agent.system_prompt.clone())
-                    } else {
-                        None
-                    },
-                };
-
-                // Call compact endpoint
-                let compact_response =
-                    llm_driver.compact(compact_request).await?.ok_or_else(|| {
-                        AgentLoopError::llm("Compaction failed: driver returned None".to_string())
-                    })?;
-
-                let compact_duration_ms = compact_start.elapsed().as_millis() as u64;
-
-                // Convert compacted output to messages
-                let (compacted_messages, compaction_items) =
-                    compact_output_to_messages(&compact_response.output);
-
-                // Track compaction token usage
-                let input_tokens_after = compact_response
-                    .usage
-                    .as_ref()
-                    .and_then(|u| u.output_tokens);
-
-                tracing::info!(
-                    session_id = %session_id,
-                    turn_id = %context.turn_id,
-                    input_items = input_count,
-                    output_items = compact_response.output.len(),
-                    compaction_items = compaction_items.len(),
-                    duration_ms = compact_duration_ms,
-                    "ReasonAtom: compaction completed"
-                );
-
-                // Record compaction info for event
-                compaction_info = Some(LlmCompactionInfo::new(
-                    Some(input_count as u32),
-                    input_tokens_after,
-                    Some(compact_duration_ms),
-                ));
-
-                // Rebuild messages for retry
-                // Start with system prompt if present
-                let mut compacted_llm_messages = Vec::new();
-                if has_system_prompt {
-                    compacted_llm_messages.push(llm_messages_for_call[0].clone());
-                }
-
-                // Add compacted messages
-                compacted_llm_messages.extend(compacted_messages);
-
-                // Add compaction items as a special message if present
-                // These contain encrypted context that the model needs
-                for item in compaction_items {
-                    if let CompactInputItem::Compaction { encrypted_content } = item {
-                        // Add as a system message containing the encrypted context
-                        // This preserves the latent context for the model
-                        compacted_llm_messages.push(LlmMessage {
-                            role: LlmMessageRole::System,
-                            content: LlmMessageContent::Text(format!(
-                                "[COMPACTED_CONTEXT:{}]",
-                                encrypted_content
-                            )),
-                            tool_calls: None,
-                            tool_call_id: None,
-                            phase: None,
-                            thinking: None,
-                            thinking_signature: None,
-                        });
-                    }
-                }
-
-                llm_messages_for_call = compacted_llm_messages;
-
-                // Retry with compacted messages
-                tracing::info!(
-                    session_id = %session_id,
-                    turn_id = %context.turn_id,
-                    message_count = llm_messages_for_call.len(),
-                    "ReasonAtom: retrying LLM call with compacted context"
-                );
-
-                llm_driver
-                    .chat_completion_stream(llm_messages_for_call.clone(), &llm_config)
-                    .await?
-            }
-            Err(e) => return Err(e),
-        };
 
         // 14. Process stream with batched output.message.delta emissions
         // Batch deltas every 100ms to reduce event volume while providing real-time feedback
         const DELTA_BATCH_INTERVAL_MS: u64 = 100;
-        let mut text = String::new();
-        let mut thinking = String::new();
-        let mut thinking_signature: Option<String> = None;
-        let mut tool_calls = Vec::new();
-        let mut completion_metadata: Option<LlmCompletionMetadata> = None;
-        let mut pending_delta = String::new();
-        let mut pending_thinking_delta = String::new();
-        let mut last_delta_emit = Instant::now();
-        let mut last_thinking_delta_emit = Instant::now();
-        let mut time_to_first_token_ms: Option<u64> = None;
+        let (
+            text,
+            thinking,
+            thinking_signature,
+            tool_calls,
+            mut completion_metadata,
+            time_to_first_token_ms,
+        ) = 'stream_attempt: loop {
+            let mut stream = match llm_driver
+                .chat_completion_stream(llm_messages_for_call.clone(), &llm_config)
+                .await
+            {
+                Ok(stream) => stream,
+                Err(e) if e.is_request_too_large() && llm_driver.supports_compact() => {
+                    // Context too large - try compacting
+                    tracing::info!(
+                        session_id = %session_id,
+                        turn_id = %context.turn_id,
+                        "ReasonAtom: context too large, attempting compaction"
+                    );
 
-        while let Some(event) = stream.next().await {
-            match event? {
-                LlmStreamEvent::TextDelta(delta) => {
-                    // Track time-to-first-token on first non-empty delta
-                    if time_to_first_token_ms.is_none() && !delta.is_empty() {
-                        let ttft = llm_start.elapsed().as_millis() as u64;
-                        time_to_first_token_ms = Some(ttft);
-                        tracing::info!(
-                            session_id = %session_id,
-                            time_to_first_token_ms = ttft,
-                            "ReasonAtom: received first token from LLM"
-                        );
+                    let compact_start = Instant::now();
+
+                    // Convert messages to compact input format
+                    // Skip the system message (index 0) as it's passed separately as instructions
+                    let messages_to_compact = if has_system_prompt {
+                        &llm_messages_for_call[1..]
+                    } else {
+                        &llm_messages_for_call[..]
+                    };
+
+                    let compact_input = messages_to_compact_input(messages_to_compact);
+                    let input_count = compact_input.len();
+
+                    // Build compact request
+                    let compact_request = CompactRequest {
+                        model: runtime_agent.model.clone(),
+                        input: compact_input,
+                        previous_response_id: previous_response_id.clone(),
+                        instructions: if has_system_prompt {
+                            Some(runtime_agent.system_prompt.clone())
+                        } else {
+                            None
+                        },
+                    };
+
+                    // Call compact endpoint
+                    let compact_response =
+                        llm_driver.compact(compact_request).await?.ok_or_else(|| {
+                            AgentLoopError::llm(
+                                "Compaction failed: driver returned None".to_string(),
+                            )
+                        })?;
+
+                    let compact_duration_ms = compact_start.elapsed().as_millis() as u64;
+
+                    // Convert compacted output to messages
+                    let (compacted_messages, compaction_items) =
+                        compact_output_to_messages(&compact_response.output);
+
+                    // Track compaction token usage
+                    let input_tokens_after = compact_response
+                        .usage
+                        .as_ref()
+                        .and_then(|u| u.output_tokens);
+
+                    tracing::info!(
+                        session_id = %session_id,
+                        turn_id = %context.turn_id,
+                        input_items = input_count,
+                        output_items = compact_response.output.len(),
+                        compaction_items = compaction_items.len(),
+                        duration_ms = compact_duration_ms,
+                        "ReasonAtom: compaction completed"
+                    );
+
+                    // Record compaction info for event
+                    compaction_info = Some(LlmCompactionInfo::new(
+                        Some(input_count as u32),
+                        input_tokens_after,
+                        Some(compact_duration_ms),
+                    ));
+
+                    // Rebuild messages for retry
+                    // Start with system prompt if present
+                    let mut compacted_llm_messages = Vec::new();
+                    if has_system_prompt {
+                        compacted_llm_messages.push(llm_messages_for_call[0].clone());
                     }
-                    text.push_str(&delta);
-                    pending_delta.push_str(&delta);
 
-                    // Emit batched delta if interval elapsed
-                    if last_delta_emit.elapsed().as_millis() as u64 >= DELTA_BATCH_INTERVAL_MS
-                        && !pending_delta.is_empty()
-                    {
-                        if let Err(e) = self
-                            .event_emitter
-                            .emit(EventRequest::new(
-                                session_id,
-                                streaming_event_context.clone(),
-                                OutputMessageDeltaData {
-                                    turn_id: context.turn_id,
-                                    delta: pending_delta.clone(),
-                                    accumulated: text.clone(),
-                                },
-                            ))
-                            .await
+                    // Add compacted messages
+                    compacted_llm_messages.extend(compacted_messages);
+
+                    // Add compaction items as a special message if present
+                    // These contain encrypted context that the model needs
+                    for item in compaction_items {
+                        if let CompactInputItem::Compaction { encrypted_content } = item {
+                            // Add as a system message containing the encrypted context
+                            // This preserves the latent context for the model
+                            compacted_llm_messages.push(LlmMessage {
+                                role: LlmMessageRole::System,
+                                content: LlmMessageContent::Text(format!(
+                                    "[COMPACTED_CONTEXT:{}]",
+                                    encrypted_content
+                                )),
+                                tool_calls: None,
+                                tool_call_id: None,
+                                phase: None,
+                                thinking: None,
+                                thinking_signature: None,
+                            });
+                        }
+                    }
+
+                    llm_messages_for_call = compacted_llm_messages;
+
+                    // Retry with compacted messages
+                    tracing::info!(
+                        session_id = %session_id,
+                        turn_id = %context.turn_id,
+                        message_count = llm_messages_for_call.len(),
+                        "ReasonAtom: retrying LLM call with compacted context"
+                    );
+
+                    llm_driver
+                        .chat_completion_stream(llm_messages_for_call.clone(), &llm_config)
+                        .await?
+                }
+                Err(e) => return Err(e),
+            };
+
+            let mut text = String::new();
+            let mut thinking = String::new();
+            let mut thinking_signature: Option<String> = None;
+            let mut tool_calls = Vec::new();
+            let mut completion_metadata: Option<LlmCompletionMetadata> = None;
+            let mut pending_delta = String::new();
+            let mut pending_thinking_delta = String::new();
+            let mut last_delta_emit = Instant::now();
+            let mut last_thinking_delta_emit = Instant::now();
+            let mut time_to_first_token_ms: Option<u64> = None;
+
+            while let Some(event) = stream.next().await {
+                match event? {
+                    LlmStreamEvent::TextDelta(delta) => {
+                        // Track time-to-first-token on first non-empty delta
+                        if time_to_first_token_ms.is_none() && !delta.is_empty() {
+                            let ttft = llm_start.elapsed().as_millis() as u64;
+                            time_to_first_token_ms = Some(ttft);
+                            tracing::info!(
+                                session_id = %session_id,
+                                time_to_first_token_ms = ttft,
+                                "ReasonAtom: received first token from LLM"
+                            );
+                        }
+                        text.push_str(&delta);
+                        pending_delta.push_str(&delta);
+
+                        // Emit batched delta if interval elapsed
+                        if last_delta_emit.elapsed().as_millis() as u64 >= DELTA_BATCH_INTERVAL_MS
+                            && !pending_delta.is_empty()
+                        {
+                            if let Err(e) = self
+                                .event_emitter
+                                .emit(EventRequest::new(
+                                    session_id,
+                                    streaming_event_context.clone(),
+                                    OutputMessageDeltaData {
+                                        turn_id: context.turn_id,
+                                        delta: pending_delta.clone(),
+                                        accumulated: text.clone(),
+                                    },
+                                ))
+                                .await
+                            {
+                                tracing::warn!(
+                                    session_id = %session_id,
+                                    error = %e,
+                                    "ReasonAtom: failed to emit output.message.delta event"
+                                );
+                            }
+                            pending_delta.clear();
+                            last_delta_emit = Instant::now();
+                        }
+                    }
+                    LlmStreamEvent::ThinkingDelta(delta) => {
+                        // Accumulate thinking content from extended thinking models
+                        thinking.push_str(&delta);
+                        pending_thinking_delta.push_str(&delta);
+                        tracing::debug!(
+                            session_id = %session_id,
+                            delta_len = delta.len(),
+                            total_thinking_len = thinking.len(),
+                            "ReasonAtom: received ThinkingDelta from LLM"
+                        );
+
+                        // Emit batched thinking delta if interval elapsed
+                        if last_thinking_delta_emit.elapsed().as_millis() as u64
+                            >= DELTA_BATCH_INTERVAL_MS
+                            && !pending_thinking_delta.is_empty()
+                        {
+                            if let Err(e) = self
+                                .event_emitter
+                                .emit(EventRequest::new(
+                                    session_id,
+                                    streaming_event_context.clone(),
+                                    ReasonThinkingDeltaData {
+                                        turn_id: context.turn_id,
+                                        delta: pending_thinking_delta.clone(),
+                                        accumulated: thinking.clone(),
+                                    },
+                                ))
+                                .await
+                            {
+                                tracing::warn!(
+                                    session_id = %session_id,
+                                    error = %e,
+                                    "ReasonAtom: failed to emit reason.thinking.delta event"
+                                );
+                            }
+                            pending_thinking_delta.clear();
+                            last_thinking_delta_emit = Instant::now();
+                        }
+                    }
+                    LlmStreamEvent::ThinkingSignature(signature) => {
+                        // Capture the cryptographic signature for thinking content (required to send it back)
+                        tracing::debug!(
+                            session_id = %session_id,
+                            signature_len = signature.len(),
+                            "ReasonAtom: received ThinkingSignature from LLM"
+                        );
+                        thinking_signature = Some(signature);
+                    }
+                    LlmStreamEvent::ToolCalls(calls) => {
+                        tool_calls = calls;
+                    }
+                    LlmStreamEvent::Done(metadata) => {
+                        // Emit any remaining pending delta before completing
+                        if !pending_delta.is_empty()
+                            && let Err(e) = self
+                                .event_emitter
+                                .emit(EventRequest::new(
+                                    session_id,
+                                    streaming_event_context.clone(),
+                                    OutputMessageDeltaData {
+                                        turn_id: context.turn_id,
+                                        delta: pending_delta.clone(),
+                                        accumulated: text.clone(),
+                                    },
+                                ))
+                                .await
                         {
                             tracing::warn!(
                                 session_id = %session_id,
                                 error = %e,
-                                "ReasonAtom: failed to emit output.message.delta event"
+                                "ReasonAtom: failed to emit final output.message.delta event"
                             );
                         }
-                        pending_delta.clear();
-                        last_delta_emit = Instant::now();
-                    }
-                }
-                LlmStreamEvent::ThinkingDelta(delta) => {
-                    // Accumulate thinking content from extended thinking models
-                    thinking.push_str(&delta);
-                    pending_thinking_delta.push_str(&delta);
-                    tracing::debug!(
-                        session_id = %session_id,
-                        delta_len = delta.len(),
-                        total_thinking_len = thinking.len(),
-                        "ReasonAtom: received ThinkingDelta from LLM"
-                    );
 
-                    // Emit batched thinking delta if interval elapsed
-                    if last_thinking_delta_emit.elapsed().as_millis() as u64
-                        >= DELTA_BATCH_INTERVAL_MS
-                        && !pending_thinking_delta.is_empty()
-                    {
-                        if let Err(e) = self
-                            .event_emitter
-                            .emit(EventRequest::new(
-                                session_id,
-                                streaming_event_context.clone(),
-                                ReasonThinkingDeltaData {
-                                    turn_id: context.turn_id,
-                                    delta: pending_thinking_delta.clone(),
-                                    accumulated: thinking.clone(),
-                                },
-                            ))
-                            .await
+                        // Emit any remaining pending thinking delta before completing
+                        if !pending_thinking_delta.is_empty()
+                            && let Err(e) = self
+                                .event_emitter
+                                .emit(EventRequest::new(
+                                    session_id,
+                                    streaming_event_context.clone(),
+                                    ReasonThinkingDeltaData {
+                                        turn_id: context.turn_id,
+                                        delta: pending_thinking_delta.clone(),
+                                        accumulated: thinking.clone(),
+                                    },
+                                ))
+                                .await
                         {
                             tracing::warn!(
                                 session_id = %session_id,
                                 error = %e,
-                                "ReasonAtom: failed to emit reason.thinking.delta event"
+                                "ReasonAtom: failed to emit final reason.thinking.delta event"
                             );
                         }
-                        pending_thinking_delta.clear();
-                        last_thinking_delta_emit = Instant::now();
-                    }
-                }
-                LlmStreamEvent::ThinkingSignature(signature) => {
-                    // Capture the cryptographic signature for thinking content (required to send it back)
-                    tracing::debug!(
-                        session_id = %session_id,
-                        signature_len = signature.len(),
-                        "ReasonAtom: received ThinkingSignature from LLM"
-                    );
-                    thinking_signature = Some(signature);
-                }
-                LlmStreamEvent::ToolCalls(calls) => {
-                    tool_calls = calls;
-                }
-                LlmStreamEvent::Done(metadata) => {
-                    // Emit any remaining pending delta before completing
-                    if !pending_delta.is_empty()
-                        && let Err(e) = self
-                            .event_emitter
-                            .emit(EventRequest::new(
-                                session_id,
-                                streaming_event_context.clone(),
-                                OutputMessageDeltaData {
-                                    turn_id: context.turn_id,
-                                    delta: pending_delta.clone(),
-                                    accumulated: text.clone(),
-                                },
-                            ))
-                            .await
-                    {
-                        tracing::warn!(
-                            session_id = %session_id,
-                            error = %e,
-                            "ReasonAtom: failed to emit final output.message.delta event"
-                        );
-                    }
 
-                    // Emit any remaining pending thinking delta before completing
-                    if !pending_thinking_delta.is_empty()
-                        && let Err(e) = self
-                            .event_emitter
-                            .emit(EventRequest::new(
-                                session_id,
-                                streaming_event_context.clone(),
-                                ReasonThinkingDeltaData {
-                                    turn_id: context.turn_id,
-                                    delta: pending_thinking_delta.clone(),
-                                    accumulated: thinking.clone(),
-                                },
-                            ))
-                            .await
-                    {
-                        tracing::warn!(
-                            session_id = %session_id,
-                            error = %e,
-                            "ReasonAtom: failed to emit final reason.thinking.delta event"
-                        );
+                        // Emit reason.thinking.completed if we had any thinking content
+                        if !thinking.is_empty()
+                            && let Err(e) = self
+                                .event_emitter
+                                .emit(EventRequest::new(
+                                    session_id,
+                                    streaming_event_context.clone(),
+                                    ReasonThinkingCompletedData {
+                                        turn_id: context.turn_id,
+                                        thinking: thinking.clone(),
+                                    },
+                                ))
+                                .await
+                        {
+                            tracing::warn!(
+                                session_id = %session_id,
+                                error = %e,
+                                "ReasonAtom: failed to emit reason.thinking.completed event"
+                            );
+                        }
+                        completion_metadata = Some(*metadata);
+                        break;
                     }
+                    LlmStreamEvent::Error(err) => {
+                        if should_retry_stream_error(
+                            &err,
+                            stream_retry_metadata.attempts,
+                            retry_config.max_retries,
+                            &text,
+                            &thinking,
+                            thinking_signature.as_deref(),
+                            &tool_calls,
+                        ) {
+                            let wait_duration =
+                                retry_config.calculate_backoff(stream_retry_metadata.attempts);
+                            tracing::warn!(
+                                session_id = %session_id,
+                                turn_id = %context.turn_id,
+                                attempt = stream_retry_metadata.attempts + 1,
+                                max_retries = retry_config.max_retries,
+                                wait_secs = wait_duration.as_secs_f64(),
+                                error = %err,
+                                "ReasonAtom: transient stream error before first token, retrying"
+                            );
+                            stream_retry_metadata.record_retry(wait_duration, None);
+                            tokio::time::sleep(wait_duration).await;
+                            continue 'stream_attempt;
+                        }
 
-                    // Emit reason.thinking.completed if we had any thinking content
-                    if !thinking.is_empty()
-                        && let Err(e) = self
+                        // Emit llm.generation failure event (child of reason span)
+                        let llm_duration_ms = llm_start.elapsed().as_millis() as u64;
+                        let event_context = EventContext::from_atom_context(context).with_span(
+                            trace_id.to_string(),
+                            Uuid::now_v7().to_string(),
+                            Some(reason_span_id.to_string()),
+                        );
+                        let tools_summary: Vec<ToolDefinitionSummary> =
+                            runtime_agent.tools.iter().map(|t| t.into()).collect();
+                        let mut generation_data = LlmGenerationData::failure(
+                            messages_for_event.clone(),
+                            tools_summary,
+                            runtime_agent.model.clone(),
+                            Some(model_with_provider.provider_type.to_string()),
+                            err.clone(),
+                            Some(llm_duration_ms),
+                            time_to_first_token_ms,
+                        );
+                        if stream_retry_metadata.had_retries() {
+                            generation_data = generation_data.with_retry(LlmRetryInfo {
+                                attempts: stream_retry_metadata.attempts,
+                                total_wait_ms: stream_retry_metadata.total_retry_wait.as_millis()
+                                    as u64,
+                            });
+                        }
+                        let _ = self
                             .event_emitter
                             .emit(EventRequest::new(
                                 session_id,
-                                streaming_event_context.clone(),
-                                ReasonThinkingCompletedData {
-                                    turn_id: context.turn_id,
-                                    thinking: thinking.clone(),
-                                },
+                                event_context,
+                                generation_data,
                             ))
-                            .await
-                    {
-                        tracing::warn!(
-                            session_id = %session_id,
-                            error = %e,
-                            "ReasonAtom: failed to emit reason.thinking.completed event"
-                        );
+                            .await;
+                        return Err(AgentLoopError::llm(err));
                     }
-                    completion_metadata = Some(*metadata);
-                    break;
-                }
-                LlmStreamEvent::Error(err) => {
-                    // Emit llm.generation failure event (child of reason span)
-                    let llm_duration_ms = llm_start.elapsed().as_millis() as u64;
-                    let event_context = EventContext::from_atom_context(context).with_span(
-                        trace_id.to_string(),
-                        Uuid::now_v7().to_string(),
-                        Some(reason_span_id.to_string()),
-                    );
-                    let tools_summary: Vec<ToolDefinitionSummary> =
-                        runtime_agent.tools.iter().map(|t| t.into()).collect();
-                    let _ = self
-                        .event_emitter
-                        .emit(EventRequest::new(
-                            session_id,
-                            event_context,
-                            LlmGenerationData::failure(
-                                messages_for_event.clone(),
-                                tools_summary,
-                                runtime_agent.model.clone(),
-                                Some(model_with_provider.provider_type.to_string()),
-                                err.clone(),
-                                Some(llm_duration_ms),
-                                time_to_first_token_ms,
-                            ),
-                        ))
-                        .await;
-                    return Err(AgentLoopError::llm(err));
                 }
             }
+            break 'stream_attempt (
+                text,
+                thinking,
+                thinking_signature,
+                tool_calls,
+                completion_metadata,
+                time_to_first_token_ms,
+            );
+        };
+
+        if let Some(metadata) = completion_metadata.as_mut() {
+            metadata.retry_metadata =
+                merge_retry_metadata(metadata.retry_metadata.take(), &stream_retry_metadata);
         }
 
         let llm_duration_ms = llm_start.elapsed().as_millis() as u64;

--- a/crates/core/src/llm_retry.rs
+++ b/crates/core/src/llm_retry.rs
@@ -375,6 +375,31 @@ pub fn is_transient_error(status: reqwest::StatusCode) -> bool {
     false
 }
 
+/// Check if an in-band provider error message looks transient and safe to retry.
+///
+/// This complements HTTP-status-based retry detection for streaming APIs that can
+/// emit retryable provider failures inside an otherwise successful event stream.
+pub fn is_transient_error_message(message: &str) -> bool {
+    let msg = message.trim().to_ascii_lowercase();
+
+    [
+        "server_error",
+        "internal server error",
+        "overloaded",
+        "overloaded_error",
+        "rate limit",
+        "too many requests",
+        "request timeout",
+        "timed out",
+        "service unavailable",
+        "bad gateway",
+        "gateway timeout",
+        "temporarily unavailable",
+    ]
+    .iter()
+    .any(|needle| msg.contains(needle))
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -527,6 +552,25 @@ mod tests {
         assert!(!is_transient_error(reqwest::StatusCode::FORBIDDEN)); // 403
         assert!(!is_transient_error(reqwest::StatusCode::NOT_FOUND)); // 404
         assert!(!is_transient_error(reqwest::StatusCode::NOT_IMPLEMENTED)); // 501
+    }
+
+    #[test]
+    fn test_is_transient_error_message_detects_provider_server_errors() {
+        assert!(is_transient_error_message(
+            "server_error: An error occurred while processing your request."
+        ));
+        assert!(is_transient_error_message("Rate limit exceeded"));
+        assert!(is_transient_error_message(
+            "Service temporarily unavailable"
+        ));
+    }
+
+    #[test]
+    fn test_is_transient_error_message_rejects_non_retryable_messages() {
+        assert!(!is_transient_error_message(
+            "invalid_request_error: bad tool schema"
+        ));
+        assert!(!is_transient_error_message("Model not available: gpt-99"));
     }
 
     #[test]

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -5,6 +5,7 @@
 //
 // Run with: cargo test -p everruns-core --test reason_atom_test
 
+use async_trait::async_trait;
 use everruns_core::AgentId;
 use everruns_core::MessageRetriever;
 use everruns_core::agent::{Agent, AgentStatus};
@@ -24,7 +25,10 @@ use everruns_core::session::{Session, SessionStatus};
 use everruns_core::traits::{ModelWithProvider, NoopEventEmitter};
 use everruns_core::typed_id::{HarnessId, MessageId, SessionId, TurnId};
 use everruns_core::{Message, ToolCall};
+use futures::stream;
 use serde_json::json;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use uuid::Uuid;
 
 /// Create a basic test setup with in-memory stores
@@ -146,6 +150,46 @@ fn create_context(session_id: Uuid) -> AtomContext {
     let turn_id = TurnId::new();
     let input_message_id = MessageId::new();
     AtomContext::new(SessionId::from_uuid(session_id), turn_id, input_message_id)
+}
+
+#[derive(Clone, Debug)]
+struct FlakyStreamDriver {
+    attempts: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl everruns_core::LlmDriver for FlakyStreamDriver {
+    async fn chat_completion_stream(
+        &self,
+        _messages: Vec<everruns_core::LlmMessage>,
+        config: &everruns_core::LlmCallConfig,
+    ) -> everruns_core::Result<everruns_core::LlmResponseStream> {
+        let attempt = self.attempts.fetch_add(1, Ordering::SeqCst);
+
+        if attempt == 0 {
+            return Ok(Box::pin(stream::iter(vec![Ok(
+                everruns_core::LlmStreamEvent::Error(
+                    "server_error: transient upstream failure".to_string(),
+                ),
+            )])));
+        }
+
+        Ok(Box::pin(stream::iter(vec![
+            Ok(everruns_core::LlmStreamEvent::TextDelta(
+                "Recovered after retry.".to_string(),
+            )),
+            Ok(everruns_core::LlmStreamEvent::Done(Box::new(
+                everruns_core::LlmCompletionMetadata {
+                    total_tokens: Some(8),
+                    prompt_tokens: Some(5),
+                    completion_tokens: Some(3),
+                    model: Some(config.model.clone()),
+                    finish_reason: Some("stop".to_string()),
+                    ..Default::default()
+                },
+            ))),
+        ])))
+    }
 }
 
 #[tokio::test]
@@ -890,6 +934,86 @@ async fn test_reason_atom_emits_output_message_completed_on_success() {
     // Check for llm.generation event
     let has_llm_generation = events.iter().any(|e| e.event_type == "llm.generation");
     assert!(has_llm_generation, "Should emit llm.generation event");
+}
+
+#[tokio::test]
+async fn test_reason_atom_retries_transient_stream_error_before_first_token() {
+    use everruns_core::memory::InMemoryEventEmitter;
+
+    let (
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever,
+        provider_store,
+        harness_id,
+        agent_id,
+        session_id,
+    ) = setup_test_environment().await;
+
+    message_retriever
+        .seed(session_id.into(), vec![Message::user("Hello!")])
+        .await;
+
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_registry = Arc::clone(&attempts);
+    let mut driver_registry = DriverRegistry::new();
+    driver_registry.register(ProviderType::LlmSim, move |_api_key, _base_url| {
+        Box::new(FlakyStreamDriver {
+            attempts: Arc::clone(&attempts_for_registry),
+        })
+    });
+
+    let event_emitter = InMemoryEventEmitter::new();
+
+    let atom = ReasonAtom::new(
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever.clone(),
+        provider_store,
+        CapabilityRegistry::new(),
+        driver_registry,
+        event_emitter.clone(),
+    );
+
+    let context = create_context(session_id);
+    let input = ReasonInput {
+        context,
+        harness_id,
+        agent_id: Some(agent_id.into()),
+        org_id: 0,
+        mcp_tool_definitions: vec![],
+        previous_response_id: None,
+        iteration: 1,
+    };
+
+    let result = atom
+        .execute(input)
+        .await
+        .expect("ReasonAtom should succeed after retry");
+
+    assert!(result.success, "Transient stream error should be retried");
+    assert_eq!(result.text, "Recovered after retry.");
+    assert_eq!(attempts.load(Ordering::SeqCst), 2);
+
+    let events = event_emitter.events().await;
+    let llm_event = events
+        .iter()
+        .find(|e| e.event_type == "llm.generation")
+        .expect("llm.generation event should be emitted");
+
+    if let everruns_core::EventData::LlmGeneration(data) = &llm_event.data {
+        let retry = data
+            .metadata
+            .retry
+            .as_ref()
+            .expect("retry metadata should be present");
+        assert_eq!(retry.attempts, 1);
+        assert!(data.metadata.success);
+    } else {
+        panic!("Expected llm.generation event data");
+    }
 }
 
 #[tokio::test]

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -306,6 +306,12 @@ The following HTTP status codes trigger automatic retry:
 - `429` - Too Many Requests (Rate Limited)
 - `5xx` - Server Errors (except 501 Not Implemented)
 
+For streaming providers, Everruns also retries a narrow class of **in-band stream errors** when:
+- the provider emits a transient server/rate-limit style error event inside an accepted stream
+- no text, thinking content, tool calls, or completion metadata have been emitted yet
+
+Once any output has been surfaced to the user, the generation is not retried automatically. This avoids duplicated partial output and preserves deterministic event history.
+
 ### Rate Limit Header Support
 
 Drivers parse provider-specific headers to determine retry timing:


### PR DESCRIPTION
## What
Retry transient OpenAI stream-level failures in the reason atom when the request has been accepted but the streamed response emits an in-band error before any output is surfaced.

Also unblock current CI by fixing two repo-level failures encountered while shipping this patch:
- update the stale prod built-in capability count assertion
- renumber duplicated `009_` SQL migrations so fresh databases can migrate successfully

## Why
We already retried transport-level failures, but not streamed `error` events like `server_error`. That left immediately failed turns unrecovered even when the failure was transient.

The branch also could not merge cleanly because CI was already red on a stale capability-count test and duplicate SQL migration versions.

## How
- add transient stream-error classification in `llm_retry`
- retry only before any text, thinking, or tool-call output has been emitted
- attach retry metadata to `llm.generation` completion/failure events for this path too
- add a regression test for the pre-first-token retry behavior
- document the behavior in the LLM driver spec
- fix the prod capability registry length assertion
- renumber the duplicate `009_` migrations to `010_` and `011_`

## Risk
- Low
- The retry path could hide a non-transient model error if classification is too broad; bounded retries and the pre-output-only guard limit that.
- Migration renumbering affects only unapplied fresh-database state in this branch; it resolves a current CI break on clean databases.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
