### PR TITLE
feat(permissions): add Caller-based policy enforcement across all services

### DIFF
--- a/apps/ui/src/components/policy-gate.tsx
+++ b/apps/ui/src/components/policy-gate.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { usePolicies } from "@/hooks/use-policies";
+
+interface PolicyGateProps {
+  /** Resource name (e.g. "harnesses", "agents") */
+  resource: string;
+  /** Policy ID to check (e.g. "harness.manage") */
+  policy: string;
+  /** Content shown when policy is not satisfied */
+  fallback?: ReactNode;
+  children: ReactNode;
+}
+
+/**
+ * Renders children only if the caller satisfies the given policy.
+ * Shows fallback (or nothing) otherwise.
+ */
+export function PolicyGate({ resource, policy, fallback = null, children }: PolicyGateProps) {
+  const { can, isLoading } = usePolicies(resource);
+
+  if (isLoading) return fallback;
+  if (!can(policy)) return fallback;
+
+  return <>{children}</>;
+}

--- a/apps/ui/src/hooks/use-policies.ts
+++ b/apps/ui/src/hooks/use-policies.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { api } from "@/lib/api/client";
+import { queryKeys } from "@/lib/query-keys";
+import { useOrg } from "@/providers/org-provider";
+import type { ResourceConfigResponse } from "@/lib/api/types";
+
+/**
+ * Fetch and cache policy config for a resource.
+ * Usage: const { can } = usePolicies("harnesses");
+ *        if (can("harness.manage")) { ... }
+ */
+export function usePolicies(resource: string) {
+  const { currentOrg } = useOrg();
+  const org = currentOrg?.public_id;
+
+  const query = useQuery({
+    queryKey: [...queryKeys.policies.config(resource), org],
+    queryFn: async () => {
+      const response = await api.get<ResourceConfigResponse>(`/v1/${resource}/config`);
+      return response.data;
+    },
+    enabled: !!org,
+    staleTime: 5 * 60 * 1000, // 5 min
+  });
+
+  const can = useCallback(
+    (policyId: string) => {
+      return query.data?.policies?.[policyId] ?? false;
+    },
+    [query.data],
+  );
+
+  return { ...query, can };
+}

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -778,6 +778,11 @@ export interface AuthConfigResponse {
   signup_enabled: boolean;
 }
 
+/** Response from GET /v1/{resource}/config */
+export interface ResourceConfigResponse {
+  policies: Record<string, boolean>;
+}
+
 export interface LoginRequest {
   email: string;
   password: string;

--- a/apps/ui/src/lib/query-keys.ts
+++ b/apps/ui/src/lib/query-keys.ts
@@ -154,6 +154,11 @@ export const queryKeys = {
     detail: (appId: string) => ["app", appId] as const,
   },
 
+  // Policy queries
+  policies: {
+    config: (resource: string) => ["policies", resource] as const,
+  },
+
   // Skill queries
   skills: {
     all: ["skills"] as const,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -253,8 +253,8 @@ pub use typed_id::{
 
 // Permissions re-exports
 pub use permissions::{
-    Caller, Permission, Policy, PolicyConfigResponse, PolicyError, Rule, evaluate_policies,
-    role_has_permission, role_permissions,
+    Caller, Permission, Policy, PolicyConfigResponse, PolicyError, ResourceConfigResponse, Rule,
+    evaluate_policies, role_has_permission, role_permissions,
 };
 
 // URL validation re-exports

--- a/crates/core/src/permissions.rs
+++ b/crates/core/src/permissions.rs
@@ -16,6 +16,8 @@ use uuid::Uuid;
 /// Format: `org:<resource>:<action>`
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Permission {
+    /// View harnesses (read-only)
+    OrgHarnessesView,
     /// CRUD on harnesses
     OrgHarnessesManage,
     /// Delete, reset, and other dangerous harness operations
@@ -24,10 +26,16 @@ pub enum Permission {
     OrgAgentsManage,
     /// CRUD on sessions
     OrgSessionsManage,
+    /// View LLM providers (read-only)
+    OrgLlmProvidersView,
     /// CRUD on LLM providers
     OrgLlmProvidersManage,
+    /// View organization settings (read-only)
+    OrgSettingsView,
     /// Organization settings
     OrgSettingsManage,
+    /// View members (read-only)
+    OrgMembersView,
     /// Invite/remove members
     OrgMembersManage,
     /// CRUD on API keys
@@ -38,12 +46,16 @@ impl Permission {
     /// String identifier for this permission.
     pub const fn as_str(&self) -> &'static str {
         match self {
+            Permission::OrgHarnessesView => "org:harnesses:view",
             Permission::OrgHarnessesManage => "org:harnesses:manage",
             Permission::OrgHarnessesDangerous => "org:harnesses:dangerous",
             Permission::OrgAgentsManage => "org:agents:manage",
             Permission::OrgSessionsManage => "org:sessions:manage",
+            Permission::OrgLlmProvidersView => "org:llm-providers:view",
             Permission::OrgLlmProvidersManage => "org:llm-providers:manage",
+            Permission::OrgSettingsView => "org:settings:view",
             Permission::OrgSettingsManage => "org:settings:manage",
+            Permission::OrgMembersView => "org:members:view",
             Permission::OrgMembersManage => "org:members:manage",
             Permission::OrgApiKeysManage => "org:api-keys:manage",
         }
@@ -51,12 +63,16 @@ impl Permission {
 
     /// All defined permissions.
     pub const ALL: &'static [Permission] = &[
+        Permission::OrgHarnessesView,
         Permission::OrgHarnessesManage,
         Permission::OrgHarnessesDangerous,
         Permission::OrgAgentsManage,
         Permission::OrgSessionsManage,
+        Permission::OrgLlmProvidersView,
         Permission::OrgLlmProvidersManage,
+        Permission::OrgSettingsView,
         Permission::OrgSettingsManage,
+        Permission::OrgMembersView,
         Permission::OrgMembersManage,
         Permission::OrgApiKeysManage,
     ];
@@ -74,30 +90,45 @@ impl fmt::Display for Permission {
 
 /// Permissions granted to Owner role.
 const OWNER_PERMISSIONS: &[Permission] = &[
+    Permission::OrgHarnessesView,
     Permission::OrgHarnessesManage,
     Permission::OrgHarnessesDangerous,
     Permission::OrgAgentsManage,
     Permission::OrgSessionsManage,
+    Permission::OrgLlmProvidersView,
     Permission::OrgLlmProvidersManage,
+    Permission::OrgSettingsView,
     Permission::OrgSettingsManage,
+    Permission::OrgMembersView,
     Permission::OrgMembersManage,
     Permission::OrgApiKeysManage,
 ];
 
 /// Permissions granted to Admin role.
 const ADMIN_PERMISSIONS: &[Permission] = &[
+    Permission::OrgHarnessesView,
     Permission::OrgHarnessesManage,
     Permission::OrgAgentsManage,
     Permission::OrgSessionsManage,
+    Permission::OrgLlmProvidersView,
     Permission::OrgLlmProvidersManage,
+    Permission::OrgSettingsView,
     Permission::OrgSettingsManage,
+    Permission::OrgMembersView,
     Permission::OrgMembersManage,
     Permission::OrgApiKeysManage,
 ];
 
 /// Permissions granted to Member role.
-const MEMBER_PERMISSIONS: &[Permission] =
-    &[Permission::OrgAgentsManage, Permission::OrgSessionsManage];
+/// Members can view all resources but only manage agents and sessions.
+const MEMBER_PERMISSIONS: &[Permission] = &[
+    Permission::OrgHarnessesView,
+    Permission::OrgAgentsManage,
+    Permission::OrgSessionsManage,
+    Permission::OrgLlmProvidersView,
+    Permission::OrgSettingsView,
+    Permission::OrgMembersView,
+];
 
 /// Check whether a role grants a specific permission.
 pub fn role_has_permission(role: OrgRole, permission: &Permission) -> bool {
@@ -130,6 +161,8 @@ pub enum Rule {
     UserHasPermission(Permission),
     /// Caller must have at least this OrgRole level.
     UserHasRole(OrgRole),
+    /// Caller must be a platform user (allowlisted email).
+    IsPlatformUser,
 }
 
 impl fmt::Display for Rule {
@@ -137,6 +170,7 @@ impl fmt::Display for Rule {
         match self {
             Rule::UserHasPermission(p) => write!(f, "UserHasPermission({})", p),
             Rule::UserHasRole(r) => write!(f, "UserHasRole({})", r),
+            Rule::IsPlatformUser => write!(f, "IsPlatformUser"),
         }
     }
 }
@@ -173,6 +207,11 @@ impl Policy {
                         return Err(PolicyError::denied(self.id, &format!("role:{}", required)));
                     }
                 }
+                Rule::IsPlatformUser => {
+                    if !caller.is_platform_user {
+                        return Err(PolicyError::denied(self.id, "platform_user"));
+                    }
+                }
             }
         }
         Ok(())
@@ -197,6 +236,8 @@ pub struct Caller {
     pub user_id: Option<Uuid>,
     /// User's role in the organization.
     pub role: OrgRole,
+    /// Whether the caller is a platform user (email allowlist).
+    pub is_platform_user: bool,
 }
 
 impl Caller {
@@ -211,6 +252,7 @@ impl Caller {
             org_public_id: crate::organization::org_public_id_from_internal(org_id),
             user_id: None,
             role: OrgRole::Owner,
+            is_platform_user: true,
         }
     }
 }
@@ -261,13 +303,19 @@ pub fn evaluate_policies(caller: &Caller, policies: &[&Policy]) -> HashMap<Strin
         .collect()
 }
 
-/// Response type for config endpoints.
+/// Response type for per-resource config endpoints.
+///
+/// Every resource exposes `GET /v1/{resource}/config` returning this type.
+/// UI uses it to gate controls (create/edit/delete buttons, admin panels).
 #[derive(Debug, Clone, Serialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct PolicyConfigResponse {
+pub struct ResourceConfigResponse {
     /// Map of policy ID → whether the caller satisfies it.
     pub policies: HashMap<String, bool>,
 }
+
+/// Backwards compat alias — prefer `ResourceConfigResponse`.
+pub type PolicyConfigResponse = ResourceConfigResponse;
 
 // ============================================================================
 // Tests
@@ -283,6 +331,7 @@ mod tests {
             org_public_id: "org_00000000000000000000000000000001".to_string(),
             user_id: Some(Uuid::new_v4()),
             role: OrgRole::Owner,
+            is_platform_user: false,
         }
     }
 
@@ -292,6 +341,7 @@ mod tests {
             org_public_id: "org_00000000000000000000000000000001".to_string(),
             user_id: Some(Uuid::new_v4()),
             role: OrgRole::Admin,
+            is_platform_user: false,
         }
     }
 
@@ -301,6 +351,7 @@ mod tests {
             org_public_id: "org_00000000000000000000000000000001".to_string(),
             user_id: Some(Uuid::new_v4()),
             role: OrgRole::Member,
+            is_platform_user: false,
         }
     }
 
