### PR TITLE
chore(ci): add SDK compatibility checks

### DIFF
--- a/.github/scripts/sdk-compat/resolve-sdk-versions.sh
+++ b/.github/scripts/sdk-compat/resolve-sdk-versions.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Keep this script portable to stock GitHub runners; avoid non-default tools.
 repo_url="https://github.com/everruns/sdk.git"
 
 mapfile -t versions < <(
   git ls-remote --tags --refs "$repo_url" \
     | awk '{print $2}' \
     | sed -E 's#refs/tags/v##' \
-    | rg '^[0-9]+\.[0-9]+\.[0-9]+$' \
+    | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
     | sort -t. -k1,1n -k2,2n -k3,3n
 )
 
@@ -21,7 +22,7 @@ IFS='.' read -r latest_major latest_minor latest_patch <<< "$latest"
 
 version_exists() {
   local candidate="$1"
-  printf '%s\n' "${versions[@]}" | rg -qx "$candidate"
+  printf '%s\n' "${versions[@]}" | grep -Fxq "$candidate"
 }
 
 find_highest_for_constraint() {

--- a/.github/scripts/sdk-compat/resolve-sdk-versions.sh
+++ b/.github/scripts/sdk-compat/resolve-sdk-versions.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_url="https://github.com/everruns/sdk.git"
+
+mapfile -t versions < <(
+  git ls-remote --tags --refs "$repo_url" \
+    | awk '{print $2}' \
+    | sed -E 's#refs/tags/v##' \
+    | rg '^[0-9]+\.[0-9]+\.[0-9]+$' \
+    | sort -t. -k1,1n -k2,2n -k3,3n
+)
+
+if [ "${#versions[@]}" -eq 0 ]; then
+  echo "No SDK versions found in $repo_url" >&2
+  exit 1
+fi
+
+latest="${versions[${#versions[@]}-1]}"
+IFS='.' read -r latest_major latest_minor latest_patch <<< "$latest"
+
+version_exists() {
+  local candidate="$1"
+  printf '%s\n' "${versions[@]}" | rg -qx "$candidate"
+}
+
+find_highest_for_constraint() {
+  local major="$1"
+  local minor="$2"
+  local best=""
+
+  for version in "${versions[@]}"; do
+    IFS='.' read -r v_major v_minor _v_patch <<< "$version"
+
+    if [ "$major" != "*" ] && [ "$v_major" -ne "$major" ]; then
+      continue
+    fi
+
+    if [ "$minor" != "*" ] && [ "$v_minor" -ne "$minor" ]; then
+      continue
+    fi
+
+    best="$version"
+  done
+
+  echo "$best"
+}
+
+latest_patch_1=""
+latest_patch_2=""
+last_minor=""
+last_major=""
+
+for ((patch=latest_patch-1; patch>=0; patch--)); do
+  candidate="${latest_major}.${latest_minor}.${patch}"
+  if version_exists "$candidate"; then
+    if [ -z "$latest_patch_1" ]; then
+      latest_patch_1="$candidate"
+    elif [ -z "$latest_patch_2" ]; then
+      latest_patch_2="$candidate"
+      break
+    fi
+  fi
+done
+
+for ((minor=latest_minor-1; minor>=0; minor--)); do
+  candidate="$(find_highest_for_constraint "$latest_major" "$minor")"
+  if [ -n "$candidate" ]; then
+    last_minor="$candidate"
+    break
+  fi
+done
+
+for ((major=latest_major-1; major>=0; major--)); do
+  candidate="$(find_highest_for_constraint "$major" "*")"
+  if [ -n "$candidate" ]; then
+    last_major="$candidate"
+    break
+  fi
+done
+
+entries=()
+for language in typescript python rust; do
+  for row in "last_major:$last_major" "last_minor:$last_minor" "patch_n1:$latest_patch_1" "patch_n2:$latest_patch_2"; do
+    cohort="${row%%:*}"
+    version="${row#*:}"
+    if [ -z "$version" ]; then
+      if [ "$cohort" = "patch_n2" ]; then
+        echo "Required cohort patch_n2 missing in SDK tags" >&2
+        exit 1
+      fi
+      version="$latest"
+      cohort="${cohort}_fallback"
+    fi
+    entries+=("{\"language\":\"$language\",\"cohort\":\"$cohort\",\"version\":\"$version\"}")
+  done
+done
+
+json_array="[$(IFS=,; echo "${entries[*]}")]"
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  printf 'matrix=%s\n' "$json_array" >> "$GITHUB_OUTPUT"
+  printf 'latest=%s\n' "$latest" >> "$GITHUB_OUTPUT"
+else
+  echo "$json_array"
+fi

--- a/.github/scripts/sdk-compat/test-python.sh
+++ b/.github/scripts/sdk-compat/test-python.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${1:?usage: test-python.sh <version> <base_url> <api_key>}"
+base_url="${2:?usage: test-python.sh <version> <base_url> <api_key>}"
+api_key="${3:?usage: test-python.sh <version> <base_url> <api_key>}"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+python3 -m venv "$workdir/.venv"
+source "$workdir/.venv/bin/activate"
+
+pip install --quiet "everruns-sdk==$version"
+
+EVERRUNS_BASE_URL="$base_url" EVERRUNS_API_KEY="$api_key" SDK_VERSION="$version" python3 - <<'PY'
+import asyncio
+import os
+import random
+import string
+
+from everruns_sdk import Client
+
+
+async def main() -> None:
+    client = Client(api_key=os.environ["EVERRUNS_API_KEY"], base_url=os.environ["EVERRUNS_BASE_URL"])
+
+    suffix = "".join(random.choices(string.ascii_lowercase + string.digits, k=8))
+
+    agent = await client.agents.create(
+        name=f"sdk-compat-py-{suffix}",
+        system_prompt="Compatibility test agent",
+    )
+    fetched_agent = await client.agents.get(agent.id)
+    if fetched_agent.id != agent.id:
+        raise RuntimeError(f"agent id mismatch: {fetched_agent.id} != {agent.id}")
+
+    session = await client.sessions.create(agent_id=agent.id)
+    fetched_session = await client.sessions.get(session.id)
+    if fetched_session.id != session.id:
+        raise RuntimeError(f"session id mismatch: {fetched_session.id} != {session.id}")
+
+    print(f"ok python sdk {os.environ['SDK_VERSION']}")
+
+
+asyncio.run(main())
+PY

--- a/.github/scripts/sdk-compat/test-rust.sh
+++ b/.github/scripts/sdk-compat/test-rust.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${1:?usage: test-rust.sh <version> <base_url> <api_key>}"
+base_url="${2:?usage: test-rust.sh <version> <base_url> <api_key>}"
+api_key="${3:?usage: test-rust.sh <version> <base_url> <api_key>}"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+cargo new --quiet --bin "$workdir/smoke"
+
+cat > "$workdir/smoke/Cargo.toml" <<TOML
+[package]
+name = "sdk-compat-rust"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+everruns-sdk = "=$version"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+rand = "0.9"
+TOML
+
+cat > "$workdir/smoke/src/main.rs" <<'RS'
+use everruns_sdk::{Client, CreateAgentRequest, CreateSessionRequest};
+use rand::{distr::Alphanumeric, Rng};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = std::env::var("EVERRUNS_API_KEY")?;
+    let base_url = std::env::var("EVERRUNS_BASE_URL")?;
+
+    let client = Client::builder().api_key(api_key).base_url(base_url).build()?;
+
+    let suffix: String = rand::rng()
+        .sample_iter(Alphanumeric)
+        .take(8)
+        .map(char::from)
+        .collect();
+
+    let agent = client
+        .agents()
+        .create(CreateAgentRequest {
+            name: format!("sdk-compat-rs-{suffix}"),
+            system_prompt: "Compatibility test agent".to_string(),
+            ..Default::default()
+        })
+        .await?;
+
+    let fetched_agent = client.agents().get(&agent.id).await?;
+    if fetched_agent.id != agent.id {
+        return Err(format!("agent id mismatch: {} != {}", fetched_agent.id, agent.id).into());
+    }
+
+    let session = client
+        .sessions()
+        .create(CreateSessionRequest {
+            agent_id: agent.id.clone(),
+            ..Default::default()
+        })
+        .await?;
+
+    let fetched_session = client.sessions().get(&session.id).await?;
+    if fetched_session.id != session.id {
+        return Err(format!("session id mismatch: {} != {}", fetched_session.id, session.id).into());
+    }
+
+    println!("ok rust sdk {}", std::env::var("SDK_VERSION")?);
+    Ok(())
+}
+RS
+
+(
+  cd "$workdir/smoke"
+  EVERRUNS_API_KEY="$api_key" \
+  EVERRUNS_BASE_URL="$base_url" \
+  SDK_VERSION="$version" \
+  cargo run --quiet
+)

