### PR TITLE
test(core): stabilize builtin capability registry assertions

### DIFF
--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -1153,11 +1153,49 @@ pub async fn apply_capabilities(
 mod tests {
     use super::*;
     use crate::typed_id::SessionId;
+    use std::collections::BTreeSet;
     use uuid::Uuid;
 
     /// Test helper: dummy context with no file store
     fn test_ctx() -> SystemPromptContext {
         SystemPromptContext::without_file_store(SessionId::new())
+    }
+
+    fn expected_core_builtin_ids() -> BTreeSet<&'static str> {
+        [
+            "agent_instructions",
+            "noop",
+            "current_time",
+            "research",
+            "platform_management",
+            "session_file_system",
+            "session_storage",
+            "session",
+            "session_sql_database",
+            "test_math",
+            "test_weather",
+            "stateless_todo_list",
+            "web_fetch",
+            "virtual_bash",
+            "session_schedule",
+            "infinity_context",
+            "openai_tool_search",
+            "skills",
+            "subagents",
+            "system_commands",
+            "openui",
+            "sample_data",
+            "fake_warehouse",
+            "fake_aws",
+            "fake_crm",
+            "fake_financial",
+        ]
+        .into_iter()
+        .collect()
+    }
+
+    fn registry_ids(registry: &CapabilityRegistry) -> BTreeSet<&str> {
+        registry.capabilities.keys().map(String::as_str).collect()
     }
 
     // =========================================================================
@@ -1174,73 +1212,16 @@ mod tests {
         // Dev mode includes all built-in capabilities
         let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
 
-        assert!(registry.has("agent_instructions"));
-        assert!(registry.has("noop"));
-        assert!(registry.has("current_time"));
-        assert!(registry.has("research"));
-        assert!(registry.has("session_file_system"));
-        assert!(registry.has("session_storage"));
-        assert!(registry.has("session"));
-        assert!(registry.has("session_sql_database"));
-        assert!(registry.has("test_math"));
-        assert!(registry.has("test_weather"));
-        assert!(registry.has("stateless_todo_list"));
-        assert!(registry.has("web_fetch"));
-        assert!(registry.has("virtual_bash"));
-        assert!(registry.has("sample_data"));
-        assert!(registry.has("fake_warehouse"));
-        assert!(registry.has("fake_aws"));
-        assert!(registry.has("fake_crm"));
-        assert!(registry.has("fake_financial"));
-        assert!(registry.has("skills"));
-        assert!(registry.has("session_schedule"));
-        assert!(registry.has("infinity_context"));
-        assert!(registry.has("platform_management"));
-        assert!(registry.has("system_commands"));
-        // 23 core built-in capabilities
-        // (integration plugins like docker_container, daytona add more when linked)
-        assert!(registry.len() >= 23);
+        assert_eq!(registry_ids(&registry), expected_core_builtin_ids());
     }
 
     #[test]
     fn test_capability_registry_with_builtins_prod() {
         // Prod mode excludes experimental capabilities
         let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Prod);
-        let expected_capabilities = [
-            "agent_instructions",
-            "noop",
-            "current_time",
-            "research",
-            "session_file_system",
-            "session_storage",
-            "session",
-            "session_sql_database",
-            "test_math",
-            "test_weather",
-            "stateless_todo_list",
-            "web_fetch",
-            "virtual_bash",
-            "sample_data",
-            "fake_warehouse",
-            "fake_aws",
-            "fake_crm",
-            "fake_financial",
-            "skills",
-            "session_schedule",
-            "infinity_context",
-            "platform_management",
-            "system_commands",
-            "openai_tool_search",
-            "openui",
-            "subagents",
-        ];
-
-        for capability in expected_capabilities {
-            assert!(registry.has(capability), "missing capability: {capability}");
-        }
+        assert_eq!(registry_ids(&registry), expected_core_builtin_ids());
         // Experimental capabilities NOT included in prod
         assert!(!registry.has("docker_container"));
-        assert_eq!(registry.len(), expected_capabilities.len());
     }
 
     #[test]

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -73,3 +73,56 @@ pub mod slack_delivery;
 // App builder for composable server configurations
 pub mod app_builder;
 pub use app_builder::{ServerAppBuilder, ServerContext};
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::fs;
+    use std::path::Path;
+
+    #[test]
+    fn migration_versions_are_unique() {
+        let migrations_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
+        let mut files_by_version: BTreeMap<String, Vec<String>> = BTreeMap::new();
+
+        for entry in fs::read_dir(&migrations_dir).expect("Failed to read migrations directory") {
+            let path = entry.expect("Failed to read migration entry").path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("sql") {
+                continue;
+            }
+
+            let file_name = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .expect("Migration file name must be valid UTF-8")
+                .to_string();
+
+            let (version, _) = file_name
+                .split_once('_')
+                .expect("Migration file names must start with '<version>_'");
+
+            files_by_version
+                .entry(version.to_string())
+                .or_default()
+                .push(file_name);
+        }
+
+        let duplicates: Vec<String> = files_by_version
+            .into_iter()
+            .filter_map(|(version, mut files)| {
+                if files.len() <= 1 {
+                    return None;
+                }
+
+                files.sort();
+                Some(format!("{version}: {}", files.join(", ")))
+            })
+            .collect();
+
+        assert!(
+            duplicates.is_empty(),
+            "Migration versions must be unique. Duplicates:\n{}",
+            duplicates.join("\n")
+        );
+    }
+}

--- a/specs/leased-resources.md
+++ b/specs/leased-resources.md
@@ -11,7 +11,7 @@ Leased resources are the generic control-plane primitive for any provider-owned 
 
 ## Model
 
-See [`crates/core/src/leased_resource.rs`](/Users/mykhailochalyi/.codex/worktrees/baaf/everruns/crates/core/src/leased_resource.rs) for the public domain type and [`crates/server/migrations/009_v0.8.6.sql`](/Users/mykhailochalyi/.codex/worktrees/baaf/everruns/crates/server/migrations/009_v0.8.6.sql) for persistence details.
+See [`crates/core/src/leased_resource.rs`](/Users/mykhailochalyi/.codex/worktrees/baaf/everruns/crates/core/src/leased_resource.rs) for the public domain type and [`crates/server/migrations/010_v0.8.6.sql`](/Users/mykhailochalyi/.codex/worktrees/baaf/everruns/crates/server/migrations/010_v0.8.6.sql) for persistence details.
 
 Important constraints:
 


### PR DESCRIPTION
## What
- Replace brittle builtin-capability count assertions with exact expected capability ID set assertions in the core registry tests.
- Renumber duplicate SQL migrations to restore a unique increasing sequence.
- Add a server-side test that fails fast when migration version prefixes collide.

## Why
`main` had two active CI breaks:
1. `Unit Tests (Pure)` failed because a builtin capability was added but the test still hard-coded the old count.
2. `Integration Tests (PostgreSQL)` failed during `sqlx migrate run` because `crates/server/migrations` contained three `009_*` files.

## How
Use a shared expected builtin ID set for the capability registry tests, then rename the conflicting migration files to `010_v0.8.6.sql` and `011_installed_models.sql` and add a guard test that scans the migration directory for duplicate prefixes.

## Risk
- Low
- Test-only change in core plus migration filename renumbering. The main risk is hidden dependence on the old duplicate filenames, which CI migration and the new guard test cover.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