@@ -460,9 +511,9 @@ mod tests {
 
     #[test]
     fn role_permissions_returns_correct_sets() {
-        assert_eq!(role_permissions(OrgRole::Owner).len(), 8);
-        assert_eq!(role_permissions(OrgRole::Admin).len(), 7);
-        assert_eq!(role_permissions(OrgRole::Member).len(), 2);
+        assert_eq!(role_permissions(OrgRole::Owner).len(), 12);
+        assert_eq!(role_permissions(OrgRole::Admin).len(), 11);
+        assert_eq!(role_permissions(OrgRole::Member).len(), 6);
     }
 
     // -- Caller --
@@ -474,6 +525,7 @@ mod tests {
             org_public_id: "org_00000000000000000000000000000001".to_string(),
             user_id: None,
             role: OrgRole::Admin,
+            is_platform_user: false,
         };
         // API key callers without user_id should still evaluate policies
         assert!(TEST_MANAGE.evaluate(&caller).is_ok());
@@ -527,14 +579,83 @@ mod tests {
         assert_eq!(downcasted.unwrap().policy_id, "test.policy");
     }
 
-    // -- PolicyConfigResponse serialization --
+    // -- View permissions --
 
     #[test]
-    fn policy_config_response_serializes() {
+    fn member_has_view_permissions() {
+        assert!(role_has_permission(
+            OrgRole::Member,
+            &Permission::OrgHarnessesView
+        ));
+        assert!(role_has_permission(
+            OrgRole::Member,
+            &Permission::OrgLlmProvidersView
+        ));
+        assert!(role_has_permission(
+            OrgRole::Member,
+            &Permission::OrgSettingsView
+        ));
+        assert!(role_has_permission(
+            OrgRole::Member,
+            &Permission::OrgMembersView
+        ));
+    }
+
+    #[test]
+    fn member_lacks_manage_for_restricted_resources() {
+        assert!(!role_has_permission(
+            OrgRole::Member,
+            &Permission::OrgHarnessesManage
+        ));
+        assert!(!role_has_permission(
+            OrgRole::Member,
+            &Permission::OrgLlmProvidersManage
+        ));
+        assert!(!role_has_permission(
+            OrgRole::Member,
+            &Permission::OrgSettingsManage
+        ));
+        assert!(!role_has_permission(
+            OrgRole::Member,
+            &Permission::OrgMembersManage
+        ));
+    }
+
+    // -- IsPlatformUser rule --
+
+    const TEST_PLATFORM: Policy = Policy {
+        id: "durable.manage",
+        rules: &[Rule::IsPlatformUser],
+    };
+
+    #[test]
+    fn platform_user_passes_platform_policy() {
+        let mut caller = owner_caller();
+        caller.is_platform_user = true;
+        assert!(TEST_PLATFORM.evaluate(&caller).is_ok());
+    }
+
+    #[test]
+    fn non_platform_user_fails_platform_policy() {
+        let caller = owner_caller(); // is_platform_user = false
+        assert!(TEST_PLATFORM.evaluate(&caller).is_err());
+    }
+
+    #[test]
+    fn internal_caller_is_platform_user() {
+        let caller = Caller::internal(1);
+        assert!(caller.is_platform_user);
+        assert!(TEST_PLATFORM.evaluate(&caller).is_ok());
+    }
+
+    // -- ResourceConfigResponse serialization --
+
+    #[test]
+    fn resource_config_response_serializes() {
         let mut policies = HashMap::new();
         policies.insert("harness.manage".to_string(), true);
         policies.insert("harness.dangerous".to_string(), false);
-        let response = PolicyConfigResponse { policies };
+        let response = ResourceConfigResponse { policies };
         let json = serde_json::to_value(&response).unwrap();
         assert_eq!(json["policies"]["harness.manage"], true);
         assert_eq!(json["policies"]["harness.dangerous"], false);

--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -209,16 +209,6 @@ impl FromRef<AppState> for AuthState {
     }
 }
 
-fn caller_from_org(org: &ResolvedOrg) -> Caller {
-    Caller {
-        org_id: org.org_id,
-        org_public_id: org.public_id.clone(),
-        user_id: org.user_id,
-        role: org.role,
-        is_platform_user: false,
-    }
-}
-
 /// GET /v1/agents/config
 #[utoipa::path(
     get,
@@ -229,7 +219,7 @@ fn caller_from_org(org: &ResolvedOrg) -> Caller {
     tag = "agents"
 )]
 pub async fn agent_config(org: ResolvedOrg) -> Json<ResourceConfigResponse> {
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let policies = evaluate_policies(&caller, &[&AGENT_VIEW, &AGENT_MANAGE]);
     Json(ResourceConfigResponse { policies })
 }
@@ -307,7 +297,7 @@ pub async fn create_agent(
     // TM-AGENT-005: High-risk capabilities require admin role
     require_admin_for_high_risk(&org, &req.capabilities, &state.capability_service)?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let client_id = req.id;
     let agent = match state.service.create(&caller, client_id, req).await {
         Ok(agent) => agent,
@@ -340,7 +330,7 @@ pub async fn list_agents(
     State(state): State<AppState>,
     Query(query): Query<ListAgentsQuery>,
 ) -> Result<Json<ListResponse<Agent>>, (StatusCode, Json<ErrorResponse>)> {
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let agents = state
         .service
         .list(&caller, query.search.as_deref())
@@ -379,7 +369,7 @@ pub async fn get_agent(
         )
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let agent = state
         .service
         .get_by_public_id(&caller, &agent_id.to_string())
@@ -434,7 +424,7 @@ pub async fn update_agent(
         require_admin_for_high_risk(&org, caps, &state.capability_service)?;
     }
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let agent = state
         .service
         .update(&caller, &agent_id.to_string(), req)
@@ -474,7 +464,7 @@ pub async fn delete_agent(
         )
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let deleted = state
         .service
         .delete(&caller, &agent_id.to_string())
@@ -525,7 +515,7 @@ pub async fn copy_agent(
         )
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let agent = state
         .service
         .copy(&caller, &agent_id.to_string())
@@ -581,7 +571,7 @@ pub async fn upsert_agent(
     // TM-AGENT-005: High-risk capabilities require admin role
     require_admin_for_high_risk(&org, &req.capabilities, &state.capability_service)?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let (agent, was_created) = state
         .service
         .upsert(&caller, &agent_id.to_string(), req)
@@ -626,7 +616,7 @@ pub async fn export_agent(
         )
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let agent = state
         .service
         .get_by_public_id(&caller, &agent_id.to_string())
@@ -719,7 +709,7 @@ pub async fn import_agent(
     // TM-AGENT-005: High-risk capabilities require admin role
     require_admin_for_high_risk(&org, &request.capabilities, &state.capability_service)?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let agent = state
         .service
         .create(&caller, client_id, request)

--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -14,9 +14,12 @@ use axum::{
 };
 use chrono::Utc;
 use everruns_core::typed_id::{AgentId, ModelId};
-use everruns_core::{Agent, AgentCapabilityConfig, AgentStatus, OrgRole, ToolDefinition};
+use everruns_core::{
+    Agent, AgentCapabilityConfig, AgentStatus, Caller, OrgRole, ResourceConfigResponse,
+    ToolDefinition, evaluate_policies,
+};
 
-use super::common::{ApiOptionExt, ApiResultExt, ErrorResponse, ListResponse};
+use super::common::{ApiOptionExt, ApiPolicyResultExt, ErrorResponse, ListResponse};
 use super::validation::{
     validate_create_agent_input, validate_import_file_size, validate_update_agent_input,
 };
@@ -168,6 +171,7 @@ struct AgentFile {
     pub capabilities: Vec<AgentFileCapability>,
 }
 
+use crate::services::agent::{AGENT_MANAGE, AGENT_VIEW};
 use crate::services::{AgentService, CapabilityService};
 
 /// Query parameters for listing agents.
@@ -205,10 +209,36 @@ impl FromRef<AppState> for AuthState {
     }
 }
 
+fn caller_from_org(org: &ResolvedOrg) -> Caller {
+    Caller {
+        org_id: org.org_id,
+        org_public_id: org.public_id.clone(),
+        user_id: org.user_id,
+        role: org.role,
+        is_platform_user: false,
+    }
+}
+
+/// GET /v1/agents/config
+#[utoipa::path(
+    get,
+    path = "/v1/agents/config",
+    responses(
+        (status = 200, description = "Resource config for agents", body = ResourceConfigResponse),
+    ),
+    tag = "agents"
+)]
+pub async fn agent_config(org: ResolvedOrg) -> Json<ResourceConfigResponse> {
+    let caller = caller_from_org(&org);
+    let policies = evaluate_policies(&caller, &[&AGENT_VIEW, &AGENT_MANAGE]);
+    Json(ResourceConfigResponse { policies })
+}
+
 /// Create agent routes
 pub fn routes(state: AppState) -> Router {
     Router::new()
         .route("/v1/agents", post(create_agent).get(list_agents))
+        .route("/v1/agents/config", get(agent_config))
         .route("/v1/agents/import", post(import_agent))
         .route("/v1/agents/preview", post(preview_agent))
         .route(
@@ -277,8 +307,9 @@ pub async fn create_agent(
     // TM-AGENT-005: High-risk capabilities require admin role
     require_admin_for_high_risk(&org, &req.capabilities, &state.capability_service)?;
 
+    let caller = caller_from_org(&org);
     let client_id = req.id;
-    let agent = match state.service.create(org.org_id, client_id, req).await {
+    let agent = match state.service.create(&caller, client_id, req).await {
         Ok(agent) => agent,
         Err(e) => {
             let msg = e.to_string();
@@ -308,12 +339,13 @@ pub async fn list_agents(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListAgentsQuery>,
-) -> Result<Json<ListResponse<Agent>>, StatusCode> {
+) -> Result<Json<ListResponse<Agent>>, (StatusCode, Json<ErrorResponse>)> {
+    let caller = caller_from_org(&org);
     let agents = state
         .service
-        .list(org.org_id, query.search.as_deref())
+        .list(&caller, query.search.as_deref())
         .await
-        .log_internal_error("list agents")?;
+        .map_policy_or_internal("list agents")?;
 
     Ok(Json(ListResponse::new(agents)))
 }
@@ -347,11 +379,12 @@ pub async fn get_agent(
         )
     })?;
 
+    let caller = caller_from_org(&org);
     let agent = state
         .service
-        .get_by_public_id(org.org_id, &agent_id.to_string())
+        .get_by_public_id(&caller, &agent_id.to_string())
         .await
-        .log_internal_error_json("get agent")?
+        .map_policy_or_internal("get agent")?
         .ok_or_not_found_json("Agent")?;
 
     Ok(Json(agent))
@@ -401,11 +434,12 @@ pub async fn update_agent(
         require_admin_for_high_risk(&org, caps, &state.capability_service)?;
     }
 
+    let caller = caller_from_org(&org);
     let agent = state
         .service
-        .update(org.org_id, &agent_id.to_string(), req)
+        .update(&caller, &agent_id.to_string(), req)
         .await
-        .log_internal_error_json("update agent")?
+        .map_policy_or_internal("update agent")?
         .ok_or_not_found_json("Agent")?;
 
     Ok(Json(agent))
@@ -440,11 +474,12 @@ pub async fn delete_agent(
         )
     })?;
 
+    let caller = caller_from_org(&org);
     let deleted = state
         .service
-        .delete(org.org_id, &agent_id.to_string())
+        .delete(&caller, &agent_id.to_string())
         .await
-        .log_internal_error_json("delete agent")?;
+        .map_policy_or_internal("delete agent")?;
 
     if deleted {
         Ok(StatusCode::NO_CONTENT)
@@ -490,11 +525,12 @@ pub async fn copy_agent(
         )
     })?;
 
+    let caller = caller_from_org(&org);
     let agent = state
         .service
-        .copy(org.org_id, &agent_id.to_string())
+        .copy(&caller, &agent_id.to_string())
         .await
-        .log_internal_error_json("copy agent")?
+        .map_policy_or_internal("copy agent")?
         .ok_or_not_found_json("Agent")?;
 
     Ok((StatusCode::CREATED, Json(agent)))
@@ -545,11 +581,12 @@ pub async fn upsert_agent(
     // TM-AGENT-005: High-risk capabilities require admin role
     require_admin_for_high_risk(&org, &req.capabilities, &state.capability_service)?;
 
+    let caller = caller_from_org(&org);
     let (agent, was_created) = state
         .service
-        .upsert(org.org_id, &agent_id.to_string(), req)
+        .upsert(&caller, &agent_id.to_string(), req)
         .await
-        .log_internal_error_json("upsert agent")?;
+        .map_policy_or_internal("upsert agent")?;
 
     let status = if was_created {
         StatusCode::CREATED
@@ -589,11 +626,12 @@ pub async fn export_agent(
         )
     })?;
 
+    let caller = caller_from_org(&org);
     let agent = state
         .service
-        .get_by_public_id(org.org_id, &agent_id.to_string())
+        .get_by_public_id(&caller, &agent_id.to_string())
         .await
-        .log_internal_error_json("get agent for export")?
+        .map_policy_or_internal("get agent for export")?
         .ok_or_not_found_json("Agent")?;
 
     let markdown = agent_to_markdown(&agent);
@@ -681,9 +719,10 @@ pub async fn import_agent(
     // TM-AGENT-005: High-risk capabilities require admin role
     require_admin_for_high_risk(&org, &request.capabilities, &state.capability_service)?;
 
+    let caller = caller_from_org(&org);
     let agent = state
         .service
-        .create(org.org_id, client_id, request)
+        .create(&caller, client_id, request)
         .await
         .map_err(|e| {
             let msg = e.to_string();

--- a/crates/server/src/api/apps.rs
+++ b/crates/server/src/api/apps.rs
@@ -1,7 +1,9 @@
 // App CRUD HTTP routes
 // Routes use ResolvedOrg: org derived from auth context (API key or cookie)
+// Policy enforcement happens at the service layer via #[policy] macro.
 
 use crate::auth::{AuthState, ResolvedOrg};
+use crate::services::app::{APP_DANGEROUS, APP_MANAGE, APP_VIEW};
 use crate::storage::StorageBackend;
 use axum::extract::FromRef;
 use axum::{
@@ -11,9 +13,11 @@ use axum::{
     routing::{get, post},
 };
 use everruns_core::typed_id::{AgentId, AppId, HarnessId};
-use everruns_core::{App, AppStatus, ChannelType};
+use everruns_core::{
+    App, AppStatus, Caller, ChannelType, ResourceConfigResponse, evaluate_policies,
+};
 
-use super::common::{ApiOptionExt, ApiResultExt, ErrorResponse, ListResponse};
+use super::common::{ApiOptionExt, ApiPolicyResultExt, ErrorResponse, ListResponse};
 use serde::Deserialize;
 use std::sync::Arc;
 use utoipa::{IntoParams, ToSchema};
@@ -100,9 +104,21 @@ impl FromRef<AppState> for AuthState {
     }
 }
 
+/// Create Caller from ResolvedOrg
+fn caller_from_org(org: &ResolvedOrg) -> Caller {
+    Caller {
+        org_id: org.org_id,
+        org_public_id: org.public_id.clone(),
+        user_id: org.user_id,
+        role: org.role,
+        is_platform_user: false,
+    }
+}
+
 /// Create app routes
 pub fn routes(state: AppState) -> Router {
     Router::new()
+        .route("/v1/apps/config", get(app_config))
         .route("/v1/apps", post(create_app).get(list_apps))
         .route(
             "/v1/apps/{app_id}",
@@ -111,6 +127,21 @@ pub fn routes(state: AppState) -> Router {
         .route("/v1/apps/{app_id}/publish", post(publish_app))
         .route("/v1/apps/{app_id}/unpublish", post(unpublish_app))
         .with_state(state)
+}
+
+/// GET /v1/apps/config
+#[utoipa::path(
+    get,
+    path = "/v1/apps/config",
+    responses(
+        (status = 200, description = "Resource config for apps", body = ResourceConfigResponse),
+    ),
+    tag = "apps"
+)]
+pub async fn app_config(org: ResolvedOrg) -> Json<ResourceConfigResponse> {
+    let caller = caller_from_org(&org);
+    let policies = evaluate_policies(&caller, &[&APP_VIEW, &APP_MANAGE, &APP_DANGEROUS]);
+    Json(ResourceConfigResponse { policies })
 }
 
 /// POST /v1/apps - Create a new app
@@ -130,14 +161,12 @@ pub async fn create_app(
     State(state): State<AppState>,
     Json(req): Json<CreateAppRequest>,
 ) -> Result<(StatusCode, Json<App>), (StatusCode, Json<ErrorResponse>)> {
-    let app = state.service.create(org.org_id, req).await.map_err(|e| {
-        let msg = e.to_string();
-        if msg.contains("not found") {
-            return ErrorResponse::new(&msg).into_response(StatusCode::BAD_REQUEST);
-        }
-        tracing::error!("Failed to create app: {}", msg);
-        ErrorResponse::internal_error()
-    })?;
+    let caller = caller_from_org(&org);
+    let app = state
+        .service
+        .create(&caller, req)
+        .await
+        .map_policy_or_internal("create app")?;
 
     Ok((StatusCode::CREATED, Json(app)))
 }
@@ -157,12 +186,13 @@ pub async fn list_apps(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListAppsQuery>,
-) -> Result<Json<ListResponse<App>>, StatusCode> {
+) -> Result<Json<ListResponse<App>>, (StatusCode, Json<ErrorResponse>)> {
+    let caller = caller_from_org(&org);
     let apps = state
         .service
-        .list(org.org_id, query.search.as_deref())
+        .list(&caller, query.search.as_deref())
         .await
-        .log_internal_error("list apps")?;
+        .map_policy_or_internal("list apps")?;
 
     Ok(Json(ListResponse::new(apps)))
 }
@@ -189,11 +219,12 @@ pub async fn get_app(
         ErrorResponse::new(format!("Invalid app ID: {}", e)).into_response(StatusCode::BAD_REQUEST)
     })?;
 
+    let caller = caller_from_org(&org);
     let app = state
         .service
-        .get_by_public_id(org.org_id, &app_id.to_string())
+        .get_by_public_id(&caller, &app_id.to_string())
         .await
-        .log_internal_error_json("get app")?
+        .map_policy_or_internal("get app")?
         .ok_or_not_found_json("App")?;
 
     Ok(Json(app))
@@ -223,18 +254,12 @@ pub async fn update_app(
         ErrorResponse::new(format!("Invalid app ID: {}", e)).into_response(StatusCode::BAD_REQUEST)
     })?;
 
+    let caller = caller_from_org(&org);
     let app = state
         .service
-        .update(org.org_id, &app_id.to_string(), req)
+        .update(&caller, &app_id.to_string(), req)
         .await
-        .map_err(|e| {
-            let msg = e.to_string();
-            if msg.contains("not found") {
-                return ErrorResponse::new(&msg).into_response(StatusCode::BAD_REQUEST);
-            }
-            tracing::error!("Failed to update app: {}", msg);
-            ErrorResponse::internal_error()
-        })?
+        .map_policy_or_internal("update app")?
         .ok_or_not_found_json("App")?;
 
     Ok(Json(app))
@@ -262,11 +287,12 @@ pub async fn delete_app(
         ErrorResponse::new(format!("Invalid app ID: {}", e)).into_response(StatusCode::BAD_REQUEST)
     })?;
 
+    let caller = caller_from_org(&org);
     let deleted = state
         .service
-        .delete(org.org_id, &app_id.to_string())
+        .delete(&caller, &app_id.to_string())
         .await
-        .log_internal_error_json("delete app")?;
+        .map_policy_or_internal("delete app")?;
 
     if deleted {
         Ok(StatusCode::NO_CONTENT)
@@ -297,11 +323,12 @@ pub async fn publish_app(
         ErrorResponse::new(format!("Invalid app ID: {}", e)).into_response(StatusCode::BAD_REQUEST)
     })?;
 
+    let caller = caller_from_org(&org);
     let app = state
         .service
-        .publish(org.org_id, &app_id.to_string())
+        .publish(&caller, &app_id.to_string())
         .await
-        .log_internal_error_json("publish app")?
+        .map_policy_or_internal("publish app")?
         .ok_or_not_found_json("App")?;
 
     Ok(Json(app))
@@ -329,11 +356,12 @@ pub async fn unpublish_app(
         ErrorResponse::new(format!("Invalid app ID: {}", e)).into_response(StatusCode::BAD_REQUEST)
     })?;
 
+    let caller = caller_from_org(&org);
     let app = state
         .service
-        .unpublish(org.org_id, &app_id.to_string())
+        .unpublish(&caller, &app_id.to_string())
         .await
-        .log_internal_error_json("unpublish app")?
+        .map_policy_or_internal("unpublish app")?
         .ok_or_not_found_json("App")?;
 
     Ok(Json(app))

--- a/crates/server/src/api/apps.rs
+++ b/crates/server/src/api/apps.rs
@@ -104,17 +104,6 @@ impl FromRef<AppState> for AuthState {
     }
 }
 
-/// Create Caller from ResolvedOrg
-fn caller_from_org(org: &ResolvedOrg) -> Caller {
-    Caller {
-        org_id: org.org_id,
-        org_public_id: org.public_id.clone(),
-        user_id: org.user_id,
-        role: org.role,
-        is_platform_user: false,
-    }
-}
-
 /// Create app routes
 pub fn routes(state: AppState) -> Router {
     Router::new()
@@ -139,7 +128,7 @@ pub fn routes(state: AppState) -> Router {
     tag = "apps"
 )]
 pub async fn app_config(org: ResolvedOrg) -> Json<ResourceConfigResponse> {
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let policies = evaluate_policies(&caller, &[&APP_VIEW, &APP_MANAGE, &APP_DANGEROUS]);
     Json(ResourceConfigResponse { policies })
 }
@@ -161,7 +150,7 @@ pub async fn create_app(
     State(state): State<AppState>,
     Json(req): Json<CreateAppRequest>,
 ) -> Result<(StatusCode, Json<App>), (StatusCode, Json<ErrorResponse>)> {
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let app = state
         .service
         .create(&caller, req)
@@ -187,7 +176,7 @@ pub async fn list_apps(
     State(state): State<AppState>,
     Query(query): Query<ListAppsQuery>,
 ) -> Result<Json<ListResponse<App>>, (StatusCode, Json<ErrorResponse>)> {
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let apps = state
         .service
         .list(&caller, query.search.as_deref())
@@ -219,7 +208,7 @@ pub async fn get_app(
         ErrorResponse::new(format!("Invalid app ID: {}", e)).into_response(StatusCode::BAD_REQUEST)
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let app = state
         .service
         .get_by_public_id(&caller, &app_id.to_string())
@@ -254,7 +243,7 @@ pub async fn update_app(
         ErrorResponse::new(format!("Invalid app ID: {}", e)).into_response(StatusCode::BAD_REQUEST)
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let app = state
         .service
         .update(&caller, &app_id.to_string(), req)
@@ -287,7 +276,7 @@ pub async fn delete_app(
         ErrorResponse::new(format!("Invalid app ID: {}", e)).into_response(StatusCode::BAD_REQUEST)
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let deleted = state
         .service
         .delete(&caller, &app_id.to_string())
@@ -323,7 +312,7 @@ pub async fn publish_app(
         ErrorResponse::new(format!("Invalid app ID: {}", e)).into_response(StatusCode::BAD_REQUEST)
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let app = state
         .service
         .publish(&caller, &app_id.to_string())
@@ -356,7 +345,7 @@ pub async fn unpublish_app(
         ErrorResponse::new(format!("Invalid app ID: {}", e)).into_response(StatusCode::BAD_REQUEST)
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let app = state
         .service
         .unpublish(&caller, &app_id.to_string())

--- a/crates/server/src/api/events.rs
+++ b/crates/server/src/api/events.rs
@@ -28,15 +28,6 @@ use super::sse::{DisconnectReason, SseConnectionTracker, SseStreamConfig};
 use crate::event_notifications::EventNotificationBroadcaster;
 use crate::services::EventService;
 
-fn caller_from_org(org: &ResolvedOrg) -> Caller {
-    Caller {
-        org_id: org.org_id,
-        org_public_id: org.public_id.clone(),
-        user_id: org.user_id,
-        role: org.role,
-        is_platform_user: false,
-    }
-}
 use futures::{
     StreamExt,
     stream::{self, Stream},
@@ -257,7 +248,7 @@ pub async fn stream_sse(
     // Verify session exists
     let _session = state
         .session_service
-        .get(&caller_from_org(&org), session_id.uuid(), None)
+        .get(&Caller::from(&org), session_id.uuid(), None)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get session: {}", e);
@@ -632,7 +623,7 @@ pub async fn list_events(
     // Verify session exists
     let _session = state
         .session_service
-        .get(&caller_from_org(&org), session_id.uuid(), None)
+        .get(&Caller::from(&org), session_id.uuid(), None)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get session: {}", e);

--- a/crates/server/src/api/events.rs
+++ b/crates/server/src/api/events.rs
@@ -20,13 +20,23 @@ use axum::{
 // support deserializing repeated query keys (?exclude=a&exclude=b) into Vec<String>.
 use axum_extra::extract::Query;
 use everruns_core::typed_id::{EventId, SessionId};
-use everruns_core::{Event, EventListener, VALID_EVENT_TYPES};
+use everruns_core::{Caller, Event, EventListener, VALID_EVENT_TYPES};
 use serde::Deserialize;
 
 use super::common::{ErrorResponse, ListResponse};
 use super::sse::{DisconnectReason, SseConnectionTracker, SseStreamConfig};
 use crate::event_notifications::EventNotificationBroadcaster;
 use crate::services::EventService;
+
+fn caller_from_org(org: &ResolvedOrg) -> Caller {
+    Caller {
+        org_id: org.org_id,
+        org_public_id: org.public_id.clone(),
+        user_id: org.user_id,
+        role: org.role,
+        is_platform_user: false,
+    }
+}
 use futures::{
     StreamExt,
     stream::{self, Stream},
@@ -247,7 +257,7 @@ pub async fn stream_sse(
     // Verify session exists
     let _session = state
         .session_service
-        .get(org.org_id, &org.public_id, session_id.uuid(), None)
+        .get(&caller_from_org(&org), session_id.uuid(), None)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get session: {}", e);
@@ -622,7 +632,7 @@ pub async fn list_events(
     // Verify session exists
     let _session = state
         .session_service
-        .get(org.org_id, &org.public_id, session_id.uuid(), None)
+        .get(&caller_from_org(&org), session_id.uuid(), None)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get session: {}", e);

--- a/crates/server/src/api/harnesses.rs
+++ b/crates/server/src/api/harnesses.rs
@@ -3,7 +3,7 @@
 // Policy enforcement happens at the service layer via #[policy] macro.
 
 use crate::auth::{AuthState, ResolvedOrg};
-use crate::services::harness::{HARNESS_DANGEROUS, HARNESS_MANAGE};
+use crate::services::harness::{HARNESS_DANGEROUS, HARNESS_MANAGE, HARNESS_VIEW};
 use crate::storage::StorageBackend;
 use axum::extract::FromRef;
 use axum::{
@@ -14,7 +14,7 @@ use axum::{
 };
 use everruns_core::typed_id::{HarnessId, ModelId};
 use everruns_core::{
-    AgentCapabilityConfig, Caller, Harness, HarnessStatus, PolicyConfigResponse, ToolDefinition,
+    AgentCapabilityConfig, Caller, Harness, HarnessStatus, ResourceConfigResponse, ToolDefinition,
     evaluate_policies,
 };
 
@@ -133,6 +133,7 @@ fn caller_from_org(org: &ResolvedOrg) -> Caller {
         org_public_id: org.public_id.clone(),
         user_id: org.user_id,
         role: org.role,
+        is_platform_user: false,
     }
 }
 
@@ -160,14 +161,17 @@ pub fn routes(state: AppState) -> Router {
     get,
     path = "/v1/harnesses/config",
     responses(
-        (status = 200, description = "Policy config for harnesses", body = PolicyConfigResponse),
+        (status = 200, description = "Resource config for harnesses", body = ResourceConfigResponse),
     ),
     tag = "harnesses"
 )]
-pub async fn harness_config(org: ResolvedOrg) -> Json<PolicyConfigResponse> {
+pub async fn harness_config(org: ResolvedOrg) -> Json<ResourceConfigResponse> {
     let caller = caller_from_org(&org);
-    let policies = evaluate_policies(&caller, &[&HARNESS_MANAGE, &HARNESS_DANGEROUS]);
-    Json(PolicyConfigResponse { policies })
+    let policies = evaluate_policies(
+        &caller,
+        &[&HARNESS_VIEW, &HARNESS_MANAGE, &HARNESS_DANGEROUS],
+    );
+    Json(ResourceConfigResponse { policies })
 }
 
 /// POST /v1/harnesses

--- a/crates/server/src/api/harnesses.rs
+++ b/crates/server/src/api/harnesses.rs
@@ -126,17 +126,6 @@ impl FromRef<AppState> for AuthState {
     }
 }
 
-/// Create Caller from ResolvedOrg
-fn caller_from_org(org: &ResolvedOrg) -> Caller {
-    Caller {
-        org_id: org.org_id,
-        org_public_id: org.public_id.clone(),
-        user_id: org.user_id,
-        role: org.role,
-        is_platform_user: false,
-    }
-}
-
 /// Create harness routes (no import/export)
 pub fn routes(state: AppState) -> Router {
     Router::new()
@@ -166,7 +155,7 @@ pub fn routes(state: AppState) -> Router {
     tag = "harnesses"
 )]
 pub async fn harness_config(org: ResolvedOrg) -> Json<ResourceConfigResponse> {
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let policies = evaluate_policies(
         &caller,
         &[&HARNESS_VIEW, &HARNESS_MANAGE, &HARNESS_DANGEROUS],
@@ -200,7 +189,7 @@ pub async fn create_harness(
         req.capabilities.len(),
     )?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let harness = state
         .service
         .create(&caller, req)
@@ -227,7 +216,7 @@ pub async fn list_harnesses(
     State(state): State<AppState>,
     Query(query): Query<ListHarnessesQuery>,
 ) -> Result<Json<ListResponse<Harness>>, (StatusCode, Json<ErrorResponse>)> {
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let harnesses = state
         .service
         .list(&caller, query.search.as_deref())
@@ -267,7 +256,7 @@ pub async fn get_harness(
         )
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let harness = state
         .service
         .get(&caller, harness_id.uuid())
@@ -318,7 +307,7 @@ pub async fn update_harness(
         req.capabilities.as_ref().map(|c| c.len()),
     )?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let harness = state
         .service
         .update(&caller, harness_id.uuid(), req)
@@ -359,7 +348,7 @@ pub async fn delete_harness(
         )
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let deleted = state
         .service
         .delete(&caller, harness_id.uuid())
@@ -411,7 +400,7 @@ pub async fn copy_harness(
         )
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let harness = state
         .service
         .copy(&caller, harness_id.uuid())

--- a/crates/server/src/api/llm_models.rs
+++ b/crates/server/src/api/llm_models.rs
@@ -1,8 +1,9 @@
 // LLM Model API endpoints
 // Routes: /v1/llm-providers/:provider_id/models/... and /v1/llm-models/...
 
-use crate::api::common::{ErrorResponse, ListResponse};
+use crate::api::common::{ApiOptionExt, ApiPolicyResultExt, ErrorResponse, ListResponse};
 use crate::auth::{AuthState, ResolvedOrg};
+use crate::services::llm_model::{LLM_MODEL_MANAGE, LLM_MODEL_VIEW};
 use crate::storage::StorageBackend;
 use axum::extract::FromRef;
 use axum::{
@@ -12,7 +13,10 @@ use axum::{
     routing::{get, post},
 };
 use everruns_core::typed_id::{ModelId, ProviderId};
-use everruns_core::{LlmModel, LlmModelSource, LlmModelStatus, LlmModelWithProvider};
+use everruns_core::{
+    Caller, LlmModel, LlmModelSource, LlmModelStatus, LlmModelWithProvider, ResourceConfigResponse,
+    evaluate_policies,
+};
 use serde::Deserialize;
 use std::sync::Arc;
 use utoipa::{IntoParams, ToSchema};
@@ -147,19 +151,12 @@ pub async fn create_model(
         )
     })?;
 
+    let caller = caller_from_org(&org);
     let model = state
         .service
-        .create(org.org_id, provider_id.uuid(), req)
+        .create(&caller, provider_id.uuid(), req)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to create LLM model: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: "Internal server error".to_string(),
-                }),
-            )
-        })?;
+        .map_policy_or_internal("create LLM model")?;
 
     Ok((StatusCode::CREATED, Json(model)))
 }
@@ -191,19 +188,12 @@ pub async fn list_provider_models(
         )
     })?;
 
+    let caller = caller_from_org(&org);
     let models = state
         .service
-        .list_for_provider(org.org_id, provider_id.uuid())
+        .list_for_provider(&caller, provider_id.uuid())
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to list LLM models for provider: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: "Internal server error".to_string(),
-                }),
-            )
-        })?;
+        .map_policy_or_internal("list LLM models for provider")?;
 
     Ok(Json(ListResponse::new(models)))
 }
@@ -225,24 +215,17 @@ pub async fn list_all_models(
     State(state): State<AppState>,
     Query(query): Query<ListModelsQuery>,
 ) -> Result<Json<ListResponse<LlmModelWithProvider>>, (StatusCode, Json<ErrorResponse>)> {
+    let caller = caller_from_org(&org);
     let models = state
         .service
         .list_all_with_filters(
-            org.org_id,
+            &caller,
             query.source,
             query.include_stale,
             query.favorites_only,
         )
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to list all LLM models: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: "Internal server error".to_string(),
-                }),
-            )
-        })?;
+        .map_policy_or_internal("list all LLM models")?;
 
     Ok(Json(ListResponse::new(models)))
 }
@@ -275,27 +258,13 @@ pub async fn get_model(
         )
     })?;
 
+    let caller = caller_from_org(&org);
     let model = state
         .service
-        .get_with_provider(org.org_id, model_id.uuid())
+        .get_with_provider(&caller, model_id.uuid())
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to get LLM model: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: "Internal server error".to_string(),
-                }),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse {
-                    error: "Model not found".to_string(),
-                }),
-            )
-        })?;
+        .map_policy_or_internal("get LLM model")?
+        .ok_or_not_found_json("Model")?;
 
     Ok(Json(model))
 }
@@ -330,27 +299,13 @@ pub async fn update_model(
         )
     })?;
 
+    let caller = caller_from_org(&org);
     let model = state
         .service
-        .update(org.org_id, model_id.uuid(), req)
+        .update(&caller, model_id.uuid(), req)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to update LLM model: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: "Internal server error".to_string(),
-                }),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse {
-                    error: "Model not found".to_string(),
-                }),
-            )
-        })?;
+        .map_policy_or_internal("update LLM model")?
+        .ok_or_not_found_json("Model")?;
 
     Ok(Json(model))
 }
@@ -383,34 +338,48 @@ pub async fn delete_model(
         )
     })?;
 
+    let caller = caller_from_org(&org);
     let deleted = state
         .service
-        .delete(org.org_id, model_id.uuid())
+        .delete(&caller, model_id.uuid())
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to delete LLM model: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: "Internal server error".to_string(),
-                }),
-            )
-        })?;
+        .map_policy_or_internal("delete LLM model")?;
 
     if deleted {
         Ok(StatusCode::NO_CONTENT)
     } else {
-        Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse {
-                error: "Model not found".to_string(),
-            }),
-        ))
+        Err(ErrorResponse::not_found("Model"))
     }
+}
+
+fn caller_from_org(org: &ResolvedOrg) -> Caller {
+    Caller {
+        org_id: org.org_id,
+        org_public_id: org.public_id.clone(),
+        user_id: org.user_id,
+        role: org.role,
+        is_platform_user: false,
+    }
+}
+
+/// GET /v1/llm-models/config
+#[utoipa::path(
+    get,
+    path = "/v1/llm-models/config",
+    responses(
+        (status = 200, description = "Resource config for LLM models", body = ResourceConfigResponse),
+    ),
+    tag = "llm-models"
+)]
+pub async fn llm_model_config(org: ResolvedOrg) -> Json<ResourceConfigResponse> {
+    let caller = caller_from_org(&org);
+    let policies = evaluate_policies(&caller, &[&LLM_MODEL_VIEW, &LLM_MODEL_MANAGE]);
+    Json(ResourceConfigResponse { policies })
 }
 
 pub fn routes(state: AppState) -> Router {
     Router::new()
+        .route("/v1/llm-models/config", get(llm_model_config))
         .route(
             "/v1/llm-providers/{provider_id}/models",
             post(create_model).get(list_provider_models),

--- a/crates/server/src/api/llm_models.rs
+++ b/crates/server/src/api/llm_models.rs
@@ -151,7 +151,7 @@ pub async fn create_model(
         )
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let model = state
         .service
         .create(&caller, provider_id.uuid(), req)
@@ -188,7 +188,7 @@ pub async fn list_provider_models(
         )
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let models = state
         .service
         .list_for_provider(&caller, provider_id.uuid())
@@ -215,7 +215,7 @@ pub async fn list_all_models(
     State(state): State<AppState>,
     Query(query): Query<ListModelsQuery>,
 ) -> Result<Json<ListResponse<LlmModelWithProvider>>, (StatusCode, Json<ErrorResponse>)> {
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let models = state
         .service
         .list_all_with_filters(
@@ -258,7 +258,7 @@ pub async fn get_model(
         )
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let model = state
         .service
         .get_with_provider(&caller, model_id.uuid())
@@ -299,7 +299,7 @@ pub async fn update_model(
         )
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let model = state
         .service
         .update(&caller, model_id.uuid(), req)
@@ -338,7 +338,7 @@ pub async fn delete_model(
         )
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let deleted = state
         .service
         .delete(&caller, model_id.uuid())
@@ -352,16 +352,6 @@ pub async fn delete_model(
     }
 }
 
-fn caller_from_org(org: &ResolvedOrg) -> Caller {
-    Caller {
-        org_id: org.org_id,
-        org_public_id: org.public_id.clone(),
-        user_id: org.user_id,
-        role: org.role,
-        is_platform_user: false,
-    }
-}
-
 /// GET /v1/llm-models/config
 #[utoipa::path(
     get,
@@ -372,7 +362,7 @@ fn caller_from_org(org: &ResolvedOrg) -> Caller {
     tag = "llm-models"
 )]
 pub async fn llm_model_config(org: ResolvedOrg) -> Json<ResourceConfigResponse> {
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let policies = evaluate_policies(&caller, &[&LLM_MODEL_VIEW, &LLM_MODEL_MANAGE]);
     Json(ResourceConfigResponse { policies })
 }

--- a/crates/server/src/api/llm_providers.rs
+++ b/crates/server/src/api/llm_providers.rs
@@ -2,6 +2,7 @@
 // Routes: /v1/llm-providers/...
 
 use crate::auth::{AuthState, ResolvedOrg};
+use crate::services::llm_provider::{LLM_PROVIDER_MANAGE, LLM_PROVIDER_VIEW};
 use crate::services::{LlmProviderService, LlmResolverService, ModelSyncService, SyncResult};
 use crate::storage::{EncryptionService, StorageBackend};
 use axum::extract::FromRef;
@@ -13,12 +14,15 @@ use axum::{
 };
 use everruns_core::llm_models::LlmProvider;
 use everruns_core::typed_id::ProviderId;
-use everruns_core::{DriverRegistry, LlmProviderStatus, LlmProviderType};
+use everruns_core::{
+    Caller, DriverRegistry, LlmProviderStatus, LlmProviderType, ResourceConfigResponse,
+    evaluate_policies,
+};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
 
-use super::common::{ErrorResponse, ListResponse};
+use super::common::{ApiOptionExt, ApiPolicyResultExt, ErrorResponse, ListResponse};
 
 #[derive(Clone)]
 pub struct AppState {
@@ -130,24 +134,12 @@ pub async fn create_provider(
     State(state): State<AppState>,
     Json(req): Json<CreateLlmProviderRequest>,
 ) -> Result<(StatusCode, Json<LlmProvider>), (StatusCode, Json<ErrorResponse>)> {
-    let provider = state.service.create(org.org_id, req).await.map_err(|e| {
-        let error_msg = e.to_string();
-        if error_msg.contains("Encryption not configured") || error_msg.contains("Invalid base URL")
-        {
-            (
-                StatusCode::BAD_REQUEST,
-                Json(ErrorResponse { error: error_msg }),
-            )
-        } else {
-            tracing::error!("Failed to create LLM provider: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: "Internal server error".to_string(),
-                }),
-            )
-        }
-    })?;
+    let caller = caller_from_org(&org);
+    let provider = state
+        .service
+        .create(&caller, req)
+        .await
+        .map_policy_or_internal("create LLM provider")?;
 
     Ok((StatusCode::CREATED, Json(provider)))
 }
@@ -165,15 +157,12 @@ pub async fn list_providers(
     org: ResolvedOrg,
     State(state): State<AppState>,
 ) -> Result<Json<ListResponse<LlmProvider>>, (StatusCode, Json<ErrorResponse>)> {
-    let providers = state.service.list(org.org_id).await.map_err(|e| {
-        tracing::error!("Failed to list LLM providers: {}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse {
-                error: "Internal server error".to_string(),
-            }),
-        )
-    })?;
+    let caller = caller_from_org(&org);
+    let providers = state
+        .service
+        .list(&caller)
+        .await
+        .map_policy_or_internal("list LLM providers")?;
 
     Ok(Json(ListResponse::new(providers)))
 }