--- a/.github/scripts/sdk-compat/test-typescript.sh
+++ b/.github/scripts/sdk-compat/test-typescript.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${1:?usage: test-typescript.sh <version> <base_url> <api_key>}"
+base_url="${2:?usage: test-typescript.sh <version> <base_url> <api_key>}"
+api_key="${3:?usage: test-typescript.sh <version> <base_url> <api_key>}"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+cat > "$workdir/package.json" <<JSON
+{
+  "name": "sdk-compat-ts",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@everruns/sdk": "$version"
+  }
+}
+JSON
+
+cat > "$workdir/test.mjs" <<'JS'
+import { Client } from "@everruns/sdk";
+
+const client = new Client({
+  apiKey: process.env.EVERRUNS_API_KEY,
+  baseUrl: process.env.EVERRUNS_BASE_URL,
+});
+
+const suffix = Math.random().toString(36).slice(2, 10);
+
+const agent = await client.agents.create({
+  name: `sdk-compat-ts-${suffix}`,
+  systemPrompt: "Compatibility test agent",
+});
+
+const fetchedAgent = await client.agents.get(agent.id);
+if (fetchedAgent.id !== agent.id) {
+  throw new Error(`agent id mismatch: ${fetchedAgent.id} != ${agent.id}`);
+}
+
+const session = await client.sessions.create({ agentId: agent.id });
+const fetchedSession = await client.sessions.get(session.id);
+if (fetchedSession.id !== session.id) {
+  throw new Error(`session id mismatch: ${fetchedSession.id} != ${session.id}`);
+}
+
+console.log(`ok typescript sdk ${process.env.SDK_VERSION}`);
+JS
+
+(
+  cd "$workdir"
+  npm install --silent
+  EVERRUNS_API_KEY="$api_key" \
+  EVERRUNS_BASE_URL="$base_url" \
+  SDK_VERSION="$version" \
+  node test.mjs
+)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
       daytona: ${{ steps.filter.outputs.daytona }}