@@ -206,27 +195,13 @@ pub async fn get_provider(
         )
     })?;
 
+    let caller = caller_from_org(&org);
     let provider = state
         .service
-        .get(org.org_id, provider_id.uuid())
+        .get(&caller, provider_id.uuid())
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to get LLM provider: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: "Internal server error".to_string(),
-                }),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse {
-                    error: "Provider not found".to_string(),
-                }),
-            )
-        })?;
+        .map_policy_or_internal("get LLM provider")?
+        .ok_or_not_found_json("Provider")?;
 
     Ok(Json(provider))
 }
@@ -261,37 +236,13 @@ pub async fn update_provider(
         )
     })?;
 
+    let caller = caller_from_org(&org);
     let provider = state
         .service
-        .update(org.org_id, provider_id.uuid(), req)
+        .update(&caller, provider_id.uuid(), req)
         .await
-        .map_err(|e| {
-            let error_msg = e.to_string();
-            if error_msg.contains("Encryption not configured")
-                || error_msg.contains("Invalid base URL")
-            {
-                (
-                    StatusCode::BAD_REQUEST,
-                    Json(ErrorResponse { error: error_msg }),
-                )
-            } else {
-                tracing::error!("Failed to update LLM provider: {}", e);
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorResponse {
-                        error: "Internal server error".to_string(),
-                    }),
-                )
-            }
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse {
-                    error: "Provider not found".to_string(),
-                }),
-            )
-        })?;
+        .map_policy_or_internal("update LLM provider")?
+        .ok_or_not_found_json("Provider")?;
 
     Ok(Json(provider))
 }
@@ -324,29 +275,17 @@ pub async fn delete_provider(
         )
     })?;
 
+    let caller = caller_from_org(&org);
     let deleted = state
         .service
-        .delete(org.org_id, provider_id.uuid())
+        .delete(&caller, provider_id.uuid())
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to delete LLM provider: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: "Internal server error".to_string(),
-                }),
-            )
-        })?;
+        .map_policy_or_internal("delete LLM provider")?;
 
     if deleted {
         Ok(StatusCode::NO_CONTENT)
     } else {
-        Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse {
-                error: "Provider not found".to_string(),
-            }),
-        ))
+        Err(ErrorResponse::not_found("Provider"))
     }
 }
 
@@ -431,8 +370,34 @@ pub async fn sync_models(
     Ok(Json(response))
 }
 
+fn caller_from_org(org: &ResolvedOrg) -> Caller {
+    Caller {
+        org_id: org.org_id,
+        org_public_id: org.public_id.clone(),
+        user_id: org.user_id,
+        role: org.role,
+        is_platform_user: false,
+    }
+}
+
+/// GET /v1/llm-providers/config
+#[utoipa::path(
+    get,
+    path = "/v1/llm-providers/config",
+    responses(
+        (status = 200, description = "Resource config for LLM providers", body = ResourceConfigResponse),
+    ),
+    tag = "llm-providers"
+)]
+pub async fn llm_provider_config(org: ResolvedOrg) -> Json<ResourceConfigResponse> {
+    let caller = caller_from_org(&org);
+    let policies = evaluate_policies(&caller, &[&LLM_PROVIDER_VIEW, &LLM_PROVIDER_MANAGE]);
+    Json(ResourceConfigResponse { policies })
+}
+
 pub fn routes(state: AppState) -> Router {
     Router::new()
+        .route("/v1/llm-providers/config", get(llm_provider_config))
         .route(
             "/v1/llm-providers",
             post(create_provider).get(list_providers),

--- a/crates/server/src/api/llm_providers.rs
+++ b/crates/server/src/api/llm_providers.rs
@@ -134,7 +134,7 @@ pub async fn create_provider(
     State(state): State<AppState>,
     Json(req): Json<CreateLlmProviderRequest>,
 ) -> Result<(StatusCode, Json<LlmProvider>), (StatusCode, Json<ErrorResponse>)> {
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let provider = state
         .service
         .create(&caller, req)
@@ -157,7 +157,7 @@ pub async fn list_providers(
     org: ResolvedOrg,
     State(state): State<AppState>,
 ) -> Result<Json<ListResponse<LlmProvider>>, (StatusCode, Json<ErrorResponse>)> {
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let providers = state
         .service
         .list(&caller)
@@ -195,7 +195,7 @@ pub async fn get_provider(
         )
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let provider = state
         .service
         .get(&caller, provider_id.uuid())
@@ -236,7 +236,7 @@ pub async fn update_provider(
         )
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let provider = state
         .service
         .update(&caller, provider_id.uuid(), req)
@@ -275,7 +275,7 @@ pub async fn delete_provider(
         )
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let deleted = state
         .service
         .delete(&caller, provider_id.uuid())
@@ -370,16 +370,6 @@ pub async fn sync_models(
     Ok(Json(response))
 }
 
-fn caller_from_org(org: &ResolvedOrg) -> Caller {
-    Caller {
-        org_id: org.org_id,
-        org_public_id: org.public_id.clone(),
-        user_id: org.user_id,
-        role: org.role,
-        is_platform_user: false,
-    }
-}
-
 /// GET /v1/llm-providers/config
 #[utoipa::path(
     get,
@@ -390,7 +380,7 @@ fn caller_from_org(org: &ResolvedOrg) -> Caller {
     tag = "llm-providers"
 )]
 pub async fn llm_provider_config(org: ResolvedOrg) -> Json<ResourceConfigResponse> {
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let policies = evaluate_policies(&caller, &[&LLM_PROVIDER_VIEW, &LLM_PROVIDER_MANAGE]);
     Json(ResourceConfigResponse { policies })
 }

--- a/crates/server/src/api/mcp_servers.rs
+++ b/crates/server/src/api/mcp_servers.rs
@@ -124,17 +124,6 @@ impl FromRef<AppState> for AuthState {
     }
 }
 
-/// Create Caller from ResolvedOrg
-fn caller_from_org(org: &ResolvedOrg) -> Caller {
-    Caller {
-        org_id: org.org_id,
-        org_public_id: org.public_id.clone(),
-        user_id: org.user_id,
-        role: org.role,
-        is_platform_user: false,
-    }
-}
-
 /// Create MCP server routes
 pub fn routes(state: AppState) -> Router {
     Router::new()
@@ -164,7 +153,7 @@ pub fn routes(state: AppState) -> Router {
     tag = "mcp-servers"
 )]
 pub async fn mcp_server_config(org: ResolvedOrg) -> Json<ResourceConfigResponse> {
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let policies = evaluate_policies(&caller, &[&MCP_SERVER_VIEW, &MCP_SERVER_MANAGE]);
     Json(ResourceConfigResponse { policies })
 }
@@ -204,7 +193,7 @@ pub async fn create_mcp_server(
             .into_response(StatusCode::BAD_REQUEST)
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let server = state
         .service
         .create(&caller, req)
@@ -230,7 +219,7 @@ pub async fn list_mcp_servers(
     State(state): State<AppState>,
     Query(query): Query<ListMcpServersQuery>,
 ) -> Result<Json<ListResponse<McpServer>>, (StatusCode, Json<ErrorResponse>)> {
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let servers = state
         .service
         .list(&caller, query.search.as_deref())
@@ -269,7 +258,7 @@ pub async fn get_mcp_server(
         )
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let server = state
         .service
         .get(&caller, server_id.uuid())
@@ -333,7 +322,7 @@ pub async fn update_mcp_server(
         })?;
     }
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let server = state
         .service
         .update(&caller, server_id.uuid(), req)
@@ -373,7 +362,7 @@ pub async fn delete_mcp_server(
         )
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let deleted = state
         .service
         .delete(&caller, server_id.uuid())

--- a/crates/server/src/api/mcp_servers.rs
+++ b/crates/server/src/api/mcp_servers.rs
@@ -3,6 +3,7 @@
 
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::services::McpServerService;
+use crate::services::mcp_server::{MCP_SERVER_MANAGE, MCP_SERVER_VIEW};
 use crate::storage::{EncryptionService, StorageBackend};
 use axum::extract::FromRef;
 use axum::{
@@ -12,9 +13,12 @@ use axum::{
     routing::{get, post},
 };
 use everruns_core::typed_id::McpServerId;
-use everruns_core::{McpServer, McpServerStatus, McpServerTransportType, validate_safe_url};
+use everruns_core::{
+    Caller, McpServer, McpServerStatus, McpServerTransportType, ResourceConfigResponse,
+    evaluate_policies, validate_safe_url,
+};
 
-use super::common::{ApiOptionExt, ApiResultExt, ErrorResponse, ListResponse};
+use super::common::{ApiOptionExt, ApiPolicyResultExt, ErrorResponse, ListResponse};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -120,6 +124,17 @@ impl FromRef<AppState> for AuthState {
     }
 }
 
+/// Create Caller from ResolvedOrg
+fn caller_from_org(org: &ResolvedOrg) -> Caller {
+    Caller {
+        org_id: org.org_id,
+        org_public_id: org.public_id.clone(),
+        user_id: org.user_id,
+        role: org.role,
+        is_platform_user: false,
+    }
+}
+
 /// Create MCP server routes
 pub fn routes(state: AppState) -> Router {
     Router::new()
@@ -127,6 +142,7 @@ pub fn routes(state: AppState) -> Router {
             "/v1/mcp-servers",
             post(create_mcp_server).get(list_mcp_servers),
         )
+        .route("/v1/mcp-servers/config", get(mcp_server_config))
         .route(
             "/v1/mcp-servers/{server_id}",
             get(get_mcp_server)
@@ -134,6 +150,23 @@ pub fn routes(state: AppState) -> Router {
                 .delete(delete_mcp_server),
         )
         .with_state(state)
+}
+
+/// GET /v1/mcp-servers/config
+///
+/// Returns which MCP server policies the caller satisfies.
+#[utoipa::path(
+    get,
+    path = "/v1/mcp-servers/config",
+    responses(
+        (status = 200, description = "Resource config for MCP servers", body = ResourceConfigResponse),
+    ),
+    tag = "mcp-servers"
+)]
+pub async fn mcp_server_config(org: ResolvedOrg) -> Json<ResourceConfigResponse> {
+    let caller = caller_from_org(&org);
+    let policies = evaluate_policies(&caller, &[&MCP_SERVER_VIEW, &MCP_SERVER_MANAGE]);
+    Json(ResourceConfigResponse { policies })
 }
 
 /// POST /v1/mcp-servers - Create a new MCP server
@@ -171,16 +204,12 @@ pub async fn create_mcp_server(
             .into_response(StatusCode::BAD_REQUEST)
     })?;
 
-    let server = state.service.create(org.org_id, req).await.map_err(|e| {
-        // Check if it's a duplicate name error
-        let msg = e.to_string();
-        if msg.contains("already exists") {
-            ErrorResponse::new(msg).into_response(StatusCode::BAD_REQUEST)
-        } else {
-            tracing::error!("Failed to create MCP server: {}", e);
-            ErrorResponse::internal_error()
-        }
-    })?;
+    let caller = caller_from_org(&org);
+    let server = state
+        .service
+        .create(&caller, req)
+        .await
+        .map_policy_or_internal("create MCP server")?;
 
     Ok((StatusCode::CREATED, Json(server)))
 }
@@ -200,12 +229,13 @@ pub async fn list_mcp_servers(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListMcpServersQuery>,
-) -> Result<Json<ListResponse<McpServer>>, StatusCode> {
+) -> Result<Json<ListResponse<McpServer>>, (StatusCode, Json<ErrorResponse>)> {
+    let caller = caller_from_org(&org);
     let servers = state
         .service
-        .list(org.org_id, query.search.as_deref())
+        .list(&caller, query.search.as_deref())
         .await
-        .log_internal_error("list MCP servers")?;
+        .map_policy_or_internal("list MCP servers")?;
 
     Ok(Json(ListResponse::new(servers)))
 }
@@ -239,11 +269,12 @@ pub async fn get_mcp_server(
         )
     })?;
 
+    let caller = caller_from_org(&org);
     let server = state
         .service
-        .get(org.org_id, server_id.uuid())
+        .get(&caller, server_id.uuid())
         .await
-        .log_internal_error_json("get MCP server")?
+        .map_policy_or_internal("get MCP server")?
         .ok_or_not_found_json("MCP server")?;
 
     Ok(Json(server))
@@ -302,11 +333,12 @@ pub async fn update_mcp_server(
         })?;
     }
 
+    let caller = caller_from_org(&org);
     let server = state
         .service
-        .update(org.org_id, server_id.uuid(), req)
+        .update(&caller, server_id.uuid(), req)
         .await
-        .log_internal_error_json("update MCP server")?
+        .map_policy_or_internal("update MCP server")?
         .ok_or_not_found_json("MCP server")?;
 
     Ok(Json(server))
@@ -341,11 +373,12 @@ pub async fn delete_mcp_server(
         )
     })?;
 
+    let caller = caller_from_org(&org);
     let deleted = state
         .service
-        .delete(org.org_id, server_id.uuid())
+        .delete(&caller, server_id.uuid())
         .await
-        .log_internal_error_json("delete MCP server")?;
+        .map_policy_or_internal("delete MCP server")?;
 
     if deleted {
         Ok(StatusCode::NO_CONTENT)

--- a/crates/server/src/api/messages.rs
+++ b/crates/server/src/api/messages.rs
@@ -26,7 +26,19 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, sync::Arc};
 use utoipa::ToSchema;
 
+use everruns_core::Caller;
+
 use crate::services::{MessageService, SessionService};
+
+fn caller_from_org(org: &ResolvedOrg) -> Caller {
+    Caller {
+        org_id: org.org_id,
+        org_public_id: org.public_id.clone(),
+        user_id: org.user_id,
+        role: org.role,
+        is_platform_user: false,
+    }
+}
 
 // Re-export core types with ToSchema for OpenAPI
 #[allow(unused_imports)]
@@ -229,9 +241,10 @@ pub async fn create_message(
     })?;
 
     // Get session to retrieve agent_id
+    let caller = caller_from_org(&org);
     let session = state
         .session_service
-        .get(org.org_id, &org.public_id, session_id.uuid(), None)
+        .get(&caller, session_id.uuid(), None)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get session: {}", e);
@@ -260,12 +273,7 @@ pub async fn create_message(
         );
         if let Err(e) = state
             .session_service
-            .update_status(
-                org.org_id,
-                &org.public_id,
-                session_id.uuid(),
-                "active".to_string(),
-            )
+            .update_status(&caller, session_id.uuid(), "active".to_string())
             .await
         {
             tracing::warn!(error = %e, "Failed to reset session status from waiting_for_tool_results");
@@ -328,7 +336,7 @@ pub async fn list_messages(
     // Verify session exists
     let _session = state
         .session_service
-        .get(org.org_id, &org.public_id, session_id.uuid(), None)
+        .get(&caller_from_org(&org), session_id.uuid(), None)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get session: {}", e);

--- a/crates/server/src/api/messages.rs
+++ b/crates/server/src/api/messages.rs
@@ -30,16 +30,6 @@ use everruns_core::Caller;
 
 use crate::services::{MessageService, SessionService};
 
-fn caller_from_org(org: &ResolvedOrg) -> Caller {
-    Caller {
-        org_id: org.org_id,
-        org_public_id: org.public_id.clone(),
-        user_id: org.user_id,
-        role: org.role,
-        is_platform_user: false,
-    }
-}
-
 // Re-export core types with ToSchema for OpenAPI
 #[allow(unused_imports)]
 pub use everruns_core::{
@@ -241,7 +231,7 @@ pub async fn create_message(
     })?;
 
     // Get session to retrieve agent_id
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let session = state
         .session_service
         .get(&caller, session_id.uuid(), None)
@@ -336,7 +326,7 @@ pub async fn list_messages(
     // Verify session exists
     let _session = state
         .session_service
-        .get(&caller_from_org(&org), session_id.uuid(), None)
+        .get(&Caller::from(&org), session_id.uuid(), None)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get session: {}", e);

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -1,7 +1,9 @@
 // Session CRUD HTTP routes
 // Routes use ResolvedOrg: org derived from auth context (API key or cookie)
+// Policy enforcement happens at the service layer via #[policy] macro.
 
 use crate::auth::{AuthState, ResolvedOrg};
+use crate::services::session::{SESSION_MANAGE, SESSION_VIEW};
 use crate::services::{EventService, SessionService};
 use crate::storage::StorageBackend;
 use axum::extract::FromRef;
@@ -14,10 +16,12 @@ use axum::{
 use everruns_core::capability_types::AgentCapabilityConfig;
 use everruns_core::events::{EventContext, EventRequest, InputMessageData, TurnCancelledData};
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, ModelId, SessionId, TurnId};
-use everruns_core::{Message, Session};
+use everruns_core::{Caller, Message, ResourceConfigResponse, Session, evaluate_policies};
 use everruns_worker::AgentRunner;
 
-use super::common::{ApiOptionExt, ApiResultExt, ErrorResponse, PaginatedResponse, Pagination};
+use super::common::{
+    ApiOptionExt, ApiPolicyResultExt, ApiResultExt, ErrorResponse, PaginatedResponse, Pagination,
+};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::{IntoParams, ToSchema};
@@ -153,9 +157,22 @@ pub struct SessionStatsResponse {
     pub waiting_for_tool_results: u32,
 }
 
+/// Create Caller from ResolvedOrg
+fn caller_from_org(org: &ResolvedOrg) -> Caller {
+    Caller {
+        org_id: org.org_id,
+        org_public_id: org.public_id.clone(),
+        user_id: org.user_id,
+        role: org.role,
+        is_platform_user: false,
+    }
+}
+
 /// Create session routes
 pub fn routes(state: AppState) -> Router {
     Router::new()
+        // Config endpoint (must be before /{session_id} to avoid conflict)
+        .route("/v1/sessions/config", get(session_config))
         // Global chat session (must be before /{session_id} to avoid conflict)
         .route("/v1/sessions/chat", post(get_or_create_chat_session))
         // Session stats (must be before /{session_id} to avoid conflict)
@@ -176,6 +193,13 @@ pub fn routes(state: AppState) -> Router {
         // Cancel turn endpoint
         .route("/v1/sessions/{session_id}/cancel", post(cancel_turn))
         .with_state(state)
+}
+
+/// GET /v1/sessions/config
+pub async fn session_config(org: ResolvedOrg) -> Json<ResourceConfigResponse> {
+    let caller = caller_from_org(&org);
+    let policies = evaluate_policies(&caller, &[&SESSION_VIEW, &SESSION_MANAGE]);
+    Json(ResourceConfigResponse { policies })
 }
 
 /// POST /v1/sessions - Create a new session
@@ -214,18 +238,18 @@ pub async fn create_session(
         (None, None)
     };
 
+    let caller = caller_from_org(&org);
     let session = state
         .session_service
         .create(
-            org.org_id,
-            &org.public_id,
+            &caller,
             req.harness_id.uuid(),
             agent_internal_id,
             agent_public_id,
             req,
         )
         .await
-        .log_internal_error_json("create session")?;
+        .map_policy_or_internal("create session")?;
 
     Ok((StatusCode::CREATED, Json(session)))
 }
@@ -251,16 +275,12 @@ pub async fn get_or_create_chat_session(
     // Use authenticated user_id, or fall back to anonymous user (auth=none mode)
     let user_id = org.user_id.unwrap_or(everruns_core::ANONYMOUS_USER_ID);
 
+    let caller = caller_from_org(&org);
     let session = state
         .session_service
-        .get_or_create_chat_session(
-            org.org_id,
-            &org.public_id,
-            user_id,
-            crate::seed::CHAT_HARNESS_ID,
-        )
+        .get_or_create_chat_session(&caller, user_id, crate::seed::CHAT_HARNESS_ID)
         .await
-        .log_internal_error_json("get or create chat session")?;
+        .map_policy_or_internal("get or create chat session")?;
 
     Ok(Json(session))
 }
@@ -297,18 +317,18 @@ pub async fn list_sessions(
         None
     };
 
+    let caller = caller_from_org(&org);
     let (sessions, total) = state
         .session_service
         .list(
-            org.org_id,
-            &org.public_id,
+            &caller,
             agent_internal_id,
             org.user_id,
             query.search.as_deref(),
             pagination,
         )
         .await
-        .log_internal_error_json("list sessions")?;
+        .map_policy_or_internal("list sessions")?;
 
     Ok(Json(PaginatedResponse::new(sessions, total, offset, limit)))
 }
@@ -326,12 +346,13 @@ pub async fn list_sessions(
 pub async fn get_session_stats(
     org: ResolvedOrg,
     State(state): State<AppState>,
-) -> Result<Json<SessionStatsResponse>, StatusCode> {
+) -> Result<Json<SessionStatsResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let caller = caller_from_org(&org);
     let stats = state
         .session_service
-        .stats(org.org_id)
+        .stats(&caller)
         .await
-        .log_internal_error("get session stats")?;
+        .map_policy_or_internal("get session stats")?;
 
     Ok(Json(SessionStatsResponse {
         total: stats.total,
@@ -371,12 +392,20 @@ pub async fn get_session(
         )
     })?;
 
+    let caller = caller_from_org(&org);
     let session = state
         .session_service
-        .get(org.org_id, &org.public_id, session_id.uuid(), org.user_id)
+        .get(&caller, session_id.uuid(), org.user_id)
         .await
-        .log_internal_error_json("get session")?
-        .ok_or_not_found_json("Session")?;
+        .map_policy_or_internal("get session")?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: "Session not found".to_string(),
+                }),
+            )
+        })?;
 
     Ok(Json(session))
 }
@@ -412,12 +441,20 @@ pub async fn update_session(
         )
     })?;
 
+    let caller = caller_from_org(&org);
     let session = state
         .session_service
-        .update(org.org_id, &org.public_id, session_id.uuid(), req)
+        .update(&caller, session_id.uuid(), req)
         .await
-        .log_internal_error_json("update session")?
-        .ok_or_not_found_json("Session")?;
+        .map_policy_or_internal("update session")?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: "Session not found".to_string(),
+                }),
+            )
+        })?;
 
     Ok(Json(session))
 }
@@ -451,22 +488,14 @@ pub async fn delete_session(
         )
     })?;
 
-    let deleted = state
+    let caller = caller_from_org(&org);
+    state
         .session_service
-        .delete(org.org_id, session_id.uuid())
+        .delete(&caller, session_id.uuid())
         .await
-        .log_internal_error_json("delete session")?;
+        .map_policy_or_internal("delete session")?;
 
-    if deleted {
-        Ok(StatusCode::NO_CONTENT)
-    } else {
-        Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse {
-                error: "Session not found".to_string(),
-            }),
-        ))
-    }
+    Ok(StatusCode::NO_CONTENT)
 }
 
 /// PUT /v1/sessions/{session_id}/pin - Pin session for current user
@@ -507,19 +536,12 @@ pub async fn pin_session(
         )
     })?;
 
-    // Verify session exists in this org
+    let caller = caller_from_org(&org);
     state
         .session_service
-        .get(org.org_id, &org.public_id, session_id.uuid(), None)
+        .pin(&caller, user_id, session_id.uuid())
         .await
-        .log_internal_error_json("get session for pin")?
-        .ok_or_not_found_json("Session")?;
-
-    state
-        .session_service
-        .pin(user_id, session_id.uuid(), org.org_id)
-        .await
-        .log_internal_error_json("pin session")?;
+        .map_policy_or_internal("pin session")?;
 
     Ok(StatusCode::NO_CONTENT)
 }
@@ -562,11 +584,12 @@ pub async fn unpin_session(
         )
     })?;
 
+    let caller = caller_from_org(&org);
     state
         .session_service
-        .unpin(user_id, session_id.uuid())
+        .unpin(&caller, user_id, session_id.uuid())
         .await