+      sdk_compat: ${{ steps.filter.outputs.sdk_compat }}
       ui: ${{ steps.filter.outputs.ui }}
       docs: ${{ steps.filter.outputs.docs }}
       docker: ${{ steps.filter.outputs.docker }}
@@ -48,6 +49,10 @@ jobs:
               - '.github/workflows/ci.yml'
             daytona:
               - 'integrations/daytona/**'
+            sdk_compat:
+              - 'crates/**'
+              - '.github/scripts/sdk-compat/**'
+              - '.github/workflows/ci.yml'
             ui:
               - 'apps/ui/**'
               - '.github/workflows/ci.yml'
@@ -546,6 +551,100 @@ jobs:
         if: always()
         run: kill $SERVER_PID || true
 
+  sdk-compat-matrix:
+    name: SDK Compat Matrix
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.sdk_compat == 'true'
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve SDK version matrix
+        id: matrix
+        run: ./.github/scripts/sdk-compat/resolve-sdk-versions.sh
+
+  sdk-compat-test:
+    name: SDK Compat (${{ matrix.language }} / ${{ matrix.cohort }} / v${{ matrix.version }})
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+      - build-binaries
+      - sdk-compat-matrix
+    if: needs.changes.outputs.sdk_compat == 'true'
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.sdk-compat-matrix.outputs.matrix) }}
+
+    env:
+      RUSTC_WRAPPER: ""
+      DEV_MODE: "true"
+      AUTH_MODE: none
+      SECRETS_ENCRYPTION_KEY: kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=
+      EVERRUNS_API_KEY: sdk-compat-test-key
+      EVERRUNS_BASE_URL: http://localhost:9000/api
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        if: matrix.language == 'typescript'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Setup Python
+        if: matrix.language == 'python'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Rust toolchain
+        if: matrix.language == 'rust'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Download server binary
+        uses: actions/download-artifact@v4
+        with:
+          name: everruns-server
+          path: ./bin
+
+      - name: Make server binary executable
+        run: chmod +x ./bin/everruns-server
+
+      - name: Start server (DEV_MODE with in-process worker)
+        run: |
+          ./bin/everruns-server > /tmp/server.log 2>&1 &
+          SERVER_PID=$!
+          echo "SERVER_PID=$SERVER_PID" >> $GITHUB_ENV
+          timeout 30 bash -c 'until curl -s http://localhost:9000/health > /dev/null; do sleep 1; done'
+          echo "Server is ready"
+
+      - name: Run TypeScript SDK compatibility suite
+        if: matrix.language == 'typescript'
+        run: ./.github/scripts/sdk-compat/test-typescript.sh "${{ matrix.version }}" "$EVERRUNS_BASE_URL" "$EVERRUNS_API_KEY"
+
+      - name: Run Python SDK compatibility suite
+        if: matrix.language == 'python'
+        run: ./.github/scripts/sdk-compat/test-python.sh "${{ matrix.version }}" "$EVERRUNS_BASE_URL" "$EVERRUNS_API_KEY"
+
+      - name: Run Rust SDK compatibility suite
+        if: matrix.language == 'rust'
+        run: ./.github/scripts/sdk-compat/test-rust.sh "${{ matrix.version }}" "$EVERRUNS_BASE_URL" "$EVERRUNS_API_KEY"
+
+      - name: Show logs on failure
+        if: failure()
+        run: |
+          echo "=== Server Logs ==="
+          cat /tmp/server.log || true
+
+      - name: Stop server
+        if: always()
+        run: kill $SERVER_PID || true
+
   # Reuses export-openapi binary from build-binaries instead of rebuilding
   openapi-check:
     name: OpenAPI Spec Freshness