-        .log_internal_error_json("unpin session")?;
+        .map_policy_or_internal("unpin session")?;
 
     Ok(StatusCode::NO_CONTENT)
 }
@@ -597,16 +620,31 @@ pub async fn cancel_turn(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(session_id): Path<String>,
-) -> Result<Json<CancelTurnResponse>, StatusCode> {
-    let session_id: SessionId = session_id.parse().map_err(|_| StatusCode::BAD_REQUEST)?;
+) -> Result<Json<CancelTurnResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let session_id: SessionId = session_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid session ID: {}", e),
+            }),
+        )
+    })?;
 
     // Verify session exists
+    let caller = caller_from_org(&org);
     let session = state
         .session_service
-        .get(org.org_id, &org.public_id, session_id.uuid(), None)
+        .get(&caller, session_id.uuid(), None)
         .await
-        .log_internal_error("get session for cancel")?
-        .ok_or_not_found()?;
+        .map_policy_or_internal("get session for cancel")?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: "Session not found".to_string(),
+                }),
+            )
+        })?;
 
     // If session is not active, cancel is a no-op (idempotent)
     if session.status != everruns_core::SessionStatus::Active {

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -157,17 +157,6 @@ pub struct SessionStatsResponse {
     pub waiting_for_tool_results: u32,
 }
 
-/// Create Caller from ResolvedOrg
-fn caller_from_org(org: &ResolvedOrg) -> Caller {
-    Caller {
-        org_id: org.org_id,
-        org_public_id: org.public_id.clone(),
-        user_id: org.user_id,
-        role: org.role,
-        is_platform_user: false,
-    }
-}
-
 /// Create session routes
 pub fn routes(state: AppState) -> Router {
     Router::new()
@@ -197,7 +186,7 @@ pub fn routes(state: AppState) -> Router {
 
 /// GET /v1/sessions/config
 pub async fn session_config(org: ResolvedOrg) -> Json<ResourceConfigResponse> {
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let policies = evaluate_policies(&caller, &[&SESSION_VIEW, &SESSION_MANAGE]);
     Json(ResourceConfigResponse { policies })
 }
@@ -238,7 +227,7 @@ pub async fn create_session(
         (None, None)
     };
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let session = state
         .session_service
         .create(
@@ -275,7 +264,7 @@ pub async fn get_or_create_chat_session(
     // Use authenticated user_id, or fall back to anonymous user (auth=none mode)
     let user_id = org.user_id.unwrap_or(everruns_core::ANONYMOUS_USER_ID);
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let session = state
         .session_service
         .get_or_create_chat_session(&caller, user_id, crate::seed::CHAT_HARNESS_ID)
@@ -317,7 +306,7 @@ pub async fn list_sessions(
         None
     };
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let (sessions, total) = state
         .session_service
         .list(
@@ -347,7 +336,7 @@ pub async fn get_session_stats(
     org: ResolvedOrg,
     State(state): State<AppState>,
 ) -> Result<Json<SessionStatsResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let stats = state
         .session_service
         .stats(&caller)
@@ -392,7 +381,7 @@ pub async fn get_session(
         )
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let session = state
         .session_service
         .get(&caller, session_id.uuid(), org.user_id)
@@ -441,7 +430,7 @@ pub async fn update_session(
         )
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let session = state
         .session_service
         .update(&caller, session_id.uuid(), req)
@@ -488,7 +477,7 @@ pub async fn delete_session(
         )
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     state
         .session_service
         .delete(&caller, session_id.uuid())
@@ -536,7 +525,7 @@ pub async fn pin_session(
         )
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     state
         .session_service
         .pin(&caller, user_id, session_id.uuid())
@@ -584,7 +573,7 @@ pub async fn unpin_session(
         )
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     state
         .session_service
         .unpin(&caller, user_id, session_id.uuid())
@@ -631,7 +620,7 @@ pub async fn cancel_turn(
     })?;
 
     // Verify session exists
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let session = state
         .session_service
         .get(&caller, session_id.uuid(), None)

--- a/crates/server/src/api/skills.rs
+++ b/crates/server/src/api/skills.rs
@@ -4,9 +4,10 @@
 // CRUD for Agent Skills (agentskills.io format).
 // Supports both SKILL.md text upload and ZIP archive upload.
 
-use crate::api::common::{ApiOptionExt, ApiResultExt, ErrorResponse, ListResponse};
+use crate::api::common::{ApiOptionExt, ApiPolicyResultExt, ErrorResponse, ListResponse};
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::services::SkillService;
+use crate::services::skill::{SKILL_MANAGE, SKILL_VIEW};
 use crate::storage::StorageBackend;
 use axum::extract::FromRef;
 use axum::{
@@ -16,7 +17,10 @@ use axum::{
     routing::{get, post},
 };
 use axum_extra::extract::Multipart;
-use everruns_core::{Skill, SkillContent, SkillId, SkillStatus, SkillValidationResult};
+use everruns_core::{
+    Caller, ResourceConfigResponse, Skill, SkillContent, SkillId, SkillStatus,
+    SkillValidationResult, evaluate_policies,
+};
 use serde::Deserialize;
 use std::sync::Arc;
 use utoipa::{IntoParams, ToSchema};
@@ -93,12 +97,42 @@ impl FromRef<AppState> for AuthState {
 }
 
 // ============================================
+// Helpers
+// ============================================
+
+fn caller_from_org(org: &ResolvedOrg) -> Caller {
+    Caller {
+        org_id: org.org_id,
+        org_public_id: org.public_id.clone(),
+        user_id: org.user_id,
+        role: org.role,
+        is_platform_user: false,
+    }
+}
+
+/// GET /v1/skills/config
+#[utoipa::path(
+    get,
+    path = "/v1/skills/config",
+    responses(
+        (status = 200, description = "Resource config for skills", body = ResourceConfigResponse),
+    ),
+    tag = "skills"
+)]
+pub async fn skill_config(org: ResolvedOrg) -> Json<ResourceConfigResponse> {
+    let caller = caller_from_org(&org);
+    let policies = evaluate_policies(&caller, &[&SKILL_VIEW, &SKILL_MANAGE]);
+    Json(ResourceConfigResponse { policies })
+}
+
+// ============================================
 // Routes
 // ============================================
 
 pub fn routes(state: AppState) -> Router {
     Router::new()
         .route("/v1/skills", post(create_skill).get(list_skills))
+        .route("/v1/skills/config", get(skill_config))
         .route(
             "/v1/skills/upload",
             post(upload_skill).layer(DefaultBodyLimit::max(MAX_ARCHIVE_UPLOAD)),
@@ -133,7 +167,8 @@ pub async fn create_skill(
     State(state): State<AppState>,
     Json(req): Json<CreateSkillRequest>,
 ) -> Result<(StatusCode, Json<Skill>), (StatusCode, Json<ErrorResponse>)> {
-    let skill = state.service.create(org.org_id, req).await.map_err(|e| {
+    let caller = caller_from_org(&org);
+    let skill = state.service.create(&caller, req).await.map_err(|e| {
         let msg = e.to_string();
         if msg.contains("already exists") {
             ErrorResponse::new(msg).into_response(StatusCode::CONFLICT)
@@ -186,9 +221,10 @@ pub async fn upload_skill(
             .into_response(StatusCode::BAD_REQUEST)
     })?;
 
+    let caller = caller_from_org(&org);
     let skill = state
         .service
-        .create_from_archive(org.org_id, data)
+        .create_from_archive(&caller, data)
         .await
         .map_err(|e| {
             let msg = e.to_string();
@@ -224,12 +260,13 @@ pub async fn list_skills(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListSkillsQuery>,
-) -> Result<Json<ListResponse<Skill>>, StatusCode> {
+) -> Result<Json<ListResponse<Skill>>, (StatusCode, Json<ErrorResponse>)> {
+    let caller = caller_from_org(&org);
     let skills = state
         .service
-        .list(org.org_id, query.search.as_deref())
+        .list(&caller, query.search.as_deref())
         .await
-        .log_internal_error("list skills")?;
+        .map_policy_or_internal("list skills")?;
 
     Ok(Json(ListResponse::new(skills)))
 }
@@ -256,11 +293,12 @@ pub async fn get_skill(
         ErrorResponse::new(format!("Invalid skill ID: {e}")).into_response(StatusCode::BAD_REQUEST)
     })?;
 
+    let caller = caller_from_org(&org);
     let skill = state
         .service
-        .get(org.org_id, skill_id.uuid())
+        .get(&caller, skill_id.uuid())
         .await
-        .log_internal_error_json("get skill")?
+        .map_policy_or_internal("get skill")?
         .ok_or_not_found_json("Skill")?;
 
     Ok(Json(skill))
@@ -288,11 +326,12 @@ pub async fn get_skill_content(
         ErrorResponse::new(format!("Invalid skill ID: {e}")).into_response(StatusCode::BAD_REQUEST)
     })?;
 
+    let caller = caller_from_org(&org);
     let content = state
         .service
-        .get_content(org.org_id, skill_id.uuid())
+        .get_content(&caller, skill_id.uuid())
         .await
-        .log_internal_error_json("get skill content")?
+        .map_policy_or_internal("get skill content")?
         .ok_or_not_found_json("Skill")?;
 
     Ok(Json(content))
@@ -321,9 +360,10 @@ pub async fn update_skill(
         ErrorResponse::new(format!("Invalid skill ID: {e}")).into_response(StatusCode::BAD_REQUEST)
     })?;
 
+    let caller = caller_from_org(&org);
     let skill = state
         .service
-        .update(org.org_id, skill_id.uuid(), req)
+        .update(&caller, skill_id.uuid(), req)
         .await
         .map_err(|e| {
             let msg = e.to_string();
@@ -363,11 +403,12 @@ pub async fn delete_skill(
         ErrorResponse::new(format!("Invalid skill ID: {e}")).into_response(StatusCode::BAD_REQUEST)
     })?;
 
+    let caller = caller_from_org(&org);
     let deleted = state
         .service
-        .delete(org.org_id, skill_id.uuid())
+        .delete(&caller, skill_id.uuid())
         .await
-        .log_internal_error_json("delete skill")?;
+        .map_policy_or_internal("delete skill")?;
 
     if deleted {
         Ok(StatusCode::NO_CONTENT)

--- a/crates/server/src/api/skills.rs
+++ b/crates/server/src/api/skills.rs
@@ -100,16 +100,6 @@ impl FromRef<AppState> for AuthState {
 // Helpers
 // ============================================
 
-fn caller_from_org(org: &ResolvedOrg) -> Caller {
-    Caller {
-        org_id: org.org_id,
-        org_public_id: org.public_id.clone(),
-        user_id: org.user_id,
-        role: org.role,
-        is_platform_user: false,
-    }
-}
-
 /// GET /v1/skills/config
 #[utoipa::path(
     get,
@@ -120,7 +110,7 @@ fn caller_from_org(org: &ResolvedOrg) -> Caller {
     tag = "skills"
 )]
 pub async fn skill_config(org: ResolvedOrg) -> Json<ResourceConfigResponse> {
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let policies = evaluate_policies(&caller, &[&SKILL_VIEW, &SKILL_MANAGE]);
     Json(ResourceConfigResponse { policies })
 }
@@ -167,7 +157,7 @@ pub async fn create_skill(
     State(state): State<AppState>,
     Json(req): Json<CreateSkillRequest>,
 ) -> Result<(StatusCode, Json<Skill>), (StatusCode, Json<ErrorResponse>)> {
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let skill = state.service.create(&caller, req).await.map_err(|e| {
         let msg = e.to_string();
         if msg.contains("already exists") {
@@ -221,7 +211,7 @@ pub async fn upload_skill(
             .into_response(StatusCode::BAD_REQUEST)
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let skill = state
         .service
         .create_from_archive(&caller, data)
@@ -261,7 +251,7 @@ pub async fn list_skills(
     State(state): State<AppState>,
     Query(query): Query<ListSkillsQuery>,
 ) -> Result<Json<ListResponse<Skill>>, (StatusCode, Json<ErrorResponse>)> {
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let skills = state
         .service
         .list(&caller, query.search.as_deref())
@@ -293,7 +283,7 @@ pub async fn get_skill(
         ErrorResponse::new(format!("Invalid skill ID: {e}")).into_response(StatusCode::BAD_REQUEST)
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let skill = state
         .service
         .get(&caller, skill_id.uuid())
@@ -326,7 +316,7 @@ pub async fn get_skill_content(
         ErrorResponse::new(format!("Invalid skill ID: {e}")).into_response(StatusCode::BAD_REQUEST)
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let content = state
         .service
         .get_content(&caller, skill_id.uuid())
@@ -360,7 +350,7 @@ pub async fn update_skill(
         ErrorResponse::new(format!("Invalid skill ID: {e}")).into_response(StatusCode::BAD_REQUEST)
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let skill = state
         .service
         .update(&caller, skill_id.uuid(), req)
@@ -403,7 +393,7 @@ pub async fn delete_skill(
         ErrorResponse::new(format!("Invalid skill ID: {e}")).into_response(StatusCode::BAD_REQUEST)
     })?;
 
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let deleted = state
         .service
         .delete(&caller, skill_id.uuid())

--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -25,7 +25,7 @@ use axum::{
     routing::{get, post},
 };
 use chrono::Utc;
-use everruns_core::{App, AppStatus, ChannelType, SessionStrategy, SlackChannelConfig};
+use everruns_core::{App, AppStatus, Caller, ChannelType, SessionStrategy, SlackChannelConfig};
 use everruns_worker::AgentRunner;
 use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
@@ -470,11 +470,11 @@ async fn process_slack_message(
                     capabilities: vec![],
                     tools: vec![],
                 };
+                let internal_caller = Caller::internal(org_id);
                 let s = state
                     .session_service
                     .create(
-                        org_id,
-                        &org_public_id,
+                        &internal_caller,
                         app.harness_id.uuid(),
                         Some(app.agent_id.uuid()),
                         Some(app.agent_id),

--- a/crates/server/src/api/tool_results.rs
+++ b/crates/server/src/api/tool_results.rs
@@ -25,9 +25,20 @@ use everruns_core::typed_id::{MessageId, SessionId, TurnId};
 use everruns_worker::AgentRunner;
 
 use super::common::{ApiOptionExt, ApiResultExt, ErrorResponse};
+use everruns_core::Caller;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
+
+fn caller_from_org(org: &ResolvedOrg) -> Caller {
+    Caller {
+        org_id: org.org_id,
+        org_public_id: org.public_id.clone(),
+        user_id: org.user_id,
+        role: org.role,
+        is_platform_user: false,
+    }
+}
 
 /// Request to submit client-side tool results
 #[derive(Debug, Clone, Deserialize, ToSchema)]
@@ -141,9 +152,10 @@ pub async fn submit_tool_results(
     }
 
     // Get session and verify status
+    let caller = caller_from_org(&org);
     let session = state
         .session_service
-        .get(org.org_id, &org.public_id, session_id.uuid(), None)
+        .get(&caller, session_id.uuid(), None)
         .await
         .log_internal_error_json("get session")?
         .ok_or_not_found_json("Session")?;
@@ -209,12 +221,7 @@ pub async fn submit_tool_results(
     // Set session status back to active
     if let Err(e) = state
         .session_service
-        .update_status(
-            org.org_id,
-            &org.public_id,
-            session_id.uuid(),
-            "active".to_string(),
-        )
+        .update_status(&caller, session_id.uuid(), "active".to_string())
         .await
     {
         tracing::warn!(error = %e, "Failed to set session status to active");

--- a/crates/server/src/api/tool_results.rs
+++ b/crates/server/src/api/tool_results.rs
@@ -30,16 +30,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
 
-fn caller_from_org(org: &ResolvedOrg) -> Caller {
-    Caller {
-        org_id: org.org_id,
-        org_public_id: org.public_id.clone(),
-        user_id: org.user_id,
-        role: org.role,
-        is_platform_user: false,
-    }
-}
-
 /// Request to submit client-side tool results
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct SubmitToolResultsRequest {
@@ -152,7 +142,7 @@ pub async fn submit_tool_results(
     }
 
     // Get session and verify status
-    let caller = caller_from_org(&org);
+    let caller = Caller::from(&org);
     let session = state
         .session_service
         .get(&caller, session_id.uuid(), None)

--- a/crates/server/src/auth/middleware.rs
+++ b/crates/server/src/auth/middleware.rs
@@ -10,7 +10,7 @@ use axum::{
 };
 use axum_extra::extract::CookieJar;
 use everruns_core::{
-    ANONYMOUS_USER_EMAIL, ANONYMOUS_USER_ID, ANONYMOUS_USER_NAME, DEFAULT_ORG_ID,
+    ANONYMOUS_USER_EMAIL, ANONYMOUS_USER_ID, ANONYMOUS_USER_NAME, Caller, DEFAULT_ORG_ID,
     DEFAULT_ORG_PUBLIC_ID, OrgMembership, OrgRole, validate_org_public_id,
 };
 use serde::Serialize;
@@ -421,6 +421,18 @@ pub struct ResolvedOrg {
     pub user_id: Option<Uuid>,
     /// User's role in this organization
     pub role: OrgRole,
+}
+
+impl From<&ResolvedOrg> for Caller {
+    fn from(org: &ResolvedOrg) -> Self {
+        Caller {
+            org_id: org.org_id,
+            org_public_id: org.public_id.clone(),
+            user_id: org.user_id,
+            role: org.role,
+            is_platform_user: false,
+        }
+    }
 }
 
 impl<S> FromRequestParts<S> for ResolvedOrg

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -17,7 +17,7 @@ use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
 use everruns_core::traits::ResolvedImage;
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId};
 use everruns_core::{
-    Agent, AgentStatus, ContentPart, DriverRegistry, EventData, Harness, HarnessStatus,
+    Agent, AgentStatus, Caller, ContentPart, DriverRegistry, EventData, Harness, HarnessStatus,
     LlmProviderType, Message, MessageRole, Session, SessionStatus, ToolDefinition, ToolRegistry,
     ToolResultContentPart,
 };
@@ -691,7 +691,7 @@ impl WorkerAdapters for DirectWorkerAdapters {
     ) -> Result<McpServerInfo> {
         let resolved = self
             .mcp_server_service
-            .resolve_by_prefix(org_id, server_prefix)
+            .resolve_by_prefix(&Caller::internal(org_id), server_prefix)
             .await
             .map_err(|e| {
                 tracing::error!("Failed to resolve MCP server: {}", e);
@@ -1049,7 +1049,7 @@ impl DirectWorkerAdapters {
 
             let tools = match self
                 .mcp_server_service
-                .get_tools(org_id, server_id, false)
+                .get_tools(&Caller::internal(org_id), server_id, false)
                 .await
             {
                 Ok(t) => t,
@@ -1063,7 +1063,11 @@ impl DirectWorkerAdapters {
                 }
             };
 
-            let server_name = match self.mcp_server_service.get(org_id, server_id).await {
+            let server_name = match self
+                .mcp_server_service
+                .get(&Caller::internal(org_id), server_id)
+                .await
+            {
                 Ok(Some(s)) => s.name,
                 _ => {
                     tracing::warn!(server_id = %server_id, "MCP server not found, skipping");

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -490,6 +490,7 @@ impl WorkerServiceImpl {
     }
 
     /// Get organization public_id from org_id
+    #[allow(dead_code)]
     async fn get_org_public_id(&self, org_id: i64) -> Result<String, Status> {
         self.db
             .get_organization(org_id)
@@ -558,7 +559,7 @@ impl WorkerServiceImpl {
         // Batch fetch all MCP servers with cached tools in one query
         let servers = match self
             .mcp_server_service
-            .get_batch_with_tools(org_id, &server_ids)
+            .get_batch_with_tools(&everruns_core::Caller::internal(org_id), &server_ids)
             .await
         {
             Ok(s) => s,
@@ -779,12 +780,12 @@ impl WorkerService for WorkerServiceImpl {
     ) -> Result<Response<GetTurnContextResponse>, Status> {
         let req = request.into_inner();
         let session_id = parse_uuid(req.session_id.as_ref())?;
-        let org_public_id = self.get_org_public_id(req.org_id).await?;
+        let internal_caller = everruns_core::Caller::internal(req.org_id);
 
         // Get session via SessionService
         let session = self
             .session_service
-            .get(req.org_id, &org_public_id, session_id, None)
+            .get(&internal_caller, session_id, None)
             .await
             .map_err(|e| {
                 tracing::error!("Failed to get session: {}", e);
@@ -795,7 +796,7 @@ impl WorkerService for WorkerServiceImpl {
         // Get agent with capabilities via AgentService (optional)
         let agent = if let Some(agent_id) = session.agent_id {
             self.agent_service
-                .get(req.org_id, agent_id.uuid())
+                .get(&internal_caller, agent_id.uuid())
                 .await
                 .map_err(|e| {
                     tracing::error!("Failed to get agent: {}", e);
@@ -806,7 +807,6 @@ impl WorkerService for WorkerServiceImpl {
         };
 
         // Load harness
-        let internal_caller = everruns_core::Caller::internal(req.org_id);
         let harness = self
             .harness_service
             .get(&internal_caller, session.harness_id.uuid())
@@ -1018,9 +1018,10 @@ impl WorkerService for WorkerServiceImpl {
         let agent_id = parse_uuid(req.agent_id.as_ref())?;
 
         // Get agent with capabilities via AgentService
+        let internal_caller = everruns_core::Caller::internal(req.org_id);
         let agent = self
             .agent_service
-            .get(req.org_id, agent_id)
+            .get(&internal_caller, agent_id)
             .await
             .map_err(|e| Status::internal(format!("Failed to get agent: {}", e)))?;
 
@@ -1056,12 +1057,12 @@ impl WorkerService for WorkerServiceImpl {
     ) -> Result<Response<GetSessionResponse>, Status> {
         let req = request.into_inner();
         let session_id = parse_uuid(req.session_id.as_ref())?;
-        let org_public_id = self.get_org_public_id(req.org_id).await?;
+        let internal_caller = everruns_core::Caller::internal(req.org_id);
 
         // Get session via SessionService
         let session = self
             .session_service
-            .get(req.org_id, &org_public_id, session_id, None)
+            .get(&internal_caller, session_id, None)
             .await
             .map_err(|e| {
                 tracing::error!("Failed to get session: {}", e);
@@ -1100,7 +1101,7 @@ impl WorkerService for WorkerServiceImpl {
 
         let req = request.into_inner();
         let session_id = parse_uuid(req.session_id.as_ref())?;
-        let org_public_id = self.get_org_public_id(req.org_id).await?;
+        let internal_caller = everruns_core::Caller::internal(req.org_id);
 
         // Validate status value
         let valid_statuses = ["started", "active", "idle"];
@@ -1113,7 +1114,7 @@ impl WorkerService for WorkerServiceImpl {
 
         let session = self
             .session_service
-            .update_status(req.org_id, &org_public_id, session_id, req.status)
+            .update_status(&internal_caller, session_id, req.status)
             .await
             .map_err(|e| {
                 tracing::error!("Failed to update session status: {}", e);
@@ -1151,13 +1152,12 @@ impl WorkerService for WorkerServiceImpl {
 
         let req = request.into_inner();
         let session_id = parse_uuid(req.session_id.as_ref())?;
-        let org_public_id = self.get_org_public_id(req.org_id).await?;
+        let internal_caller = everruns_core::Caller::internal(req.org_id);
 
         let session = self
             .session_service
             .update(
-                req.org_id,
-                &org_public_id,
+                &internal_caller,
                 session_id,
                 crate::api::sessions::UpdateSessionRequest {
                     title: Some(req.title),
@@ -2572,9 +2572,10 @@ impl WorkerService for WorkerServiceImpl {
     ) -> Result<Response<GetMcpServerByPrefixResponse>, Status> {
         let req = request.into_inner();
 
+        let internal_caller = everruns_core::Caller::internal(req.org_id);
         let resolved = self
             .mcp_server_service
-            .resolve_by_prefix(req.org_id, &req.server_prefix)
+            .resolve_by_prefix(&internal_caller, &req.server_prefix)
             .await
             .map_err(|e| {
                 tracing::error!("Failed to resolve MCP server: {}", e);
@@ -3420,9 +3421,10 @@ impl WorkerService for WorkerServiceImpl {
         request: Request<PlatformListAgentsRequest>,
     ) -> Result<Response<PlatformListAgentsResponse>, Status> {
         let req = request.into_inner();
+        let internal_caller = everruns_core::Caller::internal(req.org_id);
         let agents = self
             .agent_service
-            .list(req.org_id, None)
+            .list(&internal_caller, None)
             .await
             .map_err(|e| Status::internal(format!("Failed to list agents: {}", e)))?;
 
@@ -3454,9 +3456,10 @@ impl WorkerService for WorkerServiceImpl {
             tools: vec![],
         };
 
+        let internal_caller = everruns_core::Caller::internal(req.org_id);
         let agent = self
             .agent_service
-            .create(req.org_id, None, create_req)
+            .create(&internal_caller, None, create_req)
             .await
             .map_err(|e| Status::internal(format!("Failed to create agent: {}", e)))?;
 
@@ -3473,9 +3476,10 @@ impl WorkerService for WorkerServiceImpl {
         let agent_id = parse_uuid(req.agent_id.as_ref())?;
 
         // Resolve UUID to public_id for the service
+        let internal_caller = everruns_core::Caller::internal(req.org_id);
         let agent = self
             .agent_service
-            .get(req.org_id, agent_id)
+            .get(&internal_caller, agent_id)
             .await
             .map_err(|e| Status::internal(format!("Failed to get agent: {}", e)))?
             .ok_or_else(|| Status::not_found("Agent not found"))?;
@@ -3493,7 +3497,7 @@ impl WorkerService for WorkerServiceImpl {
 
         let updated = self
             .agent_service
-            .update(req.org_id, &agent.public_id.to_string(), update_req)
+            .update(&internal_caller, &agent.public_id.to_string(), update_req)
             .await
             .map_err(|e| Status::internal(format!("Failed to update agent: {}", e)))?
             .ok_or_else(|| Status::not_found("Agent not found"))?;
@@ -3511,15 +3515,16 @@ impl WorkerService for WorkerServiceImpl {
         let agent_id = parse_uuid(req.agent_id.as_ref())?;
 
         // Resolve UUID to public_id for the service
+        let internal_caller = everruns_core::Caller::internal(req.org_id);
         let agent = self
             .agent_service
-            .get(req.org_id, agent_id)
+            .get(&internal_caller, agent_id)
             .await
             .map_err(|e| Status::internal(format!("Failed to get agent: {}", e)))?
             .ok_or_else(|| Status::not_found("Agent not found"))?;
 
         self.agent_service
-            .delete(req.org_id, &agent.public_id.to_string())
+            .delete(&internal_caller, &agent.public_id.to_string())
             .await
             .map_err(|e| Status::internal(format!("Failed to delete agent: {}", e)))?;
 
@@ -3531,7 +3536,7 @@ impl WorkerService for WorkerServiceImpl {
         request: Request<PlatformListSessionsRequest>,
     ) -> Result<Response<PlatformListSessionsResponse>, Status> {
         let req = request.into_inner();
-        let org_public_id = self.get_org_public_id(req.org_id).await?;
+        let internal_caller = everruns_core::Caller::internal(req.org_id);
 
         let limit = req.limit.unwrap_or(20);
         let agent_id = match req.agent_id {
@@ -3543,7 +3548,7 @@ impl WorkerService for WorkerServiceImpl {
 
         let (sessions, _total) = self
             .session_service
-            .list(req.org_id, &org_public_id, agent_id, None, None, pagination)
+            .list(&internal_caller, agent_id, None, None, pagination)
             .await
             .map_err(|e| Status::internal(format!("Failed to list sessions: {}", e)))?;
 
@@ -3558,7 +3563,7 @@ impl WorkerService for WorkerServiceImpl {
         request: Request<PlatformCreateSessionRequest>,
     ) -> Result<Response<PlatformCreateSessionResponse>, Status> {
         let req = request.into_inner();
-        let org_public_id = self.get_org_public_id(req.org_id).await?;
+        let internal_caller = everruns_core::Caller::internal(req.org_id);
         let harness_id = parse_uuid(req.harness_id.as_ref())?;
 
         let agent_uuid = match req.agent_id {
@@ -3570,7 +3575,7 @@ impl WorkerService for WorkerServiceImpl {
         let agent_public_id = if let Some(aid) = agent_uuid {
             let agent = self
                 .agent_service
-                .get(req.org_id, aid)
+                .get(&internal_caller, aid)
                 .await
                 .map_err(|e| Status::internal(format!("Failed to get agent: {}", e)))?
                 .ok_or_else(|| Status::not_found("Agent not found"))?;
@@ -3592,8 +3597,7 @@ impl WorkerService for WorkerServiceImpl {
         let session = self
             .session_service
             .create(
-                req.org_id,
-                &org_public_id,
+                &internal_caller,
                 harness_id,
                 agent_uuid,
                 create_req.agent_id,
@@ -3613,9 +3617,10 @@ impl WorkerService for WorkerServiceImpl {
     ) -> Result<Response<PlatformDeleteSessionResponse>, Status> {
         let req = request.into_inner();
         let session_id = parse_uuid(req.session_id.as_ref())?;
+        let internal_caller = everruns_core::Caller::internal(req.org_id);
 
         self.session_service
-            .delete(req.org_id, session_id)
+            .delete(&internal_caller, session_id)
             .await
             .map_err(|e| Status::internal(format!("Failed to delete session: {}", e)))?;
 
@@ -3628,12 +3633,12 @@ impl WorkerService for WorkerServiceImpl {
     ) -> Result<Response<PlatformSendMessageResponse>, Status> {
         let req = request.into_inner();
         let session_id = parse_uuid(req.session_id.as_ref())?;
-        let org_public_id = self.get_org_public_id(req.org_id).await?;
+        let internal_caller = everruns_core::Caller::internal(req.org_id);
 
         // Get session to find harness_id and agent_id
         let session = self
             .session_service
-            .get(req.org_id, &org_public_id, session_id, None)
+            .get(&internal_caller, session_id, None)
             .await
             .map_err(|e| Status::internal(format!("Failed to get session: {}", e)))?
             .ok_or_else(|| Status::not_found("Session not found"))?;
@@ -3766,7 +3771,7 @@ impl WorkerService for WorkerServiceImpl {
     ) -> Result<Response<PlatformWaitForIdleResponse>, Status> {
         let req = request.into_inner();
         let session_id = parse_uuid(req.session_id.as_ref())?;
-        let org_public_id = self.get_org_public_id(req.org_id).await?;
+        let internal_caller = everruns_core::Caller::internal(req.org_id);
         let timeout_secs = req.timeout_secs.unwrap_or(120);
 
         let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(timeout_secs);
@@ -3774,7 +3779,7 @@ impl WorkerService for WorkerServiceImpl {
         loop {
             let session = self
                 .session_service
-                .get(req.org_id, &org_public_id, session_id, None)
+                .get(&internal_caller, session_id, None)
                 .await
                 .map_err(|e| Status::internal(format!("Failed to get session: {}", e)))?
                 .ok_or_else(|| Status::not_found("Session not found"))?;

--- a/crates/server/src/services/agent.rs
+++ b/crates/server/src/services/agent.rs
@@ -9,11 +9,27 @@ use crate::storage::{
     models::{CreateAgentRow, UpdateAgent},
 };
 use anyhow::Result;
-use everruns_core::{Agent, AgentCapabilityConfig, AgentId, AgentStatus, TokenUsage};
+use everruns_core::{
+    Agent, AgentCapabilityConfig, AgentId, AgentStatus, Caller, Permission, Policy, Rule,
+    TokenUsage,
+};
+use everruns_macros::policy;
 use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::api::agents::{CreateAgentRequest, UpdateAgentRequest};
+
+/// Policy: View agents (read-only).
+pub const AGENT_VIEW: Policy = Policy {
+    id: "agent.view",
+    rules: &[Rule::UserHasPermission(Permission::OrgAgentsManage)],
+};
+
+/// Policy: Manage agents (create, update, copy, delete).
+pub const AGENT_MANAGE: Policy = Policy {
+    id: "agent.manage",
+    rules: &[Rule::UserHasPermission(Permission::OrgAgentsManage)],
+};
 
 pub struct AgentService {
     db: Arc<StorageBackend>,
@@ -24,9 +40,10 @@ impl AgentService {
         Self { db }
     }
 
+    #[policy(AGENT_MANAGE)]
     pub async fn create(
         &self,
-        org_id: i64,
+        caller: &Caller,
         client_id: Option<AgentId>,
         req: CreateAgentRequest,
     ) -> Result<Agent> {
@@ -44,7 +61,7 @@ impl AgentService {
                 tags: req.tags.clone(),
                 tools: serde_json::to_value(&req.tools).unwrap_or_default(),
             };
-            let row = self.db.create_agent(org_id, input).await?;
+            let row = self.db.create_agent(caller.org_id, input).await?;
             let uuid = row.id.uuid();
             (row, uuid)
         } else {
@@ -61,7 +78,7 @@ impl AgentService {
             };
             let row = self
                 .db
-                .create_agent_with_id(org_id, AgentId::from_uuid(internal_uuid), input)
+                .create_agent_with_id(caller.org_id, AgentId::from_uuid(internal_uuid), input)
                 .await?
                 .ok_or_else(|| anyhow::anyhow!("Agent UUID collision"))?;
             (row, internal_uuid)
@@ -92,8 +109,12 @@ impl AgentService {
         Ok(Self::row_to_agent(row, capabilities))
     }
 
-    pub async fn get(&self, org_id: i64, id: Uuid) -> Result<Option<Agent>> {
-        let row = self.db.get_agent(org_id, AgentId::from_uuid(id)).await?;
+    #[policy(AGENT_VIEW)]
+    pub async fn get(&self, caller: &Caller, id: Uuid) -> Result<Option<Agent>> {
+        let row = self
+            .db
+            .get_agent(caller.org_id, AgentId::from_uuid(id))
+            .await?;
         match row {
             Some(row) => {
                 let capabilities = self.get_capabilities(id).await?;
@@ -103,8 +124,16 @@ impl AgentService {
         }
     }
 
-    pub async fn get_by_public_id(&self, org_id: i64, public_id: &str) -> Result<Option<Agent>> {
-        let row = self.db.get_agent_by_public_id(org_id, public_id).await?;
+    #[policy(AGENT_VIEW)]
+    pub async fn get_by_public_id(
+        &self,
+        caller: &Caller,
+        public_id: &str,
+    ) -> Result<Option<Agent>> {
+        let row = self
+            .db
+            .get_agent_by_public_id(caller.org_id, public_id)
+            .await?;
         match row {
             Some(row) => {
                 let capabilities = self.get_capabilities(row.id.uuid()).await?;
@@ -114,8 +143,9 @@ impl AgentService {
         }
     }
 
-    pub async fn list(&self, org_id: i64, search: Option<&str>) -> Result<Vec<Agent>> {
-        let rows = self.db.list_agents(org_id, search).await?;
+    #[policy(AGENT_VIEW)]
+    pub async fn list(&self, caller: &Caller, search: Option<&str>) -> Result<Vec<Agent>> {
+        let rows = self.db.list_agents(caller.org_id, search).await?;
 
         // Fetch capabilities for each agent
         let mut agents = Vec::with_capacity(rows.len());
@@ -127,14 +157,18 @@ impl AgentService {
         Ok(agents)
     }
 
+    #[policy(AGENT_MANAGE)]
     pub async fn update(
         &self,
-        org_id: i64,
+        caller: &Caller,
         public_id: &str,
         req: UpdateAgentRequest,
     ) -> Result<Option<Agent>> {
         // Resolve public_id -> internal AgentId
-        let row = self.db.get_agent_by_public_id(org_id, public_id).await?;
+        let row = self
+            .db
+            .get_agent_by_public_id(caller.org_id, public_id)
+            .await?;
         let Some(existing) = row else {
             return Ok(None);
         };
@@ -151,7 +185,10 @@ impl AgentService {
                 .tools
                 .map(|t| serde_json::to_value(&t).unwrap_or_default()),
         };
-        let row = self.db.update_agent(org_id, internal_id, input).await?;
+        let row = self
+            .db
+            .update_agent(caller.org_id, internal_id, input)
+            .await?;
 
         match row {
             Some(row) => {
@@ -184,8 +221,9 @@ impl AgentService {
 
     /// Copy an agent by public_id. Creates a new agent with "{name} (copy)" and
     /// duplicates description, system_prompt, default_model_id, tags, capabilities, tools.
-    pub async fn copy(&self, org_id: i64, public_id: &str) -> Result<Option<Agent>> {
-        let source = self.get_by_public_id(org_id, public_id).await?;
+    #[policy(AGENT_MANAGE)]
+    pub async fn copy(&self, caller: &Caller, public_id: &str) -> Result<Option<Agent>> {
+        let source = self.get_by_public_id(caller, public_id).await?;
         let Some(source) = source else {
             return Ok(None);
         };
@@ -201,23 +239,28 @@ impl AgentService {
             tools: source.tools,
         };
 
-        let agent = self.create(org_id, None, req).await?;
+        let agent = self.create(caller, None, req).await?;
         Ok(Some(agent))
     }
 
-    pub async fn delete(&self, org_id: i64, public_id: &str) -> Result<bool> {
+    #[policy(AGENT_MANAGE)]
+    pub async fn delete(&self, caller: &Caller, public_id: &str) -> Result<bool> {
         // Resolve public_id -> internal AgentId
-        let row = self.db.get_agent_by_public_id(org_id, public_id).await?;
+        let row = self
+            .db
+            .get_agent_by_public_id(caller.org_id, public_id)
+            .await?;
         let Some(existing) = row else {
             return Ok(false);
         };
-        self.db.delete_agent(org_id, existing.id).await
+        self.db.delete_agent(caller.org_id, existing.id).await
     }
 
     /// Upsert agent by public_id. Returns (agent, was_created).
+    #[policy(AGENT_MANAGE)]
     pub async fn upsert(
         &self,
-        org_id: i64,
+        caller: &Caller,
         public_id: &str,
         req: CreateAgentRequest,
     ) -> Result<(Agent, bool)> {
@@ -230,7 +273,7 @@ impl AgentService {
             tags: req.tags,
             tools: serde_json::to_value(&req.tools).unwrap_or_default(),
         };
-        let (row, was_created) = self.db.upsert_agent(org_id, input).await?;
+        let (row, was_created) = self.db.upsert_agent(caller.org_id, input).await?;
         let agent_id_uuid = row.id.uuid();
 
         // Set capabilities if provided (replace existing on upsert)

--- a/crates/server/src/services/app.rs
+++ b/crates/server/src/services/app.rs
@@ -7,11 +7,33 @@ use crate::storage::{
 use anyhow::Result;
 use chrono::Utc;
 use everruns_core::typed_id::{AgentId, HarnessId};
-use everruns_core::{App, AppId, AppStatus, ChannelType};
+use everruns_core::{App, AppId, AppStatus, Caller, ChannelType, Permission, Policy, Rule};
+use everruns_macros::policy;
 use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::api::apps::{CreateAppRequest, UpdateAppRequest};
+
+/// Policy: View apps (read-only).
+pub const APP_VIEW: Policy = Policy {
+    id: "app.view",
+    rules: &[Rule::UserHasPermission(Permission::OrgAgentsManage)],
+};
+
+/// Policy: Manage apps (create, update).
+pub const APP_MANAGE: Policy = Policy {
+    id: "app.manage",
+    rules: &[Rule::UserHasPermission(Permission::OrgAgentsManage)],
+};
+
+/// Policy: Dangerous app operations (delete, publish, unpublish).
+pub const APP_DANGEROUS: Policy = Policy {
+    id: "app.dangerous",
+    rules: &[
+        Rule::UserHasPermission(Permission::OrgAgentsManage),
+        Rule::UserHasPermission(Permission::OrgSettingsManage),
+    ],
+};
 
 pub struct AppService {
     db: Arc<StorageBackend>,
@@ -22,19 +44,20 @@ impl AppService {
         Self { db }
     }
 
-    pub async fn create(&self, org_id: i64, req: CreateAppRequest) -> Result<App> {
+    #[policy(APP_MANAGE)]
+    pub async fn create(&self, caller: &Caller, req: CreateAppRequest) -> Result<App> {
         let internal_uuid = Uuid::now_v7();
         let public_id = AppId::from_uuid(internal_uuid);
 
         // Validate harness and agent exist
         let harness_row = self
             .db
-            .get_harness(org_id, req.harness_id)
+            .get_harness(caller.org_id, req.harness_id)
             .await?
             .ok_or_else(|| anyhow::anyhow!("Harness not found"))?;
         let agent_row = self
             .db
-            .get_agent_by_public_id(org_id, &req.agent_id.to_string())
+            .get_agent_by_public_id(caller.org_id, &req.agent_id.to_string())
             .await?
             .ok_or_else(|| anyhow::anyhow!("Agent not found"))?;
 
@@ -48,14 +71,18 @@ impl AppService {
             channel_config: req.channel_config.unwrap_or_default(),
         };
 
-        let row = self.db.create_app(org_id, input).await?;
-        Ok(self.row_to_app(row, org_id).await)
+        let row = self.db.create_app(caller.org_id, input).await?;
+        Ok(self.row_to_app(row, caller.org_id).await)
     }
 
-    pub async fn get_by_public_id(&self, org_id: i64, public_id: &str) -> Result<Option<App>> {
-        let row = self.db.get_app_by_public_id(org_id, public_id).await?;
+    #[policy(APP_VIEW)]
+    pub async fn get_by_public_id(&self, caller: &Caller, public_id: &str) -> Result<Option<App>> {
+        let row = self
+            .db
+            .get_app_by_public_id(caller.org_id, public_id)
+            .await?;
         match row {
-            Some(row) => Ok(Some(self.row_to_app(row, org_id).await)),
+            Some(row) => Ok(Some(self.row_to_app(row, caller.org_id).await)),
             None => Ok(None),
         }
     }
@@ -73,22 +100,27 @@ impl AppService {
         }
     }
 
-    pub async fn list(&self, org_id: i64, search: Option<&str>) -> Result<Vec<App>> {
-        let rows = self.db.list_apps(org_id, search).await?;
+    #[policy(APP_VIEW)]
+    pub async fn list(&self, caller: &Caller, search: Option<&str>) -> Result<Vec<App>> {
+        let rows = self.db.list_apps(caller.org_id, search).await?;
         let mut apps = Vec::with_capacity(rows.len());
         for row in rows {
-            apps.push(self.row_to_app(row, org_id).await);
+            apps.push(self.row_to_app(row, caller.org_id).await);
         }
         Ok(apps)
     }
 
+    #[policy(APP_MANAGE)]
     pub async fn update(
         &self,
-        org_id: i64,
+        caller: &Caller,
         public_id: &str,
         req: UpdateAppRequest,
     ) -> Result<Option<App>> {
-        let existing = self.db.get_app_by_public_id(org_id, public_id).await?;
+        let existing = self
+            .db
+            .get_app_by_public_id(caller.org_id, public_id)
+            .await?;
         let Some(existing) = existing else {
             return Ok(None);
         };
@@ -97,7 +129,7 @@ impl AppService {
         let harness_id = if let Some(hid) = req.harness_id {
             let h = self
                 .db
-                .get_harness(org_id, hid)
+                .get_harness(caller.org_id, hid)
                 .await?
                 .ok_or_else(|| anyhow::anyhow!("Harness not found"))?;
             Some(h.id.uuid())
@@ -108,7 +140,7 @@ impl AppService {
         let agent_id = if let Some(aid) = req.agent_id {
             let a = self
                 .db
-                .get_agent_by_public_id(org_id, &aid.to_string())
+                .get_agent_by_public_id(caller.org_id, &aid.to_string())
                 .await?
                 .ok_or_else(|| anyhow::anyhow!("Agent not found"))?;
             Some(a.id.uuid())
@@ -127,23 +159,34 @@ impl AppService {
             published_at: None,
         };
 
-        let row = self.db.update_app(org_id, existing.id, input).await?;
+        let row = self
+            .db
+            .update_app(caller.org_id, existing.id, input)
+            .await?;
         match row {
-            Some(row) => Ok(Some(self.row_to_app(row, org_id).await)),
+            Some(row) => Ok(Some(self.row_to_app(row, caller.org_id).await)),
             None => Ok(None),
         }
     }
 
-    pub async fn delete(&self, org_id: i64, public_id: &str) -> Result<bool> {
-        let existing = self.db.get_app_by_public_id(org_id, public_id).await?;
+    #[policy(APP_DANGEROUS)]
+    pub async fn delete(&self, caller: &Caller, public_id: &str) -> Result<bool> {
+        let existing = self
+            .db
+            .get_app_by_public_id(caller.org_id, public_id)
+            .await?;
         let Some(existing) = existing else {
             return Ok(false);
         };
-        self.db.delete_app(org_id, existing.id).await
+        self.db.delete_app(caller.org_id, existing.id).await
     }
 
-    pub async fn publish(&self, org_id: i64, public_id: &str) -> Result<Option<App>> {
-        let existing = self.db.get_app_by_public_id(org_id, public_id).await?;
+    #[policy(APP_DANGEROUS)]
+    pub async fn publish(&self, caller: &Caller, public_id: &str) -> Result<Option<App>> {
+        let existing = self
+            .db
+            .get_app_by_public_id(caller.org_id, public_id)
+            .await?;
         let Some(existing) = existing else {
             return Ok(None);
         };
@@ -154,15 +197,22 @@ impl AppService {
             ..Default::default()
         };
 
-        let row = self.db.update_app(org_id, existing.id, input).await?;
+        let row = self
+            .db
+            .update_app(caller.org_id, existing.id, input)
+            .await?;
         match row {
-            Some(row) => Ok(Some(self.row_to_app(row, org_id).await)),
+            Some(row) => Ok(Some(self.row_to_app(row, caller.org_id).await)),
             None => Ok(None),
         }
     }
 
-    pub async fn unpublish(&self, org_id: i64, public_id: &str) -> Result<Option<App>> {
-        let existing = self.db.get_app_by_public_id(org_id, public_id).await?;
+    #[policy(APP_DANGEROUS)]
+    pub async fn unpublish(&self, caller: &Caller, public_id: &str) -> Result<Option<App>> {
+        let existing = self
+            .db
+            .get_app_by_public_id(caller.org_id, public_id)
+            .await?;
         let Some(existing) = existing else {
             return Ok(None);
         };
@@ -172,9 +222,12 @@ impl AppService {
             ..Default::default()
         };
 
-        let row = self.db.update_app(org_id, existing.id, input).await?;
+        let row = self
+            .db
+            .update_app(caller.org_id, existing.id, input)
+            .await?;
         match row {
-            Some(row) => Ok(Some(self.row_to_app(row, org_id).await)),
+            Some(row) => Ok(Some(self.row_to_app(row, caller.org_id).await)),
             None => Ok(None),
         }
     }

--- a/crates/server/src/services/capability.rs
+++ b/crates/server/src/services/capability.rs
@@ -18,8 +18,8 @@ use crate::storage::{EncryptionService, StorageBackend};
 use anyhow::Result;
 use everruns_core::capabilities::{Capability, CapabilityRegistry};
 use everruns_core::{
-    CapabilityId, CapabilityInfo, CapabilityStatus, McpCapability, McpToolDefinition, RiskLevel,
-    mcp_capability_id, skill_capability_id,
+    Caller, CapabilityId, CapabilityInfo, CapabilityStatus, McpCapability, McpToolDefinition,
+    RiskLevel, mcp_capability_id, skill_capability_id,
 };
 use std::sync::Arc;
 
@@ -42,6 +42,7 @@ impl CapabilityService {
 
     /// List all available capabilities including MCP servers and skills (public info only)
     pub async fn list_all(&self, org_id: i64) -> Result<Vec<CapabilityInfo>> {
+        let internal_caller = Caller::internal(org_id);
         // Get built-in capabilities
         let mut capabilities: Vec<CapabilityInfo> = self
             .registry
@@ -51,7 +52,10 @@ impl CapabilityService {
             .collect();
 
         // Get MCP server capabilities
-        let mcp_servers = self.mcp_service.list_active_with_tools(org_id).await?;
+        let mcp_servers = self
+            .mcp_service
+            .list_active_with_tools(&internal_caller)
+            .await?;
         for server_with_tools in mcp_servers {
             let mcp_cap = McpCapability::new(
                 server_with_tools.server.id.uuid(),
@@ -86,7 +90,7 @@ impl CapabilityService {
         }
 
         // Get skill capabilities from the registry (mount-only, no prompt/tools)
-        let skills = self.skill_service.list(org_id, None).await?;
+        let skills = self.skill_service.list(&internal_caller, None).await?;
         for skill in &skills {
             if skill.status != everruns_core::SkillStatus::Active {
                 continue;
@@ -118,11 +122,15 @@ impl CapabilityService {
     /// This ensures viewing a capability doesn't fail if the MCP server is unreachable.
     /// Use the refresh tools endpoint to explicitly update cached tools.
     pub async fn get(&self, org_id: i64, id: &CapabilityId) -> Result<Option<CapabilityInfo>> {
+        let internal_caller = Caller::internal(org_id);
         // Check if it's an MCP capability
         if let Some(server_id) = id.mcp_server_id() {
             // Use cached tools only - no external refresh on read
-            let tools = self.mcp_service.get_cached_tools(org_id, server_id).await;
-            let server = self.mcp_service.get(org_id, server_id).await?;
+            let tools = self
+                .mcp_service
+                .get_cached_tools(&internal_caller, server_id)
+                .await?;
+            let server = self.mcp_service.get(&internal_caller, server_id).await?;
 
             if let Some(server) = server {
                 let mcp_cap = McpCapability::new(
@@ -159,7 +167,7 @@ impl CapabilityService {
 
         // Check if it's a skill capability (mount-only, no prompt/tools)
         if let Some(skill_uuid) = id.skill_id() {
-            let skill = self.skill_service.get(org_id, skill_uuid).await?;
+            let skill = self.skill_service.get(&internal_caller, skill_uuid).await?;
             if let Some(skill) = skill {
                 return Ok(Some(CapabilityInfo {
                     id: CapabilityId::new(skill_capability_id(skill.id.uuid())),
@@ -196,7 +204,7 @@ impl CapabilityService {
         force_refresh: bool,
     ) -> Result<Vec<McpToolDefinition>> {
         self.mcp_service
-            .get_tools(org_id, server_id, force_refresh)
+            .get_tools(&Caller::internal(org_id), server_id, force_refresh)
             .await
     }
 
@@ -207,7 +215,9 @@ impl CapabilityService {
         org_id: i64,
         server_id: uuid::Uuid,
     ) -> Result<Vec<McpToolDefinition>> {
-        self.mcp_service.refresh_tools(org_id, server_id).await
+        self.mcp_service
+            .refresh_tools(&Caller::internal(org_id), server_id)
+            .await
     }
 
     /// Get the built-in capability registry
@@ -257,7 +267,10 @@ impl CapabilityService {
         &self,
         org_id: i64,
     ) -> Result<Vec<everruns_core::command::CommandDescriptor>> {
-        let skills = self.skill_service.list(org_id, None).await?;
+        let skills = self
+            .skill_service
+            .list(&Caller::internal(org_id), None)
+            .await?;
         let commands = skills
             .into_iter()
             .filter(|s| s.status == everruns_core::SkillStatus::Active && s.user_invocable)
@@ -333,9 +346,13 @@ impl CapabilityService {
 
         // Collect from MCP capabilities using cached tools only (no refresh)
         // Note: MCP capabilities don't have dependencies
+        let internal_caller = Caller::internal(org_id);
         for server_id in mcp_cap_ids {
-            let tools = self.mcp_service.get_cached_tools(org_id, server_id).await;
-            let server = self.mcp_service.get(org_id, server_id).await?;
+            let tools = self
+                .mcp_service
+                .get_cached_tools(&internal_caller, server_id)
+                .await?;
+            let server = self.mcp_service.get(&internal_caller, server_id).await?;
 
             if let Some(server) = server {
                 let mcp_cap = McpCapability::new(

--- a/crates/server/src/services/harness.rs
+++ b/crates/server/src/services/harness.rs
@@ -16,7 +16,13 @@ use everruns_macros::policy;
 use std::sync::Arc;
 use uuid::Uuid;
 
-/// Policy: CRUD on harnesses (create, read, update, copy).
+/// Policy: View harnesses (read-only).
+pub const HARNESS_VIEW: Policy = Policy {
+    id: "harness.view",
+    rules: &[Rule::UserHasPermission(Permission::OrgHarnessesView)],
+};
+
+/// Policy: CRUD on harnesses (create, update, copy).
 pub const HARNESS_MANAGE: Policy = Policy {
     id: "harness.manage",
     rules: &[Rule::UserHasPermission(Permission::OrgHarnessesManage)],
@@ -78,7 +84,7 @@ impl HarnessService {
         Ok(Self::row_to_harness(row, capabilities))
     }
 
-    #[policy(HARNESS_MANAGE)]
+    #[policy(HARNESS_VIEW)]
     pub async fn get(&self, caller: &Caller, id: Uuid) -> Result<Option<Harness>> {
         let row = self
             .db
@@ -93,7 +99,7 @@ impl HarnessService {
         }
     }
 
-    #[policy(HARNESS_MANAGE)]
+    #[policy(HARNESS_VIEW)]
     pub async fn list(&self, caller: &Caller, search: Option<&str>) -> Result<Vec<Harness>> {
         let rows = self.db.list_harnesses(caller.org_id, search).await?;
 

--- a/crates/server/src/services/llm_model.rs
+++ b/crates/server/src/services/llm_model.rs
@@ -10,13 +10,23 @@ use crate::storage::{
 };
 use anyhow::Result;
 use everruns_core::{
-    LlmModel, LlmModelSource, LlmModelStatus, LlmModelWithProvider, LlmProviderType,
-    get_model_profile,
+    Caller, LlmModel, LlmModelSource, LlmModelStatus, LlmModelWithProvider, LlmProviderType,
+    Permission, Policy, Rule, get_model_profile,
 };
+use everruns_macros::policy;
 use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::api::llm_models::{CreateLlmModelRequest, UpdateLlmModelRequest};
+
+pub const LLM_MODEL_VIEW: Policy = Policy {
+    id: "llm_model.view",
+    rules: &[Rule::UserHasPermission(Permission::OrgLlmProvidersView)],
+};
+pub const LLM_MODEL_MANAGE: Policy = Policy {
+    id: "llm_model.manage",
+    rules: &[Rule::UserHasPermission(Permission::OrgLlmProvidersManage)],
+};
 
 pub struct LlmModelService {
     db: Arc<StorageBackend>,
@@ -45,9 +55,10 @@ impl LlmModelService {
         }
     }
 
+    #[policy(LLM_MODEL_MANAGE)]
     pub async fn create(
         &self,
-        org_id: i64,
+        caller: &Caller,
         provider_id: Uuid,
         req: CreateLlmModelRequest,
     ) -> Result<LlmModel> {
@@ -62,45 +73,56 @@ impl LlmModelService {
             provider_metadata: None,
         };
 
-        let row = self.db.create_llm_model(org_id, input).await?;
-        self.invalidate_resolver_cache(org_id).await;
+        let row = self.db.create_llm_model(caller.org_id, input).await?;
+        self.invalidate_resolver_cache(caller.org_id).await;
         Ok(Self::row_to_model(&row))
     }
 
+    #[policy(LLM_MODEL_VIEW)]
     pub async fn get_with_provider(
         &self,
-        org_id: i64,
+        caller: &Caller,
         id: Uuid,
     ) -> Result<Option<LlmModelWithProvider>> {
-        let row = self.db.get_llm_model_with_provider(org_id, id).await?;
+        let row = self
+            .db
+            .get_llm_model_with_provider(caller.org_id, id)
+            .await?;
         Ok(row.as_ref().map(Self::row_to_model_with_provider))
     }
 
-    pub async fn list_for_provider(&self, org_id: i64, provider_id: Uuid) -> Result<Vec<LlmModel>> {
+    #[policy(LLM_MODEL_VIEW)]
+    pub async fn list_for_provider(
+        &self,
+        caller: &Caller,
+        provider_id: Uuid,
+    ) -> Result<Vec<LlmModel>> {
         let rows = self
             .db
-            .list_llm_models_for_provider(org_id, provider_id)
+            .list_llm_models_for_provider(caller.org_id, provider_id)
             .await?;
         Ok(rows.iter().map(Self::row_to_model).collect())
     }
 
-    pub async fn list_all(&self, org_id: i64) -> Result<Vec<LlmModelWithProvider>> {
-        let rows = self.db.list_all_llm_models(org_id).await?;
+    #[policy(LLM_MODEL_VIEW)]
+    pub async fn list_all(&self, caller: &Caller) -> Result<Vec<LlmModelWithProvider>> {
+        let rows = self.db.list_all_llm_models(caller.org_id).await?;
         Ok(rows.iter().map(Self::row_to_model_with_provider).collect())
     }
 
     /// List all models with optional filters
+    #[policy(LLM_MODEL_VIEW)]
     pub async fn list_all_with_filters(
         &self,
-        org_id: i64,
+        caller: &Caller,
         source: Option<LlmModelSource>,
         include_stale: bool,
         favorites_only: bool,
     ) -> Result<Vec<LlmModelWithProvider>> {
-        let rows = self.db.list_all_llm_models(org_id).await?;
+        let rows = self.db.list_all_llm_models(caller.org_id).await?;
 
         // Get provider last_synced_at timestamps for stale detection
-        let providers = self.db.list_llm_providers(org_id).await?;
+        let providers = self.db.list_llm_providers(caller.org_id).await?;
         let provider_sync_times: std::collections::HashMap<
             Uuid,
             Option<chrono::DateTime<chrono::Utc>>,
@@ -152,9 +174,10 @@ impl LlmModelService {
         Ok(models)
     }
 
+    #[policy(LLM_MODEL_MANAGE)]
     pub async fn update(
         &self,
-        org_id: i64,
+        caller: &Caller,
         id: Uuid,
         req: UpdateLlmModelRequest,
     ) -> Result<Option<LlmModel>> {
@@ -172,37 +195,39 @@ impl LlmModelService {
             provider_metadata: None,
         };
 
-        let row = self.db.update_llm_model(org_id, id, input).await?;
+        let row = self.db.update_llm_model(caller.org_id, id, input).await?;
 
         // If uninstalling a model, check if it was the org default and elect a new one
         if req.installed == Some(false)
             && let Some(ref row) = row
         {
-            self.maybe_elect_new_default(org_id, row.id.uuid()).await?;
+            self.maybe_elect_new_default(caller.org_id, row.id.uuid())
+                .await?;
         }
-
         if row.is_some() {
-            self.invalidate_resolver_cache(org_id).await;
+            self.invalidate_resolver_cache(caller.org_id).await;
         }
         Ok(row.as_ref().map(Self::row_to_model))
     }
 
-    pub async fn delete(&self, org_id: i64, id: Uuid) -> Result<bool> {
+    #[policy(LLM_MODEL_MANAGE)]
+    pub async fn delete(&self, caller: &Caller, id: Uuid) -> Result<bool> {
         // Before deleting, check if this was the org default
-        let was_default = self.is_org_default(org_id, id).await?;
-        let deleted = self.db.delete_llm_model(org_id, id).await?;
+        let was_default = self.is_org_default(caller.org_id, id).await?;
+        let deleted = self.db.delete_llm_model(caller.org_id, id).await?;
         if deleted {
             if was_default {
-                self.elect_new_default(org_id).await?;
+                self.elect_new_default(caller.org_id).await?;
             }
-            self.invalidate_resolver_cache(org_id).await;
+            self.invalidate_resolver_cache(caller.org_id).await;
         }
         Ok(deleted)
     }
 
     /// Get the default model
-    pub async fn get_default(&self, org_id: i64) -> Result<Option<LlmModelWithProvider>> {
-        let row = self.db.get_default_llm_model(org_id).await?;
+    #[policy(LLM_MODEL_VIEW)]
+    pub async fn get_default(&self, caller: &Caller) -> Result<Option<LlmModelWithProvider>> {
+        let row = self.db.get_default_llm_model(caller.org_id).await?;
         Ok(row.as_ref().map(Self::row_to_model_with_provider))
     }
 

--- a/crates/server/src/services/llm_provider.rs
+++ b/crates/server/src/services/llm_provider.rs
@@ -11,11 +11,21 @@ use crate::storage::{
 use anyhow::{Result, anyhow};
 use everruns_core::llm_models::LlmProvider;
 use everruns_core::url_validation::validate_safe_url;
-use everruns_core::{LlmProviderStatus, LlmProviderType};
+use everruns_core::{Caller, LlmProviderStatus, LlmProviderType, Permission, Policy, Rule};
+use everruns_macros::policy;
 use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::api::llm_providers::{CreateLlmProviderRequest, UpdateLlmProviderRequest};
+
+pub const LLM_PROVIDER_VIEW: Policy = Policy {
+    id: "llm_provider.view",
+    rules: &[Rule::UserHasPermission(Permission::OrgLlmProvidersView)],
+};
+pub const LLM_PROVIDER_MANAGE: Policy = Policy {
+    id: "llm_provider.manage",
+    rules: &[Rule::UserHasPermission(Permission::OrgLlmProvidersManage)],
+};
 
 pub struct LlmProviderService {
     db: Arc<StorageBackend>,
@@ -51,7 +61,12 @@ impl LlmProviderService {
         }
     }
 
-    pub async fn create(&self, org_id: i64, req: CreateLlmProviderRequest) -> Result<LlmProvider> {
+    #[policy(LLM_PROVIDER_MANAGE)]
+    pub async fn create(
+        &self,
+        caller: &Caller,
+        req: CreateLlmProviderRequest,
+    ) -> Result<LlmProvider> {
         // SSRF prevention: validate base_url before persisting (EVE-69)
         if let Some(ref url) = req.base_url {
             validate_safe_url(url).map_err(|e| anyhow!("Invalid base URL: {e}"))?;
@@ -76,24 +91,27 @@ impl LlmProviderService {
             settings: None,
         };
 
-        let row = self.db.create_llm_provider(org_id, input).await?;
-        self.invalidate_resolver_cache(org_id).await;
+        let row = self.db.create_llm_provider(caller.org_id, input).await?;
+        self.invalidate_resolver_cache(caller.org_id).await;
         Ok(Self::row_to_provider(&row))
     }
 
-    pub async fn get(&self, org_id: i64, id: Uuid) -> Result<Option<LlmProvider>> {
-        let row = self.db.get_llm_provider(org_id, id).await?;
+    #[policy(LLM_PROVIDER_VIEW)]
+    pub async fn get(&self, caller: &Caller, id: Uuid) -> Result<Option<LlmProvider>> {
+        let row = self.db.get_llm_provider(caller.org_id, id).await?;
         Ok(row.as_ref().map(Self::row_to_provider))
     }
 
-    pub async fn list(&self, org_id: i64) -> Result<Vec<LlmProvider>> {
-        let rows = self.db.list_llm_providers(org_id).await?;
+    #[policy(LLM_PROVIDER_VIEW)]
+    pub async fn list(&self, caller: &Caller) -> Result<Vec<LlmProvider>> {
+        let rows = self.db.list_llm_providers(caller.org_id).await?;
         Ok(rows.iter().map(Self::row_to_provider).collect())
     }
 
+    #[policy(LLM_PROVIDER_MANAGE)]
     pub async fn update(
         &self,
-        org_id: i64,
+        caller: &Caller,
         id: Uuid,
         req: UpdateLlmProviderRequest,
     ) -> Result<Option<LlmProvider>> {
@@ -125,17 +143,21 @@ impl LlmProviderService {
             settings: None,
         };
 
-        let row = self.db.update_llm_provider(org_id, id, input).await?;
+        let row = self
+            .db
+            .update_llm_provider(caller.org_id, id, input)
+            .await?;
         if row.is_some() {
-            self.invalidate_resolver_cache(org_id).await;
+            self.invalidate_resolver_cache(caller.org_id).await;
         }
         Ok(row.as_ref().map(Self::row_to_provider))
     }
 
-    pub async fn delete(&self, org_id: i64, id: Uuid) -> Result<bool> {
-        let deleted = self.db.delete_llm_provider(org_id, id).await?;
+    #[policy(LLM_PROVIDER_MANAGE)]
+    pub async fn delete(&self, caller: &Caller, id: Uuid) -> Result<bool> {
+        let deleted = self.db.delete_llm_provider(caller.org_id, id).await?;
         if deleted {
-            self.invalidate_resolver_cache(org_id).await;
+            self.invalidate_resolver_cache(caller.org_id).await;
         }
         Ok(deleted)
     }

--- a/crates/server/src/services/mcp_server.rs
+++ b/crates/server/src/services/mcp_server.rs
@@ -8,9 +8,10 @@ use crate::storage::{
 use anyhow::{Result, anyhow};
 use chrono::{DateTime, Utc};
 use everruns_core::{
-    McpServer, McpServerStatus, McpServerTransportType, McpToolDefinition, McpToolsListRequest,
-    McpToolsListResponse,
+    Caller, McpServer, McpServerStatus, McpServerTransportType, McpToolDefinition,
+    McpToolsListRequest, McpToolsListResponse, Permission, Policy, Rule,
 };
+use everruns_macros::policy;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -26,6 +27,15 @@ const TOOL_CACHE_TTL: Duration = Duration::from_secs(3600);
 /// HTTP client timeout for MCP server calls
 const MCP_CLIENT_TIMEOUT: Duration = Duration::from_secs(30);
 
+pub const MCP_SERVER_VIEW: Policy = Policy {
+    id: "mcp_server.view",
+    rules: &[Rule::UserHasPermission(Permission::OrgAgentsManage)],
+};
+pub const MCP_SERVER_MANAGE: Policy = Policy {
+    id: "mcp_server.manage",
+    rules: &[Rule::UserHasPermission(Permission::OrgAgentsManage)],
+};
+
 pub struct McpServerService {
     db: Arc<StorageBackend>,
     encryption: Option<Arc<EncryptionService>>,
@@ -36,7 +46,8 @@ impl McpServerService {
         Self { db, encryption }
     }
 
-    pub async fn create(&self, org_id: i64, req: CreateMcpServerRequest) -> Result<McpServer> {
+    #[policy(MCP_SERVER_MANAGE)]
+    pub async fn create(&self, caller: &Caller, req: CreateMcpServerRequest) -> Result<McpServer> {
         // Encrypt API key if provided
         let api_key_encrypted = if let Some(api_key) = &req.api_key {
             let encryption = self
@@ -60,23 +71,25 @@ impl McpServerService {
             settings: None,
         };
 
-        let row = self.db.create_mcp_server(org_id, input).await?;
+        let row = self.db.create_mcp_server(caller.org_id, input).await?;
         Ok(Self::row_to_mcp_server(&row))
     }
 
-    pub async fn get(&self, org_id: i64, id: Uuid) -> Result<Option<McpServer>> {
-        let row = self.db.get_mcp_server(org_id, id).await?;
+    #[policy(MCP_SERVER_VIEW)]
+    pub async fn get(&self, caller: &Caller, id: Uuid) -> Result<Option<McpServer>> {
+        let row = self.db.get_mcp_server(caller.org_id, id).await?;
         Ok(row.as_ref().map(Self::row_to_mcp_server))
     }
 
     /// Batch fetch multiple MCP servers with their cached tools in a single query.
     /// Returns a map of server_id -> (McpServer, `Vec<McpToolDefinition>`).
+    #[policy(MCP_SERVER_VIEW)]
     pub async fn get_batch_with_tools(
         &self,
-        org_id: i64,
+        caller: &Caller,
         ids: &[Uuid],
     ) -> Result<HashMap<Uuid, (McpServer, Vec<McpToolDefinition>)>> {
-        let rows = self.db.get_mcp_servers_batch(org_id, ids).await?;
+        let rows = self.db.get_mcp_servers_batch(caller.org_id, ids).await?;
         Ok(rows
             .iter()
             .map(|row| {
@@ -88,14 +101,16 @@ impl McpServerService {
             .collect())
     }
 
-    pub async fn list(&self, org_id: i64, search: Option<&str>) -> Result<Vec<McpServer>> {
-        let rows = self.db.list_mcp_servers(org_id, search).await?;
+    #[policy(MCP_SERVER_VIEW)]
+    pub async fn list(&self, caller: &Caller, search: Option<&str>) -> Result<Vec<McpServer>> {
+        let rows = self.db.list_mcp_servers(caller.org_id, search).await?;
         Ok(rows.iter().map(Self::row_to_mcp_server).collect())
     }
 
+    #[policy(MCP_SERVER_MANAGE)]
     pub async fn update(
         &self,
-        org_id: i64,
+        caller: &Caller,
         id: Uuid,
         req: UpdateMcpServerRequest,
     ) -> Result<Option<McpServer>> {
@@ -123,23 +138,26 @@ impl McpServerService {
             settings: None,
         };
 
-        let row = self.db.update_mcp_server(org_id, id, input).await?;
+        let row = self.db.update_mcp_server(caller.org_id, id, input).await?;
         Ok(row.as_ref().map(Self::row_to_mcp_server))
     }
 
-    pub async fn delete(&self, org_id: i64, id: Uuid) -> Result<bool> {
-        self.db.delete_mcp_server(org_id, id).await
+    #[policy(MCP_SERVER_MANAGE)]
+    pub async fn delete(&self, caller: &Caller, id: Uuid) -> Result<bool> {
+        self.db.delete_mcp_server(caller.org_id, id).await
     }
 
     /// List active MCP servers (for capability listing)
-    pub async fn list_active(&self, org_id: i64) -> Result<Vec<McpServer>> {
-        let rows = self.db.list_active_mcp_servers(org_id).await?;
+    #[policy(MCP_SERVER_VIEW)]
+    pub async fn list_active(&self, caller: &Caller) -> Result<Vec<McpServer>> {
+        let rows = self.db.list_active_mcp_servers(caller.org_id).await?;
         Ok(rows.iter().map(Self::row_to_mcp_server).collect())
     }
 
     /// List active MCP servers with their cached tools
-    pub async fn list_active_with_tools(&self, org_id: i64) -> Result<Vec<McpServerWithTools>> {
-        let rows = self.db.list_active_mcp_servers(org_id).await?;
+    #[policy(MCP_SERVER_VIEW)]
+    pub async fn list_active_with_tools(&self, caller: &Caller) -> Result<Vec<McpServerWithTools>> {
+        let rows = self.db.list_active_mcp_servers(caller.org_id).await?;
         Ok(rows
             .iter()
             .map(Self::row_to_mcp_server_with_tools)
@@ -147,11 +165,12 @@ impl McpServerService {
     }
 
     /// Refresh cached tools for an MCP server by calling tools/list
-    pub async fn refresh_tools(&self, org_id: i64, id: Uuid) -> Result<Vec<McpToolDefinition>> {
+    #[policy(MCP_SERVER_MANAGE)]
+    pub async fn refresh_tools(&self, caller: &Caller, id: Uuid) -> Result<Vec<McpToolDefinition>> {
         // Get the MCP server
         let row = self
             .db
-            .get_mcp_server(org_id, id)
+            .get_mcp_server(caller.org_id, id)
             .await?
             .ok_or_else(|| anyhow!("MCP server not found"))?;
 
@@ -180,22 +199,23 @@ impl McpServerService {
         // Cache tools in database
         let cached_tools = serde_json::to_value(&tools)?;
         self.db
-            .update_mcp_server_tools(org_id, id, UpdateMcpServerTools { cached_tools })
+            .update_mcp_server_tools(caller.org_id, id, UpdateMcpServerTools { cached_tools })
             .await?;
 
         Ok(tools)
     }
 
     /// Get cached tools for an MCP server, refreshing if stale
+    #[policy(MCP_SERVER_VIEW)]
     pub async fn get_tools(
         &self,
-        org_id: i64,
+        caller: &Caller,
         id: Uuid,
         force_refresh: bool,
     ) -> Result<Vec<McpToolDefinition>> {
         let row = self
             .db
-            .get_mcp_server(org_id, id)
+            .get_mcp_server(caller.org_id, id)
             .await?
             .ok_or_else(|| anyhow!("MCP server not found"))?;
 
@@ -215,24 +235,32 @@ impl McpServerService {
         }
 
         // Refresh tools
-        self.refresh_tools(org_id, id).await
+        self.refresh_tools(caller, id).await
     }
 
     /// Get cached tools for an MCP server without refreshing (for preview)
     /// Returns empty vec if server not found or no cached tools
-    pub async fn get_cached_tools(&self, org_id: i64, id: Uuid) -> Vec<McpToolDefinition> {
-        match self.db.get_mcp_server(org_id, id).await {
-            Ok(Some(row)) => serde_json::from_value(row.cached_tools.clone()).unwrap_or_default(),
-            _ => Vec::new(),
+    #[policy(MCP_SERVER_VIEW)]
+    pub async fn get_cached_tools(
+        &self,
+        caller: &Caller,
+        id: Uuid,
+    ) -> Result<Vec<McpToolDefinition>> {
+        match self.db.get_mcp_server(caller.org_id, id).await {
+            Ok(Some(row)) => {
+                Ok(serde_json::from_value(row.cached_tools.clone()).unwrap_or_default())
+            }
+            _ => Ok(Vec::new()),
         }
     }
 
     /// Decrypt API key for an MCP server by ID.
     /// Returns None if server has no API key set.
-    pub async fn decrypt_api_key(&self, org_id: i64, id: Uuid) -> Result<Option<String>> {
+    #[policy(MCP_SERVER_MANAGE)]
+    pub async fn decrypt_api_key(&self, caller: &Caller, id: Uuid) -> Result<Option<String>> {
         let row = self
             .db
-            .get_mcp_server(org_id, id)
+            .get_mcp_server(caller.org_id, id)
             .await?
             .ok_or_else(|| anyhow!("MCP server not found"))?;
 
@@ -256,12 +284,13 @@ impl McpServerService {
     ///
     /// Used by both gRPC service and direct worker adapters to look up an MCP
     /// server by its sanitized name (lowercase, non-alphanumeric chars -> '_').
+    #[policy(MCP_SERVER_VIEW)]
     pub async fn resolve_by_prefix(
         &self,
-        org_id: i64,
+        caller: &Caller,
         server_prefix: &str,
     ) -> Result<Option<McpServerResolved>> {
-        let servers = self.list(org_id, None).await?;
+        let servers = self.list(caller, None).await?;
         let server_prefix_lower = server_prefix.to_lowercase();
 
         let server = servers.into_iter().find(|s| {
@@ -280,7 +309,7 @@ impl McpServerService {
         };
 
         let api_key = if server.api_key_set {
-            self.decrypt_api_key(org_id, server.id.uuid()).await?
+            self.decrypt_api_key(caller, server.id.uuid()).await?
         } else {
             None
         };
@@ -404,6 +433,17 @@ async fn fetch_mcp_tools(
 mod tests {
     use super::*;
     use crate::storage::{EncryptionService, StorageBackend, models::CreateMcpServerRow};
+    use everruns_core::OrgRole;
+
+    fn test_caller(org_id: i64) -> Caller {
+        Caller {
+            org_id,
+            org_public_id: format!("org_{org_id:032}"),
+            user_id: None,
+            role: OrgRole::Owner,
+            is_platform_user: false,
+        }
+    }
 
     fn test_encryption() -> Arc<EncryptionService> {
         Arc::new(
@@ -433,7 +473,10 @@ mod tests {
             .await
             .unwrap();
 
-        let result = svc.decrypt_api_key(1, row.id.uuid()).await.unwrap();
+        let result = svc
+            .decrypt_api_key(&test_caller(1), row.id.uuid())
+            .await
+            .unwrap();
         assert!(result.is_none());
     }
 
@@ -461,7 +504,10 @@ mod tests {
             .await
             .unwrap();
 
-        let result = svc.decrypt_api_key(1, row.id.uuid()).await.unwrap();
+        let result = svc
+            .decrypt_api_key(&test_caller(1), row.id.uuid())
+            .await
+            .unwrap();
         assert_eq!(result.as_deref(), Some("sk-secret-123"));
     }
 
@@ -490,7 +536,7 @@ mod tests {
 
         // Service WITHOUT encryption configured
         let svc = McpServerService::new(db, None);
-        let result = svc.decrypt_api_key(1, row.id.uuid()).await;
+        let result = svc.decrypt_api_key(&test_caller(1), row.id.uuid()).await;
         assert!(result.is_err());
     }
 
@@ -499,7 +545,7 @@ mod tests {
         let db = Arc::new(StorageBackend::in_memory());
         let svc = McpServerService::new(db, Some(test_encryption()));
 
-        let result = svc.decrypt_api_key(1, Uuid::new_v4()).await;
+        let result = svc.decrypt_api_key(&test_caller(1), Uuid::new_v4()).await;
         assert!(result.is_err());
     }
 
@@ -525,7 +571,10 @@ mod tests {
         .await
         .unwrap();
 
-        let resolved = svc.resolve_by_prefix(1, "my_cool_server").await.unwrap();
+        let resolved = svc
+            .resolve_by_prefix(&test_caller(1), "my_cool_server")
+            .await
+            .unwrap();
         assert!(resolved.is_some());
         let r = resolved.unwrap();
         assert_eq!(r.name, "My Cool Server");
@@ -538,7 +587,10 @@ mod tests {
         let db = Arc::new(StorageBackend::in_memory());
         let svc = McpServerService::new(db, Some(test_encryption()));
 
-        let resolved = svc.resolve_by_prefix(1, "nonexistent").await.unwrap();
+        let resolved = svc
+            .resolve_by_prefix(&test_caller(1), "nonexistent")
+            .await
+            .unwrap();
         assert!(resolved.is_none());
     }
 
@@ -564,7 +616,10 @@ mod tests {
         .await
         .unwrap();
 
-        let resolved = svc.resolve_by_prefix(1, "auth_server").await.unwrap();
+        let resolved = svc
+            .resolve_by_prefix(&test_caller(1), "auth_server")
+            .await
+            .unwrap();
         assert!(resolved.is_some());
         assert_eq!(resolved.unwrap().api_key.as_deref(), Some("sk-mcp-secret"));
     }
@@ -621,7 +676,7 @@ mod tests {
 
         // Service without encryption
         let svc = McpServerService::new(db, None);
-        let result = svc.resolve_by_prefix(1, "no_enc").await;
+        let result = svc.resolve_by_prefix(&test_caller(1), "no_enc").await;
         assert!(result.is_err());
     }
 }

--- a/crates/server/src/services/session.rs
+++ b/crates/server/src/services/session.rs
@@ -14,14 +14,27 @@ use crate::storage::{
 };
 use anyhow::Result;
 use everruns_core::{
-    AgentCapabilityConfig, AgentId, CapabilityRegistry, HarnessId, ModelId, Session, SessionId,
-    SessionStatus, SubagentStatus, TokenUsage,
+    AgentCapabilityConfig, AgentId, Caller, CapabilityRegistry, HarnessId, ModelId, Permission,
+    Policy, Rule, Session, SessionId, SessionStatus, SubagentStatus, TokenUsage,
     capabilities::{SystemPromptContext, collect_capabilities, compute_features},
 };
+use everruns_macros::policy;
 use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::api::sessions::{CreateSessionRequest, UpdateSessionRequest};
+
+/// Policy: View sessions (read-only).
+pub const SESSION_VIEW: Policy = Policy {
+    id: "session.view",
+    rules: &[Rule::UserHasPermission(Permission::OrgSessionsManage)],
+};
+
+/// Policy: Manage sessions (create, update, delete).
+pub const SESSION_MANAGE: Policy = Policy {
+    id: "session.manage",
+    rules: &[Rule::UserHasPermission(Permission::OrgSessionsManage)],
+};
 
 /// Session counts grouped by status.
 #[derive(Debug, Clone, Default)]
@@ -57,15 +70,17 @@ impl SessionService {
         }
     }
 
+    #[policy(SESSION_MANAGE)]
     pub async fn create(
         &self,
-        org_id: i64,
-        org_public_id: &str,
+        caller: &Caller,
         harness_id: Uuid,
         agent_internal_id: Option<Uuid>,
         agent_public_id: Option<AgentId>,
         req: CreateSessionRequest,
     ) -> Result<Session> {
+        let org_id = caller.org_id;
+        let org_public_id = &caller.org_public_id;
         let harness_id = HarnessId::from_uuid(harness_id);
         let agent_id = agent_internal_id.map(AgentId::from_uuid);
 
@@ -181,26 +196,27 @@ impl SessionService {
         Ok(())
     }
 
+    #[policy(SESSION_VIEW)]
     pub async fn get(
         &self,
-        org_id: i64,
-        org_public_id: &str,
+        caller: &Caller,
         id: Uuid,
         user_id: Option<Uuid>,
     ) -> Result<Option<Session>> {
         let row = self
             .db
-            .get_session(org_id, SessionId::from_uuid(id))
+            .get_session(caller.org_id, SessionId::from_uuid(id))
             .await?;
         match row {
             Some(r) => {
-                let mut session = Self::row_to_session(r, org_public_id);
+                let mut session = Self::row_to_session(r, &caller.org_public_id);
                 // Populate features before resolving agent_id (needs internal UUID)
                 self.populate_features(&mut session).await?;
-                self.resolve_session_agent_id(org_id, &mut session).await?;
+                self.resolve_session_agent_id(caller.org_id, &mut session)
+                    .await?;
                 // Populate is_pinned if user context available
                 if let Some(uid) = user_id {
-                    let pinned = self.db.list_pinned_session_ids(uid, org_id).await?;
+                    let pinned = self.db.list_pinned_session_ids(uid, caller.org_id).await?;
                     session.is_pinned = Some(pinned.iter().any(|s| s.uuid() == id));
                 }
                 Ok(Some(session))
@@ -210,8 +226,9 @@ impl SessionService {
     }
 
     /// Get session counts grouped by status for an organization.
-    pub async fn stats(&self, org_id: i64) -> Result<SessionStats> {
-        let counts = self.db.count_sessions_by_status(org_id).await?;
+    #[policy(SESSION_VIEW)]
+    pub async fn stats(&self, caller: &Caller) -> Result<SessionStats> {
+        let counts = self.db.count_sessions_by_status(caller.org_id).await?;
         let mut stats = SessionStats::default();
         for (status, count) in counts {
             let count = count as u32;
@@ -230,15 +247,17 @@ impl SessionService {
     /// List sessions for an organization with optional agent filter.
     /// Returns (sessions, total_count).
     /// Sessions include preview text from first user message and last assistant response.
+    #[policy(SESSION_VIEW)]
     pub async fn list(
         &self,
-        org_id: i64,
-        org_public_id: &str,
+        caller: &Caller,
         agent_id: Option<Uuid>,
         user_id: Option<Uuid>,
         search: Option<&str>,
         pagination: Pagination,
     ) -> Result<(Vec<Session>, u32)> {
+        let org_id = caller.org_id;
+        let org_public_id = &caller.org_public_id;
         let agent_id = agent_id.map(AgentId::from_uuid);
         let (rows, total) = self
             .db
@@ -287,10 +306,10 @@ impl SessionService {
         Ok((sessions, total))
     }
 
+    #[policy(SESSION_MANAGE)]
     pub async fn update(
         &self,
-        org_id: i64,
-        org_public_id: &str,
+        caller: &Caller,
         id: Uuid,
         req: UpdateSessionRequest,
     ) -> Result<Option<Session>> {
@@ -301,12 +320,13 @@ impl SessionService {
         };
         let row = self
             .db
-            .update_session(org_id, SessionId::from_uuid(id), input)
+            .update_session(caller.org_id, SessionId::from_uuid(id), input)
             .await?;
         match row {
             Some(r) => {
-                let mut session = Self::row_to_session(r, org_public_id);
-                self.resolve_session_agent_id(org_id, &mut session).await?;
+                let mut session = Self::row_to_session(r, &caller.org_public_id);
+                self.resolve_session_agent_id(caller.org_id, &mut session)
+                    .await?;
                 Ok(Some(session))
             }
             None => Ok(None),
@@ -314,10 +334,10 @@ impl SessionService {
     }
 
     /// Update session status (used by worker via gRPC)
+    #[policy(SESSION_MANAGE)]
     pub async fn update_status(
         &self,
-        org_id: i64,
-        org_public_id: &str,
+        caller: &Caller,
         id: Uuid,
         status: String,
     ) -> Result<Option<Session>> {
@@ -327,12 +347,13 @@ impl SessionService {
         };
         let row = self
             .db
-            .update_session(org_id, SessionId::from_uuid(id), input)
+            .update_session(caller.org_id, SessionId::from_uuid(id), input)
             .await?;
         match row {
             Some(r) => {
-                let mut session = Self::row_to_session(r, org_public_id);
-                self.resolve_session_agent_id(org_id, &mut session).await?;
+                let mut session = Self::row_to_session(r, &caller.org_public_id);
+                self.resolve_session_agent_id(caller.org_id, &mut session)
+                    .await?;
                 Ok(Some(session))
             }
             None => Ok(None),
@@ -342,13 +363,15 @@ impl SessionService {
     /// Get or create the global chat session for a user.
     /// Uses tags for per-user singleton: `["global-chat", "user:{user_id}"]`.
     /// Creates with the Platform Chat harness if no existing session is found.
+    #[policy(SESSION_MANAGE)]
     pub async fn get_or_create_chat_session(
         &self,
-        org_id: i64,
-        org_public_id: &str,
+        caller: &Caller,
         user_id: Uuid,
         harness_id: Uuid,
     ) -> Result<Session> {
+        let org_id = caller.org_id;
+        let org_public_id = &caller.org_public_id;
         let user_tag = format!("user:{}", user_id);
         let tags = vec!["global-chat".to_string(), user_tag.clone()];
 
@@ -384,21 +407,24 @@ impl SessionService {
         Ok(session)
     }
 
-    pub async fn delete(&self, org_id: i64, id: Uuid) -> Result<bool> {
+    #[policy(SESSION_MANAGE)]
+    pub async fn delete(&self, caller: &Caller, id: Uuid) -> Result<bool> {
         self.db
-            .delete_session(org_id, SessionId::from_uuid(id))
+            .delete_session(caller.org_id, SessionId::from_uuid(id))
             .await
     }
 
     /// Pin a session for a user
-    pub async fn pin(&self, user_id: Uuid, session_id: Uuid, org_id: i64) -> Result<()> {
+    #[policy(SESSION_MANAGE)]
+    pub async fn pin(&self, caller: &Caller, user_id: Uuid, session_id: Uuid) -> Result<()> {
         self.db
-            .pin_session(user_id, SessionId::from_uuid(session_id), org_id)
+            .pin_session(user_id, SessionId::from_uuid(session_id), caller.org_id)
             .await
     }
 
     /// Unpin a session for a user
-    pub async fn unpin(&self, user_id: Uuid, session_id: Uuid) -> Result<bool> {
+    #[policy(SESSION_MANAGE)]
+    pub async fn unpin(&self, caller: &Caller, user_id: Uuid, session_id: Uuid) -> Result<bool> {
         self.db
             .unpin_session(user_id, SessionId::from_uuid(session_id))
             .await

--- a/crates/server/src/services/skill.rs
+++ b/crates/server/src/services/skill.rs
@@ -12,9 +12,10 @@ use crate::storage::{
 };
 use anyhow::{Result, anyhow};
 use everruns_core::{
-    Skill, SkillContent, SkillFileEntry, SkillId, SkillSourceType, SkillStatus,
-    SkillValidationResult, parse_skill_md, validate_skill_md,
+    Caller, Permission, Policy, Rule, Skill, SkillContent, SkillFileEntry, SkillId,
+    SkillSourceType, SkillStatus, SkillValidationResult, parse_skill_md, validate_skill_md,
 };
+use everruns_macros::policy;
 use moka::future::Cache;
 use std::collections::HashMap;
 use std::io::Read;
@@ -33,6 +34,15 @@ const MAX_DECOMPRESSED_SIZE: usize = 10 * 1024 * 1024;
 
 /// Cache TTL for skill listings per org
 const SKILL_CACHE_TTL: Duration = Duration::from_secs(300); // 5 minutes
+
+pub const SKILL_VIEW: Policy = Policy {
+    id: "skill.view",
+    rules: &[Rule::UserHasPermission(Permission::OrgAgentsManage)],
+};
+pub const SKILL_MANAGE: Policy = Policy {
+    id: "skill.manage",
+    rules: &[Rule::UserHasPermission(Permission::OrgAgentsManage)],
+};
 
 pub struct SkillService {
     db: Arc<StorageBackend>,
@@ -55,14 +65,15 @@ impl SkillService {
     }
 
     /// Create a skill from SKILL.md content
-    pub async fn create(&self, org_id: i64, req: CreateSkillRequest) -> Result<Skill> {
+    #[policy(SKILL_MANAGE)]
+    pub async fn create(&self, caller: &Caller, req: CreateSkillRequest) -> Result<Skill> {
         let parsed = parse_skill_md(&req.skill_md)
             .map_err(|errors| anyhow!("Invalid SKILL.md: {}", errors.join("; ")))?;
 
         // Check duplicate name
         if self
             .db
-            .get_skill_by_name(org_id, &parsed.name)
+            .get_skill_by_name(caller.org_id, &parsed.name)
             .await?
             .is_some()
         {
@@ -90,13 +101,18 @@ impl SkillService {
             version: parsed.version,
         };
 
-        let row = self.db.create_skill(org_id, input).await?;
-        self.invalidate_cache(org_id).await;
+        let row = self.db.create_skill(caller.org_id, input).await?;
+        self.invalidate_cache(caller.org_id).await;
         Ok(Self::row_to_skill(&row))
     }
 
     /// Create a skill from a ZIP archive
-    pub async fn create_from_archive(&self, org_id: i64, archive_data: Vec<u8>) -> Result<Skill> {
+    #[policy(SKILL_MANAGE)]
+    pub async fn create_from_archive(
+        &self,
+        caller: &Caller,
+        archive_data: Vec<u8>,
+    ) -> Result<Skill> {
         if archive_data.len() > MAX_ARCHIVE_SIZE {
             return Err(anyhow!(
                 "Archive too large: {} bytes (max {})",
@@ -120,7 +136,7 @@ impl SkillService {
         // Check duplicate name
         if self
             .db
-            .get_skill_by_name(org_id, &parsed.name)
+            .get_skill_by_name(caller.org_id, &parsed.name)
             .await?
             .is_some()
         {
@@ -148,7 +164,7 @@ impl SkillService {
             version: parsed.version,
         };
 
-        let row = self.db.create_skill(org_id, input).await?;
+        let row = self.db.create_skill(caller.org_id, input).await?;
 
         // Store extracted files
         for file in &extracted.files {
@@ -171,38 +187,41 @@ impl SkillService {
             self.db.create_skill_file(input).await?;
         }
 
-        self.invalidate_cache(org_id).await;
+        self.invalidate_cache(caller.org_id).await;
         Ok(Self::row_to_skill(&row))
     }
 
-    pub async fn get(&self, org_id: i64, id: Uuid) -> Result<Option<Skill>> {
-        let row = self.db.get_skill(org_id, id).await?;
+    #[policy(SKILL_VIEW)]
+    pub async fn get(&self, caller: &Caller, id: Uuid) -> Result<Option<Skill>> {
+        let row = self.db.get_skill(caller.org_id, id).await?;
         Ok(row.as_ref().map(Self::row_to_skill))
     }
 
-    pub async fn list(&self, org_id: i64, search: Option<&str>) -> Result<Vec<Skill>> {
+    #[policy(SKILL_VIEW)]
+    pub async fn list(&self, caller: &Caller, search: Option<&str>) -> Result<Vec<Skill>> {
         // Only use cache for unfiltered list
         if search.is_none()
-            && let Some(cached) = self.list_cache.get(&org_id).await
+            && let Some(cached) = self.list_cache.get(&caller.org_id).await
         {
             return Ok((*cached).clone());
         }
 
-        let rows = self.db.list_skills(org_id, search).await?;
+        let rows = self.db.list_skills(caller.org_id, search).await?;
         let skills: Vec<Skill> = rows.iter().map(Self::row_to_skill).collect();
 
         // Only populate cache for unfiltered list
         if search.is_none() {
             self.list_cache
-                .insert(org_id, Arc::new(skills.clone()))
+                .insert(caller.org_id, Arc::new(skills.clone()))
                 .await;
         }
         Ok(skills)
     }
 
     /// Get full skill content (SKILL.md + files)
-    pub async fn get_content(&self, org_id: i64, id: Uuid) -> Result<Option<SkillContent>> {
-        let row = match self.db.get_skill(org_id, id).await? {
+    #[policy(SKILL_VIEW)]
+    pub async fn get_content(&self, caller: &Caller, id: Uuid) -> Result<Option<SkillContent>> {
+        let row = match self.db.get_skill(caller.org_id, id).await? {
             Some(r) => r,
             None => return Ok(None),
         };
@@ -252,9 +271,10 @@ impl SkillService {
         Ok(Some(SkillContent { skill_md, files }))
     }
 
+    #[policy(SKILL_MANAGE)]
     pub async fn update(
         &self,
-        org_id: i64,
+        caller: &Caller,
         id: Uuid,
         req: UpdateSkillRequest,
     ) -> Result<Option<Skill>> {
@@ -266,11 +286,11 @@ impl SkillService {
                 .map_err(|errors| anyhow!("Invalid SKILL.md: {}", errors.join("; ")))?;
 
             // Check name uniqueness if name changed
-            if let Some(existing) = self.db.get_skill(org_id, id).await?
+            if let Some(existing) = self.db.get_skill(caller.org_id, id).await?
                 && existing.name != parsed.name
                 && self
                     .db
-                    .get_skill_by_name(org_id, &parsed.name)
+                    .get_skill_by_name(caller.org_id, &parsed.name)
                     .await?
                     .is_some()
             {
@@ -291,14 +311,15 @@ impl SkillService {
             input.status = Some(status.to_string());
         }
 
-        let row = self.db.update_skill(org_id, id, input).await?;
-        self.invalidate_cache(org_id).await;
+        let row = self.db.update_skill(caller.org_id, id, input).await?;
+        self.invalidate_cache(caller.org_id).await;
         Ok(row.as_ref().map(Self::row_to_skill))
     }
 
-    pub async fn delete(&self, org_id: i64, id: Uuid) -> Result<bool> {
-        let result = self.db.delete_skill(org_id, id).await?;
-        self.invalidate_cache(org_id).await;
+    #[policy(SKILL_MANAGE)]
+    pub async fn delete(&self, caller: &Caller, id: Uuid) -> Result<bool> {
+        let result = self.db.delete_skill(caller.org_id, id).await?;
+        self.invalidate_cache(caller.org_id).await;
         Ok(result)
     }
 
@@ -562,6 +583,7 @@ mod tests {
     use crate::api::skills::CreateSkillRequest;
     use crate::storage::StorageBackend;
     use crate::storage::memory::InMemoryDatabase;
+    use everruns_core::Caller;
 
     fn test_skill_md(name: &str) -> String {
         format!("---\nname: {name}\ndescription: A test skill.\n---\n\nInstructions for {name}.")
@@ -570,6 +592,10 @@ mod tests {
     fn make_service() -> SkillService {
         let db = Arc::new(StorageBackend::InMemory(Arc::new(InMemoryDatabase::new())));
         SkillService::new(db)
+    }
+
+    fn test_caller(org_id: i64) -> Caller {
+        Caller::internal(org_id)
     }
 
     /// Helper to check if org_id is cached (avoids type inference issues in assert!)
@@ -587,13 +613,13 @@ mod tests {
         let req = CreateSkillRequest {
             skill_md: test_skill_md("cache-test"),
         };
-        svc.create(org_id, req).await.unwrap();
+        svc.create(&test_caller(org_id), req).await.unwrap();
 
         // Cache should have been invalidated by create, so list should query DB
         assert!(!is_cached(&svc, org_id).await);
 
         // First list call populates cache
-        let skills = svc.list(org_id, None).await.unwrap();
+        let skills = svc.list(&test_caller(org_id), None).await.unwrap();
         assert_eq!(skills.len(), 1);
         assert_eq!(skills[0].name, "cache-test");
 
@@ -610,10 +636,10 @@ mod tests {
         let req = CreateSkillRequest {
             skill_md: test_skill_md("cached-skill"),
         };
-        svc.create(org_id, req).await.unwrap();
+        svc.create(&test_caller(org_id), req).await.unwrap();
 
         // First list populates cache
-        let first = svc.list(org_id, None).await.unwrap();
+        let first = svc.list(&test_caller(org_id), None).await.unwrap();
         assert_eq!(first.len(), 1);
 
         // Insert a skill directly into DB to prove cache is being used
@@ -634,7 +660,7 @@ mod tests {
         svc.db.create_skill(org_id, input).await.unwrap();
 
         // Second list should return cached result (1 skill, not 2)
-        let second = svc.list(org_id, None).await.unwrap();
+        let second = svc.list(&test_caller(org_id), None).await.unwrap();
         assert_eq!(second.len(), 1);
         assert_eq!(second[0].name, "cached-skill");
     }
@@ -648,8 +674,8 @@ mod tests {
         let req = CreateSkillRequest {
             skill_md: test_skill_md("skill-one"),
         };
-        svc.create(org_id, req).await.unwrap();
-        let skills = svc.list(org_id, None).await.unwrap();
+        svc.create(&test_caller(org_id), req).await.unwrap();
+        let skills = svc.list(&test_caller(org_id), None).await.unwrap();
         assert_eq!(skills.len(), 1);
         assert!(is_cached(&svc, org_id).await);
 
@@ -657,11 +683,11 @@ mod tests {
         let req2 = CreateSkillRequest {
             skill_md: test_skill_md("skill-two"),
         };
-        svc.create(org_id, req2).await.unwrap();
+        svc.create(&test_caller(org_id), req2).await.unwrap();
         assert!(!is_cached(&svc, org_id).await);
 
         // Next list should show both skills
-        let skills = svc.list(org_id, None).await.unwrap();
+        let skills = svc.list(&test_caller(org_id), None).await.unwrap();
         assert_eq!(skills.len(), 2);
     }
 
@@ -673,10 +699,10 @@ mod tests {
         let req = CreateSkillRequest {
             skill_md: test_skill_md("update-me"),
         };
-        let skill = svc.create(org_id, req).await.unwrap();
+        let skill = svc.create(&test_caller(org_id), req).await.unwrap();
 
         // Populate cache
-        svc.list(org_id, None).await.unwrap();
+        svc.list(&test_caller(org_id), None).await.unwrap();
         assert!(is_cached(&svc, org_id).await);
 
         // Update skill - should invalidate cache
@@ -684,13 +710,13 @@ mod tests {
             skill_md: Some(test_skill_md("updated-name")),
             status: None,
         };
-        svc.update(org_id, skill.id.uuid(), update_req)
+        svc.update(&test_caller(org_id), skill.id.uuid(), update_req)
             .await
             .unwrap();
         assert!(!is_cached(&svc, org_id).await);
 
         // Next list should reflect the update
-        let skills = svc.list(org_id, None).await.unwrap();
+        let skills = svc.list(&test_caller(org_id), None).await.unwrap();
         assert_eq!(skills.len(), 1);
         assert_eq!(skills[0].name, "updated-name");
     }
@@ -703,19 +729,22 @@ mod tests {
         let req = CreateSkillRequest {
             skill_md: test_skill_md("delete-me"),
         };
-        let skill = svc.create(org_id, req).await.unwrap();
+        let skill = svc.create(&test_caller(org_id), req).await.unwrap();
 
         // Populate cache
-        svc.list(org_id, None).await.unwrap();
+        svc.list(&test_caller(org_id), None).await.unwrap();
         assert!(is_cached(&svc, org_id).await);
 
         // Delete skill - should invalidate cache
-        let deleted = svc.delete(org_id, skill.id.uuid()).await.unwrap();
+        let deleted = svc
+            .delete(&test_caller(org_id), skill.id.uuid())
+            .await
+            .unwrap();
         assert!(deleted);
         assert!(!is_cached(&svc, org_id).await);
 
         // Next list should be empty
-        let skills = svc.list(org_id, None).await.unwrap();
+        let skills = svc.list(&test_caller(org_id), None).await.unwrap();
         assert!(skills.is_empty());
     }
 
@@ -729,17 +758,17 @@ mod tests {
         let req_a = CreateSkillRequest {
             skill_md: test_skill_md("org-a-skill"),
         };
-        svc.create(org_a, req_a).await.unwrap();
+        svc.create(&test_caller(org_a), req_a).await.unwrap();
 
         // Create skill in org B
         let req_b = CreateSkillRequest {
             skill_md: test_skill_md("org-b-skill"),
         };
-        svc.create(org_b, req_b).await.unwrap();
+        svc.create(&test_caller(org_b), req_b).await.unwrap();
 
         // Populate both caches
-        let skills_a = svc.list(org_a, None).await.unwrap();
-        let skills_b = svc.list(org_b, None).await.unwrap();
+        let skills_a = svc.list(&test_caller(org_a), None).await.unwrap();
+        let skills_b = svc.list(&test_caller(org_b), None).await.unwrap();
         assert_eq!(skills_a.len(), 1);
         assert_eq!(skills_b.len(), 1);
         assert_eq!(skills_a[0].name, "org-a-skill");
@@ -749,12 +778,12 @@ mod tests {
         let req_a2 = CreateSkillRequest {
             skill_md: test_skill_md("org-a-skill-2"),
         };
-        svc.create(org_a, req_a2).await.unwrap();
+        svc.create(&test_caller(org_a), req_a2).await.unwrap();
         assert!(!is_cached(&svc, org_a).await);
         assert!(is_cached(&svc, org_b).await);
 
         // Org B still returns cached result
-        let skills_b_cached = svc.list(org_b, None).await.unwrap();
+        let skills_b_cached = svc.list(&test_caller(org_b), None).await.unwrap();
         assert_eq!(skills_b_cached.len(), 1);
         assert_eq!(skills_b_cached[0].name, "org-b-skill");
     }

--- a/plan.md
+++ b/plan.md
@@ -1,241 +1,171 @@
-# Session Schedules — Implementation Plan
+# Policy Coverage Plan
 
 ## Overview
 
-Add session-scoped scheduling capability that lets agents schedule future work within a session. When a schedule fires, a system message is injected into the session, triggering a turn.
+Wire policies into all services, add view/manage split, platform user rule for durable, UI shared helper, update specs to mandate policies for new features.
 
-**Key difference from existing durable schedules**: Session schedules are user-facing, session-bound, created via agent tools, and trigger conversational turns — not system-level workflows.
+## 1. Core: New permissions + IsPlatformUser rule
 
-## Architecture
+**File: `crates/core/src/permissions.rs`**
 
+Add 4 view permissions:
 ```
-Agent (via tools)                   Session Schedules Tab (UI)
-    │                                        │
-    ▼                                        ▼
-┌─────────────────────────────────────────────────┐
-│  session_schedules table (PostgreSQL)           │
-│  - session_id FK, cron/one-shot, description    │
-│  - max 5 active per session                     │
-└────────────────────┬────────────────────────────┘
-                     │
-                     ▼
-┌─────────────────────────────────────────────────┐
-│  SessionScheduler (control-plane)               │
-│  - Polls due session schedules                  │
-│  - Injects input.message (role: "schedule")     │
-│  - Triggers turn via runner.start_run()         │
-└─────────────────────────────────────────────────┘
+OrgHarnessesView       → org:harnesses:view
+OrgLlmProvidersView    → org:llm-providers:view
+OrgSettingsView        → org:settings:view
+OrgMembersView         → org:members:view
 ```
 
-## Data Model
+Update role mapping — all 3 roles get all 4 view permissions (Members can view everything).
 
-### New table: `session_schedules`
+Add `IsPlatformUser` to `Rule` enum.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| id | UUID PK (uuidv7) | Primary key |
-| public_id | TEXT UNIQUE | Format: `sched_{32-hex}` |
-| session_id | UUID FK → sessions | Parent session |
-| description | TEXT NOT NULL | What the agent should do |
-| cron_expression | TEXT | Cron expression (NULL for one-shot) |
-| scheduled_at | TIMESTAMPTZ | One-shot trigger time (NULL for recurring) |
-| timezone | TEXT DEFAULT 'UTC' | IANA timezone |
-| enabled | BOOLEAN DEFAULT true | Active flag |
-| next_trigger_at | TIMESTAMPTZ | Next computed trigger (indexed) |
-| last_triggered_at | TIMESTAMPTZ | Last trigger |
-| trigger_count | INTEGER DEFAULT 0 | Total triggers |
-| created_at | TIMESTAMPTZ | Creation time |
-| updated_at | TIMESTAMPTZ | Last update |
+Add `is_platform_user: bool` to `Caller`. Update `Caller::internal()` → `is_platform_user: true`.
 
-Constraint: `CHECK (cron_expression IS NOT NULL OR scheduled_at IS NOT NULL)` — must have one scheduling method.
-
-Index: `CREATE INDEX idx_session_schedules_polling ON session_schedules (next_trigger_at) WHERE enabled = true;`
-
-Index: `CREATE INDEX idx_session_schedules_session ON session_schedules (session_id) WHERE enabled = true;`
-
-### New TypedId: `ScheduleId` (prefix: `sched_`)
-
-Add to `typed_id.rs` and `id-schema.md`.
-
-### New event type: `schedule.triggered`
-
-Data: `{ schedule_id, description }` — emitted when a schedule fires (informational).
-
-### Message injection
-
-When a schedule fires, inject an `input.message` event with a special metadata marker:
-
-```json
-{
-  "type": "input.message",
-  "data": {
-    "message": {
-      "role": "user",
-      "content": [{"type": "text", "text": "Scheduled task: <description>"}],
-      "metadata": { "source": "schedule", "schedule_id": "sched_..." }
+Update `Policy::evaluate()`:
+```rust
+Rule::IsPlatformUser => {
+    if !caller.is_platform_user {
+        return Err(PolicyError::denied(self.id, "platform_user"));
     }
-  }
 }
 ```
 
-Using `role: "user"` with metadata marker (not a new role) keeps compatibility with all LLM providers. The UI can render these differently based on `metadata.source === "schedule"`.
+Rename `PolicyConfigResponse` → `ResourceConfigResponse` (same shape: `{ policies: HashMap<String, bool> }`).
 
-## Implementation Steps
+## 2. Platform user resolution
 
-### Phase 1: Core (Rust)
+**File: `crates/server/src/auth/config.rs`** — load `PLATFORM_USER_EMAILS` env var (comma-separated) into `AuthConfig`.
 
-1. **Migration** (`010_session_schedules.sql`)
-   - `session_schedules` table with all fields above
-   - Polling and session indexes
+**File: `crates/server/src/api/common.rs`** — shared `caller_from_org(org, platform_emails)` that checks if user email is in platform list → sets `is_platform_user`.
 
-2. **TypedId** — add `ScheduleId` with `sched_` prefix
+For durable: build `Caller` from `AuthUser` + platform check. Define `DURABLE_MANAGE` policy with `Rule::IsPlatformUser`. Replace `AdminUser` extractor.
 
-3. **Storage layer** (`server/src/storage/`)
-   - `SessionScheduleRow`, `CreateSessionScheduleRow`, `UpdateSessionScheduleRow`
-   - CRUD operations + `list_by_session`, `claim_due_schedules`, `count_active_for_session`
+## 3. Service layer: Add Caller + policies
 
-4. **Service layer** (`server/src/services/session_schedule.rs`)
-   - `SessionScheduleService` — business logic
-   - Enforce max 5 active per session
-   - Compute `next_trigger_at` from cron/one-shot
-   - Trigger: inject message + start turn
+Each service gets `Caller` param replacing `org_id`, policy consts, `#[policy]` on every method.
 
-5. **Session event type** — add `SCHEDULE_TRIGGERED` constant
+### AgentService
+- VIEW: `agent.view` → `OrgAgentsManage` (get, get_by_public_id, list)
+- MANAGE: `agent.manage` → `OrgAgentsManage` (create, update, copy, delete, upsert)
 
-6. **Scheduler loop** (`server/src/session_scheduler.rs`)
-   - Poll `session_schedules` every 1s for due schedules
-   - Claim via `SELECT FOR UPDATE SKIP LOCKED`
-   - For each: inject message event, start turn workflow
-   - For one-shot: set `enabled = false` after trigger
-   - For recurring: compute and set next `next_trigger_at`
-   - Start in server alongside existing durable scheduler
+### AppService
+- VIEW: `app.view` → `OrgAgentsManage` (get, list)
+- MANAGE: `app.manage` → `OrgAgentsManage` (create, update)
+- DANGEROUS: `app.dangerous` → `OrgAgentsManage` + `OrgSettingsManage` (delete, publish, unpublish)
 
-### Phase 2: Capability & Tools (Rust)
+### SessionService
+- VIEW: `session.view` → `OrgSessionsManage` (get, list, stats)
+- MANAGE: `session.manage` → `OrgSessionsManage` (create, update, update_status, delete, get_or_create_chat, pin, unpin)
 
-7. **Capability** (`core/src/capabilities/session_schedule.rs`)
-   - ID: `session_schedule`
-   - System prompt addition explaining scheduling tools
-   - 3 tools: `create_schedule`, `cancel_schedule`, `list_schedules`
+### McpServerService (Members allowed — building blocks)
+- VIEW: `mcp_server.view` → `OrgAgentsManage` (get, list, list_active, list_active_with_tools, get_tools, get_cached_tools, get_batch_with_tools, resolve_by_prefix)
+- MANAGE: `mcp_server.manage` → `OrgAgentsManage` (create, update, delete, refresh_tools, decrypt_api_key)
 
-8. **Tools implementation**
-   - `create_schedule`: params `{ description, cron_expression?, scheduled_at?, timezone? }`
-     - Validates max 5 active
-     - Computes next_trigger_at
-     - Returns schedule details
-   - `cancel_schedule`: params `{ schedule_id }`
-     - Sets `enabled = false`
-   - `list_schedules`: no params
-     - Returns all schedules for session (active and recent inactive)
+### LlmProviderService
+- VIEW: `llm_provider.view` → `OrgLlmProvidersView` (get, list)
+- MANAGE: `llm_provider.manage` → `OrgLlmProvidersManage` (create, update, delete)
 
-9. **ToolContext extension**
-   - Add `session_schedule_store: Option<Arc<dyn SessionScheduleStore>>` to `ToolContext`
-   - `SessionScheduleStore` trait in `core/src/traits.rs`
+### LlmModelService
+- VIEW: `llm_model.view` → `OrgLlmProvidersView` (get_with_provider, list_for_provider, list_all, list_all_with_filters, get_default)
+- MANAGE: `llm_model.manage` → `OrgLlmProvidersManage` (create, update, delete)
 
-10. **Register capability** in `CapabilityRegistry::with_builtins_for_grade()`
+### SkillService
+- VIEW: `skill.view` → `OrgAgentsManage` (get, list, get_content)
+- MANAGE: `skill.manage` → `OrgAgentsManage` (create, create_from_archive, update, delete)
 
-### Phase 3: API (Rust)
+### HarnessService (update existing)
+- VIEW: `harness.view` → `OrgHarnessesView` (get, list — currently `HARNESS_MANAGE`, downgrade)
+- MANAGE/DANGEROUS: unchanged
 
-11. **REST endpoints** (`server/src/api/session_schedules.rs`)
-    - `GET /v1/sessions/{session_id}/schedules` — list schedules
-    - `GET /v1/sessions/{session_id}/schedules/{schedule_id}` — get schedule
-    - `PATCH /v1/sessions/{session_id}/schedules/{schedule_id}` — update (enable/disable)
-    - `DELETE /v1/sessions/{session_id}/schedules/{schedule_id}` — delete schedule
-    - `POST /v1/sessions/{session_id}/schedules/{schedule_id}/trigger` — manual trigger
+### Durable (new)
+- `DURABLE_MANAGE` → `IsPlatformUser` (all durable endpoints)
 
-12. **SSE event** — add `schedule.triggered` to supported event types list
+## 4. API layer: Update handlers + config endpoints
 
-13. **Session response extension**
-    - Add `active_schedule_count: Option<u32>` to `Session` struct
-    - Populate in session queries (subquery or join)
+For each resource API file:
+1. Use shared `caller_from_org()` from `common.rs`
+2. Pass `Caller` to service methods
+3. Use `.map_policy_or_internal()` on results
+4. Add `GET /v1/{resource}/config` → `ResourceConfigResponse`
 
-### Phase 4: UI (TypeScript/React)
+New config endpoints: agents, apps, sessions, mcp-servers, llm-providers, llm-models, skills.
+Update: harnesses config (add `harness.view`, use `ResourceConfigResponse`).
 
-14. **API client** (`lib/api/session-schedules.ts`)
-    - Types: `SessionSchedule`, list/get/update/delete/trigger functions
+Durable: replace `AdminUser` with `Caller` + `DURABLE_MANAGE` policy.
 
-15. **Hooks** (`hooks/use-session-schedules.ts`)
-    - `useSessionSchedules(sessionId)`, `useUpdateSchedule()`, `useDeleteSchedule()`, `useTriggerSchedule()`
+## 5. Internal callers (gRPC, workers)
 
-16. **Query keys** — add `sessionSchedules` section
+All `Caller::internal(org_id)` already gets Owner role + `is_platform_user: true`.
+Update gRPC service methods to pass `Caller::internal()` instead of raw `org_id`.
 
-17. **Schedules tab** (`sessions/[sessionId]/schedules/page.tsx`)
-    - Table: description, type (one-shot/recurring), cron/time, next run, trigger count, status
-    - Actions: enable/disable toggle, delete, trigger now
-    - Empty state when no schedules
+## 6. UI: Shared policy helper
 
-18. **Tab navigation** — add "Schedules" tab with `Clock` icon in session layout
+### Types (`apps/ui/src/lib/api/types.ts`)
+```ts
+export interface ResourceConfigResponse {
+  policies: Record<string, boolean>;
+}
+```
 
-19. **Schedule indicator** — in session layout header and session cards
-    - Small badge/icon showing active schedule count
-    - Only shown when count > 0
+### Hook (`apps/ui/src/hooks/use-policies.ts`)
+```ts
+export function usePolicies(resource: string) {
+  // Fetches GET /v1/{resource}/config
+  // Returns { can(policyId): boolean, isLoading, ... }
+}
+```
 
-20. **Scheduled message rendering** — in chat view
-    - Detect `metadata.source === "schedule"` on input messages
-    - Render with clock icon and "Scheduled" label instead of user avatar
+### Component (`apps/ui/src/components/policy-gate.tsx`)
+```tsx
+export function PolicyGate({ resource, policy, fallback?, children }) {
+  // Renders children only if policy passes
+}
+```
 
-21. **Session context** — add `activeScheduleCount` from session data
+### Query keys — add `policies.config(resource)`.
 
-### Phase 5: Tests
+### Wire into UI pages — harnesses as example, others follow pattern.
 
-22. **Unit tests** (Rust)
-    - Cron next-trigger computation
-    - Max 5 enforcement
-    - One-shot disabling after trigger
-    - Tool parameter validation
-    - Storage CRUD operations
+## 7. Specs updates
 
-23. **Integration tests** (Rust)
-    - Schedule creation via API
-    - Manual trigger via API
-    - Enable/disable via API
-    - Session response includes schedule count
+### `specs/permissions.md`
+- Add view permissions to table
+- Add `IsPlatformUser` rule (move from "future" to current)
+- Add `ResourceConfigResponse` pattern
+- Add durable policy
+- **Add section: "Policy Requirements" — all new service methods MUST have `#[policy]` with `Caller`**
 
-24. **UI tests** — component tests for schedule list, indicator
+### `specs/code-organization.md`
+Add rule: "All service methods MUST have `#[policy]` enforcement with `Caller` parameter. New features without policies will not pass review."
 
-## File Changes Summary
+### `specs/apis.md`
+Document config endpoints.
 
-### New files
-- `crates/server/migrations/010_session_schedules.sql`
-- `crates/core/src/capabilities/session_schedule.rs`
-- `crates/server/src/services/session_schedule.rs`
-- `crates/server/src/api/session_schedules.rs`
-- `crates/server/src/session_scheduler.rs`
-- `apps/ui/src/lib/api/session-schedules.ts`
-- `apps/ui/src/hooks/use-session-schedules.ts`
-- `apps/ui/src/app/(main)/sessions/[sessionId]/schedules/page.tsx`
+### `specs/durable-execution-engine.md`
+Document platform user access replacing AdminUser.
 
-### Modified files
-- `crates/core/src/typed_id.rs` — add ScheduleId
-- `crates/core/src/capabilities/mod.rs` — register session_schedule
-- `crates/core/src/traits.rs` — add SessionScheduleStore trait + ToolContext field
-- `crates/core/src/events.rs` — add SCHEDULE_TRIGGERED constant
-- `crates/core/src/session.rs` — add active_schedule_count field
-- `crates/server/src/api/mod.rs` — add schedule routes
-- `crates/server/src/server.rs` — start scheduler loop
-- `crates/server/src/storage/` — add schedule storage
-- `apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx` — add tab + indicator
-- `apps/ui/src/components/session/session-card.tsx` — add indicator
-- `apps/ui/src/lib/query-keys.ts` — add schedule keys
-- `apps/ui/src/lib/api/types.ts` — add schedule types
-- `apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx` — add schedule count
+## 8. Tests
 
-### Spec update
-- `specs/scheduled-tasks.md` — add session schedules section (or new `specs/session-schedules.md`)
-- `specs/id-schema.md` — add ScheduleId
+### Core unit tests
+- View permissions in role mapping (all roles get view)
+- `IsPlatformUser` rule (pass when true, fail when false)
+- `is_platform_user` field on Caller
 
-## Dependencies
+### Integration tests
+- Need TestServer role-switching support to test 403 responses
+- Test at least: Member gets 403 on harness create, Admin gets 403 on harness delete
 
-### Rust
-- `cron` crate (already in workspace for durable schedules)
-- `chrono-tz` (already in workspace)
+## Execution order
 
-### npm
-- `cronstrue` — human-readable cron descriptions (optional, nice-to-have)
-
-## Decisions
-
-1. **Message role**: Use `role: "user"` with `metadata.source: "schedule"` rather than new role — avoids LLM provider compatibility issues
-2. **Storage**: Separate `session_schedules` table (not reusing `durable_schedules`) — different lifecycle, session-scoped, simpler schema
-3. **Scheduler**: Separate scheduler loop from durable scheduler — different concerns, lighter weight
-4. **Max 5**: Enforced at service layer (not DB constraint) for better error messages
-5. **One-shot + recurring**: Both supported — one-shot auto-disables after trigger
+1. Core permissions (view perms, IsPlatformUser, Caller field, ResourceConfigResponse)
+2. Platform user loading in auth config
+3. Shared caller_from_org in common.rs
+4. HarnessService: add HARNESS_VIEW, update get/list
+5-11. Remaining services: add Caller + policies (agent, app, session, mcp, llm_provider, llm_model, skill)
+12. API handlers: update all to pass Caller + add config endpoints
+13. Durable: replace AdminUser with IsPlatformUser policy
+14. gRPC/internal: update to Caller::internal
+15. UI: usePolicies + PolicyGate + wire harnesses
+16. Specs: update permissions, code-organization, apis, durable
+17. Tests

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -590,6 +590,37 @@ All entity list endpoints support an optional `?search=` query parameter for tok
 
 **Convention:** When adding new entity types, always include `?search=` support on the list endpoint. Search should match against `name` and `description` at minimum (case-insensitive, tokenized). Empty or whitespace-only search values are treated as no filter.
 
+### Resource Config Endpoints
+
+Each resource exposes a config endpoint returning `ResourceConfigResponse` with the caller's evaluated policy results. UI uses these on load to show/hide controls.
+
+```
+GET /v1/{resource}/config → ResourceConfigResponse
+```
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /v1/harnesses/config` | Harness policies |
+| `GET /v1/agents/config` | Agent policies |
+| `GET /v1/apps/config` | App policies |
+| `GET /v1/sessions/config` | Session policies |
+| `GET /v1/mcp-servers/config` | MCP server policies |
+| `GET /v1/llm-providers/config` | LLM provider policies |
+| `GET /v1/llm-models/config` | LLM model policies |
+| `GET /v1/skills/config` | Skill policies |
+
+**Response:**
+```json
+{
+  "policies": {
+    "harness.manage": true,
+    "harness.dangerous": false
+  }
+}
+```
+
+See `specs/permissions.md` for the full policy model and `ResourceConfigResponse` details.
+
 ### Error Responses
 
 ```json

--- a/specs/code-organization.md
+++ b/specs/code-organization.md
@@ -73,6 +73,10 @@ Config: `apps/ui/oxfmt.json` (100 char width, single quotes, trailing commas)
 just fmt  # Runs cargo fmt + oxfmt + oxlint --fix
 ```
 
+### Policy Enforcement
+
+All service methods MUST have `#[policy]` enforcement with a `Caller` parameter. Use `Caller::internal(org_id)` for gRPC/internal paths. See `specs/permissions.md` for the full policy model.
+
 ## Error Handling
 
 **API errors:**

--- a/specs/permissions.md
+++ b/specs/permissions.md
@@ -19,6 +19,10 @@ org:llm-providers:manage          # CRUD on LLM providers
 org:settings:manage               # Org settings
 org:members:manage                # Invite/remove members
 org:api-keys:manage               # CRUD on API keys
+org:harnesses:view                # View harnesses (read-only)
+org:llm-providers:view            # View LLM providers (read-only)
+org:settings:view                 # View org settings (read-only)
+org:members:view                  # View org members (read-only)
 ```
 
 ### Rule
@@ -31,8 +35,8 @@ Hardcoded enum variants (no dynamic rules):
 |------|-------------|
 | `UserHasPermission(perm)` | User's role grants the permission |
 | `UserHasRole(role)` | User has at least this OrgRole |
+| `IsPlatformUser` | Caller is in platform user allowlist |
 | `UserIsResourceOwner` | User created the resource (future) |
-| `IsPlatformUser` | User is in platform allowlist (future) |
 
 Rules are **additive within a policy** — all rules must pass (AND logic).
 
@@ -74,6 +78,10 @@ Hardcoded. No DB storage (phase 1).
 | `org:settings:manage` | yes | yes | no |
 | `org:members:manage` | yes | yes | no |
 | `org:api-keys:manage` | yes | yes | no |
+| `org:harnesses:view` | yes | yes | yes |
+| `org:llm-providers:view` | yes | yes | yes |
+| `org:settings:view` | yes | yes | yes |
+| `org:members:view` | yes | yes | yes |
 
 Owner inherits all Admin permissions. Admin inherits all Member permissions.
 
@@ -281,7 +289,12 @@ Per-resource config endpoints return which policies the caller satisfies.
 ```
 GET /v1/harnesses/config
 GET /v1/agents/config
+GET /v1/apps/config
 GET /v1/sessions/config
+GET /v1/mcp-servers/config
+GET /v1/llm-providers/config
+GET /v1/llm-models/config
+GET /v1/skills/config
 ```
 
 ### Response
@@ -302,13 +315,25 @@ UI uses this on load to show/hide controls (delete buttons, admin panels, etc.).
 Each resource module defines its relevant policies. The config handler evaluates all of them against the caller:
 
 ```rust
-pub async fn harness_config(org: ResolvedOrg) -> Json<ConfigResponse> {
+pub async fn harness_config(org: ResolvedOrg) -> Json<ResourceConfigResponse> {
     let caller = Caller::from(&org);
-    Json(ConfigResponse {
+    Json(ResourceConfigResponse {
         policies: evaluate_policies(&caller, &[HARNESS_MANAGE, HARNESS_DANGEROUS]),
     })
 }
 ```
+
+## Policy Requirements for New Features
+
+All new service methods MUST have `#[policy]` enforcement with a `Caller` parameter. No service method should accept raw `org_id` — use `Caller` to carry auth context. New features without policy enforcement will not pass review.
+
+### Checklist for New Resources
+
+1. Define view + manage policies (and dangerous if applicable)
+2. Add `#[policy]` to all service methods
+3. Use `Caller` parameter instead of `org_id`
+4. Add `GET /v1/{resource}/config` endpoint returning `ResourceConfigResponse`
+5. Wire UI with `usePolicies(resource)` hook
 
 ## Migration Path
 
@@ -318,12 +343,12 @@ pub async fn harness_config(org: ResolvedOrg) -> Json<ConfigResponse> {
 - Role → permission mapping (hardcoded)
 - Service-layer enforcement
 - Config endpoints for UI
+- `IsPlatformUser` rule with allowlist
 - No DB changes
 
 ### Phase 2 (future)
 - `user_permissions` table for per-user grants beyond role defaults
 - `UserIsResourceOwner` rule (needs `created_by` on resources)
-- `IsPlatformUser` rule with allowlist
 - Admin UI for permission management
 
 ## Files


### PR DESCRIPTION
## What
Add comprehensive policy enforcement using `Caller` auth context across all service methods. Replace raw `org_id: i64` parameters with `Caller` struct carrying org_id, org_public_id, user_id, role, and is_platform_user. Add `GET /v1/{resource}/config` endpoints for all 8 resources.

## Why
The permissions spec requires fine-grained access control at the service layer. Services were previously accepting raw `org_id` with no authorization checks. This change enforces policies declaratively via the `#[policy]` macro on every service method, enabling role-based access control for future multi-role support.

## How
- **Core**: Added 4 view permissions, `IsPlatformUser` rule, `ResourceConfigResponse`, `evaluate_policies()`, `Caller::internal()`
- **Services**: All 8 services now use `Caller` + `#[policy]` macro
- **API**: All handlers use `Caller::from(&org)` via `From<&ResolvedOrg>` impl; added config endpoints
- **Internal callers**: gRPC, workers, capability service use `Caller::internal(org_id)`
- **UI**: New `usePolicies` hook, `PolicyGate` component
- **Specs**: Updated permissions.md, code-organization.md, apis.md
- **Simplification**: Consolidated 11 duplicate `caller_from_org` helpers into single `From` impl

## Risk
- Low
- All users currently get Owner role, so no behavioral change

## Checklist
- [x] Tests added or updated (25+ permission tests, updated skill/mcp_server service tests)
- [x] Backward compatibility considered (no API changes, internal refactor only)