@@ -706,6 +805,8 @@ jobs:
       - workflow-test
       - cli-e2e-test
       - openapi-check
+      - sdk-compat-matrix
+      - sdk-compat-test
       - ui-build
       - docs-build
       - docker-build

--- a/specs/leased-resources.md
+++ b/specs/leased-resources.md
@@ -11,7 +11,7 @@ Leased resources are the generic control-plane primitive for any provider-owned 
 
 ## Model
 
-See [`crates/core/src/leased_resource.rs`](/Users/mykhailochalyi/.codex/worktrees/baaf/everruns/crates/core/src/leased_resource.rs) for the public domain type and [`crates/server/migrations/009_v0.8.6.sql`](/Users/mykhailochalyi/.codex/worktrees/baaf/everruns/crates/server/migrations/009_v0.8.6.sql) for persistence details.
+See [`crates/core/src/leased_resource.rs`](/Users/mykhailochalyi/.codex/worktrees/baaf/everruns/crates/core/src/leased_resource.rs) for the public domain type and [`crates/server/migrations/010_v0.8.6.sql`](/Users/mykhailochalyi/.codex/worktrees/baaf/everruns/crates/server/migrations/010_v0.8.6.sql) for persistence details.
 
 Important constraints:
 


### PR DESCRIPTION
## What
- Add `.github/scripts/sdk-compat/resolve-sdk-versions.sh` plus per-language SDK smoke scripts for TypeScript, Python, and Rust, and wire `sdk-compat-matrix` / `sdk-compat-test` into `.github/workflows/ci.yml`.
- Make the SDK matrix resolver portable on stock GitHub runners by removing the `rg` dependency from the new CI path.
- Update the leased-resources spec link to the current migration filename on `main`.

## Why
- Catch API and SDK compatibility regressions against older published SDK releases before merge.
- Ensure the new SDK compatibility workflow actually runs on a fresh GitHub runner without assuming extra tooling.
- Keep the spec reference aligned with the migration layout now on `main`.

## How
- Resolve versions from `everruns/sdk` Git tags at workflow runtime and fan out a non-fail-fast matrix across languages and compatibility cohorts.
- Reuse the `build-binaries` server artifact, start the server in `DEV_MODE`, and run each language smoke script against the live API.
- Replace `rg` with `grep` in the resolver and point the leased-resources spec at `crates/server/migrations/010_v0.8.6.sql`.

## Risk
- Medium
- Risk is limited to CI behavior: tag resolution, dependency installation, or smoke-test assumptions can still make the workflow fail if runner assumptions are wrong.
- Verified locally with `./.github/scripts/sdk-compat/resolve-sdk-versions.sh`, `just pre-push`, `just pre-pr`, and a fresh-DB `sqlx migrate info/run` against PostgreSQL on port `51232`.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
